### PR TITLE
feat(evals): egress/TLS fault lab + diagnostics that name the fault

### DIFF
--- a/apps/server/src/agent-context-cloud-probe.test.ts
+++ b/apps/server/src/agent-context-cloud-probe.test.ts
@@ -814,7 +814,40 @@ describe("OpenWork Cloud catalog probe", () => {
       cleanupAttempted: false,
       cleanupSucceeded: null,
     });
-    expect(failed.steps).toEqual([expect.stringContaining("initialize failed unauthorized")]);
+    expect(failed.steps).toEqual([
+      expect.stringContaining("initialize transient 401 observed"),
+      expect.stringContaining("initialize failed unauthorized"),
+    ]);
+  });
+
+  test("retries one initialize 401 and records the recovered transient auth blip", async () => {
+    let initializeCalls = 0;
+    const fetchImpl: CloudCatalogProbeFetch = async (_url, init) => {
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      const body = requestPayload(init);
+      if (body.method === "initialize") {
+        initializeCalls += 1;
+        return initializeCalls === 1 ? new Response(null, { status: 401 }) : initializeResponse();
+      }
+      if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
+      if (body.method === "tools/list") return jsonResponse("retry-transient-401");
+      throw new Error("Unexpected JSON-RPC method");
+    };
+    const probeInput = input({ requestId: "retry-transient-401" });
+    probeInput.fetchImpl = fetchImpl;
+
+    const observed = await probeOpenworkCloudCatalog(probeInput);
+
+    expect(initializeCalls).toBe(2);
+    expect(observed.status).toBe("observed");
+    expect(observed.steps).toEqual([
+      expect.stringContaining("initialize transient 401 observed"),
+      expect.stringContaining("initialize recovered after transient 401"),
+      expect.stringContaining("initialize ok 200"),
+      expect.stringContaining("initialized_notification ok 202"),
+      expect.stringContaining("tools_list ok 200"),
+      expect.stringContaining("session_cleanup ok"),
+    ]);
   });
 
   test("rejects an unsupported negotiated protocol version", async () => {

--- a/apps/server/src/agent-context-cloud-probe.ts
+++ b/apps/server/src/agent-context-cloud-probe.ts
@@ -803,7 +803,7 @@ async function performProbe(
   let phaseStart = clock();
   const phaseMs = () => `${elapsed(phaseStart, clock)}ms`;
   try {
-    const initialized = await postJsonRpc(
+    let initialized = await postJsonRpc(
       prepared,
       baseProbeHeaders(prepared.authorization),
       {
@@ -821,6 +821,30 @@ async function performProbe(
     );
     currentHttpStatus = initialized.status;
     referenceId = captureReferenceId(initialized, referenceId);
+    if (initialized.status === 401) {
+      await cancelBody(initialized, deadline);
+      record(`initialize transient 401 observed ${phaseMs()}`);
+      currentHttpStatus = null;
+      initialized = await postJsonRpc(
+        prepared,
+        baseProbeHeaders(prepared.authorization),
+        {
+          jsonrpc: "2.0",
+          id: INITIALIZE_REQUEST_ID,
+          method: "initialize",
+          params: {
+            capabilities: {},
+            clientInfo: { name: "openwork-server-agent-context-diagnostics", version: "1.0.0" },
+            protocolVersion: MCP_PROTOCOL_VERSION,
+          },
+        },
+        fetchImpl,
+        deadline,
+      );
+      currentHttpStatus = initialized.status;
+      referenceId = captureReferenceId(initialized, referenceId);
+      if (initialized.status === 200) record(`initialize recovered after transient 401 ${phaseMs()}`);
+    }
     stage = "initialize_http";
     await requireHttpStatus(initialized, deadline, (status) => status === 200);
     stage = "initialize_protocol";

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -524,7 +524,7 @@ function collisionDetails(collisions: McpConfigCollision[]): string[] {
   });
 }
 
-function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticCheck {
+export function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticCheck {
   const common = {
     id: "cloud-tool-catalog" as const,
     durationMs: probe.durationMs,
@@ -555,16 +555,24 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
   if (probe.status === "observed") {
     const exact = probe.toolIds.length === REQUIRED_CLOUD_TOOL_IDS.length
       && REQUIRED_CLOUD_TOOL_IDS.every((toolId) => probe.toolIds.includes(toolId));
+    const transientUnauthorizedRecovered = exact
+      && probe.steps.some((step) => step.includes("recovered after transient 401"));
     return diagnosticCheck({
       ...common,
-      status: exact ? "passed" : "failed",
+      status: transientUnauthorizedRecovered ? "warning" : exact ? "passed" : "failed",
       evidenceKind: "observed",
-      code: exact ? "cloud_catalog_exact_match" : "cloud_catalog_mismatch",
-      message: exact
+      code: transientUnauthorizedRecovered
+        ? "cloud_catalog_recovered_after_transient_401"
+        : exact ? "cloud_catalog_exact_match" : "cloud_catalog_mismatch",
+      message: transientUnauthorizedRecovered
+        ? "The OpenWork runtime saw a transient HTTP 401 during the independent Cloud MCP initialize request and recovered on retry; this points to a proxy or auth-gateway blip, not a revoked OpenWork Cloud credential."
+        : exact
         ? "The canonical OpenWork Cloud catalog exposes exactly the two required capability tools."
         : "The OpenWork Cloud catalog does not match the required two-tool contract.",
-      owner: exact ? "openwork-server" : "openwork-support",
-      action: exact
+      owner: transientUnauthorizedRecovered ? "network-admin" : exact ? "openwork-server" : "openwork-support",
+      action: transientUnauthorizedRecovered
+        ? "Treat the first 401 as transient unless it repeats or carries a Den revoked-session envelope; inspect proxy and auth-gateway logs for one-off challenges."
+        : exact
         ? "No action is required."
         : "Review the OpenWork Cloud deployment and restore the canonical capability catalog.",
     });
@@ -624,11 +632,20 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       break;
     case "timeout":
     case "network_error":
-    case "redirect_rejected":
     case "http_error":
       owner = "network-admin";
-      message = "The independent runtime endpoint probe could not be completed through the configured network path.";
-      action = "Verify server egress, DNS, TLS, proxy policy, and the configured OpenWork Cloud service, then rerun diagnostics.";
+      if (probe.httpStatus === 451) {
+        message = "The independent runtime endpoint probe received HTTP 451, which indicates an egress proxy, firewall, or allowlist deny rather than an OpenWork Cloud catalog shape problem.";
+        action = "Add the configured OpenWork Cloud MCP host and its documented redirect targets to the corporate allowlist, then rerun diagnostics.";
+      } else {
+        message = "The independent runtime endpoint probe could not be completed through the configured network path.";
+        action = "Verify server egress, DNS, TLS, proxy policy, and the configured OpenWork Cloud service, then rerun diagnostics.";
+      }
+      break;
+    case "redirect_rejected":
+      owner = "network-admin";
+      message = "The independent runtime endpoint probe received an HTTP redirect during the MCP handshake and intentionally did not follow it; a proxy, captive portal, SSO challenge, or route rewrite is blocking the terminal /mcp/agent endpoint.";
+      action = "Fix the proxy or route so the configured Cloud MCP endpoint answers directly at /mcp/agent without a redirect, then rerun diagnostics.";
       break;
     case "dns_error":
       owner = "network-admin";
@@ -652,8 +669,13 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       break;
     case "proxy_error":
       owner = "network-admin";
-      message = "The configured proxy could not complete the independent runtime endpoint probe.";
-      action = "Verify proxy reachability, authentication, and bypass policy, then rerun diagnostics.";
+      if (probe.httpStatus === 451) {
+        message = "The independent runtime endpoint probe received HTTP 451, which indicates an egress proxy, firewall, or allowlist deny rather than an OpenWork Cloud catalog shape problem.";
+        action = "Add the configured OpenWork Cloud MCP host and its documented redirect targets to the corporate allowlist, then rerun diagnostics.";
+      } else {
+        message = "The configured proxy could not complete the independent runtime endpoint probe.";
+        action = "Verify proxy reachability, authentication, and bypass policy, then rerun diagnostics.";
+      }
       break;
     case "unauthorized":
       owner = "openwork-client";
@@ -720,7 +742,7 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
   });
 }
 
-function cloudDifferentialCheck(probe: CloudCatalogProbe, engineReachableNow: boolean): AgentContextDiagnosticCheck {
+export function cloudDifferentialCheck(probe: CloudCatalogProbe, engineReachableNow: boolean): AgentContextDiagnosticCheck {
   const verdict = differentialCloudVerdict(probe, engineReachableNow);
   const common = {
     id: "cloud-endpoint-differential" as const,
@@ -798,7 +820,7 @@ function cloudDifferentialCheck(probe: CloudCatalogProbe, engineReachableNow: bo
   });
 }
 
-function cloudEndpointTransportCheck(
+export function cloudEndpointTransportCheck(
   probe: CloudEndpointTransportProbe,
   notRequired: boolean,
 ): AgentContextDiagnosticCheck {
@@ -809,6 +831,11 @@ function cloudEndpointTransportCheck(
     handshakePerformed: probe.performed,
     verifiedHandshake: probe.verifiedHandshake,
     verifyErrorCode: probe.verifyErrorCode,
+    tls13Handshake: probe.tls13Handshake,
+    tls13ErrorCode: probe.tls13ErrorCode,
+    tls12Handshake: probe.tls12Handshake,
+    tls12ErrorCode: probe.tls12ErrorCode,
+    tls12Protocol: probe.tls12Protocol,
     dnsResolved: probe.dnsResolved,
     tcpConnected: probe.tcpConnected,
     servedChainLength: probe.servedChainLength,
@@ -843,7 +870,78 @@ function cloudEndpointTransportCheck(
       details,
     });
   }
+  if (
+    probe.verifiedHandshake === "failed"
+    && probe.tls13Handshake === "failed"
+    && probe.tls13ErrorCode === "ETIMEDOUT"
+    && probe.tls12Handshake === "ok"
+  ) {
+    return diagnosticCheck({
+      id: "cloud-endpoint-transport",
+      status: "failed",
+      evidenceKind: "observed",
+      code: "endpoint_tls_version_handshake_fault",
+      message: "The credential-free transport probe reproduced a TLS version fault: TLS 1.3 timed out while TLS 1.2 completed, which points to an egress proxy or firewall stalling TLS 1.3 handshakes rather than a ServiceNow, credential, or allowlist issue.",
+      owner: "network-admin",
+      action: "Fix or bypass the egress device that stalls TLS 1.3 ClientHello traffic for OpenWork Cloud hosts, or temporarily force TLS 1.2 where your policy permits it, then rerun diagnostics.",
+      details,
+    });
+  }
+  if (probe.verifiedHandshake === "failed" && probe.verifyErrorCode === "ETIMEDOUT") {
+    if (
+      probe.tls13Handshake === "failed"
+      && probe.tls13ErrorCode === "ETIMEDOUT"
+      && probe.tls12Handshake === "failed"
+      && probe.tls12ErrorCode === "ETIMEDOUT"
+    ) {
+      return diagnosticCheck({
+        id: "cloud-endpoint-transport",
+        status: "failed",
+        evidenceKind: "observed",
+        code: "endpoint_tls_handshake_timeout_tls12_comparison_failed",
+        message: "The credential-free TLS handshake timed out before any HTTP response, and the explicit TLS 1.3 probe also timed out; the runtime TLS 1.2 comparison timed out too, so this still points to an egress TLS ClientHello stall but this runtime could not prove the TLS 1.2 workaround.",
+        owner: "network-admin",
+        action: "Verify the egress proxy and firewall pass TLS ClientHello traffic to OpenWork Cloud hosts, then compare with a known Node or openssl TLS 1.2-only probe and confirm every OpenWork runtime honors any temporary TLS-version pinning policy.",
+        details,
+      });
+    }
+    return diagnosticCheck({
+      id: "cloud-endpoint-transport",
+      status: "failed",
+      evidenceKind: "observed",
+      code: "endpoint_tls_handshake_timeout",
+      message: "The credential-free TLS handshake timed out before any HTTP response; this points to a TLS handshake or egress proxy fault consistent with a TLS 1.3 ClientHello stall, not an application credential or ServiceNow problem.",
+      owner: "network-admin",
+      action: "Verify that the egress proxy and firewall pass TLS 1.3 ClientHello traffic to OpenWork Cloud hosts; compare with a TLS 1.2-only probe or temporarily force TLS 1.2 where policy permits, then rerun diagnostics.",
+      details,
+    });
+  }
   if (isCloudEndpointCertificateVerificationFailure(probe)) {
+    const servedIssuer = probe.servedChain[0]?.issuerCN ?? "";
+    if (/corporate|interception|proxy|mitm/iu.test(servedIssuer)) {
+      return diagnosticCheck({
+        id: "cloud-endpoint-transport",
+        status: "failed",
+        evidenceKind: "observed",
+        code: "endpoint_tls_interception_detected",
+        message: "The OpenWork Cloud endpoint appears to be TLS-inspected or re-signed by a corporate proxy; the runtime does not trust that inspecting issuer.",
+        owner: "network-admin",
+        action: "Install the corporate inspection root for the OpenWork runtime with NODE_EXTRA_CA_CERTS, or bypass TLS inspection for OpenWork Cloud hosts, then rerun diagnostics.",
+        details,
+      });
+    }
+    if (probe.verifyErrorCode === "UNABLE_TO_VERIFY_LEAF_SIGNATURE" && probe.servedChainLength === 1) {
+      return diagnosticCheck({
+        id: "cloud-endpoint-transport",
+        status: "failed",
+        evidenceKind: "observed",
+        code: "endpoint_tls_incomplete_chain",
+        message: "The OpenWork Cloud endpoint served a leaf-only TLS chain and verification failed with UNABLE_TO_VERIFY_LEAF_SIGNATURE; the missing intermediate/fullchain must be repaired before blaming credentials or application logic.",
+        owner: "network-admin",
+        action: "Serve the complete certificate chain from the endpoint or let the OpenWork runtime add the AIA intermediate to NODE_EXTRA_CA_CERTS, then rerun diagnostics.",
+        details,
+      });
+    }
     return diagnosticCheck({
       id: "cloud-endpoint-transport",
       status: "failed",

--- a/apps/server/src/agent-context-transport-probe.ts
+++ b/apps/server/src/agent-context-transport-probe.ts
@@ -10,6 +10,7 @@ const MAX_ENDPOINT_LENGTH = 2 * 1024;
 const REQUIRED_TERMINAL_PATH = "/mcp/agent";
 const MAX_CERT_FIELD_CHARS = 120;
 const MAX_CHAIN_ENTRIES = 5;
+const TLS_VERSION_FALLBACK_TIMEOUT_MS = 1_500;
 
 export type CloudEndpointTransportHandshake = "ok" | "failed" | "not-performed";
 
@@ -33,6 +34,11 @@ export type CloudEndpointTransportProbe = {
   performed: boolean;
   verifiedHandshake: CloudEndpointTransportHandshake;
   verifyErrorCode: string | null;
+  tls13Handshake: CloudEndpointTransportHandshake | null;
+  tls13ErrorCode: string | null;
+  tls12Handshake: CloudEndpointTransportHandshake | null;
+  tls12ErrorCode: string | null;
+  tls12Protocol: string | null;
   dnsResolved: boolean | null;
   tcpConnected: boolean | null;
   servedChain: ServedCertificateEvidence[];
@@ -47,7 +53,9 @@ export type CloudEndpointTransportProbe = {
 export type TransportProbeTlsSocket = Pick<
   TLSSocket,
   "destroy" | "getPeerCertificate" | "once" | "removeListener" | "setTimeout"
->;
+> & {
+  getProtocol?: () => string | null;
+};
 
 export type TransportProbeConnector = (
   options: ConnectionOptions,
@@ -78,6 +86,7 @@ type PreparedEndpoint = {
 type TlsAttemptResult = {
   status: "ok";
   certificate: DetailedPeerCertificate | null;
+  protocol: string | null;
 } | {
   status: "failed";
   errorCode: string | null;
@@ -186,7 +195,7 @@ function stripIpv6HostnameBrackets(hostname: string): string {
   return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
 }
 
-function tlsOptions(url: URL, rejectUnauthorized: boolean): ConnectionOptions {
+function tlsOptions(url: URL, rejectUnauthorized: boolean, version?: "TLSv1.2" | "TLSv1.3"): ConnectionOptions {
   const host = stripIpv6HostnameBrackets(url.hostname);
   const options: ConnectionOptions = {
     host,
@@ -194,6 +203,10 @@ function tlsOptions(url: URL, rejectUnauthorized: boolean): ConnectionOptions {
     rejectUnauthorized,
     ALPNProtocols: ["http/1.1"],
   };
+  if (version) {
+    options.minVersion = version;
+    options.maxVersion = version;
+  }
   // SNI forbids IP literals; Node throws ERR_INVALID_ARG_VALUE if servername is an IP address.
   if (isIP(host) === 0) options.servername = host;
   return options;
@@ -202,6 +215,7 @@ function tlsOptions(url: URL, rejectUnauthorized: boolean): ConnectionOptions {
 function connectTls(input: {
   url: URL;
   rejectUnauthorized: boolean;
+  version?: "TLSv1.2" | "TLSv1.3";
   connector: TransportProbeConnector;
   timeoutMs: number;
   inspectPeerCertificate: boolean;
@@ -242,9 +256,9 @@ function connectTls(input: {
     input.signal?.addEventListener("abort", onAbort, { once: true });
 
     try {
-      socket = input.connector(tlsOptions(input.url, input.rejectUnauthorized), () => {
+      socket = input.connector(tlsOptions(input.url, input.rejectUnauthorized, input.version), () => {
         const certificate = input.inspectPeerCertificate && socket ? socket.getPeerCertificate(true) : null;
-        settle({ status: "ok", certificate });
+        settle({ status: "ok", certificate, protocol: socket?.getProtocol?.() ?? null });
       });
       socket.once("error", onError);
       socket.setTimeout(input.timeoutMs, () => {
@@ -291,6 +305,46 @@ function caCertificateCount(tlsModule: TransportProbeTlsModule, type: "system" |
   }
 }
 
+async function timeoutVersionEvidence(input: {
+  url: URL;
+  connector: TransportProbeConnector;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<{
+  tls13Handshake: CloudEndpointTransportHandshake | null;
+  tls13ErrorCode: string | null;
+  tls12Handshake: CloudEndpointTransportHandshake | null;
+  tls12ErrorCode: string | null;
+  tls12Protocol: string | null;
+}> {
+  const timeoutMs = Math.min(input.timeoutMs, TLS_VERSION_FALLBACK_TIMEOUT_MS);
+  const tls13 = await connectTls({
+    url: input.url,
+    rejectUnauthorized: true,
+    version: "TLSv1.3",
+    connector: input.connector,
+    timeoutMs,
+    inspectPeerCertificate: false,
+    signal: input.signal,
+  });
+  const tls12 = await connectTls({
+    url: input.url,
+    rejectUnauthorized: true,
+    version: "TLSv1.2",
+    connector: input.connector,
+    timeoutMs,
+    inspectPeerCertificate: false,
+    signal: input.signal,
+  });
+  return {
+    tls13Handshake: tls13.status === "ok" ? "ok" : "failed",
+    tls13ErrorCode: tls13.status === "ok" ? null : tls13.errorCode,
+    tls12Handshake: tls12.status === "ok" ? "ok" : "failed",
+    tls12ErrorCode: tls12.status === "ok" ? null : tls12.errorCode,
+    tls12Protocol: tls12.status === "ok" ? tls12.protocol : null,
+  };
+}
+
 async function extraCaEvidence(input: {
   env: NodeJS.ProcessEnv;
   caFileReader?: (path: string) => Promise<string> | string;
@@ -330,6 +384,11 @@ export async function probeCloudEndpointTransport(
   const base = {
     endpointOrigin: endpoint ? endpointOrigin(endpoint.url) : null,
     endpointProtocol: endpointProtocol(endpoint?.url ?? null),
+    tls13Handshake: null,
+    tls13ErrorCode: null,
+    tls12Handshake: null,
+    tls12ErrorCode: null,
+    tls12Protocol: null,
     ...localTrust,
   };
   const skipReason = typeof prepared === "string"
@@ -376,6 +435,9 @@ export async function probeCloudEndpointTransport(
   }
 
   let servedChain: ServedCertificateEvidence[] = [];
+  const versionEvidence = verified.errorCode === "ETIMEDOUT"
+    ? await timeoutVersionEvidence({ url: endpoint.url, connector, timeoutMs, signal: input.signal })
+    : null;
   const certificateVerificationFailure = isCertificateVerificationError(verified.errorCode);
   if (certificateVerificationFailure) {
     const chainAttempt = await connectTls({
@@ -391,6 +453,7 @@ export async function probeCloudEndpointTransport(
 
   return {
     ...base,
+    ...(versionEvidence ?? {}),
     skipReason: null,
     performed: true,
     verifiedHandshake: "failed",

--- a/evals/flows/egress-broken-chain-repair.flow.mjs
+++ b/evals/flows/egress-broken-chain-repair.flow.mjs
@@ -1,0 +1,160 @@
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { startEgressLab } from "../runner/labs/egress.mjs";
+import { expectRuntimeTrust, expectVerdictNames, productDiagnosticsPrecondition } from "../runner/journeys/diagnostics.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "egress-broken-chain-repair";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RUNTIME_HREF = pathToFileURL(join(ROOT, "apps", "desktop", "electron", "runtime.mjs")).href;
+const COMMAND_TIMEOUT_MS = 45_000;
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function runNode(script, env = process.env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["--eval", script], { cwd: ROOT, env });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, COMMAND_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      resolve({ status: -1, stdout, stderr: `${stderr}\n${error.message}`.trim() });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ status: typeof code === "number" ? code : -1, stdout, stderr });
+    });
+  });
+}
+
+function commandOutput(label, result) {
+  return [
+    `$ ${label}`,
+    `exit: ${String(result.status)}`,
+    "--- stdout ---",
+    result.stdout.trim(),
+    "--- stderr ---",
+    result.stderr.trim(),
+  ].join("\n").trim();
+}
+
+function parseJsonStdout(result) {
+  try {
+    return JSON.parse(result.stdout.trim());
+  } catch {
+    return null;
+  }
+}
+
+function fetchProbeScript(url) {
+  return `
+    const url = ${JSON.stringify(url)};
+    fetch(url).then(async (response) => {
+      console.log(JSON.stringify({ ok: response.ok, status: response.status, body: await response.text() }));
+      process.exit(response.ok ? 0 : 1);
+    }).catch((error) => {
+      console.log(JSON.stringify({ ok: false, name: error?.name ?? null, message: error?.message ?? String(error), causeCode: error?.cause?.code ?? null }));
+      process.exit(1);
+    });
+  `;
+}
+
+function repairProbeScript(url, caPath, disabled) {
+  return `
+    const { mkdtemp, readFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const path = await import("node:path");
+    const { spawnSync } = await import("node:child_process");
+    const { resolveSystemCaEnv } = await import(${JSON.stringify(RUNTIME_HREF)});
+    const url = ${JSON.stringify(url)};
+    const caPath = ${JSON.stringify(caPath)};
+    const rootPem = await readFile(caPath, "utf8");
+    const logs = [];
+    const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-egress-chain-repair-"));
+    const parentEnv = ${disabled ? "{ OPENWORK_DISABLE_CHAIN_REPAIR: '1' }" : "{}"};
+    const caEnv = await resolveSystemCaEnv({
+      tlsModule: { getCACertificates() { return []; } },
+      userDataDir,
+      parentEnv,
+      logInfo(message) { logs.push(String(message)); },
+      loadPlatformCertificates: async () => [rootPem],
+      platformSourceName: "egress-lab-root",
+      chainRepair: { origins: [url], rootsProvider: () => [rootPem] },
+    });
+    const child = spawnSync(process.execPath, ["--eval", ${JSON.stringify(fetchProbeScript(url))}], {
+      env: { ...process.env, ...caEnv },
+      encoding: "utf8",
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    });
+    console.log(JSON.stringify({ caEnv, logs, child: { status: child.status, stdout: child.stdout, stderr: child.stderr } }));
+  `;
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, assertion);
+}
+
+function outputContainsChainError(value) {
+  return /UNABLE_TO_VERIFY_LEAF_SIGNATURE|unable to verify the first certificate|unable to get local issuer/i.test(value);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Broken TLS chains are repaired by the app-side AIA path and named by diagnostics",
+  kind: "internal",
+  requiresApp: false,
+  precondition: (ctx) => productDiagnosticsPrecondition(ctx.env),
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        let lab;
+        let plain;
+        let repaired;
+        let disabled;
+        await ctx.prove("Leaf-only TLS chains fail plainly, product repair succeeds, the kill switch fails again, and OpenWork product diagnostics name the chain fault", {
+          voiceover: vo[0],
+          action: async () => {
+            lab = await startEgressLab({ profile: "broken-chain" });
+            plain = await runNode(fetchProbeScript(lab.url), { ...process.env, NODE_EXTRA_CA_CERTS: lab.caPath });
+            repaired = await runNode(repairProbeScript(lab.url, lab.caPath, false));
+            disabled = await runNode(repairProbeScript(lab.url, lab.caPath, true));
+          },
+          assert: async () => {
+            try {
+              const plainJson = parseJsonStdout(plain);
+              const repairedJson = parseJsonStdout(repaired);
+              const disabledJson = parseJsonStdout(disabled);
+              ctx.output("Plain node fetch with root only", commandOutput("NODE_EXTRA_CA_CERTS=<root> node --eval <fetch>", plain));
+              ctx.output("Runtime chain repair probe", commandOutput("node --eval <resolveSystemCaEnv repair probe>", repaired));
+              ctx.output("Runtime chain repair disabled probe", commandOutput("node --eval <resolveSystemCaEnv disabled probe>", disabled));
+              witness(ctx, plain.status !== 0, "plain node fetch fails when only the root is trusted and the server withholds the intermediate", JSON.stringify(plainJson));
+              witness(ctx, outputContainsChainError(JSON.stringify(plainJson)), "plain failure names the first-certificate / missing-intermediate error", JSON.stringify(plainJson));
+              witness(ctx, repaired.status === 0 && repairedJson?.child?.status === 0, "app-side resolveSystemCaEnv chain repair makes the child fetch succeed", JSON.stringify(repairedJson));
+              witness(ctx, repairedJson?.logs?.some((line) => /chain repaired/.test(line)) === true, "repair logs say the AIA intermediate was added", JSON.stringify(repairedJson?.logs));
+              witness(ctx, disabled.status === 0 && disabledJson?.child?.status !== 0, "OPENWORK_DISABLE_CHAIN_REPAIR=1 fails again", JSON.stringify(disabledJson));
+              witness(ctx, outputContainsChainError(JSON.stringify(disabledJson)), "disabled repair preserves the missing-intermediate failure", JSON.stringify(disabledJson));
+              await expectRuntimeTrust(ctx, { caPath: lab.caPath });
+              await expectVerdictNames(ctx, { lab, expect: "broken-chain" });
+            } finally {
+              await lab?.stop();
+            }
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/egress-selective-deny.flow.mjs
+++ b/evals/flows/egress-selective-deny.flow.mjs
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { startEgressLab } from "../runner/labs/egress.mjs";
+import { expectVerdictNames, productDiagnosticsPrecondition } from "../runner/journeys/diagnostics.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "egress-selective-deny";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MANIFEST_PATH = join(ROOT, "docs", "enterprise", "outbound-access.json");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, assertion);
+}
+
+async function fetchDenied(lab) {
+  const url = new URL("/fetch", lab.url);
+  url.searchParams.set("url", "https://github.com/different-ai/openwork/releases/latest");
+  const response = await fetch(url);
+  const text = await response.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = null;
+  }
+  return { status: response.status, text, json };
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Selective host blocks surface as actionable allowlist failures",
+  kind: "internal",
+  requiresApp: false,
+  precondition: (ctx) => productDiagnosticsPrecondition(ctx.env),
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        let lab;
+        let denied;
+        let manifest;
+        await ctx.prove("github.com is blocked by policy, the lab error names the host, and OpenWork product diagnostics classify the HTTP 451 allowlist deny", {
+          voiceover: vo[0],
+          action: async () => {
+            lab = await startEgressLab({ profile: "deny", denyHosts: ["github.com", "127.0.0.1"] });
+            denied = await fetchDenied(lab);
+            manifest = JSON.parse(await readFile(MANIFEST_PATH, "utf8"));
+          },
+          assert: async () => {
+            try {
+              const manifestEntry = manifest.hosts.find((entry) => entry.host === "github.com");
+              ctx.output("Selective deny response", JSON.stringify(denied, null, 2));
+              ctx.output("github.com outbound manifest entry", JSON.stringify(manifestEntry, null, 2));
+              witness(ctx, denied.status === 451, "github.com fails with an explicit blocked-host HTTP status", JSON.stringify(denied));
+              witness(ctx, denied.json?.error === "EGRESS_HOST_BLOCKED", "the failure has a stable EGRESS_HOST_BLOCKED code", JSON.stringify(denied));
+              witness(ctx, denied.json?.host === "github.com", "the failure names the blocked host", JSON.stringify(denied));
+              witness(ctx, denied.text.includes("docs/enterprise/outbound-access.json"), "the error points operators at the allowlist manifest", denied.text);
+              witness(ctx, manifestEntry?.host === "github.com" && /install|update|download/i.test(manifestEntry.blockedEffect), "the allowlist manifest names github.com and its installer/update blocked effect", JSON.stringify(manifestEntry));
+              await expectVerdictNames(ctx, { lab, expect: "deny" });
+            } finally {
+              await lab?.stop();
+            }
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/egress-tls12-only.flow.mjs
+++ b/evals/flows/egress-tls12-only.flow.mjs
@@ -1,0 +1,79 @@
+import tls from "node:tls";
+import { startEgressLab } from "../runner/labs/egress.mjs";
+import { expectBunTls12PinningFinding, expectVerdictNames, productDiagnosticsPrecondition } from "../runner/journeys/diagnostics.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "egress-tls12-only";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, assertion);
+}
+
+function tlsHandshake(lab, version) {
+  const url = new URL(lab.url);
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = tls.connect({
+      host: url.hostname,
+      port: Number(url.port),
+      servername: url.hostname,
+      minVersion: version,
+      maxVersion: version,
+      ca: lab.rootPem,
+      rejectUnauthorized: true,
+    });
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    socket.once("secureConnect", () => finish({ ok: true, protocol: socket.getProtocol(), errorCode: null }));
+    socket.once("timeout", () => finish({ ok: false, protocol: null, errorCode: "ETIMEDOUT" }));
+    socket.once("error", (error) => finish({ ok: false, protocol: null, errorCode: error?.code ?? error?.message ?? String(error) }));
+    socket.setTimeout(1500);
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Egress lab names the TLS 1.3 stall while TLS 1.2 succeeds",
+  kind: "internal",
+  requiresApp: false,
+  precondition: (ctx) => productDiagnosticsPrecondition(ctx.env),
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        let lab;
+        let tls13;
+        let tls12;
+        await ctx.prove("TLS 1.3 times out, Node TLS 1.2 succeeds, OpenWork product diagnostics name the handshake fault, and the Bun pinning gap is recorded", {
+          voiceover: vo[0],
+          action: async () => {
+            lab = await startEgressLab({ profile: "tls12-only" });
+            try {
+              tls13 = await tlsHandshake(lab, "TLSv1.3");
+              tls12 = await tlsHandshake(lab, "TLSv1.2");
+            } finally {
+              // Lab cleanup happens after assertions so diagnostics can still inspect it.
+            }
+          },
+          assert: async () => {
+            try {
+              ctx.output("TLS version split", JSON.stringify({ tls13, tls12 }, null, 2));
+              witness(ctx, tls13?.ok === false && tls13?.errorCode === "ETIMEDOUT", "a TLS 1.3-only client times out against the egress proxy stall", JSON.stringify(tls13));
+              witness(ctx, tls12?.ok === true && tls12?.protocol === "TLSv1.2", "a TLS 1.2-only client completes the handshake", JSON.stringify(tls12));
+              await expectVerdictNames(ctx, { lab, expect: "tls12-only" });
+              await expectBunTls12PinningFinding(ctx, { lab });
+            } finally {
+              await lab?.stop();
+            }
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/egress-transient-401.flow.mjs
+++ b/evals/flows/egress-transient-401.flow.mjs
@@ -1,0 +1,154 @@
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { startEgressLab } from "../runner/labs/egress.mjs";
+import { expectVerdictNames, productDiagnosticsPrecondition } from "../runner/journeys/diagnostics.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "egress-transient-401";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const APP_ROOT = join(ROOT, "apps", "app");
+const COMMAND_TIMEOUT_MS = 45_000;
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function runBun(script) {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["--conditions", "development", "--eval", script], { cwd: APP_ROOT, env: process.env });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, COMMAND_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      resolve({ status: -1, stdout, stderr: `${stderr}\n${error.message}`.trim() });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ status: typeof code === "number" ? code : -1, stdout, stderr });
+    });
+  });
+}
+
+function commandOutput(label, result) {
+  return [
+    `$ ${label}`,
+    `cwd: ${APP_ROOT}`,
+    `exit: ${String(result.status)}`,
+    "--- stdout ---",
+    result.stdout.trim(),
+    "--- stderr ---",
+    result.stderr.trim(),
+  ].join("\n").trim();
+}
+
+function parseJsonStdout(result) {
+  try {
+    return JSON.parse(result.stdout.trim());
+  } catch {
+    return null;
+  }
+}
+
+function transient401Script(baseUrl) {
+  return `
+    const storage = (() => {
+      const map = new Map();
+      return {
+        get length() { return map.size; },
+        clear() { map.clear(); },
+        getItem(key) { return map.get(key) ?? null; },
+        key(index) { return Array.from(map.keys())[index] ?? null; },
+        removeItem(key) { map.delete(key); },
+        setItem(key, value) { map.set(key, String(value)); },
+      };
+    })();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage: storage, dispatchEvent() { return true; } },
+    });
+    const { createDenClient, isDenSessionRevokedError } = await import("./src/app/lib/den.ts");
+    const tokenKey = "openwork.den.authToken";
+    window.localStorage.setItem(tokenKey, "tok_stored_transient_401");
+    const client = createDenClient({ baseUrl: ${JSON.stringify(baseUrl)}, token: window.localStorage.getItem(tokenKey) });
+    let first = null;
+    try {
+      await client.getSession();
+      first = { threw: false };
+    } catch (error) {
+      const revoked = isDenSessionRevokedError(error);
+      first = {
+        threw: true,
+        revoked,
+        name: error?.name ?? null,
+        status: error?.status ?? null,
+        code: error?.code ?? null,
+        message: error?.message ?? String(error),
+      };
+      if (revoked) window.localStorage.removeItem(tokenKey);
+    }
+    const tokenAfterFirst = window.localStorage.getItem(tokenKey);
+    let second = null;
+    try {
+      second = { ok: true, user: await client.getSession() };
+    } catch (error) {
+      second = { ok: false, status: error?.status ?? null, code: error?.code ?? null, message: error?.message ?? String(error) };
+    }
+    console.log(JSON.stringify({ first, tokenAfterFirst, second, finalToken: window.localStorage.getItem(tokenKey) }));
+  `;
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, assertion);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "A transient proxy 401 does not wipe stored Den credentials",
+  kind: "internal",
+  requiresApp: false,
+  precondition: (ctx) => productDiagnosticsPrecondition(ctx.env),
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        let lab;
+        let verdictLab;
+        let result;
+        await ctx.prove("A one-off foreign 401 is treated as unavailable, not revoked, and OpenWork product diagnostics report the recovered transient 401", {
+          voiceover: vo[0],
+          action: async () => {
+            lab = await startEgressLab({ profile: "blip", blip: { route: "/api/den/v1/me", count: 1, status: 401, body: "" } });
+            result = await runBun(transient401Script(lab.url));
+            verdictLab = await startEgressLab({ profile: "blip", blip: { route: "/mcp/agent", count: 1, status: 401, body: "" } });
+          },
+          assert: async () => {
+            try {
+              const parsed = parseJsonStdout(result);
+              ctx.output("Transient 401 token resilience probe", commandOutput("bun --eval <transient 401 Den client probe>", result));
+              witness(ctx, result.status === 0, "the transient 401 probe script exits 0", commandOutput("bun --eval <transient 401 Den client probe>", result));
+              witness(ctx, parsed?.first?.threw === true && parsed?.first?.status === 401 && parsed?.first?.code === "request_failed", "the first response is a foreign/proxy-shaped 401, not a Den revoked-session envelope", JSON.stringify(parsed));
+              witness(ctx, parsed?.first?.revoked === false, "isDenSessionRevokedError rejects the proxy-shaped 401", JSON.stringify(parsed));
+              witness(ctx, parsed?.tokenAfterFirst === "tok_stored_transient_401", "the stored token remains after the transient 401", JSON.stringify(parsed));
+              witness(ctx, parsed?.second?.ok === true && parsed?.second?.user?.email === "lab@example.com", "the next request recovers with the same stored credential", JSON.stringify(parsed));
+              witness(ctx, parsed?.finalToken === "tok_stored_transient_401", "the final token is still present", JSON.stringify(parsed));
+              await expectVerdictNames(ctx, { lab: verdictLab, expect: "blip" });
+            } finally {
+              await lab?.stop();
+              await verdictLab?.stop();
+            }
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/egress-lab.test.ts
+++ b/evals/runner/egress-lab.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createBlipSchedule,
+  denyHostsFromOutboundManifest,
+  opensslCertificateCommands,
+  outboundManifestFromUnknown,
+  parseClientHelloVersions,
+  resolveEgressProfileConfig,
+} from "./labs/egress.ts";
+import { matchVerdictExpectations, productDiagnosticsPrecondition } from "./journeys/diagnostics.ts";
+
+function hi(value: number): number {
+  return (value >> 8) & 0xff;
+}
+
+function lo(value: number): number {
+  return value & 0xff;
+}
+
+function clientHelloFixture(versions: number[]): Buffer {
+  const supportedVersions = versions.flatMap((version) => [hi(version), lo(version)]);
+  const extensions = supportedVersions.length > 0
+    ? [0x00, 0x2b, 0x00, supportedVersions.length + 1, supportedVersions.length, ...supportedVersions]
+    : [];
+  const body = [
+    0x03,
+    0x03,
+    ...Array.from({ length: 32 }, () => 0),
+    0x00,
+    0x00,
+    0x02,
+    0x00,
+    0x2f,
+    0x01,
+    0x00,
+    hi(extensions.length),
+    lo(extensions.length),
+    ...extensions,
+  ];
+  const handshakeLength = body.length;
+  const recordLength = handshakeLength + 4;
+  return Buffer.from([
+    0x16,
+    0x03,
+    0x01,
+    hi(recordLength),
+    lo(recordLength),
+    0x01,
+    0x00,
+    hi(handshakeLength),
+    lo(handshakeLength),
+    ...body,
+  ]);
+}
+
+test("ClientHello parser distinguishes TLS 1.2-only from TLS 1.3-capable clients", () => {
+  const tls12 = parseClientHelloVersions(clientHelloFixture([0x0303]));
+  if (tls12.kind !== "parsed") throw new Error(`unexpected parse result: ${tls12.kind}`);
+  assert.equal(tls12.offersTls13, false);
+  assert.deepEqual(tls12.supportedVersionLabels, ["TLSv1.2"]);
+
+  const tls13 = parseClientHelloVersions(clientHelloFixture([0x0304, 0x0303]));
+  if (tls13.kind !== "parsed") throw new Error(`unexpected parse result: ${tls13.kind}`);
+  assert.equal(tls13.offersTls13, true);
+  assert.deepEqual(tls13.supportedVersionLabels, ["TLSv1.3", "TLSv1.2"]);
+});
+
+test("profile config resolution normalizes defaults", () => {
+  const config = resolveEgressProfileConfig({
+    profile: "deny",
+    port: 0,
+    denyHosts: ["GitHub.com", "github.com.", ""],
+    denyMode: "blackhole",
+    slow: { totalBytes: 10, chunkBytes: 4, delayMs: 0, latencyMs: 1 },
+    blip: { route: "api/den", count: 2, fault: "reset" },
+  });
+
+  assert.equal(config.port, null);
+  assert.deepEqual(config.denyHosts, ["github.com"]);
+  assert.equal(config.denyMode, "blackhole");
+  assert.equal(config.slow.totalBytes, 10);
+  assert.equal(config.blip.route, "/api/den");
+  assert.equal(config.blip.count, 2);
+  assert.equal(config.blip.fault, "reset");
+});
+
+test("openssl argv construction includes CA, AIA, and fullchain prerequisites", () => {
+  const commands = opensslCertificateCommands({
+    dir: "/tmp/openwork-egress-test",
+    hostname: "localhost",
+    aiaUrl: "http://127.0.0.1:9000/__egress-lab/intermediate.der",
+    corporateIssuer: true,
+  });
+  const labels = commands.map((command) => command.label);
+
+  assert.deepEqual(labels, [
+    "root-key",
+    "root-cert",
+    "intermediate-key",
+    "intermediate-csr",
+    "intermediate-cert",
+    "intermediate-der",
+    "leaf-key",
+    "leaf-csr",
+    "leaf-cert",
+  ]);
+  assert.ok(commands.some((command) => command.args.includes("/CN=OpenWork Egress Lab Corporate Interception CA")));
+  assert.ok(commands.some((command) => command.args.includes("-extfile")));
+});
+
+test("deny-list seeding reads installer-critical hosts from the outbound manifest", () => {
+  const manifest = outboundManifestFromUnknown({
+    hosts: [
+      { host: "github.com", kind: "fetched", components: ["installer"], requirement: "required-in-practice", blockedEffect: "installer dead" },
+      { host: "release-assets.githubusercontent.com", kind: "redirect-target", components: ["installer"], requirement: "required-in-practice", blockedEffect: "download fails" },
+      { host: "cdn.simpleicons.org", kind: "fetched", components: ["renderer"], requirement: "optional", blockedEffect: "icons missing" },
+    ],
+  });
+  if (!manifest) throw new Error("manifest fixture did not parse");
+
+  assert.deepEqual(denyHostsFromOutboundManifest(manifest), ["github.com", "release-assets.githubusercontent.com"]);
+});
+
+test("blip schedule fires once, then stops", () => {
+  const schedule = createBlipSchedule({ route: "/v1/me", count: 1, fault: "401", status: 401, body: "proxy" });
+  const first = schedule.next("/v1/me");
+  const second = schedule.next("/v1/me");
+
+  assert.deepEqual(first, { kind: "status", status: 401, body: "proxy" });
+  assert.deepEqual(second, { kind: "pass" });
+  assert.equal(schedule.snapshot()[0]?.remaining, 0);
+});
+
+test("verdict matcher names injected faults and rejects vague output", () => {
+  assert.equal(matchVerdictExpectations("LIKELY TLS VERSION/HANDSHAKE FAULT: TLS 1.3 timed out while TLS 1.2 completed", "tls12-only").ok, true);
+  assert.equal(matchVerdictExpectations("endpoint_tls_handshake_timeout_tls12_comparison_failed: TLS 1.3 timed out and the runtime TLS 1.2 comparison also timed out", "tls12-only").ok, true);
+  assert.equal(matchVerdictExpectations("LIKELY MISSING INTERMEDIATE OR UNTRUSTED ROOT", "broken-chain").ok, true);
+  assert.equal(matchVerdictExpectations("LIKELY TLS INTERCEPTION: endpoint leaf is re-signed by Corporate CA", "intercept").ok, true);
+  assert.equal(matchVerdictExpectations("BLOCKED HOST / PROXY DENY: github.com is blocked", "deny").ok, true);
+  assert.deepEqual(matchVerdictExpectations("TypeError: fetch failed", ["tls12-only", "broken-chain"]), {
+    ok: false,
+    missing: ["tls12-only", "broken-chain"],
+  });
+});
+
+test("product diagnostics precondition skips clearly when Bun is unavailable", () => {
+  const reason = productDiagnosticsPrecondition({ PATH: "/definitely-no-bun-here" });
+
+  if (!reason) throw new Error("Expected a missing-Bun skip reason");
+  assert.ok(reason.includes("Bun is required"));
+  assert.ok(reason.includes("product-verdict egress proofs"));
+});

--- a/evals/runner/journeys/diagnostics.mjs
+++ b/evals/runner/journeys/diagnostics.mjs
@@ -1,0 +1,1 @@
+export * from "./diagnostics.ts";

--- a/evals/runner/journeys/diagnostics.ts
+++ b/evals/runner/journeys/diagnostics.ts
@@ -729,7 +729,8 @@ async function diagnoseTlsLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> 
 }
 
 async function diagnoseDenyLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
-  const host = lab.deniedHosts.includes("github.com") ? "github.com" : lab.deniedHosts[0] ?? "github.com";
+  // Exact-match lookup (not a substring test) so the denied host is unambiguous.
+  const host = lab.deniedHosts.find((entry) => entry === "github.com") ?? lab.deniedHosts[0] ?? "github.com";
   const url = new URL("/fetch", lab.url);
   url.searchParams.set("url", `https://${host}/different-ai/openwork/releases/latest`);
   const response = await fetch(url);

--- a/evals/runner/journeys/diagnostics.ts
+++ b/evals/runner/journeys/diagnostics.ts
@@ -1,0 +1,973 @@
+import { spawn, spawnSync } from "node:child_process";
+import net from "node:net";
+import tls from "node:tls";
+import { fileURLToPath } from "node:url";
+import type { DetailedPeerCertificate } from "node:tls";
+
+import type { FlowContext } from "../flow.ts";
+import { parseClientHelloVersions } from "../labs/egress.ts";
+import type { ClientHelloParseResult, EgressLabHandle, EgressLabProfile } from "../labs/egress.ts";
+
+export type DiagnosticVerdictExpectation =
+  | EgressLabProfile
+  | "tls-version-handshake"
+  | "missing-intermediate"
+  | "untrusted-chain"
+  | "tls-interception"
+  | "blocked-host"
+  | "proxy"
+  | "redirect"
+  | "slow-link"
+  | "transient-401";
+
+export type DiagnosticVerdict = {
+  profile: EgressLabProfile;
+  text: string;
+  evidence: string;
+  source: "product" | "lab-corroboration";
+  available: boolean;
+};
+
+type CommandResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+  error: string | null;
+};
+
+type ProductDiagnosticsOkPayload = {
+  status: "ok";
+  profile: string;
+  verdictText: string;
+  checks: unknown;
+  cloudProbe: unknown;
+  transportProbe: unknown;
+};
+
+type ProductDiagnosticsErrorPayload = {
+  status: "error";
+  message: string;
+  stack: string | null;
+};
+
+type ProductDiagnosticsPayload = ProductDiagnosticsOkPayload | ProductDiagnosticsErrorPayload;
+
+type RuntimeProbePayload = {
+  reproVisible: boolean;
+  fileCount: number;
+  extraCount: number;
+  systemCount: number;
+  defaultCount: number;
+  bundledCount: number;
+};
+
+type TlsHandshakeProbe = {
+  ok: boolean;
+  protocol: string | null;
+  errorCode: string | null;
+};
+
+type ServedCertificateEvidence = {
+  subjectCN: string | null;
+  issuerCN: string | null;
+  selfIssued: boolean;
+};
+
+type TransportProbe = {
+  verifiedHandshake: "ok" | "failed";
+  verifyErrorCode: string | null;
+  servedChain: ServedCertificateEvidence[];
+  servedChainLength: number | null;
+};
+
+type TlsAttempt = {
+  ok: true;
+  certificate: DetailedPeerCertificate | null;
+} | {
+  ok: false;
+  errorCode: string | null;
+};
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const PRODUCT_DIAGNOSTICS_TIMEOUT_MS = 30_000;
+const TLS_RUNTIME_PROBE_TIMEOUT_MS = 1_500;
+const TLS_RUNTIME_COMMAND_TIMEOUT_MS = 8_000;
+
+const PRODUCT_DIAGNOSTICS_SCRIPT = String.raw`
+const profile = process.env.EGRESS_LAB_PRODUCT_PROFILE || "unknown";
+const endpoint = process.env.EGRESS_LAB_PRODUCT_ENDPOINT || "";
+const timeoutMs = Number(process.env.EGRESS_LAB_PRODUCT_TIMEOUT_MS || "1500");
+function checkLine(check) {
+  return [
+    check.id,
+    check.status,
+    check.code,
+    check.message,
+    "Action: " + check.action,
+  ].filter(Boolean).join(" | ");
+}
+async function main() {
+  const transportModule = await import("./apps/server/src/agent-context-transport-probe.ts");
+  const cloudModule = await import("./apps/server/src/agent-context-cloud-probe.ts");
+  const diagnosticsModule = await import("./apps/server/src/agent-context-diagnostics.ts");
+  const cloudProbe = await cloudModule.probeOpenworkCloudCatalog({
+    workspaceId: "ws_egress_lab_product_diagnostics",
+    workspaceType: "local",
+    runtimeConfigAvailable: true,
+    config: {
+      type: "remote",
+      enabled: true,
+      url: endpoint,
+      headers: { Authorization: "Bearer ow_diagnostics_token_abcdefghijklmnopqrstuvwxyz" },
+    },
+    engineRegistration: { status: "failed", source: "transport_failure", recordAgeMs: 1000 },
+    requestId: "11111111-1111-4111-8111-111111111111",
+    timeoutMs,
+    env: process.env,
+  });
+  const transportProbe = await transportModule.probeCloudEndpointTransport({
+    endpointUrl: endpoint,
+    performProbe: endpoint.startsWith("https:"),
+    timeoutMs,
+    env: process.env,
+  });
+  const checks = [
+    diagnosticsModule.cloudCatalogCheck(cloudProbe),
+    diagnosticsModule.cloudDifferentialCheck(cloudProbe, false),
+    diagnosticsModule.cloudEndpointTransportCheck(transportProbe, false),
+  ];
+  console.log(JSON.stringify({
+    status: "ok",
+    profile,
+    verdictText: checks.map(checkLine).join("\n"),
+    checks,
+    cloudProbe,
+    transportProbe,
+  }));
+}
+main().catch((error) => {
+  console.log(JSON.stringify({
+    status: "error",
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack ?? null : null,
+  }));
+  process.exitCode = 1;
+});
+`;
+
+const TLS_RUNTIME_PROBE_SCRIPT = String.raw`
+const fs = require("node:fs");
+const tls = require("node:tls");
+const url = new URL(process.env.EGRESS_LAB_TLS_URL || "");
+const timeoutMs = Number(process.env.EGRESS_LAB_TLS_TIMEOUT_MS || "1500");
+function errorCode(error) {
+  if (error && typeof error === "object" && typeof error.code === "string") return error.code;
+  if (error && typeof error === "object" && error.cause && typeof error.cause.code === "string") return error.cause.code;
+  if (error && typeof error === "object" && typeof error.name === "string" && error.name === "TimeoutError") return "TimeoutError";
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+async function main() {
+  if (process.env.EGRESS_LAB_TLS_MODE === "fetch") {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      console.log(JSON.stringify({ ok: true, status: response.status, body: await response.text() }));
+      return;
+    } catch (error) {
+      console.log(JSON.stringify({
+        ok: false,
+        name: error && typeof error === "object" && "name" in error ? error.name : null,
+        message: error instanceof Error ? error.message : String(error),
+        causeCode: error && typeof error === "object" && error.cause && typeof error.cause.code === "string" ? error.cause.code : null,
+        code: errorCode(error),
+      }));
+      process.exitCode = 1;
+      return;
+    }
+  }
+  const caPath = process.env.NODE_EXTRA_CA_CERTS || "";
+  const options = {
+    host: url.hostname,
+    port: Number(url.port) || 443,
+    servername: url.hostname,
+    ca: caPath ? fs.readFileSync(caPath, "utf8") : undefined,
+    rejectUnauthorized: true,
+    ALPNProtocols: ["http/1.1"],
+  };
+  if (process.env.EGRESS_LAB_TLS_MIN_VERSION) options.minVersion = process.env.EGRESS_LAB_TLS_MIN_VERSION;
+  if (process.env.EGRESS_LAB_TLS_MAX_VERSION) options.maxVersion = process.env.EGRESS_LAB_TLS_MAX_VERSION;
+  await new Promise((resolve) => {
+    let settled = false;
+    const socket = tls.connect(options);
+    const finish = (payload, status) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      console.log(JSON.stringify(payload));
+      process.exitCode = status;
+      resolve();
+    };
+    socket.once("secureConnect", () => finish({ ok: true, protocol: typeof socket.getProtocol === "function" ? socket.getProtocol() : null }, 0));
+    socket.once("timeout", () => finish({ ok: false, errorCode: "ETIMEDOUT" }, 1));
+    socket.once("error", (error) => finish({ ok: false, errorCode: errorCode(error) }, 1));
+    socket.setTimeout(timeoutMs);
+  });
+}
+main();
+`;
+
+const TLS_CLIENT_HELLO_CAPTURE_SCRIPT = String.raw`
+const tls = require("node:tls");
+const socket = tls.connect({
+  host: "127.0.0.1",
+  port: Number(process.env.EGRESS_LAB_CAPTURE_PORT || "0"),
+  servername: "localhost",
+  minVersion: "TLSv1.2",
+  maxVersion: "TLSv1.2",
+  rejectUnauthorized: false,
+});
+socket.on("error", () => undefined);
+socket.setTimeout(1000, () => socket.destroy());
+setTimeout(() => process.exit(0), 1200).unref?.();
+`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRuntimeProbePayload(value: unknown): value is RuntimeProbePayload {
+  return isRecord(value)
+    && typeof value.reproVisible === "boolean"
+    && typeof value.fileCount === "number"
+    && typeof value.extraCount === "number"
+    && typeof value.systemCount === "number"
+    && typeof value.defaultCount === "number"
+    && typeof value.bundledCount === "number";
+}
+
+function isProductDiagnosticsOkPayload(value: unknown): value is ProductDiagnosticsOkPayload {
+  return isRecord(value)
+    && value.status === "ok"
+    && typeof value.profile === "string"
+    && typeof value.verdictText === "string"
+    && Object.hasOwn(value, "checks")
+    && Object.hasOwn(value, "cloudProbe")
+    && Object.hasOwn(value, "transportProbe");
+}
+
+function isProductDiagnosticsErrorPayload(value: unknown): value is ProductDiagnosticsErrorPayload {
+  return isRecord(value)
+    && value.status === "error"
+    && typeof value.message === "string"
+    && (typeof value.stack === "string" || value.stack === null);
+}
+
+function productDiagnosticsPayloadFromStdout(stdout: string): ProductDiagnosticsPayload | null {
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    if (isProductDiagnosticsOkPayload(parsed) || isProductDiagnosticsErrorPayload(parsed)) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function endpointForDiagnostics(lab: EgressLabHandle): string {
+  const url = new URL(lab.url);
+  url.pathname = "/mcp/agent";
+  return url.toString();
+}
+
+function productDiagnosticsCaPath(lab: EgressLabHandle): string | undefined {
+  if (lab.profile === "tls12-only" || lab.profile === "broken-chain" || lab.profile === "healthy") return lab.caPath;
+  return undefined;
+}
+
+function productDiagnosticsEnv(lab: EgressLabHandle, baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    EGRESS_LAB_PRODUCT_PROFILE: lab.profile,
+    EGRESS_LAB_PRODUCT_ENDPOINT: endpointForDiagnostics(lab),
+    EGRESS_LAB_PRODUCT_TIMEOUT_MS: "1500",
+  };
+  const caPath = productDiagnosticsCaPath(lab);
+  if (caPath) env.NODE_EXTRA_CA_CERTS = caPath;
+  return env;
+}
+
+function runBunProductDiagnostics(lab: EgressLabHandle): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const child = spawn("bun", ["--conditions", "development", "--eval", PRODUCT_DIAGNOSTICS_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: productDiagnosticsEnv(lab, process.env),
+    });
+    const finish = (result: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+    timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({ status: -1, stdout, stderr, error: `Timed out after ${PRODUCT_DIAGNOSTICS_TIMEOUT_MS}ms` });
+    }, PRODUCT_DIAGNOSTICS_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => finish({ status: -1, stdout, stderr, error: error.message }));
+    child.on("close", (code) => finish({ status: typeof code === "number" ? code : -1, stdout, stderr, error: null }));
+  });
+}
+
+export function productDiagnosticsPrecondition(env: NodeJS.ProcessEnv = process.env): string | null {
+  const bun = spawnSync("bun", ["--version"], { env, encoding: "utf8", timeout: 5_000 });
+  if (bun.status !== 0) {
+    const reason = bun.error?.message ?? bun.stderr?.trim() ?? "bun --version failed";
+    return `Bun is required to import OpenWork's shipped TypeScript diagnostics modules for product-verdict egress proofs (${reason}).`;
+  }
+  const openssl = spawnSync("openssl", ["version"], { env, encoding: "utf8", timeout: 5_000 });
+  if (openssl.status !== 0) {
+    const reason = openssl.error?.message ?? openssl.stderr?.trim() ?? "openssl version failed";
+    return `OpenSSL is required to mint per-run egress lab certificates for product-verdict egress proofs (${reason}).`;
+  }
+  return null;
+}
+
+function runTlsRuntimeProbe(input: {
+  command: string;
+  label: string;
+  lab: EgressLabHandle;
+  env: NodeJS.ProcessEnv;
+  mode: "tls" | "fetch";
+  minVersion?: "TLSv1.2" | "TLSv1.3";
+  maxVersion?: "TLSv1.2" | "TLSv1.3";
+  nodeOptions?: string;
+}): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const childEnv: NodeJS.ProcessEnv = {
+      ...input.env,
+      EGRESS_LAB_TLS_URL: input.lab.url,
+      EGRESS_LAB_TLS_MODE: input.mode,
+      EGRESS_LAB_TLS_TIMEOUT_MS: String(TLS_RUNTIME_PROBE_TIMEOUT_MS),
+    };
+    if (input.lab.caPath) childEnv.NODE_EXTRA_CA_CERTS = input.lab.caPath;
+    if (input.minVersion) childEnv.EGRESS_LAB_TLS_MIN_VERSION = input.minVersion;
+    if (input.maxVersion) childEnv.EGRESS_LAB_TLS_MAX_VERSION = input.maxVersion;
+    if (input.nodeOptions) childEnv.NODE_OPTIONS = input.nodeOptions;
+    const child = spawn(input.command, ["--eval", TLS_RUNTIME_PROBE_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: childEnv,
+    });
+    const finish = (result: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+    timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({ status: -1, stdout, stderr, error: `${input.label} timed out after ${TLS_RUNTIME_COMMAND_TIMEOUT_MS}ms` });
+    }, TLS_RUNTIME_COMMAND_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => finish({ status: -1, stdout, stderr, error: error.message }));
+    child.on("close", (code) => finish({ status: typeof code === "number" ? code : -1, stdout, stderr, error: null }));
+  });
+}
+
+function listenCaptureServer(server: net.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address && typeof address === "object") {
+        resolve(address.port);
+        return;
+      }
+      reject(new Error("ClientHello capture server did not bind a TCP port."));
+    });
+  });
+}
+
+function closeCaptureServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function captureRuntimeClientHello(command: string, env: NodeJS.ProcessEnv): Promise<ClientHelloParseResult | { kind: "not-captured"; reason: string }> {
+  const server = net.createServer();
+  const port = await listenCaptureServer(server);
+  let child: ReturnType<typeof spawn> | null = null;
+  const captured = new Promise<ClientHelloParseResult | { kind: "not-captured"; reason: string }>((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ kind: "not-captured", reason: "Timed out waiting for TLS ClientHello." });
+    }, TLS_RUNTIME_COMMAND_TIMEOUT_MS);
+    server.once("connection", (socket) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      socket.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        total += chunk.byteLength;
+        const parsed = parseClientHelloVersions(Buffer.concat(chunks, total));
+        if (parsed.kind === "incomplete") return;
+        clearTimeout(timer);
+        socket.destroy();
+        resolve(parsed);
+      });
+      socket.on("error", () => undefined);
+    });
+    server.once("error", (error) => {
+      clearTimeout(timer);
+      resolve({ kind: "not-captured", reason: error.message });
+    });
+  });
+  try {
+    child = spawn(command, ["--eval", TLS_CLIENT_HELLO_CAPTURE_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: { ...env, EGRESS_LAB_CAPTURE_PORT: String(port) },
+    });
+    child.on("error", () => undefined);
+    const result = await captured;
+    return result;
+  } finally {
+    if (child) child.kill("SIGKILL");
+    await closeCaptureServer(server);
+  }
+}
+
+function outputCommandResult(result: CommandResult): Record<string, unknown> {
+  return {
+    status: result.status,
+    error: result.error,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+}
+
+function commandSucceededWith(result: CommandResult, needle: string): boolean {
+  return result.status === 0 && result.stdout.includes(needle);
+}
+
+function commandFailedWith(result: CommandResult, needle: string): boolean {
+  return result.status !== 0 && result.stdout.includes(needle);
+}
+
+export async function expectBunTls12PinningFinding(ctx: FlowContext, options: { lab: EgressLabHandle }): Promise<void> {
+  const nodeTls12 = await runTlsRuntimeProbe({
+    command: process.execPath,
+    label: "node node:tls TLSv1.2",
+    lab: options.lab,
+    env: ctx.env,
+    mode: "tls",
+    minVersion: "TLSv1.2",
+    maxVersion: "TLSv1.2",
+  });
+  const bunTls12 = await runTlsRuntimeProbe({
+    command: "bun",
+    label: "bun node:tls TLSv1.2",
+    lab: options.lab,
+    env: ctx.env,
+    mode: "tls",
+    minVersion: "TLSv1.2",
+    maxVersion: "TLSv1.2",
+  });
+  const nodeFetchPinned = await runTlsRuntimeProbe({
+    command: process.execPath,
+    label: "node fetch NODE_OPTIONS=--tls-max-v1.2",
+    lab: options.lab,
+    env: ctx.env,
+    mode: "fetch",
+    nodeOptions: "--tls-max-v1.2",
+  });
+  const bunFetchPinned = await runTlsRuntimeProbe({
+    command: "bun",
+    label: "bun fetch NODE_OPTIONS=--tls-max-v1.2",
+    lab: options.lab,
+    env: ctx.env,
+    mode: "fetch",
+    nodeOptions: "--tls-max-v1.2",
+  });
+  const nodeClientHello = await captureRuntimeClientHello(process.execPath, ctx.env);
+  const bunClientHello = await captureRuntimeClientHello("bun", ctx.env);
+  const summary = {
+    finding: "Bun 1.3.x does not currently honor Node-style TLS 1.2 pinning in node:tls or fetch for this lab; it still offers TLS 1.3 and stalls.",
+    nodeTls12: outputCommandResult(nodeTls12),
+    bunTls12: outputCommandResult(bunTls12),
+    nodeFetchPinned: outputCommandResult(nodeFetchPinned),
+    bunFetchPinned: outputCommandResult(bunFetchPinned),
+    nodeClientHello,
+    bunClientHello,
+  };
+  ctx.output("Bun vs Node TLS 1.2 pinning finding", JSON.stringify(summary, null, 2));
+  const nodeHelloOk = nodeClientHello.kind === "parsed" && !nodeClientHello.offersTls13 && nodeClientHello.supportedVersionLabels.includes("TLSv1.2");
+  const bunHelloShowsTls13 = bunClientHello.kind === "parsed" && bunClientHello.offersTls13 && bunClientHello.supportedVersionLabels.includes("TLSv1.3");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: commandSucceededWith(nodeTls12, '"protocol":"TLSv1.2"') ? "passed" : "failed",
+    assertion: "Node node:tls honors minVersion/maxVersion TLSv1.2 against the lab",
+    actual: outputCommandResult(nodeTls12),
+  });
+  ctx.assert(commandSucceededWith(nodeTls12, '"protocol":"TLSv1.2"'), "Node node:tls did not complete a TLSv1.2-pinned handshake.");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: commandFailedWith(bunTls12, "ETIMEDOUT") ? "passed" : "failed",
+    assertion: "Bun node:tls currently times out despite minVersion/maxVersion TLSv1.2",
+    actual: outputCommandResult(bunTls12),
+  });
+  ctx.assert(commandFailedWith(bunTls12, "ETIMEDOUT"), "Bun node:tls no longer times out under TLSv1.2 pinning; update the egress TLS finding and product workaround guidance.");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: commandSucceededWith(nodeFetchPinned, '"status":200') ? "passed" : "failed",
+    assertion: "Node fetch honors NODE_OPTIONS=--tls-max-v1.2 against the lab",
+    actual: outputCommandResult(nodeFetchPinned),
+  });
+  ctx.assert(commandSucceededWith(nodeFetchPinned, '"status":200'), "Node fetch did not honor NODE_OPTIONS=--tls-max-v1.2.");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: commandFailedWith(bunFetchPinned, "Timeout") ? "passed" : "failed",
+    assertion: "Bun fetch currently ignores NODE_OPTIONS=--tls-max-v1.2 for this lab and times out",
+    actual: outputCommandResult(bunFetchPinned),
+  });
+  ctx.assert(commandFailedWith(bunFetchPinned, "Timeout"), "Bun fetch no longer times out with NODE_OPTIONS=--tls-max-v1.2; update the egress TLS finding and product workaround guidance.");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: nodeHelloOk ? "passed" : "failed",
+    assertion: "Node's TLSv1.2-pinned ClientHello omits TLS 1.3",
+    actual: nodeClientHello,
+  });
+  ctx.assert(nodeHelloOk, "Node's TLSv1.2-pinned ClientHello did not look TLSv1.2-only.");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: bunHelloShowsTls13 ? "passed" : "failed",
+    assertion: "Bun's TLSv1.2-pinned ClientHello still advertises TLS 1.3 today",
+    actual: bunClientHello,
+  });
+  ctx.assert(bunHelloShowsTls13, "Bun no longer advertises TLS 1.3 under TLSv1.2 pinning; update the egress TLS finding and product workaround guidance.");
+}
+
+function endpointForTransport(lab: EgressLabHandle): URL {
+  const url = new URL(lab.url);
+  url.pathname = "/mcp/agent";
+  return url;
+}
+
+function tlsHandshake(lab: EgressLabHandle, version: "TLSv1.2" | "TLSv1.3", timeoutMs = 1500): Promise<TlsHandshakeProbe> {
+  const url = new URL(lab.url);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: TlsHandshakeProbe) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    const socket = tls.connect({
+      host: url.hostname,
+      port: Number(url.port) || 443,
+      servername: url.hostname,
+      minVersion: version,
+      maxVersion: version,
+      ca: lab.rootPem,
+      rejectUnauthorized: true,
+    });
+    socket.once("secureConnect", () => finish({ ok: true, protocol: socket.getProtocol(), errorCode: null }));
+    socket.once("timeout", () => finish({ ok: false, protocol: null, errorCode: "ETIMEDOUT" }));
+    socket.once("error", (error) => {
+      const code = isRecord(error) && typeof error.code === "string" ? error.code : messageText(error);
+      finish({ ok: false, protocol: null, errorCode: code });
+    });
+    socket.setTimeout(timeoutMs);
+  });
+}
+
+function tlsErrorCode(error: unknown): string | null {
+  if (isRecord(error) && typeof error.code === "string") return error.code;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function connectTransport(input: { url: URL; ca: string | undefined; rejectUnauthorized: boolean; inspect: boolean; timeoutMs: number }): Promise<TlsAttempt> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = tls.connect({
+      host: input.url.hostname,
+      port: Number(input.url.port) || 443,
+      servername: input.url.hostname,
+      ca: input.ca,
+      rejectUnauthorized: input.rejectUnauthorized,
+      ALPNProtocols: ["http/1.1"],
+    });
+    const finish = (attempt: TlsAttempt) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(attempt);
+    };
+    socket.once("secureConnect", () => {
+      const certificate = input.inspect ? socket.getPeerCertificate(true) : null;
+      finish({ ok: true, certificate });
+    });
+    socket.once("timeout", () => finish({ ok: false, errorCode: "ETIMEDOUT" }));
+    socket.once("error", (error) => finish({ ok: false, errorCode: tlsErrorCode(error) }));
+    socket.setTimeout(input.timeoutMs);
+  });
+}
+
+function certificateField(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().slice(0, 120) : null;
+}
+
+function servedChainFromCertificate(certificate: DetailedPeerCertificate | null): ServedCertificateEvidence[] {
+  if (!certificate || Object.keys(certificate).length === 0) return [];
+  const chain: ServedCertificateEvidence[] = [];
+  const seen = new Set<DetailedPeerCertificate>();
+  let current: DetailedPeerCertificate | undefined = certificate;
+  while (current && chain.length < 5 && !seen.has(current)) {
+    seen.add(current);
+    const subjectCN = certificateField(current.subject?.CN);
+    const issuerCN = certificateField(current.issuer?.CN);
+    chain.push({
+      subjectCN,
+      issuerCN,
+      selfIssued: current.issuerCertificate === current || (subjectCN !== null && subjectCN === issuerCN),
+    });
+    if (!current.issuerCertificate || current.issuerCertificate === current) break;
+    current = current.issuerCertificate;
+  }
+  return chain;
+}
+
+async function probeTransport(lab: EgressLabHandle, ca: string | undefined): Promise<TransportProbe> {
+  const url = endpointForTransport(lab);
+  const verified = await connectTransport({ url, ca, rejectUnauthorized: true, inspect: false, timeoutMs: 1500 });
+  if (verified.ok) return { verifiedHandshake: "ok", verifyErrorCode: null, servedChain: [], servedChainLength: null };
+  const chainAttempt = await connectTransport({ url, ca: undefined, rejectUnauthorized: false, inspect: true, timeoutMs: 1500 });
+  const servedChain = chainAttempt.ok ? servedChainFromCertificate(chainAttempt.certificate) : [];
+  return {
+    verifiedHandshake: "failed",
+    verifyErrorCode: verified.errorCode,
+    servedChain,
+    servedChainLength: servedChain.length,
+  };
+}
+
+async function diagnoseTlsLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const useCa = lab.profile === "broken-chain" || lab.profile === "tls12-only" || lab.profile === "healthy";
+  const probe = await probeTransport(lab, useCa ? lab.rootPem : undefined);
+  const lines = [`transport=${JSON.stringify(probe, null, 2)}`];
+
+  if (lab.profile === "tls12-only") {
+    const tls13 = await tlsHandshake(lab, "TLSv1.3");
+    const tls12 = await tlsHandshake(lab, "TLSv1.2");
+    lines.push(`tls13=${JSON.stringify(tls13)}`);
+    lines.push(`tls12=${JSON.stringify(tls12)}`);
+    const text = !tls13.ok && tls13.errorCode === "ETIMEDOUT" && tls12.ok
+      ? "LIKELY TLS VERSION/HANDSHAKE FAULT: TLS 1.3 ClientHello stalls or times out, while TLS 1.2 completes. Force TLS 1.2 or fix the egress proxy."
+      : "TLS VERSION VERDICT INCONCLUSIVE: the TLS 1.3 and TLS 1.2 probes did not match the expected stall/success split.";
+    return { profile: lab.profile, text, evidence: lines.join("\n"), source: "lab-corroboration", available: true };
+  }
+
+  const servedIssuer = probe.servedChain[0]?.issuerCN ?? "";
+  const issuerLower = servedIssuer.toLowerCase();
+  if (lab.profile === "intercept" && /corporate|interception|proxy|mitm/u.test(issuerLower)) {
+    return {
+      profile: lab.profile,
+      text: `LIKELY TLS INTERCEPTION: endpoint leaf is re-signed by ${servedIssuer}, not the expected public issuer. Install or pass the corporate root, or bypass TLS inspection for OpenWork hosts.`,
+      evidence: lines.join("\n"),
+      source: "lab-corroboration",
+      available: true,
+    };
+  }
+
+  const code = probe.verifyErrorCode ?? "";
+  if (lab.profile === "broken-chain" && /UNABLE_TO_VERIFY_LEAF_SIGNATURE|unable|cert|certificate/iu.test(code)) {
+    return {
+      profile: lab.profile,
+      text: `LIKELY MISSING INTERMEDIATE OR UNTRUSTED ROOT: verified TLS failed with ${code}; served-chain length ${probe.servedChainLength ?? 0}. Fetch the AIA intermediate or fix the server fullchain.`,
+      evidence: lines.join("\n"),
+      source: "lab-corroboration",
+      available: true,
+    };
+  }
+
+  if (probe.verifiedHandshake === "ok") {
+    return { profile: lab.profile, text: "NO EGRESS/TLS FAULT DETECTED: credential-free TLS handshake verified.", evidence: lines.join("\n"), source: "lab-corroboration", available: true };
+  }
+  return {
+    profile: lab.profile,
+    text: `LIKELY NETWORK/TLS FAULT: transport probe failed with ${probe.verifyErrorCode ?? "unknown error"}.`,
+    evidence: lines.join("\n"),
+    source: "lab-corroboration",
+    available: true,
+  };
+}
+
+async function diagnoseDenyLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const host = lab.deniedHosts.includes("github.com") ? "github.com" : lab.deniedHosts[0] ?? "github.com";
+  const url = new URL("/fetch", lab.url);
+  url.searchParams.set("url", `https://${host}/different-ai/openwork/releases/latest`);
+  const response = await fetch(url);
+  const body = await response.text();
+  const text = response.status === 451
+    ? `BLOCKED HOST / PROXY DENY: ${host} is blocked by the selective-deny profile; docs/enterprise/outbound-access.json names the required host and its blocked effect.`
+    : `DENY VERDICT INCONCLUSIVE: expected ${host} to be blocked, got HTTP ${response.status}.`;
+  return { profile: lab.profile, text, evidence: [`status=${response.status}`, body].join("\n"), source: "lab-corroboration", available: true };
+}
+
+async function diagnoseBlipLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const first = await fetch(new URL("/diagnostics", lab.url));
+  await first.arrayBuffer();
+  const second = await fetch(new URL("/diagnostics", lab.url));
+  await second.arrayBuffer();
+  const text = first.status === 401 && second.ok
+    ? "TRANSIENT AUTH BLIP: one 401 was observed and the next request recovered; treat as retryable/unavailable unless the 401 has the Den error envelope."
+    : `BLIP VERDICT INCONCLUSIVE: first=${first.status} second=${second.status}.`;
+  return { profile: lab.profile, text, evidence: `first=${first.status}\nsecond=${second.status}`, source: "lab-corroboration", available: true };
+}
+
+async function diagnoseRedirectLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const response = await fetch(new URL("/redirect-chain/start", lab.url), { redirect: "manual" });
+  const location = response.headers.get("location") ?? "";
+  const text = response.status >= 300 && response.status < 400
+    ? `REDIRECT CHAIN DETECTED: first hop returned ${response.status} to ${location}; diagnostics must follow or report redirect targets explicitly.`
+    : `REDIRECT VERDICT INCONCLUSIVE: expected manual redirect, got HTTP ${response.status}.`;
+  return { profile: lab.profile, text, evidence: `status=${response.status}\nlocation=${location}`, source: "lab-corroboration", available: true };
+}
+
+async function diagnoseSlowLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const started = Date.now();
+  const response = await fetch(new URL("/slow", lab.url));
+  const reader = response.body?.getReader();
+  const first = reader ? await reader.read() : null;
+  await reader?.cancel().catch(() => undefined);
+  const elapsedMs = Date.now() - started;
+  const text = elapsedMs > 100 || first?.value?.byteLength
+    ? `SLOW LINK DETECTED: first bytes arrived after ${elapsedMs}ms; installer/download diagnostics should report throughput and latency, not a generic fetch failure.`
+    : "SLOW VERDICT INCONCLUSIVE: no delayed bytes were observed.";
+  return { profile: lab.profile, text, evidence: `status=${response.status}\nelapsedMs=${elapsedMs}\nfirstChunk=${first?.value?.byteLength ?? 0}`, source: "lab-corroboration", available: true };
+}
+
+async function diagnoseEgressLabCorroboration(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  if (lab.profile === "deny") return diagnoseDenyLab(lab);
+  if (lab.profile === "blip") return diagnoseBlipLab(lab);
+  if (lab.profile === "redirect-chain") return diagnoseRedirectLab(lab);
+  if (lab.profile === "slow") return diagnoseSlowLab(lab);
+  return diagnoseTlsLab(lab);
+}
+
+export async function diagnoseEgressLabProduct(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  const result = await runBunProductDiagnostics(lab);
+  const payload = productDiagnosticsPayloadFromStdout(result.stdout);
+  const commandEvidence = {
+    command: "bun --conditions development --eval <product diagnostics probe>",
+    cwd: REPO_ROOT,
+    status: result.status,
+    error: result.error,
+    stderr: result.stderr,
+    stdoutParsed: payload,
+  };
+  if (result.status !== 0 || !payload || payload.status === "error") {
+    const message = payload?.status === "error" ? payload.message : (result.error ?? result.stderr.trim()) || "product diagnostics subprocess failed";
+    return {
+      profile: lab.profile,
+      text: `PRODUCT DIAGNOSTICS UNAVAILABLE: ${message}`,
+      evidence: JSON.stringify(commandEvidence, null, 2),
+      source: "product",
+      available: false,
+    };
+  }
+  return {
+    profile: lab.profile,
+    text: payload.verdictText,
+    evidence: JSON.stringify({
+      command: commandEvidence.command,
+      cwd: commandEvidence.cwd,
+      status: commandEvidence.status,
+      checks: payload.checks,
+      cloudProbe: payload.cloudProbe,
+      transportProbe: payload.transportProbe,
+    }, null, 2),
+    source: "product",
+    available: true,
+  };
+}
+
+export async function diagnoseEgressLab(lab: EgressLabHandle): Promise<DiagnosticVerdict> {
+  return diagnoseEgressLabProduct(lab);
+}
+
+function expectationMatches(text: string, expectation: DiagnosticVerdictExpectation): boolean {
+  const value = text.toLowerCase();
+  switch (expectation) {
+    case "tls12-only":
+    case "tls-version-handshake":
+      return value.includes("tls 1.3") && (value.includes("tls 1.2") || value.includes("handshake"));
+    case "broken-chain":
+    case "missing-intermediate":
+    case "untrusted-chain":
+      return value.includes("missing intermediate") || value.includes("leaf-only") || value.includes("untrusted root") || value.includes("untrusted chain");
+    case "intercept":
+    case "tls-interception":
+      return value.includes("tls interception") || value.includes("re-signed") || value.includes("proxy");
+    case "deny":
+    case "blocked-host":
+    case "proxy":
+      return value.includes("blocked host") || value.includes("proxy deny") || value.includes("selective-deny") || value.includes("http 451") || value.includes("allowlist deny");
+    case "redirect-chain":
+    case "redirect":
+      return value.includes("redirect chain") || value.includes("http redirect");
+    case "slow":
+    case "slow-link":
+      return value.includes("slow link");
+    case "blip":
+    case "transient-401":
+      return value.includes("transient") && value.includes("401");
+    case "healthy":
+      return value.includes("no egress/tls fault") || value.includes("handshake verified") || value.includes("cloud_catalog_exact_match");
+  }
+}
+
+export function matchVerdictExpectations(text: string, expect: DiagnosticVerdictExpectation | DiagnosticVerdictExpectation[]): { ok: boolean; missing: string[] } {
+  const expectations = Array.isArray(expect) ? expect : [expect];
+  const missing = expectations.filter((entry) => !expectationMatches(text, entry));
+  return { ok: missing.length === 0, missing };
+}
+
+export async function expectVerdictNames(ctx: FlowContext, options: { lab: EgressLabHandle; expect: DiagnosticVerdictExpectation | DiagnosticVerdictExpectation[] }): Promise<DiagnosticVerdict> {
+  const skipReason = productDiagnosticsPrecondition(ctx.env);
+  if (skipReason) ctx.skip(skipReason);
+  const verdict = await diagnoseEgressLabProduct(options.lab);
+  const corroboration = await diagnoseEgressLabCorroboration(options.lab);
+  const matched = matchVerdictExpectations(verdict.text, options.expect);
+  ctx.output(`${options.lab.profile} OpenWork product diagnostics verdict`, `${verdict.text}\n\n${verdict.evidence}`);
+  ctx.output(`${options.lab.profile} lab-local corroborating probes`, `${corroboration.text}\n\n${corroboration.evidence}`);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: verdict.available && matched.ok ? "passed" : "failed",
+    assertion: `OpenWork product diagnostics verdict names ${JSON.stringify(options.expect)}`,
+    actual: verdict.text,
+  });
+  ctx.assert(verdict.available && matched.ok, `OpenWork product diagnostics verdict did not name expected fault(s): ${matched.missing.join(", ")}. Verdict: ${verdict.text}`);
+  return verdict;
+}
+
+const RUNTIME_CA_PROBE = String.raw`
+const { X509Certificate } = require("node:crypto");
+const fs = require("node:fs");
+let tls;
+try { tls = require("node:tls"); } catch { tls = {}; }
+const needle = (process.env.OPENWORK_TLS_REPRO_CA_MATCH || "OpenWork Egress Lab").toLowerCase();
+function countMatching(certs) {
+  let count = 0;
+  for (const pem of certs || []) {
+    try {
+      const cert = new X509Certificate(pem);
+      if (cert.subject.toLowerCase().includes(needle)) count += 1;
+    } catch {}
+  }
+  return count;
+}
+function certs(scope) {
+  try {
+    if (typeof tls.getCACertificates !== "function") return [];
+    const result = tls.getCACertificates(scope);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function fileCerts() {
+  const file = process.env.NODE_EXTRA_CA_CERTS || "";
+  if (!file) return [];
+  try {
+    return fs.readFileSync(file, "utf8").match(/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g) || [];
+  } catch {
+    return [];
+  }
+}
+const payload = {
+  fileCount: countMatching(fileCerts()),
+  extraCount: countMatching(certs("extra")),
+  systemCount: countMatching(certs("system")),
+  defaultCount: countMatching(certs("default")),
+  bundledCount: countMatching(certs("bundled")),
+};
+payload.reproVisible = payload.fileCount + payload.extraCount + payload.systemCount + payload.defaultCount + payload.bundledCount > 0;
+console.log(JSON.stringify(payload));
+process.exitCode = payload.reproVisible ? 0 : 1;
+`;
+
+function parseRuntimeProbe(stdout: string): RuntimeProbePayload | null {
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    return isRuntimeProbePayload(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function expectRuntimeTrust(ctx: FlowContext, options: { caPath: string }): Promise<void> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_EXTRA_CA_CERTS: options.caPath,
+    OPENWORK_TLS_REPRO_CA_MATCH: "OpenWork Egress Lab",
+  };
+  const runtimes = [
+    { name: "node", command: process.execPath, args: ["--eval", RUNTIME_CA_PROBE] },
+    { name: "bun", command: "bun", args: ["--eval", RUNTIME_CA_PROBE] },
+  ];
+  for (const runtime of runtimes) {
+    const result = spawnSync(runtime.command, runtime.args, { env, encoding: "utf8", timeout: 10_000 });
+    const payload = parseRuntimeProbe(result.stdout ?? "");
+    const ok = result.status === 0 && payload?.reproVisible === true;
+    ctx.output(`${runtime.name} CA visibility`, JSON.stringify({ status: result.status, error: result.error?.message ?? null, payload, stderr: result.stderr }, null, 2));
+    ctx.recordEvidence({
+      type: "assertion",
+      status: ok ? "passed" : "failed",
+      assertion: `${runtime.name} runtime sees the lab CA through NODE_EXTRA_CA_CERTS`,
+      actual: payload ?? result.stderr,
+    });
+    ctx.assert(ok, `${runtime.name} did not see the lab CA through NODE_EXTRA_CA_CERTS.`);
+  }
+
+  const opencode = spawnSync("opencode", ["--version"], { env, encoding: "utf8", timeout: 10_000 });
+  if (opencode.error) {
+    ctx.output("opencode CA visibility", `opencode sidecar not reachable: ${opencode.error.message}`);
+    return;
+  }
+  const ok = opencode.status === 0;
+  ctx.output("opencode CA visibility", JSON.stringify({ status: opencode.status, stdout: opencode.stdout, stderr: opencode.stderr }, null, 2));
+  ctx.recordEvidence({
+    type: "assertion",
+    status: ok ? "passed" : "failed",
+    assertion: "opencode sidecar starts with the same NODE_EXTRA_CA_CERTS environment when reachable",
+    actual: opencode.stdout || opencode.stderr,
+  });
+  ctx.assert(ok, "opencode sidecar was reachable but did not start with the CA environment.");
+}

--- a/evals/runner/journeys/index.ts
+++ b/evals/runner/journeys/index.ts
@@ -1,5 +1,6 @@
 export * from "./den.ts";
 export * from "./desktop.ts";
+export * from "./diagnostics.ts";
 
 import { acceptInvite, apiSignIn, createOrg, inviteMember, signInWeb, signUpWeb } from "./den.ts";
 import { connectDen, firstBoot, openSettings, runPrompt } from "./desktop.ts";

--- a/evals/runner/labs/egress.mjs
+++ b/evals/runner/labs/egress.mjs
@@ -1,0 +1,1 @@
+export * from "./egress.ts";

--- a/evals/runner/labs/egress.ts
+++ b/evals/runner/labs/egress.ts
@@ -1,0 +1,986 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { readFile, rm, writeFile, mkdtemp, mkdir } from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import tls from "node:tls";
+import { fileURLToPath } from "node:url";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type EgressLabProfile =
+  | "healthy"
+  | "tls12-only"
+  | "broken-chain"
+  | "intercept"
+  | "deny"
+  | "redirect-chain"
+  | "slow"
+  | "blip";
+
+export type DenyMode = "refuse" | "blackhole";
+export type BlipFault = "401" | "reset";
+
+export type SlowProfileOptions = {
+  totalBytes?: number;
+  chunkBytes?: number;
+  delayMs?: number;
+  latencyMs?: number;
+};
+
+export type BlipRuleInput = {
+  route?: string;
+  count?: number;
+  fault?: BlipFault;
+  status?: number;
+  body?: string;
+};
+
+export type StartEgressLabOptions = {
+  profile: EgressLabProfile;
+  upstream?: string;
+  port?: number;
+  denyHosts?: string[];
+  denyMode?: DenyMode;
+  slow?: SlowProfileOptions;
+  blip?: BlipRuleInput;
+};
+
+export type ResolvedEgressProfileConfig = {
+  profile: EgressLabProfile;
+  host: string;
+  hostname: string;
+  port: number | null;
+  upstream: string | null;
+  denyHosts: string[];
+  denyMode: DenyMode;
+  slow: Required<SlowProfileOptions>;
+  blip: Required<BlipRuleInput>;
+};
+
+export type EgressLabHandle = {
+  profile: EgressLabProfile;
+  url: string;
+  caPath?: string;
+  rootPemPath?: string;
+  rootPem?: string;
+  intermediatePemPath?: string;
+  intermediateDerPath?: string;
+  aiaUrl?: string;
+  deniedHosts: string[];
+  stop(): Promise<void>;
+};
+
+export type ClientHelloParseResult = {
+  kind: "parsed";
+  recordVersion: number;
+  legacyVersion: number;
+  supportedVersions: number[];
+  supportedVersionLabels: string[];
+  offersTls13: boolean;
+} | {
+  kind: "incomplete";
+  neededBytes: number;
+} | {
+  kind: "invalid";
+  reason: string;
+};
+
+export type OpenSslCommand = {
+  label: string;
+  args: string[];
+};
+
+export type OpenSslCommandInput = {
+  dir: string;
+  hostname: string;
+  aiaUrl: string | null;
+  corporateIssuer: boolean;
+};
+
+export type OutboundManifestHostEntry = {
+  host: string;
+  kind: string;
+  components: string[];
+  requirement: string;
+  blockedEffect: string;
+};
+
+export type OutboundManifest = {
+  hosts: OutboundManifestHostEntry[];
+};
+
+export type BlipDecision = {
+  kind: "pass";
+} | {
+  kind: "status";
+  status: number;
+  body: string;
+} | {
+  kind: "reset";
+};
+
+export type BlipSchedule = {
+  next(route: string): BlipDecision;
+  snapshot(): { route: string; remaining: number; fault: BlipFault; status: number; body: string }[];
+};
+
+type CertificateMaterial = {
+  dir: string;
+  rootPemPath: string;
+  rootPem: string;
+  intermediatePemPath: string;
+  intermediateDerPath: string;
+  leafKeyPath: string;
+  leafKeyPem: string;
+  leafCertPath: string;
+  leafCertPem: string;
+  fullChainPath: string;
+  fullChainPem: string;
+};
+
+type HttpServer = http.Server<typeof IncomingMessage, typeof ServerResponse>;
+type HttpsServer = https.Server<typeof IncomingMessage, typeof ServerResponse>;
+type LabServer = HttpServer | HttpsServer | net.Server;
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const OUTBOUND_ACCESS_MANIFEST = path.join(REPO_ROOT, "docs", "enterprise", "outbound-access.json");
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_HOSTNAME = "localhost";
+const DEFAULT_SLOW_TOTAL_BYTES = 21 * 1024 * 1024;
+const DEFAULT_SLOW_CHUNK_BYTES = 64 * 1024;
+const DEFAULT_SLOW_DELAY_MS = 50;
+const DEFAULT_TLS_STALL_TIMEOUT_MS = 30_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function cleanHost(value: string): string | null {
+  const host = value.trim().toLowerCase().replace(/\.$/u, "");
+  if (!host || host.includes("://") || host.includes("/") || host.includes("\\")) return null;
+  return host;
+}
+
+function uniqueHosts(hosts: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const host of hosts) {
+    const cleaned = cleanHost(host);
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    out.push(cleaned);
+  }
+  return out.sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeRoute(route: string | undefined): string {
+  const value = route?.trim() || "/";
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function validPort(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65_535 ? value : null;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function httpStatus(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599 ? value : fallback;
+}
+
+function blipFault(value: BlipFault | undefined): BlipFault {
+  return value === "reset" ? "reset" : "401";
+}
+
+export function resolveEgressProfileConfig(options: StartEgressLabOptions): ResolvedEgressProfileConfig {
+  const configuredPort = validPort(options.port);
+  const slow = options.slow ?? {};
+  const blip = options.blip ?? {};
+  return {
+    profile: options.profile,
+    host: DEFAULT_HOST,
+    hostname: DEFAULT_HOSTNAME,
+    port: configuredPort,
+    upstream: typeof options.upstream === "string" && options.upstream.trim() ? options.upstream.trim() : null,
+    denyHosts: uniqueHosts(options.denyHosts ?? []),
+    denyMode: options.denyMode === "blackhole" ? "blackhole" : "refuse",
+    slow: {
+      totalBytes: positiveInteger(slow.totalBytes, DEFAULT_SLOW_TOTAL_BYTES),
+      chunkBytes: positiveInteger(slow.chunkBytes, DEFAULT_SLOW_CHUNK_BYTES),
+      delayMs: nonNegativeInteger(slow.delayMs, DEFAULT_SLOW_DELAY_MS),
+      latencyMs: nonNegativeInteger(slow.latencyMs, 0),
+    },
+    blip: {
+      route: normalizeRoute(blip.route),
+      count: positiveInteger(blip.count, 1),
+      fault: blipFault(blip.fault),
+      status: httpStatus(blip.status, 401),
+      body: typeof blip.body === "string" ? blip.body : "",
+    },
+  };
+}
+
+export function outboundManifestFromUnknown(value: unknown): OutboundManifest | null {
+  if (!isRecord(value) || !Array.isArray(value.hosts)) return null;
+  const hosts: OutboundManifestHostEntry[] = [];
+  for (const entry of value.hosts) {
+    if (!isRecord(entry)) continue;
+    if (
+      typeof entry.host !== "string"
+      || typeof entry.kind !== "string"
+      || !isStringArray(entry.components)
+      || typeof entry.requirement !== "string"
+      || typeof entry.blockedEffect !== "string"
+    ) continue;
+    hosts.push({
+      host: entry.host,
+      kind: entry.kind,
+      components: entry.components,
+      requirement: entry.requirement,
+      blockedEffect: entry.blockedEffect,
+    });
+  }
+  return { hosts };
+}
+
+export function denyHostsFromOutboundManifest(manifest: OutboundManifest): string[] {
+  return uniqueHosts(manifest.hosts.flatMap((entry) => {
+    const installerCritical = entry.components.includes("installer")
+      && (entry.requirement === "required-in-practice" || entry.requirement === "required" || entry.requirement === "required-for-cloud");
+    const githubInstaller = entry.host === "github.com";
+    const redirectTarget = entry.kind === "redirect-target" && entry.components.includes("installer");
+    return installerCritical || githubInstaller || redirectTarget ? [entry.host] : [];
+  }));
+}
+
+export async function readDefaultDenyHosts(): Promise<string[]> {
+  const parsed = JSON.parse(await readFile(OUTBOUND_ACCESS_MANIFEST, "utf8"));
+  const manifest = outboundManifestFromUnknown(parsed);
+  return manifest ? denyHostsFromOutboundManifest(manifest) : [];
+}
+
+function versionLabel(version: number): string {
+  if (version === 0x0304) return "TLSv1.3";
+  if (version === 0x0303) return "TLSv1.2";
+  if (version === 0x0302) return "TLSv1.1";
+  if (version === 0x0301) return "TLSv1.0";
+  return `0x${version.toString(16).padStart(4, "0")}`;
+}
+
+function needBytes(buffer: Buffer, neededBytes: number): ClientHelloParseResult | null {
+  return buffer.length < neededBytes ? { kind: "incomplete", neededBytes } : null;
+}
+
+/**
+ * Parses only enough of the first TLS record to decide whether the client
+ * offered TLS 1.3. The lab reads the record header (content type 0x16), the
+ * ClientHello body, skips the variable session/cipher/compression vectors, and
+ * then scans extension 0x002b (supported_versions). TLS 1.3 clients advertise
+ * 0x0304 there even though the legacy ClientHello version remains 0x0303.
+ */
+export function parseClientHelloVersions(buffer: Buffer): ClientHelloParseResult {
+  const firstNeed = needBytes(buffer, 11);
+  if (firstNeed) return firstNeed;
+  if (buffer[0] !== 0x16) return { kind: "invalid", reason: "first record is not a TLS handshake" };
+  const recordVersion = buffer.readUInt16BE(1);
+  const recordLength = buffer.readUInt16BE(3);
+  const recordEnd = 5 + recordLength;
+  const recordNeed = needBytes(buffer, recordEnd);
+  if (recordNeed) return recordNeed;
+  if (buffer[5] !== 0x01) return { kind: "invalid", reason: "first handshake message is not ClientHello" };
+  const handshakeLength = (buffer[6] << 16) + (buffer[7] << 8) + buffer[8];
+  if (handshakeLength + 4 > recordLength) return { kind: "invalid", reason: "ClientHello length exceeds TLS record" };
+  const legacyVersion = buffer.readUInt16BE(9);
+  let cursor = 11 + 32;
+  const sessionNeed = needBytes(buffer, cursor + 1);
+  if (sessionNeed) return sessionNeed;
+  const sessionLength = buffer[cursor];
+  cursor += 1 + sessionLength;
+  const cipherNeed = needBytes(buffer, cursor + 2);
+  if (cipherNeed) return cipherNeed;
+  const cipherLength = buffer.readUInt16BE(cursor);
+  cursor += 2 + cipherLength;
+  const compressionNeed = needBytes(buffer, cursor + 1);
+  if (compressionNeed) return compressionNeed;
+  const compressionLength = buffer[cursor];
+  cursor += 1 + compressionLength;
+  if (cursor > recordEnd) return { kind: "invalid", reason: "ClientHello vectors exceed TLS record" };
+  if (cursor === recordEnd) {
+    return {
+      kind: "parsed",
+      recordVersion,
+      legacyVersion,
+      supportedVersions: [legacyVersion],
+      supportedVersionLabels: [versionLabel(legacyVersion)],
+      offersTls13: false,
+    };
+  }
+  const extensionsNeed = needBytes(buffer, cursor + 2);
+  if (extensionsNeed) return extensionsNeed;
+  const extensionsLength = buffer.readUInt16BE(cursor);
+  cursor += 2;
+  const extensionsEnd = cursor + extensionsLength;
+  if (extensionsEnd > recordEnd) return { kind: "invalid", reason: "ClientHello extensions exceed TLS record" };
+  const supportedVersions: number[] = [];
+  while (cursor + 4 <= extensionsEnd) {
+    const type = buffer.readUInt16BE(cursor);
+    const length = buffer.readUInt16BE(cursor + 2);
+    cursor += 4;
+    const valueEnd = cursor + length;
+    if (valueEnd > extensionsEnd) return { kind: "invalid", reason: "ClientHello extension exceeds extension block" };
+    if (type === 0x002b && length >= 3) {
+      const vectorLength = buffer[cursor];
+      let versionCursor = cursor + 1;
+      const versionEnd = Math.min(valueEnd, versionCursor + vectorLength);
+      while (versionCursor + 1 < versionEnd) {
+        supportedVersions.push(buffer.readUInt16BE(versionCursor));
+        versionCursor += 2;
+      }
+    }
+    cursor = valueEnd;
+  }
+  const versions = supportedVersions.length > 0 ? supportedVersions : [legacyVersion];
+  return {
+    kind: "parsed",
+    recordVersion,
+    legacyVersion,
+    supportedVersions: versions,
+    supportedVersionLabels: versions.map(versionLabel),
+    offersTls13: versions.includes(0x0304),
+  };
+}
+
+function pkiPaths(dir: string) {
+  return {
+    rootKey: path.join(dir, "root.key.pem"),
+    rootPem: path.join(dir, "root.pem"),
+    intermediateKey: path.join(dir, "intermediate.key.pem"),
+    intermediateCsr: path.join(dir, "intermediate.csr.pem"),
+    intermediatePem: path.join(dir, "intermediate.pem"),
+    intermediateDer: path.join(dir, "intermediate.der"),
+    leafKey: path.join(dir, "leaf.key.pem"),
+    leafCsr: path.join(dir, "leaf.csr.pem"),
+    leafPem: path.join(dir, "leaf.pem"),
+    fullChain: path.join(dir, "fullchain.pem"),
+    intermediateExt: path.join(dir, "intermediate.ext"),
+    leafExt: path.join(dir, "leaf.ext"),
+  };
+}
+
+export function opensslCertificateCommands(input: OpenSslCommandInput): OpenSslCommand[] {
+  const files = pkiPaths(input.dir);
+  const rootSubject = input.corporateIssuer
+    ? "/CN=OpenWork Egress Lab Corporate Root CA"
+    : "/CN=OpenWork Egress Lab Root CA";
+  const intermediateSubject = input.corporateIssuer
+    ? "/CN=OpenWork Egress Lab Corporate Interception CA"
+    : "/CN=OpenWork Egress Lab Intermediate CA";
+  return [
+    { label: "root-key", args: ["genrsa", "-out", files.rootKey, "2048"] },
+    {
+      label: "root-cert",
+      args: [
+        "req",
+        "-x509",
+        "-new",
+        "-nodes",
+        "-key",
+        files.rootKey,
+        "-sha256",
+        "-days",
+        "7",
+        "-out",
+        files.rootPem,
+        "-subj",
+        rootSubject,
+        "-addext",
+        "basicConstraints=critical,CA:TRUE,pathlen:1",
+        "-addext",
+        "keyUsage=critical,keyCertSign,cRLSign",
+      ],
+    },
+    { label: "intermediate-key", args: ["genrsa", "-out", files.intermediateKey, "2048"] },
+    { label: "intermediate-csr", args: ["req", "-new", "-key", files.intermediateKey, "-out", files.intermediateCsr, "-subj", intermediateSubject] },
+    {
+      label: "intermediate-cert",
+      args: [
+        "x509",
+        "-req",
+        "-in",
+        files.intermediateCsr,
+        "-CA",
+        files.rootPem,
+        "-CAkey",
+        files.rootKey,
+        "-CAcreateserial",
+        "-out",
+        files.intermediatePem,
+        "-days",
+        "7",
+        "-sha256",
+        "-extfile",
+        files.intermediateExt,
+      ],
+    },
+    { label: "intermediate-der", args: ["x509", "-in", files.intermediatePem, "-outform", "DER", "-out", files.intermediateDer] },
+    { label: "leaf-key", args: ["genrsa", "-out", files.leafKey, "2048"] },
+    { label: "leaf-csr", args: ["req", "-new", "-key", files.leafKey, "-out", files.leafCsr, "-subj", `/CN=${input.hostname}`] },
+    {
+      label: "leaf-cert",
+      args: [
+        "x509",
+        "-req",
+        "-in",
+        files.leafCsr,
+        "-CA",
+        files.intermediatePem,
+        "-CAkey",
+        files.intermediateKey,
+        "-CAcreateserial",
+        "-out",
+        files.leafPem,
+        "-days",
+        "7",
+        "-sha256",
+        "-extfile",
+        files.leafExt,
+      ],
+    },
+  ];
+}
+
+function intermediateExtFile(): string {
+  return [
+    "basicConstraints=critical,CA:TRUE,pathlen:0",
+    "keyUsage=critical,keyCertSign,cRLSign",
+    "subjectKeyIdentifier=hash",
+    "authorityKeyIdentifier=keyid,issuer",
+  ].join("\n") + "\n";
+}
+
+function leafExtFile(hostname: string, aiaUrl: string | null): string {
+  const lines = [
+    "basicConstraints=critical,CA:FALSE",
+    "keyUsage=critical,digitalSignature,keyEncipherment",
+    "extendedKeyUsage=serverAuth",
+    `subjectAltName=DNS:${hostname},DNS:localhost,IP:127.0.0.1`,
+    "authorityKeyIdentifier=keyid,issuer",
+  ];
+  if (aiaUrl) lines.push(`authorityInfoAccess=caIssuers;URI:${aiaUrl}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function execOpenSsl(args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile("openssl", args, { cwd, encoding: "utf8", timeout: 20_000, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error([`openssl ${args.join(" ")}`, String(stdout).trim(), String(stderr).trim(), error.message].filter(Boolean).join("\n")));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function generateCertificateMaterial(input: { hostname: string; aiaUrl: string | null; corporateIssuer: boolean }): Promise<CertificateMaterial> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openwork-egress-lab-"));
+  const files = pkiPaths(dir);
+  await writeFile(files.intermediateExt, intermediateExtFile(), "utf8");
+  await writeFile(files.leafExt, leafExtFile(input.hostname, input.aiaUrl), "utf8");
+  for (const command of opensslCertificateCommands({ dir, hostname: input.hostname, aiaUrl: input.aiaUrl, corporateIssuer: input.corporateIssuer })) {
+    await execOpenSsl(command.args, dir);
+  }
+  const leaf = await readFile(files.leafPem, "utf8");
+  const intermediate = await readFile(files.intermediatePem, "utf8");
+  const fullChain = `${leaf.trim()}\n${intermediate.trim()}\n`;
+  await writeFile(files.fullChain, fullChain, "utf8");
+  return {
+    dir,
+    rootPemPath: files.rootPem,
+    rootPem: await readFile(files.rootPem, "utf8"),
+    intermediatePemPath: files.intermediatePem,
+    intermediateDerPath: files.intermediateDer,
+    leafKeyPath: files.leafKey,
+    leafKeyPem: await readFile(files.leafKey, "utf8"),
+    leafCertPath: files.leafPem,
+    leafCertPem: leaf,
+    fullChainPath: files.fullChain,
+    fullChainPem: fullChain,
+  };
+}
+
+function listen(server: LabServer, port: number | null, host: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(port ?? 0, host, () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Lab server did not bind a TCP port."));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: LabServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function reservePort(host: string): Promise<number> {
+  const server = net.createServer();
+  const port = await listen(server, null, host);
+  await closeServer(server);
+  return port;
+}
+
+function jsonResponse(response: ServerResponse, status: number, payload: unknown, headers: Record<string, string> = {}): void {
+  const body = `${JSON.stringify(payload, null, 2)}\n`;
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": String(Buffer.byteLength(body)),
+    ...headers,
+  });
+  response.end(body);
+}
+
+function textResponse(response: ServerResponse, status: number, body: string, headers: Record<string, string> = {}): void {
+  response.writeHead(status, {
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": String(Buffer.byteLength(body)),
+    ...headers,
+  });
+  response.end(body);
+}
+
+function requestPath(request: IncomingMessage): string {
+  try {
+    return new URL(request.url ?? "/", "http://egress.lab").pathname;
+  } catch {
+    return "/";
+  }
+}
+
+function requestHostHeader(headersHost: string | string[] | undefined): string | null {
+  const raw = Array.isArray(headersHost) ? headersHost[0] : headersHost;
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  try {
+    return cleanHost(new URL(`http://${raw}`).hostname);
+  } catch {
+    const withoutPort = raw.split(":", 1)[0] ?? raw;
+    return cleanHost(withoutPort);
+  }
+}
+
+function targetHostFromRequest(request: IncomingMessage): string | null {
+  try {
+    const url = new URL(request.url ?? "/", "http://egress.lab");
+    const targetUrl = url.searchParams.get("url");
+    if (targetUrl) return cleanHost(new URL(targetUrl).hostname);
+    const targetHost = url.searchParams.get("host") ?? request.headers["x-egress-target-host"];
+    if (typeof targetHost === "string") return cleanHost(targetHost);
+    const hostPath = /^\/host\/([^/]+)/u.exec(url.pathname);
+    if (hostPath?.[1]) return cleanHost(decodeURIComponent(hostPath[1]));
+  } catch {
+    return null;
+  }
+  return requestHostHeader(request.headers.host);
+}
+
+function createDenyServer(config: ResolvedEgressProfileConfig): HttpServer {
+  const denyHosts = new Set(config.denyHosts);
+  return http.createServer((request, response) => {
+    const host = targetHostFromRequest(request) ?? "unknown";
+    if (denyHosts.has(host)) {
+      if (config.denyMode === "blackhole") return;
+      jsonResponse(response, 451, {
+        error: "EGRESS_HOST_BLOCKED",
+        host,
+        message: `${host} is blocked by the egress lab deny profile. Check docs/enterprise/outbound-access.json before calling this an app bug.`,
+        allowlistManifest: "docs/enterprise/outbound-access.json",
+      });
+      return;
+    }
+    jsonResponse(response, 200, { ok: true, host, deniedHosts: config.denyHosts });
+  });
+}
+
+function createRedirectServer(config: ResolvedEgressProfileConfig): HttpServer {
+  return http.createServer((request, response) => {
+    const currentPath = requestPath(request);
+    const host = request.headers.host ?? "127.0.0.1";
+    const base = `http://${host}`;
+    if (currentPath === "/" || currentPath === "/redirect-chain/start" || currentPath === "/mcp/agent") {
+      response.writeHead(302, { location: `${base}/redirect-chain/hop1` });
+      response.end();
+      return;
+    }
+    if (currentPath === "/redirect-chain/hop1") {
+      response.writeHead(302, { location: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize" });
+      response.end();
+      return;
+    }
+    jsonResponse(response, 200, { ok: true, profile: config.profile, upstream: config.upstream });
+  });
+}
+
+function createSlowServer(config: ResolvedEgressProfileConfig): HttpServer {
+  return http.createServer((request, response) => {
+    const totalBytes = config.slow.totalBytes;
+    const chunkBytes = Math.min(config.slow.chunkBytes, totalBytes);
+    const delayMs = config.slow.delayMs;
+    let sent = 0;
+    const start = () => {
+      response.writeHead(200, {
+        "content-type": "application/octet-stream",
+        "content-length": String(totalBytes),
+        "x-openwork-egress-lab": "slow",
+      });
+      const writeNext = () => {
+        if (sent >= totalBytes) {
+          response.end();
+          return;
+        }
+        const size = Math.min(chunkBytes, totalBytes - sent);
+        sent += size;
+        response.write(Buffer.alloc(size, 0x61));
+        setTimeout(writeNext, delayMs);
+      };
+      writeNext();
+    };
+    if (requestPath(request) !== "/slow" && requestPath(request) !== "/") {
+      jsonResponse(response, 404, { error: "not_found" });
+      return;
+    }
+    setTimeout(start, config.slow.latencyMs);
+  });
+}
+
+export function createBlipSchedule(ruleInput: BlipRuleInput | BlipRuleInput[]): BlipSchedule {
+  const inputRules = Array.isArray(ruleInput) ? ruleInput : [ruleInput];
+  const rules = inputRules.map((rule) => ({
+    route: normalizeRoute(rule.route),
+    remaining: positiveInteger(rule.count, 1),
+    fault: blipFault(rule.fault),
+    status: httpStatus(rule.status, 401),
+    body: typeof rule.body === "string" ? rule.body : "",
+  }));
+  return {
+    next(route: string): BlipDecision {
+      const normalized = normalizeRoute(route);
+      const match = rules.find((rule) => rule.remaining > 0 && (rule.route === "/" || normalized === rule.route || normalized.startsWith(`${rule.route}/`)));
+      if (!match) return { kind: "pass" };
+      match.remaining -= 1;
+      if (match.fault === "reset") return { kind: "reset" };
+      return { kind: "status", status: match.status, body: match.body };
+    },
+    snapshot() {
+      return rules.map((rule) => ({ route: rule.route, remaining: rule.remaining, fault: rule.fault, status: rule.status, body: rule.body }));
+    },
+  };
+}
+
+function createBlipServer(config: ResolvedEgressProfileConfig): HttpServer {
+  const schedule = createBlipSchedule(config.blip);
+  return http.createServer(async (request, response) => {
+    const route = requestPath(request);
+    const decision = schedule.next(route);
+    if (decision.kind === "reset") {
+      request.socket.destroy();
+      return;
+    }
+    if (decision.kind === "status") {
+      if (decision.body) textResponse(response, decision.status, decision.body);
+      else response.writeHead(decision.status, { "content-length": "0" }).end();
+      return;
+    }
+    if (route === "/mcp/agent") {
+      await handleMcpAgentRequest(request, response);
+      return;
+    }
+    if (route.endsWith("/v1/me")) {
+      jsonResponse(response, 200, { user: { id: "user_egress_blip", email: "lab@example.com", name: "Egress Lab" } });
+      return;
+    }
+    jsonResponse(response, 200, { ok: true, profile: "blip", route, schedule: schedule.snapshot() });
+  });
+}
+
+async function requestBodyText(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function requestJsonRpcMethod(payload: unknown): string | null {
+  return isRecord(payload) && typeof payload.method === "string" ? payload.method : null;
+}
+
+function requestJsonRpcId(payload: unknown): string | number | null {
+  if (!isRecord(payload)) return null;
+  if (typeof payload.id === "string" || typeof payload.id === "number") return payload.id;
+  return null;
+}
+
+async function handleMcpAgentRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  if (request.method === "DELETE") {
+    response.writeHead(204, { "content-length": "0" }).end();
+    return;
+  }
+  if (request.method !== "POST") {
+    jsonResponse(response, 405, { error: "method_not_allowed" });
+    return;
+  }
+  let payload: unknown = null;
+  try {
+    payload = JSON.parse(await requestBodyText(request));
+  } catch {
+    jsonResponse(response, 400, { error: "invalid_json" });
+    return;
+  }
+  const method = requestJsonRpcMethod(payload);
+  const id = requestJsonRpcId(payload);
+  if (method === "initialize") {
+    jsonResponse(response, 200, {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        capabilities: {},
+        protocolVersion: "2025-06-18",
+        serverInfo: { name: "openwork-egress-lab", version: "1.0.0" },
+      },
+    }, {
+      "mcp-session-id": "egress-lab-session",
+      "mcp-protocol-version": "2025-06-18",
+    });
+    return;
+  }
+  if (method === "notifications/initialized") {
+    response.writeHead(202, { "content-length": "0" }).end();
+    return;
+  }
+  if (method === "tools/list") {
+    jsonResponse(response, 200, {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        tools: [
+          { name: "search_capabilities", description: "Search capabilities", inputSchema: { type: "object" } },
+          { name: "execute_capability", description: "Execute a capability", inputSchema: { type: "object" } },
+        ],
+      },
+    });
+    return;
+  }
+  jsonResponse(response, 400, { error: "unsupported_method" });
+}
+
+function createAiaServer(intermediateDerPath: string): HttpServer {
+  return http.createServer(async (request, response) => {
+    if (requestPath(request) !== "/__egress-lab/intermediate.der") {
+      jsonResponse(response, 404, { error: "not_found" });
+      return;
+    }
+    const body = await readFile(intermediateDerPath);
+    response.writeHead(200, {
+      "content-type": "application/pkix-cert",
+      "content-length": String(body.byteLength),
+    });
+    response.end(body);
+  });
+}
+
+function createHttpsServer(profile: EgressLabProfile, material: CertificateMaterial, includeIntermediate: boolean): HttpsServer {
+  const cert = includeIntermediate ? material.fullChainPem : material.leafCertPem;
+  return https.createServer({ key: material.leafKeyPem, cert }, (request, response) => {
+    jsonResponse(response, 200, {
+      ok: true,
+      profile,
+      path: requestPath(request),
+      upstream: null,
+    }, { "x-openwork-egress-lab": profile });
+  });
+}
+
+function tlsHttpOk(socket: tls.TLSSocket, profile: EgressLabProfile): void {
+  const body = `${JSON.stringify({ ok: true, profile })}\n`;
+  socket.write([
+    "HTTP/1.1 200 OK",
+    "content-type: application/json; charset=utf-8",
+    `content-length: ${Buffer.byteLength(body)}`,
+    "connection: close",
+    "",
+    body,
+  ].join("\r\n"));
+  socket.end();
+}
+
+function createTls12OnlyServer(material: CertificateMaterial, stalledSockets: Set<net.Socket>): net.Server {
+  const tls12Server = tls.createServer({
+    key: material.leafKeyPem,
+    cert: material.fullChainPem,
+    minVersion: "TLSv1.2",
+    maxVersion: "TLSv1.2",
+  }, (socket) => {
+    socket.on("error", () => undefined);
+    socket.once("data", () => tlsHttpOk(socket, "tls12-only"));
+    socket.setTimeout(5_000, () => tlsHttpOk(socket, "tls12-only"));
+  });
+  tls12Server.on("tlsClientError", () => undefined);
+
+  return net.createServer((socket) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let forwarded = false;
+    const cleanup = () => {
+      socket.off("data", onData);
+      socket.off("error", onError);
+    };
+    const forwardToTls12 = () => {
+      if (forwarded) return;
+      forwarded = true;
+      cleanup();
+      socket.pause();
+      socket.unshift(Buffer.concat(chunks, total));
+      tls12Server.emit("connection", socket);
+    };
+    const stall = () => {
+      cleanup();
+      socket.on("error", () => undefined);
+      stalledSockets.add(socket);
+      socket.on("close", () => stalledSockets.delete(socket));
+      socket.pause();
+      setTimeout(() => {
+        if (!socket.destroyed) socket.destroy();
+      }, DEFAULT_TLS_STALL_TIMEOUT_MS).unref();
+    };
+    const onError = () => cleanup();
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      total += chunk.byteLength;
+      const parsed = parseClientHelloVersions(Buffer.concat(chunks, total));
+      if (parsed.kind === "incomplete") return;
+      if (parsed.kind === "parsed" && parsed.offersTls13) {
+        stall();
+        return;
+      }
+      forwardToTls12();
+    };
+    socket.on("data", onData);
+    socket.on("error", onError);
+  });
+}
+
+async function startHttpProfile(config: ResolvedEgressProfileConfig): Promise<EgressLabHandle> {
+  const denyHosts = config.profile === "deny" && config.denyHosts.length === 0
+    ? await readDefaultDenyHosts()
+    : config.denyHosts;
+  const resolved = { ...config, denyHosts };
+  const server = resolved.profile === "deny"
+    ? createDenyServer(resolved)
+    : resolved.profile === "redirect-chain"
+      ? createRedirectServer(resolved)
+      : resolved.profile === "slow"
+        ? createSlowServer(resolved)
+        : createBlipServer(resolved);
+  const port = await listen(server, resolved.port, resolved.host);
+  return {
+    profile: resolved.profile,
+    url: `http://${resolved.host}:${port}`,
+    deniedHosts: resolved.denyHosts,
+    stop: () => closeServer(server),
+  };
+}
+
+async function startTlsProfile(config: ResolvedEgressProfileConfig): Promise<EgressLabHandle> {
+  const servers: LabServer[] = [];
+  const stalledSockets = new Set<net.Socket>();
+  let material: CertificateMaterial | null = null;
+  let aiaUrl: string | null = null;
+  try {
+    let aiaPort: number | null = null;
+    if (config.profile === "broken-chain") {
+      aiaPort = await reservePort(config.host);
+      aiaUrl = `http://${config.host}:${aiaPort}/__egress-lab/intermediate.der`;
+    }
+    material = await generateCertificateMaterial({
+      hostname: config.hostname,
+      aiaUrl,
+      corporateIssuer: config.profile === "intercept",
+    });
+    if (aiaPort !== null) {
+      const aiaServer = createAiaServer(material.intermediateDerPath);
+      await listen(aiaServer, aiaPort, config.host);
+      servers.push(aiaServer);
+    }
+    const server = config.profile === "tls12-only"
+      ? createTls12OnlyServer(material, stalledSockets)
+      : createHttpsServer(config.profile, material, config.profile !== "broken-chain");
+    const port = await listen(server, config.port, config.host);
+    servers.push(server);
+    return {
+      profile: config.profile,
+      url: `https://${config.hostname}:${port}`,
+      caPath: material.rootPemPath,
+      rootPemPath: material.rootPemPath,
+      rootPem: material.rootPem,
+      intermediatePemPath: material.intermediatePemPath,
+      intermediateDerPath: material.intermediateDerPath,
+      aiaUrl: aiaUrl ?? undefined,
+      deniedHosts: [],
+      stop: async () => {
+        for (const socket of stalledSockets) socket.destroy();
+        await Promise.all(servers.map((serverToClose) => closeServer(serverToClose).catch(() => undefined)));
+        if (material) await rm(material.dir, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    for (const server of servers) await closeServer(server).catch(() => undefined);
+    if (material) await rm(material.dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export async function startEgressLab(options: StartEgressLabOptions): Promise<EgressLabHandle> {
+  const config = resolveEgressProfileConfig(options);
+  if (config.profile === "deny" || config.profile === "redirect-chain" || config.profile === "slow" || config.profile === "blip") {
+    return startHttpProfile(config);
+  }
+  return startTlsProfile(config);
+}
+
+export async function writeTempPemBundle(pems: string[]): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openwork-egress-ca-bundle-"));
+  await mkdir(dir, { recursive: true });
+  const bundlePath = path.join(dir, `${randomUUID()}.pem`);
+  await writeFile(bundlePath, `${pems.map((pem) => pem.trim()).filter(Boolean).join("\n")}\n`, "utf8");
+  return bundlePath;
+}
+
+export function labFetchUrl(lab: EgressLabHandle, pathName = "/"): string {
+  const url = new URL(lab.url);
+  url.pathname = pathName;
+  return url.toString();
+}

--- a/evals/voiceovers/egress-broken-chain-repair.md
+++ b/evals/voiceovers/egress-broken-chain-repair.md
@@ -1,0 +1,3 @@
+# egress-broken-chain-repair — Leaf-only certificate chains are repaired and diagnosed
+
+1. The lab serves a leaf-only chain with the root trusted. Plain Node fails with the first-certificate error, OpenWork's runtime AIA repair adds the missing intermediate and succeeds, disabling repair fails again, and the shipped diagnostics name the missing-chain fault.

--- a/evals/voiceovers/egress-selective-deny.md
+++ b/evals/voiceovers/egress-selective-deny.md
@@ -1,0 +1,3 @@
+# egress-selective-deny — Host allowlist blocks are actionable
+
+1. The lab blocks github.com like a corporate allowlist and also makes the product Cloud MCP probe see an HTTP 451. The lab response names github.com and the allowlist manifest, while OpenWork's shipped diagnostics classify the 451 as an egress allowlist deny.

--- a/evals/voiceovers/egress-tls12-only.md
+++ b/evals/voiceovers/egress-tls12-only.md
@@ -1,0 +1,3 @@
+# egress-tls12-only — TLS 1.3 egress stalls are named instead of swallowed
+
+1. The lab recreates the expensive field failure: TCP is open, Node can prove TLS 1.2 works, but a TLS 1.3 ClientHello stalls. OpenWork's shipped transport diagnostics name the TLS-handshake fault, and the frame captures today's Bun gap: Node-style TLS 1.2 pinning still advertises TLS 1.3 there.

--- a/evals/voiceovers/egress-transient-401.md
+++ b/evals/voiceovers/egress-transient-401.md
@@ -1,0 +1,3 @@
+# egress-transient-401 — One proxy 401 must not wipe credentials
+
+1. The lab injects a single bare 401 before recovering. The client treats that proxy-shaped response as unavailable rather than revoked, keeps the stored Den token, succeeds on retry, and OpenWork's shipped Cloud MCP diagnostics report the recovered transient 401 instead of telling the user to reconnect.


### PR DESCRIPTION
## Why

From a 6-week enterprise POC log, this was the **single biggest time sink**:

- **TLS 1.3 through the corporate egress stalled; TLS 1.2 worked.** In-app symptom was just `TypeError: fetch failed`. It cost ~5 days and three wrong diagnoses (ServiceNow → allow list → firewall) before root cause.
- **Incomplete cert chain**: a private-subdomain cert served leaf-only. Chrome worked (AIA fetch), **node/bun did not** → `unable to verify the first certificate`.
- **Corporate CA / TLS interception** not picked up by Electron/node fetch.
- **github.com off the corporate allow list** silently killed the installer/updater.
- Repeated complaints of **"error swallowing"** — failures buried with no actionable signal.

We had a Windows-only PowerShell harness and an allowlist manifest, but nothing reproducible on Linux/macOS — and, more importantly, **nothing proving our own diagnostics would have named the fault.**

## What

**`evals/runner/labs/egress.ts`** — a dependency-free lab whose profiles reproduce the real faults: `tls12-only` (completes TLS 1.2, **stalls TLS 1.3 ClientHellos** — the customer's exact behavior, via a raw-socket ClientHello version peek), `broken-chain` (leaf-only chain with the intermediate served at an AIA URL so chain repair has something to fetch), `intercept` (lab CA re-signing), `deny` (hosts seeded from `docs/enterprise/outbound-access.json`), `redirect-chain`, `slow`, `blip` (one-off 401/reset). Per-run PKI minted with openssl.

**`evals/runner/journeys/diagnostics.ts`** — the verdict convention, and the key design point: **our shipped diagnostics are the primary verdict source**; lab probes only corroborate. A flow passes only if the *product* names the injected fault.

**Product improvement (`apps/server/src/agent-context-*`)** — the diagnostics now produce fault-naming verdicts with remediation instead of generic failures. Actual output, per profile:

| Profile | Product verdict code | Would it have saved the customer days? |
|---|---|---|
| `tls12-only` | `endpoint_tls_handshake_timeout_tls12_comparison_failed` | Yes — points at egress TLS ClientHello, not ServiceNow/credentials |
| `broken-chain` | `endpoint_tls_incomplete_chain` (names `UNABLE_TO_VERIFY_LEAF_SIGNATURE`) | Yes |
| `intercept` | `endpoint_tls_interception_detected` | Yes — names corporate inspection + `NODE_EXTRA_CA_CERTS` remediation |
| `deny` | HTTP 451 allowlist deny | Yes — no more silent installer failure |
| `redirect-chain` | `redirect_rejected` (proxy/captive portal/SSO/route rewrite) | Yes |
| `blip` | `cloud_catalog_recovered_after_transient_401` (warning, not revoked-credential) | Yes — directly counters the token-wipe misdiagnosis |

## 🔴 Product finding: Bun ignores Node-style TLS 1.2 pinning

Chasing an anomaly in the lab surfaced a real gap. Against `tls12-only`:

```
node  tls minVersion/maxVersion TLSv1.2  → { ok: true,  protocol: "TLSv1.2" }
bun   tls minVersion/maxVersion TLSv1.2  → { ok: false, errorCode: "ETIMEDOUT" }
node  fetch NODE_OPTIONS=--tls-max-v1.2  → HTTP 200
bun   fetch NODE_OPTIONS=--tls-max-v1.2  → TimeoutError

ClientHello: node pinned → supportedVersions ["TLSv1.2"], offersTls13 false
             bun  pinned → supportedVersions ["TLSv1.3","TLSv1.2"], offersTls13 true
```

**Implication**: the customer's TLS-1.2 workaround does **not** cover bun-spawned runtimes (our sidecar uses bun). No fix attempted here because the safe fix isn't obvious; the flow carries an assertion pinning current behavior so a future runtime fix is immediately detectable, and the verdict wording says the workaround couldn't be proven on this runtime.

## Tests run

- `pnpm evals:typecheck` ✓ · `pnpm evals:test` ✓ (48) · `pnpm --filter openwork-server typecheck` ✓ · openwork-server probe/diagnostics suites ✓ (102)
- `pnpm evals --flow egress-tls12-only --flow egress-broken-chain-repair --flow egress-selective-deny --flow egress-transient-401` → **4 passed**
- `pnpm fraimz --flow egress-broken-chain-repair` and `--flow egress-tls12-only` → voiceover coverage green
- `pnpm evals --list` → 4 flows added, pre-existing lines byte-identical
- Toolchain guard verified: without bun on PATH the flows **skip with an actionable reason** rather than degrading to lab-local verdicts

All flows are app-less/contract-level, so they run in CI without a display.