### PR TITLE
feat(evals): mock IdP lab — SSO misconfig, blocked users, invite prevalidation

### DIFF
--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -71,6 +71,16 @@ export function getSsoOidcRedirectUrl(providerId: string) {
   return `${env.betterAuthUrl}/api/auth/sso/callback/${encodeURIComponent(providerId)}`
 }
 
+function isDevLoopbackIssuer(issuer: string) {
+  if (!env.devMode) return false
+  try {
+    const url = new URL(issuer)
+    return url.hostname === "127.0.0.1" || url.hostname === "localhost"
+  } catch {
+    return false
+  }
+}
+
 function getOidcDiscoveryUrl(issuer: string) {
   return `${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`
 }
@@ -251,7 +261,7 @@ export async function deleteOrganizationSsoConnection(organizationId: Organizati
 export async function registerOrganizationSsoConnection(input: OrganizationSsoRegistrationInput) {
   const providerId = buildOrganizationSsoProviderId(input.organizationId)
   const existing = await getOrganizationSsoConnection(input.organizationId)
-  const domainVerified = isMicrosoftEntraManagedDomain({
+  const domainVerified = isDevLoopbackIssuer(input.issuer) || isMicrosoftEntraManagedDomain({
     domain: input.domain,
     issuer: input.issuer,
     entryPoint: input.kind === "saml" ? input.entryPoint : null,

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -279,7 +279,7 @@ export function AuthPanel({
   }, [authMode, isSingleOrgPrivateSignup, setAuthMode]);
 
   useEffect(() => {
-    if (!isSingleOrgSsoMode || pathname === "/") {
+    if (!isSingleOrgSsoMode || pathname === "/" || pathname === "/join-org") {
       return;
     }
 
@@ -370,10 +370,10 @@ export function AuthPanel({
     ? resolvedVerificationContent
     : isPasswordResetRequest
       ? passwordResetContent
-      : emailFirstFlow
-      ? emailFirstContent
-      : isSingleOrgSsoMode
-      ? singleOrgSsoContent
+    : isSingleOrgSsoMode
+    ? singleOrgSsoContent
+    : emailFirstFlow
+    ? emailFirstContent
       : visibleAuthMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
@@ -532,7 +532,7 @@ export function AuthPanel({
   // OpenWork button.
   const isSignedInWithDesktopHandoff = Boolean(desktopAuthRequested && user && !authError);
   const signedInEmail = user?.email?.trim() || "";
-  const emailFirstPanelActive = emailFirstFlow && !verificationRequired && !isPasswordResetRequest;
+  const emailFirstPanelActive = emailFirstFlow && !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
   const emailFirstFormBusy = loginOptionBusy || authBusy || desktopRedirectBusy;
 
   if (isSignedInWithDesktopHandoff) {

--- a/evals/flows/sso-blocked-user.flow.mjs
+++ b/evals/flows/sso-blocked-user.flow.mjs
@@ -1,0 +1,52 @@
+import { defineScenario } from "../runner/scenario.mjs";
+import { startMockIdpLab } from "../runner/labs/idp.mjs";
+import { clearOrgSso, configureOrgSso, expectSsoBlockedUserMessage } from "../runner/journeys/sso.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "sso-blocked-user";
+const REQUIRED_DEN_ENV = ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_TOKEN"];
+const BLOCKED_EMAIL = "blocked.sso@acme.test";
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+export default defineScenario({
+  id: FLOW_ID,
+  title: "Mock IdP policy blocks show an actionable SSO message",
+  kind: "user-facing",
+  requiresApp: false,
+  stage: { den: { orgMode: "single_org" } },
+  requiredEnv: REQUIRED_DEN_ENV,
+  steps: [
+    {
+      name: "Blocked user sees IdP policy copy",
+      run: async (ctx) => {
+        let idp;
+        try {
+          idp = await startMockIdpLab({ domain: "acme.test", knobs: { blockedUser: BLOCKED_EMAIL } });
+          const surface = await ctx.surfaces.chrome("sso-blocked-user", { profile: "fresh" });
+          await configureOrgSso(ctx, { idp });
+          await ctx.on(surface, async () => {
+            await ctx.prove("When the mock IdP blocks an assigned user, the browser stops on a policy message instead of a dead end", {
+              voiceover: vo[0],
+              action: async () => {
+                await expectSsoBlockedUserMessage(ctx, { subject: { email: BLOCKED_EMAIL, name: "Blocked User" } });
+              },
+              assert: async () => {
+                await ctx.expectText("identity provider policy", { timeoutMs: 10_000 });
+                await ctx.expectText("administrator has configured the application to block users", { timeoutMs: 10_000 });
+              },
+              screenshot: {
+                name: "idp-policy-block",
+                requireText: ["identity provider policy", "administrator has configured the application to block users"],
+              },
+            });
+          });
+        } finally {
+          await clearOrgSso(ctx).catch((error) => ctx.log(`SSO cleanup skipped: ${error instanceof Error ? error.message : String(error)}`));
+          if (idp) await idp.stop();
+        }
+      },
+    },
+  ],
+});

--- a/evals/flows/sso-invite-email-prevalidation.flow.mjs
+++ b/evals/flows/sso-invite-email-prevalidation.flow.mjs
@@ -1,0 +1,105 @@
+import { defineScenario } from "../runner/scenario.mjs";
+import { startMockIdpLab } from "../runner/labs/idp.mjs";
+import { denApiFetch, denWebUrl, extractInviteFromPayload } from "../runner/journeys/den.mjs";
+import { clearOrgSso, configureOrgSso, expectInviteEmailPrevalidated } from "../runner/journeys/sso.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "sso-invite-email-prevalidation";
+const REQUIRED_DEN_ENV = ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_TOKEN"];
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+function runSuffix(ctx) {
+  return `${ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || Date.now()}-${process.pid}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "run";
+}
+
+function authHeaders(ctx) {
+  const token = ctx.env.OPENWORK_EVAL_DEN_TOKEN?.trim();
+  if (!token) throw new Error("OPENWORK_EVAL_DEN_TOKEN is required.");
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${token}`);
+  return headers;
+}
+
+async function createInvite(ctx, email) {
+  const created = await denApiFetch(ctx, "/v1/invitations", {
+    method: "POST",
+    headers: authHeaders(ctx),
+    body: JSON.stringify({ email, role: "member" }),
+  });
+  if (!created.response.ok) {
+    throw new Error(`Could not create SSO invite for ${email}: ${created.response.status} ${created.text.slice(0, 500)}`);
+  }
+  return { ...extractInviteFromPayload(created.body, denWebUrl(ctx)), email };
+}
+
+async function navigate(ctx, url) {
+  const targetUrl = new URL(url).toString();
+  await ctx.client.send("Page.navigate", { url: targetUrl });
+  await ctx.waitFor(`location.href === ${JSON.stringify(targetUrl)}`, { timeoutMs: 15_000, label: "invite URL committed" });
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 45_000, label: "invite page loaded" });
+}
+
+export default defineScenario({
+  id: FLOW_ID,
+  title: "SSO invite acceptance rejects subjects whose email differs from the invite",
+  kind: "user-facing",
+  requiresApp: false,
+  stage: { den: { orgMode: "single_org" } },
+  requiredEnv: REQUIRED_DEN_ENV,
+  steps: [
+    {
+      name: "Invite email is prevalidated against the SSO subject",
+      run: async (ctx) => {
+        const suffix = runSuffix(ctx);
+        const invitedEmail = `sso.invited.${suffix}@acme.test`;
+        const actualEmail = `sso.actual.${suffix}@acme.test`;
+        let idp;
+        try {
+          idp = await startMockIdpLab({ domain: "acme.test", knobs: { emailMismatch: actualEmail } });
+          await configureOrgSso(ctx, { idp });
+          const invite = await createInvite(ctx, invitedEmail);
+          const surface = await ctx.surfaces.chrome("sso-invite-mismatch", { profile: "fresh" });
+          await ctx.on(surface, async () => {
+            await ctx.prove("The invite screen locks the expected invited email before SSO begins", {
+              voiceover: vo[0],
+              action: async () => {
+                await navigate(ctx, invite.inviteUrl);
+              },
+              assert: async () => {
+                await ctx.expectText("INVITED EMAIL", { timeoutMs: 60_000 });
+                await ctx.expectText(invitedEmail, { timeoutMs: 60_000 });
+                await ctx.expectText("Join Acme Robotics", { timeoutMs: 60_000 });
+              },
+              screenshot: { name: "invite-email-locked", requireText: ["INVITED EMAIL", invitedEmail] },
+            });
+          });
+
+          await ctx.on(surface, async () => {
+            await ctx.prove("If the IdP returns a different email, OpenWork rejects the invite coherently and does not loop", {
+              voiceover: vo[1],
+              action: async () => {
+                await expectInviteEmailPrevalidated(ctx, {
+                  invite,
+                  subject: { email: actualEmail, name: "Actual SSO User" },
+                });
+              },
+              screenshot: {
+                name: "invite-email-mismatch-rejected",
+                requireText: [invitedEmail],
+                rejectText: ["Dashboard"],
+              },
+            });
+          });
+        } finally {
+          await clearOrgSso(ctx).catch((error) => ctx.log(`SSO cleanup skipped: ${error instanceof Error ? error.message : String(error)}`));
+          if (idp) await idp.stop();
+        }
+      },
+    },
+  ],
+});

--- a/evals/flows/sso-logout-returns-to-sso.flow.mjs
+++ b/evals/flows/sso-logout-returns-to-sso.flow.mjs
@@ -1,0 +1,71 @@
+import { defineScenario } from "../runner/scenario.mjs";
+import { startMockIdpLab } from "../runner/labs/idp.mjs";
+import { clearOrgSso, configureOrgSso, expectSsoScreenAfterLogout, signInViaSso } from "../runner/journeys/sso.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "sso-logout-returns-to-sso";
+const REQUIRED_DEN_ENV = ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_TOKEN"];
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+function subjectEmail(ctx) {
+  const suffix = `${ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || Date.now()}-${process.pid}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "run";
+  return `sso.logout.${suffix}@acme.test`;
+}
+
+export default defineScenario({
+  id: FLOW_ID,
+  title: "Logging out of SSO returns to the SSO screen",
+  kind: "user-facing",
+  requiresApp: false,
+  stage: { den: { orgMode: "single_org" } },
+  requiredEnv: REQUIRED_DEN_ENV,
+  steps: [
+    {
+      name: "Logout goes back to SSO",
+      run: async (ctx) => {
+        let idp;
+        try {
+          idp = await startMockIdpLab({ domain: "acme.test" });
+          const surface = await ctx.surfaces.chrome("sso-logout", { profile: "fresh" });
+          const subject = { email: subjectEmail(ctx), name: "SSO Logout User" };
+          await configureOrgSso(ctx, { idp });
+
+          await ctx.on(surface, async () => {
+            await ctx.prove("A mock OIDC SSO user reaches the Den dashboard", {
+              voiceover: vo[0],
+              action: async () => {
+                await signInViaSso(ctx, { subject });
+              },
+              assert: async () => {
+                await ctx.expectRoute("/dashboard", { timeoutMs: 60_000 });
+              },
+              screenshot: { name: "sso-user-dashboard", requireText: ["OpenWork"] },
+            });
+          });
+
+          await ctx.on(surface, async () => {
+            await ctx.prove("After logout, the next screen is the SSO screen rather than the legacy password page", {
+              voiceover: vo[1],
+              action: async () => {
+                await expectSsoScreenAfterLogout(ctx, {});
+              },
+              assert: async () => {
+                await ctx.expectText("Continue with SSO", { timeoutMs: 60_000 });
+                await ctx.expectNoText("Forgot password?");
+              },
+              screenshot: { name: "logout-returns-to-sso", requireText: ["Continue with SSO"], rejectText: ["Forgot password?"] },
+            });
+          });
+        } finally {
+          await clearOrgSso(ctx).catch((error) => ctx.log(`SSO cleanup skipped: ${error instanceof Error ? error.message : String(error)}`));
+          if (idp) await idp.stop();
+        }
+      },
+    },
+  ],
+});

--- a/evals/flows/sso-misconfig-errors.flow.mjs
+++ b/evals/flows/sso-misconfig-errors.flow.mjs
@@ -1,0 +1,51 @@
+import { defineFlow } from "../runner/flow.ts";
+import { normalizeMockIdpConfig } from "../runner/labs/idp.mjs";
+import { expectSsoConfigError } from "../runner/journeys/sso.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "sso-misconfig-errors";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const idp = normalizeMockIdpConfig({ domain: "acme.test" });
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "SSO misconfigurations produce named, actionable lab errors",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Trailing-newline certificate is named",
+      run: async (ctx) => {
+        await ctx.prove("A pasted SAML certificate with a trailing newline is reported as sso_cert_trailing_newline", {
+          voiceover: vo[0],
+          action: async () => {
+            const match = await expectSsoConfigError(ctx, {
+              idp,
+              override: { certTrailingNewline: true },
+              expect: { code: "sso_cert_trailing_newline", includes: ["trailing newline", "certificate"] },
+            });
+            ctx.output("trailing-newline verdict", JSON.stringify(match, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Wrong IdP email domain is named",
+      run: async (ctx) => {
+        await ctx.prove("An IdP subject from the wrong domain is reported as sso_domain_mismatch", {
+          voiceover: vo[1],
+          action: async () => {
+            const match = await expectSsoConfigError(ctx, {
+              idp,
+              override: { wrongDomain: true },
+              expect: { code: "sso_domain_mismatch", includes: ["wrong-acme.test", "acme.test"] },
+            });
+            ctx.output("wrong-domain verdict", JSON.stringify(match, null, 2));
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -37,8 +37,18 @@ const MYSQL_CONTAINER = "openwork-web-local-mysql";
 const MYSQL_STATE_DIR = join(STATE_DIR, "mysql");
 const MYSQL_SOCKET = join(MYSQL_STATE_DIR, "mysql.sock");
 const COMPOSE_ARGS = ["compose", "-p", "openwork-den-local", "-f", "packaging/docker/docker-compose.web-local.yml"];
+const DEFAULT_MOCK_IDP_ISSUER = "http://127.0.0.1:19190";
+const MOCK_IDP_ISSUER = (process.env.OPENWORK_EVAL_MOCK_IDP_ISSUER?.trim() || DEFAULT_MOCK_IDP_ISSUER).replace(/\/+$/, "");
 const DEN_WEB_ORIGIN = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "http://localhost:3005").replace(/\/+$/, "");
 const DEN_WEB_PORT = new URL(DEN_WEB_ORIGIN).port || "3005";
+
+function envCsv(name: string): string[] {
+  return (process.env[name] ?? "")
+    .split(",")
+    .map((entry) => entry.trim().replace(/\/+$/, ""))
+    .filter(Boolean);
+}
+
 const DEN_TRUSTED_ORIGINS = [
   DEN_BASE_URL,
   DEN_WEB_ORIGIN,
@@ -46,6 +56,8 @@ const DEN_TRUSTED_ORIGINS = [
   `http://127.0.0.1:${DEN_WEB_PORT}`,
   "http://localhost:5173",
   "http://127.0.0.1:5173",
+  MOCK_IDP_ISSUER,
+  ...envCsv("OPENWORK_EVAL_DEN_EXTRA_TRUSTED_ORIGINS"),
 ].filter((origin, index, origins) => origins.indexOf(origin) === index).join(",");
 
 // Override with OPENWORK_EVAL_DATABASE_URL to isolate a run from the shared

--- a/evals/runner/idp-lab.test.ts
+++ b/evals/runner/idp-lab.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildBlockedUserResponse,
+  buildOidcClaims,
+  buildRs256SigningArgv,
+  buildWrongDomainEmail,
+  matchSsoExpectation,
+  normalizeCertificateMaterial,
+  normalizeDomain,
+  normalizeMockIdpConfig,
+  subjectWithKnobs,
+  validateSsoConfiguration,
+} from "./labs/idp.ts";
+
+test("mock IdP config normalization trims issuer, domain, and credentials", () => {
+  const config = normalizeMockIdpConfig({
+    issuer: " https://idp.example.test/ ",
+    domain: " @Acme.TEST. ",
+    clientId: " client-one ",
+    clientSecret: " secret-one ",
+  });
+
+  assert.equal(config.issuer, "https://idp.example.test");
+  assert.equal(config.domain, "acme.test");
+  assert.equal(config.clientId, "client-one");
+  assert.equal(config.clientSecret, "secret-one");
+  assert.equal(config.defaultSubject.email, "sso.user@acme.test");
+});
+
+test("certificate normalizer names the trailing-newline paste bug", () => {
+  const cert = "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n";
+  const normalized = normalizeCertificateMaterial(cert);
+  const validation = validateSsoConfiguration({ configuredDomain: "acme.test", cert, subjectEmail: "maya@acme.test" });
+  const match = matchSsoExpectation(validation, { code: "sso_cert_trailing_newline", includes: ["trailing newline", "certificate"] });
+
+  assert.equal(normalized.hadTrailingNewline, true);
+  assert.equal(normalized.value.endsWith("\n"), false);
+  assert.equal(validation.ok, false);
+  assert.equal(match.passed, true);
+});
+
+test("domain mismatch normalizer names IdP email domains that do not match the org", () => {
+  const wrongEmail = buildWrongDomainEmail("maya@acme.test", "acme.test");
+  const validation = validateSsoConfiguration({ configuredDomain: "ACME.test", subjectEmail: wrongEmail });
+  const match = matchSsoExpectation(validation, { code: "sso_domain_mismatch", includes: ["wrong-acme.test", "acme.test"] });
+
+  assert.equal(wrongEmail, "maya@wrong-acme.test");
+  assert.equal(normalizeDomain(" @ACME.test. "), "acme.test");
+  assert.equal(validation.normalizedDomain, "acme.test");
+  assert.equal(match.passed, true);
+});
+
+test("claim builder supports present, absent, and unexpected group claim shapes", () => {
+  const baseConfig = normalizeMockIdpConfig({ domain: "acme.test" });
+  const subject = subjectWithKnobs(baseConfig, { email: "dev@acme.test", name: "Dev User" });
+  const present = buildOidcClaims({ issuer: baseConfig.issuer, clientId: baseConfig.clientId, subject, knobs: baseConfig.knobs });
+  const absentConfig = normalizeMockIdpConfig({ knobs: { groupClaims: "absent" } });
+  const absent = buildOidcClaims({ issuer: absentConfig.issuer, clientId: absentConfig.clientId, subject, knobs: absentConfig.knobs });
+  const oddConfig = normalizeMockIdpConfig({ knobs: { groupClaims: "unexpected-shape" } });
+  const odd = buildOidcClaims({ issuer: oddConfig.issuer, clientId: oddConfig.clientId, subject, knobs: oddConfig.knobs });
+
+  assert.deepEqual(present.groups, ["Engineering", "OpenWork Lab"]);
+  assert.equal("groups" in absent, false);
+  assert.deepEqual(odd.groups, { primary: "Engineering", all: ["Engineering", "OpenWork Lab"] });
+});
+
+test("email mismatch and guest-user knobs shape SSO subjects", () => {
+  const mismatchConfig = normalizeMockIdpConfig({ knobs: { emailMismatch: "other@acme.test" } });
+  const guestConfig = normalizeMockIdpConfig({ knobs: { guestUser: true } });
+
+  assert.equal(subjectWithKnobs(mismatchConfig, { email: "invited@acme.test" }).email, "other@acme.test");
+  assert.equal(subjectWithKnobs(guestConfig, { email: "guest@external.test" }).sub, "guest:guest@external.test");
+});
+
+test("RS256 signing argv documents the dependency-free node:crypto path", () => {
+  assert.deepEqual(buildRs256SigningArgv({ keyId: "kid-one", payload: "abc" }), [
+    "node:crypto",
+    "createSign",
+    "RSA-SHA256",
+    "--kid",
+    "kid-one",
+    "--payload-bytes",
+    "3",
+  ]);
+});
+
+test("blocked-user response uses the Entra-style policy wording", () => {
+  const response = buildBlockedUserResponse({ email: "blocked@acme.test" });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.error, "access_denied");
+  assert.match(response.errorDescription, /administrator has configured the application to block users/);
+  assert.match(response.message, /IdP administrator/);
+  assert.match(response.html, /OpenWork Mock IdP policy/);
+});
+
+test("expectation matcher fails with actionable detail when the named error is missing", () => {
+  const validation = validateSsoConfiguration({ configuredDomain: "acme.test", subjectEmail: "maya@acme.test" });
+  const match = matchSsoExpectation(validation, { code: "sso_domain_mismatch" });
+
+  assert.equal(match.passed, false);
+  assert.deepEqual(match.actualCodes, []);
+  assert.match(match.detail, /Expected sso_domain_mismatch/);
+});

--- a/evals/runner/journeys/index.ts
+++ b/evals/runner/journeys/index.ts
@@ -1,5 +1,6 @@
 export * from "./den.ts";
 export * from "./desktop.ts";
+export * from "./sso.ts";
 
 import { acceptInvite, apiSignIn, createOrg, inviteMember, signInWeb, signUpWeb } from "./den.ts";
 import { connectDen, firstBoot, openSettings, runPrompt } from "./desktop.ts";

--- a/evals/runner/journeys/sso.mjs
+++ b/evals/runner/journeys/sso.mjs
@@ -1,0 +1,1 @@
+export * from "./sso.ts";

--- a/evals/runner/journeys/sso.ts
+++ b/evals/runner/journeys/sso.ts
@@ -1,0 +1,614 @@
+import { EvalError } from "../context.ts";
+import type { FlowContext } from "../flow.ts";
+import type { Surface } from "../surfaces.ts";
+import {
+  buildWrongDomainEmail,
+  matchSsoExpectation,
+  MOCK_IDP_BLOCKED_USER_PHRASE,
+  normalizeMockIdpConfig,
+  subjectWithKnobs,
+  validateSsoConfiguration,
+  type MockIdpConfig,
+  type MockIdpSubjectInput,
+  type NormalizedMockIdpConfig,
+  type SsoExpectation,
+  type SsoExpectationMatch,
+  type StartedMockIdpLab,
+} from "../labs/idp.ts";
+import { cleanBaseUrl, denApiFetch, denWebUrl, inviteUrlFromToken, type DenApiFetchResult, type InviteRef } from "./den.ts";
+
+const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
+const SSO_STATE_KEY = "__ssoJourney";
+
+export interface SsoOrganizationRef {
+  id?: string;
+  orgId?: string;
+  organizationId?: string;
+  slug?: string;
+  token?: string;
+}
+
+export interface ConfigureOrgSsoOptions {
+  org?: SsoOrganizationRef;
+  idp: StartedMockIdpLab;
+  overrides?: Partial<ReturnType<StartedMockIdpLab["registration"]>>;
+}
+
+export interface ConfiguredOrgSso {
+  path: "den-api:/v1/sso/oidc";
+  organizationId: string;
+  organizationSlug: string;
+  providerId: string;
+  signInPath: string;
+  signInUrl: string;
+  registration: ReturnType<StartedMockIdpLab["registration"]>;
+}
+
+export interface ExpectSsoConfigErrorOptions {
+  idp?: StartedMockIdpLab | NormalizedMockIdpConfig | MockIdpConfig;
+  override: {
+    cert?: string | null;
+    certTrailingNewline?: boolean;
+    wrongDomain?: boolean;
+    subjectEmail?: string | null;
+    configuredDomain?: string;
+  };
+  expect: SsoExpectation;
+}
+
+export interface SignInViaSsoOptions {
+  surface?: string | Surface;
+  subject: MockIdpSubjectInput;
+  org?: SsoOrganizationRef;
+  callbackUrl?: string;
+  loginHint?: string;
+  clearSession?: boolean;
+}
+
+export interface SsoBrowserResult {
+  email: string;
+  finalUrl: string;
+  text: string;
+}
+
+export interface ExpectSsoBlockedUserMessageOptions extends SignInViaSsoOptions {}
+
+export interface ExpectSsoScreenAfterLogoutOptions {
+  surface?: string | Surface;
+}
+
+export interface ExpectInviteEmailPrevalidatedOptions {
+  surface?: string | Surface;
+  invite: InviteRef;
+  subject: MockIdpSubjectInput;
+  org?: SsoOrganizationRef;
+}
+
+interface ResolvedOrg {
+  id: string;
+  slug: string;
+  token: string;
+}
+
+interface StoredSsoState {
+  organizationId: string;
+  organizationSlug: string;
+  signInPath: string;
+  signInUrl: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function authToken(ctx: FlowContext, org?: SsoOrganizationRef): string {
+  const token = org?.token?.trim() || ctx.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || "";
+  if (!token) {
+    throw new EvalError("OPENWORK_EVAL_DEN_TOKEN is required to configure the mock IdP through the Den SSO API.");
+  }
+  return token;
+}
+
+function organizationIdFromRef(org?: SsoOrganizationRef): string {
+  return org?.organizationId?.trim() || org?.orgId?.trim() || org?.id?.trim() || "";
+}
+
+function authHeaders(token: string, organizationId?: string, cookie?: string): Headers {
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${token}`);
+  if (cookie) {
+    headers.set("cookie", cookie);
+  }
+  if (organizationId) {
+    headers.set("x-openwork-org-id", organizationId);
+  }
+  return headers;
+}
+
+function demoOwnerEmail(ctx: FlowContext): string {
+  return ctx.env.DEN_DEMO_OWNER_EMAIL?.trim() || "alex@acme.test";
+}
+
+function demoOwnerPassword(ctx: FlowContext): string {
+  return ctx.env.DEN_DEMO_OWNER_PASSWORD?.trim() || "OpenWorkDemo123!";
+}
+
+function sessionCookieFromHeader(value: string | null): string {
+  const cookie = value?.split(";")[0]?.trim() || "";
+  if (!cookie) {
+    throw new EvalError("Den API sign-in did not return a Better Auth session cookie for SSO registration.");
+  }
+  return cookie;
+}
+
+async function demoOwnerSessionCookie(ctx: FlowContext): Promise<string> {
+  const result = await denApiFetch(ctx, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: demoOwnerEmail(ctx), password: demoOwnerPassword(ctx) }),
+  });
+  if (!result.response.ok) {
+    throw new EvalError(`Could not mint a Better Auth session cookie for SSO registration: ${result.response.status} ${result.text.slice(0, 300)}`);
+  }
+  return sessionCookieFromHeader(result.response.headers.get("set-cookie"));
+}
+
+async function clearExistingOrgSso(ctx: FlowContext, org: ResolvedOrg): Promise<void> {
+  const result = await denApiFetch(ctx, "/v1/sso", {
+    method: "DELETE",
+    headers: authHeaders(org.token, org.id),
+  });
+  if (result.response.status !== 204 && result.response.status !== 404) {
+    throw new EvalError(`Could not reset the existing SSO connection before lab registration: ${resultText(result)}`);
+  }
+}
+
+export async function clearOrgSso(ctx: FlowContext, orgRef?: SsoOrganizationRef): Promise<void> {
+  await clearExistingOrgSso(ctx, await resolveOrg(ctx, orgRef));
+}
+
+function connectionFromPayload(body: unknown): Record<string, unknown> | null {
+  if (!isRecord(body) || !isRecord(body.connection)) {
+    return null;
+  }
+  return body.connection;
+}
+
+function organizationFromPayload(body: unknown): Record<string, unknown> | null {
+  if (!isRecord(body) || !isRecord(body.organization)) {
+    return null;
+  }
+  return body.organization;
+}
+
+function inviteEmail(invite: InviteRef): string {
+  return invite.email?.trim().toLowerCase() || "";
+}
+
+function requiredInviteUrl(invite: InviteRef, webUrl: string): string {
+  if (invite.inviteUrl?.trim()) {
+    return invite.inviteUrl.trim();
+  }
+  if (invite.token?.trim()) {
+    return inviteUrlFromToken(webUrl, invite.token.trim());
+  }
+  throw new EvalError("expectInviteEmailPrevalidated requires invite.inviteUrl or invite.token.");
+}
+
+function storedSsoState(ctx: FlowContext): StoredSsoState | null {
+  const value = ctx.state[SSO_STATE_KEY];
+  if (!isRecord(value)) {
+    return null;
+  }
+  const organizationId = stringField(value, "organizationId");
+  const organizationSlug = stringField(value, "organizationSlug");
+  const signInPath = stringField(value, "signInPath");
+  const signInUrl = stringField(value, "signInUrl");
+  if (!organizationSlug || !signInPath || !signInUrl) {
+    return null;
+  }
+  return { organizationId, organizationSlug, signInPath, signInUrl };
+}
+
+function rememberSsoState(ctx: FlowContext, value: StoredSsoState): void {
+  ctx.state[SSO_STATE_KEY] = value;
+}
+
+function configFromIdp(input: StartedMockIdpLab | NormalizedMockIdpConfig | MockIdpConfig | undefined): NormalizedMockIdpConfig {
+  if (!input) {
+    return normalizeMockIdpConfig();
+  }
+  if ("config" in input && isNormalizedMockIdpConfig(input.config)) {
+    return input.config;
+  }
+  if (isNormalizedMockIdpConfig(input)) {
+    return input;
+  }
+  return normalizeMockIdpConfig(input);
+}
+
+function isNormalizedMockIdpConfig(value: unknown): value is NormalizedMockIdpConfig {
+  if (!isRecord(value) || !isRecord(value.defaultSubject) || !isRecord(value.knobs)) {
+    return false;
+  }
+  return typeof value.issuer === "string"
+    && typeof value.domain === "string"
+    && typeof value.clientId === "string"
+    && typeof value.clientSecret === "string"
+    && typeof value.defaultSubject.email === "string"
+    && typeof value.defaultSubject.sub === "string"
+    && typeof value.defaultSubject.name === "string";
+}
+
+function certificateFromIdp(input: StartedMockIdpLab | NormalizedMockIdpConfig | MockIdpConfig | undefined): string | null {
+  if (input && "certificate" in input && typeof input.certificate === "string") {
+    return input.certificate;
+  }
+  return null;
+}
+
+async function ensureReadyState(ctx: FlowContext, label: string): Promise<void> {
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 60_000, label });
+}
+
+async function navigateAbsolute(ctx: FlowContext, url: string, label: string): Promise<void> {
+  const safeUrl = new URL(url).toString();
+  const navigated = ctx.client
+    ? await ctx.client.send("Page.navigate", { url: safeUrl }).then(() => true).catch((error) => {
+        ctx.log(`CDP Page.navigate failed for ${label}; falling back to window.location: ${messageText(error)}`);
+        return false;
+      })
+    : false;
+  if (!navigated) {
+    await ctx.eval(`(() => { window.location.href = ${JSON.stringify(safeUrl)}; return true; })()`);
+  }
+  await ensureReadyState(ctx, `load ${label}`);
+}
+
+async function visibleText(ctx: FlowContext): Promise<string> {
+  const text = await ctx.eval("document.body?.innerText ?? ''");
+  return typeof text === "string" ? text : "";
+}
+
+async function currentHref(ctx: FlowContext): Promise<string> {
+  const href = await ctx.eval("location.href");
+  return typeof href === "string" ? href : "";
+}
+
+async function clearBrowserSession(ctx: FlowContext, webUrl: string): Promise<void> {
+  await navigateAbsolute(ctx, webUrl, "Den Web before SSO sign-out");
+  await ctx.eval(`(() => {
+    window.localStorage.removeItem(${JSON.stringify(AUTH_TOKEN_STORAGE_KEY)});
+    window.sessionStorage.clear();
+    return Promise.allSettled([
+      fetch('/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' }),
+      fetch('/api/den/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' }),
+    ]).then(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      return true;
+    });
+  })()`, { awaitPromise: true });
+  if (ctx.client) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch((error) => ctx.log(`Cookie clear skipped: ${messageText(error)}`));
+    await ctx.client.send("Network.clearBrowserCache", {}).catch((error) => ctx.log(`Cache clear skipped: ${messageText(error)}`));
+  }
+}
+
+async function resolveOrg(ctx: FlowContext, org?: SsoOrganizationRef): Promise<ResolvedOrg> {
+  const token = authToken(ctx, org);
+  const requestedOrganizationId = organizationIdFromRef(org);
+  const response = await denApiFetch(ctx, "/v1/org", {
+    headers: authHeaders(token, requestedOrganizationId),
+  });
+  if (!response.response.ok) {
+    throw new EvalError(`Could not resolve active organization for SSO configuration: ${response.response.status} ${response.text.slice(0, 300)}`);
+  }
+  const organization = organizationFromPayload(response.body);
+  if (!organization) {
+    throw new EvalError(`Active organization response did not include an organization: ${JSON.stringify(response.body).slice(0, 300)}`);
+  }
+  const id = requestedOrganizationId || stringField(organization, "id");
+  const slug = org?.slug?.trim() || stringField(organization, "slug");
+  if (!id || !slug) {
+    throw new EvalError(`Active organization response did not include id and slug: ${JSON.stringify(response.body).slice(0, 300)}`);
+  }
+  return { id, slug, token };
+}
+
+function resultText(result: DenApiFetchResult): string {
+  return `${result.response.status} ${result.text.slice(0, 500)}`;
+}
+
+export async function configureOrgSso(ctx: FlowContext, options: ConfigureOrgSsoOptions): Promise<ConfiguredOrgSso> {
+  const org = await resolveOrg(ctx, options.org);
+  const registration = options.idp.registration(options.overrides);
+  await clearExistingOrgSso(ctx, org);
+  const cookie = await demoOwnerSessionCookie(ctx);
+  const result = await denApiFetch(ctx, "/v1/sso/oidc", {
+    method: "POST",
+    headers: authHeaders(org.token, org.id, cookie),
+    body: JSON.stringify({
+      issuer: registration.issuer,
+      domain: registration.domain,
+      clientId: registration.clientId,
+      clientSecret: registration.clientSecret,
+      scopes: registration.scopes,
+      skipDiscovery: registration.skipDiscovery,
+      authorizationEndpoint: registration.authorizationEndpoint,
+      tokenEndpoint: registration.tokenEndpoint,
+      jwksEndpoint: registration.jwksEndpoint,
+      userInfoEndpoint: registration.userInfoEndpoint,
+      tokenEndpointAuthentication: registration.tokenEndpointAuthentication,
+    }),
+  });
+  if (!result.response.ok) {
+    throw new EvalError(`Registering mock OIDC SSO through Den API /v1/sso/oidc failed: ${resultText(result)}`);
+  }
+  const connection = connectionFromPayload(result.body);
+  if (!connection) {
+    throw new EvalError(`SSO registration response did not include a connection: ${JSON.stringify(result.body).slice(0, 500)}`);
+  }
+  const signInPath = stringField(connection, "signInPath") || `/sso/${encodeURIComponent(org.slug)}`;
+  const signInUrl = stringField(connection, "signInUrl") || new URL(signInPath, `${denWebUrl(ctx)}/`).toString();
+  const configured: ConfiguredOrgSso = {
+    path: "den-api:/v1/sso/oidc",
+    organizationId: org.id,
+    organizationSlug: org.slug,
+    providerId: stringField(connection, "providerId"),
+    signInPath,
+    signInUrl,
+    registration,
+  };
+  rememberSsoState(ctx, {
+    organizationId: configured.organizationId,
+    organizationSlug: configured.organizationSlug,
+    signInPath: configured.signInPath,
+    signInUrl: configured.signInUrl,
+  });
+  ctx.log(`Configured mock OIDC SSO through Den API /v1/sso/oidc for ${org.slug}.`);
+  return configured;
+}
+
+export async function expectSsoConfigError(ctx: FlowContext, options: ExpectSsoConfigErrorOptions): Promise<SsoExpectationMatch> {
+  const config = configFromIdp(options.idp);
+  const baseCert = certificateFromIdp(options.idp) ?? "-----BEGIN CERTIFICATE-----\nmock\n-----END CERTIFICATE-----";
+  const cert = options.override.cert !== undefined
+    ? options.override.cert
+    : options.override.certTrailingNewline
+      ? `${baseCert.replace(/(?:\r?\n)+$/g, "")}\n`
+      : baseCert.replace(/(?:\r?\n)+$/g, "");
+  const subjectEmail = options.override.subjectEmail !== undefined
+    ? options.override.subjectEmail
+    : options.override.wrongDomain
+      ? buildWrongDomainEmail(config.defaultSubject.email, config.domain)
+      : config.defaultSubject.email;
+  const validation = validateSsoConfiguration({
+    configuredDomain: options.override.configuredDomain ?? config.domain,
+    cert,
+    subjectEmail,
+  });
+  const match = matchSsoExpectation(validation, options.expect);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: match.passed ? "passed" : "failed",
+    assertion: `SSO config error is named and actionable: ${options.expect.code}`,
+    actual: {
+      expected: options.expect,
+      validation,
+      match,
+    },
+  });
+  if (!match.passed) {
+    throw new EvalError(match.detail);
+  }
+  return match;
+}
+
+function signInUrl(ctx: FlowContext, org?: SsoOrganizationRef): string {
+  const stored = storedSsoState(ctx);
+  const slug = org?.slug?.trim() || stored?.organizationSlug;
+  if (!slug) {
+    throw new EvalError("No SSO organization slug is available. Call configureOrgSso first or pass org.slug.");
+  }
+  const path = stored?.signInPath || `/sso/${encodeURIComponent(slug)}`;
+  return new URL(path, `${denWebUrl(ctx)}/`).toString();
+}
+
+async function signInViaSsoOnCurrentSurface(ctx: FlowContext, options: SignInViaSsoOptions): Promise<SsoBrowserResult> {
+  const webUrl = denWebUrl(ctx);
+  if (options.clearSession !== false) {
+    await clearBrowserSession(ctx, webUrl);
+  }
+  const target = new URL(signInUrl(ctx, options.org));
+  target.searchParams.set("callbackURL", options.callbackUrl ?? new URL("/dashboard", `${webUrl}/`).toString());
+  const loginHint = options.loginHint?.trim() || options.subject.email?.trim() || "";
+  if (loginHint) {
+    target.searchParams.set("loginHint", loginHint);
+  }
+  await navigateAbsolute(ctx, target.toString(), "organization SSO sign-in");
+  await ctx.waitFor(`(() => {
+    const text = document.body?.innerText ?? '';
+    return location.pathname.startsWith('/dashboard')
+      || location.pathname.startsWith('/join-org')
+      || location.hostname === '127.0.0.1'
+      || text.includes(${JSON.stringify(MOCK_IDP_BLOCKED_USER_PHRASE)})
+      || text.includes('Dashboard')
+      || text.includes('Could not')
+      || text.includes('Join ');
+  })()`, { timeoutMs: 90_000, label: "SSO browser reached terminal state" });
+  if (!options.callbackUrl) {
+    const href = await currentHref(ctx);
+    const webOrigin = cleanBaseUrl(webUrl);
+    if (href.startsWith(webOrigin) && !href.includes("/dashboard")) {
+      await navigateAbsolute(ctx, new URL("/dashboard", `${webUrl}/`).toString(), "dashboard after SSO");
+      await ctx.waitFor("document.body.innerText.includes('Dashboard') || location.pathname.startsWith('/dashboard')", {
+        timeoutMs: 60_000,
+        label: "dashboard after SSO",
+      });
+    }
+  }
+  return {
+    email: options.subject.email?.trim().toLowerCase() || loginHint.toLowerCase(),
+    finalUrl: await currentHref(ctx),
+    text: await visibleText(ctx),
+  };
+}
+
+export async function signInViaSso(ctx: FlowContext, options: SignInViaSsoOptions): Promise<SsoBrowserResult> {
+  if (options.surface) {
+    return ctx.on(options.surface, () => signInViaSsoOnCurrentSurface(ctx, options));
+  }
+  return signInViaSsoOnCurrentSurface(ctx, options);
+}
+
+export async function expectSsoBlockedUserMessage(ctx: FlowContext, options: ExpectSsoBlockedUserMessageOptions): Promise<SsoBrowserResult> {
+  const result = await signInViaSso(ctx, options);
+  const text = result.text.toLowerCase();
+  const passed = text.includes(MOCK_IDP_BLOCKED_USER_PHRASE) && text.includes("identity provider") && text.includes("policy");
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion: "Blocked SSO user sees an actionable identity-provider policy message",
+    actual: { finalUrl: result.finalUrl, text: result.text.slice(0, 1000) },
+  });
+  if (!passed) {
+    throw new EvalError(`Expected blocked-user IdP policy message, got: ${result.text.slice(0, 500)}`);
+  }
+  return result;
+}
+
+async function expectSsoScreenAfterLogoutOnCurrentSurface(ctx: FlowContext): Promise<string> {
+  const webUrl = denWebUrl(ctx);
+  await ctx.eval(`(() => Promise.allSettled([
+    fetch('/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' }),
+    fetch('/api/den/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' }),
+  ]).then(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.location.href = ${JSON.stringify(webUrl)};
+    return true;
+  }))()`, { awaitPromise: true });
+  await ensureReadyState(ctx, "SSO screen after logout");
+  await ctx.waitFor("document.body.innerText.includes('Continue with SSO') || document.body.innerText.includes('Sign in with SSO')", {
+    timeoutMs: 60_000,
+    label: "SSO screen after logout",
+  });
+  const text = await visibleText(ctx);
+  const legacyPassword = text.includes("Password") || text.includes("Forgot password?");
+  const passed = (text.includes("Continue with SSO") || text.includes("Sign in with SSO")) && !legacyPassword;
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion: "Logout returns to the SSO screen instead of the legacy email/password login page",
+    actual: text.slice(0, 1000),
+  });
+  if (!passed) {
+    throw new EvalError(`Logout did not return to an SSO-only screen: ${text.slice(0, 500)}`);
+  }
+  return text;
+}
+
+export async function expectSsoScreenAfterLogout(ctx: FlowContext, options: ExpectSsoScreenAfterLogoutOptions): Promise<string> {
+  if (options.surface) {
+    return ctx.on(options.surface, () => expectSsoScreenAfterLogoutOnCurrentSurface(ctx));
+  }
+  return expectSsoScreenAfterLogoutOnCurrentSurface(ctx);
+}
+
+async function clickJoinIfPresent(ctx: FlowContext): Promise<boolean> {
+  const clicked = await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\s+/g, ' ').trim();
+    const button = [...document.querySelectorAll('button')]
+      .find((entry) => normalize(entry.textContent).startsWith('Join ') && entry.disabled !== true && entry.getAttribute('aria-disabled') !== 'true');
+    button?.scrollIntoView({ block: 'center', inline: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`);
+  return clicked === true;
+}
+
+function hasCoherentInviteMismatchCopy(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return normalized.includes("does not match")
+    || normalized.includes("invited email")
+    || normalized.includes("this invite is for")
+    || normalized.includes("not invited")
+    || normalized.includes("could not join")
+    || normalized.includes("switch accounts to continue")
+    || normalized.includes("use the invited email");
+}
+
+async function expectInviteEmailPrevalidatedOnCurrentSurface(ctx: FlowContext, options: ExpectInviteEmailPrevalidatedOptions): Promise<SsoBrowserResult> {
+  const webUrl = denWebUrl(ctx);
+  const callbackUrl = requiredInviteUrl(options.invite, webUrl);
+  const loginHint = inviteEmail(options.invite);
+  const result = await signInViaSsoOnCurrentSurface(ctx, {
+    subject: options.subject,
+    org: options.org,
+    callbackUrl,
+    loginHint,
+  });
+  if (await clickJoinIfPresent(ctx)) {
+    await ctx.waitFor(`(() => {
+      const text = document.body?.innerText ?? '';
+      return Boolean(document.querySelector('[role="alert"]'))
+        || text.includes('Could not join')
+        || text.includes('does not match')
+        || text.includes('invited email')
+        || location.pathname.startsWith('/dashboard');
+    })()`, { timeoutMs: 45_000, label: "invite mismatch post-join state" }).catch(async () => {
+      await sleep(1_000);
+      return true;
+    });
+  }
+  const finalUrl = await currentHref(ctx);
+  const text = await visibleText(ctx);
+  const lowerUrl = finalUrl.toLowerCase();
+  const looped = lowerUrl.includes("/sso/") || text.includes("Signing you in");
+  const landedDashboard = lowerUrl.includes("/dashboard") || text.includes("Dashboard");
+  const coherent = hasCoherentInviteMismatchCopy(text);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: !looped ? "passed" : "failed",
+    assertion: "Invite mismatch SSO flow does not loop back through SSO",
+    actual: { finalUrl, text: text.slice(0, 600) },
+  });
+  ctx.recordEvidence({
+    type: "assertion",
+    status: !landedDashboard && coherent ? "passed" : "failed",
+    assertion: "Invite mismatch is rejected coherently before accepting the invite",
+    actual: { finalUrl, expectedInviteEmail: loginHint, actualSubject: options.subject.email, text: text.slice(0, 1000) },
+  });
+  if (looped) {
+    throw new EvalError(`Invite mismatch looped instead of stopping: ${finalUrl}`);
+  }
+  if (landedDashboard || !coherent) {
+    throw new EvalError(`Invite mismatch was not coherently rejected. Dashboard=${landedDashboard}; text=${text.slice(0, 500)}`);
+  }
+  return { ...result, finalUrl, text };
+}
+
+export async function expectInviteEmailPrevalidated(ctx: FlowContext, options: ExpectInviteEmailPrevalidatedOptions): Promise<SsoBrowserResult> {
+  if (options.surface) {
+    return ctx.on(options.surface, () => expectInviteEmailPrevalidatedOnCurrentSurface(ctx, options));
+  }
+  return expectInviteEmailPrevalidatedOnCurrentSurface(ctx, options);
+}
+
+export function previewSubjectForConfig(config: MockIdpConfig): MockIdpSubjectInput {
+  const normalized = normalizeMockIdpConfig(config);
+  return subjectWithKnobs(normalized);
+}

--- a/evals/runner/journeys/sso.ts
+++ b/evals/runner/journeys/sso.ts
@@ -265,15 +265,10 @@ async function ensureReadyState(ctx: FlowContext, label: string): Promise<void> 
 
 async function navigateAbsolute(ctx: FlowContext, url: string, label: string): Promise<void> {
   const safeUrl = new URL(url).toString();
-  const navigated = ctx.client
-    ? await ctx.client.send("Page.navigate", { url: safeUrl }).then(() => true).catch((error) => {
-        ctx.log(`CDP Page.navigate failed for ${label}; falling back to window.location: ${messageText(error)}`);
-        return false;
-      })
-    : false;
-  if (!navigated) {
-    await ctx.eval(`(() => { window.location.href = ${JSON.stringify(safeUrl)}; return true; })()`);
-  }
+  const client = ctx.client;
+  if (!client) throw new EvalError(`Cannot navigate to ${label}: no CDP client is attached to this surface.`);
+  // Structured CDP navigation only — never construct code from a URL.
+  await client.send("Page.navigate", { url: safeUrl });
   await ensureReadyState(ctx, `load ${label}`);
 }
 

--- a/evals/runner/labs/idp.mjs
+++ b/evals/runner/labs/idp.mjs
@@ -1,0 +1,1 @@
+export * from "./idp.ts";

--- a/evals/runner/labs/idp.ts
+++ b/evals/runner/labs/idp.ts
@@ -542,12 +542,25 @@ function sendJson(response: ServerResponse, status: number, body: unknown): void
   response.end(payload);
 }
 
-function sendHtml(response: ServerResponse, status: number, body: string): void {
+interface HtmlDocument {
+  title: string;
+  heading: string;
+  paragraphs: string[];
+}
+
+// Escaping happens here, at the single boundary that writes HTML, so no caller
+// can hand this server a pre-built markup string.
+function renderHtmlDocument(document: HtmlDocument): string {
+  const paragraphs = document.paragraphs.map((text) => `<p>${escapeHtml(text)}</p>`).join("");
+  return `<!doctype html><html><head><title>${escapeHtml(document.title)}</title></head><body><main style="font-family: sans-serif; max-width: 720px; margin: 48px auto;"><h1>${escapeHtml(document.heading)}</h1>${paragraphs}</main></body></html>`;
+}
+
+function sendHtml(response: ServerResponse, status: number, document: HtmlDocument): void {
   response.writeHead(status, {
     "content-type": "text/html; charset=utf-8",
     "cache-control": "no-store",
   });
-  response.end(body);
+  response.end(renderHtmlDocument(document));
 }
 
 function sendRedirect(response: ServerResponse, location: string): void {
@@ -665,8 +678,16 @@ function samlMetadata(config: NormalizedMockIdpConfig, certificate: string): str
 </EntityDescriptor>`;
 }
 
-function samlPostBindingPage(config: NormalizedMockIdpConfig): string {
-  return `<!doctype html><html><head><title>OpenWork Mock IdP SAML endpoint</title></head><body><main style="font-family: sans-serif; max-width: 720px; margin: 48px auto;"><p>OpenWork Mock IdP lab</p><h1>SAML POST binding endpoint</h1><p>This fixture exposes SAML metadata and a POST binding endpoint, but the OpenWork eval lab drives OIDC because this checkout implements OIDC and SAML SSO and OIDC keeps the signed-token path dependency-free.</p><p>Issuer: ${escapeHtml(config.issuer)}</p></main></body></html>`;
+function samlPostBindingPage(config: NormalizedMockIdpConfig): HtmlDocument {
+  return {
+    title: "OpenWork Mock IdP SAML endpoint",
+    heading: "SAML POST binding endpoint",
+    paragraphs: [
+      "OpenWork Mock IdP lab",
+      "This fixture exposes SAML metadata and a POST binding endpoint, but the OpenWork eval lab drives OIDC because this checkout implements OIDC and SAML SSO and OIDC keeps the signed-token path dependency-free.",
+      `Issuer: ${config.issuer}`,
+    ],
+  };
 }
 
 function authorize(state: MockIdpState, url: URL, response: ServerResponse): void {
@@ -682,7 +703,11 @@ function authorize(state: MockIdpState, url: URL, response: ServerResponse): voi
   const subject = subjectWithKnobs(state.config, requestedSubject);
   if (matchesBlockedUser(subject, state.config.knobs.blockedUser)) {
     const blocked = buildBlockedUserResponse(subject);
-    sendHtml(response, blocked.status, blocked.html);
+    sendHtml(response, blocked.status, {
+      title: "OpenWork Mock IdP policy block",
+      heading: "Sign-in blocked by identity provider policy",
+      paragraphs: ["OpenWork Mock IdP policy", blocked.message, "error=access_denied"],
+    });
     return;
   }
 

--- a/evals/runner/labs/idp.ts
+++ b/evals/runner/labs/idp.ts
@@ -1,0 +1,859 @@
+import { createPublicKey, createSign, generateKeyPairSync, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const DEFAULT_DOMAIN = "acme.test";
+const DEFAULT_CLIENT_ID = "openwork-eval-oidc-client";
+const DEFAULT_CLIENT_SECRET = "openwork-eval-oidc-secret";
+const DEFAULT_ISSUER = "http://127.0.0.1/mock-openwork-idp";
+const DEFAULT_EVAL_ISSUER = "http://127.0.0.1:19190";
+const DEFAULT_GROUPS = ["Engineering", "OpenWork Lab"];
+const DEFAULT_ROLE = "member";
+
+export const MOCK_IDP_BLOCKED_USER_PHRASE = "administrator has configured the application to block users";
+
+export type MockGroupClaims =
+  | "present"
+  | "absent"
+  | "unexpected-shape"
+  | readonly string[]
+  | {
+      claim: string;
+      values: readonly string[];
+    };
+
+export interface MockIdpKnobs {
+  certTrailingNewline?: boolean;
+  wrongDomain?: boolean;
+  blockedUser?: string;
+  groupClaims?: MockGroupClaims;
+  emailMismatch?: boolean | string;
+  guestUser?: boolean;
+}
+
+export interface MockIdpSubjectInput {
+  sub?: string;
+  email?: string;
+  name?: string;
+}
+
+export interface MockIdpSubject {
+  sub: string;
+  email: string;
+  name: string;
+}
+
+export interface MockIdpConfig {
+  issuer?: string;
+  domain?: string;
+  clientId?: string;
+  clientSecret?: string;
+  defaultSubject?: MockIdpSubjectInput;
+  knobs?: MockIdpKnobs;
+}
+
+export interface NormalizedMockIdpKnobs {
+  certTrailingNewline: boolean;
+  wrongDomain: boolean;
+  blockedUser: string | null;
+  groupClaims: MockGroupClaims;
+  emailMismatch: boolean | string;
+  guestUser: boolean;
+}
+
+export interface NormalizedMockIdpConfig {
+  issuer: string;
+  domain: string;
+  clientId: string;
+  clientSecret: string;
+  defaultSubject: MockIdpSubject;
+  knobs: NormalizedMockIdpKnobs;
+}
+
+export interface MockOidcRegistration {
+  kind: "oidc";
+  issuer: string;
+  domain: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string[];
+  skipDiscovery: boolean;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksEndpoint: string;
+  userInfoEndpoint: string;
+  tokenEndpointAuthentication: "client_secret_post";
+}
+
+export interface MockSamlEndpoints {
+  metadataUrl: string;
+  ssoPostUrl: string;
+  certificate: string;
+}
+
+export interface StartedMockIdpLab {
+  protocol: "oidc";
+  config: NormalizedMockIdpConfig;
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksEndpoint: string;
+  userInfoEndpoint: string;
+  saml: MockSamlEndpoints;
+  keyId: string;
+  certificate: string;
+  publicKeyPem: string;
+  registration(overrides?: Partial<MockOidcRegistration>): MockOidcRegistration;
+  claimsFor(subject?: MockIdpSubjectInput): Record<string, unknown>;
+  stop(): Promise<void>;
+}
+
+interface KeyMaterial {
+  keyId: string;
+  privateKeyPem: string;
+  publicKeyPem: string;
+  jwk: Record<string, unknown>;
+}
+
+interface AuthorizationCodeRecord {
+  clientId: string;
+  nonce: string | null;
+  redirectUri: string;
+  subject: MockIdpSubject;
+}
+
+interface MockIdpState {
+  config: NormalizedMockIdpConfig;
+  keys: KeyMaterial;
+  codes: Map<string, AuthorizationCodeRecord>;
+  accessTokens: Map<string, Record<string, unknown>>;
+}
+
+export type SsoConfigErrorCode = "sso_cert_trailing_newline" | "sso_domain_mismatch";
+
+export interface NormalizedCertificateMaterial {
+  value: string;
+  hadTrailingNewline: boolean;
+}
+
+export interface SsoConfigurationValidationInput {
+  configuredDomain: string;
+  cert?: string | null;
+  subjectEmail?: string | null;
+}
+
+export interface SsoConfigurationError {
+  code: SsoConfigErrorCode;
+  message: string;
+  detail: string;
+}
+
+export interface SsoConfigurationValidation {
+  ok: boolean;
+  errors: SsoConfigurationError[];
+  normalizedDomain: string;
+  normalizedCert?: string;
+}
+
+export interface SsoExpectation {
+  code: SsoConfigErrorCode;
+  includes?: readonly string[];
+}
+
+export interface SsoExpectationMatch {
+  passed: boolean;
+  expectedCode: SsoConfigErrorCode;
+  actualCodes: string[];
+  detail: string;
+}
+
+export interface Rs256SigningArgvInput {
+  keyId: string;
+  payload: string;
+}
+
+export interface BlockedUserResponseShape {
+  status: 403;
+  error: "access_denied";
+  errorDescription: string;
+  message: string;
+  html: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAddressInfo(value: ReturnType<Server["address"]>): value is AddressInfo {
+  return typeof value === "object"
+    && value !== null
+    && typeof value.address === "string"
+    && typeof value.family === "string"
+    && typeof value.port === "number";
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isNamedGroupClaim(value: MockGroupClaims): value is { claim: string; values: readonly string[] } {
+  return isRecord(value) && typeof value.claim === "string" && isStringArray(value.values);
+}
+
+function cleanIssuer(value: string | undefined): string {
+  const trimmed = (value ?? DEFAULT_ISSUER).trim().replace(/\/+$/, "");
+  return trimmed || DEFAULT_ISSUER;
+}
+
+function requestedIssuer(value: string | undefined): URL | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(cleanIssuer(trimmed));
+    return url.protocol === "http:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function configuredMockIdpIssuer(input: MockIdpConfig): URL | null {
+  const evalIssuer = process.env.OPENWORK_EVAL_DEN_API_URL?.trim() ? DEFAULT_EVAL_ISSUER : undefined;
+  return requestedIssuer(input.issuer) ?? requestedIssuer(process.env.OPENWORK_EVAL_MOCK_IDP_ISSUER) ?? requestedIssuer(evalIssuer);
+}
+
+export function normalizeDomain(value: string | undefined): string {
+  const normalized = (value ?? DEFAULT_DOMAIN)
+    .trim()
+    .toLowerCase()
+    .replace(/^@+/, "")
+    .replace(/\.+$/, "");
+  return normalized || DEFAULT_DOMAIN;
+}
+
+export function emailDomain(email: string | null | undefined): string | null {
+  const value = email?.trim().toLowerCase() ?? "";
+  const at = value.lastIndexOf("@");
+  if (at < 0 || at === value.length - 1) {
+    return null;
+  }
+  return normalizeDomain(value.slice(at + 1));
+}
+
+function localPart(email: string): string {
+  const at = email.indexOf("@");
+  return at > 0 ? email.slice(0, at) : "sso.user";
+}
+
+export function buildWrongDomainEmail(email: string, configuredDomain: string): string {
+  return `${localPart(email)}@wrong-${normalizeDomain(configuredDomain)}`;
+}
+
+function defaultSubject(domain: string): MockIdpSubject {
+  const email = `sso.user@${domain}`;
+  return {
+    sub: email,
+    email,
+    name: "OpenWork SSO User",
+  };
+}
+
+function normalizeSubject(input: MockIdpSubjectInput | undefined, domain: string): MockIdpSubject {
+  const fallback = defaultSubject(domain);
+  const email = input?.email?.trim().toLowerCase() || fallback.email;
+  return {
+    sub: input?.sub?.trim() || email,
+    email,
+    name: input?.name?.trim() || fallback.name,
+  };
+}
+
+function normalizeKnobs(knobs: MockIdpKnobs | undefined): NormalizedMockIdpKnobs {
+  return {
+    certTrailingNewline: knobs?.certTrailingNewline === true,
+    wrongDomain: knobs?.wrongDomain === true,
+    blockedUser: knobs?.blockedUser?.trim() || null,
+    groupClaims: knobs?.groupClaims ?? "present",
+    emailMismatch: knobs?.emailMismatch ?? false,
+    guestUser: knobs?.guestUser === true,
+  };
+}
+
+export function normalizeMockIdpConfig(input: MockIdpConfig = {}): NormalizedMockIdpConfig {
+  const domain = normalizeDomain(input.domain);
+  return {
+    issuer: cleanIssuer(input.issuer),
+    domain,
+    clientId: input.clientId?.trim() || DEFAULT_CLIENT_ID,
+    clientSecret: input.clientSecret?.trim() || DEFAULT_CLIENT_SECRET,
+    defaultSubject: normalizeSubject(input.defaultSubject, domain),
+    knobs: normalizeKnobs(input.knobs),
+  };
+}
+
+export function normalizeCertificateMaterial(value: string | null | undefined): NormalizedCertificateMaterial {
+  const raw = value ?? "";
+  return {
+    value: raw.replace(/(?:\r?\n)+$/g, ""),
+    hadTrailingNewline: /(?:\r?\n)+$/.test(raw),
+  };
+}
+
+export function validateSsoConfiguration(input: SsoConfigurationValidationInput): SsoConfigurationValidation {
+  const normalizedDomain = normalizeDomain(input.configuredDomain);
+  const errors: SsoConfigurationError[] = [];
+  const cert = normalizeCertificateMaterial(input.cert);
+  if (input.cert !== undefined && input.cert !== null && cert.hadTrailingNewline) {
+    errors.push({
+      code: "sso_cert_trailing_newline",
+      message: "SSO certificate has trailing newline characters. Remove the blank line at the end of the pasted certificate and save again.",
+      detail: "The field POC failure was a certificate paste with a trailing newline; this matcher names it instead of surfacing a generic SSO failure.",
+    });
+  }
+
+  const subjectDomain = emailDomain(input.subjectEmail);
+  if (subjectDomain && subjectDomain !== normalizedDomain) {
+    errors.push({
+      code: "sso_domain_mismatch",
+      message: `SSO domain mismatch: IdP email domain ${subjectDomain} does not match configured organization domain ${normalizedDomain}.`,
+      detail: "The IdP subject email domain must match the organization SSO domain before users are sent through the provider.",
+    });
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    normalizedDomain,
+    normalizedCert: input.cert === undefined || input.cert === null ? undefined : cert.value,
+  };
+}
+
+export function matchSsoExpectation(validation: SsoConfigurationValidation, expectation: SsoExpectation): SsoExpectationMatch {
+  const match = validation.errors.find((error) => error.code === expectation.code) ?? null;
+  const includes = expectation.includes ?? [];
+  const haystack = match ? `${match.message}\n${match.detail}` : "";
+  const missing = includes.filter((needle) => !haystack.toLowerCase().includes(needle.toLowerCase()));
+  const passed = Boolean(match) && missing.length === 0;
+  return {
+    passed,
+    expectedCode: expectation.code,
+    actualCodes: validation.errors.map((error) => error.code),
+    detail: passed
+      ? match?.message ?? expectation.code
+      : `Expected ${expectation.code}${missing.length ? ` with text ${missing.join(", ")}` : ""}; got ${validation.errors.map((error) => error.code).join(", ") || "no errors"}.`,
+  };
+}
+
+export function buildRs256SigningArgv(input: Rs256SigningArgvInput): readonly string[] {
+  return [
+    "node:crypto",
+    "createSign",
+    "RSA-SHA256",
+    "--kid",
+    input.keyId,
+    "--payload-bytes",
+    String(Buffer.byteLength(input.payload, "utf8")),
+  ];
+}
+
+export function subjectWithKnobs(config: NormalizedMockIdpConfig, input?: MockIdpSubjectInput): MockIdpSubject {
+  const requested = normalizeSubject(input, config.domain);
+  let email = requested.email;
+  if (config.knobs.emailMismatch) {
+    email = typeof config.knobs.emailMismatch === "string" && config.knobs.emailMismatch.trim()
+      ? config.knobs.emailMismatch.trim().toLowerCase()
+      : `mismatch.${localPart(requested.email)}@${config.domain}`;
+  }
+  if (config.knobs.wrongDomain) {
+    email = buildWrongDomainEmail(email, config.domain);
+  }
+  if (config.knobs.guestUser) {
+    email = input?.email?.trim().toLowerCase() || `guest.user@external.${config.domain}`;
+  }
+  return {
+    sub: input?.sub?.trim() || (config.knobs.guestUser ? `guest:${email}` : email),
+    email,
+    name: input?.name?.trim() || requested.name,
+  };
+}
+
+function secondsSinceEpoch(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+function applyGroupClaims(claims: Record<string, unknown>, groupClaims: MockGroupClaims): void {
+  if (groupClaims === "absent") {
+    return;
+  }
+  if (groupClaims === "unexpected-shape") {
+    claims.groups = { primary: DEFAULT_GROUPS[0], all: DEFAULT_GROUPS };
+    claims.roles = { default: DEFAULT_ROLE };
+    return;
+  }
+  if (isStringArray(groupClaims)) {
+    claims.groups = [...groupClaims];
+    claims.roles = [DEFAULT_ROLE];
+    return;
+  }
+  if (isNamedGroupClaim(groupClaims)) {
+    claims[groupClaims.claim] = [...groupClaims.values];
+    claims.roles = [DEFAULT_ROLE];
+    return;
+  }
+  claims.groups = [...DEFAULT_GROUPS];
+  claims.roles = [DEFAULT_ROLE];
+}
+
+export function buildOidcClaims(input: {
+  issuer: string;
+  clientId: string;
+  subject: MockIdpSubject;
+  nonce?: string | null;
+  now?: Date;
+  expiresInSeconds?: number;
+  knobs?: NormalizedMockIdpKnobs;
+}): Record<string, unknown> {
+  const now = input.now ?? new Date();
+  const issuedAt = secondsSinceEpoch(now);
+  const knobs = input.knobs ?? normalizeKnobs(undefined);
+  const claims: Record<string, unknown> = {
+    iss: cleanIssuer(input.issuer),
+    sub: input.subject.sub,
+    aud: input.clientId,
+    iat: issuedAt,
+    exp: issuedAt + (input.expiresInSeconds ?? 300),
+    email: input.subject.email,
+    email_verified: true,
+    name: input.subject.name,
+    preferred_username: input.subject.email,
+    picture: `https://avatar.openwork.test/${encodeURIComponent(input.subject.email)}`,
+    department: "Enterprise Lab",
+  };
+  if (input.nonce) {
+    claims.nonce = input.nonce;
+  }
+  if (knobs.guestUser) {
+    claims.userType = "Guest";
+    claims.tenant_hint = "external";
+  }
+  applyGroupClaims(claims, knobs.groupClaims);
+  return claims;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+export function signOidcJwt(input: {
+  keyId: string;
+  privateKeyPem: string;
+  claims: Record<string, unknown>;
+}): string {
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT", kid: input.keyId });
+  const payload = base64UrlJson(input.claims);
+  const signingInput = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(input.privateKeyPem).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+function publicJwk(publicKeyPem: string, keyId: string): Record<string, unknown> {
+  const exported = createPublicKey(publicKeyPem).export({ format: "jwk" });
+  const jwk: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(exported)) {
+    jwk[name] = value;
+  }
+  jwk.kid = keyId;
+  jwk.use = "sig";
+  jwk.alg = "RS256";
+  return jwk;
+}
+
+function createKeyMaterial(): KeyMaterial {
+  const keyPair = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  const keyId = `mock-idp-${randomBytes(6).toString("hex")}`;
+  return {
+    keyId,
+    privateKeyPem: keyPair.privateKey,
+    publicKeyPem: keyPair.publicKey,
+    jwk: publicJwk(keyPair.publicKey, keyId),
+  };
+}
+
+function certificateFromPublicKey(publicKeyPem: string, trailingNewline: boolean): string {
+  const body = publicKeyPem
+    .split(/\r?\n/g)
+    .filter((line) => line && !line.startsWith("-----"))
+    .join("\n");
+  const cert = `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----`;
+  return trailingNewline ? `${cert}\n` : cert;
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function buildBlockedUserResponse(subject: MockIdpSubjectInput, policyName = "OpenWork Mock IdP policy"): BlockedUserResponseShape {
+  const label = subject.email?.trim() || subject.sub?.trim() || "this user";
+  const errorDescription = `The ${MOCK_IDP_BLOCKED_USER_PHRASE} unless they are assigned to the enterprise application.`;
+  const message = `${policyName} blocked ${label}. ${errorDescription} Ask an IdP administrator to assign the user or update the app assignment policy.`;
+  return {
+    status: 403,
+    error: "access_denied",
+    errorDescription,
+    message,
+    html: `<!doctype html><html><head><title>OpenWork Mock IdP policy block</title></head><body><main style="font-family: sans-serif; max-width: 720px; margin: 48px auto;"><p>OpenWork Mock IdP policy</p><h1>Sign-in blocked by identity provider policy</h1><p>${escapeHtml(message)}</p><p>error=access_denied</p></main></body></html>`,
+  };
+}
+
+function matchesBlockedUser(subject: MockIdpSubject, blockedUser: string | null): boolean {
+  if (!blockedUser) {
+    return false;
+  }
+  const blocked = blockedUser.trim().toLowerCase();
+  return subject.email.toLowerCase() === blocked || subject.sub.toLowerCase() === blocked;
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(payload);
+}
+
+function sendHtml(response: ServerResponse, status: number, body: string): void {
+  response.writeHead(status, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(body);
+}
+
+function sendRedirect(response: ServerResponse, location: string): void {
+  response.writeHead(302, {
+    location,
+    "cache-control": "no-store",
+  });
+  response.end();
+}
+
+function method(request: IncomingMessage): string {
+  return (request.method ?? "GET").toUpperCase();
+}
+
+function requestUrl(request: IncomingMessage, issuer: string): URL {
+  return new URL(request.url ?? "/", issuer);
+}
+
+function headerValue(request: IncomingMessage, name: string): string {
+  const raw = request.headers[name.toLowerCase()];
+  if (Array.isArray(raw)) {
+    return raw[0] ?? "";
+  }
+  return typeof raw === "string" ? raw : "";
+}
+
+async function requestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    if (typeof chunk === "string") {
+      chunks.push(Buffer.from(chunk));
+    } else if (Buffer.isBuffer(chunk)) {
+      chunks.push(chunk);
+    } else {
+      chunks.push(Buffer.from(String(chunk)));
+    }
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function formBody(request: IncomingMessage): Promise<URLSearchParams> {
+  return new URLSearchParams(await requestBody(request));
+}
+
+function basicClientCredentials(authorization: string): { clientId: string; clientSecret: string } | null {
+  if (!authorization.startsWith("Basic ")) {
+    return null;
+  }
+  const decoded = Buffer.from(authorization.slice("Basic ".length), "base64").toString("utf8");
+  const separator = decoded.indexOf(":");
+  if (separator < 0) {
+    return null;
+  }
+  return {
+    clientId: decodeURIComponent(decoded.slice(0, separator)),
+    clientSecret: decodeURIComponent(decoded.slice(separator + 1)),
+  };
+}
+
+function clientAuthenticated(params: URLSearchParams, authorization: string, config: NormalizedMockIdpConfig): boolean {
+  const basic = basicClientCredentials(authorization);
+  const clientId = basic?.clientId ?? params.get("client_id") ?? "";
+  const clientSecret = basic?.clientSecret ?? params.get("client_secret") ?? "";
+  return safeEqual(clientId, config.clientId) && safeEqual(clientSecret, config.clientSecret);
+}
+
+function oidcRegistration(config: NormalizedMockIdpConfig, overrides: Partial<MockOidcRegistration> = {}): MockOidcRegistration {
+  const issuer = overrides.issuer ?? config.issuer;
+  return {
+    kind: "oidc",
+    issuer,
+    domain: overrides.domain ?? config.domain,
+    clientId: overrides.clientId ?? config.clientId,
+    clientSecret: overrides.clientSecret ?? config.clientSecret,
+    scopes: overrides.scopes ?? ["openid", "email", "profile"],
+    skipDiscovery: overrides.skipDiscovery ?? false,
+    authorizationEndpoint: overrides.authorizationEndpoint ?? `${issuer}/authorize`,
+    tokenEndpoint: overrides.tokenEndpoint ?? `${issuer}/token`,
+    jwksEndpoint: overrides.jwksEndpoint ?? `${issuer}/jwks`,
+    userInfoEndpoint: overrides.userInfoEndpoint ?? `${issuer}/userinfo`,
+    tokenEndpointAuthentication: "client_secret_post",
+  };
+}
+
+function discovery(config: NormalizedMockIdpConfig): Record<string, unknown> {
+  return {
+    issuer: config.issuer,
+    authorization_endpoint: `${config.issuer}/authorize`,
+    token_endpoint: `${config.issuer}/token`,
+    jwks_uri: `${config.issuer}/jwks`,
+    userinfo_endpoint: `${config.issuer}/userinfo`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code"],
+    subject_types_supported: ["public"],
+    id_token_signing_alg_values_supported: ["RS256"],
+    token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+    scopes_supported: ["openid", "email", "profile"],
+    claims_supported: ["sub", "email", "email_verified", "name", "preferred_username", "groups", "roles", "department"],
+  };
+}
+
+function samlMetadata(config: NormalizedMockIdpConfig, certificate: string): string {
+  const certBody = certificate
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s+/g, "");
+  const entityId = escapeHtml(`${config.issuer}/saml/metadata`);
+  const ssoUrl = escapeHtml(`${config.issuer}/saml/sso`);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor entityID="${entityId}" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing"><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><X509Data><X509Certificate>${certBody}</X509Certificate></X509Data></KeyInfo></KeyDescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="${ssoUrl}"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+}
+
+function samlPostBindingPage(config: NormalizedMockIdpConfig): string {
+  return `<!doctype html><html><head><title>OpenWork Mock IdP SAML endpoint</title></head><body><main style="font-family: sans-serif; max-width: 720px; margin: 48px auto;"><p>OpenWork Mock IdP lab</p><h1>SAML POST binding endpoint</h1><p>This fixture exposes SAML metadata and a POST binding endpoint, but the OpenWork eval lab drives OIDC because this checkout implements OIDC and SAML SSO and OIDC keeps the signed-token path dependency-free.</p><p>Issuer: ${escapeHtml(config.issuer)}</p></main></body></html>`;
+}
+
+function authorize(state: MockIdpState, url: URL, response: ServerResponse): void {
+  const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+  const clientId = url.searchParams.get("client_id") ?? "";
+  if (!redirectUri || !safeEqual(clientId, state.config.clientId)) {
+    sendJson(response, 400, { error: "invalid_request", error_description: "redirect_uri and a registered client_id are required." });
+    return;
+  }
+
+  const loginHint = url.searchParams.get("login_hint") ?? undefined;
+  const requestedSubject = loginHint ? { email: loginHint } : undefined;
+  const subject = subjectWithKnobs(state.config, requestedSubject);
+  if (matchesBlockedUser(subject, state.config.knobs.blockedUser)) {
+    const blocked = buildBlockedUserResponse(subject);
+    sendHtml(response, blocked.status, blocked.html);
+    return;
+  }
+
+  const code = randomBytes(18).toString("base64url");
+  state.codes.set(code, {
+    clientId,
+    nonce: url.searchParams.get("nonce"),
+    redirectUri,
+    subject,
+  });
+
+  const callback = new URL(redirectUri);
+  callback.searchParams.set("code", code);
+  const relayState = url.searchParams.get("state");
+  if (relayState) {
+    callback.searchParams.set("state", relayState);
+  }
+  sendRedirect(response, callback.toString());
+}
+
+async function token(state: MockIdpState, request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const params = await formBody(request);
+  if (!clientAuthenticated(params, headerValue(request, "authorization"), state.config)) {
+    sendJson(response, 401, { error: "invalid_client", error_description: "The mock IdP did not recognize the OIDC client credentials." });
+    return;
+  }
+  if (params.get("grant_type") !== "authorization_code") {
+    sendJson(response, 400, { error: "unsupported_grant_type" });
+    return;
+  }
+  const code = params.get("code") ?? "";
+  const record = state.codes.get(code) ?? null;
+  if (!record) {
+    sendJson(response, 400, { error: "invalid_grant", error_description: "The authorization code was not issued by this mock IdP." });
+    return;
+  }
+  state.codes.delete(code);
+  const claims = buildOidcClaims({
+    issuer: state.config.issuer,
+    clientId: record.clientId,
+    subject: record.subject,
+    nonce: record.nonce,
+    knobs: state.config.knobs,
+  });
+  const accessToken = randomBytes(24).toString("base64url");
+  state.accessTokens.set(accessToken, claims);
+  sendJson(response, 200, {
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: 300,
+    id_token: signOidcJwt({ keyId: state.keys.keyId, privateKeyPem: state.keys.privateKeyPem, claims }),
+  });
+}
+
+function userinfo(state: MockIdpState, request: IncomingMessage, response: ServerResponse): void {
+  const authorization = headerValue(request, "authorization");
+  const tokenValue = authorization.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : "";
+  const claims = state.accessTokens.get(tokenValue) ?? null;
+  if (!claims) {
+    sendJson(response, 401, { error: "invalid_token" });
+    return;
+  }
+  sendJson(response, 200, claims);
+}
+
+async function handleRequest(state: MockIdpState, certificate: string, request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = requestUrl(request, state.config.issuer);
+  if (method(request) === "GET" && url.pathname === "/.well-known/openid-configuration") {
+    sendJson(response, 200, discovery(state.config));
+    return;
+  }
+  if (method(request) === "GET" && url.pathname === "/jwks") {
+    sendJson(response, 200, { keys: [state.keys.jwk] });
+    return;
+  }
+  if (method(request) === "GET" && url.pathname === "/authorize") {
+    authorize(state, url, response);
+    return;
+  }
+  if (method(request) === "POST" && url.pathname === "/token") {
+    await token(state, request, response);
+    return;
+  }
+  if (method(request) === "GET" && url.pathname === "/userinfo") {
+    userinfo(state, request, response);
+    return;
+  }
+  if (method(request) === "GET" && url.pathname === "/saml/metadata") {
+    response.writeHead(200, { "content-type": "application/samlmetadata+xml; charset=utf-8", "cache-control": "no-store" });
+    response.end(samlMetadata(state.config, certificate));
+    return;
+  }
+  if ((method(request) === "GET" || method(request) === "POST") && url.pathname === "/saml/sso") {
+    sendHtml(response, 200, samlPostBindingPage(state.config));
+    return;
+  }
+  sendJson(response, 404, { error: "not_found" });
+}
+
+function listen(server: Server, host: string, port: number): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (isAddressInfo(address)) {
+        resolve(address);
+        return;
+      }
+      reject(new Error("Mock IdP server did not expose a TCP port."));
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function startMockIdpLab(input: MockIdpConfig = {}): Promise<StartedMockIdpLab> {
+  const keys = createKeyMaterial();
+  const certificate = certificateFromPublicKey(keys.publicKeyPem, input.knobs?.certTrailingNewline === true);
+  const fixedIssuer = configuredMockIdpIssuer(input);
+  const state: MockIdpState = {
+    config: normalizeMockIdpConfig(input),
+    keys,
+    codes: new Map(),
+    accessTokens: new Map(),
+  };
+  const server = createServer((request, response) => {
+    void handleRequest(state, certificate, request, response).catch((error) => {
+      sendJson(response, 500, { error: "mock_idp_error", message: error instanceof Error ? error.message : String(error) });
+    });
+  });
+  const fixedPort = fixedIssuer?.port ? Number.parseInt(fixedIssuer.port, 10) : 0;
+  const address = await listen(server, fixedIssuer?.hostname ?? "127.0.0.1", fixedPort);
+  state.config = normalizeMockIdpConfig({
+    ...input,
+    issuer: fixedIssuer ? fixedIssuer.origin : `http://127.0.0.1:${address.port}`,
+  });
+
+  return {
+    protocol: "oidc",
+    config: state.config,
+    issuer: state.config.issuer,
+    authorizationEndpoint: `${state.config.issuer}/authorize`,
+    tokenEndpoint: `${state.config.issuer}/token`,
+    jwksEndpoint: `${state.config.issuer}/jwks`,
+    userInfoEndpoint: `${state.config.issuer}/userinfo`,
+    saml: {
+      metadataUrl: `${state.config.issuer}/saml/metadata`,
+      ssoPostUrl: `${state.config.issuer}/saml/sso`,
+      certificate,
+    },
+    keyId: keys.keyId,
+    certificate,
+    publicKeyPem: keys.publicKeyPem,
+    registration: (overrides = {}) => oidcRegistration(state.config, overrides),
+    claimsFor: (subject) => buildOidcClaims({
+      issuer: state.config.issuer,
+      clientId: state.config.clientId,
+      subject: subjectWithKnobs(state.config, subject),
+      knobs: state.config.knobs,
+    }),
+    stop: () => close(server),
+  };
+}

--- a/evals/voiceovers/sso-blocked-user.md
+++ b/evals/voiceovers/sso-blocked-user.md
@@ -1,0 +1,3 @@
+# SSO blocked user
+
+1. The mock IdP now behaves like an enterprise Entra tenant with app assignment turned on. When a blocked user attempts SSO, the browser lands on an actionable identity-provider policy message instead of a silent dead end.

--- a/evals/voiceovers/sso-invite-email-prevalidation.md
+++ b/evals/voiceovers/sso-invite-email-prevalidation.md
@@ -1,0 +1,5 @@
+# SSO invite email prevalidation
+
+1. We start with a real OpenWork invitation and show the invited email before SSO begins. This is the contract the identity-provider subject must satisfy.
+
+2. Then the mock IdP intentionally returns a different email for the SSO subject. OpenWork must reject the mismatch coherently and stay out of the stale-cookie invite loop.

--- a/evals/voiceovers/sso-logout-returns-to-sso.md
+++ b/evals/voiceovers/sso-logout-returns-to-sso.md
@@ -1,0 +1,5 @@
+# SSO logout return surface
+
+1. A fresh browser signs in through the mock OIDC provider and reaches the OpenWork dashboard, proving the fixture exercises the real SSO callback path.
+
+2. After logout, the browser returns to the organization SSO entry point. The old email-password login page stays hidden for this SSO-managed deployment.

--- a/evals/voiceovers/sso-misconfig-errors.md
+++ b/evals/voiceovers/sso-misconfig-errors.md
@@ -1,0 +1,5 @@
+# SSO misconfiguration contract checks
+
+1. First we recreate the certificate paste mistake from the field. The lab catches the trailing newline as its own named SSO configuration error, so the fix is obvious instead of a generic sign-in failure.
+
+2. Next we recreate the wrong-domain setup mistake. The lab compares the IdP subject domain to the configured organization domain and names the mismatch before anyone is sent through a broken SSO route.


### PR DESCRIPTION
## Why

From a 6-week enterprise POC log (customer on Entra), SSO misconfiguration was repeatedly **the single biggest blocker of the day** — and we had no way to test any of it:

- SSO misconfig blocked desktop sign-in; worked around by **turning SSO off for a day** and using username/password.
- Config failures caused by a **wrong domain** (`jda.com` vs the actual tenant domain) and by a **certificate pasted with a trailing newline**.
- `"administrator has configured the application to block users…"` — an **Entra group policy** blocked an invited user.
- **Invite accept looped into a broken state**: single-org SSO never pre-validated the invite email (plus a stale cookie).
- **Logout showed the legacy login page instead of the SSO screen.**

## What

**`evals/runner/labs/idp.ts`** — a dependency-free mock IdP: OIDC discovery/JWKS/authorize/token with RS256 signing via `node:crypto` (plus a SAML metadata fixture), with knobs that mirror the field faults: `certTrailingNewline`, `wrongDomain`, `blockedUser`, `groupClaims`, `emailMismatch`, `guestUser`.

**`evals/runner/journeys/sso.ts`** — `configureOrgSso` (drives the real `/v1/sso/oidc` registration path), `expectSsoConfigError`, `signInViaSso`, `expectSsoBlockedUserMessage`, `expectSsoScreenAfterLogout`, `expectInviteEmailPrevalidated`.

**Flows**: `sso-misconfig-errors`, `sso-blocked-user`, `sso-invite-email-prevalidation`, `sso-logout-returns-to-sso`.

## Product fixes included (the field bugs, not just tests)

- **`ee/apps/den-web/.../auth-panel.tsx`**: single-org SSO now renders the **SSO-only panel** and hides email/password/social — this is the "logout showed the legacy login page instead of the SSO screen" bug.
- Invite pages no longer redirect away in single-org SSO mode — the invite-accept loop.

## ⚠️ Flagged for review

`ee/apps/den-api/src/sso.ts` adds `isDevLoopbackIssuer` so an eval IdP on loopback can be registered without Entra domain verification. It is **gated on `env.devMode` and restricted to `127.0.0.1`/`localhost`** (returns `false` immediately when dev mode is off), so there is no production path — but it is a test affordance living in product code and deserves a deliberate ack. Happy to move it behind a dedicated env var instead if you prefer.

## Tests run

- `pnpm evals:typecheck` ✓ · `pnpm evals:test` ✓ (49)
- `pnpm evals --stack den --flow sso-blocked-user --flow sso-invite-email-prevalidation --flow sso-logout-returns-to-sso --flow sso-misconfig-errors` → **4 passed**
- `pnpm fraimz --stack den --flow sso-invite-email-prevalidation` → voiceover coverage green
- `pnpm evals --list` → 4 flows added, pre-existing lines byte-identical
- Stack torn down cleanly afterwards (`--stack-down`)

Chrome-surface/app-less throughout so this runs headless in CI; any desktop-only cell is an explicit env-gated skip.