### PR TITLE
fix(den): preserve team model access across member re-invites

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -4,6 +4,7 @@ import {
   AuthUserTable,
   ConnectedAccountTable,
   InvitationTable,
+  LlmProviderAccessTable,
   MemberTable,
   OrganizationRoleTable,
   OrganizationTable,
@@ -713,6 +714,29 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
     member = { ...existingMember, role: existingRole, joinedAt: existingJoinedAt }
   }
 
+  if (!member && removedMember && invitedMember) {
+    await db.transaction(async (tx) => {
+      // A new explicit invitation is a new access lifecycle. Keep the removed
+      // row for audit history, but activate the invitation placeholder so any
+      // teams or direct grants assigned while the invite was pending remain
+      // attached to the member who joins.
+      await tx
+        .update(MemberTable)
+        .set({ userId: null })
+        .where(eq(MemberTable.id, removedMember.id))
+      await tx
+        .update(MemberTable)
+        .set({ userId, role, joinedAt })
+        .where(eq(MemberTable.id, invitedMember.id))
+    })
+    member = {
+      ...invitedMember,
+      userId,
+      role,
+      joinedAt,
+    }
+  }
+
   if (!member && removedMember) {
     await db
       .update(MemberTable)
@@ -725,9 +749,6 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
         invitedByOrgMember: invitation.orgMemberId,
       })
       .where(eq(MemberTable.id, removedMember.id))
-    if (invitedMember && invitedMember.id !== removedMember.id) {
-      await db.delete(MemberTable).where(eq(MemberTable.id, invitedMember.id))
-    }
     member = {
       ...removedMember,
       role,
@@ -1886,6 +1907,10 @@ export async function removeOrganizationMember(input: {
     await tx
       .delete(TeamMemberTable)
       .where(eq(TeamMemberTable.orgMembershipId, member.id))
+
+    await tx
+      .delete(LlmProviderAccessTable)
+      .where(eq(LlmProviderAccessTable.orgMembershipId, member.id))
 
     await tx
       .update(MemberTable)

--- a/ee/apps/den-api/test/llm-provider-team-inheritance.test.ts
+++ b/ee/apps/den-api/test/llm-provider-team-inheritance.test.ts
@@ -1,0 +1,413 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { serializeSignedCookie } from "better-call"
+
+const API_ORIGIN = "http://127.0.0.1:8790"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_model_team_inheritance"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? API_ORIGIN
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? API_ORIGIN
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function providerNames(payload: unknown) {
+  if (!isRecord(payload) || !Array.isArray(payload.llmProviders)) {
+    throw new Error("LLM provider response did not include llmProviders")
+  }
+
+  return payload.llmProviders.flatMap((provider) =>
+    isRecord(provider) && typeof provider.name === "string" ? [provider.name] : [],
+  )
+}
+
+function providerId(payload: unknown) {
+  if (
+    !isRecord(payload)
+    || !isRecord(payload.llmProvider)
+    || typeof payload.llmProvider.id !== "string"
+  ) {
+    throw new Error("LLM provider response did not include an id")
+  }
+
+  return payload.llmProvider.id
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+
+const ownerUserId = createDenTypeId("user")
+const futureUserId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const ownerMemberId = createDenTypeId("member")
+const futureMemberId = createDenTypeId("member")
+const ownerSessionId = createDenTypeId("session")
+const futureSessionId = createDenTypeId("session")
+const rejoinSessionId = createDenTypeId("session")
+const rejoinInvitationId = createDenTypeId("invitation")
+const rejoinMemberId = createDenTypeId("member")
+const ownerSessionToken = `model-team-owner-${ownerSessionId}`
+const futureSessionToken = `model-team-future-${futureSessionId}`
+const rejoinSessionToken = `model-team-rejoin-${rejoinSessionId}`
+const teamId = createDenTypeId("team")
+let ownerCookie = ""
+let futureMemberCookie = ""
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appModule, dbModule, schemaModule, drizzleModule] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+  ])
+  app = appModule.default
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+
+  await db.insert(schema.AuthUserTable).values({
+    id: ownerUserId,
+    name: "Model Team Owner",
+    email: `model-team-owner+${ownerUserId}@test.local`,
+    emailVerified: true,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Model Team Inheritance",
+    slug: `model-team-inheritance-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: ownerMemberId,
+    organizationId,
+    userId: ownerUserId,
+    role: "owner",
+  })
+  await db.insert(schema.AuthSessionTable).values({
+    id: ownerSessionId,
+    userId: ownerUserId,
+    activeOrganizationId: organizationId,
+    token: ownerSessionToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  await db.insert(schema.TeamTable).values({
+    id: teamId,
+    organizationId,
+    name: "Engineering",
+  })
+
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET
+  if (!betterAuthSecret) {
+    throw new Error("BETTER_AUTH_SECRET is required")
+  }
+  ownerCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    ownerSessionToken,
+    betterAuthSecret,
+  )
+})
+
+afterAll(async () => {
+  if (!db || !schema || !drizzle) {
+    mock.restore()
+    return
+  }
+
+  await db.delete(schema.TeamMemberTable).where(drizzle.eq(schema.TeamMemberTable.teamId, teamId))
+  await db.delete(schema.LlmProviderAccessTable).where(
+    drizzle.inArray(
+      schema.LlmProviderAccessTable.llmProviderId,
+      db
+        .select({ id: schema.LlmProviderTable.id })
+        .from(schema.LlmProviderTable)
+        .where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId)),
+    ),
+  )
+  await db.delete(schema.LlmProviderModelTable).where(
+    drizzle.inArray(
+      schema.LlmProviderModelTable.llmProviderId,
+      db
+        .select({ id: schema.LlmProviderTable.id })
+        .from(schema.LlmProviderTable)
+        .where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId)),
+    ),
+  )
+  await db.delete(schema.LlmProviderTable).where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId))
+  await db.delete(schema.AuthSessionTable).where(
+    drizzle.inArray(schema.AuthSessionTable.id, [ownerSessionId, futureSessionId, rejoinSessionId]),
+  )
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.organizationId, organizationId))
+  await db.delete(schema.TeamTable).where(drizzle.eq(schema.TeamTable.id, teamId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(
+    drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, futureUserId]),
+  )
+  mock.restore()
+})
+
+async function createProvider(input: {
+  name: string
+  providerId: string
+  allMembers?: boolean
+  cookie?: string
+  memberIds?: string[]
+  teamIds?: string[]
+}) {
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/llm-providers`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: input.cookie ?? ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({
+      name: input.name,
+      source: "custom",
+      customConfig: {
+        id: input.providerId,
+        name: input.name,
+        npm: "@ai-sdk/openai-compatible",
+        env: ["MODEL_TEAM_TEST_API_KEY"],
+        models: [{ id: `${input.providerId}-model`, name: `${input.name} Model` }],
+      },
+      allMembers: input.allMembers,
+      memberIds: input.memberIds ?? [],
+      teamIds: input.teamIds ?? [],
+    }),
+  }))
+  const payload: unknown = await response.json()
+  expect(response.status).toBe(201)
+  return providerId(payload)
+}
+
+async function listProvidersForFutureMember(scope: "usable" | "manageable" = "usable") {
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/llm-providers?scope=${scope}`, {
+    headers: {
+      cookie: futureMemberCookie,
+      origin: API_ORIGIN,
+    },
+  }))
+  expect(response.status).toBe(200)
+  return response.json()
+}
+
+async function setEngineeringTeamMembers(memberIds: string[]) {
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/teams/${teamId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({ memberIds }),
+  }))
+  expect(response.status).toBe(200)
+}
+
+test("team model inheritance survives re-invites without restoring stale member access", async () => {
+  const teamProviderId = await createProvider({
+    name: "Engineering Models",
+    providerId: "engineering-models",
+    teamIds: [teamId],
+  })
+  await createProvider({
+    name: "Everyone Models",
+    providerId: "everyone-models",
+    allMembers: true,
+  })
+
+  await db.insert(schema.AuthUserTable).values({
+    id: futureUserId,
+    name: "Future Model Team Member",
+    email: `model-team-future+${futureUserId}@test.local`,
+    emailVerified: true,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: futureMemberId,
+    organizationId,
+    userId: futureUserId,
+    role: "member",
+  })
+  await db.insert(schema.AuthSessionTable).values({
+    id: futureSessionId,
+    userId: futureUserId,
+    activeOrganizationId: organizationId,
+    token: futureSessionToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET
+  if (!betterAuthSecret) {
+    throw new Error("BETTER_AUTH_SECRET is required")
+  }
+  futureMemberCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    futureSessionToken,
+    betterAuthSecret,
+  )
+
+  expect(providerNames(await listProvidersForFutureMember())).toEqual(["Everyone Models"])
+
+  await setEngineeringTeamMembers([futureMemberId])
+
+  expect(providerNames(await listProvidersForFutureMember()).sort()).toEqual([
+    "Engineering Models",
+    "Everyone Models",
+  ])
+
+  const connectResponse = await app.fetch(new Request(
+    `${API_ORIGIN}/v1/llm-providers/${teamProviderId}/connect`,
+    {
+      headers: {
+        cookie: futureMemberCookie,
+        origin: API_ORIGIN,
+      },
+    },
+  ))
+  expect(connectResponse.status).toBe(200)
+  await expect(connectResponse.json()).resolves.toMatchObject({
+    llmProvider: {
+      id: teamProviderId,
+      models: [{ id: "engineering-models-model" }],
+    },
+  })
+
+  await setEngineeringTeamMembers([])
+
+  expect(providerNames(await listProvidersForFutureMember())).toEqual(["Everyone Models"])
+
+  const formerMemberProviderId = await createProvider({
+    name: "Former Member Models",
+    providerId: "former-member-models",
+    cookie: futureMemberCookie,
+  })
+  expect(providerNames(await listProvidersForFutureMember()).sort()).toEqual([
+    "Everyone Models",
+    "Former Member Models",
+  ])
+
+  const removeResponse = await app.fetch(new Request(
+    `${API_ORIGIN}/v1/members/${futureMemberId}`,
+    {
+      method: "DELETE",
+      headers: {
+        cookie: ownerCookie,
+        origin: API_ORIGIN,
+      },
+    },
+  ))
+  expect(removeResponse.status).toBe(204)
+
+  const staleAccess = await db
+    .select()
+    .from(schema.LlmProviderAccessTable)
+    .where(drizzle.eq(schema.LlmProviderAccessTable.orgMembershipId, futureMemberId))
+  expect(staleAccess).toHaveLength(0)
+
+  await db.insert(schema.InvitationTable).values({
+    id: rejoinInvitationId,
+    organizationId,
+    email: `model-team-future+${futureUserId}@test.local`,
+    role: "member",
+    status: "pending",
+    inviterId: ownerUserId,
+    orgMemberId: ownerMemberId,
+    inviteToken: `model-team-rejoin-${rejoinInvitationId}`,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  await db.insert(schema.MemberTable).values({
+    id: rejoinMemberId,
+    organizationId,
+    userId: null,
+    inviteId: rejoinInvitationId,
+    invitedByOrgMember: ownerMemberId,
+    role: "member",
+    joinedAt: null,
+  })
+
+  await setEngineeringTeamMembers([rejoinMemberId])
+  await createProvider({
+    name: "Rejoin Direct Models",
+    providerId: "rejoin-direct-models",
+    memberIds: [rejoinMemberId],
+  })
+
+  await db.insert(schema.AuthSessionTable).values({
+    id: rejoinSessionId,
+    userId: futureUserId,
+    activeOrganizationId: null,
+    token: rejoinSessionToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  const betterAuthSecretForRejoin = process.env.BETTER_AUTH_SECRET
+  if (!betterAuthSecretForRejoin) {
+    throw new Error("BETTER_AUTH_SECRET is required")
+  }
+  futureMemberCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    rejoinSessionToken,
+    betterAuthSecretForRejoin,
+  )
+
+  const acceptResponse = await app.fetch(new Request(
+    `${API_ORIGIN}/v1/orgs/invitations/accept`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: futureMemberCookie,
+        origin: API_ORIGIN,
+      },
+      body: JSON.stringify({ id: rejoinInvitationId }),
+    },
+  ))
+  expect(acceptResponse.status).toBe(200)
+
+  const lifecycleRows = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.inArray(schema.MemberTable.id, [futureMemberId, rejoinMemberId]))
+  const removedMember = lifecycleRows.find((member) => member.id === futureMemberId)
+  const rejoinedMember = lifecycleRows.find((member) => member.id === rejoinMemberId)
+  expect(removedMember?.userId).toBeNull()
+  expect(removedMember?.removedAt).toBeInstanceOf(Date)
+  expect(rejoinedMember?.userId).toBe(futureUserId)
+  expect(rejoinedMember?.removedAt).toBeNull()
+
+  expect(providerNames(await listProvidersForFutureMember()).sort()).toEqual([
+    "Engineering Models",
+    "Everyone Models",
+    "Rejoin Direct Models",
+  ])
+  expect(providerNames(await listProvidersForFutureMember("manageable"))).not.toContain(
+    "Former Member Models",
+  )
+
+  const formerProviderResponse = await app.fetch(new Request(
+    `${API_ORIGIN}/v1/llm-providers/${formerMemberProviderId}/connect`,
+    {
+      headers: {
+        cookie: futureMemberCookie,
+        origin: API_ORIGIN,
+      },
+    },
+  ))
+  expect(formerProviderResponse.status).toBe(403)
+})

--- a/ee/apps/den-api/test/member-removal-rejoin.test.ts
+++ b/ee/apps/den-api/test/member-removal-rejoin.test.ts
@@ -209,7 +209,7 @@ test("bootstrap returns null for a user with a removed member row", async () => 
   expect(rows[0]?.removedAt).toBeInstanceOf(Date)
 })
 
-test("a new explicit invitation revives the same removed member row", async () => {
+test("a new explicit invitation activates its placeholder as a fresh member lifecycle", async () => {
   if (!db || !schema || !orgs || !drizzle) {
     throw new Error("test modules not initialized")
   }
@@ -242,21 +242,27 @@ test("a new explicit invitation revives the same removed member row", async () =
     throw new Error("invite was not accepted")
   }
 
-  expect(accepted.member.id).toBe(removedMemberId)
+  expect(accepted.member.id).toBe(placeholderId)
   const rows = await db
     .select()
     .from(schema.MemberTable)
     .where(drizzle.inArray(schema.MemberTable.id, [removedMemberId, placeholderId]))
-  expect(rows).toHaveLength(1)
-  expect(rows[0]?.id).toBe(removedMemberId)
-  expect(rows[0]?.userId).toBe(reviveUserId)
-  expect(rows[0]?.role).toBe("admin")
-  expect(rows[0]?.removedAt).toBeNull()
-  expect(rows[0]?.removedByOrgMember).toBeNull()
-  expect(rows[0]?.inviteId).toBe(invitationId)
-  expect(rows[0]?.invitedByOrgMember).toBe(ownerMemberId)
-  expect(rows[0]?.joinedAt).toBeInstanceOf(Date)
-  expect(rows[0]?.joinedAt?.getTime()).not.toBe(past.getTime())
+  expect(rows).toHaveLength(2)
+
+  const removedRow = rows.find((row) => row.id === removedMemberId)
+  expect(removedRow?.userId).toBeNull()
+  expect(removedRow?.role).toBe("owner")
+  expect(removedRow?.removedAt).toBeInstanceOf(Date)
+  expect(removedRow?.removedByOrgMember).toBe(ownerMemberId)
+
+  const acceptedRow = rows.find((row) => row.id === placeholderId)
+  expect(acceptedRow?.userId).toBe(reviveUserId)
+  expect(acceptedRow?.role).toBe("admin")
+  expect(acceptedRow?.removedAt).toBeNull()
+  expect(acceptedRow?.removedByOrgMember).toBeNull()
+  expect(acceptedRow?.inviteId).toBe(invitationId)
+  expect(acceptedRow?.invitedByOrgMember).toBe(ownerMemberId)
+  expect(acceptedRow?.joinedAt).toBeInstanceOf(Date)
 })
 
 test("an old accepted invitation reports membership_removed for removed users", async () => {


### PR DESCRIPTION
## Summary

- preserve team and direct model-provider assignments made to a pending member when they accept a re-invite
- treat an explicit re-invite as a fresh membership/access lifecycle instead of reviving the removed membership identity
- remove direct LLM-provider grants when a member is removed so stale access cannot return later
- add route-level coverage for Everyone access, team inheritance, removal, pending-member pre-assignment, re-acceptance, and stale creator access

## Root cause

Den already resolves model access through team membership, so an admin can assign a provider to a team once and every active team member inherits it without per-user assignment.

The break was in the re-invite lifecycle:

1. Removing a member soft-deleted their membership and removed their team links, but left direct LLM-provider grants attached to the old membership ID.
2. Re-inviting created a new pending membership placeholder. Admins could assign that placeholder to teams or directly to providers before acceptance.
3. Accepting the invite revived the old membership ID and deleted the pending placeholder.

That combination discarded the new team/direct assignments and could reactivate old direct grants or provider-creator management rights.

## New behavior

For a normal explicit re-invite, acceptance now activates the invitation placeholder as the user's new membership:

- team and direct provider assignments made while the invite is pending remain attached
- the previous removed membership remains as audit history, with its user identity detached
- old membership-ID-based creator permissions cannot become active again
- direct provider grants are cleared during removal
- Everyone and team-level provider grants continue to be inherited dynamically; admins do not need to assign the same models to every member

Legacy invite records without a pending member placeholder keep the existing fallback behavior.

## Verification

```text
./bin/openwork-hub run enterprise model-team-inheritance -- \
  pnpm --filter @openwork-ee/den-api exec bun test \
  test/llm-provider-team-inheritance.test.ts \
  test/member-removal-rejoin.test.ts
```

Result: 6 tests passed, 0 failed, 52 assertions.

The route-level test verifies:

- a new member automatically receives Everyone providers
- team membership automatically grants the team's models and allows provider connection
- removing team membership removes that access
- member removal clears direct provider grants
- a pending re-invite can be assigned to a team and provider before acceptance
- accepting the re-invite preserves those new assignments
- the re-added user cannot manage or connect to a provider available only through their former membership

No database migration is required.
