### PR TITLE
fix(den): harden expired and legacy re-invite lifecycles

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -738,25 +738,33 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
   }
 
   if (!member && removedMember) {
-    await db
-      .update(MemberTable)
-      .set({
+    const memberId = createDenTypeId("member")
+    const createdMembers = await db.transaction(async (tx) => {
+      // Legacy invitations may not have a pending member placeholder. They
+      // still represent a fresh access lifecycle, so detach the audit row and
+      // create a new membership instead of reviving stale membership grants.
+      await tx
+        .update(MemberTable)
+        .set({ userId: null })
+        .where(eq(MemberTable.id, removedMember.id))
+      await tx.insert(MemberTable).values({
+        id: memberId,
+        organizationId: invitation.organizationId,
+        userId,
         role,
         joinedAt,
-        removedAt: null,
-        removedByOrgMember: null,
         inviteId: invitation.id,
         invitedByOrgMember: invitation.orgMemberId,
       })
-      .where(eq(MemberTable.id, removedMember.id))
-    member = {
-      ...removedMember,
-      role,
-      joinedAt,
-      removedAt: null,
-      removedByOrgMember: null,
-      inviteId: invitation.id,
-      invitedByOrgMember: invitation.orgMemberId,
+      return tx
+        .select()
+        .from(MemberTable)
+        .where(eq(MemberTable.id, memberId))
+        .limit(1)
+    })
+    member = createdMembers[0]
+    if (!member) {
+      throw new Error("failed_to_create_member")
     }
   }
 

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -53,6 +53,12 @@ const invitePaymentRequiredSchema = z.object({
   freeSeatCount: z.number(),
   message: z.string(),
 }).meta({ ref: "InvitePaymentRequiredError" })
+
+const invitationNotPendingSchema = z.object({
+  error: z.literal("invitation_not_pending"),
+  message: z.string(),
+  status: z.string(),
+}).meta({ ref: "InvitationNotPendingError" })
 
 type InvitationId = typeof InvitationTable.$inferSelect.id
 
@@ -158,9 +164,9 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
           eq(InvitationTable.organizationId, payload.organization.id),
           eq(InvitationTable.email, email),
           eq(InvitationTable.status, "pending"),
-          gt(InvitationTable.expiresAt, new Date()),
         ),
       )
+      .orderBy(desc(InvitationTable.createdAt))
       .limit(1)
 
     if (existingInvitation[0]) {
@@ -333,6 +339,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         401: jsonResponse("The caller must be signed in to cancel invitations.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can cancel invitations.", forbiddenSchema),
         404: jsonResponse("The invitation or organization could not be found.", notFoundSchema),
+        409: jsonResponse("The invitation is no longer pending and cannot be canceled.", invitationNotPendingSchema),
       },
     }),
     orgRoleRoute(["admin"]),
@@ -365,6 +372,14 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
 
     if (!invitationRows[0]) {
       return c.json({ error: "invitation_not_found" }, 404)
+    }
+
+    if (invitationRows[0].status !== "pending") {
+      return c.json({
+        error: "invitation_not_pending",
+        message: "Only pending invitations can be canceled.",
+        status: invitationRows[0].status,
+      }, 409)
     }
 
     const invitedMemberRows = await db

--- a/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
+++ b/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { serializeSignedCookie } from "better-call"
+
+const API_ORIGIN = "http://127.0.0.1:8790"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_invitation_lifecycle"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? API_ORIGIN
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? API_ORIGIN
+  process.env.OPENWORK_DEV_MODE = "1"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+
+const ownerUserId = createDenTypeId("user")
+const invitedUserId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const ownerMemberId = createDenTypeId("member")
+const invitedMemberId = createDenTypeId("member")
+const ownerSessionId = createDenTypeId("session")
+const invitationId = createDenTypeId("invitation")
+const teamId = createDenTypeId("team")
+const teamMemberId = createDenTypeId("teamMember")
+const ownerSessionToken = `invitation-lifecycle-owner-${ownerSessionId}`
+const invitedEmail = `invitation-lifecycle+${invitedUserId}@test.local`
+const originalInviteToken = `expired-${invitationId}`
+let ownerCookie = ""
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appModule, dbModule, schemaModule, drizzleModule] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+  ])
+  app = appModule.default
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+
+  await db.insert(schema.AuthUserTable).values([
+    {
+      id: ownerUserId,
+      name: "Invitation Lifecycle Owner",
+      email: `invitation-lifecycle-owner+${ownerUserId}@test.local`,
+      emailVerified: true,
+    },
+    {
+      id: invitedUserId,
+      name: "Invitation Lifecycle Member",
+      email: invitedEmail,
+      emailVerified: true,
+    },
+  ])
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Invitation Lifecycle Hardening",
+    slug: `invitation-lifecycle-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values([
+    {
+      id: ownerMemberId,
+      organizationId,
+      userId: ownerUserId,
+      role: "owner",
+    },
+    {
+      id: invitedMemberId,
+      organizationId,
+      userId: null,
+      inviteId: invitationId,
+      invitedByOrgMember: ownerMemberId,
+      role: "member",
+      joinedAt: null,
+    },
+  ])
+  await db.insert(schema.AuthSessionTable).values({
+    id: ownerSessionId,
+    userId: ownerUserId,
+    activeOrganizationId: organizationId,
+    token: ownerSessionToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  await db.insert(schema.InvitationTable).values({
+    id: invitationId,
+    organizationId,
+    email: invitedEmail,
+    role: "member",
+    status: "pending",
+    inviterId: ownerUserId,
+    orgMemberId: ownerMemberId,
+    inviteToken: originalInviteToken,
+    expiresAt: new Date(Date.now() - 60_000),
+  })
+  await db.insert(schema.TeamTable).values({
+    id: teamId,
+    organizationId,
+    name: "Invitation Lifecycle Team",
+  })
+  await db.insert(schema.TeamMemberTable).values({
+    id: teamMemberId,
+    teamId,
+    orgMembershipId: invitedMemberId,
+  })
+
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET
+  if (!betterAuthSecret) {
+    throw new Error("BETTER_AUTH_SECRET is required")
+  }
+  ownerCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    ownerSessionToken,
+    betterAuthSecret,
+  )
+})
+
+afterAll(async () => {
+  if (!db || !schema || !drizzle) {
+    mock.restore()
+    return
+  }
+
+  await db.delete(schema.AuditEventTable).where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
+  await db.delete(schema.TeamMemberTable).where(drizzle.eq(schema.TeamMemberTable.teamId, teamId))
+  await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, ownerSessionId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.organizationId, organizationId))
+  await db.delete(schema.TeamTable).where(drizzle.eq(schema.TeamTable.id, teamId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(
+    drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, invitedUserId]),
+  )
+  mock.restore()
+})
+
+test("resending an expired invite refreshes its pending member and assignments in place", async () => {
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/invitations`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({ email: invitedEmail, role: "admin" }),
+  }))
+  const payload: unknown = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(isRecord(payload) && payload.invitationId).toBe(invitationId)
+
+  const invitations = await db
+    .select()
+    .from(schema.InvitationTable)
+    .where(drizzle.and(
+      drizzle.eq(schema.InvitationTable.organizationId, organizationId),
+      drizzle.eq(schema.InvitationTable.email, invitedEmail),
+    ))
+  expect(invitations).toHaveLength(1)
+  expect(invitations[0]?.id).toBe(invitationId)
+  expect(invitations[0]?.inviteToken).not.toBe(originalInviteToken)
+  expect(invitations[0]?.expiresAt.getTime()).toBeGreaterThan(Date.now())
+
+  const pendingMembers = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.and(
+      drizzle.eq(schema.MemberTable.organizationId, organizationId),
+      drizzle.eq(schema.MemberTable.inviteId, invitationId),
+      drizzle.isNull(schema.MemberTable.removedAt),
+    ))
+  expect(pendingMembers).toHaveLength(1)
+  expect(pendingMembers[0]?.id).toBe(invitedMemberId)
+  expect(pendingMembers[0]?.role).toBe("admin")
+
+  const teamMembers = await db
+    .select()
+    .from(schema.TeamMemberTable)
+    .where(drizzle.eq(schema.TeamMemberTable.orgMembershipId, invitedMemberId))
+  expect(teamMembers).toHaveLength(1)
+  expect(teamMembers[0]?.id).toBe(teamMemberId)
+})
+
+test("an accepted invitation cannot be canceled by stale admin state", async () => {
+  await db
+    .update(schema.InvitationTable)
+    .set({ status: "accepted" })
+    .where(drizzle.eq(schema.InvitationTable.id, invitationId))
+  await db
+    .update(schema.MemberTable)
+    .set({ userId: invitedUserId, joinedAt: new Date() })
+    .where(drizzle.eq(schema.MemberTable.id, invitedMemberId))
+
+  const response = await app.fetch(new Request(
+    `${API_ORIGIN}/v1/invitations/${invitationId}/cancel`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: ownerCookie,
+        origin: API_ORIGIN,
+      },
+      body: JSON.stringify({}),
+    },
+  ))
+  const payload: unknown = await response.json()
+
+  expect(response.status).toBe(409)
+  expect(payload).toEqual({
+    error: "invitation_not_pending",
+    message: "Only pending invitations can be canceled.",
+    status: "accepted",
+  })
+
+  const invitations = await db
+    .select()
+    .from(schema.InvitationTable)
+    .where(drizzle.eq(schema.InvitationTable.id, invitationId))
+  expect(invitations[0]?.status).toBe("accepted")
+
+  const members = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.eq(schema.MemberTable.id, invitedMemberId))
+  expect(members[0]?.removedAt).toBeNull()
+})

--- a/ee/apps/den-api/test/member-removal-rejoin.test.ts
+++ b/ee/apps/den-api/test/member-removal-rejoin.test.ts
@@ -11,6 +11,7 @@ const ownerMemberId = createDenTypeId("member")
 const removedUserId = createDenTypeId("user")
 const bootstrapUserId = createDenTypeId("user")
 const reviveUserId = createDenTypeId("user")
+const legacyReviveUserId = createDenTypeId("user")
 const oldInviteUserId = createDenTypeId("user")
 const scimUserId = createDenTypeId("user")
 
@@ -18,10 +19,11 @@ const ownerEmail = `owner+${ownerUserId}@member-removal.test`
 const removedEmail = `removed+${removedUserId}@member-removal.test`
 const bootstrapEmail = `bootstrap+${bootstrapUserId}@member-removal.test`
 const reviveEmail = `revive+${reviveUserId}@member-removal.test`
+const legacyReviveEmail = `legacy-revive+${legacyReviveUserId}@member-removal.test`
 const oldInviteEmail = `old-invite+${oldInviteUserId}@member-removal.test`
 const scimEmail = `scim+${scimUserId}@member-removal.test`
 
-const userIds = [ownerUserId, removedUserId, bootstrapUserId, reviveUserId, oldInviteUserId, scimUserId]
+const userIds = [ownerUserId, removedUserId, bootstrapUserId, reviveUserId, legacyReviveUserId, oldInviteUserId, scimUserId]
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -145,6 +147,7 @@ beforeAll(async () => {
     { id: removedUserId, name: "Removed User", email: removedEmail, emailVerified: true },
     { id: bootstrapUserId, name: "Bootstrap Removed", email: bootstrapEmail, emailVerified: true },
     { id: reviveUserId, name: "Revive Removed", email: reviveEmail, emailVerified: true },
+    { id: legacyReviveUserId, name: "Legacy Revive Removed", email: legacyReviveEmail, emailVerified: true },
     { id: oldInviteUserId, name: "Old Invite Removed", email: oldInviteEmail, emailVerified: true },
     { id: scimUserId, name: "SCIM Removed", email: scimEmail, emailVerified: true },
   ])
@@ -263,6 +266,57 @@ test("a new explicit invitation activates its placeholder as a fresh member life
   expect(acceptedRow?.inviteId).toBe(invitationId)
   expect(acceptedRow?.invitedByOrgMember).toBe(ownerMemberId)
   expect(acceptedRow?.joinedAt).toBeInstanceOf(Date)
+})
+
+test("a legacy invitation without a placeholder still creates a fresh member lifecycle", async () => {
+  if (!db || !schema || !orgs || !drizzle) {
+    throw new Error("test modules not initialized")
+  }
+
+  const removedMemberId = createDenTypeId("member")
+  const invitationId = createDenTypeId("invitation")
+  await db.insert(schema.MemberTable).values({
+    id: removedMemberId,
+    organizationId,
+    userId: legacyReviveUserId,
+    role: "admin",
+    joinedAt: past,
+    removedAt: past,
+    removedByOrgMember: ownerMemberId,
+  })
+  await createInvitation({
+    invitationId,
+    memberId: createDenTypeId("member"),
+    email: legacyReviveEmail,
+    role: "member",
+    createPlaceholder: false,
+  })
+
+  const accepted = await orgs.acceptInvitationForUser({
+    userId: legacyReviveUserId,
+    email: legacyReviveEmail,
+    invitationId,
+  })
+  if (!accepted || accepted.status !== "accepted") {
+    throw new Error("legacy invite was not accepted")
+  }
+
+  expect(accepted.member.id).not.toBe(removedMemberId)
+  const rows = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.inArray(schema.MemberTable.id, [removedMemberId, accepted.member.id]))
+  expect(rows).toHaveLength(2)
+
+  const removedRow = rows.find((row) => row.id === removedMemberId)
+  expect(removedRow?.userId).toBeNull()
+  expect(removedRow?.removedAt).toBeInstanceOf(Date)
+
+  const acceptedRow = rows.find((row) => row.id === accepted.member.id)
+  expect(acceptedRow?.userId).toBe(legacyReviveUserId)
+  expect(acceptedRow?.role).toBe("member")
+  expect(acceptedRow?.inviteId).toBe(invitationId)
+  expect(acceptedRow?.removedAt).toBeNull()
 })
 
 test("an old accepted invitation reports membership_removed for removed users", async () => {


### PR DESCRIPTION
## Summary

- refresh expired pending invitations in place instead of creating a second pending member
- preserve team and other membership assignments attached to that pending member when the invite is resent
- reject attempts to cancel invitations that have already been accepted
- make legacy re-invites without a pending placeholder create a fresh membership identity instead of reviving the removed one

## Root causes

### Expired resend duplicated pending members

The resend lookup only considered unexpired pending invitations. Once an invite expired, submitting the same email created a new invitation and member placeholder while leaving the expired placeholder active.

That caused several related problems:

- pending users could appear twice
- the expired placeholder continued to count as a seat
- team, model, policy, or capability assignments made to the first placeholder were stranded
- admins could edit or cancel the wrong pending row

The lookup now treats the newest pending invitation as refreshable even after expiration. It rotates the token and expiry on the same invitation and keeps the same pending membership ID.

### Accepted invitations could be canceled

The cancel route loaded any invitation by ID and unconditionally changed its status to `canceled`. A stale browser action or direct API request could therefore rewrite an already-accepted invitation.

Cancellation now requires the stored status to be `pending`; otherwise the API returns `409 invitation_not_pending` without modifying the invitation or member.

### Legacy re-invites could restore stale access

Current invites create pending member placeholders, but legacy invitation rows may not have one. That fallback still revived the old removed membership ID, which could reactivate permissions tied to that ID.

Legacy acceptance now detaches the removed audit row and creates a fresh active membership, matching the access-lifecycle semantics of current invitations.

## Verification

Focused Den lifecycle suite:

```text
./bin/openwork-hub run enterprise reinvite-lifecycle-audit -- \
  pnpm --filter @openwork-ee/den-api exec bun test \
  test/invitation-lifecycle-hardening.test.ts \
  test/member-removal-rejoin.test.ts \
  test/llm-provider-team-inheritance.test.ts
```

Result: 9 tests passed, 0 failed, 75 assertions.

Den API build:

```text
./bin/openwork-hub run enterprise reinvite-lifecycle-audit -- \
  pnpm --filter @openwork-ee/den-api build
```

Result: passed.

End-to-end browser journey against the isolated Den stack:

```text
./bin/openwork-hub run enterprise reinvite-lifecycle-audit -- \
  pnpm evals --stack den --flow invite-reliability
```

Result: passed all 9 cells with 0 failures. The journey covered invite creation, separate-browser acceptance, consumed-link reopening, exactly-one membership, invalid-token handling, removal, re-invite, role preservation, and cleanup.

A local `fraimz.html` was generated by the run; it was not posted to the PR.

## Risk and compatibility

- no database migration is required
- existing accepted/canceled invitation history is preserved
- canceled invitations still start a fresh lifecycle when invited again
- expired pending invites now retain their existing assignments by design
