### PR TITLE
fix(den): revoke all member-scoped access on removal

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -2,12 +2,18 @@ import { and, asc, count, eq, gt, inArray, isNotNull, isNull, sql } from "@openw
 import {
   AuthSessionTable,
   AuthUserTable,
+  ConfigObjectAccessGrantTable,
   ConnectedAccountTable,
+  ConnectorInstanceAccessGrantTable,
+  DesktopPolicyMemberTable,
+  ExternalMcpConnectionAccessGrantTable,
   InvitationTable,
   LlmProviderAccessTable,
+  MarketplaceAccessGrantTable,
   MemberTable,
   OrganizationRoleTable,
   OrganizationTable,
+  PluginAccessGrantTable,
   SsoConnectionTable,
   TeamMemberTable,
   TeamTable,
@@ -1904,6 +1910,7 @@ export async function removeOrganizationMember(input: {
     }
 
     const member = memberRow.member
+    const removedAt = new Date()
 
     await tx
       .delete(ConnectedAccountTable)
@@ -1921,8 +1928,58 @@ export async function removeOrganizationMember(input: {
       .where(eq(LlmProviderAccessTable.orgMembershipId, member.id))
 
     await tx
+      .delete(DesktopPolicyMemberTable)
+      .where(and(
+        eq(DesktopPolicyMemberTable.organizationId, input.organizationId),
+        eq(DesktopPolicyMemberTable.orgMemberId, member.id),
+      ))
+
+    await tx
+      .delete(ExternalMcpConnectionAccessGrantTable)
+      .where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.orgMembershipId, member.id),
+      ))
+
+    await tx
+      .update(MarketplaceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(MarketplaceAccessGrantTable.organizationId, input.organizationId),
+        eq(MarketplaceAccessGrantTable.orgMembershipId, member.id),
+        isNull(MarketplaceAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConfigObjectAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConfigObjectAccessGrantTable.organizationId, input.organizationId),
+        eq(ConfigObjectAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConfigObjectAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(PluginAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(PluginAccessGrantTable.organizationId, input.organizationId),
+        eq(PluginAccessGrantTable.orgMembershipId, member.id),
+        isNull(PluginAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConnectorInstanceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConnectorInstanceAccessGrantTable.organizationId, input.organizationId),
+        eq(ConnectorInstanceAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConnectorInstanceAccessGrantTable.removedAt),
+      ))
+
+    await tx
       .update(MemberTable)
-      .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null })
+      .set({ removedAt, removedByOrgMember: input.removedByOrgMemberId ?? null })
       .where(and(eq(MemberTable.id, member.id), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
 
     return { ok: true, member }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -2,13 +2,20 @@ import { and, asc, count, eq, gt, inArray, isNotNull, isNull, sql } from "@openw
 import {
   AuthSessionTable,
   AuthUserTable,
+  ConfigObjectAccessGrantTable,
   ConnectedAccountTable,
+  ConnectorInstanceAccessGrantTable,
+  DashboardAccessGrantTable,
+  DesktopPolicyMemberTable,
+  ExternalMcpConnectionAccessGrantTable,
   InvitationTable,
   LlmProviderAccessTable,
   LlmProviderMemberCredentialTable,
+  MarketplaceAccessGrantTable,
   MemberTable,
   OrganizationRoleTable,
   OrganizationTable,
+  PluginAccessGrantTable,
   ScimGroupMemberTable,
   ScimProviderTable,
   ScimUserTombstoneTable,
@@ -2039,6 +2046,7 @@ export async function removeOrganizationMember(input: {
     }
 
     const member = memberRow.member
+    const removedAt = new Date()
 
     if (input.removedByOrgMemberId) {
       const adminTeams = await tx.select({ id: TeamTable.id }).from(TeamTable)
@@ -2078,8 +2086,67 @@ export async function removeOrganizationMember(input: {
       .where(eq(LlmProviderAccessTable.orgMembershipId, member.id))
 
     await tx
+      .delete(DesktopPolicyMemberTable)
+      .where(and(
+        eq(DesktopPolicyMemberTable.organizationId, input.organizationId),
+        eq(DesktopPolicyMemberTable.orgMemberId, member.id),
+      ))
+
+    await tx
+      .delete(ExternalMcpConnectionAccessGrantTable)
+      .where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.orgMembershipId, member.id),
+      ))
+
+    await tx
+      .update(MarketplaceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(MarketplaceAccessGrantTable.organizationId, input.organizationId),
+        eq(MarketplaceAccessGrantTable.orgMembershipId, member.id),
+        isNull(MarketplaceAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConfigObjectAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConfigObjectAccessGrantTable.organizationId, input.organizationId),
+        eq(ConfigObjectAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConfigObjectAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(PluginAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(PluginAccessGrantTable.organizationId, input.organizationId),
+        eq(PluginAccessGrantTable.orgMembershipId, member.id),
+        isNull(PluginAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConnectorInstanceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConnectorInstanceAccessGrantTable.organizationId, input.organizationId),
+        eq(ConnectorInstanceAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConnectorInstanceAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(DashboardAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(DashboardAccessGrantTable.organizationId, input.organizationId),
+        eq(DashboardAccessGrantTable.orgMembershipId, member.id),
+        isNull(DashboardAccessGrantTable.removedAt),
+      ))
+
+    await tx
       .update(MemberTable)
-      .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null })
+      .set({ removedAt, removedByOrgMember: input.removedByOrgMemberId ?? null })
       .where(and(eq(MemberTable.id, member.id), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
 
     return { ok: true, member }

--- a/ee/apps/den-api/test/member-removal-rejoin.test.ts
+++ b/ee/apps/den-api/test/member-removal-rejoin.test.ts
@@ -9,6 +9,7 @@ const organizationId = createDenTypeId("organization")
 const ownerUserId = createDenTypeId("user")
 const ownerMemberId = createDenTypeId("member")
 const removedUserId = createDenTypeId("user")
+const accessUserId = createDenTypeId("user")
 const bootstrapUserId = createDenTypeId("user")
 const reviveUserId = createDenTypeId("user")
 const legacyReviveUserId = createDenTypeId("user")
@@ -17,13 +18,23 @@ const scimUserId = createDenTypeId("user")
 
 const ownerEmail = `owner+${ownerUserId}@member-removal.test`
 const removedEmail = `removed+${removedUserId}@member-removal.test`
+const accessEmail = `access+${accessUserId}@member-removal.test`
 const bootstrapEmail = `bootstrap+${bootstrapUserId}@member-removal.test`
 const reviveEmail = `revive+${reviveUserId}@member-removal.test`
 const legacyReviveEmail = `legacy-revive+${legacyReviveUserId}@member-removal.test`
 const oldInviteEmail = `old-invite+${oldInviteUserId}@member-removal.test`
 const scimEmail = `scim+${scimUserId}@member-removal.test`
 
-const userIds = [ownerUserId, removedUserId, bootstrapUserId, reviveUserId, legacyReviveUserId, oldInviteUserId, scimUserId]
+const userIds = [
+  ownerUserId,
+  removedUserId,
+  accessUserId,
+  bootstrapUserId,
+  reviveUserId,
+  legacyReviveUserId,
+  oldInviteUserId,
+  scimUserId,
+]
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -53,6 +64,11 @@ async function cleanup() {
   const organizationIds = [...staleOrgs.map((row) => row.id), organizationId]
 
   await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.inArray(schema.DesktopPolicyMemberTable.organizationId, organizationIds))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.inArray(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.MarketplaceAccessGrantTable).where(drizzle.inArray(schema.MarketplaceAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.ConfigObjectAccessGrantTable).where(drizzle.inArray(schema.ConfigObjectAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.PluginAccessGrantTable).where(drizzle.inArray(schema.PluginAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.ConnectorInstanceAccessGrantTable).where(drizzle.inArray(schema.ConnectorInstanceAccessGrantTable.organizationId, organizationIds))
   await db.delete(schema.DesktopPolicyTable).where(drizzle.inArray(schema.DesktopPolicyTable.organizationId, organizationIds))
   await db.delete(schema.ScimUserTombstoneTable).where(drizzle.inArray(schema.ScimUserTombstoneTable.organizationId, organizationIds))
   await db.delete(schema.ExternalIdentityTable).where(drizzle.inArray(schema.ExternalIdentityTable.organizationId, organizationIds))
@@ -145,6 +161,7 @@ beforeAll(async () => {
   await db.insert(schema.AuthUserTable).values([
     { id: ownerUserId, name: "Removal Owner", email: ownerEmail, emailVerified: true },
     { id: removedUserId, name: "Removed User", email: removedEmail, emailVerified: true },
+    { id: accessUserId, name: "Access User", email: accessEmail, emailVerified: true },
     { id: bootstrapUserId, name: "Bootstrap Removed", email: bootstrapEmail, emailVerified: true },
     { id: reviveUserId, name: "Revive Removed", email: reviveEmail, emailVerified: true },
     { id: legacyReviveUserId, name: "Legacy Revive Removed", email: legacyReviveEmail, emailVerified: true },
@@ -180,6 +197,118 @@ test("removeOrganizationMember keeps userId while setting removedAt", async () =
   expect(row?.userId).toBe(removedUserId)
   expect(row?.removedAt).toBeInstanceOf(Date)
   expect(row?.removedByOrgMember).toBe(ownerMemberId)
+})
+
+test("removeOrganizationMember revokes every direct member access assignment", async () => {
+  if (!db || !schema || !orgs || !drizzle) {
+    throw new Error("test modules not initialized")
+  }
+
+  const memberId = createDenTypeId("member")
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId: accessUserId,
+    role: "member",
+  })
+  await db.insert(schema.DesktopPolicyMemberTable).values({
+    id: createDenTypeId("desktopPolicyMember"),
+    organizationId,
+    desktopPolicyId: createDenTypeId("desktopPolicy"),
+    orgMemberId: memberId,
+  })
+  await db.insert(schema.ExternalMcpConnectionAccessGrantTable).values({
+    id: createDenTypeId("externalMcpConnectionAccessGrant"),
+    organizationId,
+    externalMcpConnectionId: createDenTypeId("externalMcpConnection"),
+    orgMembershipId: memberId,
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.MarketplaceAccessGrantTable).values({
+    id: createDenTypeId("marketplaceAccessGrant"),
+    organizationId,
+    marketplaceId: createDenTypeId("marketplace"),
+    orgMembershipId: memberId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.ConfigObjectAccessGrantTable).values({
+    id: createDenTypeId("configObjectAccessGrant"),
+    organizationId,
+    configObjectId: createDenTypeId("configObject"),
+    orgMembershipId: memberId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.PluginAccessGrantTable).values({
+    id: createDenTypeId("pluginAccessGrant"),
+    organizationId,
+    pluginId: createDenTypeId("plugin"),
+    orgMembershipId: memberId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.ConnectorInstanceAccessGrantTable).values({
+    id: createDenTypeId("connectorInstanceAccessGrant"),
+    organizationId,
+    connectorInstanceId: createDenTypeId("connectorInstance"),
+    orgMembershipId: memberId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+
+  const removed = await orgs.removeOrganizationMember({
+    organizationId,
+    memberId,
+    removedByOrgMemberId: ownerMemberId,
+  })
+  if (!removed.ok) {
+    throw new Error(removed.message)
+  }
+
+  const [desktopAssignments, externalMcpAssignments] = await Promise.all([
+    db
+      .select()
+      .from(schema.DesktopPolicyMemberTable)
+      .where(drizzle.eq(schema.DesktopPolicyMemberTable.orgMemberId, memberId)),
+    db
+      .select()
+      .from(schema.ExternalMcpConnectionAccessGrantTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  expect(desktopAssignments).toHaveLength(0)
+  expect(externalMcpAssignments).toHaveLength(0)
+
+  const [marketplaceGrants, configObjectGrants, pluginGrants, connectorGrants] = await Promise.all([
+    db
+      .select()
+      .from(schema.MarketplaceAccessGrantTable)
+      .where(drizzle.eq(schema.MarketplaceAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConfigObjectAccessGrantTable)
+      .where(drizzle.eq(schema.ConfigObjectAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.PluginAccessGrantTable)
+      .where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConnectorInstanceAccessGrantTable)
+      .where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  const revokedGrants = [
+    ...marketplaceGrants,
+    ...configObjectGrants,
+    ...pluginGrants,
+    ...connectorGrants,
+  ]
+  expect(revokedGrants).toHaveLength(4)
+  expect(revokedGrants.every((grant) => grant.removedAt instanceof Date)).toBe(true)
+
+  const member = await memberById(memberId)
+  expect(member?.removedAt).toBeInstanceOf(Date)
+  expect(revokedGrants.every((grant) => grant.removedAt?.getTime() === member?.removedAt?.getTime())).toBe(true)
 })
 
 test("bootstrap returns null for a user with a removed member row", async () => {

--- a/ee/apps/den-api/test/member-removal-rejoin.test.ts
+++ b/ee/apps/den-api/test/member-removal-rejoin.test.ts
@@ -9,6 +9,7 @@ const organizationId = createDenTypeId("organization")
 const ownerUserId = createDenTypeId("user")
 const ownerMemberId = createDenTypeId("member")
 const removedUserId = createDenTypeId("user")
+const accessUserId = createDenTypeId("user")
 const bootstrapUserId = createDenTypeId("user")
 const reviveUserId = createDenTypeId("user")
 const legacyReviveUserId = createDenTypeId("user")
@@ -17,13 +18,23 @@ const scimUserId = createDenTypeId("user")
 
 const ownerEmail = `owner+${ownerUserId}@member-removal.test`
 const removedEmail = `removed+${removedUserId}@member-removal.test`
+const accessEmail = `access+${accessUserId}@member-removal.test`
 const bootstrapEmail = `bootstrap+${bootstrapUserId}@member-removal.test`
 const reviveEmail = `revive+${reviveUserId}@member-removal.test`
 const legacyReviveEmail = `legacy-revive+${legacyReviveUserId}@member-removal.test`
 const oldInviteEmail = `old-invite+${oldInviteUserId}@member-removal.test`
 const scimEmail = `scim+${scimUserId}@member-removal.test`
 
-const userIds = [ownerUserId, removedUserId, bootstrapUserId, reviveUserId, legacyReviveUserId, oldInviteUserId, scimUserId]
+const userIds = [
+  ownerUserId,
+  removedUserId,
+  accessUserId,
+  bootstrapUserId,
+  reviveUserId,
+  legacyReviveUserId,
+  oldInviteUserId,
+  scimUserId,
+]
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -53,6 +64,12 @@ async function cleanup() {
   const organizationIds = [...staleOrgs.map((row) => row.id), organizationId]
 
   await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.inArray(schema.DesktopPolicyMemberTable.organizationId, organizationIds))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.inArray(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.DashboardAccessGrantTable).where(drizzle.inArray(schema.DashboardAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.MarketplaceAccessGrantTable).where(drizzle.inArray(schema.MarketplaceAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.ConfigObjectAccessGrantTable).where(drizzle.inArray(schema.ConfigObjectAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.PluginAccessGrantTable).where(drizzle.inArray(schema.PluginAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.ConnectorInstanceAccessGrantTable).where(drizzle.inArray(schema.ConnectorInstanceAccessGrantTable.organizationId, organizationIds))
   await db.delete(schema.DesktopPolicyTable).where(drizzle.inArray(schema.DesktopPolicyTable.organizationId, organizationIds))
   await db.delete(schema.ScimUserTombstoneTable).where(drizzle.inArray(schema.ScimUserTombstoneTable.organizationId, organizationIds))
   await db.delete(schema.ExternalIdentityTable).where(drizzle.inArray(schema.ExternalIdentityTable.organizationId, organizationIds))
@@ -145,6 +162,7 @@ beforeAll(async () => {
   await db.insert(schema.AuthUserTable).values([
     { id: ownerUserId, name: "Removal Owner", email: ownerEmail, emailVerified: true },
     { id: removedUserId, name: "Removed User", email: removedEmail, emailVerified: true },
+    { id: accessUserId, name: "Access User", email: accessEmail, emailVerified: true },
     { id: bootstrapUserId, name: "Bootstrap Removed", email: bootstrapEmail, emailVerified: true },
     { id: reviveUserId, name: "Revive Removed", email: reviveEmail, emailVerified: true },
     { id: legacyReviveUserId, name: "Legacy Revive Removed", email: legacyReviveEmail, emailVerified: true },
@@ -152,6 +170,12 @@ beforeAll(async () => {
     { id: scimUserId, name: "SCIM Removed", email: scimEmail, emailVerified: true },
   ])
   await db.insert(schema.OrganizationTable).values({ id: organizationId, name: "Member Removal Rejoin Test", slug: singleOrgSlug })
+  await db.insert(schema.OrganizationRoleTable).values({
+    id: createDenTypeId("organizationRole"),
+    organizationId,
+    role: "admin",
+    permission: "{}",
+  })
   await db.insert(schema.MemberTable).values({ id: ownerMemberId, organizationId, userId: ownerUserId, role: "owner" })
 })
 
@@ -180,6 +204,160 @@ test("removeOrganizationMember keeps userId while setting removedAt", async () =
   expect(row?.userId).toBe(removedUserId)
   expect(row?.removedAt).toBeInstanceOf(Date)
   expect(row?.removedByOrgMember).toBe(ownerMemberId)
+})
+
+test("removeOrganizationMember revokes every direct member access assignment", async () => {
+  if (!db || !schema || !orgs || !drizzle) {
+    throw new Error("test modules not initialized")
+  }
+
+  const memberId = createDenTypeId("member")
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId: accessUserId,
+    role: "member",
+  })
+  for (const assignmentMemberId of [memberId, ownerMemberId]) {
+    await db.insert(schema.DashboardAccessGrantTable).values({
+      id: createDenTypeId("dashboardAccessGrant"),
+      organizationId,
+      dashboardId: createDenTypeId("dashboard"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.DesktopPolicyMemberTable).values({
+      id: createDenTypeId("desktopPolicyMember"),
+      organizationId,
+      desktopPolicyId: createDenTypeId("desktopPolicy"),
+      orgMemberId: assignmentMemberId,
+    })
+    await db.insert(schema.ExternalMcpConnectionAccessGrantTable).values({
+      id: createDenTypeId("externalMcpConnectionAccessGrant"),
+      organizationId,
+      externalMcpConnectionId: createDenTypeId("externalMcpConnection"),
+      orgMembershipId: assignmentMemberId,
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.MarketplaceAccessGrantTable).values({
+      id: createDenTypeId("marketplaceAccessGrant"),
+      organizationId,
+      marketplaceId: createDenTypeId("marketplace"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.ConfigObjectAccessGrantTable).values({
+      id: createDenTypeId("configObjectAccessGrant"),
+      organizationId,
+      configObjectId: createDenTypeId("configObject"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.PluginAccessGrantTable).values({
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId,
+      pluginId: createDenTypeId("plugin"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.ConnectorInstanceAccessGrantTable).values({
+      id: createDenTypeId("connectorInstanceAccessGrant"),
+      organizationId,
+      connectorInstanceId: createDenTypeId("connectorInstance"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+  }
+
+  const sharedPluginId = createDenTypeId("plugin")
+  await db.insert(schema.PluginAccessGrantTable).values([
+    { teamId: createDenTypeId("team") },
+    { orgWide: true },
+    { organizationRoleId: createDenTypeId("organizationRole") },
+  ].map((target) => ({
+    id: createDenTypeId("pluginAccessGrant"),
+    organizationId,
+    pluginId: sharedPluginId,
+    role: "viewer",
+    createdByOrgMembershipId: memberId,
+    ...target,
+  })))
+
+  const removed = await orgs.removeOrganizationMember({
+    organizationId,
+    memberId,
+    removedByOrgMemberId: ownerMemberId,
+  })
+  if (!removed.ok) {
+    throw new Error(removed.message)
+  }
+
+  const [desktopAssignments, externalMcpAssignments] = await Promise.all([
+    db
+      .select()
+      .from(schema.DesktopPolicyMemberTable)
+      .where(drizzle.eq(schema.DesktopPolicyMemberTable.orgMemberId, memberId)),
+    db
+      .select()
+      .from(schema.ExternalMcpConnectionAccessGrantTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  expect(desktopAssignments).toHaveLength(0)
+  expect(externalMcpAssignments).toHaveLength(0)
+
+  const [marketplaceGrants, configObjectGrants, pluginGrants, connectorGrants, dashboardGrants] = await Promise.all([
+    db
+      .select()
+      .from(schema.MarketplaceAccessGrantTable)
+      .where(drizzle.eq(schema.MarketplaceAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConfigObjectAccessGrantTable)
+      .where(drizzle.eq(schema.ConfigObjectAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.PluginAccessGrantTable)
+      .where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConnectorInstanceAccessGrantTable)
+      .where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.orgMembershipId, memberId)),
+    db.select().from(schema.DashboardAccessGrantTable).where(drizzle.eq(schema.DashboardAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  const revokedGrants = [
+    ...marketplaceGrants,
+    ...configObjectGrants,
+    ...pluginGrants,
+    ...connectorGrants,
+    ...dashboardGrants,
+  ]
+  expect(revokedGrants).toHaveLength(5)
+  expect(revokedGrants.every((grant) => grant.removedAt instanceof Date)).toBe(true)
+
+  const member = await memberById(memberId)
+  expect(member?.removedAt).toBeInstanceOf(Date)
+  expect(revokedGrants.every((grant) => grant.removedAt?.getTime() === member?.removedAt?.getTime())).toBe(true)
+
+  const [otherDesktop, otherMcp, otherMarketplace, otherConfig, otherPlugin, otherConnector, sharedPlugin, otherDashboard] = await Promise.all([
+    db.select().from(schema.DesktopPolicyMemberTable).where(drizzle.eq(schema.DesktopPolicyMemberTable.orgMemberId, ownerMemberId)),
+    db.select().from(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.MarketplaceAccessGrantTable).where(drizzle.eq(schema.MarketplaceAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.ConfigObjectAccessGrantTable).where(drizzle.eq(schema.ConfigObjectAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.ConnectorInstanceAccessGrantTable).where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.pluginId, sharedPluginId)),
+    db.select().from(schema.DashboardAccessGrantTable).where(drizzle.eq(schema.DashboardAccessGrantTable.orgMembershipId, ownerMemberId)),
+  ])
+  for (const grants of [otherDesktop, otherMcp, otherMarketplace, otherConfig, otherPlugin, otherConnector, otherDashboard]) {
+    expect(grants).toHaveLength(1)
+  }
+  expect(sharedPlugin).toHaveLength(3)
+  expect([...otherMarketplace, ...otherConfig, ...otherPlugin, ...otherConnector, ...sharedPlugin, ...otherDashboard].every((grant) => grant.removedAt === null)).toBe(true)
 })
 
 test("bootstrap returns null for a user with a removed member row", async () => {


### PR DESCRIPTION
## Summary

Reassessed against `dev` at `858414c41c63a22eecfe331d17f3f5dd348dfc6f`. This remains needed: current member removal revokes connected accounts, per-member LLM credentials, team memberships, direct model grants, sessions and API keys, and detaches SCIM projections, but leaves direct access assignments behind.

- Hard-delete direct desktop-policy and external-MCP assignments in the existing member-removal transaction.
- Soft-revoke marketplace, config-object, plugin, connector-instance and dashboard grants with the same timestamp as the membership removal. Dashboard grants were added after the original patch and have the same missing cleanup.
- Preserve the current organization lock, admin-team removal guard, SCIM cleanup and credential-revocation paths.
- Leave other members' grants, shared team/org grants, resource ownership and prior grant history intact. No migration is required.

## Focused Verification

Head: `6718c0f2045e99f26860835279446a1e6d73120f` (verified signature).

Executed from `ee/apps/den-api` with a scrubbed environment and a disposable, isolated MySQL 8.4 fixture initialized from this checkout:

```sh
pnpm exec bun --conditions=development test test/member-removal-rejoin.test.ts
```

Result: **8 passed, 0 failed, 0 skipped; 48 assertions; exit 0.**

The regression checks all seven assignment types, identical soft-removal timestamps, preservation of every other-member assignment type (including grants created by the removed member), and shared team/org plugin grants. Existing re-invite and SCIM lifecycle assertions also pass.

The first run found an existing fixture defect: the re-invite test expected an admin role without seeding an assignable admin role. The identical command reproduced that failure on clean `dev` at `544b881c6` (6 passed, 1 failed). This patch seeds the missing role; the existing admin-role assertion is unchanged.

Den DB fixture prerequisite build and `git diff --check` passed. No shared database or real provider was used.

## Verdict: Incomplete

The focused database tests pass, but they are not current-head `@openwork/testkit` runtime proof. Cold-boot member-removal/re-invite journey evidence remains deferred. No new cloud/E2E or manual review run was requested. This is not a full runtime Passed verdict.

## Historical Verification

The original head `e0b972001c8fb9acaa0894a630d804bd72a1e27f` reported 31 focused tests / 146 assertions, a Den API build, and a 9-cell invite-reliability browser journey. These are historical reports only and do not validate this rebased head; the original local browser report was not published to the PR.
