### PR TITLE
fix(app): stop the browser from materializing cloud providers (den-api owns it)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -13,6 +13,7 @@ import {
   type DenOrgLlmProvider,
   type DenOrgLlmProviderConnection,
 } from "../../../../app/lib/den";
+import { getOpenworkGatewayOrigin } from "../../../../app/lib/gateway-runtime";
 import { unwrap, waitForHealthy } from "../../../../app/lib/opencode";
 import {
   readOpencodeConfig,
@@ -101,6 +102,7 @@ type CloudProviderSyncReason =
 
 let lastGlobalProviderDisposeRefreshAt = 0;
 const globalCloudProviderSyncByContext = new Map<string, Promise<void>>();
+let loggedGatewayCloudProviderSyncSkip = false;
 
 function enqueueGlobalCloudProviderSync(
   contextKey: string,
@@ -1832,6 +1834,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   }
 
   async function runCloudProviderSync(reason: CloudProviderSyncReason) {
+    if (getOpenworkGatewayOrigin()) {
+      if (!loggedGatewayCloudProviderSyncSkip) {
+        loggedGatewayCloudProviderSyncSkip = true;
+        console.info(
+          `[cloud-provider-sync:${reason}] Provider materialization is handled server-side in gateway mode.`,
+        );
+      }
+      return { outcome: "handled_server_side" };
+    }
+
     const request = cloudProviderSyncTail
       .catch(() => undefined)
       .then(() =>

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createClient } from "../src/app/lib/opencode";
+import type { ProviderListItem, WorkspaceDisplay } from "../src/app/types";
+import { createProviderAuthStore } from "../src/react-app/domains/connections/provider-auth/store";
+
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+const originalConsoleInfo = console.info;
+const originalDeployment = process.env.VITE_OPENWORK_DEPLOYMENT;
+
+type RecordedRequest = {
+  url: string;
+  method: string;
+  body: string | null;
+};
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function installWindow(options: { origin: string; gateway?: boolean }) {
+  const localStorage = memoryStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+      localStorage,
+      location: { origin: options.origin },
+      __OPENWORK_GATEWAY__: options.gateway ? { version: 1 } : undefined,
+    },
+  });
+  return localStorage;
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (input instanceof URL) return input.toString();
+  if (typeof input === "string") return input;
+  return input.url;
+}
+
+function getRequestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return init.method;
+  if (input instanceof Request) return input.method;
+  return "GET";
+}
+
+function getRequestBody(init?: RequestInit): string | null {
+  return typeof init?.body === "string" ? init.body : null;
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function cloudProviderPayload() {
+  return {
+    id: "lpr_test",
+    source: "custom",
+    providerId: "openai",
+    name: "Team OpenAI",
+    providerConfig: { env: ["OPENAI_API_KEY"] },
+    hasApiKey: true,
+    apiKey: "sk-test",
+    models: [
+      {
+        id: "gpt-test",
+        name: "GPT Test",
+        config: {},
+        createdAt: null,
+      },
+    ],
+    createdAt: null,
+    updatedAt: "2026-07-29T00:00:00.000Z",
+  };
+}
+
+function installCloudSession(storage: Storage) {
+  storage.setItem("openwork.den.baseUrl", "https://den.example");
+  storage.setItem("openwork.den.authToken", "den-token");
+  storage.setItem("openwork.den.activeOrgId", "org_test");
+}
+
+function createProviderAuthTestStore() {
+  const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test", {
+    token: "engine-token",
+    mode: "openwork",
+  });
+  const openworkClient = createOpenworkServerClient({
+    baseUrl: "https://server.example",
+    token: "server-token",
+  });
+  const workspace = {
+    id: "workspace_test",
+    name: "Test workspace",
+    path: "/tmp/workspace_test",
+    preset: "default",
+    workspaceType: "local",
+  } satisfies WorkspaceDisplay;
+  let providers: ProviderListItem[] = [];
+  let providerDefaults: Record<string, string> = {};
+  let providerConnectedIds: string[] = [];
+  let disabledProviders: string[] = [];
+  let reloadCount = 0;
+
+  const store = createProviderAuthStore({
+    client: () => opencodeClient,
+    providers: () => providers,
+    providerDefaults: () => providerDefaults,
+    providerConnectedIds: () => providerConnectedIds,
+    disabledProviders: () => disabledProviders,
+    checkDesktopAppRestriction: () => false,
+    selectedWorkspaceDisplay: () => workspace,
+    providerBaseUrl: () => "https://engine.example",
+    selectedWorkspaceRoot: () => "/tmp/workspace_test",
+    runtimeWorkspaceId: () => "ws_1",
+    openworkServer: {
+      getSnapshot: () => ({
+        openworkServerStatus: "connected",
+        openworkServerClient: openworkClient,
+        openworkServerCapabilities: { config: { read: true, write: true } },
+      }),
+    },
+    setProviders: (value) => {
+      providers = value;
+    },
+    setProviderDefaults: (value) => {
+      providerDefaults = value;
+    },
+    setProviderConnectedIds: (value) => {
+      providerConnectedIds = value;
+    },
+    setDisabledProviders: (value) => {
+      disabledProviders = value;
+    },
+    markOpencodeConfigReloadRequired: () => {
+      reloadCount += 1;
+    },
+  });
+
+  return {
+    store,
+    reloadCount: () => reloadCount,
+  };
+}
+
+function installProviderSyncFetch(requests: RecordedRequest[]) {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(getRequestUrl(input));
+      const method = getRequestMethod(input, init);
+      requests.push({
+        url: url.toString(),
+        method,
+        body: getRequestBody(init),
+      });
+
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers") {
+        return jsonResponse({ llmProviders: [cloudProviderPayload()] });
+      }
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers/lpr_test/connect") {
+        return jsonResponse({ llmProvider: cloudProviderPayload() });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/config" && method === "GET") {
+        return jsonResponse({ opencode: {}, openwork: {} });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/config" && method === "PATCH") {
+        return jsonResponse({ updatedAt: 1 });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/env") {
+        return jsonResponse({ ok: true });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/opencode-config") {
+        return jsonResponse(null);
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/engine/reload") {
+        return jsonResponse({ ok: true, reloadedAt: 1 });
+      }
+      if (url.origin === "https://engine.example" && url.pathname === "/global/health") {
+        return jsonResponse({ healthy: true, version: "1.17.11" });
+      }
+      if (url.origin === "https://engine.example" && url.pathname === "/provider") {
+        return jsonResponse({
+          all: [
+            {
+              id: "lpr_test",
+              name: "Team OpenAI",
+              source: "custom",
+              env: ["OPENAI_API_KEY"],
+              models: { "gpt-test": { id: "gpt-test", name: "GPT Test" } },
+            },
+          ],
+          connected: ["lpr_test"],
+          default: {},
+        });
+      }
+      if (url.origin === "https://engine.example" && url.pathname === "/config") {
+        return jsonResponse({ disabled_providers: [] });
+      }
+
+      return jsonResponse({});
+    },
+  });
+}
+
+describe("cloud provider sync in gateway mode", () => {
+  beforeEach(() => {
+    process.env.VITE_OPENWORK_DEPLOYMENT = "web";
+    console.info = () => undefined;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
+    console.info = originalConsoleInfo;
+    if (originalDeployment === undefined) {
+      delete process.env.VITE_OPENWORK_DEPLOYMENT;
+    } else {
+      process.env.VITE_OPENWORK_DEPLOYMENT = originalDeployment;
+    }
+  });
+
+  test("returns a server-handled outcome without network calls or error state behind the gateway", async () => {
+    const storage = installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests);
+    const { store } = createProviderAuthTestStore();
+
+    const outcome = await store.runCloudProviderSync("settings_cloud_opened");
+
+    expect(outcome).toEqual({ outcome: "handled_server_side" });
+    expect(requests).toEqual([]);
+    expect(store.getSnapshot().providerAuthError).toBeNull();
+  });
+
+  test("keeps the client materialization path active outside gateway mode", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests);
+    const { store, reloadCount } = createProviderAuthTestStore();
+
+    await store.runCloudProviderSync("settings_cloud_opened");
+
+    const patchRequests = requests.filter(
+      (request) => request.method === "PATCH" && request.url === "https://server.example/workspace/ws_1/config",
+    );
+    expect(requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers")).toBe(true);
+    expect(requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers/lpr_test/connect")).toBe(true);
+    expect(patchRequests).toHaveLength(1);
+    expect(patchRequests[0]?.body).toContain("\"opencode\"");
+    expect(store.getSnapshot().importedCloudProviders.lpr_test?.providerId).toBe("lpr_test");
+    expect(store.getSnapshot().providerAuthError).toBeNull();
+    expect(reloadCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
den-api now materializes providers server-side (env + engine-global provider block + reload + engine read-back). The browser was still doing the same work in parallel, and failing loudly.

## Measured, not inferred

CDP network trace of one page load on `web.openworklabs.com`:

```
ERR_ABORTED canceled=true  PATCH /workspace/ws_.../config   status=(none)  after=10.01s
ERR_ABORTED canceled=true  PATCH /workspace/ws_.../config   status=(none)  after=10.01s
```

Two identical hard 10.00s timeouts with no response ever received, matching the console's `[cloud-provider-sync:app_launch] Cloud provider sync failed. Request timed out.` A 10s browser ceiling against a cold sandbox isn't a tuning problem — client-mediated config writes cannot work here.

Worse, `runCloudProviderSync` had **no cloud gating**, and fires on `app_launch`, `sign_in`, **`model_picker_open`**, `new_chat`, and `settings_cloud_opened`. So every model-picker open in the web app started a doomed sync.

## Change

In gateway mode `runCloudProviderSync` returns `{ outcome: "handled_server_side" }` immediately — no network calls, no error surfaced, one info log. The implementation stays for desktop; this is a gate, not a deletion.

**Desktop and self-host are byte-identical** — behavior only changes when `getOpenworkGatewayOrigin()` is truthy. A test asserts the non-gateway path still performs the Den list/connect and `PATCH /workspace/:id/config` writes.

## Why the browser was doing this at all

Historical: the app was born desktop-first, where the client *is* the runtime host, so client-mediated setup was correct. In cloud the browser is merely a viewer, and the same code became a liability — the browser cannot reliably configure someone else's machine across a proxy on a 10s budget. This lands the invariant: **the server materializes, the client displays.**

## Tests

| Command | Result |
| --- | --- |
| `apps/app` full suite | 516 pass / 0 fail |
| `tsc --noEmit` + `build:web` | clean |

Coverage: gateway mode makes zero network calls and leaves `providerAuthError` clean; non-gateway still runs the full client flow.

## Not fixed here (deliberately)

The same trace showed two more issues in **shared** code, so they need desktop-aware work rather than being bundled in:

- `/opencode/event` (the agent SSE stream) is cancelled client-side and re-established ~8 times in 45s — the likely cause of chats showing `Aborted` mid-tool-call.
- `/events?since=0` is polled continuously without ever advancing its cursor.