### PR TITLE
fix(den): harden team lifecycle cleanup

### DIFF
--- a/ee/apps/den-api/src/routes/org/teams.ts
+++ b/ee/apps/den-api/src/routes/org/teams.ts
@@ -1,6 +1,14 @@
 import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import {
+  ConfigObjectAccessGrantTable,
+  ConnectorInstanceAccessGrantTable,
+  DesktopPolicyMemberTable,
+  ExternalMcpConnectionAccessGrantTable,
+  InvitationTable,
+  LlmProviderAccessTable,
+  MarketplaceAccessGrantTable,
   MemberTable,
+  PluginAccessGrantTable,
   TeamMemberTable,
   TeamTable,
 } from "@openwork-ee/den-db/schema"
@@ -249,6 +257,12 @@ export function registerOrgTeamRoutes<T extends { Variables: OrgRouteVariables }
       }
 
       const updatedAt = new Date()
+      const responseMemberIds = memberIds ?? (await db
+        .select({ id: TeamMemberTable.orgMembershipId })
+        .from(TeamMemberTable)
+        .where(eq(TeamMemberTable.teamId, team.id)))
+        .map((row) => row.id)
+
       await db.transaction(async (tx) => {
         await tx.update(TeamTable).set({ name: nextName, updatedAt }).where(eq(TeamTable.id, team.id))
 
@@ -272,7 +286,7 @@ export function registerOrgTeamRoutes<T extends { Variables: OrgRouteVariables }
           ...team,
           name: nextName,
           updatedAt,
-          memberIds: memberIds ?? [],
+          memberIds: responseMemberIds,
           managedByScim: false,
         },
       })
@@ -326,6 +340,38 @@ export function registerOrgTeamRoutes<T extends { Variables: OrgRouteVariables }
       }
 
       await db.transaction(async (tx) => {
+        const removedAt = new Date()
+
+        await tx
+          .update(InvitationTable)
+          .set({ teamId: null })
+          .where(and(
+            eq(InvitationTable.organizationId, payload.organization.id),
+            eq(InvitationTable.teamId, team.id),
+            eq(InvitationTable.status, "pending"),
+          ))
+
+        await tx.delete(DesktopPolicyMemberTable).where(eq(DesktopPolicyMemberTable.teamId, team.id))
+        await tx.delete(ExternalMcpConnectionAccessGrantTable).where(eq(ExternalMcpConnectionAccessGrantTable.teamId, team.id))
+        await tx.delete(LlmProviderAccessTable).where(eq(LlmProviderAccessTable.teamId, team.id))
+
+        await tx
+          .update(MarketplaceAccessGrantTable)
+          .set({ removedAt })
+          .where(and(eq(MarketplaceAccessGrantTable.teamId, team.id), isNull(MarketplaceAccessGrantTable.removedAt)))
+        await tx
+          .update(ConfigObjectAccessGrantTable)
+          .set({ removedAt })
+          .where(and(eq(ConfigObjectAccessGrantTable.teamId, team.id), isNull(ConfigObjectAccessGrantTable.removedAt)))
+        await tx
+          .update(PluginAccessGrantTable)
+          .set({ removedAt })
+          .where(and(eq(PluginAccessGrantTable.teamId, team.id), isNull(PluginAccessGrantTable.removedAt)))
+        await tx
+          .update(ConnectorInstanceAccessGrantTable)
+          .set({ removedAt })
+          .where(and(eq(ConnectorInstanceAccessGrantTable.teamId, team.id), isNull(ConnectorInstanceAccessGrantTable.removedAt)))
+
         await tx.delete(TeamMemberTable).where(eq(TeamMemberTable.teamId, team.id))
         await tx.delete(TeamTable).where(eq(TeamTable.id, team.id))
       })

--- a/ee/apps/den-api/test/team-lifecycle-hardening.test.ts
+++ b/ee/apps/den-api/test/team-lifecycle-hardening.test.ts
@@ -1,0 +1,295 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { serializeSignedCookie } from "better-call"
+
+const API_ORIGIN = "http://127.0.0.1:8790"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_team_lifecycle"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? API_ORIGIN
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? API_ORIGIN
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+
+const ownerUserId = createDenTypeId("user")
+const memberUserId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const ownerMemberId = createDenTypeId("member")
+const memberId = createDenTypeId("member")
+const ownerSessionId = createDenTypeId("session")
+const renameTeamId = createDenTypeId("team")
+const deleteTeamId = createDenTypeId("team")
+const invitationId = createDenTypeId("invitation")
+const historicalGrantId = createDenTypeId("marketplaceAccessGrant")
+const historicalRemovedAt = new Date(Date.now() - 60_000)
+const ownerSessionToken = `team-lifecycle-owner-${ownerSessionId}`
+let ownerCookie = ""
+
+async function cleanup() {
+  await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.eq(schema.DesktopPolicyMemberTable.organizationId, organizationId))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.LlmProviderAccessTable).where(drizzle.inArray(schema.LlmProviderAccessTable.teamId, [renameTeamId, deleteTeamId]))
+  await db.delete(schema.MarketplaceAccessGrantTable).where(drizzle.eq(schema.MarketplaceAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.ConfigObjectAccessGrantTable).where(drizzle.eq(schema.ConfigObjectAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.ConnectorInstanceAccessGrantTable).where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.TeamMemberTable).where(drizzle.inArray(schema.TeamMemberTable.teamId, [renameTeamId, deleteTeamId]))
+  await db.delete(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.organizationId, organizationId))
+  await db.delete(schema.TeamTable).where(drizzle.eq(schema.TeamTable.organizationId, organizationId))
+  await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, ownerSessionId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, memberUserId]))
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appModule, dbModule, schemaModule, drizzleModule] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+  ])
+  app = appModule.default
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+
+  await cleanup()
+  await db.insert(schema.AuthUserTable).values([
+    {
+      id: ownerUserId,
+      name: "Team Lifecycle Owner",
+      email: `team-lifecycle-owner+${ownerUserId}@test.local`,
+      emailVerified: true,
+    },
+    {
+      id: memberUserId,
+      name: "Team Lifecycle Member",
+      email: `team-lifecycle-member+${memberUserId}@test.local`,
+      emailVerified: true,
+    },
+  ])
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Team Lifecycle",
+    slug: `team-lifecycle-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values([
+    {
+      id: ownerMemberId,
+      organizationId,
+      userId: ownerUserId,
+      role: "owner",
+    },
+    {
+      id: memberId,
+      organizationId,
+      userId: memberUserId,
+      role: "member",
+    },
+  ])
+  await db.insert(schema.AuthSessionTable).values({
+    id: ownerSessionId,
+    userId: ownerUserId,
+    activeOrganizationId: organizationId,
+    token: ownerSessionToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET
+  if (!betterAuthSecret) {
+    throw new Error("BETTER_AUTH_SECRET is required")
+  }
+  ownerCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    ownerSessionToken,
+    betterAuthSecret,
+  )
+})
+
+afterAll(async () => {
+  if (db && schema && drizzle) {
+    await cleanup()
+  }
+  mock.restore()
+})
+
+test("name-only team updates preserve member IDs in the response and database", async () => {
+  await db.insert(schema.TeamTable).values({
+    id: renameTeamId,
+    organizationId,
+    name: "Engineering",
+  })
+  await db.insert(schema.TeamMemberTable).values({
+    id: createDenTypeId("teamMember"),
+    teamId: renameTeamId,
+    orgMembershipId: memberId,
+  })
+
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/teams/${renameTeamId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({ name: "Product Engineering" }),
+  }))
+  const payload: unknown = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(isRecord(payload) && isRecord(payload.team) ? payload.team.memberIds : null).toEqual([memberId])
+
+  const memberships = await db
+    .select()
+    .from(schema.TeamMemberTable)
+    .where(drizzle.eq(schema.TeamMemberTable.teamId, renameTeamId))
+  expect(memberships.map((row) => row.orgMembershipId)).toEqual([memberId])
+})
+
+test("team deletion revokes active team access and clears pending invite references", async () => {
+  await db.insert(schema.TeamTable).values({
+    id: deleteTeamId,
+    organizationId,
+    name: "Temporary Team",
+  })
+  await db.insert(schema.TeamMemberTable).values({
+    id: createDenTypeId("teamMember"),
+    teamId: deleteTeamId,
+    orgMembershipId: memberId,
+  })
+  await db.insert(schema.InvitationTable).values({
+    id: invitationId,
+    organizationId,
+    email: `future-team-member+${invitationId}@test.local`,
+    role: "member",
+    status: "pending",
+    teamId: deleteTeamId,
+    inviterId: ownerUserId,
+    orgMemberId: ownerMemberId,
+    inviteToken: `team-lifecycle-${invitationId}`,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  await db.insert(schema.DesktopPolicyMemberTable).values({
+    id: createDenTypeId("desktopPolicyMember"),
+    organizationId,
+    desktopPolicyId: createDenTypeId("desktopPolicy"),
+    teamId: deleteTeamId,
+  })
+  await db.insert(schema.ExternalMcpConnectionAccessGrantTable).values({
+    id: createDenTypeId("externalMcpConnectionAccessGrant"),
+    organizationId,
+    externalMcpConnectionId: createDenTypeId("externalMcpConnection"),
+    teamId: deleteTeamId,
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.LlmProviderAccessTable).values({
+    id: createDenTypeId("llmProviderAccess"),
+    llmProviderId: createDenTypeId("llmProvider"),
+    teamId: deleteTeamId,
+  })
+  await db.insert(schema.MarketplaceAccessGrantTable).values({
+    id: createDenTypeId("marketplaceAccessGrant"),
+    organizationId,
+    marketplaceId: createDenTypeId("marketplace"),
+    teamId: deleteTeamId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.MarketplaceAccessGrantTable).values({
+    id: historicalGrantId,
+    organizationId,
+    marketplaceId: createDenTypeId("marketplace"),
+    teamId: deleteTeamId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+    removedAt: historicalRemovedAt,
+  })
+  await db.insert(schema.ConfigObjectAccessGrantTable).values({
+    id: createDenTypeId("configObjectAccessGrant"),
+    organizationId,
+    configObjectId: createDenTypeId("configObject"),
+    teamId: deleteTeamId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.PluginAccessGrantTable).values({
+    id: createDenTypeId("pluginAccessGrant"),
+    organizationId,
+    pluginId: createDenTypeId("plugin"),
+    teamId: deleteTeamId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  await db.insert(schema.ConnectorInstanceAccessGrantTable).values({
+    id: createDenTypeId("connectorInstanceAccessGrant"),
+    organizationId,
+    connectorInstanceId: createDenTypeId("connectorInstance"),
+    teamId: deleteTeamId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/teams/${deleteTeamId}`, {
+    method: "DELETE",
+    headers: {
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+  }))
+  expect(response.status).toBe(204)
+
+  const [teams, memberships, desktopAssignments, mcpGrants, modelGrants, invitations] = await Promise.all([
+    db.select().from(schema.TeamTable).where(drizzle.eq(schema.TeamTable.id, deleteTeamId)),
+    db.select().from(schema.TeamMemberTable).where(drizzle.eq(schema.TeamMemberTable.teamId, deleteTeamId)),
+    db.select().from(schema.DesktopPolicyMemberTable).where(drizzle.eq(schema.DesktopPolicyMemberTable.teamId, deleteTeamId)),
+    db.select().from(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.teamId, deleteTeamId)),
+    db.select().from(schema.LlmProviderAccessTable).where(drizzle.eq(schema.LlmProviderAccessTable.teamId, deleteTeamId)),
+    db.select().from(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.id, invitationId)),
+  ])
+  expect(teams).toHaveLength(0)
+  expect(memberships).toHaveLength(0)
+  expect(desktopAssignments).toHaveLength(0)
+  expect(mcpGrants).toHaveLength(0)
+  expect(modelGrants).toHaveLength(0)
+  expect(invitations[0]?.status).toBe("pending")
+  expect(invitations[0]?.teamId).toBeNull()
+
+  const [marketplaceGrants, configObjectGrants, pluginGrants, connectorGrants] = await Promise.all([
+    db.select().from(schema.MarketplaceAccessGrantTable).where(drizzle.eq(schema.MarketplaceAccessGrantTable.teamId, deleteTeamId)),
+    db.select().from(schema.ConfigObjectAccessGrantTable).where(drizzle.eq(schema.ConfigObjectAccessGrantTable.teamId, deleteTeamId)),
+    db.select().from(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.teamId, deleteTeamId)),
+    db.select().from(schema.ConnectorInstanceAccessGrantTable).where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.teamId, deleteTeamId)),
+  ])
+  const revokedGrants = [
+    ...marketplaceGrants,
+    ...configObjectGrants,
+    ...pluginGrants,
+    ...connectorGrants,
+  ]
+  expect(revokedGrants).toHaveLength(5)
+  expect(revokedGrants.every((grant) => grant.removedAt instanceof Date)).toBe(true)
+  expect(
+    marketplaceGrants.find((grant) => grant.id === historicalGrantId)?.removedAt?.getTime(),
+  ).toBe(historicalRemovedAt.getTime())
+})


### PR DESCRIPTION
## Summary

- revoke every active team-scoped model, desktop policy, MCP, marketplace, plugin, config-object, and connector grant when a team is deleted
- clear deleted team references from pending invitations while keeping those invitations usable for organization membership
- preserve the original audit timestamp on grants that were already revoked
- return the real member list from name-only team updates instead of reporting an empty team

## Root cause

The team deletion route removed only `team_member` and `team` rows. Authorization records stored in the seven team-aware access tables were left behind, and pending invitations retained a team ID that could no longer resolve. Separately, the update route used `memberIds ?? []` in its response, so a name-only update reported no members even though the database membership rows were unchanged.

## Behavior after this change

Team deletion is one transaction:

1. pending invitations are detached from the deleted team but remain pending
2. hard-delete access tables are cleaned
3. active soft-delete grants receive one shared `removedAt` timestamp
4. existing historical removal timestamps are left unchanged
5. team memberships and the team are deleted

This does not change organization-wide, role-based, direct-member, or resource-creator records.

## Validation

- `./bin/openwork-hub run enterprise team-lifecycle-audit -- pnpm --filter @openwork-ee/den-api exec bun test test/team-lifecycle-hardening.test.ts test/llm-provider-team-inheritance.test.ts test/invitation-lifecycle-hardening.test.ts`
  - 5 passed, 0 failed, 58 assertions
- `./bin/openwork-hub run enterprise team-lifecycle-audit -- pnpm --filter @openwork-ee/den-api build`
  - passed
- `./bin/openwork-hub run enterprise team-lifecycle-audit -- pnpm evals --stack den --flow invite-reliability`
  - passed all 9 invite/removal/re-invite cells with 0 failures or skips on commit `65384570d`
  - listeners on ports 8790, 8791, and 3005 were verified to be owned by this exact worktree
  - local report: `evals/results/2026-07-29T10-32-40-205Z/report.md`
  - local fraimz: `evals/results/2026-07-29T10-32-40-205Z/fraimz.html`

Two preliminary eval invocations found stale listeners owned by earlier worktrees, including the internal API port. Those runs are not treated as branch evidence. All three ports were cleared before the exact-head rerun above.

## Risk and rollout

- no schema change or migration
- pending invitees still join the organization, but no longer inherit a team that was intentionally deleted
- historical soft-deleted grant records remain available for audit
- no production credentials or production data were used
- manual behavior was not separately user-confirmed; the real browser coded journey is the end-to-end evidence
