### PR TITLE
fix(app): stop the 10s transport timeout from killing agent streams on web

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -361,8 +361,10 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
 
   const fetchImpl = isDesktopRuntime()
     ? createDesktopFetch(auth)
-    : (input: RequestInfo | URL, init?: RequestInit) =>
-        fetchWithTimeout(globalThis.fetch, input, init, DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS);
+    : (input: RequestInfo | URL, init?: RequestInit) => {
+        const timeoutMs = requestIsStreaming(input, init) ? 0 : DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS;
+        return fetchWithTimeout(globalThis.fetch, input, init, timeoutMs);
+      };
   const client = createOpencodeClient({
     baseUrl,
     directory,

--- a/apps/app/tests/opencode-stream-timeout.test.ts
+++ b/apps/app/tests/opencode-stream-timeout.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let capturedFetch: typeof globalThis.fetch | null = null;
+
+async function unusedSessionMethod() {
+  throw new Error("SDK mock method should not be called");
+}
+
+mock.module("@opencode-ai/sdk/v2/client", () => ({
+  createOpencodeClient: (options: { fetch?: typeof globalThis.fetch }) => {
+    capturedFetch = options.fetch ?? null;
+    return {
+      session: {
+        list: unusedSessionMethod,
+        get: unusedSessionMethod,
+        messages: unusedSessionMethod,
+        todo: unusedSessionMethod,
+        promptAsync: unusedSessionMethod,
+        command: unusedSessionMethod,
+      },
+    };
+  },
+}));
+
+const { createClient } = await import("../src/app/lib/opencode");
+
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+
+type PromiseState = "pending" | "fulfilled" | "rejected";
+
+function installWindow(value: unknown) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value,
+  });
+}
+
+function restoreGlobals() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: originalFetch,
+  });
+  capturedFetch = null;
+}
+
+function installControllableFetch() {
+  let observedSignal: AbortSignal | null = null;
+  let rejectResponse: ((reason: unknown) => void) | null = null;
+  const fetchImpl: typeof globalThis.fetch = (input, init) => {
+    observedSignal = init?.signal ?? (input instanceof Request ? input.signal : null);
+    return new Promise<Response>((_resolve, reject) => {
+      rejectResponse = reject;
+      if (!observedSignal) return;
+      const abort = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+      if (observedSignal.aborted) {
+        abort();
+        return;
+      }
+      observedSignal.addEventListener("abort", abort, { once: true });
+    });
+  };
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: fetchImpl,
+  });
+  return {
+    observedSignal: () => observedSignal,
+    cancel: () => rejectResponse?.(new Error("test cleanup")),
+  };
+}
+
+function createCapturedFetch() {
+  capturedFetch = null;
+  createClient("https://web.example/workspace/ws_test/opencode");
+  if (!capturedFetch) {
+    throw new Error("SDK mock did not receive an OpenCode fetch implementation");
+  }
+  return capturedFetch;
+}
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function trackPromise<T>(promise: Promise<T>) {
+  let state: PromiseState = "pending";
+  void promise.then(
+    () => {
+      state = "fulfilled";
+    },
+    () => {
+      state = "rejected";
+    },
+  );
+  return () => state;
+}
+
+describe("OpenCode transport timeouts", () => {
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test("does not transport-timeout web OpenCode event streams", async () => {
+    installWindow(undefined);
+    const { cancel, observedSignal } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+
+    const response = fetchImpl("https://web.example/workspace/ws_test/opencode/event", {
+      headers: { Accept: "text/event-stream" },
+    });
+    const state = trackPromise(response);
+
+    try {
+      await delay(10_050);
+
+      expect(observedSignal()).toBeNull();
+      expect(state()).toBe("pending");
+    } finally {
+      cancel();
+    }
+  }, 15_000);
+
+  test("keeps timing out ordinary web OpenCode requests", async () => {
+    installWindow(undefined);
+    const { cancel, observedSignal } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+
+    const response = fetchImpl("https://web.example/workspace/ws_test/opencode/global/health");
+    const errorPromise = response.catch((error: unknown) => error);
+
+    try {
+      const error = await errorPromise;
+      expect(error).toMatchObject({ message: "Request timed out." });
+      expect(observedSignal()?.aborted).toBe(true);
+    } finally {
+      cancel();
+    }
+  }, 15_000);
+
+  test("lets caller AbortSignal cancel web streams", async () => {
+    installWindow(undefined);
+    const { cancel, observedSignal } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+    const controller = new AbortController();
+
+    const response = fetchImpl("https://web.example/workspace/ws_test/opencode/output", {
+      headers: { Accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    const errorPromise = response.catch((error: unknown) => error);
+
+    try {
+      controller.abort();
+
+      expect(observedSignal()).toBe(controller.signal);
+      const error = await errorPromise;
+      expect(error).toMatchObject({ name: "AbortError" });
+    } finally {
+      cancel();
+    }
+  }, 15_000);
+
+  test("leaves desktop OpenCode event streams untimed", async () => {
+    installWindow({ __OPENWORK_ELECTRON__: {} });
+    const { cancel, observedSignal } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+
+    const response = fetchImpl("https://web.example/workspace/ws_test/opencode/event", {
+      headers: { Accept: "text/event-stream" },
+    });
+    const state = trackPromise(response);
+
+    try {
+      await Promise.resolve();
+
+      expect(observedSignal()).toBeNull();
+      expect(state()).toBe("pending");
+    } finally {
+      cancel();
+    }
+  });
+});


### PR DESCRIPTION
Agent runs in the web app abort mid-tool-call ("Searched your connections … **Aborted**"). Cause found in source and confirmed in production.

## Root cause: a desktop-only exemption

`apps/app/src/app/lib/opencode.ts` → `createClient`:

```ts
const fetchImpl = isDesktopRuntime()
  ? createDesktopFetch(auth)                                    // exempts streams
  : (input, init) => fetchWithTimeout(globalThis.fetch, input, init, DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS);
```

The desktop path deliberately opts streams out:

```ts
// Streams should never be timed out at the transport layer; the caller
// aborts via AbortSignal when the subscription unmounts.
const timeoutMs = shouldStream ? 0 : DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS;
```

The web path applied the 10s timeout **unconditionally**, and `fetchWithTimeout` calls `controller.abort()` when it fires. So on web, every SSE subscription was guaranteed to be torn down — desktop was immune. Another instance of a desktop-first assumption failing in cloud.

Production CDP trace on `web.openworklabs.com`:

```
ERR_ABORTED canceled=true  GET /workspace/…/opencode/event  status=200  text/event-stream  after=2.78s
ERR_ABORTED canceled=true  GET /workspace/…/opencode/event  status=200  text/event-stream  after=0.36s
```

with the stream re-established ~8× in 45s.

## Fix

The web path now reuses the existing `requestIsStreaming` helper and passes `timeoutMs = 0` for streams — the same rule desktop already used. Ordinary requests keep the 10s timeout. Caller-supplied `AbortSignal` still cancels a stream on subscription unmount (`fetchWithTimeout` early-returns the underlying fetch when the timeout is non-positive, so the caller's signal is preserved). Desktop code untouched; the shared constant is unchanged.

## Proof

The regression test fails against current code at exactly the timeout boundary and passes after:

```
error: expect(received).toBeNull()
Received: AbortSignal { aborted: true, … }
(fail) does not transport-timeout web OpenCode event streams [10053.80ms]
```

| Command | Result |
| --- | --- |
| `apps/app` full suite | 520 pass / 0 fail |
| `tsc --noEmit` + `build:web` | clean |

Coverage: web streams not timed out; web ordinary requests still time out at 10s; caller abort still cancels streams; desktop unchanged.

## Deliberately not in this PR

Two findings from the same trace live in code shared with desktop and need their own desktop-aware change:

- `session-sync.ts` re-subscribes repeatedly (churn beyond the timeout kills)
- `/events?since=0` is polled continuously without advancing its cursor