### PR TITLE
test(evals): add dashboard UI acceptance flows

### DIFF
--- a/evals/flows/desktop-policies-dashboard-section.flow.ts
+++ b/evals/flows/desktop-policies-dashboard-section.flow.ts
@@ -1,0 +1,92 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import { denWebUrl, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "desktop-policies-dashboard-section";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+async function setViewport(ctx: FlowContext, width: number): Promise<void> {
+  ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
+  await ctx.client?.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: width < 768,
+  });
+}
+
+async function navigate(ctx: FlowContext, path: string): Promise<void> {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: path });
+}
+
+const POLICIES_SECTION = `(() => {
+  const heading = [...document.querySelectorAll("h1,h2,h3")]
+    .find((entry) => /desktop policies/i.test(entry.textContent || ""));
+  const section = heading?.closest("section");
+  if (!section) return false;
+  return Boolean(
+    section.querySelector("table") ||
+    /loading desktop policies|no desktop policies/i.test(section.textContent || "")
+  );
+})()`;
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Desktop Policies render as one independent responsive dashboard section",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Desktop Policies keep an independent responsive boundary",
+      run: async (ctx) => {
+        await ctx.prove("Desktop Policies remain clearly bounded across loaded, empty, and narrow layouts", {
+          voiceover: vo[0],
+          action: async () => {
+            await setViewport(ctx, 1440);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD);
+            await navigate(ctx, "/dashboard/desktop-policies");
+            await ctx.expectText("Desktop policies", { timeoutMs: 30_000 });
+            await ctx.waitFor(POLICIES_SECTION, { timeoutMs: 20_000, label: "dedicated Desktop Policies section" });
+            await setViewport(ctx, 390);
+            await ctx.waitFor(POLICIES_SECTION, { timeoutMs: 10_000, label: "Desktop Policies section at narrow width" });
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => {
+              const heading = [...document.querySelectorAll("h1,h2,h3")]
+                .find((entry) => /desktop policies/i.test(entry.textContent || ""));
+              const section = heading?.closest("section");
+              if (!section) return null;
+              const rect = section.getBoundingClientRect();
+              const table = section.querySelector("table");
+              const scroller = table?.closest(".overflow-x-auto");
+              return {
+                width: rect.width,
+                headingCount: [...section.querySelectorAll("h1,h2,h3")]
+                  .filter((entry) => /desktop policies/i.test(entry.textContent || "")).length,
+                hasState: Boolean(table) || /loading desktop policies|no desktop policies/i.test(section.textContent || ""),
+                tableContained: !table || Boolean(scroller),
+              };
+            })()`);
+            ctx.assert(Boolean(state), "Expected a measurable Desktop Policies section.");
+            const measured = state as { width: number; headingCount: number; hasState: boolean; tableContained: boolean };
+            ctx.assert(measured.width > 0, "Desktop Policies section must remain visible.");
+            ctx.assert(measured.headingCount === 1, `Expected one Desktop Policies heading, found ${measured.headingCount}.`);
+            ctx.assert(measured.hasState, "Expected the policy table, loading state, or empty state inside the section.");
+            ctx.assert(measured.tableContained, "The policy table must keep its narrow-width overflow container.");
+          },
+          screenshot: {
+            name: "desktop-policies-section-narrow",
+            requireText: ["Desktop policies"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/extensions-sidebar-and-header.flow.ts
+++ b/evals/flows/extensions-sidebar-and-header.flow.ts
@@ -1,0 +1,97 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+const FLOW_ID = "extensions-sidebar-and-header";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const EXTENSIONS_SIDEBAR_DESTINATION = `(() => {
+  const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+  if (!sidebar) return null;
+  const destination = [...sidebar.querySelectorAll("a,button")]
+    .find((entry) => (entry.textContent || "").trim() === "Extensions" || entry.getAttribute("aria-label") === "Extensions");
+  if (!destination) return null;
+  return {
+    tag: destination.tagName,
+    href: destination.getAttribute("href"),
+    active: destination.getAttribute("aria-current") === "page" || destination.getAttribute("data-active") === "true",
+    focused: document.activeElement === destination,
+  };
+})()`;
+
+function settingsPrefix(route: string): string {
+  const workspace = route.match(/^(\/workspace\/[^/]+)\/(?:session|settings(?:\/.*)?)$/);
+  return workspace ? workspace[1] : "";
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Extensions are directly discoverable in the desktop sidebar with one correct page header",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Sidebar navigation and Extensions header survive history and collapse",
+      run: async (ctx) => {
+        await ctx.prove("The desktop sidebar opens the existing Extensions route and keeps its active state and single header", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+            const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
+            const prefix = settingsPrefix(route);
+            const sessionRoute = `${prefix}/session`;
+            const extensionsRoute = `${prefix}/settings/extensions`;
+            const generalRoute = `${prefix}/settings/general`;
+
+            await ctx.navigateHash(sessionRoute);
+            await ctx.waitFor(EXTENSIONS_SIDEBAR_DESTINATION, { timeoutMs: 20_000, label: "Extensions sidebar destination" });
+            const clicked = await ctx.eval(`(() => {
+              const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+              const destination = [...(sidebar?.querySelectorAll("a,button") || [])]
+                .find((entry) => (entry.textContent || "").trim() === "Extensions" || entry.getAttribute("aria-label") === "Extensions");
+              if (!(destination instanceof HTMLElement)) return false;
+              destination.focus();
+              destination.click();
+              return true;
+            })()`);
+            ctx.assert(clicked === true, "Expected to focus and open Extensions from the sidebar.");
+            await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
+
+            await ctx.eval("location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after reload" });
+            await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
+
+            await ctx.navigateHash(generalRoute);
+            await ctx.waitForRoute(generalRoute, { timeoutMs: 20_000 });
+            await ctx.eval("history.back()");
+            await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
+
+            const toggled = await ctx.eval(`(() => {
+              const trigger = document.querySelector('[data-sidebar="rail"], [data-sidebar="trigger"]');
+              if (!(trigger instanceof HTMLElement)) return false;
+              trigger.click();
+              return true;
+            })()`);
+            ctx.assert(toggled === true, "Expected the desktop sidebar collapse control.");
+            await new Promise((resolve) => setTimeout(resolve, 300));
+          },
+          assert: async () => {
+            const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
+            ctx.assert(route.endsWith("/settings/extensions"), `Expected Extensions route, got ${route}.`);
+            const headings = await ctx.eval(`([...document.querySelectorAll("h1")]
+              .filter((entry) => (entry.textContent || "").trim() === "Extensions").length)`);
+            ctx.assert(headings === 1, `Expected one Extensions page header, found ${JSON.stringify(headings)}.`);
+            const destination = await ctx.eval(EXTENSIONS_SIDEBAR_DESTINATION);
+            ctx.assert(Boolean(destination), "Extensions must remain represented in the collapsed sidebar.");
+            const measured = destination as { active: boolean };
+            ctx.assert(measured.active, "Extensions sidebar destination must expose its active state.");
+          },
+          screenshot: {
+            name: "extensions-sidebar-collapsed",
+            requireText: ["Extensions"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/flat-plugin-card-treatment.flow.ts
+++ b/evals/flows/flat-plugin-card-treatment.flow.ts
@@ -1,0 +1,125 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import { denWebUrl, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "flat-plugin-card-treatment";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+async function setViewport(ctx: FlowContext, width: number): Promise<void> {
+  ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
+  await ctx.client?.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: width < 768,
+  });
+}
+
+async function navigate(ctx: FlowContext, path: string): Promise<void> {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: path });
+}
+
+const FLAT_PLUGIN_CARDS = `(selector) => {
+  const cards = [...document.querySelectorAll(selector)];
+  if (cards.length === 0) return { count: 0, decorative: [] };
+  const decorative = cards.flatMap((card, cardIndex) =>
+    [card, ...card.querySelectorAll("*")].flatMap((entry) => {
+      const style = getComputedStyle(entry);
+      const image = style.backgroundImage || "";
+      return image !== "none" && image !== "" ? [{ cardIndex, image }] : [];
+    })
+  );
+  return { count: cards.length, decorative };
+}`;
+
+async function assertFlatCards(ctx: FlowContext, selector: string, label: string): Promise<void> {
+  const result = await ctx.eval(`(${FLAT_PLUGIN_CARDS})(${JSON.stringify(selector)})`);
+  const measured = result as { count: number; decorative: Array<{ cardIndex: number; image: string }> };
+  ctx.assert(measured.count > 0, `Expected at least one ${label} Plugin card.`);
+  ctx.assert(
+    measured.decorative.length === 0,
+    `${label} Plugin cards still contain decorative background images: ${JSON.stringify(measured.decorative).slice(0, 500)}`,
+  );
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Den and Marketplace Plugin cards use a consistent flat semantic surface",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL"],
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Plugin cards stay flat across surfaces and responsive states",
+      run: async (ctx) => {
+        await ctx.prove("Plugin cards keep their content and interactions without gradients or decorative image overlays", {
+          voiceover: vo[0],
+          action: async () => {
+            await setViewport(ctx, 1440);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD);
+            await navigate(ctx, "/dashboard/plugins");
+            await ctx.expectText("Plugins", { timeoutMs: 30_000 });
+            await ctx.waitFor(
+              "Boolean(document.querySelector('a[href*=\"/dashboard/plugins/\"]:not([href$=\"/new\"]):not([href$=\"/import\"])'))",
+              { timeoutMs: 30_000, label: "Den Plugin card" },
+            );
+            await assertFlatCards(
+              ctx,
+              'a[href*="/dashboard/plugins/"]:not([href$="/new"]):not([href$="/import"])',
+              "Den",
+            );
+
+            const marketplaceHref = await ctx.eval(`(() => {
+              const link = [...document.querySelectorAll('a[href*="/dashboard/marketplaces/"]')]
+                .find((entry) => !entry.getAttribute("href")?.endsWith("/new"));
+              return link?.getAttribute("href") || "";
+            })()`);
+            ctx.assert(typeof marketplaceHref === "string" && marketplaceHref.length > 0, "Expected a seeded Marketplace detail link.");
+            await navigate(ctx, String(marketplaceHref));
+            await ctx.waitFor("Boolean(document.querySelector('div[id^=\"plugin-\"]'))", {
+              timeoutMs: 30_000,
+              label: "Marketplace Plugin card",
+            });
+            await assertFlatCards(ctx, 'div[id^="plugin-"]', "Marketplace");
+
+            await ctx.eval(`(() => {
+              document.documentElement.classList.add("dark");
+              const card = document.querySelector('div[id^="plugin-"] a, div[id^="plugin-"] button');
+              if (card instanceof HTMLElement) card.focus();
+              return true;
+            })()`);
+            await assertFlatCards(ctx, 'div[id^="plugin-"]', "dark-mode Marketplace");
+            await setViewport(ctx, 390);
+            await assertFlatCards(ctx, 'div[id^="plugin-"]', "narrow Marketplace");
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => {
+              const cards = [...document.querySelectorAll('div[id^="plugin-"]')];
+              const visible = cards.every((card) => {
+                const rect = card.getBoundingClientRect();
+                return rect.width > 0 && rect.right <= document.documentElement.clientWidth + 1;
+              });
+              const focused = document.activeElement?.closest('div[id^="plugin-"]') !== null;
+              return { count: cards.length, visible, focused };
+            })()`);
+            const measured = state as { count: number; visible: boolean; focused: boolean };
+            ctx.assert(measured.count > 0, "Expected Marketplace Plugin cards.");
+            ctx.assert(measured.visible, "Plugin cards must stay within the narrow viewport.");
+            ctx.assert(measured.focused, "A Plugin card action must retain visible keyboard focus.");
+          },
+          screenshot: {
+            name: "flat-plugin-cards-dark-narrow",
+            requireText: ["Plugins"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/lib/den-web.d.mts
+++ b/evals/flows/lib/den-web.d.mts
@@ -1,3 +1,5 @@
+import type { FlowContext } from "../../runner/flow.ts";
+
 export interface DenApiResult {
   response: Response;
   body: unknown;
@@ -6,3 +8,4 @@ export interface DenApiResult {
 export function denWebUrl(): string;
 export function denApiUrl(): string;
 export function denApiFetch(path: string, options?: RequestInit): Promise<DenApiResult>;
+export function signInViaBrowser(ctx: FlowContext, email: string, password: string): Promise<void>;

--- a/evals/flows/organization-form-dashboard-section.flow.ts
+++ b/evals/flows/organization-form-dashboard-section.flow.ts
@@ -1,0 +1,99 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import { denWebUrl, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "organization-form-dashboard-section";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+async function setViewport(ctx: FlowContext, width: number): Promise<void> {
+  ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
+  await ctx.client?.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: width < 768,
+  });
+}
+
+async function navigate(ctx: FlowContext, path: string): Promise<void> {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: path });
+}
+
+const ORGANIZATION_SECTION = `(() => {
+  const headings = [...document.querySelectorAll("h1,h2,h3")]
+    .filter((entry) => /organization/i.test(entry.textContent || ""));
+  return headings.some((heading) => {
+    const section = heading.closest("section");
+    return Boolean(section && section.querySelector("form") && section.querySelector('input[type="text"]'));
+  });
+})()`;
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Organization settings render as one dedicated responsive section",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Organization form keeps its section boundary and behavior",
+      run: async (ctx) => {
+        await ctx.prove("The Organization form is independently headed, responsive, and still saves through its existing workflow", {
+          voiceover: vo[0],
+          action: async () => {
+            await setViewport(ctx, 1440);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD);
+            await navigate(ctx, "/dashboard/org-settings");
+            await ctx.expectText("Organization", { timeoutMs: 30_000 });
+            await ctx.waitFor(ORGANIZATION_SECTION, { timeoutMs: 15_000, label: "dedicated Organization section" });
+
+            const name = await ctx.eval(`(() => {
+              const label = [...document.querySelectorAll("label")].find((entry) =>
+                (entry.textContent || "").trim().startsWith("Name"));
+              const input = label?.querySelector('input[type="text"]');
+              return input instanceof HTMLInputElement ? input.value : "";
+            })()`);
+            ctx.assert(typeof name === "string" && name.length >= 2, "Expected the existing organization name.");
+            await ctx.fill('label input[type="text"]', String(name));
+            await ctx.clickText("Save settings", { selector: "button" });
+            await ctx.expectText("Workspace settings updated.", { timeoutMs: 30_000 });
+
+            await setViewport(ctx, 390);
+            await ctx.waitFor(ORGANIZATION_SECTION, { timeoutMs: 10_000, label: "Organization section at narrow width" });
+          },
+          assert: async () => {
+            const metrics = await ctx.eval(`(() => {
+              const heading = [...document.querySelectorAll("h1,h2,h3")]
+                .find((entry) => /organization/i.test(entry.textContent || "") && entry.closest("section")?.querySelector("form"));
+              const section = heading?.closest("section");
+              const form = section?.querySelector("form");
+              if (!section || !form) return null;
+              const sectionRect = section.getBoundingClientRect();
+              const formRect = form.getBoundingClientRect();
+              return {
+                sectionWidth: sectionRect.width,
+                formWidth: formRect.width,
+                overflow: Math.max(0, formRect.right - sectionRect.right),
+                heading: heading?.textContent?.trim(),
+              };
+            })()`);
+            ctx.assert(Boolean(metrics), "Expected measurable Organization section and form.");
+            const measured = metrics as { sectionWidth: number; formWidth: number; overflow: number };
+            ctx.assert(measured.sectionWidth > 0 && measured.formWidth > 0, "Organization section must remain visible.");
+            ctx.assert(measured.overflow <= 1, `Organization form overflowed its narrow section by ${measured.overflow}px.`);
+          },
+          screenshot: {
+            name: "organization-section-narrow",
+            requireText: ["Organization", "Save settings"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/desktop-policies-dashboard-section.md
+++ b/evals/voiceovers/desktop-policies-dashboard-section.md
@@ -1,0 +1,3 @@
+# desktop-policies-dashboard-section — Desktop Policies stand on their own
+
+1. Open the dashboard and inspect Desktop Policies at desktop and narrow widths.

--- a/evals/voiceovers/extensions-sidebar-and-header.md
+++ b/evals/voiceovers/extensions-sidebar-and-header.md
@@ -1,0 +1,3 @@
+# extensions-sidebar-and-header — Extensions are easy to find
+
+1. Open Extensions from the sidebar, reload it, navigate away and back, and inspect expanded and collapsed sidebar states.

--- a/evals/voiceovers/flat-plugin-card-treatment.md
+++ b/evals/voiceovers/flat-plugin-card-treatment.md
@@ -1,0 +1,3 @@
+# flat-plugin-card-treatment — Plugin cards use one calm visual language
+
+1. Compare Plugin cards in Den and Marketplace across default, hover, selected, disabled, light, dark, and narrow states.

--- a/evals/voiceovers/organization-form-dashboard-section.md
+++ b/evals/voiceovers/organization-form-dashboard-section.md
@@ -1,0 +1,3 @@
+# organization-form-dashboard-section — Organization settings stay clear and usable
+
+1. Open the dashboard, review the Organization section, edit a safe field, and verify the result at desktop and narrow width.


### PR DESCRIPTION
## What changed

- add typed acceptance flows for the Organization section, Desktop Policies section, flat Plugin cards, and Extensions sidebar/header outcomes
- add one approved voiceover script per user-facing flow
- declare the existing Den browser sign-in helper for typed evaluator consumers

## Why

The dashboard feature wave could not start four implementation runs because these exact immutable acceptance evaluator IDs were absent from the authoritative base. The new flows establish the required proof contract before replacement runs begin.

## Validation

- `pnpm evals:typecheck`
- `pnpm evals --list`
- `pnpm evals:test` — 78 passed
- `git diff --check`
