### PR TITLE
fix(den): migrate legacy SSO providers on update

### DIFF
--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -12,6 +12,7 @@ import { ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED } from "./sso-saml-policy.js"
 
 type SsoConnection = typeof SsoConnectionTable.$inferSelect
 type OrganizationId = SsoConnection["organizationId"]
+type SsoTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
 
 type SamlRegistrationInput = {
   kind: "saml"
@@ -211,6 +212,58 @@ export async function getOrganizationSsoConnection(organizationId: OrganizationI
   return rows[0] ?? null
 }
 
+async function cleanupExternalIdentitiesForDeletedSsoConnection(
+  tx: SsoTransaction,
+  connection: SsoConnection,
+) {
+  await tx
+    .update(ExternalIdentityTable)
+    .set({
+      source: "scim",
+      ssoProviderId: null,
+      remoteId: null,
+      attributesJson: null,
+      lastSsoLoginAt: null,
+    })
+    .where(and(
+      eq(ExternalIdentityTable.organizationId, connection.organizationId),
+      eq(ExternalIdentityTable.ssoProviderId, connection.providerId),
+      isNotNull(ExternalIdentityTable.scimProviderId),
+    ))
+
+  await tx
+    .update(ExternalIdentityTable)
+    .set({
+      active: false,
+      ssoProviderId: null,
+      remoteId: null,
+      attributesJson: null,
+      lastSsoLoginAt: null,
+    })
+    .where(and(
+      eq(ExternalIdentityTable.organizationId, connection.organizationId),
+      eq(ExternalIdentityTable.ssoProviderId, connection.providerId),
+      isNull(ExternalIdentityTable.scimProviderId),
+    ))
+
+  await tx
+    .delete(AuthAccountTable)
+    .where(eq(AuthAccountTable.providerId, connection.providerId))
+}
+
+async function cleanupLegacySsoProvider(
+  tx: SsoTransaction,
+  connection: SsoConnection,
+  canonicalProviderId: string,
+) {
+  if (connection.providerId === canonicalProviderId) {
+    return
+  }
+
+  await cleanupExternalIdentitiesForDeletedSsoConnection(tx, connection)
+  await tx.delete(SsoProviderTable).where(eq(SsoProviderTable.providerId, connection.providerId))
+}
+
 export async function deleteOrganizationSsoConnection(organizationId: OrganizationId) {
   const connection = await getOrganizationSsoConnection(organizationId)
   if (!connection) {
@@ -218,40 +271,7 @@ export async function deleteOrganizationSsoConnection(organizationId: Organizati
   }
 
   await db.transaction(async (tx) => {
-    await tx
-      .update(ExternalIdentityTable)
-      .set({
-        source: "scim",
-        ssoProviderId: null,
-        remoteId: null,
-        attributesJson: null,
-        lastSsoLoginAt: null,
-      })
-      .where(and(
-        eq(ExternalIdentityTable.organizationId, connection.organizationId),
-        eq(ExternalIdentityTable.ssoProviderId, connection.providerId),
-        isNotNull(ExternalIdentityTable.scimProviderId),
-      ))
-
-    await tx
-      .update(ExternalIdentityTable)
-      .set({
-        active: false,
-        ssoProviderId: null,
-        remoteId: null,
-        attributesJson: null,
-        lastSsoLoginAt: null,
-      })
-      .where(and(
-        eq(ExternalIdentityTable.organizationId, connection.organizationId),
-        eq(ExternalIdentityTable.ssoProviderId, connection.providerId),
-        isNull(ExternalIdentityTable.scimProviderId),
-      ))
-
-    await tx
-      .delete(AuthAccountTable)
-      .where(eq(AuthAccountTable.providerId, connection.providerId))
-
+    await cleanupExternalIdentitiesForDeletedSsoConnection(tx, connection)
     await tx.delete(SsoConnectionTable).where(eq(SsoConnectionTable.id, connection.id))
     await tx.delete(SsoProviderTable).where(eq(SsoProviderTable.providerId, connection.providerId))
   })
@@ -277,18 +297,22 @@ export async function registerOrganizationSsoConnection(input: OrganizationSsoRe
           .set({ domainVerified: true })
           .where(eq(SsoProviderTable.providerId, providerId))
       }
-      await db
-        .update(SsoConnectionTable)
-        .set({
-          kind: input.kind,
-          issuer: input.issuer,
-          domain: input.domain,
-          status: "enabled",
-          signInPath: getOrganizationSsoSignInPath(input.organizationSlug),
-          lastTestedAt: new Date(),
-          lastError: null,
-        })
-        .where(eq(SsoConnectionTable.id, existing.id))
+      await db.transaction(async (tx) => {
+        await cleanupLegacySsoProvider(tx, existing, providerId)
+        await tx
+          .update(SsoConnectionTable)
+          .set({
+            providerId,
+            kind: input.kind,
+            issuer: input.issuer,
+            domain: input.domain,
+            status: "enabled",
+            signInPath: getOrganizationSsoSignInPath(input.organizationSlug),
+            lastTestedAt: new Date(),
+            lastError: null,
+          })
+          .where(eq(SsoConnectionTable.id, existing.id))
+      })
 
       const connection = await getOrganizationSsoConnection(input.organizationId)
       if (!connection) {
@@ -318,9 +342,11 @@ export async function registerOrganizationSsoConnection(input: OrganizationSsoRe
         })
         .where(eq(SsoProviderTable.providerId, providerId))
 
+      await cleanupLegacySsoProvider(tx, existing, providerId)
       await tx
         .update(SsoConnectionTable)
         .set({
+          providerId,
           kind: input.kind,
           issuer: input.issuer,
           domain: input.domain,

--- a/ee/apps/den-api/test/sso-provider-rotation.test.ts
+++ b/ee/apps/den-api/test/sso-provider-rotation.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_sso_provider_rotation"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+const ownerUserId = createDenTypeId("user")
+const ssoOnlyUserId = createDenTypeId("user")
+const ssoAndScimUserId = createDenTypeId("user")
+const firstOrganizationId = createDenTypeId("organization")
+const recoveryOrganizationId = createDenTypeId("organization")
+const organizationIds = [firstOrganizationId, recoveryOrganizationId]
+const legacyProviderIds = {
+  first: `legacy-sso-${firstOrganizationId}`,
+  recovery: `legacy-sso-${recoveryOrganizationId}`,
+}
+const canonicalProviderIds = {
+  first: `openwork-sso-${firstOrganizationId}`,
+  recovery: `openwork-sso-${recoveryOrganizationId}`,
+}
+
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let registerOrganizationSsoConnection: typeof import("../src/sso.js").registerOrganizationSsoConnection
+
+async function cleanup() {
+  await db.delete(schema.ExternalIdentityTable).where(drizzle.inArray(schema.ExternalIdentityTable.organizationId, organizationIds))
+  await db.delete(schema.AuthAccountTable).where(drizzle.inArray(schema.AuthAccountTable.userId, [ssoOnlyUserId, ssoAndScimUserId]))
+  await db.delete(schema.SsoConnectionTable).where(drizzle.inArray(schema.SsoConnectionTable.organizationId, organizationIds))
+  await db.delete(schema.SsoProviderTable).where(drizzle.inArray(schema.SsoProviderTable.organizationId, organizationIds))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, organizationIds))
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, ssoOnlyUserId, ssoAndScimUserId]))
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+  mock.module("../src/auth.js", () => ({
+    auth: {
+      api: {
+        registerSSOProvider: async (input: {
+          body: {
+            providerId: string
+            issuer: string
+            domain: string
+            organizationId: typeof firstOrganizationId
+            samlConfig?: unknown
+            oidcConfig?: unknown
+          }
+        }) => {
+          await realDb.insert(schema.SsoProviderTable).values({
+            id: createDenTypeId("ssoProvider"),
+            providerId: input.body.providerId,
+            issuer: input.body.issuer,
+            domain: input.body.domain,
+            organizationId: input.body.organizationId,
+            userId: ownerUserId,
+            samlConfig: JSON.stringify(input.body.samlConfig ?? input.body.oidcConfig ?? {}),
+          })
+        },
+      },
+    },
+  }))
+
+  const [dbModule, schemaModule, drizzleModule, ssoModule] = await Promise.all([
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/sso.js"),
+  ])
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+  registerOrganizationSsoConnection = ssoModule.registerOrganizationSsoConnection
+
+  await cleanup()
+  await db.insert(schema.AuthUserTable).values([
+    {
+      id: ownerUserId,
+      name: "SSO owner",
+      email: `sso-owner+${ownerUserId}@test.local`,
+      emailVerified: true,
+    },
+    {
+      id: ssoOnlyUserId,
+      name: "SSO-only user",
+      email: `sso-only+${ssoOnlyUserId}@test.local`,
+      emailVerified: true,
+    },
+    {
+      id: ssoAndScimUserId,
+      name: "SSO and SCIM user",
+      email: `sso-scim+${ssoAndScimUserId}@test.local`,
+      emailVerified: true,
+    },
+  ])
+  await db.insert(schema.OrganizationTable).values([
+    {
+      id: firstOrganizationId,
+      name: "First SSO migration",
+      slug: `sso-provider-first-${firstOrganizationId}`,
+    },
+    {
+      id: recoveryOrganizationId,
+      name: "Stranded SSO migration recovery",
+      slug: `sso-provider-recovery-${recoveryOrganizationId}`,
+    },
+  ])
+  await db.insert(schema.SsoProviderTable).values([
+    {
+      id: createDenTypeId("ssoProvider"),
+      providerId: legacyProviderIds.first,
+      issuer: "https://legacy-first.example.test",
+      domain: "first.example.test",
+      organizationId: firstOrganizationId,
+      userId: ownerUserId,
+      samlConfig: "legacy-first",
+    },
+    {
+      id: createDenTypeId("ssoProvider"),
+      providerId: legacyProviderIds.recovery,
+      issuer: "https://legacy-recovery.example.test",
+      domain: "recovery.example.test",
+      organizationId: recoveryOrganizationId,
+      userId: ownerUserId,
+      samlConfig: "legacy-recovery",
+    },
+    {
+      id: createDenTypeId("ssoProvider"),
+      providerId: canonicalProviderIds.recovery,
+      issuer: "https://stranded-canonical.example.test",
+      domain: "recovery.example.test",
+      organizationId: recoveryOrganizationId,
+      userId: ownerUserId,
+      samlConfig: "stranded-canonical",
+    },
+  ])
+  await db.insert(schema.SsoConnectionTable).values([
+    {
+      id: createDenTypeId("ssoConnection"),
+      organizationId: firstOrganizationId,
+      providerId: legacyProviderIds.first,
+      kind: "saml",
+      issuer: "https://legacy-first.example.test",
+      domain: "first.example.test",
+      signInPath: "/sso/first",
+    },
+    {
+      id: createDenTypeId("ssoConnection"),
+      organizationId: recoveryOrganizationId,
+      providerId: legacyProviderIds.recovery,
+      kind: "saml",
+      issuer: "https://legacy-recovery.example.test",
+      domain: "recovery.example.test",
+      signInPath: "/sso/recovery",
+    },
+  ])
+  await db.insert(schema.ExternalIdentityTable).values([
+    {
+      id: createDenTypeId("externalIdentity"),
+      organizationId: firstOrganizationId,
+      userId: ssoOnlyUserId,
+      source: "sso",
+      ssoProviderId: legacyProviderIds.first,
+      remoteId: "legacy-sso-only",
+      attributesJson: { department: "Engineering" },
+      active: true,
+      lastSsoLoginAt: new Date(),
+    },
+    {
+      id: createDenTypeId("externalIdentity"),
+      organizationId: firstOrganizationId,
+      userId: ssoAndScimUserId,
+      source: "scim+sso",
+      scimProviderId: "test-scim-provider",
+      ssoProviderId: legacyProviderIds.first,
+      remoteId: "legacy-sso-scim",
+      attributesJson: { department: "Design" },
+      active: true,
+      lastSsoLoginAt: new Date(),
+    },
+  ])
+  await db.insert(schema.AuthAccountTable).values([
+    {
+      id: createDenTypeId("account"),
+      userId: ssoOnlyUserId,
+      accountId: "legacy-sso-only",
+      providerId: legacyProviderIds.first,
+    },
+    {
+      id: createDenTypeId("account"),
+      userId: ssoAndScimUserId,
+      accountId: "legacy-sso-scim",
+      providerId: legacyProviderIds.first,
+    },
+  ])
+})
+
+afterAll(async () => {
+  await cleanup()
+  mock.restore()
+})
+
+test("legacy SSO connections move to the canonical provider and recover a stranded canonical provider", async () => {
+  const firstConnection = await registerOrganizationSsoConnection({
+    kind: "saml",
+    issuer: "https://new-first.example.test",
+    domain: "first.example.test",
+    entryPoint: "https://new-first.example.test/sso",
+    cert: "new-first-cert",
+    organizationId: firstOrganizationId,
+    organizationSlug: `sso-provider-first-${firstOrganizationId}`,
+    headers: new Headers(),
+  })
+  const recoveredConnection = await registerOrganizationSsoConnection({
+    kind: "saml",
+    issuer: "https://new-recovery.example.test",
+    domain: "recovery.example.test",
+    entryPoint: "https://new-recovery.example.test/sso",
+    cert: "new-recovery-cert",
+    organizationId: recoveryOrganizationId,
+    organizationSlug: `sso-provider-recovery-${recoveryOrganizationId}`,
+    headers: new Headers(),
+  })
+
+  expect(firstConnection.providerId).toBe(canonicalProviderIds.first)
+  expect(recoveredConnection.providerId).toBe(canonicalProviderIds.recovery)
+
+  const [firstProviders, recoveryProviders, identities, oldAccounts] = await Promise.all([
+    db.select().from(schema.SsoProviderTable).where(drizzle.eq(schema.SsoProviderTable.organizationId, firstOrganizationId)),
+    db.select().from(schema.SsoProviderTable).where(drizzle.eq(schema.SsoProviderTable.organizationId, recoveryOrganizationId)),
+    db.select().from(schema.ExternalIdentityTable).where(drizzle.eq(schema.ExternalIdentityTable.organizationId, firstOrganizationId)),
+    db.select().from(schema.AuthAccountTable).where(drizzle.eq(schema.AuthAccountTable.providerId, legacyProviderIds.first)),
+  ])
+
+  expect(firstProviders).toHaveLength(1)
+  expect(firstProviders[0]).toMatchObject({
+    providerId: canonicalProviderIds.first,
+    domain: "first.example.test",
+  })
+  expect(recoveryProviders).toHaveLength(1)
+  expect(recoveryProviders[0]).toMatchObject({
+    providerId: canonicalProviderIds.recovery,
+    domain: "recovery.example.test",
+  })
+  expect(recoveryProviders[0]?.samlConfig).toContain("new-recovery.example.test")
+  expect(oldAccounts).toHaveLength(0)
+
+  const ssoOnlyIdentity = identities.find((identity) => identity.userId === ssoOnlyUserId)
+  expect(ssoOnlyIdentity).toMatchObject({
+    source: "sso",
+    ssoProviderId: null,
+    scimProviderId: null,
+    remoteId: null,
+    active: false,
+    attributesJson: null,
+    lastSsoLoginAt: null,
+  })
+
+  const ssoAndScimIdentity = identities.find((identity) => identity.userId === ssoAndScimUserId)
+  expect(ssoAndScimIdentity).toMatchObject({
+    source: "scim",
+    ssoProviderId: null,
+    scimProviderId: "test-scim-provider",
+    remoteId: null,
+    active: true,
+    attributesJson: null,
+    lastSsoLoginAt: null,
+  })
+})


### PR DESCRIPTION
## Summary

Updating an organization that still has a legacy SSO provider id can create OpenWork's canonical `openwork-sso-*` provider without moving the organization's `sso_connection` to it. The API reports a successful update, but authentication continues through the legacy provider and the new configuration is unused.

A retry makes the state harder to recover: the canonical provider already exists, so Den updates that provider through a draft while the connection remains permanently attached to the legacy row.

This PR makes legacy-provider replacement an atomic part of both existing SSO update paths:

- the connection is moved to the canonical provider id;
- the old provider row is removed;
- Better Auth accounts for the old provider are deleted;
- SSO-only external identities are deactivated and detached;
- combined SSO + SCIM identities retain SCIM access and become SCIM-only;
- an already-stranded canonical provider is reused and refreshed, so organizations affected by the old behavior recover on their next SSO update.

The identity/account cleanup is extracted from the existing explicit SSO-disconnect transaction and reused for legacy migration. Normal canonical-provider updates retain their current behavior.

No schema or data migration is required.

## Verification

- `./bin/openwork-hub run enterprise sso-provider-rotation -- pnpm --filter @openwork-ee/den-api build`
  - Passed.
- `./bin/openwork-hub run enterprise sso-provider-rotation -- pnpm --filter @openwork-ee/den-api exec bun test test/sso-provider-rotation.test.ts test/sso-account-linking-policy.test.ts test/sso-entra-domain.test.ts test/sso-jit.test.ts test/sso-readiness.test.ts test/sso-saml-policy.test.ts test/sso-saml-response-policy.test.ts`
  - Passed: 17 tests, 0 failures, 34 assertions.
- `./bin/openwork-hub run enterprise sso-provider-rotation -- pnpm evals --stack den --flow invite-reliability`
  - Passed on commit `f8cc48275f311be1c1b16f0ae870091ccc70e860`: 9 journey steps, 0 failures, 0 skips.
  - Covers invite, separate-browser acceptance, consumed-link reopen, removal, same-email re-invite, explicit admin-role preservation, and cleanup.
  - Local report: `evals/results/2026-07-29T10-50-10-674Z/report.md`
  - Local fraimz: `evals/results/2026-07-29T10-50-10-674Z/fraimz.html`

The real-database regression test covers both a first legacy-to-canonical migration and recovery when the canonical provider was already stranded by an earlier update.
