### PR TITLE
fix(app): stop credential changes from tearing down the agent event stream

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -65,6 +65,20 @@ const syncs = new Map<string, SyncEntry>();
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
 
+type SyncSubscriptionFactory = (
+  baseUrl: string,
+  openworkToken: string,
+  signal: AbortSignal,
+) => Promise<AsyncIterable<unknown>>;
+
+const defaultSyncSubscriptionFactory: SyncSubscriptionFactory = async (baseUrl, openworkToken, signal) => {
+  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const subscription = await client.event.subscribe(undefined, { signal });
+  return subscription.stream;
+};
+
+let syncSubscriptionFactory = defaultSyncSubscriptionFactory;
+
 export const snapshotKey = (workspaceId: string, sessionId: string) =>
   ["react-session-snapshot", workspaceId, sessionId] as const;
 export const transcriptKey = (workspaceId: string, sessionId: string) =>
@@ -1082,11 +1096,10 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
     const connectionController = new AbortController();
     activeConnectionController = connectionController;
     try {
-      const client = createClient(input.baseUrl, undefined, { token: entry.openworkToken, mode: "openwork" });
-      const sub = await client.event.subscribe(undefined, { signal: connectionController.signal });
+      const stream = await syncSubscriptionFactory(input.baseUrl, entry.openworkToken, connectionController.signal);
       retryDelayMs = 1_000;
       lastEventAt = Date.now();
-      for await (const raw of sub.stream) {
+      for await (const raw of stream) {
         if (controller.signal.aborted || connectionController.signal.aborted) return;
         lastEventAt = Date.now();
         const event = normalizeEvent(raw);
@@ -1318,4 +1331,8 @@ export function __applySessionSyncEventForTest(input: SyncOptions, event: Openco
   const entry = syncs.get(syncKey(input));
   if (!entry) return;
   applyEvent(entry, input.workspaceId, event);
+}
+
+export function __setWorkspaceSessionSyncSubscriptionFactoryForTest(factory: SyncSubscriptionFactory | null) {
+  syncSubscriptionFactory = factory ?? defaultSyncSubscriptionFactory;
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -40,6 +40,7 @@ type PendingDelta = {
 
 type SyncEntry = {
   input: SyncOptions;
+  openworkToken: string;
   refs: number;
   dispose: () => void;
   disposeTimer: ReturnType<typeof setTimeout> | null;
@@ -78,7 +79,7 @@ export const questionKey = (workspaceId: string, sessionId: string) =>
   ["react-session-questions", workspaceId, sessionId] as const;
 
 function syncKey(input: SyncOptions) {
-  return `${input.workspaceId}:${input.baseUrl}:${input.openworkToken}`;
+  return `${input.workspaceId}:${input.baseUrl}`;
 }
 
 function getErrorStatus(error: unknown) {
@@ -1057,10 +1058,8 @@ function flushDeltas(entry: SyncEntry, workspaceId: string) {
   }
 }
 
-function startSync(input: SyncOptions) {
-  const client = createClient(input.baseUrl, undefined, { token: input.openworkToken, mode: "openwork" });
+function startSync(input: SyncOptions, entry: SyncEntry) {
   const controller = new AbortController();
-  const entry = syncs.get(syncKey(input));
   let disposed = false;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let watchdogTimer: ReturnType<typeof setInterval> | null = null;
@@ -1083,6 +1082,7 @@ function startSync(input: SyncOptions) {
     const connectionController = new AbortController();
     activeConnectionController = connectionController;
     try {
+      const client = createClient(input.baseUrl, undefined, { token: entry.openworkToken, mode: "openwork" });
       const sub = await client.event.subscribe(undefined, { signal: connectionController.signal });
       retryDelayMs = 1_000;
       lastEventAt = Date.now();
@@ -1091,7 +1091,6 @@ function startSync(input: SyncOptions) {
         lastEventAt = Date.now();
         const event = normalizeEvent(raw);
         if (!event) continue;
-        if (!entry) continue;
         applyEvent(entry, input.workspaceId, event);
       }
       if (!controller.signal.aborted && activeConnectionController === connectionController) scheduleRetry();
@@ -1130,6 +1129,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   const key = syncKey(input);
   const existing = syncs.get(key);
   if (existing) {
+    existing.openworkToken = input.openworkToken;
     if (existing.disposeTimer) {
       clearTimeout(existing.disposeTimer);
       existing.disposeTimer = null;
@@ -1144,6 +1144,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
 
   syncs.set(key, {
     input,
+    openworkToken: input.openworkToken,
     refs: 1,
     dispose: () => {},
     disposeTimer: null,
@@ -1159,7 +1160,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   });
 
   const created = syncs.get(key)!;
-  created.dispose = startSync(input);
+  created.dispose = startSync(input, created);
 
   return () => releaseWorkspaceSessionSync(input);
 }
@@ -1278,6 +1279,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
   const key = syncKey(input);
   syncs.set(key, {
     input,
+    openworkToken: input.openworkToken,
     refs: 1,
     dispose: () => {},
     disposeTimer: null,

--- a/apps/app/tests/session-sync-lifecycle.test.ts
+++ b/apps/app/tests/session-sync-lifecycle.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, mock, setSystemTime, test } from "bun:test";
+
+type SyncInput = {
+  workspaceId: string;
+  baseUrl: string;
+  openworkToken: string;
+};
+
+type Subscription = {
+  baseUrl: string;
+  token: string;
+  signal: AbortSignal;
+  end: () => void;
+};
+
+const subscriptions: Subscription[] = [];
+
+mock.module("../src/app/lib/opencode", () => ({
+  createClient: (
+    baseUrl: string,
+    _directory: string | undefined,
+    options: { token: string },
+  ) => ({
+    event: {
+      subscribe: async (_body: undefined, request: { signal: AbortSignal }) => {
+        let end = () => {};
+        const ended = new Promise<void>((resolve) => {
+          end = resolve;
+        });
+        request.signal.addEventListener("abort", end, { once: true });
+        async function* stream() {
+          await ended;
+        }
+        subscriptions.push({ baseUrl, token: options.token, signal: request.signal, end });
+        return { stream: stream() };
+      },
+    },
+  }),
+}));
+
+const {
+  __disposeWorkspaceSessionSyncForTest,
+  ensureWorkspaceSessionSync,
+} = await import("../src/react-app/domains/session/sync/session-sync");
+
+const inputs: SyncInput[] = [];
+const originalSetInterval = globalThis.setInterval;
+
+function input(baseUrl: string, openworkToken: string): SyncInput {
+  const value = { workspaceId: "ws_shared", baseUrl, openworkToken };
+  inputs.push(value);
+  return value;
+}
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForSubscriptions(count: number) {
+  const deadline = Date.now() + 2_000;
+  while (subscriptions.length < count && Date.now() < deadline) {
+    await delay(5);
+  }
+  expect(subscriptions).toHaveLength(count);
+}
+
+afterEach(() => {
+  for (const syncInput of inputs) __disposeWorkspaceSessionSyncForTest(syncInput);
+  inputs.length = 0;
+  subscriptions.length = 0;
+  setSystemTime();
+  Object.defineProperty(globalThis, "setInterval", {
+    configurable: true,
+    writable: true,
+    value: originalSetInterval,
+  });
+});
+
+describe("workspace session sync lifecycle", () => {
+  test("reuses an active stream when only the token changes", async () => {
+    const first = input("https://one.example/opencode", "token-old");
+    const second = input("https://one.example/opencode", "token-new");
+
+    const releaseFirst = ensureWorkspaceSessionSync(first);
+    await waitForSubscriptions(1);
+    const firstSignal = subscriptions[0]!.signal;
+    const releaseSecond = ensureWorkspaceSessionSync(second);
+
+    await delay(20);
+    expect(subscriptions).toHaveLength(1);
+    expect(firstSignal.aborted).toBe(false);
+
+    releaseSecond();
+    releaseFirst();
+  });
+
+  test("uses the updated token after a stream reconnects", async () => {
+    const first = input("https://one.example/opencode", "token-old");
+    const second = input("https://one.example/opencode", "token-new");
+    const releaseFirst = ensureWorkspaceSessionSync(first);
+    await waitForSubscriptions(1);
+    const releaseSecond = ensureWorkspaceSessionSync(second);
+
+    subscriptions[0]!.end();
+    await waitForSubscriptions(2);
+
+    expect(subscriptions.map(({ token }) => token)).toEqual(["token-old", "token-new"]);
+    releaseSecond();
+    releaseFirst();
+  });
+
+  test("keeps the same workspace id separate across base URLs", async () => {
+    const first = input("https://one.example/opencode", "token-one");
+    const second = input("https://two.example/opencode", "token-two");
+    const releaseFirst = ensureWorkspaceSessionSync(first);
+    const releaseSecond = ensureWorkspaceSessionSync(second);
+
+    await waitForSubscriptions(2);
+    expect(subscriptions.map(({ baseUrl }) => baseUrl).sort()).toEqual([
+      "https://one.example/opencode",
+      "https://two.example/opencode",
+    ]);
+    expect(subscriptions.every(({ signal }) => !signal.aborted)).toBe(true);
+
+    releaseSecond();
+    releaseFirst();
+  });
+
+  test("dispose aborts the active stream and cancels a pending retry", async () => {
+    const activeInput = input("https://one.example/opencode", "token");
+    ensureWorkspaceSessionSync(activeInput);
+    await waitForSubscriptions(1);
+
+    __disposeWorkspaceSessionSyncForTest(activeInput);
+    expect(subscriptions[0]!.signal.aborted).toBe(true);
+
+    const retryInput = input("https://two.example/opencode", "token");
+    ensureWorkspaceSessionSync(retryInput);
+    await waitForSubscriptions(2);
+    subscriptions[1]!.end();
+    await delay(20);
+
+    __disposeWorkspaceSessionSyncForTest(retryInput);
+    await delay(1_100);
+    expect(subscriptions).toHaveLength(2);
+  });
+
+  test("the stale-stream watchdog aborts and retries", async () => {
+    Object.defineProperty(globalThis, "setInterval", {
+      configurable: true,
+      writable: true,
+      value: (handler: TimerHandler) => originalSetInterval(handler, 5),
+    });
+    const syncInput = input("https://one.example/opencode", "token");
+    ensureWorkspaceSessionSync(syncInput);
+    await waitForSubscriptions(1);
+
+    const firstSignal = subscriptions[0]!.signal;
+    setSystemTime(Date.now() + 31_000);
+    await delay(20);
+    expect(firstSignal.aborted).toBe(true);
+    await waitForSubscriptions(2);
+  });
+});

--- a/apps/app/tests/session-sync-lifecycle.test.ts
+++ b/apps/app/tests/session-sync-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, setSystemTime, test } from "bun:test";
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
 
 type SyncInput = {
   workspaceId: string;
@@ -15,31 +15,9 @@ type Subscription = {
 
 const subscriptions: Subscription[] = [];
 
-mock.module("../src/app/lib/opencode", () => ({
-  createClient: (
-    baseUrl: string,
-    _directory: string | undefined,
-    options: { token: string },
-  ) => ({
-    event: {
-      subscribe: async (_body: undefined, request: { signal: AbortSignal }) => {
-        let end = () => {};
-        const ended = new Promise<void>((resolve) => {
-          end = resolve;
-        });
-        request.signal.addEventListener("abort", end, { once: true });
-        async function* stream() {
-          await ended;
-        }
-        subscriptions.push({ baseUrl, token: options.token, signal: request.signal, end });
-        return { stream: stream() };
-      },
-    },
-  }),
-}));
-
 const {
   __disposeWorkspaceSessionSyncForTest,
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
 } = await import("../src/react-app/domains/session/sync/session-sync");
 
@@ -56,6 +34,19 @@ function delay(milliseconds: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 }
 
+async function createSubscription(baseUrl: string, token: string, signal: AbortSignal) {
+  let end = () => {};
+  const ended = new Promise<void>((resolve) => {
+    end = resolve;
+  });
+  signal.addEventListener("abort", end, { once: true });
+  async function* stream() {
+    await ended;
+  }
+  subscriptions.push({ baseUrl, token, signal, end });
+  return stream();
+}
+
 async function waitForSubscriptions(count: number) {
   const deadline = Date.now() + 2_000;
   while (subscriptions.length < count && Date.now() < deadline) {
@@ -68,6 +59,7 @@ afterEach(() => {
   for (const syncInput of inputs) __disposeWorkspaceSessionSyncForTest(syncInput);
   inputs.length = 0;
   subscriptions.length = 0;
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
   setSystemTime();
   Object.defineProperty(globalThis, "setInterval", {
     configurable: true,
@@ -78,6 +70,7 @@ afterEach(() => {
 
 describe("workspace session sync lifecycle", () => {
   test("reuses an active stream when only the token changes", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     const first = input("https://one.example/opencode", "token-old");
     const second = input("https://one.example/opencode", "token-new");
 
@@ -95,6 +88,7 @@ describe("workspace session sync lifecycle", () => {
   });
 
   test("uses the updated token after a stream reconnects", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     const first = input("https://one.example/opencode", "token-old");
     const second = input("https://one.example/opencode", "token-new");
     const releaseFirst = ensureWorkspaceSessionSync(first);
@@ -110,6 +104,7 @@ describe("workspace session sync lifecycle", () => {
   });
 
   test("keeps the same workspace id separate across base URLs", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     const first = input("https://one.example/opencode", "token-one");
     const second = input("https://two.example/opencode", "token-two");
     const releaseFirst = ensureWorkspaceSessionSync(first);
@@ -127,6 +122,7 @@ describe("workspace session sync lifecycle", () => {
   });
 
   test("dispose aborts the active stream and cancels a pending retry", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     const activeInput = input("https://one.example/opencode", "token");
     ensureWorkspaceSessionSync(activeInput);
     await waitForSubscriptions(1);
@@ -146,6 +142,7 @@ describe("workspace session sync lifecycle", () => {
   });
 
   test("the stale-stream watchdog aborts and retries", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     Object.defineProperty(globalThis, "setInterval", {
       configurable: true,
       writable: true,


### PR DESCRIPTION
Tool calls appeared to **fail** and runs printed **Aborted** even though the server completed the work correctly.

## The full chain, measured

Probed from inside the affected user's real cloud instance, the MCP tool **succeeds**:

```
initialize:                     200 in 198ms
tools/list:                     200 -> ["search_capabilities","execute_capability"]
tools/call search_capabilities: 200 in 3232ms   (returns real results)
```

Meanwhile the browser's event stream was aborted client-side long before that finished (production CDP trace, taken after #3279 removed the 10s transport kill):

```
ERR_ABORTED canceled=true GET /workspace/…/opencode/event after=0.14s
ERR_ABORTED canceled=true GET /workspace/…/opencode/event after=0.13s
ERR_ABORTED canceled=true GET /workspace/…/opencode/event after=0.48s
ERR_ABORTED canceled=true GET /workspace/…/opencode/event after=2.54s
```

So a ~3.2s tool result arrived after the stream carrying it had been killed. The UI marked the tool failed and aborted the run. Den was never at fault.

## Cause

```ts
function syncKey(input: SyncOptions) {
  return `${input.workspaceId}:${input.baseUrl}:${input.openworkToken}`;
}
```

The **credential was part of the stream's identity**. Any token change — including the empty → resolved transition during boot, which is exactly what gateway/web mode does when it reads `openwork.den.authToken` — produced a new key, started a second sync, and the old sync's dispose aborted a live stream. `startSync` captured the token when it built its client, which is why re-keying was used to pick up a new one.

## Fix

Identity is now `workspaceId:baseUrl` (baseUrl stays — cloud workspace ids are deterministic per instance path, so the same `ws_…` can exist on different servers and must not collide). The token becomes mutable state on the entry, and each reconnect builds its client with the latest value, so reconnects use the freshest credential **without** aborting a healthy stream.

Unchanged on purpose: 1s→10s exponential backoff, the 30s stale-stream watchdog, the `activeConnectionController === connectionController` guards, immediate disposal, and retained-session timers. Desktop benefits identically — a token refresh no longer kills its stream.

## Review note

My first brief for this claimed a "dispose grace timer" existed and asked for it to be preserved. The executor checked, found `disposeTimer` is declared, cleared, and initialized but **never assigned**, and stopped rather than inventing behavior. Scope was corrected to preserve current disposal semantics. Flagging because that vestigial field reads like a feature and will mislead the next person.

## Tests

Regression guard fails against current code and passes here:

```
Expected length: 1
Received length: 2     ← two subscriptions created on token change
```

| Command | Result |
| --- | --- |
| `apps/app` full suite | 525 pass / 0 fail |
| `tsc --noEmit` + `build:web` | clean |

Coverage: token change reuses one sync and never aborts the stream; reconnect uses the updated token; different baseUrl stays isolated; dispose still aborts and clears timers; stale watchdog still retries.