### PR TITLE
Rename dashboard Stripe terminology to Billing

### DIFF
--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -773,7 +773,7 @@ async function shapeAdminUserRows(users: AdminUserBaseRow[], includeBilling: boo
         subscriptionStatus: null,
         currentPeriodEnd: null,
         source: "subscription",
-        note: "No cached Stripe organization subscription covers this user.",
+        note: "No cached organization subscription covers this user.",
       } : null,
       organizations: membershipsByUser.get(entry.id) ?? [],
     }
@@ -825,7 +825,7 @@ async function loadBillingForUsers(userIds: UserId[]) {
       subscriptionStatus,
       currentPeriodEnd,
       source: "subscription",
-      note: paid ? "Covered by an active Stripe organization subscription." : "Stripe organization subscription is not active.",
+      note: paid ? "Covered by an active organization subscription." : "Organization subscription is not active.",
     }
     const current = billingByUser.get(row.userId)
     if (!current || shouldReplaceBillingStatus(current, billing)) {

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/billing/stripe/checking/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/billing/stripe/checking/page.tsx
@@ -80,7 +80,7 @@ export default function StripeCheckingPage() {
   return (
     <DashboardPageTemplate
       icon={CreditCard}
-      title="Confirming Stripe"
+      title="Confirming subscription"
       description="Finishing your checkout and refreshing workspace access."
       colors={["#F5F3FF", "#312E81", "#635BFF", "#C4B5FD"]}
     >
@@ -90,15 +90,15 @@ export default function StripeCheckingPage() {
             <AlertCircle className="h-10 w-10 text-red-500" aria-hidden="true" />
             <p className="text-[17px] font-medium text-gray-950">We couldn&apos;t confirm the subscription yet</p>
             <p className="max-w-[480px] text-[14px] leading-6 text-gray-600">
-              If your payment went through, refresh Stripe from the billing page or contact{" "}
+              If your payment went through, refresh the billing page or contact{" "}
               <a className="font-medium text-blue-600 hover:underline" href="mailto:team@openworklabs.com">team@openworklabs.com</a>.
             </p>
-            <DenButton onClick={() => router.replace(billingRoute)}>Return to Stripe</DenButton>
+            <DenButton onClick={() => router.replace(billingRoute)}>Return to Billing</DenButton>
           </>
         ) : (
           <>
             <Loader2 className="h-9 w-9 animate-spin text-[#635BFF]" aria-hidden="true" />
-            <p className="text-[16px] font-medium text-gray-950">Stripe is confirming your subscription</p>
+            <p className="text-[16px] font-medium text-gray-950">Your subscription is being confirmed</p>
             <p className="max-w-sm text-[13px] leading-6 text-gray-500">This page updates automatically. You&apos;ll return to your workspace as soon as access is ready.</p>
           </>
         )}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -154,14 +154,14 @@ export function BillingDashboardScreen() {
     if (!quiet) setStripeError(null);
     try {
       const { response, payload } = await requestJson("/v1/billing", { method: "GET" }, 12000);
-      if (!response.ok) throw new Error(getErrorMessage(payload, `Stripe billing lookup failed (${response.status}).`));
+      if (!response.ok) throw new Error(getErrorMessage(payload, `Billing lookup failed (${response.status}).`));
       const parsed = parseStripeBilling(payload);
-      if (!parsed) throw new Error("Stripe billing response was incomplete.");
+      if (!parsed) throw new Error("Billing response was incomplete.");
       setStripeBilling(parsed);
       setPolarBilling(parsePolarBilling(payload));
       return parsed;
     } catch (error) {
-      if (!quiet) setStripeError(error instanceof Error ? error.message : "Could not load Stripe billing.");
+      if (!quiet) setStripeError(error instanceof Error ? error.message : "Could not load billing details.");
       return null;
     } finally {
       setStripeBusy(false);
@@ -195,12 +195,12 @@ export function BillingDashboardScreen() {
               12000,
             );
             if (!response.ok) {
-              setStripeError(getErrorMessage(payload, `Stripe checkout sync failed (${response.status}).`));
+              setStripeError(getErrorMessage(payload, `Checkout sync failed (${response.status}).`));
             }
           });
         } catch (error) {
           if (!cancelled) {
-            setStripeError(error instanceof Error ? error.message : "Could not sync Stripe checkout session.");
+            setStripeError(error instanceof Error ? error.message : "Could not sync the checkout session.");
           }
         }
       }
@@ -228,7 +228,7 @@ export function BillingDashboardScreen() {
 
   async function startSeatCheckout() {
     if (!canManageBillingSettings) {
-      setStripeError("Admins can start seat checkout from Members. Owners and super-admins manage Stripe settings here.");
+      setStripeError("Admins can start seat checkout from Members. Owners and super-admins manage Billing settings here.");
       return;
     }
 
@@ -270,7 +270,7 @@ export function BillingDashboardScreen() {
         window.location.href = url;
       });
     } catch (error) {
-      setStripeError(error instanceof Error ? error.message : "Could not open Stripe billing portal.");
+      setStripeError(error instanceof Error ? error.message : "Could not open the billing portal.");
     } finally {
       setStripeActionBusy(null);
     }
@@ -286,7 +286,7 @@ export function BillingDashboardScreen() {
     <div data-testid="stripe-billing-screen">
       <DashboardPageTemplate
         icon={CreditCard}
-        title="Stripe"
+        title="Billing"
         description="Manage workspace subscriptions, seats, and OpenWork Models in one place."
         colors={["#F5F3FF", "#312E81", "#635BFF", "#C4B5FD"]}
       >
@@ -296,13 +296,13 @@ export function BillingDashboardScreen() {
 
       {canManageBillingSettings ? null : (
         <div className="mb-6 rounded-[20px] border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] text-amber-800">
-          Admins can view Stripe settings here. Owners and super-admins can open billing portals or start Settings checkouts.
+          Admins can view Billing settings here. Owners and super-admins can open billing portals or start Settings checkouts.
         </div>
       )}
 
       {stripeReturnChecking ? (
         <div className="mb-6 rounded-[20px] border border-blue-200 bg-blue-50 px-4 py-3 text-[13px] text-blue-800">
-          We&apos;re checking your Stripe subscription. This page will refresh automatically.
+          We&apos;re checking your subscription. This page will refresh automatically.
         </div>
       ) : null}
 
@@ -311,11 +311,11 @@ export function BillingDashboardScreen() {
           {stripeBusy ? (
             <div className="flex min-h-36 items-center justify-center gap-3 text-[14px] text-gray-500">
               <RefreshCw className="size-4 animate-spin text-[#635BFF]" aria-hidden="true" />
-              Loading Stripe billing details...
+              Loading billing details...
             </div>
           ) : (
             <div className="mx-auto grid max-w-lg justify-items-start gap-3">
-              <p className="text-[16px] font-medium text-gray-950">Stripe details could not be loaded</p>
+              <p className="text-[16px] font-medium text-gray-950">Billing details could not be loaded</p>
               <p className="text-[13px] leading-6 text-gray-500">{stripeError ?? "The billing response did not include the details this page needs."}</p>
               <DenButton icon={RefreshCw} onClick={() => void refreshStripeBilling(false)}>Try again</DenButton>
             </div>
@@ -325,8 +325,8 @@ export function BillingDashboardScreen() {
         <>
           <div className="mb-6 flex items-center justify-between gap-4 rounded-2xl border border-violet-100 bg-violet-50/70 px-5 py-4">
             <div>
-              <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#635BFF]">Stripe workspace billing</p>
-              <p className="mt-1 text-[13px] text-violet-950/70">Prices and billing intervals below come directly from your Stripe configuration.</p>
+              <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#635BFF]">Workspace billing</p>
+              <p className="mt-1 text-[13px] text-violet-950/70">Prices and billing intervals below come directly from your billing configuration.</p>
             </div>
             <DenButton variant="secondary" icon={RefreshCw} loading={stripeBusy} onClick={() => void refreshStripeBilling(false)}>Refresh</DenButton>
           </div>
@@ -353,7 +353,7 @@ export function BillingDashboardScreen() {
       <section className="mb-6 rounded-2xl border border-violet-100 bg-white p-8 shadow-[0_8px_30px_-20px_rgba(49,46,129,0.45)]">
         <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
-            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Stripe</p>
+            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Billing</p>
             <h2 className="text-[20px] font-medium text-gray-950">OpenWork Users</h2>
             <p className="mt-2 max-w-[620px] text-[14px] leading-6 text-gray-500">
               The first {seatBilling?.freeSeatCount} users in your organization are included. Additional users are {seatPrice} per user per {seatBilling?.interval}.
@@ -400,7 +400,7 @@ export function BillingDashboardScreen() {
               <p className="mt-1 text-[13px] leading-5 text-blue-900/70">You will only be charged for users above the free included seats.</p>
             </div>
             <DenButton disabled={!canManageBillingSettings || seatBilling?.configured === false} loading={stripeActionBusy === "seat-checkout"} onClick={startSeatCheckout}>
-              Subscribe with Stripe
+              Subscribe
             </DenButton>
           </div>
         )}
@@ -409,7 +409,7 @@ export function BillingDashboardScreen() {
       <section className="rounded-2xl border border-violet-100 bg-white p-8 shadow-[0_8px_30px_-20px_rgba(49,46,129,0.45)]">
         <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
-            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Stripe</p>
+            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Billing</p>
             <h2 className="text-[20px] font-medium text-gray-950">OpenWork Models</h2>
             <p className="mt-2 max-w-[620px] text-[14px] leading-6 text-gray-500">
               Model access is billed at {stripePrice} per user per {stripeBilling.interval}.

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -365,7 +365,7 @@ export function InferenceScreen() {
         window.location.href = url;
       });
     } catch (checkoutError) {
-      setError(checkoutError instanceof Error ? checkoutError.message : "Could not start Stripe checkout.");
+      setError(checkoutError instanceof Error ? checkoutError.message : "Could not start checkout.");
       setSubscribeBusy(false);
     }
   }
@@ -419,7 +419,7 @@ export function InferenceScreen() {
   const subscribed = status?.subscribed === true;
   const showGettingStarted = !loading && status !== null && !subscribed;
   const memberCount = status?.memberCount ?? 0;
-  const actionLabel = subscribed ? (enabled ? "Manage subscription" : "Enable") : "Subscribe with Stripe";
+  const actionLabel = subscribed ? (enabled ? "Manage subscription" : "Enable") : "Subscribe";
   const memberCaption = memberCount > 0
     ? `${memberCount} active member${memberCount === 1 ? "" : "s"}`
     : "billed per active member";

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -283,7 +283,7 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
     return "Your Connections";
   }
   if (pathname.startsWith(getBillingRoute(orgSlug))) {
-    return "Stripe";
+    return "Billing";
   }
   if (pathname.startsWith(getBrandAppearanceRoute(orgSlug))) {
     return "Brand appearance";
@@ -404,7 +404,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
               { href: getDiagnosticsRoute(activeOrg.slug), label: "Diagnostics" },
               { href: getBrandAppearanceRoute(activeOrg.slug), label: "Brand appearance" },
               { href: getDesktopPoliciesRoute(activeOrg.slug), label: "Desktop Policies" },
-              { href: getBillingRoute(activeOrg.slug), label: "Stripe" },
+              { href: getBillingRoute(activeOrg.slug), label: "Billing" },
               { href: getApiKeysRoute(activeOrg.slug), label: "API Keys" },
               { href: getSsoRoute(activeOrg.slug), label: "SSO" },
               { href: getScimRoute(activeOrg.slug), label: "SCIM" },

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -658,7 +658,7 @@ function buildFixtureUser(index: number, includeBilling: boolean): AdminUser {
       subscriptionStatus: target ? "active" : null,
       currentPeriodEnd: target ? "2026-08-01T00:00:00.000Z" : null,
       source: "subscription",
-      note: target ? "Covered by an active Stripe organization subscription." : "No cached Stripe organization subscription covers this user."
+      note: target ? "Covered by an active organization subscription." : "No cached organization subscription covers this user."
     } : null,
     organizations: [{
       id: organizationId,

--- a/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
+++ b/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
@@ -87,7 +87,7 @@ describe("cloud super-admin role hierarchy", () => {
       expect(shell).toContain(`label: "${label}"`);
     }
 
-    for (const label of ["General", "Diagnostics", "Brand appearance", "Desktop Policies", "Stripe", "API Keys", "SSO", "SCIM"]) {
+    for (const label of ["General", "Diagnostics", "Brand appearance", "Desktop Policies", "Billing", "API Keys", "SSO", "SCIM"]) {
       expect(shell).toContain(`label: "${label}"`);
     }
 

--- a/ee/apps/den-web/tests/openwork-models-page.test.ts
+++ b/ee/apps/den-web/tests/openwork-models-page.test.ts
@@ -31,8 +31,9 @@ describe("OpenWork Models page", () => {
     }
   });
 
-  test("keeps the Stripe subscribe and enable flows", () => {
-    expect(screen).toContain("Subscribe with Stripe");
+  test("keeps the billing subscribe and enable flows", () => {
+    expect(screen).toContain(': "Subscribe";');
+    expect(screen).not.toContain("Subscribe with Stripe");
     expect(screen).toContain("Manage subscription");
     expect(screen).toContain("/v1/billing/stripe/checkout");
     expect(screen).toContain('method: "PATCH"');

--- a/ee/apps/den-web/tests/settings-stripe-layout.test.ts
+++ b/ee/apps/den-web/tests/settings-stripe-layout.test.ts
@@ -7,25 +7,43 @@ function read(relativePath: string) {
 }
 
 describe("Den settings destinations", () => {
-  test("exposes Brand appearance and Stripe as distinct Settings entries", () => {
+  test("exposes Brand appearance and Billing as distinct Settings entries", () => {
     const shell = read("../app/(den)/dashboard/_components/org-dashboard-shell.tsx");
     const routes = read("../app/(den)/_lib/den-org.ts");
 
     expect(routes).toContain('return `${getOrgDashboardRoute(orgSlug)}/brand-appearance`');
     expect(shell).toContain('label: "Brand appearance"');
-    expect(shell).toContain('label: "Stripe"');
+    expect(shell).toContain('label: "Billing"');
+    expect(shell).not.toContain('label: "Stripe"');
   });
 
-  test("renders one truthful Stripe refresh surface with explicit loading and error states", () => {
+  test("renders one truthful Billing refresh surface with explicit loading and error states", () => {
     const billing = read("../app/(den)/dashboard/_components/billing-dashboard-screen.tsx");
     const refreshLabels = billing.match(/>Refresh<\/DenButton>/g) ?? [];
 
     expect(billing).toContain('data-testid="stripe-billing-screen"');
-    expect(billing).toContain('title="Stripe"');
-    expect(billing).toContain("Loading Stripe billing details...");
-    expect(billing).toContain("Stripe details could not be loaded");
+    expect(billing).toContain('title="Billing"');
+    expect(billing).toContain("Loading billing details...");
+    expect(billing).toContain("Billing details could not be loaded");
+    expect(billing).not.toContain("Subscribe with Stripe");
+    expect(billing).toContain('"/v1/billing/stripe/checkout"');
     expect(billing).toContain("per user per {seatBilling?.interval}");
     expect(refreshLabels).toHaveLength(1);
+  });
+
+  test("uses Billing terminology throughout the checkout confirmation screen", () => {
+    const checking = read("../app/(den)/dashboard/(admin)/billing/stripe/checking/page.tsx");
+
+    expect(checking).toContain('title="Confirming subscription"');
+    expect(checking).toContain("Return to Billing");
+    expect(checking).not.toContain('title="Confirming Stripe"');
+  });
+
+  test("keeps provider terminology out of admin billing notes", () => {
+    const adminApi = read("../../den-api/src/routes/admin/index.ts");
+
+    expect(adminApi).toContain("Covered by an active organization subscription.");
+    expect(adminApi).not.toContain("Stripe organization subscription");
   });
 
   test("uses designed access transitions instead of bare redirect copy", () => {


### PR DESCRIPTION
## Summary

- Rename user-facing Den dashboard references from “Stripe” to “Billing”.
- Keep the underlying Stripe checkout, portal, API, and route mechanics unchanged.
- Update related copy and regression expectations across workspace billing, OpenWork Models, and admin surfaces.

## What changed

- **Navigation and page identity** — renames the Settings destination and dashboard page title to Billing.
- **Billing states** — replaces provider-specific loading, confirmation, error, subscription, and action copy with product-facing Billing language.
- **OpenWork Models** — simplifies the unsubscribed action from “Subscribe with Stripe” to “Subscribe”.
- **Admin context** — removes unnecessary Stripe wording from cached subscription notes while preserving the underlying billing data model.
- **Regression coverage** — updates billing-layout, model-page, and role-hierarchy expectations.

## Why

Stripe is an implementation detail. Users should encounter a stable Billing destination and product language even if the payment provider or checkout implementation changes later.

## Verification

Current scoped candidate: `7dab959b32758fa2b39655ec71673c0280e9031e` on `dev@7908ad1dd429aaabcbb273c22872eb003a34ef7a`.

- [x] Focused Billing, Models, and role-hierarchy tests — 16 passed, 0 failed.
- [x] `pnpm --dir ee/apps/den-web typecheck` — passed.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [x] Scope audit — 1 feature commit, 9 intended files; no inherited auth or evaluator changes.
- [ ] Deterministic real-app proof was not requested.
- [ ] GitHub checks are recomputing for the rebuilt head; no preview deployment is claimed.

## Risks and untested scope

- Internal route names, API paths, state variables, and provider integrations still use Stripe where that identifier is technically accurate.
- No deterministic browser journey was requested, so human review should scan the Billing navigation, checkout return state, error states, and OpenWork Models subscription entry point.
- Private Kitchen evidence and raw provider logs are intentionally not attached.

## Lineage

- Current fork draft: [reachjalil/openwork#10](https://github.com/reachjalil/openwork/pull/10)

## Exact candidate

- Current base: `7908ad1dd429aaabcbb273c22872eb003a34ef7a`
- Current head: `7dab959b32758fa2b39655ec71673c0280e9031e`
- Original Kitchen head: `88025e440e806011d9cf46595b4bde1554d6cc31`
- Kitchen run: `b4c2b9fa-471a-4e08-ac32-d2a4d3bf42b1`

## Automation boundary

Prepared by OpenWork Kitchen, then reconstructed as one clean feature commit on current `dev` under the authorized GitHub identity `@reachjalil`. This remains a draft; review requests, ready-for-review, merge, release, and deployment remain manual.
