### PR TITLE
Mark Sources as Alpha

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
@@ -42,6 +42,23 @@ export type DashboardPageTemplateProps = {
   children?: React.ReactNode;
 };
 
+export function DashboardPageMaturityBadge({
+  label,
+  title,
+}: {
+  label: string;
+  title: string;
+}) {
+  return (
+    <span
+      className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md"
+      aria-label={`${title} maturity: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 export function DashboardPageTemplate({
   icon: Icon,
   badgeLabel,
@@ -118,9 +135,7 @@ export function DashboardPageTemplate({
           }`}
         >
           {badgeLabel ? (
-            <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
-              {badgeLabel}
-            </span>
+            <DashboardPageMaturityBadge label={badgeLabel} title={title} />
           ) : null}
           <h1
             className={`font-medium text-white ${

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
@@ -56,7 +56,7 @@ export function IntegrationsScreen() {
   return (
     <DashboardPageTemplate
       icon={Cable}
-      badgeLabel="Preview"
+      badgeLabel="Alpha"
       title="Sources"
       description="Connect to GitHub or Bitbucket. Once an account is linked, plugins and skills from those repositories show up on the Plugins page."
       colors={["#E0F2FE", "#0C4A6E", "#0284C7", "#7DD3FC"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -371,7 +371,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         icon: Puzzle,
         children: [
           { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" },
-          { href: getIntegrationsRoute(activeOrg.slug), label: "Sources" },
+          { href: getIntegrationsRoute(activeOrg.slug), label: "Sources", badge: "Alpha" },
           { href: getPluginsRoute(activeOrg.slug), label: "Plugins" },
           { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" },
         ],
@@ -662,7 +662,10 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                   </span>
                   <span className="flex items-center gap-1.5">
                     {item.badge ? (
-                      <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                      <span
+                        className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500"
+                        aria-label={`${item.label} maturity: ${item.badge}`}
+                      >
                         {item.badge}
                       </span>
                     ) : null}
@@ -688,7 +691,10 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                       >
                         {child.label}
                         {child.badge ? (
-                          <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                          <span
+                            className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500"
+                            aria-label={`${child.label} maturity: ${child.badge}`}
+                          >
                             {child.badge}
                           </span>
                         ) : null}

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -13,7 +13,7 @@ describe("connector and marketplace polish", () => {
   test("puts Marketplace first and renames the org connection surface to Connectors beta", () => {
     const shell = readDashboardComponent("org-dashboard-shell.tsx");
     const marketplaceIndex = shell.indexOf('{ href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" }');
-    const sourcesIndex = shell.indexOf('{ href: getIntegrationsRoute(activeOrg.slug), label: "Sources" }');
+    const sourcesIndex = shell.indexOf('{ href: getIntegrationsRoute(activeOrg.slug), label: "Sources", badge: "Alpha" }');
     const pluginsIndex = shell.indexOf('{ href: getPluginsRoute(activeOrg.slug), label: "Plugins" }');
     const connectorsIndex = shell.indexOf('{ href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" }');
 

--- a/ee/apps/den-web/tests/sources-alpha.test.tsx
+++ b/ee/apps/den-web/tests/sources-alpha.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DashboardPageMaturityBadge } from "../app/(den)/_components/ui/dashboard-page-template";
+
+function readDashboardComponent(name: string) {
+  return readFileSync(
+    fileURLToPath(new URL(`../app/(den)/dashboard/_components/${name}`, import.meta.url)),
+    "utf8",
+  );
+}
+
+describe("Sources Alpha maturity", () => {
+  test("labels the Sources navigation and page hero as Alpha", () => {
+    const shell = readDashboardComponent("org-dashboard-shell.tsx");
+    const screen = readDashboardComponent("integrations-screen.tsx");
+
+    expect(shell).toContain('label: "Sources", badge: "Alpha"');
+    expect(shell).toContain('return "Sources";');
+    expect(screen).toContain('title="Sources"');
+    expect(screen).toContain('badgeLabel="Alpha"');
+    expect(screen).not.toContain('badgeLabel="Preview"');
+  });
+
+  test("gives the shared page maturity badge an explicit accessible name", () => {
+    const markup = renderToStaticMarkup(
+      <DashboardPageMaturityBadge label="Alpha" title="Sources" />,
+    );
+
+    expect(markup).toContain('aria-label="Sources maturity: Alpha"');
+    expect(markup).toContain(">Alpha</span>");
+  });
+
+  test("gives sidebar maturity badges explicit accessible names", () => {
+    const shell = readDashboardComponent("org-dashboard-shell.tsx");
+
+    expect(shell).toContain('aria-label={`${child.label} maturity: ${child.badge}`}');
+    expect(shell).toContain('aria-label={`${item.label} maturity: ${item.badge}`}');
+  });
+});


### PR DESCRIPTION
## Summary

Mark Sources as Alpha so the dashboard communicates the feature's maturity before users rely on it.

## Verification

**Incomplete.** Historical focused implementation checks were recorded, but visual verification was skipped. The branch now conflicts with current dev and requires a scoped rebase, a fresh covering journey, and Warden review before merging. This PR is open for review; the ready state does not claim that verification passed.
