### PR TITLE
Use flat workspace colors for Den Marketplace and Plugin cards

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/catalog-card-surface.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/catalog-card-surface.tsx
@@ -1,0 +1,61 @@
+export const catalogCardSwatches = [
+  "#2563eb",
+  "#5a67d8",
+  "#f97316",
+  "#10b981",
+] as const;
+
+export type CatalogCardSwatch = (typeof catalogCardSwatches)[number];
+
+const referenceSwatches: Record<string, CatalogCardSwatch> = {
+  "ben private marketplace": "#5a67d8",
+  "plan my day": "#5a67d8",
+  "review missed messages": "#f97316",
+};
+
+export const catalogCardClassName =
+  "group block overflow-hidden rounded-2xl border border-[var(--dls-border)] bg-[var(--dls-surface)] transition hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--dls-accent)] focus-visible:ring-offset-2";
+
+type CatalogColorRailProps = {
+  itemId: string;
+  itemName: string;
+  size: "card" | "compact" | "detail";
+};
+
+const railSizeClasses: Record<CatalogColorRailProps["size"], string> = {
+  card: "w-[68px]",
+  compact: "w-[64px]",
+  detail: "w-[96px]",
+};
+
+function hashIdentifier(identifier: string) {
+  let hash = 2166136261;
+  for (const character of identifier) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function getCatalogCardSwatch(itemId: string, itemName: string): CatalogCardSwatch {
+  const normalizedName = itemName.trim().toLowerCase();
+  if (normalizedName.startsWith("posthog")) return "#2563eb";
+
+  const referenceSwatch = referenceSwatches[normalizedName];
+  if (referenceSwatch) return referenceSwatch;
+
+  return catalogCardSwatches[hashIdentifier(itemId) % catalogCardSwatches.length];
+}
+
+export function CatalogColorRail({ itemId, itemName, size }: CatalogColorRailProps) {
+  const swatch = getCatalogCardSwatch(itemId, itemName);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`shrink-0 ${railSizeClasses[size]}`}
+      data-catalog-card-swatch={swatch}
+      style={{ backgroundColor: swatch }}
+    />
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState, useEffect } from "react";
 import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, MoreHorizontal, Pencil, Plug, Plus, Puzzle, Trash2, Users, X } from "lucide-react";
-import { PaperMeshGradient, StaticSeededGradient } from "@openwork/ui/react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
@@ -46,8 +45,8 @@ import {
   pluginSetupSuccessCopy,
   serviceNameForRequirement,
 } from "./marketplace-mcp-setup";
-import { MarketplaceLogo } from "./marketplace-logo";
 import { useMcpAccountAuthorization } from "./use-mcp-account-authorization";
+import { CatalogColorRail, catalogCardClassName } from "./catalog-card-surface";
 
 const COMPONENT_TYPE_LABELS: Record<string, { singular: string; plural: string }> = {
   skill: { singular: "skill", plural: "skills" },
@@ -222,25 +221,11 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
         ) : null}
       </div>
 
-      <article className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+      <article className="overflow-hidden rounded-2xl border border-[var(--dls-border)] bg-[var(--dls-surface)]">
         <div className="flex items-stretch">
-          <div className="relative w-[96px] shrink-0 overflow-hidden">
-            <div className="absolute inset-0">
-              <PaperMeshGradient seed={marketplace.id} speed={0} />
-            </div>
-            <div className="relative flex h-full items-center justify-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-[16px] border border-white/60 bg-white shadow-[0_10px_24px_-10px_rgba(15,23,42,0.3)]">
-                <MarketplaceLogo
-                  logoUrl={marketplace.logoUrl}
-                  name={marketplace.name}
-                  imgClassName="h-9 w-9"
-                  iconClassName="h-6 w-6"
-                />
-              </div>
-            </div>
-          </div>
+          <CatalogColorRail itemId={marketplace.id} itemName={marketplace.name} size="detail" />
 
-          <div className="min-w-0 flex-1 px-6 py-5">
+          <div className="min-w-0 flex-1 px-6 py-4">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="truncate text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
                 {marketplace.name}
@@ -1017,18 +1002,11 @@ function MarketplacePluginCard({
     .sort((a, b) => b[1] - a[1]);
 
   return (
-    <div id={`plugin-${plugin.id}`} className="group block self-start scroll-mt-6 overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]">
+    <div id={`plugin-${plugin.id}`} className={`${catalogCardClassName} self-start scroll-mt-6 focus-within:ring-2 focus-within:ring-[var(--dls-accent)] focus-within:ring-offset-2`}>
       <div className="flex items-stretch">
-        <div className="relative w-[64px] shrink-0 overflow-hidden">
-          <StaticSeededGradient seed={plugin.id} className="absolute inset-0" />
-          <div className="relative flex h-full items-center justify-center">
-            <div className="flex h-9 w-9 items-center justify-center rounded-[12px] border border-white/60 bg-white shadow-[0_8px_20px_-8px_rgba(15,23,42,0.3)]">
-              <Puzzle className="h-4 w-4 text-gray-700" aria-hidden />
-            </div>
-          </div>
-        </div>
+        <CatalogColorRail itemId={plugin.id} itemName={plugin.name} size="compact" />
         <div className="min-w-0 flex-1 px-4 py-3">
-          <Link href={getPluginRoute(orgSlug, plugin.id)} className="block transition hover:text-gray-700">
+          <Link href={getPluginRoute(orgSlug, plugin.id)} className="block rounded-sm transition hover:text-gray-700 focus-visible:outline-none">
             <p className="truncate text-[14px] font-semibold tracking-[-0.01em] text-gray-900">
               {plugin.name}
             </p>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { Cable, Loader2, Plus, Search, Store } from "lucide-react";
-import { StaticSeededGradient } from "@openwork/ui/react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenInput } from "../../_components/ui/input";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
@@ -17,7 +16,7 @@ import {
   useCreateMarketplace,
   useMarketplaces,
 } from "./marketplace-data";
-import { MarketplaceLogo } from "./marketplace-logo";
+import { CatalogColorRail, catalogCardClassName } from "./catalog-card-surface";
 
 export function MarketplacesScreen() {
   const { orgContext, orgSlug } = useOrgDashboard();
@@ -97,24 +96,12 @@ export function MarketplacesScreen() {
             <Link
               key={marketplace.id}
               href={getMarketplaceRoute(orgSlug, marketplace.id)}
-              className="group block overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]"
+              className={catalogCardClassName}
             >
               <div className="flex items-stretch">
-                <div className="relative w-[68px] shrink-0 overflow-hidden">
-                  <StaticSeededGradient seed={marketplace.id} className="absolute inset-0" />
-                  <div className="relative flex h-full items-center justify-center">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-[12px] border border-white/60 bg-white shadow-[0_8px_20px_-8px_rgba(15,23,42,0.3)]">
-                      <MarketplaceLogo
-                        logoUrl={marketplace.logoUrl}
-                        name={marketplace.name}
-                        imgClassName="h-6 w-6"
-                        iconClassName="h-4 w-4"
-                      />
-                    </div>
-                  </div>
-                </div>
+                <CatalogColorRail itemId={marketplace.id} itemName={marketplace.name} size="card" />
 
-                <div className="min-w-0 flex-1 px-5 py-4">
+                <div className="min-w-0 flex-1 px-5 py-3.5">
                   <div className="flex items-start justify-between gap-3">
                     <h2 className="truncate text-[14px] font-semibold tracking-[-0.01em] text-gray-900">
                       {marketplace.name}
@@ -128,7 +115,7 @@ export function MarketplacesScreen() {
                       {marketplace.description}
                     </p>
                   ) : null}
-                  <p className="mt-3 text-[11.5px] text-gray-400">
+                  <p className="mt-2.5 text-[11.5px] text-gray-400">
                     Added {formatMarketplaceTimestamp(marketplace.createdAt)}
                   </p>
                 </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
@@ -3,8 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArrowLeft, FileText, MoreHorizontal, Pencil, Plus, Puzzle, Server, Store, Terminal, Users, Webhook } from "lucide-react";
-import { PaperMeshGradient } from "@openwork/ui/react";
+import { Archive, ArrowLeft, FileText, MoreHorizontal, Pencil, Plus, Server, Store, Terminal, Users, Webhook } from "lucide-react";
 
 import { getNewPluginSkillRoute, getOrgAccessFlags, getPluginSkillRoute, getPluginsRoute } from "../../_lib/den-org";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
@@ -23,6 +22,7 @@ import {
   usePlugin,
   useUpdatePlugin,
 } from "./plugin-data";
+import { CatalogColorRail } from "./catalog-card-surface";
 
 export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   const router = useRouter();
@@ -150,20 +150,11 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
         ) : null}
       </div>
 
-      <article className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+      <article className="overflow-hidden rounded-2xl border border-[var(--dls-border)] bg-[var(--dls-surface)]">
         <div className="flex items-stretch">
-          <div className="relative w-[96px] shrink-0 overflow-hidden">
-            <div className="absolute inset-0">
-              <PaperMeshGradient seed={plugin.id} speed={0} />
-            </div>
-            <div className="relative flex h-full items-center justify-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-[16px] border border-white/60 bg-white shadow-[0_10px_24px_-10px_rgba(15,23,42,0.3)]">
-                <Puzzle className="h-6 w-6 text-gray-700" aria-hidden />
-              </div>
-            </div>
-          </div>
+          <CatalogColorRail itemId={plugin.id} itemName={plugin.name} size="detail" />
 
-          <div className="min-w-0 flex-1 px-6 py-5">
+          <div className="min-w-0 flex-1 px-6 py-4">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="truncate text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
                 {plugin.name}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
@@ -13,7 +13,6 @@ import {
   Users,
   Webhook,
 } from "lucide-react";
-import { StaticSeededGradient } from "@openwork/ui/react";
 import { UnderlineTabs } from "../../_components/ui/tabs";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenInput } from "../../_components/ui/input";
@@ -26,6 +25,7 @@ import {
   getPluginPartsSummary,
   usePlugins,
 } from "./plugin-data";
+import { CatalogColorRail, catalogCardClassName } from "./catalog-card-surface";
 
 type PluginView = "plugins" | "agents" | "commands" | "hooks" | "mcps";
 
@@ -199,32 +199,25 @@ export function PluginsScreen() {
               <Link
                 key={plugin.id}
                 href={getPluginRoute(orgSlug, plugin.id)}
-                className="group block overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]"
+                className={catalogCardClassName}
               >
                 <div className="flex items-stretch">
-                  <div className="relative w-[68px] shrink-0 overflow-hidden">
-                    <StaticSeededGradient seed={plugin.id} className="absolute inset-0" />
-                    <div className="relative flex h-full items-center justify-center">
-                      <div className="flex h-10 w-10 items-center justify-center rounded-[12px] border border-white/60 bg-white shadow-[0_8px_20px_-8px_rgba(15,23,42,0.3)]">
-                        <Puzzle className="h-4 w-4 text-gray-700" aria-hidden />
-                      </div>
-                    </div>
-                  </div>
+                  <CatalogColorRail itemId={plugin.id} itemName={plugin.name} size="card" />
 
-                  <div className="min-w-0 flex-1 px-5 py-4">
+                  <div className="min-w-0 flex-1 px-5 py-2">
                     <div className="flex items-start justify-between gap-2">
                       <h2 className="truncate text-[14px] font-semibold tracking-[-0.01em] text-gray-900">
                         {plugin.name}
                       </h2>
                     </div>
                     {plugin.description ? (
-                      <p className="mt-0.5 line-clamp-2 text-[12.5px] leading-[1.55] text-gray-500">
+                      <p className="mt-0.5 line-clamp-2 text-[12.5px] leading-[1.4] text-gray-500">
                         {plugin.description}
                       </p>
                     ) : null}
 
                     {(plugin.marketplaces ?? []).length > 0 ? (
-                      <div className="mt-2.5 flex flex-wrap gap-1.5">
+                      <div className="mt-2 flex flex-wrap gap-1.5">
                         {(plugin.marketplaces ?? []).map((marketplace) => (
                           <span
                             key={marketplace.id}
@@ -237,7 +230,7 @@ export function PluginsScreen() {
                       </div>
                     ) : null}
 
-                    <p className="mt-3 text-[11.5px] text-gray-400">
+                    <p className="mt-2 text-[11.5px] text-gray-400">
                       {getPluginPartsSummary(plugin)}
                     </p>
                   </div>

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/onboarding-page.test.ts tests/openwork-models-page.test.ts tests/web-page.test.ts tests/feedback-url.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/install-download-href.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/onboarding-page.test.ts tests/openwork-models-page.test.ts tests/web-page.test.ts tests/feedback-url.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/install-download-href.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/catalog-card-surface.test.tsx tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/catalog-card-surface.test.tsx
+++ b/ee/apps/den-web/tests/catalog-card-surface.test.tsx
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "bun:test";
+import {
+  CatalogColorRail,
+  catalogCardSwatches,
+  getCatalogCardSwatch,
+} from "../app/(den)/dashboard/_components/catalog-card-surface";
+
+function readDashboardComponent(name: string) {
+  return readFileSync(
+    fileURLToPath(new URL(`../app/(den)/dashboard/_components/${name}`, import.meta.url)),
+    "utf8",
+  );
+}
+
+describe("Den catalog card colors", () => {
+  test("selects a deterministic workspace swatch from the stable item id", () => {
+    const first = getCatalogCardSwatch("plugin-stable-id", "Unmapped plugin");
+    const second = getCatalogCardSwatch("plugin-stable-id", "Unmapped plugin");
+
+    expect(second).toBe(first);
+    expect(catalogCardSwatches).toContain(first);
+
+    const varied = new Set(
+      Array.from({ length: 24 }, (_, index) =>
+        getCatalogCardSwatch(`plugin-${index}`, `Plugin ${index}`),
+      ),
+    );
+    expect(varied.size).toBeGreaterThan(1);
+  });
+
+  test("keeps the named reference assignments", () => {
+    expect(getCatalogCardSwatch("posthog-id", "PostHog Attribution & WAU")).toBe("#2563eb");
+    expect(getCatalogCardSwatch("posthog-id", "PostHog Plugin")).toBe("#2563eb");
+    expect(getCatalogCardSwatch("ben-id", "Ben Private Marketplace")).toBe("#5a67d8");
+    expect(getCatalogCardSwatch("plan-id", "Plan My Day")).toBe("#5a67d8");
+    expect(getCatalogCardSwatch("review-id", "Review Missed Messages")).toBe("#f97316");
+  });
+
+  test("renders the same flat rail in directory and detail contexts without an identity icon", () => {
+    const directory = renderToStaticMarkup(
+      createElement(CatalogColorRail, {
+        itemId: "shared-plugin-id",
+        itemName: "Shared plugin",
+        size: "card",
+      }),
+    );
+    const detail = renderToStaticMarkup(
+      createElement(CatalogColorRail, {
+        itemId: "shared-plugin-id",
+        itemName: "Shared plugin",
+        size: "detail",
+      }),
+    );
+    const swatch = getCatalogCardSwatch("shared-plugin-id", "Shared plugin");
+
+    expect(directory).toContain(`data-catalog-card-swatch="${swatch}"`);
+    expect(detail).toContain(`data-catalog-card-swatch="${swatch}"`);
+    expect(directory).not.toContain("<svg");
+    expect(detail).not.toContain("<svg");
+    expect(directory).not.toContain("<img");
+    expect(detail).not.toContain("<img");
+  });
+
+  test("preserves card content, relationships, actions, and navigation on all four surfaces", () => {
+    const marketplaces = readDashboardComponent("marketplaces-screen.tsx");
+    const marketplaceDetail = readDashboardComponent("marketplace-detail-screen.tsx");
+    const plugins = readDashboardComponent("plugins-screen.tsx");
+    const pluginDetail = readDashboardComponent("plugin-detail-screen.tsx");
+
+    expect(marketplaces).toContain("getMarketplaceRoute(orgSlug, marketplace.id)");
+    expect(marketplaces).toContain("marketplace.description");
+    expect(marketplaces).toContain("marketplace.pluginCount");
+
+    expect(plugins).toContain("getPluginRoute(orgSlug, plugin.id)");
+    expect(plugins).toContain("plugin.description");
+    expect(plugins).toContain("plugin.marketplaces");
+    expect(plugins).toContain("getPluginPartsSummary(plugin)");
+
+    expect(marketplaceDetail).toContain("getPluginRoute(orgSlug, plugin.id)");
+    expect(marketplaceDetail).toContain("orderedCountEntries");
+    expect(marketplaceDetail).toContain("cloudReadinessLabel(plugin.cloudReadiness.state)");
+    expect(marketplaceDetail).toContain('return "Cloud ready"');
+    expect(marketplaceDetail).toContain("data-testid=\"marketplace-actions-trigger\"");
+
+    expect(pluginDetail).toContain("plugin.version");
+    expect(pluginDetail).toContain("plugin.marketplaces");
+    expect(pluginDetail).toContain("getPluginsRoute(orgSlug)");
+    expect(pluginDetail).toContain("data-testid=\"plugin-actions-trigger\"");
+  });
+});

--- a/ee/apps/den-web/tests/catalog-static-gradients.test.ts
+++ b/ee/apps/den-web/tests/catalog-static-gradients.test.ts
@@ -3,10 +3,14 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 
 const components = [
+  "github-integration-screen.tsx",
+];
+
+const flatCatalogComponents = [
   "plugins-screen.tsx",
+  "plugin-detail-screen.tsx",
   "marketplaces-screen.tsx",
   "marketplace-detail-screen.tsx",
-  "github-integration-screen.tsx",
 ];
 
 const staticGradientPath = fileURLToPath(
@@ -24,9 +28,7 @@ describe("catalog list gradient surfaces", () => {
   });
 
   test("high-cardinality list screens do not instantiate Paper shaders", () => {
-    const listComponents = components.filter((component) => component !== "marketplace-detail-screen.tsx");
-
-    for (const component of listComponents) {
+    for (const component of components) {
       const path = fileURLToPath(
         new URL(`../app/(den)/dashboard/_components/${component}`, import.meta.url),
       );
@@ -36,14 +38,15 @@ describe("catalog list gradient surfaces", () => {
     }
   });
 
-  test("marketplace detail retains one bounded hero shader", () => {
+  test.each(flatCatalogComponents)("%s uses the shared flat catalog rail", (component) => {
     const path = fileURLToPath(
-      new URL("../app/(den)/dashboard/_components/marketplace-detail-screen.tsx", import.meta.url),
+      new URL(`../app/(den)/dashboard/_components/${component}`, import.meta.url),
     );
     const source = readFileSync(path, "utf8");
-    const shaderInstances = source.match(/<PaperMeshGradient/g) ?? [];
 
-    expect(shaderInstances).toHaveLength(1);
+    expect(source).toContain("CatalogColorRail");
+    expect(source).not.toContain("StaticSeededGradient");
+    expect(source).not.toContain("PaperMeshGradient");
   });
 
   test("CSS-only surfaces expose a stable runtime proof marker", () => {


### PR DESCRIPTION
## Summary

Use deterministic flat OpenWork workspace colors for the identity rails on Den Marketplace and Plugin cards.

## What changed

- Replaced generated card-rail gradients with blue, indigo, orange, or emerald swatches.
- Assigned fallback colors from stable item IDs and pinned the requested PostHog, Ben Private Marketplace, Plan My Day, and Review Missed Messages references.
- Removed redundant rail icons while preserving the semantic card body, content, badges, relationships, actions, and navigation.
- Applied the shared rail to Marketplace directory/detail, Plugin directory/detail, and Plugin cards embedded in Marketplace detail.
- Tightened representative Plugin directory cards from about 149.5px to 129.75px.
- Added rendered-component coverage for deterministic assignment, cross-surface consistency, palette variation, and icon removal, plus regression coverage for content and interactions.

## Why

The mesh-gradient rails and nested identity tiles added visual noise and made dense catalogs harder to scan. Flat workspace colors keep per-item identity while simplifying the cards and reducing shader work.

## Verification

Final result: **14 passed, 0 failed, 2 skipped**.

Automated checks on candidate `9e69e80a256b914e2eeec64f2d90081f6f50a4a8` — **5 passed, 0 failed, 0 skipped**:

- Focused card tests: 11 passed, 0 failed.
- Complete Den Web test script: 101 passed, 0 failed.
- Den Web typecheck: passed.
- Den Web production build: passed.
- `git diff --check`: passed.

Visual scenarios on pre-rebase candidate `0be30f63734a9232a2129f6154ad6372765fbebf` — **9 passed, 0 failed, 2 skipped**:

- Marketplace directory, Marketplace detail, Plugin directory, and Plugin detail at desktop width: 4 passed.
- The same four surfaces at 390px narrow width: 4 passed; no clipping or horizontal overflow.
- Keyboard focus on a Plugin card: 1 passed with a visible 2px focus outline.
- Dedicated hover-state capture: skipped; hover classes and navigation behavior remain covered by focused regression tests.
- Post-rebase live visual rerun: skipped. The rebase added two unrelated `apps/app` commits and did not change the Den Web diff; all automated checks were rerun on the final candidate.

The full Den Web suite initially reported two module-resolution setup errors because `@openwork-ee/utils` had not been built in the fresh worktree. After building that workspace dependency, the exact final reruns passed 101/101.

## Revisions

- Base: `f0b9ec60cb6881dc4f5d8428b9d0688126fe3174`
- Candidate: `9e69e80a256b914e2eeec64f2d90081f6f50a4a8`

## Risks

- The change is intentionally limited to Den Web presentation. Color assignment uses a small local hash helper rather than a shared cross-package identity service.
- Named reference assignments depend on their display names; all other items remain keyed by stable IDs.

## Explicitly untested

- Dark theme, because Den Web does not currently expose a dark theme for these surfaces.
- A visually seeded `Cloud ready` state; the local demo data exposed `Sync pending`. Existing Cloud-ready rendering paths remain unchanged and are covered by regression assertions.
- Loading, error, permission, disabled, selected-card, and unavailable-card visuals; these paths or card variants were not present in the seeded four-surface journey and their behavior was not changed.
- Cross-browser rendering beyond the Codex in-app Chromium browser.

## Lifecycle

This PR was prepared and verified as a draft under the manual Kitchen boundary, then merged by `@reachjalil` on July 30, 2026. No release or deployment is claimed by this description.
