### PR TITLE
Open Extensions as a first-class main-sidebar page

### DIFF
--- a/apps/app/src/react-app/ARCHITECTURE.md
+++ b/apps/app/src/react-app/ARCHITECTURE.md
@@ -92,7 +92,7 @@ Canonical workspace-scoped routes:
 - `/workspace/:workspaceId/session`
 - `/workspace/:workspaceId/session/:sessionId`
 - `/workspace/:workspaceId/settings/:tab`
-- `/workspace/:workspaceId/settings/extensions/:section`
+- `/workspace/:workspaceId/extensions/:section`
 
 Use `react-app/shell/workspace-routes.ts` to build these paths. Do not
 hand-build `/session/...` or `/settings/...` URLs for workspace-scoped flows.

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -187,6 +187,7 @@ export type SessionPageProps = {
   mcpConnectedCount: number;
   onSendFeedback: () => void;
   onOpenSettings: () => void;
+  onOpenExtensions: () => void;
   sidebar: SessionPageSidebarProps;
   surface?: SessionPageSurfaceProps | null;
   history?: SessionPageHistoryControls | null;
@@ -1045,6 +1046,7 @@ export function SessionPage(props: SessionPageProps) {
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
           onOpenAccountSettings={props.onOpenSettings}
+          onOpenExtensions={props.onOpenExtensions}
           status={{
             clientConnected: props.clientConnected,
             openworkServerStatus: props.openworkServerStatus,

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -205,6 +205,8 @@ export type SessionPageProps = {
   statusBar?: Partial<StatusBarOverrides>;
   notFoundMessage?: string | null;
   mainContentTakeover?: React.ReactNode;
+  mainContentTitle?: string;
+  extensionsActive?: boolean;
   onOpenProviderAuth?: () => void;
   /** Chat-first: create a default workspace and start a task from the empty-state composer. */
   onChatFirstTask?: (prompt: string, attachments?: ComposerAttachment[]) => void;
@@ -1047,6 +1049,7 @@ export function SessionPage(props: SessionPageProps) {
           onStartResize={startLeftSidebarResize}
           onOpenAccountSettings={props.onOpenSettings}
           onOpenExtensions={props.onOpenExtensions}
+          extensionsActive={props.extensionsActive}
           status={{
             clientConnected: props.clientConnected,
             openworkServerStatus: props.openworkServerStatus,
@@ -1075,7 +1078,9 @@ export function SessionPage(props: SessionPageProps) {
             <div className="flex min-w-0 items-center gap-3">
               {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
               <h1 className="truncate text-[13px] font-medium text-dls-text">
-                {showWorkspaceSetupEmptyState
+                {props.mainContentTitle
+                  ? props.mainContentTitle
+                  : showWorkspaceSetupEmptyState
                   ? t("session.create_or_connect_workspace")
                   : selectedSessionTitle || t("session.default_title")}
               </h1>
@@ -1093,7 +1098,7 @@ export function SessionPage(props: SessionPageProps) {
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {/* Revert/redo moved to per-message actions */}
-              {findButtonSessionId ? (
+              {findButtonSessionId && !hasMainContentTakeover ? (
                 <Tooltip>
                   <TooltipTrigger
                     render={

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -846,6 +846,7 @@ export type AppSidebarProps = {
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
   onOpenAccountSettings?: () => void;
   onOpenExtensions: () => void;
+  extensionsActive?: boolean;
   /** Live app status, shown inside the footer account menu. */
   status: Omit<AccountStatusMenuProps, "onOpenAccountSettings">;
 };
@@ -1105,7 +1106,7 @@ export function AppSidebar(props: AppSidebarProps) {
               </SidebarMenuItem>
             ) : null}
             <SidebarDestination
-              active={false}
+              active={props.extensionsActive === true}
               icon={Puzzle}
               label={t("settings.tab_extensions")}
               onSelect={props.onOpenExtensions}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Pin,
   PinOff,
   Plus,
+  Puzzle,
   Search,
   Share2,
   Trash2,
@@ -138,6 +139,7 @@ import {
 } from "./sidebar-lanes";
 import { WorkspaceAvatarPicker } from "./workspace-avatar-picker";
 import { useWorkbenchStore } from "../chat/workbench-store";
+import { SidebarDestination } from "./sidebar-destination";
 
 /** Paper Desktop: unread #2FBE54, needs-action #E8933A (14px artboard → ~8px app). */
 const OUTCOME_DOT_UNREAD = "#2FBE54";
@@ -843,6 +845,7 @@ export type AppSidebarProps = {
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
   onOpenAccountSettings?: () => void;
+  onOpenExtensions: () => void;
   /** Live app status, shown inside the footer account menu. */
   status: Omit<AccountStatusMenuProps, "onOpenAccountSettings">;
 };
@@ -1158,6 +1161,14 @@ export function AppSidebar(props: AppSidebarProps) {
         </LazyMotion>
 
         <SidebarFooter className="border-t border-sidebar-border/60 p-1.5 pe-0">
+          <SidebarMenu>
+            <SidebarDestination
+              active={false}
+              icon={Puzzle}
+              label={t("settings.tab_extensions")}
+              onSelect={props.onOpenExtensions}
+            />
+          </SidebarMenu>
           <AccountStatusMenu {...props.status} onOpenAccountSettings={props.onOpenAccountSettings} />
         </SidebarFooter>
 

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1087,9 +1087,9 @@ export function AppSidebar(props: AppSidebarProps) {
             </Button>
           </div>
         ) : null}
-        {props.onOpenSessionSearch ? (
-          <SidebarHeader className="pb-0 pe-0">
-            <SidebarMenu>
+        <SidebarHeader className="pb-0 pe-0">
+          <SidebarMenu>
+            {props.onOpenSessionSearch ? (
               <SidebarMenuItem>
                 <SidebarMenuButton
                   onClick={props.onOpenSessionSearch}
@@ -1103,9 +1103,15 @@ export function AppSidebar(props: AppSidebarProps) {
                   </kbd>
                 </SidebarMenuButton>
               </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarHeader>
-        ) : null}
+            ) : null}
+            <SidebarDestination
+              active={false}
+              icon={Puzzle}
+              label={t("settings.tab_extensions")}
+              onSelect={props.onOpenExtensions}
+            />
+          </SidebarMenu>
+        </SidebarHeader>
         <SidebarSplitPill
           workspaceSessionGroups={props.workspaceSessionGroups}
           selectedWorkspaceId={props.selectedWorkspaceId}
@@ -1161,14 +1167,6 @@ export function AppSidebar(props: AppSidebarProps) {
         </LazyMotion>
 
         <SidebarFooter className="border-t border-sidebar-border/60 p-1.5 pe-0">
-          <SidebarMenu>
-            <SidebarDestination
-              active={false}
-              icon={Puzzle}
-              label={t("settings.tab_extensions")}
-              onSelect={props.onOpenExtensions}
-            />
-          </SidebarMenu>
           <AccountStatusMenu {...props.status} onOpenAccountSettings={props.onOpenAccountSettings} />
         </SidebarFooter>
 

--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-destination.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-destination.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource react */
+import type { ComponentType, ReactNode } from "react";
+
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+type SidebarDestinationProps = {
+  active: boolean;
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  labelContent?: ReactNode;
+  onSelect: () => void;
+};
+
+export function SidebarDestination({ active, icon: Icon, label, labelContent, onSelect }: SidebarDestinationProps) {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        type="button"
+        isActive={active}
+        aria-current={active ? "page" : undefined}
+        aria-label={label}
+        tooltip={label}
+        onClick={onSelect}
+      >
+        <Icon />
+        {labelContent ?? <span>{label}</span>}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -100,7 +100,7 @@ export function buildConnectRows(input: {
 export function ConnectView() {
   const navigate = useNavigate();
   useEffect(() => {
-    navigate("/settings/extensions", { replace: true });
+    navigate("/extensions", { replace: true });
   }, [navigate]);
   return null;
 }

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -8,7 +8,6 @@ import {
   LifeBuoy,
   MessageCircle,
   Paintbrush,
-  Puzzle,
   RefreshCcw,
   ShieldCheck,
   Sparkles,
@@ -36,7 +35,6 @@ type SettingsCardDefinition = { tab: SettingsTab; icon: typeof Sparkles } & (
 const workspaceCards: SettingsCardDefinition[] = [
   { tab: "preferences", icon: Cog, title: "Preferences", desc: "Default model, reasoning, and compaction." },
   { tab: "permissions", icon: FolderLock, title: "Permissions", desc: "Authorized folders and file access." },
-  { tab: "extensions", icon: Puzzle, titleKey: "settings.tab_extensions", descKey: "settings.tab_description_extensions" },
   { tab: "advanced", icon: Wrench, title: "Advanced", desc: "Runtime, engine, and developer options." },
 ];
 

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -164,7 +164,7 @@ export type McpViewProps = {
   disconnectOrgMcp?: (connectionId: string) => void;
   initialFilter?: ExtensionInventoryFilter;
   onFilterChange?: (filter: ExtensionInventoryFilter) => void;
-  /** Stable extension detail id from `/settings/extensions/:id`. */
+  /** Stable extension detail id from `/extensions/:id`. */
   detailId?: string | null;
   /** Navigate when detail opens/closes. When set, detail renders as a page. */
   onDetailIdChange?: (id: string | null) => void;

--- a/apps/app/src/react-app/domains/settings/shell/panel.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/panel.tsx
@@ -44,7 +44,7 @@ type SettingsPanelTitleProps = {
 };
 
 export function SettingsPanelTitle(props: SettingsPanelTitleProps) {
-  return <h2 className={cn("text-xl font-semibold tracking-tight", props.className)}>{props.children}</h2>;
+  return <h1 className={cn("text-xl font-semibold tracking-tight", props.className)}>{props.children}</h1>;
 }
 
 type SettingsPanelDescriptionProps = {

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -33,6 +33,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarRail,
 } from "@/components/ui/sidebar";
 import {
   DropdownMenu,
@@ -59,6 +60,7 @@ import {
   SettingsPanelToolbarStatus,
 } from "./panel";
 import { useFeatureFlagsPreferences } from "../state/feature-flags-preferences";
+import { SidebarDestination } from "../../session/sidebar/sidebar-destination";
 
 export function getSettingsTabIcon(tab: SettingsTab) {
   switch (tab) {
@@ -204,6 +206,10 @@ export function isSettingsTabBeta(_tab: SettingsTab) {
   return false;
 }
 
+export function isSettingsTabActive(activeTab: SettingsTab, tab: SettingsTab) {
+  return activeTab === tab;
+}
+
 export function SettingsBetaBadge({ className }: { className?: string }) {
   return (
     <span
@@ -268,7 +274,7 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
   const cloudTabs = getCloudSettingsTabs(memoryEnabled);
 
   return (
-    <Sidebar className="mac:**:data-[sidebar=sidebar]:bg-transparent">
+    <Sidebar collapsible="icon" className="mac:**:data-[sidebar=sidebar]:bg-transparent">
       <div className="hidden h-10 mac:block mac:titlebar-drag" />
       <SidebarHeader>
         <SidebarMenu>
@@ -311,7 +317,9 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   type="button"
-                  isActive={props.activeTab === "general"}
+                  isActive={isSettingsTabActive(props.activeTab, "general")}
+                  aria-current={isSettingsTabActive(props.activeTab, "general") ? "page" : undefined}
+                  tooltip={getSettingsTabLabel("general")}
                   onClick={() => props.onSelectTab("general")}
                 >
                   <Cog />
@@ -329,16 +337,14 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
               {workspaceTabs.map((tab) => {
                 const Icon = getSettingsTabIcon(tab);
                 return (
-                  <SidebarMenuItem key={tab}>
-                    <SidebarMenuButton
-                      type="button"
-                      isActive={props.activeTab === tab}
-                      onClick={() => props.onSelectTab(tab)}
-                    >
-                      <Icon />
-                      <SettingsSidebarTabLabel tab={tab} />
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
+                  <SidebarDestination
+                    key={tab}
+                    active={isSettingsTabActive(props.activeTab, tab)}
+                    icon={Icon}
+                    label={getSettingsTabLabel(tab)}
+                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
+                    onSelect={() => props.onSelectTab(tab)}
+                  />
                 );
               })}
             </SidebarMenu>
@@ -352,16 +358,14 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
               {globalTabs.map((tab) => {
                 const Icon = getSettingsTabIcon(tab);
                 return (
-                  <SidebarMenuItem key={tab}>
-                    <SidebarMenuButton
-                      type="button"
-                      isActive={props.activeTab === tab}
-                      onClick={() => props.onSelectTab(tab)}
-                    >
-                      <Icon />
-                      <SettingsSidebarTabLabel tab={tab} />
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
+                  <SidebarDestination
+                    key={tab}
+                    active={isSettingsTabActive(props.activeTab, tab)}
+                    icon={Icon}
+                    label={getSettingsTabLabel(tab)}
+                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
+                    onSelect={() => props.onSelectTab(tab)}
+                  />
                 );
               })}
             </SidebarMenu>
@@ -375,22 +379,21 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
               {cloudTabs.map((tab) => {
                 const Icon = getSettingsTabIcon(tab);
                 return (
-                  <SidebarMenuItem key={tab}>
-                    <SidebarMenuButton
-                      type="button"
-                      isActive={props.activeTab === tab}
-                      onClick={() => props.onSelectTab(tab)}
-                    >
-                      <Icon />
-                      <SettingsSidebarTabLabel tab={tab} />
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
+                  <SidebarDestination
+                    key={tab}
+                    active={isSettingsTabActive(props.activeTab, tab)}
+                    icon={Icon}
+                    label={getSettingsTabLabel(tab)}
+                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
+                    onSelect={() => props.onSelectTab(tab)}
+                  />
                 );
               })}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <SidebarRail />
     </Sidebar>
   );
 }
@@ -425,14 +428,20 @@ function DesktopPolicyBanner() {
   );
 }
 
+export function SettingsPageHeading({ activeTab }: Pick<SettingsPageProps, "activeTab">) {
+  return (
+    <SettingsPanelHeading>
+      <SettingsPanelTitle>{getSettingsTabLabel(activeTab)}</SettingsPanelTitle>
+      <SettingsPanelDescription>{getSettingsTabDescription(activeTab)}</SettingsPanelDescription>
+    </SettingsPanelHeading>
+  );
+}
+
 export function SettingsPage(props: SettingsPageProps) {
   return (
     <SettingsContent>
       <SettingsPanel>
-        <SettingsPanelHeading>
-          <SettingsPanelTitle>{getSettingsTabLabel(props.activeTab)}</SettingsPanelTitle>
-          <SettingsPanelDescription>{getSettingsTabDescription(props.activeTab)}</SettingsPanelDescription>
-        </SettingsPanelHeading>
+        <SettingsPageHeading activeTab={props.activeTab} />
         <DesktopPolicyBanner />
 
         {props.showUpdateToolbar && props.activeTab === "general" ? (

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -184,7 +184,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["preferences", "permissions", "extensions", "advanced"];
+  return ["preferences", "permissions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -101,7 +101,7 @@ export function SettingsShell(props: SettingsShellProps) {
 
   return (
     <div className="flex h-dvh min-h-screen w-full overflow-hidden">
-      <SidebarProvider open={true} className="relative min-h-0 flex-1">
+      <SidebarProvider defaultOpen className="relative min-h-0 flex-1">
         <SettingsSidebar
           activeTab={props.activeTab}
           onSelectTab={props.onSelectTab}
@@ -119,7 +119,7 @@ export function SettingsShell(props: SettingsShellProps) {
               <div className="flex min-w-0 items-center gap-3">
                 <SidebarTrigger className="mac:titlebar-no-drag md:hidden" />
                 {props.headerLeadingSlot}
-                <h1 className="truncate text-[15px] font-semibold text-dls-text">{title}</h1>
+                <div className="truncate text-[15px] font-semibold text-dls-text">{title}</div>
                 <span className="hidden truncate text-[13px] text-dls-secondary lg:inline">
                   {props.selectedWorkspaceName}
                 </span>

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -413,6 +413,22 @@ export function AppRoot() {
                 }
               />
               <Route
+                path="/workspace/:workspaceId/extensions/*"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
+                path="/extensions/*"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
                 path="/workspace/:workspaceId/settings/*"
                 element={
                   <DevProfiler id="SettingsRoute">

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -89,6 +89,8 @@ export type CommandPaletteProps = {
   onCreateNewSession: () => void;
   /** Called when "Open settings" is chosen. Accepts an optional route to jump straight to a tab. */
   onOpenSettings: (route?: string) => void;
+  /** Called when the first-class Extensions page is chosen. */
+  onOpenExtensions: () => void;
   /** Optional: open the full default-model picker. */
   onOpenModelPicker?: () => void;
   selectedModelLabel?: string;
@@ -266,13 +268,13 @@ export function CommandPalette(props: CommandPaletteProps) {
       },
     },
     {
-      id: "settings-extensions",
+      id: "open-extensions",
       title: t("settings.tab_extensions"),
       detail: t("settings.tab_description_extensions"),
-      meta: t("session.cmd_settings_meta"),
+      meta: t("settings.tab_extensions"),
       action: () => {
         props.onClose();
-        props.onOpenSettings("/settings/extensions");
+        props.onOpenExtensions();
       },
     },
     {

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -703,7 +703,9 @@ export function useControlActions(actions: readonly OpenworkControlAction[]) {
 
 import { SETTINGS_TAB_VALUES } from "../../../app/types";
 
-const SETTINGS_TABS: ReadonlySet<string> = new Set<string>(SETTINGS_TAB_VALUES);
+const SETTINGS_TABS: ReadonlySet<string> = new Set<string>(
+  SETTINGS_TAB_VALUES.filter((tab) => tab !== "extensions"),
+);
 
 export function OpenworkRouteControlActions() {
   const navigate = useNavigate();
@@ -724,11 +726,11 @@ export function OpenworkRouteControlActions() {
       execute: () => navigate("/settings/general"),
     },
     {
-      id: "route.settings.skills",
+      id: "route.extensions.skills",
       label: "Open extensions",
       description: "Browse the skills and MCPs available to this agent.",
       sideEffect: "navigation",
-      execute: () => navigate("/settings/extensions/skills"),
+      execute: () => navigate("/extensions/skills"),
     },
     {
       id: "route.settings.providers",
@@ -763,7 +765,7 @@ export function OpenworkRouteControlActions() {
           type: "string",
           required: true,
           description:
-            "Settings tab: general | ai | preferences | permissions | shell | extensions | environment | advanced | appearance | updates | recovery | debug | cloud-account | cloud-providers",
+            "Settings tab: general | ai | preferences | permissions | shell | environment | advanced | appearance | updates | recovery | debug | cloud-account | cloud-providers",
         },
       ],
       previewArgs: { panel: "ai" },
@@ -814,7 +816,7 @@ export function OpenworkRouteControlActions() {
           { id: "automations", label: "Automations", description: "Schedule recurring tasks and background agents." },
           { id: "sharing", label: "Share sessions", description: "Share workspace sessions with collaborators via OpenWork Cloud." },
         ],
-        hint: "Use settings.panel.open to configure any of these. For example: settings.panel.open({panel:'ai'}) for providers, settings.panel.open({panel:'extensions'}) for skills and MCPs.",
+        hint: "Use settings.panel.open for settings such as AI providers, and route.extensions.skills to browse Extensions.",
       }),
     },
   ], [navigate]);

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -116,9 +116,9 @@ export function NotificationBell() {
       } else if (action.type === "reload-engine") {
         void reloadCoordinator.reloadWorkspaceEngine();
       } else if (action.type === "open-extensions-marketplace") {
-        navigate("/settings/extensions");
+        navigate("/extensions");
       } else if (action.type === "install-marketplace-plugin") {
-        navigate("/settings/extensions");
+        navigate("/extensions");
       }
     },
     [markAllRead, navigate, reloadCoordinator],

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2424,6 +2424,7 @@ export function SessionRoute() {
         );
       }}
       onOpenSettings={() => handleOpenSettings("/settings/general")}
+      onOpenExtensions={() => handleOpenSettings("/settings/extensions")}
       onOpenProviderAuth={handleOpenProviderAuth}
       onChatFirstTask={handleChatFirstTask}
       chatFirstBusy={createWorkspaceBusy}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { toast } from "@/components/ui/sonner";
 import type {
   AgentPartInput,
@@ -198,7 +198,13 @@ import {
 } from "./cloud-workspace-status";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
-import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
+import {
+  globalExtensionsRoute,
+  legacySessionRoute,
+  workspaceExtensionsRoute,
+  workspaceSessionRoute,
+  workspaceSettingsRoute,
+} from "./workspace-routes";
 import { WorkspaceProvider } from "./workspace-provider";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { SettingsSurface } from "./settings-route";
@@ -450,6 +456,7 @@ function singlePickedDirectory(selection: string | string[] | null) {
 
 export function SessionRoute() {
   const navigate = useNavigate();
+  const location = useLocation();
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
@@ -1103,6 +1110,22 @@ export function SessionRoute() {
     navigate(target, { state: { workspaceId, sessionId } });
   }, [navigate, selectedSessionId, sidebarActiveWorkspaceId]);
 
+  const handleOpenExtensions = useCallback((path = "", workspaceId = sidebarActiveWorkspaceId) => {
+    const sessionId = workspaceId === sidebarActiveWorkspaceId ? selectedSessionId : null;
+    const extensionPath = path
+      .replace(/^\/settings\/extensions\/?/, "")
+      .replace(/^\/extensions\/?/, "")
+      .replace(/^\/+|\/+$/g, "")
+      .replace(/^mcp$/, "mcps");
+    const target = workspaceId
+      ? workspaceExtensionsRoute(workspaceId, extensionPath)
+      : globalExtensionsRoute(extensionPath);
+    writeActiveWorkspaceId(workspaceId || null);
+    navigate(target, { state: { workspaceId, sessionId } });
+  }, [navigate, selectedSessionId, sidebarActiveWorkspaceId]);
+
+  const extensionsMainOpen = /^\/(?:workspace\/[^/]+\/)?extensions(?:\/|$)/.test(location.pathname);
+
   const surfaceProps = useMemo(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId || !opencodeBaseUrl || !token || !opencodeClient) {
       return null;
@@ -1168,7 +1191,11 @@ export function SessionRoute() {
       },
       providerConnectedCount: hasUsableModel ? 1 : providerConnectedIds.length,
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "extensions" | "providers") => {
-        handleOpenSettings(section === "skills" ? "/settings/extensions/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : section === "providers" ? "/settings/ai" : "/settings/extensions");
+        if (section === "providers") {
+          handleOpenSettings("/settings/ai");
+          return;
+        }
+        handleOpenExtensions(section === "skills" ? "skills" : section === "mcps" ? "mcps" : section === "plugins" ? "plugins" : "");
       },
       onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || selectedSessionId;
@@ -1266,7 +1293,7 @@ export function SessionRoute() {
       },
       cloudMcpSubmissionState: effectiveCloudMcpSubmissionState,
       onRetryCloudConnection: sessionMcpMaintenance.retry,
-      onOpenConnect: () => navigate("/settings/extensions"),
+      onOpenConnect: () => handleOpenExtensions(),
       onDraftChange: () => {
         // Draft persistence will be wired once the full React shell owns session state.
       },
@@ -1353,6 +1380,7 @@ export function SessionRoute() {
   }, [
     client,
     modelPicker.compactOpen,
+    handleOpenExtensions,
     handleOpenSettings,
     hasUsableModel,
     handleApplyEnvironmentChanges,
@@ -1467,14 +1495,15 @@ export function SessionRoute() {
         ? effectiveCloudMcpSubmissionState
         : IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
       onRetryCloudConnection: sessionMcpMaintenance.retry,
-      onOpenConnect: () => navigate("/settings/extensions"),
+      onOpenConnect: () => handleOpenExtensions(),
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "extensions") => {
-        handleOpenSettings(section === "skills" ? "/settings/extensions/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : "/settings/extensions");
+        handleOpenExtensions(section === "skills" ? "skills" : section === "mcps" ? "mcps" : section === "plugins" ? "plugins" : "");
       },
     };
   }, [
     client,
     effectiveCloudMcpSubmissionState,
+    handleOpenExtensions,
     handleOpenSettings,
     listAgents,
     listSlashCommands,
@@ -2424,7 +2453,7 @@ export function SessionRoute() {
         );
       }}
       onOpenSettings={() => handleOpenSettings("/settings/general")}
-      onOpenExtensions={() => handleOpenSettings("/settings/extensions")}
+      onOpenExtensions={() => handleOpenExtensions()}
       onOpenProviderAuth={handleOpenProviderAuth}
       onChatFirstTask={handleChatFirstTask}
       chatFirstBusy={createWorkspaceBusy}
@@ -2693,7 +2722,16 @@ export function SessionRoute() {
         openWorkConnectState: sessionMcpMaintenance,
       }}
       notFoundMessage={gatedRouteNotFoundMessage}
-      mainContentTakeover={cloudWorkspaceMainContentTakeover}
+      mainContentTakeover={
+        extensionsMainOpen ? (
+          <SettingsSurface
+            standaloneExtensions
+            workspaceId={selectedWorkspaceId || undefined}
+          />
+        ) : cloudWorkspaceMainContentTakeover
+      }
+      mainContentTitle={extensionsMainOpen ? t("settings.tab_extensions") : undefined}
+      extensionsActive={extensionsMainOpen}
       onAccessibleTargetsChange={setPaletteAccessibleTargets}
     />
     <CreateWorkspaceModal
@@ -2750,6 +2788,7 @@ export function SessionRoute() {
       }}
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
+      onOpenExtensions={() => handleOpenExtensions()}
       onOpenModelPicker={() => {
         modelPicker.setQuery("");
         modelPicker.setRecentProviderIds(new Set());

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -108,6 +108,7 @@ import { useDenSession } from "@/react-app/domains/settings/cloud/use-den-sessio
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useBootState } from "./boot-state";
 import { SettingsShell } from "@/react-app/domains/settings/shell/settings-shell";
+import { SettingsContent } from "@/react-app/domains/settings/shell/panel";
 import { createExtensionsStore, useExtensionsStoreSnapshot } from "@/react-app/domains/settings/state/extensions-store";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { useLocal } from "@/react-app/kernel/local-provider";
@@ -174,7 +175,12 @@ import { useCommandPaletteShortcut } from "./use-shell-shortcuts";
 import { buildFeedbackUrl } from "@/app/lib/feedback";
 import { getDenInferenceUrl, type DenSettings } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
-import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
+import {
+  globalExtensionsRoute,
+  workspaceExtensionsRoute,
+  workspaceSessionRoute,
+  workspaceSettingsRoute,
+} from "./workspace-routes";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
 import {
@@ -331,6 +337,14 @@ export function parseSettingsPath(pathname: string): {
   }
 }
 
+export function parseExtensionsPath(pathname: string): ReturnType<typeof parseSettingsPath> {
+  const extensionPath = pathname
+    .replace(/^\/workspace\/[^/]+\/extensions\/?/, "")
+    .replace(/^\/extensions\/?/, "")
+    .replace(/^\/+|\/+$/g, "");
+  return parseSettingsPath(`/settings/extensions${extensionPath ? `/${extensionPath}` : ""}`);
+}
+
 function readStoredBoolean(key: string, fallback: boolean) {
   if (typeof window === "undefined") return fallback;
   try {
@@ -390,8 +404,19 @@ function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
   return route.tab;
 }
 
+function extensionsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
+  if (route.extensionDetailId) {
+    return encodeURIComponent(route.extensionDetailId);
+  }
+  if (route.extensionsSection && route.extensionsSection !== "all") {
+    return route.extensionsSection;
+  }
+  return "";
+}
+
 export type SettingsSurfaceProps = {
   embedded?: boolean;
+  standaloneExtensions?: boolean;
   initialPath?: string;
   workspaceId?: string;
   onClose?: () => void;
@@ -410,7 +435,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const desktopConfig = useDesktopConfig();
   const reloadCoordinator = useReloadCoordinator();
   const [embeddedPath, setEmbeddedPath] = useState(props.initialPath ?? "general");
-  const route = props.embedded ? parseSettingsPath(`/settings/${embeddedPath}`) : parseSettingsPath(location.pathname);
+  const route = props.embedded
+    ? parseSettingsPath(`/settings/${embeddedPath}`)
+    : props.standaloneExtensions
+      ? parseExtensionsPath(location.pathname)
+      : parseSettingsPath(location.pathname);
   const navigationWorkspaceId = readNavigationWorkspaceId(location.state);
   const navigationSessionId = readNavigationSessionId(location.state);
 
@@ -432,8 +461,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       setEmbeddedPath(path);
       return;
     }
+    if (props.standaloneExtensions) {
+      const extensionPath = path.replace(/^extensions\/?/, "");
+      navigate(
+        selectedWorkspaceId
+          ? workspaceExtensionsRoute(selectedWorkspaceId, extensionPath)
+          : globalExtensionsRoute(extensionPath),
+      );
+      return;
+    }
     navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, path) : `/settings/${path}`);
-  }, [navigate, props.embedded, selectedWorkspaceId]);
+  }, [navigate, props.embedded, props.standaloneExtensions, selectedWorkspaceId]);
   const [baseUrl, setBaseUrl] = useState("");
   const [token, setToken] = useState("");
   const [openworkClient, setOpenworkClient] = useState<OpenworkServerClient | null>(null);
@@ -2006,8 +2044,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       void workspaceSetSelected(workspaceId).catch(() => undefined);
       void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
     }
-    navigate(workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)), { state: location.state });
-  }, [location, navigate, route, selectedWorkspaceId, workspaceServerClientResolver, workspaces]);
+    navigate(
+      props.standaloneExtensions
+        ? workspaceExtensionsRoute(workspaceId, extensionsPathForRoute(route))
+        : workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)),
+      { state: location.state },
+    );
+  }, [location, navigate, props.standaloneExtensions, route, selectedWorkspaceId, workspaceServerClientResolver, workspaces]);
 
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -2159,15 +2202,30 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }
   };
 
-  if (route.redirectPath && !props.embedded) {
+  if (!props.embedded && !props.standaloneExtensions && route.tab === "extensions") {
+    const extensionPath = extensionsPathForRoute(route);
     const target = selectedWorkspaceId
-      ? workspaceSettingsRoute(selectedWorkspaceId, route.redirectPath)
-      : `/settings/${route.redirectPath}`;
+      ? workspaceExtensionsRoute(selectedWorkspaceId, extensionPath)
+      : globalExtensionsRoute(extensionPath);
+    return <Navigate to={target} replace state={location.state} />;
+  }
+
+  if (route.redirectPath && !props.embedded) {
+    const target = props.standaloneExtensions
+      ? selectedWorkspaceId
+        ? workspaceExtensionsRoute(selectedWorkspaceId, extensionsPathForRoute(route))
+        : globalExtensionsRoute(extensionsPathForRoute(route))
+      : selectedWorkspaceId
+        ? workspaceSettingsRoute(selectedWorkspaceId, route.redirectPath)
+        : `/settings/${route.redirectPath}`;
     return <Navigate to={target} replace state={location.state} />;
   }
 
   if (!props.embedded && !routeWorkspaceId && selectedWorkspaceId) {
-    return <Navigate to={workspaceSettingsRoute(selectedWorkspaceId, settingsPathForRoute(route))} replace state={location.state} />;
+    const target = props.standaloneExtensions
+      ? workspaceExtensionsRoute(selectedWorkspaceId, extensionsPathForRoute(route))
+      : workspaceSettingsRoute(selectedWorkspaceId, settingsPathForRoute(route));
+    return <Navigate to={target} replace state={location.state} />;
   }
 
   const openCloudAccountSettings = () => {
@@ -2534,22 +2592,28 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   return (
     <>
-      <SettingsShell
-        activeTab={route.tab}
-        onSelectTab={(tab) => navigateSettingsPath(tab)}
-        developerMode={developerMode}
-        selectedWorkspaceId={selectedWorkspaceId}
-        selectedWorkspaceName={selectedWorkspaceName}
-        selectedWorkspaceColor={selectedWorkspaceColor}
-        workspaces={workspaceOptions}
-        onSelectWorkspace={handleSelectSettingsWorkspace}
-        headerStatus={routeOpenworkStatus}
-        busyHint={loading ? t("session.loading_detail") : busyLabel}
-        onClose={props.onClose ?? (() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session"))}
-        compact={props.embedded}
-      >
-        {settingsView}
-      </SettingsShell>
+      {props.standaloneExtensions ? (
+        <div data-extensions-main-surface className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
+          <SettingsContent>{settingsView}</SettingsContent>
+        </div>
+      ) : (
+        <SettingsShell
+          activeTab={route.tab}
+          onSelectTab={(tab) => navigateSettingsPath(tab)}
+          developerMode={developerMode}
+          selectedWorkspaceId={selectedWorkspaceId}
+          selectedWorkspaceName={selectedWorkspaceName}
+          selectedWorkspaceColor={selectedWorkspaceColor}
+          workspaces={workspaceOptions}
+          onSelectWorkspace={handleSelectSettingsWorkspace}
+          headerStatus={routeOpenworkStatus}
+          busyHint={loading ? t("session.loading_detail") : busyLabel}
+          onClose={props.onClose ?? (() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session"))}
+          compact={props.embedded}
+        >
+          {settingsView}
+        </SettingsShell>
+      )}
 
       <CommandPalette
         open={commandPaletteOpen}
@@ -2559,7 +2623,22 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           navigate(workspaceSessionRoute(workspaceId, sessionId));
         }}
         onOpenSettings={(path = "/settings/general") => {
-          navigateSettingsPath(path.replace(/^\/settings\//, ""));
+          const settingsPath = path.replace(/^\/settings\//, "");
+          if (props.standaloneExtensions) {
+            navigate(
+              selectedWorkspaceId
+                ? workspaceSettingsRoute(selectedWorkspaceId, settingsPath)
+                : `/settings/${settingsPath}`,
+            );
+            return;
+          }
+          navigateSettingsPath(settingsPath);
+        }}
+        onOpenExtensions={() => {
+          const target = selectedWorkspaceId
+            ? workspaceExtensionsRoute(selectedWorkspaceId)
+            : globalExtensionsRoute();
+          navigate(target);
         }}
         onOpenModelPicker={() => {
           modelPicker.setQuery("");

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -6,7 +6,7 @@
 // session-route.tsx as the final step of its decomposition; the route keeps
 // composition, handlers, and JSX.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import {
@@ -63,6 +63,7 @@ import {
   preserveWorkspaceRouteSession,
   removeWorkspaceRouteSession,
   sessionIdForLegacyWorkspaceInference,
+  workspaceExtensionsRoute,
   workspaceSessionRoute,
 } from "./workspace-routes";
 
@@ -105,11 +106,19 @@ function withRouteRefreshTimeout<T>(promise: Promise<T>, label: string): Promise
 export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const { developerMode, onServerSettingsChanged, onHostInfo } = input;
   const navigate = useNavigate();
+  const location = useLocation();
   const local = useLocal();
   const denAuth = useDenAuth();
   const params = useParams<{ workspaceId?: string; sessionId?: string }>();
   const routeWorkspaceId = params.workspaceId?.trim() || "";
   const selectedSessionId = params.sessionId?.trim() || null;
+  const extensionsRouteActive = /^\/(?:workspace\/[^/]+\/)?extensions(?:\/|$)/.test(location.pathname);
+  const extensionsRoutePath = extensionsRouteActive
+    ? location.pathname
+      .replace(/^\/workspace\/[^/]+\/extensions\/?/, "")
+      .replace(/^\/extensions\/?/, "")
+      .replace(/^\/+|\/+$/g, "")
+    : "";
   const workspaceInferenceSessionId = sessionIdForLegacyWorkspaceInference(routeWorkspaceId, selectedSessionId);
   const navigateToWorkspaceSession = useCallback((workspaceId: string, sessionId?: string | null, options?: { replace?: boolean }) => {
     const id = workspaceId.trim();
@@ -754,16 +763,27 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         ? legacySelectedWorkspaceId
         : workspaces[0]?.id || "";
       if (fallbackWorkspaceId) {
-        navigateToWorkspaceSession(fallbackWorkspaceId, selectedSessionId, { replace: true });
+        if (extensionsRouteActive) {
+          navigate(workspaceExtensionsRoute(fallbackWorkspaceId, extensionsRoutePath), { replace: true });
+        } else {
+          navigateToWorkspaceSession(fallbackWorkspaceId, selectedSessionId, { replace: true });
+        }
       }
       return;
     }
     if (!routeWorkspaceId && selectedWorkspaceId) {
-      navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId, { replace: true });
+      if (extensionsRouteActive) {
+        navigate(workspaceExtensionsRoute(selectedWorkspaceId, extensionsRoutePath), { replace: true });
+      } else {
+        navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId, { replace: true });
+      }
     }
   }, [
+    extensionsRouteActive,
+    extensionsRoutePath,
     loading,
     legacySelectedWorkspaceId,
+    navigate,
     navigateToWorkspaceSession,
     routeWorkspaceId,
     selectedSessionId,

--- a/apps/app/src/react-app/shell/workspace-routes.ts
+++ b/apps/app/src/react-app/shell/workspace-routes.ts
@@ -19,6 +19,19 @@ export function globalSettingsRoute(tab: SettingsTab) {
   return `/settings/${tab}`;
 }
 
+function extensionsRouteSuffix(path?: string | null) {
+  const suffix = path?.trim().replace(/^\/+|\/+$/g, "") ?? "";
+  return suffix ? `/${suffix}` : "";
+}
+
+export function workspaceExtensionsRoute(workspaceId: string, path?: string | null) {
+  return `/workspace/${encodeURIComponent(workspaceId.trim())}/extensions${extensionsRouteSuffix(path)}`;
+}
+
+export function globalExtensionsRoute(path?: string | null) {
+  return `/extensions${extensionsRouteSuffix(path)}`;
+}
+
 export function sessionIdForLegacyWorkspaceInference(
   routeWorkspaceId?: string | null,
   routeSessionId?: string | null,

--- a/apps/app/tests/extensions-sidebar-header.test.tsx
+++ b/apps/app/tests/extensions-sidebar-header.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Puzzle } from "lucide-react";
+
+import { SidebarProvider, SidebarMenu } from "../src/components/ui/sidebar";
+import { SidebarDestination } from "../src/react-app/domains/session/sidebar/sidebar-destination";
+import { SettingsPageHeading } from "../src/react-app/domains/settings/shell/settings-page";
+
+describe("Extensions sidebar destination", () => {
+  test("exposes its label, keyboard button, and active page state", () => {
+    const html = renderToStaticMarkup(
+      <SidebarProvider>
+        <SidebarMenu>
+          <SidebarDestination
+            active
+            icon={Puzzle}
+            label="Extensions"
+            onSelect={() => {}}
+          />
+        </SidebarMenu>
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain('type="button"');
+    expect(html).toContain('aria-label="Extensions"');
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain("data-active");
+    expect(html).toContain(">Extensions<");
+  });
+});
+
+describe("Extensions page header", () => {
+  test("renders one correctly named page heading", () => {
+    const html = renderToStaticMarkup(<SettingsPageHeading activeTab="extensions" />);
+
+    expect(html.match(/<h1/g)).toHaveLength(1);
+    expect(html).toContain(">Extensions</h1>");
+    expect(html).not.toContain("<h2");
+  });
+});

--- a/apps/app/tests/extensions-sidebar-header.test.tsx
+++ b/apps/app/tests/extensions-sidebar-header.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Puzzle } from "lucide-react";
@@ -5,6 +7,10 @@ import { Puzzle } from "lucide-react";
 import { SidebarProvider, SidebarMenu } from "../src/components/ui/sidebar";
 import { SidebarDestination } from "../src/react-app/domains/session/sidebar/sidebar-destination";
 import { SettingsPageHeading } from "../src/react-app/domains/settings/shell/settings-page";
+
+const appSidebarPath = fileURLToPath(
+  new URL("../src/react-app/domains/session/sidebar/app-sidebar.tsx", import.meta.url),
+);
 
 describe("Extensions sidebar destination", () => {
   test("exposes its label, keyboard button, and active page state", () => {
@@ -26,6 +32,20 @@ describe("Extensions sidebar destination", () => {
     expect(html).toContain('aria-current="page"');
     expect(html).toContain("data-active");
     expect(html).toContain(">Extensions<");
+  });
+
+  test("sits below Search and above Pinned sessions", () => {
+    const source = readFileSync(appSidebarPath, "utf8");
+    const searchIndex = source.indexOf("<Search");
+    const extensionsIndex = source.indexOf("<SidebarDestination");
+    const pinnedIndex = source.indexOf("{pinnedSessions.length");
+    const footerIndex = source.indexOf("<SidebarFooter");
+
+    expect(searchIndex).toBeGreaterThan(-1);
+    expect(extensionsIndex).toBeGreaterThan(searchIndex);
+    expect(pinnedIndex).toBeGreaterThan(extensionsIndex);
+    expect(footerIndex).toBeGreaterThan(extensionsIndex);
+    expect(source.slice(footerIndex)).not.toContain("<SidebarDestination");
   });
 });
 

--- a/apps/app/tests/extensions-sidebar-header.test.tsx
+++ b/apps/app/tests/extensions-sidebar-header.test.tsx
@@ -6,10 +6,16 @@ import { Puzzle } from "lucide-react";
 
 import { SidebarProvider, SidebarMenu } from "../src/components/ui/sidebar";
 import { SidebarDestination } from "../src/react-app/domains/session/sidebar/sidebar-destination";
-import { SettingsPageHeading } from "../src/react-app/domains/settings/shell/settings-page";
+import { getWorkspaceSettingsTabs } from "../src/react-app/domains/settings/shell/settings-page";
 
 const appSidebarPath = fileURLToPath(
   new URL("../src/react-app/domains/session/sidebar/app-sidebar.tsx", import.meta.url),
+);
+const sessionPagePath = fileURLToPath(
+  new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),
+);
+const generalSettingsPath = fileURLToPath(
+  new URL("../src/react-app/domains/settings/pages/general-view.tsx", import.meta.url),
 );
 
 describe("Extensions sidebar destination", () => {
@@ -49,12 +55,14 @@ describe("Extensions sidebar destination", () => {
   });
 });
 
-describe("Extensions page header", () => {
-  test("renders one correctly named page heading", () => {
-    const html = renderToStaticMarkup(<SettingsPageHeading activeTab="extensions" />);
+describe("Extensions main page", () => {
+  test("uses the main content header and is absent from Settings navigation", () => {
+    const sessionPageSource = readFileSync(sessionPagePath, "utf8");
+    const generalSettingsSource = readFileSync(generalSettingsPath, "utf8");
 
-    expect(html.match(/<h1/g)).toHaveLength(1);
-    expect(html).toContain(">Extensions</h1>");
-    expect(html).not.toContain("<h2");
+    expect(sessionPageSource).toContain("props.mainContentTitle");
+    expect(sessionPageSource).toContain("<h1");
+    expect(getWorkspaceSettingsTabs()).not.toContain("extensions");
+    expect(generalSettingsSource).not.toContain('{ tab: "extensions"');
   });
 });

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, test } from "bun:test";
 
 import { parseSettingsPath } from "../src/react-app/shell/settings-route";
+import {
+  getWorkspaceSettingsTabs,
+  isSettingsTabActive,
+} from "../src/react-app/domains/settings/shell/settings-page";
 
 describe("settings route parsing", () => {
+  test("selects the Extensions destination for direct workspace navigation and reloads", () => {
+    const pathname = "/workspace/workspace_1/settings/extensions";
+    const route = parseSettingsPath(pathname);
+
+    expect(route).toEqual({ tab: "extensions", redirectPath: null, extensionsSection: "all" });
+    expect(parseSettingsPath(pathname)).toEqual(route);
+    expect(isSettingsTabActive(route.tab, "extensions")).toBe(true);
+    expect(isSettingsTabActive(route.tab, "general")).toBe(false);
+    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "extensions", "advanced"]);
+  });
+
   test("redirects Connect settings into Extensions", () => {
     expect(parseSettingsPath("/settings/connect")).toEqual({
       tab: "extensions",

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -1,21 +1,32 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseSettingsPath } from "../src/react-app/shell/settings-route";
+import { parseExtensionsPath, parseSettingsPath } from "../src/react-app/shell/settings-route";
 import {
   getWorkspaceSettingsTabs,
   isSettingsTabActive,
 } from "../src/react-app/domains/settings/shell/settings-page";
 
 describe("settings route parsing", () => {
-  test("selects the Extensions destination for direct workspace navigation and reloads", () => {
-    const pathname = "/workspace/workspace_1/settings/extensions";
-    const route = parseSettingsPath(pathname);
+  test("parses the first-class Extensions route for direct workspace navigation and reloads", () => {
+    const pathname = "/workspace/workspace_1/extensions";
+    const route = parseExtensionsPath(pathname);
 
     expect(route).toEqual({ tab: "extensions", redirectPath: null, extensionsSection: "all" });
-    expect(parseSettingsPath(pathname)).toEqual(route);
+    expect(parseExtensionsPath(pathname)).toEqual(route);
     expect(isSettingsTabActive(route.tab, "extensions")).toBe(true);
     expect(isSettingsTabActive(route.tab, "general")).toBe(false);
-    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "extensions", "advanced"]);
+    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "advanced"]);
+  });
+
+  test("preserves top-level Extensions section and detail deep links", () => {
+    expect(parseExtensionsPath("/extensions/apps")).toEqual({ tab: "extensions", redirectPath: null, extensionsSection: "apps" });
+    expect(parseExtensionsPath("/workspace/workspace_1/extensions/mcps")).toEqual({ tab: "extensions", redirectPath: null, extensionsSection: "mcps" });
+    expect(parseExtensionsPath("/workspace/workspace_1/extensions/skill%3Abriefing")).toEqual({
+      tab: "extensions",
+      redirectPath: null,
+      extensionsSection: "all",
+      extensionDetailId: "skill:briefing",
+    });
   });
 
   test("redirects Connect settings into Extensions", () => {

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -10,7 +10,16 @@ import {
   preserveWorkspaceRouteSession,
   removeWorkspaceRouteSession,
   sessionIdForLegacyWorkspaceInference,
+  workspaceSettingsRoute,
 } from "../src/react-app/shell/workspace-routes";
+
+describe("workspace settings routes", () => {
+  test("builds the existing Extensions destination", () => {
+    expect(workspaceSettingsRoute(" workspace/a ", "extensions")).toBe(
+      "/workspace/workspace%2Fa/settings/extensions",
+    );
+  });
+});
 
 describe("workspace route session inference", () => {
   test("modern workspace routes do not contribute a refresh session id", () => {

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -10,14 +10,23 @@ import {
   preserveWorkspaceRouteSession,
   removeWorkspaceRouteSession,
   sessionIdForLegacyWorkspaceInference,
+  globalExtensionsRoute,
+  workspaceExtensionsRoute,
   workspaceSettingsRoute,
 } from "../src/react-app/shell/workspace-routes";
 
-describe("workspace settings routes", () => {
-  test("builds the existing Extensions destination", () => {
+describe("workspace surface routes", () => {
+  test("keeps Extensions outside Settings and preserves deep links", () => {
     expect(workspaceSettingsRoute(" workspace/a ", "extensions")).toBe(
       "/workspace/workspace%2Fa/settings/extensions",
     );
+    expect(workspaceExtensionsRoute(" workspace/a ")).toBe(
+      "/workspace/workspace%2Fa/extensions",
+    );
+    expect(workspaceExtensionsRoute(" workspace/a ", "/skills/")).toBe(
+      "/workspace/workspace%2Fa/extensions/skills",
+    );
+    expect(globalExtensionsRoute("mcps")).toBe("/extensions/mcps");
   });
 });
 

--- a/evals/flows/extensions-sidebar-and-header.flow.ts
+++ b/evals/flows/extensions-sidebar-and-header.flow.ts
@@ -19,8 +19,8 @@ const EXTENSIONS_SIDEBAR_DESTINATION = `(() => {
   };
 })()`;
 
-function settingsPrefix(route: string): string {
-  const workspace = route.match(/^(\/workspace\/[^/]+)\/(?:session|settings(?:\/.*)?)$/);
+function appPrefix(route: string): string {
+  const workspace = route.match(/^(\/workspace\/[^/]+)\/(?:session(?:\/.*)?|extensions(?:\/.*)?|settings(?:\/.*)?)$/);
   return workspace ? workspace[1] : "";
 }
 
@@ -37,7 +37,7 @@ export default defineFlow({
           action: async () => {
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
             const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
-            const prefix = settingsPrefix(route);
+            const prefix = appPrefix(route);
             const sessionRoute = `${prefix}/session`;
 
             await ctx.navigateHash(sessionRoute);
@@ -92,15 +92,15 @@ export default defineFlow({
       },
     },
     {
-      name: "Extensions header survives reload and history",
+      name: "Extensions opens as a main page and survives reload and history",
       run: async (ctx) => {
-        await ctx.prove("Opening Extensions keeps one correct page heading through reload and history", {
+        await ctx.prove("Opening Extensions uses the main content area with one correct heading through reload and history", {
           voiceover: vo[1],
           action: async () => {
             const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
-            const prefix = settingsPrefix(route);
-            const extensionsRoute = `${prefix}/settings/extensions`;
-            const generalRoute = `${prefix}/settings/general`;
+            const prefix = appPrefix(route);
+            const extensionsRoute = `${prefix}/extensions`;
+            const sessionRoute = `${prefix}/session`;
             const clicked = await ctx.eval(`(() => {
               const sidebar = document.querySelector('[data-sidebar="sidebar"]');
               const destination = [...(sidebar?.querySelectorAll("a,button") || [])]
@@ -140,25 +140,30 @@ export default defineFlow({
               });
             }
 
-            await ctx.navigateHash(generalRoute);
-            await ctx.waitForRoute(generalRoute, { timeoutMs: 20_000 });
+            await ctx.navigateHash(sessionRoute);
+            await ctx.waitForRoute(sessionRoute, { timeoutMs: 20_000 });
             await ctx.eval("history.back()");
             await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
           },
           assert: async () => {
             const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
-            ctx.assert(route.endsWith("/settings/extensions"), `Expected Extensions route, got ${route}.`);
+            ctx.assert(route.endsWith("/extensions"), `Expected main Extensions route, got ${route}.`);
             const headings = await ctx.eval(`([...document.querySelectorAll("h1")]
               .filter((entry) => (entry.textContent || "").trim() === "Extensions").length)`);
             ctx.assert(headings === 1, `Expected one Extensions page header, found ${JSON.stringify(headings)}.`);
             const destination = await ctx.eval(EXTENSIONS_SIDEBAR_DESTINATION);
-            ctx.assert(Boolean(destination), "Extensions must remain represented in the settings sidebar.");
+            ctx.assert(Boolean(destination), "Extensions must remain represented in the main sidebar.");
             const measured = destination as { active: boolean };
-            ctx.assert(measured.active, "Extensions sidebar destination must expose its active state.");
+            ctx.assert(measured.active, "Main Extensions destination must expose its active state.");
+            const mainSurface = await ctx.eval("Boolean(document.querySelector('[data-extensions-main-surface]'))");
+            ctx.assert(mainSurface === true, "Extensions must render in the main content surface.");
+            const settingsHeading = await ctx.eval(`([...document.querySelectorAll("h1")]
+              .some((entry) => (entry.textContent || "").trim() === "Settings"))`);
+            ctx.assert(settingsHeading === false, "Extensions must not render inside the Settings page.");
           },
           screenshot: {
             name: "extensions-page-header",
-            requireText: ["Extensions", "Browse the skills and MCPs available to your agent."],
+            requireText: ["Extensions", "Everything your agent can use in one place.", "Refresh"],
             rejectText: ["Preparing workspace", "Failed to fetch", "Something went wrong"],
           },
         });

--- a/evals/flows/extensions-sidebar-and-header.flow.ts
+++ b/evals/flows/extensions-sidebar-and-header.flow.ts
@@ -1,4 +1,4 @@
-import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { defineFlow } from "../runner/flow.ts";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
 
 const FLOW_ID = "extensions-sidebar-and-header";
@@ -30,20 +30,77 @@ export default defineFlow({
   kind: "user-facing",
   steps: [
     {
-      name: "Sidebar navigation and Extensions header survive history and collapse",
+      name: "Extensions sits directly below Search and before Pinned",
       run: async (ctx) => {
-        await ctx.prove("The desktop sidebar opens the existing Extensions route and keeps its active state and single header", {
+        await ctx.prove("The main sidebar places Extensions directly below Search and before Pinned", {
           voiceover: vo[0],
           action: async () => {
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
             const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
             const prefix = settingsPrefix(route);
             const sessionRoute = `${prefix}/session`;
-            const extensionsRoute = `${prefix}/settings/extensions`;
-            const generalRoute = `${prefix}/settings/general`;
 
             await ctx.navigateHash(sessionRoute);
-            await ctx.waitFor(EXTENSIONS_SIDEBAR_DESTINATION, { timeoutMs: 20_000, label: "Extensions sidebar destination" });
+            await ctx.waitFor(`(() => {
+              const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+              const search = sidebar?.querySelector('[aria-keyshortcuts]');
+              const destination = [...(sidebar?.querySelectorAll("a,button") || [])]
+                .find((entry) => (entry.textContent || "").trim() === "Extensions" || entry.getAttribute("aria-label") === "Extensions");
+              if (!(search instanceof HTMLElement) || !(destination instanceof HTMLElement)) return false;
+              const shell = sidebar.closest('[data-state]');
+              if (shell?.getAttribute("data-state") === "collapsed") {
+                const rail = sidebar.querySelector('[data-sidebar="rail"]');
+                if (rail instanceof HTMLElement) rail.click();
+                return false;
+              }
+              const destinationRect = destination.getBoundingClientRect();
+              return destinationRect.width > 0
+                && destinationRect.height > 0
+                && !document.body.innerText.includes("Preparing workspace")
+                && !document.body.innerText.includes("Failed to fetch");
+            })()`, { timeoutMs: 30_000, label: "expanded primary sidebar" });
+          },
+          assert: async () => {
+            const placement = await ctx.eval(`(() => {
+              const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+              const search = sidebar?.querySelector('[aria-keyshortcuts]');
+              const destination = [...(sidebar?.querySelectorAll("a,button") || [])]
+                .find((entry) => (entry.textContent || "").trim() === "Extensions" || entry.getAttribute("aria-label") === "Extensions");
+              if (!(search instanceof HTMLElement) || !(destination instanceof HTMLElement)) return null;
+              const searchItem = search.closest('[data-sidebar="menu-item"]');
+              const destinationItem = destination.closest('[data-sidebar="menu-item"]');
+              const pinned = sidebar.querySelector('[data-global-pinned-sessions]');
+              const footer = sidebar.querySelector('[data-sidebar="footer"]');
+              return {
+                adjacent: searchItem?.nextElementSibling === destinationItem,
+                beforePinned: !pinned || Boolean(destination.compareDocumentPosition(pinned) & Node.DOCUMENT_POSITION_FOLLOWING),
+                inFooter: Boolean(footer?.contains(destination)),
+              };
+            })()`);
+            ctx.assert(Boolean(placement), "Expected Search and Extensions in the main sidebar.");
+            const measured = placement as { adjacent: boolean; beforePinned: boolean; inFooter: boolean };
+            ctx.assert(measured.adjacent, "Expected Extensions immediately after Search.");
+            ctx.assert(measured.beforePinned, "Expected Extensions before the Pinned section.");
+            ctx.assert(!measured.inFooter, "Expected Extensions outside the account footer.");
+          },
+          screenshot: {
+            name: "extensions-below-search",
+            requireText: ["Search", "Extensions"],
+            rejectText: ["Preparing workspace", "Failed to fetch", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Extensions header survives reload and history",
+      run: async (ctx) => {
+        await ctx.prove("Opening Extensions keeps one correct page heading through reload and history", {
+          voiceover: vo[1],
+          action: async () => {
+            const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
+            const prefix = settingsPrefix(route);
+            const extensionsRoute = `${prefix}/settings/extensions`;
+            const generalRoute = `${prefix}/settings/general`;
             const clicked = await ctx.eval(`(() => {
               const sidebar = document.querySelector('[data-sidebar="sidebar"]');
               const destination = [...(sidebar?.querySelectorAll("a,button") || [])]
@@ -59,20 +116,34 @@ export default defineFlow({
             await ctx.eval("location.reload()");
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after reload" });
             await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
+            await ctx.waitFor(`(() => {
+              const heading = [...document.querySelectorAll("h1")]
+                .find((entry) => (entry.textContent || "").trim() === "Extensions");
+              if (!(heading instanceof HTMLElement)) return false;
+              const rect = heading.getBoundingClientRect();
+              return rect.width > 0
+                && rect.height > 0
+                && !document.body.innerText.includes("Preparing workspace");
+            })()`, { timeoutMs: 30_000, label: "visible Extensions page after reload" });
+            const refreshed = await ctx.eval(`(() => {
+              if (!document.body.innerText.includes("Failed to fetch")) return false;
+              const refresh = [...document.querySelectorAll("button")]
+                .find((entry) => (entry.textContent || "").trim() === "Refresh");
+              if (!(refresh instanceof HTMLElement)) return false;
+              refresh.click();
+              return true;
+            })()`);
+            if (refreshed === true) {
+              await ctx.waitFor(`!document.body.innerText.includes("Failed to fetch")`, {
+                timeoutMs: 30_000,
+                label: "Extensions refresh recovery",
+              });
+            }
 
             await ctx.navigateHash(generalRoute);
             await ctx.waitForRoute(generalRoute, { timeoutMs: 20_000 });
             await ctx.eval("history.back()");
             await ctx.waitForRoute(extensionsRoute, { timeoutMs: 20_000 });
-
-            const toggled = await ctx.eval(`(() => {
-              const trigger = document.querySelector('[data-sidebar="rail"], [data-sidebar="trigger"]');
-              if (!(trigger instanceof HTMLElement)) return false;
-              trigger.click();
-              return true;
-            })()`);
-            ctx.assert(toggled === true, "Expected the desktop sidebar collapse control.");
-            await new Promise((resolve) => setTimeout(resolve, 300));
           },
           assert: async () => {
             const route = String(await ctx.eval("window.__openworkControl.snapshot().route || ''"));
@@ -81,14 +152,14 @@ export default defineFlow({
               .filter((entry) => (entry.textContent || "").trim() === "Extensions").length)`);
             ctx.assert(headings === 1, `Expected one Extensions page header, found ${JSON.stringify(headings)}.`);
             const destination = await ctx.eval(EXTENSIONS_SIDEBAR_DESTINATION);
-            ctx.assert(Boolean(destination), "Extensions must remain represented in the collapsed sidebar.");
+            ctx.assert(Boolean(destination), "Extensions must remain represented in the settings sidebar.");
             const measured = destination as { active: boolean };
             ctx.assert(measured.active, "Extensions sidebar destination must expose its active state.");
           },
           screenshot: {
-            name: "extensions-sidebar-collapsed",
-            requireText: ["Extensions"],
-            rejectText: ["Something went wrong"],
+            name: "extensions-page-header",
+            requireText: ["Extensions", "Browse the skills and MCPs available to your agent."],
+            rejectText: ["Preparing workspace", "Failed to fetch", "Something went wrong"],
           },
         });
       },

--- a/evals/flows/lib/session-workspace.mjs
+++ b/evals/flows/lib/session-workspace.mjs
@@ -1,0 +1,50 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export async function ensureSessionWorkspace(ctx, flowId) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  const canCreateTask = await ctx.eval(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+  );
+  if (!canCreateTask) {
+    const workspacePath = resolve(
+      process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
+      "..",
+      `${flowId}-workspace`,
+    );
+    await mkdir(workspacePath, { recursive: true });
+    const welcomeInput = 'input[placeholder="/workspace/my-project"]';
+    const onWelcome = await ctx.eval(
+      `Boolean(document.querySelector(${JSON.stringify(welcomeInput)}))`,
+    );
+    if (onWelcome) {
+      await ctx.fill(welcomeInput, workspacePath);
+      await ctx.clickText("Use this folder", {
+        selector: "button",
+        timeoutMs: 10_000,
+      });
+      await ctx
+        .clickText("Skip and use the free model", {
+          selector: "button",
+          timeoutMs: 30_000,
+        })
+        .catch(() => {});
+      await ctx
+        .clickText("Skip", { selector: "button", timeoutMs: 10_000 })
+        .catch(() => {});
+    } else {
+      await ctx.waitFor(
+        "window.__openworkControl.listActions().some((action) => action.id === 'workspace.create' && !action.disabled)",
+        { timeoutMs: 30_000, label: "workspace.create enabled" },
+      );
+      await ctx.control("workspace.create", { path: workspacePath });
+    }
+  }
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+    { timeoutMs: 90_000, label: "session.create_task enabled" },
+  );
+}

--- a/evals/flows/right-panel-action-empty-state.flow.mjs
+++ b/evals/flows/right-panel-action-empty-state.flow.mjs
@@ -1,3 +1,5 @@
+import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
+
 const READ_CHOOSER = `(() => {
   const panel = [...document.querySelectorAll('aside, [role="complementary"], main + div, [data-side-panel]')]
     .find((entry) => /choose|open in (the )?side panel|side panel/i.test(entry.textContent || ''));
@@ -24,15 +26,11 @@ export default {
     {
       name: "Opening an empty panel presents an actionable chooser",
       run: async (ctx) => {
-        await ctx.waitFor("Boolean(window.__openworkControl)", {
-          timeoutMs: 60_000,
-          label: "control API",
-        });
+        await ensureSessionWorkspace(
+          ctx,
+          "right-panel-action-empty-state",
+        );
         if (!String(await ctx.eval("window.__openworkControl.snapshot().route || ''")).includes("/session/")) {
-          await ctx.waitFor(
-            "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
-            { timeoutMs: 60_000, label: "session.create_task enabled" },
-          );
           await ctx.control("session.create_task");
           await ctx.waitFor(
             "window.__openworkControl.snapshot().route.includes('/session/')",

--- a/evals/flows/right-panel-action-empty-state.flow.mjs
+++ b/evals/flows/right-panel-action-empty-state.flow.mjs
@@ -29,6 +29,10 @@ export default {
           label: "control API",
         });
         if (!String(await ctx.eval("window.__openworkControl.snapshot().route || ''")).includes("/session/")) {
+          await ctx.waitFor(
+            "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+            { timeoutMs: 60_000, label: "session.create_task enabled" },
+          );
           await ctx.control("session.create_task");
           await ctx.waitFor(
             "window.__openworkControl.snapshot().route.includes('/session/')",

--- a/evals/flows/sidebar-session-number-shortcuts.flow.mjs
+++ b/evals/flows/sidebar-session-number-shortcuts.flow.mjs
@@ -1,3 +1,5 @@
+import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
+
 const READ_SHORTCUT_ROWS = `(() => [...document.querySelectorAll('[aria-keyshortcuts]')]
   .map((entry) => ({
     shortcut: entry.getAttribute('aria-keyshortcuts'),
@@ -14,13 +16,9 @@ export default {
     {
       name: "Holding the platform modifier reveals accurate first-nine session shortcuts",
       run: async (ctx) => {
-        await ctx.waitFor("Boolean(window.__openworkControl)", {
-          timeoutMs: 60_000,
-          label: "control API",
-        });
-        await ctx.waitFor(
-          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
-          { timeoutMs: 60_000, label: "session.create_task enabled" },
+        await ensureSessionWorkspace(
+          ctx,
+          "sidebar-session-number-shortcuts",
         );
         for (let index = 1; index <= 3; index += 1) {
           await ctx.control("session.create_task");

--- a/evals/flows/sidebar-session-number-shortcuts.flow.mjs
+++ b/evals/flows/sidebar-session-number-shortcuts.flow.mjs
@@ -18,6 +18,10 @@ export default {
           timeoutMs: 60_000,
           label: "control API",
         });
+        await ctx.waitFor(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+          { timeoutMs: 60_000, label: "session.create_task enabled" },
+        );
         for (let index = 1; index <= 3; index += 1) {
           await ctx.control("session.create_task");
           const sessionId = await ctx.waitFor(`(() => {

--- a/evals/flows/sidebar-title-hover-marquee.flow.mjs
+++ b/evals/flows/sidebar-title-hover-marquee.flow.mjs
@@ -1,3 +1,5 @@
+import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
+
 const LONG_TITLE =
   "Review the OpenWork desktop sidebar title animation across a deliberately overflowing conversation name";
 
@@ -39,14 +41,7 @@ export default {
     {
       name: "Overflow-only title motion preserves the sidebar row",
       run: async (ctx) => {
-        await ctx.waitFor("Boolean(window.__openworkControl)", {
-          timeoutMs: 60_000,
-          label: "control API",
-        });
-        await ctx.waitFor(
-          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
-          { timeoutMs: 60_000, label: "session.create_task enabled" },
-        );
+        await ensureSessionWorkspace(ctx, "sidebar-title-hover-marquee");
         await ctx.control("session.create_task");
         const sessionId = await ctx.waitFor(`(() => {
           const route = window.__openworkControl.snapshot().route || "";

--- a/evals/flows/sidebar-title-hover-marquee.flow.mjs
+++ b/evals/flows/sidebar-title-hover-marquee.flow.mjs
@@ -43,6 +43,10 @@ export default {
           timeoutMs: 60_000,
           label: "control API",
         });
+        await ctx.waitFor(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+          { timeoutMs: 60_000, label: "session.create_task enabled" },
+        );
         await ctx.control("session.create_task");
         const sessionId = await ctx.waitFor(`(() => {
           const route = window.__openworkControl.snapshot().route || "";

--- a/evals/voiceovers/extensions-sidebar-and-header.md
+++ b/evals/voiceovers/extensions-sidebar-and-header.md
@@ -2,4 +2,4 @@
 
 1. In the main sidebar, Search stays at the top, with Extensions directly beneath it before pinned conversations, so Extensions remains easy to reach while working.
 
-2. Opening Extensions shows one clear Extensions page heading, and that destination stays correct through reload and browser history.
+2. Opening Extensions uses the main content area instead of Settings, shows one clear page heading, and stays correct through reload and browser history.

--- a/evals/voiceovers/extensions-sidebar-and-header.md
+++ b/evals/voiceovers/extensions-sidebar-and-header.md
@@ -1,3 +1,5 @@
 # extensions-sidebar-and-header — Extensions are easy to find
 
-1. Open Extensions from the sidebar, reload it, navigate away and back, and inspect expanded and collapsed sidebar states.
+1. In the main sidebar, Search stays at the top, with Extensions directly beneath it before pinned conversations, so Extensions remains easy to reach while working.
+
+2. Opening Extensions shows one clear Extensions page heading, and that destination stays correct through reload and browser history.


### PR DESCRIPTION
## Summary

- Keep Extensions directly below Search and above Pinned conversations in the main desktop sidebar.
- Open Extensions in the main content area at `/workspace/:workspaceId/extensions`, not inside Settings.
- Remove Extensions from the Settings sidebar and Settings overview while preserving legacy Settings deep links as redirects.

## What changed

- Added workspace-scoped and global first-class Extensions routes, including section and detail deep links.
- Reused the existing Extensions inventory in a standalone main-content surface with the main sidebar still visible and active.
- Updated composer, command-palette, notification, Connect, and control-action navigation to use the new route.
- Kept `/settings/extensions`, `/settings/skills`, `/settings/mcp`, and related legacy paths working by redirecting them to the canonical Extensions page.
- Removed the Extensions destination and overview card from Settings.
- Updated route, sidebar, reload/history, and real-app proof coverage.

## Why

Extensions is a primary product destination rather than a Settings panel. The new route keeps it visible in the normal app shell, gives it a stable first-class location, and prevents users from being taken into Settings when they select Extensions.

## Verification

Exact candidate: `9a09d6453d212f3f8f69fafe51cc2087d785c102`

- [x] `pnpm --dir apps/app test` — 540 passed, 0 failed.
- [x] `pnpm --dir apps/app typecheck` — passed.
- [x] `pnpm --dir apps/app build` — passed.
- [x] `pnpm evals:typecheck` — passed.
- [x] `pnpm fraimz --flow extensions-sidebar-and-header --cdp-url http://127.0.0.1:9224` — 1 flow passed, 0 failed, 0 skipped; both narrated frames passed.
- [x] `git diff --check` — passed.
- [x] [Updated public fraimz proof summary](https://github.com/different-ai/openwork/pull/3287#issuecomment-5129269283) — exact candidate, 1 flow passed, 0 failed, 0 skipped; both narrated frames passed.

### Observed behavior

In the real Electron app, Extensions appears immediately below Search. Selecting it opens the inventory in the main content area with the main sidebar retained, marks the Extensions destination active, uses `/workspace/:workspaceId/extensions`, and remains correct through reload and browser history. No Settings page or Settings navigation is shown.

## Risks and untested scope

- Real-app proof covers the desktop main sidebar and Extensions page on macOS.
- A separate mobile-width visual frame was not recorded.
- Local Den was not started because this route and layout change does not touch Den.

## Lineage

This updates the candidate originally prepared by OpenWork Kitchen Snack `8e6707ec-7b6d-4abc-a094-2459823b1755`, then corrected under `@reachjalil` authenticated fork identity after combined Mix Tape review.

## Automation boundary

This PR was prepared and verified as a draft under the manual Kitchen boundary, then merged by `@reachjalil` on July 30, 2026. No release or deployment is claimed by this description.