### PR TITLE
Extract Organization form into a dashboard section

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Copy, Pencil, SlidersHorizontal, Trash2 } from "lucide-react";
+import { SlidersHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
 import {
@@ -12,10 +12,9 @@ import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-templ
 import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
-import { DenTextarea } from "../../_components/ui/textarea";
-import { DenNotice } from "../../_components/ui/notice";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
+import { OrganizationSettingsSection } from "./organization-settings-section";
 import {
   allPublishedDesktopVersionsAllowed,
   compareDesktopVersions,
@@ -46,44 +45,6 @@ function toggleAllowedDesktopVersion(
   }
 
   return current.filter((entry) => entry !== version);
-}
-
-function SettingsToggle({
-  label,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (nextValue: boolean) => void;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-      className={[
-        "relative inline-flex h-7 w-12 items-center rounded-full border transition-colors",
-        checked
-          ? "border-[#0f172a] bg-[#0f172a]"
-          : "border-gray-200 bg-gray-200",
-        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-      ].join(" ")}
-    >
-      <span
-        aria-hidden="true"
-        className={[
-          "inline-block h-5 w-5 rounded-full bg-white transition-transform",
-          checked ? "translate-x-6" : "translate-x-1",
-        ].join(" ")}
-      />
-    </button>
-  );
 }
 
 function DeleteOrganizationDialog({
@@ -522,294 +483,43 @@ export function OrgSettingsScreen() {
       {orgContext && !orgContext.entitlements.orgControls ? (
         <EnterprisePlanNotice feature="Enforced SSO and desktop version control" />
       ) : null}
-      {pageError ? (
-        <DenNotice message={pageError} className="mb-6" />
-      ) : null}
-      {pageSuccess ? (
-        <div className="mb-6 rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">
-          {pageSuccess}
-        </div>
-      ) : null}
-
-      <form className="grid min-w-0 grid-cols-1 gap-6" onSubmit={handleSaveSettings}>
-        <DenCard size="spacious" className="grid gap-6">
-          <div className="grid gap-2">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-              Core
-            </p>
-            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
-              Organization Identity
-            </h2>
-          </div>
-
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
-            <label className="grid gap-3">
-              <span className="text-[14px] font-medium text-gray-700">
-                Name
-              </span>
-              <DenInput
-                type="text"
-                value={orgNameDraft}
-                onChange={(event) => setOrgNameDraft(event.target.value)}
-                minLength={2}
-                maxLength={120}
-                disabled={!canManageSettings}
-                required
-              />
-            </label>
-
-            <div className="grid gap-3">
-              <span className="text-[14px] font-medium text-gray-700">ID</span>
-              <div className="flex gap-2">
-                <DenInput
-                  value={organizationId}
-                  readOnly
-                  aria-label="Organization ID"
-                  className="font-mono text-[13px]"
-                />
-                <DenButton
-                  variant="secondary"
-                  type="button"
-                  icon={copiedOrgId ? Check : Copy}
-                  onClick={() => void handleCopyOrgId()}
-                >
-                  {copiedOrgId ? "Copied" : "Copy"}
-                </DenButton>
-              </div>
-            </div>
-          </div>
-        </DenCard>
-
-        <DenCard size="spacious" className="grid gap-6">
-          <div className="flex items-start justify-between gap-4">
-            <div className="grid gap-2">
-              <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-                Access rules
-              </p>
-              <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
-                Allowed email domains
-              </h2>
-              <p className="text-[14px] text-gray-500">
-                Only allow people with specific email domains to join this
-                Organization.
-              </p>
-            </div>
-            <div className="flex items-center gap-3 pt-1">
-              <span className="text-[13px] font-medium text-gray-500">
-                {domainRestrictionsEnabled ? "On" : "Off"}
-              </span>
-              <SettingsToggle
-                label="Restrict allowed email domains"
-                checked={domainRestrictionsEnabled}
-                disabled={
-                  !canManageSettings || (domainRestrictionsEnabled && hasDraftDomains)
-                }
-                onChange={handleDomainRestrictionToggle}
-              />
-            </div>
-          </div>
-
-          {domainRestrictionsEnabled && domainEditModeEnabled ? (
-            <label className="grid gap-3">
-              <span className="text-[14px] font-medium text-gray-700">
-                Domain allowlist
-              </span>
-              <span className="text-[10px] text-gray-500">
-                Enter domains one per line or with comma as separator
-              </span>
-              <DenTextarea
-                value={allowedDomainsDraft}
-                onChange={(event) => setAllowedDomainsDraft(event.target.value)}
-                rows={6}
-                disabled={!canManageSettings}
-                placeholder={"company.com\npartner.org"}
-              />
-            </label>
-          ) : null}
-
-          {domainRestrictionsEnabled && !domainEditModeEnabled ? (
-            <div className="grid gap-3 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-4">
-              <div className="flex items-start justify-between gap-3">
-                {currentAllowedDomains && currentAllowedDomains.length > 0 ? (
-                  <div className="flex flex-wrap w-full gap-2">
-                    {currentAllowedDomains.map((domain) => (
-                      <span
-                        key={domain}
-                        className="rounded-full border border-gray-200 bg-white px-3 py-1 text-[13px] text-gray-700"
-                      >
-                        {domain}
-                      </span>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-[14px] text-gray-600">
-                    No email domains are configured yet.
-                  </p>
-                )}
-                {canManageSettings ? (
-                  <DenButton
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    icon={Pencil}
-                    onClick={() => {
-                      setPageError(null);
-                      clearOrgSettingsCompletion();
-                      setDomainEditModeEnabled(true);
-                    }}
-                  >
-                    Edit
-                  </DenButton>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-        </DenCard>
-
-        <DenCard size="spacious" className="grid gap-6">
-          <div className="grid gap-2">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-              Authentication
-            </p>
-            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
-              Single sign-on requirement
-            </h2>
-            <p className="text-[14px] text-gray-500">
-              Require members to use the workspace SSO entrypoint when their email domain matches this organization.
-            </p>
-          </div>
-
-          <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
-            <div className="grid gap-1 pr-4">
-              <p className="text-[15px] font-medium text-gray-900">Require SSO for matching domains</p>
-              <p className="text-[13px] text-gray-500">
-                Email/password sign-in will redirect users to the org SSO flow when their email domain matches the configured SSO connection.
-              </p>
-            </div>
-            <SettingsToggle
-              label="Require SSO for this organization"
-              checked={requireSsoEnabled}
-              disabled={!canManageSettings}
-              onChange={setRequireSsoEnabled}
-            />
-          </div>
-        </DenCard>
-
-        <DenCard size="spacious" className="grid gap-6">
-          <div className="grid gap-2">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-              Desktop app
-            </p>
-            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
-              Allowed Desktop Versions
-            </h2>
-            <p className="text-[14px] text-gray-500">
-              Choose which supported desktop versions can sign in to this
-              workspace.
-            </p>
-            {desktopVersionRange ? (
-              <p className="text-[10px] text-gray-400">
-                This server currently supports desktop v
-                {desktopVersionRange.minVersion} to v
-                {desktopVersionRange.maxVersion}.
-              </p>
-            ) : null}
-          </div>
-
-          {desktopVersionOptionsBusy ? (
-            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-4 text-[14px] text-gray-500">
-              Loading desktop versions...
-            </div>
-          ) : null}
-
-          {desktopVersionOptionsError ? (
-            <div className="rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] text-amber-800">
-              {desktopVersionOptionsError}
-            </div>
-          ) : null}
-
-          {!desktopVersionOptionsBusy &&
-          !desktopVersionOptionsError &&
-          desktopVersionOptions.length > 0 ? (
-            <div className="grid gap-4">
-              <div
-                data-testid="desktop-version-list"
-                className="grid max-h-[400px] gap-3 overflow-y-auto pr-2"
-              >
-                {desktopVersionOptions.map((version) => {
-                  const checked = selectedDesktopVersions.has(version);
-                  const requiresServerUpgrade =
-                    desktopVersionRange !== null &&
-                    compareDesktopVersions(
-                      version,
-                      desktopVersionRange.maxVersion,
-                    ) > 0;
-
-                  return (
-                    <label
-                      key={version}
-                      data-desktop-version={version}
-                      data-supported={!requiresServerUpgrade}
-                      className={[
-                        "flex items-center justify-between gap-4 rounded-[24px] border px-5 py-4",
-                        requiresServerUpgrade
-                          ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
-                          : "border-gray-200 bg-white",
-                      ].join(" ")}
-                    >
-                      <div className="grid gap-1">
-                        <p
-                          className={[
-                            "text-[15px] font-medium",
-                            requiresServerUpgrade
-                              ? "text-gray-400"
-                              : "text-gray-900",
-                          ].join(" ")}
-                        >
-                          v{version}
-                        </p>
-                        {requiresServerUpgrade ? (
-                          <p className="text-[12px] text-gray-400">
-                            Upgrade server to allow this version
-                          </p>
-                        ) : null}
-                      </div>
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        disabled={!canManageDesktopVersions || requiresServerUpgrade}
-                        aria-label={`Allow desktop version v${version}`}
-                        onChange={(event) =>
-                          setAllowedDesktopVersionsDraft((current) =>
-                            toggleAllowedDesktopVersion(
-                              current,
-                              version,
-                              event.target.checked,
-                            ),
-                          )
-                        }
-                      />
-                    </label>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
-        </DenCard>
-
-        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-          <p className="text-[13px] text-gray-500">
-            {!canManageSettings ? "Admins can view settings here. Owners and super-admins can change them." : null}
-          </p>
-          <DenButton
-            type="submit"
-            loading={mutationBusy === "update-organization-settings"}
-            disabled={!canManageSettings}
-          >
-            Save settings
-          </DenButton>
-        </div>
-      </form>
+      <OrganizationSettingsSection
+        error={pageError}
+        success={pageSuccess}
+        canManageSettings={canManageSettings}
+        canManageDesktopVersions={canManageDesktopVersions}
+        saving={mutationBusy === "update-organization-settings"}
+        organizationId={organizationId}
+        organizationName={orgNameDraft}
+        copiedOrganizationId={copiedOrgId}
+        currentAllowedDomains={currentAllowedDomains}
+        allowedDomains={allowedDomainsDraft}
+        domainRestrictionsEnabled={domainRestrictionsEnabled}
+        domainEditModeEnabled={domainEditModeEnabled}
+        hasDraftDomains={hasDraftDomains}
+        requireSsoEnabled={requireSsoEnabled}
+        desktopVersionOptions={desktopVersionOptions}
+        desktopVersionRange={desktopVersionRange}
+        selectedDesktopVersions={selectedDesktopVersions}
+        desktopVersionOptionsBusy={desktopVersionOptionsBusy}
+        desktopVersionOptionsError={desktopVersionOptionsError}
+        onOrganizationNameChange={setOrgNameDraft}
+        onCopyOrganizationId={() => void handleCopyOrgId()}
+        onDomainRestrictionToggle={handleDomainRestrictionToggle}
+        onDomainEdit={() => {
+          setPageError(null);
+          clearOrgSettingsCompletion();
+          setDomainEditModeEnabled(true);
+        }}
+        onAllowedDomainsChange={setAllowedDomainsDraft}
+        onRequireSsoChange={setRequireSsoEnabled}
+        onDesktopVersionChange={(version, checked) =>
+          setAllowedDesktopVersionsDraft((current) =>
+            toggleAllowedDesktopVersion(current, version, checked),
+          )
+        }
+        onSubmit={handleSaveSettings}
+      />
 
       {canDeleteOrganization ? (
         <DenCard size="spacious" className="mt-6 grid gap-5 !border-red-200 bg-red-50/30">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/organization-settings-section.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/organization-settings-section.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { Check, Copy, Pencil } from "lucide-react";
+import { DenButton } from "../../_components/ui/button";
+import { DenCard } from "../../_components/ui/card";
+import { DenInput } from "../../_components/ui/input";
+import { DenNotice } from "../../_components/ui/notice";
+import { DenTextarea } from "../../_components/ui/textarea";
+import { compareDesktopVersions } from "./desktop-version-options";
+
+type DesktopVersionRange = {
+  minVersion: string;
+  maxVersion: string;
+};
+
+type OrganizationSettingsSectionProps = {
+  error: string | null;
+  success: string | null;
+  canManageSettings: boolean;
+  canManageDesktopVersions: boolean;
+  saving: boolean;
+  organizationId: string;
+  organizationName: string;
+  copiedOrganizationId: boolean;
+  currentAllowedDomains: string[] | null;
+  allowedDomains: string;
+  domainRestrictionsEnabled: boolean;
+  domainEditModeEnabled: boolean;
+  hasDraftDomains: boolean;
+  requireSsoEnabled: boolean;
+  desktopVersionOptions: string[];
+  desktopVersionRange: DesktopVersionRange | null;
+  selectedDesktopVersions: ReadonlySet<string>;
+  desktopVersionOptionsBusy: boolean;
+  desktopVersionOptionsError: string | null;
+  onOrganizationNameChange: (value: string) => void;
+  onCopyOrganizationId: () => void;
+  onDomainRestrictionToggle: (value: boolean) => void;
+  onDomainEdit: () => void;
+  onAllowedDomainsChange: (value: string) => void;
+  onRequireSsoChange: (value: boolean) => void;
+  onDesktopVersionChange: (version: string, checked: boolean) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+function SettingsToggle({
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (nextValue: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={[
+        "relative inline-flex h-7 w-12 items-center rounded-full border transition-colors",
+        checked
+          ? "border-[#0f172a] bg-[#0f172a]"
+          : "border-gray-200 bg-gray-200",
+        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+      ].join(" ")}
+    >
+      <span
+        aria-hidden="true"
+        className={[
+          "inline-block h-5 w-5 rounded-full bg-white transition-transform",
+          checked ? "translate-x-6" : "translate-x-1",
+        ].join(" ")}
+      />
+    </button>
+  );
+}
+
+export function OrganizationSettingsSection({
+  error,
+  success,
+  canManageSettings,
+  canManageDesktopVersions,
+  saving,
+  organizationId,
+  organizationName,
+  copiedOrganizationId,
+  currentAllowedDomains,
+  allowedDomains,
+  domainRestrictionsEnabled,
+  domainEditModeEnabled,
+  hasDraftDomains,
+  requireSsoEnabled,
+  desktopVersionOptions,
+  desktopVersionRange,
+  selectedDesktopVersions,
+  desktopVersionOptionsBusy,
+  desktopVersionOptionsError,
+  onOrganizationNameChange,
+  onCopyOrganizationId,
+  onDomainRestrictionToggle,
+  onDomainEdit,
+  onAllowedDomainsChange,
+  onRequireSsoChange,
+  onDesktopVersionChange,
+  onSubmit,
+}: OrganizationSettingsSectionProps) {
+  return (
+    <section
+      aria-labelledby="organization-settings-section-title"
+      className="grid min-w-0 gap-6"
+      data-testid="organization-settings-section"
+    >
+      <div className="grid gap-1">
+        <h2
+          id="organization-settings-section-title"
+          className="text-[20px] font-semibold tracking-[-0.03em] text-gray-950"
+        >
+          Organization settings
+        </h2>
+        <p className="text-[13px] leading-6 text-gray-500">
+          Manage your organization identity and access requirements.
+        </p>
+      </div>
+
+      {error ? <DenNotice message={error} /> : null}
+      {success ? (
+        <div className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">
+          {success}
+        </div>
+      ) : null}
+
+      <form className="grid min-w-0 grid-cols-1 gap-6" onSubmit={onSubmit}>
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Core
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              Organization Identity
+            </h2>
+          </div>
+
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
+            <label className="grid gap-3">
+              <span className="text-[14px] font-medium text-gray-700">
+                Name
+              </span>
+              <DenInput
+                type="text"
+                value={organizationName}
+                onChange={(event) => onOrganizationNameChange(event.target.value)}
+                minLength={2}
+                maxLength={120}
+                disabled={!canManageSettings}
+                required
+              />
+            </label>
+
+            <div className="grid gap-3">
+              <span className="text-[14px] font-medium text-gray-700">ID</span>
+              <div className="flex gap-2">
+                <DenInput
+                  value={organizationId}
+                  readOnly
+                  aria-label="Organization ID"
+                  className="font-mono text-[13px]"
+                />
+                <DenButton
+                  variant="secondary"
+                  type="button"
+                  icon={copiedOrganizationId ? Check : Copy}
+                  onClick={onCopyOrganizationId}
+                >
+                  {copiedOrganizationId ? "Copied" : "Copy"}
+                </DenButton>
+              </div>
+            </div>
+          </div>
+        </DenCard>
+
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="grid gap-2">
+              <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                Access rules
+              </p>
+              <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+                Allowed email domains
+              </h2>
+              <p className="text-[14px] text-gray-500">
+                Only allow people with specific email domains to join this
+                Organization.
+              </p>
+            </div>
+            <div className="flex items-center gap-3 pt-1">
+              <span className="text-[13px] font-medium text-gray-500">
+                {domainRestrictionsEnabled ? "On" : "Off"}
+              </span>
+              <SettingsToggle
+                label="Restrict allowed email domains"
+                checked={domainRestrictionsEnabled}
+                disabled={
+                  !canManageSettings || (domainRestrictionsEnabled && hasDraftDomains)
+                }
+                onChange={onDomainRestrictionToggle}
+              />
+            </div>
+          </div>
+
+          {domainRestrictionsEnabled && domainEditModeEnabled ? (
+            <label className="grid gap-3">
+              <span className="text-[14px] font-medium text-gray-700">
+                Domain allowlist
+              </span>
+              <span className="text-[10px] text-gray-500">
+                Enter domains one per line or with comma as separator
+              </span>
+              <DenTextarea
+                value={allowedDomains}
+                onChange={(event) => onAllowedDomainsChange(event.target.value)}
+                rows={6}
+                disabled={!canManageSettings}
+                placeholder={"company.com\npartner.org"}
+              />
+            </label>
+          ) : null}
+
+          {domainRestrictionsEnabled && !domainEditModeEnabled ? (
+            <div className="grid gap-3 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-4">
+              <div className="flex items-start justify-between gap-3">
+                {currentAllowedDomains && currentAllowedDomains.length > 0 ? (
+                  <div className="flex flex-wrap w-full gap-2">
+                    {currentAllowedDomains.map((domain) => (
+                      <span
+                        key={domain}
+                        className="rounded-full border border-gray-200 bg-white px-3 py-1 text-[13px] text-gray-700"
+                      >
+                        {domain}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-[14px] text-gray-600">
+                    No email domains are configured yet.
+                  </p>
+                )}
+                {canManageSettings ? (
+                  <DenButton
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    icon={Pencil}
+                    onClick={onDomainEdit}
+                  >
+                    Edit
+                  </DenButton>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </DenCard>
+
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Authentication
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              Single sign-on requirement
+            </h2>
+            <p className="text-[14px] text-gray-500">
+              Require members to use the workspace SSO entrypoint when their email domain matches this organization.
+            </p>
+          </div>
+
+          <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+            <div className="grid gap-1 pr-4">
+              <p className="text-[15px] font-medium text-gray-900">Require SSO for matching domains</p>
+              <p className="text-[13px] text-gray-500">
+                Email/password sign-in will redirect users to the org SSO flow when their email domain matches the configured SSO connection.
+              </p>
+            </div>
+            <SettingsToggle
+              label="Require SSO for this organization"
+              checked={requireSsoEnabled}
+              disabled={!canManageSettings}
+              onChange={onRequireSsoChange}
+            />
+          </div>
+        </DenCard>
+
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Desktop app
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              Allowed Desktop Versions
+            </h2>
+            <p className="text-[14px] text-gray-500">
+              Choose which supported desktop versions can sign in to this
+              workspace.
+            </p>
+            {desktopVersionRange ? (
+              <p className="text-[10px] text-gray-400">
+                This server currently supports desktop v
+                {desktopVersionRange.minVersion} to v
+                {desktopVersionRange.maxVersion}.
+              </p>
+            ) : null}
+          </div>
+
+          {desktopVersionOptionsBusy ? (
+            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-4 text-[14px] text-gray-500">
+              Loading desktop versions...
+            </div>
+          ) : null}
+
+          {desktopVersionOptionsError ? (
+            <div className="rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] text-amber-800">
+              {desktopVersionOptionsError}
+            </div>
+          ) : null}
+
+          {!desktopVersionOptionsBusy &&
+          !desktopVersionOptionsError &&
+          desktopVersionOptions.length > 0 ? (
+            <div className="grid gap-4">
+              <div
+                data-testid="desktop-version-list"
+                className="grid max-h-[400px] gap-3 overflow-y-auto pr-2"
+              >
+                {desktopVersionOptions.map((version) => {
+                  const checked = selectedDesktopVersions.has(version);
+                  const requiresServerUpgrade =
+                    desktopVersionRange !== null &&
+                    compareDesktopVersions(
+                      version,
+                      desktopVersionRange.maxVersion,
+                    ) > 0;
+
+                  return (
+                    <label
+                      key={version}
+                      data-desktop-version={version}
+                      data-supported={!requiresServerUpgrade}
+                      className={[
+                        "flex items-center justify-between gap-4 rounded-[24px] border px-5 py-4",
+                        requiresServerUpgrade
+                          ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
+                          : "border-gray-200 bg-white",
+                      ].join(" ")}
+                    >
+                      <div className="grid gap-1">
+                        <p
+                          className={[
+                            "text-[15px] font-medium",
+                            requiresServerUpgrade
+                              ? "text-gray-400"
+                              : "text-gray-900",
+                          ].join(" ")}
+                        >
+                          v{version}
+                        </p>
+                        {requiresServerUpgrade ? (
+                          <p className="text-[12px] text-gray-400">
+                            Upgrade server to allow this version
+                          </p>
+                        ) : null}
+                      </div>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={!canManageDesktopVersions || requiresServerUpgrade}
+                        aria-label={`Allow desktop version v${version}`}
+                        onChange={(event) =>
+                          onDesktopVersionChange(version, event.target.checked)
+                        }
+                      />
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+        </DenCard>
+
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <p className="text-[13px] text-gray-500">
+            {!canManageSettings ? "Admins can view settings here. Owners and super-admins can change them." : null}
+          </p>
+          <DenButton
+            type="submit"
+            loading={saving}
+            disabled={!canManageSettings}
+          >
+            Save settings
+          </DenButton>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
+++ b/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
@@ -97,6 +97,7 @@ describe("cloud super-admin role hierarchy", () => {
 
   test("keeps admins read-only across Settings while super-admins inherit mutation flags", () => {
     const orgSettings = read("../app/(den)/dashboard/_components/org-settings-screen.tsx");
+    const orgSettingsSection = read("../app/(den)/dashboard/_components/organization-settings-section.tsx");
     const diagnostics = read("../app/(den)/dashboard/_components/diagnostics-screen.tsx");
     const diagnosticCard = read("../app/(den)/dashboard/_components/egress-diagnostics-card.tsx");
     const brand = read("../app/(den)/dashboard/_components/brand-appearance-screen.tsx");
@@ -110,8 +111,8 @@ describe("cloud super-admin role hierarchy", () => {
     expect(getOrgAccessFlags("super-admin", false).canManageSettings).toBe(true);
     expect(getOrgAccessFlags("admin", false).canManageSettings).toBe(false);
     expect(orgSettings).toContain("const canManageSettings = access.canManageSettings");
-    expect(orgSettings).toContain("Admins can view settings here. Owners and super-admins can change them.");
-    expect(orgSettings).toContain("disabled={!canManageDesktopVersions || requiresServerUpgrade}");
+    expect(orgSettingsSection).toContain("Admins can view settings here. Owners and super-admins can change them.");
+    expect(orgSettingsSection).toContain("disabled={!canManageDesktopVersions || requiresServerUpgrade}");
     expect(diagnostics).toContain("canView={access.canViewSettings} canManage={access.canManageSettings}");
     expect(diagnosticCard).toContain("disabled={!canManage || loading || !available}");
     expect(diagnosticCard).toContain("Only workspace owners and super-admins can run this diagnostic.");

--- a/ee/apps/den-web/tests/org-settings-desktop-versions.test.ts
+++ b/ee/apps/den-web/tests/org-settings-desktop-versions.test.ts
@@ -2,22 +2,26 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 
-const settingsPath = fileURLToPath(
+const screenPath = fileURLToPath(
   new URL("../app/(den)/dashboard/_components/org-settings-screen.tsx", import.meta.url),
+);
+const sectionPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/organization-settings-section.tsx", import.meta.url),
 );
 
 describe("organization desktop version settings", () => {
   test("renders generated versions newest-first in a bounded scrolling list", () => {
-    const source = readFileSync(settingsPath, "utf8");
+    const screen = readFileSync(screenPath, "utf8");
+    const section = readFileSync(sectionPath, "utf8");
 
-    expect(source).toContain("metadata.publishedDesktopVersions");
-    expect(source).toContain('data-testid="desktop-version-list"');
-    expect(source).toContain("max-h-[400px]");
-    expect(source).toContain("overflow-y-auto");
+    expect(screen).toContain("metadata.publishedDesktopVersions");
+    expect(section).toContain('data-testid="desktop-version-list"');
+    expect(section).toContain("max-h-[400px]");
+    expect(section).toContain("overflow-y-auto");
   });
 
   test("disables versions newer than the server maximum with guidance", () => {
-    const source = readFileSync(settingsPath, "utf8");
+    const source = readFileSync(sectionPath, "utf8");
 
     expect(source).toContain("requiresServerUpgrade");
     expect(source).toContain("disabled={!canManageDesktopVersions || requiresServerUpgrade}");
@@ -25,10 +29,11 @@ describe("organization desktop version settings", () => {
   });
 
   test("keeps workspace admins read-only for desktop version settings", () => {
-    const source = readFileSync(settingsPath, "utf8");
+    const screen = readFileSync(screenPath, "utf8");
+    const section = readFileSync(sectionPath, "utf8");
 
-    expect(source).toContain("const canManageDesktopVersions = access.canManageSettings");
-    expect(source).toContain("Admins can view settings here. Owners and super-admins can change them.");
-    expect(source).toContain("disabled={!canManageSettings}");
+    expect(screen).toContain("const canManageDesktopVersions = access.canManageSettings");
+    expect(section).toContain("Admins can view settings here. Owners and super-admins can change them.");
+    expect(section).toContain("disabled={!canManageSettings}");
   });
 });

--- a/ee/apps/den-web/tests/organization-settings-section.test.ts
+++ b/ee/apps/den-web/tests/organization-settings-section.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const screenPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/org-settings-screen.tsx", import.meta.url),
+);
+const sectionPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/organization-settings-section.tsx", import.meta.url),
+);
+
+describe("organization settings dashboard section", () => {
+  test("renders the existing form through a dedicated labelled section component", () => {
+    const screen = readFileSync(screenPath, "utf8");
+    const section = readFileSync(sectionPath, "utf8");
+
+    expect(screen).toContain('import { OrganizationSettingsSection } from "./organization-settings-section"');
+    expect(screen).toContain("<OrganizationSettingsSection");
+    expect(section).toContain("export function OrganizationSettingsSection");
+    expect(section).toContain('<section\n      aria-labelledby="organization-settings-section-title"');
+    expect(section).toContain('data-testid="organization-settings-section"');
+    expect(section).toContain('id="organization-settings-section-title"');
+    expect(section).toContain("Organization settings");
+    expect(section).toContain('<form className="grid min-w-0 grid-cols-1 gap-6" onSubmit={onSubmit}>');
+  });
+
+  test("preserves controlled values, validation, permissions, mutation feedback, and error wiring", () => {
+    const screen = readFileSync(screenPath, "utf8");
+    const section = readFileSync(sectionPath, "utf8");
+
+    expect(screen).toContain("setOrgNameDraft(orgContext.organization.name)");
+    expect(screen).toContain("allowedEmailDomains: domainRestrictionsEnabled");
+    expect(screen).toContain("requireSso: requireSsoEnabled");
+    expect(screen).toContain("await updateOrganizationSettings({");
+    expect(screen).toContain("error instanceof Error");
+    expect(screen).toContain("success={pageSuccess}");
+    expect(screen).toContain("onSubmit={handleSaveSettings}");
+    expect(section).toContain("value={organizationName}");
+    expect(section).toContain("minLength={2}");
+    expect(section).toContain("maxLength={120}");
+    expect(section).toContain("required");
+    expect(section).toContain("disabled={!canManageSettings}");
+    expect(section).toContain("loading={saving}");
+    expect(section).toContain("{error ? <DenNotice message={error} /> : null}");
+    expect(section).toContain("{success}");
+  });
+});


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- Extract Organization settings into a dedicated, reusable dashboard section.
- Preserve organization identity, domain restrictions, SSO requirements, desktop-version controls, permissions, and the existing save workflow.
- Keep the complete form usable at desktop and narrow widths.

## What changed

- **Section boundary** — moves the Organization form into `OrganizationSettingsSection` with its own accessible heading and stable test target.
- **Presentation** — keeps identity, access rules, SSO, and desktop-version controls grouped within one responsive section.
- **State ownership** — leaves data loading, authorization, mutations, success/error handling, and callbacks in the screen container.
- **Regression coverage** — updates existing organization settings tests and adds focused rendered-section coverage.

## Why

The dashboard needs independently composable sections without duplicating business logic or weakening the existing Organization settings workflow. A dedicated section makes the page easier to evolve and verify while preserving behavior.

## Verification

Current scoped candidate: `0a776411f370861c3e580fbc478b0eeacc9cbc93` on `dev@7908ad1dd429aaabcbb273c22872eb003a34ef7a`.

- [x] Organization section, desktop-version, and role-hierarchy tests — 12 passed, 0 failed.
- [x] `pnpm --dir ee/apps/den-web typecheck` — passed.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [x] Scope audit — 1 feature commit, 5 intended files; no inherited evaluator changes.
- [x] Original Kitchen candidate `4dc47e68dc7837068de83d46f62fadda01c3ac21` passed `organization-form-dashboard-section`.
- [ ] The deterministic browser flow was not rerun after the clean current-`dev` rebuild; the original exact-head result is proof provenance, not a fresh current-head claim.

### Observed behavior

The original exact-head deterministic web flow signed in, opened Organization settings, verified the dedicated section and existing organization name, submitted the safe save path successfully, and confirmed the form remained contained without horizontal overflow at 390px.

## Risks and untested scope

- The acceptance flow covers the existing-name save path and responsive containment; it does not separately mutate domain, SSO, or desktop-version settings.
- Permission-specific disabled states and every error path remain covered by regression tests rather than separate visual frames.
- Proof artifacts remain private in the authenticated Kitchen receipt.

## Lineage

- Current fork draft: [reachjalil/openwork#8](https://github.com/reachjalil/openwork/pull/8)

## Exact candidate

- Current base: `7908ad1dd429aaabcbb273c22872eb003a34ef7a`
- Current head: `0a776411f370861c3e580fbc478b0eeacc9cbc93`
- Original Kitchen head: `4dc47e68dc7837068de83d46f62fadda01c3ac21`
- Kitchen run: `9f18c9a0-1fbc-4972-ae71-b85da9208a39`

## Automation boundary

