### PR TITLE
Tighten sidebar horizontal spacing

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -749,7 +749,7 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
   ];
 
   return (
-    <div className="px-2 pb-1">
+    <div className="px-1.5 pb-1">
       <div className="mb-1 flex items-center gap-1 px-1 text-[12px] font-medium uppercase tracking-wide text-sidebar-foreground/50">
         <Columns2 className="size-3" />
         {t("session_management.split_view")}
@@ -766,7 +766,7 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
               key={pane}
               data-session-tab-id={sessionId}
               className={cn(
-                "flex min-w-0 flex-1 items-center gap-1 px-2 py-1.5 text-xs transition-colors",
+                "flex min-w-0 flex-1 items-center gap-1 px-1.5 py-1.5 text-xs transition-colors",
                 focused
                   ? "bg-black/[0.07] text-sidebar-foreground dark:bg-white/[0.12]"
                   : "text-sidebar-foreground/70 hover:bg-black/[0.05] dark:hover:bg-white/[0.09]",
@@ -1043,7 +1043,7 @@ export function AppSidebar(props: AppSidebarProps) {
         {brandLogoUrl ? (
           <div
             data-testid="brand-logo"
-            className="flex h-14 shrink-0 items-center px-3 pb-3 pt-2 mac:pt-0"
+            className="flex h-14 shrink-0 items-center px-2 pb-3 pt-2 mac:pt-0"
           >
             <img
               src={brandLogoUrl}
@@ -1085,13 +1085,13 @@ export function AppSidebar(props: AppSidebarProps) {
           </div>
         ) : null}
         {props.onOpenSessionSearch ? (
-          <SidebarHeader className="pb-0 pe-0">
+          <SidebarHeader className="pb-0 pe-0 ps-1.5">
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton
                   onClick={props.onOpenSessionSearch}
                   aria-keyshortcuts={isMacPlatform() ? "Meta+Shift+F" : "Control+Shift+F"}
-                  className="text-sidebar-foreground/70"
+                  className="px-2 text-sidebar-foreground/70"
                 >
                   <Search className="size-4" />
                   <span className="flex-1 truncate">{t("workspace_list.search_sessions")}</span>
@@ -1182,7 +1182,7 @@ type GlobalPinnedSessionEntry = {
 
 function GlobalPinnedSessions({ entries }: { entries: GlobalPinnedSessionEntry[] }) {
   return (
-    <SidebarGroup data-global-pinned-sessions className="pb-1 pe-0 pt-2">
+    <SidebarGroup data-global-pinned-sessions className="pb-1 pe-0 ps-1.5 pt-2">
       <SidebarGroupContent>
         <div className={cn("flex items-center gap-2 pb-1 pr-3", SIDEBAR_ROW_LANE)}>
           <SidebarGlyphSlot>
@@ -1217,7 +1217,7 @@ function GlobalArchivedSessions({ entries }: { entries: GlobalArchivedSessionEnt
   const [expanded, setExpanded] = React.useState(false);
 
   return (
-    <SidebarGroup data-global-archived-sessions className="pb-1 pe-0 pt-1">
+    <SidebarGroup data-global-archived-sessions className="pb-1 pe-0 ps-1.5 pt-1">
       <SidebarGroupContent>
         <Collapsible open={expanded} onOpenChange={setExpanded} className="group/archived">
           <CollapsibleTrigger
@@ -1395,7 +1395,7 @@ function WorkspaceHeader({
     <SidebarMenuButton
       {...props}
       className={cn(
-        "gap-2 group-hover/workspace-header:bg-sidebar-accent group-hover/workspace-header:text-sidebar-accent-foreground mac:group-hover/workspace-header:bg-black/5 dark:mac:group-hover/workspace-header:bg-white/10",
+        "gap-2 ps-2 group-hover/workspace-header:bg-sidebar-accent group-hover/workspace-header:text-sidebar-accent-foreground mac:group-hover/workspace-header:bg-black/5 dark:mac:group-hover/workspace-header:bg-white/10",
         statusLabel && "h-10",
       )}
       onClick={(event) => {
@@ -1520,7 +1520,7 @@ function WorkspaceSidebarGroup({
     : t("workspace_list.show_more_fallback");
 
   return (
-    <SidebarGroup className={cn(className, "pe-0")}>
+    <SidebarGroup className={cn(className, "pe-0 ps-1.5")}>
       <SidebarGroupContent>
         <SidebarMenu>
           <Collapsible

--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-lane-metrics.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-lane-metrics.ts
@@ -1,5 +1,5 @@
-/** Base inline-start padding (px) matching `SIDEBAR_ROW_LANE` / `ps-3`. */
-export const SIDEBAR_ROW_BASE_PAD_PX = 12;
+/** Base inline-start padding (px) matching `SIDEBAR_ROW_LANE` / `ps-2`. */
+export const SIDEBAR_ROW_BASE_PAD_PX = 8;
 
 /** Nesting step (px) — one step per tree depth level. */
 export const SIDEBAR_ROW_NEST_STEP_PX = 16;

--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx
@@ -16,9 +16,9 @@ export {
 /**
  * Sidebar lane system — two vertical rails shared by every row in the sidebar.
  *
- *   8px   row pill edge (SidebarGroup `p-2`)
- *   20px  glyph lane  — activity dot-matrix, chevrons, row icons, section labels
- *   44px  label lane  — every row title (glyph lane + 16px glyph + 8px `gap-2`)
+ *   6px   row pill edge (sidebar section `ps-1.5`)
+ *   14px  glyph lane  — activity dot-matrix, chevrons, row icons, section labels
+ *   38px  label lane  — every row title (glyph lane + 16px glyph + 8px `gap-2`)
  *
  * Rules:
  * 1. A row's first child is a `SidebarGlyphSlot`, rendered even when it has no
@@ -28,13 +28,13 @@ export {
  */
 
 /** Row padding that puts the glyph slot on the glyph lane. */
-export const SIDEBAR_ROW_LANE = "ps-3";
+export const SIDEBAR_ROW_LANE = "ps-2";
 
-/** One 12px nesting step right of `SIDEBAR_ROW_LANE`. */
+/** One 16px nesting step right of `SIDEBAR_ROW_LANE`. */
 export const SIDEBAR_ROW_LANE_NESTED = "ps-6";
 
 /** Glyph lane for direct children of the sidebar content, which have no row edge. */
-export const SIDEBAR_SECTION_LANE = "pl-5";
+export const SIDEBAR_SECTION_LANE = "ps-3.5";
 
 export const SIDEBAR_SECTION_LABEL =
   "text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground";

--- a/evals/flows/sidebar-lanes.flow.mjs
+++ b/evals/flows/sidebar-lanes.flow.mjs
@@ -1,15 +1,26 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
 /**
  * Sidebar lane system: every sidebar row lands on one of two vertical rails —
- * the 20px glyph lane (activity dot-matrix, chevrons, top-level section label)
- * and the 44px label lane (workspace names, session titles, group labels,
- * placeholders, account name). Regression for the ragged sidebar where the
+ * the 14px glyph lane (search, activity dot-matrix, chevrons, section label)
+ * and the 38px label lane (search, workspace names, session titles, group
+ * labels and placeholders). Regression for the ragged sidebar where the
  * section label, workspace titles and session titles each had their own left
  * edge. Lanes are defined in
  * `apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx`.
  */
-const GLYPH_LANE = 20;
-const LABEL_LANE = 44;
+const vo = await loadVoiceoverParagraphs("sidebar-lanes");
+const GLYPH_LANE = 14;
+const LABEL_LANE = 38;
 const NEST_STEP = 16;
+const FIXTURE_WORKSPACE = resolve(
+  process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
+  "..",
+  "sidebar-lanes-workspace",
+);
 
 const MEASURE_LANES = `(() => {
   const sidebar = document.querySelector('[data-slot="sidebar"]');
@@ -45,6 +56,8 @@ const MEASURE_LANES = `(() => {
     const label = firstTextX(el);
     rows.push({ kind, glyph: glyphX(el, label), label, text });
   };
+  const search = sidebar.querySelector('[data-sidebar="header"] [data-sidebar="menu-button"]');
+  if (search) add("search", search);
   for (const el of sidebar.querySelectorAll(".group\\\\/workspaces-header")) add("section", el);
   for (const el of sidebar.querySelectorAll('.group\\\\/workspace-header [data-sidebar="menu-button"]')) add("workspace", el);
   for (const el of sidebar.querySelectorAll("[data-session-group]")) add("group-label", el);
@@ -53,18 +66,14 @@ const MEASURE_LANES = `(() => {
     if (el.closest("[data-sidebar-session-id]")) continue;
     add("placeholder", el);
   }
-  const account = sidebar.querySelector('[data-testid="account-status-menu"]');
-  if (account) rows.push({ kind: "account", glyph: null, label: firstTextX(account), text: "account" });
   return rows;
 })()`;
 
 const EXPAND_ALL_WORKSPACES = `(() => {
   let clicked = 0;
   for (const header of document.querySelectorAll(".group\\\\/workspace-header")) {
-    const toggle = Array.from(header.querySelectorAll("button")).find(
-      (button) => button.getAttribute("aria-expanded") === "false",
-    );
-    if (toggle) {
+    const toggle = header.querySelector("button.group\\\\/expand-collapse-button");
+    if (toggle?.getAttribute("aria-expanded") === "false") {
       toggle.click();
       clicked += 1;
     }
@@ -74,15 +83,17 @@ const EXPAND_ALL_WORKSPACES = `(() => {
 
 export default {
   id: "sidebar-lanes",
-  title: "Every sidebar row aligns on the shared glyph (20px) and label (44px) lanes",
+  title: "Sidebar rows align on tighter shared glyph (14px) and label (38px) lanes",
+  kind: "user-facing",
   spec: "apps/app/src/react-app/ARCHITECTURE.md",
   steps: [
     {
       name: "App is ready and Electron-backed",
       run: async (ctx) => {
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
         const userAgent = await ctx.eval("navigator.userAgent");
         ctx.assert(userAgent.includes("Electron/"), `Expected Electron userAgent, got ${userAgent}`);
-        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
       },
     },
     {
@@ -90,6 +101,38 @@ export default {
       run: async (ctx) => {
         const hasSession = await ctx.eval(`document.querySelectorAll("[data-sidebar-session-id]").length > 0`);
         if (!hasSession) {
+          const canCreateTask = await ctx.eval(
+            "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+          );
+          if (!canCreateTask) {
+            await mkdir(FIXTURE_WORKSPACE, { recursive: true });
+            const welcomeInput = 'input[placeholder="/workspace/my-project"]';
+            const onWelcome = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(welcomeInput)}))`);
+            if (onWelcome) {
+              await ctx.fill(welcomeInput, FIXTURE_WORKSPACE);
+              await ctx.clickText("Use this folder", { selector: "button", timeoutMs: 10_000 });
+              await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 30_000 }).catch(() => {});
+              await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
+              await ctx.waitFor("location.hash.includes('/workspace/')", {
+                timeoutMs: 60_000,
+                label: "workspace route after folder selection",
+              });
+              await ctx.waitFor("Boolean(window.__openworkControl)", {
+                timeoutMs: 60_000,
+                label: "control API after onboarding",
+              });
+            } else {
+              await ctx.waitFor(
+                "window.__openworkControl.listActions().some((action) => action.id === 'workspace.create' && !action.disabled)",
+                { timeoutMs: 30_000, label: "workspace creation control" },
+              );
+              await ctx.control("workspace.create", { path: FIXTURE_WORKSPACE });
+            }
+            await ctx.waitFor(
+              "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+              { timeoutMs: 60_000, label: "enabled task creation" },
+            );
+          }
           await ctx.control("session.create_task");
         }
         await ctx.eval(EXPAND_ALL_WORKSPACES);
@@ -107,6 +150,7 @@ export default {
         ctx.log(`Measured rows: ${JSON.stringify(rows)}`);
 
         const kinds = new Set(rows.map((row) => row.kind));
+        ctx.assert(kinds.has("search"), "No search row was measured.");
         ctx.assert(kinds.has("workspace"), "No workspace header row was measured.");
         ctx.assert(kinds.has("session"), "No session row was measured.");
 
@@ -122,14 +166,15 @@ export default {
         });
 
         await ctx.prove("Sidebar rows land on the two shared lanes", {
+          voiceover: vo[0],
           claim:
-            "Section label, workspace titles, group labels, session titles, placeholders and the account name all sit on the 20px glyph lane or the 44px label lane (+16px per nesting depth).",
+            "Search, section labels, workspace titles, group labels, session titles and placeholders all sit on the 14px glyph lane or the 38px label lane (+16px per nesting depth).",
           assert: () => {
             ctx.assert(
               offLane.length === 0,
               `Rows off the shared lanes: ${JSON.stringify(offLane)}`,
             );
-            const titles = rows.filter((row) => row.kind === "workspace" || row.kind === "session");
+            const titles = rows.filter((row) => row.kind === "search" || row.kind === "workspace" || row.kind === "session");
             for (const row of titles) {
               const onANestLane = allowedLabel.some((lane) => lane >= LABEL_LANE && Math.abs(row.label - lane) <= 1);
               ctx.assert(
@@ -138,7 +183,10 @@ export default {
               );
             }
           },
-          screenshot: { name: "sidebar-lanes-aligned" },
+          screenshot: {
+            name: "sidebar-lanes-aligned",
+            requireText: ["Search sessions", "WORKSPACES"],
+          },
         });
       },
     },

--- a/evals/voiceovers/sidebar-lanes.md
+++ b/evals/voiceovers/sidebar-lanes.md
@@ -1,0 +1,3 @@
+# sidebar-lanes — Tighter sidebar lanes show more information
+
+1. The sidebar now uses a tighter left edge for search, workspace, and task rows. More of each name stays visible, while icons and nested items remain aligned and easy to scan.


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- reduce the sidebar main content lane from 20px to 14px
- tighten search, workspace, session, split-view, pinned, archived, and brand-logo insets
- preserve the 16px nesting step so hierarchy remains readable
- upgrade the sidebar-lanes eval to narrated Fraimz coverage

## Why

The sidebar was spending too much horizontal space on repeated left insets. Tightening those lanes keeps more workspace and task text visible without changing row height or interaction targets.

## Verification

- `pnpm --filter @openwork/app typecheck`
- `pnpm fraimz --flow sidebar-lanes` against the Hub-assigned Electron CDP endpoint
- Fraimz result: 1 passed, 0 failed, 0 skipped on commit e51772b80
- visually inspected the final unobstructed Fraimz screenshot

## Notes

The live journey was verified on macOS Electron. Other operating systems and RTL layout were not exercised end to end.