### PR TITLE
fix(den): serialize invitation lifecycle races

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -625,7 +625,8 @@ export async function acceptPendingInvitationForBootstrapMembership(input: {
 
   // Bootstrap paths already grant same-org membership before email verification.
   // organization-join-verification.ts keeps that gate on the explicit accept endpoint.
-  return acceptInvitation(invitation, input.userId, { fallbackRole: input.defaultRole })
+  const accepted = await acceptInvitation(invitation, input.userId, { fallbackRole: input.defaultRole })
+  return accepted?.member ?? null
 }
 
 export async function reconcilePendingInvitationsForUser(userId: UserId) {
@@ -667,8 +668,10 @@ export async function reconcilePendingInvitationsForUser(userId: UserId) {
       continue
     }
 
-    await acceptInvitation(invitation, userId)
-    acceptedCount += 1
+    const accepted = await acceptInvitation(invitation, userId)
+    if (accepted) {
+      acceptedCount += 1
+    }
   }
 
   return acceptedCount
@@ -676,46 +679,68 @@ export async function reconcilePendingInvitationsForUser(userId: UserId) {
 
 async function acceptInvitation(invitation: InvitationRow, userId: UserId, options?: { fallbackRole?: string }) {
   const availableRoles = await listAssignableRoles(invitation.organizationId)
-  const role = normalizeAssignableRole(invitation.role, availableRoles, options?.fallbackRole)
-  const joinedAt = new Date()
-
-  const existingMemberRows = await db
-    .select()
-    .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, invitation.organizationId), eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
-    .limit(1)
-
-  const invitedMemberRows = await db
-    .select()
-    .from(MemberTable)
-    .where(and(eq(MemberTable.inviteId, invitation.id), eq(MemberTable.organizationId, invitation.organizationId), isNull(MemberTable.removedAt)))
-    .limit(1)
-
-  const invitedMember = invitedMemberRows[0] ?? null
-  const existingMember = existingMemberRows[0] ?? null
-  const removedMember = existingMember
-    ? null
-    : await findSoftRemovedMemberForUser({
-      organizationId: invitation.organizationId,
-      userId,
-    })
-  let member = existingMember
-
-  if (existingMember && invitedMember) {
-    const existingJoinedAt = existingMember.joinedAt ?? joinedAt
-    const existingRole = roleIncludesOwner(existingMember.role) ? existingMember.role : role
-    await db
-      .update(MemberTable)
-      .set({ role: existingRole, joinedAt: existingJoinedAt })
-      .where(eq(MemberTable.id, existingMember.id))
-    if (invitedMember.id !== existingMember.id) {
-      await db.delete(MemberTable).where(eq(MemberTable.id, invitedMember.id))
+  return db.transaction(async (tx) => {
+    const lockedInvitations = await tx
+      .select()
+      .from(InvitationTable)
+      .where(and(
+        eq(InvitationTable.id, invitation.id),
+        eq(InvitationTable.organizationId, invitation.organizationId),
+      ))
+      .for("update")
+    const currentInvitation = lockedInvitations[0] ?? null
+    if (!currentInvitation) {
+      return null
     }
-    member = { ...existingMember, role: existingRole, joinedAt: existingJoinedAt }
-  }
 
-  if (!member && removedMember && invitedMember) {
-    await db.transaction(async (tx) => {
+    const existingMemberRows = await tx
+      .select()
+      .from(MemberTable)
+      .where(and(eq(MemberTable.organizationId, currentInvitation.organizationId), eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+      .limit(1)
+      .for("update")
+    const existingMember = existingMemberRows[0] ?? null
+    const invitationStatus = getInvitationStatus(currentInvitation)
+    if (invitationStatus !== "pending") {
+      return invitationStatus === "accepted" && existingMember
+        ? { invitation: currentInvitation, member: existingMember, newlyAccepted: false }
+        : null
+    }
+
+    const role = normalizeAssignableRole(currentInvitation.role, availableRoles, options?.fallbackRole)
+    const joinedAt = new Date()
+    const invitedMemberRows = await tx
+      .select()
+      .from(MemberTable)
+      .where(and(eq(MemberTable.inviteId, currentInvitation.id), eq(MemberTable.organizationId, currentInvitation.organizationId), isNull(MemberTable.removedAt)))
+      .limit(1)
+      .for("update")
+    const invitedMember = invitedMemberRows[0] ?? null
+    const removedMemberRows = existingMember
+      ? []
+      : await tx
+          .select()
+          .from(MemberTable)
+          .where(and(eq(MemberTable.organizationId, currentInvitation.organizationId), eq(MemberTable.userId, userId), isNotNull(MemberTable.removedAt)))
+          .limit(1)
+          .for("update")
+    const removedMember = removedMemberRows[0] ?? null
+    let member = existingMember
+
+    if (existingMember && invitedMember) {
+      const existingJoinedAt = existingMember.joinedAt ?? joinedAt
+      const existingRole = roleIncludesOwner(existingMember.role) ? existingMember.role : role
+      await tx
+        .update(MemberTable)
+        .set({ role: existingRole, joinedAt: existingJoinedAt })
+        .where(eq(MemberTable.id, existingMember.id))
+      if (invitedMember.id !== existingMember.id) {
+        await tx.delete(MemberTable).where(eq(MemberTable.id, invitedMember.id))
+      }
+      member = { ...existingMember, role: existingRole, joinedAt: existingJoinedAt }
+    }
+
+    if (!member && removedMember && invitedMember) {
       // A new explicit invitation is a new access lifecycle. Keep the removed
       // row for audit history, but activate the invitation placeholder so any
       // teams or direct grants assigned while the invite was pending remain
@@ -728,18 +753,16 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
         .update(MemberTable)
         .set({ userId, role, joinedAt })
         .where(eq(MemberTable.id, invitedMember.id))
-    })
-    member = {
-      ...invitedMember,
-      userId,
-      role,
-      joinedAt,
+      member = {
+        ...invitedMember,
+        userId,
+        role,
+        joinedAt,
+      }
     }
-  }
 
-  if (!member && removedMember) {
-    const memberId = createDenTypeId("member")
-    const createdMembers = await db.transaction(async (tx) => {
+    if (!member && removedMember) {
+      const memberId = createDenTypeId("member")
       // Legacy invitations may not have a pending member placeholder. They
       // still represent a fresh access lifecycle, so detach the audit row and
       // create a new membership instead of reviving stale membership grants.
@@ -749,75 +772,88 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
         .where(eq(MemberTable.id, removedMember.id))
       await tx.insert(MemberTable).values({
         id: memberId,
-        organizationId: invitation.organizationId,
+        organizationId: currentInvitation.organizationId,
         userId,
         role,
         joinedAt,
-        inviteId: invitation.id,
-        invitedByOrgMember: invitation.orgMemberId,
+        inviteId: currentInvitation.id,
+        invitedByOrgMember: currentInvitation.orgMemberId,
       })
-      return tx
+      const createdMembers = await tx
         .select()
         .from(MemberTable)
         .where(eq(MemberTable.id, memberId))
         .limit(1)
-    })
-    member = createdMembers[0]
-    if (!member) {
-      throw new Error("failed_to_create_member")
-    }
-  }
-
-  if (!member && invitedMember) {
-    await db
-      .update(MemberTable)
-      .set({ userId, role, joinedAt })
-      .where(eq(MemberTable.id, invitedMember.id))
-    member = { ...invitedMember, userId, role, joinedAt }
-  }
-
-  if (!member) {
-    const createdMember = await insertMemberIfMissing({
-      organizationId: invitation.organizationId,
-      userId,
-      role,
-    })
-    if (!createdMember) {
-      throw new Error("failed_to_create_member")
-    }
-    member = createdMember
-  }
-
-  if (invitation.teamId) {
-    const teams = await db
-      .select({ id: TeamTable.id })
-      .from(TeamTable)
-      .where(eq(TeamTable.id, invitation.teamId))
-      .limit(1)
-
-    if (teams[0]) {
-      const existingTeamMember = await db
-        .select({ id: TeamMemberTable.id })
-        .from(TeamMemberTable)
-        .where(and(eq(TeamMemberTable.teamId, invitation.teamId), eq(TeamMemberTable.orgMembershipId, member.id)))
-        .limit(1)
-
-      if (!existingTeamMember[0]) {
-        await db.insert(TeamMemberTable).values({
-          id: createDenTypeId("teamMember"),
-          teamId: invitation.teamId,
-          orgMembershipId: member.id,
-        })
+      member = createdMembers[0]
+      if (!member) {
+        throw new Error("failed_to_create_member")
       }
     }
-  }
 
-  await db
-    .update(InvitationTable)
-    .set({ status: "accepted" })
-    .where(eq(InvitationTable.id, invitation.id))
+    if (!member && invitedMember) {
+      await tx
+        .update(MemberTable)
+        .set({ userId, role, joinedAt })
+        .where(eq(MemberTable.id, invitedMember.id))
+      member = { ...invitedMember, userId, role, joinedAt }
+    }
 
-  return member
+    if (!member) {
+      const memberId = createDenTypeId("member")
+      await tx.insert(MemberTable).values({
+        id: memberId,
+        organizationId: currentInvitation.organizationId,
+        userId,
+        role,
+        joinedAt,
+        inviteId: currentInvitation.id,
+        invitedByOrgMember: currentInvitation.orgMemberId,
+      })
+      const createdMembers = await tx
+        .select()
+        .from(MemberTable)
+        .where(eq(MemberTable.id, memberId))
+        .limit(1)
+      member = createdMembers[0]
+      if (!member) {
+        throw new Error("failed_to_create_member")
+      }
+    }
+
+    if (currentInvitation.teamId) {
+      const teams = await tx
+        .select({ id: TeamTable.id })
+        .from(TeamTable)
+        .where(and(
+          eq(TeamTable.id, currentInvitation.teamId),
+          eq(TeamTable.organizationId, currentInvitation.organizationId),
+        ))
+        .limit(1)
+
+      if (teams[0]) {
+        const existingTeamMember = await tx
+          .select({ id: TeamMemberTable.id })
+          .from(TeamMemberTable)
+          .where(and(eq(TeamMemberTable.teamId, currentInvitation.teamId), eq(TeamMemberTable.orgMembershipId, member.id)))
+          .limit(1)
+
+        if (!existingTeamMember[0]) {
+          await tx.insert(TeamMemberTable).values({
+            id: createDenTypeId("teamMember"),
+            teamId: currentInvitation.teamId,
+            orgMembershipId: member.id,
+          })
+        }
+      }
+    }
+
+    await tx
+      .update(InvitationTable)
+      .set({ status: "accepted" })
+      .where(and(eq(InvitationTable.id, currentInvitation.id), eq(InvitationTable.status, "pending")))
+
+    return { invitation: currentInvitation, member, newlyAccepted: true }
+  })
 }
 
 export async function acceptInvitationForUser(input: {
@@ -882,12 +918,34 @@ export async function acceptInvitationForUser(input: {
     throw new OrganizationEmailDomainRestrictionError(input.email, allowedEmailDomains ?? [])
   }
 
-  const member = await acceptInvitation(invitation, input.userId)
-  await runPostOrganizationMemberChangeHooks({ organizationId: invitation.organizationId, memberId: member.id, change: "added" })
+  const accepted = await acceptInvitation(invitation, input.userId)
+  if (!accepted) {
+    const currentInvitation = await getInvitationById(input.invitationId)
+    if (currentInvitation && getInvitationStatus(currentInvitation) === "accepted") {
+      const removedMember = await findSoftRemovedMemberForUser({
+        organizationId: currentInvitation.organizationId,
+        userId: input.userId,
+      })
+      if (removedMember) {
+        return {
+          status: "membership_removed",
+          invitation: currentInvitation,
+        }
+      }
+    }
+    return null
+  }
+  if (accepted.newlyAccepted) {
+    await runPostOrganizationMemberChangeHooks({
+      organizationId: accepted.invitation.organizationId,
+      memberId: accepted.member.id,
+      change: "added",
+    })
+  }
   return {
     status: "accepted",
-    invitation,
-    member,
+    invitation: accepted.invitation,
+    member: accepted.member,
   }
 }
 

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, isNull } from "@openwork-ee/den-db/drizzle"
-import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
+import { AuthUserTable, InvitationTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -142,93 +142,114 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     }
     const assignedRole = assignableRole.role
 
-    const existingMembers = await db
-      .select({ id: MemberTable.id })
-      .from(MemberTable)
-      .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-      .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email), isNull(MemberTable.removedAt)))
-      .limit(1)
+    const invitationWrite = await db.transaction(async (tx) => {
+      await tx
+        .select({ id: OrganizationTable.id })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, payload.organization.id))
+        .for("update")
 
-    if (existingMembers[0]) {
-      return c.json({
-        error: "member_exists",
-        message: "That email address is already a member of this organization.",
-      }, 409)
-    }
+      const existingInvitationRows = await tx
+        .select()
+        .from(InvitationTable)
+        .where(
+          and(
+            eq(InvitationTable.organizationId, payload.organization.id),
+            eq(InvitationTable.email, email),
+          ),
+        )
+        .orderBy(desc(InvitationTable.createdAt))
+        .for("update")
+      const existingInvitation = existingInvitationRows.find((row) => row.status === "pending") ?? null
 
-    const existingInvitation = await db
-      .select()
-      .from(InvitationTable)
-      .where(
-        and(
-          eq(InvitationTable.organizationId, payload.organization.id),
-          eq(InvitationTable.email, email),
-          eq(InvitationTable.status, "pending"),
-        ),
-      )
-      .orderBy(desc(InvitationTable.createdAt))
-      .limit(1)
-
-    if (existingInvitation[0]) {
-      const refreshRole = validateInvitationRefreshRole({
-        existingRole: existingInvitation[0].role,
-        availableRoles,
-        currentMember: payload.currentMember,
-        roles: payload.roles,
-      })
-      if (!refreshRole.ok) {
-        if (refreshRole.error === "invalid_role") {
-          return c.json({ error: refreshRole.error, message: refreshRole.message }, 400)
-        }
-        return c.json({ error: refreshRole.error, message: refreshRole.message }, 403)
-      }
-    }
-
-    if (!existingInvitation[0]) {
-      const seatEligibility = await getOrganizationSeatAddEligibility(payload.organization.id)
-      if (!seatEligibility.allowed) {
-        return c.json({
-          error: "payment_required",
-          reason: "seat_subscription_required",
-          subscriptionType: "seat",
-          currentCount: seatEligibility.currentCount,
-          freeSeatCount: seatEligibility.freeSeatCount,
-          message: `This workspace includes ${seatEligibility.freeSeatCount} free members. Start seat billing before inviting another member.`,
-        }, 402)
-      }
-    }
-
-    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
-    const invitationId = existingInvitation[0]?.id ?? createInvitationId()
-    const inviteToken = createInvitationToken()
-    let createdOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
-    let invitationOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
-
-    if (existingInvitation[0]) {
-      await db
-        .update(InvitationTable)
-        .set({ role: assignedRole, inviterId: normalizeDenTypeId("user", user.id), orgMemberId: payload.currentMember.id, inviteToken, expiresAt })
-        .where(eq(InvitationTable.id, existingInvitation[0].id))
-
-      const invitedMemberRows = await db
+      const existingMembers = await tx
         .select({ id: MemberTable.id })
         .from(MemberTable)
-        .where(and(eq(MemberTable.inviteId, existingInvitation[0].id), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
+        .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+        .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email), isNull(MemberTable.removedAt)))
         .limit(1)
+        .for("update")
+      if (existingMembers[0]) {
+        return { status: "member_exists" as const }
+      }
 
-      if (invitedMemberRows[0]) {
-        await db
-          .update(MemberTable)
-          .set({ role: assignedRole, invitedByOrgMember: payload.currentMember.id })
-          .where(eq(MemberTable.id, invitedMemberRows[0].id))
-        invitationOrgMemberId = invitedMemberRows[0].id
+      if (existingInvitation) {
+        const refreshRole = validateInvitationRefreshRole({
+          existingRole: existingInvitation.role,
+          availableRoles,
+          currentMember: payload.currentMember,
+          roles: payload.roles,
+        })
+        if (!refreshRole.ok) {
+          return { status: "role_error" as const, validation: refreshRole }
+        }
       } else {
+        const seatEligibility = await getOrganizationSeatAddEligibility(payload.organization.id)
+        if (!seatEligibility.allowed) {
+          return { status: "payment_required" as const, seatEligibility }
+        }
+      }
+
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7)
+      const invitationId = existingInvitation?.id ?? createInvitationId()
+      const inviteToken = existingInvitation?.inviteToken && existingInvitation.expiresAt > now
+        ? existingInvitation.inviteToken
+        : createInvitationToken()
+      let createdOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
+      let invitationOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
+
+      if (existingInvitation) {
+        await tx
+          .update(InvitationTable)
+          .set({ role: assignedRole, inviterId: normalizeDenTypeId("user", user.id), orgMemberId: payload.currentMember.id, inviteToken, expiresAt })
+          .where(and(eq(InvitationTable.id, existingInvitation.id), eq(InvitationTable.status, "pending")))
+
+        const invitedMemberRows = await tx
+          .select({ id: MemberTable.id })
+          .from(MemberTable)
+          .where(and(eq(MemberTable.inviteId, existingInvitation.id), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
+          .limit(1)
+
+        if (invitedMemberRows[0]) {
+          await tx
+            .update(MemberTable)
+            .set({ role: assignedRole, invitedByOrgMember: payload.currentMember.id })
+            .where(eq(MemberTable.id, invitedMemberRows[0].id))
+          invitationOrgMemberId = invitedMemberRows[0].id
+        } else {
+          const memberId = createDenTypeId("member")
+          await tx.insert(MemberTable).values({
+            id: memberId,
+            organizationId: payload.organization.id,
+            userId: null,
+            inviteId: existingInvitation.id,
+            invitedByOrgMember: payload.currentMember.id,
+            role: assignedRole,
+            joinedAt: null,
+          })
+          createdOrgMemberId = memberId
+          invitationOrgMemberId = memberId
+        }
+      } else {
+        await tx.insert(InvitationTable).values({
+          id: invitationId,
+          organizationId: payload.organization.id,
+          email,
+          role: assignedRole,
+          status: "pending",
+          inviterId: normalizeDenTypeId("user", user.id),
+          orgMemberId: payload.currentMember.id,
+          inviteToken,
+          expiresAt,
+        })
+
         const memberId = createDenTypeId("member")
-        await db.insert(MemberTable).values({
+        await tx.insert(MemberTable).values({
           id: memberId,
           organizationId: payload.organization.id,
           userId: null,
-          inviteId: existingInvitation[0].id,
+          inviteId: invitationId,
           invitedByOrgMember: payload.currentMember.id,
           role: assignedRole,
           joinedAt: null,
@@ -236,32 +257,51 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         createdOrgMemberId = memberId
         invitationOrgMemberId = memberId
       }
-    } else {
-      await db.insert(InvitationTable).values({
-        id: invitationId,
-        organizationId: payload.organization.id,
-        email,
-        role: assignedRole,
-        status: "pending",
-        inviterId: normalizeDenTypeId("user", user.id),
-        orgMemberId: payload.currentMember.id,
-        inviteToken,
-        expiresAt,
-      })
 
-      const memberId = createDenTypeId("member")
-      await db.insert(MemberTable).values({
-        id: memberId,
-        organizationId: payload.organization.id,
-        userId: null,
-        inviteId: invitationId,
-        invitedByOrgMember: payload.currentMember.id,
-        role: assignedRole,
-        joinedAt: null,
-      })
-      createdOrgMemberId = memberId
-      invitationOrgMemberId = memberId
+      return {
+        status: "saved" as const,
+        createdOrgMemberId,
+        expiresAt,
+        invitationId,
+        invitationOrgMemberId,
+        inviteToken,
+        refreshed: Boolean(existingInvitation),
+      }
+    })
+
+    if (invitationWrite.status === "member_exists") {
+      return c.json({
+        error: "member_exists",
+        message: "That email address is already a member of this organization.",
+      }, 409)
     }
+    if (invitationWrite.status === "role_error") {
+      const validation = invitationWrite.validation
+      if (validation.error === "invalid_role") {
+        return c.json({ error: validation.error, message: validation.message }, 400)
+      }
+      return c.json({ error: validation.error, message: validation.message }, 403)
+    }
+    if (invitationWrite.status === "payment_required") {
+      const { seatEligibility } = invitationWrite
+      return c.json({
+        error: "payment_required",
+        reason: "seat_subscription_required",
+        subscriptionType: "seat",
+        currentCount: seatEligibility.currentCount,
+        freeSeatCount: seatEligibility.freeSeatCount,
+        message: `This workspace includes ${seatEligibility.freeSeatCount} free members. Start seat billing before inviting another member.`,
+      }, 402)
+    }
+
+    const {
+      createdOrgMemberId,
+      expiresAt,
+      invitationId,
+      invitationOrgMemberId,
+      inviteToken,
+      refreshed,
+    } = invitationWrite
 
     if (createdOrgMemberId) {
       await runPostOrganizationMemberChangeHooks({ organizationId: payload.organization.id, memberId: createdOrgMemberId, change: "added" })
@@ -270,7 +310,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     await recordOrganizationAuditEvent({
       organizationId: payload.organization.id,
       actorUserId: payload.currentMember.userId,
-      action: existingInvitation[0]
+      action: refreshed
         ? ORGANIZATION_AUDIT_ACTIONS.invitationRefreshed
         : ORGANIZATION_AUDIT_ACTIONS.invitationCreated,
       payload: {
@@ -323,7 +363,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       throw error
     }
 
-    return c.json({ invitationId, email, role: assignedRole, expiresAt, inviteToken }, existingInvitation[0] ? 200 : 201)
+    return c.json({ invitationId, email, role: assignedRole, expiresAt, inviteToken }, refreshed ? 200 : 201)
     },
   )
 
@@ -359,38 +399,56 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       return c.json({ error: "invitation_not_found" }, 404)
     }
 
-    const invitationRows = await db
-      .select({
-        id: InvitationTable.id,
-        email: InvitationTable.email,
-        role: InvitationTable.role,
-        status: InvitationTable.status,
-      })
-      .from(InvitationTable)
-      .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
-      .limit(1)
+    const cancellation = await db.transaction(async (tx) => {
+      const invitationRows = await tx
+        .select({
+          id: InvitationTable.id,
+          email: InvitationTable.email,
+          role: InvitationTable.role,
+          status: InvitationTable.status,
+        })
+        .from(InvitationTable)
+        .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
+        .for("update")
+      const invitation = invitationRows[0] ?? null
+      if (!invitation) {
+        return { status: "not_found" as const }
+      }
+      if (invitation.status !== "pending") {
+        return { status: "not_pending" as const, invitation }
+      }
 
-    if (!invitationRows[0]) {
+      const invitedMemberRows = await tx
+        .select({ id: MemberTable.id })
+        .from(MemberTable)
+        .where(and(eq(MemberTable.inviteId, invitationId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.joinedAt), isNull(MemberTable.removedAt)))
+        .limit(1)
+
+      await tx
+        .update(InvitationTable)
+        .set({ status: "canceled" })
+        .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.status, "pending")))
+
+      return {
+        status: "canceled" as const,
+        invitation,
+        invitedMember: invitedMemberRows[0] ?? null,
+      }
+    })
+
+    if (cancellation.status === "not_found") {
       return c.json({ error: "invitation_not_found" }, 404)
     }
 
-    if (invitationRows[0].status !== "pending") {
+    if (cancellation.status === "not_pending") {
       return c.json({
         error: "invitation_not_pending",
         message: "Only pending invitations can be canceled.",
-        status: invitationRows[0].status,
+        status: cancellation.invitation.status,
       }, 409)
     }
 
-    const invitedMemberRows = await db
-      .select({ id: MemberTable.id })
-      .from(MemberTable)
-      .where(and(eq(MemberTable.inviteId, invitationId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.joinedAt), isNull(MemberTable.removedAt)))
-      .limit(1)
-
-    await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
-
-    const invitedMember = invitedMemberRows[0]
+    const invitedMember = cancellation.invitedMember
     if (invitedMember) {
       const removed = await removeOrganizationMember({
         organizationId: payload.organization.id,
@@ -407,11 +465,11 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       actorUserId: payload.currentMember.userId,
       action: ORGANIZATION_AUDIT_ACTIONS.invitationCanceled,
       payload: {
-        invitationId: invitationRows[0].id,
+        invitationId: cancellation.invitation.id,
         targetOrgMembershipId: invitedMember?.id ?? null,
-        targetEmail: invitationRows[0].email,
-        role: invitationRows[0].role,
-        previousStatus: invitationRows[0].status,
+        targetEmail: cancellation.invitation.email,
+        role: cancellation.invitation.role,
+        previousStatus: cancellation.invitation.status,
       },
     })
 

--- a/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
+++ b/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
@@ -24,17 +24,22 @@ let drizzle: typeof import("@openwork-ee/den-db/drizzle")
 
 const ownerUserId = createDenTypeId("user")
 const invitedUserId = createDenTypeId("user")
+const racingUserId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
 const ownerMemberId = createDenTypeId("member")
 const invitedMemberId = createDenTypeId("member")
 const ownerSessionId = createDenTypeId("session")
+const racingSessionId = createDenTypeId("session")
 const invitationId = createDenTypeId("invitation")
 const teamId = createDenTypeId("team")
 const teamMemberId = createDenTypeId("teamMember")
 const ownerSessionToken = `invitation-lifecycle-owner-${ownerSessionId}`
+const racingSessionToken = `invitation-lifecycle-racing-${racingSessionId}`
 const invitedEmail = `invitation-lifecycle+${invitedUserId}@test.local`
+const racingEmail = `invitation-lifecycle-racing+${racingUserId}@test.local`
 const originalInviteToken = `expired-${invitationId}`
 let ownerCookie = ""
+let racingCookie = ""
 
 beforeAll(async () => {
   seedRequiredEnv()
@@ -70,6 +75,12 @@ beforeAll(async () => {
       email: invitedEmail,
       emailVerified: true,
     },
+    {
+      id: racingUserId,
+      name: "Invitation Lifecycle Racing Member",
+      email: racingEmail,
+      emailVerified: true,
+    },
   ])
   await db.insert(schema.OrganizationTable).values({
     id: organizationId,
@@ -93,13 +104,22 @@ beforeAll(async () => {
       joinedAt: null,
     },
   ])
-  await db.insert(schema.AuthSessionTable).values({
-    id: ownerSessionId,
-    userId: ownerUserId,
-    activeOrganizationId: organizationId,
-    token: ownerSessionToken,
-    expiresAt: new Date(Date.now() + 60_000),
-  })
+  await db.insert(schema.AuthSessionTable).values([
+    {
+      id: ownerSessionId,
+      userId: ownerUserId,
+      activeOrganizationId: organizationId,
+      token: ownerSessionToken,
+      expiresAt: new Date(Date.now() + 60_000),
+    },
+    {
+      id: racingSessionId,
+      userId: racingUserId,
+      activeOrganizationId: null,
+      token: racingSessionToken,
+      expiresAt: new Date(Date.now() + 60_000),
+    },
+  ])
   await db.insert(schema.InvitationTable).values({
     id: invitationId,
     organizationId,
@@ -131,6 +151,11 @@ beforeAll(async () => {
     ownerSessionToken,
     betterAuthSecret,
   )
+  racingCookie = await serializeSignedCookie(
+    "better-auth.session_token",
+    racingSessionToken,
+    betterAuthSecret,
+  )
 })
 
 afterAll(async () => {
@@ -141,14 +166,14 @@ afterAll(async () => {
 
   await db.delete(schema.AuditEventTable).where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
   await db.delete(schema.TeamMemberTable).where(drizzle.eq(schema.TeamMemberTable.teamId, teamId))
-  await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, ownerSessionId))
+  await db.delete(schema.AuthSessionTable).where(drizzle.inArray(schema.AuthSessionTable.id, [ownerSessionId, racingSessionId]))
   await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
   await db.delete(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.organizationId, organizationId))
   await db.delete(schema.TeamTable).where(drizzle.eq(schema.TeamTable.id, teamId))
   await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
   await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
   await db.delete(schema.AuthUserTable).where(
-    drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, invitedUserId]),
+    drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, invitedUserId, racingUserId]),
   )
   mock.restore()
 })
@@ -200,6 +225,50 @@ test("resending an expired invite refreshes its pending member and assignments i
   expect(teamMembers[0]?.id).toBe(teamMemberId)
 })
 
+test("concurrent invite requests converge on one pending invitation and one usable token", async () => {
+  const concurrentEmail = `concurrent-${organizationId}@test.local`
+  const request = () => app.fetch(new Request(`${API_ORIGIN}/v1/invitations`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({ email: concurrentEmail, role: "member" }),
+  }))
+
+  const responses = await Promise.all([request(), request()])
+  const payloads = await Promise.all(responses.map((response) => response.json()))
+
+  expect(responses.map((response) => response.status).sort()).toEqual([200, 201])
+  expect(payloads.every(isRecord)).toBe(true)
+  if (!payloads.every(isRecord)) {
+    throw new Error("Invitation responses were not objects")
+  }
+  expect(new Set(payloads.map((payload) => payload.invitationId)).size).toBe(1)
+  expect(new Set(payloads.map((payload) => payload.inviteToken)).size).toBe(1)
+
+  const invitations = await db
+    .select()
+    .from(schema.InvitationTable)
+    .where(drizzle.and(
+      drizzle.eq(schema.InvitationTable.organizationId, organizationId),
+      drizzle.eq(schema.InvitationTable.email, concurrentEmail),
+      drizzle.eq(schema.InvitationTable.status, "pending"),
+    ))
+  expect(invitations).toHaveLength(1)
+
+  const pendingMembers = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.and(
+      drizzle.eq(schema.MemberTable.organizationId, organizationId),
+      drizzle.eq(schema.MemberTable.inviteId, invitations[0]?.id ?? invitationId),
+      drizzle.isNull(schema.MemberTable.removedAt),
+    ))
+  expect(pendingMembers).toHaveLength(1)
+})
+
 test("an accepted invitation cannot be canceled by stale admin state", async () => {
   await db
     .update(schema.InvitationTable)
@@ -242,4 +311,73 @@ test("an accepted invitation cannot be canceled by stale admin state", async () 
     .from(schema.MemberTable)
     .where(drizzle.eq(schema.MemberTable.id, invitedMemberId))
   expect(members[0]?.removedAt).toBeNull()
+})
+
+test("acceptance cannot overwrite a cancellation committed after its initial read", async () => {
+  const racingInvitationId = createDenTypeId("invitation")
+  const racingMemberId = createDenTypeId("member")
+  const racingInviteToken = `racing-${racingInvitationId}`
+  await db.insert(schema.InvitationTable).values({
+    id: racingInvitationId,
+    organizationId,
+    email: racingEmail,
+    role: "member",
+    status: "pending",
+    inviterId: ownerUserId,
+    orgMemberId: ownerMemberId,
+    inviteToken: racingInviteToken,
+    expiresAt: new Date(Date.now() + 60_000),
+  })
+  await db.insert(schema.MemberTable).values({
+    id: racingMemberId,
+    organizationId,
+    userId: null,
+    inviteId: racingInvitationId,
+    invitedByOrgMember: ownerMemberId,
+    role: "member",
+    joinedAt: null,
+  })
+
+  let acceptancePromise: Promise<Response> | undefined
+  await db.transaction(async (tx) => {
+    await tx
+      .select({ id: schema.InvitationTable.id })
+      .from(schema.InvitationTable)
+      .where(drizzle.eq(schema.InvitationTable.id, racingInvitationId))
+      .for("update")
+
+    acceptancePromise = app.fetch(new Request(`${API_ORIGIN}/v1/orgs/invitations/accept`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: racingCookie,
+        origin: API_ORIGIN,
+      },
+      body: JSON.stringify({ id: racingInviteToken }),
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    await tx
+      .update(schema.InvitationTable)
+      .set({ status: "canceled" })
+      .where(drizzle.eq(schema.InvitationTable.id, racingInvitationId))
+  })
+
+  if (!acceptancePromise) {
+    throw new Error("Acceptance request did not start")
+  }
+  const response = await acceptancePromise
+  expect(response.status).toBe(404)
+
+  const invitations = await db
+    .select({ status: schema.InvitationTable.status })
+    .from(schema.InvitationTable)
+    .where(drizzle.eq(schema.InvitationTable.id, racingInvitationId))
+  expect(invitations[0]?.status).toBe("canceled")
+
+  const members = await db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.eq(schema.MemberTable.id, racingMemberId))
+  expect(members[0]?.userId).toBeNull()
+  expect(members[0]?.joinedAt).toBeNull()
 })


### PR DESCRIPTION
## Summary

- serialize invitation creation and refreshes per workspace so concurrent requests for the same email converge on one pending invitation and one placeholder member
- preserve a still-valid invite token during refreshes so overlapping resend emails cannot invalidate each other; expired invitations still receive a fresh token
- lock invitation acceptance and cancellation in database transactions so a canceled invite cannot be overwritten back to accepted
- keep member activation, removed-member rejoin handling, team inheritance, and the terminal invitation update in the same acceptance transaction
- scope inherited team lookup to the invitation's organization

## Root cause

Invitation creation, acceptance, and cancellation used separate read-then-write operations. There is intentionally no unique database constraint that can represent only one pending invitation while retaining accepted/canceled history, so two admin requests could both observe no pending invitation and insert duplicates. Likewise, acceptance unconditionally wrote `accepted` after its initial status read, allowing it to overwrite a concurrent cancellation.

## User impact

The Members flow now has deterministic behavior under double clicks, retries, multiple admins, and accept-versus-cancel races:

- one email has one pending invitation and one pending member
- concurrent resend responses reference the same usable token
- exactly one terminal state wins
- a canceled invitation cannot create or reactivate workspace access

## Regression coverage added

- concurrent invite requests must return one create and one refresh response while sharing one invitation, one token, and one pending member
- an acceptance request that initially observed `pending` must still fail if cancellation commits before acceptance acquires the invitation lock
- the existing expired-invite, member-assignment, accepted-invite cancellation, re-invite, and team-inheritance paths remain represented by their existing focused tests

## Checks

Checks not run (level 0). This is intentionally a draft PR under the repository's user-selected verification policy. The focused regression test to run is:

```bash
pnpm --filter @openwork-ee/den-api exec bun test test/invitation-lifecycle-hardening.test.ts
```

## Risk and implementation notes

- invite writes are serialized at workspace scope; these are low-volume admin operations
- email delivery, audit recording, and post-member hooks remain outside the database transaction, so no external network call holds a database lock
- no schema, API response, or Den Web changes are required
