### PR TITLE
Make Den evaluator organization selection deterministic

### DIFF
--- a/evals/flows/flat-plugin-card-treatment.flow.ts
+++ b/evals/flows/flat-plugin-card-treatment.flow.ts
@@ -8,6 +8,7 @@ if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
 
 const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const ORGANIZATION_NAME = "Acme Robotics";
 
 async function setViewport(ctx: FlowContext, width: number): Promise<void> {
   ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
@@ -65,7 +66,7 @@ export default defineFlow({
           voiceover: vo[0],
           action: async () => {
             await setViewport(ctx, 1440);
-            await signInViaBrowser(ctx, EMAIL, PASSWORD);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD, ORGANIZATION_NAME);
             await navigate(ctx, "/dashboard/plugins");
             await ctx.expectText("Plugins", { timeoutMs: 60_000 });
             await ctx.waitFor(

--- a/evals/flows/lib/den-web.d.mts
+++ b/evals/flows/lib/den-web.d.mts
@@ -8,4 +8,9 @@ export interface DenApiResult {
 export function denWebUrl(): string;
 export function denApiUrl(): string;
 export function denApiFetch(path: string, options?: RequestInit): Promise<DenApiResult>;
-export function signInViaBrowser(ctx: FlowContext, email: string, password: string): Promise<void>;
+export function signInViaBrowser(
+  ctx: FlowContext,
+  email: string,
+  password: string,
+  organizationName?: string,
+): Promise<void>;

--- a/evals/flows/lib/den-web.mjs
+++ b/evals/flows/lib/den-web.mjs
@@ -41,7 +41,7 @@ export async function signInApi(email, password) {
   return body.token ?? null;
 }
 
-export async function signInViaBrowser(ctx, email, password) {
+export async function signInViaBrowser(ctx, email, password, organizationName) {
   // Land on the den-web origin first so the relative sign-out fetch below
   // actually reaches den-web (a leftover session would otherwise bounce the
   // root URL straight to /dashboard with no sign-in card).
@@ -110,11 +110,21 @@ export async function signInViaBrowser(ctx, email, password) {
     const selected = await ctx.eval(`(() => {
       const list = document.querySelector('[data-testid="org-chooser-list"]');
       if (!list) return false;
-      const button = list.querySelector('button:not([disabled])');
+      const buttons = [...list.querySelectorAll('button:not([disabled])')];
+      const target = ${JSON.stringify(organizationName?.trim() ?? "")};
+      const button =
+        target
+          ? buttons.find((entry) => (entry.textContent ?? "").includes(target))
+          : buttons[0];
       button?.click();
       return Boolean(button);
     })()`);
-    ctx.assert(selected, "No selectable organization found.");
+    ctx.assert(
+      selected,
+      organizationName
+        ? `No selectable organization matching ${organizationName} found.`
+        : "No selectable organization found.",
+    );
     await ctx.waitFor(
       `(() => {
         const text = document.body?.innerText ?? '';

--- a/evals/flows/organization-form-dashboard-section.flow.ts
+++ b/evals/flows/organization-form-dashboard-section.flow.ts
@@ -8,6 +8,7 @@ if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
 
 const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const ORGANIZATION_NAME = "Acme Robotics";
 
 async function setViewport(ctx: FlowContext, width: number): Promise<void> {
   ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
@@ -47,7 +48,7 @@ export default defineFlow({
           voiceover: vo[0],
           action: async () => {
             await setViewport(ctx, 1440);
-            await signInViaBrowser(ctx, EMAIL, PASSWORD);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD, ORGANIZATION_NAME);
             await navigate(ctx, "/dashboard/org-settings");
             await ctx.expectText("Organization", { timeoutMs: 30_000 });
             await ctx.waitFor(ORGANIZATION_SECTION, { timeoutMs: 15_000, label: "dedicated Organization section" });


### PR DESCRIPTION
## Summary
- allow Den browser sign-in helpers to select a named organization
- pin the two organization-admin acceptance flows to Acme Robotics
- fail clearly instead of silently choosing a non-admin organization

## Validation
- 
- ✔ waitForRoute prefers the canonical control route immediately (0.632667ms)
✔ waitForRoute falls back to the Electron URL hash (0.112167ms)
✔ waitForRoute reports the last observed route at the configured deadline (32.320417ms)
✔ waitForRoute bounds a browser probe that never resolves (30.892083ms)
✔ Daytona previewUrl parses the first https URL and caches by port (5.261166ms)
✔ spawnElectron starts isolated Daytona Electron profiles and writes bootstrap over base64 (5.730208ms)
✔ spawnElectron skips reserved Daytona CDP ports (0.127875ms)
✔ spawnChrome launches Chromium with Daytona CDP flags and allocates a second port (0.210041ms)
✔ disposeSurface uses self-match-safe pkill patterns in separate execs (0.287834ms)
✔ Daytona host requires a sandbox option or OPENWORK_EVAL_DAYTONA_SANDBOX (0.22225ms)
✔ startDen attaches to preset Den env without running daytona exec (17.020708ms)
✔ native MariaDB explicitly permits root-owned Daytona runtimes (0.378084ms)
✔ native MariaDB supports fresh and resumed socket authentication (0.294916ms)
✔ demo-org seed resolves development exports without package builds (0.765291ms)
✔ Den evaluator explicitly permits the isolated demo signup (0.062375ms)
✔ Den evaluator threads orgMode only when requested (0.061416ms)
✔ Den evaluator trusts both loopback spellings used by the proof browser (0.048791ms)
✔ Den Web startup discards generated output from a reusable image (26.854084ms)
✔ ClientHello parser distinguishes TLS 1.2-only from TLS 1.3-capable clients (0.768042ms)
✔ profile config resolution normalizes defaults (0.207125ms)
✔ openssl argv construction includes CA, AIA, and fullchain prerequisites (0.174583ms)
✔ deny-list seeding reads installer-critical hosts from the outbound manifest (5.757084ms)
✔ blip schedule fires once, then stops (0.167333ms)
✔ verdict matcher names injected faults and rejects vague output (0.101084ms)
✔ product diagnostics precondition skips clearly when Bun is unavailable (13.541959ms)
✔ mock IdP config normalization trims issuer, domain, and credentials (0.450208ms)
✔ certificate normalizer names the trailing-newline paste bug (0.229042ms)
✔ domain mismatch normalizer names IdP email domains that do not match the org (0.074417ms)
✔ claim builder supports present, absent, and unexpected group claim shapes (0.473ms)
✔ email mismatch and guest-user knobs shape SSO subjects (0.072375ms)
✔ RS256 signing argv documents the dependency-free node:crypto path (0.054042ms)
✔ blocked-user response uses the Entra-style policy wording (0.108791ms)
✔ expectation matcher fails with actionable detail when the named error is missing (0.054875ms)
✔ Den URL helpers trim bases and build invite URLs (0.453417ms)
✔ invite extraction rewrites email HTML links onto the driven Den Web origin (0.160958ms)
✔ invite extraction accepts JSON payload links and tokens (0.161375ms)
✔ Den env resolution reports missing URLs clearly (0.183875ms)
✔ actor validation accepts complete actors and rejects incomplete shapes (0.337917ms)
✔ hostile gateway journey exposes the required app-less fault cases (0.072459ms)
✔ hostile gateway precondition reports an actionable bun skip reason (10.060459ms)
✔ hostile-gateway-mcp flow is app-less and has one step per hostile case (6.478833ms)
✔ MCP journey helpers read text content and search_capabilities matches (0.512875ms)
✔ allocateFreePorts returns distinct usable ports (6.248292ms)
✔ env manifests round-trip and apply without overwriting explicit env (1.93125ms)
✔ defineScenario returns a flow, preserves steps, gates Den env, and passes actors (0.45875ms)
✔ org-invite-two-desktops scenario loads with Den env gates and one step per narrated frame (14.364ms)
✔ host placement defaults to Daytona when the manifest adopts a Daytona surface (0.155875ms)
✔ resolveActors honors seeded owner env defaults (0.082958ms)
✔ eval CLI parses repeat and rejects non-positive values (0.30025ms)
✔ runFlowRepeated threads iteration runstamps and keeps first plus failing iteration evidence (0.42475ms)
✔ core reliability scenarios are web-only, Den-staged, and narrated frame-for-frame (2.130583ms)
✔ reporters render soak tables only when repeat summaries are present (0.309542ms)
✔ SurfaceRegistry is idempotent, adopts manifest surfaces, and disposes only spawned handles (9.057125ms)
✔ EvalContext.on swaps clients, restores through nesting, and labels frames (3.641667ms)
✔ kube profile selection maps values files and org modes (0.615208ms)
✔ helm upgrade argv includes release, chart, profile, context, and local image overrides (0.124208ms)
✔ kubectl rollout and port-forward argv use the kind context (0.074625ms)
✔ published image decision uses manifest platform support (0.362292ms)
✔ local image decision skips manifest inspection when explicitly requested (0.084792ms)
✔ explicit published image mode fails when manifests do not support this platform (0.234083ms)
✔ kubeStackDown stops port-forwards before uninstalling the release (17.653208ms)
✔ rollout failure surfaces pod status and recent logs (0.293625ms)
✔ electronProfilePaths returns all expected paths under the profile root (0.674625ms)
✔ electronSurfaceEnv matches the isolated Electron demo contract (0.140584ms)
✔ resolveChromeBinary honors CHROME_BIN before platform defaults (0.077083ms)
✔ resolveChromeBinary returns the macOS default path (0.045333ms)
✔ resolveChromeBinary finds Linux Chrome on PATH and reports a helpful error otherwise (21.064791ms)
✔ owt arg parsing handles subcommands and rejects unknown input (0.942916ms)
✔ owt --adopt parsing validates kind, name, and port (0.126333ms)
✔ owt delegates run/proof to the eval CLI with the selected env (0.12675ms)
✔ owt manifest lifecycle writes fake surfaces, shares links, and tolerates ESRCH on down (21.625833ms)
✔ owt up adopts existing Daytona surfaces without spawning (2.317833ms)
▶ release feed catalog resolution
  ✔ selects highest allowed instead of latest and treats empty allowlist as unrestricted (1.787875ms)
✔ release feed catalog resolution (2.180291ms)
▶ release feed URL and filename handling
  ✔ constructs release asset URLs and resolves browser-renamed filenames (4.09ms)
✔ release feed URL and filename handling (4.168542ms)
▶ release feed cache semantics
  ✔ honors cache TTL and explicit staleUntil (0.177917ms)
✔ release feed cache semantics (0.242834ms)
▶ release feed fault knobs
  ✔ turns a 504 artifact response into an actionable error (10.3345ms)
  ✔ serves slow chunked assets without corrupting the artifact body (6.927042ms)
✔ release feed fault knobs (17.390958ms)
▶ bootstrap precedence helper
  ✔ drives workspace-store precedence so an installed organization URL outranks a newer hosted bundle (5.633541ms)
✔ bootstrap precedence helper (5.744667ms)
ℹ tests 78
ℹ suites 5
ℹ pass 78
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 186.85575 (78 passed)
- 