### PR TITLE
fix(den): harden email sign-in resolution

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -55,6 +55,7 @@
     "@standard-schema/spec": "^1.1.0",
     "better-auth": "1.6.11",
     "better-call": "1.3.5",
+    "botid": "^1.5.11",
     "dotenv": "^16.4.5",
     "fast-xml-parser": "5.8.0",
     "grammy": "^1.44.0",

--- a/ee/apps/den-api/src/bot-protection.ts
+++ b/ee/apps/den-api/src/bot-protection.ts
@@ -1,0 +1,19 @@
+import { checkBotId } from "botid/server"
+import { env } from "./env.js"
+
+export type BotProtectionResult =
+  | { ok: true }
+  | { ok: false; status: 403; message: string }
+
+export async function verifyBotProtection(): Promise<BotProtectionResult> {
+  if (env.devMode) {
+    return { ok: true }
+  }
+
+  const result = await checkBotId()
+  if (result.isBot) {
+    return { ok: false, status: 403, message: "Request verification failed." }
+  }
+
+  return { ok: true }
+}

--- a/ee/apps/den-api/src/enterprise-auth-requirement.ts
+++ b/ee/apps/den-api/src/enterprise-auth-requirement.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
+  AuthAccountTable,
   AuthUserTable,
   MemberTable,
   OrganizationTable,
@@ -24,8 +25,20 @@ export type EnterpriseAuthRequirement = {
   hasSso: boolean
 }
 
+export type ResolvedNonSsoMethod = "google" | "password" | "signup"
+
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase()
+}
+
+function getEmailDomain(email: string) {
+  const normalizedEmail = normalizeEmail(email)
+  const atIndex = normalizedEmail.lastIndexOf("@")
+  if (atIndex <= 0 || atIndex === normalizedEmail.length - 1) {
+    return null
+  }
+  const domain = normalizedEmail.slice(atIndex + 1)
+  return domain.includes(".") ? domain : null
 }
 
 function getOrganizationSsoSignInPath(organizationSlug: string) {
@@ -82,6 +95,62 @@ export async function findEnterpriseAuthRequirementForEmail(email: string) {
   }
 
   return findEnterpriseAuthRequirement(sql`lower(${AuthUserTable.email}) = ${normalizedEmail}`)
+}
+
+export async function findEnterpriseAuthRequirementForEmailDomain(email: string) {
+  const domain = getEmailDomain(email)
+  if (!domain) {
+    return null
+  }
+
+  const rows = await db
+    .select({
+      organizationId: OrganizationTable.id,
+      organizationSlug: OrganizationTable.slug,
+      signInPath: SsoConnectionTable.signInPath,
+      ssoProviderId: SsoProviderTable.providerId,
+    })
+    .from(OrganizationTable)
+    .innerJoin(SsoConnectionTable, and(
+      eq(OrganizationTable.id, SsoConnectionTable.organizationId),
+      eq(SsoConnectionTable.status, "enabled"),
+      eq(SsoConnectionTable.domain, domain),
+    ))
+    .innerJoin(SsoProviderTable, and(
+      eq(SsoConnectionTable.providerId, SsoProviderTable.providerId),
+      eq(OrganizationTable.id, SsoProviderTable.organizationId),
+      eq(SsoProviderTable.domain, domain),
+      eq(SsoProviderTable.domainVerified, true),
+    ))
+
+  const requirement = pickRequirement(rows)
+  return requirement ? toRequirement(requirement) : null
+}
+
+export async function resolveNonSsoSignInMethodForEmail(email: string): Promise<ResolvedNonSsoMethod> {
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) {
+    return "signup"
+  }
+
+  const rows = await db
+    .select({
+      providerId: AuthAccountTable.providerId,
+      password: AuthAccountTable.password,
+    })
+    .from(AuthUserTable)
+    .innerJoin(AuthAccountTable, eq(AuthUserTable.id, AuthAccountTable.userId))
+    .where(sql`lower(${AuthUserTable.email}) = ${normalizedEmail}`)
+
+  if (rows.length === 0) {
+    return "signup"
+  }
+
+  if (rows.some((row) => row.providerId.trim().toLowerCase() === "google")) {
+    return "google"
+  }
+
+  return "password"
 }
 
 export async function findEnterpriseAuthRequirementForUserId(userId: string) {

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -1,4 +1,5 @@
 import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } from "@better-auth/oauth-provider"
+import { createHash } from "node:crypto"
 import { eq, sql } from "@openwork-ee/den-db/drizzle"
 import { AuthAccountTable, AuthUserTable, OAuthClientTable } from "@openwork-ee/den-db/schema"
 import type { Hono } from "hono"
@@ -6,6 +7,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth, DEN_MCP_OAUTH_RESOURCE, normalizeMcpOAuthResource } from "../../auth.js"
 import { normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
+import { verifyBotProtection } from "../../bot-protection.js"
 import {
   getBreachedPasswordResponse,
   getEmailPasswordLockoutResponse,
@@ -15,7 +17,7 @@ import {
 } from "../../auth-protection.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
-import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
+import { findEnterpriseAuthRequirementForEmailDomain } from "../../enterprise-auth-requirement.js"
 import { getInvalidMcpOAuthRedirectUris, isAllowedMcpOAuthRedirectUri, MCP_OAUTH_REDIRECT_URI_ERROR_DESCRIPTION } from "../../mcp/oauth-client-policy.js"
 import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, queryValidator, tokenRoute } from "../../middleware/index.js"
@@ -24,6 +26,7 @@ import { getSingletonSsoStatus } from "../../orgs.js"
 import { getAuthRequestEmail, getSingleOrgEmailSignupPolicyViolation, type SingleOrgEmailSignupPolicyViolation } from "../../single-org-signup-policy.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import { revokeBearerSession, type AuthContextVariables } from "../../session.js"
+import { checkRateLimit } from "../../utils/rate-limit.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
 import { normalizeOAuthAuthorizeRedirect } from "./oauth-redirect.js"
 import { registerScimAuthRoutes } from "./scim.js"
@@ -460,6 +463,48 @@ const loginOptionsResponseSchema = z.object({
   signInUrl: z.string().url().optional(),
 }).meta({ ref: "AuthLoginOptionsResponse" })
 
+const loginOptionsBotVerificationFailedSchema = z.object({
+  error: z.literal("bot_verification_failed"),
+  message: z.string(),
+}).meta({ ref: "LoginOptionsBotVerificationFailedError" })
+
+const loginOptionsRateLimitedSchema = z.object({
+  error: z.literal("rate_limited"),
+  message: z.string(),
+}).meta({ ref: "LoginOptionsRateLimitedError" })
+
+function readRequestAddress(headers: Headers) {
+  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
+}
+
+function sha256Hex(value: string) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function readEmailDomain(email: string) {
+  const atIndex = email.lastIndexOf("@")
+  return atIndex > 0 && atIndex < email.length - 1 ? email.slice(atIndex + 1) : "unknown"
+}
+
+async function checkLoginOptionsRateLimit(headers: Headers, email: string) {
+  const now = Date.now()
+  const keys = [
+    `auth-login-options:ip:${sha256Hex(readRequestAddress(headers))}`,
+    `auth-login-options:email:${sha256Hex(email)}`,
+    `auth-login-options:domain:${sha256Hex(readEmailDomain(email))}`,
+  ]
+
+  for (const key of keys) {
+    const retryAfter = await checkRateLimit(key, 20, 60_000, now)
+    if (retryAfter !== null) {
+      return retryAfter
+    }
+  }
+
+  return null
+}
+
 async function getLoginOptionAccounts(email: string) {
   const rows = await db
     .select({
@@ -553,12 +598,31 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
       responses: {
         200: jsonResponse("Login option resolved successfully.", loginOptionsResponseSchema),
         400: jsonResponse("The login option query parameters were invalid.", z.object({ error: z.literal("invalid_request") })),
+        403: jsonResponse("Bot verification failed.", loginOptionsBotVerificationFailedSchema),
+        429: jsonResponse("Too many login option attempts.", loginOptionsRateLimitedSchema),
       },
     }),
     publicRoute,
     queryValidator(loginOptionsQuerySchema),
     async (c) => {
       const { email } = c.req.valid("query")
+      const botProtection = await verifyBotProtection()
+      if (!botProtection.ok) {
+        return c.json({
+          error: "bot_verification_failed",
+          message: botProtection.message,
+        }, botProtection.status)
+      }
+
+      const retryAfter = await checkLoginOptionsRateLimit(c.req.raw.headers, email)
+      if (retryAfter !== null) {
+        c.header("Retry-After", String(retryAfter))
+        return c.json({
+          error: "rate_limited",
+          message: "Too many sign-in option attempts. Try again later.",
+        }, 429)
+      }
+
       const singletonSsoStatus = env.orgMode === "single_org" ? await getSingletonSsoStatus() : null
       const singletonSsoRequirement = singletonSsoStatus?.configured
         ? {
@@ -566,7 +630,7 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
             signInPath: singletonSsoStatus.signInPath,
           }
         : null
-      const requirement = singletonSsoRequirement ?? await findEnterpriseAuthRequirementForEmail(email)
+      const requirement = singletonSsoRequirement ?? await findEnterpriseAuthRequirementForEmailDomain(email)
       const accounts = requirement ? [] : await getLoginOptionAccounts(email)
       const allowPublicSignup = env.orgMode !== "single_org" || env.singleOrg.allowPublicSignup
       const nextStep = resolveLoginOptionKind({ requireSso: Boolean(requirement), accounts, allowNewAccount: allowPublicSignup })

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable, ScimProviderTable, SsoConnectionTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
@@ -5,6 +6,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
+import { verifyBotProtection } from "../../bot-protection.js"
 import { validateBrandIconUrl } from "../../brand-icon-validation.js"
 import { organizationCloudEnabled } from "../../capability-sources/cloud-rollout.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
@@ -12,7 +14,7 @@ import { organizationInstallLinksEnabled } from "../../capability-sources/instal
 import { db } from "../../db.js"
 import { checkEntitlement, getOrganizationEntitlements, parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
-import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
+import { findEnterpriseAuthRequirementForEmailDomain, resolveNonSsoSignInMethodForEmail } from "../../enterprise-auth-requirement.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidator, resolveMemberTeamsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
@@ -30,6 +32,7 @@ import {
   updateOrganizationSettings,
 } from "../../orgs.js"
 import { getRequiredUserEmail } from "../../user.js"
+import { checkRateLimit } from "../../utils/rate-limit.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationSuperAdmin, orgAccessFailureStatus } from "./shared.js"
 
@@ -55,11 +58,25 @@ const resolveSsoByEmailQuerySchema = z.object({
 })
 
 const resolveSsoByEmailResponseSchema = z.object({
-  requireSso: z.boolean(),
+  requireSso: z.literal(true),
+  method: z.literal("sso"),
   organizationSlug: z.string(),
   signInPath: z.string(),
   signInUrl: z.string().url(),
-}).meta({ ref: "ResolveOrganizationSsoByEmailResponse" })
+}).or(z.object({
+  requireSso: z.literal(false),
+  method: z.union([z.literal("google"), z.literal("password"), z.literal("signup")]),
+})).meta({ ref: "ResolveOrganizationSsoByEmailResponse" })
+
+const botVerificationFailedSchema = z.object({
+  error: z.literal("bot_verification_failed"),
+  message: z.string(),
+}).meta({ ref: "BotVerificationFailedError" })
+
+const rateLimitedSchema = z.object({
+  error: z.literal("rate_limited"),
+  message: z.string(),
+}).meta({ ref: "RateLimitedError" })
 
 const singleOrgSsoStatusResponseSchema = z.object({
   configured: z.boolean(),
@@ -174,6 +191,44 @@ function getStoredSessionId(session: { id?: string | null } | null) {
   } catch {
     return null
   }
+}
+
+function getRequestAddress(headers: Headers) {
+  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
+}
+
+function sha256Hex(value: string) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function normalizeResolveEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function getResolveEmailDomain(email: string) {
+  const normalized = normalizeResolveEmail(email)
+  const atIndex = normalized.lastIndexOf("@")
+  return atIndex > 0 && atIndex < normalized.length - 1 ? normalized.slice(atIndex + 1) : "unknown"
+}
+
+async function checkSsoResolveRateLimit(headers: Headers, email: string) {
+  const normalizedEmail = normalizeResolveEmail(email)
+  const now = Date.now()
+  const keys = [
+    `org-sso-resolve:ip:${sha256Hex(getRequestAddress(headers))}`,
+    `org-sso-resolve:email:${sha256Hex(normalizedEmail)}`,
+    `org-sso-resolve:domain:${sha256Hex(getResolveEmailDomain(normalizedEmail))}`,
+  ]
+
+  for (const key of keys) {
+    const retryAfter = await checkRateLimit(key, 20, 60_000, now)
+    if (retryAfter !== null) {
+      return retryAfter
+    }
+  }
+
+  return null
 }
 
 async function setRequestActiveOrganization(
@@ -479,28 +534,59 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     describeRoute({
       tags: ["Organizations"],
       hide: true,
-      summary: "Resolve required organization SSO by email",
-      description: "Returns the org SSO entry URL when the email belongs to a member of any organization with SSO or SCIM configured.",
+      summary: "Resolve sign-in method by email",
+      description: "Returns a uniform sign-in routing envelope. SSO routing is resolved by verified domain; non-SSO routing is protected by bot verification and rate limiting.",
       responses: {
-        200: jsonResponse("Organization SSO resolution returned successfully.", resolveSsoByEmailResponseSchema),
-        204: { description: "No organization SSO or SCIM requirement matched this email." },
+        200: jsonResponse("Sign-in resolution returned successfully.", resolveSsoByEmailResponseSchema),
         400: jsonResponse("The SSO resolution query parameters were invalid.", invalidRequestSchema),
+        403: jsonResponse("Bot verification failed.", botVerificationFailedSchema),
+        429: jsonResponse("Too many SSO resolution attempts.", rateLimitedSchema),
       },
     }),
     publicRoute,
     queryValidator(resolveSsoByEmailQuerySchema),
     async (c) => {
       const query = c.req.valid("query")
-      const requirement = await findEnterpriseAuthRequirementForEmail(query.email)
-      if (!requirement) {
-        return c.body(null, 204)
+
+      // Security note:
+      // This endpoint intentionally preserves per-user auth-method routing for non-SSO
+      // accounts as a product UX decision. To reduce enumeration risk it:
+      // 1. resolves SSO by verified domain, not membership,
+      // 2. requires Vercel BotID verification before per-user method resolution,
+      // 3. relies on Better Auth/routing rate limits,
+      // 4. returns a uniform 200 response envelope for successful lookups.
+      const botProtection = await verifyBotProtection()
+      if (!botProtection.ok) {
+        return c.json({
+          error: "bot_verification_failed",
+          message: botProtection.message,
+        }, botProtection.status)
+      }
+
+      const retryAfter = await checkSsoResolveRateLimit(c.req.raw.headers, query.email)
+      if (retryAfter !== null) {
+        c.header("Retry-After", String(retryAfter))
+        return c.json({
+          error: "rate_limited",
+          message: "Too many sign-in resolution attempts. Try again later.",
+        }, 429)
+      }
+
+      const requirement = await findEnterpriseAuthRequirementForEmailDomain(query.email)
+
+      if (requirement) {
+        return c.json({
+          requireSso: true,
+          method: "sso",
+          organizationSlug: requirement.organizationSlug,
+          signInPath: requirement.signInPath,
+          signInUrl: new URL(requirement.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
+        })
       }
 
       return c.json({
-        requireSso: true,
-        organizationSlug: requirement.organizationSlug,
-        signInPath: requirement.signInPath,
-        signInUrl: new URL(requirement.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
+        requireSso: false,
+        method: await resolveNonSsoSignInMethodForEmail(query.email),
       })
     },
   )

--- a/ee/apps/den-api/test/sso-resolve-helpers.test.ts
+++ b/ee/apps/den-api/test/sso-resolve-helpers.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, beforeEach, expect, mock, test } from "bun:test"
+
+type QueryRow = Record<string, unknown>
+
+let queryRows: QueryRow[] = []
+let fromTable: unknown = null
+let joinedTables: unknown[] = []
+let findEnterpriseAuthRequirementForEmailDomain: typeof import("../src/enterprise-auth-requirement.js").findEnterpriseAuthRequirementForEmailDomain
+let resolveNonSsoSignInMethodForEmail: typeof import("../src/enterprise-auth-requirement.js").resolveNonSsoSignInMethodForEmail
+let schema: typeof import("@openwork-ee/den-db/schema")
+
+function createQueryBuilder() {
+  const builder = {
+    from(table: unknown) {
+      fromTable = table
+      return builder
+    },
+    innerJoin(table: unknown) {
+      joinedTables.push(table)
+      return builder
+    },
+    where() {
+      return Promise.resolve(queryRows)
+    },
+    then<TResult1 = QueryRow[], TResult2 = never>(
+      onfulfilled?: ((value: QueryRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+    ) {
+      return Promise.resolve(queryRows).then(onfulfilled, onrejected)
+    },
+  }
+  return builder
+}
+
+mock.module("../src/db.js", () => ({
+  db: {
+    select: () => createQueryBuilder(),
+  },
+}))
+
+beforeAll(async () => {
+  const [schemaModule, requirementModule] = await Promise.all([
+    import("@openwork-ee/den-db/schema"),
+    import("../src/enterprise-auth-requirement.js"),
+  ])
+  schema = schemaModule
+  findEnterpriseAuthRequirementForEmailDomain = requirementModule.findEnterpriseAuthRequirementForEmailDomain
+  resolveNonSsoSignInMethodForEmail = requirementModule.resolveNonSsoSignInMethodForEmail
+})
+
+beforeEach(() => {
+  queryRows = []
+  fromTable = null
+  joinedTables = []
+})
+
+test("domain-based SSO resolution does not query through users or members", async () => {
+  queryRows = [{
+    organizationId: "organization_sso_domain",
+    organizationSlug: "verified-sso",
+    signInPath: "/sso/verified-sso",
+    ssoProviderId: "openwork-sso-organization_sso_domain",
+  }]
+
+  const realMember = await findEnterpriseAuthRequirementForEmailDomain("real-user@verified.example.test")
+  const fakeMember = await findEnterpriseAuthRequirementForEmailDomain("fake-user@verified.example.test")
+
+  expect(realMember).toEqual(fakeMember)
+  expect(realMember).toEqual({
+    organizationId: "organization_sso_domain",
+    organizationSlug: "verified-sso",
+    signInPath: "/sso/verified-sso",
+    ssoProviderId: "openwork-sso-organization_sso_domain",
+    hasSso: true,
+  })
+  expect(fromTable).toBe(schema.OrganizationTable)
+  expect(joinedTables).toContain(schema.SsoConnectionTable)
+  expect(joinedTables).toContain(schema.SsoProviderTable)
+  expect(joinedTables).not.toContain(schema.AuthUserTable)
+  expect(joinedTables).not.toContain(schema.MemberTable)
+})
+
+test("domain-based SSO resolution ignores invalid email domains", async () => {
+  const requirement = await findEnterpriseAuthRequirementForEmailDomain("not-an-email")
+
+  expect(requirement).toBeNull()
+  expect(fromTable).toBeNull()
+})
+
+test("non-SSO sign-in method routing returns only google, password, or signup", async () => {
+  queryRows = [{ providerId: "google", password: null }]
+  await expect(resolveNonSsoSignInMethodForEmail("google@example.test")).resolves.toBe("google")
+
+  queryRows = [{ providerId: "credential", password: "hash" }]
+  await expect(resolveNonSsoSignInMethodForEmail("password@example.test")).resolves.toBe("password")
+
+  queryRows = []
+  await expect(resolveNonSsoSignInMethodForEmail("unknown@example.test")).resolves.toBe("signup")
+})

--- a/ee/apps/den-api/test/sso-resolve-route.test.ts
+++ b/ee/apps/den-api/test/sso-resolve-route.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, beforeEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.OPENWORK_DEV_MODE = "0"
+}
+
+type EnterpriseRequirement = {
+  organizationId: string
+  organizationSlug: string
+  signInPath: string
+  ssoProviderId: string | null
+  hasSso: boolean
+}
+
+let botAllowed = true
+let retryAfter: number | null = null
+let requirement: EnterpriseRequirement | null = null
+let nonSsoMethod: "google" | "password" | "signup" = "signup"
+let registerOrgCoreRoutes: typeof import("../src/routes/org/core.js").registerOrgCoreRoutes
+let registerAuthRoutes: typeof import("../src/routes/auth/index.js").registerAuthRoutes
+
+mock.module("../src/bot-protection.js", () => ({
+  verifyBotProtection: async () => botAllowed
+    ? { ok: true }
+    : { ok: false, status: 403, message: "Request verification failed." },
+}))
+
+mock.module("../src/utils/rate-limit.js", () => ({
+  checkRateLimit: async () => retryAfter,
+  enforceRateLimit: async () => retryAfter,
+}))
+
+mock.module("../src/enterprise-auth-requirement.js", () => ({
+  findEnterpriseAuthRequirementForEmail: async () => null,
+  findEnterpriseAuthRequirementForEmailDomain: async () => requirement,
+  findEnterpriseAuthRequirementForUserId: async () => null,
+  resolveNonSsoSignInMethodForEmail: async () => nonSsoMethod,
+}))
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const [orgModule, authModule] = await Promise.all([
+    import("../src/routes/org/core.js"),
+    import("../src/routes/auth/index.js"),
+  ])
+  registerOrgCoreRoutes = orgModule.registerOrgCoreRoutes
+  registerAuthRoutes = authModule.registerAuthRoutes
+})
+
+beforeEach(() => {
+  botAllowed = true
+  retryAfter = null
+  requirement = null
+  nonSsoMethod = "signup"
+})
+
+function createApp() {
+  const app = new Hono()
+  registerOrgCoreRoutes(app)
+  return app
+}
+
+function createAuthApp() {
+  const app = new Hono()
+  registerAuthRoutes(app)
+  return app
+}
+
+test("SSO resolve returns a uniform 200 domain-routed SSO envelope", async () => {
+  requirement = {
+    organizationId: "organization_sso_resolve_test",
+    organizationSlug: "verified-sso",
+    signInPath: "/sso/verified-sso",
+    ssoProviderId: "openwork-sso-organization_sso_resolve_test",
+    hasSso: true,
+  }
+
+  const response = await createApp().request("http://den.local/v1/orgs/sso/resolve?email=fake@verified.example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual({
+    requireSso: true,
+    method: "sso",
+    organizationSlug: "verified-sso",
+    signInPath: "/sso/verified-sso",
+    signInUrl: "http://127.0.0.1:8790/sso/verified-sso",
+  })
+})
+
+test("SSO resolve no longer returns 204 for unknown emails", async () => {
+  nonSsoMethod = "signup"
+
+  const response = await createApp().request("http://den.local/v1/orgs/sso/resolve?email=unknown@example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual({ requireSso: false, method: "signup" })
+})
+
+test("SSO resolve preserves non-SSO method routing without sensitive fields", async () => {
+  nonSsoMethod = "google"
+
+  const response = await createApp().request("http://den.local/v1/orgs/sso/resolve?email=google@example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual({ requireSso: false, method: "google" })
+  expect(JSON.stringify(body)).not.toContain("user")
+  expect(JSON.stringify(body)).not.toContain("organization")
+})
+
+test("SSO resolve requires BotID verification before route-specific disclosure", async () => {
+  botAllowed = false
+
+  const response = await createApp().request("http://den.local/v1/orgs/sso/resolve?email=google@example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(403)
+  expect(body).toEqual({
+    error: "bot_verification_failed",
+    message: "Request verification failed.",
+  })
+})
+
+test("SSO resolve returns 429 when route-specific rate limiting blocks the lookup", async () => {
+  retryAfter = 30
+
+  const response = await createApp().request("http://den.local/v1/orgs/sso/resolve?email=google@example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(429)
+  expect(response.headers.get("retry-after")).toBe("30")
+  expect(body).toEqual({
+    error: "rate_limited",
+    message: "Too many sign-in resolution attempts. Try again later.",
+  })
+})
+
+test("login-options also requires BotID before deterministic auth-method routing", async () => {
+  botAllowed = false
+
+  const response = await createAuthApp().request("http://den.local/v1/auth/login-options?email=google@example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(403)
+  expect(body).toEqual({
+    error: "bot_verification_failed",
+    message: "Request verification failed.",
+  })
+})

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -457,7 +457,7 @@ export function AuthPanel({
     try {
       const { response, payload } = await requestJson(`/v1/auth/login-options?email=${encodeURIComponent(trimmedEmail)}`, { method: "GET" }, 12000);
       if (!response.ok) {
-        setLoginOptionError(getErrorMessage(payload, `Could not check sign-in options (${response.status}).`));
+        setLoginOptionError(getErrorMessage(payload, response.status === 403 ? "We could not verify this sign-in attempt. Please refresh and try again." : `Could not check sign-in options (${response.status}).`));
         return;
       }
 

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -393,12 +393,15 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   async function redirectToRequiredSso(trimmedEmail: string) {
     const { response, payload } = await requestJson(`/v1/orgs/sso/resolve?email=${encodeURIComponent(trimmedEmail)}`, { method: "GET" }, 12000);
 
-    if (response.status === 204) {
-      return false;
+    if (!response.ok) {
+      throw new Error(getErrorMessage(payload, response.status === 403 ? "We could not verify this sign-in attempt. Please refresh and try again." : `Could not resolve workspace SSO (${response.status}).`));
     }
 
-    if (!response.ok) {
-      throw new Error(getErrorMessage(payload, `Could not resolve workspace SSO (${response.status}).`));
+    const method = typeof (payload as { method?: unknown } | null)?.method === "string"
+      ? (payload as { method: string }).method
+      : "";
+    if (method !== "sso") {
+      return false;
     }
 
     const signInUrl = typeof (payload as { signInUrl?: unknown } | null)?.signInUrl === "string"

--- a/ee/apps/enterprise-mock-lab/test/control-plane.integration.test.ts
+++ b/ee/apps/enterprise-mock-lab/test/control-plane.integration.test.ts
@@ -23,6 +23,16 @@ async function freePort(): Promise<number> {
   return reservation.port
 }
 
+async function freePortExcept(excluded: number): Promise<number> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const port = await freePort()
+    if (port !== excluded) {
+      return port
+    }
+  }
+  throw new Error("Could not allocate a distinct free port")
+}
+
 async function isPortOpen(port: number): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const socket = createConnection({ host: "127.0.0.1", port })
@@ -176,7 +186,7 @@ describe("package-backed Enterprise Mock Lab", () => {
       profileId: "servicenow-inbound-quickstart",
     })).rejects.toMatchObject({ code: "conflict" })
 
-    const incompatiblePort = await freePort()
+    const incompatiblePort = await freePortExcept(reservedPort)
     await expect(reservedLab.create({
       clientSecret: CLIENT_SECRET,
       displayName: "Incompatible profile fault",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
       better-call:
         specifier: 1.3.5
         version: 1.3.5(zod@4.3.6)
+      botid:
+        specifier: ^1.5.11
+        version: 1.5.11(next@16.2.3(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -13503,6 +13506,11 @@ snapshots:
     optionalDependencies:
       next: 14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+
+  botid@1.5.11(next@16.2.3(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    optionalDependencies:
+      next: 16.2.3(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   bowser@2.14.1: {}
 


### PR DESCRIPTION
## Summary
- resolve SSO routing by verified email domain instead of member lookup
- add BotID + hashed route-specific rate limits before email-first auth method disclosure
- return stable 200 envelopes for SSO resolve and update frontend handling
- add focused tests for no-enumeration behavior, BotID/rate-limit failures, method routing, and response shape

## Tests
- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/sso-resolve-helpers.test.ts test/sso-resolve-route.test.ts
- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/auth-login-options.test.ts
- pnpm --filter @openwork-ee/den-api exec tsc --noEmit && pnpm --filter @openwork-ee/den-web run typecheck
- git diff --check

## Not run
- test/sso-provider-rotation.test.ts: local MySQL at 127.0.0.1:3306 was unavailable (ECONNREFUSED).
- Fraimz/e2e browser proof: backend security hardening with focused route/type tests; no running Den environment in this worktree.
