### PR TITLE
fix(den-api): stop provider re-materialization from aborting live agent runs

### DIFF
--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -65,6 +65,7 @@ type FetchImpl = (input: string, init?: RequestInit) => Promise<Response>
 
 type MaterializationLogger = {
   warn: (message: string, metadata?: JsonRecord) => void
+  error: (message: string, metadata?: JsonRecord) => void
 }
 
 export type CloudProviderMaterializationResult =
@@ -94,8 +95,6 @@ export type CloudProviderMaterializationResult =
     }
 
 export type MaterializeCloudWorkerProviders = typeof materializeCloudWorkerProviders
-
-export const OPENWORK_PROVIDERS_FINGERPRINT_ENV = "OPENWORK_PROVIDERS_FINGERPRINT"
 
 const logger = appLogger.child({ component: "cloud_provider_materialization" })
 const requestTimeoutMs = 8_000
@@ -434,12 +433,14 @@ function hostTokenHeaders(hostToken: string) {
 class MaterializationHttpError extends Error {
   readonly label: string
   readonly status: number
+  readonly responseBody: string
 
-  constructor(label: string, status: number) {
+  constructor(label: string, status: number, responseBody = "") {
     super(`${label}_failed_${status}`)
     this.name = "MaterializationHttpError"
     this.label = label
     this.status = status
+    this.responseBody = responseBody
   }
 }
 
@@ -465,29 +466,8 @@ async function requestOk(input: {
 }) {
   const response = await fetchWithTimeout(input.fetchImpl, input.url, input.init)
   if (!response.ok) {
-    throw new MaterializationHttpError(input.label, response.status)
+    throw new MaterializationHttpError(input.label, response.status, await response.text())
   }
-}
-
-async function readStoredFingerprint(input: {
-  fetchImpl: FetchImpl
-  instanceUrl: string
-  hostToken: string
-}) {
-  const response = await fetchWithTimeout(input.fetchImpl, `${input.instanceUrl}/env/${OPENWORK_PROVIDERS_FINGERPRINT_ENV}`, {
-    method: "GET",
-    headers: hostTokenHeaders(input.hostToken),
-  })
-  if (response.status === 404) {
-    return null
-  }
-  if (!response.ok) {
-    throw new Error(`fingerprint_read_failed_${response.status}`)
-  }
-
-  const payload = await readJsonObject(response)
-  const item = isRecord(payload.item) ? payload.item : null
-  return item ? readString(item.value) : null
 }
 
 async function readRuntimeManagedProviders(input: {
@@ -578,6 +558,19 @@ function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentMan
   }
 
   return patch
+}
+
+function materializedProviderStateMatches(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
+  const desiredManagedProviders: JsonRecord = {}
+  for (const provider of prepared.providers) {
+    desiredManagedProviders[provider.runtimeProviderId] = provider.config
+  }
+
+  return stableJson(currentManagedProviders) === stableJson(desiredManagedProviders)
+}
+
+function materializedEnvStateMatches(entries: EnvEntry[], snapshot: EnvSnapshot) {
+  return entries.every((entry) => snapshot.get(entry.key) === entry.value)
 }
 
 function buildRuntimeProviderRollbackPatch(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
@@ -781,7 +774,9 @@ function failureResult(input: {
   fingerprint: string | null
   providers: number
 }) {
-  const message = input.error instanceof Error ? input.error.message : input.reason
+  const message = input.error instanceof MaterializationHttpError && input.error.responseBody
+    ? `${input.error.message}: ${input.error.responseBody}`
+    : input.error instanceof Error ? input.error.message : input.reason
   return {
     ok: false,
     status: "failed",
@@ -822,15 +817,31 @@ function logFailure(input: {
   workerId: WorkerId
   organizationId: OrganizationId
   result: Extract<CloudProviderMaterializationResult, { ok: false }>
+  cause: unknown
 }) {
-  input.logger.warn("cloud provider materialization failed", {
+  const metadata = {
     worker_id: input.workerId,
     organization_id: input.organizationId,
     reason: input.result.reason,
     message: input.result.message,
     fingerprint: input.result.fingerprint,
     providers: input.result.providers,
-  })
+  }
+  if (
+    input.cause instanceof MaterializationHttpError
+    && input.cause.status >= 400
+    && input.cause.status < 500
+    && (input.cause.label === "env_write" || input.cause.label === "runtime_provider_patch")
+  ) {
+    input.logger.error("cloud provider materialization write rejected", {
+      ...metadata,
+      status: input.cause.status,
+      response_body: input.cause.responseBody,
+    })
+    return
+  }
+
+  input.logger.warn("cloud provider materialization failed", metadata)
 }
 
 async function logUnsupportedOnce(input: {
@@ -884,8 +895,6 @@ export async function materializeCloudWorkerProviders(input: {
   const instanceUrl = normalizeBaseUrl(input.instanceUrl)
   let fingerprint: string | null = null
   let providerCount = 0
-  let cleanupHostToken: string | null = null
-  let clearStoredFingerprintOnFailure = false
 
   try {
     if (!instanceUrl) {
@@ -910,29 +919,7 @@ export async function materializeCloudWorkerProviders(input: {
     if (!tokens.hostToken || !tokens.clientToken) {
       throw new Error("worker_tokens_missing")
     }
-    cleanupHostToken = tokens.hostToken
-
-    const storedFingerprint = await readStoredFingerprint({
-      fetchImpl,
-      instanceUrl,
-      hostToken: tokens.hostToken,
-    })
     const desiredProviderIds = prepared.providers.map((provider) => provider.runtimeProviderId)
-    if (storedFingerprint === fingerprint) {
-      try {
-        await verifyRuntimeProviders({
-          fetchImpl,
-          instanceUrl,
-          clientToken: tokens.clientToken,
-          providerIds: desiredProviderIds,
-        })
-        materializedFingerprintByWorker.set(input.workerId, fingerprint)
-        return { ok: true, status: "noop", fingerprint, providers: providerCount }
-      } catch {
-        clearStoredFingerprintOnFailure = true
-      }
-    }
-
     const currentManagedProviders = await readRuntimeManagedProviders({
       fetchImpl,
       instanceUrl,
@@ -946,6 +933,14 @@ export async function materializeCloudWorkerProviders(input: {
       hostToken: tokens.hostToken,
       entries: prepared.envEntries,
     })
+    if (
+      materializedProviderStateMatches(prepared, currentManagedProviders)
+      && materializedEnvStateMatches(prepared.envEntries, envSnapshot)
+    ) {
+      materializedFingerprintByWorker.set(input.workerId, fingerprint)
+      return { ok: true, status: "noop", fingerprint, providers: providerCount }
+    }
+
     let envWritten = false
     let providerPatched = false
 
@@ -1023,29 +1018,9 @@ export async function materializeCloudWorkerProviders(input: {
       throw error
     }
 
-    // The fingerprint is intentionally stored inside the instance's env store:
-    // it survives restarts with the rest of the sandbox state, contains only
-    // hashes/non-secret metadata, and avoids a Den schema migration for a value
-    // whose truth is scoped to that one runtime.
-    await writeEnvEntries({
-      fetchImpl,
-      instanceUrl,
-      hostToken: tokens.hostToken,
-      entries: [{ key: OPENWORK_PROVIDERS_FINGERPRINT_ENV, value: fingerprint }],
-    })
-
     materializedFingerprintByWorker.set(input.workerId, fingerprint)
     return { ok: true, status: "applied", fingerprint, providers: providerCount }
   } catch (error) {
-    if (clearStoredFingerprintOnFailure && cleanupHostToken && fingerprint) {
-      await deleteEnvEntry({
-        fetchImpl,
-        instanceUrl,
-        hostToken: cleanupHostToken,
-        key: OPENWORK_PROVIDERS_FINGERPRINT_ENV,
-        ignoreNotFound: true,
-      }).catch(() => undefined)
-    }
     const result = failureResult({
       reason: error instanceof Error ? error.message : "provider_materialization_failed",
       error,
@@ -1057,6 +1032,7 @@ export async function materializeCloudWorkerProviders(input: {
       workerId: input.workerId,
       organizationId: input.organizationId,
       result,
+      cause: error,
     })
     return result
   }

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -18,7 +18,6 @@ const organizationId = createDenTypeId("organization")
 const instanceUrl = "https://worker.example.test"
 let materializeCloudWorkerProviders: MaterializerModule["materializeCloudWorkerProviders"]
 let computeCloudProviderMaterializationFingerprint: MaterializerModule["computeCloudProviderMaterializationFingerprint"]
-let openworkProvidersFingerprintEnv: string
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -33,7 +32,6 @@ beforeAll(async () => {
   const materializer = await import("../src/llm/cloud-provider-materialization.js")
   materializeCloudWorkerProviders = materializer.materializeCloudWorkerProviders
   computeCloudProviderMaterializationFingerprint = materializer.computeCloudProviderMaterializationFingerprint
-  openworkProvidersFingerprintEnv = materializer.OPENWORK_PROVIDERS_FINGERPRINT_ENV
 })
 
 function jsonResponse(body: unknown, status = 200) {
@@ -114,6 +112,23 @@ function makeAnthropicProvider(input: {
   }
 }
 
+function makeAnthropicRuntimeProvider(modelId = "claude-fable-5") {
+  return {
+    api: "https://api.anthropic.com/v1",
+    npm: "@ai-sdk/anthropic",
+    models: {
+      [modelId]: {
+        tool_call: true,
+        name: modelId,
+        id: modelId,
+      },
+    },
+    env: ["ANTHROPIC_API_KEY"],
+    name: "Anthropic",
+    id: "anthropic",
+  }
+}
+
 function makeStore(providers: () => CloudProviderMaterializationProvider[]): Store {
   return {
     async listProviders() {
@@ -129,22 +144,18 @@ function makeStore(providers: () => CloudProviderMaterializationProvider[]): Sto
 }
 
 function makeInstance(input: {
-  storedFingerprint?: string | null
   envValues?: Record<string, string>
   failEnvWrites?: number
+  envWriteRejection?: { status: number; body: unknown }
   failConfigPatches?: number
   providerRouteStatus?: number
   runtimeVersion?: string | null
   runtimeProviders?: Record<string, unknown>
   opencodeConfigProviders?: Record<string, unknown>
   missingEngineReadbacks?: number
-  rejectReservedEnvWrites?: boolean
 } = {}) {
   const calls: FetchCall[] = []
   const envValues = new Map(Object.entries(input.envValues ?? {}))
-  if (input.storedFingerprint) {
-    envValues.set(openworkProvidersFingerprintEnv, input.storedFingerprint)
-  }
   let failEnvWrites = input.failEnvWrites ?? 0
   let failConfigPatches = input.failConfigPatches ?? 0
   let missingEngineReadbacks = input.missingEngineReadbacks ?? 0
@@ -189,25 +200,26 @@ function makeInstance(input: {
     }
 
     if (method === "PUT" && parsed.pathname === "/env") {
+      if (input.envWriteRejection) {
+        return jsonResponse(input.envWriteRejection.body, input.envWriteRejection.status)
+      }
       if (failEnvWrites > 0) {
         failEnvWrites -= 1
         return jsonResponse({ error: "env_write_failed" }, 500)
       }
-      if (input.rejectReservedEnvWrites) {
-        const persistableInternalKeys = new Set([
-          "OPENWORK_API_KEY",
-          "OPENWORK_MODELS_API_KEY",
-          "OPENWORK_INFERENCE_BASE_URL",
-          "OPENWORK_MODELS_BASE_URL",
-        ])
-        const hasReservedEntry = bodyEntries(body).some((entry) => (
-          typeof entry.key === "string"
-          && /^(OPENWORK_|OPENCODE_)/.test(entry.key)
-          && !persistableInternalKeys.has(entry.key)
-        ))
-        if (hasReservedEntry) {
-          return jsonResponse({ code: "reserved_env_key" }, 400)
-        }
+      const persistableInternalKeys = new Set([
+        "OPENWORK_API_KEY",
+        "OPENWORK_MODELS_API_KEY",
+        "OPENWORK_INFERENCE_BASE_URL",
+        "OPENWORK_MODELS_BASE_URL",
+      ])
+      const hasReservedEntry = bodyEntries(body).some((entry) => (
+        typeof entry.key === "string"
+        && /^(OPENWORK_|OPENCODE_)/.test(entry.key)
+        && !persistableInternalKeys.has(entry.key)
+      ))
+      if (hasReservedEntry) {
+        return jsonResponse({ code: "reserved_env_key" }, 400)
       }
       for (const entry of bodyEntries(body)) {
         if (typeof entry.key === "string" && typeof entry.value === "string") {
@@ -251,11 +263,11 @@ function makeInstance(input: {
   return {
     calls,
     fetchImpl,
-    get storedFingerprint() {
-      return envValues.get(openworkProvidersFingerprintEnv) ?? null
-    },
     envValue(key: string) {
       return envValues.get(key) ?? null
+    },
+    runtimeProvider(providerId: string) {
+      return runtimeProviders[providerId] ?? null
     },
   }
 }
@@ -291,24 +303,9 @@ async function materialize(input: {
 describe("Cloud provider materialization", () => {
   test("does not rewrite matching provider state after the den-api cache is lost", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
-    const runtimeProvider = {
-      id: "anthropic",
-      name: "Anthropic",
-      env: ["ANTHROPIC_API_KEY"],
-      models: {
-        "claude-fable-5": {
-          id: "claude-fable-5",
-          name: "claude-fable-5",
-          tool_call: true,
-        },
-      },
-      npm: "@ai-sdk/anthropic",
-      api: "https://api.anthropic.com/v1",
-    }
     const instance = makeInstance({
       envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
-      runtimeProviders: { [provider.id]: runtimeProvider },
-      rejectReservedEnvWrites: true,
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
     const workerId = createDenTypeId("worker")
 
@@ -335,21 +332,19 @@ describe("Cloud provider materialization", () => {
     expect(result.ok).toBe(true)
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
-      "PUT /env",
     ])
-    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[3]?.body).toEqual({
+    expect(instance.calls[2]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[2]?.body).toEqual({
       entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
     })
-    expect(instance.calls[4]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[4]?.headers.authorization).toBeUndefined()
-    expect(instance.calls[4]?.body).toEqual({
+    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[3]?.headers.authorization).toBeUndefined()
+    expect(instance.calls[3]?.body).toEqual({
       provider: {
         [provider.id]: {
           id: "anthropic",
@@ -367,13 +362,16 @@ describe("Cloud provider materialization", () => {
         },
       },
     })
-    expect(instance.storedFingerprint).toBe(result.fingerprint)
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
   })
 
-  test("skips writes and reloads when the stored fingerprint is unchanged", async () => {
+  test("skips writes and reloads when observed provider and env state match", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
-    const instance = makeInstance({ storedFingerprint: fingerprint, runtimeProviders: { [provider.id]: { id: "anthropic" } } })
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
 
     const result = await materialize({
       providers: () => [provider],
@@ -383,16 +381,18 @@ describe("Cloud provider materialization", () => {
 
     expect(result).toEqual({ ok: true, status: "noop", fingerprint, providers: 1 })
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
+      "GET /env/ANTHROPIC_API_KEY",
     ])
     expect(writeCalls(instance.calls)).toHaveLength(0)
   })
 
-  test("retries a stored fingerprint when provider read-back is missing", async () => {
+  test("applies when the observed provider config is incomplete", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
-    const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
-    const instance = makeInstance({ storedFingerprint: fingerprint, missingEngineReadbacks: 1 })
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: { id: "anthropic" } },
+    })
 
     const result = await materialize({
       providers: () => [provider],
@@ -403,16 +403,12 @@ describe("Cloud provider materialization", () => {
     expect(result.ok).toBe(true)
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /opencode/config",
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
-      "PUT /env",
     ])
-    expect(instance.storedFingerprint).toBe(result.fingerprint)
   })
 
   test("treats missing provider read-back as materialization failure", async () => {
@@ -430,7 +426,6 @@ describe("Cloud provider materialization", () => {
       expect(result.reason).toBe(`provider_readback_missing_${provider.id}`)
     }
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
@@ -439,7 +434,6 @@ describe("Cloud provider materialization", () => {
       "PATCH /runtime-config/providers",
       "DELETE /env/ANTHROPIC_API_KEY",
     ])
-    expect(instance.storedFingerprint).toBeNull()
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
   })
 
@@ -487,13 +481,112 @@ describe("Cloud provider materialization", () => {
     const drift = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
     expect(drift.ok).toBe(true)
     expect(drift.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
 
     instance.calls.length = 0
     const cached = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
     expect(cached.ok).toBe(true)
     expect(cached.status).toBe("cached")
     expect(instance.calls).toHaveLength(0)
+  })
+
+  test("removes a provider that is no longer desired", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+
+    const result = await materialize({
+      providers: () => [],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PATCH"])
+    expect(instance.calls.find((call) => call.method === "PATCH")?.body).toEqual({
+      provider: { [provider.id]: null },
+    })
+    expect(instance.runtimeProvider(provider.id)).toBeNull()
+  })
+
+  test("rewrites env when an API key rotates", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-rotated" })
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-original" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
+    expect(instance.calls.find((call) => call.method === "PUT")?.body).toEqual({
+      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-rotated" }],
+    })
+  })
+
+  test("rewrites providers when the model list changes", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic", modelId: "claude-updated" })
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider("claude-original") },
+    })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
+    expect(instance.runtimeProvider(provider.id)).toEqual(makeAnthropicRuntimeProvider("claude-updated"))
+  })
+
+  test("logs and returns a rejected env write with its status and response body", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({
+      envWriteRejection: { status: 400, body: { code: "reserved_env_key" } },
+    })
+    const logs: Array<{ level: "warn" | "error"; message: string; metadata?: Record<string, unknown> }> = []
+    const logger: Logger = {
+      warn(message, metadata) {
+        logs.push({ level: "warn", message, metadata })
+      },
+      error(message, metadata) {
+        logs.push({ level: "error", message, metadata })
+      },
+    }
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      logger,
+      force: true,
+    })
+
+    expect(result.status).toBe("failed")
+    if (!result.ok) {
+      expect(result.reason).toBe("env_write_failed_400")
+      expect(result.message).toBe('env_write_failed_400: {"code":"reserved_env_key"}')
+    }
+    expect(logs).toEqual([
+      {
+        level: "error",
+        message: "cloud provider materialization write rejected",
+        metadata: expect.objectContaining({
+          reason: "env_write_failed_400",
+          status: 400,
+          response_body: '{"code":"reserved_env_key"}',
+        }),
+      },
+    ])
   })
 
   test("does not patch provider blocks when credential env write fails, and retries next resolve", async () => {
@@ -507,13 +600,11 @@ describe("Cloud provider materialization", () => {
 
     expect(failed.ok).toBe(false)
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
     ])
     expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
-    expect(instance.storedFingerprint).toBeNull()
 
     instance.calls.length = 0
     const retried = await materialize({
@@ -522,10 +613,10 @@ describe("Cloud provider materialization", () => {
     })
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
   })
 
-  test("rolls back credential env, skips fingerprint, and retries when config patch fails", async () => {
+  test("rolls back credential env and retries when config patch fails", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({ failConfigPatches: 1 })
 
@@ -539,7 +630,6 @@ describe("Cloud provider materialization", () => {
       expect(failed.reason).toBe("runtime_provider_patch_failed_500")
     }
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
@@ -547,7 +637,6 @@ describe("Cloud provider materialization", () => {
       "PATCH /runtime-config/providers",
       "DELETE /env/ANTHROPIC_API_KEY",
     ])
-    expect(instance.storedFingerprint).toBeNull()
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
 
     instance.calls.length = 0
@@ -557,16 +646,19 @@ describe("Cloud provider materialization", () => {
     })
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
   })
 
-  test("preserves credential env and skips fingerprint when the global provider route is unsupported", async () => {
+  test("preserves credential env when the global provider route is unsupported", async () => {
     const workerId = createDenTypeId("worker")
     let provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({ providerRouteStatus: 404, runtimeVersion: "openwork-0.18.8" })
     const logs: Array<{ message: string; metadata?: Record<string, unknown> }> = []
     const logger: Logger = {
       warn(message, metadata) {
+        logs.push({ message, metadata })
+      },
+      error(message, metadata) {
         logs.push({ message, metadata })
       },
     }
@@ -581,7 +673,6 @@ describe("Cloud provider materialization", () => {
     expect(unsupported.ok).toBe(false)
     expect(unsupported.status).toBe("unsupported")
     expect(callMethods(instance.calls)).toEqual([
-      `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
@@ -589,7 +680,6 @@ describe("Cloud provider materialization", () => {
       "GET /runtime/versions",
     ])
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
-    expect(instance.storedFingerprint).toBeNull()
     expect(instance.calls.some((call) => call.method === "DELETE")).toBe(false)
     expect(logs).toHaveLength(1)
     expect(logs[0]).toMatchObject({
@@ -610,7 +700,6 @@ describe("Cloud provider materialization", () => {
 
     expect(repeated.status).toBe("unsupported")
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
-    expect(instance.storedFingerprint).toBeNull()
     expect(logs).toHaveLength(1)
     expect(instance.calls.some((call) => call.path === "/runtime/versions")).toBe(false)
 
@@ -624,7 +713,6 @@ describe("Cloud provider materialization", () => {
 
     expect(changed.status).toBe("unsupported")
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic-rotated")
-    expect(instance.storedFingerprint).toBeNull()
     expect(logs).toHaveLength(2)
   })
 
@@ -635,6 +723,9 @@ describe("Cloud provider materialization", () => {
     const logs: Array<{ message: string; metadata?: Record<string, unknown> }> = []
     const logger: Logger = {
       warn(message, metadata) {
+        logs.push({ message, metadata })
+      },
+      error(message, metadata) {
         logs.push({ message, metadata })
       },
     }

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -130,6 +130,7 @@ function makeStore(providers: () => CloudProviderMaterializationProvider[]): Sto
 
 function makeInstance(input: {
   storedFingerprint?: string | null
+  envValues?: Record<string, string>
   failEnvWrites?: number
   failConfigPatches?: number
   providerRouteStatus?: number
@@ -137,9 +138,10 @@ function makeInstance(input: {
   runtimeProviders?: Record<string, unknown>
   opencodeConfigProviders?: Record<string, unknown>
   missingEngineReadbacks?: number
+  rejectReservedEnvWrites?: boolean
 } = {}) {
   const calls: FetchCall[] = []
-  const envValues = new Map<string, string>()
+  const envValues = new Map(Object.entries(input.envValues ?? {}))
   if (input.storedFingerprint) {
     envValues.set(openworkProvidersFingerprintEnv, input.storedFingerprint)
   }
@@ -190,6 +192,22 @@ function makeInstance(input: {
       if (failEnvWrites > 0) {
         failEnvWrites -= 1
         return jsonResponse({ error: "env_write_failed" }, 500)
+      }
+      if (input.rejectReservedEnvWrites) {
+        const persistableInternalKeys = new Set([
+          "OPENWORK_API_KEY",
+          "OPENWORK_MODELS_API_KEY",
+          "OPENWORK_INFERENCE_BASE_URL",
+          "OPENWORK_MODELS_BASE_URL",
+        ])
+        const hasReservedEntry = bodyEntries(body).some((entry) => (
+          typeof entry.key === "string"
+          && /^(OPENWORK_|OPENCODE_)/.test(entry.key)
+          && !persistableInternalKeys.has(entry.key)
+        ))
+        if (hasReservedEntry) {
+          return jsonResponse({ code: "reserved_env_key" }, 400)
+        }
       }
       for (const entry of bodyEntries(body)) {
         if (typeof entry.key === "string" && typeof entry.value === "string") {
@@ -271,6 +289,39 @@ async function materialize(input: {
 }
 
 describe("Cloud provider materialization", () => {
+  test("does not rewrite matching provider state after the den-api cache is lost", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const runtimeProvider = {
+      id: "anthropic",
+      name: "Anthropic",
+      env: ["ANTHROPIC_API_KEY"],
+      models: {
+        "claude-fable-5": {
+          id: "claude-fable-5",
+          name: "claude-fable-5",
+          tool_call: true,
+        },
+      },
+      npm: "@ai-sdk/anthropic",
+      api: "https://api.anthropic.com/v1",
+    }
+    const instance = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: runtimeProvider },
+      rejectReservedEnvWrites: true,
+    })
+    const workerId = createDenTypeId("worker")
+
+    await materialize({ workerId, providers: () => [provider], fetchImpl: instance.fetchImpl, force: true })
+    instance.calls.length = 0
+
+    const second = await materialize({ workerId, providers: () => [provider], fetchImpl: instance.fetchImpl, force: true })
+
+    expect(second.status).toBe("noop")
+    expect(instance.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(0)
+    expect(instance.calls.filter((call) => call.method === "PATCH" && call.path === "/runtime-config/providers")).toHaveLength(0)
+  })
+
   test("writes a models.dev provider block, credential env, and reloads OpenCode", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance()


### PR DESCRIPTION
Cloud agent runs were dying mid-tool-call. Users saw `Searched your connections for capabilities · failed` followed by `Tool execution aborted`, while Den had actually completed the work.

## What was happening

The opencode engine inside the user's sandbox was being disposed and recreated every ~18s. Engine log from a real user instance:

```
12:49:10.978  evaluated permission=openwork-cloud_search_capabilities action=allow
12:49:11.497  process msg_...                                <- tool in flight
12:49:11.591  "disposing instance" /tmp/openwork-workspace    <- engine torn down
12:49:11.620  ERROR process ... error=Aborted
12:49:11.675  loading /tmp/openwork-data/runtime-opencode-config.json
12:49:11.694  "event disconnected"                           <- and the SSE stream dies
```

`grep -c 'disposing instance'` = **991**, in bursts of 3-4 every ~18s, matching the client's cloud-instance poll. The same reloads explain SSE streams reopening every ~15-18s.

## Root cause

Materialization stored its idempotence marker in the instance env key `OPENWORK_PROVIDERS_FINGERPRINT`. But `apps/server/src/env-file.ts` refuses it:

```ts
const RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"];
const PERSISTABLE_INTERNAL_KEYS = new Set([
  "OPENWORK_API_KEY","OPENWORK_MODELS_API_KEY",
  "OPENWORK_INFERENCE_BASE_URL","OPENWORK_MODELS_BASE_URL",
]);
```

`PUT /env` returns 400 `reserved_env_key`, so the marker never persisted — confirmed live: `GET /env/keys` → `{"keys":["ANTHROPIC_API_KEY"]}`, `GET /env/OPENWORK_PROVIDERS_FINGERPRINT` → 404. The rejection was swallowed into a generic `providerSync: degraded`, so every poll re-ran the full write path (env write + config patch), and every write reloaded the engine, killing whatever run was in flight. Self-perpetuating, invisible.

This was my own mistake in the provider-materialization work: I chose a key the server's security policy forbids, and let the failure hide behind a soft status.

## Fix

Idempotence now derives from the instance's **observed state** instead of a marker it refuses to store:

- Compare the cloud-managed provider map from `/opencode/config` (canonical key ordering) plus the exact required env key/values read back with the host token. If everything matches, perform **zero** writes — no `PUT /env`, no `PATCH /runtime-config/providers`, therefore no engine reload.
- Additions, removals, model-list changes, and API-key rotation all still apply, because the comparison is on real values rather than a hash.
- Removed the fingerprint write/read and its cleanup path entirely — it could never work and cost an extra env write plus reload per cycle.
- 4xx write failures are now logged at error level with status and response body and surfaced as `failed` with the status in `reason`, instead of a generic `degraded`.

Scoped to den-api deliberately: it deploys from `dev`, while the sandbox image is snapshot-pinned. Follow-ups worth doing separately: whitelist a marker key (or drop the concept) in `env-file.ts`, and make a no-op provider patch skip the engine reload — that would kill this whole class of bug at the source.

## Tests

Regression fails before, passes after:

```
Expected: "noop"        Received: "failed"      0 pass / 1 fail   (before)
1 pass / 0 fail                                                   (after)
```

Coverage: no-op after cache loss (simulating a restarted den-api, with the stub rejecting reserved keys exactly like the real server), provider add, provider remove, key rotation, model-list change, and 4xx surfacing.

| Command | Result |
| --- | --- |
| materialization + cloud-route suites | 49 pass / 0 fail |
| `tsc --noEmit` (den-api) | exit 0 |