### PR TITLE
fix(den): restrict mcp connector updates

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -951,6 +951,7 @@ export type UpdateExternalMcpConnectionInput = {
   oauthConfiguration?: ExternalMcpOAuthConfiguration | null
   access: ExternalMcpAccessInput
   updatedByOrgMembershipId: OrgMembershipId
+  createdByOrgMembershipId?: OrgMembershipId
   validatedAt?: Date
 }
 
@@ -975,12 +976,16 @@ export async function updateExternalMcpConnection(
   input: UpdateExternalMcpConnectionInput,
 ): Promise<UpdateExternalMcpConnectionResult> {
   return db.transaction(async (tx) => {
+    const ownershipConditions = input.createdByOrgMembershipId === undefined
+      ? []
+      : [eq(ExternalMcpConnectionTable.createdByOrgMembershipId, input.createdByOrgMembershipId)]
     const rows = await tx
       .select()
       .from(ExternalMcpConnectionTable)
       .where(and(
         eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
         eq(ExternalMcpConnectionTable.id, input.connectionId),
+        ...ownershipConditions,
       ))
       .limit(1)
       .for("update")

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -1913,12 +1913,12 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Edit an External MCP Connection",
-      description: "Organization-admin-only. Name and direct access changes preserve credentials. URL, authentication type, or credential-mode changes invalidate the old identity atomically. Secret fields are write-only optional replacements and are never returned. expectedUpdatedAt prevents stale edits.",
+      description: "Workspace owners and super-admins can edit any connection. Other org members can edit only connections they created. Name and direct access changes preserve credentials. URL, authentication type, or credential-mode changes invalidate the old identity atomically. Secret fields are write-only optional replacements and are never returned. expectedUpdatedAt prevents stale edits.",
       responses: {
         200: jsonResponse("Connection updated.", connectionUpdatedResponseSchema),
         400: jsonResponse("Invalid request.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners and admins can edit MCP connections.", forbiddenSchema),
+        403: jsonResponse("Only workspace owners, super-admins, or the connection creator can edit MCP connections.", forbiddenSchema),
         404: jsonResponse("Unknown connection.", connectionNotFoundSchema),
         409: jsonResponse("The edit is stale or changes marketplace-owned identity fields.", connectionUpdateConflictSchema),
         502: jsonResponse("The proposed API-key or no-auth configuration could not be validated.", connectionValidationFailedSchema),
@@ -1929,8 +1929,9 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     jsonValidator(updateConnectionBodySchema),
     async (c) => {
       const payload = c.get("organizationContext")
-      const admin = ensureOrganizationAdminRole(c, "Only workspace owners and admins can edit MCP connections.")
-      if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+      if (!hasFreshPrivilegedSession({ session: c.get("session") })) {
+        return c.json(getFreshPrivilegedSessionRequiredResponse(), 403)
+      }
 
       const { connectionId } = c.req.valid("param")
       const externalMcpConnectionId = normalizeDenTypeId("externalMcpConnection", connectionId)
@@ -1940,6 +1941,18 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       if (!connection) {
         return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+
+      const canUpdateAnyConnection = organizationRoleValueSatisfies({
+        roleValue: payload.currentMember.role,
+        requiredRole: ORGANIZATION_SUPER_ADMIN_ROLE,
+        isOwner: payload.currentMember.isOwner,
+      })
+      if (!canUpdateAnyConnection && connection.createdByOrgMembershipId !== payload.currentMember.id) {
+        return c.json({
+          error: "forbidden",
+          message: "Only workspace owners, super-admins, or the connection creator can edit this MCP connection.",
+        }, 403)
       }
 
       const body = c.req.valid("json")
@@ -2115,6 +2128,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           teamIds: body.access.teamIds.map((id) => normalizeDenTypeId("team", id)),
         },
         updatedByOrgMembershipId: payload.currentMember.id,
+        ...(canUpdateAnyConnection ? {} : { createdByOrgMembershipId: payload.currentMember.id }),
         ...(validatedAt ? { validatedAt } : {}),
       })
       if (result.status === "not_found") {

--- a/ee/apps/den-api/test/mcp-connections-edit.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-edit.test.ts
@@ -272,6 +272,93 @@ function oauthConfigurationInApiOrder(
 }
 
 describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
+  test("members and admins can edit their own connections but not connections created by others", async () => {
+    const own = await createConnection({ name: "Admin-owned edit", authType: "none", credentialMode: "shared" })
+    const ownBefore = await currentConnection(own.id)
+    const ownResponse = await humanRequest({
+      connectionId: own.id,
+      body: updateBody(ownBefore, { name: "Admin-owned edit renamed" }),
+    })
+    expect(ownResponse.status).toBe(200)
+    expect(await currentConnection(own.id)).toMatchObject({ name: "Admin-owned edit renamed" })
+
+    const memberOwned = await createConnection({
+      memberId,
+      name: "Member-owned edit",
+      authType: "none",
+      credentialMode: "shared",
+    })
+    const memberBefore = await currentConnection(memberOwned.id)
+    const memberOwnResponse = await humanRequest({
+      connectionId: memberOwned.id,
+      token: memberToken,
+      body: updateBody(memberBefore, { name: "Member-owned edit renamed" }),
+    })
+    expect(memberOwnResponse.status).toBe(200)
+    expect(await currentConnection(memberOwned.id)).toMatchObject({ name: "Member-owned edit renamed" })
+
+    const peerAdminConnection = await createConnection({
+      memberId: peerAdminMemberId,
+      name: "Peer admin edit target",
+      authType: "none",
+      credentialMode: "shared",
+    })
+    const peerBefore = await currentConnection(peerAdminConnection.id)
+    const denied = await humanRequest({
+      connectionId: peerAdminConnection.id,
+      body: updateBody(peerBefore, { name: "Admin should not rename peer" }),
+    })
+    expect(denied.status).toBe(403)
+    expect(await currentConnection(peerAdminConnection.id)).toMatchObject({ name: "Peer admin edit target" })
+
+    const memberDenied = await humanRequest({
+      connectionId: peerAdminConnection.id,
+      token: memberToken,
+      body: updateBody(peerBefore, { name: "Member should not rename peer" }),
+    })
+    expect(memberDenied.status).toBe(403)
+    expect(await currentConnection(peerAdminConnection.id)).toMatchObject({ name: "Peer admin edit target" })
+
+    const peerOwnResponse = await humanRequest({
+      connectionId: peerAdminConnection.id,
+      token: peerAdminToken,
+      body: updateBody(peerBefore, { name: "Peer admin renamed own" }),
+    })
+    expect(peerOwnResponse.status).toBe(200)
+    expect(await currentConnection(peerAdminConnection.id)).toMatchObject({ name: "Peer admin renamed own" })
+  })
+
+  test("super-admins can edit connections created by other admins", async () => {
+    const adminConnection = await createConnection({ name: "Admin connector for super-admin edit", authType: "none", credentialMode: "shared" })
+    const before = await currentConnection(adminConnection.id)
+    const response = await humanRequest({
+      connectionId: adminConnection.id,
+      token: superAdminToken,
+      body: updateBody(before, { name: "Super-admin renamed admin connector" }),
+    })
+    expect(response.status).toBe(200)
+    expect(await currentConnection(adminConnection.id)).toMatchObject({ name: "Super-admin renamed admin connector" })
+  })
+
+  test("store update keeps the creator guard under the row lock", async () => {
+    const guarded = await createConnection({ name: "Guarded update", authType: "none", credentialMode: "shared" })
+    const before = await currentConnection(guarded.id)
+    const result = await connections.updateExternalMcpConnection({
+      organizationId,
+      connectionId: guarded.id,
+      expectedUpdatedAt: before.updatedAt,
+      name: "Guarded update should not change",
+      url: before.url,
+      authType: before.authType,
+      credentialMode: before.credentialMode,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+      updatedByOrgMembershipId: peerAdminMemberId,
+      createdByOrgMembershipId: peerAdminMemberId,
+    })
+    expect(result.status).toBe("not_found")
+    expect(await currentConnection(guarded.id)).toMatchObject({ name: "Guarded update" })
+  })
+
   test("rename preserves a connected shared OAuth session and client registration", async () => {
     const created = await createConnection({ name: "Shared OAuth", authType: "oauth", credentialMode: "shared" })
     const connectedAt = new Date()


### PR DESCRIPTION
## Summary
- restrict MCP connection updates to workspace owners/super-admins or the original connection creator
- add a store-level creator guard under the row lock to avoid TOCTOU gaps
- add focused PUT coverage mirroring the recent DELETE ownership rules

## Tests
- ✅ pnpm --filter @openwork-ee/den-api build
- ✅ DEN_API_PUBLIC_URL="http://localhost:8790" bun test --conditions development "ee/apps/den-api/test/mcp-connections-edit.test.ts" (20 pass)

## Proof
- API/security-only change; fraimz not run because there is no UI flow. Targeted route tests validate the authorization behavior.