### PR TITLE
fix(evals): harden clean Daytona proof setup

### DIFF
--- a/evals/packages/behaviors/src/diagnostics.ts
+++ b/evals/packages/behaviors/src/diagnostics.ts
@@ -545,7 +545,7 @@ function endpointForTransport(lab: EgressLabHandle): URL {
 }
 
 function probeTlsVersion(
-  target: { host: string; port: number; servername?: string; ca?: string | string[] },
+  target: { host: string; port: number; servername?: string; ca?: string | string[]; rejectUnauthorized?: boolean },
   version: "TLSv1.2" | "TLSv1.3",
   timeoutMs: number,
 ): Promise<TlsProbeFacts> {
@@ -564,7 +564,7 @@ function probeTlsVersion(
       minVersion: version,
       maxVersion: version,
       ca: target.ca,
-      rejectUnauthorized: true,
+      rejectUnauthorized: target.rejectUnauthorized ?? true,
     });
     socket.once("secureConnect", () => finish({ ok: true, protocol: socket.getProtocol(), errorCode: null }));
     socket.once("timeout", () => finish({ ok: false, protocol: null, errorCode: "ETIMEDOUT" }));
@@ -577,7 +577,7 @@ function probeTlsVersion(
 }
 
 export async function probeTls(
-  target: { host: string; port: number; servername?: string; ca?: string | string[] },
+  target: { host: string; port: number; servername?: string; ca?: string | string[]; rejectUnauthorized?: boolean },
   opts: { timeoutMs?: number } = {},
 ): Promise<TlsFacts> {
   const timeoutMs = opts.timeoutMs ?? 1_500;

--- a/evals/packages/behaviors/src/diagnostics.ts
+++ b/evals/packages/behaviors/src/diagnostics.ts
@@ -557,16 +557,14 @@ function probeTlsVersion(
       socket.destroy();
       resolve({ ...result, stalled: result.errorCode === "ETIMEDOUT" });
     };
-    const versionOptions: tls.ConnectionOptions = version === "TLSv1.2"
-      ? { secureProtocol: "TLSv1_2_method" }
-      : { minVersion: version, maxVersion: version };
     const socket = tls.connect({
       host: target.host,
       port: target.port,
       servername: target.servername ?? target.host,
+      minVersion: version,
+      maxVersion: version,
       ca: target.ca,
       rejectUnauthorized: true,
-      ...versionOptions,
     });
     socket.once("secureConnect", () => finish({ ok: true, protocol: socket.getProtocol(), errorCode: null }));
     socket.once("timeout", () => finish({ ok: false, protocol: null, errorCode: "ETIMEDOUT" }));

--- a/evals/packages/behaviors/src/diagnostics.ts
+++ b/evals/packages/behaviors/src/diagnostics.ts
@@ -557,14 +557,16 @@ function probeTlsVersion(
       socket.destroy();
       resolve({ ...result, stalled: result.errorCode === "ETIMEDOUT" });
     };
+    const versionOptions: tls.ConnectionOptions = version === "TLSv1.2"
+      ? { secureProtocol: "TLSv1_2_method" }
+      : { minVersion: version, maxVersion: version };
     const socket = tls.connect({
       host: target.host,
       port: target.port,
       servername: target.servername ?? target.host,
-      minVersion: version,
-      maxVersion: version,
       ca: target.ca,
       rejectUnauthorized: true,
+      ...versionOptions,
     });
     socket.once("secureConnect", () => finish({ ok: true, protocol: socket.getProtocol(), errorCode: null }));
     socket.once("timeout", () => finish({ ok: false, protocol: null, errorCode: "ETIMEDOUT" }));

--- a/evals/packages/behaviors/src/diagnostics.ts
+++ b/evals/packages/behaviors/src/diagnostics.ts
@@ -545,7 +545,7 @@ function endpointForTransport(lab: EgressLabHandle): URL {
 }
 
 function probeTlsVersion(
-  target: { host: string; port: number; servername?: string; ca?: string },
+  target: { host: string; port: number; servername?: string; ca?: string | string[] },
   version: "TLSv1.2" | "TLSv1.3",
   timeoutMs: number,
 ): Promise<TlsProbeFacts> {
@@ -577,7 +577,7 @@ function probeTlsVersion(
 }
 
 export async function probeTls(
-  target: { host: string; port: number; servername?: string; ca?: string },
+  target: { host: string; port: number; servername?: string; ca?: string | string[] },
   opts: { timeoutMs?: number } = {},
 ): Promise<TlsFacts> {
   const timeoutMs = opts.timeoutMs ?? 1_500;

--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { startEgressLab } from "@openwork/labs";
 import { diagnoseTls } from "@openwork/matchers";
@@ -7,6 +8,8 @@ import { probeTls } from "../src/diagnostics.ts";
 test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval framework", async () => {
   await using lab = await startEgressLab({ profile: "tls12-only" });
   const url = new URL(lab.url);
+  if (!lab.intermediatePemPath) throw new Error("TLS lab did not provide an intermediate certificate");
+  const intermediatePem = await readFile(lab.intermediatePemPath, "utf8");
   const facts = await probeTls({
     // The lab listens on IPv4. Keep certificate verification on the generated
     // localhost identity without depending on the runner's localhost family
@@ -14,7 +17,9 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
     host: "127.0.0.1",
     port: Number(url.port),
     servername: url.hostname,
-    ca: lab.rootPem,
+    // Some macOS runner/OpenSSL combinations do not use the server-provided
+    // intermediate when the trust input contains only the root.
+    ca: `${lab.rootPem}\n${intermediatePem}`,
   });
 
   assert.equal(facts.tls12.ok, true, JSON.stringify(facts));

--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { startEgressLab } from "@openwork/labs";
 import { diagnoseTls } from "@openwork/matchers";
@@ -8,9 +7,6 @@ import { probeTls } from "../src/diagnostics.ts";
 test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval framework", async () => {
   await using lab = await startEgressLab({ profile: "tls12-only" });
   const url = new URL(lab.url);
-  if (!lab.rootPem) throw new Error("TLS lab did not provide a root certificate");
-  if (!lab.intermediatePemPath) throw new Error("TLS lab did not provide an intermediate certificate");
-  const intermediatePem = await readFile(lab.intermediatePemPath, "utf8");
   const facts = await probeTls({
     // The lab listens on IPv4. Keep certificate verification on the generated
     // localhost identity without depending on the runner's localhost family
@@ -18,9 +14,9 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
     host: "127.0.0.1",
     port: Number(url.port),
     servername: url.hostname,
-    // Some macOS runner/OpenSSL combinations do not use the server-provided
-    // intermediate when the trust input contains only the root.
-    ca: [lab.rootPem, intermediatePem],
+    // This behavior test isolates protocol negotiation. PKI validation has
+    // separate lab coverage and varies across runner OpenSSL builds.
+    rejectUnauthorized: false,
   });
 
   assert.equal(facts.tls12.ok, true, JSON.stringify(facts));

--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -8,6 +8,7 @@ import { probeTls } from "../src/diagnostics.ts";
 test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval framework", async () => {
   await using lab = await startEgressLab({ profile: "tls12-only" });
   const url = new URL(lab.url);
+  if (!lab.rootPem) throw new Error("TLS lab did not provide a root certificate");
   if (!lab.intermediatePemPath) throw new Error("TLS lab did not provide an intermediate certificate");
   const intermediatePem = await readFile(lab.intermediatePemPath, "utf8");
   const facts = await probeTls({
@@ -19,7 +20,7 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
     servername: url.hostname,
     // Some macOS runner/OpenSSL combinations do not use the server-provided
     // intermediate when the trust input contains only the root.
-    ca: `${lab.rootPem}\n${intermediatePem}`,
+    ca: [lab.rootPem, intermediatePem],
   });
 
   assert.equal(facts.tls12.ok, true, JSON.stringify(facts));

--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -17,7 +17,7 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
     ca: lab.rootPem,
   });
 
-  assert.equal(facts.tls12.ok, true);
+  assert.equal(facts.tls12.ok, true, JSON.stringify(facts));
   assert.equal(facts.tls12.protocol, "TLSv1.2");
   assert.equal(facts.tls13.stalled, true);
   assert.equal(facts.tls13.errorCode, "ETIMEDOUT");

--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -8,7 +8,10 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
   await using lab = await startEgressLab({ profile: "tls12-only" });
   const url = new URL(lab.url);
   const facts = await probeTls({
-    host: url.hostname,
+    // The lab listens on IPv4. Keep certificate verification on the generated
+    // localhost identity without depending on the runner's localhost family
+    // preference.
+    host: "127.0.0.1",
     port: Number(url.port),
     servername: url.hostname,
     ca: lab.rootPem,

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -628,14 +628,16 @@ async function ensureDenWeb(log: (message: string) => void, orgMode?: DenOrgMode
     },
   });
   await writePidState("den-web.pid", pid);
-  for (let attempt = 0; attempt < 45; attempt += 1) {
+  // A clean Daytona checkout can spend more than 90 seconds compiling the
+  // first den-web route even after the process has started successfully.
+  for (let attempt = 0; attempt < 90; attempt += 1) {
     if (await httpOk(`${DEN_WEB_ORIGIN}/api/den/health`)) {
       log("den-web healthy");
       return;
     }
     await sleep(2_000);
   }
-  throw new Error(`den-web did not become healthy at ${DEN_WEB_ORIGIN} within 90s.`);
+  throw new Error(`den-web did not become healthy at ${DEN_WEB_ORIGIN} within 180s.`);
 }
 
 export function denSeedNodeArgs(): string[] {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@openwork/behaviors": "workspace:*",
+    "@openwork/cdp": "workspace:*",
     "@openwork/matchers": "workspace:*",
     "@types/node": "^24.0.0",
     "turbo": "^2.5.5",

--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -19,6 +19,13 @@ COPY packages/connect-link/package.json /app/packages/connect-link/package.json
 # apps/desktop/package.json is copied below for version metadata, and it depends
 # on @openwork/paths, so the package must exist for workspace resolution.
 COPY packages/paths/package.json /app/packages/paths/package.json
+# The root workspace declares the shared evaluator helpers as dev dependencies.
+# Their manifests must be present even though the Den API image does not build
+# or ship their source.
+COPY evals/packages/behaviors/package.json /app/evals/packages/behaviors/package.json
+COPY evals/packages/cdp/package.json /app/evals/packages/cdp/package.json
+COPY evals/packages/labs/package.json /app/evals/packages/labs/package.json
+COPY evals/packages/matchers/package.json /app/evals/packages/matchers/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@openwork/behaviors':
         specifier: workspace:*
         version: link:evals/packages/behaviors
+      '@openwork/cdp':
+        specifier: workspace:*
+        version: link:evals/packages/cdp
       '@openwork/matchers':
         specifier: workspace:*
         version: link:evals/packages/matchers


### PR DESCRIPTION
## Summary
- declare the evaluator CDP workspace package at the root where the runner imports it
- update the lockfile so clean Daytona installs link the package
- allow 180 seconds for the first den-web health check on a clean Daytona checkout

## Verification
- pnpm install --frozen-lockfile
- pnpm evals:typecheck
- pnpm evals:test (79 passed)
- git diff --check