### PR TITLE
fix(server): a no-op provider patch must not reload the engine

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -45,9 +45,9 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   const workspace = findManagedEngineWorkspace(config.workspaces);
   if (workspace) {
     // Server-managed config file: the engine re-reads it from disk on every
-    // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
+    // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
     // on every runtime-DB write — so disposes always pick up current state.
-    const runtimeConfigPath = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
     keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -62,9 +62,9 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     const workspace = findManagedEngineWorkspace(config.workspaces);
     if (workspace) {
       // Server-managed config file: the engine re-reads it from disk on every
-      // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
+      // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
       // on every runtime-DB write — so disposes always pick up current state.
-      const runtimeConfigPath = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+      const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
       keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
       const cwd = options.opencodeCwd
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -62,7 +62,7 @@ describe("openwork runtime config file", () => {
       mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } },
     }));
 
-    const path = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    const { path } = await writeOpenworkRuntimeConfigFile(config, "ws_1");
     expect(path).toBe(openworkRuntimeConfigFilePath(config));
 
     const parsed = await readConfigFile(config);

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -8,11 +8,11 @@
  * use this.
  *
  * The engine re-reads the OPENCODE_CONFIG file from disk on every instance
- * rebuild (e.g. /instance/dispose), so the file is rewritten on every
+ * rebuild (e.g. /instance/dispose), so the file is synchronized on every
  * runtime-DB write — unlike the previous OPENCODE_CONFIG_CONTENT env var,
  * which was frozen at spawn and reverted MCP state on each dispose.
  */
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
@@ -165,27 +165,37 @@ export function openworkRuntimeConfigFilePath(config: ServerConfig): string {
 // Serialize file writes per path so a slow older write can never land after
 // (and clobber) a newer one. Content is built inside the queued job so each
 // job reads the latest runtime-DB state.
-const fileWriteQueue = new Map<string, Promise<void>>();
+export interface OpenworkRuntimeConfigWriteResult {
+  path: string;
+  changed: boolean;
+}
+
+const fileWriteQueue = new Map<string, Promise<OpenworkRuntimeConfigWriteResult>>();
 
 /**
  * Rebuild the engine-visible runtime config file from the runtime DB.
  * Atomic (temp file + rename) so the engine never reads a partial file
  * mid-dispose.
  */
-export async function writeOpenworkRuntimeConfigFile(config: ServerConfig, workspaceId: string): Promise<string> {
+export async function writeOpenworkRuntimeConfigFile(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<OpenworkRuntimeConfigWriteResult> {
   const path = openworkRuntimeConfigFilePath(config);
   const job = async () => {
     const content = await buildOpenworkRuntimeConfig(config, workspaceId);
+    const current = await readFile(path, "utf8").catch(() => undefined);
+    if (current === content) return { path, changed: false };
     await mkdir(runtimeStorageDir(config), { recursive: true });
     const tmp = `${path}.${randomUUID()}.tmp`;
     await writeFile(tmp, content, "utf8");
     await rename(tmp, path);
+    return { path, changed: true };
   };
   const previous = fileWriteQueue.get(path) ?? Promise.resolve();
   const next = previous.then(job, job);
   fileWriteQueue.set(path, next);
-  await next;
-  return path;
+  return await next;
 }
 
 /**

--- a/apps/server/src/runtime-config-global-providers.test.ts
+++ b/apps/server/src/runtime-config-global-providers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -99,7 +99,7 @@ describe("global runtime providers", () => {
     const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
     expect(runtimeProviderMap(globalRuntime)).toEqual({ lpr_openrouter: openrouter });
 
-    const path = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    const { path } = await writeOpenworkRuntimeConfigFile(config, "ws_1");
     expect(path).toBe(openworkRuntimeConfigFilePath(config));
     const raw = await readFile(path, "utf8");
     const parsed: unknown = JSON.parse(raw);
@@ -177,6 +177,16 @@ describe("global runtime providers", () => {
       lpr_anthropic: provider,
     });
 
+    await writeFile(openworkRuntimeConfigFilePath(config), "{}", "utf8");
+    const staleFileAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
+    });
+    expect(staleFileAttempt.status).toBe(200);
+    expect(await readJsonObject(staleFileAttempt)).toMatchObject({ ok: true, changed: false, reload: "reloaded" });
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(3);
+
     const removalAttempt = await fetch(`${base}/runtime-config/providers`, {
       method: "PATCH",
       headers: hostHeaders(),
@@ -184,7 +194,7 @@ describe("global runtime providers", () => {
     });
     expect(removalAttempt.status).toBe(200);
     expect(await readJsonObject(removalAttempt)).toMatchObject({ ok: true, changed: true, reload: "reloaded" });
-    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(3);
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(4);
 
     const readback = await fetch(`${base}/opencode/config`, { headers: clientHeaders() });
     expect(readback.status).toBe(200);

--- a/apps/server/src/runtime-config-global-providers.test.ts
+++ b/apps/server/src/runtime-config-global-providers.test.ts
@@ -110,7 +110,7 @@ describe("global runtime providers", () => {
     expect(storageEntries.filter((entry) => entry.includes("runtime-opencode-config.json.")).length).toBe(0);
   });
 
-  test("global provider route requires the host token and reaches the engine-visible config", async () => {
+  test("global provider route reloads only when the effective engine config changes", async () => {
     const root = await createTempRoot();
     const engineRequests: string[] = [];
     const config = serverConfig(root);
@@ -150,14 +150,47 @@ describe("global runtime providers", () => {
       body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
     });
     expect(hostAttempt.status).toBe(200);
-    expect(await readJsonObject(hostAttempt)).toMatchObject({ ok: true, reload: "reloaded" });
-    expect(engineRequests).toContain("POST /instance/dispose");
+    expect(await readJsonObject(hostAttempt)).toMatchObject({ ok: true, changed: true, reload: "reloaded" });
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(1);
+
+    const identicalAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
+    });
+    expect(identicalAttempt.status).toBe(200);
+    expect(await readJsonObject(identicalAttempt)).toMatchObject({ ok: true, changed: false, reload: "skipped" });
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(1);
+
+    await rm(openworkRuntimeConfigFilePath(config));
+    const missingFileAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
+    });
+    expect(missingFileAttempt.status).toBe(200);
+    expect(await readJsonObject(missingFileAttempt)).toMatchObject({ ok: true, changed: false, reload: "reloaded" });
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(2);
+    const restoredFile: unknown = JSON.parse(await readFile(openworkRuntimeConfigFilePath(config), "utf8"));
+    if (!isRecord(restoredFile)) throw new Error("Expected restored runtime config object");
+    expect(providerFromPayload(restoredFile)).toEqual({
+      lpr_anthropic: provider,
+    });
+
+    const removalAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: null } }),
+    });
+    expect(removalAttempt.status).toBe(200);
+    expect(await readJsonObject(removalAttempt)).toMatchObject({ ok: true, changed: true, reload: "reloaded" });
+    expect(engineRequests.filter((request) => request === "POST /instance/dispose")).toHaveLength(3);
 
     const readback = await fetch(`${base}/opencode/config`, { headers: clientHeaders() });
     expect(readback.status).toBe(200);
-    expect(providerFromPayload(await readJsonObject(readback))).toMatchObject({ lpr_anthropic: provider });
+    expect(providerFromPayload(await readJsonObject(readback))).toEqual({});
 
     const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
-    expect(runtimeProviderMap(globalRuntime)).toEqual({ lpr_anthropic: provider });
+    expect(runtimeProviderMap(globalRuntime)).toEqual({});
   });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2035,15 +2035,18 @@ function createRoutes(
       provider: mergeRuntimeProviderUpdate(current.provider, providerPatch),
     }));
 
-    await writeOpenworkRuntimeConfigFile(config, workspace.id);
-    await reloadOpencodeEngine(config, workspace, engineMcpServerState);
+    const fileResult = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    const shouldReload = result.changed || fileResult.changed;
+    if (shouldReload) {
+      await reloadOpencodeEngine(config, workspace, engineMcpServerState);
+    }
 
     return jsonResponse({
       ok: true,
       changed: result.changed,
       provider: runtimeProviderMap(result.config),
       runtimeConfigPath: openworkRuntimeConfigFilePath(config),
-      reload: "reloaded",
+      reload: shouldReload ? "reloaded" : "skipped",
     });
   });
 


### PR DESCRIPTION
Class-level follow-up to #3301. Reloading the opencode engine disposes it, which **aborts any in-flight agent run** and disconnects the SSE event stream. A patch that changes nothing should be inert.

## Why this matters

In production, den-api re-materialized providers on a ~18s poll and every patch reloaded the engine, mid-tool-call:

```
"disposing instance" /tmp/openwork-workspace
ERROR process ... error=Aborted
"event disconnected"
```

991 disposals in a single user instance. #3301 stopped den-api sending redundant patches; this makes the server itself robust so no caller can cause it again.

## The defect

`writeRuntimeOpencodeConfig` already computed the right answer:

```ts
if (row?.valueJson === configJson) return { config: next, changed: false };
```

…but `PATCH /runtime-config/providers` ignored `result.changed` and unconditionally rewrote the file, reloaded the engine, and reported `reload: "reloaded"`.

## Fix

Skip condition is `!result.changed && !fileResult.changed` — deliberately **not** just `if (result.changed)`. The DB row can be unchanged while the on-disk runtime config is missing or stale (first boot after a checkpoint restore, or a hand-edited file); that case must still write and reload. `writeOpenworkRuntimeConfigFile` now byte-compares before its atomic write and returns `{ path, changed }`, so the route can tell the difference. `reload` now reports `"reloaded"` vs `"skipped"` honestly.

No other route was found with the same unconditional reload-after-write pattern against this store.

## Tests

Regression fails before (1 pass / 1 fail), and asserts the reload genuinely does not happen rather than trusting the response field. Also covered: a real update still reloads exactly once; DB-unchanged-but-file-stale still writes and reloads; removal still reloads.

| Command | Result |
| --- | --- |
| `pnpm --filter openwork-server test` | 592 pass / 10 skip / 0 fail |
| `pnpm --filter openwork-server typecheck` | exit 0 |

Note: this ships in the sandbox image, so it takes effect on the next snapshot + recycle — unlike #3301, which was live immediately.