### PR TITLE
fix(app): advance the session-groups event cursor instead of refetching from 0

### DIFF
--- a/apps/app/src/react-app/shell/session-group-event-poller.ts
+++ b/apps/app/src/react-app/shell/session-group-event-poller.ts
@@ -1,0 +1,27 @@
+import type { OpenworkSessionGroupEvent } from "@/app/lib/openwork-server";
+
+export type SessionGroupEventResponse = {
+  items: OpenworkSessionGroupEvent[];
+  cursor?: number;
+};
+
+export class SessionGroupEventPoller {
+  private cursorByWorkspace = new Map<string, number>();
+
+  async poll(
+    key: string,
+    request: (options: { since: number }) => Promise<SessionGroupEventResponse>,
+    apply: () => Promise<void>,
+  ): Promise<void> {
+    const currentCursor = this.cursorByWorkspace.get(key) ?? 0;
+    const response = await request({ since: currentCursor });
+    this.cursorByWorkspace.set(
+      key,
+      typeof response.cursor === "number"
+        ? response.cursor
+        : Math.max(currentCursor, ...response.items.map((item) => Number(item.seq) || 0)),
+    );
+    if (currentCursor === 0 || response.items.length === 0) return;
+    await apply();
+  }
+}

--- a/apps/app/src/react-app/shell/session-group-event-poller.ts
+++ b/apps/app/src/react-app/shell/session-group-event-poller.ts
@@ -2,26 +2,47 @@ import type { OpenworkSessionGroupEvent } from "@/app/lib/openwork-server";
 
 export type SessionGroupEventResponse = {
   items: OpenworkSessionGroupEvent[];
-  cursor?: number;
+  gap?: boolean;
+  reset?: boolean;
 };
 
 export class SessionGroupEventPoller {
   private cursorByWorkspace = new Map<string, number>();
 
+  setWorkspaces(keys: string[]): void {
+    const activeKeys = new Set(keys);
+    for (const key of this.cursorByWorkspace.keys()) {
+      if (!activeKeys.has(key)) this.cursorByWorkspace.delete(key);
+    }
+  }
+
   async poll(
     key: string,
     request: (options: { since: number }) => Promise<SessionGroupEventResponse>,
-    apply: () => Promise<void>,
+    apply: (items: OpenworkSessionGroupEvent[]) => Promise<void>,
   ): Promise<void> {
     const currentCursor = this.cursorByWorkspace.get(key) ?? 0;
-    const response = await request({ since: currentCursor });
-    this.cursorByWorkspace.set(
-      key,
-      typeof response.cursor === "number"
-        ? response.cursor
-        : Math.max(currentCursor, ...response.items.map((item) => Number(item.seq) || 0)),
-    );
-    if (currentCursor === 0 || response.items.length === 0) return;
-    await apply();
+    try {
+      const response = await request({ since: currentCursor });
+      if (response.gap || response.reset) {
+        this.cursorByWorkspace.set(key, 0);
+        return;
+      }
+
+      const items = response.items.filter((item) => Number.isFinite(item.seq) && item.seq > currentCursor);
+      if (items.length === 0) return;
+
+      const sequences = [...new Set(items.map((item) => item.seq))].sort((left, right) => left - right);
+      if (currentCursor > 0 && sequences.some((sequence, index) => sequence !== currentCursor + index + 1)) {
+        this.cursorByWorkspace.set(key, 0);
+        return;
+      }
+
+      await apply(items);
+      const latestSequence = sequences.at(-1);
+      if (latestSequence !== undefined) this.cursorByWorkspace.set(key, latestSequence);
+    } catch {
+      this.cursorByWorkspace.set(key, 0);
+    }
   }
 }

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -150,6 +150,12 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
 
   useEffect(() => {
     let cancelled = false;
+    const eventWorkspaceKeys: string[] = [];
+    for (const workspace of workspacesRef.current) {
+      const endpoint = endpointForWorkspaceRef.current(workspace);
+      if (endpoint) eventWorkspaceKeys.push(`${endpoint.baseUrl}:${endpoint.workspaceId}`);
+    }
+    eventPollerRef.current.setWorkspaces(eventWorkspaceKeys);
 
     const syncWorkspace = async (workspace: RouteWorkspace, migrateLocal: boolean) => {
       const endpoint = endpointForWorkspaceRef.current(workspace);

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -12,6 +12,7 @@ import {
   type WorkspaceGroupState,
 } from "@/react-app/domains/session/sidebar/session-management-store";
 import type { RouteWorkspace } from "./route-workspaces";
+import { SessionGroupEventPoller } from "./session-group-event-poller";
 
 const MIGRATION_PREFIX = "openwork.sessionGroups.migrated.v2";
 
@@ -86,7 +87,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
   const { workspaces, endpointForWorkspace } = input;
   const workspacesRef = useRef(workspaces);
   const endpointForWorkspaceRef = useRef(endpointForWorkspace);
-  const eventCursorByWorkspaceRef = useRef<Record<string, number | null>>({});
+  const eventPollerRef = useRef(new SessionGroupEventPoller());
   const pollInFlightRef = useRef(false);
   const groupSyncKey = useMemo(
     () => workspaceEndpointSyncKey(workspaces, endpointForWorkspace),
@@ -192,20 +193,13 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
           const endpoint = endpointForWorkspaceRef.current(workspace);
           if (!endpoint) continue;
           const key = `${endpoint.baseUrl}:${endpoint.workspaceId}`;
-          const currentCursor = eventCursorByWorkspaceRef.current[key];
           try {
-            const response = await endpoint.client.listSessionGroupEvents(
-              endpoint.workspaceId,
-              typeof currentCursor === "number" ? { since: currentCursor } : undefined,
+            await eventPollerRef.current.poll(
+              key,
+              (options) => endpoint.client.listSessionGroupEvents(endpoint.workspaceId, options),
+              () => syncWorkspace(workspace, false),
             );
             if (cancelled) return;
-            eventCursorByWorkspaceRef.current[key] =
-              typeof response.cursor === "number"
-                ? response.cursor
-                : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item) => Number(item.seq) || 0)));
-            if (currentCursor === undefined || currentCursor === null) continue;
-            if ((response.items ?? []).length === 0) continue;
-            await syncWorkspace(workspace, false);
           } catch {
             // Best effort: normal workspace/session loading still surfaces connection issues.
           }

--- a/apps/app/tests/session-group-event-poller.test.ts
+++ b/apps/app/tests/session-group-event-poller.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import type { OpenworkSessionGroupEvent } from "../src/app/lib/openwork-server";
+import { SessionGroupEventPoller } from "../src/react-app/shell/session-group-event-poller";
+
+function event(seq: number, workspaceId = "workspace-a"): OpenworkSessionGroupEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    workspaceId,
+    type: "session_groups.updated",
+    action: "updated",
+    timestamp: seq,
+  };
+}
+
+describe("session group event poller", () => {
+  test("sends the newest returned sequence on the next poll", async () => {
+    const poller = new SessionGroupEventPoller();
+    const requests: number[] = [];
+    const events = [event(1), event(2)];
+    const request = async ({ since }: { since: number }) => {
+      requests.push(since);
+      return { items: events.filter((item) => item.seq > since), cursor: 0 };
+    };
+
+    await poller.poll("workspace-a", request, async () => {});
+    await poller.poll("workspace-a", request, async () => {});
+
+    expect(requests).toEqual([0, 2]);
+  });
+
+  test("keeps its cursor when a poll returns no events", async () => {
+    const poller = new SessionGroupEventPoller();
+    const requests: number[] = [];
+    const request = async ({ since }: { since: number }) => {
+      requests.push(since);
+      return { items: since === 0 ? [event(3)] : [] };
+    };
+
+    await poller.poll("workspace-a", request, async () => {});
+    await poller.poll("workspace-a", request, async () => {});
+    await poller.poll("workspace-a", request, async () => {});
+
+    expect(requests).toEqual([0, 3, 3]);
+  });
+
+  test("resets removed workspaces without leaking another workspace cursor", async () => {
+    const poller = new SessionGroupEventPoller();
+    const requests: Array<{ key: string; since: number }> = [];
+    const poll = (key: string, seq: number) => poller.poll(
+      key,
+      async ({ since }) => {
+        requests.push({ key, since });
+        return { items: since === 0 ? [event(seq, key)] : [] };
+      },
+      async () => {},
+    );
+
+    poller.setWorkspaces(["workspace-a"]);
+    await poll("workspace-a", 4);
+    poller.setWorkspaces(["workspace-b"]);
+    await poll("workspace-b", 7);
+    poller.setWorkspaces(["workspace-a"]);
+    await poll("workspace-a", 8);
+
+    expect(requests).toEqual([
+      { key: "workspace-a", since: 0 },
+      { key: "workspace-b", since: 0 },
+      { key: "workspace-a", since: 0 },
+    ]);
+  });
+
+  test("applies each event once across the exclusive cursor boundary", async () => {
+    const poller = new SessionGroupEventPoller();
+    const events = [event(1), event(2)];
+    const applied: string[] = [];
+    const request = async ({ since }: { since: number }) => ({
+      items: events.filter((item) => item.seq > since),
+    });
+    const apply = async (items: OpenworkSessionGroupEvent[]) => {
+      applied.push(...items.map((item) => item.id));
+    };
+
+    await poller.poll("workspace-a", request, apply);
+    events.push(event(3));
+    await poller.poll("workspace-a", request, apply);
+
+    expect(applied).toEqual(["event-1", "event-2", "event-3"]);
+  });
+
+  test("falls back to zero after an error or sequence gap", async () => {
+    const poller = new SessionGroupEventPoller();
+    const requests: number[] = [];
+    let call = 0;
+    const request = async ({ since }: { since: number }) => {
+      requests.push(since);
+      call += 1;
+      if (call === 2) throw new Error("offline");
+      if (call === 4) return { items: [event(3)] };
+      if (call === 5) return { items: [event(1), event(3)] };
+      return { items: since === 0 ? [event(1)] : [] };
+    };
+
+    await poller.poll("workspace-a", request, async () => {});
+    await expect(poller.poll("workspace-a", request, async () => {})).resolves.toBeUndefined();
+    await poller.poll("workspace-a", request, async () => {});
+    await poller.poll("workspace-a", request, async () => {});
+    await poller.poll("workspace-a", request, async () => {});
+
+    expect(requests).toEqual([0, 1, 0, 1, 0]);
+  });
+});


### PR DESCRIPTION
The session-groups poller re-requested the entire event history every 3 seconds, forever.

## Evidence (production CDP trace)

```
+0.27s  -> GET /workspace/ws_49372819c6f0/events?since=0
+3.27s  -> GET /workspace/ws_49372819c6f0/events?since=0
+6.27s  -> GET /workspace/ws_49372819c6f0/events?since=0
...never advancing
```

## Cause

The poller preferred `response.cursor`, and a stale `0` overwrote the cursor derived from the returned events on every tick — so it reset itself each poll.

## Fix

Server semantics are **exclusive** (`event.seq > since`), now matched explicitly. The poller commits the highest returned `seq` only *after* events are applied, so a failure can't skip events. Empty responses preserve the cursor rather than resetting to 0. Errors, gaps, and reset signals fall back to 0 deliberately. Cursor state is keyed per endpoint/workspace and dropped when a workspace goes away, so no workspace can inherit another's cursor.

Shared with desktop; the hook is common to both paths.

## Tests

Regression fails before — `Expected: [0, 2] / Received: [0, 0]` (1 pass / 4 fail) — and passes after (5 pass). Covers cursor advance, empty-response preservation, workspace isolation, boundary correctness against the server's exclusive semantics, and error/gap fallback.

| Command | Result |
| --- | --- |
| `apps/app` suite | 533 pass / 0 fail |
| `tsc --noEmit` + `build:web` | clean |