### PR TITLE
fix(app): type sonner CSS custom properties so tsc is clean

### DIFF
--- a/apps/app/src/components/ui/sonner.tsx
+++ b/apps/app/src/components/ui/sonner.tsx
@@ -14,6 +14,13 @@ function useTheme() {
   )
 }
 
+const toasterStyle: React.CSSProperties & Record<`--${string}`, string> = {
+  "--normal-bg": "var(--popover)",
+  "--normal-text": "var(--popover-foreground)",
+  "--normal-border": "var(--border)",
+  "--border-radius": "var(--radius)",
+}
+
 const Toaster = ({ ...props }: ToasterProps) => {
   const theme = useTheme()
 
@@ -38,12 +45,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           <Loader2Icon className="size-4 animate-spin" />
         ),
       }}
-      style={{
-        "--normal-bg": "var(--popover)",
-        "--normal-text": "var(--popover-foreground)",
-        "--normal-border": "var(--border)",
-        "--border-radius": "var(--radius)",
-      }}
+      style={toasterStyle}
       toastOptions={{
         classNames: {
           toast: "cn-toast",


### PR DESCRIPTION
`apps/app` typecheck was failing on `dev`. Green gate restored.

```
src/components/ui/sonner.tsx(42,9): error TS2353: Object literal may only specify known properties,
and '"--normal-bg"' does not exist in type 'Properties<string | number, string & {}>'.
```

It only reproduces on a **fresh install** of unmodified `dev`, not against stale `node_modules` — which is why it went unnoticed, and why I initially misattributed it to an unrelated PR's dependency change.

## Fix

The style object is declared as `React.CSSProperties & Record<`--${string}`, string>`, so CSS custom properties are legal without a cast. No `as`, no `any`. Built-JS grep confirms all four custom properties and their values are unchanged.

| Command | Result |
| --- | --- |
| `tsc --noEmit` | exit 0, no output |
| `apps/app` suite | 528 pass / 0 fail |
| `build:web` | exit 0 |