### PR TITLE
fix(evals): generate the egress lab root CA with -extfile (openssl 1.1.1 emitted CA:FALSE)

### DIFF
--- a/evals/packages/behaviors/test/probe-tls.test.ts
+++ b/evals/packages/behaviors/test/probe-tls.test.ts
@@ -14,19 +14,17 @@ test("probeTls and diagnoseTls identify a TLS 1.3-only stall without the eval fr
     host: "127.0.0.1",
     port: Number(url.port),
     servername: url.hostname,
-    // This behavior test isolates protocol negotiation. PKI validation has
-    // separate lab coverage and varies across runner OpenSSL builds.
-    rejectUnauthorized: false,
+    // Chain verification is back on: the lab root is now generated with an
+    // explicit basicConstraints extension, so it is a real CA on every openssl
+    // build (1.1.1 silently emitted CA:FALSE before).
+    ca: lab.rootPem,
   });
 
   const message = JSON.stringify(facts);
   assert.equal(facts.tls12.handshakeOk, true, message);
   assert.equal(facts.tls12.stalled, false, message);
-  if (facts.tls12.chainVerified) {
-    assert.equal(facts.tls12.protocol, "TLSv1.2", message);
-  } else {
-    assert.equal(facts.tls12.protocol === null || facts.tls12.protocol === "TLSv1.2", true, message);
-  }
+  assert.equal(facts.tls12.chainVerified, true, message);
+  assert.equal(facts.tls12.protocol, "TLSv1.2", message);
   assert.equal(facts.tls13.stalled, true, message);
   assert.equal(facts.tls13.errorCode, "ETIMEDOUT", message);
   assert.equal(diagnoseTls(facts).code, "tls_handshake_stall_tls13_only", message);

--- a/evals/packages/labs/src/egress.ts
+++ b/evals/packages/labs/src/egress.ts
@@ -1,5 +1,5 @@
-import { execFile } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { execFile, spawnSync } from "node:child_process";
+import { randomUUID, X509Certificate } from "node:crypto";
 import { readFile, rm, writeFile, mkdtemp, mkdir } from "node:fs/promises";
 import http from "node:http";
 import https from "node:https";
@@ -369,6 +369,7 @@ export function parseClientHelloVersions(buffer: Buffer): ClientHelloParseResult
 function pkiPaths(dir: string) {
   return {
     rootKey: path.join(dir, "root.key.pem"),
+    rootCsr: path.join(dir, "root.csr.pem"),
     rootPem: path.join(dir, "root.pem"),
     intermediateKey: path.join(dir, "intermediate.key.pem"),
     intermediateCsr: path.join(dir, "intermediate.csr.pem"),
@@ -378,6 +379,7 @@ function pkiPaths(dir: string) {
     leafCsr: path.join(dir, "leaf.csr.pem"),
     leafPem: path.join(dir, "leaf.pem"),
     fullChain: path.join(dir, "fullchain.pem"),
+    rootExt: path.join(dir, "root.ext"),
     intermediateExt: path.join(dir, "intermediate.ext"),
     leafExt: path.join(dir, "leaf.ext"),
   };
@@ -393,26 +395,19 @@ export function opensslCertificateCommands(input: OpenSslCommandInput): OpenSslC
     : "/CN=OpenWork Egress Lab Intermediate CA";
   return [
     { label: "root-key", args: ["genrsa", "-out", files.rootKey, "2048"] },
+    { label: "root-csr", args: ["req", "-new", "-key", files.rootKey, "-out", files.rootCsr, "-subj", rootSubject] },
     {
+      // Self-sign via `x509 -req -extfile` instead of `req -x509 -addext`.
+      // OpenSSL 1.1.1 applies `-addext` to the CSR's requested extensions and
+      // does not copy them into the self-signed certificate, so the root was
+      // emitted with no basicConstraints (CA:FALSE) and clients could not build
+      // the chain (UNABLE_TO_GET_ISSUER_CERT_LOCALLY). OpenSSL 3.x applies them,
+      // which is why this only broke on runners shipping 1.1.1 (macos-14).
+      // `-extfile` is honored identically by 1.1.1, 3.x and LibreSSL.
       label: "root-cert",
       args: [
-        "req",
-        "-x509",
-        "-new",
-        "-nodes",
-        "-key",
-        files.rootKey,
-        "-sha256",
-        "-days",
-        "7",
-        "-out",
-        files.rootPem,
-        "-subj",
-        rootSubject,
-        "-addext",
-        "basicConstraints=critical,CA:TRUE,pathlen:1",
-        "-addext",
-        "keyUsage=critical,keyCertSign,cRLSign",
+        "x509", "-req", "-in", files.rootCsr, "-signkey", files.rootKey,
+        "-sha256", "-days", "7", "-out", files.rootPem, "-extfile", files.rootExt,
       ],
     },
     { label: "intermediate-key", args: ["genrsa", "-out", files.intermediateKey, "2048"] },
@@ -484,6 +479,15 @@ export function opensslFlavor(env: NodeJS.ProcessEnv = process.env): Promise<Ope
   });
 }
 
+function rootExtFile(): string {
+  return [
+    "basicConstraints=critical,CA:TRUE,pathlen:1",
+    "keyUsage=critical,keyCertSign,cRLSign",
+    "subjectKeyIdentifier=hash",
+    "",
+  ].join("\n");
+}
+
 function intermediateExtFile(): string {
   return [
     "basicConstraints=critical,CA:TRUE,pathlen:0",
@@ -518,9 +522,26 @@ function execOpenSsl(args: string[], cwd: string): Promise<void> {
   });
 }
 
+/**
+ * Fail loudly when the local openssl emitted a non-CA certificate. Without this
+ * the defect surfaces much later as an opaque TLS error in whichever test
+ * happens to verify a chain.
+ */
+function assertGeneratedCa(label: "root" | "intermediate", pem: string): void {
+  const certificate = new X509Certificate(pem);
+  if (certificate.ca) return;
+  const version = spawnSync("openssl", ["version"], { encoding: "utf8" });
+  throw new Error([
+    `Egress lab ${label} certificate was generated without basicConstraints CA:TRUE.`,
+    `openssl: ${String(version.stdout || version.stderr).trim() || "unknown"}`,
+    `subject: ${certificate.subject}`,
+  ].join(" "));
+}
+
 async function generateCertificateMaterial(input: { hostname: string; aiaUrl: string | null; corporateIssuer: boolean }): Promise<CertificateMaterial> {
   const dir = await mkdtemp(path.join(tmpdir(), "openwork-egress-lab-"));
   const files = pkiPaths(dir);
+  await writeFile(files.rootExt, rootExtFile(), "utf8");
   await writeFile(files.intermediateExt, intermediateExtFile(), "utf8");
   await writeFile(files.leafExt, leafExtFile(input.hostname, input.aiaUrl), "utf8");
   for (const command of opensslCertificateCommands({ dir, hostname: input.hostname, aiaUrl: input.aiaUrl, corporateIssuer: input.corporateIssuer })) {
@@ -528,6 +549,8 @@ async function generateCertificateMaterial(input: { hostname: string; aiaUrl: st
   }
   const leaf = await readFile(files.leafPem, "utf8");
   const intermediate = await readFile(files.intermediatePem, "utf8");
+  assertGeneratedCa("root", await readFile(files.rootPem, "utf8"));
+  assertGeneratedCa("intermediate", intermediate);
   const fullChain = `${leaf.trim()}\n${intermediate.trim()}\n`;
   await writeFile(files.fullChain, fullChain, "utf8");
   return {

--- a/evals/packages/labs/test/egress-lab.test.ts
+++ b/evals/packages/labs/test/egress-lab.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { X509Certificate } from "node:crypto";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -9,6 +11,7 @@ import {
   outboundManifestFromUnknown,
   parseClientHelloVersions,
   resolveEgressProfileConfig,
+  startEgressLab,
 } from "../src/egress.ts";
 import { productDiagnosticsPrecondition } from "@openwork/behaviors";
 import { matchVerdictExpectations } from "@openwork/matchers";
@@ -99,6 +102,7 @@ test("openssl argv construction includes CA, AIA, and fullchain prerequisites", 
 
   assert.deepEqual(labels, [
     "root-key",
+    "root-csr",
     "root-cert",
     "intermediate-key",
     "intermediate-csr",
@@ -110,6 +114,13 @@ test("openssl argv construction includes CA, AIA, and fullchain prerequisites", 
   ]);
   assert.ok(commands.some((command) => command.args.includes("/CN=OpenWork Egress Lab Corporate Interception CA")));
   assert.ok(commands.some((command) => command.args.includes("-extfile")));
+  const rootCert = commands.find((command) => command.label === "root-cert");
+  assert.ok(rootCert, "root-cert command must exist");
+  assert.ok(
+    rootCert.args.includes("-extfile"),
+    "root CA extensions must come from -extfile; openssl 1.1.1 ignores `req -x509 -addext`",
+  );
+  assert.ok(!rootCert.args.includes("-addext"), "root-cert must not depend on -addext");
 });
 
 test("openssl flavor probe returns a known value", async () => {
@@ -158,4 +169,16 @@ test("product diagnostics precondition skips clearly when Bun is unavailable", (
   if (!reason) throw new Error("Expected a missing-Bun skip reason");
   assert.ok(reason.includes("Bun is required"));
   assert.ok(reason.includes("product-verdict egress proofs"));
+});
+
+test("generated egress lab CA certificates carry basicConstraints on every openssl build", async () => {
+  await using lab = await startEgressLab({ profile: "tls12-only" });
+  assert.ok(lab.rootPem, "lab must expose its root PEM");
+  const root = new X509Certificate(lab.rootPem);
+  // openssl 1.1.1 silently produced a non-CA root, which broke chain building
+  // only on runners shipping 1.1.1 (macos-14).
+  assert.equal(root.ca, true, `root must be a CA (subject: ${root.subject})`);
+  assert.ok(lab.intermediatePemPath, "lab must expose its intermediate path");
+  const intermediate = new X509Certificate(readFileSync(lab.intermediatePemPath, "utf8"));
+  assert.equal(intermediate.ca, true, `intermediate must be a CA (subject: ${intermediate.subject})`);
 });


### PR DESCRIPTION
Fixes the real defect behind the `macos-14` red on `dev`, and restores the chain-verification coverage that #3310 had to switch off to get green.

## Diagnosis

The test failed **only** on `macos-14`, deterministically (a rerun reproduced it), and passed locally in isolation, under full-lane load, and with LibreSSL forced. I instrumented the assertions and had CI print the facts:

```
macos-14  openssl(cli)=OpenSSL 1.1.1w   root ca:false   tls12.errorCode=UNABLE_TO_GET_ISSUER_CERT_LOCALLY
ubuntu    openssl(cli)=OpenSSL 3.0.2    root ca:true    tls12.ok=true
local     openssl(cli)=OpenSSL 3.6.3    root ca:true    tls12.ok=true
```

The lab's root was built with `req -x509 ... -addext basicConstraints=critical,CA:TRUE`. **OpenSSL 1.1.1 applies `-addext` to the CSR's requested extensions and does not copy them into the self-signed certificate**; 3.x does. So on 1.1.1 the root carried no `basicConstraints`, was not a CA, and no client could build the chain. The lab silently depended on an OpenSSL-3 default.

## Fix

- The root is now created as a CSR and self-signed with `x509 -req -extfile`, which is honored identically by 1.1.1, 3.x and LibreSSL. No reliance on version defaults.
- `generateCertificateMaterial` now asserts the generated root and intermediate really are CAs, and fails with the local `openssl version` in the message — so future toolchain drift surfaces at setup instead of as an opaque TLS error in whichever test happens to verify a chain.
- Second commit re-enables verification in `probe-tls.test.ts` (`ca: lab.rootPem`, asserting `chainVerified`), replacing the conditional PKI assertion #3310 introduced. If `macos-14` disagrees, that commit can be dropped on its own and the CA fix still stands.

## Tests

New: `generated egress lab CA certificates carry basicConstraints on every openssl build` — asserts `root.ca` and `intermediate.ca`, which is exactly what was false on 1.1.1. The argv test now pins that `root-cert` uses `-extfile` and **not** `-addext`.

Full `pnpm test:eval-runner`, both toolchains available to me:

| openssl | result |
| --- | --- |
| OpenSSL 3.6.3 | 87 pass / 0 fail |
| LibreSSL 3.3.6 | 87 pass / 0 fail |

## Honest limits

I could not run OpenSSL 1.1.1 locally — Homebrew has removed `openssl@1.1`, so the 1.1.1 behavior is evidenced by the CI output above rather than a local repro. My first attempt to prove the quirk locally was invalid (on 3.x, `req -x509` adds `CA:TRUE` even without `-addext`, so 1.1.1 can't be emulated), and I'm flagging that rather than dressing it up. The fix does not depend on the quirk being characterized exactly: it sets `basicConstraints` explicitly instead of inheriting any default. `macos-14` in this PR is the confirming test.