### PR TITLE
test(evals): add sidebar and panel Snack flows

### DIFF
--- a/evals/flows/right-panel-action-empty-state.flow.mjs
+++ b/evals/flows/right-panel-action-empty-state.flow.mjs
@@ -1,0 +1,76 @@
+const READ_CHOOSER = `(() => {
+  const panel = [...document.querySelectorAll('aside, [role="complementary"], main + div, [data-side-panel]')]
+    .find((entry) => /choose|open in (the )?side panel|side panel/i.test(entry.textContent || ''));
+  if (!(panel instanceof HTMLElement)) return null;
+  const actions = [...panel.querySelectorAll('button, a')]
+    .filter((entry) => !entry.hasAttribute('disabled'))
+    .map((entry) => ({
+      label: (entry.getAttribute('aria-label') || entry.textContent || '').trim(),
+      shortcut: entry.getAttribute('aria-keyshortcuts'),
+    }))
+    .filter((entry) => entry.label.length > 0);
+  return {
+    text: (panel.textContent || '').trim(),
+    actions,
+    width: Math.round(panel.getBoundingClientRect().width),
+  };
+})()`;
+
+export default {
+  id: "right-panel-action-empty-state",
+  title: "The empty right panel offers real runtime-supported destinations",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Opening an empty panel presents an actionable chooser",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "control API",
+        });
+        if (!String(await ctx.eval("window.__openworkControl.snapshot().route || ''")).includes("/session/")) {
+          await ctx.control("session.create_task");
+          await ctx.waitFor(
+            "window.__openworkControl.snapshot().route.includes('/session/')",
+            { timeoutMs: 30_000, label: "session route" },
+          );
+        }
+        const opened = await ctx.eval(`(() => {
+          const button = document.querySelector('button[aria-label="Open side panel"]');
+          if (!(button instanceof HTMLElement)) return false;
+          button.click();
+          return true;
+        })()`);
+        ctx.assert(opened === true, "The general Open side panel control was not actionable.");
+        await ctx.waitFor(`Boolean(${READ_CHOOSER})`, {
+          timeoutMs: 20_000,
+          label: "right-panel action chooser",
+        });
+
+        await ctx.prove("The no-content side panel exposes supported destinations as keyboard-accessible actions", {
+          action: async () => {},
+          assert: async () => {
+            const chooser = await ctx.eval(READ_CHOOSER);
+            ctx.assert(chooser, "The deliberate right-panel empty state was not found.");
+            const labels = chooser.actions.map((entry) => entry.label);
+            ctx.assert(labels.length >= 2, `Expected at least two real destinations, got ${JSON.stringify(labels)}.`);
+            ctx.assert(
+              labels.some((label) => /browser/i.test(label)),
+              `Expected a Browser destination in the desktop runtime, got ${JSON.stringify(labels)}.`,
+            );
+            ctx.assert(
+              labels.some((label) => /files|artifacts/i.test(label)),
+              `Expected a Files or Artifacts destination, got ${JSON.stringify(labels)}.`,
+            );
+            ctx.assert(chooser.width >= 300, `Expected a usable panel width, got ${chooser.width}px.`);
+          },
+          screenshot: {
+            name: "right-panel-action-chooser",
+            requireText: ["Browser"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/sidebar-session-number-shortcuts.flow.mjs
+++ b/evals/flows/sidebar-session-number-shortcuts.flow.mjs
@@ -1,0 +1,72 @@
+const READ_SHORTCUT_ROWS = `(() => [...document.querySelectorAll('[aria-keyshortcuts]')]
+  .map((entry) => ({
+    shortcut: entry.getAttribute('aria-keyshortcuts'),
+    label: (entry.getAttribute('aria-label') || entry.textContent || '').trim(),
+    visible: Boolean(entry.getClientRects().length),
+  }))
+  .filter((entry) => entry.visible && /(?:Meta|Control)\\+[1-9]/.test(entry.shortcut || '')))()`;
+
+export default {
+  id: "sidebar-session-number-shortcuts",
+  title: "Platform-modifier number shortcuts match visible session order",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Holding the platform modifier reveals accurate first-nine session shortcuts",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "control API",
+        });
+        for (let index = 1; index <= 3; index += 1) {
+          await ctx.control("session.create_task");
+          const sessionId = await ctx.waitFor(`(() => {
+            const route = window.__openworkControl.snapshot().route || "";
+            const match = route.match(/session\\/([^/?#]+)/);
+            return match ? decodeURIComponent(match[1]) : null;
+          })()`, { timeoutMs: 30_000, label: `created session ${index}` });
+          await ctx.control("session.rename", {
+            sessionId,
+            title: `Shortcut proof chat ${index}`,
+          });
+        }
+
+        const isMac = await ctx.eval("navigator.platform.toLowerCase().includes('mac')");
+        await ctx.client.send("Input.dispatchKeyEvent", {
+          type: "keyDown",
+          key: isMac ? "Meta" : "Control",
+          code: isMac ? "MetaLeft" : "ControlLeft",
+          modifiers: isMac ? 4 : 2,
+        });
+        await ctx.waitFor(`${READ_SHORTCUT_ROWS}.length >= 3`, {
+          timeoutMs: 20_000,
+          label: "numbered visible session rows",
+        });
+
+        await ctx.prove("Modifier badges appear without changing layout and expose accessible shortcuts", {
+          action: async () => {},
+          assert: async () => {
+            const rows = await ctx.eval(READ_SHORTCUT_ROWS);
+            ctx.assert(rows.length >= 3, `Expected at least three numbered rows, got ${JSON.stringify(rows)}.`);
+            const firstNine = rows.slice(0, 9).map((entry) => entry.shortcut);
+            ctx.assert(new Set(firstNine).size === firstNine.length, "Visible session shortcuts must be unique.");
+            ctx.assert(
+              firstNine.every((shortcut, index) => shortcut.endsWith(`+${index + 1}`)),
+              `Shortcut numbering did not match visible order: ${JSON.stringify(firstNine)}.`,
+            );
+          },
+          screenshot: {
+            name: "sidebar-session-number-shortcuts-held",
+            requireText: ["Shortcut proof chat"],
+          },
+        });
+
+        await ctx.client.send("Input.dispatchKeyEvent", {
+          type: "keyUp",
+          key: isMac ? "Meta" : "Control",
+          code: isMac ? "MetaLeft" : "ControlLeft",
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/sidebar-title-hover-marquee.flow.mjs
+++ b/evals/flows/sidebar-title-hover-marquee.flow.mjs
@@ -1,0 +1,96 @@
+const LONG_TITLE =
+  "Review the OpenWork desktop sidebar title animation across a deliberately overflowing conversation name";
+
+const READ_TITLE = `(() => {
+  const title = [...document.querySelectorAll('[title], [aria-label]')]
+    .find((entry) => {
+      const label = entry.getAttribute('title') || entry.getAttribute('aria-label') || '';
+      return label === ${JSON.stringify(LONG_TITLE)};
+    });
+  if (!(title instanceof HTMLElement)) return null;
+  const viewport = title.parentElement;
+  if (!(viewport instanceof HTMLElement)) return null;
+  const titleStyle = getComputedStyle(title);
+  const viewportStyle = getComputedStyle(viewport);
+  const titleRect = title.getBoundingClientRect();
+  const viewportRect = viewport.getBoundingClientRect();
+  return {
+    left: titleRect.left,
+    top: titleRect.top,
+    width: titleRect.width,
+    height: titleRect.height,
+    clientWidth: viewport.clientWidth,
+    scrollWidth: viewport.scrollWidth,
+    transform: titleStyle.transform,
+    translate: titleStyle.translate,
+    animationName: titleStyle.animationName,
+    maskImage: viewportStyle.maskImage || viewportStyle.webkitMaskImage,
+    overflow: viewportStyle.overflow,
+    viewportLeft: viewportRect.left,
+    viewportRight: viewportRect.right,
+  };
+})()`;
+
+export default {
+  id: "sidebar-title-hover-marquee",
+  title: "Overflowing session titles become readable after hover intent without moving row controls",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Overflow-only title motion preserves the sidebar row",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "control API",
+        });
+        await ctx.control("session.create_task");
+        const sessionId = await ctx.waitFor(`(() => {
+          const route = window.__openworkControl.snapshot().route || "";
+          const match = route.match(/session\\/([^/?#]+)/);
+          return match ? decodeURIComponent(match[1]) : null;
+        })()`, { timeoutMs: 30_000, label: "created session" });
+        await ctx.control("session.rename", { sessionId, title: LONG_TITLE });
+        await ctx.waitFor(`${READ_TITLE}?.scrollWidth > ${READ_TITLE}?.clientWidth`, {
+          timeoutMs: 30_000,
+          label: "overflowing session title",
+        });
+
+        const before = await ctx.eval(READ_TITLE);
+        ctx.assert(before, "Could not measure the overflowing title.");
+        await ctx.client.send("Input.dispatchMouseEvent", {
+          type: "mouseMoved",
+          x: Math.round(before.left + Math.min(before.width / 2, 80)),
+          y: Math.round(before.top + before.height / 2),
+        });
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+        await ctx.prove("A genuinely overflowing title moves only after hover intent and keeps clipped-edge affordance", {
+          action: async () => {},
+          assert: async () => {
+            const after = await ctx.eval(READ_TITLE);
+            ctx.assert(after, "Could not measure the title after hover.");
+            ctx.assert(
+              after.animationName !== "none" ||
+                after.transform !== "none" ||
+                after.translate !== "none" ||
+                after.left < before.left - 1,
+              `Expected visible title motion after hover intent: ${JSON.stringify({ before, after })}`,
+            );
+            ctx.assert(
+              after.maskImage !== "none",
+              `Expected a clipped-edge mask while the title is moving, got ${after.maskImage}.`,
+            );
+            ctx.assert(
+              after.viewportLeft === before.viewportLeft && after.viewportRight === before.viewportRight,
+              "The title viewport changed position while animating.",
+            );
+          },
+          screenshot: {
+            name: "overflowing-title-mid-animation",
+            requireText: ["Review the OpenWork desktop sidebar"],
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Adds the three deterministic evaluator entry points required by the sidebar-title, right-panel empty-state, and session-number shortcut Snacks.\n\nValidation:\n- `pnpm evals --list` (all three flows discovered)\n- `node --check` for all three flows\n- `git diff --check`\n\nEvaluator-only support; no product runtime behavior changes.