### PR TITLE
Animate overflowing chat titles on hover and focus

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -239,6 +239,22 @@ body {
   mask-image: linear-gradient(to right, black calc(100% - 18px), transparent);
 }
 
+/* The viewport stays put while an overflowing session title makes one measured pass. */
+[data-session-title-viewport][data-moving="true"] {
+  mask-image: linear-gradient(to right, transparent, black 10px, black calc(100% - 10px), transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-session-title-text] {
+    transform: none !important;
+    transition: none !important;
+  }
+
+  [data-session-title-viewport] {
+    mask-image: none !important;
+  }
+}
+
 .ow-soft-card {
   border: 1px solid var(--dls-border);
   background: var(--dls-surface);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -129,6 +129,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getSessionActivityStatusLabel, type SessionActivityStatus } from "../status/session-activity-store";
 import { SessionDotMatrixLoader } from "./session-dot-matrix-loader";
+import { SessionTitleMarquee } from "./session-title-marquee";
 import {
   SIDEBAR_ROW_LANE,
   SIDEBAR_SECTION_LABEL,
@@ -2206,6 +2207,7 @@ function SessionMenuItem({
   workspaceName,
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
+  const [keyboardFocused, setKeyboardFocused] = React.useState(false);
   const unreadIds = useUnreadSessionIds();
   const isSelected = ctx.selectedSessionId === session.id;
   const displayTitle = getDisplaySessionTitle(session.title);
@@ -2299,13 +2301,19 @@ function SessionMenuItem({
                 data-session-tab-active={isSelected ? "true" : undefined}
                 onClick={openSession}
                 onPointerEnter={prefetchSession}
-                onFocus={prefetchSession}
+                onFocus={(event) => {
+                  prefetchSession();
+                  setKeyboardFocused(event.currentTarget.matches(":focus-visible"));
+                }}
+                onBlur={() => setKeyboardFocused(false)}
                 aria-label={accessibleState}
               >
                 {leading}
-                <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>
-                  {displayTitle}
-                </span>
+                <SessionTitleMarquee
+                  keyboardFocused={keyboardFocused}
+                  title={displayTitle}
+                  tooltip={itemTitle}
+                />
                 <span className="flex size-6 shrink-0 items-center justify-center">
                   <ChevronRight className="size-4 text-muted-foreground transition-transform duration-200 group-data-open/session-collapsible:rotate-90 hover:text-foreground" />
                 </span>
@@ -2325,13 +2333,21 @@ function SessionMenuItem({
           data-session-tab-active={isSelected ? "true" : undefined}
           onClick={openSession}
           onPointerEnter={prefetchSession}
-          onFocus={prefetchSession}
+          onFocus={(event) => {
+            prefetchSession();
+            setKeyboardFocused(event.currentTarget.matches(":focus-visible"));
+          }}
+          onBlur={() => setKeyboardFocused(false)}
           aria-label={accessibleState}
           className={rowButtonClass}
           style={rowButtonStyle}
         >
           {leading}
-          <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>{displayTitle}</span>
+          <SessionTitleMarquee
+            keyboardFocused={keyboardFocused}
+            title={displayTitle}
+            tooltip={itemTitle}
+          />
         </SidebarMenuSubButton>
       </SessionContextMenu>
       {trailing}

--- a/apps/app/src/react-app/domains/session/sidebar/session-title-marquee.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/session-title-marquee.tsx
@@ -1,0 +1,142 @@
+/** @jsxImportSource react */
+import * as React from "react";
+
+const POINTER_INTENT_DELAY_MS = 500;
+const MARQUEE_SPEED_PX_PER_SECOND = 36;
+const OVERFLOW_TOLERANCE_PX = 1;
+
+export type SessionTitleMarqueeMetrics = {
+  distance: number;
+  durationMs: number;
+};
+
+export function getSessionTitleMarqueeMetrics(
+  titleWidth: number,
+  viewportWidth: number,
+): SessionTitleMarqueeMetrics {
+  const distance = Math.max(0, Math.ceil(titleWidth - viewportWidth));
+  if (distance <= OVERFLOW_TOLERANCE_PX) return { distance: 0, durationMs: 0 };
+
+  return {
+    distance,
+    durationMs: Math.round((distance / MARQUEE_SPEED_PX_PER_SECOND) * 1_000),
+  };
+}
+
+export function shouldMoveSessionTitle(
+  distance: number,
+  pointerIntent: boolean,
+  keyboardFocus: boolean,
+  reducedMotion: boolean,
+) {
+  return distance > 0 && (pointerIntent || keyboardFocus) && !reducedMotion;
+}
+
+export function scheduleSessionTitlePointerIntent(activate: () => void) {
+  const timer = setTimeout(activate, POINTER_INTENT_DELAY_MS);
+  return () => clearTimeout(timer);
+}
+
+type SessionTitleMarqueeProps = {
+  keyboardFocused: boolean;
+  title: string;
+  tooltip: string;
+};
+
+export function SessionTitleMarquee({ keyboardFocused, title, tooltip }: SessionTitleMarqueeProps) {
+  const viewportRef = React.useRef<HTMLSpanElement>(null);
+  const titleRef = React.useRef<HTMLSpanElement>(null);
+  const [metrics, setMetrics] = React.useState<SessionTitleMarqueeMetrics>({ distance: 0, durationMs: 0 });
+  const [pointerHover, setPointerHover] = React.useState(false);
+  const [pointerIntent, setPointerIntent] = React.useState(false);
+  const [reducedMotion, setReducedMotion] = React.useState(false);
+  const [transitioning, setTransitioning] = React.useState(false);
+
+  const measure = React.useCallback(() => {
+    const viewport = viewportRef.current;
+    const titleElement = titleRef.current;
+    if (!viewport || !titleElement) return;
+
+    const next = getSessionTitleMarqueeMetrics(titleElement.scrollWidth, viewport.clientWidth);
+    setMetrics((current) => (
+      current.distance === next.distance && current.durationMs === next.durationMs ? current : next
+    ));
+  }, []);
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    const titleElement = titleRef.current;
+    if (!viewport || !titleElement) return;
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(viewport);
+    observer.observe(titleElement);
+    return () => observer.disconnect();
+  }, [measure, title]);
+
+  React.useEffect(() => {
+    const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setReducedMotion(preference.matches);
+    updatePreference();
+    preference.addEventListener("change", updatePreference);
+    return () => preference.removeEventListener("change", updatePreference);
+  }, []);
+
+  React.useEffect(() => {
+    if (!pointerHover || metrics.distance === 0 || reducedMotion) {
+      setPointerIntent(false);
+      return;
+    }
+
+    return scheduleSessionTitlePointerIntent(() => setPointerIntent(true));
+  }, [metrics.distance, pointerHover, reducedMotion]);
+
+  const active = shouldMoveSessionTitle(
+    metrics.distance,
+    pointerIntent,
+    keyboardFocused,
+    reducedMotion,
+  );
+
+  return (
+    <span
+      ref={viewportRef}
+      data-session-title-viewport
+      data-overflowing={metrics.distance > 0 ? "true" : undefined}
+      data-moving={transitioning ? "true" : undefined}
+      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap"
+      onPointerEnter={(event) => {
+        if (event.pointerType !== "touch") setPointerHover(true);
+      }}
+      onPointerLeave={() => {
+        setPointerHover(false);
+        setPointerIntent(false);
+      }}
+    >
+      <span
+        ref={titleRef}
+        data-session-title-text
+        className="block w-max max-w-none"
+        title={tooltip}
+        style={{
+          transform: `translateX(-${active ? metrics.distance : 0}px)`,
+          transitionDuration: reducedMotion ? "0ms" : active ? `${metrics.durationMs}ms` : "180ms",
+          transitionProperty: "transform",
+          transitionTimingFunction: active ? "linear" : "ease-out",
+        }}
+        onTransitionRun={(event) => {
+          if (event.propertyName === "transform") setTransitioning(true);
+        }}
+        onTransitionEnd={(event) => {
+          if (event.propertyName === "transform") setTransitioning(false);
+        }}
+        onTransitionCancel={(event) => {
+          if (event.propertyName === "transform") setTransitioning(false);
+        }}
+      >
+        {title}
+      </span>
+    </span>
+  );
+}

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -142,6 +142,19 @@ const SPOTLIGHT_TIMING_MS = Object.freeze({
 
 const wait = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
+export async function waitForControlActionRegistration<T>(
+  read: () => T | null,
+  pause: () => Promise<void>,
+  attempts = 200,
+) {
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    const value = read();
+    if (value) return value;
+    if (attempt < attempts) await pause();
+  }
+  return null;
+}
+
 function describeError(error: unknown) {
   return error instanceof Error ? error.message : String(error || "Unknown error");
 }
@@ -392,7 +405,16 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const executeAction = useCallback(async (actionId: string, args?: unknown): Promise<OpenworkControlResult> => {
-    const registered = actionsRef.current.get(actionId);
+    // The global bridge mounts before route-scoped actions while startup gates
+    // are resolving. Treat the first control call as readiness-sensitive so a
+    // known action does not fail merely because its route is still mounting.
+    const registered = await waitForControlActionRegistration(
+      () => {
+        const candidate = actionsRef.current.get(actionId);
+        return candidate?.ref.current ? candidate : null;
+      },
+      () => wait(50),
+    );
     const action = registered?.ref.current;
     if (!registered || !action) return { ok: false, actionId, error: `Unknown action: ${actionId}` };
     if (action.disabled) return { ok: false, actionId, error: `Action is disabled: ${action.label}` };

--- a/apps/app/tests/control-action-registration.test.ts
+++ b/apps/app/tests/control-action-registration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { waitForControlActionRegistration } from "../src/react-app/shell/control/control-provider";
+
+describe("control action registration readiness", () => {
+  test("returns an action that is already registered", async () => {
+    let pauses = 0;
+    const action = await waitForControlActionRegistration(
+      () => "session.create_task",
+      async () => { pauses += 1; },
+    );
+
+    expect(action).toBe("session.create_task");
+    expect(pauses).toBe(0);
+  });
+
+  test("waits for a route-scoped action to register during startup", async () => {
+    let action: string | null = null;
+    let pauses = 0;
+    const registered = await waitForControlActionRegistration(
+      () => action,
+      async () => {
+        pauses += 1;
+        if (pauses === 2) action = "session.create_task";
+      },
+      3,
+    );
+
+    expect(registered).toBe("session.create_task");
+    expect(pauses).toBe(2);
+  });
+
+  test("still reports actions that never register as unknown", async () => {
+    let pauses = 0;
+    const action = await waitForControlActionRegistration(
+      () => null,
+      async () => { pauses += 1; },
+      2,
+    );
+
+    expect(action).toBeNull();
+    expect(pauses).toBe(2);
+  });
+});

--- a/apps/app/tests/session-title-marquee.test.tsx
+++ b/apps/app/tests/session-title-marquee.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, jest, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  SessionTitleMarquee,
+  getSessionTitleMarqueeMetrics,
+  scheduleSessionTitlePointerIntent,
+  shouldMoveSessionTitle,
+} from "../src/react-app/domains/session/sidebar/session-title-marquee";
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("session title marquee", () => {
+  test("measures only genuine overflow at a constant readable speed", () => {
+    expect(getSessionTitleMarqueeMetrics(160, 160)).toEqual({ distance: 0, durationMs: 0 });
+    expect(getSessionTitleMarqueeMetrics(160.4, 160)).toEqual({ distance: 0, durationMs: 0 });
+    expect(getSessionTitleMarqueeMetrics(232, 160)).toEqual({ distance: 72, durationMs: 2_000 });
+    expect(getSessionTitleMarqueeMetrics(304, 160)).toEqual({ distance: 144, durationMs: 4_000 });
+  });
+
+  test("recalculates distance when nesting, resizing, or action spacing changes the viewport", () => {
+    expect(getSessionTitleMarqueeMetrics(240, 200).distance).toBe(40);
+    expect(getSessionTitleMarqueeMetrics(240, 184).distance).toBe(56);
+    expect(getSessionTitleMarqueeMetrics(240, 152).distance).toBe(88);
+    expect(getSessionTitleMarqueeMetrics(240, 260).distance).toBe(0);
+  });
+
+  test("activates for delayed pointer intent or keyboard focus, but not reduced motion", () => {
+    expect(shouldMoveSessionTitle(80, false, false, false)).toBe(false);
+    expect(shouldMoveSessionTitle(80, true, false, false)).toBe(true);
+    expect(shouldMoveSessionTitle(80, false, true, false)).toBe(true);
+    expect(shouldMoveSessionTitle(80, true, true, true)).toBe(false);
+    expect(shouldMoveSessionTitle(0, true, true, false)).toBe(false);
+  });
+
+  test("delays hover activation and cleanup cancels pending intent", () => {
+    jest.useFakeTimers();
+    let activations = 0;
+    const cancel = scheduleSessionTitlePointerIntent(() => activations += 1);
+
+    jest.advanceTimersByTime(499);
+    expect(activations).toBe(0);
+    cancel();
+    jest.advanceTimersByTime(1);
+    expect(activations).toBe(0);
+
+    scheduleSessionTitlePointerIntent(() => activations += 1);
+    jest.advanceTimersByTime(500);
+    expect(activations).toBe(1);
+  });
+
+  test("keeps the full tooltip and accessible text in stable single-line markup", () => {
+    const title = "A complete and deliberately long session title";
+    const html = renderToStaticMarkup(
+      <SessionTitleMarquee keyboardFocused={false} title={title} tooltip={title} />,
+    );
+
+    expect(html).toContain("data-session-title-viewport");
+    expect(html).toContain("overflow-hidden whitespace-nowrap");
+    expect(html).toContain(`title="${title}"`);
+    expect(html).toContain(title);
+    expect(html).not.toContain("tabindex");
+  });
+});


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

<!-- open-work-snacks-run:bfd0aff0-7f6e-4d58-ada3-e4a28f52cc02 -->
## Summary

- Animates genuinely overflowing chat titles after hover or keyboard-focus intent.
- Keeps fitting titles, row controls, selected states, and reduced-motion behavior stable.
- Adds a bounded control-bridge readiness fix needed by the Electron evaluator.

## What changed

- `apps/app/src/app/index.css`
- `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx`
- `apps/app/src/react-app/domains/session/sidebar/session-title-marquee.tsx`
- `apps/app/src/react-app/shell/control/control-provider.tsx`
- `apps/app/tests/control-action-registration.test.ts`
- `apps/app/tests/session-title-marquee.test.tsx`

## Why

Long chat titles should become readable without shifting sidebar controls or adding continuous motion. The behavior remains intent-driven and respects reduced-motion preferences.

## Verification

- [x] Control and sidebar tests — 22 passed, 0 failed
- [x] App typecheck — passed
- [x] `git diff --check` — passed
- [ ] Electron semantic inspection — skipped because the read-only inspection call was cancelled
- [ ] Electron acceptance proof — **0 passed, 1 failed, 0 skipped**
- Failure: the evaluator reached the flow but `Runtime.evaluate` timed out after 20 seconds before the assertion completed.
- Result: **qualified, not fully verified**; no successful public proof frame was produced.

### Acceptance target

- [ ] `sidebar-title-hover-marquee` (Electron) — not proven: only overflowing titles should move after intent, controls must remain usable, exit should restore rest, and reduced-motion should stay truncated and accessible.

## Exact candidate

- Base: `0de0798228d617eb71a4ed393e1d8793d5d0f0ba`
- Head: `c3f41c9da80f57bfc352ec156b5056cbaa98a8ea`
- Run: `bfd0aff0-7f6e-4d58-ada3-e4a28f52cc02`

## Automation boundary

