### PR TITLE
feat(release): make the Daytona snapshot pin follow releases, and reject untagged snapshots

### DIFF
--- a/.github/workflows/daytona-snapshot-drift.yml
+++ b/.github/workflows/daytona-snapshot-drift.yml
@@ -1,0 +1,74 @@
+name: Daytona Snapshot Drift
+
+on:
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-snapshot-pin:
+    name: Compare production pin with latest release
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
+      DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
+      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+
+    steps:
+      - name: Check drift configuration
+        id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=""
+          [ -z "${DAYTONA_CLOUD_ENV_GROUP_ID:-}" ] && missing="$missing DAYTONA_CLOUD_ENV_GROUP_ID"
+          [ -z "${RENDER_API_KEY:-}" ] && missing="$missing RENDER_API_KEY"
+          if [ -n "$missing" ]; then
+            echo "::notice::Skipping Daytona snapshot drift check; missing GitHub configuration:$missing."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.config.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+
+      - name: Resolve expected snapshot from latest release
+        if: steps.config.outputs.enabled == 'true'
+        id: expected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          release_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Latest GitHub release returned invalid tag: ${release_tag}"
+            exit 1
+          fi
+
+          base_name="${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}"
+          snapshot_name="${base_name}-${release_tag#v}"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "snapshot_name=$snapshot_name" >> "$GITHUB_OUTPUT"
+          echo "Expected snapshot for ${release_tag}: ${snapshot_name}"
+
+      - name: Compare production snapshot pin
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        env:
+          EXPECTED_SNAPSHOT_NAME: ${{ steps.expected.outputs.snapshot_name }}
+        run: |
+          set -euo pipefail
+
+          node scripts/update-daytona-snapshot-pin.mjs \
+            --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" \
+            --snapshot "$EXPECTED_SNAPSHOT_NAME" \
+            --compare

--- a/.github/workflows/daytona-snapshot-drift.yml
+++ b/.github/workflows/daytona-snapshot-drift.yml
@@ -48,9 +48,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          release_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          release_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq 'map(select(.draft == false))[0].tag_name')"
           if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Latest GitHub release returned invalid tag: ${release_tag}"
+            echo "::error::Newest published GitHub release returned invalid tag: ${release_tag}"
             exit 1
           fi
 

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -82,6 +82,21 @@ jobs:
           echo "snapshot_name=$snapshot_name" >> "$GITHUB_OUTPUT"
           echo "snapshot_region=$snapshot_region" >> "$GITHUB_OUTPUT"
 
+      - name: Verify release ref is a tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if ! git ls-remote --exit-code --tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            echo "::error::Ref ${RELEASE_TAG} does not exist as a tag in ${GITHUB_REPOSITORY}."
+            exit 1
+          fi
+          echo "Verified tag: ${RELEASE_TAG}"
+
       - name: Checkout release source
         uses: actions/checkout@v6
         with:
@@ -132,6 +147,7 @@ jobs:
           daytona version
 
       - name: Build and push snapshot
+        id: publish
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -153,3 +169,37 @@ jobs:
 
           echo "Publishing Daytona snapshot: ${DAYTONA_SNAPSHOT_NAME}"
           ./scripts/create-daytona-openwork-snapshot.sh "${DAYTONA_SNAPSHOT_NAME}"
+
+      - name: Update production snapshot pin
+        if: steps.publish.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DAYTONA_CLOUD_ENV_GROUP_ID:-}" ]; then
+            echo "::notice::DAYTONA_CLOUD_ENV_GROUP_ID is not configured; skipping production snapshot pin update."
+            {
+              echo "### Daytona snapshot pin"
+              echo
+              echo "Skipped: repository variable \`DAYTONA_CLOUD_ENV_GROUP_ID\` is not configured."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -z "${RENDER_API_KEY:-}" ]; then
+            echo "::error::Missing required secret: RENDER_API_KEY"
+            exit 1
+          fi
+
+          result="$(node scripts/update-daytona-snapshot-pin.mjs \
+            --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" \
+            --snapshot "$DAYTONA_SNAPSHOT_NAME")"
+          echo "$result"
+          {
+            echo "### Daytona snapshot pin"
+            echo
+            echo "$result"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ steps.resolve.outputs.release_tag }}
+          ref: refs/tags/${{ steps.resolve.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -170,6 +170,15 @@ jobs:
           echo "Publishing Daytona snapshot: ${DAYTONA_SNAPSHOT_NAME}"
           ./scripts/create-daytona-openwork-snapshot.sh "${DAYTONA_SNAPSHOT_NAME}"
 
+      - name: Checkout snapshot pin automation
+        if: steps.publish.outcome == 'success' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .snapshot-pin-automation
+          sparse-checkout: scripts/update-daytona-snapshot-pin.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Update production snapshot pin
         if: steps.publish.outcome == 'success'
         shell: bash
@@ -194,7 +203,7 @@ jobs:
             exit 1
           fi
 
-          result="$(node scripts/update-daytona-snapshot-pin.mjs \
+          result="$(node .snapshot-pin-automation/scripts/update-daytona-snapshot-pin.mjs \
             --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" \
             --snapshot "$DAYTONA_SNAPSHOT_NAME")"
           echo "$result"

--- a/scripts/update-daytona-snapshot-pin.mjs
+++ b/scripts/update-daytona-snapshot-pin.mjs
@@ -1,0 +1,234 @@
+import process from "node:process"
+import { pathToFileURL } from "node:url"
+
+const RENDER_API_BASE_URL = "https://api.render.com/v1"
+const SNAPSHOT_ENV_VAR_KEY = "DAYTONA_SNAPSHOT"
+
+function requiredValue(value, message) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(message)
+  }
+
+  return value.trim()
+}
+
+function validateSnapshotName(snapshotName) {
+  const value = requiredValue(
+    snapshotName,
+    "Missing snapshot name. Pass --snapshot <name>.",
+  )
+
+  if (value !== snapshotName || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    throw new Error(
+      `Invalid snapshot name ${JSON.stringify(snapshotName)}. Use only letters, numbers, dots, underscores, and hyphens, with no whitespace.`,
+    )
+  }
+
+  return value
+}
+
+function envVarUrl(envGroupId) {
+  const id = requiredValue(
+    envGroupId,
+    "Missing env group id. Pass --env-group-id <id>.",
+  )
+  return `${RENDER_API_BASE_URL}/env-groups/${encodeURIComponent(id)}/env-vars/${SNAPSHOT_ENV_VAR_KEY}`
+}
+
+function authorizationHeaders(apiKey) {
+  const key = requiredValue(
+    apiKey,
+    "Missing Render API key. Set RENDER_API_KEY before running this command.",
+  )
+  return {
+    Accept: "application/json",
+    Authorization: `Bearer ${key}`,
+  }
+}
+
+async function responseBody(response) {
+  const body = await response.text()
+  if (!response.ok) {
+    const statusText = response.statusText ? ` ${response.statusText}` : ""
+    throw new Error(
+      `Render API request failed with HTTP ${response.status}${statusText}: ${body}`,
+    )
+  }
+  return body
+}
+
+export function updateRequest(envGroupId, snapshotName) {
+  const value = validateSnapshotName(snapshotName)
+  return {
+    method: "PUT",
+    url: envVarUrl(envGroupId),
+    body: JSON.stringify({ value }),
+  }
+}
+
+export async function readDaytonaSnapshotPin({
+  envGroupId,
+  apiKey,
+  fetchImpl = globalThis.fetch,
+}) {
+  const url = envVarUrl(envGroupId)
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: authorizationHeaders(apiKey),
+  })
+  const body = await responseBody(response)
+
+  let parsed
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    throw new Error(`Render API returned invalid JSON for ${SNAPSHOT_ENV_VAR_KEY}: ${body}`)
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    typeof parsed.value !== "string"
+  ) {
+    throw new Error(
+      `Render API response did not contain a string value for ${SNAPSHOT_ENV_VAR_KEY}: ${body}`,
+    )
+  }
+
+  return parsed.value
+}
+
+export async function updateDaytonaSnapshotPin({
+  envGroupId,
+  snapshotName,
+  apiKey,
+  dryRun = false,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+}) {
+  const request = updateRequest(envGroupId, snapshotName)
+  authorizationHeaders(apiKey)
+
+  if (dryRun) {
+    log("dry-run: no request sent")
+    log(`method: ${request.method}`)
+    log(`url: ${request.url}`)
+    log(`body: ${request.body}`)
+    return { status: "dry-run", snapshotName }
+  }
+
+  const current = await readDaytonaSnapshotPin({
+    envGroupId,
+    apiKey,
+    fetchImpl,
+  })
+  if (current === snapshotName) {
+    const message = `unchanged: ${SNAPSHOT_ENV_VAR_KEY} is already ${snapshotName}`
+    log(message)
+    return { status: "unchanged", current, snapshotName, message }
+  }
+
+  const response = await fetchImpl(request.url, {
+    method: request.method,
+    headers: {
+      ...authorizationHeaders(apiKey),
+      "Content-Type": "application/json",
+    },
+    body: request.body,
+  })
+  await responseBody(response)
+
+  const message = `updated: ${SNAPSHOT_ENV_VAR_KEY} ${current} -> ${snapshotName}`
+  log(message)
+  return { status: "updated", current, snapshotName, message }
+}
+
+export async function compareDaytonaSnapshotPin({
+  envGroupId,
+  snapshotName,
+  apiKey,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+}) {
+  const expected = validateSnapshotName(snapshotName)
+  const current = await readDaytonaSnapshotPin({
+    envGroupId,
+    apiKey,
+    fetchImpl,
+  })
+
+  if (current !== expected) {
+    throw new Error(
+      `Daytona snapshot drift: expected ${SNAPSHOT_ENV_VAR_KEY}=${expected}, found ${SNAPSHOT_ENV_VAR_KEY}=${current}`,
+    )
+  }
+
+  const message = `agreement: ${SNAPSHOT_ENV_VAR_KEY}=${expected}`
+  log(message)
+  return { status: "agreement", current, snapshotName: expected, message }
+}
+
+function optionValue(args, index, option) {
+  const value = args[index + 1]
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}.`)
+  }
+  return value
+}
+
+export function parseArgs(args) {
+  const options = {
+    envGroupId: "",
+    snapshotName: "",
+    dryRun: false,
+    compare: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === "--env-group-id") {
+      options.envGroupId = optionValue(args, index, argument)
+      index += 1
+    } else if (argument === "--snapshot") {
+      options.snapshotName = optionValue(args, index, argument)
+      index += 1
+    } else if (argument === "--dry-run") {
+      options.dryRun = true
+    } else if (argument === "--compare") {
+      options.compare = true
+    } else {
+      throw new Error(`Unknown argument: ${argument}`)
+    }
+  }
+
+  if (options.dryRun && options.compare) {
+    throw new Error("--dry-run and --compare cannot be used together.")
+  }
+
+  return options
+}
+
+export async function main(args, environment = process.env) {
+  const options = parseArgs(args)
+  const input = {
+    envGroupId: options.envGroupId,
+    snapshotName: options.snapshotName,
+    apiKey: environment.RENDER_API_KEY,
+  }
+
+  if (options.compare) {
+    return compareDaytonaSnapshotPin(input)
+  }
+
+  return updateDaytonaSnapshotPin({ ...input, dryRun: options.dryRun })
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+  main(process.argv.slice(2)).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Error: ${message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/update-daytona-snapshot-pin.mjs
+++ b/scripts/update-daytona-snapshot-pin.mjs
@@ -177,12 +177,31 @@ function optionValue(args, index, option) {
   return value
 }
 
+export const USAGE = `Update or check the Daytona sandbox snapshot pin (DAYTONA_SNAPSHOT) in a Render env group.
+
+Usage:
+  node scripts/update-daytona-snapshot-pin.mjs --env-group-id <id> --snapshot <name> [--dry-run]
+  node scripts/update-daytona-snapshot-pin.mjs --env-group-id <id> --snapshot <name> --compare
+
+Options:
+  --env-group-id <id>  Render env group holding DAYTONA_SNAPSHOT (e.g. evg-...).
+  --snapshot <name>    Desired snapshot name (e.g. openwork-0.18.11).
+  --dry-run            Print the request that would be sent; write nothing.
+  --compare            Read-only drift check; exits non-zero when the pin differs.
+  -h, --help           Show this help.
+
+Environment:
+  RENDER_API_KEY       Required (except with --help).
+
+This mutates which image every cloud sandbox boots. Prefer --dry-run or --compare first.`
+
 export function parseArgs(args) {
   const options = {
     envGroupId: "",
     snapshotName: "",
     dryRun: false,
     compare: false,
+    help: false,
   }
 
   for (let index = 0; index < args.length; index += 1) {
@@ -197,9 +216,15 @@ export function parseArgs(args) {
       options.dryRun = true
     } else if (argument === "--compare") {
       options.compare = true
+    } else if (argument === "--help" || argument === "-h") {
+      options.help = true
     } else {
       throw new Error(`Unknown argument: ${argument}`)
     }
+  }
+
+  if (options.help) {
+    return options
   }
 
   if (options.dryRun && options.compare) {
@@ -211,6 +236,10 @@ export function parseArgs(args) {
 
 export async function main(args, environment = process.env) {
   const options = parseArgs(args)
+  if (options.help) {
+    console.log(USAGE)
+    return { status: "help" }
+  }
   const input = {
     envGroupId: options.envGroupId,
     snapshotName: options.snapshotName,

--- a/scripts/update-daytona-snapshot-pin.test.mjs
+++ b/scripts/update-daytona-snapshot-pin.test.mjs
@@ -73,11 +73,18 @@ test("a different pin makes exactly one documented PUT and reports the transitio
 })
 
 test("a non-2xx response fails with the status and response body", async () => {
-  const fetchImpl = async () =>
-    new Response("upstream exploded", {
+  const fetchImpl = async (_url, options) => {
+    if (options.method === "GET") {
+      return jsonResponse({
+        key: "DAYTONA_SNAPSHOT",
+        value: "openwork-0.18.9",
+      })
+    }
+    return new Response("upstream exploded", {
       status: 503,
       statusText: "Service Unavailable",
     })
+  }
 
   await assert.rejects(
     updateDaytonaSnapshotPin({

--- a/scripts/update-daytona-snapshot-pin.test.mjs
+++ b/scripts/update-daytona-snapshot-pin.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  compareDaytonaSnapshotPin,
+  updateDaytonaSnapshotPin,
+} from "./update-daytona-snapshot-pin.mjs"
+
+const envGroupId = "evg-d83537f2gups73em0m90"
+const apiKey = "test-render-api-key"
+const snapshotName = "openwork-0.18.10"
+const expectedUrl =
+  "https://api.render.com/v1/env-groups/evg-d83537f2gups73em0m90/env-vars/DAYTONA_SNAPSHOT"
+
+function jsonResponse(value, init) {
+  return new Response(JSON.stringify(value), init)
+}
+
+test("an already-correct pin makes zero write requests and reports unchanged", async () => {
+  const calls = []
+  const messages = []
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options })
+    return jsonResponse({ key: "DAYTONA_SNAPSHOT", value: snapshotName })
+  }
+
+  const result = await updateDaytonaSnapshotPin({
+    envGroupId,
+    snapshotName,
+    apiKey,
+    fetchImpl,
+    log: (message) => messages.push(message),
+  })
+
+  assert.equal(result.status, "unchanged")
+  assert.equal(calls.filter((call) => call.options.method === "PUT").length, 0)
+  assert.deepEqual(messages, [
+    "unchanged: DAYTONA_SNAPSHOT is already openwork-0.18.10",
+  ])
+})
+
+test("a different pin makes exactly one documented PUT and reports the transition", async () => {
+  const calls = []
+  const messages = []
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options })
+    if (options.method === "GET") {
+      return jsonResponse({
+        key: "DAYTONA_SNAPSHOT",
+        value: "openwork-0.18.9",
+      })
+    }
+    return jsonResponse({ id: envGroupId })
+  }
+
+  const result = await updateDaytonaSnapshotPin({
+    envGroupId,
+    snapshotName,
+    apiKey,
+    fetchImpl,
+    log: (message) => messages.push(message),
+  })
+
+  const writes = calls.filter((call) => call.options.method === "PUT")
+  assert.equal(result.status, "updated")
+  assert.equal(writes.length, 1)
+  assert.equal(writes[0].url, expectedUrl)
+  assert.equal(writes[0].options.body, '{"value":"openwork-0.18.10"}')
+  assert.equal(writes[0].options.headers["Content-Type"], "application/json")
+  assert.deepEqual(messages, [
+    "updated: DAYTONA_SNAPSHOT openwork-0.18.9 -> openwork-0.18.10",
+  ])
+})
+
+test("a non-2xx response fails with the status and response body", async () => {
+  const fetchImpl = async () =>
+    new Response("upstream exploded", {
+      status: 503,
+      statusText: "Service Unavailable",
+    })
+
+  await assert.rejects(
+    updateDaytonaSnapshotPin({
+      envGroupId,
+      snapshotName,
+      apiKey,
+      fetchImpl,
+    }),
+    (error) => {
+      assert.match(error.message, /503 Service Unavailable/)
+      assert.match(error.message, /upstream exploded/)
+      return true
+    },
+  )
+})
+
+test("empty or missing snapshot names are refused before any request", async (context) => {
+  for (const invalidName of [undefined, "", "   "]) {
+    await context.test(JSON.stringify(invalidName), async () => {
+      let requests = 0
+      await assert.rejects(
+        updateDaytonaSnapshotPin({
+          envGroupId,
+          snapshotName: invalidName,
+          apiKey,
+          fetchImpl: async () => {
+            requests += 1
+            return jsonResponse({})
+          },
+        }),
+        /Missing snapshot name/,
+      )
+      assert.equal(requests, 0)
+    })
+  }
+})
+
+test("an obviously invalid snapshot name is refused before any request", async () => {
+  await assert.rejects(
+    updateDaytonaSnapshotPin({
+      envGroupId,
+      snapshotName: "not/a snapshot",
+      apiKey,
+      fetchImpl: async () => jsonResponse({}),
+    }),
+    /Invalid snapshot name/,
+  )
+})
+
+test("a missing env group id is refused with an actionable message", async () => {
+  await assert.rejects(
+    updateDaytonaSnapshotPin({
+      envGroupId: " ",
+      snapshotName,
+      apiKey,
+      fetchImpl: async () => jsonResponse({}),
+    }),
+    /Missing env group id\. Pass --env-group-id <id>/,
+  )
+})
+
+test("dry-run makes no requests and prints the exact proposed request", async () => {
+  let requests = 0
+  const messages = []
+
+  const result = await updateDaytonaSnapshotPin({
+    envGroupId,
+    snapshotName,
+    apiKey,
+    dryRun: true,
+    fetchImpl: async () => {
+      requests += 1
+      return jsonResponse({})
+    },
+    log: (message) => messages.push(message),
+  })
+
+  assert.equal(result.status, "dry-run")
+  assert.equal(requests, 0)
+  assert.deepEqual(messages, [
+    "dry-run: no request sent",
+    "method: PUT",
+    `url: ${expectedUrl}`,
+    'body: {"value":"openwork-0.18.10"}',
+  ])
+})
+
+test("compare mode reports agreement without writing", async () => {
+  const calls = []
+  const messages = []
+  const result = await compareDaytonaSnapshotPin({
+    envGroupId,
+    snapshotName,
+    apiKey,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options })
+      return jsonResponse({ key: "DAYTONA_SNAPSHOT", value: snapshotName })
+    },
+    log: (message) => messages.push(message),
+  })
+
+  assert.equal(result.status, "agreement")
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].options.method, "GET")
+  assert.deepEqual(messages, ["agreement: DAYTONA_SNAPSHOT=openwork-0.18.10"])
+})
+
+test("compare mode fails with a clear diff when drift is detected", async () => {
+  await assert.rejects(
+    compareDaytonaSnapshotPin({
+      envGroupId,
+      snapshotName,
+      apiKey,
+      fetchImpl: async () =>
+        jsonResponse({
+          key: "DAYTONA_SNAPSHOT",
+          value: "openwork-0.18.9",
+        }),
+    }),
+    /expected DAYTONA_SNAPSHOT=openwork-0\.18\.10, found DAYTONA_SNAPSHOT=openwork-0\.18\.9/,
+  )
+})


### PR DESCRIPTION
Cloud sandboxes boot whichever image `DAYTONA_SNAPSHOT` names. Nothing ever wrote that pin, so it moved only by hand — and today production is pinned to `openwork-0.18.9-cloudproviders`, an image that corresponds to **no release tag**.

## How that happened (my fault)

`release-daytona-snapshot.yml` validated only that the tag *string* looked like a tag, then checked out that ref. I pointed it at a **branch** named `v0.18.9-cloudproviders` to ship provider materialization without cutting a release. It worked, and the fleet has been running an untraceable image since.

## What this adds

1. **`scripts/update-daytona-snapshot-pin.mjs`** — logic in a tested script rather than inline YAML. Reads the current pin, writes only when it differs (`unchanged` otherwise), refuses empty/invalid snapshot names or a missing env group id, and fails loudly with status + response body on any non-2xx. Injectable `fetch`, plus `--dry-run` and read-only `--compare`.
2. **Pin update wired into the release** — after a successful publish, the pin is set from the release tag and the transition is written to the job summary. Env group id comes from repo variable `DAYTONA_CLOUD_ENV_GROUP_ID` (already set); if absent it emits a notice instead of failing the release.
3. **The branch-as-tag hole is closed** — the ref is now verified to exist as an actual tag (`git ls-remote --exit-code --tags … refs/tags/$TAG`) before checkout, and the checkout uses `refs/tags/$TAG`. What I did earlier can no longer happen.
4. **`daytona-snapshot-drift.yml`** — daily + manual check comparing the live pin against the newest published release, failing with an explicit diff so a stale fleet is visible instead of silent.

## Verification against live Render (read-only, by me — not the agent)

Endpoint confirmed from Render's OpenAPI spec and then against the real API:

```
GET /v1/env-groups/evg-d83537f2gups73em0m90/env-vars/DAYTONA_SNAPSHOT
HTTP 200  {"key":"DAYTONA_SNAPSHOT","value":"openwork-0.18.9-cloudproviders"}
```

```
--compare openwork-0.18.11              -> exit 1  "drift: expected …0.18.11, found …0.18.9-cloudproviders"
--compare openwork-0.18.9-cloudproviders -> exit 0  "agreement"
--dry-run openwork-0.18.11               -> no request sent; prints PUT + body
```

Unit tests: `node --test scripts/update-daytona-snapshot-pin.test.mjs` — **12 pass / 0 fail**, covering unchanged/changed/non-2xx/empty-name/missing-id/dry-run/compare.

Workflows: `node --check`, YAML parse, and filtered `actionlint` clean (raw actionlint only flags the pre-existing Blacksmith runner labels and an existing SC2129).

## Notes

- I added `--help` to the CLI. Earlier today I accidentally dispatched a workflow because a sibling script lacked one; a script that mutates which image every sandbox boots should say what it does before it does it.
- Unrelated stale state worth a follow-up: there is also a **repo variable** `DAYTONA_SNAPSHOT = openwork-260316` (March). Production reads the Render env group, not this, so it is inert here — but two things named `DAYTONA_SNAPSHOT` is a trap.
- This PR does not rebuild or recycle anything. Cutting the real `v0.18.11` tag is the next step and will exercise the automation end to end.