### PR TITLE
chore(release): v0.18.11

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.10",
+  "version": "0.18.11",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.10",
+  "version": "0.18.11",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.10",
+  "version": "0.18.11",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.11",
   "0.18.10",
   "0.18.9",
   "0.18.8",


### PR DESCRIPTION
Version bump for `v0.18.11`, produced by `node scripts/release/prepare.mjs --ci patch`.

Cutting a real tag so the cloud sandbox fleet stops running an untagged image. Today's pin is `openwork-0.18.9-cloudproviders`, which I built from a **branch** named like a tag — it corresponds to no release. #3318 closed that hole and made the pin follow releases; this is the first release to exercise it.

Release review is clean at 0.18.11:

```
ok: App/desktop versions match
ok: App/openwork-server versions match
ok: OpenCode version pin exists (1.17.11)
```

On tag push the workflow creates a **draft** release ("Keep tag-triggered releases out of /releases/latest until assets + latest.json are ready"), so the stable desktop channel is not promoted by this. I'll mark it prerelease explicitly once assets land.

It also publishes the Daytona snapshot (`openwork-0.18.11`) and — new in #3318 — updates the `DAYTONA_SNAPSHOT` pin, after which instances recycle onto it via checkpoint/restore (~30s each).