### PR TITLE
fix(release): redeploy den-api after updating the snapshot pin

### DIFF
--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -180,6 +180,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Update production snapshot pin
+        id: pin
         if: steps.publish.outcome == 'success'
         shell: bash
         env:
@@ -211,4 +212,39 @@ jobs:
             echo "### Daytona snapshot pin"
             echo
             echo "$result"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Redeploy den-api so the new pin takes effect
+        # Render does not redeploy services when an env group value changes, so
+        # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
+        # Without this the pin moves but `latestVersion` stays stale and no
+        # sandbox ever recycles - observed for real on v0.18.11.
+        if: steps.pin.outcome == 'success'
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_DEN_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RENDER_DEN_SERVICE_ID:-}" ] || [ -z "${RENDER_API_KEY:-}" ]; then
+            echo "::notice::Render den-api credentials unavailable; skipping redeploy. The pin will take effect on the next den-api deploy."
+            exit 0
+          fi
+
+          response="$(curl -s -w '\n%{http_code}' -X POST \
+            "https://api.render.com/v1/services/${RENDER_DEN_SERVICE_ID}/deploys" \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}')"
+          code="$(printf '%s' "$response" | tail -1)"
+          body="$(printf '%s' "$response" | sed '$d')"
+          if [ "$code" -ge 400 ]; then
+            echo "::error::POST /deploys returned HTTP $code: $body"
+            exit 1
+          fi
+
+          {
+            echo
+            echo "Triggered a den-api deploy so the new pin takes effect."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Gap in #3318, found by driving the real v0.18.11 release rather than trusting it.

## What happened

The release published `openwork-0.18.11` and the automation moved the pin correctly:

```
snapshot-job=completed/success   pin=openwork-0.18.11
```

But nothing recycled, and `POST /v1/cloud/instance/update` answered `{"ok":false,"error":"already_current"}`. The reason:

```
imageVersion:  openwork-0.18.9-cloudproviders
latestVersion: openwork-0.18.9-cloudproviders   <- den-api still serving the OLD pin
```

**Render does not redeploy services when an env group value changes.** den-api kept its process env, so `latestVersion` stayed stale, `shouldRecycleDaytonaSandbox` never saw a version difference, and the fleet would have sat on the old image indefinitely. I had to POST a deploy by hand; afterwards `latestVersion` became `openwork-0.18.11` and the recycle worked:

```
imageVersion:  openwork-0.18.11
latestVersion: openwork-0.18.11
sandbox:       den-daytona-worker-cloud-gateway-test-wrk-01ky-openwork-0-18-11
```

The precedent workflow `den-api-env.yml` already does update-then-deploy; #3318 only did the update half. My mistake.

## Fix

After a successful pin update, POST a den-api deploy using the existing `RENDER_DEN_CONTROL_PLANE_SERVICE_ID` secret, failing loudly on 4xx and skipping with a notice when credentials are unavailable. YAML verified to parse.

## Not fixed here

While validating I found that **#3307's no-op guard does not work in production**. On the 0.18.11 image an identical patch reports `changed=false` but still `reload="reloaded"`, and the engine disposes (`disposals 3 -> 4`) even though the config file is byte-identical (`sha=1b1e31152dbf` before and after). I confirmed the running binary genuinely contains #3307's code, so `fileResult.changed` is returning true for an unchanged file. Mechanism not yet isolated; filed separately rather than guessed at. It is defence-in-depth only — #3301 already stops the redundant patches that caused the incident.