### PR TITLE
fix(server): skip duplicate managed MCP startup sync

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -36,6 +36,7 @@ const logger = createServerLogger(config);
 const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
 let managedOpencode: ManagedOpencodeServer | null = null;
 let managedOpencodeIdentity: string | null = null;
+let managedRuntimeConfigWorkspaceId: string | null = null;
 
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
@@ -48,6 +49,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
     // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
     // on every runtime-DB write — so disposes always pick up current state.
     const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    managedRuntimeConfigWorkspaceId = workspace.id;
     keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
@@ -92,11 +94,17 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
 const server = await startServer(config);
 const workerActivityHeartbeat = startWorkerActivityHeartbeat(config, logger);
 
-// The runtime config file above only covers workspaces[0]. Push every
-// workspace's runtime-DB MCPs into the engine so they aren't invisible
-// until a manual reload. Best-effort.
+// The runtime config file above already covers the managed workspace. Push
+// the remaining workspaces' runtime-DB MCPs into the engine so they aren't
+// invisible until a manual reload. Best-effort.
 if (managedOpencode) {
-  void syncAllWorkspacesRuntimeMcpToEngine(config);
+  if (managedRuntimeConfigWorkspaceId) {
+    void syncAllWorkspacesRuntimeMcpToEngine(config, {
+      skipRuntimeMcpWorkspaceIds: new Set([managedRuntimeConfigWorkspaceId]),
+    });
+  } else {
+    void syncAllWorkspacesRuntimeMcpToEngine(config);
+  }
 }
 
 const url = `http://${config.host}:${server.port}`;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -53,6 +53,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
   let managedOpencode: ManagedOpencodeServer | null = null;
   let managedOpencodeIdentity: string | null = null;
+  let managedRuntimeConfigWorkspaceId: string | null = null;
 
   if (!config.readOnly) {
     await ensureLocalWorkspaceFiles(config.workspaces);
@@ -65,6 +66,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
       // on every runtime-DB write — so disposes always pick up current state.
       const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+      managedRuntimeConfigWorkspaceId = workspace.id;
       keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
       const cwd = options.opencodeCwd
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
@@ -118,11 +120,17 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   const server = await startServer(config);
 
-  // The runtime config file above only covers workspaces[0]. Push every
-  // workspace's runtime-DB MCPs into the engine so they aren't invisible
-  // until a manual reload. Best-effort.
+  // The runtime config file above already covers the managed workspace. Push
+  // the remaining workspaces' runtime-DB MCPs into the engine so they aren't
+  // invisible until a manual reload. Best-effort.
   if (managedOpencode) {
-    void syncAllWorkspacesRuntimeMcpToEngine(config);
+    if (managedRuntimeConfigWorkspaceId) {
+      void syncAllWorkspacesRuntimeMcpToEngine(config, {
+        skipRuntimeMcpWorkspaceIds: new Set([managedRuntimeConfigWorkspaceId]),
+      });
+    } else {
+      void syncAllWorkspacesRuntimeMcpToEngine(config);
+    }
   }
 
   return {

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -977,6 +977,50 @@ describe("runtime MCP engine sync", () => {
     }
   });
 
+  test("startup sync skips the managed workspace already covered by OPENCODE_CONFIG", async () => {
+    const rootA = await createWorkspaceRoot();
+    const rootB = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(rootA, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+      const config: ServerConfig = {
+        host: "127.0.0.1",
+        port: 0,
+        token: "owt_test_token",
+        hostToken: "owt_host_token",
+        approval: { mode: "auto", timeoutMs: 1000 },
+        corsOrigins: ["*"],
+        workspaces: [
+          { id: "ws_1", name: "A", path: rootA, preset: "starter", workspaceType: "local", baseUrl },
+          { id: "ws_2", name: "B", path: rootB, preset: "starter", workspaceType: "local", baseUrl },
+        ],
+        authorizedRoots: [rootA, rootB],
+        readOnly: false,
+        startedAt: Date.now(),
+        tokenSource: "cli",
+        hostTokenSource: "cli",
+        logFormat: "pretty",
+        logRequests: false,
+      };
+
+      await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({ ...current, mcp: { posthog: POSTHOG_CONFIG } }));
+      await writeRuntimeOpencodeConfig(config, "ws_2", (current) => ({ ...current, mcp: { stripe: POSTHOG_CONFIG } }));
+
+      await syncAllWorkspacesRuntimeMcpToEngine(config, {
+        skipRuntimeMcpWorkspaceIds: new Set(["ws_1"]),
+      });
+
+      const syncs = mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(syncs.map((entry) => (entry.body as { name?: string } | null)?.name)).toEqual(["stripe"]);
+      expect(syncs[0]?.search).toContain(`directory=${encodeURIComponent(rootB)}`);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
   test("MCP add still succeeds when the engine is unreachable", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const previousDb = process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4255,23 +4255,32 @@ function logPersistedCloudMcpReconcileError(input: {
   );
 }
 
+type SyncAllWorkspacesRuntimeMcpOptions = {
+  skipRuntimeMcpWorkspaceIds?: ReadonlySet<string>;
+};
+
 // Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
-// the runtime config file injected via OPENCODE_CONFIG covers workspaces[0]
-// only, so other workspaces' runtime MCPs are invisible to the engine until
-// something re-syncs them. Best-effort.
-export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
+// the runtime config file injected via OPENCODE_CONFIG covers the managed
+// engine workspace only, so other workspaces' runtime MCPs are invisible to
+// the engine until something re-syncs them. Best-effort.
+export async function syncAllWorkspacesRuntimeMcpToEngine(
+  config: ServerConfig,
+  options: SyncAllWorkspacesRuntimeMcpOptions = {},
+): Promise<void> {
   const serverState = activeEngineMcpServerState(config) ?? null;
   for (const workspace of config.workspaces) {
-    try {
-      await syncRuntimeMcpToOpencodeEngine(
-        config,
-        workspace,
-        undefined,
-        undefined,
-        serverState,
-      );
-    } catch (error) {
-      logRuntimeMcpSyncError({ config, workspace, trigger: "startup", error });
+    if (!options.skipRuntimeMcpWorkspaceIds?.has(workspace.id)) {
+      try {
+        await syncRuntimeMcpToOpencodeEngine(
+          config,
+          workspace,
+          undefined,
+          undefined,
+          serverState,
+        );
+      } catch (error) {
+        logRuntimeMcpSyncError({ config, workspace, trigger: "startup", error });
+      }
     }
     try {
       const health = await reconcilePersistedOpenworkCloudMcp({


### PR DESCRIPTION
## Summary

Prevents managed local MCP servers from being registered twice during OpenWork startup.

When OpenWork manages the OpenCode sidecar, the managed workspace MCP config is already injected through `OPENCODE_CONFIG`. Startup was also pushing that same workspace's runtime MCPs into the engine again, which can start local stdio MCP servers twice.

This skips that duplicate startup sync for the managed workspace while still syncing other workspaces.

## Issue

- Closes #3325

## Testing

- `pnpm --filter openwork-server exec bun test src/mcp.engine-sync.e2e.test.ts` — passed, 21 tests
- `pnpm --filter openwork-server typecheck` — passed
- `git diff --check` — passed

## Manual verification

I could not verify the Windows process-tree repro directly from macOS. The regression test verifies the root mechanism: the managed workspace's MCP is no longer POSTed to `/mcp` again at startup, while a second non-managed workspace still syncs normally.

## Risk

Low — the skip only applies to the one workspace already covered by `OPENCODE_CONFIG`; every other workspace still goes through the normal sync path.