### PR TITLE
feat(den-api): convert Office uploads to native Google Docs, and stop advertising an impossible inline base64 limit

### DIFF
--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -38,6 +38,12 @@ const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
 const MAX_GMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENTS_TOTAL_BYTES = 20 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENT_BASE64_LENGTH = Math.ceil(MAX_GMAIL_ATTACHMENT_BYTES / 3) * 4
+const uploadDriveFileConversionSchema = z.enum(["document", "spreadsheet", "presentation"])
+const DRIVE_CONVERSION_MIME_TYPES: Record<z.infer<typeof uploadDriveFileConversionSchema>, string> = {
+  document: "application/vnd.google-apps.document",
+  spreadsheet: "application/vnd.google-apps.spreadsheet",
+  presentation: "application/vnd.google-apps.presentation",
+}
 const GMAIL_REPLY_SUBJECT_RE = /^\s*(re|fwd?)\s*:/i
 
 const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard."
@@ -45,7 +51,7 @@ const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open 
 const gmailDraftAttachmentSchema = z.object({
   filename: z.string().trim().min(1).max(255).refine((value) => !/[\r\n]/.test(value), "Filename must not contain line breaks.").describe("Filename to show in Gmail."),
   mimeType: z.string().trim().regex(/^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/).describe("Attachment MIME type."),
-  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes encoded as standard base64. Read the file from the active workspace and base64-encode it. Maximum decoded size: 10 MiB per file and 20 MiB total."),
+  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes encoded as standard base64. Inline bytes are practical only for small files (roughly a few hundred KB), because the base64 must pass through the agent's context window; large files will fail before the request is sent. Maximum decoded size: 10 MiB per file and 20 MiB total (server ceiling, not a practical inline limit)."),
 }).strict()
 
 const createDraftBodySchema = z.object({
@@ -232,8 +238,9 @@ const driveFilesQuerySchema = z.object({
 const uploadDriveFileBodySchema = z.object({
   filename: z.string().trim().min(1).max(255).refine((value) => !/[\r\n]/.test(value), "Filename must not contain line breaks.").describe("Filename to create in Google Drive."),
   mimeType: z.string().trim().regex(/^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/).describe("File MIME type."),
-  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes as standard base64. The gmail-attachment capability returns dataBase64 in this exact encoding — pass it through directly to save an email attachment to Drive. Maximum decoded size: 10 MiB."),
+  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes as standard base64. Inline bytes are practical only for small files (roughly a few hundred KB), because the base64 must pass through the agent's context window; large files will fail before the request is sent. The gmail-attachment capability returns dataBase64 in this exact encoding for direct passthrough to Drive. Maximum decoded size: 10 MiB (server ceiling, not a practical inline limit)."),
   folderId: z.string().trim().min(1).max(512).optional().describe("Optional Google Drive parent folder id."),
+  convertTo: uploadDriveFileConversionSchema.optional().describe("Optional. Convert the uploaded file into a native Google editor file so it can be edited and commented on in the browser: \"document\" for a Google Doc (from .docx), \"spreadsheet\" for a Google Sheet (from .xlsx), \"presentation\" for Google Slides (from .pptx). Omit to store the file as-is."),
 }).strict().superRefine((input, context) => {
   if (Buffer.byteLength(input.dataBase64, "base64") > MAX_GMAIL_ATTACHMENT_BYTES) {
     context.addIssue({
@@ -829,7 +836,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Upload file bytes to Google Drive as the calling member",
-      description: "Creates a file in the calling member's Google Drive using standard base64 bytes. The gmail-attachment capability returns dataBase64 in this exact encoding — pass it through directly to save an email attachment to Drive. The response file.webViewLink is the user-facing link — share it with the user.",
+      description: "Creates a file in the calling member's Google Drive using standard base64 bytes, optionally converting Office files to native Google editor files. The gmail-attachment capability returns dataBase64 in this exact encoding — pass it through directly to save an email attachment to Drive. The response file.webViewLink is the user-facing link — share it with the user.",
       responses: {
         200: jsonResponse("Google Drive file uploaded. The file.webViewLink is the user-facing link — share it with the user.", uploadDriveFileResponseSchema),
         400: jsonResponse("The upload request was invalid.", invalidRequestSchema),
@@ -857,9 +864,12 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       }
 
       const input = c.req.valid("json")
-      const metadata: { name: string; parents?: string[] } = { name: input.filename }
+      const metadata: { name: string; parents?: string[]; mimeType?: string } = { name: input.filename }
       if (input.folderId) {
         metadata.parents = [input.folderId]
+      }
+      if (input.convertTo) {
+        metadata.mimeType = DRIVE_CONVERSION_MIME_TYPES[input.convertTo]
       }
       const boundary = `openwork-${randomUUID()}`
       const url = new URL(`${driveApiBase()}/upload/drive/v3/files`)

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -932,6 +932,44 @@ test("drive upload stores decoded bytes as multipart and returns the user-facing
   })
 })
 
+test("drive upload converts an Office file to a native Google editor file", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const uploadBytes = Buffer.from("docx bytes", "utf8")
+  const response = await request("/v1/capabilities/google-workspace/drive-files", {
+    method: "POST",
+    body: {
+      filename: "plan.docx",
+      mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      dataBase64: uploadBytes.toString("base64"),
+      convertTo: "document",
+    },
+  })
+  expect(response.status).toBe(200)
+  const contentType = expectString(lastDriveUploadContentType, "drive upload content type")
+  const boundary = contentType.match(/boundary=(.+)$/)?.[1]
+  if (!boundary || !lastDriveUploadBody) {
+    throw new Error("Expected drive upload multipart body")
+  }
+  expect(lastDriveUploadBody.includes(Buffer.from('{"name":"plan.docx","mimeType":"application/vnd.google-apps.document"}', "utf8"))).toBe(true)
+  expect(lastDriveUploadBody.includes(Buffer.from(`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document\r\n\r\n`, "utf8"))).toBe(true)
+  expect(lastDriveUploadBody.includes(uploadBytes)).toBe(true)
+})
+
+test("drive upload rejects an invalid conversion target without calling Google", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-files", {
+    method: "POST",
+    body: {
+      filename: "plan.docx",
+      mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      dataBase64: Buffer.from("docx bytes", "utf8").toString("base64"),
+      convertTo: "pdf",
+    },
+  })
+  expect(response.status).toBe(400)
+  expect(googleCallCount).toBe(0)
+})
+
 test("drive upload requires Drive write scope before calling Google", async () => {
   await seedConnectedAccount([DRIVE_READ_SCOPE])
   resetFakeGoogle()

--- a/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
+++ b/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
@@ -74,7 +74,7 @@ export default {
               route.includes("body.attachments: [{ filename, mimeType, dataBase64 }]") ,
               "The searchable operation summary exposes the exact attachment body shape",
             );
-            witness(ctx, route.includes("Read the file from the active workspace and base64-encode it"), "The data field directs the agent to the active workspace file");
+            witness(ctx, route.includes("Inline bytes are practical only for small files (roughly a few hundred KB)"), "The data field honestly describes the practical inline file limit");
             witness(ctx, route.includes("attachments: z.array(gmailDraftAttachmentSchema).min(1).max(10).optional()"), "The draft body accepts an optional bounded attachment list");
             ctx.output("discoverable Gmail-draft contract", [
               snippet(route, "const gmailDraftAttachmentSchema", 20),


### PR DESCRIPTION
## Why

Two separate defects, found while trying to get a `.docx` agreement into Drive as an editable Google Doc.

**1. The Drive upload capability cannot produce a Google Doc.** `POST /v1/capabilities/google-workspace/drive-files` built its multipart metadata as `{ name, parents }` with no `mimeType`, so an uploaded `.docx` could only ever land as a `.docx`. There was no path to a native, editable, commentable Google Doc — which is what you actually want for anything that needs redlines.

**2. The `dataBase64` descriptions instruct an operation that cannot succeed.** The schema told agents to *"Read the file from the active workspace and base64-encode it"* and advertised `maxLength: 13981016` (10 MiB).

That 10 MiB ceiling is real server-side but unreachable in practice. I audited every hop and **there is no byte limit anywhere in our code**:

| Hop | Cap |
|---|---|
| `execute_capability` `inputSchema.body` | none — `z.unknown()` (`mcp/agent.ts:517`) |
| `normalizeToolBody` → `JSON.stringify` → `app.fetch` | none (`mcp/invoke.ts:29,97,132`) — in-process, never crosses a socket |
| den-api Hono app | none — no global `bodyLimit` |
| `@hono/mcp` transport | none |
| `uploadDriveFileBodySchema` | 10 MiB |

The actual ceiling is the **model's tool-call output budget**: the base64 must be emitted by the model as a JSON string argument. A ~137KB payload (a small `.docx`) truncated mid-generation and arrived as `{}` — no server error, because the request never became a well-formed tool call. So we were advertising ~100× more headroom than is reachable, and telling agents to walk straight into it.

## What changed

- **`convertTo`** (`document` | `spreadsheet` | `presentation`), optional. Sets the metadata mimeType to the target Google editor type while the media part keeps the caller's source mimeType — the documented Drive conversion mechanism. `.docx`→Doc, `.xlsx`→Sheet, `.pptx`→Slides.
- Omitting `convertTo` is **byte-identical to today** (no `mimeType` key emitted at all). Pinned by the pre-existing test, which asserts the exact metadata JSON `{"name":"plan.pdf","parents":["folder_1"]}`.
- Reworded both `dataBase64` descriptions to state the practical inline limit and keep 10 MiB labelled as a *server* ceiling, not a usable one.
- Updated `evals/flows/google-workspace-gmail-draft-attachments.flow.mjs:77`, which asserted the old wording verbatim.

No validation limits changed. Change 2 is descriptions only.

## Tests

```
$ pnpm --filter @openwork-ee/den-api exec bun test test/google-workspace-capabilities.test.ts
 31 pass
 0 fail
 188 expect() calls

$ pnpm --filter @openwork-ee/den-api exec tsc --noEmit
(exit 0, no output)
```

Three new tests: conversion sets the right metadata mimeType *and* preserves the source media mimeType; invalid `convertTo` 400s without calling Google; the existing omission test is unchanged and still passes.

## Validation honesty

Per AGENTS.md: **there is no live Drive proof in this PR, and I want to be explicit about that.** Verifying an actual `.docx`→Google Doc conversion requires a connected Google Workspace account hitting real Drive, against a deployed den-api carrying this change. I ran the unit suite against the fake Google, which asserts the exact multipart bytes we send — that proves *we send the documented conversion request*, not that Google converts it.

**Reviewer check:** upload a `.docx` with `convertTo: "document"` and confirm `file.mimeType` comes back as `application/vnd.google-apps.document` and `webViewLink` opens in the Docs editor.

## Deliberately not in this PR

- **Path- or URL-based upload.** This is the real fix for defect 2 — bytes should never transit model context. The correct pattern already exists at `apps/server/src/extensions/google-workspace.ts:91-104` (takes `attachments: [{ path }]`, server reads the bytes at `:759`), but it has no Drive equivalent and is gated off for Cloud users (`extensions/index.ts:61-72`). Closing that gap spans `apps/server`↔den-api auth, or needs server-side URL fetching with real SSRF hardening. That's a design decision, not a patch.
- **`packages/docs/openapi.json`.** It is already stale on `dev`. Regenerating it pulls in ~230 unrelated keys (cloud gateway routes, `/v1/org.delete`, install-connect, marketplace-capabilities) and 7 unrelated description edits. That belongs in its own chore PR. The runtime path reads live-generated OpenAPI (`mcp/catalog.ts`), so this change takes effect regardless.
- **The same trap in reverse.** `gmail-attachment` returns up to 10 MiB of base64 *into* model context (`google-workspace.ts:553`) and will fail the same way on large attachments.
