### PR TITLE
Mark Sources as Alpha

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
@@ -56,7 +56,7 @@ export function IntegrationsScreen() {
   return (
     <DashboardPageTemplate
       icon={Cable}
-      badgeLabel="Preview"
+      badgeLabel="Alpha"
       title="Sources"
       description="Connect to GitHub or Bitbucket. Once an account is linked, plugins and skills from those repositories show up on the Plugins page."
       colors={["#E0F2FE", "#0C4A6E", "#0284C7", "#7DD3FC"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -371,7 +371,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         icon: Puzzle,
         children: [
           { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" },
-          { href: getIntegrationsRoute(activeOrg.slug), label: "Sources" },
+          { href: getIntegrationsRoute(activeOrg.slug), label: "Sources", badge: "Alpha" },
           { href: getPluginsRoute(activeOrg.slug), label: "Plugins" },
           { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" },
         ],

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -10,10 +10,10 @@ function readDashboardComponent(name: string) {
 }
 
 describe("connector and marketplace polish", () => {
-  test("puts Marketplace first and renames the org connection surface to Connectors beta", () => {
+  test("labels Sources alpha and keeps Marketplace first and Connectors beta", () => {
     const shell = readDashboardComponent("org-dashboard-shell.tsx");
     const marketplaceIndex = shell.indexOf('{ href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" }');
-    const sourcesIndex = shell.indexOf('{ href: getIntegrationsRoute(activeOrg.slug), label: "Sources" }');
+    const sourcesIndex = shell.indexOf('{ href: getIntegrationsRoute(activeOrg.slug), label: "Sources", badge: "Alpha" }');
     const pluginsIndex = shell.indexOf('{ href: getPluginsRoute(activeOrg.slug), label: "Plugins" }');
     const connectorsIndex = shell.indexOf('{ href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" }');
 
@@ -21,6 +21,14 @@ describe("connector and marketplace polish", () => {
     expect(marketplaceIndex).toBeLessThan(sourcesIndex);
     expect(sourcesIndex).toBeLessThan(pluginsIndex);
     expect(pluginsIndex).toBeLessThan(connectorsIndex);
+  });
+
+  test("uses the shared page maturity badge to label Sources alpha", () => {
+    const screen = readDashboardComponent("integrations-screen.tsx");
+
+    expect(screen).toContain('title="Sources"');
+    expect(screen).toContain('badgeLabel="Alpha"');
+    expect(screen).not.toContain('badgeLabel="Preview"');
   });
 
   test("uses one Add MCP action and the approved connector copy", () => {


### PR DESCRIPTION
## Summary

- Mark the user-facing Sources capability as Alpha in its dashboard entry points.
- Reuse the existing product-maturity badge treatment instead of introducing a Sources-specific style.
- Keep Sources routing, availability, permissions, and integration behavior unchanged.

## What changed

- **Integrations screen** — adds the standard Alpha treatment to the Sources presentation.
- **Dashboard navigation** — carries the same maturity signal into the relevant Sources entry point.
- **Regression coverage** — updates the connector marketplace test for the visible and accessible label contract.

## Why

Sources is available as an early product capability and should communicate that maturity consistently wherever users intentionally enter it.

## Verification

Current scoped candidate: `029b06f7662190b7e5d37178c217f89ea3f8fbe2` on `dev@7908ad1dd429aaabcbb273c22872eb003a34ef7a`.

- [x] `pnpm --dir ee/apps/den-web exec bun test tests/connector-marketplace-polish.test.ts` — 5 passed, 0 failed.
- [x] `pnpm --dir ee/apps/den-web typecheck` — passed.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [x] Scope audit — 1 feature commit, 3 intended files; no inherited auth or evaluator changes.
- [ ] Deterministic real-app proof was not requested.
- [ ] GitHub checks are recomputing for the rebuilt head; no preview deployment is claimed.

## Risks and untested scope

- This draft has no deterministic browser screenshot or real-app acceptance run by policy.
- Human review should confirm every intended Sources entry point, accessible output, and light/dark presentation.
- Private Kitchen evidence and raw provider logs are intentionally not attached.

## Lineage

- Current fork draft: [reachjalil/openwork#11](https://github.com/reachjalil/openwork/pull/11)
- Supersedes the older upstream candidate in [#3285](https://github.com/different-ai/openwork/pull/3285).

## Exact candidate

- Current base: `7908ad1dd429aaabcbb273c22872eb003a34ef7a`
- Current head: `029b06f7662190b7e5d37178c217f89ea3f8fbe2`
- Original Kitchen head: `0adbc5b739e88be3a954aafaa1d40701d8ea6865`
- Kitchen run: `024e0020-9163-4b43-9471-6703dca8c034`

## Automation boundary

Prepared from the OpenWork Kitchen candidate and reconstructed as one clean feature commit on current `dev` under `@reachjalil`'s authorized fork. This remains a draft; review requests, ready-for-review, merge, release, and deployment remain manual.
