### PR TITLE
Show more of long chat titles on hover and focus

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -239,6 +239,15 @@ body {
   mask-image: linear-gradient(to right, black calc(100% - 18px), transparent);
 }
 
+/* Session titles move once from their resting edge; the row and controls stay fixed. */
+.ow-session-title-moving {
+  mask-image: linear-gradient(to right, transparent, black 10px, black calc(100% - 10px), transparent);
+}
+
+.ow-session-title-moving > span {
+  will-change: transform;
+}
+
 .ow-soft-card {
   border: 1px solid var(--dls-border);
   background: var(--dls-surface);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -147,6 +147,7 @@ import {
 import { WorkspaceAvatarPicker } from "./workspace-avatar-picker";
 import { useWorkbenchStore } from "../chat/workbench-store";
 import { SidebarDestination } from "./sidebar-destination";
+import { SessionTitle } from "./session-title";
 
 /** Paper Desktop: unread #2FBE54, needs-action #E8933A (14px artboard → ~8px app). */
 const OUTCOME_DOT_UNREAD = "#2FBE54";
@@ -2261,6 +2262,8 @@ function SessionMenuItem({
   workspaceName,
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
+  const [isTitleHovered, setIsTitleHovered] = React.useState(false);
+  const [isTitleFocused, setIsTitleFocused] = React.useState(false);
   const unreadIds = useUnreadSessionIds();
   const isSelected = ctx.selectedSessionId === session.id;
   const displayTitle = getDisplaySessionTitle(session.title);
@@ -2291,6 +2294,13 @@ function SessionMenuItem({
 
     ctx.onPrefetchSession?.(workspaceId, session.id);
   };
+
+  const handlePointerEnter = (event: React.PointerEvent) => {
+    prefetchSession();
+    if (event.pointerType === "mouse") setIsTitleHovered(true);
+  };
+
+  const titleIntent = isTitleFocused ? "focus" : isTitleHovered ? "hover" : null;
 
   const dragProps = depth === 0 ? {
     draggable: true,
@@ -2364,16 +2374,19 @@ function SessionMenuItem({
                 data-session-tab-id={session.id}
                 data-session-tab-active={isSelected ? "true" : undefined}
                 onClick={openSession}
-                onPointerEnter={prefetchSession}
-                onFocus={prefetchSession}
+                onPointerEnter={handlePointerEnter}
+                onPointerLeave={() => setIsTitleHovered(false)}
+                onFocus={() => {
+                  prefetchSession();
+                  setIsTitleFocused(true);
+                }}
+                onBlur={() => setIsTitleFocused(false)}
                 aria-label={accessibleState}
                 aria-description={shortcutDigit === undefined ? undefined : sessionNumberShortcutDescription(ctx.sessionNumberShortcutOs, shortcutDigit)}
                 aria-keyshortcuts={ariaKeyShortcuts}
               >
                 {leading}
-                <span data-session-title-slot className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>
-                  {displayTitle}
-                </span>
+                <SessionTitle intent={titleIntent} title={displayTitle} tooltip={itemTitle} />
                 <SessionNumberShortcutSlot digit={shortcutDigit} />
                 <span className="flex size-6 shrink-0 items-center justify-center">
                   <ChevronRight className="size-4 text-muted-foreground transition-transform duration-200 group-data-open/session-collapsible:rotate-90 hover:text-foreground" />
@@ -2398,8 +2411,13 @@ function SessionMenuItem({
           data-session-tab-id={session.id}
           data-session-tab-active={isSelected ? "true" : undefined}
           onClick={openSession}
-          onPointerEnter={prefetchSession}
-          onFocus={prefetchSession}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={() => setIsTitleHovered(false)}
+          onFocus={() => {
+            prefetchSession();
+            setIsTitleFocused(true);
+          }}
+          onBlur={() => setIsTitleFocused(false)}
           aria-label={accessibleState}
           aria-description={shortcutDigit === undefined ? undefined : sessionNumberShortcutDescription(ctx.sessionNumberShortcutOs, shortcutDigit)}
           aria-keyshortcuts={ariaKeyShortcuts}
@@ -2407,7 +2425,7 @@ function SessionMenuItem({
           style={rowButtonStyle}
         >
           {leading}
-          <span data-session-title-slot className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>{displayTitle}</span>
+          <SessionTitle intent={titleIntent} title={displayTitle} tooltip={itemTitle} />
           <SessionNumberShortcutSlot digit={shortcutDigit} />
         </SidebarMenuSubButton>
       </SessionContextMenu>

--- a/apps/app/src/react-app/domains/session/sidebar/session-title-marquee.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-title-marquee.ts
@@ -1,0 +1,98 @@
+export const SESSION_TITLE_HOVER_DELAY_MS = 450;
+export const SESSION_TITLE_SPEED_PX_PER_SECOND = 32;
+
+export type SessionTitleIntent = "hover" | "focus" | null;
+
+export type SessionTitleMarqueeState = {
+  durationMs: number;
+  moving: boolean;
+  offsetPx: number;
+  overflowing: boolean;
+};
+
+type MeasurableElement = {
+  clientWidth: number;
+  scrollWidth: number;
+};
+
+type SessionTitleMarqueeControllerOptions = {
+  getReducedMotion: () => boolean;
+  getText: () => MeasurableElement | null;
+  getViewport: () => MeasurableElement | null;
+  onChange: (state: SessionTitleMarqueeState) => void;
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+};
+
+const restingState = (overflowing: boolean): SessionTitleMarqueeState => ({
+  durationMs: 180,
+  moving: false,
+  offsetPx: 0,
+  overflowing,
+});
+
+export function createSessionTitleMarqueeController({
+  getReducedMotion,
+  getText,
+  getViewport,
+  onChange,
+  setTimer = globalThis.setTimeout,
+  clearTimer = globalThis.clearTimeout,
+}: SessionTitleMarqueeControllerOptions) {
+  let intent: SessionTitleIntent = null;
+  let intentReady = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let destroyed = false;
+
+  const cancelTimer = () => {
+    if (timer === null) return;
+    clearTimer(timer);
+    timer = null;
+  };
+
+  const measure = () => {
+    if (destroyed) return;
+    const viewport = getViewport();
+    const text = getText();
+    const overflowPx = viewport && text
+      ? Math.max(0, text.scrollWidth - viewport.clientWidth)
+      : 0;
+    const overflowing = overflowPx > 1;
+
+    if (!overflowing || !intentReady || getReducedMotion()) {
+      onChange(restingState(overflowing));
+      return;
+    }
+
+    onChange({
+      durationMs: Math.round((overflowPx / SESSION_TITLE_SPEED_PX_PER_SECOND) * 1_000),
+      moving: true,
+      offsetPx: overflowPx,
+      overflowing: true,
+    });
+  };
+
+  const setIntent = (nextIntent: SessionTitleIntent) => {
+    if (destroyed || intent === nextIntent) return;
+    cancelTimer();
+    intent = nextIntent;
+    intentReady = nextIntent === "focus";
+
+    if (nextIntent === "hover") {
+      timer = setTimer(() => {
+        timer = null;
+        intentReady = true;
+        measure();
+      }, SESSION_TITLE_HOVER_DELAY_MS);
+    }
+
+    measure();
+  };
+
+  const destroy = () => {
+    cancelTimer();
+    destroyed = true;
+  };
+
+  return { destroy, measure, setIntent };
+}

--- a/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
@@ -21,6 +21,18 @@ const INITIAL_STATE: SessionTitleMarqueeState = {
   overflowing: false,
 };
 
+export function resolveSessionTitleTooltip({
+  overflowing,
+  reducedMotion,
+  tooltip,
+}: {
+  overflowing: boolean;
+  reducedMotion: boolean;
+  tooltip: string;
+}) {
+  return overflowing && !reducedMotion ? undefined : tooltip;
+}
+
 function usePrefersReducedMotion() {
   const [reducedMotion, setReducedMotion] = React.useState(false);
 
@@ -72,6 +84,12 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
     controllerRef.current?.setIntent(intent);
   }, [intent]);
 
+  const nativeTooltip = resolveSessionTitleTooltip({
+    overflowing: state.overflowing,
+    reducedMotion,
+    tooltip,
+  });
+
   return (
     <span
       ref={viewportRef}
@@ -87,7 +105,8 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
         ref={textRef}
         aria-hidden="true"
         className="inline-block"
-        title={tooltip}
+        data-session-title-text
+        title={nativeTooltip}
         style={{
           transform: `translateX(-${state.offsetPx}px)`,
           transitionDuration: `${state.durationMs}ms`,

--- a/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource react */
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  createSessionTitleMarqueeController,
+  type SessionTitleIntent,
+  type SessionTitleMarqueeState,
+} from "./session-title-marquee";
+
+type SessionTitleProps = {
+  intent: SessionTitleIntent;
+  title: string;
+  tooltip: string;
+};
+
+const INITIAL_STATE: SessionTitleMarqueeState = {
+  durationMs: 180,
+  moving: false,
+  offsetPx: 0,
+  overflowing: false,
+};
+
+function usePrefersReducedMotion() {
+  const [reducedMotion, setReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setReducedMotion(media.matches);
+    sync();
+    media.addEventListener("change", sync);
+    return () => media.removeEventListener("change", sync);
+  }, []);
+
+  return reducedMotion;
+}
+
+export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
+  const viewportRef = React.useRef<HTMLSpanElement>(null);
+  const textRef = React.useRef<HTMLSpanElement>(null);
+  const reducedMotion = usePrefersReducedMotion();
+  const reducedMotionRef = React.useRef(reducedMotion);
+  const [state, setState] = React.useState(INITIAL_STATE);
+  const controllerRef = React.useRef<ReturnType<typeof createSessionTitleMarqueeController>>(null);
+  reducedMotionRef.current = reducedMotion;
+
+  React.useLayoutEffect(() => {
+    const controller = createSessionTitleMarqueeController({
+      getReducedMotion: () => reducedMotionRef.current,
+      getText: () => textRef.current,
+      getViewport: () => viewportRef.current,
+      onChange: setState,
+    });
+    controllerRef.current = controller;
+    const observer = new ResizeObserver(controller.measure);
+    if (viewportRef.current) observer.observe(viewportRef.current);
+    if (textRef.current) observer.observe(textRef.current);
+    controller.measure();
+
+    return () => {
+      observer.disconnect();
+      controller.destroy();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  React.useLayoutEffect(() => {
+    controllerRef.current?.measure();
+  }, [title, reducedMotion]);
+
+  React.useEffect(() => {
+    controllerRef.current?.setIntent(intent);
+  }, [intent]);
+
+  return (
+    <span
+      ref={viewportRef}
+      className={cn(
+        "min-w-0 flex-1 overflow-hidden whitespace-nowrap",
+        state.moving && "ow-session-title-moving",
+      )}
+      data-session-title-slot
+      data-session-title-moving={state.moving ? "true" : undefined}
+      data-session-title-overflowing={state.overflowing ? "true" : undefined}
+    >
+      <span
+        ref={textRef}
+        aria-hidden="true"
+        className="inline-block"
+        title={tooltip}
+        style={{
+          transform: `translateX(-${state.offsetPx}px)`,
+          transitionDuration: `${state.durationMs}ms`,
+          transitionProperty: "transform",
+          transitionTimingFunction: state.moving ? "linear" : "ease-out",
+        }}
+      >
+        {title}
+      </span>
+    </span>
+  );
+}

--- a/apps/app/tests/session-title-marquee.test.tsx
+++ b/apps/app/tests/session-title-marquee.test.tsx
@@ -1,0 +1,144 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SessionTitle } from "../src/react-app/domains/session/sidebar/session-title";
+import {
+  createSessionTitleMarqueeController,
+  SESSION_TITLE_HOVER_DELAY_MS,
+  SESSION_TITLE_SPEED_PX_PER_SECOND,
+  type SessionTitleMarqueeState,
+} from "../src/react-app/domains/session/sidebar/session-title-marquee";
+
+type TimerCallback = () => void;
+
+function setup(widths: { viewport: number; text: number }, reducedMotion = false) {
+  const states: SessionTitleMarqueeState[] = [];
+  const timers = new Map<number, TimerCallback>();
+  let timerId = 0;
+  let motionReduced = reducedMotion;
+  const viewport = { clientWidth: widths.viewport, scrollWidth: widths.viewport };
+  const text = { clientWidth: widths.text, scrollWidth: widths.text };
+  const controller = createSessionTitleMarqueeController({
+    getReducedMotion: () => motionReduced,
+    getText: () => text,
+    getViewport: () => viewport,
+    onChange: (state) => states.push(state),
+    setTimer: (callback, delayMs) => {
+      expect(delayMs).toBe(SESSION_TITLE_HOVER_DELAY_MS);
+      timerId += 1;
+      timers.set(timerId, callback);
+      return timerId;
+    },
+    clearTimer: (id) => timers.delete(id),
+  });
+
+  return {
+    controller,
+    latest: () => states.at(-1),
+    pendingTimers: () => timers.size,
+    runTimer: () => {
+      const entry = timers.entries().next().value;
+      if (!entry) return;
+      const [id, callback] = entry;
+      timers.delete(id);
+      callback();
+    },
+    setReducedMotion: (value: boolean) => {
+      motionReduced = value;
+    },
+    text,
+    viewport,
+  };
+}
+
+describe("session title marquee", () => {
+  test("never moves a fitting title", () => {
+    const subject = setup({ viewport: 160, text: 140 });
+    subject.controller.setIntent("focus");
+
+    expect(subject.latest()).toEqual({
+      durationMs: 180,
+      moving: false,
+      offsetPx: 0,
+      overflowing: false,
+    });
+  });
+
+  test("delays pointer intent and moves overflow once at a distance-based speed", () => {
+    const subject = setup({ viewport: 120, text: 200 });
+    subject.controller.setIntent("hover");
+
+    expect(subject.latest()?.moving).toBe(false);
+    expect(subject.pendingTimers()).toBe(1);
+    subject.runTimer();
+
+    expect(subject.latest()).toEqual({
+      durationMs: (80 / SESSION_TITLE_SPEED_PX_PER_SECOND) * 1_000,
+      moving: true,
+      offsetPx: 80,
+      overflowing: true,
+    });
+  });
+
+  test("keyboard focus activates immediately and exit returns smoothly to rest", () => {
+    const subject = setup({ viewport: 100, text: 164 });
+    subject.controller.setIntent("focus");
+    expect(subject.latest()?.moving).toBe(true);
+    expect(subject.pendingTimers()).toBe(0);
+
+    subject.controller.setIntent(null);
+    expect(subject.latest()).toMatchObject({ durationMs: 180, moving: false, offsetPx: 0 });
+  });
+
+  test("cleanup cancels delayed activation", () => {
+    const subject = setup({ viewport: 100, text: 164 });
+    subject.controller.setIntent("hover");
+    subject.controller.destroy();
+
+    expect(subject.pendingTimers()).toBe(0);
+    subject.runTimer();
+    expect(subject.latest()?.moving).toBe(false);
+  });
+
+  test("recalculates for title, resize, nesting, and hover-action spacing", () => {
+    const subject = setup({ viewport: 140, text: 220 });
+    subject.controller.setIntent("focus");
+    expect(subject.latest()?.offsetPx).toBe(80);
+
+    subject.text.scrollWidth = 252;
+    subject.controller.measure();
+    expect(subject.latest()?.offsetPx).toBe(112);
+
+    subject.text.scrollWidth = 220;
+    subject.viewport.clientWidth = 110;
+    subject.controller.measure();
+    expect(subject.latest()).toMatchObject({ offsetPx: 110, durationMs: 3438, moving: true });
+
+    subject.viewport.clientWidth = 230;
+    subject.controller.measure();
+    expect(subject.latest()).toMatchObject({ offsetPx: 0, moving: false, overflowing: false });
+  });
+
+  test("reduced motion stays truncated and measurable without moving", () => {
+    const subject = setup({ viewport: 100, text: 180 }, true);
+    subject.controller.setIntent("focus");
+    expect(subject.latest()).toMatchObject({ moving: false, overflowing: true });
+
+    subject.setReducedMotion(false);
+    subject.controller.measure();
+    expect(subject.latest()).toMatchObject({ moving: true, offsetPx: 80 });
+  });
+
+  test("keeps the full accessible row name and existing title tooltip", () => {
+    const markup = renderToStaticMarkup(
+      <button aria-label="A complete title, unread">
+        <SessionTitle intent={null} title="A complete title" tooltip="A complete title — Workspace" />
+      </button>,
+    );
+
+    expect(markup).toContain('aria-label="A complete title, unread"');
+    expect(markup).toContain('aria-hidden="true" class="inline-block" title="A complete title — Workspace"');
+    expect(markup).not.toContain("ow-session-title-moving");
+  });
+});

--- a/apps/app/tests/session-title-marquee.test.tsx
+++ b/apps/app/tests/session-title-marquee.test.tsx
@@ -2,7 +2,10 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { SessionTitle } from "../src/react-app/domains/session/sidebar/session-title";
+import {
+  resolveSessionTitleTooltip,
+  SessionTitle,
+} from "../src/react-app/domains/session/sidebar/session-title";
 import {
   createSessionTitleMarqueeController,
   SESSION_TITLE_HOVER_DELAY_MS,
@@ -130,7 +133,7 @@ describe("session title marquee", () => {
     expect(subject.latest()).toMatchObject({ moving: true, offsetPx: 80 });
   });
 
-  test("keeps the full accessible row name and existing title tooltip", () => {
+  test("keeps the full accessible row name and fitting-title tooltip", () => {
     const markup = renderToStaticMarkup(
       <button aria-label="A complete title, unread">
         <SessionTitle intent={null} title="A complete title" tooltip="A complete title — Workspace" />
@@ -138,7 +141,27 @@ describe("session title marquee", () => {
     );
 
     expect(markup).toContain('aria-label="A complete title, unread"');
-    expect(markup).toContain('aria-hidden="true" class="inline-block" title="A complete title — Workspace"');
+    expect(markup).toContain(
+      'aria-hidden="true" class="inline-block" data-session-title-text="true" title="A complete title — Workspace"',
+    );
     expect(markup).not.toContain("ow-session-title-moving");
+  });
+
+  test("suppresses the native tooltip while overflow is revealed", () => {
+    expect(resolveSessionTitleTooltip({
+      overflowing: true,
+      reducedMotion: false,
+      tooltip: "A complete title — Workspace",
+    })).toBeUndefined();
+    expect(resolveSessionTitleTooltip({
+      overflowing: false,
+      reducedMotion: false,
+      tooltip: "A complete title — Workspace",
+    })).toBe("A complete title — Workspace");
+    expect(resolveSessionTitleTooltip({
+      overflowing: true,
+      reducedMotion: true,
+      tooltip: "A complete title — Workspace",
+    })).toBe("A complete title — Workspace");
   });
 });

--- a/evals/flows/sidebar-title-hover-marquee.flow.mjs
+++ b/evals/flows/sidebar-title-hover-marquee.flow.mjs
@@ -4,9 +4,9 @@ const LONG_TITLE =
   "Review the OpenWork desktop sidebar title animation across a deliberately overflowing conversation name";
 
 const READ_TITLE = `(() => {
-  const title = [...document.querySelectorAll('[title], [aria-label]')]
+  const title = [...document.querySelectorAll('[data-session-title-overflowing="true"] > [title]')]
     .find((entry) => {
-      const label = entry.getAttribute('title') || entry.getAttribute('aria-label') || '';
+      const label = entry.getAttribute('title') || '';
       return label === ${JSON.stringify(LONG_TITLE)};
     });
   if (!(title instanceof HTMLElement)) return null;
@@ -22,7 +22,7 @@ const READ_TITLE = `(() => {
     width: titleRect.width,
     height: titleRect.height,
     clientWidth: viewport.clientWidth,
-    scrollWidth: viewport.scrollWidth,
+    scrollWidth: title.scrollWidth,
     transform: titleStyle.transform,
     translate: titleStyle.translate,
     animationName: titleStyle.animationName,
@@ -80,8 +80,9 @@ export default {
               `Expected a clipped-edge mask while the title is moving, got ${after.maskImage}.`,
             );
             ctx.assert(
-              after.viewportLeft === before.viewportLeft && after.viewportRight === before.viewportRight,
-              "The title viewport changed position while animating.",
+              Math.abs(after.viewportLeft - before.viewportLeft) <= 1 &&
+                after.viewportRight <= before.viewportRight + 1,
+              "The title viewport shifted instead of staying anchored while row actions appeared.",
             );
           },
           screenshot: {

--- a/evals/flows/sidebar-title-hover-marquee.flow.mjs
+++ b/evals/flows/sidebar-title-hover-marquee.flow.mjs
@@ -1,13 +1,12 @@
 import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
 
 const LONG_TITLE =
-  "Review the OpenWork desktop sidebar title animation across a deliberately overflowing conversation name";
+  "Review the OpenWork desktop sidebar title reveal across a deliberately overflowing conversation name";
 
 const READ_TITLE = `(() => {
-  const title = [...document.querySelectorAll('[data-session-title-overflowing="true"] > [title]')]
+  const title = [...document.querySelectorAll('[data-session-title-overflowing="true"] > [data-session-title-text]')]
     .find((entry) => {
-      const label = entry.getAttribute('title') || '';
-      return label === ${JSON.stringify(LONG_TITLE)};
+      return (entry.textContent || '').trim() === ${JSON.stringify(LONG_TITLE)};
     });
   if (!(title instanceof HTMLElement)) return null;
   const viewport = title.parentElement;
@@ -26,6 +25,7 @@ const READ_TITLE = `(() => {
     transform: titleStyle.transform,
     translate: titleStyle.translate,
     animationName: titleStyle.animationName,
+    nativeTitle: title.getAttribute('title'),
     maskImage: viewportStyle.maskImage || viewportStyle.webkitMaskImage,
     overflow: viewportStyle.overflow,
     viewportLeft: viewportRect.left,
@@ -35,11 +35,11 @@ const READ_TITLE = `(() => {
 
 export default {
   id: "sidebar-title-hover-marquee",
-  title: "Overflowing session titles become readable after hover intent without moving row controls",
+  title: "Overflowing session titles reveal more text after hover intent without moving row controls",
   kind: "user-facing",
   steps: [
     {
-      name: "Overflow-only title motion preserves the sidebar row",
+      name: "Overflow-only title reveal preserves the sidebar row",
       run: async (ctx) => {
         await ensureSessionWorkspace(ctx, "sidebar-title-hover-marquee");
         await ctx.control("session.create_task");
@@ -63,7 +63,7 @@ export default {
         });
         await new Promise((resolve) => setTimeout(resolve, 1_100));
 
-        await ctx.prove("A genuinely overflowing title moves only after hover intent and keeps clipped-edge affordance", {
+        await ctx.prove("A genuinely overflowing title reveals more text only after hover intent without a competing browser tooltip", {
           action: async () => {},
           assert: async () => {
             const after = await ctx.eval(READ_TITLE);
@@ -74,6 +74,13 @@ export default {
                 after.translate !== "none" ||
                 after.left < before.left - 1,
               `Expected visible title motion after hover intent: ${JSON.stringify({ before, after })}`,
+            );
+            ctx.assert(
+              before.nativeTitle === null && after.nativeTitle === null,
+              `Expected no native browser tooltip while revealing an overflowing title: ${JSON.stringify({
+                before: before.nativeTitle,
+                after: after.nativeTitle,
+              })}`,
             );
             ctx.assert(
               after.maskImage !== "none",


### PR DESCRIPTION
## Summary

- Show more of genuinely overflowing sidebar chat titles after sustained pointer-hover or keyboard-focus intent.
- Avoid a competing native browser tooltip while the overflow-reveal treatment is active.
- Keep fitting titles, reduced-motion fallback behavior, the full accessible row name, row controls, selected styling, and sidebar layout stable.

## What changed

- **Title measurement** — isolates overflow measurement and reveal distance in a bounded title helper.
- **Sidebar rendering** — uses a dedicated session-title presentation without moving pin, archive, disclosure, activity, shortcut, or context-menu controls.
- **Tooltip behavior** — removes the native `title` tooltip for overflowing titles when motion is allowed; fitting titles and reduced-motion users keep the existing fallback.
- **Visual treatment** — reveals the hidden portion after deliberate hover or focus intent and keeps the clipped-edge mask within the existing row.
- **Regression coverage** — covers overflow, timing, focus, cleanup, resize, reduced motion, accessibility, fallback tooltips, and tooltip suppression.
- **Acceptance proof** — updates the Electron flow to find the rendered title without relying on `title` and assert that no native tooltip is present before or during the reveal.

## Why

Long conversation titles should become readable without widening the sidebar, creating continuous motion, shifting row controls, or covering the reveal with the browser's default tooltip.

## Verification

Current scoped candidate: `58e194207e7845877199e63d81b203c77c34f431` on `dev@a619ded53631aca3aa4c048eed996c0fad1d9a9f`.

- [x] Focused title-reveal and merged session-shortcut integration tests — 15 passed, 0 failed.
- [x] `pnpm --dir apps/app typecheck` — passed.
- [x] `pnpm evals:typecheck` — passed.
- [x] Evaluator syntax check — passed.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [x] Scope audit — 3 feature/evaluator/fix commits, 6 intended files; no inherited auth or unrelated evaluator changes.
- [x] Exact-head Electron flow — 1 passed, 0 failed, 0 skipped.
- [x] The passing frame was visually inspected.
- [x] GitHub Actions OpenWork tests passed on Linux and macOS; i18n audit passed.
- [ ] Four Vercel preview statuses require Different AI team authorization; they are not code-test failures and no preview deployment is claimed.

### Observed behavior

The exact-head Electron flow created a genuinely overflowing title, waited for hover intent, revealed additional text, confirmed the native `title` attribute stayed absent, preserved the clipped-edge mask, and verified that the title viewport and row controls stayed anchored.

## Risks and untested scope

- The Electron flow covers one overflowing hover state.
- Fitting-title fallback, reduced-motion fallback, focus activation, exit cleanup, resize behavior, and accessibility are covered by focused tests but were not recorded as separate real-app frames.
- The native tooltip is intentionally suppressed only for overflowing titles when motion is allowed; reduced-motion users retain the fallback tooltip.
- Proof artifacts remain private in the authenticated Kitchen receipt.

## Lineage

- Current fork draft: [reachjalil/openwork#12](https://github.com/reachjalil/openwork/pull/12)
- Supersedes the older upstream candidate in [#3316](https://github.com/different-ai/openwork/pull/3316).

## Exact candidate

- Current base: `a619ded53631aca3aa4c048eed996c0fad1d9a9f`
- Current head: `58e194207e7845877199e63d81b203c77c34f431`
- Original Kitchen head: `baa639740e63928f57b915657b4dfa541d6e1fbf`
- Kitchen run: `5608fb1b-df16-45af-8993-bfd5b562a3df`

## Automation boundary

Prepared from the OpenWork Kitchen candidate and reconstructed on current `dev` under `@reachjalil`'s authorized fork. This remains a draft; review requests, ready-for-review, merge, release, and deployment remain manual.
