### PR TITLE
Add a useful right-panel action chooser

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -525,6 +525,9 @@ export function SessionPage(props: SessionPageProps) {
   const closeRightPane = useCallback(() => {
     setCurrentSidePanel(null);
   }, [setCurrentSidePanel]);
+  const openGeneralSidePanel = useCallback(() => {
+    setCurrentSidePanel("panel");
+  }, [setCurrentSidePanel]);
   const openBrowserRailPane = useCallback(() => {
     if (!hasBrowserTabs) return;
     // Opening the browser pane should land on a usable page, not an empty
@@ -574,7 +577,11 @@ export function SessionPage(props: SessionPageProps) {
   }), []);
   useControlAction(setBrowserProxyControlAction);
   const openArtifactRailPane = useCallback(() => {
-    if (!hasArtifactTargets || !props.selectedSessionId) return;
+    if (!hasArtifactTargets) {
+      setCurrentSidePanel("panel");
+      return;
+    }
+    if (!props.selectedSessionId) return;
     const activeTab = sessionPanelState.tabs.find((tab) => tab.id === sessionPanelState.activeTabId);
     const artifactTargetIds = new Set(artifactFileTargets.map((target) => target.id));
     const currentArtifactTab = activeTab?.type === "artifact" && artifactTargetIds.has(activeTab.id) ? activeTab : null;
@@ -608,7 +615,7 @@ export function SessionPage(props: SessionPageProps) {
     if (!panelRailActive) {
       toggleCurrentSidePanel("panel");
     }
-  }, [artifactFileTargets, hasArtifactTargets, openTab, panelRailActive, props.selectedSessionId, selectTab, sessionPanelState, toggleCurrentSidePanel]);
+  }, [artifactFileTargets, hasArtifactTargets, openTab, panelRailActive, props.selectedSessionId, selectTab, sessionPanelState, setCurrentSidePanel, toggleCurrentSidePanel]);
   const openVoiceRailPane = useCallback(() => {
     toggleCurrentSidePanel("voice");
   }, [toggleCurrentSidePanel]);
@@ -1133,7 +1140,7 @@ export function SessionPage(props: SessionPageProps) {
                         if (sidePanelOpen) {
                           closeRightPane();
                         } else {
-                          openBrowserRailPane();
+                          openGeneralSidePanel();
                         }
                       }}
                     >
@@ -1429,6 +1436,8 @@ export function SessionPage(props: SessionPageProps) {
                       workspaceRoot={props.selectedWorkspaceRoot}
                       isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
                       onClose={closeRightPane}
+                      onOpenExtensions={props.settingsSlot ? () => setCurrentSidePanel("extensions") : undefined}
+                      onOpenVoice={voiceExtensionEnabled ? openVoiceRailPane : undefined}
                     />
                   ) : null}
                   </div>
@@ -1474,14 +1483,13 @@ export function SessionPage(props: SessionPageProps) {
               variant="ghost"
               size="icon-sm"
               className={cn(
-                "rounded-xl transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
-                panelRailActive && hasArtifactTargets && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+                "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
+                panelRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
               )}
               onClick={openArtifactRailPane}
-              title={hasArtifactTargets ? `Artifacts (${artifactTargetCount})` : "No artifacts yet"}
-              aria-label={hasArtifactTargets ? `Artifacts (${artifactTargetCount})` : "No artifacts yet"}
-              aria-pressed={panelRailActive && hasArtifactTargets}
-              disabled={!hasArtifactTargets}
+              title={`Artifacts (${artifactTargetCount})`}
+              aria-label={`Artifacts (${artifactTargetCount})`}
+              aria-pressed={panelRailActive}
             >
               <FileText size={15} />
               {artifactTargetCount > 0 ? (

--- a/apps/app/src/react-app/domains/session/panel/panel-empty.tsx
+++ b/apps/app/src/react-app/domains/session/panel/panel-empty.tsx
@@ -1,0 +1,140 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import { ArrowLeft, ArrowRight, FileText, Globe, Mic2, Puzzle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PanelEmptyActions = {
+  onOpenBrowser?: () => void;
+  onOpenExtensions?: () => void;
+  onOpenVoice?: () => void;
+};
+
+export function handlePanelEscape(key: string, onClose: () => void) {
+  if (key !== "Escape") return false;
+  onClose();
+  return true;
+}
+
+type PanelDestination = {
+  id: "browser" | "files" | "extensions" | "voice";
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  activate: () => void;
+};
+
+export function getPanelDestinations(
+  actions: PanelEmptyActions,
+  onOpenFiles: () => void,
+): PanelDestination[] {
+  const destinations: PanelDestination[] = [];
+
+  if (actions.onOpenBrowser) {
+    destinations.push({
+      id: "browser",
+      label: "Browser",
+      description: "Open a new page in the built-in browser.",
+      icon: <Globe aria-hidden="true" />,
+      activate: actions.onOpenBrowser,
+    });
+  }
+
+  destinations.push({
+    id: "files",
+    label: "Files & artifacts",
+    description: "View files and artifacts created in this session.",
+    icon: <FileText aria-hidden="true" />,
+    activate: onOpenFiles,
+  });
+
+  if (actions.onOpenExtensions) {
+    destinations.push({
+      id: "extensions",
+      label: "Extensions",
+      description: "Browse the skills and connections available to your agent.",
+      icon: <Puzzle aria-hidden="true" />,
+      activate: actions.onOpenExtensions,
+    });
+  }
+
+  if (actions.onOpenVoice) {
+    destinations.push({
+      id: "voice",
+      label: "Voice Mode",
+      description: "Talk to OpenWork with real-time voice.",
+      icon: <Mic2 aria-hidden="true" />,
+      activate: actions.onOpenVoice,
+    });
+  }
+
+  return destinations;
+}
+
+export function PanelEmpty({ onOpenBrowser, onOpenExtensions, onOpenVoice }: PanelEmptyActions) {
+  const [destination, setDestination] = React.useState<"chooser" | "files">("chooser");
+
+  if (destination === "files") {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 sm:p-6">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mb-6 w-fit gap-2"
+          onClick={() => setDestination("chooser")}
+        >
+          <ArrowLeft />
+          All destinations
+        </Button>
+        <div className="m-auto max-w-sm text-center">
+          <span className="mx-auto mb-4 flex size-11 items-center justify-center rounded-xl bg-muted text-muted-foreground">
+            <FileText aria-hidden="true" />
+          </span>
+          <h2 className="text-base font-medium text-foreground">No files or artifacts yet</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Files and artifacts created in this session will appear here automatically.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const destinations = getPanelDestinations(
+    { onOpenBrowser, onOpenExtensions, onOpenVoice },
+    () => setDestination("files"),
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 sm:p-6">
+      <div className="my-auto w-full max-w-xl self-center">
+        <h2 className="text-base font-medium text-foreground">Choose a destination</h2>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          Open a tool or return here whenever you want to switch.
+        </p>
+        <div className="mt-5 grid gap-2" aria-label="Panel destinations">
+          {destinations.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={cn(
+                "group flex min-h-16 w-full items-center gap-3 rounded-xl border border-border bg-background p-3 text-left",
+                "transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              onClick={item.activate}
+            >
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground [&_svg]:size-4">
+                {item.icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-foreground">{item.label}</span>
+                <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">{item.description}</span>
+              </span>
+              <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -33,6 +33,7 @@ import {
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import type { OpenTarget } from "../artifacts/open-target";
 import { useSidePanelTabs } from "./use-side-panel-tabs";
+import { handlePanelEscape, PanelEmpty } from "./panel-empty";
 import {
   computeBounds,
   getElectronBrowser,
@@ -48,6 +49,8 @@ type SidePanelProps = {
   workspaceRoot: string;
   isRemoteWorkspace?: boolean;
   onClose: () => void;
+  onOpenExtensions?: () => void;
+  onOpenVoice?: () => void;
 };
 
 // HMR can remount this module without unmounting BrowserPanelContent, leaving
@@ -403,6 +406,8 @@ export function SidePanel({
   workspaceRoot,
   isRemoteWorkspace = false,
   onClose,
+  onOpenExtensions,
+  onOpenVoice,
 }: SidePanelProps) {
   const { tabs } = useSessionPanelState(sessionId);
   const activeTab = useActivePanelTab(sessionId);
@@ -586,7 +591,14 @@ export function SidePanel({
 
   return (
     <TooltipProvider delay={1000}>
-      <div className="flex h-full flex-col">
+      <div
+        className="flex h-full flex-col"
+        onKeyDownCapture={(event) => {
+          if (!handlePanelEscape(event.key, onClose)) return;
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+      >
         <div className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
           <div className="flex h-10 items-center gap-1 border-b border-border/60 px-2">
             <div className="no-scrollbar min-w-0 flex-1 overflow-x-auto">
@@ -605,7 +617,8 @@ export function SidePanel({
                 ))}
               </PanelTabList>
             </div>
-            {isBrowserAvailable ? (
+            {!activeTab ? <span className="sr-only">Panel destinations</span> : null}
+            {activeTab && isBrowserAvailable ? (
               <Tooltip>
                 <TooltipTrigger
                   render={(
@@ -621,11 +634,24 @@ export function SidePanel({
                 />
                 <TooltipContent>New tab</TooltipContent>
               </Tooltip>
+            ) : !activeTab ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onClose}
+                aria-label="Close panel"
+              >
+                <X />
+              </Button>
             ) : null}
           </div>
         </div>
         {!activeTab ? (
-          <PanelEmpty />
+          <PanelEmpty
+            onOpenBrowser={isBrowserAvailable ? createTab : undefined}
+            onOpenExtensions={onOpenExtensions}
+            onOpenVoice={onOpenVoice}
+          />
         ) : null}
         {activeTab?.type === "browser" ? (
           <BrowserPanelContent tab={activeTab} onClose={onClose} />
@@ -644,13 +670,5 @@ export function SidePanel({
         ) : null}
       </div>
     </TooltipProvider>
-  );
-}
-
-function PanelEmpty() {
-  return (
-    <div className="flex h-full items-center justify-center p-4 text-center">
-      <p className="text-sm text-muted-foreground">Open an artifact or browser tab to get started.</p>
-    </div>
   );
 }

--- a/apps/app/tests/right-panel-empty.test.tsx
+++ b/apps/app/tests/right-panel-empty.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  getPanelDestinations,
+  handlePanelEscape,
+  PanelEmpty,
+} from "../src/react-app/domains/session/panel/panel-empty";
+
+describe("right panel empty state", () => {
+  test("renders spacious keyboard-accessible destination actions", () => {
+    const html = renderToStaticMarkup(
+      <PanelEmpty
+        onOpenBrowser={() => undefined}
+        onOpenExtensions={() => undefined}
+        onOpenVoice={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Choose a destination");
+    expect(html).toContain("Browser");
+    expect(html).toContain("Files &amp; artifacts");
+    expect(html).toContain("Extensions");
+    expect(html).toContain("Voice Mode");
+    expect(html).toContain('aria-label="Panel destinations"');
+    expect(html.match(/<button/g)).toHaveLength(4);
+    expect(html).toContain("min-h-16");
+    expect(html).toContain("w-full");
+    expect(html).toContain("overflow-y-auto");
+  });
+
+  test("shows only destinations supported by the runtime", () => {
+    const html = renderToStaticMarkup(<PanelEmpty />);
+
+    expect(html).toContain("Files &amp; artifacts");
+    expect(html).not.toContain("Browser");
+    expect(html).not.toContain("Extensions");
+    expect(html).not.toContain("Voice Mode");
+    expect(html.match(/<button/g)).toHaveLength(1);
+  });
+
+  test("activates every available destination through its supplied handler", () => {
+    const activated: string[] = [];
+    const destinations = getPanelDestinations(
+      {
+        onOpenBrowser: () => activated.push("browser"),
+        onOpenExtensions: () => activated.push("extensions"),
+        onOpenVoice: () => activated.push("voice"),
+      },
+      () => activated.push("files"),
+    );
+
+    for (const destination of destinations) destination.activate();
+
+    expect(activated).toEqual(["browser", "files", "extensions", "voice"]);
+  });
+
+  test("closes on Escape without consuming unrelated keys", () => {
+    let closeCount = 0;
+
+    expect(handlePanelEscape("ArrowDown", () => { closeCount += 1; })).toBe(false);
+    expect(handlePanelEscape("Escape", () => { closeCount += 1; })).toBe(true);
+    expect(closeCount).toBe(1);
+  });
+});

--- a/apps/app/tests/ui-state-store.test.ts
+++ b/apps/app/tests/ui-state-store.test.ts
@@ -4,6 +4,7 @@ import type { UiState } from "../src/react-app/shell/ui-state-store";
 
 const PERSISTED_UI_STATE_KEY = "openwork:ui-state:v1";
 const originalWindow = globalThis.window;
+const originalLocalStorage = globalThis.localStorage;
 
 function memoryStorage(): Storage {
   const map = new Map<string, string>();
@@ -62,10 +63,15 @@ Object.defineProperty(globalThis, "window", {
     localStorage: storage,
   },
 });
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: storage,
+});
 
 const { persistUiState, toggleSidePanelState, useUiStateStore } = await import(
   "../src/react-app/shell/ui-state-store"
 );
+const { usePanelTabStore } = await import("../src/react-app/domains/session/panel/panel-tab-store");
 
 const importedSidePanelState = useUiStateStore.getState().sidePanelState;
 const importedWorkspaceRightSidebarExpanded = useUiStateStore.getState().workspaceRightSidebarExpanded;
@@ -74,6 +80,10 @@ afterAll(() => {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: originalLocalStorage,
   });
 });
 
@@ -94,6 +104,7 @@ describe("ui state store", () => {
     const parsed = requireJsonObject(storage.getItem(PERSISTED_UI_STATE_KEY));
     expect("sidePanelState" in parsed).toBe(false);
     expect(objectValue(parsed, "workspaceRightSidebarExpanded")).toBe(true);
+    expect(objectValue(parsed, "workspaceRightSidebarExpandedWidth")).toBe(520);
   });
 
   test("ignores legacy persisted side panel state on startup", () => {
@@ -117,5 +128,24 @@ describe("ui state store", () => {
 
     const closed = toggleSidePanelState(opened, "ses_1", "extensions");
     expect(closed.sidePanelState).toEqual({ ses_1: null });
+  });
+
+  test("preserves active panel content while the panel closes and reopens", () => {
+    usePanelTabStore.getState().openTab("ses_preserve", {
+      id: "file:report.md",
+      type: "artifact",
+      label: "report.md",
+      preview: "markdown",
+    });
+
+    const closed = toggleSidePanelState({
+      ...useUiStateStore.getState(),
+      sidePanelState: { ses_preserve: "panel" },
+    }, "ses_preserve", "panel");
+    const reopened = toggleSidePanelState(closed, "ses_preserve", "panel");
+
+    expect(reopened.sidePanelState.ses_preserve).toBe("panel");
+    expect(usePanelTabStore.getState().sessions.ses_preserve?.activeTabId).toBe("file:report.md");
+    usePanelTabStore.getState().clearSession("ses_preserve");
   });
 });

--- a/evals/flows/right-panel-action-empty-state.flow.mjs
+++ b/evals/flows/right-panel-action-empty-state.flow.mjs
@@ -1,9 +1,17 @@
 import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
 
 const READ_CHOOSER = `(() => {
-  const panel = [...document.querySelectorAll('aside, [role="complementary"], main + div, [data-side-panel]')]
-    .find((entry) => /choose|open in (the )?side panel|side panel/i.test(entry.textContent || ''));
+  const heading = [...document.querySelectorAll('h1, h2, h3')]
+    .find((entry) => /choose a destination/i.test(entry.textContent || ''));
+  const panel = heading?.parentElement;
   if (!(panel instanceof HTMLElement)) return null;
+  let panelFrame = panel;
+  for (let candidate = panel; candidate instanceof HTMLElement; candidate = candidate.parentElement) {
+    if (candidate.querySelector('button[aria-label="Close side panel"]')) {
+      panelFrame = candidate;
+      break;
+    }
+  }
   const actions = [...panel.querySelectorAll('button, a')]
     .filter((entry) => !entry.hasAttribute('disabled'))
     .map((entry) => ({
@@ -14,7 +22,7 @@ const READ_CHOOSER = `(() => {
   return {
     text: (panel.textContent || '').trim(),
     actions,
-    width: Math.round(panel.getBoundingClientRect().width),
+    width: Math.round(panelFrame.getBoundingClientRect().width),
   };
 })()`;
 


### PR DESCRIPTION
## Summary

- Keep the general right-panel control usable before a session has artifacts or open panel content.
- Present a deliberate empty-state chooser containing only real destinations supported by the current runtime.
- Reuse the existing side-panel state, destination handlers, close behavior, and persisted width.

## What changed

- **Session shell** — allows the existing side-panel control to open when a session exists without active content.
- **Empty state** — adds spacious, keyboard-accessible destination rows for Browser, Files & artifacts, and Extensions when supported by the runtime.
- **Panel state** — preserves the populated-panel path while routing the no-content state through the chooser.
- **Regression coverage** — adds focused right-panel empty-state and UI-state-store tests.
- **Current-dev proof repair** — updates the deterministic evaluator to find the current side-panel DOM and measure the complete panel frame after the upstream layout refactor.

## Why

The previous disabled affordance stranded users before an artifact or panel tab existed. The panel should help them choose a real destination instead of looking unavailable.

## Verification

Exact current-dev candidate: `e8987a129f7bcc224c490198722c7abc41a6c42e`

- [x] `pnpm --filter @openwork/app exec bun test --isolate tests/right-panel-empty.test.tsx tests/ui-state-store.test.ts` — 8 passed, 0 failed.
- [x] `pnpm --filter @openwork/app typecheck` — passed.
- [x] `pnpm evals:typecheck` — passed.
- [x] `pnpm fraimz --flow right-panel-action-empty-state --cdp-url http://127.0.0.1:9823` — 1 flow passed, 0 failed, 0 skipped; the frame was visually inspected.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [ ] The monolithic app suite reported 550 passed and 2 order-dependent failures in `message-list-loading.test.tsx`. That file is outside this PR's six-file diff, and its 3 tests pass when run in isolation. GitHub checks on this new head are still recomputing.

### Observed behavior

In the real Electron app, the general side-panel control opens a deliberate chooser before any panel content exists. Browser, Files & artifacts, and Extensions are visible as enabled destination actions, and the complete panel frame remains at a usable width.

## Risks and untested scope

- The deterministic flow proves chooser availability, destination labels, and complete panel width.
- Focused tests activate every supplied destination handler and cover Escape behavior.
- Runtime-specific navigation after each destination, populated-state preservation, and narrow-panel interaction remain human review targets.

## Lineage

- Original Kitchen run: `e9cf7d72-908a-42f2-884b-ba24ae0422db`
- Fork PR: [reachjalil/openwork#4](https://github.com/reachjalil/openwork/pull/4)

## Exact candidate

- Current base: `09143f592260cf313906867fcefa432f4fa0ccfa`
- Head: `e8987a129f7bcc224c490198722c7abc41a6c42e`

## Automation boundary

Prepared from the OpenWork Kitchen candidate and reconstructed on current `dev` under `@reachjalil`'s authorized fork. This PR is currently ready for review; merge, release, and deployment remain manual.
