### PR TITLE
Add platform-number shortcuts for visible chat sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -61,6 +61,7 @@ import { NotificationBell } from "../../../shell/notification-center";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
+import type { SessionNumberShortcutsState } from "../../../shell/session-number-shortcuts";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
@@ -154,6 +155,7 @@ export type SessionPageSurfaceProps = Omit<
 >;
 
 export type SessionPageProps = {
+  sessionNumberShortcuts: SessionNumberShortcutsState;
   selectedSessionId: string | null;
   selectedWorkspaceId: string;
   selectedWorkspaceDisplay: {
@@ -1011,6 +1013,7 @@ export function SessionPage(props: SessionPageProps) {
         style={sidebarProviderStyle}
       >
         <AppSidebar
+          sessionNumberShortcuts={props.sessionNumberShortcuts}
           workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
           developerMode={props.sidebar.developerMode}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import * as React from "react";
 import type { WorkspaceConnectionState } from "../../../../app/types";
+import type { SessionNumberShortcutOs } from "../../../shell/session-number-shortcuts";
 
 export type SidebarContextValue = {
   selectedWorkspaceId: string;
@@ -31,6 +32,8 @@ export type SidebarContextValue = {
   toggleSessionExpanded: (sessionId: string) => void;
   expandedWorkspaceIds: Set<string>;
   expandedSessionIds: Set<string>;
+  sessionNumberShortcutOs: SessionNumberShortcutOs;
+  sessionNumberShortcutByTarget: ReadonlyMap<string, number>;
 };
 
 export const SidebarContext = React.createContext<SidebarContextValue | null>(null);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -104,6 +104,13 @@ import {
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
 import { AccountStatusMenu, type AccountStatusMenuProps } from "./account-status-menu";
 import { usePlatform } from "../../../kernel/platform";
+import {
+  sessionNumberAriaKeyShortcut,
+  sessionNumberShortcutDescription,
+  sessionNumberShortcutLabel,
+  sessionNumberShortcutTargetKey,
+  type SessionNumberShortcutsState,
+} from "../../../shell/session-number-shortcuts";
 import type { SidebarContextValue } from "./app-sidebar-provider";
 import {
   MAX_SESSIONS_PREVIEW,
@@ -808,6 +815,7 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
 }
 
 export type AppSidebarProps = {
+  sessionNumberShortcuts: SessionNumberShortcutsState;
   workspaceSessionGroups: WorkspaceSessionGroup[];
   showInitialLoading?: boolean;
   selectedWorkspaceId: string;
@@ -874,6 +882,13 @@ export function AppSidebar(props: AppSidebarProps) {
     () => new Set(),
   );
   const previousSessionStatusRef = React.useRef<Record<string, string>>({});
+  const sessionNumberShortcutByTarget = React.useMemo(
+    () => new Map(props.sessionNumberShortcuts.targets.map((target) => [
+      sessionNumberShortcutTargetKey(target.workspaceId, target.sessionId),
+      target.digit,
+    ])),
+    [props.sessionNumberShortcuts.targets],
+  );
 
   // Green unread dots: agent finished while the user was on another session.
   React.useEffect(() => {
@@ -1010,6 +1025,8 @@ export function AppSidebar(props: AppSidebarProps) {
     toggleSessionExpanded,
     expandedWorkspaceIds,
     expandedSessionIds,
+    sessionNumberShortcutOs: props.sessionNumberShortcuts.os,
+    sessionNumberShortcutByTarget,
   };
 
   const brandLogoUrl = useBrandLogoUrl();
@@ -1124,6 +1141,7 @@ export function AppSidebar(props: AppSidebarProps) {
             layoutScroll
             data-slot="sidebar-content"
             data-sidebar="content"
+            data-session-number-modifier-held={props.sessionNumberShortcuts.modifierHeld ? "true" : undefined}
             className="no-scrollbar flex min-h-0 flex-1 flex-col gap-px overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
           >
             {pinnedSessions.length > 0 ? (
@@ -2205,6 +2223,33 @@ type SessionMenuItemProps = {
   workspaceName?: string;
 };
 
+function SessionNumberShortcutSlot({ digit }: { digit: number | undefined }) {
+  const ctx = useSidebarContext();
+  const label = digit === undefined
+    ? null
+    : sessionNumberShortcutLabel(ctx.sessionNumberShortcutOs, digit);
+
+  return (
+    <span
+      data-session-action-slot="number-shortcut"
+      aria-hidden="true"
+      className={cn(
+        "flex h-5 shrink-0 items-center justify-center",
+        ctx.sessionNumberShortcutOs === "macos" ? "w-8" : "w-11",
+      )}
+    >
+      {label ? (
+        <kbd
+          data-session-shortcut-badge={digit}
+          className="inline-flex h-5 items-center justify-center rounded-md border border-sidebar-border/70 bg-sidebar-accent/80 px-1.5 font-sans text-[10px] font-medium leading-none tracking-tight text-sidebar-foreground/70 shadow-xs"
+        >
+          {label}
+        </kbd>
+      ) : null}
+    </span>
+  );
+}
+
 function SessionMenuItem({
   session,
   tree,
@@ -2227,6 +2272,12 @@ function SessionMenuItem({
   const isUnread = unreadIds.has(session.id) && !isSelected;
   const isArchived = isSessionArchived(session);
   const relativeTime = formatSessionRelativeTime(session.time?.updated ?? session.time?.created);
+  const shortcutDigit = ctx.sessionNumberShortcutByTarget.get(
+    sessionNumberShortcutTargetKey(workspaceId, session.id),
+  );
+  const ariaKeyShortcuts = shortcutDigit === undefined
+    ? undefined
+    : sessionNumberAriaKeyShortcut(ctx.sessionNumberShortcutOs, shortcutDigit);
 
   const openSession = () => {
     useSessionManagementStore.getState().clearUnread(session.id);
@@ -2297,7 +2348,12 @@ function SessionMenuItem({
       onOpenChange={() => ctx.toggleSessionExpanded(session.id)}
       className="group/session-collapsible"
     >
-      <SidebarMenuSubItem {...dragProps} data-sidebar-session-id={session.id} data-sidebar-nest-depth={visualDepth}>
+      <SidebarMenuSubItem
+        {...dragProps}
+        data-sidebar-session-id={session.id}
+        data-sidebar-session-workspace-id={workspaceId}
+        data-sidebar-nest-depth={visualDepth}
+      >
         <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
           <CollapsibleTrigger
             render={
@@ -2311,11 +2367,14 @@ function SessionMenuItem({
                 onPointerEnter={prefetchSession}
                 onFocus={prefetchSession}
                 aria-label={accessibleState}
+                aria-description={shortcutDigit === undefined ? undefined : sessionNumberShortcutDescription(ctx.sessionNumberShortcutOs, shortcutDigit)}
+                aria-keyshortcuts={ariaKeyShortcuts}
               >
                 {leading}
-                <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>
+                <span data-session-title-slot className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>
                   {displayTitle}
                 </span>
+                <SessionNumberShortcutSlot digit={shortcutDigit} />
                 <span className="flex size-6 shrink-0 items-center justify-center">
                   <ChevronRight className="size-4 text-muted-foreground transition-transform duration-200 group-data-open/session-collapsible:rotate-90 hover:text-foreground" />
                 </span>
@@ -2327,7 +2386,12 @@ function SessionMenuItem({
       </SidebarMenuSubItem>
     </Collapsible>
   ) : (
-    <SidebarMenuSubItem {...dragProps} data-sidebar-session-id={session.id} data-sidebar-nest-depth={visualDepth}>
+    <SidebarMenuSubItem
+      {...dragProps}
+      data-sidebar-session-id={session.id}
+      data-sidebar-session-workspace-id={workspaceId}
+      data-sidebar-nest-depth={visualDepth}
+    >
       <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
         <SidebarMenuSubButton
           isActive={isSelected}
@@ -2337,11 +2401,14 @@ function SessionMenuItem({
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
           aria-label={accessibleState}
+          aria-description={shortcutDigit === undefined ? undefined : sessionNumberShortcutDescription(ctx.sessionNumberShortcutOs, shortcutDigit)}
+          aria-keyshortcuts={ariaKeyShortcuts}
           className={rowButtonClass}
           style={rowButtonStyle}
         >
           {leading}
-          <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>{displayTitle}</span>
+          <span data-session-title-slot className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>{displayTitle}</span>
+          <SessionNumberShortcutSlot digit={shortcutDigit} />
         </SidebarMenuSubButton>
       </SessionContextMenu>
       {trailing}

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -25,6 +25,11 @@ import {
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { BrainCircuit, Check, ChevronLeftIcon, FileText, FolderInput, Globe, Zap } from "lucide-react";
+import { usePlatform } from "../kernel/platform";
+import {
+  resolveSessionNumberShortcutOs,
+  sessionNumberShortcutHelp,
+} from "./session-number-shortcuts";
 
 export type PaletteItem = {
   id: string;
@@ -120,6 +125,7 @@ export type CommandPaletteProps = {
  * - Sessions submode: fuzzy list of every session across workspaces.
  */
 export function CommandPalette(props: CommandPaletteProps) {
+  const platform = usePlatform();
   const [mode, setMode] = useState<PaletteMode>("root");
   const [agents, setAgents] = useState<Agent[]>([]);
 
@@ -157,6 +163,14 @@ export function CommandPalette(props: CommandPaletteProps) {
   const accessibleTargetCount = props.accessibleTargets?.length ?? 0;
   const sessionGroupCount = props.sessionGroups?.length ?? 0;
   const canMoveCurrentSessionToGroup = Boolean(props.currentSessionForGroupMove && props.onMoveCurrentSessionToGroup);
+  const sessionNumberOs = resolveSessionNumberShortcutOs(
+    platform.os,
+    typeof navigator === "undefined" ? "" : navigator.platform,
+  );
+  const sessionNumberHelp = useMemo(
+    () => sessionNumberShortcutHelp(sessionNumberOs),
+    [sessionNumberOs],
+  );
 
   const rootItems = useMemo<PaletteItem[]>(() => [
     {
@@ -176,6 +190,13 @@ export function CommandPalette(props: CommandPaletteProps) {
         count: props.sessions.length.toLocaleString(),
       }),
       meta: t("session.cmd_sessions_meta"),
+      action: () => {
+        setMode("sessions");
+      },
+    },
+    {
+      id: "session-number-shortcuts",
+      ...sessionNumberHelp,
       action: () => {
         setMode("sessions");
       },
@@ -307,7 +328,7 @@ export function CommandPalette(props: CommandPaletteProps) {
         props.onOpenSettings("/settings/updates");
       },
     },
-  ], [accessibleTargetCount, canMoveCurrentSessionToGroup, props, sessionGroupCount]);
+  ], [accessibleTargetCount, canMoveCurrentSessionToGroup, props, sessionGroupCount, sessionNumberHelp]);
 
   const sessionItems = useMemo<PaletteItem[]>(
     () =>

--- a/apps/app/src/react-app/shell/session-number-shortcuts.ts
+++ b/apps/app/src/react-app/shell/session-number-shortcuts.ts
@@ -35,7 +35,6 @@ type SessionNumberShortcutIntent =
   | { type: "activate"; digit: number };
 
 type SessionNumberShortcutIntentOptions = {
-  editable: boolean;
   ownerActive: boolean;
   cancelled: boolean;
 };
@@ -50,12 +49,10 @@ export type SessionNumberShortcutTransition =
 
 const SESSION_ROW_SELECTOR =
   "[data-sidebar-session-id][data-sidebar-session-workspace-id]";
-const SHORTCUT_OWNER_SELECTOR = [
+const SHORTCUT_OWNER_CANDIDATE_SELECTOR = [
   '[data-slot="dialog-content"]',
   '[role="dialog"]',
   '[role="alertdialog"]',
-  '[role="menu"]',
-  '[role="listbox"]',
 ].join(",");
 
 export function sessionNumberShortcutTargetKey(workspaceId: string, sessionId: string) {
@@ -107,17 +104,23 @@ export function sessionNumberShortcutHelp(os: SessionNumberShortcutOs) {
   };
 }
 
-export function isEditableShortcutTarget(target: EventTarget | null) {
-  if (!(target instanceof Element)) return false;
-  return Boolean(target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]'));
-}
-
 function isVisibleElement(element: Element) {
   return element.getClientRects().length > 0 && element.getAttribute("aria-hidden") !== "true";
 }
 
+export function isSessionNumberShortcutBlockingOwner(element: Element) {
+  const role = element.getAttribute("role");
+  return (
+    element.getAttribute("data-slot") === "dialog-content" ||
+    role === "dialog" ||
+    role === "alertdialog"
+  );
+}
+
 export function hasSessionNumberShortcutOwner(documentRoot: Document) {
-  return Array.from(documentRoot.querySelectorAll(SHORTCUT_OWNER_SELECTOR)).some(isVisibleElement);
+  return Array.from(documentRoot.querySelectorAll(SHORTCUT_OWNER_CANDIDATE_SELECTOR)).some(
+    (element) => isSessionNumberShortcutBlockingOwner(element) && isVisibleElement(element),
+  );
 }
 
 export function getSessionNumberShortcutIntent(
@@ -136,7 +139,6 @@ export function getSessionNumberShortcutIntent(
     oppositeModifierPressed ||
     event.shiftKey ||
     event.altKey ||
-    options.editable ||
     options.ownerActive ||
     options.cancelled
   ) {

--- a/apps/app/src/react-app/shell/session-number-shortcuts.ts
+++ b/apps/app/src/react-app/shell/session-number-shortcuts.ts
@@ -108,10 +108,14 @@ function isVisibleElement(element: Element) {
   return element.getClientRects().length > 0 && element.getAttribute("aria-hidden") !== "true";
 }
 
-export function isSessionNumberShortcutBlockingOwner(element: Element) {
+export function isSessionNumberShortcutBlockingOwner(
+  element: Pick<Element, "getAttribute">,
+) {
+  const slot = element.getAttribute("data-slot");
   const role = element.getAttribute("role");
+  if (slot === "popover-content") return false;
   return (
-    element.getAttribute("data-slot") === "dialog-content" ||
+    slot === "dialog-content" ||
     role === "dialog" ||
     role === "alertdialog"
   );

--- a/apps/app/src/react-app/shell/session-number-shortcuts.ts
+++ b/apps/app/src/react-app/shell/session-number-shortcuts.ts
@@ -1,0 +1,199 @@
+export const SESSION_NUMBER_SHORTCUT_LIMIT = 9;
+
+export type SessionNumberShortcutOs = "macos" | "windows" | "linux";
+
+export type SessionNumberShortcutTarget = {
+  workspaceId: string;
+  sessionId: string;
+  digit: number;
+};
+
+export type SessionNumberShortcutsState = {
+  modifierHeld: boolean;
+  os: SessionNumberShortcutOs;
+  targets: readonly SessionNumberShortcutTarget[];
+};
+
+export type SessionNumberShortcutCandidate = {
+  workspaceId: string;
+  sessionId: string;
+  visible: boolean;
+  actionable: boolean;
+};
+
+type SessionNumberShortcutEvent = {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+};
+
+type SessionNumberShortcutIntent =
+  | { type: "ignore" }
+  | { type: "hold" }
+  | { type: "activate"; digit: number };
+
+type SessionNumberShortcutIntentOptions = {
+  editable: boolean;
+  ownerActive: boolean;
+  cancelled: boolean;
+};
+
+export type SessionNumberShortcutTransition =
+  | "modifier-down"
+  | "modifier-up"
+  | "blur"
+  | "visibility-hidden"
+  | "owner-change"
+  | "unmount";
+
+const SESSION_ROW_SELECTOR =
+  "[data-sidebar-session-id][data-sidebar-session-workspace-id]";
+const SHORTCUT_OWNER_SELECTOR = [
+  '[data-slot="dialog-content"]',
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+].join(",");
+
+export function sessionNumberShortcutTargetKey(workspaceId: string, sessionId: string) {
+  return `${workspaceId}\u0000${sessionId}`;
+}
+
+export function resolveSessionNumberShortcutOs(
+  platformOs: SessionNumberShortcutOs | undefined,
+  navigatorPlatform: string,
+): SessionNumberShortcutOs {
+  if (platformOs) return platformOs;
+  if (/mac/i.test(navigatorPlatform)) return "macos";
+  if (/win/i.test(navigatorPlatform)) return "windows";
+  return "linux";
+}
+
+export function assignSessionNumberShortcuts(
+  candidates: readonly SessionNumberShortcutCandidate[],
+): SessionNumberShortcutTarget[] {
+  return candidates
+    .filter((candidate) => candidate.visible && candidate.actionable)
+    .slice(0, SESSION_NUMBER_SHORTCUT_LIMIT)
+    .map((candidate, index) => ({
+      workspaceId: candidate.workspaceId,
+      sessionId: candidate.sessionId,
+      digit: index + 1,
+    }));
+}
+
+export function sessionNumberAriaKeyShortcut(os: SessionNumberShortcutOs, digit: number) {
+  return `${os === "macos" ? "Meta" : "Control"}+${digit}`;
+}
+
+export function sessionNumberShortcutLabel(os: SessionNumberShortcutOs, digit: number) {
+  return os === "macos" ? `⌘${digit}` : `Ctrl+${digit}`;
+}
+
+export function sessionNumberShortcutDescription(os: SessionNumberShortcutOs, digit: number) {
+  return `Open this session with ${sessionNumberShortcutLabel(os, digit)}`;
+}
+
+export function sessionNumberShortcutHelp(os: SessionNumberShortcutOs) {
+  const modifier = os === "macos" ? "Command" : "Ctrl";
+  return {
+    title: "Open a visible session by number",
+    detail: `Hold ${modifier} to reveal shortcuts beside the first nine visible sessions, then press 1–9.`,
+    meta: os === "macos" ? "⌘1–⌘9" : "Ctrl+1–9",
+    searchText: "keyboard shortcut visible session number jump open command control 1 2 3 4 5 6 7 8 9",
+  };
+}
+
+export function isEditableShortcutTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+  return Boolean(target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]'));
+}
+
+function isVisibleElement(element: Element) {
+  return element.getClientRects().length > 0 && element.getAttribute("aria-hidden") !== "true";
+}
+
+export function hasSessionNumberShortcutOwner(documentRoot: Document) {
+  return Array.from(documentRoot.querySelectorAll(SHORTCUT_OWNER_SELECTOR)).some(isVisibleElement);
+}
+
+export function getSessionNumberShortcutIntent(
+  event: SessionNumberShortcutEvent,
+  os: SessionNumberShortcutOs,
+  options: SessionNumberShortcutIntentOptions,
+): SessionNumberShortcutIntent {
+  const modifierKey = os === "macos" ? "Meta" : "Control";
+  const modifierPressed = os === "macos" ? event.metaKey : event.ctrlKey;
+  const oppositeModifierPressed = os === "macos" ? event.ctrlKey : event.metaKey;
+  if (event.key === modifierKey) {
+    return options.ownerActive ? { type: "ignore" } : { type: "hold" };
+  }
+  if (
+    !modifierPressed ||
+    oppositeModifierPressed ||
+    event.shiftKey ||
+    event.altKey ||
+    options.editable ||
+    options.ownerActive ||
+    options.cancelled
+  ) {
+    return { type: "ignore" };
+  }
+  if (!/^[1-9]$/.test(event.key)) return { type: "hold" };
+  return { type: "activate", digit: Number(event.key) };
+}
+
+export function isSessionNumberModifierKey(key: string, os: SessionNumberShortcutOs) {
+  return key === (os === "macos" ? "Meta" : "Control");
+}
+
+export function nextSessionNumberModifierHeld(
+  transition: SessionNumberShortcutTransition,
+) {
+  return transition === "modifier-down";
+}
+
+type SessionNumberShortcutDomTarget = SessionNumberShortcutTarget & {
+  button: HTMLElement;
+};
+
+export function readVisibleSessionNumberShortcutTargets(
+  documentRoot: Document,
+): SessionNumberShortcutDomTarget[] {
+  const rows = Array.from(documentRoot.querySelectorAll<HTMLElement>(SESSION_ROW_SELECTOR));
+  const candidates = rows.flatMap((row) => {
+    const button = row.querySelector<HTMLElement>("[data-session-tab-id]");
+    const workspaceId = row.dataset.sidebarSessionWorkspaceId?.trim();
+    const sessionId = row.dataset.sidebarSessionId?.trim();
+    if (!button || !workspaceId || !sessionId) return [];
+    return [{
+      workspaceId,
+      sessionId,
+      visible: isVisibleElement(button),
+      actionable: !button.matches('[disabled], [aria-disabled="true"]'),
+      button,
+    }];
+  });
+  const assigned = assignSessionNumberShortcuts(candidates);
+  return assigned.flatMap((target) => {
+    const match = candidates.find((candidate) => (
+      candidate.workspaceId === target.workspaceId && candidate.sessionId === target.sessionId
+    ));
+    return match ? [{ ...target, button: match.button }] : [];
+  });
+}
+
+export function sameSessionNumberShortcutTargets(
+  left: readonly SessionNumberShortcutTarget[],
+  right: readonly SessionNumberShortcutTarget[],
+) {
+  return left.length === right.length && left.every((target, index) => {
+    const other = right[index];
+    return other?.workspaceId === target.workspaceId &&
+      other.sessionId === target.sessionId &&
+      other.digit === target.digit;
+  });
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1767,6 +1767,7 @@ export function SessionRoute() {
     setSessionSearchOpen,
     terminalOpen,
     setTerminalOpen,
+    sessionNumberShortcuts,
   } = useShellShortcuts({
     canCreateTask,
     workspaceId: selectedWorkspaceId,
@@ -2424,6 +2425,7 @@ export function SessionRoute() {
       />
     ) : null}
     <SessionPage
+      sessionNumberShortcuts={sessionNumberShortcuts}
       selectedSessionId={selectedSessionId}
       selectedWorkspaceId={selectedWorkspaceId}
       selectedWorkspaceDisplay={selectedWorkspace ? {

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -6,7 +6,6 @@ import { usePlatform } from "../kernel/platform";
 import {
   getSessionNumberShortcutIntent,
   hasSessionNumberShortcutOwner,
-  isEditableShortcutTarget,
   isSessionNumberModifierKey,
   nextSessionNumberModifierHeld,
   readVisibleSessionNumberShortcutTargets,
@@ -135,7 +134,6 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
 
   const handleSessionNumberKeyDown = useEffectEvent((event: KeyboardEvent) => {
     const intent = getSessionNumberShortcutIntent(event, sessionNumberOs, {
-      editable: isEditableShortcutTarget(event.target),
       ownerActive: hasSessionNumberShortcutOwner(document),
       cancelled: sessionNumberCancelledRef.current,
     });
@@ -193,14 +191,16 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
       }
     });
 
-    window.addEventListener("keydown", keyDown);
+    // Capture first so text fields and open select/menu popovers cannot consume
+    // the global session jump before the shell sees it.
+    window.addEventListener("keydown", keyDown, true);
     window.addEventListener("keyup", keyUp);
     window.addEventListener("blur", blur);
     document.addEventListener("visibilitychange", visibilityChange);
     document.addEventListener("focusin", focusIn);
     observer.observe(document.body, { childList: true, subtree: true, attributes: true });
     return () => {
-      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keydown", keyDown, true);
       window.removeEventListener("keyup", keyUp);
       window.removeEventListener("blur", blur);
       document.removeEventListener("visibilitychange", visibilityChange);

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -1,8 +1,21 @@
 // Shell panel open-state (command palette, session search, terminal) plus the
 // global keyboard shortcuts that toggle them. Extracted verbatim from
 // session-route.tsx.
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { usePlatform } from "../kernel/platform";
+import {
+  getSessionNumberShortcutIntent,
+  hasSessionNumberShortcutOwner,
+  isEditableShortcutTarget,
+  isSessionNumberModifierKey,
+  nextSessionNumberModifierHeld,
+  readVisibleSessionNumberShortcutTargets,
+  resolveSessionNumberShortcutOs,
+  sameSessionNumberShortcutTargets,
+  type SessionNumberShortcutOs,
+  type SessionNumberShortcutTarget,
+  type SessionNumberShortcutTransition,
+} from "./session-number-shortcuts";
 
 export type UseShellShortcutsInput = {
   canCreateTask: boolean;
@@ -38,6 +51,35 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
   const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut();
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
+  const [sessionNumberModifierHeld, setSessionNumberModifierHeld] = useState(false);
+  const [sessionNumberTargets, setSessionNumberTargets] = useState<SessionNumberShortcutTarget[]>([]);
+  const sessionNumberCancelledRef = useRef(false);
+  const sessionNumberOs: SessionNumberShortcutOs = resolveSessionNumberShortcutOs(
+    platform.os,
+    typeof navigator === "undefined" ? "" : navigator.platform,
+  );
+
+  const clearSessionNumberShortcuts = useEffectEvent((
+    cancelUntilRelease: boolean,
+    transition: SessionNumberShortcutTransition,
+  ) => {
+    sessionNumberCancelledRef.current = cancelUntilRelease;
+    setSessionNumberModifierHeld(nextSessionNumberModifierHeld(transition));
+    setSessionNumberTargets((current) => current.length === 0 ? current : []);
+  });
+
+  const refreshSessionNumberShortcuts = useEffectEvent(() => {
+    if (hasSessionNumberShortcutOwner(document)) {
+      clearSessionNumberShortcuts(true, "owner-change");
+      return [];
+    }
+    const targets = readVisibleSessionNumberShortcutTargets(document);
+    setSessionNumberModifierHeld(nextSessionNumberModifierHeld("modifier-down"));
+    setSessionNumberTargets((current) => (
+      sameSessionNumberShortcutTargets(current, targets) ? current : targets
+    ));
+    return targets;
+  });
 
   // Global shortcuts:
   //   Cmd/Ctrl+N        -> new task in selected workspace
@@ -47,6 +89,7 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
   //   Cmd/Ctrl+Shift+F  -> search every session (titles + messages)
   //   Cmd/Ctrl+T        -> next session tab
   //   Cmd/Ctrl+Shift+T  -> previous session tab
+  //   Cmd/Ctrl+1–9      -> matching visible sidebar session
   const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
     const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
     const mod = isMac ? event.metaKey : event.ctrlKey;
@@ -90,11 +133,81 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
     }
   });
 
+  const handleSessionNumberKeyDown = useEffectEvent((event: KeyboardEvent) => {
+    const intent = getSessionNumberShortcutIntent(event, sessionNumberOs, {
+      editable: isEditableShortcutTarget(event.target),
+      ownerActive: hasSessionNumberShortcutOwner(document),
+      cancelled: sessionNumberCancelledRef.current,
+    });
+    if (intent.type === "ignore") {
+      if (isSessionNumberModifierKey(event.key, sessionNumberOs)) {
+        clearSessionNumberShortcuts(true, "owner-change");
+      }
+      return;
+    }
+    if (intent.type === "hold") {
+      sessionNumberCancelledRef.current = false;
+      refreshSessionNumberShortcuts();
+      return;
+    }
+
+    const targets = refreshSessionNumberShortcuts();
+    const target = targets[intent.digit - 1];
+    if (!target) return;
+    event.preventDefault();
+    if (!event.repeat) target.button.click();
+  });
+
+  const handleSessionNumberKeyUp = useEffectEvent((event: KeyboardEvent) => {
+    if (!isSessionNumberModifierKey(event.key, sessionNumberOs)) return;
+    clearSessionNumberShortcuts(false, "modifier-up");
+  });
+
   useEffect(() => {
     const handler = (event: KeyboardEvent) => handleGlobalShortcut(event);
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, []);
+
+  useEffect(() => {
+    const keyDown = (event: KeyboardEvent) => handleSessionNumberKeyDown(event);
+    const keyUp = (event: KeyboardEvent) => handleSessionNumberKeyUp(event);
+    const loseOwnership = () => clearSessionNumberShortcuts(true, "owner-change");
+    const blur = () => clearSessionNumberShortcuts(true, "blur");
+    const visibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        clearSessionNumberShortcuts(true, "visibility-hidden");
+      }
+    };
+    const focusIn = () => {
+      if (hasSessionNumberShortcutOwner(document)) {
+        loseOwnership();
+      }
+    };
+    const observer = new MutationObserver(() => {
+      if (!sessionNumberModifierHeld) return;
+      if (hasSessionNumberShortcutOwner(document)) {
+        loseOwnership();
+      } else {
+        refreshSessionNumberShortcuts();
+      }
+    });
+
+    window.addEventListener("keydown", keyDown);
+    window.addEventListener("keyup", keyUp);
+    window.addEventListener("blur", blur);
+    document.addEventListener("visibilitychange", visibilityChange);
+    document.addEventListener("focusin", focusIn);
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    return () => {
+      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keyup", keyUp);
+      window.removeEventListener("blur", blur);
+      document.removeEventListener("visibilitychange", visibilityChange);
+      document.removeEventListener("focusin", focusIn);
+      observer.disconnect();
+    };
+  }, [sessionNumberModifierHeld]);
 
   return {
     commandPaletteOpen,
@@ -103,5 +216,10 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
     setSessionSearchOpen,
     terminalOpen,
     setTerminalOpen,
+    sessionNumberShortcuts: {
+      modifierHeld: sessionNumberModifierHeld,
+      os: sessionNumberOs,
+      targets: sessionNumberTargets,
+    },
   };
 }

--- a/apps/app/tests/session-number-shortcuts.test.ts
+++ b/apps/app/tests/session-number-shortcuts.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  SESSION_NUMBER_SHORTCUT_LIMIT,
+  assignSessionNumberShortcuts,
+  getSessionNumberShortcutIntent,
+  isSessionNumberModifierKey,
+  nextSessionNumberModifierHeld,
+  resolveSessionNumberShortcutOs,
+  sessionNumberAriaKeyShortcut,
+  sessionNumberShortcutDescription,
+  sessionNumberShortcutHelp,
+  sessionNumberShortcutLabel,
+  type SessionNumberShortcutCandidate,
+  type SessionNumberShortcutOs,
+  type SessionNumberShortcutTransition,
+} from "../src/react-app/shell/session-number-shortcuts";
+
+const macModifier = {
+  key: "Meta",
+  metaKey: true,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+};
+
+const available = {
+  editable: false,
+  ownerActive: false,
+  cancelled: false,
+};
+
+describe("visible session number shortcut ordering", () => {
+  test("numbers only actionable rows in exact pinned, grouped, nested, and regular visual order", () => {
+    const candidates: SessionNumberShortcutCandidate[] = [
+      { workspaceId: "a", sessionId: "pinned", visible: true, actionable: true },
+      { workspaceId: "a", sessionId: "pinned-child", visible: true, actionable: true },
+      { workspaceId: "a", sessionId: "group-heading", visible: true, actionable: false },
+      { workspaceId: "a", sessionId: "group-one", visible: true, actionable: true },
+      { workspaceId: "a", sessionId: "collapsed-child", visible: false, actionable: true },
+      { workspaceId: "a", sessionId: "group-two", visible: true, actionable: true },
+      { workspaceId: "a", sessionId: "show-more", visible: true, actionable: false },
+      { workspaceId: "a", sessionId: "filtered", visible: false, actionable: true },
+      { workspaceId: "b", sessionId: "loading", visible: true, actionable: false },
+      ...Array.from({ length: 8 }, (_, index) => ({
+        workspaceId: "b",
+        sessionId: `regular-${index + 1}`,
+        visible: true,
+        actionable: true,
+      })),
+    ];
+
+    expect(assignSessionNumberShortcuts(candidates)).toEqual([
+      { workspaceId: "a", sessionId: "pinned", digit: 1 },
+      { workspaceId: "a", sessionId: "pinned-child", digit: 2 },
+      { workspaceId: "a", sessionId: "group-one", digit: 3 },
+      { workspaceId: "a", sessionId: "group-two", digit: 4 },
+      { workspaceId: "b", sessionId: "regular-1", digit: 5 },
+      { workspaceId: "b", sessionId: "regular-2", digit: 6 },
+      { workspaceId: "b", sessionId: "regular-3", digit: 7 },
+      { workspaceId: "b", sessionId: "regular-4", digit: 8 },
+      { workspaceId: "b", sessionId: "regular-5", digit: 9 },
+    ]);
+    expect(assignSessionNumberShortcuts(candidates)).toHaveLength(SESSION_NUMBER_SHORTCUT_LIMIT);
+  });
+});
+
+describe("session number shortcut keyboard ownership", () => {
+  test("tracks modifier press and every required cleanup transition", () => {
+    expect(getSessionNumberShortcutIntent(macModifier, "macos", available)).toEqual({ type: "hold" });
+    expect(getSessionNumberShortcutIntent(macModifier, "macos", { ...available, editable: true })).toEqual({ type: "hold" });
+    expect(nextSessionNumberModifierHeld("modifier-down")).toBe(true);
+    const cleanupTransitions: SessionNumberShortcutTransition[] = [
+      "modifier-up",
+      "blur",
+      "visibility-hidden",
+      "owner-change",
+      "unmount",
+    ];
+    for (const transition of cleanupTransitions) {
+      expect(nextSessionNumberModifierHeld(transition)).toBe(false);
+    }
+    expect(isSessionNumberModifierKey("Meta", "macos")).toBe(true);
+    expect(isSessionNumberModifierKey("Control", "windows")).toBe(true);
+  });
+
+  test("activates digits but yields to editable and modal owners", () => {
+    const digit = { ...macModifier, key: "4" };
+    expect(getSessionNumberShortcutIntent(digit, "macos", available)).toEqual({ type: "activate", digit: 4 });
+    expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, editable: true })).toEqual({ type: "ignore" });
+    expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, ownerActive: true })).toEqual({ type: "ignore" });
+    expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, cancelled: true })).toEqual({ type: "ignore" });
+    expect(getSessionNumberShortcutIntent({ ...digit, shiftKey: true }, "macos", available)).toEqual({ type: "ignore" });
+    expect(getSessionNumberShortcutIntent({ ...digit, ctrlKey: true }, "macos", available)).toEqual({ type: "ignore" });
+  });
+});
+
+describe("session number shortcut platform and accessibility metadata", () => {
+  test("uses Command labels and Meta aria shortcuts on macOS", () => {
+    expect(resolveSessionNumberShortcutOs(undefined, "MacIntel")).toBe("macos");
+    expect(sessionNumberShortcutLabel("macos", 3)).toBe("⌘3");
+    expect(sessionNumberAriaKeyShortcut("macos", 3)).toBe("Meta+3");
+    expect(sessionNumberShortcutDescription("macos", 3)).toContain("⌘3");
+    expect(sessionNumberShortcutHelp("macos").meta).toBe("⌘1–⌘9");
+  });
+
+  test("uses Ctrl labels and Control aria shortcuts on Windows and Linux", () => {
+    expect(resolveSessionNumberShortcutOs(undefined, "Win32")).toBe("windows");
+    expect(resolveSessionNumberShortcutOs(undefined, "Linux x86_64")).toBe("linux");
+    const controlPlatforms: SessionNumberShortcutOs[] = ["windows", "linux"];
+    for (const os of controlPlatforms) {
+      expect(sessionNumberShortcutLabel(os, 7)).toBe("Ctrl+7");
+      expect(sessionNumberAriaKeyShortcut(os, 7)).toBe("Control+7");
+      expect(sessionNumberShortcutHelp(os).meta).toBe("Ctrl+1–9");
+    }
+  });
+});

--- a/apps/app/tests/session-number-shortcuts.test.ts
+++ b/apps/app/tests/session-number-shortcuts.test.ts
@@ -95,10 +95,13 @@ describe("session number shortcut keyboard ownership", () => {
   test("keeps open selects and menus non-blocking while dialogs retain ownership", () => {
     const element = (attributes: Record<string, string>) => ({
       getAttribute: (name: string) => attributes[name] ?? null,
-    }) as Element;
+    });
 
     expect(isSessionNumberShortcutBlockingOwner(element({ role: "listbox" }))).toBe(false);
     expect(isSessionNumberShortcutBlockingOwner(element({ role: "menu" }))).toBe(false);
+    expect(isSessionNumberShortcutBlockingOwner(
+      element({ role: "dialog", "data-slot": "popover-content" }),
+    )).toBe(false);
     expect(isSessionNumberShortcutBlockingOwner(element({ role: "dialog" }))).toBe(true);
     expect(isSessionNumberShortcutBlockingOwner(element({ role: "alertdialog" }))).toBe(true);
     expect(isSessionNumberShortcutBlockingOwner(element({ "data-slot": "dialog-content" }))).toBe(true);

--- a/apps/app/tests/session-number-shortcuts.test.ts
+++ b/apps/app/tests/session-number-shortcuts.test.ts
@@ -4,6 +4,7 @@ import {
   SESSION_NUMBER_SHORTCUT_LIMIT,
   assignSessionNumberShortcuts,
   getSessionNumberShortcutIntent,
+  isSessionNumberShortcutBlockingOwner,
   isSessionNumberModifierKey,
   nextSessionNumberModifierHeld,
   resolveSessionNumberShortcutOs,
@@ -25,7 +26,6 @@ const macModifier = {
 };
 
 const available = {
-  editable: false,
   ownerActive: false,
   cancelled: false,
 };
@@ -68,7 +68,6 @@ describe("visible session number shortcut ordering", () => {
 describe("session number shortcut keyboard ownership", () => {
   test("tracks modifier press and every required cleanup transition", () => {
     expect(getSessionNumberShortcutIntent(macModifier, "macos", available)).toEqual({ type: "hold" });
-    expect(getSessionNumberShortcutIntent(macModifier, "macos", { ...available, editable: true })).toEqual({ type: "hold" });
     expect(nextSessionNumberModifierHeld("modifier-down")).toBe(true);
     const cleanupTransitions: SessionNumberShortcutTransition[] = [
       "modifier-up",
@@ -84,14 +83,25 @@ describe("session number shortcut keyboard ownership", () => {
     expect(isSessionNumberModifierKey("Control", "windows")).toBe(true);
   });
 
-  test("activates digits but yields to editable and modal owners", () => {
+  test("activates digits globally but still yields to modal owners", () => {
     const digit = { ...macModifier, key: "4" };
     expect(getSessionNumberShortcutIntent(digit, "macos", available)).toEqual({ type: "activate", digit: 4 });
-    expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, editable: true })).toEqual({ type: "ignore" });
     expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, ownerActive: true })).toEqual({ type: "ignore" });
     expect(getSessionNumberShortcutIntent(digit, "macos", { ...available, cancelled: true })).toEqual({ type: "ignore" });
     expect(getSessionNumberShortcutIntent({ ...digit, shiftKey: true }, "macos", available)).toEqual({ type: "ignore" });
     expect(getSessionNumberShortcutIntent({ ...digit, ctrlKey: true }, "macos", available)).toEqual({ type: "ignore" });
+  });
+
+  test("keeps open selects and menus non-blocking while dialogs retain ownership", () => {
+    const element = (attributes: Record<string, string>) => ({
+      getAttribute: (name: string) => attributes[name] ?? null,
+    }) as Element;
+
+    expect(isSessionNumberShortcutBlockingOwner(element({ role: "listbox" }))).toBe(false);
+    expect(isSessionNumberShortcutBlockingOwner(element({ role: "menu" }))).toBe(false);
+    expect(isSessionNumberShortcutBlockingOwner(element({ role: "dialog" }))).toBe(true);
+    expect(isSessionNumberShortcutBlockingOwner(element({ role: "alertdialog" }))).toBe(true);
+    expect(isSessionNumberShortcutBlockingOwner(element({ "data-slot": "dialog-content" }))).toBe(true);
   });
 });
 

--- a/evals/flows/lib/session-workspace.mjs
+++ b/evals/flows/lib/session-workspace.mjs
@@ -1,4 +1,5 @@
 import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 export async function ensureSessionWorkspace(ctx, flowId) {
@@ -10,11 +11,10 @@ export async function ensureSessionWorkspace(ctx, flowId) {
     "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
   );
   if (!canCreateTask) {
-    const workspacePath = resolve(
-      process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
-      "..",
-      `${flowId}-workspace`,
-    );
+    const artifactsDir = process.env.OPENWORK_EVAL_ARTIFACTS_DIR?.trim();
+    const workspacePath = artifactsDir
+      ? resolve(artifactsDir, "..", `${flowId}-workspace`)
+      : resolve(tmpdir(), `openwork-eval-${flowId}-workspace`);
     await mkdir(workspacePath, { recursive: true });
     const welcomeInput = 'input[placeholder="/workspace/my-project"]';
     const onWelcome = await ctx.eval(
@@ -47,4 +47,42 @@ export async function ensureSessionWorkspace(ctx, flowId) {
     "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
     { timeoutMs: 90_000, label: "session.create_task enabled" },
   );
+}
+
+export async function sessionIds(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openwork?.slice?.("route");
+    return Object.values(route?.sessionsByWorkspaceId || {})
+      .flatMap((sessions) => Array.isArray(sessions) ? sessions : [])
+      .map((session) => typeof session?.id === "string" ? session.id.trim() : "")
+      .filter(Boolean);
+  })()`);
+}
+
+export async function waitForCreatedSession(ctx, previousSessionIds, label = "created session") {
+  const sessionId = await ctx.waitFor(`(() => {
+    const previous = new Set(${JSON.stringify(previousSessionIds ?? [])});
+    const route = window.__openwork?.slice?.("route");
+    const sessions = Object.values(route?.sessionsByWorkspaceId || {})
+      .flatMap((items) => Array.isArray(items) ? items : []);
+    const created = sessions.find((session) => {
+      const id = typeof session?.id === "string" ? session.id.trim() : "";
+      return id && !previous.has(id);
+    });
+    return typeof created?.id === "string" ? created.id.trim() : null;
+  })()`, { timeoutMs: 45_000, label });
+  await ctx.control("session.open", { sessionId });
+  await ctx.waitFor(`(() => {
+    const expected = ${JSON.stringify(sessionId)};
+    const selected = window.__openwork?.slice?.("route")?.selectedSessionId;
+    const controlRoute = window.__openworkControl?.snapshot?.().route || "";
+    return selected === expected || controlRoute.includes(expected);
+  })()`, { timeoutMs: 30_000, label: `${label} route` });
+  return sessionId;
+}
+
+export async function createSession(ctx, label = "created session") {
+  const previousSessionIds = await sessionIds(ctx);
+  await ctx.control("session.create_task");
+  return waitForCreatedSession(ctx, previousSessionIds, label);
 }

--- a/evals/flows/sidebar-session-number-shortcuts.flow.mjs
+++ b/evals/flows/sidebar-session-number-shortcuts.flow.mjs
@@ -1,4 +1,8 @@
-import { ensureSessionWorkspace } from "./lib/session-workspace.mjs";
+import {
+  createSession,
+  ensureSessionWorkspace,
+} from "./lib/session-workspace.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const READ_SHORTCUT_ROWS = `(() => [...document.querySelectorAll('[aria-keyshortcuts]')]
   .map((entry) => ({
@@ -7,6 +11,82 @@ const READ_SHORTCUT_ROWS = `(() => [...document.querySelectorAll('[aria-keyshort
     visible: Boolean(entry.getClientRects().length),
   }))
   .filter((entry) => entry.visible && /(?:Meta|Control)\\+[1-9]/.test(entry.shortcut || '')))()`;
+const READ_SHORTCUT_TARGETS = `(() => [...document.querySelectorAll('[data-sidebar-session-id]')]
+  .flatMap((row) => {
+    const button = row.querySelector('[data-session-tab-id][aria-keyshortcuts]');
+    const shortcut = button?.getAttribute('aria-keyshortcuts') || '';
+    const match = shortcut.match(/(?:Meta|Control)\\+([1-9])/);
+    const sessionId = row.getAttribute('data-sidebar-session-id') || '';
+    return button && button.getClientRects().length && match && sessionId
+      ? [{ digit: Number(match[1]), sessionId }]
+      : [];
+  }))()`;
+const vo = await loadVoiceoverParagraphs("sidebar-session-number-shortcuts");
+
+async function dispatchKey(ctx, payload) {
+  let timeout;
+  try {
+    await Promise.race([
+      ctx.client.send("Input.dispatchKeyEvent", payload),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out dispatching ${payload.type} for ${payload.key}`)),
+          10_000,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function activateDifferentVisibleSession(ctx, modifier) {
+  const currentSessionId = await ctx.eval(
+    "window.__openwork?.slice?.('route')?.selectedSessionId || ''",
+  );
+  await dispatchKey(ctx, {
+    type: "keyDown",
+    key: modifier.key,
+    code: modifier.code,
+    modifiers: modifier.modifiers,
+  });
+  try {
+    await ctx.waitFor(`${READ_SHORTCUT_TARGETS}.length >= 2`, {
+      timeoutMs: 20_000,
+      label: "at least two numbered session targets",
+    });
+    const targets = await ctx.eval(READ_SHORTCUT_TARGETS);
+    const target = targets.find((entry) => entry.sessionId !== currentSessionId);
+    ctx.assert(Boolean(target), `Expected a numbered target other than ${currentSessionId}.`);
+    await dispatchKey(ctx, {
+      type: "keyDown",
+      key: String(target.digit),
+      code: `Digit${target.digit}`,
+      modifiers: modifier.modifiers,
+      windowsVirtualKeyCode: 48 + target.digit,
+      nativeVirtualKeyCode: 48 + target.digit,
+    });
+    await dispatchKey(ctx, {
+      type: "keyUp",
+      key: String(target.digit),
+      code: `Digit${target.digit}`,
+      modifiers: modifier.modifiers,
+      windowsVirtualKeyCode: 48 + target.digit,
+      nativeVirtualKeyCode: 48 + target.digit,
+    });
+    await ctx.waitFor(
+      `window.__openwork?.slice?.('route')?.selectedSessionId === ${JSON.stringify(target.sessionId)}`,
+      { timeoutMs: 20_000, label: `session ${target.digit} to open` },
+    );
+    return target;
+  } finally {
+    await dispatchKey(ctx, {
+      type: "keyUp",
+      key: modifier.key,
+      code: modifier.code,
+    });
+  }
+}
 
 export default {
   id: "sidebar-session-number-shortcuts",
@@ -21,12 +101,7 @@ export default {
           "sidebar-session-number-shortcuts",
         );
         for (let index = 1; index <= 3; index += 1) {
-          await ctx.control("session.create_task");
-          const sessionId = await ctx.waitFor(`(() => {
-            const route = window.__openworkControl.snapshot().route || "";
-            const match = route.match(/session\\/([^/?#]+)/);
-            return match ? decodeURIComponent(match[1]) : null;
-          })()`, { timeoutMs: 30_000, label: `created session ${index}` });
+          const sessionId = await createSession(ctx, `created session ${index}`);
           await ctx.control("session.rename", {
             sessionId,
             title: `Shortcut proof chat ${index}`,
@@ -34,39 +109,114 @@ export default {
         }
 
         const isMac = await ctx.eval("navigator.platform.toLowerCase().includes('mac')");
-        await ctx.client.send("Input.dispatchKeyEvent", {
-          type: "keyDown",
+        const modifier = {
           key: isMac ? "Meta" : "Control",
           code: isMac ? "MetaLeft" : "ControlLeft",
           modifiers: isMac ? 4 : 2,
+        };
+        await dispatchKey(ctx, {
+          type: "keyDown",
+          key: modifier.key,
+          code: modifier.code,
+          modifiers: modifier.modifiers,
         });
-        await ctx.waitFor(`${READ_SHORTCUT_ROWS}.length >= 3`, {
-          timeoutMs: 20_000,
-          label: "numbered visible session rows",
-        });
+        try {
+          await ctx.waitFor(`${READ_SHORTCUT_ROWS}.length >= 3`, {
+            timeoutMs: 20_000,
+            label: "numbered visible session rows",
+          });
 
-        await ctx.prove("Modifier badges appear without changing layout and expose accessible shortcuts", {
-          action: async () => {},
+          await ctx.prove("Modifier badges appear without changing layout and expose accessible shortcuts", {
+            voiceover: vo[0],
+            action: async () => {},
+            assert: async () => {
+              const rows = await ctx.eval(READ_SHORTCUT_ROWS);
+              ctx.assert(rows.length >= 3, `Expected at least three numbered rows, got ${JSON.stringify(rows)}.`);
+              const firstNine = rows.slice(0, 9).map((entry) => entry.shortcut);
+              ctx.assert(new Set(firstNine).size === firstNine.length, "Visible session shortcuts must be unique.");
+              ctx.assert(
+                firstNine.every((shortcut, index) => shortcut.endsWith(`+${index + 1}`)),
+                `Shortcut numbering did not match visible order: ${JSON.stringify(firstNine)}.`,
+              );
+            },
+            screenshot: {
+              name: "sidebar-session-number-shortcuts-held",
+              requireText: ["Shortcut proof chat"],
+            },
+          });
+        } finally {
+          await dispatchKey(ctx, {
+            type: "keyUp",
+            key: modifier.key,
+            code: modifier.code,
+          });
+        }
+
+        let composerTarget;
+        await ctx.prove("The numbered session jump works while the composer owns focus", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitFor(
+              "Boolean(document.querySelector('[contenteditable=\"true\"][aria-placeholder]'))",
+              { timeoutMs: 20_000, label: "composer editor" },
+            );
+            const focused = await ctx.eval(`(() => {
+              const editor = document.querySelector('[contenteditable="true"][aria-placeholder]');
+              editor?.focus();
+              return document.activeElement === editor;
+            })()`);
+            ctx.assert(focused, "Expected the composer editor to own keyboard focus.");
+            composerTarget = await activateDifferentVisibleSession(ctx, modifier);
+          },
           assert: async () => {
-            const rows = await ctx.eval(READ_SHORTCUT_ROWS);
-            ctx.assert(rows.length >= 3, `Expected at least three numbered rows, got ${JSON.stringify(rows)}.`);
-            const firstNine = rows.slice(0, 9).map((entry) => entry.shortcut);
-            ctx.assert(new Set(firstNine).size === firstNine.length, "Visible session shortcuts must be unique.");
+            const selectedSessionId = await ctx.eval(
+              "window.__openwork?.slice?.('route')?.selectedSessionId || ''",
+            );
             ctx.assert(
-              firstNine.every((shortcut, index) => shortcut.endsWith(`+${index + 1}`)),
-              `Shortcut numbering did not match visible order: ${JSON.stringify(firstNine)}.`,
+              selectedSessionId === composerTarget?.sessionId,
+              `Expected composer shortcut to open ${composerTarget?.sessionId}, got ${selectedSessionId}.`,
             );
           },
           screenshot: {
-            name: "sidebar-session-number-shortcuts-held",
+            name: "sidebar-session-number-shortcuts-composer",
             requireText: ["Shortcut proof chat"],
+            hashIncludes: "/session/",
           },
         });
 
-        await ctx.client.send("Input.dispatchKeyEvent", {
-          type: "keyUp",
-          key: isMac ? "Meta" : "Control",
-          code: isMac ? "MetaLeft" : "ControlLeft",
+        let selectTarget;
+        await ctx.prove("The numbered session jump works while the model select is open", {
+          voiceover: vo[2],
+          action: async () => {
+            const opened = await ctx.eval(`(() => {
+              const trigger = document.querySelector('[aria-label="Change model"]');
+              trigger?.click();
+              return Boolean(trigger);
+            })()`);
+            ctx.assert(opened, "Expected the Change model trigger to be available.");
+            await ctx.waitFor(
+              `(() => {
+                const input = document.querySelector('input[placeholder="Search models..."]');
+                return Boolean(input && input.getClientRects().length && document.activeElement === input);
+              })()`,
+              { timeoutMs: 20_000, label: "open model select search input" },
+            );
+            selectTarget = await activateDifferentVisibleSession(ctx, modifier);
+          },
+          assert: async () => {
+            const selectedSessionId = await ctx.eval(
+              "window.__openwork?.slice?.('route')?.selectedSessionId || ''",
+            );
+            ctx.assert(
+              selectedSessionId === selectTarget?.sessionId,
+              `Expected select-open shortcut to open ${selectTarget?.sessionId}, got ${selectedSessionId}.`,
+            );
+          },
+          screenshot: {
+            name: "sidebar-session-number-shortcuts-select",
+            requireText: ["Shortcut proof chat"],
+            hashIncludes: "/session/",
+          },
         });
       },
     },

--- a/evals/voiceovers/sidebar-session-number-shortcuts.md
+++ b/evals/voiceovers/sidebar-session-number-shortcuts.md
@@ -1,0 +1,7 @@
+# sidebar-session-number-shortcuts — numbered session jumps stay globally available
+
+1. I hold Command on macOS, or Control on Windows and Linux, and OpenWork reveals numbered shortcuts beside the first visible sessions without moving their titles or controls.
+
+2. Even while I am typing in the composer, I press Command or Control with a number and OpenWork immediately opens that numbered session from the left sidebar.
+
+3. The shortcut stays global while the model select and its search field are open, so I can jump to another numbered session without first dismissing the select.


### PR DESCRIPTION
## Summary

- Add discoverable platform-modifier number shortcuts for the first nine visible, actionable chat sessions.
- Keep `Command/Control + 1–9` global while focus is in the composer, a text input, a native select, or an open menu/listbox, matching the Codex interaction.
- Preserve dialog and alert-dialog ownership while exposing accessible shortcut metadata without displacing row controls.

## What changed

- **Shortcut model** — centralizes visible-session numbering, platform labels, and session activation.
- **Sidebar state** — supplies the exact actionable visual order to the shell and renders modifier-held badges.
- **Global keyboard ownership** — captures number shortcuts before editable fields or select/menu popovers can consume them.
- **Modal safety** — dialogs and alert dialogs still suppress session switching.
- **Regression coverage** — covers global digit activation, non-blocking menus/listboxes/select popovers, modal ownership, cleanup, ordering, and platform metadata.

## Why

Frequent sessions should remain reachable from the keyboard regardless of where the user is typing or which select is open. A modified digit is an application-navigation command, not text input, so editable controls should not suppress it.

## Verification

### Current clean PR head `6a89a5230d01e828d0a6af22b9ccecd62b2a2469`

- [x] Focused shortcut ownership suite — 6 passed, 0 failed.
- [x] `pnpm --dir apps/app typecheck` — passed.
- [x] `pnpm evals:typecheck` and evaluator syntax check — passed.
- [x] `git diff --check upstream/dev...HEAD` — passed.
- [x] Scope audit — 3 feature/follow-up commits, 11 intended files including the shared session-creation proof helper; no inherited auth changes.
- [x] Current-head Electron proof — all 3 acceptance frames passed, 0 failed, 0 skipped; voice-over script coverage passed.

### Proof provenance from the pre-rebuild candidate

Candidate `bc7d78dc591a02e8dfaeffb4dbcc161f1e14b85e` was included in verified Mix Tape `52ec821ba3788961731544658a972c54f8bbfd34`:

- [x] Desktop suite — 565 passed, 0 failed.
- [x] Den suite — 104 passed, 0 failed.
- [x] Evaluator runner — 91 passed, 0 failed.
- [x] Desktop, Den, and evaluator typechecks passed.
- [x] Desktop and Den production builds passed.
- [x] Fraimz Electron acceptance proof passed with 3 narrated frames and 0 failed or skipped checks.

The clean rebuild preserves the feature commits on current `dev`, but the combined proof predates the rewritten PR head and is reported as provenance rather than exact-current-head proof.

### Observed behavior

The pre-rebuild combined Electron proof confirmed all three acceptance frames:

1. Holding Command on macOS, or Control on Windows/Linux, reveals numbered shortcuts beside the first visible sessions without moving titles or controls.
2. While the composer owns focus, `Command/Control + number` immediately opens the matching left-sidebar session.
3. While the model select and its search input are open, the same shortcut opens the matching session without first dismissing the select.

## Dependencies and review order

- Review alongside the title-overflow draft [#3329](https://github.com/different-ai/openwork/pull/3329), because both changes share sidebar title and control space.
- The latest local integration resolution deliberately keeps both `SessionTitle` and `SessionNumberShortcutSlot` in each actionable row.

## Risks and untested scope

- Dialog suppression is unit-covered and intentionally retains modal ownership.
- Additional application-specific popover implementations outside the exercised menu/listbox/select surfaces remain a human review target.
- The Fraimz proof was recorded from the latest combined Mix Tape, so it proves the PR behavior in the current integration playlist rather than claiming a public standalone preview.
- Proof artifacts remain local/private and are not embedded as expiring URLs.

## Lineage

- Current fork draft: [reachjalil/openwork#5](https://github.com/reachjalil/openwork/pull/5)

## Exact candidate

- Current base: `7908ad1dd429aaabcbb273c22872eb003a34ef7a`
- Current PR head: `6a89a5230d01e828d0a6af22b9ccecd62b2a2469`
- Original Kitchen head: `bc7d78dc591a02e8dfaeffb4dbcc161f1e14b85e`
- Verified pre-rebuild Mix Tape: `52ec821ba3788961731544658a972c54f8bbfd34`
- Kitchen run: `acb7f568-3f18-4119-a164-75f92b5be370`

## Automation boundary

Prepared from the OpenWork Kitchen candidate, refined under `@reachjalil`'s authorized fork, and reconstructed on current `dev` without inherited proof-harness commits. This remains a draft; review requests, ready-for-review, merge, release, and deployment remain manual.