### PR TITLE
fix(server): deliver managed provider credentials to the engine (cloud providers were unusable)

### DIFF
--- a/apps/server/src/managed-provider-auth.test.ts
+++ b/apps/server/src/managed-provider-auth.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetManagedProviderAuthCache, syncManagedProviderAuth } from "./managed-provider-auth.js";
+import { ENGINE_GLOBAL_RUNTIME_CONFIG_ID, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+type Call = { method: string; url: string; body: unknown; authorization: string | null };
+
+const PROVIDER = "lpr_01kyhvcrn0eshb3rp2dt10z29j";
+
+function stubFetch(status = 200) {
+  const calls: Call[] = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      method: init?.method ?? "GET",
+      url: String(input),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : null,
+      authorization: new Headers(init?.headers).get("authorization"),
+    });
+    return new Response(status >= 400 ? "nope" : "{}", { status });
+  }) as unknown as typeof globalThis.fetch;
+  return { calls, impl };
+}
+
+async function makeConfig(dir: string): Promise<ServerConfig> {
+  const config = {
+    port: 0,
+    token: "test-token",
+    approval: "manual",
+    readOnly: false,
+    storageDir: dir,
+    opencodeBaseUrl: "http://127.0.0.1:39999",
+    opencodeUsername: "engine-user",
+    opencodePassword: "engine-pass",
+    workspaces: [
+      {
+        id: "ws_test",
+        name: "test",
+        path: join(dir, "workspace"),
+      },
+    ],
+  } as unknown as ServerConfig;
+  return config;
+}
+
+async function seedProvider(config: ServerConfig, entry: Record<string, unknown>): Promise<void> {
+  await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({
+    ...current,
+    provider: { [PROVIDER]: entry },
+  }));
+}
+
+describe("managed provider auth delivery", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    resetManagedProviderAuthCache();
+    dir = await mkdtemp(join(tmpdir(), "openwork-provider-auth-"));
+  });
+
+  test("delivers a stored credential to the engine auth API", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", name: "Ben - Anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] },
+      fetchImpl: fetchStub.impl,
+    });
+
+    expect(result.delivered).toEqual([PROVIDER]);
+    expect(fetchStub.calls).toHaveLength(1);
+    expect(fetchStub.calls[0]?.method).toBe("PUT");
+    expect(fetchStub.calls[0]?.url).toBe(`http://127.0.0.1:39999/auth/${PROVIDER}`);
+    expect(fetchStub.calls[0]?.body).toEqual({ type: "api", key: "sk-ant-secret" });
+    expect(fetchStub.calls[0]?.authorization).toBe(
+      `Basic ${Buffer.from("engine-user:engine-pass").toString("base64")}`,
+    );
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("does not re-deliver an unchanged credential", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    const second = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(second.unchanged).toEqual([PROVIDER]);
+    expect(fetchStub.calls.filter((call) => call.method === "PUT")).toHaveLength(1);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("re-delivers after the credential rotates", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    let value = "sk-ant-first";
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value }] };
+
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    value = "sk-ant-rotated";
+    const second = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(second.delivered).toEqual([PROVIDER]);
+    const puts = fetchStub.calls.filter((call) => call.method === "PUT");
+    expect(puts).toHaveLength(2);
+    expect(puts[1]?.body).toEqual({ type: "api", key: "sk-ant-rotated" });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("skips a provider whose credential is not in the env store", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const warnings: Array<Record<string, unknown> | undefined> = [];
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [] },
+      fetchImpl: fetchStub.impl,
+      logger: { warn: (_m, meta) => warnings.push(meta), error: () => {} },
+    });
+
+    expect(result.skipped).toEqual([{ providerId: PROVIDER, reason: "no_stored_credential" }]);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(JSON.stringify(warnings)).not.toContain("sk-");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("removes engine auth for a provider this process delivered and that is no longer managed", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({
+      ...current,
+      provider: {},
+    }));
+    const result = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(result.removed).toEqual([PROVIDER]);
+    expect(fetchStub.calls.some((call) => call.method === "DELETE" && call.url.endsWith(PROVIDER))).toBe(true);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("never touches providers this process did not deliver", async () => {
+    const config = await makeConfig(dir);
+    // No managed providers at all: a desktop user's own engine credentials must
+    // not be deleted just because the managed map is empty.
+    await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({
+      ...current,
+      provider: {},
+    }));
+    const fetchStub = stubFetch();
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] },
+      fetchImpl: fetchStub.impl,
+    });
+
+    expect(result.delivered).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(fetchStub.calls).toHaveLength(0);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("reports an engine rejection with its status and no credential", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch(401);
+    const errors: Array<Record<string, unknown> | undefined> = [];
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] },
+      fetchImpl: fetchStub.impl,
+      logger: { warn: () => {}, error: (_m, meta) => errors.push(meta) },
+    });
+
+    expect(result.failed).toEqual([{ providerId: PROVIDER, status: 401 }]);
+    expect(JSON.stringify(errors)).toContain("401");
+    expect(JSON.stringify(errors)).not.toContain("sk-ant-secret");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("re-delivers after the engine is replaced", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    resetManagedProviderAuthCache();
+    const afterRestart = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(afterRestart.delivered).toEqual([PROVIDER]);
+    expect(fetchStub.calls.filter((call) => call.method === "PUT")).toHaveLength(2);
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -1,0 +1,181 @@
+import { createHash } from "node:crypto";
+
+import { resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
+import { readGlobalRuntimeOpencodeConfig, runtimeProviderMap } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+import { findManagedEngineWorkspace } from "./workspaces.js";
+
+/**
+ * Deliver server-managed provider credentials to the engine.
+ *
+ * Cloud provider materialization writes two things: the provider entry into the
+ * engine-global runtime config (which only *names* its credential env vars via
+ * `env: [...]`), and the credential value into this server's env store. Nothing
+ * bridged the two: the engine process is spawned with a fixed env allowlist and
+ * never receives store values, so every run failed with "API key is missing"
+ * while the provider still appeared in the picker.
+ *
+ * The desktop app has always delivered credentials by calling the engine's auth
+ * API directly. This module does the same thing server-side, so cloud
+ * credentials never need to reach a browser.
+ */
+
+type ManagedProviderAuthLogger = {
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+type EnvReader = { list: () => Promise<Array<{ key: string; value: string }>> };
+
+export type ManagedProviderAuthInput = {
+  config: ServerConfig;
+  env: EnvReader;
+  fetchImpl?: typeof globalThis.fetch;
+  logger?: ManagedProviderAuthLogger;
+};
+
+export type ManagedProviderAuthResult = {
+  delivered: string[];
+  unchanged: string[];
+  removed: string[];
+  skipped: Array<{ providerId: string; reason: "no_env_names" | "no_stored_credential" }>;
+  failed: Array<{ providerId: string; status: number | null }>;
+};
+
+/**
+ * Providers this process has delivered, with a fingerprint of the delivered
+ * value. Redundant writes are what caused a prior production incident, so we
+ * only ever write on a real change. Keyed per engine base URL so a respawned
+ * engine on a different port is treated as fresh.
+ */
+const deliveredFingerprints = new Map<string, string>();
+
+const fingerprintKey = (baseUrl: string, providerId: string) => `${baseUrl}\u0000${providerId}`;
+
+const fingerprint = (value: string) => createHash("sha256").update(value).digest("hex");
+
+function readEnvNames(entry: Record<string, unknown>): string[] {
+  if (!Array.isArray(entry.env)) return [];
+  return entry.env.filter((name): name is string => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * Forget what we believe the engine holds. Call this when the engine process is
+ * replaced: opencode persists auth outside the process, but a fresh engine may
+ * have been started against a different store, and re-delivery is cheap.
+ */
+export function resetManagedProviderAuthCache(): void {
+  deliveredFingerprints.clear();
+}
+
+export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): Promise<ManagedProviderAuthResult> {
+  const result: ManagedProviderAuthResult = {
+    delivered: [],
+    unchanged: [],
+    removed: [],
+    skipped: [],
+    failed: [],
+  };
+
+  const workspace = findManagedEngineWorkspace(input.config.workspaces) ?? input.config.workspaces[0];
+  if (!workspace) return result;
+
+  const connection = resolveWorkspaceOpencodeConnection(input.config, workspace);
+  const baseUrl = connection.baseUrl?.replace(/\/+$/, "");
+  if (!baseUrl) return result;
+
+  const runtimeConfig = await readGlobalRuntimeOpencodeConfig(input.config);
+  const providers = runtimeProviderMap(runtimeConfig);
+
+  const storedValues = new Map<string, string>();
+  for (const record of await input.env.list()) {
+    if (typeof record.value === "string" && record.value.trim().length > 0) {
+      storedValues.set(record.key, record.value);
+    }
+  }
+
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (connection.authHeader) headers.authorization = connection.authHeader;
+
+  const managedIds = new Set(Object.keys(providers));
+
+  for (const [providerId, entry] of Object.entries(providers)) {
+    const envNames = readEnvNames(entry);
+    if (envNames.length === 0) {
+      result.skipped.push({ providerId, reason: "no_env_names" });
+      continue;
+    }
+
+    const credentialName = envNames.find((name) => storedValues.has(name));
+    if (!credentialName) {
+      result.skipped.push({ providerId, reason: "no_stored_credential" });
+      input.logger?.warn("managed provider credential missing from env store", {
+        provider_id: providerId,
+        env_names: envNames,
+      });
+      continue;
+    }
+
+    const credential = storedValues.get(credentialName) ?? "";
+    const key = fingerprintKey(baseUrl, providerId);
+    const next = fingerprint(credential);
+    if (deliveredFingerprints.get(key) === next) {
+      result.unchanged.push(providerId);
+      continue;
+    }
+
+    try {
+      const response = await fetchImpl(`${baseUrl}/auth/${encodeURIComponent(providerId)}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ type: "api", key: credential }),
+      });
+      if (!response.ok) {
+        result.failed.push({ providerId, status: response.status });
+        input.logger?.error("managed provider auth delivery rejected by engine", {
+          provider_id: providerId,
+          status: response.status,
+        });
+        continue;
+      }
+      deliveredFingerprints.set(key, next);
+      result.delivered.push(providerId);
+    } catch (error) {
+      result.failed.push({ providerId, status: null });
+      input.logger?.error("managed provider auth delivery failed", {
+        provider_id: providerId,
+        message: error instanceof Error ? error.message : "unknown_error",
+      });
+    }
+  }
+
+  // Only ever remove ids this process delivered. Desktop users authenticate
+  // providers themselves and those must never be touched here.
+  for (const key of [...deliveredFingerprints.keys()]) {
+    const [keyBaseUrl, providerId] = key.split("\u0000");
+    if (keyBaseUrl !== baseUrl || managedIds.has(providerId ?? "")) continue;
+    try {
+      const response = await fetchImpl(`${baseUrl}/auth/${encodeURIComponent(providerId ?? "")}`, {
+        method: "DELETE",
+        headers,
+      });
+      if (!response.ok) {
+        input.logger?.error("managed provider auth removal rejected by engine", {
+          provider_id: providerId,
+          status: response.status,
+        });
+        continue;
+      }
+      deliveredFingerprints.delete(key);
+      result.removed.push(providerId ?? "");
+    } catch (error) {
+      input.logger?.error("managed provider auth removal failed", {
+        provider_id: providerId,
+        message: error instanceof Error ? error.message : "unknown_error",
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -10,6 +10,7 @@ import {
 import type { CloudMcpLiveStatusObserver } from "../cloud-mcp-health.js";
 import { readOpenWorkConnectSkillCatalog, renderOpenWorkConnectSkillInstruction } from "../connect-skill-catalog.js";
 import { EnvStoreReadError, InvalidEnvKeyError, isValidEnvKey, type EnvService } from "../env-file.js";
+import { syncManagedProviderAuth } from "../managed-provider-auth.js";
 import { ApiError } from "../errors.js";
 import {
   createGoogleWorkspaceConnectFlowManager,
@@ -62,6 +63,10 @@ interface RegisterCoreRoutesOptions {
   resolveToyUiEnabled: () => boolean;
   resolveDevLogPath: () => string | null;
   createOpenAiRealtimeVoiceSession: (env: EnvService, input: unknown) => Promise<unknown>;
+  managedProviderAuthLogger?: {
+    warn: (message: string, attributes?: Record<string, unknown>) => void;
+    error: (message: string, attributes?: Record<string, unknown>) => void;
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -120,6 +125,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     resolveToyUiEnabled,
     resolveDevLogPath,
     createOpenAiRealtimeVoiceSession,
+    managedProviderAuthLogger,
   } = options;
   const googleWorkspaceConnectFlows = createGoogleWorkspaceConnectFlowManager(config);
   const envPendingChangesByRuntime = new Map<string, boolean>();
@@ -549,6 +555,9 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
       }
       throw error;
     }
+    // A stored credential is useless until the engine holds it: deliver it now
+    // rather than waiting for the next engine start.
+    await syncManagedProviderAuth({ config, env, logger: managedProviderAuthLogger }).catch(() => undefined);
     return jsonResponse({ ok: true, count: entries.length });
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -23,6 +23,7 @@ import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { defaultWorkspaceOpenworkConfig, ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
 import { sanitizeCommandName, validateMcpName } from "./validators.js";
 import { TokenService } from "./tokens.js";
+import { resetManagedProviderAuthCache, syncManagedProviderAuth } from "./managed-provider-auth.js";
 import { EnvService } from "./env-file.js";
 import {
   normalizeResourceSnapshot,
@@ -684,6 +685,16 @@ type ServerLogger = {
   log: (level: LogLevel, message: string, attributes?: LogAttributes) => void;
 };
 
+/** Adapt the server logger to the warn/error shape helpers expect. */
+function toManagedProviderAuthLogger(logger: ServerLogger) {
+  return {
+    warn: (message: string, attributes?: Record<string, unknown>) =>
+      logger.log("warn", message, attributes as LogAttributes | undefined),
+    error: (message: string, attributes?: Record<string, unknown>) =>
+      logger.log("error", message, attributes as LogAttributes | undefined),
+  };
+}
+
 const LOG_LEVEL_NUMBERS: Record<LogLevel, number> = {
   info: 9,
   warn: 13,
@@ -847,6 +858,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     env,
     restartReloadWatchers,
     engineMcpServerState,
+    logger,
   );
 
   const serverOptions: {
@@ -1017,6 +1029,13 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     invalidateEngineMcpServerState(config, engineMcpServerState);
     throw error;
   }
+
+  // Deliver server-managed provider credentials to the engine on startup. The
+  // engine process receives a fixed env allowlist, so credentials materialized
+  // into the env store only reach it through the engine's auth API. Fire and
+  // forget: a credential problem must never stop the server from serving.
+  resetManagedProviderAuthCache();
+  void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) }).catch(() => undefined);
 
   return {
     ...server,
@@ -1508,6 +1527,7 @@ function createRoutes(
   env: EnvService,
   onWorkspacesChanged: () => void,
   engineMcpServerState: EngineMcpServerState,
+  logger: ServerLogger,
 ): Route[] {
   const routes: Route[] = [];
   registerCoreRoutes({
@@ -1515,6 +1535,7 @@ function createRoutes(
     config,
     tokens,
     env,
+    managedProviderAuthLogger: toManagedProviderAuthLogger(logger),
     serverVersion: SERVER_VERSION,
     opencodeVersion: OPENCODE_VERSION,
     jsonResponse,
@@ -2040,6 +2061,13 @@ function createRoutes(
     if (shouldReload) {
       await reloadOpencodeEngine(config, workspace, engineMcpServerState);
     }
+    // The provider entry only names its credential env vars; the engine needs
+    // the value itself via its auth API.
+    await syncManagedProviderAuth({
+      config,
+      env,
+      logger: toManagedProviderAuthLogger(logger),
+    }).catch(() => undefined);
 
     return jsonResponse({
       ok: true,


### PR DESCRIPTION
Cloud org providers appear in the model picker but every run fails with "API key is missing". Only the free `opencode/big-pickle` model works.

```
hi    -> Anthropic API key is missing... Provider: lpr_01kyhvcrn0eshb3rp2dt10z29j
hi    -> OpenRouter API key is missing... Provider: openwork
hi    -> (Big Pickle answers fine)
```

## Root cause

Materialization writes two halves and nothing joins them. Measured inside a real cloud sandbox on `openwork-0.18.11`:

```
/env/keys                    -> ["ANTHROPIC_API_KEY","OPENWORK_API_KEY","OPENWORK_INFERENCE_BASE_URL"]   (value IS stored)
runtime config provider entry -> declares `env: ["ANTHROPIC_API_KEY"]`, no apiKey
opencode serve process env    -> ANTHROPIC_API_KEY=absent  OPENWORK_API_KEY=absent  OPENROUTER_API_KEY=absent
openwork-server process env   -> same, absent
```

`cli.ts` spawns the engine with a fixed allowlist (`OPENWORK_SERVER_URL`, `OPENWORK_SERVER_TOKEN`, `OPENCODE_CONFIG`, `OPENCODE_MODELS_URL`, two dev flags) and **no env-store values**, and no server code called the engine's auth API. So the credential sat in a store nothing reads while the config merely *named* the variable — the engine resolved that name against its own empty environment.

The desktop app has always delivered credentials by calling the engine's auth API from the client. **#3275 (mine) disabled that path in cloud** — correctly, the browser shouldn't hold org keys — and the server-side replacement I built never delivered the credential. That's the whole bug.

## Fix

New `apps/server/src/managed-provider-auth.ts` does server-side what the client used to do: for each provider in the engine-global managed config, resolve its declared credential env name from the env store and `PUT /auth/{providerID}` with the `ApiAuth` shape (`{ type: "api", key }`), reusing the existing engine connection (`resolveWorkspaceOpencodeConnection`) so credentials never reach a browser.

The `ApiAuth` shape and the endpoint were taken from the running engine's own `/doc`, not guessed:

```
PUT /auth/{providerID}   body = anyOf(OAuth, ApiAuth, WellKnownAuth)
ApiAuth = { type: "api", key: string, metadata?: Record<string,string> }   (type, key required)
```

The engine keys providers by the runtime config id (`lpr_…`), which matches the id in the user-facing error, so auth is written under that exact id — including the built-in `openwork` entry.

Delivery runs at three points: server startup (covers engine start and every entry point), after `PATCH /runtime-config/providers`, and after `PUT /env` (so a rotated key applies immediately).

Safety properties, deliberately:
- **Idempotent.** A per-provider fingerprint of the delivered value means unchanged credentials are never re-sent. Redundant writes caused the earlier 991-engine-disposal incident; this does not loop.
- **Scoped to managed providers.** Removal only ever deletes ids *this process* delivered, so a desktop user's own engine credentials are never touched.
- **Never logs a credential.** Failures log provider id + HTTP status only; tests assert the key never appears in log payloads.
- Non-blocking: a credential failure can't stop the server from serving.

## Tests

`apps/server/src/managed-provider-auth.test.ts` — 8 tests: delivery with correct id/shape/auth header, no re-delivery when unchanged, re-delivery on rotation, skip + warning when no stored credential, removal when unmanaged, **never touching non-managed providers**, engine rejection surfaced with status and no key, and re-delivery after engine replacement.

| Command | Result |
| --- | --- |
| `pnpm --filter openwork-server test` | 600 pass / 10 skip / 0 fail |
| `pnpm --filter openwork-server typecheck` | exit 0 |

While wiring this I hit a real bug in my own first attempt: the `PATCH` route referenced a `logger` that wasn't in scope, which threw synchronously and turned the route into a 500 — caught by the existing `runtime-config-global-providers` test. `ServerLogger` is `{ log(level, …) }`, so there's now an explicit adapter and the logger is threaded into `createRoutes` and the core routes.

## Not yet proven end to end

This ships inside the sandbox image, so it is **not live** until a release publishes a new snapshot and instances recycle. I have not yet watched a real org provider answer a prompt — that requires the new image. I'm cutting a release next and will verify the credential lands in the engine's auth store on a real instance, and report back honestly either way. Related open bug: #3321.