### PR TITLE
feat(release): add canary and experimental channels

### DIFF
--- a/.github/workflows/pre-alpha-macos-aarch64.yml
+++ b/.github/workflows/pre-alpha-macos-aarch64.yml
@@ -1,0 +1,256 @@
+name: Pre-Alpha Channels (macOS arm64)
+
+# Canary and experimental are independent integration branches. They receive
+# dev changes, but they are never merged back into dev. A successful push
+# produces one signed, notarized, immutable prerelease from the exact branch
+# commit. Standard dev CI and Vercel deployments do not run for these branches.
+
+on:
+  push:
+    branches:
+      - canary
+      - experimental
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pre-alpha-macos-aarch64-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  publish-pre-alpha-macos-aarch64:
+    name: Build + Publish ${{ github.ref_name }} (aarch64-apple-darwin)
+    runs-on: macos-14
+    timeout-minutes: 180
+
+    env:
+      CHANNEL: ${{ github.ref_name }}
+      MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'true' }}
+
+    steps:
+      - name: Validate channel branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$CHANNEL" in
+            canary|experimental) ;;
+            *)
+              echo "This workflow must run from the canary or experimental branch, not $CHANNEL." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout exact channel commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: macos-pre-alpha-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            macos-pre-alpha-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Resolve channel version
+        id: channel-version
+        shell: bash
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require("node:fs");
+          const path = "apps/desktop/package.json";
+          const raw = JSON.parse(fs.readFileSync(path, "utf8"));
+          const current = String(raw.version || "").trim();
+          const match = current.match(/^(\d+)\.(\d+)\.(\d+)(?:-.+)?$/);
+          if (!match) {
+            throw new Error(`Unsupported version in ${path}: ${current}`);
+          }
+
+          const channel = process.env.CHANNEL;
+          if (channel !== "canary" && channel !== "experimental") {
+            throw new Error(`Unsupported pre-alpha channel: ${channel}`);
+          }
+
+          const [, major, minor, patch] = match;
+          const nextPatch = Number(patch) + 1;
+          const run = process.env.GITHUB_RUN_NUMBER || "0";
+          const sha = (process.env.GITHUB_SHA || "").slice(0, 7) || "local";
+          const version = `${major}.${minor}.${nextPatch}-${channel}.${run}+${sha}`;
+          const releaseTag =
+            `${channel}-macos-v${major}.${minor}.${nextPatch}-${channel}.${run}-${sha}`;
+
+          console.log(`channel_version=${version}`);
+          console.log(`base_version=${major}.${minor}.${nextPatch}`);
+          console.log(`release_tag=${releaseTag}`);
+          console.log(`pointer_tag=${channel}-macos-latest`);
+          console.log(`channel_title=${channel[0].toUpperCase()}${channel.slice(1)}`);
+          NODE
+
+      - name: Stamp channel package version
+        shell: bash
+        env:
+          CHANNEL_VERSION: ${{ steps.channel-version.outputs.channel_version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("node:fs");
+          for (const path of ["apps/desktop/package.json", "apps/app/package.json"]) {
+            const json = JSON.parse(fs.readFileSync(path, "utf8"));
+            json.version = process.env.CHANNEL_VERSION;
+            fs.writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
+          }
+          NODE
+
+      - name: Write notary API key
+        if: env.MACOS_NOTARIZE == 'true'
+        env:
+          APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          NOTARY_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64" | base64 --decode > "$NOTARY_KEY_PATH"
+          chmod 600 "$NOTARY_KEY_PATH"
+          echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Reject unsigned channel release
+        if: env.MACOS_NOTARIZE != 'true'
+        shell: bash
+        run: |
+          echo "Canary and experimental artifacts must be signed and notarized." >&2
+          exit 1
+
+      - name: Build Electron app
+        if: env.MACOS_NOTARIZE == 'true'
+        shell: bash
+        env:
+          TARGET: aarch64-apple-darwin
+        run: pnpm --filter @openwork/desktop build:electron
+
+      - name: Package Electron app
+        if: env.MACOS_NOTARIZE == 'true'
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
+          MACOS_NOTARIZE: true
+          APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+          APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            --mac \
+            --arm64 \
+            --publish never
+
+      - name: Create immutable channel prerelease
+        if: env.MACOS_NOTARIZE == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL_VERSION: ${{ steps.channel-version.outputs.channel_version }}
+          CHANNEL_TITLE: ${{ steps.channel-version.outputs.channel_title }}
+          RUN_RELEASE_TAG: ${{ steps.channel-version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RUN_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Prerelease $RUN_RELEASE_TAG already exists; reusing it."
+            exit 0
+          fi
+
+          gh release create "$RUN_RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "OpenWork $CHANNEL_TITLE $CHANNEL_VERSION" \
+            --notes "Unsupported pre-alpha macOS arm64 build from ${CHANNEL} at ${GITHUB_SHA}. This channel is independent from dev and may change or be reverted without notice." \
+            --target "$GITHUB_SHA" \
+            --prerelease
+
+      - name: Upload channel artifacts
+        if: env.MACOS_NOTARIZE == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_RELEASE_TAG: ${{ steps.channel-version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(
+            apps/desktop/dist-electron/*.dmg
+            apps/desktop/dist-electron/*.zip
+            apps/desktop/dist-electron/*.blockmap
+            apps/desktop/dist-electron/latest-mac.yml
+          )
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No Electron channel assets found in apps/desktop/dist-electron." >&2
+            exit 1
+          fi
+          gh release upload "$RUN_RELEASE_TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Update rolling channel manifest
+        if: env.MACOS_NOTARIZE == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL_TITLE: ${{ steps.channel-version.outputs.channel_title }}
+          POINTER_TAG: ${{ steps.channel-version.outputs.pointer_tag }}
+          RUN_RELEASE_TAG: ${{ steps.channel-version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          POINTER_MANIFEST="$RUNNER_TEMP/latest-mac.yml"
+          export POINTER_MANIFEST
+          node <<'NODE'
+          const fs = require("node:fs");
+          const manifestPath = "apps/desktop/dist-electron/latest-mac.yml";
+          const baseUrl =
+            `https://github.com/different-ai/openwork/releases/download/${process.env.RUN_RELEASE_TAG}`;
+          const rewritten = fs.readFileSync(manifestPath, "utf8")
+            .replace(/(url:\s*)(openwork-[^\n]+)/g, `$1${baseUrl}/$2`)
+            .replace(/(path:\s*)(openwork-[^\n]+)/g, `$1${baseUrl}/$2`);
+          fs.writeFileSync(process.env.POINTER_MANIFEST, rewritten);
+          NODE
+
+          if ! gh release view "$POINTER_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$POINTER_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "OpenWork $CHANNEL_TITLE (macOS arm64)" \
+              --notes "Rolling updater manifest for the newest unsupported $CHANNEL macOS arm64 prerelease." \
+              --target "$GITHUB_SHA" \
+              --prerelease
+          fi
+
+          gh release upload "$POINTER_TAG" "$POINTER_MANIFEST#latest-mac.yml" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
+  "git": {
+    "deploymentEnabled": {
+      "canary": false,
+      "experimental": false
+    }
+  },
   "buildCommand": "pnpm run build:web",
   "outputDirectory": "dist",
   "rewrites": [

--- a/docs/pre-alpha-release-channels.md
+++ b/docs/pre-alpha-release-channels.md
@@ -65,9 +65,9 @@ the stable `v*` application, npm, EE image, AUR, or Daytona release paths.
 ## Reduced CI/CD
 
 The repository's standard test and i18n workflows target `dev`, so direct
-pushes to these two channel branches do not run them. Each Vercel project's
-`vercel.json` also disables Git-triggered deployments for the exact `canary`
-and `experimental` branch names.
+pushes to these two channel branches do not run them. Each of the five Vercel
+projects has a `vercel.json` that also disables Git-triggered deployments for
+the exact `canary` and `experimental` branch names.
 
 These builds are unsupported and may contain incomplete migrations, broken
 flows, or features that are reverted without promotion.

--- a/docs/pre-alpha-release-channels.md
+++ b/docs/pre-alpha-release-channels.md
@@ -1,0 +1,73 @@
+# Pre-alpha release channels
+
+OpenWork has two unsupported, independently evolving pre-alpha integration
+branches:
+
+- `canary`
+- `experimental`
+
+They are intended for rapid, opinionated product iteration before work is ready
+for the `dev` alpha channel.
+
+## Branch contract
+
+- `dev` changes flow into `canary` and `experimental`.
+- `canary` and `experimental` are never merged wholesale into `dev`.
+- A feature branch may be merged independently into any or all three branches.
+- A channel-only change reaches `dev` through a separate reviewed feature PR,
+  not by merging the channel branch.
+- Direct pushes to `canary` and `experimental` are allowed.
+- Prefer merge commits or reverts on the channel branches after releases exist;
+  do not rewrite commits that already have release tags.
+
+For example, synchronize a channel with:
+
+```bash
+git switch canary
+git merge origin/dev
+git push origin canary
+```
+
+Repeat the same operation independently for `experimental`.
+
+## Build and release behavior
+
+Every push to either channel runs
+`.github/workflows/pre-alpha-macos-aarch64.yml`. The workflow intentionally
+does not run the normal OpenWork test suites. It performs only the dependency
+installation and signed/notarized macOS arm64 application build required to
+produce an installable artifact.
+
+Successful runs produce immutable prerelease tags:
+
+```text
+canary-macos-v0.18.12-canary.<run>-<sha>
+experimental-macos-v0.18.12-experimental.<run>-<sha>
+```
+
+The packaged versions follow SemVer prerelease notation:
+
+```text
+0.18.12-canary.<run>+<sha>
+0.18.12-experimental.<run>+<sha>
+```
+
+Rolling updater manifests are published at:
+
+```text
+canary-macos-latest/latest-mac.yml
+experimental-macos-latest/latest-mac.yml
+```
+
+The tag prefixes deliberately do not begin with `v`, so they cannot trigger
+the stable `v*` application, npm, EE image, AUR, or Daytona release paths.
+
+## Reduced CI/CD
+
+The repository's standard test and i18n workflows target `dev`, so direct
+pushes to these two channel branches do not run them. Each Vercel project's
+`vercel.json` also disables Git-triggered deployments for the exact `canary`
+and `experimental` branch names.
+
+These builds are unsupported and may contain incomplete migrations, broken
+flows, or features that are reverted without promotion.

--- a/ee/apps/den-web/vercel.json
+++ b/ee/apps/den-web/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "canary": false,
+      "experimental": false
+    }
+  }
 }

--- a/ee/apps/den-worker-proxy/vercel.json
+++ b/ee/apps/den-worker-proxy/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "canary": false,
+      "experimental": false
+    }
+  }
+}

--- a/ee/apps/diagnostics/vercel.json
+++ b/ee/apps/diagnostics/vercel.json
@@ -2,6 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "fluid": true,
+  "git": {
+    "deploymentEnabled": {
+      "canary": false,
+      "experimental": false
+    }
+  },
   "headers": [
     {
       "source": "/(.*)",

--- a/ee/apps/landing/vercel.json
+++ b/ee/apps/landing/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "canary": false,
+      "experimental": false
+    }
+  },
   "buildCommand": "pnpm --dir ../../../packages/email build && pnpm --dir ../../../packages/ui build && pnpm exec next build"
 }


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- add directly pushable `canary` and `experimental` integration branches
- build signed and notarized macOS arm64 apps on every push to either branch
- publish immutable channel-specific prereleases and rolling updater manifests
- disable Vercel Git deployments for both branches across all five connected projects
- document the one-way `dev` synchronization and independent feature-merge contract

## Why

OpenWork needs two deliberately unstable pre-alpha lanes where risky and opinionated features can be integrated, reverted, and tested as installable desktop builds without running the normal `dev` test/Vercel delivery surface or merging either integration branch back into `dev`.

## Behavior

- `dev` flows into `canary` and `experimental`; neither channel branch flows wholesale back into `dev`.
- A feature branch may merge independently into `dev`, `canary`, and/or `experimental`.
- Direct channel pushes are supported.
- Successful channel pushes create versions such as `0.18.13-canary.<run>+<sha>` and tags such as `canary-macos-v0.18.13-canary.<run>-<sha>`.
- Channel tags do not begin with `v`, so stable application, npm, EE image, AUR, and Daytona release workflows do not match them.

## Verification

Passed locally:

- `actionlint 1.7.12 .github/workflows/pre-alpha-macos-aarch64.yml`
- JSON parsing and exact `git.deploymentEnabled` assertions for all five Vercel projects
- generated canary SemVer and tag-format assertion
- `git diff --check`

Passed live:

- initial canary run at `5c32d09a`: 18/18 applicable steps passed in 6m04s
- initial experimental run at `5c32d09a`: 18/18 applicable steps passed in 6m27s
- synchronized canary run at `2f83eef1`: all applicable steps passed
- synchronized experimental run at `7fa7e0d2`: all applicable steps passed
- each successful run published a signed/notarized DMG, ZIP, blockmaps, immutable manifest, prerelease tag, and rolling manifest
- latest completed canary prerelease: `canary-macos-v0.18.12-canary.3-2f83eef`
- latest completed experimental prerelease: `experimental-macos-v0.18.12-experimental.4-7fa7e0d`
- rolling manifests resolve to the exact immutable assets with matching versions, sizes, and SHA-512 values

Current exact channel heads:

- canary `a095cba9`, containing current `dev` v0.18.12 and all five Vercel suppressions
- experimental `4845c6a8`, containing current `dev` v0.18.12 and all five Vercel suppressions
- GitHub reports no Vercel status contexts and no deployments for either current head
- their 0.18.13 build runs are queued behind shared macOS runner capacity and are not claimed passed yet

Annotation:

- `pnpm/action-setup@v4` emits GitHub's Node 20 action-runtime deprecation warning while GitHub forces it onto Node 24; completed runs pass.

## Risk and boundary

These are unsupported pre-alpha builds with a deliberately minimal CI floor. They use the existing OpenWork application identity and macOS signing path. The existing full-matrix staging lane in #3187 remains separate and retains its `dev`-ancestry requirement.

## Rollback

Delete or stop using the two channel branches and revert this PR. Published immutable prerelease tags should be retained as build provenance.