### PR TITLE
chore(release): v0.18.12

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.11",
+  "version": "0.18.12",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.11",
+  "version": "0.18.12",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.11",
+  "version": "0.18.12",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.12",
   "0.18.11",
   "0.18.10",
   "0.18.9",


### PR DESCRIPTION
Version bump for `v0.18.12`, cut so #3332 (managed provider credential delivery to the engine) reaches cloud sandboxes. Cloud org providers are currently unusable — they appear in the picker but every run fails with "API key is missing" — and that fix ships inside the snapshot image, so it needs a release + recycle to take effect.

Release review clean at 0.18.12. Tag push creates a draft release; I'll mark it prerelease as before, so the stable desktop channel stays on v0.18.10.