### PR TITLE
fix(app): show thinking feedback while chat submits

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1138,8 +1138,13 @@ interface MessageListProps {
   retryStatus?: RetryStatus | null
 }
 
+export function shouldShowMessageListLoading(status: ThreadStatus, messageCount: number) {
+  return status === "streaming" || (status === "submitted" && messageCount > 0)
+}
+
 export function MessageList({ messages, status, retryStatus }: MessageListProps) {
   const isStreaming = status === "streaming" || status === "retrying"
+  const showLoading = shouldShowMessageListLoading(status, messages.length)
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
@@ -1180,7 +1185,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
         )
       })}
 
-      {status === "streaming" && <LoadingMessage label={liveActionLabel ?? undefined} />}
+      {showLoading && <LoadingMessage label={liveActionLabel ?? undefined} />}
       {retryStatus ? <RetryMessage status={retryStatus} /> : null}
       {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
     </div>

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -1,0 +1,60 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { UIMessage } from "ai";
+
+import {
+  MessageList,
+  shouldShowMessageListLoading,
+} from "../src/components/chat/message-list";
+import { MessageListProvider } from "../src/components/chat/message-list-provider";
+import type { ThreadStatus } from "../src/lib/messages";
+
+const userMessage: UIMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "Send this", state: "done" }],
+};
+
+function renderList(messages: UIMessage[], status: ThreadStatus) {
+  return renderToStaticMarkup(
+    <MessageListProvider
+      workspaceId="ws"
+      sessionId="session"
+      showThinking={true}
+      developerMode={false}
+      displaySuggestions={false}
+      providerConnectedCount={1}
+      dispatchAction={() => {}}
+      setPrompt={() => {}}
+      onRevertToUserMessage={() => {}}
+      onForkAtMessage={() => {}}
+      onEditUserMessage={() => {}}
+      onMcpReconnect={() => Promise.reject(new Error("unused"))}
+      onMcpReopenAuthorization={() => Promise.resolve()}
+      onMcpRetry={() => {}}
+    >
+      <MessageList messages={messages} status={status} />
+    </MessageListProvider>,
+  );
+}
+
+describe("message-list loading feedback", () => {
+  test("acknowledges a submitted message before streaming starts", () => {
+    const markup = renderList([userMessage], "submitted");
+
+    expect(markup).toContain("Thinking…");
+    expect(markup).not.toContain("Loading…");
+  });
+
+  test("does not duplicate the empty-conversation waiting treatment", () => {
+    expect(shouldShowMessageListLoading("submitted", 0)).toBe(false);
+  });
+
+  test("keeps the same loading treatment when streaming begins", () => {
+    const markup = renderList([userMessage], "streaming");
+
+    expect(markup).toContain("Thinking…");
+    expect(markup).not.toContain("Loading…");
+  });
+});


### PR DESCRIPTION
## Summary

- show the existing colored loading circle while a non-empty chat is still in
  the pre-stream `submitted` state
- retain “Thinking…” for the generic feedback row
- avoid duplicating the separate empty-conversation waiting treatment

## Why

The send coordinator enters `submitted` before the first server/model event,
but the transcript previously rendered its loading row only for `streaming`.
Existing conversations could therefore look frozen immediately after Send.

## Verification

- `pnpm exec bun test --isolate apps/app/tests/message-list-loading.test.tsx` — 3 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Review steps

1. Open a non-empty conversation.
2. Send a message while delaying the server response.
3. Confirm the colored circle and “Thinking…” appear immediately.
4. Confirm no generic “Loading…” row appears and the empty-task treatment is
   not duplicated.

## Evidence boundary

The submitted, empty, and streaming rendering states are covered by focused
SSR tests. No live delayed-response fraimz recording was captured in this quick
pass.
