### PR TITLE
fix(app): support super-admin organizations on desktop

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -139,11 +139,13 @@ export type DenBootstrapConfig = DenBaseUrls & {
 
 export type DenDesktopConfig = SharedDesktopConfig;
 
+export type DenOrgRole = "super-admin" | "owner" | "admin" | "member";
+
 export type DenOrgSummary = {
   id: string;
   name: string;
   slug: string;
-  role: "owner" | "admin" | "member";
+  role: DenOrgRole;
 };
 
 export type DenWorkerSummary = {
@@ -1128,7 +1130,12 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
       typeof entry.id !== "string" ||
       typeof entry.name !== "string" ||
       typeof entry.slug !== "string" ||
-      (entry.role !== "owner" && entry.role !== "admin" && entry.role !== "member")
+      (
+        entry.role !== "super-admin" &&
+        entry.role !== "owner" &&
+        entry.role !== "admin" &&
+        entry.role !== "member"
+      )
     ) {
       return [];
     }

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -26,6 +26,19 @@ export interface CloudAccountSectionProps {
   onSignOut: () => void | Promise<void>;
 }
 
+function organizationRoleLabel(role: DenOrgSummary["role"]) {
+  switch (role) {
+    case "super-admin":
+      return "Super admin";
+    case "owner":
+      return "Owner";
+    case "admin":
+      return "Admin";
+    case "member":
+      return "Member";
+  }
+}
+
 export function CloudAccountSection({
   activeOrgId,
   authBusy,
@@ -118,7 +131,7 @@ function ConnectedOrg({ org }: { org: DenOrgSummary }) {
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-dls-text">{org.name}</div>
         <div className="text-xs text-dls-secondary">
-          {org.role === "owner" ? "Owner" : "Member"} &middot; Connected
+          {organizationRoleLabel(org.role)} &middot; Connected
         </div>
       </div>
       <Check size={16} className="shrink-0 text-green-11" />
@@ -202,7 +215,7 @@ function OrgPicker({
             <div className="min-w-0 flex-1">
               <div className="text-sm font-medium text-dls-text">{org.name}</div>
               <div className="text-xs text-dls-secondary">
-                {org.role === "owner" ? "Owner" : "Member"}
+                {organizationRoleLabel(org.role)}
               </div>
             </div>
           </button>

--- a/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
+++ b/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
@@ -14,7 +14,7 @@ const instructionalTypes = new Set(["agent", "command", "context", "custom", "sk
 const desktopInstallTypes = new Set(["hook", "tool"]);
 
 export function isConnectAdminRole(role: ConnectOrgRole) {
-  return role === "owner" || role === "admin";
+  return role === "super-admin" || role === "owner" || role === "admin";
 }
 
 export function pluginHasInstructionalComponents(componentCounts: Record<string, number>) {

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -9,6 +9,7 @@ import {
   isConnectAdminRole,
   resolveConnectRowGroup,
   resolveConnectionRowGroup,
+  type ConnectOrgRole,
   type ConnectRowGroup,
 } from "@/react-app/domains/settings/connect-cloud-readiness";
 import type { ExtensionItem } from "@/react-app/domains/settings/extension-items";
@@ -61,7 +62,7 @@ type ConnectOrganizationRow =
 export function buildConnectRows(input: {
   connections: DenExternalMcpConnection[];
   items: ExtensionItem[];
-  role: "owner" | "admin" | "member" | null | undefined;
+  role: ConnectOrgRole;
 }) {
   const marketplaceItems = input.items.filter(isCloudMarketplaceItem);
   const pluginConnectionIds = new Set(

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -178,7 +178,11 @@ import { useComposerStateStore } from "@/react-app/domains/session/surface/compo
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
 
-import { createDenClient, readDenSettings } from "@/app/lib/den";
+import {
+  createDenClient,
+  readDenSettings,
+  type DenOrgRole,
+} from "@/app/lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "@/app/lib/den-session-events";
 
 import { filterProviderList } from "@/app/utils/providers";
@@ -457,7 +461,7 @@ export function SessionRoute() {
   const reloadCoordinator = useReloadCoordinator();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const restrictionNotice = useRestrictionNotice();
-  const [activeOrganizationRole, setActiveOrganizationRole] = useState<"owner" | "admin" | "member" | null>(null);
+  const [activeOrganizationRole, setActiveOrganizationRole] = useState<DenOrgRole | null>(null);
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
   const [developerMode, setDeveloperMode] = useState(() => {
@@ -859,7 +863,11 @@ export function SessionRoute() {
     await refreshOrganizationModelAccess();
   }, [refreshOrganizationModelAccess]);
   const organizationModelsSettingsUrl = useMemo(() => {
-    if (activeOrganizationRole !== "owner" && activeOrganizationRole !== "admin") {
+    if (
+      activeOrganizationRole !== "super-admin" &&
+      activeOrganizationRole !== "owner" &&
+      activeOrganizationRole !== "admin"
+    ) {
       return undefined;
     }
     return new URL("/dashboard/custom-llm-providers", readDenSettings().baseUrl).toString();

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -141,6 +141,7 @@ describe("Connect cloud-readiness row resolution", () => {
     expect(resolveConnectRowGroup({ state: "needs_signin", hasInstructional: false, connections: [] }, "member")).toBe("needs_signin");
     expect(resolveConnectRowGroup({ state: "ready", hasInstructional: true, connections: [] }, "member")).toBe("ready");
     expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "admin")).toBe("needs_admin_setup");
+    expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "super-admin")).toBe("needs_admin_setup");
   });
 
   test("hides admin setup, desktop-only, and not-synced rows from non-admin Connect", () => {

--- a/apps/app/tests/den-org-roles.test.ts
+++ b/apps/app/tests/den-org-roles.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createDenClient } from "../src/app/lib/den";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: originalFetch,
+  });
+});
+
+describe("Den organization roles", () => {
+  test("keeps super-admin organizations in the desktop organization list", async () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: (async () =>
+        new Response(JSON.stringify({
+          orgs: [{
+            id: "org_super",
+            name: "Super organization",
+            slug: "super-organization",
+            role: "super-admin",
+          }],
+          activeOrgId: "org_super",
+          activeOrgSlug: "super-organization",
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) satisfies typeof fetch,
+    });
+
+    await expect(
+      createDenClient({
+        baseUrl: "https://den.test",
+        token: "tok_test",
+      }).listOrgs(),
+    ).resolves.toEqual({
+      orgs: [{
+        id: "org_super",
+        name: "Super organization",
+        slug: "super-organization",
+        role: "super-admin",
+      }],
+      activeOrgId: "org_super",
+      activeOrgSlug: "super-organization",
+      defaultOrgId: "org_super",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- recognize Den's `super-admin` role in the desktop organization contract
- keep `super-admin` organizations selectable instead of silently dropping them
- grant the same desktop and Connect management affordances as `admin`
- preserve the distinct `owner` role and show accurate role labels

## Why

Den added `super-admin`, but the desktop parser still allowed only `owner`,
`admin`, and `member`. A valid `super-admin` organization was discarded while
parsing `/v1/me/orgs`, which left the active organization role unset and hid
admin-capable controls.

## Verification

- `pnpm --filter @openwork/app exec bun test --isolate tests/den-org-roles.test.ts tests/connect-view.test.ts` — 17 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Review steps

1. Sign in with a Den account whose active organization role is
   `super-admin`.
2. Confirm the organization remains selected in desktop.
3. Confirm organization model and Connect admin setup affordances are
   available.
4. Confirm the role is displayed as “Super admin,” not Owner or Member.

## Evidence boundary

No live `super-admin` fixture or fraimz recording was available in this quick
pass. The parser and management predicates are covered by focused tests; the
review steps above remain the final desktop proof.
