### PR TITLE
fix(app): move attachment actions into a menu

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -8,7 +8,9 @@ import {
   Copy,
   Download,
   FileIcon,
+  FolderOpen,
   LoaderCircle,
+  MoreHorizontal,
   Pencil,
   Split,
   Undo2,
@@ -22,7 +24,8 @@ import {
   type UIMessage,
 } from "ai"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
-import { openDesktopUrl } from "@/app/lib/desktop"
+import { openDesktopUrl, revealDesktopItemInDir } from "@/app/lib/desktop"
+import { isElectronRuntime } from "@/app/lib/runtime-env"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
@@ -48,6 +51,12 @@ import {
   DescriptiveButtonTitle,
 } from "@/components/descriptive-button"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -97,7 +106,7 @@ import {
 } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { cn } from "@/lib/utils"
-import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
+import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
 import type { AnyToolPart } from "@/lib/tool-aggregate"
 
 const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
@@ -266,6 +275,8 @@ function FileMessage({ part, tone }: FileMessageProps) {
   const badge = getMediaBadge(part)
   const isImage = part.mediaType.startsWith("image/") && Boolean(part.url)
   const downloadUrl = getSafeFileDownloadUrl(part)
+  const revealPath = getSafeFileRevealPath(part)
+  const canReveal = isElectronRuntime() && Boolean(revealPath)
 
   const handleDownload = React.useCallback(() => {
     if (!downloadUrl) return
@@ -277,6 +288,11 @@ function FileMessage({ part, tone }: FileMessageProps) {
     anchor.click()
     anchor.remove()
   }, [downloadUrl, title])
+
+  const handleReveal = React.useCallback(() => {
+    if (!revealPath) return
+    void revealDesktopItemInDir(revealPath)
+  }, [revealPath])
 
   if (isImage && tone === "user") {
     return <ImageAttachmentBadge src={part.url} alt={title} />
@@ -311,17 +327,35 @@ function FileMessage({ part, tone }: FileMessageProps) {
           ) : null}
         </DescriptiveButtonContent>
       </div>
-      {downloadUrl ? (
-        <Button
-          type="button"
-          variant="outline"
-          size="xs"
-          onClick={handleDownload}
-          aria-label={`Download ${title}`}
-        >
-          <Download className="size-3" />
-          Download
-        </Button>
+      {downloadUrl || canReveal ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`More actions for ${title}`}
+              >
+                <MoreHorizontal />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end" className="min-w-44">
+            {downloadUrl ? (
+              <DropdownMenuItem onClick={handleDownload}>
+                <Download />
+                Download
+              </DropdownMenuItem>
+            ) : null}
+            {canReveal ? (
+              <DropdownMenuItem onClick={handleReveal}>
+                <FolderOpen />
+                Reveal in Finder
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
       ) : null}
     </div>
   )

--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -81,6 +81,18 @@ export function getSafeFileDownloadUrl(part: Pick<FileUIPart, "url">) {
   }
 }
 
+export function getSafeFileRevealPath(part: Pick<FileUIPart, "url">) {
+  try {
+    const url = new URL(part.url)
+    if (url.protocol !== "file:") return null
+    const pathname = decodeURIComponent(url.pathname)
+    if (!pathname) return null
+    return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname
+  } catch {
+    return null
+  }
+}
+
 function getMessageOpencodeMetadata(message: UIMessage): object | null {
   const metadata: unknown = message.metadata
   if (!metadata || typeof metadata !== "object" || !("opencode" in metadata)) return null

--- a/apps/app/tests/office-attachment-ui.test.ts
+++ b/apps/app/tests/office-attachment-ui.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { getMediaBadge, getSafeFileDownloadUrl } from "../src/components/chat/utils";
+import {
+  getMediaBadge,
+  getSafeFileDownloadUrl,
+  getSafeFileRevealPath,
+} from "../src/components/chat/utils";
 import { getArtifactsFromMessages } from "../src/lib/artifacts";
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
@@ -22,6 +26,14 @@ describe("Office attachment UI affordances", () => {
     expect(getSafeFileDownloadUrl({ url: "file:///workspace/artifacts/QuarterlyBrief.docx" })).toBeNull();
     expect(getSafeFileDownloadUrl({ url: "https://example.com/QuarterlyBrief.docx" })).toBeNull();
     expect(getSafeFileDownloadUrl({ url: "javascript:alert(1)" })).toBeNull();
+  });
+
+  test("only exposes reveal actions for local file URLs", () => {
+    expect(getSafeFileRevealPath({ url: "file:///workspace/artifacts/Quarterly%20Brief.docx" })).toBe("/workspace/artifacts/Quarterly Brief.docx");
+    expect(getSafeFileRevealPath({ url: "file:///C:/Users/Jalil/Quarterly%20Brief.docx" })).toBe("C:/Users/Jalil/Quarterly Brief.docx");
+    expect(getSafeFileRevealPath({ url: "blob:http://localhost/office-download" })).toBeNull();
+    expect(getSafeFileRevealPath({ url: "https://example.com/QuarterlyBrief.docx" })).toBeNull();
+    expect(getSafeFileRevealPath({ url: "javascript:alert(1)" })).toBeNull();
   });
 
   test("collects DOCX artifacts as document previews", () => {


### PR DESCRIPTION
## Summary

- remove the always-visible Download button from non-image attachment cards
- replace it with the standard compact overflow menu
- keep Download inside the menu for browser-managed `data:` and `blob:` files
- offer Reveal in Finder for local `file:` attachments in Electron

## Why

The previous Download button appeared based on the attachment URL protocol,
so it surfaced unexpectedly on some upload paths and not others. Attachment
actions now live in the existing menu pattern, and local file URLs get the
desktop-native reveal action.

## Verification

- `pnpm --filter @openwork/app exec bun test --isolate tests/office-attachment-ui.test.ts` — 4 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Review steps

1. Attach a DOCX or other non-image file from the composer.
2. Confirm the card has a compact overflow button rather than a visible
   Download button.
3. Open the menu and confirm Download works for the sent browser-managed file.
4. Open a workspace-backed local attachment and confirm Reveal in Finder is
   offered in Electron.

## Evidence boundary

No fraimz recording was captured in this quick pass. URL safety and local path
decoding are covered by focused tests; the menu interaction remains a short
desktop review step.
