### PR TITLE
fix(den-api): re-materialize provider credentials after a recycle

### DIFF
--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -98,7 +98,21 @@ export type MaterializeCloudWorkerProviders = typeof materializeCloudWorkerProvi
 
 const logger = appLogger.child({ component: "cloud_provider_materialization" })
 const requestTimeoutMs = 8_000
-const materializedFingerprintByWorker = new Map<WorkerId, string>()
+/**
+ * Cache of what we have already materialized, keyed by worker AND instance.
+ *
+ * Keying by worker alone was a bug: a recycle onto a new snapshot replaces the
+ * sandbox, and the new instance starts with an empty env store (only the runtime
+ * config survives, on the shared volume). With a worker-only key den-api kept
+ * answering "cached" and never wrote the credential into the new instance, so
+ * every provider failed with "API key is missing" while still showing up in the
+ * picker.
+ */
+const materializedFingerprintByWorkerInstance = new Map<string, string>()
+
+function materializationCacheKey(workerId: WorkerId, instanceUrl: string): string {
+  return `${workerId}\u0000${instanceUrl}`
+}
 const unsupportedLogFingerprintByWorker = new Map<WorkerId, string>()
 const modelConfigPassthroughKeys = [
   "family",
@@ -906,7 +920,8 @@ export async function materializeCloudWorkerProviders(input: {
     fingerprint = prepared.fingerprint
     providerCount = prepared.providers.length
 
-    if (!input.force && materializedFingerprintByWorker.get(input.workerId) === fingerprint) {
+    const cacheKey = materializationCacheKey(input.workerId, instanceUrl)
+    if (!input.force && materializedFingerprintByWorkerInstance.get(cacheKey) === fingerprint) {
       return { ok: true, status: "cached", fingerprint, providers: providerCount }
     }
 
@@ -937,7 +952,7 @@ export async function materializeCloudWorkerProviders(input: {
       materializedProviderStateMatches(prepared, currentManagedProviders)
       && materializedEnvStateMatches(prepared.envEntries, envSnapshot)
     ) {
-      materializedFingerprintByWorker.set(input.workerId, fingerprint)
+      materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)
       return { ok: true, status: "noop", fingerprint, providers: providerCount }
     }
 
@@ -968,7 +983,7 @@ export async function materializeCloudWorkerProviders(input: {
     } catch (error) {
       const unsupportedReason = unsupportedProviderRouteReason(error)
       if (unsupportedReason) {
-        materializedFingerprintByWorker.delete(input.workerId)
+        materializedFingerprintByWorkerInstance.delete(cacheKey)
         await logUnsupportedOnce({
           logger: materializationLogger,
           workerId: input.workerId,
@@ -1018,7 +1033,7 @@ export async function materializeCloudWorkerProviders(input: {
       throw error
     }
 
-    materializedFingerprintByWorker.set(input.workerId, fingerprint)
+    materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)
     return { ok: true, status: "applied", fingerprint, providers: providerCount }
   } catch (error) {
     const result = failureResult({

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -286,11 +286,12 @@ async function materialize(input: {
   fetchImpl: FetchImpl
   logger?: Logger
   force?: boolean
+  instanceUrl?: string
 }) {
   return materializeCloudWorkerProviders({
     organizationId,
     workerId: input.workerId ?? createDenTypeId("worker"),
-    instanceUrl,
+    instanceUrl: input.instanceUrl ?? instanceUrl,
     hostToken: "host-token",
     clientToken: "client-token",
     store: makeStore(input.providers),
@@ -317,6 +318,41 @@ describe("Cloud provider materialization", () => {
     expect(second.status).toBe("noop")
     expect(instance.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(0)
     expect(instance.calls.filter((call) => call.method === "PATCH" && call.path === "/runtime-config/providers")).toHaveLength(0)
+  })
+
+  test("re-materializes after a recycle replaces the instance", async () => {
+    // A recycle onto a new snapshot gives the worker a brand new sandbox: only
+    // the runtime config survives (shared volume), the env store starts empty.
+    // Keying the cache by worker alone made den-api answer "cached" and never
+    // write the credential into the new instance, so every provider failed with
+    // "API key is missing" while still appearing in the picker.
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const workerId = createDenTypeId("worker")
+
+    const before = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+    await materialize({ workerId, providers: () => [provider], fetchImpl: before.fetchImpl })
+
+    // Same worker, same credential fingerprint, new sandbox: config persisted on
+    // the volume, env store empty.
+    const recycled = makeInstance({
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+    const result = await materialize({
+      workerId,
+      providers: () => [provider],
+      fetchImpl: recycled.fetchImpl,
+      instanceUrl: "https://worker-recycled.example.test",
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("applied")
+    expect(recycled.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(1)
+    expect(recycled.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
+      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
+    })
   })
 
   test("writes a models.dev provider block, credential env, and reloads OpenCode", async () => {


### PR DESCRIPTION
Second half of "org providers say API key is missing". #3332 fixed delivery to the engine; this fixes the credential never being written to a recycled sandbox in the first place. Regression from my #3301.

## Evidence (live, on a freshly recycled 0.18.12 instance)

```
runtime config (persisted on the shared volume):  lpr_01kyn7yad3exs8xk0sd0fc9ae0  env=["ANTHROPIC_API_KEY"]
env store (NOT on the volume):                    {"keys":[]}      <- lost in the recycle
den-api providerSync:                             null             <- decided nothing needed doing
```

## Cause

```ts
const materializedFingerprintByWorker = new Map<WorkerId, string>()
if (!input.force && materializedFingerprintByWorker.get(input.workerId) === fingerprint) {
  return { ok: true, status: "cached", ... }
}
```

Keyed by **worker alone**. A recycle onto a new snapshot replaces the sandbox: the runtime config survives (shared volume) but the env store starts empty. den-api kept answering `cached` for that worker and never looked at the new instance, so the credential was never written — while the provider still appeared in the picker, because its config had persisted. Every run then failed with "API key is missing".

Note the deeper `noop` path was already correct — it compares provider config **and** env values, so it would have caught the empty env store. The early `cached` return jumped over it.

## Fix

Key the cache by worker **and** instance URL, so a replaced sandbox is always re-inspected. One line of behaviour, plus the rename and comment explaining why.

## Test

`re-materializes after a recycle replaces the instance` — same worker, same credential fingerprint, new instance with config present and env empty. Proven to fail against the old key:

```
with worker-only key:  Expected: "applied"   Received: "cached"    0 pass / 1 fail
with the fix:          1 pass / 0 fail
```

| Command | Result |
| --- | --- |
| materialization + cloud-route suites | 50 pass / 0 fail |
| `tsc --noEmit` (den-api) | clean |

## Why this is separate from #3332

Two independent defects had to line up for the user-visible failure:
1. **This one** — the credential was never written into the recycled instance's env store.
2. **#3332** — even when the credential *was* stored, nothing delivered it to the engine, whose process env is a fixed allowlist.

den-api deploys from `dev`, so this takes effect immediately. #3332 ships in the sandbox image and is already live as of `openwork-0.18.12`.