### PR TITLE
feat(desktop): unlock elevated developer update channels

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -139,11 +139,13 @@ export type DenBootstrapConfig = DenBaseUrls & {
 
 export type DenDesktopConfig = SharedDesktopConfig;
 
+export type DenOrgRole = "super-admin" | "owner" | "admin" | "member";
+
 export type DenOrgSummary = {
   id: string;
   name: string;
   slug: string;
-  role: "owner" | "admin" | "member";
+  role: DenOrgRole;
 };
 
 export type DenWorkerSummary = {
@@ -1128,7 +1130,12 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
       typeof entry.id !== "string" ||
       typeof entry.name !== "string" ||
       typeof entry.slug !== "string" ||
-      (entry.role !== "owner" && entry.role !== "admin" && entry.role !== "member")
+      (
+        entry.role !== "super-admin" &&
+        entry.role !== "owner" &&
+        entry.role !== "admin" &&
+        entry.role !== "member"
+      )
     ) {
       return [];
     }

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -1,4 +1,5 @@
 import { nativeDeepLinkEvent } from "./deep-link-bridge";
+import type { ReleaseChannel } from "../types";
 
 export type * from "./desktop-types";
 export type {
@@ -111,22 +112,22 @@ declare global {
       };
       updater?: {
         getChannel?: () => Promise<{
-          channel: "stable" | "alpha";
+          channel: ReleaseChannel;
           feedUrl: string;
           currentVersion: string;
         }>;
-        setChannel?: (channel: "stable" | "alpha") => Promise<{
-          channel: "stable" | "alpha";
+        setChannel?: (channel: ReleaseChannel) => Promise<{
+          channel: ReleaseChannel;
           feedUrl: string;
           currentVersion: string;
         }>;
-        check?: (channel?: "stable" | "alpha", targetVersion?: string) => Promise<{
+        check?: (channel?: ReleaseChannel, targetVersion?: string) => Promise<{
           available: boolean;
           currentVersion?: string;
           latestVersion?: string | null;
           releaseDate?: string | null;
           releaseNotes?: unknown;
-          channel?: "stable" | "alpha";
+          channel?: ReleaseChannel;
           feedUrl?: string;
           reason?: string;
         }>;

--- a/apps/app/src/app/lib/elevated-developer-mode.ts
+++ b/apps/app/src/app/lib/elevated-developer-mode.ts
@@ -1,0 +1,41 @@
+export const ELEVATED_DEVELOPER_MODE_TOGGLE_COUNT = 5;
+export const ELEVATED_DEVELOPER_MODE_TOGGLE_WINDOW_MS = 8_000;
+
+export type ElevatedDeveloperModeToggleSequence = {
+  count: number;
+  startedAt: number | null;
+};
+
+export const EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE: ElevatedDeveloperModeToggleSequence = {
+  count: 0,
+  startedAt: null,
+};
+
+export function recordElevatedDeveloperModeToggle(
+  sequence: ElevatedDeveloperModeToggleSequence,
+  now = Date.now(),
+): {
+  sequence: ElevatedDeveloperModeToggleSequence;
+  triggered: boolean;
+} {
+  const sequenceExpired =
+    sequence.startedAt === null ||
+    now < sequence.startedAt ||
+    now - sequence.startedAt > ELEVATED_DEVELOPER_MODE_TOGGLE_WINDOW_MS;
+  const nextCount = sequenceExpired ? 1 : sequence.count + 1;
+
+  if (nextCount >= ELEVATED_DEVELOPER_MODE_TOGGLE_COUNT) {
+    return {
+      sequence: EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+      triggered: true,
+    };
+  }
+
+  return {
+    sequence: {
+      count: nextCount,
+      startedAt: sequenceExpired ? now : sequence.startedAt,
+    },
+    triggered: false,
+  };
+}

--- a/apps/app/src/app/lib/release-channels.ts
+++ b/apps/app/src/app/lib/release-channels.ts
@@ -1,7 +1,7 @@
 /**
  * Release-channel concept for OpenWork desktop builds.
  *
- * There are two channels users can opt into:
+ * There are four channels users can opt into:
  *
  * - "stable": the default. The desktop app auto-updates from the rolling
  *   "latest" GitHub release attached to whichever semver tag most recently
@@ -12,8 +12,12 @@
  *   (`alpha-macos-latest`) so the updater endpoint stays stable while the
  *   underlying artifact is replaced on every dev push.
  *
- * Only the macOS (arm64) build is published to the alpha channel today.
- * Linux and Windows always resolve to the stable channel.
+ * - "canary" and "experimental": hidden Electron/macOS-only rolling channels
+ *   used by the corresponding long-lived branches. The UI exposes these only
+ *   while elevated Developer mode is enabled.
+ *
+ * Only macOS (arm64) prerelease builds are published today. Linux and Windows
+ * always resolve to the stable channel.
  */
 
 import type { ReleaseChannel } from "../types";
@@ -29,7 +33,30 @@ export const ALPHA_UPDATER_ENDPOINT =
 /** Rolling GitHub release tag that alpha macOS artifacts are published to. */
 export const ALPHA_MACOS_RELEASE_TAG = "alpha-macos-latest";
 
+export const CANARY_MACOS_RELEASE_TAG = "canary-macos-latest";
+export const EXPERIMENTAL_MACOS_RELEASE_TAG = "experimental-macos-latest";
+
 export type PlatformKind = "darwin" | "linux" | "windows" | "web" | "unknown";
+
+export function isPrereleaseChannel(
+  channel: ReleaseChannel,
+): channel is Exclude<ReleaseChannel, "stable"> {
+  return channel !== "stable";
+}
+
+export function isPreAlphaChannel(
+  channel: ReleaseChannel,
+): channel is Extract<ReleaseChannel, "canary" | "experimental"> {
+  return channel === "canary" || channel === "experimental";
+}
+
+export function visibleReleaseChannels(
+  elevatedDeveloperMode: boolean,
+): ReleaseChannel[] {
+  return elevatedDeveloperMode
+    ? ["stable", "alpha", "canary", "experimental"]
+    : ["stable", "alpha"];
+}
 
 /**
  * Returns true when the given platform supports the alpha channel.
@@ -53,13 +80,18 @@ export function resolveUpdaterEndpoint(
   channel: ReleaseChannel,
   platform: PlatformKind = "darwin",
 ): string {
-  if (channel === "alpha" && isAlphaChannelSupported(platform)) {
-    return ALPHA_UPDATER_ENDPOINT;
+  if (!isAlphaChannelSupported(platform)) {
+    return STABLE_UPDATER_ENDPOINT;
   }
+  if (channel === "alpha") return ALPHA_UPDATER_ENDPOINT;
+  // Canary and Experimental publish Electron's latest-mac.yml manifest, not
+  // the retired Tauri latest.json format used by this legacy resolver.
   return STABLE_UPDATER_ENDPOINT;
 }
 
 /** Narrow an arbitrary string to a valid ReleaseChannel, defaulting to stable. */
 export function coerceReleaseChannel(value: unknown): ReleaseChannel {
-  return value === "alpha" ? "alpha" : "stable";
+  return value === "alpha" || value === "canary" || value === "experimental"
+    ? value
+    : "stable";
 }

--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -11,6 +11,7 @@ import {
   type DenDesktopConfig,
 } from "./den";
 import type { ReleaseChannel } from "../types";
+import { isPrereleaseChannel } from "./release-channels";
 
 declare global {
   interface Window {
@@ -136,7 +137,7 @@ export function resolveDesktopUpdateChannel(
   channel: ReleaseChannel,
   desktopConfig: DenDesktopConfig | null | undefined,
 ): ReleaseChannel {
-  return channel === "alpha" && !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
+  return isPrereleaseChannel(channel) && !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
     ? "stable"
     : channel;
 }
@@ -321,9 +322,10 @@ export async function isUpdateSupportedByDen(updateVersion: string): Promise<boo
 }
 
 /**
- * Alpha channel builds may run one patch ahead of the current Den/org maximum
- * (e.g. Den allows 0.13.3, alpha 0.13.4-alpha.N is allowed). Larger jumps are
- * still blocked so alpha cannot bypass staged rollout ceilings entirely.
+ * Prerelease channel builds may run one patch ahead of the current Den/org
+ * maximum (e.g. Den allows 0.13.3 and alpha/canary/experimental may serve
+ * 0.13.4-*.N). Larger jumps are still blocked so prerelease channels cannot
+ * bypass staged rollout ceilings entirely.
  */
 export async function isAlphaUpdateAllowed(
   updateVersion: string,

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -168,10 +168,12 @@ export type StartupPreference = "local" | "server";
  * - "stable": default. Auto-updates from the rolling stable GitHub release.
  * - "alpha": macOS-only. Auto-updates from the rolling alpha release that
  *   every merge to `dev` publishes to.
+ * - "canary": hidden macOS-only rolling builds for early integration testing.
+ * - "experimental": hidden macOS-only rolling builds for riskier prototypes.
  *
  * See `apps/app/src/app/lib/release-channels.ts` for URL resolution.
  */
-export type ReleaseChannel = "stable" | "alpha";
+export type ReleaseChannel = "stable" | "alpha" | "canary" | "experimental";
 
 export type EngineRuntime = "direct";
 

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -33,6 +33,7 @@ import {
   isAlphaUpdateAllowed,
   resolveFreshStableDesktopUpdate,
 } from "@/app/lib/version-gate";
+import { isPrereleaseChannel } from "@/app/lib/release-channels";
 import {
   DEN_HANDOFF_AUTO_CONTINUE_KEY,
   exchangeHandoffAndSignIn,
@@ -116,7 +117,7 @@ async function stageOnboardingUpdate(
 
   const channelState = await updater.getChannel();
   if (
-    channelState.channel === "alpha" &&
+    isPrereleaseChannel(channelState.channel) &&
     !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
   ) {
     await updater.setChannel?.("stable");
@@ -135,7 +136,7 @@ async function stageOnboardingUpdate(
   const update = await updater.check(channelState.channel, targetVersion);
   if (!update.available || update.reason) return false;
   if (
-    channelState.channel === "alpha" &&
+    isPrereleaseChannel(channelState.channel) &&
     update.latestVersion &&
     !(await isAlphaUpdateAllowed(update.latestVersion, desktopConfig))
   ) {

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -26,6 +26,19 @@ export interface CloudAccountSectionProps {
   onSignOut: () => void | Promise<void>;
 }
 
+function organizationRoleLabel(role: DenOrgSummary["role"]) {
+  switch (role) {
+    case "super-admin":
+      return "Super admin";
+    case "owner":
+      return "Owner";
+    case "admin":
+      return "Admin";
+    case "member":
+      return "Member";
+  }
+}
+
 export function CloudAccountSection({
   activeOrgId,
   authBusy,
@@ -118,7 +131,7 @@ function ConnectedOrg({ org }: { org: DenOrgSummary }) {
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-dls-text">{org.name}</div>
         <div className="text-xs text-dls-secondary">
-          {org.role === "owner" ? "Owner" : "Member"} &middot; Connected
+          {organizationRoleLabel(org.role)} &middot; Connected
         </div>
       </div>
       <Check size={16} className="shrink-0 text-green-11" />
@@ -202,7 +215,7 @@ function OrgPicker({
             <div className="min-w-0 flex-1">
               <div className="text-sm font-medium text-dls-text">{org.name}</div>
               <div className="text-xs text-dls-secondary">
-                {org.role === "owner" ? "Owner" : "Member"}
+                {organizationRoleLabel(org.role)}
               </div>
             </div>
           </button>

--- a/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
+++ b/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
@@ -14,7 +14,7 @@ const instructionalTypes = new Set(["agent", "command", "context", "custom", "sk
 const desktopInstallTypes = new Set(["hook", "tool"]);
 
 export function isConnectAdminRole(role: ConnectOrgRole) {
-  return role === "owner" || role === "admin";
+  return role === "super-admin" || role === "owner" || role === "admin";
 }
 
 export function pluginHasInstructionalComponents(componentCounts: Record<string, number>) {

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -792,6 +792,7 @@ export function AdvancedFeatureFlagsSection(props: AdvancedFeatureFlagsSectionPr
 interface AdvancedDeveloperSectionProps {
   busy: boolean;
   developerMode: boolean;
+  elevatedDeveloperMode: boolean;
   opencodeDevModeEnabled: boolean;
   deepLinkOpen: boolean;
   deepLinkInput: string;
@@ -818,6 +819,12 @@ export function AdvancedDeveloperSection(props: AdvancedDeveloperSectionProps) {
             <Switch
               aria-label={t("settings.developer_mode_title")}
               checked={props.developerMode}
+              className={
+                props.elevatedDeveloperMode
+                  ? "border-gold-9 bg-gold-9 data-checked:border-gold-9 data-checked:bg-gold-9 data-unchecked:border-gold-9 data-unchecked:bg-gold-9"
+                  : undefined
+              }
+              data-elevated-developer-mode={props.elevatedDeveloperMode || undefined}
               onCheckedChange={props.onToggleDeveloperMode}
             />
           </LayoutSectionItemHeaderActions>

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -38,6 +38,7 @@ export type AdvancedViewProps = {
   opencodeConnectStatus: OpencodeConnectStatus | null;
   openworkServerStatus: OpenworkServerStatus;
   developerMode: boolean;
+  elevatedDeveloperMode: boolean;
   toggleDeveloperMode: () => void;
   opencodeDevModeEnabled: boolean;
   openDebugDeepLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
@@ -224,6 +225,7 @@ export function AdvancedView(props: AdvancedViewProps) {
       <AdvancedDeveloperSection
         busy={props.busy}
         developerMode={props.developerMode}
+        elevatedDeveloperMode={props.elevatedDeveloperMode}
         opencodeDevModeEnabled={props.opencodeDevModeEnabled}
         deepLinkOpen={debugDeepLinkOpen}
         deepLinkInput={debugDeepLinkInput}

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -9,6 +9,7 @@ import {
   isConnectAdminRole,
   resolveConnectRowGroup,
   resolveConnectionRowGroup,
+  type ConnectOrgRole,
   type ConnectRowGroup,
 } from "@/react-app/domains/settings/connect-cloud-readiness";
 import type { ExtensionItem } from "@/react-app/domains/settings/extension-items";
@@ -61,7 +62,7 @@ type ConnectOrganizationRow =
 export function buildConnectRows(input: {
   connections: DenExternalMcpConnection[];
   items: ExtensionItem[];
-  role: "owner" | "admin" | "member" | null | undefined;
+  role: ConnectOrgRole;
 }) {
   const marketplaceItems = input.items.filter(isCloudMarketplaceItem);
   const pluginConnectionIds = new Set(

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -1153,7 +1153,10 @@ export function DebugView(props: DebugViewProps) {
               </div>
             </div>
             <div className="rounded-full border border-dls-border bg-dls-sidebar/50 px-2.5 py-1 text-[11px] font-medium text-dls-secondary">
-              {props.electronAlphaUpdaterChannel === "alpha" ? "Alpha" : "Stable"}
+              {props.electronAlphaUpdaterChannel === "stable"
+                ? "Stable"
+                : props.electronAlphaUpdaterChannel[0]?.toUpperCase() +
+                  props.electronAlphaUpdaterChannel.slice(1)}
             </div>
           </div>
 

--- a/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
@@ -18,6 +18,7 @@ import { Switch } from "@/components/ui/switch";
 import { formatBytes, formatRelativeTime } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import type { ReleaseChannel } from "../../../../app/types";
+import { visibleReleaseChannels } from "../../../../app/lib/release-channels";
 import type { SettingsUpdateStatus } from "../state/electron-updater-state";
 import {
   LayoutSectionItem,
@@ -33,6 +34,8 @@ import { Spinner } from "../settings-section";
 const RELEASE_CHANNEL_OPTIONS: { label: string; value: ReleaseChannel }[] = [
   { label: "Stable", value: "stable" },
   { label: "Alpha", value: "alpha" },
+  { label: "Canary", value: "canary" },
+  { label: "Experimental", value: "experimental" },
 ];
 
 type UpdateDownloadProgressProps = {
@@ -87,9 +90,17 @@ export type UpdatesViewProps = {
    * toggle is hidden.
    */
   alphaChannelSupported?: boolean;
+  /** Whether the hidden canary and experimental channels are unlocked. */
+  elevatedDeveloperMode?: boolean;
 };
 
 export function UpdatesView(props: UpdatesViewProps) {
+  const visibleChannels = visibleReleaseChannels(
+    props.elevatedDeveloperMode === true,
+  );
+  const releaseChannelOptions = RELEASE_CHANNEL_OPTIONS.filter((option) =>
+    visibleChannels.includes(option.value)
+  );
   const [confirmRestartOpen, setConfirmRestartOpen] = useState(false);
   const updateState = props.updateStatus?.state ?? "idle";
   const updateVersion = props.updateStatus?.version ?? null;
@@ -247,15 +258,20 @@ export function UpdatesView(props: UpdatesViewProps) {
               <LayoutSectionItemHeader>
                 <LayoutSectionItemTitle>Release channel</LayoutSectionItemTitle>
                 <LayoutSectionItemDescription>
-                  Stable gets fully tested releases. Alpha includes the very latest changes but may be less polished (macOS only).
+                  {props.elevatedDeveloperMode
+                    ? "Elevated Developer mode also exposes the riskier Canary and Experimental rolling builds (macOS only)."
+                    : "Stable gets fully tested releases. Alpha includes the very latest changes but may be less polished (macOS only)."}
                 </LayoutSectionItemDescription>
                 <LayoutSectionItemHeaderActions>
                   <Select
                     value={props.releaseChannel}
-                    items={RELEASE_CHANNEL_OPTIONS}
+                    items={releaseChannelOptions}
                     onValueChange={(value) => {
-                      if (value === "stable" || value === "alpha") {
-                        props.onReleaseChannelChange?.(value);
+                      const option = releaseChannelOptions.find(
+                        (candidate) => candidate.value === value,
+                      );
+                      if (option) {
+                        props.onReleaseChannelChange?.(option.value);
                       }
                     }}
                     disabled={!props.onReleaseChannelChange}
@@ -265,7 +281,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectGroup>
-                        {RELEASE_CHANNEL_OPTIONS.map((option) => (
+                        {releaseChannelOptions.map((option) => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
                           </SelectItem>

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -44,6 +44,7 @@ import {
 import { t } from "../../../../i18n";
 import type { DebugViewProps } from "../pages/debug-view";
 import type { ReleaseChannel } from "../../../../app/types";
+import { isPrereleaseChannel } from "../../../../app/lib/release-channels";
 import type { OpenworkServerStore, OpenworkServerStoreSnapshot } from "../../connections/openwork-server-store";
 
 type DebugViewModelProps = Omit<DebugViewProps, "agentContextDiagnostics">;
@@ -607,8 +608,8 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       setElectronAlphaUpdaterStatus("Electron updater channels are available only in the Electron desktop app.");
       return;
     }
-    if (channel === "alpha" && !isMacPlatform()) {
-      setElectronAlphaUpdaterStatus("Electron alpha updates are macOS-only for now.");
+    if (isPrereleaseChannel(channel) && !isMacPlatform()) {
+      setElectronAlphaUpdaterStatus("Electron prerelease updates are macOS-only for now.");
       return;
     }
     const bridge = window.__OPENWORK_ELECTRON__?.updater;

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -12,6 +12,7 @@ import {
   resolveFreshStableDesktopUpdate,
 } from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
+import { isPrereleaseChannel } from "../../../../app/lib/release-channels";
 import { isElectronRuntime, safeStringify } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import { useUpdateCheckRequestStore } from "./update-check-request";
@@ -165,7 +166,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   const resolvePolicyReleaseChannel = useCallback(
     async (channel: ReleaseChannel) => {
       if (
-        channel !== "alpha" ||
+        !isPrereleaseChannel(channel) ||
         !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
       ) {
         return {
@@ -189,8 +190,10 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     }
     if (isAlphaChannelAllowedByDesktopConfig(desktopConfig)) return;
     if (
-      availableReleaseChannelRef.current === "alpha" ||
-      downloadedReleaseChannelRef.current === "alpha"
+      (availableReleaseChannelRef.current &&
+        isPrereleaseChannel(availableReleaseChannelRef.current)) ||
+      (downloadedReleaseChannelRef.current &&
+        isPrereleaseChannel(downloadedReleaseChannelRef.current))
     ) {
       availableReleaseChannelRef.current = null;
       downloadedReleaseChannelRef.current = null;
@@ -302,7 +305,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         return;
       }
       if (
-        releaseChannelResolution.channel === "alpha" &&
+        isPrereleaseChannel(releaseChannelResolution.channel) &&
         !isAlphaChannelAllowedByDesktopConfig(desktopConfigRef.current)
       ) {
         onReleaseChannelChange("stable");
@@ -444,13 +447,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         });
         return;
       }
-      const latestDesktopConfig = checkedReleaseChannel === "alpha"
+      const latestDesktopConfig = isPrereleaseChannel(checkedReleaseChannel)
         ? desktopConfigRef.current
         : freshDesktopConfig;
       const availableAllowed = result.available && result.latestVersion
         ? targetVersion
           ? result.latestVersion === targetVersion
-          : checkedReleaseChannel === "alpha"
+          : isPrereleaseChannel(checkedReleaseChannel)
             ? await isAlphaUpdateAllowed(result.latestVersion, latestDesktopConfig)
             : await isUpdateAllowed(result.latestVersion, latestDesktopConfig)
         : result.available;
@@ -520,9 +523,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       return;
     }
     try {
-      if (downloadedReleaseChannelRef.current === "alpha") {
-        const releaseChannelResolution = await resolvePolicyReleaseChannel("alpha");
-        if (releaseChannelResolution.channel !== "alpha") {
+      if (
+        downloadedReleaseChannelRef.current &&
+        isPrereleaseChannel(downloadedReleaseChannelRef.current)
+      ) {
+        const downloadedChannel = downloadedReleaseChannelRef.current;
+        const releaseChannelResolution = await resolvePolicyReleaseChannel(downloadedChannel);
+        if (releaseChannelResolution.channel !== downloadedChannel) {
           onReleaseChannelChange(releaseChannelResolution.channel);
           await bridge.setChannel?.(releaseChannelResolution.channel);
           downloadedReleaseChannelRef.current = null;

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -11,7 +11,10 @@ import {
 } from "react";
 
 import { THINKING_PREF_KEY } from "../../app/constants";
-import { coerceReleaseChannel } from "../../app/lib/release-channels";
+import {
+  coerceReleaseChannel,
+  isPreAlphaChannel,
+} from "../../app/lib/release-channels";
 import type { ModelRef, ReleaseChannel, SettingsTab, View } from "../../app/types";
 import {
   DEFAULT_DESKTOP_NOTIFICATION_PREFERENCE,
@@ -48,6 +51,8 @@ export type LocalPreferences = {
   releaseChannel: ReleaseChannel;
   featureFlags: {
     microsandboxCreateSandbox: boolean;
+    /** Unlocks hidden canary and experimental desktop update channels. */
+    elevatedDeveloperMode: boolean;
     /**
      * Memory Bank preview. Client-only, per-device, never synced. Gates desktop
      * UI surfacing (the management panel + copy-prompt affordance); the routes
@@ -93,7 +98,11 @@ const INITIAL_PREFS: LocalPreferences = {
   defaultModel: null,
   selectedAgent: null,
   releaseChannel: "stable",
-  featureFlags: { microsandboxCreateSandbox: true, memory: false },
+  featureFlags: {
+    microsandboxCreateSandbox: true,
+    elevatedDeveloperMode: false,
+    memory: false,
+  },
   hasCompletedOnboarding: false,
   analyticsEnabled: true,
   desktopNotifications: DEFAULT_DESKTOP_NOTIFICATION_PREFERENCE,
@@ -133,6 +142,17 @@ export function LocalProvider({ children }: LocalProviderProps) {
   );
   const [prefs, setPrefsRaw] = useState<LocalPreferences>(() => {
     const persisted = readPersisted(LOCAL_PREFERENCES_KEY, INITIAL_PREFS);
+    persisted.releaseChannel = coerceReleaseChannel(persisted.releaseChannel);
+    persisted.featureFlags = {
+      ...INITIAL_PREFS.featureFlags,
+      ...persisted.featureFlags,
+    };
+    if (
+      !persisted.featureFlags.elevatedDeveloperMode &&
+      isPreAlphaChannel(persisted.releaseChannel)
+    ) {
+      persisted.releaseChannel = "stable";
+    }
     persisted.desktopNotifications = isDesktopNotificationPreference(persisted.desktopNotifications)
       ? persisted.desktopNotifications
       : DEFAULT_DESKTOP_NOTIFICATION_PREFERENCE;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -178,7 +178,11 @@ import { useComposerStateStore } from "@/react-app/domains/session/surface/compo
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
 
-import { createDenClient, readDenSettings } from "@/app/lib/den";
+import {
+  createDenClient,
+  readDenSettings,
+  type DenOrgRole,
+} from "@/app/lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "@/app/lib/den-session-events";
 
 import { filterProviderList } from "@/app/utils/providers";
@@ -457,7 +461,7 @@ export function SessionRoute() {
   const reloadCoordinator = useReloadCoordinator();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const restrictionNotice = useRestrictionNotice();
-  const [activeOrganizationRole, setActiveOrganizationRole] = useState<"owner" | "admin" | "member" | null>(null);
+  const [activeOrganizationRole, setActiveOrganizationRole] = useState<DenOrgRole | null>(null);
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
   const [developerMode, setDeveloperMode] = useState(() => {
@@ -859,7 +863,11 @@ export function SessionRoute() {
     await refreshOrganizationModelAccess();
   }, [refreshOrganizationModelAccess]);
   const organizationModelsSettingsUrl = useMemo(() => {
-    if (activeOrganizationRole !== "owner" && activeOrganizationRole !== "admin") {
+    if (
+      activeOrganizationRole !== "super-admin" &&
+      activeOrganizationRole !== "owner" &&
+      activeOrganizationRole !== "admin"
+    ) {
       return undefined;
     }
     return new URL("/dashboard/custom-llm-providers", readDenSettings().baseUrl).toString();

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -35,12 +35,18 @@ import {
 import type {
   Client,
   ProviderListItem,
+  ReleaseChannel,
   SettingsTab,
   WorkspaceConnectionState,
   WorkspaceDisplay,
   WorkspacePreset,
   WorkspaceSessionGroup,
 } from "@/app/types";
+import {
+  EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+  recordElevatedDeveloperModeToggle,
+} from "@/app/lib/elevated-developer-mode";
+import { isPreAlphaChannel } from "@/app/lib/release-channels";
 import { getWorkspaceTaskLoadErrorDisplay } from "@/app/utils";
 import { currentLocale, t, setLocale, type Language } from "@/i18n";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
@@ -456,6 +462,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem("openwork.developerMode") === "1";
   });
+  const elevatedDeveloperModeToggleSequenceRef = useRef(
+    EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+  );
+  const elevatedDeveloperMode =
+    local.prefs.featureFlags.elevatedDeveloperMode === true;
   const [themeMode, setThemeModeState] = useState<ThemeMode>(getInitialThemeMode);
   const [hideTitlebar, setHideTitlebar] = useState(() => readStoredBoolean(SETTINGS_HIDE_TITLEBAR_KEY, false));
   const [updateAutoCheck, setUpdateAutoCheck] = useState(() =>
@@ -917,11 +928,48 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       }
     },
   });
+  const toggleDeveloperMode = useCallback(() => {
+    const gesture = recordElevatedDeveloperModeToggle(
+      elevatedDeveloperModeToggleSequenceRef.current,
+    );
+    elevatedDeveloperModeToggleSequenceRef.current = gesture.sequence;
+
+    if (gesture.triggered) {
+      local.setPrefs((previous) => {
+        const nextElevatedDeveloperMode =
+          !previous.featureFlags.elevatedDeveloperMode;
+        return {
+          ...previous,
+          releaseChannel:
+            !nextElevatedDeveloperMode &&
+            isPreAlphaChannel(previous.releaseChannel)
+              ? "stable"
+              : previous.releaseChannel,
+          featureFlags: {
+            ...previous.featureFlags,
+            elevatedDeveloperMode: nextElevatedDeveloperMode,
+          },
+        };
+      });
+    }
+
+    setDeveloperMode((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(
+          "openwork.developerMode",
+          next ? "1" : "0",
+        );
+      } catch {}
+      return next;
+    });
+  }, [local]);
   const onReleaseChannelChange = useCallback(
-    (next: "stable" | "alpha") => {
+    (next: ReleaseChannel) => {
+      if (isPreAlphaChannel(next) && !elevatedDeveloperMode) return;
       local.setPrefs((previous) => ({ ...previous, releaseChannel: next }));
     },
-    [local],
+    [elevatedDeveloperMode, local],
   );
   const electronUpdaterState = useElectronUpdaterState({
     releaseChannel: local.prefs.releaseChannel ?? "stable",
@@ -2410,11 +2458,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             opencodeConnectStatus={null}
             openworkServerStatus={openworkServerSnapshot.openworkServerStatus}
             developerMode={developerMode}
-            toggleDeveloperMode={() => setDeveloperMode((current) => {
-              const next = !current;
-              try { window.localStorage.setItem("openwork.developerMode", next ? "1" : "0"); } catch {}
-              return next;
-            })}
+            elevatedDeveloperMode={elevatedDeveloperMode}
+            toggleDeveloperMode={toggleDeveloperMode}
             opencodeDevModeEnabled={false}
             openDebugDeepLink={async () => ({ ok: false, message: "Debug deep links are not wired into the React settings route yet." })}
             cloudMcpUrl={openworkCloudMcpUrl}
@@ -2476,6 +2521,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               isMacPlatform() &&
               desktopConfig.config.allowAlphaUpdates !== false
             }
+            elevatedDeveloperMode={elevatedDeveloperMode}
           />
         );
       case "recovery":

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -141,6 +141,7 @@ describe("Connect cloud-readiness row resolution", () => {
     expect(resolveConnectRowGroup({ state: "needs_signin", hasInstructional: false, connections: [] }, "member")).toBe("needs_signin");
     expect(resolveConnectRowGroup({ state: "ready", hasInstructional: true, connections: [] }, "member")).toBe("ready");
     expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "admin")).toBe("needs_admin_setup");
+    expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "super-admin")).toBe("needs_admin_setup");
   });
 
   test("hides admin setup, desktop-only, and not-synced rows from non-admin Connect", () => {

--- a/apps/app/tests/den-org-roles.test.ts
+++ b/apps/app/tests/den-org-roles.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createDenClient } from "../src/app/lib/den";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: originalFetch,
+  });
+});
+
+describe("Den organization roles", () => {
+  test("keeps super-admin organizations in the desktop organization list", async () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: (async () =>
+        new Response(JSON.stringify({
+          orgs: [{
+            id: "org_super",
+            name: "Super organization",
+            slug: "super-organization",
+            role: "super-admin",
+          }],
+          activeOrgId: "org_super",
+          activeOrgSlug: "super-organization",
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) satisfies typeof fetch,
+    });
+
+    await expect(
+      createDenClient({
+        baseUrl: "https://den.test",
+        token: "tok_test",
+      }).listOrgs(),
+    ).resolves.toEqual({
+      orgs: [{
+        id: "org_super",
+        name: "Super organization",
+        slug: "super-organization",
+        role: "super-admin",
+      }],
+      activeOrgId: "org_super",
+      activeOrgSlug: "super-organization",
+      defaultOrgId: "org_super",
+    });
+  });
+});

--- a/apps/app/tests/elevated-developer-mode.test.ts
+++ b/apps/app/tests/elevated-developer-mode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+  ELEVATED_DEVELOPER_MODE_TOGGLE_WINDOW_MS,
+  recordElevatedDeveloperModeToggle,
+} from "../src/app/lib/elevated-developer-mode";
+
+describe("elevated Developer mode gesture", () => {
+  test("triggers on the fifth rapid Developer mode toggle", () => {
+    let sequence = EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE;
+
+    for (let index = 0; index < 4; index += 1) {
+      const result = recordElevatedDeveloperModeToggle(sequence, 1_000 + index);
+      expect(result.triggered).toBe(false);
+      sequence = result.sequence;
+    }
+
+    const result = recordElevatedDeveloperModeToggle(sequence, 1_004);
+    expect(result.triggered).toBe(true);
+    expect(result.sequence).toEqual(
+      EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+    );
+  });
+
+  test("restarts the gesture after the toggle window expires", () => {
+    const first = recordElevatedDeveloperModeToggle(
+      EMPTY_ELEVATED_DEVELOPER_MODE_TOGGLE_SEQUENCE,
+      1_000,
+    );
+    const expired = recordElevatedDeveloperModeToggle(
+      first.sequence,
+      1_000 + ELEVATED_DEVELOPER_MODE_TOGGLE_WINDOW_MS + 1,
+    );
+
+    expect(expired).toEqual({
+      sequence: {
+        count: 1,
+        startedAt: 1_000 + ELEVATED_DEVELOPER_MODE_TOGGLE_WINDOW_MS + 1,
+      },
+      triggered: false,
+    });
+  });
+});

--- a/apps/app/tests/release-channels.test.ts
+++ b/apps/app/tests/release-channels.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  STABLE_UPDATER_ENDPOINT,
+  coerceReleaseChannel,
+  resolveUpdaterEndpoint,
+  visibleReleaseChannels,
+} from "../src/app/lib/release-channels";
+
+describe("desktop release channels", () => {
+  test("coerces the hidden channel names without accepting arbitrary values", () => {
+    expect(coerceReleaseChannel("canary")).toBe("canary");
+    expect(coerceReleaseChannel("experimental")).toBe("experimental");
+    expect(coerceReleaseChannel("nightly")).toBe("stable");
+  });
+
+  test("keeps Electron-only hidden channels out of the legacy Tauri resolver", () => {
+    expect(resolveUpdaterEndpoint("canary", "darwin")).toBe(
+      STABLE_UPDATER_ENDPOINT,
+    );
+    expect(resolveUpdaterEndpoint("experimental", "darwin")).toBe(
+      STABLE_UPDATER_ENDPOINT,
+    );
+    expect(resolveUpdaterEndpoint("canary", "linux")).toBe(
+      STABLE_UPDATER_ENDPOINT,
+    );
+  });
+
+  test("shows pre-alpha choices only in elevated Developer mode", () => {
+    expect(visibleReleaseChannels(false)).toEqual(["stable", "alpha"]);
+    expect(visibleReleaseChannels(true)).toEqual([
+      "stable",
+      "alpha",
+      "canary",
+      "experimental",
+    ]);
+  });
+});

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -19,6 +19,8 @@ describe("alpha desktop update policy", () => {
     expect(isAlphaChannelAllowedByDesktopConfig({})).toBe(true);
     expect(isAlphaChannelAllowedByDesktopConfig({ allowAlphaUpdates: true })).toBe(true);
     expect(resolveDesktopUpdateChannel("alpha", {})).toBe("alpha");
+    expect(resolveDesktopUpdateChannel("canary", {})).toBe("canary");
+    expect(resolveDesktopUpdateChannel("experimental", {})).toBe("experimental");
   });
 
   test("forces policy-disabled alpha selections back to stable", () => {
@@ -26,6 +28,8 @@ describe("alpha desktop update policy", () => {
 
     expect(isAlphaChannelAllowedByDesktopConfig(desktopConfig)).toBe(false);
     expect(resolveDesktopUpdateChannel("alpha", desktopConfig)).toBe("stable");
+    expect(resolveDesktopUpdateChannel("canary", desktopConfig)).toBe("stable");
+    expect(resolveDesktopUpdateChannel("experimental", desktopConfig)).toBe("stable");
     expect(resolveDesktopUpdateChannel("stable", desktopConfig)).toBe("stable");
   });
 

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -32,11 +32,22 @@ function resolveAppVersion(app) {
 const ELECTRON_UPDATER_FEEDS = Object.freeze({
   stable: "https://github.com/different-ai/openwork/releases/latest/download",
   alpha: "https://github.com/different-ai/openwork/releases/download/alpha-macos-latest",
+  canary: "https://github.com/different-ai/openwork/releases/download/canary-macos-latest",
+  experimental: "https://github.com/different-ai/openwork/releases/download/experimental-macos-latest",
 });
 
-function normalizeElectronUpdaterChannel(value, manifestChannel = "latest") {
+export function normalizeElectronUpdaterChannel(
+  value,
+  manifestChannel = "latest",
+  platform = process.platform,
+) {
   if (manifestChannel !== "latest") return "stable";
-  if (value === "alpha" && process.platform === "darwin") return "alpha";
+  if (
+    platform === "darwin" &&
+    (value === "alpha" || value === "canary" || value === "experimental")
+  ) {
+    return value;
+  }
   return "stable";
 }
 
@@ -66,8 +77,14 @@ async function writeElectronUpdaterChannel(app, channel, manifestChannel = "late
   return normalized;
 }
 
-function electronUpdaterFeedUrl(channel, manifestChannel = "latest") {
-  return ELECTRON_UPDATER_FEEDS[normalizeElectronUpdaterChannel(channel, manifestChannel)];
+export function electronUpdaterFeedUrl(
+  channel,
+  manifestChannel = "latest",
+  platform = process.platform,
+) {
+  return ELECTRON_UPDATER_FEEDS[
+    normalizeElectronUpdaterChannel(channel, manifestChannel, platform)
+  ];
 }
 
 function normalizeStableTargetVersion(value) {
@@ -181,10 +198,11 @@ async function applyElectronUpdaterFeed(app, updater, targetVersion = null, mani
     throw new Error("Version-specific update feeds are supported only on the stable channel.");
   }
   const state = updaterChannelState(app, channel, targetVersion, manifestChannel);
-  updater.allowPrerelease = state.channel === "alpha";
-  // Moving from alpha back to stable can be a semver downgrade; still show
-  // the latest stable so users can return to the stable channel deliberately.
-  updater.allowDowngrade = state.channel === "stable" && !targetVersion;
+  updater.allowPrerelease = state.channel !== "stable";
+  // Moving between rolling channels can be a semver downgrade (for example,
+  // canary -> experimental when the canary timestamp is newer). Still show
+  // the selected channel so users can switch deliberately.
+  updater.allowDowngrade = !targetVersion;
   // Select the manifest through the generic provider's own `channel` option
   // rather than AppUpdater#channel: that setter is a no-op unless the instance
   // was constructed with a channel, which would silently leave a custom

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -6,6 +6,8 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  electronUpdaterFeedUrl,
+  normalizeElectronUpdaterChannel,
   preventPendingUpdaterInstall,
   registerUpdaterIpc,
   staleUpdaterStatePaths,
@@ -219,6 +221,25 @@ describe("downloaded update lifecycle", () => {
 });
 
 describe("release channel changes", () => {
+  it("resolves hidden prerelease channels to their rolling macOS feeds", () => {
+    assert.equal(
+      electronUpdaterFeedUrl("canary", "latest", "darwin"),
+      "https://github.com/different-ai/openwork/releases/download/canary-macos-latest",
+    );
+    assert.equal(
+      electronUpdaterFeedUrl("experimental", "latest", "darwin"),
+      "https://github.com/different-ai/openwork/releases/download/experimental-macos-latest",
+    );
+  });
+
+  it("falls hidden prerelease channels back to stable off macOS", () => {
+    assert.equal(normalizeElectronUpdaterChannel("canary", "latest", "linux"), "stable");
+    assert.equal(
+      normalizeElectronUpdaterChannel("experimental", "latest", "win32"),
+      "stable",
+    );
+  });
+
   it("prevents a previously downloaded update from installing on quit", () => {
     const updater = { autoInstallOnAppQuit: true };
 

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -98,7 +98,21 @@ export type MaterializeCloudWorkerProviders = typeof materializeCloudWorkerProvi
 
 const logger = appLogger.child({ component: "cloud_provider_materialization" })
 const requestTimeoutMs = 8_000
-const materializedFingerprintByWorker = new Map<WorkerId, string>()
+/**
+ * Cache of what we have already materialized, keyed by worker AND instance.
+ *
+ * Keying by worker alone was a bug: a recycle onto a new snapshot replaces the
+ * sandbox, and the new instance starts with an empty env store (only the runtime
+ * config survives, on the shared volume). With a worker-only key den-api kept
+ * answering "cached" and never wrote the credential into the new instance, so
+ * every provider failed with "API key is missing" while still showing up in the
+ * picker.
+ */
+const materializedFingerprintByWorkerInstance = new Map<string, string>()
+
+function materializationCacheKey(workerId: WorkerId, instanceUrl: string): string {
+  return `${workerId}\u0000${instanceUrl}`
+}
 const unsupportedLogFingerprintByWorker = new Map<WorkerId, string>()
 const modelConfigPassthroughKeys = [
   "family",
@@ -906,7 +920,8 @@ export async function materializeCloudWorkerProviders(input: {
     fingerprint = prepared.fingerprint
     providerCount = prepared.providers.length
 
-    if (!input.force && materializedFingerprintByWorker.get(input.workerId) === fingerprint) {
+    const cacheKey = materializationCacheKey(input.workerId, instanceUrl)
+    if (!input.force && materializedFingerprintByWorkerInstance.get(cacheKey) === fingerprint) {
       return { ok: true, status: "cached", fingerprint, providers: providerCount }
     }
 
@@ -937,7 +952,7 @@ export async function materializeCloudWorkerProviders(input: {
       materializedProviderStateMatches(prepared, currentManagedProviders)
       && materializedEnvStateMatches(prepared.envEntries, envSnapshot)
     ) {
-      materializedFingerprintByWorker.set(input.workerId, fingerprint)
+      materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)
       return { ok: true, status: "noop", fingerprint, providers: providerCount }
     }
 
@@ -968,7 +983,7 @@ export async function materializeCloudWorkerProviders(input: {
     } catch (error) {
       const unsupportedReason = unsupportedProviderRouteReason(error)
       if (unsupportedReason) {
-        materializedFingerprintByWorker.delete(input.workerId)
+        materializedFingerprintByWorkerInstance.delete(cacheKey)
         await logUnsupportedOnce({
           logger: materializationLogger,
           workerId: input.workerId,
@@ -1018,7 +1033,7 @@ export async function materializeCloudWorkerProviders(input: {
       throw error
     }
 
-    materializedFingerprintByWorker.set(input.workerId, fingerprint)
+    materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)
     return { ok: true, status: "applied", fingerprint, providers: providerCount }
   } catch (error) {
     const result = failureResult({

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -286,11 +286,12 @@ async function materialize(input: {
   fetchImpl: FetchImpl
   logger?: Logger
   force?: boolean
+  instanceUrl?: string
 }) {
   return materializeCloudWorkerProviders({
     organizationId,
     workerId: input.workerId ?? createDenTypeId("worker"),
-    instanceUrl,
+    instanceUrl: input.instanceUrl ?? instanceUrl,
     hostToken: "host-token",
     clientToken: "client-token",
     store: makeStore(input.providers),
@@ -317,6 +318,41 @@ describe("Cloud provider materialization", () => {
     expect(second.status).toBe("noop")
     expect(instance.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(0)
     expect(instance.calls.filter((call) => call.method === "PATCH" && call.path === "/runtime-config/providers")).toHaveLength(0)
+  })
+
+  test("re-materializes after a recycle replaces the instance", async () => {
+    // A recycle onto a new snapshot gives the worker a brand new sandbox: only
+    // the runtime config survives (shared volume), the env store starts empty.
+    // Keying the cache by worker alone made den-api answer "cached" and never
+    // write the credential into the new instance, so every provider failed with
+    // "API key is missing" while still appearing in the picker.
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const workerId = createDenTypeId("worker")
+
+    const before = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+    await materialize({ workerId, providers: () => [provider], fetchImpl: before.fetchImpl })
+
+    // Same worker, same credential fingerprint, new sandbox: config persisted on
+    // the volume, env store empty.
+    const recycled = makeInstance({
+      runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
+    })
+    const result = await materialize({
+      workerId,
+      providers: () => [provider],
+      fetchImpl: recycled.fetchImpl,
+      instanceUrl: "https://worker-recycled.example.test",
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("applied")
+    expect(recycled.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(1)
+    expect(recycled.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
+      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
+    })
   })
 
   test("writes a models.dev provider block, credential env, and reloads OpenCode", async () => {

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = openwork
 	pkgdesc = An Open source alternative to Claude Cowork
-	pkgver = 0.18.11
+	pkgver = 0.18.12
 	pkgrel = 1
 	url = https://github.com/different-ai/openwork
 	arch = x86_64
@@ -19,9 +19,9 @@ pkgbase = openwork
 	depends = dbus
 	depends = hicolor-icon-theme
 	options = !strip
-	source_x86_64 = openwork-0.18.11-x64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.11/openwork-linux-x64-0.18.11.tar.gz
-	sha256sums_x86_64 = c951993b4b64bd17839ef0593791345a7f0308e9f03db13ea8b5489090aa7207
-	source_aarch64 = openwork-0.18.11-arm64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.11/openwork-linux-arm64-0.18.11.tar.gz
-	sha256sums_aarch64 = f74efb206d4ff33221e496355d20e0ea456a450c4db89b2db2323303f134f300
+	source_x86_64 = openwork-0.18.12-x64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.12/openwork-linux-x64-0.18.12.tar.gz
+	sha256sums_x86_64 = 5b9962e0abda01a3d0c0a55326fb99bb5719f7840f9a25adb9986f89643e8281
+	source_aarch64 = openwork-0.18.12-arm64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.12/openwork-linux-arm64-0.18.12.tar.gz
+	sha256sums_aarch64 = 536f26f8f97e871bb9878ef0dd7d505649f483b3b10ea7848b63eec5d6041d11
 
 pkgname = openwork

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=openwork
-pkgver=0.18.11
+pkgver=0.18.12
 pkgrel=1 # pkgrel should change when PKGBUILD does. Standard is to change back to 1 next time. Any interger is valid.
 pkgdesc="An Open source alternative to Claude Cowork"
 arch=('x86_64' 'aarch64')
@@ -10,10 +10,10 @@ options=(!strip)
 
 # Architecture-specific sources and checksums
 source_x86_64=("${pkgname}-${pkgver}-x64.tar.gz::${url}/releases/download/v${pkgver}/openwork-linux-x64-${pkgver}.tar.gz")
-sha256sums_x86_64=('c951993b4b64bd17839ef0593791345a7f0308e9f03db13ea8b5489090aa7207')
+sha256sums_x86_64=('5b9962e0abda01a3d0c0a55326fb99bb5719f7840f9a25adb9986f89643e8281')
 
 source_aarch64=("${pkgname}-${pkgver}-arm64.tar.gz::${url}/releases/download/v${pkgver}/openwork-linux-arm64-${pkgver}.tar.gz")
-sha256sums_aarch64=('f74efb206d4ff33221e496355d20e0ea456a450c4db89b2db2323303f134f300')
+sha256sums_aarch64=('536f26f8f97e871bb9878ef0dd7d505649f483b3b10ea7848b63eec5d6041d11')
 
 package() {
   cd "${srcdir}"


### PR DESCRIPTION
## Summary

- toggle the existing Developer mode switch five times within eight seconds to enable or disable a persisted elevated Developer mode flag
- render the Developer mode switch in gold while the elevated flag is active
- expose Canary and Experimental choices in Settings → Updates only while elevated mode is active
- connect both choices to their rolling macOS Electron updater feeds and treat all prerelease channels consistently under desktop update policy
- fall back to Stable when elevated mode is disabled while Canary or Experimental is selected

## Scope

This PR targets `experimental` only. The same feature head has a separate PR targeting `canary`; there is intentionally no PR to `dev`.

Because pre-alpha branches stay downstream of `dev`, this also syncs `experimental` to live `dev` at `9ffb0ef8` before applying the feature commit.

## Verification

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --filter @openwork/app test` (540 passed)
- `pnpm --filter @openwork/desktop test` (176 passed, 1 platform skip)
- `pnpm --filter @openwork/app build`
- conflict-free merge-tree verification against both `canary` and `experimental`