### PR TITLE
fix(app): support custom organization roles on desktop

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -139,7 +139,8 @@ export type DenBootstrapConfig = DenBaseUrls & {
 
 export type DenDesktopConfig = SharedDesktopConfig;
 
-export type DenOrgRole = "super-admin" | "owner" | "admin" | "member";
+export type DenCanonicalOrgRole = "super-admin" | "owner" | "admin" | "member";
+export type DenOrgRole = string;
 
 export type DenOrgSummary = {
   id: string;
@@ -147,6 +148,57 @@ export type DenOrgSummary = {
   slug: string;
   role: DenOrgRole;
 };
+
+function normalizeDenCanonicalOrgRole(role: string): DenCanonicalOrgRole | null {
+  const normalized = role.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  if (normalized === "super-admin") return "super-admin";
+  if (normalized === "owner") return "owner";
+  if (normalized === "admin") return "admin";
+  if (normalized === "member") return "member";
+  return null;
+}
+
+function denCanonicalOrgRoles(roleValue: string) {
+  const roles = new Set<DenCanonicalOrgRole>();
+  for (const role of roleValue.split(",")) {
+    const canonicalRole = normalizeDenCanonicalOrgRole(role);
+    if (canonicalRole) roles.add(canonicalRole);
+  }
+  return roles;
+}
+
+export function getDenCanonicalOrgRole(roleValue: string): DenCanonicalOrgRole {
+  const roles = denCanonicalOrgRoles(roleValue);
+  if (roles.has("owner")) return "owner";
+  if (roles.has("super-admin")) return "super-admin";
+  if (roles.has("admin")) return "admin";
+  return "member";
+}
+
+export function isDenOrgAdminRole(roleValue: string | null | undefined) {
+  if (!roleValue) return false;
+  return getDenCanonicalOrgRole(roleValue) !== "member";
+}
+
+export function formatDenOrgRoleLabel(roleValue: string) {
+  return roleValue
+    .split(",")
+    .map((role) => role.trim())
+    .filter(Boolean)
+    .map((role) => {
+      const canonicalRole = normalizeDenCanonicalOrgRole(role);
+      if (canonicalRole === "super-admin") return "Super admin";
+      if (canonicalRole === "owner") return "Owner";
+      if (canonicalRole === "admin") return "Admin";
+      if (canonicalRole === "member") return "Member";
+      return role
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+        .join(" ");
+    })
+    .join(", ");
+}
 
 export type DenWorkerSummary = {
   workerId: string;
@@ -1130,12 +1182,8 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
       typeof entry.id !== "string" ||
       typeof entry.name !== "string" ||
       typeof entry.slug !== "string" ||
-      (
-        entry.role !== "super-admin" &&
-        entry.role !== "owner" &&
-        entry.role !== "admin" &&
-        entry.role !== "member"
-      )
+      typeof entry.role !== "string" ||
+      !entry.role.trim()
     ) {
       return [];
     }
@@ -1145,7 +1193,7 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
         id: entry.id,
         name: entry.name,
         slug: entry.slug,
-        role: entry.role,
+        role: entry.role.trim(),
       } satisfies DenOrgSummary,
     ];
   });

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -1,7 +1,10 @@
 /** @jsxImportSource react */
 import { ArrowUpRight, Building2, Check, LogOut, Loader2 } from "lucide-react";
 
-import type { DenOrgSummary } from "../../../../app/lib/den";
+import {
+  formatDenOrgRoleLabel,
+  type DenOrgSummary,
+} from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -24,19 +27,6 @@ export interface CloudAccountSectionProps {
   onOpenDashboard: () => void;
   onRefreshOrgs: () => void | Promise<void>;
   onSignOut: () => void | Promise<void>;
-}
-
-function organizationRoleLabel(role: DenOrgSummary["role"]) {
-  switch (role) {
-    case "super-admin":
-      return "Super admin";
-    case "owner":
-      return "Owner";
-    case "admin":
-      return "Admin";
-    case "member":
-      return "Member";
-  }
 }
 
 export function CloudAccountSection({
@@ -131,7 +121,7 @@ function ConnectedOrg({ org }: { org: DenOrgSummary }) {
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-dls-text">{org.name}</div>
         <div className="text-xs text-dls-secondary">
-          {organizationRoleLabel(org.role)} &middot; Connected
+          {formatDenOrgRoleLabel(org.role)} &middot; Connected
         </div>
       </div>
       <Check size={16} className="shrink-0 text-green-11" />
@@ -215,7 +205,7 @@ function OrgPicker({
             <div className="min-w-0 flex-1">
               <div className="text-sm font-medium text-dls-text">{org.name}</div>
               <div className="text-xs text-dls-secondary">
-                {organizationRoleLabel(org.role)}
+                {formatDenOrgRoleLabel(org.role)}
               </div>
             </div>
           </button>

--- a/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
+++ b/apps/app/src/react-app/domains/settings/connect-cloud-readiness.ts
@@ -1,8 +1,9 @@
-import type {
-  DenExternalMcpConnection,
-  DenOrgPlugin,
-  DenOrgSummary,
-  DenPluginCloudReadiness,
+import {
+  isDenOrgAdminRole,
+  type DenExternalMcpConnection,
+  type DenOrgPlugin,
+  type DenOrgSummary,
+  type DenPluginCloudReadiness,
 } from "@/app/lib/den";
 import { t } from "@/i18n";
 import { connectionNeedsReconnect } from "@/react-app/domains/connections/native-provider-connections";
@@ -14,7 +15,7 @@ const instructionalTypes = new Set(["agent", "command", "context", "custom", "sk
 const desktopInstallTypes = new Set(["hook", "tool"]);
 
 export function isConnectAdminRole(role: ConnectOrgRole) {
-  return role === "super-admin" || role === "owner" || role === "admin";
+  return isDenOrgAdminRole(role);
 }
 
 export function pluginHasInstructionalComponents(componentCounts: Record<string, number>) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -180,6 +180,7 @@ import { useReactRenderWatchdog } from "./react-render-watchdog";
 
 import {
   createDenClient,
+  isDenOrgAdminRole,
   readDenSettings,
   type DenOrgRole,
 } from "@/app/lib/den";
@@ -863,11 +864,7 @@ export function SessionRoute() {
     await refreshOrganizationModelAccess();
   }, [refreshOrganizationModelAccess]);
   const organizationModelsSettingsUrl = useMemo(() => {
-    if (
-      activeOrganizationRole !== "super-admin" &&
-      activeOrganizationRole !== "owner" &&
-      activeOrganizationRole !== "admin"
-    ) {
+    if (!isDenOrgAdminRole(activeOrganizationRole)) {
       return undefined;
     }
     return new URL("/dashboard/custom-llm-providers", readDenSettings().baseUrl).toString();

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -142,6 +142,8 @@ describe("Connect cloud-readiness row resolution", () => {
     expect(resolveConnectRowGroup({ state: "ready", hasInstructional: true, connections: [] }, "member")).toBe("ready");
     expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "admin")).toBe("needs_admin_setup");
     expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "super-admin")).toBe("needs_admin_setup");
+    expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "qa-reviewer, super-admin")).toBe("needs_admin_setup");
+    expect(resolveConnectRowGroup({ state: "needs_admin_setup", hasInstructional: false, connections: [] }, "qa-reviewer")).toBe("excluded");
   });
 
   test("hides admin setup, desktop-only, and not-synced rows from non-admin Connect", () => {

--- a/apps/app/tests/den-org-roles.test.ts
+++ b/apps/app/tests/den-org-roles.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { createDenClient } from "../src/app/lib/den";
+import {
+  createDenClient,
+  formatDenOrgRoleLabel,
+  getDenCanonicalOrgRole,
+  isDenOrgAdminRole,
+} from "../src/app/lib/den";
 
 const originalFetch = globalThis.fetch;
 
@@ -47,5 +52,54 @@ describe("Den organization roles", () => {
       activeOrgSlug: "super-organization",
       defaultOrgId: "org_super",
     });
+  });
+
+  test("keeps custom and combined roles without collapsing their role strings", async () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: (async () =>
+        new Response(JSON.stringify({
+          orgs: [
+            {
+              id: "org_custom",
+              name: "Custom organization",
+              slug: "custom-organization",
+              role: "qa-reviewer",
+            },
+            {
+              id: "org_combined",
+              name: "Combined organization",
+              slug: "combined-organization",
+              role: "qa-reviewer, super-admin",
+            },
+          ],
+          activeOrgId: "org_custom",
+          activeOrgSlug: "custom-organization",
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) satisfies typeof fetch,
+    });
+
+    await expect(
+      createDenClient({
+        baseUrl: "https://den.test",
+        token: "tok_test",
+      }).listOrgs(),
+    ).resolves.toMatchObject({
+      orgs: [
+        { id: "org_custom", role: "qa-reviewer" },
+        { id: "org_combined", role: "qa-reviewer, super-admin" },
+      ],
+    });
+  });
+
+  test("derives built-in access while preserving custom role labels", () => {
+    expect(getDenCanonicalOrgRole("qa-reviewer")).toBe("member");
+    expect(getDenCanonicalOrgRole("admin, qa-reviewer")).toBe("admin");
+    expect(getDenCanonicalOrgRole("qa-reviewer, super_admin")).toBe("super-admin");
+    expect(isDenOrgAdminRole("qa-reviewer")).toBe(false);
+    expect(isDenOrgAdminRole("qa-reviewer, super-admin")).toBe(true);
+    expect(formatDenOrgRoleLabel("qa-reviewer, super-admin")).toBe("Qa Reviewer, Super admin");
   });
 });


### PR DESCRIPTION
## Summary

- keep organizations whose Den membership uses a custom or combined role
- preserve the complete role string for desktop display
- derive owner, super-admin, and admin access from comma-separated built-in roles
- treat custom-only roles as member-level for desktop admin affordances

## Root cause

The desktop organization parser accepted only four exact role strings. Den
stores membership roles as comma-separated strings, so values such as
`qa-reviewer` or `qa-reviewer, super-admin` were dropped from the organization
list even though Den Web supports them.

## Verification

- `pnpm exec bun test --isolate apps/app/tests/den-org-roles.test.ts apps/app/tests/connect-view.test.ts` — 19 passed
- `pnpm --filter @openwork/app test` — 538 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Review steps

1. Sign in on desktop with a custom-only organization membership.
2. Confirm the organization remains selectable and its custom role label is visible.
3. Repeat with a combined role such as `qa-reviewer, super-admin`.
4. Confirm the organization remains visible and super-admin desktop affordances remain available.

## Evidence boundary

Parser, label, canonical hierarchy, Connect, and model-settings behavior are
covered by focused and full app tests. A live fraimz was not captured because
the local signed-in profile does not have custom-role Den memberships; the
manual review steps above reproduce the user-facing flow.
