### PR TITLE
fix(den-api): keep chat sessions across version recycles

### DIFF
--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -339,7 +339,13 @@ function checkpointLastFlushMarkerPath() {
 }
 
 function checkpointEnvironmentScript() {
-  return `OPENWORK_STATE_MANIFEST=${shellQuote(checkpointStateManifest())}
+  // The engine keeps its sessions in a SQLite database under its own data dir
+  // (opencode.db), which lives on the container overlay rather than a volume.
+  // It was missing from the checkpoint, so every recycle onto a new snapshot
+  // started the user from scratch. Resolved from $HOME in-shell so it tracks
+  // the image instead of a hardcoded /root.
+  return `ENGINE_STATE_PATH=\${OPENWORK_ENGINE_STATE_PATH:-\$HOME/.local/share/opencode}
+OPENWORK_STATE_MANIFEST="${checkpointStateManifest()} \$ENGINE_STATE_PATH"
 CHECKPOINT_DIR=${shellQuote(checkpointDir())}
 RESTORE_MARKER=${shellQuote(checkpointRestoreMarkerPath())}
 LAST_FLUSH_MARKER=${shellQuote(checkpointLastFlushMarkerPath())}
@@ -387,7 +393,14 @@ flush_checkpoint() {
   for state_path in $OPENWORK_STATE_MANIFEST; do
     set -- "$@" "\${state_path#/}"
   done
-  if tar -C / -cf "$tmp_checkpoint" "$@"; then
+  # Collapse the WAL so the copied database is self-consistent and small. Best
+  # effort: a locked or absent database must never fail the flush.
+  if [ -f "$ENGINE_STATE_PATH/opencode.db" ]; then
+    node -e 'const{DatabaseSync}=require("node:sqlite");const db=new DatabaseSync(process.argv[1]);db.exec("PRAGMA wal_checkpoint(TRUNCATE)");db.close()' "$ENGINE_STATE_PATH/opencode.db" >/dev/null 2>&1 || true
+  fi
+  # Credentials are re-materialized and re-delivered on every start, so they are
+  # deliberately not persisted to the shared volume. Logs are noise.
+  if tar -C / --exclude="\${ENGINE_STATE_PATH#/}/auth.json" --exclude="\${ENGINE_STATE_PATH#/}/log" -cf "$tmp_checkpoint" "$@"; then
     if cp "$tmp_checkpoint" "$CHECKPOINT_DIR/ckpt-$epoch.tar"; then
       touch "$LAST_FLUSH_MARKER"
       rm -f "$tmp_checkpoint"

--- a/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
+++ b/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
@@ -38,6 +38,16 @@ describe("Daytona OpenWork checkpoint start command", () => {
     })
 
     expect(command).toContain("OPENWORK_STATE_MANIFEST=")
+    // The engine keeps sessions in opencode.db on the container overlay. It was
+    // missing from the manifest, so every recycle onto a new snapshot started
+    // the user from scratch.
+    expect(command).toContain("ENGINE_STATE_PATH=${OPENWORK_ENGINE_STATE_PATH:-$HOME/.local/share/opencode}")
+    expect(command).toContain('OPENWORK_STATE_MANIFEST="/tmp/openwork-data /tmp/openwork-workspace $ENGINE_STATE_PATH"')
+    // Collapse the WAL first so the copied database is self-consistent.
+    expect(command).toContain("PRAGMA wal_checkpoint(TRUNCATE)")
+    // Credentials are re-materialized every start; never persist them to the volume.
+    expect(command).toContain('--exclude="${ENGINE_STATE_PATH#/}/auth.json"')
+    expect(command).toContain('--exclude="${ENGINE_STATE_PATH#/}/log"')
     expect(command).toContain("/tmp/openwork-data /tmp/openwork-workspace")
     expect(command).toContain("CHECKPOINT_DIR=")
     expect(command).toContain("/persist/openwork/checkpoints")
@@ -47,7 +57,7 @@ describe("Daytona OpenWork checkpoint start command", () => {
     expect(command).toContain("DEN_CKPT_KEEP")
     expect(command).toContain("find \"$CHECKPOINT_DIR\" -maxdepth 1 -type f -name")
     expect(command).toContain("ckpt-*.tar")
-    expect(command).toContain("tar -C / -cf")
+    expect(command).toContain("-cf \"$tmp_checkpoint\"")
     expect(command).toContain("tar -C / -xf")
     expect(command).not.toContain("tar -h")
     expect(command).not.toContain("tar -ch")


### PR DESCRIPTION
"Every new version I start from scratch." Confirmed: the checkpoint never contained the engine's session database, so a recycle onto a new snapshot wiped all chat history.

## Evidence (live sandbox)

Only two paths persist, both `mountpoint-s3`:

```
mountpoint-s3  /workspace
mountpoint-s3  /persist/openwork
```

Sessions live elsewhere — on the container overlay, which a recycle discards:

```
/root/.local/share/opencode/opencode.db      249 KB   (+ -wal 3 MB, -shm)   <- sessions and messages
```

And the checkpoint tar contained only openwork-server's own state:

```
tmp/openwork-data/runtime.sqlite, runtime-opencode-config.json, connect-state.json, audit/
tmp/openwork-workspace/volumes/{data,workspace}   (symlinks)
```

Cause, one line:

```ts
function checkpointStateManifest() {
  return `${env.daytona.runtimeDataPath} ${env.daytona.runtimeWorkspacePath}`
}
```

The engine's data dir was never in the manifest, so `flush_checkpoint`'s `tar` never captured it and `hydrate_checkpoint` had nothing to restore. This also explains the empty env store I saw after recycling (`/env/keys` → `[]`).

## Fix

- `ENGINE_STATE_PATH` is resolved **in-shell** from `$HOME` (override: `OPENWORK_ENGINE_STATE_PATH`) rather than hardcoding `/root`, so it tracks the image, and is appended to the state manifest. Both flush and hydrate already operate on the manifest with `tar -C /`, so no other plumbing changes.
- Before tar, a best-effort `PRAGMA wal_checkpoint(TRUNCATE)` via `node:sqlite` (Node 22 in the image; there is no `sqlite3` CLI) so the copied database is self-consistent and the 3 MB WAL doesn't bloat every checkpoint. Wrapped so a locked or absent database can never fail the flush.
- `auth.json` and `log/` are **excluded**: credentials are re-materialized (#3338) and re-delivered to the engine (#3332) on every start, so there's no reason to persist secrets to the shared volume, and logs are noise.

## Verified for real, not just unit-tested

Ran the generated flush script inside an actual cloud sandbox against a live WAL database, then wiped the engine dir to simulate a new sandbox and hydrated:

```
--- checkpoint contents ---
   tmp/ckpt-test/openwork-data/marker
   tmp/ckpt-test/engine/opencode.db
--- sessions after restore ---
   sessions recovered: 50
   sample: my chat 0
   auth.json present? no (correct - re-delivered)
   log present? no (correct - excluded)
```

| Command | Result |
| --- | --- |
| checkpoint + materialization + cloud-route suites | 51 pass / 0 fail |
| `tsc --noEmit` (den-api) | clean |

The start command is generated by den-api, so this deploys immediately and applies at the next sandbox start — no snapshot or new release required.

## Limits

- Existing checkpoints don't contain the engine database, so **history already lost is not recoverable**. This stops the bleeding from the next flush onward.
- The WAL collapse is best-effort. If the database is mid-write and locked, the tar still captures `db` + `-wal` + `-shm` together, which SQLite can normally recover; I have not tried to prove behaviour under a torn write.
- `state_dirs_pristine` still gates hydrate on the two `/tmp` dirs only. If those are populated but the engine dir is empty, hydrate is skipped and sessions stay missing. Narrow, and I'd rather flag it than quietly widen the gate in the same change.