### PR TITLE
fix(evals): app readiness as interactive UI, shared predicate, den bootstrap, self-diagnosing failures

### DIFF
--- a/evals/packages/behaviors/src/composer.ts
+++ b/evals/packages/behaviors/src/composer.ts
@@ -70,7 +70,7 @@ export async function writeComposerText(app: Surface, text: string): Promise<voi
   const hasControl = await evalIn(app, `Boolean(window.__openworkControl?.listActions?.()
     .find((entry) => entry.id === "composer.set_text" && entry.disabled === false))`).catch(() => false);
   if (hasControl === true) {
-    await control(app, "composer.set_text", { text });
+    await control(app, "composer.set_text", { text }, { timeoutMs: 120_000 });
     await waitFor(app, `(() => {
       const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
         ?? document.querySelector('[contenteditable="true"]');

--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -134,9 +134,9 @@ export async function createAndSelectWorkspace(
     }
   }
   if (!workspaceId) throw new Error("Workspace creation did not produce a workspace ID.");
-  const route = await waitForTaskUi(app, workspaceId);
+  const taskRoute = await waitForTaskUi(app, workspaceId);
   // The task UI can be mounted while the panel still renders placeholders, so
   // hand back only once the app is actually interactive.
   await waitUntilInteractive(app);
-  return { workspaceId, route };
+  return { workspaceId, route: taskRoute };
 }

--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -6,6 +6,30 @@ import { createLocalWorkspaceViaUi } from "./onboarding.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function waitForDenState(
+  app: Surface,
+  den: DenRef,
+  expression: string,
+  options: { timeoutMs: number; label: string },
+): Promise<void> {
+  try {
+    await waitFor(app, expression, options);
+  } catch (error) {
+    const keys = await evalIn(
+      app,
+      "Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(Boolean).sort()",
+      { timeoutMs: 5_000 },
+    ).catch((keysError: unknown) => [`<unavailable: ${messageText(keysError)}>`]);
+    throw new Error(
+      `${messageText(error)} Resolved Den URLs: web=${den.webUrl}, api=${den.apiUrl}. Current localStorage keys: ${JSON.stringify(keys)}.`,
+    );
+  }
+}
+
 export interface SelectedWorkspaceFacts {
   workspaceId: string;
   route: string;
@@ -18,11 +42,11 @@ export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSess
   });
   const grant = await createDesktopHandoffGrant(member);
   await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
-  await waitFor(app, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
+  await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
     timeoutMs: 45_000,
     label: "persisted den auth token",
   });
-  await waitFor(app, "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
+  await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
     timeoutMs: 60_000,
     label: "active org resolved",
   });

--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -1,7 +1,8 @@
+import { readActiveWorkspaceId } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import type { DenRef, DenSession } from "./den.ts";
 import { createDesktopHandoffGrant } from "./den.ts";
-import { clickButton, control, currentHash, evalIn, go, waitFor, waitForText } from "./desktop.ts";
+import { clickButton, control, currentHash, evalIn, go, waitFor, waitForText, waitUntilInteractive } from "./desktop.ts";
 import { createLocalWorkspaceViaUi } from "./onboarding.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -93,6 +94,13 @@ async function waitForTaskUi(app: Surface, workspaceId: string): Promise<string>
   return currentHash(app);
 }
 
+/** The active workspace id from the product's own state, with the route as fallback. */
+async function resolveWorkspaceId(app: Surface): Promise<string> {
+  const fromState = await readActiveWorkspaceId(app.client, { timeoutMs: 30_000 }).catch(() => null);
+  if (fromState) return fromState;
+  return workspaceIdFromRoute(await currentHash(app));
+}
+
 export async function createAndSelectWorkspace(
   app: Surface,
   input: { path: string },
@@ -101,13 +109,13 @@ export async function createAndSelectWorkspace(
   const route = await currentHash(app);
   if (route.includes("/welcome")) {
     const workspace = await createLocalWorkspaceViaUi(app, input);
-    workspaceId = workspace.id;
+    workspaceId = workspace.id || (await resolveWorkspaceId(app));
     await clickButton(app, "Skip and use the free model", { timeoutMs: 30_000 });
     await waitForText(app, "How did you hear about OpenWork?", { timeoutMs: 30_000 });
     await clickButton(app, "Skip", { timeoutMs: 15_000 });
   } else {
     if (route.includes("/onboarding")) await completeOrganizationOnboarding(app);
-    workspaceId = workspaceIdFromRoute(await currentHash(app));
+    workspaceId = await resolveWorkspaceId(app);
     if (!workspaceId) {
       await waitFor(app, `window.__openworkControl.listActions()
         .some((action) => action.id === "workspace.create" && !action.disabled)`, {
@@ -115,13 +123,20 @@ export async function createAndSelectWorkspace(
         label: "workspace.create enabled",
       });
       await control(app, "workspace.create", input);
-      await waitFor(app, "/\\/workspace\\/[^/?#]+\\/session/.test(window.location.hash)", {
+      // The app does not always put a new workspace in the hash, so wait for its
+      // own active-workspace state to settle instead of matching a route shape.
+      await waitFor(app, `Boolean(localStorage.getItem("openwork.react.activeWorkspace"))
+        || /\\/workspace\\/[^/?#]+/.test(window.location.hash)`, {
         timeoutMs: 120_000,
-        label: "created workspace route",
+        label: "created workspace selected",
       });
-      workspaceId = workspaceIdFromRoute(await currentHash(app));
+      workspaceId = await resolveWorkspaceId(app);
     }
   }
   if (!workspaceId) throw new Error("Workspace creation did not produce a workspace ID.");
-  return { workspaceId, route: await waitForTaskUi(app, workspaceId) };
+  const route = await waitForTaskUi(app, workspaceId);
+  // The task UI can be mounted while the panel still renders placeholders, so
+  // hand back only once the app is actually interactive.
+  await waitUntilInteractive(app);
+  return { workspaceId, route };
 }

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -1,5 +1,5 @@
-import { evaluate } from "@openwork/cdp";
-import type { EvaluateOptions, Surface } from "@openwork/cdp";
+import { describeAppState, evaluate, isInteractive, probeAppState } from "@openwork/cdp";
+import type { AppStateProbe, EvaluateOptions, Surface } from "@openwork/cdp";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -30,9 +30,13 @@ export async function waitFor(
 ): Promise<unknown> {
   const startedAt = Date.now();
   let lastError: unknown = null;
+  // A busy renderer can take longer than the CDP client's default per-call
+  // timeout to answer; the wait's own deadline bounds the loop, so let each
+  // evaluation use the remaining budget instead of dying on the default.
+  const evalTimeoutMs = Math.min(Math.max(timeoutMs, 20_000), 120_000);
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const value = await evalIn(app, expression);
+      const value = await evalIn(app, expression, { timeoutMs: evalTimeoutMs });
       if (value) return value;
       lastError = null;
     } catch (error) {
@@ -50,12 +54,12 @@ export async function waitForText(app: Surface, text: string, opts: { timeoutMs?
   });
 }
 
-export async function hasText(app: Surface, text: string): Promise<boolean> {
-  return Boolean(await evalIn(app, `document.body.innerText.includes(${jsValue(text)})`));
+export async function hasText(app: Surface, text: string, opts: EvaluateOptions = {}): Promise<boolean> {
+  return Boolean(await evalIn(app, `document.body.innerText.includes(${jsValue(text)})`, opts));
 }
 
-export async function visibleText(app: Surface): Promise<string> {
-  const text = await evalIn(app, "document.body.innerText");
+export async function visibleText(app: Surface, opts: EvaluateOptions = {}): Promise<string> {
+  const text = await evalIn(app, "document.body.innerText", opts);
   if (typeof text !== "string") throw new Error("CDP did not return document.body.innerText as a string.");
   return text;
 }
@@ -160,4 +164,28 @@ export async function control(
     throw new Error(`Desktop control action ${action} failed: ${isRecord(result) ? String(result.error ?? "unknown") : "unknown"}`);
   }
   return result.result;
+}
+
+/**
+ * Wait until the app is interactive again — the same predicate the lifecycle
+ * layer applies when handing out a desktop handle. Use it after any action that
+ * navigates or creates a workspace/session, so assertions and frames never race
+ * the app's loading placeholders.
+ */
+export async function waitUntilInteractive(
+  app: Surface,
+  { timeoutMs = 120_000 }: { timeoutMs?: number } = {},
+): Promise<AppStateProbe> {
+  const deadline = Date.now() + timeoutMs;
+  let last: AppStateProbe = { controlReady: false, transitional: null, surface: null, workspaceId: null, route: "", text: "" };
+  while (Date.now() < deadline) {
+    try {
+      last = await probeAppState(app.client, { timeoutMs: Math.min(timeoutMs, 120_000) });
+      if (isInteractive(last)) return last;
+    } catch {
+      // A navigation can destroy the execution context mid-probe.
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`App did not become interactive after ${timeoutMs}ms: ${describeAppState(last)}`);
 }

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -145,11 +145,16 @@ export async function enabledButtons(app: Surface): Promise<string[]> {
 }
 
 /** Invoke a registered `window.__openworkControl` action, the product's own automation seam. */
-export async function control(app: Surface, action: string, args?: unknown): Promise<unknown> {
+export async function control(
+  app: Surface,
+  action: string,
+  args?: unknown,
+  opts: EvaluateOptions = {},
+): Promise<unknown> {
   const result = await evalIn(
     app,
     `window.__openworkControl.execute(${JSON.stringify(action)}, ${JSON.stringify(args ?? null)})`,
-    { awaitPromise: true },
+    { ...opts, awaitPromise: true },
   );
   if (!isRecord(result) || result.ok !== true) {
     throw new Error(`Desktop control action ${action} failed: ${isRecord(result) ? String(result.error ?? "unknown") : "unknown"}`);

--- a/evals/packages/behaviors/src/onboarding.ts
+++ b/evals/packages/behaviors/src/onboarding.ts
@@ -141,6 +141,6 @@ export async function createLocalWorkspaceViaUi(
       route: location.hash,
       entrypoint: ${JSON.stringify(entrypoint)},
     };
-  })()`, { awaitPromise: true });
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
   return parseWorkspaceFacts(raw);
 }

--- a/evals/packages/cdp/src/app-state.ts
+++ b/evals/packages/cdp/src/app-state.ts
@@ -1,0 +1,115 @@
+import { evaluate } from "./cdp.ts";
+import type { CdpClient, EvaluateOptions } from "./cdp.ts";
+
+/**
+ * Readiness of the OpenWork desktop is defined by the UI being *interactive*,
+ * not by the route matching an allowlist: a fresh profile with no workspace
+ * legitimately sits on `/session` offering "Create or connect a workspace",
+ * and a workspace can be selected while the panel still renders placeholders.
+ *
+ * This module is the single implementation of that predicate so the lifecycle
+ * layer (@openwork/hosts) and the behaviours specs call (@openwork/behaviors)
+ * cannot drift apart. It lives in @openwork/cdp because both already depend on
+ * it, which keeps the dependency graph acyclic.
+ */
+
+/** Copy the app renders while it is still settling (from apps/app/src/i18n/locales/en.ts). */
+export const APP_TRANSITIONAL_TEXTS = [
+  "Preparing workspace",
+  "Connecting signed-in services",
+  "Connecting services",
+  "Loading available resources",
+  "Loading tasks",
+  "Pulling in the latest messages",
+] as const;
+
+export type AppSurfaceState = "welcome" | "workspace" | "no-workspace";
+
+export interface AppStateProbe {
+  /** The automation control API is registered. */
+  controlReady: boolean;
+  /** The transitional message currently on screen, if any. */
+  transitional: string | null;
+  /** Which interactive surface is showing, or null while nothing is usable yet. */
+  surface: AppSurfaceState | null;
+  workspaceId: string | null;
+  route: string;
+  /** First 300 characters of visible text, for self-diagnosing failures. */
+  text: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function surfaceOrNull(value: unknown): AppSurfaceState | null {
+  return value === "welcome" || value === "workspace" || value === "no-workspace" ? value : null;
+}
+
+export function parseAppStateProbe(value: unknown): AppStateProbe {
+  if (!isRecord(value)) {
+    return { controlReady: false, transitional: null, surface: null, workspaceId: null, route: "", text: "" };
+  }
+  return {
+    controlReady: value.controlReady === true,
+    transitional: stringOrNull(value.transitional),
+    surface: surfaceOrNull(value.surface),
+    workspaceId: stringOrNull(value.workspaceId),
+    route: typeof value.route === "string" ? value.route : "",
+    text: typeof value.text === "string" ? value.text : "",
+  };
+}
+
+/** The app is usable: control registered, nothing still loading, and a surface a user can act on. */
+export function isInteractive(probe: AppStateProbe): boolean {
+  return probe.controlReady && probe.transitional === null && probe.surface !== null;
+}
+
+export function describeAppState(probe: AppStateProbe): string {
+  const blocker = probe.transitional ? `still showing ${JSON.stringify(probe.transitional)}` : "no interactive surface";
+  return `route ${probe.route || "<unknown>"}, ${probe.controlReady ? "control ready" : "control missing"}, ${blocker}. Visible text: ${JSON.stringify(probe.text)}`;
+}
+
+const PROBE_EXPRESSION = `(() => {
+  const text = document.body?.innerText ?? "";
+  const route = window.location.hash.replace(/^#/, "") || window.location.pathname;
+  const transitional = ${JSON.stringify([...APP_TRANSITIONAL_TEXTS])}
+    .find((message) => text.includes(message)) ?? null;
+  const buttonLabels = [...document.querySelectorAll("button")].map((button) => (button.textContent ?? "").trim());
+  const taskUi = text.includes("What do you need done?") || buttonLabels.includes("Run task");
+  const needsWorkspace = text.includes("Create or connect a workspace");
+  const welcome = text.includes("Welcome to OpenWork");
+  // The product's own active-workspace state; the route is only a fallback
+  // because a selected workspace does not always appear in the hash.
+  const stored = localStorage.getItem("openwork.react.activeWorkspace");
+  const routeMatch = (route.match(/\\/workspace\\/([^/?#]+)/) ?? [])[1] ?? null;
+  const workspaceId = (stored && stored.length > 0 ? stored : null) ?? routeMatch;
+  const surface = welcome
+    ? "welcome"
+    : taskUi && workspaceId && !needsWorkspace
+      ? "workspace"
+      : taskUi || needsWorkspace
+        ? "no-workspace"
+        : null;
+  return {
+    controlReady: Boolean(window.__openworkControl),
+    transitional,
+    surface,
+    workspaceId: surface === "welcome" ? null : workspaceId,
+    route,
+    text: text.slice(0, 300),
+  };
+})()`;
+
+export async function probeAppState(client: CdpClient, opts: EvaluateOptions = {}): Promise<AppStateProbe> {
+  return parseAppStateProbe(await evaluate(client, PROBE_EXPRESSION, opts));
+}
+
+/** The product's active workspace id, read from its own state. */
+export async function readActiveWorkspaceId(client: CdpClient, opts: EvaluateOptions = {}): Promise<string | null> {
+  return (await probeAppState(client, opts)).workspaceId;
+}

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -16,8 +16,12 @@ export interface CdpTarget {
 export interface CdpClient {
   targetId?: string | null;
   webSocketDebuggerUrl?: string;
-  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  send(method: string, params?: Record<string, unknown>, options?: CdpSendOptions): Promise<unknown>;
   close(): void;
+}
+
+export interface CdpSendOptions {
+  timeoutMs?: number;
 }
 
 export interface CdpConnectOptions {
@@ -27,6 +31,7 @@ export interface CdpConnectOptions {
 
 export interface EvaluateOptions {
   awaitPromise?: boolean;
+  timeoutMs?: number;
 }
 
 interface PendingCallbacks {
@@ -178,15 +183,15 @@ export function connect(
         targetId: new URL(webSocketDebuggerUrl).pathname.split("/").pop() ?? null,
         webSocketDebuggerUrl,
         close: () => socket.close(),
-        send(method: string, params: Record<string, unknown> = {}) {
+        send(method: string, params: Record<string, unknown> = {}, { timeoutMs = sendTimeoutMs }: CdpSendOptions = {}) {
           const id = nextId;
           nextId += 1;
           return new Promise((innerResolve, innerReject) => {
-            const timer = sendTimeoutMs > 0
+            const timer = timeoutMs > 0
               ? setTimeout(() => {
                 pending.delete(id);
-                innerReject(new Error(`CDP call ${method} timed out after ${sendTimeoutMs}ms.`));
-              }, sendTimeoutMs)
+                innerReject(new Error(`CDP call ${method} timed out after ${timeoutMs}ms.`));
+              }, timeoutMs)
               : null;
             pending.set(id, { resolve: innerResolve, reject: innerReject, timer });
             try {
@@ -234,12 +239,16 @@ export function connect(
   });
 }
 
-export async function evaluate(client: CdpClient, expression: string, { awaitPromise = false }: EvaluateOptions = {}): Promise<unknown> {
+export async function evaluate(
+  client: CdpClient,
+  expression: string,
+  { awaitPromise = false, timeoutMs }: EvaluateOptions = {},
+): Promise<unknown> {
   const payload = await client.send("Runtime.evaluate", {
     expression,
     awaitPromise,
     returnByValue: true,
-  });
+  }, { timeoutMs });
   if (!isRecord(payload)) return undefined;
   if (isRecord(payload.exceptionDetails)) {
     const exception = payload.exceptionDetails.exception;

--- a/evals/packages/cdp/src/index.ts
+++ b/evals/packages/cdp/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./app-state.ts";
 export * from "./cdp.ts";
 export * from "./ports.ts";
 export * from "./surface.ts";

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -616,6 +616,11 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     share,
     disposeSurface,
     stop,
-    [Symbol.asyncDispose]: stop,
+    async [Symbol.asyncDispose](): Promise<void> {
+      for (const handle of [...spawnedSurfaces]) {
+        await disposeSurface(handle)
+          .catch((error: unknown) => options.log(`Daytona surface ${handle.name} cleanup failed: ${messageText(error)}`));
+      }
+    },
   };
 }

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -8,6 +8,14 @@ const POLL_INTERVAL_MS = 250;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function logCleanupError(name: string, error: unknown): void {
+  console.warn(`[openwork/evals] Desktop ${name} cleanup failed: ${messageText(error)}`);
+}
+
 export interface DesktopOptions {
   name?: string;
   mode?: "spawn" | "attach";
@@ -154,15 +162,19 @@ export async function desktop(opts: DesktopOptions = {}): Promise<DesktopHandle>
       stopped = true;
       await closeSpawnedSurface(attached, host, handle);
     };
+    const dispose = async (): Promise<void> => {
+      await stop().catch((error: unknown) => logCleanupError(handle.name, error));
+    };
     return {
       handle: attached.handle,
       client: attached.client,
       readiness,
       stop,
-      [Symbol.asyncDispose]: stop,
+      [Symbol.asyncDispose]: dispose,
     };
   } catch (error) {
-    await closeSpawnedSurface(attached, host, handle).catch(() => undefined);
+    await closeSpawnedSurface(attached, host, handle)
+      .catch((cleanupError: unknown) => logCleanupError(handle.name, cleanupError));
     throw error;
   }
 }

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -1,6 +1,6 @@
-import { attachSurface, evaluate } from "@openwork/cdp";
+import { attachSurface, describeAppState, isInteractive, probeAppState } from "@openwork/cdp";
 import { resolveHost } from "./resolve.ts";
-import type { AttachedSurface, Surface, SurfaceHandle } from "@openwork/cdp";
+import type { AppStateProbe, AppSurfaceState, AttachedSurface, Surface, SurfaceHandle } from "@openwork/cdp";
 import type { Host } from "./types.ts";
 
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -29,7 +29,7 @@ export interface DesktopOptions {
 }
 
 export interface AppReadiness {
-  state: "welcome" | "workspace";
+  state: AppSurfaceState;
   workspaceId: string | null;
   route: string;
 }
@@ -39,79 +39,24 @@ export interface DesktopHandle extends AttachedSurface {
   stop(): Promise<void>;
 }
 
-interface ReadinessProbe {
-  ready: boolean;
-  state: AppReadiness["state"] | null;
-  workspaceId: string | null;
-  route: string;
-  text: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseProbe(value: unknown): ReadinessProbe {
-  if (!isRecord(value)) {
-    return { ready: false, state: null, workspaceId: null, route: "", text: "" };
-  }
-  const state = value.state === "welcome" || value.state === "workspace" ? value.state : null;
-  return {
-    ready: value.ready === true,
-    state,
-    workspaceId: typeof value.workspaceId === "string" ? value.workspaceId : null,
-    route: typeof value.route === "string" ? value.route : "",
-    text: typeof value.text === "string" ? value.text : "",
-  };
-}
-
-async function probeReadiness(app: Surface): Promise<ReadinessProbe> {
-  const value = await evaluate(app.client, `(() => {
-    const text = document.body?.innerText ?? "";
-    const route = window.location.hash.replace(/^#/, "") || window.location.pathname;
-    const workspace = /^\\/workspace\\/([^/?#]+)\\/session\\/?$/.exec(route);
-    const transitional = [
-      "Preparing workspace",
-      "Connecting signed-in services",
-      "Connecting services",
-      "Loading available resources",
-    ].some((message) => text.includes(message));
-    const taskUiMounted = text.includes("What do you need done?")
-      || [...document.querySelectorAll("button")]
-        .some((button) => (button.textContent ?? "").trim() === "Run task");
-    const state = route === "/welcome"
-      ? "welcome"
-      : workspace && taskUiMounted
-        ? "workspace"
-        : null;
-    return {
-      ready: Boolean(window.__openworkControl && !transitional && state),
-      state,
-      workspaceId: state === "workspace" ? workspace?.[1] ?? null : null,
-      route,
-      text: text.slice(0, 300),
-    };
-  })()`);
-  return parseProbe(value);
-}
-
 async function waitForReadiness(app: Surface, timeoutMs: number): Promise<AppReadiness> {
   const deadline = Date.now() + timeoutMs;
-  let last = await probeReadiness(app).catch(() => parseProbe(null));
+  // Give each probe room to answer while the app is busy; the poll's own
+  // deadline is what bounds the wait, not a per-call default.
+  const probeTimeoutMs = Math.min(Math.max(timeoutMs, 20_000), 120_000);
+  let last: AppStateProbe = { controlReady: false, transitional: null, surface: null, workspaceId: null, route: "", text: "" };
   while (Date.now() < deadline) {
     try {
-      last = await probeReadiness(app);
-      if (last.ready && last.state) {
-        return { state: last.state, workspaceId: last.workspaceId, route: last.route };
+      last = await probeAppState(app.client, { timeoutMs: probeTimeoutMs });
+      if (isInteractive(last) && last.surface) {
+        return { state: last.surface, workspaceId: last.workspaceId, route: last.route };
       }
     } catch {
-      // Navigations can briefly destroy the execution context while the app boots.
+      // Navigations briefly destroy the execution context while the app boots.
     }
     await sleep(POLL_INTERVAL_MS);
   }
-  throw new Error(
-    `OpenWork desktop did not become ready after ${timeoutMs}ms. Current route: ${last.route || "<unknown>"}. Visible text: ${JSON.stringify(last.text)}`,
-  );
+  throw new Error(`OpenWork desktop did not become ready after ${timeoutMs}ms: ${describeAppState(last)}`);
 }
 
 async function closeSpawnedSurface(

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -541,7 +541,10 @@ function containerLaunchArgs(existing: string | undefined): string | undefined {
     },
 
     async [Symbol.asyncDispose](): Promise<void> {
-      await this.stop();
+      for (const handle of [...spawnedSurfaces]) {
+        await this.disposeSurface(handle)
+          .catch((error: unknown) => log(`Local surface ${handle.name} cleanup failed: ${messageText(error)}`));
+      }
     },
   };
 }

--- a/evals/specs/models-available.slow.test.ts
+++ b/evals/specs/models-available.slow.test.ts
@@ -329,7 +329,10 @@ test.skipIf(!appSpecsEnabled || !apiUrl)(managedTitle, async () => {
   onTestFinished(async () => restoreManagedState(admin, state));
   await configureManagedEmpty(admin, state);
 
-  await using app = await desktop({ name: "models-managed-recovery" });
+  await using app = await desktop({
+    name: "models-managed-recovery",
+    bootstrap: { baseUrl: den.webUrl, apiBaseUrl: den.webUrl, requireSignin: false },
+  });
   await using roll = photoRoll("models-managed-recovery");
   await signInDesktopAs(app, den, admin);
   const workspacePath = `/tmp/openwork-managed-models-${Date.now()}`;

--- a/evals/specs/org-connection-lifecycle.slow.test.ts
+++ b/evals/specs/org-connection-lifecycle.slow.test.ts
@@ -103,7 +103,10 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   onTestFinished(async () => deleteConnection(admin, connection.id));
   expect((await readUsableConnection(member, connection.id))?.connectedForMe).toBe(false);
 
-  await using app = await desktop({ name: "org-connection-lifecycle" });
+  await using app = await desktop({
+    name: "org-connection-lifecycle",
+    bootstrap: { baseUrl: den.webUrl, apiBaseUrl: den.webUrl, requireSignin: false },
+  });
   await using roll = photoRoll("org-connection-lifecycle");
   await signInDesktopAs(app, den, member);
   const workspacePath = `/tmp/openwork-org-connection-lifecycle-${Date.now()}`;


### PR DESCRIPTION
## What

Follow-up to #3322, fixing the infrastructure-level reasons the app-driving eval specs could not pass, and making every remaining failure self-diagnosing.

1. **App readiness is now defined by an interactive UI, not a route allowlist.** The previous predicate accepted only `/welcome` or `/workspace/<id>/session`, so it rejected a genuinely-ready app: a fresh profile with no workspace legitimately sits on `/session` offering "Create or connect a workspace". Readiness is now: control API registered · no transitional copy on screen (`Preparing workspace`, `Connecting signed-in services`, `Loading available resources`, `Loading tasks`, `Pulling in the latest messages` — taken from `apps/app/src/i18n/locales/en.ts`, not invented) · one interactive surface observable (welcome | workspace | no-workspace).
2. **One shared predicate.** It lives in `@openwork/cdp` (`app-state.ts`) because both the lifecycle layer (`@openwork/hosts`) and the behaviours specs call (`@openwork/behaviors`) already depend on it, so there is no cycle and the two cannot drift. `waitUntilInteractive()` is exported for use after any action that navigates or creates a workspace/session.
3. **Workspace id comes from the product's own state** (`openwork.react.activeWorkspace`, verified against a live app) with the route only as a fallback — a selected workspace does not always appear in the hash.
4. **Den-dependent specs point at the local den**: `bootstrap: { baseUrl, apiBaseUrl }` = the den **web** origin, because the app derives its `/api/den` proxy base from those and den-api does not serve that prefix (documented in the legacy flow).
5. **Per-call CDP timeouts are parameterised** (`send`/`evaluate` accept `timeoutMs`; default stays 20s) and the polling helpers derive a budget from the wait's own deadline, so a busy renderer no longer kills a poll with `CDP call Runtime.evaluate timed out after 20000ms`.
6. **Disposal is best-effort and logged**, so a dead app no longer masks the real assertion error behind `SuppressedError: An error was suppressed during disposal`.

## Tests run

`pnpm evals:typecheck` clean · `pnpm --dir evals run test` **91/91** · `pnpm --dir evals run spec` **4/4** (the gating `pr` lane) · `pnpm --dir evals run spec:nightly` app specs skip with their opt-in reason.

Real Daytona sandbox (den stack + isolated per-spec Electron), several runs: **5 of 9 spec files pass** — both egress specs in both projects, plus `app-smoke` end-to-end (isolated spawn → readiness gate → assertions → vision-validated photo roll).

## Remaining failures, now precisely known

Four files still fail, and the errors name themselves:

- `Timed out after 120000ms waiting for created workspace selected` (`models-available`, `org-connection-lifecycle`) and `Workspace creation did not produce a workspace ID` (`skills-local`) — `workspace.create` (real, registered by `session-route.tsx:2308`, requires an absolute `path`) reports success but the app does not settle on a workspace in a fresh profile. Needs live observation next, the way the onboarding sequence was pinned down.
- `first-run-local`: vision refused an expectation and was right — *"The selected model reads 'big-pickle,' but the 'Run task' control is gray and visibly disabled."* The spec asserts a usable model; the honest state without cloud or an in-app key is *selected but not runnable*. The expectation needs to state that truth.
- `models-available`: the duplicate-pixel guard fires on the Models-picker frame — the picker action runs but the frame is captured before it visibly renders, so the capture must wait for the picker.

None of this gates CI: the `pr` lane is green and gating; app specs are nightly-only, opt-in via `OPENWORK_EVAL_APP_SPECS=1`, and that step is `continue-on-error` while they stabilise.
