### PR TITLE
fix(den-api): report old workspaces as needing an update, not an opaque failure

### DIFF
--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -725,16 +725,41 @@ async function patchRuntimeProviders(input: {
   hostToken: string
   patch: JsonRecord
 }) {
-  await requestOk({
-    fetchImpl: input.fetchImpl,
-    label: "runtime_provider_patch",
-    url: `${input.instanceUrl}/runtime-config/providers`,
-    init: {
-      method: "PATCH",
-      headers: hostTokenHeaders(input.hostToken),
-      body: JSON.stringify({ provider: input.patch }),
-    },
+  const response = await fetchWithTimeout(input.fetchImpl, `${input.instanceUrl}/runtime-config/providers`, {
+    method: "PATCH",
+    headers: hostTokenHeaders(input.hostToken),
+    body: JSON.stringify({ provider: input.patch }),
   })
+  if (!response.ok) {
+    throw new MaterializationHttpError("runtime_provider_patch", response.status, await response.text())
+  }
+
+  // An instance older than this route answers 200 with the SPA index.html
+  // instead of 404, because the web root is the catch-all. Observed on a real
+  // worker still running openwork-server 0.18.3: the patch "succeeded", the
+  // engine ended up with zero providers, and the org saw an opaque failure
+  // instead of "this workspace needs an update". Treat a non-JSON body as an
+  // unsupported route so the caller can degrade honestly.
+  const body = await response.text()
+  if (!looksLikeJsonObject(body)) {
+    throw new MaterializationHttpError("runtime_provider_patch", UNSUPPORTED_ROUTE_STATUS, body.slice(0, 200))
+  }
+}
+
+/**
+ * Synthetic status for "this instance does not implement the route", used when
+ * the instance answers 200 with something that is not the route's JSON.
+ */
+const UNSUPPORTED_ROUTE_STATUS = 501
+
+function looksLikeJsonObject(body: string): boolean {
+  const trimmed = body.trim()
+  if (!trimmed.startsWith("{")) return false
+  try {
+    return typeof JSON.parse(trimmed) === "object"
+  } catch {
+    return false
+  }
 }
 
 async function verifyRuntimeProviders(input: {
@@ -821,7 +846,7 @@ function unsupportedResult(input: {
 function unsupportedProviderRouteReason(error: unknown) {
   return error instanceof MaterializationHttpError
     && error.label === "runtime_provider_patch"
-    && (error.status === 404 || error.status === 405)
+    && (error.status === 404 || error.status === 405 || error.status === UNSUPPORTED_ROUTE_STATUS)
     ? error.message
     : null
 }

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -149,6 +149,7 @@ function makeInstance(input: {
   envWriteRejection?: { status: number; body: unknown }
   failConfigPatches?: number
   providerRouteStatus?: number
+  providerRouteServesSpa?: boolean
   runtimeVersion?: string | null
   runtimeProviders?: Record<string, unknown>
   opencodeConfigProviders?: Record<string, unknown>
@@ -239,6 +240,14 @@ function makeInstance(input: {
     }
 
     if (method === "PATCH" && parsed.pathname === "/runtime-config/providers") {
+      if (input.providerRouteServesSpa) {
+        // Instances older than this route fall through to the SPA catch-all and
+        // answer 200 with index.html (seen on a real worker on 0.18.3).
+        return new Response("<!doctype html>\n<html lang=\"en\"><head><title>OpenWork</title></head></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        })
+      }
       if (input.providerRouteStatus) {
         return jsonResponse({ error: "runtime_provider_route_unavailable" }, input.providerRouteStatus)
       }
@@ -683,6 +692,26 @@ describe("Cloud provider materialization", () => {
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
     expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
+  })
+
+  test("treats an instance that serves the SPA on the provider route as unsupported", async () => {
+    // A real worker still running openwork-server 0.18.3 answered PATCH
+    // /runtime-config/providers with 200 + index.html, so the patch looked like
+    // a success while the engine ended up with zero providers. The org then saw
+    // an opaque failure instead of "this workspace needs an update", and every
+    // model failed with "no API keys".
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({ providerRouteServesSpa: true })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe("unsupported")
+    await Promise.resolve()
   })
 
   test("preserves credential env when the global provider route is unsupported", async () => {


### PR DESCRIPTION
From Omar's session on `web.openworklabs.com`: OpenWork models showed **"Hosted, no API keys"** and pushed him to a payment tab despite an active subscription.

## What his instance actually looked like

```
sandbox:  den-daytona-worker-cloud-omar-mcadam-wrk-01kyf4mk
image:    openwork-cloud-0.18.2-plugins   (created Jul 26 — ten versions behind)
server:   openwork-server 0.18.3
state:    started  (so version-aware recycle, which requires `stopped`, never fired)
```

```
PATCH /runtime-config/providers -> 200 <!doctype html> …   <- route absent; SPA catch-all answered
/env/keys                       -> ["ANTHROPIC_API_KEY","OPENWORK_API_KEY","OPENWORK_INFERENCE_BASE_URL"]
auth.json                        -> openwork(api)
engine providers                 -> []          <- nothing for a model to resolve against
```

His server predates the provider-config route, so den-api could never write provider definitions. The engine had **zero** providers, which is why every OpenWork model reported no key.

## The detection bug

```ts
&& (error.status === 404 || error.status === 405)
```

Only 404/405 counted as "route unsupported". An old instance answers **200 with index.html** (the web root is the catch-all), so the PATCH looked like a success, `verifyRuntimeProviders` then failed on read-back, and the org got a generic failure:

```
reason: provider_readback_missing_lpr_…      status: failed
```

instead of "this workspace needs an update".

## Fix

`patchRuntimeProviders` now checks that a 200 body is actually a JSON object. A non-JSON body is treated as an unsupported route (synthetic 501), so the existing `unsupported` path reports honestly:

```
reason: runtime_provider_patch_failed_501    status: unsupported
message: cloud provider materialization unsupported by worker version
```

That flows into `providerSync: { status: "degraded", reason: "unsupported" }`, which the app already renders as needing attention — instead of silently pretending providers were written.

## Test

`treats an instance that serves the SPA on the provider route as unsupported`, with the harness answering 200 + `index.html` exactly like the real 0.18.3 worker. Proven to fail before:

```
before:  Expected "unsupported"  Received "failed"   0 pass / 1 fail
after:   1 pass / 0 fail
```

| Command | Result |
| --- | --- |
| materialization + cloud-route + checkpoint suites | 52 pass / 0 fail |
| `tsc --noEmit` (den-api) | clean |

## Also done operationally (no code)

Omar was stuck because recycle only fires for a **stopped** sandbox and his had been running since Jul 26. I stopped it, after confirming a fresh 583 KB checkpoint exists (it now includes his session database, so hydrate restores his chats). His next app open recycles him onto `openwork-0.18.12`, where the provider route, credential delivery (#3332) and re-materialization (#3338) all exist.

## Not fixed here, worth deciding separately

A long-running instance **never** receives a new image: `shouldRecycleDaytonaSandbox` requires `isStoppedSandboxState`. The UI does surface staleness (`cloud-workspace-status.ts` flags `imageVersion !== latestVersion` and the overlay calls `updateCloudInstance`), but it relies on the user noticing and confirming — which is how Omar sat ten versions behind for four days. Auto-recycling an idle-but-running workspace would fix it properly; I didn't want to make that call inside this fix.