### PR TITLE
fix(app): open Browser before a session starts

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -68,6 +68,7 @@ import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTa
 import type { OpenTargetOptions } from "@/lib/target-provider";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
+import { getSidePanelSessionKey } from "../panel/side-panel-session";
 import { TerminalDock } from "../terminal/terminal-dock";
 import { useActivePanelTab, usePanelTabStore, useSessionPanelState } from "../panel/panel-tab-store";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
@@ -316,8 +317,9 @@ export function SessionPage(props: SessionPageProps) {
   const denAuth = useDenAuth();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
+  const sidePanelSessionKey = getSidePanelSessionKey(props.selectedSessionId);
   const sessionSidePanel = useUiStateStore((state) => (
-    props.selectedSessionId ? state.sidePanelState[props.selectedSessionId] ?? null : null
+    state.sidePanelState[sidePanelSessionKey] ?? null
   ));
   const voiceSidePanelOpen = useUiStateStore((state) => state.sidePanelState[GLOBAL_VOICE_SIDE_PANEL_KEY] === "voice");
   const setSidePanelState = useUiStateStore((state) => state.setSidePanelState);
@@ -328,8 +330,8 @@ export function SessionPage(props: SessionPageProps) {
   const transcriptTargets = usePanelTabStore((state) => (
     props.selectedSessionId ? state.transcriptArtifactTargets[props.selectedSessionId] ?? EMPTY_TRANSCRIPT_TARGETS : EMPTY_TRANSCRIPT_TARGETS
   ));
-  const sessionPanelState = useSessionPanelState(props.selectedSessionId ?? "");
-  const activePanelTab = useActivePanelTab(props.selectedSessionId ?? "");
+  const sessionPanelState = useSessionPanelState(sidePanelSessionKey);
+  const activePanelTab = useActivePanelTab(sidePanelSessionKey);
   const [hiddenTargetRevision, setHiddenTargetRevision] = useState(0);
   const [, setExtensionStateVersion] = useState(0);
   const hiddenAccessibleTargetIds = useMemo(
@@ -398,8 +400,8 @@ export function SessionPage(props: SessionPageProps) {
   const setCurrentSidePanel = useCallback((panel: SidePanelItem | null) => {
     setSidePanelState(GLOBAL_VOICE_SIDE_PANEL_KEY, panel === "voice" ? "voice" : null);
     if (panel === "voice") return;
-    setSidePanelState(props.selectedSessionId, panel);
-  }, [props.selectedSessionId, setSidePanelState]);
+    setSidePanelState(sidePanelSessionKey, panel);
+  }, [setSidePanelState, sidePanelSessionKey]);
 
   const toggleCurrentSidePanel = useCallback((panel: SidePanelItem) => {
     if (panel === "voice") {
@@ -407,8 +409,8 @@ export function SessionPage(props: SessionPageProps) {
       return;
     }
     setSidePanelState(GLOBAL_VOICE_SIDE_PANEL_KEY, null);
-    toggleSidePanelState(props.selectedSessionId, panel);
-  }, [props.selectedSessionId, setSidePanelState, toggleSidePanelState]);
+    toggleSidePanelState(sidePanelSessionKey, panel);
+  }, [setSidePanelState, sidePanelSessionKey, toggleSidePanelState]);
 
   // When the agent calls a built-in browser tool, the main process opens
   // the WebContentsView and sends panel-opened; when hide_browser is called
@@ -1431,9 +1433,9 @@ export function SessionPage(props: SessionPageProps) {
                       sessionId={props.selectedSessionId}
                       onClose={closeRightPane}
                     />
-                  ) : activeSidePanel === "panel" && props.selectedSessionId ? (
+                  ) : activeSidePanel === "panel" ? (
                     <SidePanel
-                      sessionId={props.selectedSessionId}
+                      sessionId={sidePanelSessionKey}
                       client={props.openworkServerClient}
                       workspaceId={props.runtimeWorkspaceId}
                       workspaceRoot={props.selectedWorkspaceRoot}

--- a/apps/app/src/react-app/domains/session/panel/panel-empty.tsx
+++ b/apps/app/src/react-app/domains/session/panel/panel-empty.tsx
@@ -121,7 +121,7 @@ export function PanelEmpty({ onOpenBrowser, onOpenExtensions, onOpenVoice }: Pan
                 "group flex min-h-16 w-full items-center gap-3 rounded-xl border border-border bg-background p-3 text-left",
                 "transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               )}
-              onClick={item.activate}
+              onClick={() => item.activate()}
             >
               <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground [&_svg]:size-4">
                 {item.icon}

--- a/apps/app/src/react-app/domains/session/panel/side-panel-session.ts
+++ b/apps/app/src/react-app/domains/session/panel/side-panel-session.ts
@@ -1,0 +1,9 @@
+export const NO_SESSION_SIDE_PANEL_KEY = "__openwork_no_session__";
+
+export function getSidePanelSessionKey(sessionId: string | null) {
+  if (!sessionId?.trim()) {
+    return NO_SESSION_SIDE_PANEL_KEY;
+  }
+
+  return sessionId;
+}

--- a/apps/app/tests/right-panel-empty.test.tsx
+++ b/apps/app/tests/right-panel-empty.test.tsx
@@ -6,8 +6,19 @@ import {
   handlePanelEscape,
   PanelEmpty,
 } from "../src/react-app/domains/session/panel/panel-empty";
+import {
+  getSidePanelSessionKey,
+  NO_SESSION_SIDE_PANEL_KEY,
+} from "../src/react-app/domains/session/panel/side-panel-session";
 
 describe("right panel empty state", () => {
+  test("keeps the panel addressable before a session exists", () => {
+    expect(getSidePanelSessionKey(null)).toBe(NO_SESSION_SIDE_PANEL_KEY);
+    expect(getSidePanelSessionKey("")).toBe(NO_SESSION_SIDE_PANEL_KEY);
+    expect(getSidePanelSessionKey("   ")).toBe(NO_SESSION_SIDE_PANEL_KEY);
+    expect(getSidePanelSessionKey("ses_existing")).toBe("ses_existing");
+  });
+
   test("renders spacious keyboard-accessible destination actions", () => {
     const html = renderToStaticMarkup(
       <PanelEmpty

--- a/evals/flows/right-panel-action-empty-state.flow.mjs
+++ b/evals/flows/right-panel-action-empty-state.flow.mjs
@@ -28,23 +28,34 @@ const READ_CHOOSER = `(() => {
 
 export default {
   id: "right-panel-action-empty-state",
-  title: "The empty right panel offers real runtime-supported destinations",
+  title: "The built-in browser opens before a chat session starts",
   kind: "user-facing",
   steps: [
     {
-      name: "Opening an empty panel presents an actionable chooser",
+      name: "Opening Browser from a session-free panel creates a usable tab",
       run: async (ctx) => {
         await ensureSessionWorkspace(
           ctx,
           "right-panel-action-empty-state",
         );
-        if (!String(await ctx.eval("window.__openworkControl.snapshot().route || ''")).includes("/session/")) {
-          await ctx.control("session.create_task");
-          await ctx.waitFor(
-            "window.__openworkControl.snapshot().route.includes('/session/')",
-            { timeoutMs: 30_000, label: "session route" },
-          );
-        }
+        const workspaceId = await ctx.eval(
+          "(location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? localStorage.getItem('openwork.react.activeWorkspace') ?? ''",
+        );
+        ctx.assert(workspaceId, "Expected an active workspace before opening the session-free browser.");
+        await ctx.navigateHash(`/workspace/${workspaceId}/session`);
+        await ctx.waitFor(
+          "!window.__openwork?.slice?.('route')?.selectedSessionId",
+          { timeoutMs: 20_000, label: "workspace route without a selected session" },
+        );
+        await ctx.eval("window.__OPENWORK_ELECTRON__.browser.closeAllTabs?.()", { awaitPromise: true });
+        await ctx.eval(`(() => {
+          const button = document.querySelector('button[aria-label="Close side panel"]');
+          if (button instanceof HTMLElement) button.click();
+        })()`);
+        await ctx.waitFor(
+          "Boolean(document.querySelector('button[aria-label=\"Open side panel\"]'))",
+          { timeoutMs: 5_000, label: "closed session-free side panel" },
+        );
         const opened = await ctx.eval(`(() => {
           const button = document.querySelector('button[aria-label="Open side panel"]');
           if (!(button instanceof HTMLElement)) return false;
@@ -56,13 +67,26 @@ export default {
           timeoutMs: 20_000,
           label: "right-panel action chooser",
         });
+        const chooserBefore = await ctx.eval(READ_CHOOSER);
 
-        await ctx.prove("The no-content side panel exposes supported destinations as keyboard-accessible actions", {
-          action: async () => {},
+        await ctx.prove("Browser remains available before any chat session is selected or started", {
+          action: async () => {
+            const browserOpened = await ctx.eval(`(() => {
+              const button = [...document.querySelectorAll('button')]
+                .find((entry) => (entry.textContent || '').trim().startsWith('Browser'));
+              if (!(button instanceof HTMLElement)) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(browserOpened === true, "The Browser destination was not actionable.");
+            await ctx.waitFor(
+              "document.querySelectorAll('button[aria-label^=\"Select tab:\"]').length >= 1",
+              { timeoutMs: 20_000, label: "browser tab created without a session" },
+            );
+          },
           assert: async () => {
-            const chooser = await ctx.eval(READ_CHOOSER);
-            ctx.assert(chooser, "The deliberate right-panel empty state was not found.");
-            const labels = chooser.actions.map((entry) => entry.label);
+            ctx.assert(chooserBefore, "The deliberate right-panel empty state was not found.");
+            const labels = chooserBefore.actions.map((entry) => entry.label);
             ctx.assert(labels.length >= 2, `Expected at least two real destinations, got ${JSON.stringify(labels)}.`);
             ctx.assert(
               labels.some((label) => /browser/i.test(label)),
@@ -72,11 +96,19 @@ export default {
               labels.some((label) => /files|artifacts/i.test(label)),
               `Expected a Files or Artifacts destination, got ${JSON.stringify(labels)}.`,
             );
-            ctx.assert(chooser.width >= 300, `Expected a usable panel width, got ${chooser.width}px.`);
+            ctx.assert(chooserBefore.width >= 300, `Expected a usable panel width, got ${chooserBefore.width}px.`);
+            const selectedSessionId = await ctx.eval(
+              "window.__openwork?.slice?.('route')?.selectedSessionId ?? null",
+            );
+            ctx.assert(selectedSessionId === null, `Expected no selected session, got ${selectedSessionId}.`);
+            const browserState = await ctx.eval(
+              "window.__OPENWORK_ELECTRON__.browser.getState()",
+              { awaitPromise: true },
+            );
+            ctx.assert(browserState?.tabs?.length >= 1, "Expected a native browser tab after activating Browser.");
           },
           screenshot: {
-            name: "right-panel-action-chooser",
-            requireText: ["Browser"],
+            name: "browser-open-without-session",
             rejectText: ["Something went wrong"],
           },
         });


### PR DESCRIPTION
## Summary

- Keep the unified right panel addressable while the workspace is on **New session**.
- Let **Browser** create and display a native browser tab before any chat session has started.
- Preserve the existing per-session panel behavior once a real session is selected.
- Add deterministic evaluator coverage for the session-free Browser path.

## Root cause

The right panel was keyed and rendered only by a selected chat session, so its state update was dropped when no session existed. After making the panel addressable, the destination button also forwarded React's click event into the optional browser URL parameter, which native IPC could not clone into a tab request.

## What changed

- Introduced a stable internal panel key for null or blank session identifiers.
- Routed no-session panel state and tabs through that key.
- Removed the selected-session render gate for the general side panel.
- Wrapped destination activation so UI events are never forwarded as action arguments.
- Updated the right-panel evaluator to start from a clean, closed panel and prove Browser tab creation with no selected session.

## Verification

- `bun test tests/right-panel-empty.test.tsx` — 5 passed, 0 failed.
- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm evals:typecheck` — passed.
- `node --check evals/flows/right-panel-action-empty-state.flow.mjs` — passed.
- `pnpm fraimz --flow right-panel-action-empty-state --cdp-url <isolated-candidate>` — 1 passed, 0 failed, 0 skipped.
- Full app suite observation: 557 passed and 2 unrelated existing failures in `message-list-loading.test.tsx` (`target.addEventListener is not a function` in the test's partial window shim). This branch does not touch that surface.

## Risk

Low and localized to right-panel state ownership and destination activation. The fallback key is internal-only and real session IDs continue to use their existing isolated state.