### PR TITLE
Prevent shortcut badges from sticking after a missed modifier release

### DIFF
--- a/apps/app/src/react-app/shell/session-number-shortcuts.ts
+++ b/apps/app/src/react-app/shell/session-number-shortcuts.ts
@@ -42,7 +42,9 @@ type SessionNumberShortcutIntentOptions = {
 export type SessionNumberShortcutTransition =
   | "modifier-down"
   | "modifier-up"
+  | "modifier-mismatch"
   | "blur"
+  | "focus"
   | "visibility-hidden"
   | "owner-change"
   | "unmount";
@@ -133,7 +135,7 @@ export function getSessionNumberShortcutIntent(
   options: SessionNumberShortcutIntentOptions,
 ): SessionNumberShortcutIntent {
   const modifierKey = os === "macos" ? "Meta" : "Control";
-  const modifierPressed = os === "macos" ? event.metaKey : event.ctrlKey;
+  const modifierPressed = isSessionNumberModifierPressed(event, os);
   const oppositeModifierPressed = os === "macos" ? event.ctrlKey : event.metaKey;
   if (event.key === modifierKey) {
     return options.ownerActive ? { type: "ignore" } : { type: "hold" };
@@ -154,6 +156,13 @@ export function getSessionNumberShortcutIntent(
 
 export function isSessionNumberModifierKey(key: string, os: SessionNumberShortcutOs) {
   return key === (os === "macos" ? "Meta" : "Control");
+}
+
+export function isSessionNumberModifierPressed(
+  event: Pick<SessionNumberShortcutEvent, "metaKey" | "ctrlKey">,
+  os: SessionNumberShortcutOs,
+) {
+  return os === "macos" ? event.metaKey : event.ctrlKey;
 }
 
 export function nextSessionNumberModifierHeld(

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -7,6 +7,7 @@ import {
   getSessionNumberShortcutIntent,
   hasSessionNumberShortcutOwner,
   isSessionNumberModifierKey,
+  isSessionNumberModifierPressed,
   nextSessionNumberModifierHeld,
   readVisibleSessionNumberShortcutTargets,
   resolveSessionNumberShortcutOs,
@@ -53,6 +54,7 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
   const [sessionNumberModifierHeld, setSessionNumberModifierHeld] = useState(false);
   const [sessionNumberTargets, setSessionNumberTargets] = useState<SessionNumberShortcutTarget[]>([]);
   const sessionNumberCancelledRef = useRef(false);
+  const sessionNumberModifierHeldRef = useRef(false);
   const sessionNumberOs: SessionNumberShortcutOs = resolveSessionNumberShortcutOs(
     platform.os,
     typeof navigator === "undefined" ? "" : navigator.platform,
@@ -63,7 +65,9 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
     transition: SessionNumberShortcutTransition,
   ) => {
     sessionNumberCancelledRef.current = cancelUntilRelease;
-    setSessionNumberModifierHeld(nextSessionNumberModifierHeld(transition));
+    const modifierHeld = nextSessionNumberModifierHeld(transition);
+    sessionNumberModifierHeldRef.current = modifierHeld;
+    setSessionNumberModifierHeld(modifierHeld);
     setSessionNumberTargets((current) => current.length === 0 ? current : []);
   });
 
@@ -73,7 +77,8 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
       return [];
     }
     const targets = readVisibleSessionNumberShortcutTargets(document);
-    setSessionNumberModifierHeld(nextSessionNumberModifierHeld("modifier-down"));
+    sessionNumberModifierHeldRef.current = true;
+    setSessionNumberModifierHeld(true);
     setSessionNumberTargets((current) => (
       sameSessionNumberShortcutTargets(current, targets) ? current : targets
     ));
@@ -133,6 +138,12 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
   });
 
   const handleSessionNumberKeyDown = useEffectEvent((event: KeyboardEvent) => {
+    if (
+      sessionNumberModifierHeldRef.current &&
+      !isSessionNumberModifierPressed(event, sessionNumberOs)
+    ) {
+      clearSessionNumberShortcuts(false, "modifier-mismatch");
+    }
     const intent = getSessionNumberShortcutIntent(event, sessionNumberOs, {
       ownerActive: hasSessionNumberShortcutOwner(document),
       cancelled: sessionNumberCancelledRef.current,
@@ -161,6 +172,15 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
     clearSessionNumberShortcuts(false, "modifier-up");
   });
 
+  const handleSessionNumberMouseMove = useEffectEvent((event: MouseEvent) => {
+    if (
+      sessionNumberModifierHeldRef.current &&
+      !isSessionNumberModifierPressed(event, sessionNumberOs)
+    ) {
+      clearSessionNumberShortcuts(false, "modifier-mismatch");
+    }
+  });
+
   useEffect(() => {
     const handler = (event: KeyboardEvent) => handleGlobalShortcut(event);
     window.addEventListener("keydown", handler);
@@ -170,8 +190,10 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
   useEffect(() => {
     const keyDown = (event: KeyboardEvent) => handleSessionNumberKeyDown(event);
     const keyUp = (event: KeyboardEvent) => handleSessionNumberKeyUp(event);
+    const mouseMove = (event: MouseEvent) => handleSessionNumberMouseMove(event);
     const loseOwnership = () => clearSessionNumberShortcuts(true, "owner-change");
     const blur = () => clearSessionNumberShortcuts(true, "blur");
+    const focus = () => clearSessionNumberShortcuts(true, "focus");
     const visibilityChange = () => {
       if (document.visibilityState !== "visible") {
         clearSessionNumberShortcuts(true, "visibility-hidden");
@@ -183,7 +205,7 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
       }
     };
     const observer = new MutationObserver(() => {
-      if (!sessionNumberModifierHeld) return;
+      if (!sessionNumberModifierHeldRef.current) return;
       if (hasSessionNumberShortcutOwner(document)) {
         loseOwnership();
       } else {
@@ -195,19 +217,24 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
     // the global session jump before the shell sees it.
     window.addEventListener("keydown", keyDown, true);
     window.addEventListener("keyup", keyUp);
+    window.addEventListener("mousemove", mouseMove, { passive: true });
     window.addEventListener("blur", blur);
+    window.addEventListener("focus", focus);
     document.addEventListener("visibilitychange", visibilityChange);
     document.addEventListener("focusin", focusIn);
     observer.observe(document.body, { childList: true, subtree: true, attributes: true });
     return () => {
       window.removeEventListener("keydown", keyDown, true);
       window.removeEventListener("keyup", keyUp);
+      window.removeEventListener("mousemove", mouseMove);
       window.removeEventListener("blur", blur);
+      window.removeEventListener("focus", focus);
       document.removeEventListener("visibilitychange", visibilityChange);
       document.removeEventListener("focusin", focusIn);
+      sessionNumberModifierHeldRef.current = false;
       observer.disconnect();
     };
-  }, [sessionNumberModifierHeld]);
+  }, []);
 
   return {
     commandPaletteOpen,

--- a/apps/app/tests/session-number-shortcuts.test.ts
+++ b/apps/app/tests/session-number-shortcuts.test.ts
@@ -6,6 +6,7 @@ import {
   getSessionNumberShortcutIntent,
   isSessionNumberShortcutBlockingOwner,
   isSessionNumberModifierKey,
+  isSessionNumberModifierPressed,
   nextSessionNumberModifierHeld,
   resolveSessionNumberShortcutOs,
   sessionNumberAriaKeyShortcut,
@@ -71,7 +72,9 @@ describe("session number shortcut keyboard ownership", () => {
     expect(nextSessionNumberModifierHeld("modifier-down")).toBe(true);
     const cleanupTransitions: SessionNumberShortcutTransition[] = [
       "modifier-up",
+      "modifier-mismatch",
       "blur",
+      "focus",
       "visibility-hidden",
       "owner-change",
       "unmount",
@@ -81,6 +84,15 @@ describe("session number shortcut keyboard ownership", () => {
     }
     expect(isSessionNumberModifierKey("Meta", "macos")).toBe(true);
     expect(isSessionNumberModifierKey("Control", "windows")).toBe(true);
+  });
+
+  test("reconciles held state from later keyboard and pointer modifier flags", () => {
+    expect(isSessionNumberModifierPressed(macModifier, "macos")).toBe(true);
+    expect(isSessionNumberModifierPressed({ metaKey: false, ctrlKey: false }, "macos")).toBe(false);
+    expect(isSessionNumberModifierPressed({ metaKey: false, ctrlKey: true }, "windows")).toBe(true);
+    expect(isSessionNumberModifierPressed({ metaKey: false, ctrlKey: false }, "windows")).toBe(false);
+    expect(nextSessionNumberModifierHeld("modifier-mismatch")).toBe(false);
+    expect(nextSessionNumberModifierHeld("focus")).toBe(false);
   });
 
   test("activates digits globally but still yields to modal owners", () => {

--- a/evals/flows/sidebar-session-number-shortcuts.flow.mjs
+++ b/evals/flows/sidebar-session-number-shortcuts.flow.mjs
@@ -21,6 +21,9 @@ const READ_SHORTCUT_TARGETS = `(() => [...document.querySelectorAll('[data-sideb
       ? [{ digit: Number(match[1]), sessionId }]
       : [];
   }))()`;
+const READ_VISIBLE_SHORTCUT_BADGES =
+  `(() => [...document.querySelectorAll('[data-session-shortcut-badge]')]
+    .filter((entry) => entry.getClientRects().length > 0).length)()`;
 const vo = await loadVoiceoverParagraphs("sidebar-session-number-shortcuts");
 
 async function dispatchKey(ctx, payload) {
@@ -214,6 +217,61 @@ export default {
           },
           screenshot: {
             name: "sidebar-session-number-shortcuts-select",
+            requireText: ["Shortcut proof chat"],
+            hashIncludes: "/session/",
+          },
+        });
+
+        await ctx.prove("A later unmodified pointer event clears a missed modifier release", {
+          voiceover: vo[3],
+          action: async () => {
+            await activateDifferentVisibleSession(ctx, modifier);
+            await dispatchKey(ctx, {
+              type: "keyDown",
+              key: modifier.key,
+              code: modifier.code,
+              modifiers: modifier.modifiers,
+            });
+            await ctx.waitFor(`${READ_VISIBLE_SHORTCUT_BADGES} >= 3`, {
+              timeoutMs: 20_000,
+              label: "numbered badges after the simulated missed release",
+            });
+            await ctx.eval(`(() => {
+              const modifierKey = ${JSON.stringify(modifier.key)};
+              document.addEventListener("keyup", (event) => {
+                if (event.key === modifierKey) event.stopPropagation();
+              }, { capture: true, once: true });
+              return true;
+            })()`);
+            await dispatchKey(ctx, {
+              type: "keyUp",
+              key: modifier.key,
+              code: modifier.code,
+            });
+            await ctx.waitFor(`${READ_VISIBLE_SHORTCUT_BADGES} >= 3`, {
+              timeoutMs: 5_000,
+              label: "stale badges after the app misses the release event",
+            });
+            await ctx.client.send("Input.dispatchMouseEvent", {
+              type: "mouseMoved",
+              x: 120,
+              y: 120,
+              modifiers: 0,
+            });
+            await ctx.waitFor(`${READ_VISIBLE_SHORTCUT_BADGES} === 0`, {
+              timeoutMs: 10_000,
+              label: "numbered badges to clear from unmodified pointer state",
+            });
+          },
+          assert: async () => {
+            const visibleBadges = await ctx.eval(READ_VISIBLE_SHORTCUT_BADGES);
+            ctx.assert(
+              visibleBadges === 0,
+              `Expected no stale shortcut badges, found ${visibleBadges}.`,
+            );
+          },
+          screenshot: {
+            name: "sidebar-session-number-shortcuts-missed-keyup-recovered",
             requireText: ["Shortcut proof chat"],
             hashIncludes: "/session/",
           },

--- a/evals/voiceovers/sidebar-session-number-shortcuts.md
+++ b/evals/voiceovers/sidebar-session-number-shortcuts.md
@@ -5,3 +5,5 @@
 2. Even while I am typing in the composer, I press Command or Control with a number and OpenWork immediately opens that numbered session from the left sidebar.
 
 3. The shortcut stays global while the model select and its search field are open, so I can jump to another numbered session without first dismissing the select.
+
+4. If OpenWork misses the key release, the shortcut display safely disappears as soon as I move the pointer without holding Command or Control.


### PR DESCRIPTION
## Summary

Prevents the sidebar session-number shortcut display from remaining active when Chromium or Electron misses the Command/Control `keyup` event.

The shortcut state now reconciles with later trustworthy input and lifecycle signals:

- an unmodified `keydown` clears stale modifier state
- an unmodified pointer move clears stale modifier state
- window focus clears stale state after an app switch
- the synchronous held-state ref prevents the mutation observer from re-adding badges during React state cleanup

## Root cause

The shortcut UI depended on receiving the matching modifier `keyup`. If that event was missed, React still considered the modifier held. During cleanup, the DOM mutation observer could also execute with a stale `modifierHeld=true` closure and repopulate the shortcut targets, leaving the numbered badges visible.

## Verification

- `pnpm --filter @openwork/app exec bun test --isolate tests/session-number-shortcuts.test.ts` — 7 passed, 43 assertions
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm evals:typecheck` — passed
- `node --check evals/flows/sidebar-session-number-shortcuts.flow.mjs` — passed
- `pnpm build:ui` — passed
- `pnpm fraimz --flow sidebar-session-number-shortcuts --cdp-url http://127.0.0.1:9877` — passed, including a deliberately swallowed modifier release followed by unmodified pointer recovery

The broader app suite completed 557 of 559 tests. The two failures were in the unrelated `message-list-loading.test.tsx` rendering tests; both passed immediately when rerun in isolation. The changed shortcut test file remained fully green.

## Scope and risk

This is limited to the existing session-number shortcut state machine and its evidence flow. It does not change shortcut mappings or navigation behavior. The main tradeoff is that moving the pointer without Command/Control intentionally dismisses a stale shortcut display, which matches the actual physical modifier state.