### PR TITLE
fix(desktop): prevent renderer crash on windows during app exit (#2908)

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1158,7 +1158,7 @@ let runtimeBootstrapPromise = null;
 
 function showShutdownScreen() {
   const win = mainWindow;
-  if (!win || win.isDestroyed()) return;
+  if (!win || win.isDestroyed() || win.webContents?.isDestroyed()) return;
   try {
     win.show();
     win.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(`<!doctype html>
@@ -1187,11 +1187,14 @@ function showShutdownScreen() {
     // Ignore renderer teardown races during quit.
   }
 }
-
 async function disposeRuntimeBeforeQuit() {
   if (runtimeDisposedForQuit || runtimeDisposeInProgress) return;
   runtimeDisposeInProgress = true;
   try {
+    // Kill all lingering pty terminal processes before webContents teardown
+    for (const [terminalId] of terminalProcesses.entries()) {
+      killTerminal(terminalId);
+    }
     await runtimeManager.dispose().catch(() => undefined);
     runtimeDisposedForQuit = true;
   } finally {


### PR DESCRIPTION
Summary
Fixes #2908

On Windows, closing or quitting the desktop app could trigger a native access violation crash when `showShutdownScreen()` attempted to interact with a destroyed renderer window or when active pty terminal sessions emitted IPC messages into destroyed web contents.

### Changes
* Added `win.webContents?.isDestroyed()` guard inside `showShutdownScreen()`.
* Ensured active terminal processes are explicitly killed during `disposeRuntimeBeforeQuit()`.

### Testing
* Verified typecheck with `pnpm --filter @openwork/desktop typecheck:electron`.