### PR TITLE
Autosave artifact edits safely

### DIFF
--- a/apps/app/scripts/artifact-spreadsheet.test.ts
+++ b/apps/app/scripts/artifact-spreadsheet.test.ts
@@ -7,17 +7,17 @@ import {
 
 describe("artifact spreadsheet model", () => {
   it("round-trips CSV edits", async () => {
-    const rows = await parseSpreadsheet({ name: "artifact-eval.csv", text: "name,revenue\nAda,10\n" });
+    const rows = await parseSpreadsheet({ name: "artifact-eval.csv", content: { kind: "text", data: "name,revenue\nAda,10\n" } });
     rows[1]![1] = "11";
     const output = await serializeSpreadsheet("artifact-eval.csv", rows);
-    expect(output).toEqual({ kind: "text", content: "name,revenue\nAda,11\n" });
+    expect(output).toEqual({ kind: "text", data: "name,revenue\nAda,11\n" });
   });
 
   it("round-trips XLSX edits", async () => {
     const output = await serializeSpreadsheet("artifact-eval.xlsx", [["name", "revenue"], ["Ada", "10"]]);
     expect(output.kind).toBe("binary");
     if (output.kind !== "binary") throw new Error("expected binary");
-    const parsed = await parseSpreadsheet({ name: "artifact-eval.xlsx", data: output.data });
+    const parsed = await parseSpreadsheet({ name: "artifact-eval.xlsx", content: output });
     expect(parsed.slice(0, 2)).toEqual([["name", "revenue"], ["Ada", "10"]]);
   });
 });

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-autosave.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-autosave.ts
@@ -1,0 +1,213 @@
+export type ArtifactAutosaveResult = { updatedAt: number };
+
+export type ArtifactAutosaveStatus = "idle" | "debouncing" | "saving" | "conflict" | "error";
+
+export type ArtifactAutosaveSnapshot<T> = {
+  value: T;
+  baseUpdatedAt: number | null;
+  dirty: boolean;
+  ready: boolean;
+  sourceRevision: number;
+  status: ArtifactAutosaveStatus;
+  failure: "conflict" | "error" | null;
+  error: unknown;
+};
+
+type ArtifactAutosaveOptions<T> = {
+  initialValue: T;
+  initialUpdatedAt: number | null;
+  debounceMs?: number;
+  equals?: (left: T, right: T) => boolean;
+  isConflict: (error: unknown) => boolean;
+  write: (value: T, baseUpdatedAt: number | null) => Promise<ArtifactAutosaveResult>;
+  onSaved?: (value: T, result: ArtifactAutosaveResult) => void;
+};
+
+type InFlight<T> = {
+  id: number;
+  value: T;
+};
+
+const DEFAULT_DEBOUNCE_MS = 600;
+
+export class ArtifactAutosaveController<T> {
+  private readonly debounceMs: number;
+  private readonly equals: (left: T, right: T) => boolean;
+  private readonly isConflict: (error: unknown) => boolean;
+  private readonly write: ArtifactAutosaveOptions<T>["write"];
+  private readonly onSaved: ArtifactAutosaveOptions<T>["onSaved"];
+  private readonly listeners = new Set<() => void>();
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight: InFlight<T> | null = null;
+  private nextWriteId = 1;
+  private snapshot: ArtifactAutosaveSnapshot<T>;
+
+  constructor(options: ArtifactAutosaveOptions<T>) {
+    this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.equals = options.equals ?? Object.is;
+    this.isConflict = options.isConflict;
+    this.write = options.write;
+    this.onSaved = options.onSaved;
+    this.snapshot = {
+      value: options.initialValue,
+      baseUpdatedAt: options.initialUpdatedAt,
+      dirty: false,
+      ready: false,
+      sourceRevision: 0,
+      status: "idle",
+      failure: null,
+      error: null,
+    };
+  }
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getSnapshot = () => this.snapshot;
+
+  edit(value: T) {
+    if (this.equals(value, this.snapshot.value)) return;
+
+    this.update({ value, dirty: true, ready: true });
+    if (this.isStopped()) return;
+    if (this.inFlight) {
+      this.clearTimer();
+      return;
+    }
+    this.schedule();
+  }
+
+  acceptExternal(value: T, updatedAt: number | null) {
+    if (this.snapshot.dirty || this.inFlight || this.isStopped()) return false;
+    if (
+      this.snapshot.ready &&
+      typeof this.snapshot.baseUpdatedAt === "number" &&
+      typeof updatedAt === "number" &&
+      updatedAt < this.snapshot.baseUpdatedAt &&
+      this.equals(this.snapshot.value, value)
+    ) return false;
+    if (
+      this.snapshot.ready &&
+      this.snapshot.baseUpdatedAt === updatedAt &&
+      this.equals(this.snapshot.value, value)
+    ) return true;
+
+    this.clearTimer();
+    this.update({
+      value,
+      baseUpdatedAt: updatedAt,
+      dirty: false,
+      ready: true,
+      sourceRevision: this.snapshot.sourceRevision + 1,
+      status: "idle",
+      failure: null,
+      error: null,
+    });
+    return true;
+  }
+
+  applyReload(value: T, updatedAt: number | null) {
+    this.clearTimer();
+    this.update({
+      value,
+      baseUpdatedAt: updatedAt,
+      dirty: false,
+      ready: true,
+      sourceRevision: this.snapshot.sourceRevision + 1,
+      status: "idle",
+      failure: null,
+      error: null,
+    });
+  }
+
+  retry(baseUpdatedAt = this.snapshot.baseUpdatedAt) {
+    if (!this.snapshot.dirty || this.inFlight) return;
+    this.clearTimer();
+    this.update({ baseUpdatedAt });
+    this.startWrite(true);
+  }
+
+  flush() {
+    this.clearTimer();
+    if (this.snapshot.dirty && !this.inFlight && !this.isStopped()) {
+      this.startWrite();
+    }
+  }
+
+  dispose() {
+    this.flush();
+    this.listeners.clear();
+  }
+
+  private isStopped() {
+    return this.snapshot.failure !== null;
+  }
+
+  private schedule() {
+    this.clearTimer();
+    this.update({ status: "debouncing" });
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.startWrite();
+    }, this.debounceMs);
+  }
+
+  private startWrite(retrying = false) {
+    if (this.inFlight || !this.snapshot.dirty || (this.isStopped() && !retrying)) return;
+
+    const pending: InFlight<T> = { id: this.nextWriteId, value: this.snapshot.value };
+    this.nextWriteId += 1;
+    this.inFlight = pending;
+    this.update({ status: "saving" });
+
+    void this.write(pending.value, this.snapshot.baseUpdatedAt).then(
+      (result) => this.completeWrite(pending, result),
+      (error: unknown) => this.failWrite(pending, error),
+    );
+  }
+
+  private completeWrite(pending: InFlight<T>, result: ArtifactAutosaveResult) {
+    if (this.inFlight?.id !== pending.id) return;
+    this.inFlight = null;
+
+    if (this.equals(this.snapshot.value, pending.value)) {
+      this.update({
+        baseUpdatedAt: result.updatedAt,
+        dirty: false,
+        status: "idle",
+        failure: null,
+        error: null,
+      });
+      this.onSaved?.(pending.value, result);
+      return;
+    }
+
+    this.update({ baseUpdatedAt: result.updatedAt, dirty: true, status: "idle", failure: null, error: null });
+    this.startWrite();
+  }
+
+  private failWrite(pending: InFlight<T>, error: unknown) {
+    if (this.inFlight?.id !== pending.id) return;
+    this.inFlight = null;
+    const failure = this.isConflict(error) ? "conflict" : "error";
+    this.update({
+      dirty: true,
+      status: failure,
+      failure,
+      error,
+    });
+  }
+
+  private clearTimer() {
+    if (this.timer === null) return;
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private update(patch: Partial<ArtifactAutosaveSnapshot<T>>) {
+    this.snapshot = { ...this.snapshot, ...patch };
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,17 +1,20 @@
 /** @jsxImportSource react */
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
+import { lazy, Suspense, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
-import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import { OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
 import { isElectronRuntime } from "@/app/utils";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatFileSize } from "@/lib/utils";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { type ArtifactPanelTab, usePanelTabStore } from "../panel/panel-tab-store";
+import { ArtifactAutosaveController } from "./artifact-autosave";
+import { serializeSpreadsheet, type SpreadsheetRows } from "./artifact-spreadsheet-model";
 import { isCollectibleArtifactTarget, type BinaryData, type Data, type OpenTarget, type TextData } from "./open-target";
 import { HTMLPreview, ImagePreview, MarkdownPreview, PdfPreview, PlainText, PreviewError, PreviewLoading, PreviewUnavailable } from "./preview";
 
@@ -57,7 +60,19 @@ type ArtifactQueryState =
   | (TextData & { updatedAt: number | null })
   | (BinaryData & { contentType: string | null; updatedAt: number | null });
 
-type SaveArtifactInput = Data & { baseUpdatedAt: number | null };
+type SpreadsheetDraft = { kind: "spreadsheet"; rows: SpreadsheetRows };
+type ArtifactDraft = Data | SpreadsheetDraft;
+
+const autosaveControllers = new WeakMap<OpenworkServerClient, Map<string, ArtifactAutosaveController<ArtifactDraft>>>();
+const dirtyAutosaves = new Set<ArtifactAutosaveController<ArtifactDraft>>();
+
+function flushRetainedAutosaves() {
+  for (const autosave of dirtyAutosaves) autosave.flush();
+}
+
+function hasDirtyRetainedAutosave() {
+  return dirtyAutosaves.size > 0;
+}
 
 function absoluteWorkspacePath(root: string, path: string) {
   const cleanRoot = root.trim().replace(/[/\\]+$/, "");
@@ -68,6 +83,39 @@ function absoluteWorkspacePath(root: string, path: string) {
 
 function isTextContent(target: OpenTarget): boolean {
   return ["markdown", "text", "sheet", "html"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
+}
+
+function dataEquals(left: ArtifactDraft, right: ArtifactDraft) {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "spreadsheet" && right.kind === "spreadsheet") {
+    return left.rows.length === right.rows.length && left.rows.every((row, rowIndex) => {
+      const other = right.rows[rowIndex];
+      return other !== undefined && row.length === other.length && row.every((cell, columnIndex) => cell === other[columnIndex]);
+    });
+  }
+  if (left.kind === "text" && right.kind === "text") return left.data === right.data;
+  if (left.kind !== "binary" || right.kind !== "binary") return false;
+  if (left.data.byteLength !== right.data.byteLength) return false;
+  const leftBytes = new Uint8Array(left.data);
+  const rightBytes = new Uint8Array(right.data);
+  return leftBytes.every((value, index) => value === rightBytes[index]);
+}
+
+function isConflict(error: unknown) {
+  return error instanceof OpenworkServerError && error.status === 409;
+}
+
+function conflictUpdatedAt(error: unknown) {
+  if (!(error instanceof OpenworkServerError) || !error.details || typeof error.details !== "object") return null;
+  if (!("currentUpdatedAt" in error.details)) return null;
+  const value = error.details.currentUpdatedAt;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function editablePayload(data: ArtifactQueryState): ArtifactDraft {
+  return data.kind === "text"
+    ? { kind: "text", data: data.data }
+    : { kind: "binary", data: data.data };
 }
 
 export function ArtifactPanel({ sessionId, tab, client, workspaceId, workspaceRoot, isRemoteWorkspace = false, onClose }: ArtifactPanelProps) {
@@ -95,7 +143,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   const platform = usePlatform();
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState("");
+  const [reloading, setReloading] = useState(false);
   const isDirectTextEdit = isTextContent(target) && target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target);
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
   const canUseDesktopFileActions = target.kind === "file" && !isRemoteWorkspace && platform.capabilities.revealInFileManager;
@@ -124,15 +172,77 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
         return { kind: "text", data: result.content, updatedAt: result.updatedAt ?? null };
       }
 
+      const before = await client.statWorkspaceFile(workspaceId, target.value);
       const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+      const after = await client.statWorkspaceFile(workspaceId, target.value);
+      if (before.updatedAt !== after.updatedAt) {
+        throw new Error("The file changed while it was loading. Try again.");
+      }
 
-      return { kind: "binary", data: result.data, contentType: result.contentType, updatedAt: target.updatedAt ?? null };
+      return { kind: "binary", data: result.data, contentType: result.contentType, updatedAt: after.updatedAt ?? null };
     },
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     staleTime: Infinity,
     gcTime: 0,
   });
+
+  const autosave = useMemo(() => {
+    let controllers = autosaveControllers.get(client);
+    if (!controllers) {
+      controllers = new Map();
+      autosaveControllers.set(client, controllers);
+    }
+    const key = `${workspaceId}:${target.id}:${target.value}`;
+    const existing = controllers.get(key);
+    if (existing) return existing;
+
+    const queryKey = ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const;
+    const created = new ArtifactAutosaveController<ArtifactDraft>({
+      initialValue: isTextContent(target)
+        ? { kind: "text", data: "" }
+        : { kind: "binary", data: new ArrayBuffer(0) },
+      initialUpdatedAt: target.updatedAt ?? null,
+      equals: dataEquals,
+      isConflict,
+      write: async (payload, baseUpdatedAt) => {
+        if (target.kind !== "file") throw new Error("Cannot save non-file artifact.");
+        const serialized = payload.kind === "spreadsheet"
+          ? await serializeSpreadsheet(target.name, payload.rows)
+          : payload;
+        if (serialized.kind === "text") {
+          return client.writeWorkspaceFile(workspaceId, {
+            path: target.value,
+            content: serialized.data,
+            baseUpdatedAt,
+          });
+        }
+        return client.writeWorkspaceBinaryFile(workspaceId, {
+          path: target.value,
+          data: serialized.data,
+          baseUpdatedAt,
+        });
+      },
+      onSaved: (payload, result) => {
+        if (payload.kind === "spreadsheet") return;
+        queryClient.setQueryData<ArtifactQueryState>(queryKey, (current) => payload.kind === "text"
+          ? { kind: "text", data: payload.data, updatedAt: result.updatedAt }
+          : {
+              kind: "binary",
+              data: payload.data,
+              contentType: current?.kind === "binary" ? current.contentType : null,
+              updatedAt: result.updatedAt,
+            });
+      },
+    });
+    controllers.set(key, created);
+    created.subscribe(() => {
+      if (created.getSnapshot().dirty) dirtyAutosaves.add(created);
+      else dirtyAutosaves.delete(created);
+    });
+    return created;
+  }, [client, queryClient, target.id, target.kind, target.value, workspaceId]);
+  const autosaveState = useSyncExternalStore(autosave.subscribe, autosave.getSnapshot, autosave.getSnapshot);
 
   const [binaryObjectUrl, setBinaryObjectUrl] = useState<string | null>(null);
 
@@ -153,40 +263,35 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
 
   useEffect(() => {
     setEditing(false);
-    setDraft("");
   }, [target.id, workspaceId]);
 
   useEffect(() => {
-    if (data?.kind === "text") {
-      setDraft(data.data);
-    }
-  }, [data]);
+    if (!data) return;
+    autosave.acceptExternal(editablePayload(data), data.updatedAt);
+  }, [autosave, data]);
 
-  const { mutate, mutateAsync, isPending: isSaving } = useMutation({
-    mutationFn: async (input: SaveArtifactInput) => {
-      if (target.kind !== "file") {
-        throw new Error("Cannot save non-file artifact.");
-      }
+  useEffect(() => {
+    const flush = () => flushRetainedAutosaves();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      flush();
+      if (!hasDirtyRetainedAutosave()) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
 
-      if (input.kind === "text") {
-        return client.writeWorkspaceFile(workspaceId, { path: target.value, content: input.data, baseUpdatedAt: input.baseUpdatedAt });
-      }
-
-      return client.writeWorkspaceBinaryFile(workspaceId, { path: target.value, data: input.data, baseUpdatedAt: input.baseUpdatedAt });
-    },
-    onSuccess: (result, input) => {
-      queryClient.setQueryData<ArtifactQueryState>(
-        ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
-        input.kind === "text"
-          ? { kind: "text", data: input.data, updatedAt: result.updatedAt ?? null }
-          : { kind: "binary", data: input.data, contentType: data?.kind === "binary" ? data.contentType : null, updatedAt: result.updatedAt ?? null },
-      );
-
-      if (input.kind === "text") {
-        setDraft(input.data);
-      }
-    },
-  });
+    window.addEventListener("pagehide", flush);
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      flush();
+      window.removeEventListener("pagehide", flush);
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [autosave]);
 
   const download = async () => {
     if (target.kind === "url") {
@@ -232,30 +337,47 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     }
   };
 
-  const save = () => {
-    if (target.kind !== "file" || !isTextContent(target) || data?.kind !== "text") {
-      return;
+  const reloadExternal = async () => {
+    if (target.kind !== "file") return;
+    setReloading(true);
+    try {
+      let next: ArtifactQueryState;
+      if (isTextContent(target)) {
+        const result = await client.readWorkspaceFile(workspaceId, target.value);
+        const after = await client.statWorkspaceFile(workspaceId, target.value);
+        if (result.updatedAt !== after.updatedAt) {
+          throw new Error("The file changed while it was reloading. Try again.");
+        }
+        next = { kind: "text", data: result.content, updatedAt: result.updatedAt };
+      } else {
+        const before = await client.statWorkspaceFile(workspaceId, target.value);
+        const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+        const after = await client.statWorkspaceFile(workspaceId, target.value);
+        if (before.updatedAt !== after.updatedAt) {
+          throw new Error("The file changed while it was reloading. Try again.");
+        }
+        next = {
+          kind: "binary",
+          data: result.data,
+          contentType: result.contentType,
+          updatedAt: after.updatedAt ?? null,
+        };
+      }
+      autosave.applyReload(editablePayload(next), next.updatedAt);
+      queryClient.setQueryData(
+        ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
+        next,
+      );
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : "Could not reload this file.");
+    } finally {
+      setReloading(false);
     }
-
-    mutate(
-      {
-        kind: "text",
-        data: draft,
-        baseUpdatedAt: data.updatedAt,
-      },
-      { onSuccess: () => setEditing(false) },
-    );
   };
 
-  const saveSpreadsheetContent = async (payload: Data) => {
-    if (target.kind !== "file") {
-      return;
-    }
-
-    await mutateAsync({
-      ...payload,
-      baseUpdatedAt: data?.kind === payload.kind ? data.updatedAt : target.updatedAt ?? null,
-    });
+  const close = () => {
+    autosave.flush();
+    onClose();
   };
 
   return (
@@ -274,38 +396,9 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-          {isTextContent(target) && data?.kind === "text" ? (
-            editing || isDirectTextEdit ? (
-              <>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={(
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          if (data?.kind === "text") {
-                            setDraft(data.data);
-                          }
-                          setEditing(false);
-                        }}
-                        disabled={isSaving}
-                      >
-                        Discard
-                      </Button>
-                    )}
-                  />
-                  <TooltipContent>Discard changes</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={(
-                      <Button variant="default" size="sm" onClick={() => void save()} disabled={isSaving || draft === data.data}>{isSaving ? "Saving" : "Save"}</Button>
-                    )}
-                  />
-                  <TooltipContent>Save changes</TooltipContent>
-                </Tooltip>
-              </>
+          {isTextContent(target) && autosaveState.ready && !isDirectTextEdit ? (
+            editing ? (
+              <Button variant="ghost" size="sm" onClick={() => { autosave.flush(); setEditing(false); }}>Done</Button>
             ) : (
               <Tooltip>
                 <TooltipTrigger
@@ -356,7 +449,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
           <Tooltip>
             <TooltipTrigger
               render={(
-                <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact">
+                <Button variant="ghost" size="icon-sm" onClick={close} aria-label="Close artifact">
                   <X />
                 </Button>
               )}
@@ -366,21 +459,58 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
           </div>
         </div>
       </div>
+      {autosaveState.failure ? (
+        <div className="shrink-0 border-b border-border p-2">
+          <Alert variant="warning" className="rounded-lg py-2">
+            <AlertTriangle />
+            <AlertTitle>{autosaveState.failure === "conflict" ? "This file changed outside OpenWork" : "Changes could not be saved"}</AlertTitle>
+            <AlertDescription>
+              <p>
+                {autosaveState.failure === "conflict"
+                  ? "Review the external version, then reload it or retry with your newest edits."
+                  : autosaveState.error instanceof Error ? autosaveState.error.message : "Your newest edits are still here."}
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {autosaveState.failure === "conflict" ? (
+                  <Button variant="outline" size="xs" disabled={reloading || autosaveState.status === "saving"} onClick={() => void reloadExternal()}>
+                    {reloading ? "Reloading" : "Reload external version"}
+                  </Button>
+                ) : null}
+                <Button
+                  variant="default"
+                  size="xs"
+                  disabled={reloading || autosaveState.status === "saving"}
+                  onClick={() => autosave.retry(conflictUpdatedAt(autosaveState.error) ?? autosaveState.baseUpdatedAt)}
+                >
+                  {autosaveState.status === "saving" ? "Retrying" : "Retry newest changes"}
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-hidden">
-        {isLoading || (data?.kind === "binary" && !binaryObjectUrl) ? (
+        {(!autosaveState.ready && isLoading) || (target.preview !== "sheet" && data?.kind === "binary" && !binaryObjectUrl) ? (
           <PreviewLoading />
-        ) : isError ? (
+        ) : isError && !autosaveState.ready ? (
           <PreviewError message={error instanceof Error ? error.message : "Failed to load artifact" } />
-        ) : data?.kind === "text" && (editing || isDirectTextEdit) ? (
-          <TextEditor value={draft} language={target.preview === "markdown" ? "markdown" : "text"} onChange={setDraft} />
-        ) : target.preview === "markdown" && data?.kind === "text" ? (
-          <MarkdownPreview content={data.data} />
-        ) : target.preview === "sheet" ? (
+        ) : autosaveState.value.kind === "text" && (editing || isDirectTextEdit) ? (
+          <TextEditor
+            key={`${workspaceId}:${target.id}`}
+            value={autosaveState.value.data}
+            language={target.preview === "markdown" ? "markdown" : "text"}
+            onChange={(value) => autosave.edit({ kind: "text", data: value })}
+          />
+        ) : target.preview === "markdown" && autosaveState.value.kind === "text" ? (
+          <MarkdownPreview content={autosaveState.value.data} />
+        ) : target.preview === "sheet" && autosaveState.ready ? (
           <SheetEditor
+            key={`${workspaceId}:${target.id}`}
             name={target.name}
-            content={data ?? { kind: "binary", data: new ArrayBuffer(0) }}
-            saving={isSaving}
-            onSave={saveSpreadsheetContent}
+            source={autosaveState.value.kind === "spreadsheet"
+              ? { kind: "rows", rows: autosaveState.value.rows }
+              : { kind: "content", content: autosaveState.value, revision: autosaveState.sourceRevision }}
+            onChange={(rows) => autosave.edit({ kind: "spreadsheet", rows })}
           />
         ) : target.preview === "html" && data?.kind === "text" ? (
           <HTMLPreview type="text" title={target.name} content={data.data} />

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
@@ -1,19 +1,21 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import { Loader2, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { parseSpreadsheet, serializeSpreadsheet, type SpreadsheetRows } from "./artifact-spreadsheet-model";
 import { cn } from "@/lib/utils";
+import { parseSpreadsheet, type SpreadsheetRows } from "./artifact-spreadsheet-model";
 import type { Data } from "./open-target";
+
+type SpreadsheetSource =
+  | { kind: "content"; content: Data; revision: number }
+  | { kind: "rows"; rows: SpreadsheetRows };
 
 type ArtifactSpreadsheetEditorProps = {
   className?: string;
   name: string;
-  content: Data;
-  saving?: boolean;
-  onSave: (payload: Data) => void | Promise<void>;
+  source: SpreadsheetSource;
+  onChange: (rows: SpreadsheetRows) => void;
 };
 
 function cloneRows(rows: SpreadsheetRows): SpreadsheetRows {
@@ -22,70 +24,73 @@ function cloneRows(rows: SpreadsheetRows): SpreadsheetRows {
 
 function normalizeShape(rows: SpreadsheetRows): SpreadsheetRows {
   const width = Math.max(1, ...rows.map((row) => row.length));
-
   return rows.map((row) => Array.from({ length: width }, (_, index) => row[index] ?? ""));
 }
 
-interface UseSpreadsheetProps {
-  name: string;
-  content: Data;
-  onSave: (payload: Data) => void | Promise<void>;
-}
-
-function useSpreadsheet({ name, content, onSave }: UseSpreadsheetProps) {
-  const { data, error, isLoading } = useQuery({
-    queryKey: ["artifact-spreadsheet", name, content] as const,
-    queryFn: async () => normalizeShape(await parseSpreadsheet({ name, content })),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    staleTime: Infinity,
-  });
-
-  const [rows, setRows] = useState<SpreadsheetRows>([[""]]);
-  const [baseRows, setBaseRows] = useState<SpreadsheetRows>([[""]]);
-  const isDirty = useMemo(() => JSON.stringify(rows) !== JSON.stringify(baseRows), [baseRows, rows]);
+export function ArtifactSpreadsheetEditor(props: ArtifactSpreadsheetEditorProps) {
+  const initialRows = props.source.kind === "rows" ? cloneRows(props.source.rows) : [[""]];
+  const [rows, setRows] = useState<SpreadsheetRows>(initialRows);
+  const rowsRef = useRef(rows);
+  const [error, setError] = useState<unknown>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const onChangeRef = useRef(props.onChange);
 
   useEffect(() => {
-    if (!data) {
+    onChangeRef.current = props.onChange;
+  }, [props.onChange]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (props.source.kind === "rows") {
+      const nextRows = cloneRows(props.source.rows);
+      rowsRef.current = nextRows;
+      setRows(nextRows);
+      setIsLoading(false);
+      setError(null);
       return;
     }
+    setIsLoading(true);
+    setError(null);
+    void parseSpreadsheet({ name: props.name, content: props.source.content }).then(
+      (nextRows) => {
+        if (cancelled) return;
+        const normalizedRows = normalizeShape(nextRows);
+        rowsRef.current = normalizedRows;
+        setRows(normalizedRows);
+        setIsLoading(false);
+      },
+      (cause: unknown) => {
+        if (cancelled) return;
+        setError(cause);
+        setIsLoading(false);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [props.name, props.source.kind === "content" ? props.source.revision : null]);
 
-    setRows(data);
-    setBaseRows(cloneRows(data));
-  }, [data]);
-
-  const { mutate: save, isPending: isSaving } = useMutation({
-    mutationFn: async () => {
-      const serialized = await serializeSpreadsheet(name, rows);
-
-      await onSave(serialized);
-    },
-    onSuccess: () => {
-      setBaseRows(cloneRows(rows));
-    },
-  });
+  const updateRows = (update: (current: SpreadsheetRows) => SpreadsheetRows) => {
+    const next = normalizeShape(update(rowsRef.current));
+    rowsRef.current = next;
+    setRows(next);
+    onChangeRef.current(next);
+  };
 
   const updateCell = (rowIndex: number, columnIndex: number, value: string) => {
-    setRows((current) => {
+    updateRows((current) => {
       const next = cloneRows(current);
-
       next[rowIndex] = [...(next[rowIndex] ?? [])];
       next[rowIndex][columnIndex] = value;
-
-      return normalizeShape(next);
+      return next;
     });
   };
 
-  const addRow = () => setRows((current) => [...current, Array.from({ length: Math.max(1, current[0]?.length ?? 1) }, () => "")]);
-  const addColumn = () => setRows((current) => current.map((row) => [...row, ""]));
-  const discard = () => setRows(cloneRows(baseRows));
-
-  return { rows, error, isLoading, updateCell, addRow, addColumn, discard, isDirty, save, isSaving };
-}
-
-export function ArtifactSpreadsheetEditor(props: ArtifactSpreadsheetEditorProps) {
-  const { rows, error, isLoading, updateCell, addRow, addColumn, discard, isDirty, save, isSaving } = useSpreadsheet(props);
-  const saving = props.saving || isSaving;
+  const addRow = () => updateRows((current) => [
+    ...current,
+    Array.from({ length: Math.max(1, current[0]?.length ?? 1) }, () => ""),
+  ]);
+  const addColumn = () => updateRows((current) => current.map((row) => [...row, ""]));
 
   if (isLoading) {
     return (
@@ -98,19 +103,16 @@ export function ArtifactSpreadsheetEditor(props: ArtifactSpreadsheetEditorProps)
   if (error) {
     return (
       <div className="p-4 text-sm text-muted-foreground">
-        {error instanceof Error ? error.message : "Failed to parse spreadsheet"}
+        {error instanceof Error ? error.message : "Failed to prepare spreadsheet"}
       </div>
     );
   }
 
   return (
     <div className={cn("flex h-full min-h-0 flex-col", props.className)}>
-      <div className="flex shrink-0 items-center gap-2 px-3 py-2 border-b border-border">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
         <Button variant="ghost" size="xs" onClick={addRow}><Plus className="size-3" /> Row</Button>
         <Button variant="ghost" size="xs" onClick={addColumn}><Plus className="size-3" /> Column</Button>
-        <div className="min-w-0 flex-1" />
-        <Button variant="ghost" size="xs" onClick={discard} disabled={!isDirty || saving}>Discard</Button>
-        <Button variant="default" size="xs" onClick={() => save()} disabled={!isDirty || saving}>{saving ? "Saving" : "Save"}</Button>
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
         <table className="w-full border-collapse text-xs">

--- a/apps/app/tests/artifact-autosave.test.ts
+++ b/apps/app/tests/artifact-autosave.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, jest, test } from "bun:test";
+
+import { ArtifactAutosaveController } from "../src/react-app/domains/session/artifacts/artifact-autosave";
+
+type PendingWrite = {
+  value: string;
+  baseUpdatedAt: number | null;
+  resolve: (result: { updatedAt: number }) => void;
+  reject: (error: unknown) => void;
+};
+
+const conflict = new Error("conflict");
+
+function setup() {
+  const writes: PendingWrite[] = [];
+  const saved: string[] = [];
+  const controller = new ArtifactAutosaveController<string>({
+    initialValue: "",
+    initialUpdatedAt: null,
+    debounceMs: 500,
+    isConflict: (error) => error === conflict,
+    write: (value, baseUpdatedAt) => new Promise((resolve, reject) => {
+      writes.push({ value, baseUpdatedAt, resolve, reject });
+    }),
+    onSaved: (value) => saved.push(value),
+  });
+  controller.acceptExternal("one", 1);
+  return { controller, saved, writes };
+}
+
+async function drainMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("artifact autosave lifecycle", () => {
+  test("debounces and coalesces edits into the newest payload", async () => {
+    jest.useFakeTimers();
+    const { controller, writes } = setup();
+
+    controller.edit("two");
+    jest.advanceTimersByTime(300);
+    controller.edit("three");
+    jest.advanceTimersByTime(499);
+    expect(writes).toHaveLength(0);
+
+    jest.advanceTimersByTime(1);
+    expect(writes).toMatchObject([{ value: "three", baseUpdatedAt: 1 }]);
+    writes[0]!.resolve({ updatedAt: 2 });
+    await drainMicrotasks();
+    expect(controller.getSnapshot()).toMatchObject({ dirty: false, baseUpdatedAt: 2, status: "idle" });
+  });
+
+  test("orders one write at a time and saves edits made during a write against its matching result", async () => {
+    jest.useFakeTimers();
+    const { controller, saved, writes } = setup();
+
+    controller.edit("two");
+    jest.advanceTimersByTime(500);
+    controller.edit("three");
+    controller.edit("four");
+    expect(writes).toMatchObject([{ value: "two", baseUpdatedAt: 1 }]);
+
+    writes[0]!.resolve({ updatedAt: 2 });
+    await drainMicrotasks();
+    expect(writes).toMatchObject([
+      { value: "two", baseUpdatedAt: 1 },
+      { value: "four", baseUpdatedAt: 2 },
+    ]);
+    expect(controller.getSnapshot()).toMatchObject({ value: "four", dirty: true, baseUpdatedAt: 2 });
+    expect(saved).toEqual([]);
+
+    writes[1]!.resolve({ updatedAt: 3 });
+    await drainMicrotasks();
+    expect(controller.getSnapshot()).toMatchObject({ value: "four", dirty: false, baseUpdatedAt: 3 });
+    expect(saved).toEqual(["four"]);
+  });
+
+  test("stops on conflict and retries only the newest draft against the reviewed base", async () => {
+    jest.useFakeTimers();
+    const { controller, writes } = setup();
+
+    controller.edit("two");
+    jest.advanceTimersByTime(500);
+    writes[0]!.reject(conflict);
+    await drainMicrotasks();
+    expect(controller.getSnapshot()).toMatchObject({ dirty: true, failure: "conflict", baseUpdatedAt: 1 });
+
+    controller.edit("newest");
+    jest.advanceTimersByTime(5_000);
+    expect(writes).toHaveLength(1);
+    controller.retry(9);
+    expect(writes[1]).toMatchObject({ value: "newest", baseUpdatedAt: 9 });
+    expect(controller.getSnapshot()).toMatchObject({ failure: "conflict", status: "saving" });
+
+    writes[1]!.resolve({ updatedAt: 10 });
+    await drainMicrotasks();
+    expect(controller.getSnapshot()).toMatchObject({ dirty: false, failure: null, baseUpdatedAt: 10 });
+  });
+
+  test("keeps the newest draft after a retryable failure", async () => {
+    jest.useFakeTimers();
+    const { controller, writes } = setup();
+    const failure = new Error("offline");
+
+    controller.edit("two");
+    jest.advanceTimersByTime(500);
+    writes[0]!.reject(failure);
+    await drainMicrotasks();
+    controller.edit("latest while offline");
+    expect(controller.getSnapshot()).toMatchObject({ value: "latest while offline", failure: "error", error: failure });
+
+    controller.retry();
+    expect(writes[1]).toMatchObject({ value: "latest while offline", baseUpdatedAt: 1 });
+  });
+
+  test("explicit reload clears stopped state and replaces the draft", async () => {
+    jest.useFakeTimers();
+    const { controller, writes } = setup();
+    const sourceRevision = controller.getSnapshot().sourceRevision;
+
+    controller.edit("local");
+    jest.advanceTimersByTime(500);
+    writes[0]!.reject(conflict);
+    await drainMicrotasks();
+    controller.applyReload("external", 8);
+
+    expect(controller.getSnapshot()).toMatchObject({
+      value: "external",
+      baseUpdatedAt: 8,
+      dirty: false,
+      failure: null,
+      sourceRevision: sourceRevision + 1,
+    });
+  });
+
+  test("ignores stale external refreshes while dirty or saving", () => {
+    jest.useFakeTimers();
+    const { controller } = setup();
+
+    controller.edit("local");
+    expect(controller.acceptExternal("stale", 2)).toBe(false);
+    expect(controller.getSnapshot()).toMatchObject({ value: "local", baseUpdatedAt: 1, dirty: true });
+  });
+
+  test("accepts an external refresh when the local draft is clean", () => {
+    const { controller } = setup();
+    const sourceRevision = controller.getSnapshot().sourceRevision;
+
+    expect(controller.acceptExternal("external", 2)).toBe(true);
+    expect(controller.getSnapshot()).toMatchObject({
+      value: "external",
+      baseUpdatedAt: 2,
+      dirty: false,
+      sourceRevision: sourceRevision + 1,
+    });
+  });
+
+  test("does not roll back a matching clean payload to stale target metadata", () => {
+    const { controller } = setup();
+    const sourceRevision = controller.getSnapshot().sourceRevision;
+
+    expect(controller.acceptExternal("one", 0)).toBe(false);
+    expect(controller.getSnapshot()).toMatchObject({
+      value: "one",
+      baseUpdatedAt: 1,
+      dirty: false,
+      sourceRevision,
+    });
+  });
+
+  test("flushes a pending debounce during lifecycle cleanup", () => {
+    jest.useFakeTimers();
+    const { controller, writes } = setup();
+
+    controller.edit("pending");
+    controller.dispose();
+    expect(writes).toMatchObject([{ value: "pending", baseUpdatedAt: 1 }]);
+    jest.advanceTimersByTime(1_000);
+    expect(writes).toHaveLength(1);
+  });
+});

--- a/apps/app/tests/artifact-editor-components.test.ts
+++ b/apps/app/tests/artifact-editor-components.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function source(relativePath: string) {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+describe("artifact editor components", () => {
+  test("keeps Markdown live preview while delegating every edit to autosave", () => {
+    const textEditor = source("../src/react-app/domains/session/artifacts/artifact-text-editor.tsx");
+    const panel = source("../src/react-app/domains/session/artifacts/artifact-panel.tsx");
+
+    expect(textEditor).toContain("markdownLivePreview()");
+    expect(panel).toContain("autosave.edit({ kind: \"text\", data: value })");
+    expect(panel).not.toMatch(/>\s*(?:Save|Discard)\s*</);
+  });
+
+  test("keeps spreadsheet format support and removes manual persistence controls", () => {
+    const editor = source("../src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx");
+    const model = source("../src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts");
+    const panel = source("../src/react-app/domains/session/artifacts/artifact-panel.tsx");
+
+    expect(editor).toContain("SpreadsheetSource");
+    expect(editor).toContain("onChangeRef.current(next)");
+    expect(editor).not.toContain("serializeSpreadsheet");
+    expect(panel).toContain("await serializeSpreadsheet(target.name, payload.rows)");
+    expect(editor).not.toMatch(/>\s*(?:Save|Discard)\s*</);
+    expect(model).toContain('ext === "csv" || ext === "tsv"');
+    expect(model).toContain('ext === "xls" ? "xls" : ext === "ods" ? "ods" : "xlsx"');
+  });
+
+  test("renders persistent conflict recovery choices in the shared panel", () => {
+    const panel = source("../src/react-app/domains/session/artifacts/artifact-panel.tsx");
+
+    expect(panel).toContain("This file changed outside OpenWork");
+    expect(panel).toContain("Reload external version");
+    expect(panel).toContain("Retry newest changes");
+  });
+
+  test("protects retained target drafts and reads binary baselines authoritatively", () => {
+    const panel = source("../src/react-app/domains/session/artifacts/artifact-panel.tsx");
+
+    expect(panel).toContain("dirtyAutosaves");
+    expect(panel).toContain("flushRetainedAutosaves()");
+    expect(panel).toContain("before.updatedAt !== after.updatedAt");
+    expect(panel).toContain("updatedAt: after.updatedAt ?? null");
+    expect(panel).toContain('key={`${workspaceId}:${target.id}`}');
+  });
+});

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -30,6 +30,12 @@ async function createWorkspaceRoot() {
 }
 
 async function startOpenworkServer(workspaceRoot: string) {
+  const previousDataDir = process.env.OPENWORK_DATA_DIR;
+  process.env.OPENWORK_DATA_DIR = join(workspaceRoot, ".openwork-test-data");
+  stops.push(() => {
+    if (previousDataDir === undefined) delete process.env.OPENWORK_DATA_DIR;
+    else process.env.OPENWORK_DATA_DIR = previousDataDir;
+  });
   const config: ServerConfig = {
     host: "127.0.0.1",
     port: 0,
@@ -46,9 +52,20 @@ async function startOpenworkServer(workspaceRoot: string) {
     logFormat: "pretty",
     logRequests: false,
   };
-  const server = await startServer(config) as Served;
+  const transport: { fetch?: (request: Request) => Response | Promise<Response> } = {};
+  const server = await startServer(config, {
+    serve: async (options) => {
+      transport.fetch = options.fetch;
+      return { port: 0, stop: () => {} };
+    },
+  }) as Served;
   stops.push(() => server.stop(true));
-  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+  const dispatch = transport.fetch;
+  if (!dispatch) throw new Error("Expected the in-process server handler");
+  return {
+    request: (path: string, init?: RequestInit) => dispatch(new Request(`http://openwork.test${path}`, init)),
+    token: config.token,
+  };
 }
 
 function auth(token: string) {
@@ -58,9 +75,9 @@ function auth(token: string) {
 describe("artifact file routes", () => {
   test("resolve, read, write, and download markdown/csv/xlsx/pptx/docx/html artifacts", async () => {
     const root = await createWorkspaceRoot();
-    const { base, token } = await startOpenworkServer(root);
+    const { request, token } = await startOpenworkServer(root);
 
-    const resolveResponse = await fetch(`${base}/workspace/ws_1/artifacts/resolve`, {
+    const resolveResponse = await request("/workspace/ws_1/artifacts/resolve", {
       method: "POST",
       headers: auth(token),
       body: JSON.stringify({
@@ -90,10 +107,10 @@ describe("artifact file routes", () => {
     expect(resolved.items.find((item) => item.value === "http://localhost:4321/")).toMatchObject({ kind: "url", preview: "browser" });
     expect(resolved.items.find((item) => item.value === "ws://localhost:4321/socket")).toMatchObject({ kind: "url", preview: "browser" });
 
-    const csvRead = await fetch(`${base}/workspace/ws_1/files/content?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
+    const csvRead = await request(`/workspace/ws_1/files/content?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
     expect(await csvRead.json()).toMatchObject({ content: "name,revenue\nAda,10\nGrace,20\n" });
 
-    const mdWrite = await fetch(`${base}/workspace/ws_1/files/content`, {
+    const mdWrite = await request("/workspace/ws_1/files/content", {
       method: "POST",
       headers: auth(token),
       body: JSON.stringify({ path: "reports/artifact-eval.md", content: "# Updated\n" }),
@@ -101,15 +118,59 @@ describe("artifact file routes", () => {
     expect(mdWrite.status).toBe(200);
     expect(await readFile(join(root, "reports", "artifact-eval.md"), "utf8")).toBe("# Updated\n");
 
-    const xlsxWrite = await fetch(`${base}/workspace/ws_1/files/raw`, {
+    const xlsxWrite = await request("/workspace/ws_1/files/raw", {
       method: "POST",
       headers: auth(token),
       body: JSON.stringify({ path: "reports/artifact-eval.xlsx", dataBase64: Buffer.from([80, 75, 9, 9]).toString("base64") }),
     });
     expect(xlsxWrite.status).toBe(200);
 
-    const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
+    const xlsxDownload = await request(`/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
     expect(xlsxDownload.status).toBe(200);
     expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
+  });
+
+  test("rejects stale text and binary writes without replacing external changes", async () => {
+    const root = await createWorkspaceRoot();
+    const { request, token } = await startOpenworkServer(root);
+    const markdownPath = join(root, "reports", "artifact-eval.md");
+    const binaryPath = join(root, "reports", "artifact-eval.xlsx");
+
+    const markdownBase = (await stat(markdownPath)).mtimeMs;
+    await writeFile(markdownPath, "# External markdown\n", "utf8");
+    await utimes(markdownPath, new Date(), new Date(markdownBase + 2_000));
+    const markdownCurrent = (await stat(markdownPath)).mtimeMs;
+
+    const staleMarkdownWrite = await request("/workspace/ws_1/files/content", {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ path: "reports/artifact-eval.md", content: "# Stale local markdown\n", baseUpdatedAt: markdownBase }),
+    });
+    expect(staleMarkdownWrite.status).toBe(409);
+    expect(await staleMarkdownWrite.json()).toMatchObject({
+      code: "conflict",
+      details: { baseUpdatedAt: markdownBase, currentUpdatedAt: markdownCurrent },
+    });
+    expect(await readFile(markdownPath, "utf8")).toBe("# External markdown\n");
+
+    const binaryBase = (await stat(binaryPath)).mtimeMs;
+    await writeFile(binaryPath, new Uint8Array([80, 75, 7, 7]));
+    await utimes(binaryPath, new Date(), new Date(binaryBase + 2_000));
+    const binaryCurrent = (await stat(binaryPath)).mtimeMs;
+    const staleBinaryWrite = await request("/workspace/ws_1/files/raw", {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        path: "reports/artifact-eval.xlsx",
+        dataBase64: Buffer.from([80, 75, 8, 8]).toString("base64"),
+        baseUpdatedAt: binaryBase,
+      }),
+    });
+    expect(staleBinaryWrite.status).toBe(409);
+    expect(await staleBinaryWrite.json()).toMatchObject({
+      code: "conflict",
+      details: { baseUpdatedAt: binaryBase, currentUpdatedAt: binaryCurrent },
+    });
+    expect(Array.from(await readFile(binaryPath))).toEqual([80, 75, 7, 7]);
   });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -836,7 +836,10 @@ function isSessionCommandProxyRequest(method: string, proxyPath: string) {
   return method === "POST" && /^\/session\/[^/]+\/command$/.test(normalizeOpencodeProxyPath(proxyPath));
 }
 
-export async function startServer(config: ServerConfig): Promise<ServeResult> {
+export async function startServer(
+  config: ServerConfig,
+  options?: { serve?: typeof serve },
+): Promise<ServeResult> {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
   const tokens = new TokenService(config);
@@ -1021,7 +1024,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
 
   let server: ServeResult;
   try {
-    server = await serve({
+    server = await (options?.serve ?? serve)({
       ...serverOptions,
       idleTimeout: 120,
     });


### PR DESCRIPTION
## Summary

Replaces manual Markdown and spreadsheet Save/Discard controls with a debounced, ordered autosave lifecycle that protects newer edits, handles conflicts, and exposes actionable recovery.

## What changed

- Coalesces rapid edits and serializes writes so older completions cannot overwrite newer local content.
- Advances `baseUpdatedAt` only from the matching successful write.
- Preserves dirty edits during serialization, transport failures, target changes, and lifecycle flushing.
- Stops automatic writes on HTTP 409 and presents clear reload or retry recovery.
- Removes redundant manual persistence controls while preserving Markdown preview and spreadsheet format support.
- Adds a narrow in-process server transport seam for authenticated artifact-route tests; production startup still uses the normal adapter.

## Why

The server already enforces optimistic concurrency, but the editors issued independent manual writes and did not provide a safe autosave, conflict, or retry lifecycle. This change makes persistence continuous without allowing stale responses to replace newer edits.

## Verification

- Focused autosave/editor/spreadsheet tests: 15 passed, 0 failed.
- Server artifact and workspace tests: 25 passed, 0 failed.
- OpenWork app typecheck: passed.
- OpenWork server typecheck: passed.
- OpenWork UI build: passed.
- OpenWork server build: passed.
- `git diff --check`: passed.
- The eight feature files are byte-for-byte identical to the operator-reviewed Mix Tape integration.

Automated Fraimz proof was not rerun on this clean upstream-facing commit. Full repository and cross-platform checks are delegated to PR CI.

## Exact candidate

- Base: `319e0719134479901c9160201c390d6696a283bb`
- Head: `988234484`
- Branch: `reachjalil:feature/codex-artifact-editor-autosave-v3`

## Lineage

