### PR TITLE
Deduplicate live Thinking feedback

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1142,15 +1142,31 @@ export function shouldShowMessageListLoading(status: ThreadStatus, messageCount:
   return status === "streaming" || (status === "submitted" && messageCount > 0)
 }
 
+export function hasVisibleStreamingReasoning(messages: UIMessage[], showThinking: boolean) {
+  if (!showThinking) return false
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message.role !== "assistant") return false
+    if (message.parts.some((part) =>
+      part.type === "reasoning" && part.state === "streaming" && part.text.trim()
+    )) return true
+  }
+
+  return false
+}
+
 export function MessageList({ messages, status, retryStatus }: MessageListProps) {
+  const { showThinking } = useMessageList()
   const isStreaming = status === "streaming" || status === "retrying"
-  const showLoading = shouldShowMessageListLoading(status, messages.length)
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
   const liveActionLabel = isStreaming
     ? getActiveToolLabel(collectToolParts(messages))
     : null
+  const showLoading = shouldShowMessageListLoading(status, messages.length)
+    && (liveActionLabel !== null || !hasVisibleStreamingReasoning(messages, showThinking))
 
   return (
     <div className={cn("flex flex-col gap-2 @container/message-list")}>

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { UIMessage } from "ai";
 
 import {
+  hasVisibleStreamingReasoning,
   MessageList,
   shouldShowMessageListLoading,
 } from "../src/components/chat/message-list";
@@ -16,7 +17,11 @@ const userMessage: UIMessage = {
   parts: [{ type: "text", text: "Send this", state: "done" }],
 };
 
-function renderList(messages: UIMessage[], status: ThreadStatus) {
+function renderList(
+  messages: UIMessage[],
+  status: ThreadStatus,
+  retryStatus?: React.ComponentProps<typeof MessageList>["retryStatus"],
+) {
   return renderToStaticMarkup(
     <MessageListProvider
       workspaceId="ws"
@@ -34,7 +39,7 @@ function renderList(messages: UIMessage[], status: ThreadStatus) {
       onMcpReopenAuthorization={() => Promise.resolve()}
       onMcpRetry={() => {}}
     >
-      <MessageList messages={messages} status={status} />
+      <MessageList messages={messages} status={status} retryStatus={retryStatus} />
     </MessageListProvider>,
   );
 }
@@ -51,10 +56,72 @@ describe("message-list loading feedback", () => {
     expect(shouldShowMessageListLoading("submitted", 0)).toBe(false);
   });
 
-  test("keeps the same loading treatment when streaming begins", () => {
+  test("keeps Thinking visible during plain streaming", () => {
     const markup = renderList([userMessage], "streaming");
 
     expect(markup).toContain("Thinking…");
     expect(markup).not.toContain("Loading…");
+  });
+
+  test("uses streaming reasoning as the single Thinking treatment", () => {
+    const assistantMessage: UIMessage = {
+      id: "assistant-reasoning",
+      role: "assistant",
+      parts: [{ type: "reasoning", text: "Working this through", state: "streaming" }],
+    };
+    const messages = [userMessage, assistantMessage];
+    const markup = renderList(messages, "streaming");
+
+    expect(hasVisibleStreamingReasoning(messages, true)).toBe(true);
+    expect(hasVisibleStreamingReasoning(messages, false)).toBe(false);
+    expect(markup.match(/Thinking…/g)).toHaveLength(1);
+    expect(markup).toContain("data-reasoning-block");
+  });
+
+  test("preserves the active tool label", () => {
+    const assistantMessage: UIMessage = {
+      id: "assistant-tool",
+      role: "assistant",
+      parts: [{
+        type: "dynamic-tool",
+        toolName: "custom_capability",
+        toolCallId: "tool-1",
+        state: "input-available",
+        input: {},
+      }],
+    };
+    const markup = renderList([userMessage, assistantMessage], "streaming");
+
+    expect(markup).toContain("Running custom capability");
+    expect(markup).not.toContain("Thinking…");
+  });
+
+  test("shows retry feedback without a generic Thinking row", () => {
+    const markup = renderList([userMessage], "retrying", {
+      type: "retry",
+      attempt: 2,
+      message: "Temporarily unavailable",
+      next: Date.now() + 5_000,
+    });
+
+    expect(markup).toContain("Temporarily unavailable");
+    expect(markup).toContain("attempt 2");
+    expect(markup).not.toContain("Thinking…");
+  });
+
+  test("keeps completed Thought history without live feedback", () => {
+    const assistantMessage: UIMessage = {
+      id: "assistant-complete",
+      role: "assistant",
+      parts: [
+        { type: "reasoning", text: "Finished reasoning", state: "done" },
+        { type: "text", text: "Complete", state: "done" },
+      ],
+    };
+    const markup = renderList([userMessage, assistantMessage], "ready");
+
+    expect(markup).toContain("Thought");
+    expect(markup).not.toContain("Thinking…");
+    expect(markup).toContain("Complete");
   });
 });


### PR DESCRIPTION
## Summary

Prevents the chat timeline from showing duplicate live “Thinking…” treatments while preserving immediate feedback before streaming begins.

## What changed

- Keeps the generic loading row during the submitted state.
- Suppresses that generic row once live reasoning or a more specific activity treatment is visible.
- Preserves plain-streaming feedback, active-tool labels, retry and error behavior, grouping, and completed Thought history.
- Adds focused coverage for submitted, streaming, reasoning, grouping, retry, and completion behavior.

## Why

The submitted-state acknowledgement and the streaming reasoning row can currently render at the same time with the same “Thinking…” label. The fix keeps the immediate acknowledgement but ensures only one live treatment is visible once specific activity exists.

## Verification

- Focused message-list tests: 7 passed, 0 failed.
- OpenWork app typecheck: passed.
- OpenWork UI build: passed.
- `git diff --check`: passed.
- Both feature files are byte-for-byte identical to the operator-reviewed Mix Tape integration.

Automated Fraimz proof was not rerun on this clean upstream-facing commit. Full repository and cross-platform checks are delegated to PR CI.

## Exact candidate

- Base: `319e0719134479901c9160201c390d6696a283bb`
- Head: `d17734ae4`
- Branch: `reachjalil:feature/codex-chat-thinking-dedup-v3`

## Lineage

