### PR TITLE
fix(den): disable BotID enforcement by default

### DIFF
--- a/ee/apps/den-api/src/bot-protection.ts
+++ b/ee/apps/den-api/src/bot-protection.ts
@@ -6,12 +6,20 @@ export type BotProtectionResult =
   | { ok: false; status: 403; message: string }
 
 export async function verifyBotProtection(): Promise<BotProtectionResult> {
-  if (env.devMode) {
+  // Temporarily default BotID enforcement off until Den Web can initialize
+  // BotID client protection on the browser-facing /api/den proxy routes.
+  // Without that client-side setup, checkBotId() throws a Vercel
+  // misconfiguration error and breaks login with a 500.
+  if (env.devMode || !env.botIdProtectionEnabled) {
     return { ok: true }
   }
 
-  const result = await checkBotId()
-  if (result.isBot) {
+  try {
+    const result = await checkBotId()
+    if (result.isBot) {
+      return { ok: false, status: 403, message: "Request verification failed." }
+    }
+  } catch {
     return { ok: false, status: 403, message: "Request verification failed." }
   }
 

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -51,6 +51,7 @@ const EnvSchema = z.object({
   LINEAR_API_BASE: z.string().optional(),
   LINEAR_COMPLIANCE_COMPLETED_STATE_ID: z.string().optional(),
   OPENWORK_DEV_MODE: z.string().optional(),
+  DEN_BOTID_PROTECTION_ENABLED: z.string().optional(),
   DEN_ALLOW_PRIVATE_MCP_URLS: z.string().optional(),
   DEN_DIAGNOSTICS_ORIGIN: z.string().optional(),
   DEN_DIAGNOSTICS_BEARER_TOKEN: z.string().optional(),
@@ -372,6 +373,7 @@ const mcpConnectionsGatingEnabled =
   (parsed.DEN_MCP_CONNECTIONS_GATING_ENABLED ?? "false").toLowerCase() === "true"
 
 const devMode = (parsed.OPENWORK_DEV_MODE ?? "0").trim() === "1"
+const botIdProtectionEnabled = (parsed.DEN_BOTID_PROTECTION_ENABLED ?? "0").trim() === "1"
 const diagnosticsOrigin = normalizeDiagnosticsOrigin(parsed.DEN_DIAGNOSTICS_ORIGIN, devMode)
 const diagnosticsBearerToken = optionalString(parsed.DEN_DIAGNOSTICS_BEARER_TOKEN)
 if (diagnosticsBearerToken && diagnosticsBearerToken.length < 24) {
@@ -431,6 +433,7 @@ export const env = {
   // are treated as suffix matches, e.g. ".example.com".
   webAppHosts: splitCsv(parsed.DEN_WEB_APP_HOSTS).map((host) => host.toLowerCase()),
   devMode,
+  botIdProtectionEnabled,
   allowPrivateMcpUrls,
   diagnostics: {
     origin: diagnosticsOrigin,


### PR DESCRIPTION
## Summary
- temporarily default Den API BotID enforcement off behind DEN_BOTID_PROTECTION_ENABLED=1
- keep dev mode bypass and convert BotID misconfiguration/verification exceptions into generic 403 when explicitly enabled
- add comments explaining this is a temporary guard until Den Web client-side BotID protection is wired to /api/den routes

## Tests
- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/sso-resolve-route.test.ts test/auth-login-options.test.ts
- pnpm --filter @openwork-ee/den-api exec tsc --noEmit
- git diff --check
