### PR TITLE
ci: add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary\n- Add Dependabot npm version-update configuration for the root pnpm workspace\n- Set a 3-day cooldown so routine Dependabot updates align with pnpm minimumReleaseAge\n\n## Verification\n- ruby -e 'require "yaml"; p YAML.load_file(".github/dependabot.yml")'\n\n## Notes\n- Dependabot cooldown applies to version updates, not security updates, so vulnerability PRs can still open immediately.\n- Fraimz not run: config-only CI/dependency scheduling change with no runtime UI path.