### PR TITLE
Report Cloud MCP failures to Sentry

### DIFF
--- a/apps/app/src/app/lib/den-telemetry.ts
+++ b/apps/app/src/app/lib/den-telemetry.ts
@@ -22,7 +22,7 @@ export type TelemetryDimensionInput = {
   metadata?: Record<string, unknown>;
 };
 
-type TelemetryEventFields = {
+export type TelemetryEventFields = {
   sessionId?: string;
   durationMs?: number;
   success?: boolean;

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-sentry.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-sentry.ts
@@ -1,0 +1,226 @@
+import {
+  type TelemetryDimensionInput,
+  type TelemetryEventFields,
+  trackTelemetryEvent,
+} from "../../../app/lib/den-telemetry";
+import { sanitizeDiagnosticString } from "../../../app/lib/diagnostic-sanitizer";
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+} from "../../../app/lib/openwork-server";
+
+type CloudMcpFailureSummary = Pick<OpenworkCloudMcpFailure, "code" | "stage" | "retryable">;
+type CloudMcpTelemetryTrack = (type: string, fields: TelemetryEventFields) => void;
+
+const lastReportedFingerprintByTarget = new Map<string, string>();
+const SAFE_DIMENSION_VALUE_PATTERN = /^[a-z0-9][a-z0-9_.:-]{0,127}$/u;
+const SAFE_VERSION_PATTERN = /^[a-z0-9][a-z0-9.+_() -]{0,39}$/iu;
+const CLOUD_MCP_FAILURE_CODES = new Set([
+  "cloud_desired_missing",
+  "cloud_mcp_missing",
+  "cloud_mcp_disabled",
+  "cloud_endpoint_invalid",
+  "cloud_token_org_mismatch",
+  "cloud_mcp_needs_auth",
+  "invalid_mcp_token",
+  "missing_mcp_token",
+  "mcp_session_revoked",
+  "mcp_membership_revoked",
+  "insufficient_mcp_scope",
+  "wrong_mcp_resource",
+  "workspace_directory_ambiguous",
+  "opencode_unconfigured",
+  "opencode_engine_unreachable",
+  "opencode_unreachable",
+  "opencode_mcp_sync_failed",
+  "cloud_status_missing",
+  "cloud_disabled",
+  "openwork_cloud_auth_required",
+  "openwork_cloud_auth_invalid",
+  "openwork_cloud_token_expired",
+  "openwork_cloud_membership_required",
+  "openwork_cloud_scope_missing",
+  "openwork_cloud_resource_forbidden",
+  "openwork_cloud_resource_not_found",
+  "openwork_cloud_client_registration_required",
+  "cloud_connection_failed",
+  "cloud_registration_failed",
+  "cloud_tools_denied",
+  "opencode_tool_ids_unsupported",
+  "opencode_tool_ids_unavailable",
+  "cloud_tools_missing",
+  "provider_projection_unavailable",
+  "provider_projection_missing",
+  "provider_tool_projection_missing",
+  "extensions_plugin_missing",
+  "probe_unreachable",
+  "cloud_mcp_token_mint_failed",
+  "cloud_mcp_maintenance_failed",
+]);
+const CLOUD_MCP_FAILURE_STAGES = new Set([
+  "prerequisites",
+  "token_mint",
+  "desired_config",
+  "engine_delivery",
+  "transport_auth",
+  "tool_registration",
+  "provider_projection",
+  "plugin_load",
+  "steering",
+  "desired",
+  "workspace",
+  "configuration",
+  "registration",
+  "engine_status",
+  "tool_ids",
+  "plugin_canary",
+]);
+const CLOUD_MCP_HEALTH_PHASES = new Set([
+  "missing_desired",
+  "workspace_ambiguous",
+  "engine_unconfigured",
+  "engine_unreachable",
+  "engine_missing",
+  "engine_disabled",
+  "engine_needs_auth",
+  "engine_needs_client_registration",
+  "engine_failed",
+  "registration_failed",
+  "denied_by_tools",
+  "tool_ids_unsupported",
+  "cloud_tools_missing",
+  "provider_projection_missing",
+  "extensions_plugin_missing",
+  "ready",
+]);
+const CLOUD_MCP_ENGINE_STATUSES = new Set([
+  "not_checked",
+  "missing",
+  "connected",
+  "disabled",
+  "failed",
+  "needs_auth",
+  "needs_client_registration",
+  "unreachable",
+  "unknown",
+]);
+const CLOUD_MCP_DELIVERY_STATES = new Set([
+  "not_desired",
+  "pending",
+  "registering",
+  "ready",
+  "failed",
+  "stale",
+]);
+const CLOUD_MCP_PROBE_STEPS = new Set(["initialize", "initialized_notice", "tools_list"]);
+
+function safeDimensionValue(value: unknown, fallback: string): string {
+  const sanitized = sanitizeDiagnosticString(String(value ?? "")).trim().toLowerCase();
+  const normalized = sanitized
+    .replace(/[^a-z0-9_.:-]+/gu, "_")
+    .replace(/^[_:.-]+|[_:.-]+$/gu, "")
+    .slice(0, 128);
+  return SAFE_DIMENSION_VALUE_PATTERN.test(normalized) ? normalized : fallback;
+}
+
+function dimension(type: string, value: unknown, fallback = "unknown"): TelemetryDimensionInput {
+  const safeValue = safeDimensionValue(value, fallback);
+  return { type, value: safeValue, label: safeValue };
+}
+
+function allowlistedDimensionValue(value: unknown, allowed: ReadonlySet<string>, fallback: string): string {
+  const safeValue = safeDimensionValue(value, fallback);
+  return allowed.has(safeValue) ? safeValue : fallback;
+}
+
+function directProbeSummary(health: OpenworkCloudMcpHealth | null): string {
+  const direct = health?.tools?.direct;
+  if (!direct?.checked && !direct?.trace) return "not_checked";
+  const failedStep = direct.trace?.steps.find((step) => !step.ok);
+  if (failedStep) {
+    const step = allowlistedDimensionValue(failedStep.step, CLOUD_MCP_PROBE_STEPS, "unknown_step");
+    return failedStep.httpStatus === undefined
+      ? `${step}_failed`
+      : `${step}_http_${failedStep.httpStatus}`;
+  }
+  return direct.checked && direct.missing.length === 0 && direct.present.length > 0
+    ? "passed"
+    : "failed";
+}
+
+function safeVersion(value: unknown): string {
+  const sanitized = sanitizeDiagnosticString(String(value ?? "")).trim().toLowerCase();
+  if (!SAFE_VERSION_PATTERN.test(sanitized)) return "unknown";
+  return sanitized.replace(/[^a-z0-9_.:-]+/gu, "_").replace(/_+/gu, "_").slice(0, 40);
+}
+
+function compatibilityVersions(health: OpenworkCloudMcpHealth | null): string {
+  const appVersion = health?.compatibility?.openwork.app?.version;
+  const serverVersion = health?.compatibility?.openwork.serverVersion;
+  const engineVersion = health?.compatibility?.opencode.actualVersion;
+  return [
+    `app_${safeVersion(appVersion)}`,
+    `server_${safeVersion(serverVersion)}`,
+    `engine_${safeVersion(engineVersion)}`,
+  ].join("__");
+}
+
+export function buildCloudMcpFailureTelemetryDimensions(input: {
+  issue: CloudMcpFailureSummary;
+  health: OpenworkCloudMcpHealth | null;
+}): TelemetryDimensionInput[] {
+  return [
+    dimension(
+      "cloud_mcp.failure_code",
+      allowlistedDimensionValue(input.issue.code, CLOUD_MCP_FAILURE_CODES, "connect_failure"),
+    ),
+    dimension(
+      "cloud_mcp.failure_stage",
+      allowlistedDimensionValue(input.issue.stage, CLOUD_MCP_FAILURE_STAGES, "unknown"),
+    ),
+    dimension("cloud_mcp.retryable", input.issue.retryable ? "true" : "false"),
+    dimension(
+      "cloud_mcp.health_phase",
+      allowlistedDimensionValue(input.health?.phase, CLOUD_MCP_HEALTH_PHASES, "unknown"),
+    ),
+    dimension(
+      "cloud_mcp.engine_status",
+      allowlistedDimensionValue(input.health?.engine?.status, CLOUD_MCP_ENGINE_STATUSES, "unknown"),
+    ),
+    dimension(
+      "cloud_mcp.delivery_state",
+      allowlistedDimensionValue(input.health?.delivery?.state, CLOUD_MCP_DELIVERY_STATES, "unknown"),
+    ),
+    dimension("cloud_mcp.direct_probe", directProbeSummary(input.health)),
+    dimension("cloud_mcp.versions", compatibilityVersions(input.health)),
+  ];
+}
+
+export function reportCloudMcpFailureToSentry(input: {
+  targetKey: string;
+  issue: CloudMcpFailureSummary;
+  health: OpenworkCloudMcpHealth | null;
+  track?: CloudMcpTelemetryTrack;
+}): boolean {
+  const dimensions = buildCloudMcpFailureTelemetryDimensions(input);
+  const fingerprint = dimensions.map((item) => `${item.type}=${item.value}`).join("|");
+  if (lastReportedFingerprintByTarget.get(input.targetKey) === fingerprint) return false;
+
+  try {
+    (input.track ?? trackTelemetryEvent)("connect.mcp_failed", {
+      success: false,
+      ...(typeof input.health?.durationMs === "number" && Number.isFinite(input.health.durationMs)
+        ? { durationMs: Math.min(86_400_000, Math.max(0, Math.round(input.health.durationMs))) }
+        : {}),
+      dimensions,
+    });
+    lastReportedFingerprintByTarget.set(input.targetKey, fingerprint);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearCloudMcpSentryFailure(targetKey: string): void {
+  lastReportedFingerprintByTarget.delete(targetKey);
+}

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -16,6 +16,10 @@ import type {
 import { unwrap } from "../../../app/lib/opencode";
 import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
+import {
+  clearCloudMcpSentryFailure,
+  reportCloudMcpFailureToSentry,
+} from "./cloud-mcp-sentry";
 import { recordCloudMcpMaintenanceOutcome } from "./cloud-mcp-maintenance-outcome";
 import {
   CLOUD_MCP_SERVER_NAME,
@@ -424,7 +428,7 @@ export function useSessionMcpMaintenance(input: {
         targetKey,
         task: async () => {
           if (input.cloudSignedIn) {
-            await runCloudMcpMaintenanceWithRetry({
+            const result = await runCloudMcpMaintenanceWithRetry({
               attempt: () => syncCloudControlMcpInBackground({
                 client,
                 workspaceId,
@@ -432,6 +436,15 @@ export function useSessionMcpMaintenance(input: {
               }),
               onAttempt: recordCloudAttempt,
             });
+            if (result.outcome === "ready") {
+              clearCloudMcpSentryFailure(targetKey);
+            } else if (result.outcome === "failed") {
+              reportCloudMcpFailureToSentry({
+                targetKey,
+                issue: result.issue,
+                health: result.health,
+              });
+            }
           }
           await healWorkspaceMcpInBackground({
             client,

--- a/apps/app/tests/cloud-mcp-diagnostics.test.ts
+++ b/apps/app/tests/cloud-mcp-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { TelemetryEventFields } from "../src/app/lib/den-telemetry";
 import type { OpenworkCloudMcpHealth } from "../src/app/lib/openwork-server";
 import {
   buildCloudMcpSupportBundle,
@@ -8,6 +9,11 @@ import {
   cloudMcpEngineRefreshLines,
   cloudMcpProbeTraceLines,
 } from "../src/react-app/domains/connections/cloud-mcp-diagnostics";
+import {
+  buildCloudMcpFailureTelemetryDimensions,
+  clearCloudMcpSentryFailure,
+  reportCloudMcpFailureToSentry,
+} from "../src/react-app/domains/connections/cloud-mcp-sentry";
 
 const CHECKED_AT = "2026-07-22T10:00:00.000Z";
 
@@ -218,5 +224,142 @@ describe("cloud MCP advanced diagnostics", () => {
     expect(parsed.capturedAt).toBe(CHECKED_AT);
     expect((parsed.context as Record<string, unknown>).workspaceId).toBe("ws_1");
     expect(bundle).not.toContain("owt_super_secret_token_value");
+  });
+
+  test("builds bounded Sentry context from diagnostics without private payloads", () => {
+    const health = baseHealth({
+      workspace: {
+        id: "private-workspace-id",
+        type: "local",
+        directory: "/Users/private/customer",
+        path: "/Users/private/customer",
+      },
+      desired: {
+        ...baseHealth().desired,
+        config: {
+          headers: { Authorization: "Bearer owt_super_secret_token_value" },
+          url: "https://private.customer.example/mcp",
+        },
+        org: { id: "private-org-id", slug: "private-customer", name: "Private Customer" },
+      },
+      tools: {
+        ...baseHealth().tools,
+        direct: {
+          checked: true,
+          source: "mcp_tools_list",
+          expected: ["search_capabilities", "execute_capability"],
+          present: [],
+          missing: ["search_capabilities", "execute_capability"],
+          trace: {
+            endpoint: "https://private.customer.example/mcp/agent?token=secret",
+            startedAt: CHECKED_AT,
+            latencyMs: 42,
+            protocolVersion: null,
+            serverInfo: null,
+            steps: [
+              {
+                step: "initialize",
+                ok: false,
+                httpStatus: 401,
+                latencyMs: 42,
+                error: { message: "member@example.com Bearer owt_super_secret_token_value" },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const issue = health.firstFailure;
+    if (!issue) throw new Error("Expected a synthetic Cloud MCP failure.");
+
+    const dimensions = buildCloudMcpFailureTelemetryDimensions({ issue, health });
+    expect(Object.fromEntries(dimensions.map((item) => [item.type, item.value]))).toEqual({
+      "cloud_mcp.failure_code": "opencode_mcp_sync_failed",
+      "cloud_mcp.failure_stage": "engine_delivery",
+      "cloud_mcp.retryable": "true",
+      "cloud_mcp.health_phase": "engine_failed",
+      "cloud_mcp.engine_status": "failed",
+      "cloud_mcp.delivery_state": "failed",
+      "cloud_mcp.direct_probe": "initialize_http_401",
+      "cloud_mcp.versions": "app_0.17.36__server_0.17.36__engine_1.17.11",
+    });
+    const serialized = JSON.stringify(dimensions);
+    expect(serialized).not.toContain("private");
+    expect(serialized).not.toContain("member@example.com");
+    expect(serialized).not.toContain("owt_super_secret_token_value");
+  });
+
+  test("maps content-like diagnostic classifications to safe fallbacks", () => {
+    const health = baseHealth({
+      phase: "member@example.com",
+      engine: { status: "private_customer" },
+      delivery: {
+        ...baseHealth().delivery,
+        state: "private_customer",
+      },
+      compatibility: {
+        ...baseHealth().compatibility,
+        openwork: {
+          serverVersion: "member@example.com",
+          app: { version: "private/customer" },
+        },
+        opencode: {
+          ...baseHealth().compatibility.opencode,
+          actualVersion: "Bearer private-token",
+        },
+      },
+    });
+    const dimensions = buildCloudMcpFailureTelemetryDimensions({
+      issue: {
+        code: "member@example.com",
+        stage: "private_customer",
+        retryable: true,
+      },
+      health,
+    });
+
+    expect(Object.fromEntries(dimensions.map((item) => [item.type, item.value]))).toMatchObject({
+      "cloud_mcp.failure_code": "connect_failure",
+      "cloud_mcp.failure_stage": "unknown",
+      "cloud_mcp.health_phase": "unknown",
+      "cloud_mcp.engine_status": "unknown",
+      "cloud_mcp.delivery_state": "unknown",
+      "cloud_mcp.versions": "app_unknown__server_unknown__engine_unknown",
+    });
+    const serialized = JSON.stringify(dimensions);
+    expect(serialized).not.toContain("member");
+    expect(serialized).not.toContain("private");
+  });
+
+  test("reports one Sentry telemetry event per failure fingerprint until recovery", () => {
+    const health = baseHealth();
+    const issue = health.firstFailure;
+    if (!issue) throw new Error("Expected a synthetic Cloud MCP failure.");
+    const events: Array<{ type: string; fields: TelemetryEventFields }> = [];
+    const track = (type: string, fields: TelemetryEventFields) => events.push({ type, fields });
+    const targetKey = "sentry-dedupe-target";
+
+    expect(reportCloudMcpFailureToSentry({ targetKey, issue, health, track })).toBe(true);
+    expect(reportCloudMcpFailureToSentry({ targetKey, issue, health, track })).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "connect.mcp_failed",
+      fields: { success: false, durationMs: 480 },
+    });
+
+    clearCloudMcpSentryFailure(targetKey);
+    expect(reportCloudMcpFailureToSentry({ targetKey, issue, health, track })).toBe(true);
+    expect(events).toHaveLength(2);
+
+    const failingTargetKey = "sentry-reporter-failure-target";
+    expect(reportCloudMcpFailureToSentry({
+      targetKey: failingTargetKey,
+      issue,
+      health,
+      track: () => {
+        throw new Error("Telemetry unavailable");
+      },
+    })).toBe(false);
+    expect(reportCloudMcpFailureToSentry({ targetKey: failingTargetKey, issue, health, track })).toBe(true);
   });
 });

--- a/ee/apps/den-api/src/routes/telemetry/index.ts
+++ b/ee/apps/den-api/src/routes/telemetry/index.ts
@@ -17,6 +17,7 @@ import { enterprisePlanRequiredSchema, invalidRequestSchema, jsonResponse, unaut
 import type { AuthContextVariables } from "../../session.js"
 import type { UserOrganizationsContext, OrganizationContextVariables } from "../../middleware/index.js"
 import { deriveDimensionValue } from "./dimension-value.js"
+import { captureTelemetrySentryEvent } from "./sentry-events.js"
 
 type TelemetryRouteVariables = AuthContextVariables & Partial<UserOrganizationsContext> & Partial<OrganizationContextVariables>
 
@@ -299,6 +300,9 @@ export function registerTelemetryRoutes<T extends { Variables: TelemetryRouteVar
             orgId,
             ...pendingDimension,
           })
+        }
+        for (const event of acceptedEvents) {
+          captureTelemetrySentryEvent(event)
         }
       } catch {
         // Swallow errors -- telemetry should never break the app

--- a/ee/apps/den-api/src/routes/telemetry/sentry-events.ts
+++ b/ee/apps/den-api/src/routes/telemetry/sentry-events.ts
@@ -1,0 +1,199 @@
+import { captureException } from "../../observability/runtime.js"
+
+type TelemetryDimension = {
+  type: string
+  value?: string
+  label: string
+  metadata?: Record<string, unknown>
+}
+
+type TelemetrySentryEvent = {
+  type: string
+  source?: string
+  durationMs?: number
+  dimensions?: TelemetryDimension[]
+}
+
+type CaptureException = (
+  error: unknown,
+  fields?: Readonly<Record<string, unknown>>,
+) => void
+
+const CLOUD_MCP_CONTEXT_FIELDS = new Map([
+  ["cloud_mcp.failure_code", "failure_code"],
+  ["cloud_mcp.failure_stage", "failure_stage"],
+  ["cloud_mcp.retryable", "retryable"],
+  ["cloud_mcp.health_phase", "health_phase"],
+  ["cloud_mcp.engine_status", "engine_status"],
+  ["cloud_mcp.delivery_state", "delivery_state"],
+  ["cloud_mcp.direct_probe", "direct_probe"],
+  ["cloud_mcp.versions", "versions"],
+])
+const CLOUD_MCP_FAILURE_CODES = new Set([
+  "cloud_desired_missing",
+  "cloud_mcp_missing",
+  "cloud_mcp_disabled",
+  "cloud_endpoint_invalid",
+  "cloud_token_org_mismatch",
+  "cloud_mcp_needs_auth",
+  "invalid_mcp_token",
+  "missing_mcp_token",
+  "mcp_session_revoked",
+  "mcp_membership_revoked",
+  "insufficient_mcp_scope",
+  "wrong_mcp_resource",
+  "workspace_directory_ambiguous",
+  "opencode_unconfigured",
+  "opencode_engine_unreachable",
+  "opencode_unreachable",
+  "opencode_mcp_sync_failed",
+  "cloud_status_missing",
+  "cloud_disabled",
+  "openwork_cloud_auth_required",
+  "openwork_cloud_auth_invalid",
+  "openwork_cloud_token_expired",
+  "openwork_cloud_membership_required",
+  "openwork_cloud_scope_missing",
+  "openwork_cloud_resource_forbidden",
+  "openwork_cloud_resource_not_found",
+  "openwork_cloud_client_registration_required",
+  "cloud_connection_failed",
+  "cloud_registration_failed",
+  "cloud_tools_denied",
+  "opencode_tool_ids_unsupported",
+  "opencode_tool_ids_unavailable",
+  "cloud_tools_missing",
+  "provider_projection_unavailable",
+  "provider_projection_missing",
+  "provider_tool_projection_missing",
+  "extensions_plugin_missing",
+  "probe_unreachable",
+  "cloud_mcp_token_mint_failed",
+  "cloud_mcp_maintenance_failed",
+])
+const CLOUD_MCP_FAILURE_STAGES = new Set([
+  "prerequisites",
+  "token_mint",
+  "desired_config",
+  "engine_delivery",
+  "transport_auth",
+  "tool_registration",
+  "provider_projection",
+  "plugin_load",
+  "steering",
+  "desired",
+  "workspace",
+  "configuration",
+  "registration",
+  "engine_status",
+  "tool_ids",
+  "plugin_canary",
+])
+const CLOUD_MCP_HEALTH_PHASES = new Set([
+  "missing_desired",
+  "workspace_ambiguous",
+  "engine_unconfigured",
+  "engine_unreachable",
+  "engine_missing",
+  "engine_disabled",
+  "engine_needs_auth",
+  "engine_needs_client_registration",
+  "engine_failed",
+  "registration_failed",
+  "denied_by_tools",
+  "tool_ids_unsupported",
+  "cloud_tools_missing",
+  "provider_projection_missing",
+  "extensions_plugin_missing",
+  "ready",
+])
+const CLOUD_MCP_ENGINE_STATUSES = new Set([
+  "not_checked",
+  "missing",
+  "connected",
+  "disabled",
+  "failed",
+  "needs_auth",
+  "needs_client_registration",
+  "unreachable",
+  "unknown",
+])
+const CLOUD_MCP_DELIVERY_STATES = new Set([
+  "not_desired",
+  "pending",
+  "registering",
+  "ready",
+  "failed",
+  "stale",
+])
+const DIRECT_PROBE_PATTERN = /^(?:not_checked|passed|failed|(?:initialize|initialized_notice|tools_list)_(?:failed|http_[1-5][0-9]{2}))$/u
+const VERSIONS_PATTERN = /^app_[a-z0-9][a-z0-9_.:-]{0,39}__server_[a-z0-9][a-z0-9_.:-]{0,39}__engine_[a-z0-9][a-z0-9_.:-]{0,39}$/u
+
+function allowlistedValue(value: string, allowed: ReadonlySet<string>, fallback: string) {
+  return allowed.has(value) ? value : fallback
+}
+
+function safeContextValue(type: string, value: string): string | null {
+  switch (type) {
+    case "cloud_mcp.failure_code":
+      return allowlistedValue(value, CLOUD_MCP_FAILURE_CODES, "connect_failure")
+    case "cloud_mcp.failure_stage":
+      return allowlistedValue(value, CLOUD_MCP_FAILURE_STAGES, "unknown")
+    case "cloud_mcp.retryable":
+      return value === "true" || value === "false" ? value : "unknown"
+    case "cloud_mcp.health_phase":
+      return allowlistedValue(value, CLOUD_MCP_HEALTH_PHASES, "unknown")
+    case "cloud_mcp.engine_status":
+      return allowlistedValue(value, CLOUD_MCP_ENGINE_STATUSES, "unknown")
+    case "cloud_mcp.delivery_state":
+      return allowlistedValue(value, CLOUD_MCP_DELIVERY_STATES, "unknown")
+    case "cloud_mcp.direct_probe":
+      return DIRECT_PROBE_PATTERN.test(value) ? value : "unknown"
+    case "cloud_mcp.versions":
+      return VERSIONS_PATTERN.test(value) ? value : "unknown"
+    default:
+      return null
+  }
+}
+
+export class CloudMcpReconciliationFailure extends Error {
+  constructor(code: string, stage: string) {
+    super(`OpenWork Cloud MCP reconciliation failed: ${code} at ${stage}`)
+    this.name = "CloudMcpReconciliationFailure"
+  }
+}
+
+export function cloudMcpFailureSentryFields(
+  event: TelemetrySentryEvent,
+): Record<string, string | number | boolean | null> {
+  const fields: Record<string, string | number | boolean | null> = {
+    component: "openwork_cloud_mcp",
+    event_type: "connect.mcp_failed",
+    source: event.source === "app" ? "app" : "unknown",
+    duration_ms: typeof event.durationMs === "number" ? event.durationMs : null,
+  }
+  for (const item of event.dimensions ?? []) {
+    const field = CLOUD_MCP_CONTEXT_FIELDS.get(item.type)
+    const value = safeContextValue(item.type, item.value?.trim().toLowerCase() ?? "")
+    if (field && value !== null) {
+      fields[field] = value
+    }
+  }
+  return fields
+}
+
+export function captureTelemetrySentryEvent(
+  event: TelemetrySentryEvent,
+  capture: CaptureException = captureException,
+): boolean {
+  if (event.type !== "connect.mcp_failed") return false
+  const fields = cloudMcpFailureSentryFields(event)
+  const code = typeof fields.failure_code === "string" ? fields.failure_code : "unknown"
+  const stage = typeof fields.failure_stage === "string" ? fields.failure_stage : "unknown"
+  try {
+    capture(new CloudMcpReconciliationFailure(code, stage), fields)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/ee/apps/den-api/test/telemetry-sentry.test.ts
+++ b/ee/apps/den-api/test/telemetry-sentry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  CloudMcpReconciliationFailure,
+  captureTelemetrySentryEvent,
+  cloudMcpFailureSentryFields,
+} from "../src/routes/telemetry/sentry-events.js"
+
+describe("telemetry Sentry promotion", () => {
+  test("captures a Cloud MCP failure with only allowlisted diagnostic fields", () => {
+    const captured: Array<{
+      error: unknown
+      fields?: Readonly<Record<string, unknown>>
+    }> = []
+    const event = {
+      type: "connect.mcp_failed",
+      source: "app",
+      durationMs: 480,
+      dimensions: [
+        { type: "cloud_mcp.failure_code", value: "opencode_mcp_sync_failed", label: "member@example.com" },
+        { type: "cloud_mcp.failure_stage", value: "engine_delivery", label: "Bearer private-token" },
+        { type: "cloud_mcp.retryable", value: "true", label: "true" },
+        { type: "cloud_mcp.health_phase", value: "engine_failed", label: "engine_failed" },
+        { type: "cloud_mcp.engine_status", value: "failed", label: "failed" },
+        { type: "cloud_mcp.delivery_state", value: "failed", label: "failed" },
+        { type: "cloud_mcp.direct_probe", value: "initialize_http_401", label: "initialize_http_401" },
+        {
+          type: "cloud_mcp.versions",
+          value: "app_0.18.12__server_0.18.12__engine_1.17.11",
+          label: "app_0.18.12__server_0.18.12__engine_1.17.11",
+          metadata: { secret: "private-diagnostic-payload" },
+        },
+        { type: "untrusted.private_context", value: "should_not_pass", label: "private.customer.example" },
+      ],
+    }
+
+    expect(captureTelemetrySentryEvent(event, (error, fields) => {
+      captured.push({ error, fields })
+    })).toBe(true)
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.error).toBeInstanceOf(CloudMcpReconciliationFailure)
+    expect(captured[0]?.fields).toEqual({
+      component: "openwork_cloud_mcp",
+      event_type: "connect.mcp_failed",
+      source: "app",
+      duration_ms: 480,
+      failure_code: "opencode_mcp_sync_failed",
+      failure_stage: "engine_delivery",
+      retryable: "true",
+      health_phase: "engine_failed",
+      engine_status: "failed",
+      delivery_state: "failed",
+      direct_probe: "initialize_http_401",
+      versions: "app_0.18.12__server_0.18.12__engine_1.17.11",
+    })
+    const serialized = JSON.stringify(captured)
+    expect(serialized).not.toContain("member@example.com")
+    expect(serialized).not.toContain("private-token")
+    expect(serialized).not.toContain("private-diagnostic-payload")
+    expect(serialized).not.toContain("private.customer.example")
+    expect(serialized).not.toContain("should_not_pass")
+  })
+
+  test("ignores unrelated telemetry and contains reporter failures", () => {
+    expect(captureTelemetrySentryEvent({ type: "task.failed" }, () => {
+      throw new Error("should not run")
+    })).toBe(false)
+    expect(captureTelemetrySentryEvent({ type: "connect.mcp_failed" }, () => {
+      throw new Error("Sentry unavailable")
+    })).toBe(false)
+  })
+
+  test("maps schema-shaped but unknown classifications to safe fallbacks", () => {
+    const fields = cloudMcpFailureSentryFields({
+      type: "connect.mcp_failed",
+      dimensions: [
+        { type: "cloud_mcp.failure_code", value: "member_example.com", label: "member@example.com" },
+        { type: "cloud_mcp.failure_stage", value: "private_customer", label: "private_customer" },
+        { type: "cloud_mcp.health_phase", value: "private_customer", label: "private_customer" },
+        { type: "cloud_mcp.engine_status", value: "private_customer", label: "private_customer" },
+        { type: "cloud_mcp.delivery_state", value: "private_customer", label: "private_customer" },
+        { type: "cloud_mcp.direct_probe", value: "private_customer", label: "private_customer" },
+        { type: "cloud_mcp.versions", value: "private_customer", label: "private_customer" },
+      ],
+    })
+
+    expect(fields).toMatchObject({
+      failure_code: "connect_failure",
+      failure_stage: "unknown",
+      health_phase: "unknown",
+      engine_status: "unknown",
+      delivery_state: "unknown",
+      direct_probe: "unknown",
+      versions: "unknown",
+    })
+    const serialized = JSON.stringify(fields)
+    expect(serialized).not.toContain("member")
+    expect(serialized).not.toContain("private")
+  })
+})

--- a/ee/packages/den-db/src/schema/telemetry.ts
+++ b/ee/packages/den-db/src/schema/telemetry.ts
@@ -12,6 +12,7 @@ export const TelemetryEventType = [
   "task.started",
   "task.completed",
   "task.failed",
+  "connect.mcp_failed",
 ] as const
 
 export const TelemetryEventTable = mysqlTable(


### PR DESCRIPTION
## Summary

- report terminal `openwork-cloud` MCP reconciliation failures through the existing authenticated Den telemetry path
- promote the allowlisted event to Den's Sentry backend when it is configured
- attach bounded diagnostic context and deduplicate the same failure fingerprint until recovery

## Root cause

The app showed a blocking Cloud MCP failure but retained the evidence only in the local UI and diagnostics. The desktop does not have its own Sentry SDK, so the terminal reconciliation failure never reached production error monitoring.

## Privacy and scope

The event includes only allowlisted classification/status fields and component versions. Both the client and server map unknown or content-like values to safe fallbacks. It never sends messages, raw errors, URLs, paths, IDs, tokens, labels, metadata, or raw diagnostic payloads.

This does not change UI or recovery behavior. It is separate from #3198's Cloud MCP repair work and from #3073/#3074's explicit opt-in diagnostics relay.

## Verification

- `corepack pnpm --filter @openwork/app exec bun test --isolate tests/cloud-mcp-diagnostics.test.ts tests/session-mcp-maintenance.test.ts` — 17 passed
- `corepack pnpm --filter @openwork-ee/den-api exec bun test test/telemetry-sentry.test.ts` — 3 passed
- `corepack pnpm --filter @openwork/app typecheck` — passed
- `corepack pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — passed
- `git diff --check` — passed

No Fraimz/browser proof is included because this is an observability-only change with no user-visible UI behavior.
