### PR TITLE
fix: normalize local MCP command string+args (fixes #3372)

### DIFF
--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -65,6 +65,27 @@ export async function removeMcpFromConfig(
   }
 }
 
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.flatMap((entry) => {
+        const text = readNonEmptyString(entry);
+        return text ? [text] : [];
+      })
+    : [];
+}
+
+/** Normalize Claude Code–style `command` string + `args` into OpenCode's `command: string[]`. */
+function mcpCommandFromConfig(config: Record<string, unknown>): string[] {
+  if (Array.isArray(config.command)) return readStringArray(config.command);
+  const command = readNonEmptyString(config.command);
+  if (!command) return [];
+  return [command, ...readStringArray(config.args)];
+}
+
 export function parseMcpServersFromContent(content: string): McpServerEntry[] {
   if (!content.trim()) return [];
 
@@ -81,12 +102,22 @@ export function parseMcpServersFromContent(content: string): McpServerEntry[] {
         return [];
       }
 
-      const config = value as McpServerConfig;
-      if (config.type !== "remote" && config.type !== "local") {
+      const raw = value as Record<string, unknown>;
+      if (raw.type !== "remote" && raw.type !== "local") {
         return [];
       }
 
-      return [{ name, config, source: "config.project" as const }];
+      if (raw.type === "local") {
+        const { args: _args, ...rest } = raw;
+        const config: McpServerConfig = {
+          ...(rest as McpServerConfig),
+          type: "local",
+          command: mcpCommandFromConfig(raw),
+        };
+        return [{ name, config, source: "config.project" as const }];
+      }
+
+      return [{ name, config: raw as McpServerConfig, source: "config.project" as const }];
     });
   } catch {
     return [];

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1794,7 +1794,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     // For now, treat it as loaded if the plugin is in the MCP/plugin list — this will
     // be refined when we add a real plugin-loaded signal from the engine.
     const browserPluginConfigured = connectionsSnapshot.mcpServers.some(
-      (s) => s.name === "opencode-chrome-devtools" || s.config.command?.some((c: string) => c.includes("chrome-devtools")),
+      (s) =>
+        s.name === "opencode-chrome-devtools" ||
+        (Array.isArray(s.config.command) &&
+          s.config.command.some((c: string) => c.includes("chrome-devtools"))),
     );
     if (browserPluginConfigured) loadedPlugins.add("opencode-chrome-devtools");
 

--- a/apps/app/tests/mcp.test.ts
+++ b/apps/app/tests/mcp.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseMcpServersFromContent } from "../src/app/mcp"
+
+describe("parseMcpServersFromContent", () => {
+  test("normalizes string command + separate args into a command array", () => {
+    // Exact repro shape from https://github.com/different-ai/openwork/issues/3372
+    const content = JSON.stringify({
+      mcp: {
+        servers: {
+          command: "python3",
+          args: ["${OPENCODE_PLUGIN_ROOT}/mcp_servers/browser/server.py"],
+          enabled: true,
+          type: "local",
+        },
+      },
+    })
+
+    const entries = parseMcpServersFromContent(content)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.name).toBe("servers")
+    expect(entries[0]?.config.type).toBe("local")
+    expect(entries[0]?.config.command).toEqual([
+      "python3",
+      "${OPENCODE_PLUGIN_ROOT}/mcp_servers/browser/server.py",
+    ])
+    expect("args" in (entries[0]?.config ?? {})).toBe(false)
+  })
+
+  test("keeps array-form command unchanged", () => {
+    const content = JSON.stringify({
+      mcp: {
+        browser: {
+          type: "local",
+          command: [
+            "python3",
+            "${OPENCODE_PLUGIN_ROOT}/mcp_servers/browser/server.py",
+          ],
+          enabled: true,
+        },
+      },
+    })
+
+    const entries = parseMcpServersFromContent(content)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.config.command).toEqual([
+      "python3",
+      "${OPENCODE_PLUGIN_ROOT}/mcp_servers/browser/server.py",
+    ])
+  })
+
+  test("string command with no args becomes a single-element array", () => {
+    const content = JSON.stringify({
+      mcp: {
+        echo: {
+          type: "local",
+          command: "python3",
+          enabled: true,
+        },
+      },
+    })
+
+    const entries = parseMcpServersFromContent(content)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.config.command).toEqual(["python3"])
+    expect("args" in (entries[0]?.config ?? {})).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Normalizes local MCP `command` (Claude Code-style string + separate `args`) into a proper `string[]` inside `parseMcpServersFromContent`, and adds a defensive `Array.isArray` guard at the crashing call site in `settings-route.tsx`.

## Why
- Settings rendered a blank/white page whenever a local MCP server config used string-form `command` + `args`. `parseMcpServersFromContent` cast raw parsed JSON straight to `McpServerConfig` without validating that `command` was actually an array, even though the type declares `command?: string[]`. Downstream code in the Settings `useMemo` then called `.some()` on that value and threw, unmounting the route.

## Issue
- Closes #3372

## Scope
- `apps/app/src/app/mcp.ts`: normalize `command`/`args` into `string[]` at the parse boundary — this is the shared parser for both `config.project` and `config.global` MCP sources, so the fix covers every consumer, not just Settings
- `apps/app/src/react-app/shell/settings-route.tsx`: guard the `.some()` call with `Array.isArray` as defense-in-depth
- `apps/app/tests/mcp.test.ts` (new): covers string+args, array-form, and string-only command

## Out of scope
- Did not touch the equivalent `mcpCommandFromConfig` already present server-side in `apps/server/src/cloud-plugins.ts` — that one already normalizes correctly
- Did not consolidate the now-several near-duplicate `mcpCommandFromConfig`-style implementations across the codebase into one shared util — worth a follow-up issue, not this fix

## Testing
### Ran
- `bun test tests/mcp.test.ts`
### Result
- pass: 3 pass, 0 fail

## CI status
- pass: <fill in once CI finishes on the PR>
- code-related failures: none observed locally
- external/env/auth blockers: none

## Manual verification
1. Configured a local MCP server in `opencode.json` using the exact string `command` + `args` repro from #3372
2. Launched the app, opened Settings — renders normally instead of going blank
3. Confirmed an existing array-form MCP config still loads correctly (no regression)

## Evidence
- <attach a before/after screenshot or short screen recording of Settings loading with the repro config — worth doing since this is a visible UI crash fix>

## Risk
- Low — change is scoped to one parsing function and one call site; normalization is additive and falls back to `[]` on malformed input rather than throwing

## Rollback
- Revert this PR; no schema or migration changes involved