### PR TITLE
feat(gateway): replace the stalled boot bar with a checkpoint ladder

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -482,29 +482,51 @@ select:disabled {
    "awaiting first token", and any idle-but-alive hint. */
 @keyframes ow-dot-ticker {
   0% {
-    background-color: rgba(var(--dls-secondary-rgb, 120, 120, 120), 0.22);
-    box-shadow: 0 0 0 rgba(var(--dls-accent-rgb), 0);
+    background-color: rgb(var(--dls-secondary-rgb) / 0.22);
+    box-shadow: 0 0 0 rgb(var(--dls-accent-rgb) / 0);
   }
   20% {
-    background-color: rgba(var(--dls-accent-rgb), 0.95);
-    box-shadow: 0 0 8px rgba(var(--dls-accent-rgb), 0.45);
+    background-color: rgb(var(--dls-accent-rgb) / 0.95);
+    box-shadow: 0 0 8px rgb(var(--dls-accent-rgb) / 0.45);
   }
   55%,
   100% {
-    background-color: rgba(var(--dls-secondary-rgb, 120, 120, 120), 0.22);
-    box-shadow: 0 0 0 rgba(var(--dls-accent-rgb), 0);
+    background-color: rgb(var(--dls-secondary-rgb) / 0.22);
+    box-shadow: 0 0 0 rgb(var(--dls-accent-rgb) / 0);
   }
 }
 
 .ow-dot-ticker {
   animation: ow-dot-ticker 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
-  background-color: rgba(var(--dls-secondary-rgb, 120, 120, 120), 0.22);
+  background-color: rgb(var(--dls-secondary-rgb) / 0.22);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .ow-dot-ticker {
     animation: none;
-    background-color: rgba(var(--dls-accent-rgb), 0.6);
+    background-color: rgb(var(--dls-accent-rgb) / 0.6);
+  }
+}
+
+/* Sweep under the active boot checkpoint. Stays in CSS so the gateway can poll
+   without an endless JS animation competing for the main thread. */
+@keyframes ow-stage-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.ow-stage-shimmer {
+  animation: ow-stage-shimmer 1.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ow-stage-shimmer {
+    animation: none;
+    transform: translateX(0);
   }
 }
 

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
+import { AnimatePresence, LazyMotion, domMax, m, useReducedMotion } from "motion/react";
 
 import { clearDenSession, createDenClient, readDenSettings } from "@/app/lib/den";
 import { isOpenworkGatewayRuntime } from "@/app/lib/gateway-runtime";
@@ -10,7 +11,16 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { softCardClass } from "@/react-app/domains/workspace/modal-styles";
-import { mapCloudWorkspaceState, type CloudWorkspaceMainContentDecision, type CloudWorkspacePillVariant, type CloudWorkspaceViewModel } from "./cloud-workspace-status";
+import {
+  cloudWorkspaceBootIsSlow,
+  cloudWorkspaceBootStages,
+  cloudWorkspaceTakeoverCopy,
+  formatCloudWorkspaceElapsed,
+  mapCloudWorkspaceState,
+  type CloudWorkspaceBootStage,
+  type CloudWorkspaceMainContentDecision,
+  type CloudWorkspaceViewModel,
+} from "./cloud-workspace-status";
 import type { DenCloudInstance } from "@/app/lib/den";
 import { OwDotTicker } from "./dot-ticker";
 
@@ -24,6 +34,12 @@ type CloudWorkspaceStatusContextValue = {
   refresh: () => Promise<void>;
   signOut: () => void;
   updateNow: () => void;
+  /**
+   * The takeover and the pill share one `layoutId`, so only one of them may own
+   * the indicator at a time or the handoff animates against itself.
+   */
+  takeoverActive: boolean;
+  setTakeoverActive: (active: boolean) => void;
 };
 
 const fallbackViewModel = mapCloudWorkspaceState({ instance: null, updating: false });
@@ -42,9 +58,12 @@ const fallbackCloudWorkspaceStatus: CloudWorkspaceStatusContextValue = {
   refresh: noopRefresh,
   signOut: noopAction,
   updateNow: noopAction,
+  takeoverActive: false,
+  setTakeoverActive: noopAction,
 };
 
-const CloudWorkspaceStatusContext = createContext<CloudWorkspaceStatusContextValue | null>(null);
+/** Exported so tests can mount the takeover without standing up Den auth. */
+export const CloudWorkspaceStatusContext = createContext<CloudWorkspaceStatusContextValue | null>(null);
 
 const readDenSettingsSnapshot = () => {
   const settings = readDenSettings();
@@ -70,6 +89,7 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
   const [instance, setInstance] = useState<DenCloudInstance | null>(null);
   const [requestFailed, setRequestFailed] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [takeoverActive, setTakeoverActive] = useState(false);
   const gatewayMode = isOpenworkGatewayRuntime();
   const settingsSnapshot = useSyncExternalStore(
     subscribeToDenSettings,
@@ -164,7 +184,9 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
     refresh,
     signOut,
     updateNow,
-  }), [gatewayMode, instance, refresh, requestFailed, signOut, updateNow, updating, viewModel, visible]);
+    takeoverActive,
+    setTakeoverActive,
+  }), [gatewayMode, instance, refresh, requestFailed, signOut, takeoverActive, updateNow, updating, viewModel, visible]);
 
   return (
     <CloudWorkspaceStatusContext.Provider value={value}>
@@ -173,101 +195,177 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
   );
 }
 
-function cloudWorkspaceTakeoverCopy(variant: CloudWorkspacePillVariant) {
-  if (variant === "provisioning") {
-    return {
-      title: "Starting your workspace…",
-      body: "We’re preparing your sandbox and reconnecting the app. This usually takes less than a minute.",
-    };
-  }
-  if (variant === "updating") {
-    return {
-      title: "Updating your workspace…",
-      body: "We’re applying the latest OpenWork image. Your files and sessions come along.",
-    };
-  }
-  if (variant === "failed") {
-    return {
-      title: "Workspace needs attention",
-      body: "We couldn’t start the sandbox. Retry, or sign out and reconnect.",
-    };
-  }
-  return {
-    title: "Waking your workspace…",
-    body: "Your sandbox is coming back online. We’ll open your workspace as soon as it’s ready.",
-  };
+/**
+ * Owned by the takeover while it is on screen and by the corner pill afterwards,
+ * so the indicator travels into the pill instead of one element disappearing and
+ * an unrelated one appearing.
+ */
+const gatewayIndicatorLayoutId = "gateway-workspace-indicator";
+
+function BootStageRow(props: { stage: CloudWorkspaceBootStage; reduceMotion: boolean }) {
+  const { stage } = props;
+
+  return (
+    <li className="flex flex-col gap-2">
+      <div className="flex items-center gap-2.5">
+        <span className="flex size-5 shrink-0 items-center justify-center">
+          {stage.state === "done" ? (
+            <svg viewBox="0 0 24 24" className="size-4 text-green-11" aria-hidden="true">
+              <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth={1.5} opacity={0.35} />
+              <m.path
+                d="M8 12.5l2.5 2.5L16 9.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                initial={props.reduceMotion ? false : { pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={{ duration: 0.26, ease: "easeOut" }}
+              />
+            </svg>
+          ) : stage.state === "active" ? (
+            <OwDotTicker size="md" />
+          ) : (
+            <span className="size-2.5 rounded-full border-[1.5px] border-[rgb(var(--dls-secondary-rgb)/0.45)]" />
+          )}
+        </span>
+        <span
+          className={cn(
+            "min-w-0 flex-1 text-[13px] leading-5",
+            stage.state === "active" ? "font-medium text-dls-text" : "text-dls-secondary",
+          )}
+        >
+          {stage.label}
+        </span>
+      </div>
+      {stage.state === "active" ? (
+        <div className="ml-[30px] h-1 overflow-hidden rounded-full bg-dls-surface" aria-hidden="true">
+          <div className="ow-stage-shimmer h-1 w-1/4 rounded-full bg-dls-accent/70" />
+        </div>
+      ) : null}
+    </li>
+  );
 }
 
 export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMainContentDecision }) {
   const cloudWorkspace = useCloudWorkspaceStatus();
-  if (!cloudWorkspace.gatewayMode || !cloudWorkspace.visible || props.decision !== "takeover") return null;
+  const { setTakeoverActive } = cloudWorkspace;
+  const reduceMotion = useReducedMotion() ?? false;
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const active = cloudWorkspace.gatewayMode && cloudWorkspace.visible && props.decision === "takeover";
+
+  useEffect(() => {
+    setTakeoverActive(active);
+    return () => setTakeoverActive(false);
+  }, [active, setTakeoverActive]);
+
+  useEffect(() => {
+    if (!active) return;
+    const startedAt = Date.now();
+    setElapsedMs(0);
+    const intervalId = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 1_000);
+    return () => window.clearInterval(intervalId);
+  }, [active]);
+
+  if (!active) return null;
 
   const { viewModel } = cloudWorkspace;
   const failed = viewModel.variant === "failed";
-  const copy = cloudWorkspaceTakeoverCopy(viewModel.variant);
+  const slow = !failed && cloudWorkspaceBootIsSlow(elapsedMs);
+  const copy = cloudWorkspaceTakeoverCopy({ variant: viewModel.variant, slow });
+  const stages = cloudWorkspaceBootStages(viewModel.variant);
 
   return (
-    <div
-      className="flex h-full min-h-[420px] items-center justify-center px-6 py-16"
-      role={failed ? "alert" : "status"}
-      aria-live="polite"
-      data-testid="cloud-workspace-takeover"
-      data-cloud-workspace-state={viewModel.variant}
-    >
+    <LazyMotion features={domMax}>
       <div
-        className={cn(
-          "w-full max-w-md rounded-[20px] border p-6 shadow-[var(--dls-card-shadow)]",
-          failed
-            ? "border-amber-7/35 bg-amber-3/30"
-            : "border-dls-border bg-dls-surface",
-        )}
+        className="flex h-full min-h-[420px] items-center justify-center px-6 py-16"
+        role={failed ? "alert" : "status"}
+        aria-live="polite"
+        data-testid="cloud-workspace-takeover"
+        data-cloud-workspace-state={viewModel.variant}
+        data-cloud-workspace-wait={slow ? "slow" : "normal"}
       >
-        <div className="flex items-start gap-4">
-          <div
-            className={cn(
-              "flex size-12 shrink-0 items-center justify-center rounded-2xl border",
-              failed
-                ? "border-amber-7/35 bg-amber-3/60 text-amber-11"
-                : "border-dls-border bg-dls-hover text-dls-accent",
-            )}
-          >
-            {failed ? <AlertTriangle className="size-5" aria-hidden="true" /> : <OwDotTicker size="lg" />}
+        <m.div
+          layout
+          initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.32, ease: "easeOut" }}
+          className={cn(
+            "w-full max-w-md rounded-[20px] border p-6 shadow-[var(--dls-card-shadow)]",
+            failed
+              ? "border-amber-7/35 bg-amber-3/30"
+              : "border-dls-border bg-dls-surface",
+          )}
+        >
+          <div className="flex items-start gap-4">
+            <div
+              className={cn(
+                "flex size-12 shrink-0 items-center justify-center rounded-2xl border",
+                failed
+                  ? "border-amber-7/35 bg-amber-3/60 text-amber-11"
+                  : "border-dls-border bg-dls-hover text-dls-accent",
+              )}
+            >
+              {failed ? (
+                <AlertTriangle className="size-5" aria-hidden="true" />
+              ) : (
+                <m.span layoutId={gatewayIndicatorLayoutId} className="flex items-center justify-center">
+                  <OwDotTicker size="lg" />
+                </m.span>
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              {/* Keyed on the title so a state change reads as a change rather than a flicker. */}
+              <AnimatePresence mode="wait" initial={false}>
+                <m.div
+                  key={copy.title}
+                  initial={reduceMotion ? false : { opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={reduceMotion ? undefined : { opacity: 0, y: -4 }}
+                  transition={{ duration: 0.18, ease: "easeOut" }}
+                >
+                  <h2 className="text-[24px] font-semibold leading-tight tracking-[-0.03em] text-dls-text">
+                    {copy.title}
+                  </h2>
+                  <p className="mt-2 text-[14px] leading-6 text-dls-secondary">
+                    {copy.body}
+                  </p>
+                </m.div>
+              </AnimatePresence>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <h2 className="text-[24px] font-semibold leading-tight tracking-[-0.03em] text-dls-text">
-              {copy.title}
-            </h2>
-            <p className="mt-2 text-[14px] leading-6 text-dls-secondary">
-              {copy.body}
-            </p>
-          </div>
-        </div>
 
-        {failed ? (
-          <div className="mt-6 flex flex-wrap gap-2">
-            <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
-              Retry
-            </Button>
-            <Button type="button" size="sm" variant="ghost" onClick={cloudWorkspace.signOut}>
-              Sign out
-            </Button>
-          </div>
-        ) : (
-          <div className={cn("mt-6", softCardClass)}>
-            <div className="flex items-center gap-2 text-[12px] font-semibold text-dls-text">
-              <Loader2 size={14} className="animate-spin text-dls-accent" aria-hidden="true" />
-              Sandbox setup
-            </div>
-            <div className="mt-4 overflow-hidden rounded-full bg-dls-surface">
-              <div className="h-1.5 w-2/3 animate-pulse rounded-full bg-dls-accent/60" />
-            </div>
-            <p className="mt-3 text-[12px] leading-5 text-dls-secondary">
-              We’ll refresh your workspace automatically when it’s ready.
+          {stages.length ? (
+            <m.ul layout className={cn("mt-6 space-y-3.5", softCardClass)} data-testid="cloud-workspace-boot-stages">
+              {stages.map((stage) => (
+                <BootStageRow key={stage.id} stage={stage} reduceMotion={reduceMotion} />
+              ))}
+            </m.ul>
+          ) : null}
+
+          {failed || slow ? (
+            <m.div layout className="mt-5 flex items-center gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
+                Retry
+              </Button>
+              <Button type="button" size="sm" variant="ghost" onClick={cloudWorkspace.signOut}>
+                Sign out
+              </Button>
+              {slow ? (
+                <span className="ml-auto text-[12px] text-dls-secondary" data-testid="cloud-workspace-elapsed">
+                  {formatCloudWorkspaceElapsed(elapsedMs)}
+                </span>
+              ) : null}
+            </m.div>
+          ) : (
+            <p className="mt-4 text-[12px] leading-5 text-dls-secondary">
+              We’ll open your workspace automatically when it’s ready.
             </p>
-          </div>
-        )}
+          )}
+        </m.div>
       </div>
-    </div>
+    </LazyMotion>
   );
 }
 
@@ -330,42 +428,59 @@ function CloudWorkspaceOverlayInner() {
   if (!cloudWorkspace.gatewayMode || !cloudWorkspace.visible) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[100]">
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              data-testid="cloud-workspace-pill"
-              data-cloud-workspace-state={viewModel.variant}
-              className={cn(
-                "h-8 rounded-full border bg-popover/90 px-3 text-xs shadow-sm backdrop-blur-sm",
-                viewModel.tone === "amber"
-                  ? "border-amber-7/70 bg-amber-3 text-amber-12 hover:bg-amber-4"
-                  : "border-border/80 text-muted-foreground hover:text-foreground",
-              )}
-              aria-label={`Open cloud workspace status: ${viewModel.label}`}
-            >
-              {viewModel.label}
-            </Button>
-          }
-        />
-        <PopoverContent align="end" side="top" sideOffset={8} className="w-80 gap-3 p-4">
-          <CloudWorkspaceStatusPanel
-            viewModel={viewModel}
-            updating={cloudWorkspace.updating}
-            onRefresh={() => void cloudWorkspace.refresh()}
-            onUpdateNow={cloudWorkspace.updateNow}
-            onSignOut={() => {
-              cloudWorkspace.signOut();
-              setOpen(false);
-            }}
+    <LazyMotion features={domMax}>
+      <div className="fixed bottom-4 right-4 z-[100]">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                data-testid="cloud-workspace-pill"
+                data-cloud-workspace-state={viewModel.variant}
+                className={cn(
+                  "h-8 gap-1.5 rounded-full border bg-popover/90 px-3 text-xs shadow-sm backdrop-blur-sm",
+                  viewModel.tone === "amber"
+                    ? "border-amber-7/70 bg-amber-3 text-amber-12 hover:bg-amber-4"
+                    : "border-border/80 text-muted-foreground hover:text-foreground",
+                )}
+                aria-label={`Open cloud workspace status: ${viewModel.label}`}
+              >
+                {cloudWorkspace.takeoverActive ? null : (
+                  <m.span
+                    layoutId={gatewayIndicatorLayoutId}
+                    transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                    className="flex items-center justify-center"
+                    aria-hidden="true"
+                  >
+                    <span
+                      className={cn(
+                        "size-1.5 rounded-full",
+                        viewModel.tone === "amber" ? "bg-amber-9" : "bg-green-9",
+                      )}
+                    />
+                  </m.span>
+                )}
+                {viewModel.label}
+              </Button>
+            }
           />
-        </PopoverContent>
-      </Popover>
-    </div>
+          <PopoverContent align="end" side="top" sideOffset={8} className="w-80 gap-3 p-4">
+            <CloudWorkspaceStatusPanel
+              viewModel={viewModel}
+              updating={cloudWorkspace.updating}
+              onRefresh={() => void cloudWorkspace.refresh()}
+              onUpdateNow={cloudWorkspace.updateNow}
+              onSignOut={() => {
+                cloudWorkspace.signOut();
+                setOpen(false);
+              }}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    </LazyMotion>
   );
 }
 

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -25,6 +25,97 @@ export type CloudWorkspaceViewModel = {
 
 export type CloudWorkspaceMainContentDecision = "takeover" | "error" | "content";
 
+export type CloudWorkspaceBootStageState = "done" | "active" | "pending";
+
+export type CloudWorkspaceBootStage = {
+  id: string;
+  label: string;
+  state: CloudWorkspaceBootStageState;
+};
+
+/**
+ * Boot progress is derived from the status we already poll rather than from a
+ * timer, so the ladder can never claim more progress than we can prove. Each
+ * variant tells us which checkpoint the sandbox is standing on: a provisioning
+ * sandbox is still being reserved, while a waking or updating one demonstrably
+ * exists already.
+ */
+const BOOT_STAGES: Partial<
+  Record<CloudWorkspacePillVariant, { labels: readonly [string, string, string]; activeIndex: number }>
+> = {
+  provisioning: {
+    labels: ["Reserving your computer", "Restoring your files", "Connecting the app"],
+    activeIndex: 0,
+  },
+  waking: {
+    labels: ["Reserving your computer", "Restoring your files", "Connecting the app"],
+    activeIndex: 1,
+  },
+  updating: {
+    labels: ["Saving your session", "Applying the latest image", "Reconnecting the app"],
+    activeIndex: 1,
+  },
+};
+
+export function cloudWorkspaceBootStages(variant: CloudWorkspacePillVariant): CloudWorkspaceBootStage[] {
+  const stages = BOOT_STAGES[variant];
+  if (!stages) return [];
+  return stages.labels.map((label, index) => ({
+    id: `${variant}-${index}`,
+    label,
+    state: index < stages.activeIndex ? "done" : index === stages.activeIndex ? "active" : "pending",
+  }));
+}
+
+/** Past this point "usually under a minute" stops being true, so the copy and the actions change. */
+export const CLOUD_WORKSPACE_SLOW_BOOT_MS = 45_000;
+
+export function cloudWorkspaceBootIsSlow(elapsedMs: number): boolean {
+  return elapsedMs >= CLOUD_WORKSPACE_SLOW_BOOT_MS;
+}
+
+export function formatCloudWorkspaceElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s elapsed`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s elapsed`;
+}
+
+export function cloudWorkspaceTakeoverCopy(input: {
+  variant: CloudWorkspacePillVariant;
+  slow: boolean;
+}): { title: string; body: string } {
+  if (input.variant === "failed") {
+    return {
+      title: "Workspace needs attention",
+      body: "We couldn’t start the sandbox. Retry, or sign out and reconnect.",
+    };
+  }
+  if (input.slow) {
+    return {
+      title: "Still working on it…",
+      body: "This is taking longer than usual. Nothing is broken — wait it out, or retry.",
+    };
+  }
+  if (input.variant === "provisioning") {
+    return {
+      title: "Starting your workspace…",
+      body: "Usually under a minute. We’ll open it the moment it’s ready.",
+    };
+  }
+  if (input.variant === "updating") {
+    return {
+      title: "Updating your workspace…",
+      body: "We’re applying the latest OpenWork image. Your files and sessions come along.",
+    };
+  }
+  return {
+    title: "Waking your workspace…",
+    body: "Your sandbox is coming back online. We’ll open it as soon as it’s ready.",
+  };
+}
+
 export function formatCloudWorkspaceVersion(version: string | null): string | null {
   const trimmed = version?.trim() ?? "";
   if (!trimmed) return null;

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -1,11 +1,21 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { DenCloudInstance } from "../src/app/lib/den";
-import { CloudWorkspaceOverlay, CloudWorkspaceStatusPanel } from "../src/react-app/shell/cloud-workspace-overlay";
 import {
+  CloudWorkspaceBootTakeover,
+  CloudWorkspaceOverlay,
+  CloudWorkspaceStatusContext,
+  CloudWorkspaceStatusPanel,
+} from "../src/react-app/shell/cloud-workspace-overlay";
+import {
+  CLOUD_WORKSPACE_SLOW_BOOT_MS,
+  cloudWorkspaceBootIsSlow,
+  cloudWorkspaceBootStages,
   cloudWorkspaceStatusHasReadyContent,
+  cloudWorkspaceTakeoverCopy,
   cloudWorkspaceUpdateAvailable,
+  formatCloudWorkspaceElapsed,
   mapCloudWorkspaceMainContentDecision,
   mapCloudWorkspaceState,
   shouldRefetchCloudWorkspaceOnReadyTransition,
@@ -163,6 +173,137 @@ describe("cloud workspace overlay state", () => {
       nextStatus: "ready",
       gatewayMode: true,
     })).toBe(false);
+  });
+});
+
+describe("cloud workspace boot stages", () => {
+  test("derives one active checkpoint per booting state and none once ready", () => {
+    const provisioning = cloudWorkspaceBootStages("provisioning");
+    const waking = cloudWorkspaceBootStages("waking");
+
+    // A provisioning sandbox is still being reserved; a waking one demonstrably
+    // exists already, so its first checkpoint is genuinely done.
+    expect(provisioning.map((stage) => stage.state)).toEqual(["active", "pending", "pending"]);
+    expect(waking.map((stage) => stage.state)).toEqual(["done", "active", "pending"]);
+    expect(provisioning[0].label).toBe("Reserving your computer");
+    expect(waking[1].label).toBe("Restoring your files");
+
+    expect(cloudWorkspaceBootStages("ready")).toEqual([]);
+    expect(cloudWorkspaceBootStages("stale")).toEqual([]);
+    expect(cloudWorkspaceBootStages("failed")).toEqual([]);
+  });
+
+  test("gives the update path its own checkpoint labels", () => {
+    const updating = cloudWorkspaceBootStages("updating");
+
+    expect(updating.map((stage) => stage.label)).toEqual([
+      "Saving your session",
+      "Applying the latest image",
+      "Reconnecting the app",
+    ]);
+    expect(updating.map((stage) => stage.state)).toEqual(["done", "active", "pending"]);
+  });
+
+  test("never reports more than one active checkpoint", () => {
+    for (const variant of ["provisioning", "waking", "updating"] as const) {
+      const active = cloudWorkspaceBootStages(variant).filter((stage) => stage.state === "active");
+      expect(active.length).toBe(1);
+    }
+  });
+});
+
+describe("cloud workspace slow boot escalation", () => {
+  test("escalates copy only once the under-a-minute promise stops being true", () => {
+    expect(cloudWorkspaceBootIsSlow(0)).toBe(false);
+    expect(cloudWorkspaceBootIsSlow(CLOUD_WORKSPACE_SLOW_BOOT_MS - 1)).toBe(false);
+    expect(cloudWorkspaceBootIsSlow(CLOUD_WORKSPACE_SLOW_BOOT_MS)).toBe(true);
+
+    const early = cloudWorkspaceTakeoverCopy({ variant: "provisioning", slow: false });
+    const late = cloudWorkspaceTakeoverCopy({ variant: "provisioning", slow: true });
+
+    expect(early.title).toBe("Starting your workspace…");
+    expect(late.title).toBe("Still working on it…");
+    expect(late.body).toContain("Nothing is broken");
+  });
+
+  test("keeps the failure message even when the wait has gone long", () => {
+    const failed = cloudWorkspaceTakeoverCopy({ variant: "failed", slow: true });
+
+    expect(failed.title).toBe("Workspace needs attention");
+  });
+
+  test("formats elapsed time for both short and long waits", () => {
+    expect(formatCloudWorkspaceElapsed(0)).toBe("0s elapsed");
+    expect(formatCloudWorkspaceElapsed(48_000)).toBe("48s elapsed");
+    expect(formatCloudWorkspaceElapsed(125_000)).toBe("2m 05s elapsed");
+  });
+});
+
+function renderTakeover(status: DenCloudInstance["status"]) {
+  const viewModel = mapCloudWorkspaceState({ instance: instance({ status }), updating: false });
+
+  return renderToStaticMarkup(
+    <CloudWorkspaceStatusContext.Provider
+      value={{
+        gatewayMode: true,
+        visible: true,
+        instance: instance({ status }),
+        requestFailed: false,
+        updating: false,
+        viewModel,
+        refresh: async () => {},
+        signOut: () => {},
+        updateNow: () => {},
+        takeoverActive: true,
+        setTakeoverActive: () => {},
+      }}
+    >
+      <CloudWorkspaceBootTakeover decision="takeover" />
+    </CloudWorkspaceStatusContext.Provider>,
+  );
+}
+
+describe("cloud workspace boot takeover", () => {
+  // Render as a true server pass. Other suites leave a partial `window` stub on
+  // the global, and motion's reduced-motion hook needs a real one to subscribe to.
+  let stashedWindow: typeof globalThis.window | undefined;
+
+  beforeEach(() => {
+    stashedWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", { configurable: true, value: undefined });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", { configurable: true, value: stashedWindow });
+  });
+
+  test("shows the checkpoint ladder instead of a progress bar that cannot complete", () => {
+    const html = renderTakeover("provisioning");
+
+    expect(html).toContain("cloud-workspace-boot-stages");
+    expect(html).toContain("Reserving your computer");
+    expect(html).toContain("Restoring your files");
+    expect(html).toContain("Connecting the app");
+    // The old bar was hardcoded to two thirds and pulsed there forever.
+    expect(html).not.toContain("w-2/3");
+    expect(html).not.toContain("animate-pulse");
+  });
+
+  test("keeps the wait calm until the promised minute is at risk", () => {
+    const html = renderTakeover("waking");
+
+    expect(html).toContain('data-cloud-workspace-wait="normal"');
+    expect(html).toContain("We’ll open your workspace automatically when it’s ready.");
+    expect(html).not.toContain("Retry");
+  });
+
+  test("drops the ladder and offers recovery when the sandbox failed", () => {
+    const html = renderTakeover("failed");
+
+    expect(html).not.toContain("cloud-workspace-boot-stages");
+    expect(html).toContain("Workspace needs attention");
+    expect(html).toContain("Retry");
+    expect(html).toContain("Sign out");
   });
 });
 


### PR DESCRIPTION
## Summary

The gateway boot takeover had a progress bar hardcoded to two thirds that only pulsed:

```tsx
<div className="h-1.5 w-2/3 animate-pulse rounded-full bg-dls-accent/60" />
```

It never moved and never completed, so a slow sandbox read as frozen at 66%.

- **Checkpoint ladder replaces the bar.** Progress is derived from the status we already poll, so it can never claim more than we can prove: a `provisioning` sandbox is still being reserved, while a `waking` or `updating` one demonstrably exists already. `updating` gets its own labels since it isn't a cold boot.
- **Only one thing animates.** The card previously ran the dot ticker and a `Loader2` spinner at the same time; now just the active row does.
- **Slow waits are handled.** At 45s the copy escalates to "Still working on it…", an elapsed counter appears, and Retry / Sign out fade in. Previously those only existed after a hard failure, so a slow but healthy boot left people with nothing to do.
- **Ready has a payoff.** The indicator shares a `layoutId` with the corner pill, so it travels into the pill instead of one element vanishing and another appearing. The context tracks whether the takeover is on screen so the two never claim the indicator at once.

### Drive-by bug fix

The dot ticker computed to **fully transparent**. The `--dls-*-rgb` tokens are space-separated (`96 100 108`) but these rules used legacy comma `rgba()`, which is invalid CSS. The indicator was invisible everywhere it's used, including the composer wait state. Lines 454–458 of the same file already used the correct `rgb(var(--x) / a)` form; this matches it. Confirmed in-browser: now computes to `rgba(96, 100, 108, 0.22)`.

## Motion

Uses `motion` v12, already a dependency. `AnimatePresence` for state crossfades, `pathLength` for the check draw, `layout` so the card glides, spring for the pill settle, `useReducedMotion` to degrade to plain crossfades. Infinite loops (ticker, shimmer) stay in CSS so the gateway isn't holding the main thread while it polls. `LazyMotion` with `domMax` — layout animations require `domMax`, and `app-sidebar.tsx` already loads it, so no new bytes.

## Test plan

Ran and passing:

- `npx tsc --noEmit` — clean
- `bun test tests/cloud-workspace-overlay.test.tsx` — 21 pass
- `bun test` (full suite, on the combined branch) — 667 pass; the 6 failures are pre-existing and fail identically on an untouched baseline
- `pnpm build` — clean

New tests cover the stage mapping (exactly one active checkpoint, none once ready), the 45s escalation boundary, elapsed formatting, and render-level assertions that the ladder is present and `w-2/3` / `animate-pulse` are gone.

I verified appearance by rendering the takeover against the built stylesheet and screenshotting all three states — that is how the invisible dot ticker was caught, along with pending rings that were too low-contrast. **Animation timing and the pill handoff are unverified in motion**, since driving the live takeover needs a Den-authenticated gateway runtime. Worth a real boot before this leaves draft.

## Open question

The ladder assumes three checkpoints, but `mapCloudWorkspaceState` collapses everything into single variants. This PR maps variants onto stages, which is honest but coarse. If Den can report a finer-grained boot stage, the ladder would reflect actual progress rather than an inferred position.

Made with [Cursor](https://cursor.com)