### PR TITLE
ci: Warden security clearance for PR diffs

### DIFF
--- a/.github/workflows/build-electron-desktop.yml
+++ b/.github/workflows/build-electron-desktop.yml
@@ -14,6 +14,9 @@ on:
       - package.json
       - .github/workflows/build-electron-desktop.yml
 
+permissions:
+  contents: read
+
 jobs:
   build-electron:
     strategy:

--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Download clearance summary
         if: steps.identity.outputs.configured == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: warden-summary
           run-id: ${{ github.event.workflow_run.id }}
@@ -114,7 +114,7 @@ jobs:
       - name: Mint clearance token
         if: steps.verdict.outputs.verdict == 'clear' || steps.verdict.outputs.verdict == 'flagged'
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.WARDEN_APP_ID }}
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}

--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -1,0 +1,149 @@
+# Warden security clearance.
+#
+# Grants or revokes a "security clearance" review on PRs based on the Warden
+# diff-security-review verdict. Humans still review and merge; the clearance
+# only satisfies the required-review gate in the branch ruleset for clean
+# diffs.
+#
+# Why workflow_run: this file always executes from the default branch, so a
+# PR cannot tamper with the clearance logic. The verdict step additionally
+# refuses to self-clear any PR that touches review machinery
+# (.github/, warden.toml, .warden/, .agents/skills/, .claude/skills/).
+#
+# Identity: a dedicated GitHub App (WARDEN_APP_ID / WARDEN_PRIVATE_KEY in the
+# `warden-clearance` environment). The app never pushes commits, so
+# require_last_push_approval always holds (clearance identity != pusher !=
+# author). Until the app secrets are configured this workflow no-ops.
+
+name: Warden Clearance
+
+on:
+  workflow_run:
+    workflows: [Warden]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  clearance:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment: warden-clearance
+    steps:
+      - name: Check clearance identity is configured
+        id: identity
+        env:
+          APP_ID: ${{ secrets.WARDEN_APP_ID }}
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "WARDEN_APP_ID is not configured; clearance disabled."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download clearance summary
+        if: steps.identity.outputs.configured == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: warden-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Evaluate verdict
+        if: steps.identity.outputs.configured == 'true'
+        id: verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          verdict() { echo "verdict=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          summary_sha="$(jq -r '.head_sha' warden-summary.json)"
+          count="$(jq -r '.findings_count' warden-summary.json)"
+
+          if [ "$summary_sha" != "$HEAD_SHA" ]; then
+            echo "Summary SHA ($summary_sha) does not match analyzed SHA ($HEAD_SHA); skipping."
+            verdict skip
+          fi
+
+          pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          if [ -z "$pr" ]; then
+            echo "No PR associated with $HEAD_SHA; skipping."
+            verdict skip
+          fi
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+
+          current_head="$(gh api "repos/$REPO/pulls/$pr" --jq '.head.sha')"
+          if [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "PR #$pr head moved to $current_head; skipping stale run."
+            verdict skip
+          fi
+
+          # Never self-clear a PR that touches the review machinery.
+          guarded="$(gh api --paginate "repos/$REPO/pulls/$pr/files" --jq '.[].filename' \
+            | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+          if [ -n "$guarded" ]; then
+            echo "PR #$pr touches review machinery; human review required:"
+            echo "$guarded"
+            verdict guarded
+          fi
+
+          if [ "$count" = "0" ]; then
+            echo "No new security issues found for $HEAD_SHA."
+            verdict clear
+          else
+            echo "$count finding(s) on $HEAD_SHA."
+            verdict flagged
+          fi
+
+      - name: Mint clearance token
+        if: steps.verdict.outputs.verdict == 'clear' || steps.verdict.outputs.verdict == 'flagged'
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.WARDEN_APP_ID }}
+          private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
+
+      - name: Grant clearance
+        if: steps.verdict.outputs.verdict == 'clear'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.verdict.outputs.pr }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/$PR/reviews" \
+            -f event=APPROVE \
+            -f commit_id="$HEAD_SHA" \
+            -f body="**Warden security clearance: clear.** No new security issues found in this diff (\`$HEAD_SHA\`). Automated clearance satisfies the required-review gate only — a human still reviews and merges. [Analysis run]($RUN_URL)"
+
+      - name: Revoke stale clearance
+        if: steps.verdict.outputs.verdict == 'flagged'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.verdict.outputs.pr }}
+          APP_SLUG: ${{ steps.app.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          rid="$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq "[.[] | select(.user.login == \"${APP_SLUG}[bot]\" and .state == \"APPROVED\")] | last | .id // empty")"
+          if [ -n "$rid" ]; then
+            gh api -X PUT "repos/$REPO/pulls/$PR/reviews/$rid/dismissals" \
+              -f message="Warden found new security findings on the latest diff; clearance revoked." \
+              || echo "Could not dismiss review $rid (may already be dismissed)."
+          else
+            echo "No active clearance to revoke."
+          fi

--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: warden-clearance-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   clearance:
     if: >-
@@ -34,6 +38,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: warden-clearance
     steps:
       - name: Check clearance identity is configured

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -11,7 +11,10 @@ on:
     branches: [dev]
 
 permissions:
-  contents: read
+  # contents:write is required by GitHub to resolve review threads via
+  # GraphQL; Warden auto-resolves its own findings once fixed, which the
+  # ruleset's required_review_thread_resolution depends on.
+  contents: write
   pull-requests: write
   checks: write
 

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
-  WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+  WARDEN_OPENAI_API_KEY: ${{ secrets.WARDEN_OPENAI_API_KEY }}
 
 jobs:
   warden:

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,0 +1,63 @@
+name: Warden
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: warden-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+  WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+
+jobs:
+  warden:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Analyze
+        id: analyze
+        uses: getsentry/warden@v0
+        with:
+          mode: analyze
+
+      - name: Report
+        uses: getsentry/warden@v0
+        with:
+          mode: report
+          findings-file: ${{ steps.analyze.outputs.findings-file }}
+
+      # Consumed by warden-clearance.yml (workflow_run). The clearance
+      # workflow refuses to act on PRs that touch review machinery, so this
+      # artifact cannot be forged without tripping that guard.
+      - name: Write clearance summary
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FINDINGS_COUNT: ${{ steps.analyze.outputs.findings-count }}
+          HIGH_COUNT: ${{ steps.analyze.outputs.high-count }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg sha "$HEAD_SHA" \
+            --arg count "$FINDINGS_COUNT" \
+            --arg high "$HIGH_COUNT" \
+            '{head_sha: $sha, findings_count: ($count | tonumber), high_count: ($high | tonumber)}' \
+            > warden-summary.json
+          cat warden-summary.json
+
+      - name: Upload clearance summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: warden-summary
+          path: warden-summary.json

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,8 +1,13 @@
 name: Warden
 
+# Trigger types must stay aligned with the warden.toml trigger actions:
+# an event that runs this workflow but matches no warden trigger would
+# produce findings_count=0 without analysis and wrongly grant clearance.
+# (ready_for_review is deliberately absent — warden does not support it;
+# draft-to-ready PRs get analyzed on their next push.)
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches: [dev]
 
 permissions:
@@ -20,8 +25,13 @@ env:
 
 jobs:
   warden:
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip drafts and fork PRs: forks have no secrets, so analysis cannot
+    # run (and clearance is fork-blocked in warden-clearance.yml anyway).
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -34,16 +34,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Analyze
         id: analyze
-        uses: getsentry/warden@v0
+        uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0
         with:
           mode: analyze
 
       - name: Report
-        uses: getsentry/warden@v0
+        uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0
         with:
           mode: report
           findings-file: ${{ steps.analyze.outputs.findings-file }}
@@ -67,7 +67,7 @@ jobs:
           cat warden-summary.json
 
       - name: Upload clearance summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: warden-summary
           path: warden-summary.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ transcript-analysis
 evals/results/
 .playwright-mcp/
 .vscode/
+
+# Warden local run logs
+.warden/logs/

--- a/.warden/skills/diff-security-review/SKILL.md
+++ b/.warden/skills/diff-security-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: diff-security-review
+description: Flag only new security issues introduced by this diff. Gates Warden security clearance.
+allowed-tools: Read Grep Glob
+---
+
+You are reviewing a diff to answer exactly one question: does this change
+introduce a NEW security issue that did not exist before?
+
+Only report an issue when ALL of these hold:
+
+- It is introduced or made materially worse by the changed lines, not a
+  pre-existing problem in surrounding code.
+- It has a concrete security impact: command/SQL/code injection, XSS, SSRF,
+  path traversal, authn/authz bypass, secret or credential exposure, unsafe
+  deserialization, prototype pollution, insecure crypto or randomness, PII
+  leakage, supply-chain risk (new dependency with install scripts, typosquats,
+  unpinned remote code), or unsafe Electron patterns (enabling
+  `nodeIntegration`, disabling `contextIsolation` or `sandbox`, IPC handlers
+  trusting renderer input for filesystem/shell operations,
+  `shell.openExternal` with untrusted input, loading remote content in
+  privileged windows).
+- There is a plausible attack path: attacker-controlled input reaches the
+  sink, or a secret is actually exposed to an untrusted party.
+
+Do NOT report:
+
+- Style, performance, correctness, or maintainability issues.
+- Pre-existing issues in unchanged code, even if you notice them.
+- Theoretical weaknesses with no plausible attacker-controlled input path.
+- Hardening that was already absent before this change.
+- Test fixtures, mocks, or intentionally fake credentials that never grant
+  real access.
+
+For each finding, report:
+
+- The exact file and changed lines that introduce the issue.
+- The attack path: who controls the input and what they gain.
+- Severity: `critical` (RCE, auth bypass, real secret leak), `high`
+  (injection, XSS, SSRF, traversal), `medium` (info disclosure, weak crypto),
+  `low` (defense-in-depth regression introduced by this diff).
+- A concrete fix in the changed code.
+
+If the diff introduces no new security issues, report nothing. Silence is the
+correct output for a clean diff; do not manufacture findings.

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,32 @@
+version = 1
+
+# Warden gates "security clearance" on a single question: does this diff
+# introduce a new security issue? See .warden/skills/diff-security-review.
+# The clearance itself is granted by .github/workflows/warden-clearance.yml.
+
+[defaults]
+reportOn = "low"
+ignorePaths = [
+  "**/node_modules/**",
+  "**/pnpm-lock.yaml",
+  "**/dist/**",
+  "**/*.min.js",
+]
+
+[defaults.agent]
+model = "anthropic/claude-sonnet-4-6"
+
+[defaults.auxiliary]
+model = "anthropic/claude-haiku-4-5"
+
+[[skills]]
+name = "diff-security-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+draft = false
+
+# Lets developers run `warden` locally on uncommitted changes before pushing.
+[[skills.triggers]]
+type = "local"

--- a/warden.toml
+++ b/warden.toml
@@ -14,10 +14,13 @@ ignorePaths = [
 ]
 
 [defaults.agent]
-model = "anthropic/claude-sonnet-4-6"
+model = "openai/gpt-5.6-luna"
 
+# Auxiliary verifies/merges findings and gates what survives to the report;
+# keep it on the same strong model so weak verification can't cause a false
+# clearance.
 [defaults.auxiliary]
-model = "anthropic/claude-haiku-4-5"
+model = "openai/gpt-5.6-luna"
 
 [[skills]]
 name = "diff-security-review"


### PR DESCRIPTION
## Summary
- Adds Sentry Warden (open-source, runs on our own Anthropic key — no Sentry account/DSN involved) to review every PR diff with one custom skill: `diff-security-review`, which answers a single question: **does this diff introduce a new security issue?**
- Adds a "security clearance" flow: when the diff is clean, a dedicated GitHub App posts a review that satisfies the required-review gate in the `dev` branch ruleset. Humans still review and merge — this only removes the wait-for-review blocker on clean diffs.
- Deliberately avoids "approval" language everywhere; the concept is a clearance with verdicts `clear` / `flagged`.

## Why
- The ruleset on `dev` requires 1 approving review with `require_last_push_approval`. Clean PRs (docs, chores, agent-authored fixes) stall waiting for a reviewer. This gives them an independent, automated security gate while keeping humans on the merge button and on anything the gate refuses to clear.

## Issue
- Closes # (none)

## Scope
- `warden.toml` — single skill, PR trigger (+ `local` trigger so devs can run `warden` before pushing)
- `.warden/skills/diff-security-review/SKILL.md` — the custom prompt (new security issues only; explicit do-not-report list)
- `.github/workflows/warden.yml` — analyze + report on PRs to `dev`, uploads `{head_sha, findings_count}` summary artifact
- `.github/workflows/warden-clearance.yml` — `workflow_run` gatekeeper: grants clearance on `clear`, revokes on `flagged`, refuses (`guarded`) when the PR touches review machinery
- `.gitignore` — ignore `.warden/logs/`

## Out of scope
- Creating the GitHub App and secrets (admin setup, listed below)
- Auto-fix / fix PRs (`--fix`, `createFixPR`) — intentionally off; the clearance identity must never push
- CODEOWNERS

## Testing
### Ran
- `actionlint .github/workflows/warden.yml .github/workflows/warden-clearance.yml`
- Live skill test with the real CLI (`pnpm dlx @sentry/warden preview-server.ts --json --log`, `anthropic/claude-sonnet-4-6`, team Anthropic key) against three scratch diffs:
  1. planted command injection + reflected XSS
  2. subtly weak version (fixed `/tmp` output path)
  3. genuinely clean version

### Result
- pass/fail: pass
  - actionlint: 0 issues
  - vulnerable diff -> 2 high findings (exec injection, reflected XSS), correct files/lines -> would be `flagged`
  - subtle diff -> 1 medium (symlink overwrite via predictable `/tmp/preview.png`) -> `flagged` (legitimate catch, not planted)
  - clean diff -> 0 findings -> `clear`
- ~$0.09 / ~1 min per run at small-diff size

## CI status
- pass: expected — both new workflows no-op safely until secrets exist (`warden.yml` needs `WARDEN_ANTHROPIC_API_KEY`; `warden-clearance.yml` logs "clearance disabled" without `WARDEN_APP_ID`)
- code-related failures: none known
- external/env/auth blockers: app + secrets not yet created (see below)

## Manual verification
Admin setup required first:
1. Create the GitHub App: `npx @sentry/warden setup-app --org different-ai` (name e.g. "Warden Clearance"; needs only Pull requests: write, Contents: read; never pushes)
2. Repo secrets: `WARDEN_ANTHROPIC_API_KEY` (+ optional `WARDEN_MODEL`); environment `warden-clearance` restricted to `dev` with `WARDEN_APP_ID`, `WARDEN_PRIVATE_KEY`
3. Recommended: turn OFF "Allow GitHub Actions to create and approve pull requests" so the app is the only automated review identity

Then prove end-to-end on live PRs:
1. Open a test PR with a planted vuln -> expect inline findings, no clearance
2. Push a clean fix -> expect prior state dismissed, clearance granted, required-review gate green
3. Open a PR touching `.github/**` -> expect `guarded`, no clearance (this PR itself demonstrates that case)

## Evidence
- N/A for video (CI/GitHub-side flow, no app runtime path — fraimz does not apply). Validation is the CLI runs above; repro commands included. Live-PR proof happens right after admin setup via the steps in Manual verification.

## Risk
- An LLM reviewer can be prompt-injected by diff content into staying silent; residual risk accepted because: clearance never covers review-machinery paths, CodeQL + signed commits + thread resolution still gate, fork PRs never auto-clear, and humans still merge.
- Verdict gate is `findings_count == 0` (any severity blocks clearance).
- Note: once merged, this system refuses to clear PRs like this one (touches `.github/` + `warden.toml`) — review-machinery changes always need a human.

## Rollback
- Delete the two workflows (or the app secrets) — everything no-ops. No app code touched.
