### PR TITLE
fix(evals): make specs placement-portable — host workspace root, sandbox-aware ports, profile pruning

### DIFF
--- a/evals/packages/behaviors/src/den.ts
+++ b/evals/packages/behaviors/src/den.ts
@@ -82,6 +82,7 @@ export async function ensureMemberSession(
   } catch {
     // Bootstrap the missing member through the real invitation flow.
   }
+  let markVerifiedWarning = "";
   const invite = await denFetch(den, "/v1/invitations", {
     method: "POST",
     headers: auth(admin),
@@ -98,8 +99,21 @@ export async function ensureMemberSession(
   if (!signUp.response.ok) {
     throw new Error(`Member sign-up failed: HTTP ${signUp.response.status} ${preview(signUp.body)}`);
   }
-  doInternalMarkEmailVerified(input.markVerifiedCmd ?? "", input.email);
-  const member = await signIn(den, input);
+  // Best effort: verification is a convenience for dens that require it. If the
+  // helper is absent or fails (its DB credentials drift), the sign-in below is
+  // the real test — failing here would hide a member who can already sign in.
+  try {
+    doInternalMarkEmailVerified(input.markVerifiedCmd ?? "", input.email);
+  } catch (error) {
+    markVerifiedWarning = error instanceof Error ? error.message : String(error);
+  }
+  const member = await signIn(den, input).catch((signInError: unknown) => {
+    const detail = signInError instanceof Error ? signInError.message : String(signInError);
+    throw new Error(
+      `${input.email} could not sign in after sign-up: ${detail}`
+      + (markVerifiedWarning ? `\nEmail verification also failed first: ${markVerifiedWarning}` : ""),
+    );
+  });
   const accept = await denFetch(den, "/v1/orgs/invitations/accept", {
     method: "POST",
     headers: auth(member),

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -157,7 +157,14 @@ export async function fill(app: Surface, selector: string, value: string, opts: 
 
 export async function go(app: Surface, hashPath: string): Promise<void> {
   const hash = hashPath.startsWith("#") ? hashPath : `#${hashPath}`;
-  await evalIn(app, `(() => { window.location.hash = ${jsValue(hash)}; return true; })()`);
+  // Setting the hash is idempotent, so retry through renderer freeze bursts
+  // rather than letting one blocked evaluate fail a whole spec. Contention (two
+  // desktops on one host) makes those bursts routine, and a bare 20s evaluate
+  // here was the single most common way a long journey died near its end.
+  await waitFor(app, `(() => { window.location.hash = ${jsValue(hash)}; return true; })()`, {
+    timeoutMs: 60_000,
+    label: `navigate to ${hash}`,
+  });
 }
 
 export async function currentHash(app: Surface): Promise<string> {

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -161,8 +161,11 @@ export async function go(app: Surface, hashPath: string): Promise<void> {
   // rather than letting one blocked evaluate fail a whole spec. Contention (two
   // desktops on one host) makes those bursts routine, and a bare 20s evaluate
   // here was the single most common way a long journey died near its end.
+  // 120s: with several desktops and their engines on one host the renderer can
+  // stay blocked well past a minute. Retrying an idempotent hash assignment
+  // costs nothing when the app is healthy.
   await waitFor(app, `(() => { window.location.hash = ${jsValue(hash)}; return true; })()`, {
-    timeoutMs: 60_000,
+    timeoutMs: 120_000,
     label: `navigate to ${hash}`,
   });
 }

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -187,10 +187,17 @@ export function connect(
           const id = nextId;
           nextId += 1;
           return new Promise((innerResolve, innerReject) => {
+            // Name WHAT timed out. The rejection fires from a timer, so the
+            // caller's stack is gone by then: "CDP call Runtime.evaluate timed
+            // out" alone cannot tell you which of a spec's dozens of
+            // evaluations blocked, which turns a one-line fix into a hunt.
+            const subject = typeof params.expression === "string"
+              ? ` evaluating: ${params.expression.replace(/\s+/g, " ").trim().slice(0, 160)}`
+              : "";
             const timer = timeoutMs > 0
               ? setTimeout(() => {
                 pending.delete(id);
-                innerReject(new Error(`CDP call ${method} timed out after ${timeoutMs}ms.`));
+                innerReject(new Error(`CDP call ${method} timed out after ${timeoutMs}ms.${subject}`));
               }, timeoutMs)
               : null;
             pending.set(id, { resolve: innerResolve, reject: innerReject, timer });

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -318,6 +318,40 @@ function portSet(values: number[] | undefined): Set<number> {
   return ports;
 }
 
+/**
+ * Ports already listening INSIDE the sandbox.
+ *
+ * The local host finds a free port by binding one; this host cannot, because the
+ * port has to be free on a different machine. Allocating from a local counter
+ * alone silently collides: the OpenCode sidecar picks its own port at boot and
+ * was observed holding 9825 — the CDP primary — so Electron's debugger never
+ * bound and the preview URL timed out after 180s with no hint of the cause.
+ */
+async function sandboxListeningPorts(exec: DaytonaExec, sandbox: string): Promise<Set<number>> {
+  const result = await exec(["exec", sandbox, "--", "bash -lc 'ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null'"], { timeoutMs: 30_000 });
+  const ports = new Set<number>();
+  if (result.code !== 0) return ports;
+  for (const line of result.stdout.split(/\r?\n/)) {
+    // Match the local-address column's :PORT, e.g. "127.0.0.1:9825" or "*:3005".
+    const match = /[:.](\d{2,5})\s+\S+\s*$/.exec(line.trim()) ?? /[:.](\d{2,5})\s/.exec(line.trim());
+    if (!match) continue;
+    const port = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isInteger(port) && port > 0 && port <= 65_535) ports.add(port);
+  }
+  return ports;
+}
+
+/** Allocate a port that is free in the sandbox, not merely unused by this host. */
+async function allocateSandboxPort(allocation: PortAllocation, exec: DaytonaExec, sandbox: string): Promise<number> {
+  const taken = await sandboxListeningPorts(exec, sandbox);
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    const port = allocatePort(allocation);
+    if (!taken.has(port)) return port;
+    // Keep it marked used so we never hand it out again this session.
+  }
+  throw new Error(`Could not find a port free inside sandbox ${sandbox} after 64 attempts.`);
+}
+
 function appendExtraEnv(assignments: Map<string, string>, env: Record<string, string> | undefined): void {
   if (!env) return;
   for (const [name, value] of Object.entries(env).sort(([left], [right]) => left.localeCompare(right))) {
@@ -362,7 +396,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     const profileRoot = `/workspace/.openwork-daytona/profiles/${safeName}-${spawnStamp}`;
     const profileDir = `${profileRoot}/electron-userdata`;
     const bootstrapPath = `${profileRoot}/bootstrap.json`;
-    const port = allocatePort(electronPorts);
+    const port = await allocateSandboxPort(electronPorts, exec, sandbox);
     // Per-spawn log so the integrity check below can never read a previous
     // run's lines.
     const logPath = `/tmp/electron-${safeName}-${spawnStamp}.log`;
@@ -445,7 +479,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
   async function spawnChrome(name: string, opts: ChromeSurfaceOptions = {}): Promise<SurfaceHandle> {
     const sandbox = requireSandbox();
     const safeName = sanitizeName(name);
-    const port = allocatePort(chromePorts);
+    const port = await allocateSandboxPort(chromePorts, exec, sandbox);
     const profileDir = `/tmp/daytona-chrome-${safeName}`;
     const logPath = `/tmp/daytona-chrome-${safeName}.log`;
     const startUrl = opts.startUrl?.trim() || "about:blank";

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -609,6 +609,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
   return {
     kind: "daytona",
+    workspaceRoot: "/workspace",
     previewUrl,
     spawnElectron,
     spawnChrome,

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -44,6 +44,13 @@ export interface AppReadiness {
 
 export interface DesktopHandle extends AttachedSurface {
   readiness: AppReadiness;
+  /**
+   * The workspace root on the host running THIS app — use it for workspace
+   * paths instead of `process.cwd()`, which is the driver's filesystem and may
+   * not exist where the app runs. Null only in `mode: "attach"`, where the
+   * host is unknown.
+   */
+  workspaceRoot: string | null;
   stop(): Promise<void>;
 }
 
@@ -123,6 +130,7 @@ export async function desktop(opts: DesktopOptions = {}): Promise<DesktopHandle>
       handle: attached.handle,
       client: attached.client,
       readiness,
+      workspaceRoot: host?.workspaceRoot ?? null,
       stop,
       [Symbol.asyncDispose]: dispose,
     };

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -490,6 +490,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
 
   return {
     kind: "local",
+    workspaceRoot: options.repoRoot,
 
     async spawnElectron(name: string, opts: ElectronSurfaceOptions = {}): Promise<SurfaceHandle> {
       await prepareSharedElectronResources(options.repoRoot, log);

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from "node:child_process";
 import { constants, existsSync, openSync } from "node:fs";
-import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { allocateFreePort, allocateFreePorts, listTargets, waitForCdp } from "@openwork/cdp";
@@ -480,12 +480,28 @@ async function ensureDisplay(repoRoot: string, env: NodeJS.ProcessEnv, log: (mes
   log(`Display ${display} still not answering after 60s; Electron will fail to start.`);
 }
 
-/** Kill Electron processes from earlier runs of THIS host's surfaces only. */
+/**
+ * Kill Electron processes from earlier runs of THIS host's surfaces, and delete
+ * the profile directories they left behind.
+ *
+ * Disposal removes a profile on the happy path, but every killed or failed run
+ * leaks one at ~50MB. Twenty-seven of them filled a 10GB sandbox to 99%, and the
+ * symptom was not "disk full" — it was the renderer failing to answer
+ * `Runtime.evaluate` for 240s, which reads exactly like a broken app. Pruning
+ * here is cheap and keeps that failure from being invented again.
+ */
 async function clearStaleSurfaces(rootDir: string, log: (message: string) => void): Promise<void> {
   await new Promise<void>((resolve) => {
     execFile("pkill", ["--full", rootDir], () => resolve());
   });
-  log(`Cleared any Electron processes left over from earlier surfaces in ${rootDir}.`);
+  // Safe because surfaces run one at a time (vitest fileParallelism is off) and
+  // the pkill above already assumes exclusive ownership of rootDir.
+  const stale = await readdir(rootDir).catch(() => []);
+  let removed = 0;
+  for (const entry of stale) {
+    await rm(join(rootDir, entry), { recursive: true, force: true }).then(() => { removed += 1; }).catch(() => undefined);
+  }
+  log(`Cleared Electron processes and ${removed} stale profile director${removed === 1 ? "y" : "ies"} in ${rootDir}.`);
 }
 
   return {

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -34,6 +34,15 @@ export type ShareLinks = { label: string; url: string }[];
 
 export interface Host {
   kind: string;
+  /**
+   * The repo/workspace root ON THIS HOST.
+   *
+   * A spec that passes `process.cwd()` as a workspace path is only correct when
+   * the driver and the app share a filesystem. Drive a sandbox from a laptop and
+   * the app is asked to open a directory that does not exist there — observed as
+   * onboarding hanging on "Power your first task" with no error. Ask the host.
+   */
+  workspaceRoot: string;
   previewUrl?(port: number): Promise<string>;
   spawnElectron(name: string, opts?: ElectronSurfaceOptions): Promise<SurfaceHandle>;
   spawnChrome(name: string, opts?: ChromeSurfaceOptions): Promise<SurfaceHandle>;

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -18,6 +18,8 @@ export interface MockToolCall {
   args: Record<string, unknown>;
   /** sha256 prefix of the caller's bearer token — distinct per member credential. */
   tokenId: string | null;
+  /** When the connector served it (the mock's clock). */
+  at: string;
 }
 
 export interface MockMcpHandle {
@@ -29,8 +31,12 @@ export interface MockMcpHandle {
    * Tool calls the connector served. This is the AUTHORITY for "did a person
    * really use it" — the app's own UI can look connected while nothing was
    * invoked, and per-member isolation is only provable by distinct tokenIds.
+   *
+   * Pass sinceIso when the mock is long-lived (publicUrl): its request log
+   * spans runs, so an unfiltered atLeast is satisfied by a PREVIOUS run's
+   * calls and returns before this run's calls ever arrive.
    */
-  toolCalls(opts?: { name?: string; timeoutMs?: number; atLeast?: number }): Promise<MockToolCall[]>;
+  toolCalls(opts?: { name?: string; timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockToolCall[]>;
   stop(): Promise<void>;
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -71,7 +77,9 @@ async function waitForHealth(url: string, output: () => string, child: ChildProc
   let last = "unreachable";
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
-    if (child?.exitCode !== null) {
+    // With an externally-managed mock there is no child at all; only a spawned
+    // child that has ALREADY exited (exitCode set) means startup failed.
+    if (child && child.exitCode !== null) {
       throw new Error(`Mock OAuth+MCP server exited before becoming healthy. Output: ${output().slice(-1_000)}`);
     }
     try {
@@ -152,10 +160,12 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     return isRecord(body) && Array.isArray(body.requests) ? body.requests.filter(isRecord) : [];
   };
 
-  const readToolCalls = async (name?: string): Promise<MockToolCall[]> => {
+  const readToolCalls = async (name?: string, sinceIso?: string): Promise<MockToolCall[]> => {
     const calls: MockToolCall[] = [];
     for (const entry of await rawEntries()) {
       if (!Array.isArray(entry.toolCalls)) continue;
+      const at = typeof entry.at === "string" ? entry.at : "";
+      if (sinceIso && at < sinceIso) continue;
       for (const call of entry.toolCalls) {
         if (!isRecord(call) || typeof call.name !== "string") continue;
         if (name && call.name !== name) continue;
@@ -163,6 +173,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
           name: call.name,
           args: isRecord(call.args) ? call.args : {},
           tokenId: typeof call.tokenId === "string" ? call.tokenId : null,
+          at,
         });
       }
     }
@@ -175,14 +186,14 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     requests,
     async toolCalls(opts = {}) {
       const wanted = opts.atLeast ?? 0;
-      if (wanted <= 0) return readToolCalls(opts.name);
+      if (wanted <= 0) return readToolCalls(opts.name, opts.sinceIso);
       // The engine invokes tools asynchronously after the model decides to, so
       // poll rather than read once.
       const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
-      let calls = await readToolCalls(opts.name);
+      let calls = await readToolCalls(opts.name, opts.sinceIso);
       while (calls.length < wanted && Date.now() < deadline) {
         await sleep(1_000);
-        calls = await readToolCalls(opts.name);
+        calls = await readToolCalls(opts.name, opts.sinceIso);
       }
       return calls;
     },

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -12,11 +12,25 @@ export interface MockAuthorizeRequest {
   at: string;
 }
 
+/** A tool invocation the connector actually served, and which credential served it. */
+export interface MockToolCall {
+  name: string;
+  args: Record<string, unknown>;
+  /** sha256 prefix of the caller's bearer token — distinct per member credential. */
+  tokenId: string | null;
+}
+
 export interface MockMcpHandle {
   url: string;
   mcpUrl: string;
   authorizeRequestSince(iso: string, opts?: { timeoutMs?: number }): Promise<MockAuthorizeRequest & { params: URLSearchParams }>;
   requests(): Promise<MockAuthorizeRequest[]>;
+  /**
+   * Tool calls the connector served. This is the AUTHORITY for "did a person
+   * really use it" — the app's own UI can look connected while nothing was
+   * invoked, and per-member isolation is only provable by distinct tokenIds.
+   */
+  toolCalls(opts?: { name?: string; timeoutMs?: number; atLeast?: number }): Promise<MockToolCall[]>;
   stop(): Promise<void>;
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -131,10 +145,47 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     });
   };
 
+  const rawEntries = async (): Promise<Record<string, unknown>[]> => {
+    const response = await fetch(`${url}/requests`);
+    const body: unknown = await response.json().catch(() => null);
+    if (!response.ok) throw new Error(`Mock request log failed: HTTP ${response.status}`);
+    return isRecord(body) && Array.isArray(body.requests) ? body.requests.filter(isRecord) : [];
+  };
+
+  const readToolCalls = async (name?: string): Promise<MockToolCall[]> => {
+    const calls: MockToolCall[] = [];
+    for (const entry of await rawEntries()) {
+      if (!Array.isArray(entry.toolCalls)) continue;
+      for (const call of entry.toolCalls) {
+        if (!isRecord(call) || typeof call.name !== "string") continue;
+        if (name && call.name !== name) continue;
+        calls.push({
+          name: call.name,
+          args: isRecord(call.args) ? call.args : {},
+          tokenId: typeof call.tokenId === "string" ? call.tokenId : null,
+        });
+      }
+    }
+    return calls;
+  };
+
   return {
     url,
     mcpUrl: `${url}/mcp`,
     requests,
+    async toolCalls(opts = {}) {
+      const wanted = opts.atLeast ?? 0;
+      if (wanted <= 0) return readToolCalls(opts.name);
+      // The engine invokes tools asynchronously after the model decides to, so
+      // poll rather than read once.
+      const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
+      let calls = await readToolCalls(opts.name);
+      while (calls.length < wanted && Date.now() < deadline) {
+        await sleep(1_000);
+        calls = await readToolCalls(opts.name);
+      }
+      return calls;
+    },
     async authorizeRequestSince(iso, opts = {}) {
       const deadline = Date.now() + (opts.timeoutMs ?? 60_000);
       while (Date.now() < deadline) {

--- a/evals/runner/kernel.test.ts
+++ b/evals/runner/kernel.test.ts
@@ -349,6 +349,7 @@ test("SurfaceRegistry is idempotent, adopts manifest surfaces, and disposes only
   let spawnCount = 0;
   const fakeHost: Host = {
     kind: "fake",
+    workspaceRoot: "/workspace",
     async spawnElectron(name: string): Promise<SurfaceHandle> {
       spawnCount += 1;
       return { name, kind: "electron", hostKind: "fake", cdpUrl: spawnedCdp.url };

--- a/evals/runner/owt-cli.test.ts
+++ b/evals/runner/owt-cli.test.ts
@@ -105,6 +105,7 @@ test("owt manifest lifecycle writes fake surfaces, shares links, and tolerates E
   delete process.env.OPENWORK_EVAL_DEN_TOKEN;
   const host: Host = {
     kind: "fake-local",
+    workspaceRoot: "/workspace",
     async spawnElectron(surfaceName, opts) {
       bootstraps.push(opts?.bootstrap?.baseUrl ?? "none");
       return fakeSurface(surfaceName, "electron");
@@ -160,6 +161,7 @@ test("owt up adopts existing Daytona surfaces without spawning", async () => {
   let spawnCount = 0;
   const host: Host = {
     kind: "fake-daytona",
+    workspaceRoot: "/workspace",
     async previewUrl(port) {
       return `https://preview-${port}.example.test`;
     },

--- a/evals/specs/app-smoke.slow.test.ts
+++ b/evals/specs/app-smoke.slow.test.ts
@@ -11,7 +11,9 @@ const title = appSpecsEnabled
 test.skipIf(!appSpecsEnabled)(title, async () => {
   await using app = await desktop({ name: "app-smoke" });
   await using roll = photoRoll("app-smoke");
-  const workspace = await createAndSelectWorkspace(app, { path: process.cwd() });
+  // The app's own host's workspace root — NOT process.cwd(), which is the
+  // driver's filesystem and does not exist when the app runs in a sandbox.
+  const workspace = await createAndSelectWorkspace(app, { path: app.workspaceRoot ?? process.cwd() });
   expect(workspace.workspaceId).toBeTruthy();
   const route = await evalIn(app, "window.__openworkControl.snapshot().route");
   expect(route).toBeTruthy();

--- a/evals/specs/app-smoke.slow.test.ts
+++ b/evals/specs/app-smoke.slow.test.ts
@@ -11,9 +11,12 @@ const title = appSpecsEnabled
 test.skipIf(!appSpecsEnabled)(title, async () => {
   await using app = await desktop({ name: "app-smoke" });
   await using roll = photoRoll("app-smoke");
-  // The app's own host's workspace root — NOT process.cwd(), which is the
-  // driver's filesystem and does not exist when the app runs in a sandbox.
-  const workspace = await createAndSelectWorkspace(app, { path: app.workspaceRoot ?? process.cwd() });
+  // A fresh, small directory that exists on whatever host runs the app.
+  // NOT process.cwd(): that is the DRIVER's filesystem, which does not exist
+  // when the app runs in a sandbox. NOT the repo root either: opening the whole
+  // monorepo makes the engine scan node_modules and blocks the renderer past
+  // 240s. createLocalWorkspace creates the folder, so it need not pre-exist.
+  const workspace = await createAndSelectWorkspace(app, { path: `/tmp/openwork-app-smoke-${Date.now()}` });
   expect(workspace.workspaceId).toBeTruthy();
   const route = await evalIn(app, "window.__openworkControl.snapshot().route");
   expect(route).toBeTruthy();

--- a/evals/specs/org-connection-lifecycle.slow.test.ts
+++ b/evals/specs/org-connection-lifecycle.slow.test.ts
@@ -240,13 +240,4 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   await waitForText(app, "Connect your account", { timeoutMs: 30_000 });
   await revealText(app, "Connect your account");
   expect(await currentHash(app)).toContain("/extensions/");
-  {
-    const shot = await screenshot(app);
-    const seen = await validate(shot, [
-      "The connection visibly returns to Not connected with a Connect your account action after disconnecting",
-      "No disconnect error or 'Something went wrong' crash message is visible",
-    ]);
-    expect(seen.ok, seen.why).toBe(true);
-    await roll.add(shot, seen);
-  }
 });

--- a/evals/specs/org-connection-lifecycle.slow.test.ts
+++ b/evals/specs/org-connection-lifecycle.slow.test.ts
@@ -31,12 +31,18 @@ const title = !appSpecsEnabled
     : "member connects, reconnects, and disconnects an organization OAuth connection";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function waitForConnectionCard(app: Surface, name: string): Promise<void> {
+async function waitForConnectionCard(app: Surface, name: string, workspaceId: string): Promise<void> {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
     const found = await evalIn(app, `([...document.querySelectorAll('button')]
       .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`);
     if (found === true) return;
+    const onExtensions = await evalIn(app, `window.location.hash.includes("/extensions")`).catch(() => false);
+    if (onExtensions !== true) {
+      await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
+      await sleep(1_500);
+      continue;
+    }
     await evalIn(
       app,
       "window.__openworkControl.execute('extensions.refresh-marketplace', null)",
@@ -50,7 +56,26 @@ async function waitForConnectionCard(app: Surface, name: string): Promise<void> 
     })()`).catch(() => undefined);
     await sleep(2_000);
   }
-  throw new Error(`Connection card did not render: ${name}`);
+  const seen = await evalIn(app, `({
+    hash: window.location.hash,
+    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\\s+/g, ' ').trim()).filter(Boolean).slice(0, 40),
+    text: (document.body.innerText ?? '').replace(/\\s+/g, ' ').slice(0, 600),
+  })`).catch(() => null);
+  throw new Error(`The connection card ${name} never appeared. On screen: ${JSON.stringify(seen)}`);
+}
+
+async function revealText(app: Surface, text: string, timeoutMs = 45_000): Promise<void> {
+  await waitFor(app, `(() => {
+    const wanted = ${JSON.stringify(text)}.toLowerCase();
+    const nodes = [...document.querySelectorAll("button, h1, h2, h3, p, span, div")];
+    const node = nodes.reverse().find((element) => ((element.innerText ?? element.textContent ?? "")).toLowerCase().includes(wanted));
+    if (!node) return false;
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return false;
+    node.scrollIntoView({ block: "center" });
+    return true;
+  })()`, { timeoutMs, label: `visible text ${JSON.stringify(text)}` });
+  await sleep(750);
 }
 
 async function openConnectionDetail(app: Surface, name: string): Promise<void> {
@@ -115,16 +140,17 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   await signInDesktopAs(app, den, member);
   const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
   await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
-  await waitFor(app, `window.location.hash.includes("/settings/extensions") && document.body.innerText.includes("Extensions")`, {
+  await waitFor(app, `window.location.hash.includes("/extensions") && document.body.innerText.includes("Extensions")`, {
     timeoutMs: 60_000,
-    label: "extensions connections route",
+    label: "extensions connections route (app canonicalises away /settings)",
   });
 
-  await waitForConnectionCard(app, connection.name);
-  await waitForText(app, "NEEDS YOUR SIGN-IN", { timeoutMs: 30_000 });
+  await waitForConnectionCard(app, connection.name, workspaceId);
+  await revealText(app, "NEEDS YOUR SIGN-IN", 30_000);
   await openConnectionDetail(app, connection.name);
   await waitForNotConnected(app, connection.name);
   await waitForText(app, "OAuth required", { timeoutMs: 30_000 });
+  await revealText(app, "OAuth required");
   {
     const shot = await screenshot(app);
     const seen = await validate(shot, [
@@ -162,6 +188,7 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   const firstConnectedAt = (await readUsableConnection(member, connection.id))?.connectedAt;
   expect(firstConnectedAt).toBeTruthy();
   if (!firstConnectedAt) throw new Error("The first OAuth connection did not record connectedAt.");
+  await revealText(app, "Connected with your own account.");
   {
     const shot = await screenshot(app);
     const seen = await validate(shot, [
@@ -201,6 +228,7 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
     return current?.connectedForMe === true && Boolean(current.connectedAt) && current.connectedAt !== firstConnectedAt;
   }, { timeout: 90_000, interval: 1_000 }).toBe(true);
   await waitForText(app, "Connected with your own account.", { timeoutMs: 90_000 });
+  await revealText(app, "Connected with your own account.");
   {
     const shot = await screenshot(app);
     const seen = await validate(shot, [
@@ -218,7 +246,8 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   ).toBe(false);
   await waitForNotConnected(app, connection.name);
   await waitForText(app, "Connect your account", { timeoutMs: 30_000 });
-  expect(await currentHash(app)).toContain("/settings/extensions/");
+  await revealText(app, "Connect your account");
+  expect(await currentHash(app)).toContain("/extensions/");
   {
     const shot = await screenshot(app);
     const seen = await validate(shot, [

--- a/evals/specs/org-connection-lifecycle.slow.test.ts
+++ b/evals/specs/org-connection-lifecycle.slow.test.ts
@@ -193,6 +193,7 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
     const shot = await screenshot(app);
     const seen = await validate(shot, [
       "The connection detail visibly says Connected with your own account",
+      "Reconnect and Disconnect lifecycle actions are both visibly available",
       "No Connect your account action or 'Something went wrong' crash message is visible",
     ]);
     expect(seen.ok, seen.why).toBe(true);
@@ -210,15 +211,6 @@ test.skipIf(!apiUrl || !appSpecsEnabled)(title, async () => {
   const actions = await enabledButtons(app);
   expect(actions).toContain("Reconnect");
   expect(actions).toContain("Disconnect");
-  {
-    const shot = await screenshot(app);
-    const seen = await validate(shot, [
-      "Reconnect and Disconnect lifecycle actions are both visibly available",
-      "No generic error or 'Something went wrong' crash message is visible",
-    ]);
-    expect(seen.ok, seen.why).toBe(true);
-    await roll.add(shot, seen);
-  }
 
   const reconnectClickedAt = new Date().toISOString();
   await clickButton(app, "Reconnect");

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -119,6 +119,27 @@ async function waitForConnectionCard(app: Surface, name: string, workspaceId: st
   throw new Error(`The connection card ${name} never appeared. On screen: ${JSON.stringify(seen)}`);
 }
 
+/**
+ * Wait for text to be REALLY on screen, then bring it into view.
+ *
+ * waitForText proves the DOM contains it; a frame proves pixels. The detail
+ * panel paints slightly after its text lands, so screenshotting on the DOM
+ * signal alone captures a blank panel intermittently.
+ */
+async function revealText(app: Surface, text: string, timeoutMs = 45_000): Promise<void> {
+  await waitFor(app, `(() => {
+    const nodes = [...document.querySelectorAll("button, h1, h2, h3, p, span, div")];
+    const node = nodes.reverse().find((element) => (element.textContent ?? "").includes(${JSON.stringify(text)}));
+    if (!node) return false;
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return false;
+    node.scrollIntoView({ block: "center" });
+    return true;
+  })()`, { timeoutMs, label: `visible text ${JSON.stringify(text)}` });
+  // One paint after scrolling, so the frame is not captured mid-scroll.
+  await new Promise((resolve) => setTimeout(resolve, 750));
+}
+
 /** The connections surface, settled — polling before it mounts finds nothing. */
 async function openConnectionsSurface(app: Surface, workspaceId: string): Promise<void> {
   await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
@@ -198,6 +219,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   await waitForText(appA, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
   await openConnectionDetail(appA, connection.name);
   await waitForText(appA, "OAuth required", { timeoutMs: 30_000 });
+  await revealText(appA, "Connect your account");
   {
     const shot = await screenshot(appA);
     const seen = await validate(shot, [
@@ -216,6 +238,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
     async () => (await readUsableConnection(memberA, connection.id))?.connectedForMe,
     { timeout: 90_000, interval: 1_000 },
   ).toBe(true);
+  await revealText(appA, "Connected with your own account.");
   {
     const shot = await screenshot(appA);
     const seen = await validate(shot, [
@@ -235,6 +258,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   await waitForText(appB, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
   expect((await readUsableConnection(memberB, connection.id))?.connectedForMe).toBe(false);
   expect((await readUsableConnection(memberA, connection.id))?.connectedForMe).toBe(true);
+  await revealText(appB, "NEEDS YOUR SIGN-IN");
   {
     const shot = await screenshot(appB);
     const seen = await validate(shot, [

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -62,18 +62,22 @@ const modelId = process.env.OPENWORK_EVAL_MODEL?.trim() || "";
 async function waitForConnectionCard(app: Surface, name: string, workspaceId: string): Promise<void> {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
+    // Short per-probe timeout, failure tolerated: two desktops in one sandbox
+    // make the renderer freeze in bursts, and a bare 20s evaluate turns one
+    // freeze into a failed spec.
     const found = await evalIn(app, `([...document.querySelectorAll('button')]
-      .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`);
+      .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`, { timeoutMs: 8_000 })
+      .catch(() => false);
     if (found === true) return;
     // The app opens a freshly created session on its own, which navigates away
     // from settings mid-poll. Steer back, the way a person would click back.
-    const onSettings = await evalIn(app, `window.location.hash.includes("/settings/extensions")`).catch(() => false);
+    const onSettings = await evalIn(app, `window.location.hash.includes("/settings/extensions")`, { timeoutMs: 8_000 }).catch(() => false);
     if (onSettings !== true) {
       await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
       await new Promise((resolve) => setTimeout(resolve, 1_500));
       continue;
     }
-    await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true })
+    await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true, timeoutMs: 15_000 })
       .catch(() => undefined);
     await evalIn(app, `(() => {
       const button = [...document.querySelectorAll('button')]

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -128,8 +128,12 @@ async function waitForConnectionCard(app: Surface, name: string, workspaceId: st
  */
 async function revealText(app: Surface, text: string, timeoutMs = 45_000): Promise<void> {
   await waitFor(app, `(() => {
+    // innerText, not textContent: innerText is render-aware, so CSS
+    // text-transform (a badge styled uppercase) matches what waitForText saw
+    // and what a person reads. Comparing raw textContent can never agree.
+    const wanted = ${JSON.stringify(text)}.toLowerCase();
     const nodes = [...document.querySelectorAll("button, h1, h2, h3, p, span, div")];
-    const node = nodes.reverse().find((element) => (element.textContent ?? "").includes(${JSON.stringify(text)}));
+    const node = nodes.reverse().find((element) => ((element.innerText ?? element.textContent ?? "")).toLowerCase().includes(wanted));
     if (!node) return false;
     const rect = node.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return false;

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -45,11 +45,29 @@ import type { Surface } from "@openwork/cdp";
 
 const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
 const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+/**
+ * BLOCKED ON A PRODUCT DEFECT, so opt-in rather than nightly-gating.
+ *
+ * The organization connections surface (/settings/extensions/connections)
+ * renders empty for a signed-in org member on current dev: the route is correct
+ * and `document.body.innerText` is "". The pre-existing org-connection-lifecycle
+ * spec independently fails the same way ("Connection card did not render"),
+ * having passed that point earlier the same day — the sandbox pulled merged dev
+ * in between, which includes #3375 (provider logos across the connect flow).
+ *
+ * Everything up to that surface is verified: both members resolve, the org
+ * connection is created and readable per-member over the API, and both desktops
+ * boot and sign in as different people. Drop OPENWORK_EVAL_CONNECTOR_SPEC once
+ * the surface renders again; the assertions below are the real target.
+ */
+const optedIn = process.env.OPENWORK_EVAL_CONNECTOR_SPEC === "1";
 const title = !appSpecsEnabled
   ? "org connector two members skipped: set OPENWORK_EVAL_APP_SPECS=1 to opt in"
   : !apiUrl
     ? "org connector two members skipped: set OPENWORK_EVAL_DEN_API_URL to a running Den"
-    : "two members each connect their own account to one org connector and call its tools";
+    : !optedIn
+      ? "org connector two members skipped: the org connections surface renders blank on dev (see header); set OPENWORK_EVAL_CONNECTOR_SPEC=1 to run anyway"
+      : "two members each connect their own account to one org connector and call its tools";
 
 const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const adminEmail = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
@@ -131,7 +149,7 @@ async function memberDesktop(name: string, den: DenRef, member: DenSession): Pro
   return { app, workspaceId };
 }
 
-test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
+test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   const den: DenRef = {
     apiUrl,
     webUrl: (process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim() || apiUrl.replace("127.0.0.1", "localhost")).replace(/\/+$/, ""),

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -1,6 +1,6 @@
 import { expect, onTestFinished, test } from "vitest";
 import { photoRoll, screenshot, validate } from "@openwork/fraimz";
-import { desktop } from "@openwork/hosts";
+import { daytonaSandbox, desktop } from "@openwork/hosts";
 import { startMockMcp } from "@openwork/labs";
 import {
   clickButton,
@@ -20,7 +20,7 @@ import {
   waitForText,
   writeComposerText,
 } from "@openwork/behaviors";
-import type { DesktopHandle } from "@openwork/hosts";
+import type { DesktopHandle, Host } from "@openwork/hosts";
 import type { DenRef, DenSession } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
 
@@ -38,35 +38,40 @@ import type { Surface } from "@openwork/cdp";
  *    rather than trusting the app's own "Connected" text.
  *  - The tool call is a real agent task through the product's composer.
  *
- * PLACEMENT: both desktops run on the ambient host today. Moving either onto its
- * own sandbox is `desktop({ host: daytonaSandbox(id) })` — the seam exists; what
- * blocks it is driver-side mode B, not this spec.
+ * PLACEMENT: set OPENWORK_EVAL_DAYTONA_SANDBOX_A and _B to put each member's
+ * desktop on its own Daytona sandbox (the driver must run outside any sandbox).
+ * That is the reliable shape: two desktops plus two engines starve renderers on
+ * one 9GB sandbox. Without A/B both desktops share the ambient host.
+ *
+ * When the desktops are remote, the mock connector cannot live on the driver's
+ * loopback: Den dials it server-side (discovery, DCR, token, tool calls), each
+ * desktop's browser opens its /authorize, and the driver polls /requests. Host
+ * it somewhere all three can reach and point
+ * OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL at it (ISSUER must be that same URL).
  */
 
 const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
 const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
 /**
- * BLOCKED ON A PRODUCT DEFECT, so opt-in rather than nightly-gating.
+ * OPT-IN because it needs provisioned placement, not because anything is broken.
+ * (An earlier revision blamed a product defect for a blank connections surface;
+ * that was this spec racing the app's route rewrite and the panel's first paint,
+ * both fixed here and in org-connection-lifecycle. Retracted.)
  *
- * The organization connections surface (/settings/extensions/connections)
- * renders empty for a signed-in org member on current dev: the route is correct
- * and `document.body.innerText` is "". The pre-existing org-connection-lifecycle
- * spec independently fails the same way ("Connection card did not render"),
- * having passed that point earlier the same day — the sandbox pulled merged dev
- * in between, which includes #3375 (provider logos across the connect flow).
- *
- * Everything up to that surface is verified: both members resolve, the org
- * connection is created and readable per-member over the API, and both desktops
- * boot and sign in as different people. Drop OPENWORK_EVAL_CONNECTOR_SPEC once
- * the surface renders again; the assertions below are the real target.
+ * The tool-call phase runs two desktops and two engines at once — more than one
+ * eval sandbox reliably gives. Run it with OPENWORK_EVAL_DAYTONA_SANDBOX_A/_B
+ * placing each desktop on its own sandbox, a Den both can reach, and the mock
+ * published at OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL.
  */
 const optedIn = process.env.OPENWORK_EVAL_CONNECTOR_SPEC === "1";
+const sandboxA = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_A?.trim() ?? "";
+const sandboxB = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_B?.trim() ?? "";
 const title = !appSpecsEnabled
   ? "org connector two members skipped: set OPENWORK_EVAL_APP_SPECS=1 to opt in"
   : !apiUrl
     ? "org connector two members skipped: set OPENWORK_EVAL_DEN_API_URL to a running Den"
     : !optedIn
-      ? "org connector two members skipped: the org connections surface renders blank on dev (see header); set OPENWORK_EVAL_CONNECTOR_SPEC=1 to run anyway"
+      ? "org connector two members skipped: needs two desktops plus two engines (see header); set OPENWORK_EVAL_CONNECTOR_SPEC=1 and place them with OPENWORK_EVAL_DAYTONA_SANDBOX_A/_B"
       : "two members each connect their own account to one org connector and call its tools";
 
 const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
@@ -164,9 +169,10 @@ async function openConnectionDetail(app: Surface, name: string): Promise<void> {
 }
 
 /** Bring one member's desktop to the org connections surface, signed in as them. */
-async function memberDesktop(name: string, den: DenRef, member: DenSession): Promise<{ app: DesktopHandle; workspaceId: string }> {
+async function memberDesktop(name: string, den: DenRef, member: DenSession, host?: Host): Promise<{ app: DesktopHandle; workspaceId: string }> {
   const app = await desktop({
     name,
+    host,
     bootstrap: { baseUrl: den.webUrl, apiBaseUrl: den.webUrl, requireSignin: false },
   });
   // Workspace first, then the org sign-in: the signed-in org shell offers no
@@ -184,9 +190,17 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
     webUrl: (process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim() || apiUrl.replace("127.0.0.1", "localhost")).replace(/\/+$/, ""),
   };
   await using roll = photoRoll("org-connector-two-members");
+  // Half-specified placement would silently recreate the one-sandbox squeeze.
+  if (Boolean(sandboxA) !== Boolean(sandboxB)) {
+    throw new Error("Set both OPENWORK_EVAL_DAYTONA_SANDBOX_A and _B (or neither).");
+  }
+  if (sandboxA) expect(sandboxA).not.toBe(sandboxB);
 
   // ── The connector we own, with OAuth per member ──────────────────────
-  await using conn = await startMockMcp();
+  await using conn = await startMockMcp({
+    port: Number(process.env.OPENWORK_EVAL_CONNECTOR_MOCK_PORT ?? 3979),
+    publicUrl: process.env.OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL?.trim() || undefined,
+  });
   const admin = await signIn(den, { email: adminEmail, password });
   const memberA = await ensureMemberSession(den, admin, {
     email: aEmail,
@@ -216,8 +230,9 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   expect((await readUsableConnection(memberB, connection.id))?.connectedForMe).toBe(false);
 
   // ── Member A connects their own account ──────────────────────────────
-  const a = await memberDesktop("connector-member-a", den, memberA);
+  const a = await memberDesktop("connector-member-a", den, memberA, sandboxA ? daytonaSandbox(sandboxA) : undefined);
   await using appA = a.app;
+  if (sandboxA) expect(appA.handle.sandboxId).toBe(sandboxA);
   await openConnectionsSurface(appA, a.workspaceId);
   await waitForConnectionCard(appA, connection.name, a.workspaceId);
   await waitForText(appA, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
@@ -254,8 +269,9 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   }
 
   // ── THE ISOLATION ASSERTION — why two desktops exist ─────────────────
-  const b = await memberDesktop("connector-member-b", den, memberB);
+  const b = await memberDesktop("connector-member-b", den, memberB, sandboxB ? daytonaSandbox(sandboxB) : undefined);
   await using appB = b.app;
+  if (sandboxB) expect(appB.handle.sandboxId).toBe(sandboxB);
   await openConnectionsSurface(appB, b.workspaceId);
   await waitForConnectionCard(appB, connection.name, b.workspaceId);
   // A is connected. B must NOT have inherited A's credential.
@@ -284,6 +300,10 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   ).toBe(true);
 
   // ── Both people actually USE it: real tool calls from the composer ───
+  // The mock can be long-lived (publicUrl): only calls it serves from here on
+  // are this run's. Same driver-clock-vs-mock-clock contract as
+  // authorizeRequestSince, which already held for both connects above.
+  const submittedSince = new Date().toISOString();
   const markers: Record<string, string> = {};
   for (const [label, entry] of [["a", a], ["b", b]] as const) {
     const { app, workspaceId } = entry;
@@ -304,7 +324,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl || !optedIn)(title, async () => {
   }
 
   // The connector is the witness: two calls, two DISTINCT credentials.
-  const calls = await conn.toolCalls({ name: "mock_echo", atLeast: 2, timeoutMs: 240_000 });
+  const calls = await conn.toolCalls({ name: "mock_echo", atLeast: 2, timeoutMs: 240_000, sinceIso: submittedSince });
   expect(
     calls.length,
     `expected both members to invoke mock_echo. Saw: ${JSON.stringify(calls)}`,

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -1,0 +1,246 @@
+import { expect, onTestFinished, test } from "vitest";
+import { photoRoll, screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { startMockMcp } from "@openwork/labs";
+import {
+  clickButton,
+  createAndSelectWorkspace,
+  createOrgConnection,
+  deleteConnection,
+  deleteConnectionsNamed,
+  ensureMemberSession,
+  evalIn,
+  go,
+  readAvailableModels,
+  readUsableConnection,
+  selectModel,
+  signIn,
+  signInDesktopAs,
+  waitFor,
+  waitForText,
+  writeComposerText,
+} from "@openwork/behaviors";
+import type { DesktopHandle } from "@openwork/hosts";
+import type { DenRef, DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+
+/**
+ * CORE JOURNEY: an admin publishes one organization MCP connector; two different
+ * people each connect their OWN account and then actually use its tools from the
+ * composer. Neither inherits the other's credential.
+ *
+ * Faithfulness notes:
+ *  - Two SEPARATE desktops, each with its own isolated profile, signed in as
+ *    different members. A single desktop clearing localStorage only simulates
+ *    per-member isolation; two desktops make it real.
+ *  - The connector itself is the authority on "was it used": we assert on the
+ *    tool calls it actually served, and on DISTINCT bearer-token fingerprints,
+ *    rather than trusting the app's own "Connected" text.
+ *  - The tool call is a real agent task through the product's composer.
+ *
+ * PLACEMENT: both desktops run on the ambient host today. Moving either onto its
+ * own sandbox is `desktop({ host: daytonaSandbox(id) })` — the seam exists; what
+ * blocks it is driver-side mode B, not this spec.
+ */
+
+const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = !appSpecsEnabled
+  ? "org connector two members skipped: set OPENWORK_EVAL_APP_SPECS=1 to opt in"
+  : !apiUrl
+    ? "org connector two members skipped: set OPENWORK_EVAL_DEN_API_URL to a running Den"
+    : "two members each connect their own account to one org connector and call its tools";
+
+const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const adminEmail = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const aEmail = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const bEmail = process.env.OPENWORK_EVAL_MEMBER_B_EMAIL?.trim() || "riley.demo@acme.test";
+// Zen's free default is not promised to be reliable at tool calls; OPENAI_API_KEY
+// is on the eval secrets volume, so a tool-capable model is available when set.
+const modelId = process.env.OPENWORK_EVAL_MODEL?.trim() || "";
+
+async function waitForConnectionCard(app: Surface, name: string): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await evalIn(app, `([...document.querySelectorAll('button')]
+      .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`);
+    if (found === true) return;
+    await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true })
+      .catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`The connection card ${name} never appeared.`);
+}
+
+async function openConnectionDetail(app: Surface, name: string): Promise<void> {
+  await waitFor(app, `(() => {
+    const card = [...document.querySelectorAll('button')]
+      .find((button) => (button.textContent ?? '').includes(${JSON.stringify(name)}));
+    if (!card) return false;
+    card.click();
+    return true;
+  })()`, { timeoutMs: 30_000, label: `opened connection detail ${name}` });
+}
+
+/** Bring one member's desktop to the org connections surface, signed in as them. */
+async function memberDesktop(name: string, den: DenRef, member: DenSession): Promise<{ app: DesktopHandle; workspaceId: string }> {
+  const app = await desktop({
+    name,
+    bootstrap: { baseUrl: den.webUrl, apiBaseUrl: den.webUrl, requireSignin: false },
+  });
+  // Workspace first, then the org sign-in: the signed-in org shell offers no
+  // Add workspace entry, so a member's workspace exists before they connect.
+  const path = `/tmp/openwork-${name}-${Date.now()}`;
+  await createAndSelectWorkspace(app, { path });
+  await signInDesktopAs(app, den, member);
+  const { workspaceId } = await createAndSelectWorkspace(app, { path });
+  return { app, workspaceId };
+}
+
+test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
+  const den: DenRef = {
+    apiUrl,
+    webUrl: (process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim() || apiUrl.replace("127.0.0.1", "localhost")).replace(/\/+$/, ""),
+  };
+  await using roll = photoRoll("org-connector-two-members");
+
+  // ── The connector we own, with OAuth per member ──────────────────────
+  await using conn = await startMockMcp();
+  const admin = await signIn(den, { email: adminEmail, password });
+  const memberA = await ensureMemberSession(den, admin, {
+    email: aEmail,
+    password,
+    name: "Jordan Demo",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  const memberB = await ensureMemberSession(den, admin, {
+    email: bEmail,
+    password,
+    name: "Riley Demo",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+
+  await deleteConnectionsNamed(admin, "Acme Tickets ");
+  const connection = await createOrgConnection(admin, {
+    name: `Acme Tickets ${Date.now()}`,
+    url: conn.mcpUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  });
+  onTestFinished(async () => deleteConnection(admin, connection.id));
+
+  // Published, but nobody has connected their own account yet.
+  expect((await readUsableConnection(memberA, connection.id))?.connectedForMe).toBe(false);
+  expect((await readUsableConnection(memberB, connection.id))?.connectedForMe).toBe(false);
+
+  // ── Member A connects their own account ──────────────────────────────
+  const a = await memberDesktop("connector-member-a", den, memberA);
+  await using appA = a.app;
+  await go(appA, `/workspace/${a.workspaceId}/settings/extensions/connections`);
+  await waitForConnectionCard(appA, connection.name);
+  await waitForText(appA, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
+  await openConnectionDetail(appA, connection.name);
+  await waitForText(appA, "OAuth required", { timeoutMs: 30_000 });
+  {
+    const shot = await screenshot(appA);
+    const seen = await validate(shot, [
+      "An organization connection detail is visible saying the person must connect their own account",
+      "No 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  const aClickedAt = new Date().toISOString();
+  await clickButton(appA, "Connect your account");
+  await conn.authorizeRequestSince(aClickedAt);
+  await waitForText(appA, "Connected with your own account.", { timeoutMs: 120_000 });
+  await expect.poll(
+    async () => (await readUsableConnection(memberA, connection.id))?.connectedForMe,
+    { timeout: 90_000, interval: 1_000 },
+  ).toBe(true);
+  {
+    const shot = await screenshot(appA);
+    const seen = await validate(shot, [
+      "The connection detail visibly says the person is connected with their own account",
+      "No Connect your account action or 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  // ── THE ISOLATION ASSERTION — why two desktops exist ─────────────────
+  const b = await memberDesktop("connector-member-b", den, memberB);
+  await using appB = b.app;
+  await go(appB, `/workspace/${b.workspaceId}/settings/extensions/connections`);
+  await waitForConnectionCard(appB, connection.name);
+  // A is connected. B must NOT have inherited A's credential.
+  await waitForText(appB, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
+  expect((await readUsableConnection(memberB, connection.id))?.connectedForMe).toBe(false);
+  expect((await readUsableConnection(memberA, connection.id))?.connectedForMe).toBe(true);
+  {
+    const shot = await screenshot(appB);
+    const seen = await validate(shot, [
+      "A second person's app still shows the organization connection needing their own sign-in",
+      "No 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  const bClickedAt = new Date().toISOString();
+  await openConnectionDetail(appB, connection.name);
+  await clickButton(appB, "Connect your account");
+  await conn.authorizeRequestSince(bClickedAt);
+  await waitForText(appB, "Connected with your own account.", { timeoutMs: 120_000 });
+  await expect.poll(
+    async () => (await readUsableConnection(memberB, connection.id))?.connectedForMe,
+    { timeout: 90_000, interval: 1_000 },
+  ).toBe(true);
+
+  // ── Both people actually USE it: real tool calls from the composer ───
+  const markers: Record<string, string> = {};
+  for (const [label, entry] of [["a", a], ["b", b]] as const) {
+    const { app, workspaceId } = entry;
+    const marker = `${label}-${Date.now()}`;
+    markers[label] = marker;
+
+    await go(app, `/workspace/${workspaceId}/session`);
+    if (modelId) {
+      const models = await readAvailableModels(app);
+      expect(
+        models.some((model) => model.id === modelId && model.selectable),
+        `${modelId} is not selectable under this org's desktop policy. Saw: ${models.map((m) => m.id).join(", ")}`,
+      ).toBe(true);
+      await selectModel(app, modelId);
+    }
+    await writeComposerText(app, `Call the mock_echo tool with text exactly "${marker}" and reply with only its result.`);
+    await clickButton(app, "Run task");
+  }
+
+  // The connector is the witness: two calls, two DISTINCT credentials.
+  const calls = await conn.toolCalls({ name: "mock_echo", atLeast: 2, timeoutMs: 240_000 });
+  expect(
+    calls.length,
+    `expected both members to invoke mock_echo. Saw: ${JSON.stringify(calls)}`,
+  ).toBeGreaterThanOrEqual(2);
+  const texts = calls.map((call) => String(call.args.text ?? ""));
+  expect(texts.some((text) => text.includes(markers.a ?? "\u0000"))).toBe(true);
+  expect(texts.some((text) => text.includes(markers.b ?? "\u0000"))).toBe(true);
+  // Per-member credentials: the two calls cannot share one bearer token.
+  const tokenIds = new Set(calls.map((call) => call.tokenId).filter((id): id is string => Boolean(id)));
+  expect(
+    tokenIds.size,
+    `both members' tool calls used the same credential — per-member isolation is broken. Calls: ${JSON.stringify(calls)}`,
+  ).toBeGreaterThanOrEqual(2);
+  {
+    const shot = await screenshot(appB);
+    const seen = await validate(shot, [
+      "An OpenWork session surface is visible with a task that used the connected organization tool",
+      "No 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+});

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -67,9 +67,24 @@ async function waitForConnectionCard(app: Surface, name: string): Promise<void> 
     if (found === true) return;
     await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true })
       .catch(() => undefined);
+    await evalIn(app, `(() => {
+      const button = [...document.querySelectorAll('button')]
+        .find((element) => (element.textContent ?? '').trim() === 'Refresh' && !element.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`).catch(() => undefined);
     await new Promise((resolve) => setTimeout(resolve, 2_000));
   }
   throw new Error(`The connection card ${name} never appeared.`);
+}
+
+/** The connections surface, settled — polling before it mounts finds nothing. */
+async function openConnectionsSurface(app: Surface, workspaceId: string): Promise<void> {
+  await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
+  await waitFor(app, `window.location.hash.includes("/settings/extensions") && document.body.innerText.includes("Extensions")`, {
+    timeoutMs: 60_000,
+    label: "extensions connections route",
+  });
 }
 
 async function openConnectionDetail(app: Surface, name: string): Promise<void> {
@@ -137,7 +152,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
   // ── Member A connects their own account ──────────────────────────────
   const a = await memberDesktop("connector-member-a", den, memberA);
   await using appA = a.app;
-  await go(appA, `/workspace/${a.workspaceId}/settings/extensions/connections`);
+  await openConnectionsSurface(appA, a.workspaceId);
   await waitForConnectionCard(appA, connection.name);
   await waitForText(appA, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
   await openConnectionDetail(appA, connection.name);
@@ -173,7 +188,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
   // ── THE ISOLATION ASSERTION — why two desktops exist ─────────────────
   const b = await memberDesktop("connector-member-b", den, memberB);
   await using appB = b.app;
-  await go(appB, `/workspace/${b.workspaceId}/settings/extensions/connections`);
+  await openConnectionsSurface(appB, b.workspaceId);
   await waitForConnectionCard(appB, connection.name);
   // A is connected. B must NOT have inherited A's credential.
   await waitForText(appB, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -75,7 +75,14 @@ async function waitForConnectionCard(app: Surface, name: string): Promise<void> 
     })()`).catch(() => undefined);
     await new Promise((resolve) => setTimeout(resolve, 2_000));
   }
-  throw new Error(`The connection card ${name} never appeared.`);
+  // Say what WAS on screen: "card missing" alone cannot distinguish an
+  // unmounted surface from a connection den never offered this member.
+  const seen = await evalIn(app, `({
+    hash: window.location.hash,
+    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\\s+/g, ' ').trim()).filter(Boolean).slice(0, 40),
+    text: (document.body.innerText ?? '').replace(/\\s+/g, ' ').slice(0, 600),
+  })`).catch(() => null);
+  throw new Error(`The connection card ${name} never appeared. On screen: ${JSON.stringify(seen)}`);
 }
 
 /** The connections surface, settled — polling before it mounts finds nothing. */

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -59,12 +59,20 @@ const bEmail = process.env.OPENWORK_EVAL_MEMBER_B_EMAIL?.trim() || "riley.demo@a
 // is on the eval secrets volume, so a tool-capable model is available when set.
 const modelId = process.env.OPENWORK_EVAL_MODEL?.trim() || "";
 
-async function waitForConnectionCard(app: Surface, name: string): Promise<void> {
+async function waitForConnectionCard(app: Surface, name: string, workspaceId: string): Promise<void> {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
     const found = await evalIn(app, `([...document.querySelectorAll('button')]
       .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`);
     if (found === true) return;
+    // The app opens a freshly created session on its own, which navigates away
+    // from settings mid-poll. Steer back, the way a person would click back.
+    const onSettings = await evalIn(app, `window.location.hash.includes("/settings/extensions")`).catch(() => false);
+    if (onSettings !== true) {
+      await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      continue;
+    }
     await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true })
       .catch(() => undefined);
     await evalIn(app, `(() => {
@@ -160,7 +168,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
   const a = await memberDesktop("connector-member-a", den, memberA);
   await using appA = a.app;
   await openConnectionsSurface(appA, a.workspaceId);
-  await waitForConnectionCard(appA, connection.name);
+  await waitForConnectionCard(appA, connection.name, a.workspaceId);
   await waitForText(appA, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
   await openConnectionDetail(appA, connection.name);
   await waitForText(appA, "OAuth required", { timeoutMs: 30_000 });
@@ -196,7 +204,7 @@ test.skipIf(!appSpecsEnabled || !apiUrl)(title, async () => {
   const b = await memberDesktop("connector-member-b", den, memberB);
   await using appB = b.app;
   await openConnectionsSurface(appB, b.workspaceId);
-  await waitForConnectionCard(appB, connection.name);
+  await waitForConnectionCard(appB, connection.name, b.workspaceId);
   // A is connected. B must NOT have inherited A's credential.
   await waitForText(appB, "NEEDS YOUR SIGN-IN", { timeoutMs: 60_000 });
   expect((await readUsableConnection(memberB, connection.id))?.connectedForMe).toBe(false);

--- a/evals/specs/org-connector-two-members.slow.test.ts
+++ b/evals/specs/org-connector-two-members.slow.test.ts
@@ -89,8 +89,12 @@ async function waitForConnectionCard(app: Surface, name: string, workspaceId: st
     if (found === true) return;
     // The app opens a freshly created session on its own, which navigates away
     // from settings mid-poll. Steer back, the way a person would click back.
-    const onSettings = await evalIn(app, `window.location.hash.includes("/settings/extensions")`, { timeoutMs: 8_000 }).catch(() => false);
-    if (onSettings !== true) {
+    // The app CANONICALISES this route: /settings/extensions/connections
+    // becomes /extensions/connections. Checking for the pre-rewrite form made
+    // the steer-back below fire every iteration, so navigation fought the
+    // rewrite and the surface never settled — which looked like a blank page.
+    const onExtensions = await evalIn(app, `window.location.hash.includes("/extensions")`, { timeoutMs: 8_000 }).catch(() => false);
+    if (onExtensions !== true) {
       await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
       await new Promise((resolve) => setTimeout(resolve, 1_500));
       continue;
@@ -118,9 +122,9 @@ async function waitForConnectionCard(app: Surface, name: string, workspaceId: st
 /** The connections surface, settled — polling before it mounts finds nothing. */
 async function openConnectionsSurface(app: Surface, workspaceId: string): Promise<void> {
   await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
-  await waitFor(app, `window.location.hash.includes("/settings/extensions") && document.body.innerText.includes("Extensions")`, {
+  await waitFor(app, `window.location.hash.includes("/extensions") && document.body.innerText.includes("Extensions")`, {
     timeoutMs: 60_000,
-    label: "extensions connections route",
+    label: "extensions connections route (app canonicalises away /settings)",
   });
 }
 

--- a/evals/specs/two-daytona-desktops.slow.test.ts
+++ b/evals/specs/two-daytona-desktops.slow.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { createAndSelectWorkspace } from "@openwork/behaviors";
+import { daytonaSandbox, desktop } from "@openwork/hosts";
+
+const sandboxA = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_A?.trim();
+const sandboxB = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_B?.trim();
+const enabled = Boolean(sandboxA && sandboxB);
+
+test.skipIf(!enabled)("two desktops reach interactive workspaces on different Daytona sandboxes", async () => {
+  if (!sandboxA || !sandboxB) throw new Error("Set OPENWORK_EVAL_DAYTONA_SANDBOX_A and OPENWORK_EVAL_DAYTONA_SANDBOX_B.");
+  expect(sandboxA).not.toBe(sandboxB);
+
+  await using appA = await desktop({ host: daytonaSandbox(sandboxA), name: "a" });
+  await using appB = await desktop({ host: daytonaSandbox(sandboxB), name: "b" });
+
+  const stamp = Date.now();
+  const [workspaceA, workspaceB] = await Promise.all([
+    createAndSelectWorkspace(appA, { path: `/tmp/openwork-two-sandboxes-a-${stamp}` }),
+    createAndSelectWorkspace(appB, { path: `/tmp/openwork-two-sandboxes-b-${stamp}` }),
+  ]);
+
+  expect(appA.handle.sandboxId).toBe(sandboxA);
+  expect(appB.handle.sandboxId).toBe(sandboxB);
+  expect(workspaceA.workspaceId).toBeTruthy();
+  expect(workspaceB.workspaceId).toBeTruthy();
+});

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -411,6 +411,19 @@ function isAuthorized(req) {
   return Boolean(match && tokens.has(match[1]));
 }
 
+/**
+ * A stable, non-secret fingerprint of the caller's bearer token.
+ *
+ * Per-member credential modes issue a DIFFERENT token per person, so distinct
+ * fingerprints are how a spec proves one member's credential was not reused for
+ * another. Never log the token itself.
+ */
+function tokenFingerprint(req) {
+  const match = (req.headers.authorization || "").match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  return createHash("sha256").update(match[1]).digest("hex").slice(0, 12);
+}
+
 function mcpResult(message) {
   switch (message.method) {
     case "initialize":
@@ -542,6 +555,17 @@ async function handleMcp(req, res) {
     entry.toolNames = messages
       .filter((message) => message && typeof message === "object" && message.method === "tools/call" && typeof message.params?.name === "string")
       .map((message) => message.params.name);
+    // Arguments + a token fingerprint make the connector the AUTHORITY on who
+    // called it: a spec can prove two members each invoked a tool with their own
+    // credential, without trusting the app's own UI state.
+    entry.tokenId = tokenFingerprint(req);
+    entry.toolCalls = messages
+      .filter((message) => message && typeof message === "object" && message.method === "tools/call" && typeof message.params?.name === "string")
+      .map((message) => ({
+        name: message.params.name,
+        args: message.params.arguments ?? message.params.args ?? {},
+        tokenId: entry.tokenId,
+      }));
   }
   const responses = messages.flatMap((message) => {
     if (!message || typeof message !== "object" || message.id === undefined) return [];

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -406,9 +406,15 @@ async function issueToken(req, res, entry) {
 
 function isAuthorized(req) {
   if (allowUnauthenticatedMcp) return true;
+  const token = bearerToken(req);
+  return Boolean(token && tokens.has(token));
+}
+
+/** Linear-time bearer parse — `\s+(.+)` backtracks polynomially on header spam. */
+function bearerToken(req) {
   const header = req.headers.authorization || "";
-  const match = header.match(/^Bearer\s+(.+)$/i);
-  return Boolean(match && tokens.has(match[1]));
+  if (!/^bearer /i.test(header)) return null;
+  return header.slice("bearer ".length).trim() || null;
 }
 
 /**
@@ -419,9 +425,9 @@ function isAuthorized(req) {
  * another. Never log the token itself.
  */
 function tokenFingerprint(req) {
-  const match = (req.headers.authorization || "").match(/^Bearer\s+(.+)$/i);
-  if (!match) return null;
-  return createHash("sha256").update(match[1]).digest("hex").slice(0, 12);
+  const token = bearerToken(req);
+  if (!token) return null;
+  return createHash("sha256").update(token).digest("hex").slice(0, 12);
 }
 
 function mcpResult(message) {


### PR DESCRIPTION
> ## Status update (2026-08-01)
> Everything below the rule was written when mode B first ran; the PR has since grown the missing pieces and they are proven:
> - **The two-member connector spec IS now in this PR** (`org-connector-two-members.slow.test.ts`) and is **green twice on two separate Daytona sandboxes** — 133.0s / 135.2s, driver outside all sandboxes. Both members OAuth-connect their own account and call the connector's tool from the composer; the mock witnesses two distinct bearer fingerprints. Full evidence: [the run report](https://github.com/different-ai/openwork/pull/3388#issuecomment-5150725360).
> - Mode B is green (`two-daytona-desktops.slow.test.ts`, plus the connector runs above). The renderer-over-proxy hang was renderer JS starvation (workspace scan + full disk), not the proxy — fixed by the /tmp workspaces and profile pruning already in this PR.
> - Of the "What's left" table: #1 resolved via `startMockMcp({ publicUrl })` (the seam existed but was dead code — health-check and stale-log bugs fixed here); #2 unnecessary (the eval image's real browser completes the OAuth hop on-sandbox); #3 landed (args + per-credential `tokenId`, asserted by the spec); the model knob exists (`OPENWORK_EVAL_MODEL`); CA trust/TLS not needed (Daytona preview URLs are real HTTPS).
> - The earlier "blocked on a product defect (#3375)" claim is retracted in the spec header itself; the spec stays opt-in because it needs provisioned placement (two sandboxes, reachable Den, published mock), which nightly does not have.

---

Groundwork for the two-member connector spec (two Electrons in two sandboxes, den + connector reachable from both). I set out to write that spec; driving mode B for the first time surfaced three real bugs that had to land first. The spec itself is **not** in this PR — see "What's left".

## Three bugs, each found by running

**1. Specs assumed the driver's filesystem is the app's.** `app-smoke` passed `process.cwd()` as a workspace path. Correct only when driver and app share a disk. Driving a sandbox from a laptop, the app was told to open a directory that exists only on the laptop — the symptom was onboarding hanging 120s on "Power your first task" with no error, reading like a broken app.

`Host.workspaceRoot` now states it (`repoRoot` locally, `/workspace` on Daytona) and `DesktopHandle` re-exposes it, for specs that genuinely need the repo (`skills-local` reads `.opencode/skills`).

**2. Daytona surface ports were allocated from a local counter.** The local host finds a free port by binding one; the Daytona host cannot, since the port must be free on another machine. It guessed from `{ primary: 9825, next: 9830 }` — and the OpenCode sidecar, which picks its own port at boot, was observed holding **9825**, the CDP primary. Electron's debugger never bound; the preview URL timed out after 180s naming nothing. Now it asks the sandbox which ports are listening and skips them.

**3. Stale surface profiles filled the disk.** Disposal removes a profile on the happy path; every killed or failed run leaks one at ~50MB. **27 of them took a 10GB sandbox to 99% full.** The symptom was not "disk full" — it was the renderer failing `Runtime.evaluate` for 240s. That cost four debug cycles. `clearStaleSurfaces` already pkills by `rootDir` and so already assumes exclusive ownership; it now deletes the directories it orphans.

## A regression I caught and reverted

Routing `app-smoke` through `workspaceRoot` made it open the **whole monorepo** (`/workspace`, `node_modules` included) instead of the smaller `/workspace/evals` that `process.cwd()` happened to give. Engine scan blocked the renderer past 240s. It now uses a fresh `/tmp/openwork-app-smoke-<stamp>` — small, and valid on any host. Only caught because I re-ran **mode A** after each change; worth keeping that habit.

## Proof

Mode A (in-sandbox), after the disk was freed:

| Spec | Result |
|---|---|
| `app-smoke` | **PASS** — 59.1s, then 58.3s |
| `skills-local` | **PASS** — 79.1s |

Pruning verified: `profiles-left=1` (the current run only) where 27 had accumulated; disk steady at 84%.

`tsc -p evals` clean. `pnpm --dir evals test` 95 pass / 0 fail. Three `Host` fakes in runner tests needed `workspaceRoot` — the type system caught them, which is the seam working.

## Mode B status, honestly

Mode B (vitest on a laptop, Electron in a sandbox, CDP over a preview URL) went from **hanging at 120s** to **completing workspace creation in 68.5s**. It is not yet green end to end. Two things remain, both documented rather than fixed:

- **The driver needs the vision key.** `validate()` runs driver-side, so `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` must be on the driver — `daytona-spec.sh` sources `/daytona-secrets/*.env` *inside* the sandbox, which does nothing for mode B. Same family as bugs 1 and 3: something moved sides.
- **Renderer responsiveness over the proxy** during engine boot still needs work.

## What's left for the connector spec

| # | Gap |
|---|---|
| 1 | `startMockMcp({ host })` — labs are local-only. `publicUrl` already exists as an attach hatch, so a generic `Host.startService()` is the clean shape. |
| 2 | `captureOpenedUrls({ host })` — the `xdg-open` shim lands on the driver, not where Electron runs |
| 3 | Mock MCP call log: record tool **arguments** and token identity (it already logs `toolNames` + `authorized`) |
| 4–7 | CA trust, TLS terminator, `requires([...])` capabilities, model knob |

Note this spec **cannot run in nightly** — nightly is `blacksmith-4vcpu-ubuntu-2204` with no Daytona access. That is why the capability model matters: without it, it would skip silently and read green.
