### PR TITLE
fix(server): skip startup MCP re-registration already covered by the config file (fixes #3325)

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -37,6 +37,7 @@ const logger = createServerLogger(config);
 const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
 let managedOpencode: ManagedOpencodeServer | null = null;
 let managedOpencodeIdentity: string | null = null;
+let configCoveredWorkspaceId: string | undefined;
 
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
@@ -45,6 +46,9 @@ if (!config.readOnly) {
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   const workspace = findManagedEngineWorkspace(config.workspaces);
   if (workspace) {
+    // The runtime config file covers this workspace, so its runtime MCPs are
+    // loaded by the engine at spawn (see the startup sync below).
+    configCoveredWorkspaceId = workspace.id;
     // Server-managed config file: the engine re-reads it from disk on every
     // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
     // on every runtime-DB write — so disposes always pick up current state.
@@ -95,11 +99,14 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
 const server = await startServer(config);
 const workerActivityHeartbeat = startWorkerActivityHeartbeat(config, logger);
 
-// The runtime config file above only covers workspaces[0]. Push every
-// workspace's runtime-DB MCPs into the engine so they aren't invisible
-// until a manual reload. Best-effort.
+// The runtime config file above only covers the managed engine's workspace.
+// Push every workspace's runtime-DB MCPs into the engine so they aren't
+// invisible until a manual reload. Best-effort. The covered workspace's MCPs
+// are already in the OPENCODE_CONFIG file the engine loaded at spawn, so only
+// entries the file does not contain are registered explicitly — re-POSTing
+// every entry would spawn a duplicate, idle process tree per server (#3325).
 if (managedOpencode) {
-  void syncAllWorkspacesRuntimeMcpToEngine(config);
+  void syncAllWorkspacesRuntimeMcpToEngine(config, { configCoveredWorkspaceId });
 }
 
 const url = `http://${config.host}:${server.port}`;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -196,9 +196,15 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   // The runtime config file above only covers workspaces[0]. Push every
   // workspace's runtime-DB MCPs into the engine so they aren't invisible
-  // until a manual reload. Best-effort.
+  // until a manual reload. Best-effort. Workspaces[0]'s MCPs are already in
+  // the OPENCODE_CONFIG file the engine loaded at spawn, so only entries the
+  // file does not contain are registered explicitly — re-POSTing every entry
+  // would spawn a duplicate, idle process tree per server (see #3325).
   if (managedOpencode) {
-    void syncAllWorkspacesRuntimeMcpToEngine(config);
+    const managedWorkspace = findManagedEngineWorkspace(config.workspaces);
+    void syncAllWorkspacesRuntimeMcpToEngine(config, {
+      configCoveredWorkspaceId: managedWorkspace?.id,
+    });
   }
 
   return {

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   startServer,
   syncAllWorkspacesRuntimeMcpToEngine,
 } from "./server.js";
+import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -163,6 +164,64 @@ const POSTHOG_CONFIG = {
 };
 
 describe("runtime MCP engine sync", () => {
+  test("does not re-register runtime MCPs the engine already loaded from the config file (fixes #3325)", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+        ...current,
+        mcp: { posthog: POSTHOG_CONFIG },
+      }));
+      // The managed-engine spawn path writes the OPENCODE_CONFIG file before
+      // starting the engine, so the engine loads posthog from that file itself.
+      await writeOpenworkRuntimeConfigFile(openwork.config, "ws_1");
+
+      mock.requests.length = 0;
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config, { configCoveredWorkspaceId: "ws_1" });
+
+      const mcpPosts = mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(mcpPosts).toHaveLength(0);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("still registers runtime MCPs absent from the config-covered file", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+        ...current,
+        mcp: {
+          posthog: POSTHOG_CONFIG,
+          stripe: { type: "remote", url: "https://mcp.stripe.com", enabled: true },
+        },
+      }));
+      // The config file only carries posthog; stripe is runtime-DB-only and
+      // must still reach the engine explicitly.
+      await writeOpenworkRuntimeConfigFile(openwork.config, "ws_1");
+
+      mock.requests.length = 0;
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config, { configCoveredWorkspaceId: "ws_1" });
+
+      const mcpPosts = mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(mcpPosts).toHaveLength(1);
+      expect(mcpPosts[0]?.body).toMatchObject({ name: "stripe" });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
   test("hot-adds a runtime MCP into the running engine when added", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const previousDb = process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3475,7 +3475,7 @@ async function syncRuntimeMcpToOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,
   onlyNames?: string[],
-  options?: { throwOnFailure?: boolean; deferred?: boolean },
+  options?: EngineMcpSyncOptions | null,
   serverState?: EngineMcpServerState | null,
 ): Promise<EngineMcpSyncResult> {
   const activeState = activeEngineMcpServerState(config, serverState);
@@ -3493,6 +3493,16 @@ async function syncRuntimeMcpToOpencodeEngine(
   const entries = Object.entries(runtimeMcpMap(runtimeConfig)).filter(
     ([name]) => !onlyNames || onlyNames.includes(name),
   );
+  const configCoveredNames = options?.skipNamesIfConfigCovered ?? null;
+  if (configCoveredNames) {
+    // MCPs the engine already loaded from the OPENCODE_CONFIG file at spawn
+    // must not be re-POSTed: the engine would start a second, idle process
+    // tree for each one (see #3325). Only entries absent from the file need
+    // the explicit registration.
+    const entriesToSync = entries.filter(([name]) => !configCoveredNames.has(name));
+    entries.length = 0;
+    entries.push(...entriesToSync);
+  }
   if (entries.length === 0) {
     if (!onlyNames) {
       recordEngineMcpSyncResult(
@@ -3842,6 +3852,14 @@ export type EngineMcpSyncResult = {
   status: "ok" | "failed" | "skipped";
   syncedNames: string[];
   failures: EngineMcpSyncFailure[];
+};
+export type EngineMcpSyncOptions = {
+  throwOnFailure?: boolean;
+  deferred?: boolean;
+  /** Names already loaded by the engine from the OPENCODE_CONFIG file. These
+   *  entries must not be re-POSTed or the engine spawns a duplicate, idle
+   *  process tree per server (see #3325). */
+  skipNamesIfConfigCovered?: Set<string> | null;
 };
 export type EngineMcpSyncState = { status: "ok" | "failed"; at: number; failures: EngineMcpSyncFailure[] };
 
@@ -4376,19 +4394,48 @@ function logPersistedCloudMcpReconcileError(input: {
   );
 }
 
+// Names of the runtime-DB MCPs that the engine has already loaded from the
+// server-managed OPENCODE_CONFIG file (the engine reads that file at spawn
+// and on every rebuild). Returns null when the file is missing or unreadable,
+// in which case the caller must fall back to the full POST sync.
+async function runtimeMcpNamesInOpenworkRuntimeConfigFile(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<Set<string> | null> {
+  try {
+    const content = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+    const parsed = JSON.parse(content) as unknown;
+    const mcp = (parsed as { mcp?: unknown })?.mcp;
+    if (!isRecord(mcp)) return null;
+    return new Set(Object.keys(mcp));
+  } catch {
+    return null;
+  }
+}
+
 // Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
-// the runtime config file injected via OPENCODE_CONFIG covers workspaces[0]
-// only, so other workspaces' runtime MCPs are invisible to the engine until
-// something re-syncs them. Best-effort.
-export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
+// the runtime config file injected via OPENCODE_CONFIG covers the managed
+// engine's workspace only, so other workspaces' runtime MCPs are invisible to
+// the engine until something re-syncs them. Best-effort.
+export async function syncAllWorkspacesRuntimeMcpToEngine(
+  config: ServerConfig,
+  options?: { configCoveredWorkspaceId?: string },
+): Promise<void> {
   const serverState = activeEngineMcpServerState(config) ?? null;
+  const configCoveredWorkspaceId = options?.configCoveredWorkspaceId;
+  // The engine already started the config-covered workspace's runtime MCPs
+  // from the OPENCODE_CONFIG file; re-POSTing them would spawn a second,
+  // idle process tree per server (see #3325).
+  const configCoveredMcpNames = configCoveredWorkspaceId
+    ? await runtimeMcpNamesInOpenworkRuntimeConfigFile(config, configCoveredWorkspaceId)
+    : null;
   for (const workspace of config.workspaces) {
     try {
       await syncRuntimeMcpToOpencodeEngine(
         config,
         workspace,
         undefined,
-        undefined,
+        workspace.id === configCoveredWorkspaceId ? { skipNamesIfConfigCovered: configCoveredMcpNames } : undefined,
         serverState,
       );
     } catch (error) {


### PR DESCRIPTION
### Summary

Fixes #3325 — every custom-configured local MCP server spawns **two** child process trees under the opencode sidecar on startup; only one is used.

### Root cause

On desktop startup, `cli.ts` / `embedded.ts` write the server-managed runtime config file (`runtime-opencode-config.json`) and pass it to the engine as `OPENCODE_CONFIG`. The engine loads MCP definitions from that file **itself** at spawn (and on every instance rebuild). Immediately after, `syncAllWorkspacesRuntimeMcpToEngine()` re-POSTed **every** runtime-DB MCP entry via `POST /mcp`, so each local MCP server was registered twice and the engine started a second, idle process tree per server. Bundled MCPs (e.g. `imagegen-mcp-server`) were unaffected because they only ever reach the engine via `POST /mcp`.

### Changes

- `syncAllWorkspacesRuntimeMcpToEngine()` now accepts an optional `configCoveredWorkspaceId` — the managed-engine workspace whose runtime config file the engine already read.
- For that workspace, it reads the MCP names currently present in the config file and **skips** their `POST /mcp` registration, registering only entries absent from the file (e.g. cloud MCPs, runtime-only entries).
- Other workspaces behave exactly as before (the config file only covers the managed engine's workspace).
- If the config file is missing or unreadable, the full POST sync runs as before — no behaviour regression.
- Added two e2e tests in `mcp.engine-sync.e2e.test.ts`: config-covered MCPs are not re-POSTed, and runtime-only MCPs are still registered.

### Testing

- New e2e cases verified with a focused harness (the full e2e suite has pre-existing Windows-only failures — verified identical on a clean baseline).
- `tsc --noEmit` passes.