### PR TITLE
fix(app): replace Tailwind color classes outside the Radix palette (fixes #2341)

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -833,7 +833,7 @@ function ErrorMessage({ error }: ErrorMessageProps) {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
+        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-8 bg-red-8/20 px-2 py-1">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
           <p className="whitespace-pre-wrap text-destructive">{error}</p>
         </div>
@@ -851,7 +851,7 @@ function RetryActionButton(props: { link: string; label: string }) {
     <Button
       variant="outline"
       size="sm"
-      className="h-7 border-amber-500/70 bg-amber-50 text-xs text-amber-950 hover:bg-amber-100"
+      className="h-7 border-amber-9/70 bg-amber-2 text-xs text-amber-12 hover:bg-amber-3"
       onClick={() => void openDesktopUrl(props.link)}
     >
       {props.label}
@@ -877,18 +877,18 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-300 bg-amber-300/20 px-3 py-2">
+        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-8 bg-amber-8/20 px-3 py-2">
           <div className="flex items-start gap-2">
-            <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-700" />
+            <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-11" />
             <div className="min-w-0 space-y-1">
-              <p className="whitespace-pre-wrap text-sm font-medium text-amber-900">{status.message}</p>
-              <p className="text-xs text-amber-800">{info}</p>
+              <p className="whitespace-pre-wrap text-sm font-medium text-amber-12">{status.message}</p>
+              <p className="text-xs text-amber-11">{info}</p>
             </div>
           </div>
           {action ? (
-            <div className="ml-6 space-y-1 border-t border-amber-400/60 pt-2">
-              <p className="text-xs font-medium text-amber-950">{action.title}</p>
-              <p className="text-xs text-amber-900">{action.message}</p>
+            <div className="ml-6 space-y-1 border-t border-amber-8/60 pt-2">
+              <p className="text-xs font-medium text-amber-12">{action.title}</p>
+              <p className="text-xs text-amber-12">{action.message}</p>
               {action.link ? (
                 <RetryActionButton link={action.link} label={action.label} />
               ) : null}

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -72,7 +72,7 @@ export const Image = ({
         aria-label={alt}
         role="img"
         className={cn(
-          "h-24 w-40 animate-pulse overflow-hidden rounded-md bg-gray-100 dark:bg-neutral-800",
+          "h-24 w-40 animate-pulse overflow-hidden rounded-md bg-gray-3 dark:bg-gray-8",
           className
         )}
         {...props}

--- a/apps/app/src/components/ui/sonner.tsx
+++ b/apps/app/src/components/ui/sonner.tsx
@@ -84,7 +84,7 @@ const toastTile = cva(
     variants: {
       type: {
         default: "text-sky-11",
-        success: "text-emerald-11",
+        success: "text-green-11",
         info: "text-sky-11",
         warning: "text-amber-11",
         error: "text-red-11",
@@ -96,7 +96,7 @@ const toastTile = cva(
     },
     compoundVariants: [
       { size: "default", type: "default", className: "border-sky-6/40 bg-sky-4/80" },
-      { size: "default", type: "success", className: "border-emerald-6/40 bg-emerald-4/80" },
+      { size: "default", type: "success", className: "border-green-6/40 bg-green-4/80" },
       { size: "default", type: "info", className: "border-sky-6/40 bg-sky-4/80" },
       { size: "default", type: "warning", className: "border-amber-6/40 bg-amber-4/80" },
       { size: "default", type: "error", className: "border-red-6/40 bg-red-4/80" },

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -795,7 +795,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                                     method.type === "oauth"
                                       ? "bg-indigo-3/30 text-indigo-11 border-indigo-5/30"
                                       : method.type === "cloud"
-                                        ? "bg-emerald-3/30 text-emerald-11 border-emerald-5/30"
+                                        ? "bg-green-3/30 text-green-11 border-green-5/30"
                                         : "bg-gray-3/40 text-gray-11 border-gray-6/40"
                                   }`}
                                 >

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1701,7 +1701,7 @@ function WorkspaceSidebarGroup({
                   <SidebarMenuSubItem>
                     <SidebarMenuSubButton
                       aria-disabled
-                      className={cn("text-xs", taskLoadError.tone === "offline" ? "text-amber-600" : "text-destructive")}
+                      className={cn("text-xs", taskLoadError.tone === "offline" ? "text-amber-11" : "text-destructive")}
                     >
                       <span className="truncate">{taskLoadError.message}</span>
                     </SidebarMenuSubButton>

--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -80,7 +80,7 @@ export type CreateWorkspaceLocalPanelProps = {
 
 function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "done")
-    return <XCircle size={16} className="text-emerald-10" />;
+    return <XCircle size={16} className="text-green-10" />;
   if (status === "active")
     return <Loader2 size={16} className="animate-spin text-dls-accent" />;
   if (status === "error") return <XCircle size={16} className="text-red-10" />;
@@ -124,15 +124,15 @@ export function CreateWorkspaceLocalPanel(
             </div>
             <ul className="mt-3 space-y-1.5 pl-1">
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_read")}
               </li>
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_write")}
               </li>
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_anything")}
               </li>
             </ul>

--- a/apps/app/src/react-app/domains/workspace/modal-styles.ts
+++ b/apps/app/src/react-app/domains/workspace/modal-styles.ts
@@ -49,13 +49,13 @@ export const errorBannerClass =
   "rounded-[20px] border border-red-7/20 bg-red-1/40 px-4 py-3 text-[13px] text-red-11";
 
 export const successBannerClass =
-  "rounded-[20px] border border-emerald-7/20 bg-emerald-3/30 px-4 py-3 text-[13px] text-emerald-11";
+  "rounded-[20px] border border-green-7/20 bg-green-3/30 px-4 py-3 text-[13px] text-green-11";
 
 export const modalNoticeNeutralClass =
   "rounded-xl border border-dls-border bg-dls-hover px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
 
 export const modalNoticeSuccessClass =
-  "rounded-xl border border-dls-border bg-emerald-2/25 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
+  "rounded-xl border border-dls-border bg-green-2/25 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
 
 export const modalNoticeErrorClass =
   "rounded-xl border border-dls-border bg-red-2/20 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";

--- a/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
@@ -77,7 +77,7 @@ function CredentialField(props: CredentialFieldProps) {
           title="Copy"
         >
           {props.copiedKey === props.fieldKey ? (
-            <Check size={14} className="text-emerald-600" />
+            <Check size={14} className="text-green-10" />
           ) : (
             <Copy size={14} />
           )}
@@ -172,7 +172,7 @@ export function ShareWorkspaceAccessPanel(
                 }
                 disabled={props.remoteAccess.busy}
               />
-              <div className="h-6 w-11 rounded-full bg-zinc-300 transition-colors peer-checked:bg-[var(--dls-accent)] peer-disabled:opacity-50 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-5" />
+              <div className="h-6 w-11 rounded-full bg-gray-6 transition-colors peer-checked:bg-[var(--dls-accent)] peer-disabled:opacity-50 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-5" />
             </label>
           </div>
 

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -103,7 +103,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
         <section className="w-full overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.04] shadow-2xl shadow-black/40">
           <div className="grid gap-0 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="space-y-8 p-8 sm:p-10 lg:p-12">
-              <div className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
+              <div className="inline-flex rounded-full border border-amber-8/30 bg-amber-8/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-3">
                 Architecture mismatch
               </div>
               <div className="space-y-4">
@@ -121,10 +121,10 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
                   <div className="mt-2 text-2xl font-semibold text-white">{info.appArchLabel}</div>
                   <div className="mt-1 font-mono text-xs text-white/45">{info.appArch}</div>
                 </div>
-                <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4">
-                  <div className="text-xs uppercase tracking-[0.2em] text-emerald-100/70">Your system</div>
-                  <div className="mt-2 text-2xl font-semibold text-emerald-50">{info.systemArchLabel}</div>
-                  <div className="mt-1 font-mono text-xs text-emerald-100/55">{info.systemArch}</div>
+                <div className="rounded-2xl border border-green-8/20 bg-green-8/10 p-4">
+                  <div className="text-xs uppercase tracking-[0.2em] text-green-3/70">Your system</div>
+                  <div className="mt-2 text-2xl font-semibold text-green-2">{info.systemArchLabel}</div>
+                  <div className="mt-1 font-mono text-xs text-green-3/55">{info.systemArch}</div>
                 </div>
               </div>
 
@@ -132,7 +132,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
                 <button
                   type="button"
                   onClick={openDownload}
-                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-100"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-green-3"
                 >
                   Download correct version
                 </button>
@@ -146,7 +146,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
               </div>
             </div>
 
-            <aside className="border-t border-white/10 bg-gradient-to-br from-emerald-300/12 via-sky-300/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">
+            <aside className="border-t border-white/10 bg-gradient-to-br from-green-8/12 via-sky-8/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">
               <div className="space-y-5 rounded-[28px] border border-white/10 bg-black/25 p-6 text-sm leading-6 text-white/68">
                 <div className="text-lg font-semibold text-white">Why OpenWork stopped here</div>
                 <p>

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -70,7 +70,7 @@ function targetIcon(target: AccessibleTargetOption) {
   if (target.kind === "url") return <Globe className="size-4 text-primary" />;
   if (target.preview === "sheet") {
     return (
-      <span className="inline-flex h-4 min-w-6 shrink-0 items-center justify-center rounded-[4px] border border-emerald-500/30 bg-emerald-500/10 px-0.5 text-[7px] font-bold leading-none text-emerald-700">
+      <span className="inline-flex h-4 min-w-6 shrink-0 items-center justify-center rounded-[4px] border border-green-9/30 bg-green-9/10 px-0.5 text-[7px] font-bold leading-none text-green-11">
         XLS
       </span>
     );

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -35,7 +35,7 @@ const SEVERITY_ICONS: Record<NotificationSeverity, LucideIcon> = {
 
 const SEVERITY_CLASSES: Record<NotificationSeverity, string> = {
   info: "text-sky-11",
-  success: "text-emerald-11",
+  success: "text-green-11",
   warning: "text-amber-11",
   error: "text-red-11",
 };


### PR DESCRIPTION
### Summary

Fixes #2341 — 38 Tailwind color classes in `apps/app` compile to no CSS rule because they fall outside the app's Radix palette (31 families, steps 1–12 only, defined in `tailwind-theme.css` / `colors.css`). Affected elements render with no background/border or wrong text color — most visibly the invisible "Remote access" toggle track (`bg-zinc-300`).

### Changes

Replaced every remaining out-of-palette class in 11 files (31 classes; some from the original list were already fixed by #2329 or removed with the messaging feature):

| Issue | Mapping |
|---|---|
| `emerald-*` (not in Radix) | → `green-*`, matching the green/red/amber severity convention already used in each file |
| `zinc-*`, `neutral-*` | → `gray-*` |
| Default Tailwind 50–950 steps on valid families | → Radix steps (`50→2`, `100→3`, `300→8`, `500→9`, `600→10`, `700→11`, `900/950→12`), opacity modifiers preserved |

No layout changes, no theme configuration changes.

### Verification

Both grep patterns from the issue now return zero matches across `apps/app/src`:
- `(bg|text|border|ring|from|via|to|fill|stroke)-(zinc|neutral|stone|emerald|rose|fuchsia)-[0-9]`
- `(bg|text|border|ring|from|via|to)-(amber|red|sky|gray|blue|green|orange|yellow)-(50|[1-9]00|950)`

Files touched:
- `react-app/shell/architecture-mismatch-gate.tsx`
- `components/chat/message-list.tsx`
- `components/ui/image.tsx`
- `components/ui/sonner.tsx`
- `react-app/shell/notification-center.tsx`
- `react-app/shell/command-palette.tsx`
- `react-app/domains/workspace/modal-styles.ts`
- `react-app/domains/connections/provider-auth/provider-auth-modal.tsx`
- `react-app/domains/workspace/create-workspace-local-panel.tsx`
- `react-app/domains/workspace/share-workspace-access-panel.tsx`
- `react-app/domains/session/sidebar/app-sidebar.tsx`