### PR TITLE
fix(landing): make hero demo tabs responsive on mobile (fixes #2321)

### DIFF
--- a/ee/apps/landing/components/landing-app-demo-panel.tsx
+++ b/ee/apps/landing/components/landing-app-demo-panel.tsx
@@ -48,18 +48,18 @@ export function LandingAppDemoPanel(props: Props) {
                   key={flow.id}
                   type="button"
                   onClick={() => props.onSelectFlow(flow.id)}
-                  className={`flex items-center justify-between rounded-xl px-3 py-2.5 text-left text-[13px] transition-colors ${
-                      isActive ? "bg-[var(--lp-tonal)]" : "hover:bg-[var(--lp-tonal)]"
+                  className={`flex items-center justify-between gap-2 rounded-xl px-3 py-2.5 text-left text-[13px] transition-colors ${
+                    isActive ? "bg-[var(--lp-tonal)]" : "hover:bg-[var(--lp-tonal)]"
                   }`}
                 >
                   <span
-                    className={`mr-2 truncate ${
+                    className={`min-w-0 flex-1 truncate ${
                       isActive ? "font-medium text-[var(--lp-ink)]" : "text-[var(--lp-body)]"
                     }`}
                   >
                     {flow.tabLabel}
                   </span>
-                  <span className="whitespace-nowrap text-[var(--lp-muted)]">
+                  <span className="shrink-0 whitespace-nowrap text-[var(--lp-muted)]">
                     {timesById[flow.id] ?? "Now"}
                   </span>
                 </button>

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -189,7 +189,7 @@ export function LandingHome(props: Props) {
               </div>
 
               <div className="relative z-10 mb-4 flex w-full flex-col items-start justify-between gap-4 px-2 md:flex-row md:items-center">
-                <div className="landing-chip flex w-full flex-wrap gap-2 overflow-x-auto rounded-full p-1.5 md:w-[600px]">
+                <div className="landing-chip flex w-full gap-2 overflow-x-auto rounded-full p-1.5 md:w-[600px] md:flex-wrap md:overflow-visible">
                   {landingDemoFlows.map((flow) => {
                     const isActive = flow.id === activeDemo.id;
 


### PR DESCRIPTION
### Summary

Fixes #2321 — the landing hero's demo panel tabs break on mobile: the category tab strip overflows the card and the flow-list labels truncate aggressively.

### Root cause (current code)

1. **Category tab strip** (`landing-home.tsx`): the chip container used `flex-wrap` **and** `overflow-x-auto` together. On a narrow viewport these conflict — the row neither wraps cleanly nor scrolls predictably, so the active pill and labels can overflow the card edge.
2. **Flow list** (`landing-app-demo-panel.tsx`): each flow button put a `truncate` label next to a `whitespace-nowrap` timestamp with only `mr-2` separating them. On narrow widths the timestamp pushed the label off-screen, truncating it to e.g. `Like Twitter replies and exp...`.

### Changes

- `landing-home.tsx`: drop `flex-wrap` on mobile so the tab strip is a single scrollable row; restore `flex-wrap` + `overflow-visible` at `md` where there is room. Desktop behaviour is unchanged.
- `landing-app-demo-panel.tsx`: give the label a `min-w-0 flex-1 truncate` pair and the timestamp `shrink-0`, so the row lays out correctly and the timestamp never pushes the label off-screen.

No layout changes above `md`.

### Notes

The original report (June 2026) predates several landing refactors; the hero headline and CTA row are already responsive in the current code. This PR targets the two mobile breakages that remain in the current demo panel. `tsc --noEmit` reports no new errors in the touched files (pre-existing unrelated type errors in `packages/email` and `packages/ui` are not introduced here).