### PR TITLE
fix(desktop): never leave the app windowless when startup branding or shortcut registration fails

### DIFF
--- a/apps/desktop/electron/connect-link.test.mjs
+++ b/apps/desktop/electron/connect-link.test.mjs
@@ -190,6 +190,24 @@ test("startup branding applies a saved icon and skips an absent one", async () =
   assert.deepEqual(applied, ["https://assets.acme.example.com/icon.png"]);
 });
 
+test("startup branding propagates icon failures to its caller", async () => {
+  // applyBrandIconUrl fetches the icon over the network, so an offline start or
+  // an expired branding URL rejects here. Startup awaits this before the window
+  // exists, so the caller has to catch it or the app never shows any UI.
+  const applyBrandIconUrl = async () => {
+    throw new Error("net::ERR_INTERNET_DISCONNECTED");
+  };
+
+  await assert.rejects(
+    () =>
+      applyDesktopBootstrapBrandIcon(
+        { brandIconUrl: "https://assets.acme.example.com/icon.png" },
+        applyBrandIconUrl,
+      ),
+    /ERR_INTERNET_DISCONNECTED/,
+  );
+});
+
 test("fails closed for ambiguous, insecure, mismatched, expired, and replayed exchanges", async () => {
   const code = "abcdefghijklmnopqrstuvwxyz123456";
   const apiBaseUrl = "https://api.openwork.acme.example.com";

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2546,10 +2546,14 @@ or use: pnpm dev:worktree`);
       },
     );
     if (process.platform === "win32") {
-      await registerWindowsDisplayShortcut();
+      await registerWindowsDisplayShortcut().catch((error) => {
+        console.warn("[windows-shortcut] startup registration failed", error);
+      });
     }
     if (process.platform !== "linux") {
-      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl);
+      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl).catch((error) =>
+        brandIconFailure("bootstrap-apply-failed", error),
+      );
     }
     applicationMenu.install();
     if (!desktopActivationRequired(DESKTOP_DISTRIBUTION, bootstrapConfig)) {
@@ -2578,7 +2582,9 @@ or use: pnpm dev:worktree`);
     queueDeepLinks(forwardedDeepLinks(process.argv));
     const win = await createMainWindow();
     if (process.platform === "linux") {
-      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl);
+      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl).catch((error) =>
+        brandIconFailure("bootstrap-apply-failed", error),
+      );
     }
     win.webContents.on("did-finish-load", () => {
       flushPendingDeepLinks();
@@ -2593,6 +2599,15 @@ or use: pnpm dev:worktree`);
     // a working app first. Renderer-owned checks pass the selected release
     // channel explicitly, avoiding stale stable-feed results for alpha users.
     void ensureAutoUpdater();
+  }).catch((error) => {
+    // Anything that rejects here happened before the window was shown, so the
+    // user would otherwise be left with a running process and no UI. Surface
+    // the reason instead of failing silently.
+    console.error("[startup] failed before the main window was ready", error);
+    const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    if (BrowserWindow.getAllWindows().length === 0) {
+      dialog.showErrorBox(`${APP_NAME} failed to start`, detail);
+    }
   });
 
   app.on("activate", async () => {


### PR DESCRIPTION
## Summary
- Guard the two `await`s that run before `createMainWindow()` in `app.whenReady()`, and add a `.catch()` to the `whenReady` chain itself.

## Why
`app.whenReady().then(async () => { ... })` had no `.catch()`, and two awaits inside it ran unguarded before the window was created:

- `registerWindowsDisplayShortcut()` (`main.mjs:2549`) — can reject with `EPERM`/`EBUSY` renaming into the Start Menu, or when `execFileSync("powershell.exe", ...)` is blocked by AppLocker / Constrained Language Mode.
- `applyDesktopBootstrapBrandIcon()` (`main.mjs:2552`) — resolves the brand icon over the network, so an offline start or an expired branding URL rejects.

Either rejection skips `createMainWindow()` entirely. The process stays alive with no window and nothing printed, which presents to the user as "the app doesn't open".

The fix follows a pattern already established in this file: the same brand-icon call is wrapped as `applyBrandIconUrl(iconUrl).catch((error) => brandIconFailure(...))` on the connect-link path at `main.mjs:1025`, and the neighbouring startup awaits (`runPendingNukeCleanup`, `prepareFreshRuntime`, `uiControlServer.start`) are all already `.catch()`ed. These two were the outliers.

The outer `.catch()` is the backstop: anything else that rejects before the window exists now surfaces through `dialog.showErrorBox` instead of failing silently.

## Issue
- Related to #3324, #1487, #2968 — reports of the app not opening / hanging on launch with no error. I can't confirm from those threads that this is their specific root cause, so this does not claim to close them.

## Scope
- `apps/desktop/electron/main.mjs` — guard the two pre-window awaits (and the post-window Linux branding call), add `.catch()` on `whenReady`.
- `apps/desktop/electron/connect-link.test.mjs` — cover the rejection contract that made this reachable.

## Out of scope
- `process.on("uncaughtException"/"unhandledRejection")` in the main process. There are none anywhere in production code today, and since the OpenWork server runs in-process (`runtime.mjs:1599`), an unhandled rejection in server code can take down the desktop app. That's a broader change to crash semantics and belongs in its own PR — happy to open it if you want it.
- Why `applyBrandIconUrl` rejects in the first place (network/CDN behaviour).

## Testing
### Ran
- `node --test electron/connect-link.test.mjs`
- `node --test <the 18 files in the desktop "test" script>`
- `node --check apps/desktop/electron/main.mjs`

### Result
- pass: `connect-link.test.mjs` — 10/10 pass, including the new case.
- pass: `node --check` clean.
- Pre-existing failures, unrelated to this change: `runtime.test.mjs`, `runtime-chain-repair.test.mjs`, `workspace-store.test.mjs` fail with `ERR_MODULE_NOT_FOUND: Cannot find package '@openwork/paths'` when the workspace isn't installed. I confirmed these fail identically on unmodified `dev` (stashed my diff and re-ran) — they are not caused by this PR.

## CI status
- pass: n/a — the test workflow does not run on this PR.
- code-related failures: none observed locally.
- external/env/auth blockers: yes. As a fork PR, `OpenWork Tests` and `i18n Audit` sit in `action_required` pending maintainer approval, and the Vercel checks fail with "Authorization required to deploy" because forks can't reach deploy credentials. Both are independent of this diff.

## Manual verification
Because this is a pre-window failure path, I reproduced it against the real module rather than the packaged app:

1. Drove `applyDesktopBootstrapBrandIcon` (the actual export from `connect-link-branding.mjs`) with an `applyBrandIconUrl` that rejects with `net::ERR_INTERNET_DISCONNECTED` — the offline-start case.
2. Ran it through the current `whenReady` shape (bare `await`, no `.catch()`), then through the shape in this PR.

```
BEFORE (current dev)
  !! unhandledRejection: net::ERR_INTERNET_DISCONNECTED
  !! window created: false        <-- process alive, no UI, nothing logged

AFTER (this PR)
  [brand-icon] bootstrap-apply-failed: net::ERR_INTERNET_DISCONNECTED
  window created: true
```

To reproduce on a packaged build: set `brandIconUrl` in the desktop bootstrap config to any unreachable host and launch with the network off. On `dev` you get a running process and no window; with this patch the window opens and the failure is logged as `[brand-icon] bootstrap-apply-failed`.

## Evidence
- The before/after output above. No screen recording: the failure is a missing window, so the "before" state is an empty screen and a video of nothing is less informative than the trace. Happy to record the packaged-build repro if you'd prefer it.

## Risk
Low. Behaviour only changes on paths that previously rejected — those now log and continue instead of aborting startup. No change when branding and shortcut registration succeed. Failures stay visible (`console.warn` via the existing `brandIconFailure`, which also records `{ ok: false, reason }` in the brand-icon runtime state), so this suppresses a crash, not the diagnostic.

## Rollback
Revert the commit. The change is contained to one function in `main.mjs` plus one test.
