### PR TITLE
fix(app): show a recovery screen instead of a blank window when a render throws

### DIFF
--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -16,6 +16,7 @@ import {
   PlatformProvider,
 } from "./react-app/kernel/platform";
 import { AppProviders } from "./react-app/shell/providers";
+import { AppErrorBoundary } from "./react-app/shell/app-error-boundary";
 import { AppRoot } from "./react-app/shell/app-root";
 import { setWebNotificationHandler } from "./react-app/shell/desktop-notifications";
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
@@ -41,16 +42,18 @@ const Router = isDesktopRuntime() ? HashRouter : BrowserRouter;
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <PlatformProvider value={platform}>
-          <AppProviders>
-            <Router>
-              <AppRoot />
-            </Router>
-          </AppProviders>
-        </PlatformProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <AppErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <PlatformProvider value={platform}>
+            <AppProviders>
+              <Router>
+                <AppRoot />
+              </Router>
+            </AppProviders>
+          </PlatformProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </AppErrorBoundary>
   </React.StrictMode>,
 );

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -1,0 +1,82 @@
+/** @jsxImportSource react */
+
+import * as React from "react";
+
+interface AppErrorBoundaryState {
+  error: Error | null;
+}
+
+function formatError(error: Error): string {
+  return error.stack ?? `${error.name}: ${error.message}`;
+}
+
+/**
+ * Last-resort boundary around the whole application.
+ *
+ * React unmounts the entire tree when a render throws, so before this existed a
+ * single bad value rendered the app as a blank white window with nothing in the
+ * UI to explain it. The same failure mode is documented on the tool-part
+ * boundary in components/chat/message-list.tsx, which was added after it was
+ * seen in production.
+ *
+ * This deliberately renders plain elements and does not call `t()`: locale
+ * initialization runs before the tree mounts and has itself been a source of
+ * startup failures, so the screen that reports a crash must not depend on it.
+ */
+export class AppErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[app] render failed", error, info.componentStack);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
+        <div className="flex w-full max-w-lg flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-lg font-semibold text-foreground">
+              OpenWork hit an unexpected error
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              The window recovered instead of going blank. Reloading usually clears it.
+            </p>
+          </div>
+
+          <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs text-muted-foreground">
+            {formatError(error)}
+          </pre>
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground"
+              onClick={() => {
+                void navigator.clipboard?.writeText(formatError(error));
+              }}
+            >
+              Copy details
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AppErrorBoundary } from "../src/react-app/shell/app-error-boundary";
+
+// react-dom/server rethrows instead of running error boundaries, so the catch
+// path is exercised by driving the state transition directly:
+// getDerivedStateFromError produces the state, then render() produces the
+// fallback the user actually sees.
+function renderFallback(error: Error): string {
+  const boundary = new AppErrorBoundary({ children: null });
+  boundary.state = AppErrorBoundary.getDerivedStateFromError(error);
+  return renderToStaticMarkup(<>{boundary.render()}</>);
+}
+
+test("getDerivedStateFromError captures the error for the fallback", () => {
+  const error = new Error("boom");
+  expect(AppErrorBoundary.getDerivedStateFromError(error)).toEqual({ error });
+});
+
+test("a captured error renders the recovery screen instead of a blank window", () => {
+  const html = renderFallback(new Error("render exploded"));
+
+  expect(html).toContain("OpenWork hit an unexpected error");
+  expect(html).toContain("render exploded");
+  expect(html).toContain("Reload");
+  expect(html).toContain("Copy details");
+});
+
+test("the recovery screen prefers a stack when one is available", () => {
+  const error = new Error("no stack here");
+  error.stack = "Error: no stack here\n    at sessionRoute (session-route.tsx:1797)";
+
+  expect(renderFallback(error)).toContain("session-route.tsx:1797");
+});
+
+test("children render untouched when nothing throws", () => {
+  const html = renderToStaticMarkup(
+    <AppErrorBoundary>
+      <p>session surface</p>
+    </AppErrorBoundary>,
+  );
+
+  expect(html).toBe("<p>session surface</p>");
+});


### PR DESCRIPTION
## Summary
- Add a last-resort React error boundary around the whole app, so a render throw shows a recovery screen with the error and stack instead of a blank window.

## Why
React unmounts the entire tree when a render throws. The renderer has only two boundaries today — `LexicalErrorBoundary` (`composer/editor.tsx:1249`) and the tool-part boundary in `components/chat/message-list.tsx:148` — and nothing above the routes. The comment on that second one already describes this failure mode:

> Tool inputs from streamed or interrupted runs can violate their type contracts (partial/undefined input); without this boundary a single bad part unmounts the entire app (white screen). Seen in production on v0.15.3 via a todowrite part with missing `input.todos`.

The same shape reaches the whole app from route-level render work. #3372 is a live example: a local MCP server configured with a string `command` throws `config.command?.some is not a function` inside a `useMemo` in `settings-route.tsx:1797`, and the user gets a blank window with nothing to report. `composer.tsx:1605` throws the same way and takes out the main chat screen.

This does not fix any individual crash — #3373 is the right fix for #3372 specifically. It changes what a crash *looks like*: an error card with a copyable stack instead of a white screen, which also makes the next one of these reportable.

## Issue
- Related to #3372, #3137 — blank/unusable screens where the underlying throw is invisible to the user. Not claiming to close either; the boundary changes presentation, not the root cause.

## Scope
- `apps/app/src/react-app/shell/app-error-boundary.tsx` (new) — the boundary and its fallback UI.
- `apps/app/src/index.react.tsx` — wrap the tree, inside `StrictMode` so provider failures are caught too.
- `apps/app/tests/app-error-boundary.test.tsx` (new).

## Out of scope
- Fixing the individual crashes (#3372 has #3373 open).
- Global `window.addEventListener("error"/"unhandledrejection")` capture in production. `debug-logger.ts:243,255` registers these but `isEnabled()` returns `false` under `import.meta.env.PROD` unless a localStorage flag is set, so production has no global capture. Separate concern, happy to take it in a follow-up.

## Testing
### Ran
- `bun test --isolate tests/app-error-boundary.test.tsx`
- `bun test --isolate tests/` (full app suite)
- `pnpm --filter @openwork/app typecheck`

### Result
- pass: 4/4 new tests.
- pass: full app suite 580 pass / 0 fail across 105 files.
- pass: typecheck exits 0.

One note on how the tests are written: `react-dom/server` rethrows instead of running error boundaries, so `renderToStaticMarkup(<Boundary><Throws/></Boundary>)` cannot exercise the catch path — I tried that first and it fails. The tests instead drive the state transition directly (`getDerivedStateFromError` → `render()`), which covers the same code the boundary runs. The actual catching is verified in the running app below.

## Manual verification
1. `pnpm --filter @openwork/app dev`
2. Temporarily rendered a component that throws `config.command?.some is not a function` inside the router, simulating #3372.
3. Loaded the app.

Before: blank window, nothing rendered, no indication of what happened.
After: the recovery screen renders — heading "OpenWork hit an unexpected error", the full stack in a scrollable block (`at Boom (http://localhost:5199/src/index.react.tsx:28:9)` etc.), and working Reload / Copy details buttons. Correct in dark theme.

The throwing component was removed before committing; the diff contains no test scaffolding.

## CI status
- pass: n/a — the test workflow does not run on this PR.
- code-related failures: none observed locally.
- external/env/auth blockers: yes. As a fork PR, `OpenWork Tests` and `i18n Audit` sit in `action_required` pending maintainer approval, and the Vercel checks fail with "Authorization required to deploy". Both are independent of this diff.

## Evidence
- Screenshot of the recovery screen available on request — I can attach it to this thread if useful.

## Risk
Low. The boundary is inert until something throws; the passthrough case is covered by a test asserting the children render byte-identically. Worst case is a cosmetic issue on a screen only reachable when the app has already broken.

Two deliberate choices worth flagging for review:
- It renders plain elements rather than `@/components` primitives, and does **not** call `t()`. `initLocale()` runs before the tree mounts and has itself been a startup failure (#2767), so the screen that reports a crash shouldn't depend on i18n or on component code that may be implicated in the crash. This means the strings are English-only — tell me if you'd rather take the i18n dependency and I'll switch it.
- It's placed inside `StrictMode` but outside `QueryClientProvider`, so provider-level failures are caught too.

## Rollback
Revert the commit — remove the wrapper in `index.react.tsx` and delete the two new files. Nothing else imports the boundary.
