### PR TITLE
Fix Settings page crash when local MCP server command is a string

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -317,7 +317,8 @@ export type McpServerSource = "config.project" | "config.global" | "config.remot
 export type McpServerConfig = {
   type: "remote" | "local";
   url?: string;
-  command?: string[];
+  command?: string | string[];
+  args?: string[];
   enabled?: boolean;
   headers?: Record<string, string>;
   environment?: Record<string, string>;

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1602,8 +1602,8 @@ export function ReactSessionComposer(props: ComposerProps) {
                                               || entry.config.url
                                               || "Remote app"
                                             : entry.config.type === "remote"
-                                              ? entry.config.url ?? entry.config.command?.join(" ") ?? "Remote app"
-                                              : entry.config.command?.join(" ") ?? "Local app"}
+                                              ? entry.config.url ?? (Array.isArray(entry.config.command) ? entry.config.command.join(" ") : entry.config.command) ?? "Remote app"
+                                              : (Array.isArray(entry.config.command) ? entry.config.command.join(" ") : entry.config.command) ?? "Local app"}
                                         </div>
                                       </div>
                                     </div>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1603,7 +1603,7 @@ function McpConfiguredServerDetails(props: Parameters<typeof McpConfiguredServer
           <ChevronDown size={10} className="transition-transform group-open:rotate-180" />
         </summary>
         <div className="mt-1.5 break-all rounded-lg bg-dls-hover px-3 py-2 font-mono text-[11px] text-dls-secondary">
-          {props.entry.config.type === "remote" ? props.entry.config.url : props.entry.config.command?.join(" ")}
+          {props.entry.config.type === "remote" ? props.entry.config.url : (Array.isArray(props.entry.config.command) ? props.entry.config.command.join(" ") : props.entry.config.command)}
         </div>
       </details>
       <McpConfiguredServerAuthActions {...props} />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1793,9 +1793,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     // Browser plugin detection: check if any configured plugin matches the chrome-devtools name.
     // For now, treat it as loaded if the plugin is in the MCP/plugin list — this will
     // be refined when we add a real plugin-loaded signal from the engine.
-    const browserPluginConfigured = connectionsSnapshot.mcpServers.some(
-      (s) => s.name === "opencode-chrome-devtools" || s.config.command?.some((c: string) => c.includes("chrome-devtools")),
-    );
+    const browserPluginConfigured = connectionsSnapshot.mcpServers.some((s) => {
+      if (s.name === "opencode-chrome-devtools") return true;
+      const cmdArgs = Array.isArray(s.config.command)
+        ? s.config.command
+        : [s.config.command, ...(s.config.args ?? [])].filter(Boolean);
+      return cmdArgs.some((c: string | undefined) => c?.includes("chrome-devtools"));
+    });
     if (browserPluginConfigured) loadedPlugins.add("opencode-chrome-devtools");
 
     return {


### PR DESCRIPTION
# PR: Fix Settings page crash with string MCP command

## Title
Fix Settings page crash when local MCP server command is a string

## Description
This PR resolves a complete UI crash on the Settings page caused by valid `opencode.json` configurations where an MCP server uses a string `command` rather than an array.

### Root Cause
In `settings-route.tsx`, checking if the browser plugin is configured involved checking if `s.config.command?.some(...)` contains `"chrome-devtools"`. Because `s.config.command` can legitimately be a string (e.g. `"python3"`), calling `.some()` on it throws `TypeError: s.config.command?.some is not a function`. Since this was unhandled during render, it completely crashed the route. 

### Solution Overview
Normalized `s.config.command` to an array inline before checking for the substring, mirroring the exact normalization logic already present in the server's backend parsing.

### Testing Performed
- Validated via `pnpm --filter @openwork/app typecheck`
- Verified that providing a string command in `opencode.json` no longer crashes the Settings page.

### Screenshots
N/A - This resolves a crash (white screen). The UI appearance is unchanged when working correctly.

### Risks
None. This is a purely defensive type coercion guard in a `useMemo` block.

### Follow-up Improvements
- Ensure other frontend components consuming `s.config.command` or `s.config.args` also correctly normalize or type-guard the fields since they are not strictly typed across the wire.
- Potentially export the backend normalization function and share it with the frontend so we don't repeat the `Array.isArray` fallback logic.

Fixes #3372