### PR TITLE
Fix den-dev docker-compose startup (MySQL prefix index & missing tsx loader)

### DIFF
--- a/ee/packages/den-db/src/schema/auth.ts
+++ b/ee/packages/den-db/src/schema/auth.ts
@@ -204,7 +204,7 @@ export const OAuthAccessTokenTable = mysqlTable(
     scopes: text("scopes").notNull(),
   },
   (table) => [
-    index("oauth_access_token_token").on(sql`${table.token}(191)`),
+    index("oauth_access_token_token").on(sql.raw("token(191)")),
     index("oauth_access_token_client_id").on(table.clientId),
     index("oauth_access_token_session_id").on(table.sessionId),
     index("oauth_access_token_user_id").on(table.userId),

--- a/packaging/docker/docker-compose.den-dev.yml
+++ b/packaging/docker/docker-compose.den-dev.yml
@@ -96,7 +96,7 @@ services:
     build:
       context: ../../
       dockerfile: packaging/docker/Dockerfile.den
-    command: ["sh", "-lc", "cd /app/ee/packages/den-db && yes | node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts && node /app/ee/apps/den-api/dist/main.js"]
+    command: ["sh", "-lc", "cd /app/ee/packages/den-db && yes | node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts && node --import tsx /app/ee/apps/den-api/dist/main.js"]
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
# PR: Fix den-dev docker-compose startup

## Title
Fix den-dev docker-compose startup (MySQL prefix index & missing tsx loader)

## Description
This PR resolves two bugs preventing `docker-compose.den-dev.yml` from successfully starting the `den` API against a local MySQL database.

### Root Cause
1. `drizzle-kit` fails with a SQL syntax error when generating the schema because it double-wraps interpolated column identifiers on prefix-length indexes (e.g., `sql\`${table.token}(191)\``).
2. The `den` service fails to start because it attempts to load extensionless TypeScript schema files natively in Node without a loader. The `den` service command had a missing `--import tsx` argument.

### Solution Overview
1. Changed the prefix index definition in `auth.ts` to use `sql.raw("token(191)")` to avoid the `drizzle-kit` interpolation bug.
2. Added the missing `--import tsx` argument to the second Node invocation in the docker compose `den` service command.

### Testing Performed
- Validated that `docker compose -f packaging/docker/docker-compose.den-dev.yml up` no longer fails on `drizzle-kit push`.
- Validated that the `den` API successfully starts without `ERR_MODULE_NOT_FOUND` errors.

### Screenshots
N/A

### Risks
None. This strictly targets developer tooling and local database provisioning.

### Follow-up Improvements
None needed.

Fixes #3392