### PR TITLE
feat(i18n): default to Simplified Chinese when system language is zh

### DIFF
--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -213,6 +213,17 @@ export const initLocale = (): Language => {
     console.warn("Failed to read language preference:", e);
   }
 
+  // When no stored preference exists, follow the system language:
+  // Chinese systems default to Simplified Chinese, everything else to English.
+  const browserLang = (typeof navigator !== "undefined" ? navigator.language || "" : "").toLowerCase();
+  if (browserLang.startsWith("zh")) {
+    localeValue = "zh";
+    if (typeof document !== "undefined") {
+      document.documentElement.setAttribute("lang", "zh");
+    }
+    return "zh";
+  }
+
   if (typeof document !== "undefined") {
     document.documentElement.setAttribute("lang", "en");
   }


### PR DESCRIPTION
## Summary

When no stored language preference exists, `initLocale` currently always returns `"en"`. This makes first-run Chinese users see an English UI even though a complete Simplified Chinese translation ships with the app.

This change follows the browser/system language instead: if it starts with `zh`, default to `zh` (Simplified Chinese); otherwise fall back to `en`.

- Users can still switch manually via **Settings > Appearance > Language**
- A stored preference (localStorage `openwork.language`) always takes priority
- No behavior change for English users

Only `apps/app/src/i18n/index.ts` is modified (11 insertions). No other files touched.