### PR TITLE
feat(den-api): grant-native capability index — chat-created skills usable without a marketplace (skill-sharing P1)

### DIFF
--- a/ee/apps/den-api/src/mcp/builtin-skills.ts
+++ b/ee/apps/den-api/src/mcp/builtin-skills.ts
@@ -24,7 +24,7 @@ description: |
 
 # Create Skill
 
-Create exactly one new Cloud skill. Do not publish it to a marketplace and do not grant org-wide access in this flow.
+Create exactly one new Cloud skill. It is immediately usable by its creator. Do not attach it to a marketplace or grant org-wide access in this flow.
 
 ## Fast path (prefer these exact MCP names)
 
@@ -60,7 +60,7 @@ Produce one complete \`SKILL.md\` with:
    }
    \`\`\`
    Do not send \`marketplaceId\` or \`orgWide\`.
-3. Execute \`getPluginsResolved\` with the returned plugin id. Report plugin id, skill/config-object id, and that it is private until published or shared.
+3. Execute \`getPluginsResolved\` with the returned plugin id. Report plugin id, skill/config-object id, and that the skill is ready to use now.
 4. On authorization or validation errors, report them. Do not fall back to a workspace-local skill unless the user explicitly asks for one.
 `
 
@@ -160,7 +160,7 @@ export const BUILTIN_SKILLS: BuiltinSkillDefinition[] = [
     descriptor: {
       name: "create-skill",
       title: "Create Skill",
-      description: "Create a new OpenWork Cloud skill as a private plugin with one skill component.",
+      description: "Create a new OpenWork Cloud skill that its creator can use immediately.",
       capability: BUILTIN_CREATE_SKILL_CAPABILITY,
       location: "skill://create-skill/SKILL.md",
     },

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNull, notExists } from "@openwork-ee/den-db/drizzle"
 import {
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
@@ -48,7 +48,7 @@ export type RemoteSkillDescriptor = {
 
 export type AccessibleMarketplaceCapabilityReference = {
   configObjectId: string
-  marketplaceId: string
+  marketplaceId: string | null
   objectType: MarketplaceCapabilityObjectType
   pluginId: string
 }
@@ -85,7 +85,7 @@ type MemberRow = Pick<typeof MemberTable.$inferSelect, "id" | "role">
 type UsableExternalMcpConnection = Awaited<ReturnType<typeof listUsableExternalMcpConnections>>[number]
 type MarketplaceCapabilityRow = {
   configObject: ConfigObjectRow
-  marketplace: typeof MarketplaceTable.$inferSelect
+  marketplace: typeof MarketplaceTable.$inferSelect | null
   plugin: typeof PluginTable.$inferSelect
 }
 type GrantRow = {
@@ -136,7 +136,7 @@ export type MarketplaceMcpRequirementStatus = {
 export type MarketplaceCapabilityExecutePayload = {
   kind: ConfigObjectType
   plugin: string
-  marketplace: string
+  marketplace: string | null
   name: string
   description: string | null
   provenance: string
@@ -277,7 +277,9 @@ function provenance(pluginName: string): string {
 }
 
 function objectHint(row: MarketplaceCapabilityRow): string {
-  return `Install marketplace plugin "${row.plugin.name}" from "${row.marketplace.name}" locally to use "${row.configObject.title}".`
+  return row.marketplace
+    ? `Install marketplace plugin "${row.plugin.name}" from "${row.marketplace.name}" locally to use "${row.configObject.title}".`
+    : `Install plugin "${row.plugin.name}" locally to use "${row.configObject.title}".`
 }
 
 function contentNotSyncedHint(row: MarketplaceCapabilityRow): string {
@@ -285,7 +287,9 @@ function contentNotSyncedHint(row: MarketplaceCapabilityRow): string {
 }
 
 function summaryFor(row: MarketplaceCapabilityRow): string {
-  const prefix = `[${row.marketplace.name} / ${row.plugin.name}] ${row.configObject.title}`
+  const prefix = row.marketplace
+    ? `[${row.marketplace.name} / ${row.plugin.name}] ${row.configObject.title}`
+    : `[${row.plugin.name}] ${row.configObject.title}`
   const description = row.configObject.description?.trim()
   return description ? `${prefix}: ${description}` : prefix
 }
@@ -307,7 +311,7 @@ function basePayload(row: MarketplaceCapabilityRow): MarketplaceCapabilityExecut
   return {
     kind: row.configObject.objectType,
     plugin: row.plugin.name,
-    marketplace: row.marketplace.name,
+    marketplace: row.marketplace ? row.marketplace.name : null,
     name: row.configObject.title,
     description: row.configObject.description,
     provenance: provenance(row.plugin.name),
@@ -371,6 +375,58 @@ async function listActiveMarketplaceRows(organizationId: OrganizationId): Promis
   return rows
 }
 
+async function listGrantOnlyRows(organizationId: OrganizationId): Promise<MarketplaceCapabilityRow[]> {
+  const rows = await db
+    .select({
+      configObject: ConfigObjectTable,
+      plugin: PluginTable,
+    })
+    .from(ConfigObjectTable)
+    .innerJoin(
+      PluginConfigObjectTable,
+      eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id),
+    )
+    .innerJoin(
+      PluginTable,
+      eq(PluginTable.id, PluginConfigObjectTable.pluginId),
+    )
+    .where(and(
+      eq(ConfigObjectTable.organizationId, organizationId),
+      eq(ConfigObjectTable.status, "active"),
+      isNull(ConfigObjectTable.deletedAt),
+      eq(PluginConfigObjectTable.organizationId, organizationId),
+      isNull(PluginConfigObjectTable.removedAt),
+      eq(PluginTable.organizationId, organizationId),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+      notExists(
+        db
+          .select({ id: MarketplacePluginTable.id })
+          .from(MarketplacePluginTable)
+          .innerJoin(
+            MarketplaceTable,
+            eq(MarketplaceTable.id, MarketplacePluginTable.marketplaceId),
+          )
+          .where(and(
+            eq(MarketplacePluginTable.pluginId, PluginTable.id),
+            eq(MarketplacePluginTable.organizationId, organizationId),
+            isNull(MarketplacePluginTable.removedAt),
+            eq(MarketplaceTable.organizationId, organizationId),
+            eq(MarketplaceTable.status, "active"),
+            isNull(MarketplaceTable.deletedAt),
+          )),
+      ),
+    ))
+    .orderBy(PluginTable.name, ConfigObjectTable.title)
+  return rows.map((row) => ({ ...row, marketplace: null }))
+}
+
+async function listActiveCapabilityRows(organizationId: OrganizationId): Promise<MarketplaceCapabilityRow[]> {
+  const marketplaceRows = await listActiveMarketplaceRows(organizationId)
+  const grantOnlyRows = await listGrantOnlyRows(organizationId)
+  return [...marketplaceRows, ...grantOnlyRows]
+}
+
 async function listActiveMarketplaceRowsForCapability(input: {
   configObjectId: ConfigObjectId
   organizationId: OrganizationId
@@ -419,6 +475,51 @@ async function listActiveMarketplaceRowsForCapability(input: {
     ))
     .orderBy(MarketplaceTable.name)
   return rows
+}
+
+async function listGrantOnlyRowsForCapability(input: {
+  configObjectId: ConfigObjectId
+  organizationId: OrganizationId
+  pluginId: PluginId
+}): Promise<MarketplaceCapabilityRow[]> {
+  const rows = await db
+    .select({
+      configObject: ConfigObjectTable,
+      plugin: PluginTable,
+    })
+    .from(ConfigObjectTable)
+    .innerJoin(
+      PluginConfigObjectTable,
+      eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id),
+    )
+    .innerJoin(
+      PluginTable,
+      eq(PluginTable.id, PluginConfigObjectTable.pluginId),
+    )
+    .where(and(
+      eq(ConfigObjectTable.id, input.configObjectId),
+      eq(ConfigObjectTable.organizationId, input.organizationId),
+      eq(ConfigObjectTable.status, "active"),
+      isNull(ConfigObjectTable.deletedAt),
+      eq(PluginConfigObjectTable.organizationId, input.organizationId),
+      eq(PluginConfigObjectTable.pluginId, input.pluginId),
+      isNull(PluginConfigObjectTable.removedAt),
+      eq(PluginTable.id, input.pluginId),
+      eq(PluginTable.organizationId, input.organizationId),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+    ))
+  return rows.map((row) => ({ ...row, marketplace: null }))
+}
+
+async function listActiveRowsForCapability(input: {
+  configObjectId: ConfigObjectId
+  organizationId: OrganizationId
+  pluginId: PluginId
+}): Promise<MarketplaceCapabilityRow[]> {
+  const marketplaceRows = await listActiveMarketplaceRowsForCapability(input)
+  if (marketplaceRows.length > 0) return marketplaceRows
+  return listGrantOnlyRowsForCapability(input)
 }
 
 async function listConfigObjectGrants(organizationId: OrganizationId, configObjectIds: ConfigObjectId[]) {
@@ -490,7 +591,7 @@ async function filterVisibleRows(input: {
   )
   const marketplaceGrantRows = await listMarketplaceGrants(
     input.organizationId,
-    unique(input.rows.map((row) => row.marketplace.id)),
+    unique(input.rows.flatMap((row) => row.marketplace ? [row.marketplace.id] : [])),
   )
   const configObjectGrants = groupGrants(configObjectGrantRows)
   const pluginGrants = groupGrants(pluginGrantRows)
@@ -503,7 +604,9 @@ async function filterVisibleRows(input: {
     // for every role so admins can curate what OpenWork exposes to them.
     if (grantRole(input.member, configObjectGrants.get(row.configObject.id) ?? [])) return true
     if (grantRole(input.member, pluginGrants.get(row.plugin.id) ?? [])) return true
-    return Boolean(grantRole(input.member, marketplaceGrants.get(row.marketplace.id) ?? []))
+    return row.marketplace
+      ? Boolean(grantRole(input.member, marketplaceGrants.get(row.marketplace.id) ?? []))
+      : false
   })
 }
 
@@ -519,23 +622,31 @@ export async function listAccessibleMarketplaceCapabilityReferences(input: {
   const rows = await filterVisibleRows({
     organizationId,
     member: input.member,
-    rows: await listActiveMarketplaceRows(organizationId),
+    rows: await listActiveCapabilityRows(organizationId),
   })
   const references = new Map<string, AccessibleMarketplaceCapabilityReference>()
   for (const row of rows) {
-    const key = `${row.marketplace.id}:${row.plugin.id}:${row.configObject.id}`
+    const marketplaceId = row.marketplace ? row.marketplace.id : null
+    const key = `${marketplaceId ?? "grant-only"}:${row.plugin.id}:${row.configObject.id}`
     references.set(key, {
       configObjectId: row.configObject.id,
-      marketplaceId: row.marketplace.id,
+      marketplaceId,
       objectType: row.configObject.objectType,
       pluginId: row.plugin.id,
     })
   }
-  return [...references.values()].sort((left, right) =>
-    left.marketplaceId.localeCompare(right.marketplaceId)
-    || left.pluginId.localeCompare(right.pluginId)
-    || left.configObjectId.localeCompare(right.configObjectId)
-  )
+  return [...references.values()].sort((left, right) => {
+    const marketplaceOrder = left.marketplaceId === right.marketplaceId
+      ? 0
+      : left.marketplaceId === null
+        ? 1
+        : right.marketplaceId === null
+          ? -1
+          : left.marketplaceId.localeCompare(right.marketplaceId)
+    return marketplaceOrder
+      || left.pluginId.localeCompare(right.pluginId)
+      || left.configObjectId.localeCompare(right.configObjectId)
+  })
 }
 
 export async function listAccessibleMarketplaceSkillDescriptors(input: {
@@ -552,7 +663,7 @@ export async function listAccessibleMarketplaceSkillDescriptors(input: {
   const rows = await filterVisibleRows({
     organizationId,
     member: input.member,
-    rows: (await listActiveMarketplaceRows(organizationId))
+    rows: (await listActiveCapabilityRows(organizationId))
       .filter((row) => row.configObject.objectType === "skill"),
   })
   const descriptors = new Map<string, RemoteSkillDescriptor>()
@@ -569,7 +680,7 @@ export async function listAccessibleMarketplaceSkillDescriptors(input: {
         name,
         title: row.configObject.title,
       }),
-      marketplaceName: row.marketplace.name,
+      ...(row.marketplace ? { marketplaceName: row.marketplace.name } : {}),
       pluginName: row.plugin.name,
       capability,
       location: `skill://${name}/SKILL.md`,
@@ -1234,7 +1345,7 @@ export async function searchMarketplaceCapabilities(input: {
   const rows = await filterVisibleRows({
     organizationId,
     member: input.member,
-    rows: await listActiveMarketplaceRows(organizationId),
+    rows: await listActiveCapabilityRows(organizationId),
   })
   const requirementStatusesByPluginId = await marketplacePluginMcpRequirementStatuses({
     organizationId,
@@ -1260,7 +1371,7 @@ export async function searchMarketplaceCapabilities(input: {
       hasBody: row.configObject.objectType === "command",
       kind: row.configObject.objectType,
       plugin: row.plugin.name,
-      marketplace: row.marketplace.name,
+      ...(row.marketplace ? { marketplace: row.marketplace.name } : {}),
     }
     if (row.configObject.objectType === "tool") {
       match.status = "needs_install"
@@ -1308,7 +1419,7 @@ export async function executeMarketplaceCapability(input: {
   }
 
   const organizationId = normalizeDenTypeId("organization", input.organizationId)
-  const rows = await listActiveMarketplaceRowsForCapability({
+  const rows = await listActiveRowsForCapability({
     organizationId,
     pluginId: normalizedIds.pluginId,
     configObjectId: normalizedIds.configObjectId,

--- a/ee/apps/den-api/src/routes/org/resources.ts
+++ b/ee/apps/den-api/src/routes/org/resources.ts
@@ -276,7 +276,7 @@ export function registerOrgResourceRoutes<T extends { Variables: OrgRouteVariabl
         c.get("memberTeams"),
         organizationContext.organization.id,
       ).map((team) => team.id)
-      const items = await listAccessibleMarketplaceCapabilityReferences({
+      const items = (await listAccessibleMarketplaceCapabilityReferences({
         organizationId: organizationContext.organization.id,
         member: {
           orgMembershipId: organizationContext.currentMember.id,
@@ -285,7 +285,7 @@ export function registerOrgResourceRoutes<T extends { Variables: OrgRouteVariabl
         enabled: memberFacingMcpConnectionsEnabled(organizationContext.organization.metadata, {
           gatingEnabled: env.mcpConnectionsGatingEnabled,
         }),
-      })
+      })).filter((item) => item.marketplaceId !== null)
       return c.json({ items })
     },
   )

--- a/ee/apps/den-api/test/grant-native-capabilities.test.ts
+++ b/ee/apps/den-api/test/grant-native-capabilities.test.ts
@@ -1,0 +1,446 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test"
+import { inArray } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthUserTable,
+  ConfigObjectAccessGrantTable,
+  ConfigObjectTable,
+  ConfigObjectVersionTable,
+  ConnectedAccountTable,
+  ExternalMcpConnectionAccessGrantTable,
+  ExternalMcpConnectionTable,
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  PluginMcpRequirementBindingTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+  OrganizationTable,
+  TeamTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import type { McpMemberIdentity } from "../src/mcp/external-capabilities.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_grantnative"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+type Db = typeof import("../src/db.js").db
+type MarketplaceCapabilities = typeof import("../src/mcp/marketplace-capabilities.js")
+
+type SeededMember = {
+  member: McpMemberIdentity
+  memberId: DenTypeId<"member">
+  organizationId: DenTypeId<"organization">
+  userId: DenTypeId<"user">
+}
+
+type SeededCapability = {
+  configObjectId: DenTypeId<"configObject">
+  marketplaceId: DenTypeId<"marketplace"> | null
+  name: string
+  pluginId: DenTypeId<"plugin">
+}
+
+type PluginGrant = {
+  orgMembershipId?: DenTypeId<"member">
+  role: "viewer" | "editor" | "manager"
+  teamId?: DenTypeId<"team">
+}
+
+let db: Db
+let marketplaceCapabilities: MarketplaceCapabilities
+
+const createdOrganizationIds: DenTypeId<"organization">[] = []
+const createdUserIds: DenTypeId<"user">[] = []
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+  db = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db }))
+  marketplaceCapabilities = await import("../src/mcp/marketplace-capabilities.js")
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+afterEach(async () => {
+  if (createdOrganizationIds.length > 0) {
+    await db.delete(ConnectedAccountTable).where(inArray(ConnectedAccountTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginMcpRequirementBindingTable).where(inArray(PluginMcpRequirementBindingTable.organizationId, createdOrganizationIds))
+    await db.delete(ExternalMcpConnectionAccessGrantTable).where(inArray(ExternalMcpConnectionAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(ExternalMcpConnectionTable).where(inArray(ExternalMcpConnectionTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectVersionTable).where(inArray(ConfigObjectVersionTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectAccessGrantTable).where(inArray(ConfigObjectAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginConfigObjectTable).where(inArray(PluginConfigObjectTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginAccessGrantTable).where(inArray(PluginAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplacePluginTable).where(inArray(MarketplacePluginTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplaceAccessGrantTable).where(inArray(MarketplaceAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectTable).where(inArray(ConfigObjectTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginTable).where(inArray(PluginTable.organizationId, createdOrganizationIds))
+    await db.delete(TeamTable).where(inArray(TeamTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplaceTable).where(inArray(MarketplaceTable.organizationId, createdOrganizationIds))
+    await db.delete(MemberTable).where(inArray(MemberTable.organizationId, createdOrganizationIds))
+    await db.delete(OrganizationTable).where(inArray(OrganizationTable.id, createdOrganizationIds))
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(AuthUserTable).where(inArray(AuthUserTable.id, createdUserIds))
+  }
+  createdOrganizationIds.length = 0
+  createdUserIds.length = 0
+})
+
+async function seedMember(input: {
+  organization?: SeededMember
+  role?: string
+  teamIds?: DenTypeId<"team">[]
+} = {}): Promise<SeededMember> {
+  const organizationId = input.organization?.organizationId ?? createDenTypeId("organization")
+  const userId = createDenTypeId("user")
+  const memberId = createDenTypeId("member")
+  createdUserIds.push(userId)
+
+  await db.insert(AuthUserTable).values({
+    id: userId,
+    name: "Grant Native Tester",
+    email: `${userId}@grant-native.test.local`,
+  })
+  if (!input.organization) {
+    createdOrganizationIds.push(organizationId)
+    await db.insert(OrganizationTable).values({
+      id: organizationId,
+      name: "Grant Native Test Org",
+      slug: `grant-native-${organizationId}`,
+      metadata: null,
+    })
+  }
+  await db.insert(MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: input.role ?? "member",
+  })
+
+  return {
+    organizationId,
+    userId,
+    memberId,
+    member: { orgMembershipId: memberId, teamIds: input.teamIds ?? [] },
+  }
+}
+
+async function seedTeam(owner: SeededMember): Promise<DenTypeId<"team">> {
+  const teamId = createDenTypeId("team")
+  await db.insert(TeamTable).values({
+    id: teamId,
+    organizationId: owner.organizationId,
+    name: `Team ${teamId}`,
+  })
+  return teamId
+}
+
+async function seedCapability(input: {
+  marketplace?: boolean
+  marketplaceGrant?: boolean
+  owner: SeededMember
+  pluginGrants?: PluginGrant[]
+  pluginName?: string
+  rawSourceText: string
+  title: string
+}): Promise<SeededCapability> {
+  const now = new Date()
+  const marketplaceId = input.marketplace ? createDenTypeId("marketplace") : null
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+
+  if (marketplaceId) {
+    await db.insert(MarketplaceTable).values({
+      id: marketplaceId,
+      organizationId: input.owner.organizationId,
+      name: "Team Marketplace",
+      description: "Curated marketplace for grant-native tests",
+      logoUrl: null,
+      status: "active",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    })
+  }
+  await db.insert(PluginTable).values({
+    id: pluginId,
+    organizationId: input.owner.organizationId,
+    name: input.pluginName ?? "Grant Native Plugin",
+    description: "Grant-native capability test plugin",
+    status: "active",
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  })
+  await db.insert(ConfigObjectTable).values({
+    id: configObjectId,
+    organizationId: input.owner.organizationId,
+    objectType: "skill",
+    sourceMode: "cloud",
+    title: input.title,
+    description: `Use ${input.title}`,
+    searchText: `${input.title}\n${input.rawSourceText}`,
+    currentFileName: "SKILL.md",
+    currentFileExtension: ".md",
+    currentRelativePath: `skills/${input.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}/SKILL.md`,
+    status: "active",
+    createdByOrgMembershipId: input.owner.memberId,
+    connectorInstanceId: null,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  })
+  await db.insert(PluginConfigObjectTable).values({
+    id: createDenTypeId("pluginConfigObject"),
+    organizationId: input.owner.organizationId,
+    pluginId,
+    configObjectId,
+    membershipSource: "manual",
+    connectorMappingId: null,
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    removedAt: null,
+  })
+  await db.insert(ConfigObjectVersionTable).values({
+    id: createDenTypeId("configObjectVersion"),
+    organizationId: input.owner.organizationId,
+    configObjectId,
+    normalizedPayloadJson: null,
+    rawSourceText: input.rawSourceText,
+    schemaVersion: null,
+    createdVia: "cloud",
+    createdByOrgMembershipId: input.owner.memberId,
+    connectorSyncEventId: null,
+    sourceRevisionRef: null,
+    isDeletedVersion: false,
+    createdAt: now,
+  })
+
+  if (marketplaceId) {
+    await db.insert(MarketplacePluginTable).values({
+      id: createDenTypeId("marketplacePlugin"),
+      organizationId: input.owner.organizationId,
+      marketplaceId,
+      pluginId,
+      membershipSource: "manual",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+  if (marketplaceId && input.marketplaceGrant) {
+    await db.insert(MarketplaceAccessGrantTable).values({
+      id: createDenTypeId("marketplaceAccessGrant"),
+      organizationId: input.owner.organizationId,
+      marketplaceId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      role: "viewer",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+  for (const grant of input.pluginGrants ?? []) {
+    await db.insert(PluginAccessGrantTable).values({
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId: input.owner.organizationId,
+      pluginId,
+      orgMembershipId: grant.orgMembershipId ?? null,
+      teamId: grant.teamId ?? null,
+      orgWide: false,
+      role: grant.role,
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+
+  return {
+    configObjectId,
+    marketplaceId,
+    pluginId,
+    name: marketplaceCapabilities.buildMarketplaceCapabilityName(pluginId, configObjectId),
+  }
+}
+
+async function search(member: SeededMember, query: string) {
+  return marketplaceCapabilities.searchMarketplaceCapabilities({
+    organizationId: member.organizationId,
+    member: member.member,
+    query,
+    limit: 20,
+    enabled: true,
+  })
+}
+
+async function execute(member: SeededMember, capability: SeededCapability) {
+  return marketplaceCapabilities.executeMarketplaceCapability({
+    organizationId: member.organizationId,
+    member: member.member,
+    pluginId: capability.pluginId,
+    configObjectId: capability.configObjectId,
+    enabled: true,
+  })
+}
+
+describe("grant-native marketplace capabilities", () => {
+  test("A1 creator grant makes a marketplace-free skill discoverable and executable", async () => {
+    const creator = await seedMember()
+    const rawSourceText = "---\nname: creator-ready\ndescription: Creator-ready skill\n---\n\n# Creator Ready"
+    const capability = await seedCapability({
+      owner: creator,
+      title: "Creator Ready",
+      rawSourceText,
+      pluginGrants: [{ orgMembershipId: creator.memberId, role: "manager" }],
+    })
+
+    const matches = await search(creator, "creator ready")
+    const match = matches.find((candidate) => candidate.name === capability.name)
+    expect(match).toMatchObject({
+      method: "PLUGIN",
+      kind: "skill",
+      plugin: "Grant Native Plugin",
+      summary: "[Grant Native Plugin] Creator Ready: Use Creator Ready",
+    })
+    expect(match?.marketplace).toBeUndefined()
+
+    const result = await execute(creator, capability)
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result).toMatchObject({
+      kind: "skill",
+      plugin: "Grant Native Plugin",
+      marketplace: null,
+      name: "Creator Ready",
+      content: rawSourceText,
+    })
+
+    const descriptors = await marketplaceCapabilities.listAccessibleMarketplaceSkillDescriptors({
+      organizationId: creator.organizationId,
+      member: creator.member,
+      enabled: true,
+    })
+    const descriptor = descriptors.find((candidate) => candidate.capability === capability.name)
+    expect(descriptor).toMatchObject({
+      title: "Creator Ready",
+      pluginName: "Grant Native Plugin",
+      capability: capability.name,
+    })
+    expect(descriptor?.marketplaceName).toBeUndefined()
+
+    const references = await marketplaceCapabilities.listAccessibleMarketplaceCapabilityReferences({
+      organizationId: creator.organizationId,
+      member: creator.member,
+      enabled: true,
+    })
+    expect(references).toContainEqual({
+      configObjectId: capability.configObjectId,
+      marketplaceId: null,
+      objectType: "skill",
+      pluginId: capability.pluginId,
+    })
+  })
+
+  test("A2 team grant permits team members and denies non-members", async () => {
+    const owner = await seedMember()
+    const teamId = await seedTeam(owner)
+    const teamMember = await seedMember({ organization: owner, teamIds: [teamId] })
+    const nonMember = await seedMember({ organization: owner })
+    const capability = await seedCapability({
+      owner,
+      title: "Team Shared Skill",
+      rawSourceText: "# Team Shared Skill",
+      pluginGrants: [{ teamId, role: "viewer" }],
+    })
+
+    expect((await search(teamMember, "team shared")).some((match) => match.name === capability.name)).toBe(true)
+    const teamResult = await execute(teamMember, capability)
+    expect(teamResult.ok).toBe(true)
+    if (!teamResult.ok) throw new Error(teamResult.message)
+    expect(teamResult.result.marketplace).toBeNull()
+
+    expect((await search(nonMember, "team shared")).some((match) => match.name === capability.name)).toBe(false)
+    expect(await execute(nonMember, capability)).toMatchObject({ ok: false, error: "forbidden" })
+  })
+
+  test("A3 a marketplace-free skill with no grants stays inaccessible", async () => {
+    const owner = await seedMember()
+    const capability = await seedCapability({
+      owner,
+      title: "Nobody Skill",
+      rawSourceText: "# Nobody Skill",
+    })
+
+    expect((await search(owner, "nobody skill")).some((match) => match.name === capability.name)).toBe(false)
+    expect(await execute(owner, capability)).toMatchObject({ ok: false, error: "forbidden" })
+  })
+
+  test("A4 marketplace-attached capabilities keep their marketplace payload", async () => {
+    const owner = await seedMember()
+    const capability = await seedCapability({
+      owner,
+      title: "Marketplace Skill",
+      rawSourceText: "# Marketplace Skill",
+      marketplace: true,
+      marketplaceGrant: true,
+    })
+
+    const matches = await search(owner, "marketplace skill")
+    const match = matches.find((candidate) => candidate.name === capability.name)
+    expect(match?.marketplace).toBe("Team Marketplace")
+    expect(match?.summary).toBe("[Team Marketplace / Grant Native Plugin] Marketplace Skill: Use Marketplace Skill")
+
+    const result = await execute(owner, capability)
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result.marketplace).toBe("Team Marketplace")
+
+    const references = await marketplaceCapabilities.listAccessibleMarketplaceCapabilityReferences({
+      organizationId: owner.organizationId,
+      member: owner.member,
+      enabled: true,
+    })
+    expect(references).toContainEqual({
+      configObjectId: capability.configObjectId,
+      marketplaceId: capability.marketplaceId,
+      objectType: "skill",
+      pluginId: capability.pluginId,
+    })
+  })
+
+  test("A5 marketplace membership wins over a direct grant without duplicate search matches", async () => {
+    const owner = await seedMember()
+    const capability = await seedCapability({
+      owner,
+      title: "Catalog And Direct",
+      rawSourceText: "# Catalog And Direct",
+      marketplace: true,
+      pluginGrants: [{ orgMembershipId: owner.memberId, role: "manager" }],
+    })
+
+    const matches = (await search(owner, "catalog direct"))
+      .filter((candidate) => candidate.name === capability.name)
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.marketplace).toBe("Team Marketplace")
+
+    const result = await execute(owner, capability)
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result.marketplace).toBe("Team Marketplace")
+  })
+})

--- a/ee/packages/den-db/src/drizzle.ts
+++ b/ee/packages/den-db/src/drizzle.ts
@@ -1,2 +1,2 @@
-export { and, asc, count, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm"
+export { and, asc, count, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, notExists, or, sql } from "drizzle-orm"
 export type { SQL } from "drizzle-orm"

--- a/evals/packages/behaviors/src/den.ts
+++ b/evals/packages/behaviors/src/den.ts
@@ -83,6 +83,15 @@ export async function ensureMemberSession(
     // Bootstrap the missing member through the real invitation flow.
   }
   let markVerifiedWarning = "";
+  const loginOptions = await denFetch(
+    den,
+    `/v1/auth/login-options?email=${encodeURIComponent(input.email)}`,
+  );
+  if (isRecord(loginOptions.body) && loginOptions.body.allowPublicSignup === false) {
+    throw new Error(
+      `Member bootstrap needs public signup, but this Den runs single-org mode with signup disabled. Start den-api with DEN_ORG_MODE=multi_org (like the demo:den script) or DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP=true, or pre-provision ${input.email}.`,
+    );
+  }
   const invite = await denFetch(den, "/v1/invitations", {
     method: "POST",
     headers: auth(admin),

--- a/evals/packages/behaviors/test/ensure-member-session.test.ts
+++ b/evals/packages/behaviors/test/ensure-member-session.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import { ensureMemberSession, type DenSession } from "../src/den.ts";
+
+function respondJson(response: import("node:http").ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function withStubServer(
+  allowPublicSignup: boolean,
+  run: (den: { apiUrl: string; webUrl: string }, requests: string[]) => Promise<void>,
+): Promise<void> {
+  const requests: string[] = [];
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://stub.test");
+    requests.push(`${request.method} ${url.pathname}`);
+    if (request.method === "POST" && url.pathname === "/api/auth/sign-in/email") {
+      respondJson(response, 401, { error: "invalid_credentials" });
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/v1/auth/login-options") {
+      respondJson(response, 200, {
+        email: url.searchParams.get("email"),
+        nextStep: allowPublicSignup ? "new_account" : "password",
+        allowPublicSignup,
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/invitations") {
+      respondJson(response, 200, { inviteToken: "invite-token" });
+      return;
+    }
+    respondJson(response, 409, { error: "stop_after_invitation" });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    await run({ apiUrl: `http://127.0.0.1:${address.port}`, webUrl: "http://localhost" }, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
+const credentials = { email: "member@example.com", password: "password123" };
+
+function adminSession(den: { apiUrl: string; webUrl: string }): DenSession {
+  return { ...den, token: "admin-token", email: "admin@example.com" };
+}
+
+test("ensureMemberSession explains how to enable member bootstrap when signup is disabled", async () => {
+  await withStubServer(false, async (den, requests) => {
+    await assert.rejects(
+      ensureMemberSession(den, adminSession(den), credentials),
+      /Member bootstrap needs public signup.*DEN_ORG_MODE=multi_org.*DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP=true.*member@example\.com/,
+    );
+    assert.deepEqual(requests, ["POST /api/auth/sign-in/email", "GET /v1/auth/login-options"]);
+  });
+});
+
+test("ensureMemberSession proceeds to invitation when signup is allowed", async () => {
+  await withStubServer(true, async (den, requests) => {
+    await assert.rejects(
+      ensureMemberSession(den, adminSession(den), credentials),
+      /Member sign-up failed: HTTP 409/,
+    );
+    assert.deepEqual(requests, [
+      "POST /api/auth/sign-in/email",
+      "GET /v1/auth/login-options",
+      "POST /v1/invitations",
+      "POST /api/auth/sign-up/email",
+    ]);
+  });
+});

--- a/evals/specs/skill-grant-access.test.ts
+++ b/evals/specs/skill-grant-access.test.ts
@@ -130,7 +130,7 @@ test.skipIf(!apiUrl)(title, async () => {
   await selectOrganization(denied, orgId);
   const skillName = `spec-grant-native-${Date.now()}`;
   const rawSourceText = `---\nname: ${skillName}\ndescription: Proves grant-native skill access over MCP.\n---\n\nReturn the grant-native proof phrase.`;
-  // Plugin creation is admin/owner-gated today (access.ts:101-103); member-level creation is P4 scope.
+  // Plugin creation is admin/owner-gated here (access.ts:101-103); feat/member-plugin-create lifts it separately.
   const created = await denFetch(admin, "/v1/plugins", {
     method: "POST",
     headers: {

--- a/evals/specs/skill-grant-access.test.ts
+++ b/evals/specs/skill-grant-access.test.ts
@@ -1,0 +1,193 @@
+import { expect, onTestFinished, test } from "vitest";
+import { denFetch, ensureMemberSession, signIn } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+
+const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
+const title = apiUrl
+  ? "grant-native cloud skills are usable only by their creator"
+  : "skill grant access skipped: set OPENWORK_EVAL_DEN_API_URL";
+let requestId = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value).slice(0, 500)}`);
+  return value;
+}
+
+function toolText(result: unknown): string {
+  const record = requireRecord(result, "MCP tool result");
+  const first = Array.isArray(record.content) ? record.content[0] : null;
+  if (!isRecord(first) || typeof first.text !== "string") {
+    throw new Error(`MCP tool result had no text content: ${JSON.stringify(result).slice(0, 500)}`);
+  }
+  return first.text;
+}
+
+function toolJson(result: unknown): unknown {
+  return JSON.parse(toolText(result));
+}
+
+function searchMatches(result: unknown): Record<string, unknown>[] {
+  const payload = requireRecord(toolJson(result), "search_capabilities payload");
+  return Array.isArray(payload.matches) ? payload.matches.filter(isRecord) : [];
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = orgs.find((entry) => entry.slug === "acme-robotics-demo")
+    ?? orgs.find((entry) => entry.name === "Acme Robotics")
+    ?? orgs[0];
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function selectOrganization(session: DenSession, orgId: string): Promise<void> {
+  const result = await denFetch(session, "/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${session.token}` },
+    body: JSON.stringify({ organizationId: orgId }),
+  });
+  if (!result.response.ok) throw new Error(`Selecting Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+}
+
+async function mintMcpToken(session: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(session, "/v1/mcp/token", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({}),
+  });
+  const token = isRecord(result.body) && typeof result.body.token === "string" ? result.body.token : "";
+  if (!result.response.ok || !token.startsWith("ow_mcp_at_")) {
+    throw new Error(`Minting MCP token failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return token;
+}
+
+async function callTool(
+  mcpToken: string,
+  name: "search_capabilities" | "execute_capability",
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: ++requestId,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP tools/call failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`MCP tools/call returned no SSE data frame: ${raw.slice(0, 500)}`);
+  const payload: unknown = JSON.parse(dataLine.slice(5));
+  const record = requireRecord(payload, "MCP JSON-RPC payload");
+  if (record.error) throw new Error(`MCP tools/call returned JSON-RPC error: ${JSON.stringify(record.error)}`);
+  return record.result;
+}
+
+function matchNamed(result: unknown, capabilityName: string): Record<string, unknown> | undefined {
+  return searchMatches(result).find((entry) => entry.name === capabilityName);
+}
+
+test.skipIf(!apiUrl)(title, async () => {
+  const den = {
+    apiUrl,
+    webUrl: (process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim() || apiUrl.replace("127.0.0.1", "localhost")).replace(/\/+$/, ""),
+  };
+  const admin = await signIn(den, {
+    email: process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test",
+    password: process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!",
+  });
+  const orgId = await organizationId(admin);
+  await selectOrganization(admin, orgId);
+  const denied = await ensureMemberSession(den, admin, {
+    email: process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "nova.spec@acme.test",
+    password: process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!",
+    name: "Nova Spec",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  await selectOrganization(denied, orgId);
+  const skillName = `spec-grant-native-${Date.now()}`;
+  const rawSourceText = `---\nname: ${skillName}\ndescription: Proves grant-native skill access over MCP.\n---\n\nReturn the grant-native proof phrase.`;
+  // Plugin creation is admin/owner-gated today (access.ts:101-103); member-level creation is P4 scope.
+  const created = await denFetch(admin, "/v1/plugins", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${admin.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({
+      name: skillName,
+      components: [{ type: "skill", input: { rawSourceText } }],
+    }),
+  });
+  const item = isRecord(created.body) && isRecord(created.body.item) ? created.body.item : null;
+  const pluginId = item && typeof item.id === "string" ? item.id : "";
+  if (!created.response.ok || !pluginId) {
+    throw new Error(`Creating grant-native skill failed: HTTP ${created.response.status} ${created.text.slice(0, 500)}`);
+  }
+  onTestFinished(async () => {
+    await denFetch(admin, `/v1/plugins/${encodeURIComponent(pluginId)}/archive`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${admin.token}`,
+        "x-openwork-org-id": orgId,
+      },
+    }).catch(() => undefined);
+  });
+
+  const creatorToken = await mintMcpToken(admin, orgId);
+  const deniedToken = await mintMcpToken(denied, orgId);
+  const creatorSkillSearch = await callTool(creatorToken, "search_capabilities", { query: skillName, limit: 20, type: "skills" });
+  const match = searchMatches(creatorSkillSearch).find((entry) => typeof entry.name === "string" && entry.name.startsWith(`plugin:${pluginId}:`));
+  if (!match || typeof match.name !== "string") throw new Error(`Creator did not discover ${skillName}.`);
+  const capabilityName = match.name;
+  expect(capabilityName.length).toBeGreaterThan(`plugin:${pluginId}:`.length);
+  expect(match.kind).toBe("skill");
+  expect(match).not.toHaveProperty("marketplace");
+
+  const creatorAllSearch = await callTool(creatorToken, "search_capabilities", { query: skillName, limit: 20 });
+  const allMatch = matchNamed(creatorAllSearch, capabilityName);
+  expect(allMatch).toBeDefined();
+  expect(allMatch).not.toHaveProperty("marketplace");
+
+  const creatorExecution = await callTool(creatorToken, "execute_capability", { name: capabilityName });
+  expect(isRecord(creatorExecution) && creatorExecution.isError === true).toBe(false);
+  expect(toolJson(creatorExecution)).toMatchObject({ kind: "skill", content: rawSourceText, marketplace: null });
+
+  const deniedSkillSearch = await callTool(deniedToken, "search_capabilities", { query: skillName, limit: 20, type: "skills" });
+  const deniedAllSearch = await callTool(deniedToken, "search_capabilities", { query: skillName, limit: 20 });
+  expect(matchNamed(deniedSkillSearch, capabilityName)).toBeUndefined();
+  expect(matchNamed(deniedAllSearch, capabilityName)).toBeUndefined();
+
+  const deniedExecution = requireRecord(
+    await callTool(deniedToken, "execute_capability", { name: capabilityName }),
+    "denied execute_capability result",
+  );
+  expect(deniedExecution.isError).toBe(true);
+  expect(toolJson(deniedExecution)).toEqual({
+    error: "forbidden",
+    message: "You have not been granted access to this marketplace plugin capability.",
+  });
+});

--- a/prds/skill-sharing/grant-native-skill-sharing.md
+++ b/prds/skill-sharing/grant-native-skill-sharing.md
@@ -177,8 +177,9 @@ Workflow to reproduce from a worktree (MySQL docker on :3306):
 
 ```bash
 pnpm dev:den:db-push
-DEN_ORG_MODE=multi_org pnpm dev:den:api        # :8790; multi_org needed for the
-                                               # member-bootstrap signup flow
+DEN_ORG_MODE=multi_org pnpm dev:den:api        # :8790; demo:den also uses multi_org.
+                                               # The spec self-diagnoses disabled signup;
+                                               # DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP=true also works.
 DEN_DEMO_SEED_FETCH_GITHUB=0 pnpm --filter @openwork-ee/den-api run seed:demo-org -- --reset
 export OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790
 export OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005

--- a/prds/skill-sharing/grant-native-skill-sharing.md
+++ b/prds/skill-sharing/grant-native-skill-sharing.md
@@ -158,6 +158,47 @@ acceptance criteria + suites instead of fraimz, per program owner decision):**
   (5 new A1–A5 + 58 existing); `pnpm exec tsc --noEmit` clean.
   Per program owner decision, proof is spec acceptance suites, not fraimz.
 
+#### P1 wire proof — spec lane (verified 2026-08-01)
+
+`evals/specs/skill-grant-access.test.ts` proves the claim over the exact
+surface desktop chat uses — `POST /v1/mcp/token` → `POST /mcp/agent`
+(Streamable HTTP JSON-RPC `tools/call`): the seeded owner creates a
+plugin+skill via `POST /v1/plugins` (no `marketplaceId`/`orgWide`, the
+`create-skill` contract), then `search_capabilities` (with and without
+`type: "skills"`) returns the capability with no `marketplace` field,
+`execute_capability` returns the raw SKILL.md with `marketplace: null`, and a
+freshly invited member (real invitation → signup → accept flow) neither
+discovers it nor executes it (exact denial:
+`{"error":"forbidden","message":"You have not been granted access to this
+marketplace plugin capability."}`). Runs in the `pr` project (fast lane),
+env-gated skip without a stack.
+
+Workflow to reproduce from a worktree (MySQL docker on :3306):
+
+```bash
+pnpm dev:den:db-push
+DEN_ORG_MODE=multi_org pnpm dev:den:api        # :8790; multi_org needed for the
+                                               # member-bootstrap signup flow
+DEN_DEMO_SEED_FETCH_GITHUB=0 pnpm --filter @openwork-ee/den-api run seed:demo-org -- --reset
+export OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790
+export OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005
+export OPENWORK_EVAL_MARK_VERIFIED_CMD='docker exec openwork-web-local-mysql mysql -uroot -ppassword openwork_den -e "UPDATE \`user\` SET email_verified = 1 WHERE email = '\''{email}'\''"'
+pnpm --dir evals install && pnpm --dir evals run spec specs/skill-grant-access.test.ts
+```
+
+Results: spec passes against a pristine `--reset` seed (both the
+invitation-bootstrap and direct-sign-in paths); full `pr` lane
+`pnpm --dir evals run spec` → 3 files / 5 tests passed; skip path verified;
+`pnpm --dir evals run typecheck` clean.
+
+**Discovered while proving (feeds P4):** `hasPluginArchCapability` ignores its
+capability argument — every plugin-arch capability is admin/owner-only today
+(`access.ts:101-103`). So member-level skill creation does not exist yet;
+P1's "creator" claim holds for whoever may create (admins/owners), and
+opening `plugin.create` per posture is exactly P4's job. The P4 pre-flight
+question about the capability→role mechanism is answered: it is a stub to
+replace.
+
 ### P2 — Share verbs in chat
 
 New builtin `share-plugin` skill (person/team/org → writes a

--- a/prds/skill-sharing/grant-native-skill-sharing.md
+++ b/prds/skill-sharing/grant-native-skill-sharing.md
@@ -1,0 +1,215 @@
+# Grant-Native Skill Sharing Program
+
+Make access to skills a grant edge, not a marketplace membership. A skill you
+create in chat is usable in your next message; sharing it with a person or a
+team is one grant row; marketplaces are demoted to what they really are —
+browsable catalogs.
+
+## Goal
+
+- A cloud skill created from the chat (`create-skill` builtin → `POST
+  /v1/plugins`) is immediately discoverable and executable by its creator via
+  `search_capabilities` / `execute_capability` — no marketplace involved.
+- Sharing with a person, a team, or the whole org is a single
+  `plugin_access_grant` row, drivable from chat.
+- The dashboard shows one library ("Mine / Shared with me / Team / Everyone")
+  with provenance on every row.
+- Org admins can set a sharing posture (Open / Team-scoped / Curated) without
+  a deploy.
+- Marketplaces keep working exactly as today for catalogs (OpenWork defaults,
+  Anthropic starters, GitHub imports). Nothing is deleted.
+
+## Short answer
+
+This is four independent phases, each shippable alone. The root defect is one
+pair of SQL queries: the chat capability index builds its candidate set by
+inner-joining `marketplace_plugin` + `marketplace`
+(`ee/apps/den-api/src/mcp/marketplace-capabilities.ts:331-372` and `:374-422`),
+so a plugin outside an active marketplace is invisible in search and returns
+`unknown_capability` on execute — even for its creator, who already holds a
+`manager` grant written at creation
+(`ee/apps/den-api/src/routes/org/plugin-system/store.ts:1984-1994`). Grants are
+already consulted, but only as a *filter* (`filterVisibleRows`, `:478-508`)
+over rows that survived the marketplace join.
+
+Everything else in the model already exists: `plugin_access_grant` supports
+`orgMembershipId | teamId | orgWide` with `viewer/editor/manager`
+(`ee/packages/den-db/src/schema/sharables/plugin-arch.ts:228-250`), and
+`resolvePluginArchGrantRole` resolves all three shapes
+(`ee/apps/den-api/src/routes/org/plugin-system/access.ts:183-199`). Phase 1
+requires **zero schema migrations**.
+
+## Current coupling (verified)
+
+| Fact | Where |
+|---|---|
+| Candidate set requires an active marketplace membership (inner joins) | `marketplace-capabilities.ts:331-372` (search/descriptors/references), `:374-422` (execute) |
+| Grants only filter, never admit | `filterVisibleRows` `:478-508`; `grantRole` → `access.ts:183-199` (skips `removedAt`, `maxRole` viewer<editor<manager; **no admin bypass by design**, comment `:500-503`) |
+| Capability name encodes plugin+configObject only — `plugin:<pluginId>:<configObjectId>` | `buildMarketplaceCapabilityName` / `parseMarketplaceCapabilityName` `:210-223` |
+| Execute payload requires `marketplace: string` | `MarketplaceCapabilityExecutePayload` `:136-151`; fed by `basePayload` `:306-315` |
+| Search match `marketplace?` and descriptor `marketplaceName?` are already optional | `:100-108`, `:39-47` |
+| References require `marketplaceId` and dedupe on it | `:49-54`, `:524-538`; consumed by `GET /v1/resources/marketplace-capabilities` (`routes/org/resources.ts:257-291`) |
+| Plugin in N marketplaces → N rows; deduped by capability name in search (`:1250-1251`) and by capability in descriptors (`:561`); winner = alphabetically first marketplace (`orderBy` `:370`, `:420`) | search `:1218-1288`, descriptors `:541-581` |
+| Marketplace-name strings in user-facing copy | `summaryFor` `:287-291`, `objectHint` `:279-281`; `provenance()` `:275-277` uses plugin name only |
+| MCP-requirement + cloud-readiness machinery is marketplace-independent | `resolveMarketplacePluginCloudReadiness` `:1073-1155` (joins only plugin⋈configObject); `marketplaceMcpServerEntries` `:638-651` |
+| Creator gets `manager` grant at plugin creation | `store.ts:1968-1998` |
+| `create-skill` builtin tells the agent the skill is "private until published or shared" | `ee/apps/den-api/src/mcp/builtin-skills.ts:27,62-63,163` |
+| Chat consumers of this module | `mcp/agent.ts:416-432` (skill resources), `:483-492` (search tool), `:563-582` (execute tool) |
+
+## Target architecture
+
+```
+ WHO                        EDGE (one row each)                WHAT
+ ───                        ───────────────────                ────
+ creator ─────────────── manager grant (auto on create) ──┐
+ person  ─────────────── viewer grant  ("share w/ Ben")  ──┤
+ team    ─────────────── viewer grant  ("share w/ team") ──┼─▶ PLUGIN ─▶ SKILL(s)
+ org     ─────────────── org-wide grant (admin)          ──┤
+ catalog (marketplace) ── membership   (browse ▸ add)    ──┘
+
+ capability index candidate set: ConfigObject ⋈ PluginConfigObject ⋈ Plugin
+   LEFT JOIN marketplace membership          (was: INNER JOIN)
+ visibility: unchanged filterVisibleRows — configObject grant, plugin grant,
+   or marketplace grant when a marketplace edge exists
+```
+
+Permission gate (Phase 4): org capability (`plugin.share_member|share_team|
+share_org|grant_editor`, added to the `PluginArchCapability` union,
+`access.ts:18-20`) AND `manager` on the plugin. Default grant role on every
+share: `viewer`. Recipients can never re-share.
+
+## Phases
+
+### P1 — Grant-native capability index (this PR)
+
+Candidate set moves from "marketplace-attached" to "grant-reachable ∪
+marketplace-attached"; everything downstream keeps working.
+
+1. `listActiveMarketplaceRows` / `listActiveMarketplaceRowsForCapability`:
+   inner join on `marketplace_plugin`+`marketplace` becomes LEFT JOIN
+   (membership `removedAt IS NULL` and marketplace active/undeleted move into
+   the join condition). Row type: `marketplace: MarketplaceRow | null`.
+2. `filterVisibleRows`: skip the marketplace-grant path when `marketplace` is
+   null. Grant-only rows must carry a config-object or plugin grant to pass —
+   same rule as today, minus the mandatory catalog hop.
+3. Payloads: `MarketplaceCapabilityExecutePayload.marketplace` →
+   `string | null`; `basePayload`, `summaryFor` (`[Plugin] title` when no
+   catalog), `objectHint` fallback copy. Search-match `marketplace?` and
+   descriptor `marketplaceName?` stay optional and simply omit.
+4. References (`AccessibleMarketplaceCapabilityReference.marketplaceId`) →
+   `string | null`; dedupe key already includes plugin+configObject. Verify
+   consumers of `/v1/resources/marketplace-capabilities` tolerate null before
+   changing; if any consumer hard-requires it, exclude null-marketplace rows
+   from that route only and note it here.
+5. Determinism: plugins with catalog membership never produce a
+   null-marketplace row (LEFT JOIN yields null only when no membership), so
+   existing payloads are byte-identical; keep `orderBy` marketplace-name for
+   multi-catalog winners.
+6. `builtin-skills.ts`: `create-skill` copy — the skill is usable by its
+   creator immediately; report that instead of "private until published".
+   Keep "Do not send `marketplaceId` or `orgWide`."
+7. Sweep steering copy that asserts the old behavior
+   (`mcp/agent.ts:117`, `apps/server/src/opencode-plugins/
+   openwork-extensions-preview-steering.ts:141`,
+   `openwork-capabilities-knowledge.ts:95`) — update only if they state
+   "unusable until published".
+
+**Proof (spec acceptance, run with `bun test` — this program uses spec
+acceptance criteria + suites instead of fraimz, per program owner decision):**
+
+- New suite `ee/apps/den-api/test/grant-native-capabilities.test.ts`
+  (pattern: copy of `test/marketplace-capabilities.test.ts` harness, own
+  `openwork_test_*` database):
+  - A1 creator: plugin+skill with member `manager` grant, **no marketplace**
+    → search finds it, execute returns raw SKILL.md content, descriptors
+    include it, `marketplace` is null/omitted in payloads.
+  - A2 team: team-scoped `viewer` grant, no marketplace → visible/executable
+    for a team member, invisible + `forbidden`/`unknown_capability` for a
+    non-member.
+  - A3 nobody: active plugin+skill, zero grants, no marketplace → not in
+    search, execute denies.
+  - A4 unchanged: marketplace-attached plugin behaves exactly as before
+    (payload carries the marketplace name).
+  - A5 both: plugin in a catalog AND direct grant → exactly one search match,
+    marketplace name still present.
+- Full existing suites stay green: `test/marketplace-capabilities.test.ts`,
+  `test/marketplace-cloud-readiness.test.ts`,
+  `test/plugin-system-create-bundle.test.ts`.
+- `tsc --noEmit` clean for den-api.
+
+#### P1 results — PASSED (verified 2026-08-01, branch `feat/grant-native-skills`)
+
+- Two-query design as specified: existing inner-join queries byte-identical;
+  grant-only candidates via `notExists` active-membership subquery
+  (`listGrantOnlyRows`, `listGrantOnlyRowsForCapability`); execute falls back
+  to the grant-only resolver only when the marketplace resolver returns zero
+  rows.
+- **Step-4 decision:** internal references now carry
+  `marketplaceId: string | null` (null sorted last); the desktop route
+  `GET /v1/resources/marketplace-capabilities` filters out null-marketplace
+  rows because its consumer requires marketplace ids — grant-only skills reach
+  chat via search/execute/descriptors, not that route. Revisit in P3.
+- **Step-7 outcome:** steering copy in `mcp/agent.ts`,
+  `openwork-extensions-preview-steering.ts`, `openwork-capabilities-knowledge.ts`
+  made no stale "unusable until published" claims — unchanged.
+- Proof: `bun test test/grant-native-capabilities.test.ts
+  test/marketplace-capabilities.test.ts test/marketplace-cloud-readiness.test.ts
+  test/plugin-system-create-bundle.test.ts` → **63 pass / 0 fail**
+  (5 new A1–A5 + 58 existing); `pnpm exec tsc --noEmit` clean.
+  Per program owner decision, proof is spec acceptance suites, not fraimz.
+
+### P2 — Share verbs in chat
+
+New builtin `share-plugin` skill (person/team/org → writes a
+`plugin_access_grant` via the plugin access routes; verify they are exposed —
+`createResourceAccessGrant` exists in `store.ts`). `create-skill` gains the
+post-create "share it?" offer. Same-creator+same-name plugin creation → 409
+pointing at the existing id. Verify `syncPluginMcpRequirementAccessForResource`
+fires on grant creation as it does on marketplace attach (`store.ts:2626-2658`).
+Hardcoded Team-scoped defaults (person ✔, own team ✔, org admin-only).
+Proof: suite covering grant writes, recipient visibility via P1 index,
+non-manager denial, recipient cannot re-share.
+
+### P3 — Library UI + provenance
+
+Dashboard library: Mine / Shared with me / Team / Everyone, one row per
+plugin, provenance chips (Yours / Shared by N / Team T / catalog M /
+built-in), per-skill access list, revoke, delete blast-radius warning.
+Persist GitHub source URL on imports if absent (only migration candidate in
+the program). Proof: den-web component tests + P1/P2 suites; manual demo per
+north star.
+
+### P4 — Postures
+
+`plugin.share_member|share_team|share_org|grant_editor` in the
+`PluginArchCapability` union; role wiring (verify capability→role mapping
+mechanism at `access.ts:366-373` and where org role permissions persist);
+settings screen with Open / Team-scoped / Curated presets. Proof: suite
+asserting each posture's allow/deny matrix.
+
+## Risks
+
+1. **Over-exposure regression** — the index gets *wider*. Mitigated: admission
+   still requires a live grant (`filterVisibleRows` unchanged in semantics);
+   A3/A4 pin it; the deliberate no-admin-bypass comment (`:500-503`) is
+   preserved and tested by the existing suite (`test/marketplace-capabilities
+   .test.ts:516`).
+2. **Reference-shape consumers** — `marketplaceId: null` may surprise the
+   desktop resources route consumer. Checked in P1 step 4; excluded from that
+   route if unsafe.
+3. **Search noise** — grant-only rows enlarge the candidate scan. Same
+   order-of-magnitude as today (org-scoped joins); revisit only if orgs with
+   thousands of plugins appear.
+4. **Copy drift** — agent-facing SKILL.md text (`builtin-skills.ts`) and
+   steering prompts must agree with the new behavior or agents will
+   "helpfully" attach marketplaces. P1 steps 6–7.
+
+## North-star demo
+
+1. I ask OpenWork to create a skill that formats my standup notes; it
+   confirms the skill is ready to use — no publish step, nowhere to browse.
+2. In the same chat I ask it to use the skill, and it just works.
+3. I say "share it with Ben"; Ben asks his own OpenWork to use it and it
+   works for him too, labeled "Shared by Laurent".
+4. I open the dashboard library and see mine, Ben sees "shared with me", and
+   the org catalogs sit untouched in Catalogs.


### PR DESCRIPTION
## What

Phase 1 of the **Grant-Native Skill Sharing** program (spec: `prds/skill-sharing/grant-native-skill-sharing.md`, included in this PR).

A skill created from the chat (`create-skill` builtin → `POST /v1/plugins`) was invisible and unexecutable in chat — even for its creator, who already holds a `manager` grant — because the capability index built its candidate set by inner-joining `marketplace_plugin` + `marketplace`. Grants only *filtered*; they never *admitted*.

This PR makes the index grant-native:

- Candidate set = marketplace-attached rows (existing queries **byte-identical**) ∪ grant-only rows (new `notExists` active-membership query). Execute falls back to the grant-only resolver only when the marketplace resolver returns zero rows.
- `filterVisibleRows` semantics unchanged: a row still requires a live config-object / plugin / (when present) marketplace grant. The deliberate no-admin-bypass behavior is preserved.
- Payloads: `marketplace` is now `string | null`; summaries/hints degrade gracefully. Capability names never encoded the marketplace, so naming is untouched.
- Desktop route `GET /v1/resources/marketplace-capabilities` keeps its non-null contract (grant-only rows filtered there; revisit in P3).
- `create-skill` builtin copy: reports the skill is **ready to use now** instead of "private until published or shared".

No schema migrations. Marketplaces/catalogs unchanged.

## Tests (commands + results)

```
cd ee/apps/den-api
bun test test/grant-native-capabilities.test.ts \
         test/marketplace-capabilities.test.ts \
         test/marketplace-cloud-readiness.test.ts \
         test/plugin-system-create-bundle.test.ts
# → 63 pass / 0 fail (5 new A1–A5 acceptance tests + 58 existing), 350 assertions
pnpm exec tsc --noEmit   # clean
```

New suite `test/grant-native-capabilities.test.ts` (real MySQL, same harness as `marketplace-capabilities.test.ts`): A1 creator grant → search/execute/descriptors work with `marketplace: null`; A2 team grant admits team members, `forbidden` for others; A3 zero grants stays inaccessible; A4 marketplace-attached payloads byte-identical; A5 catalog + direct grant → one match, catalog name wins.

## Proof format

Per program-owner decision this program uses **spec acceptance suites instead of fraimz**; the spec records the P1 results section with the evidence. No video/fraimz attached — reproduce with the commands above (MySQL at 127.0.0.1:3306, per-suite DBs via `pnpm --filter @openwork-ee/den-db db:push`).

## Next (specced, not built)

P2 share verbs in chat · P3 library UI + provenance · P4 sharing postures.