### PR TITLE
feat(den-api): members can create plugins and cloud skills (skill-sharing posture slice)

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -98,7 +98,10 @@ export function isPluginArchOrgAdmin(context: PluginArchActorContext) {
   return context.organizationContext.currentMember.isOwner || memberHasRole(context.organizationContext.currentMember.role, "admin")
 }
 
-export function hasPluginArchCapability(context: PluginArchActorContext, _capability: PluginArchCapability) {
+export function hasPluginArchCapability(context: PluginArchActorContext, capability: PluginArchCapability) {
+  if (capability === "plugin.create" || capability === "config_object.create") {
+    return true
+  }
   return isPluginArchOrgAdmin(context)
 }
 

--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -105,7 +105,7 @@ import {
 } from "./schemas.js"
 
 type EndpointMethod = "DELETE" | "GET" | "PATCH" | "POST"
-type EndpointAudience = "admin" | "public_webhook"
+type EndpointAudience = "admin" | "member" | "public_webhook"
 type EndpointTag = "Config Objects" | "Plugins" | "Marketplaces" | "Connectors" | "GitHub" | "Webhooks"
 
 type EndpointContract = {
@@ -233,7 +233,7 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
     tag: "Config Objects",
   },
   createConfigObject: {
-    audience: "admin",
+    audience: "member",
     description: "Create a cloud or imported config object and optionally attach it to plugins.",
     method: "POST",
     path: pluginArchRoutePaths.configObjects,
@@ -377,7 +377,7 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
     tag: "Plugins",
   },
   createPlugin: {
-    audience: "admin",
+    audience: "member",
     description: "Create a private-by-default plugin, optionally bundled with components, org-wide sharing, and marketplace publishing.",
     method: "POST",
     path: pluginArchRoutePaths.plugins,

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -107,7 +107,7 @@ import {
   pluginUpdateSchema,
   resourceAccessGrantWriteSchema,
 } from "./schemas.js"
-import { requirePluginArchCapability, type PluginArchActorContext, PluginArchAuthorizationError } from "./access.js"
+import { isPluginArchOrgAdmin, requirePluginArchCapability, type PluginArchActorContext, PluginArchAuthorizationError } from "./access.js"
 import { pluginArchRoutePaths } from "./contracts.js"
 import { ensureOrganizationAdmin, orgAccessFailureStatus } from "../shared.js"
 import { isAgentOAuthClientConnection } from "../mcp-connections.js"
@@ -713,6 +713,9 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
         const context = actorContext(c)
         await requirePluginArchCapability(context, "plugin.create")
         const body = validJson<PluginCreateBody>(c)
+        if (body.orgWide === true && !isPluginArchOrgAdmin(context)) {
+          throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can create org-wide plugins.")
+        }
         if ((body.components?.length ?? 0) > 0) {
           await requirePluginArchCapability(context, "config_object.create")
         }

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -27,7 +27,7 @@ import {
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { hasSkillFrontmatterName, parseSkillMarkdown } from "@openwork-ee/utils"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
-import { requirePluginArchResourceRole, resolvePluginArchResourceRole } from "./access.js"
+import { isPluginArchOrgAdmin, PluginArchAuthorizationError, requirePluginArchResourceRole, resolvePluginArchResourceRole } from "./access.js"
 import {
   buildGithubAppInstallUrl,
   createGithubInstallStateToken,
@@ -1879,6 +1879,9 @@ export async function listResourceAccess(input: { context: PluginArchActorContex
 export async function createResourceAccessGrant(input: { context: PluginArchActorContext; value: AccessGrantWrite } & ResourceTarget) {
   await ensureResourceInOrganization(input.context, input)
   await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
+  if (input.value.orgWide === true && !isPluginArchOrgAdmin(input.context)) {
+    throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can grant org-wide access.")
+  }
   await ensureGrantTargetsInOrganization(input.context, input.value)
   const grant = await upsertGrant(input)
   await syncPluginMcpRequirementAccessForResource(input)
@@ -2005,6 +2008,10 @@ export async function createPluginBundle(input: {
   name: string
   orgWide?: boolean
 }) {
+  if (input.orgWide === true && !isPluginArchOrgAdmin(input.context)) {
+    throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can create org-wide plugins.")
+  }
+
   for (const component of input.components ?? []) {
     deriveProjection({ objectType: component.type, value: component.value })
   }
@@ -4587,6 +4594,10 @@ export async function importGithubPluginMcps(input: {
   selectedServerKeys?: string[]
   selectedServerNames?: string[]
 }) {
+  if (!isPluginArchOrgAdmin(input.context)) {
+    throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can import plugins from GitHub.")
+  }
+
   if (input.marketplaceId) {
     await ensureEditableMarketplace(input.context, input.marketplaceId)
   }
@@ -5848,6 +5859,10 @@ export async function getGithubConnectorDiscoveryTree(input: { connectorInstance
 }
 
 export async function applyGithubConnectorDiscovery(input: { autoImportNewPlugins: boolean; connectorInstanceId: ConnectorInstanceId; connectorSyncEventId?: ConnectorSyncEventId; context: PluginArchActorContext; forceRefresh?: boolean; selectedKeys: string[] }) {
+  if (!isPluginArchOrgAdmin(input.context)) {
+    throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can apply connector discovery.")
+  }
+
   const discovery = await resolveGithubConnectorDiscovery({ connectorInstanceId: input.connectorInstanceId, context: input.context, forceRefresh: input.forceRefresh })
   const selectedKeySet = new Set(input.selectedKeys.map((key) => key.trim()).filter(Boolean))
   const selectedPlugins = discovery.cache.discoveredPlugins.filter((plugin) => plugin.supported && selectedKeySet.has(plugin.key))

--- a/ee/apps/den-api/test/plugin-system-access.test.ts
+++ b/ee/apps/den-api/test/plugin-system-access.test.ts
@@ -43,7 +43,10 @@ test("org owners and admins get plugin-system capability access", () => {
   expect(accessModule.hasPluginArchCapability(createActorContext({ isOwner: true }), "plugin.create")).toBe(true)
   expect(accessModule.hasPluginArchCapability(createActorContext({ role: "admin" }), "marketplace.create")).toBe(true)
   expect(accessModule.hasPluginArchCapability(createActorContext({ role: "admin" }), "connector_instance.create")).toBe(true)
-  expect(accessModule.hasPluginArchCapability(createActorContext({ role: "member" }), "config_object.create")).toBe(false)
+  expect(accessModule.hasPluginArchCapability(createActorContext({ role: "member" }), "plugin.create")).toBe(true)
+  expect(accessModule.hasPluginArchCapability(createActorContext({ role: "member" }), "config_object.create")).toBe(true)
+  expect(accessModule.hasPluginArchCapability(createActorContext({ role: "member" }), "marketplace.create")).toBe(false)
+  expect(accessModule.hasPluginArchCapability(createActorContext({ role: "member" }), "connector_instance.create")).toBe(false)
 })
 
 test("grant resolution supports direct, team, org-wide, and highest-role precedence", () => {

--- a/ee/apps/den-api/test/plugin-system-member-create.test.ts
+++ b/ee/apps/den-api/test/plugin-system-member-create.test.ts
@@ -1,0 +1,275 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { and, eq } from "@openwork-ee/den-db/drizzle"
+import {
+  ConfigObjectAccessGrantTable,
+  ConfigObjectTable,
+  ConfigObjectVersionTable,
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  OrganizationTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
+
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_membercreate"
+process.env.DB_MODE ??= "mysql"
+process.env.DEN_DB_ENCRYPTION_KEY ??= "member-create-test-key-123456789"
+process.env.BETTER_AUTH_SECRET ??= "member-create-test-secret-123456"
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790"
+
+let db: typeof import("../src/db.js").db
+let store: typeof import("../src/routes/org/plugin-system/store.js")
+
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+const memberUserId = createDenTypeId("user")
+const otherMemberId = createDenTypeId("member")
+const otherMemberUserId = createDenTypeId("user")
+const adminId = createDenTypeId("member")
+const adminUserId = createDenTypeId("user")
+const marketplaceId = createDenTypeId("marketplace")
+
+async function clearRows() {
+  await db.delete(MarketplacePluginTable).where(eq(MarketplacePluginTable.organizationId, organizationId))
+  await db.delete(ConfigObjectAccessGrantTable).where(eq(ConfigObjectAccessGrantTable.organizationId, organizationId))
+  await db.delete(PluginConfigObjectTable).where(eq(PluginConfigObjectTable.organizationId, organizationId))
+  await db.delete(PluginAccessGrantTable).where(eq(PluginAccessGrantTable.organizationId, organizationId))
+  await db.delete(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.organizationId, organizationId))
+  await db.delete(ConfigObjectVersionTable).where(eq(ConfigObjectVersionTable.organizationId, organizationId))
+  await db.delete(ConfigObjectTable).where(eq(ConfigObjectTable.organizationId, organizationId))
+  await db.delete(PluginTable).where(eq(PluginTable.organizationId, organizationId))
+  await db.delete(MarketplaceTable).where(eq(MarketplaceTable.organizationId, organizationId))
+  await db.delete(MemberTable).where(eq(MemberTable.organizationId, organizationId))
+  await db.delete(OrganizationTable).where(eq(OrganizationTable.id, organizationId))
+}
+
+beforeAll(async () => {
+  mock.restore()
+  db = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db }))
+  store = await import("../src/routes/org/plugin-system/store.js")
+  await clearRows()
+
+  await db.insert(OrganizationTable).values({
+    id: organizationId,
+    name: "Member Plugin Creation Test",
+    slug: `member-plugin-create-${organizationId}`,
+  })
+  await db.insert(MemberTable).values([
+    { id: memberId, organizationId, role: "member", userId: memberUserId },
+    { id: otherMemberId, organizationId, role: "member", userId: otherMemberUserId },
+    { id: adminId, organizationId, role: "admin", userId: adminUserId },
+  ])
+  await db.insert(MarketplaceTable).values({
+    createdByOrgMembershipId: adminId,
+    description: "Visible but not editable by members",
+    id: marketplaceId,
+    name: "Admin Marketplace",
+    organizationId,
+    status: "active",
+  })
+  await db.insert(MarketplaceAccessGrantTable).values({
+    createdByOrgMembershipId: adminId,
+    id: createDenTypeId("marketplaceAccessGrant"),
+    marketplaceId,
+    organizationId,
+    orgMembershipId: null,
+    orgWide: true,
+    role: "viewer",
+    teamId: null,
+  })
+})
+
+afterAll(async () => {
+  await clearRows()
+  mock.restore()
+})
+
+function actorContext(input: {
+  id: typeof memberId
+  isOwner: boolean
+  role: string
+  userId: typeof memberUserId
+}): PluginArchActorContext {
+  const now = new Date()
+  return {
+    memberTeams: [],
+    organizationContext: {
+      organization: {
+        id: organizationId,
+        name: "Member Plugin Creation Test",
+        slug: `member-plugin-create-${organizationId}`,
+        logo: null,
+        allowedEmailDomains: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      currentMember: {
+        id: input.id,
+        userId: input.userId,
+        role: input.role,
+        createdAt: now,
+        joinedAt: now,
+        isOwner: input.isOwner,
+      },
+      invitations: [],
+      members: [],
+      roles: [],
+      teams: [],
+    },
+    session: { createdAt: now },
+  }
+}
+
+const memberContext = actorContext({ id: memberId, isOwner: false, role: "member", userId: memberUserId })
+const adminContext = actorContext({ id: adminId, isOwner: false, role: "admin", userId: adminUserId })
+
+function skillComponent(name: string): { type: "skill"; value: { rawSourceText: string } } {
+  return {
+    type: "skill",
+    value: { rawSourceText: `---\nname: ${name}\ndescription: Test ${name}.\n---\n\nFollow the test instructions.` },
+  }
+}
+
+async function rejectedStatus(action: () => Promise<unknown>) {
+  try {
+    await action()
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "status" in error && typeof error.status === "number") {
+      return error.status
+    }
+    throw error
+  }
+  throw new Error("Expected action to reject")
+}
+
+async function pluginCount() {
+  const rows = await db.select({ id: PluginTable.id }).from(PluginTable).where(eq(PluginTable.organizationId, organizationId))
+  return rows.length
+}
+
+test("a member creates a plugin bundle with a skill and receives manager access", async () => {
+  const plugin = await store.createPluginBundle({
+    components: [skillComponent("member-created-skill")],
+    context: memberContext,
+    name: "Member-created plugin",
+  })
+
+  const managerGrants = await db
+    .select()
+    .from(PluginAccessGrantTable)
+    .where(and(
+      eq(PluginAccessGrantTable.pluginId, plugin.id),
+      eq(PluginAccessGrantTable.orgMembershipId, memberId),
+      eq(PluginAccessGrantTable.role, "manager"),
+    ))
+  expect(managerGrants).toHaveLength(1)
+  expect(await store.getPluginDetail(memberContext, plugin.id)).toMatchObject({ id: plugin.id, memberCount: 1 })
+})
+
+test("a member cannot import plugins from GitHub without starting a fetch", async () => {
+  const originalFetch = globalThis.fetch
+  let fetchCalls = 0
+  globalThis.fetch = (input, init) => {
+    fetchCalls += 1
+    return originalFetch(input, init)
+  }
+
+  try {
+    expect(await rejectedStatus(() => store.importGithubPluginMcps({
+      authType: "none",
+      context: memberContext,
+      credentialMode: "shared",
+      githubUrl: "https://github.com/openworklabs/test-plugin",
+    }))).toBe(403)
+    expect(fetchCalls).toBe(0)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a member cannot apply connector discovery", async () => {
+  expect(await rejectedStatus(() => store.applyGithubConnectorDiscovery({
+    autoImportNewPlugins: false,
+    connectorInstanceId: createDenTypeId("connectorInstance"),
+    context: memberContext,
+    selectedKeys: [],
+  }))).toBe(403)
+})
+
+test("a member cannot create an org-wide bundle and no plugin is written", async () => {
+  const before = await pluginCount()
+  const status = await rejectedStatus(() => store.createPluginBundle({
+    components: [skillComponent("blocked-org-wide-skill")],
+    context: memberContext,
+    name: "Blocked org-wide plugin",
+    orgWide: true,
+  }))
+
+  expect(status).toBe(403)
+  expect(await pluginCount()).toBe(before)
+})
+
+test("a member cannot publish to a marketplace they cannot edit and no plugin is written", async () => {
+  const before = await pluginCount()
+  const status = await rejectedStatus(() => store.createPluginBundle({
+    context: memberContext,
+    marketplaceId,
+    name: "Blocked marketplace plugin",
+  }))
+
+  expect([403, 404]).toContain(status)
+  expect(await pluginCount()).toBe(before)
+})
+
+test("a member manager can grant another member access but cannot grant org-wide access", async () => {
+  const plugin = await store.createPluginBundle({ context: memberContext, name: "Member-managed plugin" })
+
+  expect(await rejectedStatus(() => store.createResourceAccessGrant({
+    context: memberContext,
+    resourceId: plugin.id,
+    resourceKind: "plugin",
+    value: { orgWide: true, role: "viewer" },
+  }))).toBe(403)
+
+  const grant = await store.createResourceAccessGrant({
+    context: memberContext,
+    resourceId: plugin.id,
+    resourceKind: "plugin",
+    value: { orgMembershipId: otherMemberId, role: "viewer" },
+  })
+  expect(grant).toMatchObject({ orgMembershipId: otherMemberId, orgWide: false, role: "viewer" })
+})
+
+test("an admin can create an org-wide plugin bundle end-to-end", async () => {
+  const plugin = await store.createPluginBundle({
+    components: [skillComponent("admin-org-wide-skill")],
+    context: adminContext,
+    name: "Admin org-wide plugin",
+    orgWide: true,
+  })
+  const memberships = await db.select().from(PluginConfigObjectTable).where(eq(PluginConfigObjectTable.pluginId, plugin.id))
+  const pluginGrants = await db.select().from(PluginAccessGrantTable).where(and(
+    eq(PluginAccessGrantTable.pluginId, plugin.id),
+    eq(PluginAccessGrantTable.orgWide, true),
+  ))
+  const configObjectGrants = memberships[0]
+    ? await db.select().from(ConfigObjectAccessGrantTable).where(and(
+        eq(ConfigObjectAccessGrantTable.configObjectId, memberships[0].configObjectId),
+        eq(ConfigObjectAccessGrantTable.orgWide, true),
+      ))
+    : []
+
+  expect(await store.getPluginDetail(adminContext, plugin.id)).toMatchObject({ id: plugin.id, memberCount: 1 })
+  expect(pluginGrants).toHaveLength(1)
+  expect(configObjectGrants).toHaveLength(1)
+})


### PR DESCRIPTION
## What

Members (not just admins/owners) can now create plugins and cloud skills — the `create-skill` chat flow works for everyone in the org. Slice of the **Grant-Native Skill Sharing** program (spec on #3410, `prds/skill-sharing/grant-native-skill-sharing.md`); pairs with #3410's index fix, which makes a created skill immediately usable by its creator.

`hasPluginArchCapability` was a stub returning `isOrgAdmin` for every capability (`access.ts:101-103`). Now:

| Capability | Member | Admin/Owner |
|---|---|---|
| `plugin.create`, `config_object.create` | ✅ | ✅ |
| `marketplace.create`, `connector_account.create`, `connector_instance.create` | ❌ | ✅ |

**Deliberately NOT opened to members (each gated explicitly):**
- **Org-wide publishing** — `orgWide: true` on bundles and on access grants now requires admin (route + `createPluginBundle` + `createResourceAccessGrant`). Without this, member-create would silently ship the `share_org` posture; that stays a program decision (P4).
- **GitHub plugin import** (`importGithubPluginMcps`) and **connector discovery apply** (`applyGithubConnectorDiscovery`) — both also sat behind `plugin.create`; pinned to admin at the store level so this PR changes exactly two surfaces: `POST /v1/plugins` and `POST /v1/config-objects`.

Member/team-scoped grants by a plugin's own manager keep today's semantics. Marketplace publishing already requires marketplace `editor` (unchanged). OpenAPI `audience` docs updated for the two endpoints (documentation-only field — verified unused by enforcement/clients).

## Tests (commands + results)

```
cd ee/apps/den-api
bun test test/plugin-system-member-create.test.ts test/plugin-system-access.test.ts \
         test/plugin-system-create-bundle.test.ts test/plugin-system-cross-org-idor.test.ts \
         test/plugin-system-config-object-ownership.test.ts \
         test/github-plugin-import-schema.test.ts test/github-discovery.test.ts
# → 34 pass / 0 fail (138 assertions)
pnpm exec tsc --noEmit   # clean
```

New suite `test/plugin-system-member-create.test.ts` (real MySQL): member creates bundle+skill and holds `manager`; member `orgWide` bundle → 403 with **zero rows written**; member publish to uneditable marketplace → rejected, no rows; member manager grants another member ✅ but org-wide ❌; admin org-wide end-to-end ✅; member GitHub import → 403 pre-fetch; member discovery apply → 403.

Per program-owner decision, proof is spec acceptance suites (no fraimz); reproduce with the commands above (MySQL at 127.0.0.1:3306, suite DB via `pnpm --filter @openwork-ee/den-db db:push`).