### PR TITLE
fix(server): release embedded runtime config listener

### DIFF
--- a/apps/server/src/embedded-runtime-config-lifecycle.test.ts
+++ b/apps/server/src/embedded-runtime-config-lifecycle.test.ts
@@ -1,0 +1,147 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { startEmbeddedServer } from "./embedded.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+
+const HOST = "127.0.0.1";
+const SERVER_TOKEN = "server-token";
+const HOST_TOKEN = "host-token";
+const PROVIDER_ID = "lpr_anthropic";
+const PROVIDER = { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] };
+const DEV_MODE_ENV = "OPENWORK_DEV_MODE";
+const RUNTIME_DB_ENV = "OPENWORK_RUNTIME_DB";
+const OPENCODE_BASE_URL_ENV = "OPENWORK_OPENCODE_BASE_URL";
+const FIRST_WORKSPACE_DIR = "first-workspace";
+const SECOND_WORKSPACE_DIR = "second-workspace";
+const RUNTIME_DB_FILE = "runtime.sqlite";
+const FIRST_CONFIG_FILE = "first-server.json";
+const SECOND_CONFIG_FILE = "second-server.json";
+const HTTP_OK = 200;
+const PATCH_METHOD = "PATCH";
+const CONTENT_TYPE = "application/json";
+const SKIPPED = "skipped";
+const STALE_MCP_URL = "https://stale.example.test/mcp";
+
+function restoreProcessEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function writeFakeOpencodeBin(root: string): Promise<string> {
+  const binPath = join(root, "fake-opencode.mjs");
+  await writeFile(binPath, [
+    "#!/usr/bin/env bun",
+    "const portIndex = process.argv.indexOf(\"--port\");",
+    "const requestedPort = Number(process.argv[portIndex + 1] ?? 0);",
+    "const server = Bun.serve({ port: requestedPort, fetch: () => Response.json({ ok: true }) });",
+    "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
+    "process.on(\"SIGTERM\", () => { server.stop(true); process.exit(0); });",
+  ].join("\n"));
+  await chmod(binPath, 0o755);
+  return binPath;
+}
+
+function hostHeaders(): Record<string, string> {
+  return {
+    "content-type": CONTENT_TYPE,
+    "x-openwork-host-token": HOST_TOKEN,
+  };
+}
+
+describe("embedded runtime config lifecycle", () => {
+  test("stopped embedded servers cannot rewrite the active runtime config file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-embedded-runtime-lifecycle-"));
+    const previousDevMode = process.env[DEV_MODE_ENV];
+    const previousRuntimeDb = process.env[RUNTIME_DB_ENV];
+    const previousOpencodeBaseUrl = process.env[OPENCODE_BASE_URL_ENV];
+    let activeHandle: Awaited<ReturnType<typeof startEmbeddedServer>> | null = null;
+
+    try {
+      const firstWorkspace = join(root, FIRST_WORKSPACE_DIR);
+      const secondWorkspace = join(root, SECOND_WORKSPACE_DIR);
+      await Promise.all([
+        mkdir(firstWorkspace, { recursive: true }),
+        mkdir(secondWorkspace, { recursive: true }),
+      ]);
+      const opencodeBin = await writeFakeOpencodeBin(root);
+      process.env[DEV_MODE_ENV] = "1";
+      process.env[RUNTIME_DB_ENV] = join(root, RUNTIME_DB_FILE);
+      delete process.env[OPENCODE_BASE_URL_ENV];
+
+      const stoppedHandle = await startEmbeddedServer({
+        configPath: join(root, FIRST_CONFIG_FILE),
+        host: HOST,
+        port: 0,
+        token: SERVER_TOKEN,
+        hostToken: HOST_TOKEN,
+        workspaces: [firstWorkspace],
+        manageOpencode: true,
+        opencodeBin,
+        opencodeCwd: firstWorkspace,
+      });
+      await stoppedHandle.stop();
+
+      activeHandle = await startEmbeddedServer({
+        configPath: join(root, SECOND_CONFIG_FILE),
+        host: HOST,
+        port: 0,
+        token: SERVER_TOKEN,
+        hostToken: HOST_TOKEN,
+        workspaces: [secondWorkspace],
+        manageOpencode: true,
+        opencodeBin,
+        opencodeCwd: secondWorkspace,
+      });
+
+      const providerPatch = { provider: { [PROVIDER_ID]: PROVIDER } };
+      const initialPatch = await fetch(`${activeHandle.url}/runtime-config/providers`, {
+        method: PATCH_METHOD,
+        headers: hostHeaders(),
+        body: JSON.stringify(providerPatch),
+      });
+      expect(initialPatch.status).toBe(HTTP_OK);
+      // The engine reload may be applied in place or deferred to a rollover;
+      // either way the patch must not be reported as skipped.
+      const initialBody = await initialPatch.json() as { changed: boolean; reload: string };
+      expect(initialBody.changed).toBe(true);
+      expect(initialBody.reload).not.toBe(SKIPPED);
+
+      const stoppedWorkspace = stoppedHandle.config.workspaces[0];
+      if (!stoppedWorkspace) throw new Error("Expected the stopped server workspace");
+      await writeRuntimeOpencodeConfig(stoppedHandle.config, stoppedWorkspace.id, (current) => ({
+        ...current,
+        mcp: { stale: { type: "remote", url: STALE_MCP_URL } },
+      }));
+
+      const identicalPatch = await fetch(`${activeHandle.url}/runtime-config/providers`, {
+        method: PATCH_METHOD,
+        headers: hostHeaders(),
+        body: JSON.stringify(providerPatch),
+      });
+      expect(identicalPatch.status).toBe(HTTP_OK);
+      expect(await identicalPatch.json()).toMatchObject({ changed: false, reload: SKIPPED });
+    } finally {
+      const cleanupErrors: unknown[] = [];
+      try {
+        await activeHandle?.stop();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+      restoreProcessEnv(DEV_MODE_ENV, previousDevMode);
+      restoreProcessEnv(RUNTIME_DB_ENV, previousRuntimeDb);
+      restoreProcessEnv(OPENCODE_BASE_URL_ENV, previousOpencodeBaseUrl);
+      try {
+        await rm(root, { recursive: true, force: true });
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+      if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "Failed to clean up embedded runtime config lifecycle test");
+    }
+  });
+});

--- a/evals/flows/embedded-runtime-config-listener-lifecycle.flow.mjs
+++ b/evals/flows/embedded-runtime-config-listener-lifecycle.flow.mjs
@@ -1,0 +1,78 @@
+/**
+ * Internal proof: execute the embedded-server lifecycle regression test in the
+ * pinned Bun environment and bind its HTTP observations to Fraimz claims.
+ */
+import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "embedded-runtime-config-listener-lifecycle";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DOCKER_BIN = "docker";
+const BUN_IMAGE = "oven/bun:1.3.6";
+const CLEANUP_LABEL = "com.ora.cleanup.scope=fraimz";
+const CONTAINER_ROOT = "/workspace";
+const SERVER_WORKDIR = `${CONTAINER_ROOT}/apps/server`;
+const TEST_PATH = "src/embedded-runtime-config-lifecycle.test.ts";
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const PASS_MARKER = "1 pass";
+const FAILURE_MARKER = "0 fail";
+const PATCH_MARKER = "PATCH /runtime-config/providers 200";
+const execFileAsync = promisify(execFile);
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+let testOutput = "";
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, actual ? `${assertion} (actual: ${actual})` : assertion);
+}
+
+async function runLifecycleTest() {
+  const { stdout, stderr } = await execFileAsync(DOCKER_BIN, [
+    "run", "--rm", "--label", CLEANUP_LABEL,
+    "-v", `${ROOT}:${CONTAINER_ROOT}`,
+    "-w", SERVER_WORKDIR,
+    BUN_IMAGE,
+    "bun", "test", TEST_PATH,
+  ], { maxBuffer: MAX_OUTPUT_BYTES });
+  return `${stdout}\n${stderr}`.trim();
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Stopped embedded servers release runtime config listeners",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Stopping an embedded server releases its listener",
+      run: async (ctx) => {
+        await ctx.prove("A real embedded server is stopped before another starts against the shared runtime database", {
+          voiceover: vo[0],
+          assert: async () => {
+            testOutput = await runLifecycleTest();
+            witness(ctx, testOutput.includes(PASS_MARKER), "The lifecycle regression test passes", testOutput);
+            witness(ctx, testOutput.includes(FAILURE_MARKER), "The lifecycle regression test has no failures", testOutput);
+            ctx.output("pinned Bun lifecycle test", testOutput);
+          },
+        });
+      },
+    },
+    {
+      name: "An identical provider update skips reload",
+      run: async (ctx) => {
+        await ctx.prove("The active HTTP endpoint accepts both provider PATCH requests and the identical request skips reload", {
+          voiceover: vo[1],
+          assert: async () => {
+            const patchCount = testOutput.split(PATCH_MARKER).length - 1;
+            witness(ctx, patchCount === 2, "Both provider PATCH requests returned HTTP 200", String(patchCount));
+            witness(ctx, testOutput.includes(PASS_MARKER), "The skipped-reload assertion passed", testOutput);
+            ctx.output("provider PATCH observations", testOutput);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/embedded-runtime-config-listener-lifecycle.md
+++ b/evals/voiceovers/embedded-runtime-config-listener-lifecycle.md
@@ -1,0 +1,5 @@
+# embedded-runtime-config-listener-lifecycle — stopped servers release runtime config listeners
+
+1. An embedded OpenWork server is stopped and another server starts against the same runtime database. Updating the stopped server's workspace can no longer rewrite the active server's generated OpenCode config.
+
+2. Repeating the active server's provider configuration is now a true no-op. OpenWork reports that nothing changed and skips the OpenCode reload.


### PR DESCRIPTION
## Summary
- release the embedded server's runtime-config listener when its handle stops
- cover an in-process server replacement sharing the same runtime database
- add an app-less Fraimz flow that executes the real lifecycle regression test

## Why
- a stopped embedded server kept its runtime-config subscription alive and could rewrite the shared generated OpenCode config from its stale workspace
- that second writer made an identical provider PATCH appear file-changing and reloaded the engine
- Related PR #3349 improves no-op identity inside `mergeRuntimeProviderUpdate`, but the unchanged lifecycle regression test remains RED on its exact head (`bb090e630cda81421af72d4b9188587032f76dea`). This patch addresses the separate listener lifecycle that causes the file rewrite.

## Issue
- Closes #3321

## Scope
- embedded managed-OpenCode server listener registration and shutdown
- one server lifecycle integration test
- one internal Fraimz proof flow and voiceover

## Out of scope
- provider merge semantics covered by #3349
- CLI-owned process lifetime

## Testing
### Ran
- `bun test src/embedded-runtime-config-lifecycle.test.ts`
- `pnpm --filter openwork-server typecheck`
- `bun test` (full server suite, compared with an identically provisioned `origin/dev` worktree)
- `pnpm fraimz --flow embedded-runtime-config-listener-lifecycle`
- real `curl -X PATCH /runtime-config/providers` after the two-server lifecycle setup

### Result
- targeted test: 1 pass, 0 fail
- typecheck: pass
- full server baseline: 597 pass, 10 skip, 4 fail, 1 error
- full server patched: 598 pass, 10 skip, 4 fail, 1 error; identical pre-existing failure set plus the new passing test
- Fraimz: PASSED, 1 passed, 0 failed, 0 skipped
- curl response: `changed:false`, `reload:"skipped"`

## Test verification (RED → GREEN)

Upstream `origin/dev` (`3f9c38a37125450e9b11ff74061ed500626254c9`) with only the new test:

```text
expected { changed: false, reload: "skipped" }
received { changed: false, reload: "reloaded" }
0 pass
1 fail
```

The same unchanged test on PR #3349 (`bb090e630cda81421af72d4b9188587032f76dea`):

```text
expected { changed: false, reload: "skipped" }
received { changed: false, reload: "reloaded" }
0 pass
1 fail
```

With this patch:

```text
PATCH /runtime-config/providers 200
PATCH /runtime-config/providers 200
1 pass
0 fail
```

Reverting only `apps/server/src/embedded.ts` returns the test to the same RED failure.

## CI status
- pass: targeted lifecycle test, TypeScript typecheck, Fraimz runtime proof
- code-related failures: none
- external/env/auth blockers: the pinned local Bun container has the same four server-suite failures and one `node:sqlite` runner error on upstream and patched trees; no baseline passing test regressed

## Manual verification
1. Start and stop an embedded managed server against a shared runtime DB.
2. Start a replacement server, patch a provider, then mutate the stopped workspace in that shared DB.
3. Repeat the provider PATCH and observe HTTP 200 with `changed:false` and `reload:"skipped"`.

## Evidence
- `evals/results/2026-08-01T12-15-15-633Z/fraimz.html` generated locally; every internal claim passed against the executed pinned-Bun integration test
- video/screenshot: N/A — internal server lifecycle with no visible UI surface

## Risk
- low: the change only retains and invokes an unsubscribe callback already returned by the runtime-config helper
- writes already queued before shutdown remain ordered by the existing per-path write queue, so the replacement server's later initial write lands last

## Rollback
- revert this commit; the previous behavior leaks the listener for the lifetime of the process
