### PR TITLE
fix(billing): distinguish team seats from AI model access

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/action-row.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/action-row.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+export type DenActionRowProps = {
+  /** Plain-language explanation of when this action is the right one. */
+  description: ReactNode;
+  /** The control itself, usually a DenButton. */
+  action: ReactNode;
+  className?: string;
+};
+
+/**
+ * DenActionRow
+ *
+ * Pairs a control with a sentence describing when to use it.
+ *
+ * Use this instead of a bare row of buttons wherever the consequence of
+ * pressing one is not obvious from its label — billing, destructive
+ * operations, anything that reaches a third party. The description carries the
+ * meaning, so it is the wider column; the action sits in a fixed slot so
+ * buttons line up across rows regardless of how long the text is.
+ */
+export function DenActionRow({ description, action, className = "" }: DenActionRowProps) {
+  return (
+    <div className={`flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:gap-4 ${className}`}>
+      <p className="flex-1 text-[13px] leading-5 text-gray-600">{description}</p>
+      <div className="flex shrink-0 sm:w-[200px] sm:justify-end">{action}</div>
+    </div>
+  );
+}
+
+export type DenActionListProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+/** Stacks DenActionRows with the dividers that separate one choice from the next. */
+export function DenActionList({ children, className = "" }: DenActionListProps) {
+  return (
+    <div
+      className={`flex flex-col border-t border-gray-200 [&>*+*]:border-t [&>*+*]:border-gray-100 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/line-item-row.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/line-item-row.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+
+export type DenMarkTileProps = {
+  /** Short mark such as "4/5" or "4x". Rendered in mono so figures align. */
+  label: string;
+  /** Solid tile when the thing is billing, muted when it is not. */
+  active?: boolean;
+  className?: string;
+};
+
+/**
+ * DenMarkTile
+ *
+ * Small square that carries the number driving a row, matching the icon tile
+ * geometry used by DenToggleRow.
+ */
+export function DenMarkTile({ label, active = false, className = "" }: DenMarkTileProps) {
+  return (
+    <span
+      aria-hidden
+      className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-[11px] font-mono text-[12px] font-medium ${
+        active ? "bg-gray-900 text-white" : "bg-gray-100 text-gray-500"
+      } ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export type DenLineItemRowProps = {
+  /** Usually a DenMarkTile. */
+  leading?: ReactNode;
+  title: string;
+  description?: ReactNode;
+  value: string;
+  valueCaption?: string;
+  /** Usually a DenBadge. */
+  badge?: ReactNode;
+  /** Emphasised summing row. Drops the badge slot and enlarges the value. */
+  emphasis?: boolean;
+  className?: string;
+};
+
+/**
+ * DenLineItemRow
+ *
+ * Read-only counterpart to DenSelectableRow, for statements and receipts where
+ * each row is a charge rather than a choice. Leading, value, and badge sit in
+ * fixed-width slots so figures and status align down the column.
+ */
+export function DenLineItemRow({
+  leading,
+  title,
+  description,
+  value,
+  valueCaption,
+  badge,
+  emphasis = false,
+  className = "",
+}: DenLineItemRowProps) {
+  return (
+    <div className={`flex items-center gap-3 px-4 py-3.5 ${className}`}>
+      <div className="w-9 shrink-0">{leading}</div>
+      <div className="min-w-0 flex-1">
+        <p className={`text-[14px] ${emphasis ? "font-medium text-gray-700" : "font-medium text-gray-950"}`}>{title}</p>
+        {description ? <p className="mt-0.5 text-[12px] leading-4 text-gray-500">{description}</p> : null}
+      </div>
+      <div className="flex w-[112px] shrink-0 flex-col items-end gap-0.5">
+        <span
+          className={
+            emphasis
+              ? "text-[20px] font-semibold tracking-[-0.03em] text-gray-950"
+              : "text-[15px] font-medium text-gray-950"
+          }
+        >
+          {value}
+        </span>
+        {valueCaption ? <span className="text-[12px] text-gray-500">{valueCaption}</span> : null}
+      </div>
+      <div className="flex w-[96px] shrink-0 justify-end">{emphasis ? null : badge}</div>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
@@ -1,11 +1,25 @@
-import { CircleAlert, Info } from "lucide-react";
+import { CircleAlert, Info, TriangleAlert, type LucideIcon } from "lucide-react";
 import { WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../../_lib/den-flow";
 
-type DenNoticeTone = "error" | "info";
+export type DenNoticeTone = "error" | "info" | "warning" | "neutral";
 
 const ROUTINE_SECURITY_MESSAGES = new Set([
   WORKSPACE_REAUTH_SECURITY_MESSAGE,
 ]);
+
+const toneClasses: Record<DenNoticeTone, string> = {
+  error: "border-red-200 bg-red-50 text-red-700",
+  info: "border-sky-200 bg-sky-50 text-slate-700",
+  warning: "border-amber-200 bg-amber-50 text-amber-800",
+  neutral: "border-gray-200 bg-gray-50 text-gray-600",
+};
+
+const toneIcons: Record<DenNoticeTone, LucideIcon> = {
+  error: CircleAlert,
+  info: Info,
+  warning: TriangleAlert,
+  neutral: Info,
+};
 
 export function DenNotice({
   message,
@@ -18,7 +32,7 @@ export function DenNotice({
 }) {
   const resolvedTone =
     tone ?? (ROUTINE_SECURITY_MESSAGES.has(message) ? "info" : "error");
-  const Icon = resolvedTone === "info" ? Info : CircleAlert;
+  const Icon = toneIcons[resolvedTone];
 
   return (
     <div
@@ -26,9 +40,7 @@ export function DenNotice({
       data-notice-tone={resolvedTone}
       className={[
         "flex items-start gap-3 rounded-[24px] border px-5 py-4 text-[14px]",
-        resolvedTone === "info"
-          ? "border-sky-200 bg-sky-50 text-slate-700"
-          : "border-red-200 bg-red-50 text-red-700",
+        toneClasses[resolvedTone],
         className ?? "",
       ]
         .filter(Boolean)

--- a/ee/apps/den-web/app/(den)/_components/ui/usage-meter.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/usage-meter.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+export type DenUsageMeterProps = {
+  label: string;
+  /** Units consumed. Values above `total` render as an overflow segment. */
+  used: number;
+  total: number;
+  /** Right-aligned readout. Defaults to `used/total`. */
+  readout?: string;
+  caption?: ReactNode;
+  className?: string;
+};
+
+/**
+ * DenUsageMeter
+ *
+ * Segmented allowance meter for "x of y included" limits.
+ *
+ * Segments are discrete rather than a continuous bar because these values are
+ * always small whole units (seats, keys, workers) where each one is a decision
+ * the user made. Once `used` exceeds `total` the meter collapses to two
+ * proportional segments — filled allowance, then overflow in a lighter tone —
+ * since drawing dozens of ticks stops being readable.
+ */
+export function DenUsageMeter({ label, used, total, readout, caption, className = "" }: DenUsageMeterProps) {
+  const safeTotal = Math.max(0, total);
+  const safeUsed = Math.max(0, used);
+  const overflow = Math.max(0, safeUsed - safeTotal);
+
+  return (
+    <div className={`flex flex-col gap-2.5 ${className}`}>
+      <div className="flex items-baseline gap-2">
+        <span className="flex-1 text-[13px] font-medium text-gray-700">{label}</span>
+        <span className="font-mono text-[13px] font-medium text-gray-950">
+          {readout ?? `${safeUsed}/${safeTotal}`}
+        </span>
+      </div>
+      <div className="flex h-1.5 gap-1" role="presentation">
+        {overflow > 0 ? (
+          <>
+            <span className="rounded-full bg-gray-900" style={{ flexGrow: safeTotal }} />
+            <span className="rounded-full bg-gray-400" style={{ flexGrow: overflow }} />
+          </>
+        ) : (
+          Array.from({ length: safeTotal }, (_, index) => (
+            <span
+              key={index}
+              className={`flex-1 rounded-full ${index < safeUsed ? "bg-gray-900" : "bg-gray-200"}`}
+            />
+          ))
+        )}
+      </div>
+      {caption ? <p className="text-[12px] leading-4 text-gray-500">{caption}</p> : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -2,9 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { CreditCard, RefreshCw } from "lucide-react";
+import { Check, CreditCard, RefreshCw } from "lucide-react";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
+import { DenActionList, DenActionRow } from "../../_components/ui/action-row";
+import { DenBadge } from "../../_components/ui/badge";
+import { DenCard } from "../../_components/ui/card";
+import { DenLineItemRow, DenMarkTile } from "../../_components/ui/line-item-row";
 import { DenNotice } from "../../_components/ui/notice";
+import { DenSectionHeader } from "../../_components/ui/section-header";
+import { DenUsageMeter } from "../../_components/ui/usage-meter";
 import { formatMoneyMinor, formatSubscriptionStatus, getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { getInferenceRoute, getMembersRoute, getOrgAccessFlags } from "../../_lib/den-org";
@@ -113,6 +119,22 @@ function parseStripeBilling(payload: unknown): StripeBilling | null {
 
 const STRIPE_RETURN_POLL_ATTEMPTS = 20;
 const STRIPE_RETURN_POLL_INTERVAL_MS = 3000;
+
+function formatBillingDate(value: string | null): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+}
+
+function BillingStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[16px] border border-gray-200 bg-white px-4 py-3.5">
+      <p className="text-[13px] text-gray-500">{label}</p>
+      <p className="mt-0.5 text-[20px] font-semibold tracking-[-0.02em] text-gray-950">{value}</p>
+    </div>
+  );
+}
 function parsePolarBilling(payload: unknown): PolarBilling | null {
   if (!payload || typeof payload !== "object" || !("billing" in payload)) return null;
   const billing = (payload as { billing?: unknown }).billing;
@@ -282,12 +304,40 @@ export function BillingDashboardScreen() {
   const seatPrice = seatBilling ? formatMoneyMinor(seatBilling.unitAmount, seatBilling.currency) : null;
   const activeMemberCount = stripeBilling?.memberCount ?? 0;
 
+  // Without Stripe keys the deployment never charges for either product, so the
+  // page must not quote prices or threaten future charges.
+  const aiConfigured = stripeBilling?.configured === true;
+  const seatsConfigured = seatBilling?.configured === true;
+
+  const aiActive = stripeBilling?.hasActiveSubscription === true;
+  const aiStatus = stripeBilling?.subscription?.status ?? null;
+  const aiPaymentFailed = aiStatus === "past_due" || aiStatus === "unpaid";
+  const aiChargeMinor = stripeBilling ? stripeBilling.unitAmount * activeMemberCount : 0;
+  const aiChargeLabel = stripeBilling ? formatMoneyMinor(aiChargeMinor, stripeBilling.currency) : null;
+  const aiRenewsOn = formatBillingDate(stripeBilling?.subscription?.currentPeriodEnd ?? null);
+  const aiCancelling = stripeBilling?.subscription?.cancelAtPeriodEnd === true;
+
+  const seatsActive = seatBilling?.hasActiveSubscription === true;
+  const freeSeatCount = seatBilling?.freeSeatCount ?? 0;
+  const billableSeatCount = seatBilling?.billableSeatCount ?? 0;
+  const seatChargeMinor = seatBilling ? seatBilling.unitAmount * billableSeatCount : 0;
+  const seatChargeLabel = seatBilling ? formatMoneyMinor(seatChargeMinor, seatBilling.currency) : null;
+  const freeSeatsLeft = Math.max(0, freeSeatCount - activeMemberCount);
+
+  const totalMinor = (aiActive ? aiChargeMinor : 0) + (seatsActive ? seatChargeMinor : 0);
+  const totalLabel = stripeBilling ? formatMoneyMinor(totalMinor, stripeBilling.currency) : null;
+
+  const membersRoute = getMembersRoute(activeOrg?.slug);
+  const goToMembers = () => {
+    window.location.href = membersRoute;
+  };
+
   return (
     <div data-testid="stripe-billing-screen">
       <DashboardPageTemplate
         icon={CreditCard}
         title="Billing"
-        description="Manage workspace subscriptions, seats, and OpenWork Models in one place."
+        description="Two separate subscriptions: seats for your team, and access to OpenWork's built-in AI models. You can have one without the other."
         colors={["#F5F3FF", "#312E81", "#635BFF", "#C4B5FD"]}
       >
       {stripeError && stripeBilling ? (
@@ -295,19 +345,23 @@ export function BillingDashboardScreen() {
       ) : null}
 
       {canManageBillingSettings ? null : (
-        <div className="mb-6 rounded-[20px] border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] text-amber-800">
-          Admins can view Billing settings here. Owners and super-admins can open billing portals or start Settings checkouts.
-        </div>
+        <DenNotice
+          tone="warning"
+          className="mb-6"
+          message="Admins can view Billing settings here. Owners and super-admins can open billing portals or start Settings checkouts."
+        />
       )}
 
       {stripeReturnChecking ? (
-        <div className="mb-6 rounded-[20px] border border-blue-200 bg-blue-50 px-4 py-3 text-[13px] text-blue-800">
-          We&apos;re checking your subscription. This page will refresh automatically.
-        </div>
+        <DenNotice
+          tone="info"
+          className="mb-6"
+          message="We're checking your subscription. This page will refresh automatically."
+        />
       ) : null}
 
       {!stripeBilling ? (
-        <section className="rounded-2xl border border-gray-200 bg-white p-8 shadow-[0_8px_30px_-20px_rgba(49,46,129,0.45)]">
+        <DenCard size="spacious">
           {stripeBusy ? (
             <div className="flex min-h-36 items-center justify-center gap-3 text-[14px] text-gray-500">
               <RefreshCw className="size-4 animate-spin text-[#635BFF]" aria-hidden="true" />
@@ -320,17 +374,9 @@ export function BillingDashboardScreen() {
               <DenButton icon={RefreshCw} onClick={() => void refreshStripeBilling(false)}>Try again</DenButton>
             </div>
           )}
-        </section>
+        </DenCard>
       ) : (
         <>
-          <div className="mb-6 flex items-center justify-between gap-4 rounded-2xl border border-violet-100 bg-violet-50/70 px-5 py-4">
-            <div>
-              <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#635BFF]">Workspace billing</p>
-              <p className="mt-1 text-[13px] text-violet-950/70">Prices and billing intervals below come directly from your billing configuration.</p>
-            </div>
-            <DenButton variant="secondary" icon={RefreshCw} loading={stripeBusy} onClick={() => void refreshStripeBilling(false)}>Refresh</DenButton>
-          </div>
-
       {showPolar ? (
         <section className="mb-6 rounded-[20px] border border-gray-100 bg-white p-8 shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06)]">
           <div className="mb-6 flex items-start justify-between gap-4">
@@ -350,110 +396,243 @@ export function BillingDashboardScreen() {
         </section>
       ) : null}
 
-      <section className="mb-6 rounded-2xl border border-violet-100 bg-white p-8 shadow-[0_8px_30px_-20px_rgba(49,46,129,0.45)]">
-        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Billing</p>
-            <h2 className="text-[20px] font-medium text-gray-950">OpenWork Users</h2>
-            <p className="mt-2 max-w-[620px] text-[14px] leading-6 text-gray-500">
-              The first {seatBilling?.freeSeatCount} users in your organization are included. Additional users are {seatPrice} per user per {seatBilling?.interval}.
-            </p>
-          </div>
+      <DenCard className="mb-6 !p-0" data-testid="billing-summary-card">
+        <DenSectionHeader
+          className="p-6 pb-4"
+          title="Your subscriptions"
+          description="These are two separate purchases. You can have one without the other."
+          action={
+            <DenButton variant="secondary" size="sm" icon={RefreshCw} loading={stripeBusy} onClick={() => void refreshStripeBilling(false)}>
+              Refresh
+            </DenButton>
+          }
+        />
+        <div className="border-t border-gray-200">
+          <DenLineItemRow
+            className="mx-4 rounded-[18px]"
+            leading={
+              <DenMarkTile
+                label={seatsConfigured ? `${activeMemberCount}/${freeSeatCount}` : String(activeMemberCount)}
+                active={seatsActive && billableSeatCount > 0}
+              />
+            }
+            title="Team seats"
+            description={
+              !seatsConfigured
+                ? `${activeMemberCount} active ${activeMemberCount === 1 ? "user" : "users"} · this deployment does not charge for seats`
+                : billableSeatCount > 0
+                  ? `${billableSeatCount} paid ${billableSeatCount === 1 ? "user" : "users"} beyond the free ${freeSeatCount}`
+                  : `${activeMemberCount} of ${freeSeatCount} included users · nothing to pay yet`
+            }
+            value={seatsActive ? seatChargeLabel ?? "" : formatMoneyMinor(0, seatBilling?.currency ?? "usd")}
+            valueCaption={`per ${seatBilling?.interval ?? "month"}`}
+            badge={
+              !seatsConfigured
+                ? <DenBadge tone="neutral">Not billed</DenBadge>
+                : seatsActive
+                  ? <DenBadge tone="success" icon={Check}>Active</DenBadge>
+                  : <DenBadge tone="neutral">Included</DenBadge>
+            }
+          />
+          <DenLineItemRow
+            className="mx-4 rounded-[18px]"
+            leading={<DenMarkTile label={`${activeMemberCount}x`} active={aiActive} />}
+            title="AI model access"
+            description={
+              !aiConfigured
+                ? "This deployment does not sell model access · your team uses their own API keys"
+                : aiActive
+                  ? `${activeMemberCount} active ${activeMemberCount === 1 ? "member" : "members"} × ${stripePrice} · billed for every member`
+                  : "Not subscribed · your team uses their own API keys"
+            }
+            value={aiActive ? aiChargeLabel ?? "" : formatMoneyMinor(0, stripeBilling.currency)}
+            valueCaption={`per ${stripeBilling.interval}`}
+            badge={
+              !aiConfigured
+                ? <DenBadge tone="neutral">Not billed</DenBadge>
+                : aiPaymentFailed
+                  ? <DenBadge tone="warning">Payment failed</DenBadge>
+                  : aiActive
+                    ? <DenBadge tone="success" icon={Check}>Active</DenBadge>
+                    : <DenBadge tone="neutral">Off</DenBadge>
+            }
+          />
+          <DenLineItemRow
+            className="mt-1 border-t border-gray-200"
+            emphasis
+            title="Total"
+            value={totalLabel ?? ""}
+            valueCaption={`per ${stripeBilling.interval}`}
+          />
+        </div>
+      </DenCard>
+
+      <DenCard className="mb-6" data-testid="billing-seats-card">
+        <DenSectionHeader
+          title="Team seats"
+          description={
+            seatsConfigured
+              ? `Invite more than ${freeSeatCount} people. The first ${freeSeatCount} users are free; each additional user is ${seatPrice} per ${seatBilling?.interval ?? "month"}.`
+              : "Everyone you invite can use this workspace."
+          }
+          action={
+            !seatsConfigured
+              ? <DenBadge tone="neutral">Not billed</DenBadge>
+              : seatsActive
+                ? <DenBadge tone="success" icon={Check}>Active</DenBadge>
+                : <DenBadge tone="neutral">Included</DenBadge>
+          }
+        />
+
+        <DenNotice
+          tone="neutral"
+          className="mt-5"
+          message={
+            seatsConfigured
+              ? "Does not include AI model access. That is a separate subscription, below."
+              : "Seat billing is not set up on this deployment, so there is no member limit and no seat charge. AI model access is tracked separately, below."
+          }
+        />
+
+        {seatsConfigured ? (
+          <DenUsageMeter
+            className="mt-5"
+            label={billableSeatCount > 0 ? `${activeMemberCount} users · ${freeSeatCount} free, ${billableSeatCount} paid` : "Free seats used"}
+            used={activeMemberCount}
+            total={freeSeatCount}
+            caption={
+              billableSeatCount > 0
+                ? `You are charged ${seatChargeLabel} per ${seatBilling?.interval ?? "month"} for the ${billableSeatCount} ${billableSeatCount === 1 ? "user" : "users"} beyond the free ${freeSeatCount}.`
+                : freeSeatsLeft > 0
+                  ? `${freeSeatsLeft} ${freeSeatsLeft === 1 ? "seat" : "seats"} left before charges begin.`
+                  : `Your free seats are full. The next invite costs ${seatPrice} per ${seatBilling?.interval ?? "month"}.`
+            }
+          />
+        ) : null}
+
+        <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <BillingStat label="Active users" value={String(activeMemberCount)} />
+          <BillingStat label="Seat cost" value={seatsConfigured ? seatChargeLabel ?? "" : formatMoneyMinor(0, seatBilling?.currency ?? "usd")} />
         </div>
 
-        <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Included users</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.freeSeatCount}</p>
-          </div>
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Active users</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{activeMemberCount}</p>
-          </div>
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Billable users</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.billableSeatCount}</p>
-          </div>
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Status</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">
-              {seatBilling?.hasActiveSubscription ? formatSubscriptionStatus(seatBilling.subscription?.status ?? "active") : "Not subscribed"}
-            </p>
-          </div>
-        </div>
+        <DenActionList className="mt-5">
+          <DenActionRow
+            description={
+              seatsConfigured
+                ? "Invite, remove, or change roles. Removing someone frees their seat and lowers your AI bill."
+                : "Invite, remove, or change roles. There is no member limit on this deployment."
+            }
+            action={<DenButton variant="secondary" onClick={goToMembers}>Manage members</DenButton>}
+          />
+          {!seatsConfigured ? null : seatsActive ? (
+            <DenActionRow
+              description={`Opens Stripe. Change your card, download invoices, or cancel seat billing. You keep the free ${freeSeatCount} seats either way.`}
+              action={
+                <DenButton variant="secondary" disabled={!canManageBillingSettings} loading={stripeActionBusy === "portal"} onClick={openStripePortal}>
+                  Manage subscription
+                </DenButton>
+              }
+            />
+          ) : (
+            <DenActionRow
+              description={`Only needed once you pass ${freeSeatCount} users. Saves a card now, then charges ${seatPrice} per extra user each ${seatBilling?.interval ?? "month"}.`}
+              action={
+                <DenButton
+                 
+                  disabled={!canManageBillingSettings || seatBilling?.configured === false}
+                  loading={stripeActionBusy === "seat-checkout"}
+                  onClick={startSeatCheckout}
+                >
+                  Add paid seats
+                </DenButton>
+              }
+            />
+          )}
+        </DenActionList>
+      </DenCard>
 
-        {seatBilling?.hasActiveSubscription ? (
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <DenButton variant="secondary" onClick={() => {
-              window.location.href = getMembersRoute(activeOrg?.slug);
-            }}>
-              Manage Members
-            </DenButton>
-            <DenButton disabled={!canManageBillingSettings} loading={stripeActionBusy === "portal"} onClick={openStripePortal}>
-              Manage subscription
-            </DenButton>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-4 rounded-[16px] border border-blue-100 bg-blue-50 p-5 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="text-[15px] font-medium text-blue-950">Subscribe when your workspace grows beyond {seatBilling?.freeSeatCount} users</p>
-              <p className="mt-1 text-[13px] leading-5 text-blue-900/70">You will only be charged for users above the free included seats.</p>
-            </div>
-            <DenButton disabled={!canManageBillingSettings || seatBilling?.configured === false} loading={stripeActionBusy === "seat-checkout"} onClick={startSeatCheckout}>
-              Subscribe
-            </DenButton>
-          </div>
-        )}
-      </section>
+      <DenCard data-testid="billing-ai-card">
+        <DenSectionHeader
+          title="AI model access"
+          description="Use OpenWork's built-in models with no API keys to manage. Separate from seats."
+          action={
+            !aiConfigured
+              ? <DenBadge tone="neutral">Not billed</DenBadge>
+              : aiPaymentFailed
+                ? <DenBadge tone="warning">Payment failed</DenBadge>
+                : aiActive
+                  ? <DenBadge tone="success" icon={Check}>Active</DenBadge>
+                  : <DenBadge tone="neutral">Off</DenBadge>
+          }
+        />
 
-      <section className="rounded-2xl border border-violet-100 bg-white p-8 shadow-[0_8px_30px_-20px_rgba(49,46,129,0.45)]">
-        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Billing</p>
-            <h2 className="text-[20px] font-medium text-gray-950">OpenWork Models</h2>
-            <p className="mt-2 max-w-[620px] text-[14px] leading-6 text-gray-500">
-              Model access is billed at {stripePrice} per user per {stripeBilling.interval}.
-            </p>
-          </div>
-        </div>
+        <DenNotice
+          tone={!aiConfigured ? "neutral" : aiPaymentFailed ? "error" : "warning"}
+          className="mt-5"
+          message={
+            !aiConfigured
+              ? "Model billing is not set up on this deployment, so nothing is charged for AI access. Your team connects their own provider keys instead."
+              : aiPaymentFailed
+                ? `Your last payment failed. Models stop working for everyone until it is settled. Seats and team access are not affected.${aiStatus ? ` Stripe reports this subscription as ${formatSubscriptionStatus(aiStatus).toLowerCase()}.` : ""}`
+                : `Billed for every active member${seatsConfigured ? `, including the free ${freeSeatCount} seats` : ""}. Inviting someone increases this bill by ${stripePrice} per ${stripeBilling.interval}.`
+          }
+        />
 
-        <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-3">
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Price</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{stripePrice}<span className="text-[13px] font-medium text-gray-500"> / user / {stripeBilling.interval}</span></p>
+        {aiConfigured ? (
+          <div className="mt-5 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-[13px] text-gray-500">
+              {activeMemberCount} active {activeMemberCount === 1 ? "member" : "members"} × {stripePrice} =
+            </span>
+            <span className="text-[22px] font-semibold tracking-[-0.03em] text-gray-950">{aiChargeLabel}</span>
+            <span className="text-[13px] text-gray-500">
+              per {stripeBilling.interval}
+              {aiActive && aiRenewsOn ? (aiCancelling ? ` · access ends ${aiRenewsOn}` : ` · renews ${aiRenewsOn}`) : ""}
+            </span>
           </div>
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Active members</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{stripeBilling.memberCount}</p>
-          </div>
-          <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[12px] text-gray-500">Status</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">
-              {stripeBilling?.hasActiveSubscription ? formatSubscriptionStatus(stripeBilling.subscription?.status ?? "active") : "Not subscribed"}
-            </p>
-          </div>
-        </div>
+        ) : null}
 
-        {stripeBilling?.hasActiveSubscription ? (
-          <div className="flex justify-end">
-            <DenButton disabled={!canManageBillingSettings} loading={stripeActionBusy === "portal"} onClick={openStripePortal}>
-              Manage subscription
-            </DenButton>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-4 rounded-[16px] border border-blue-100 bg-blue-50 p-5 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="text-[15px] font-medium text-blue-950">Not subscribed yet</p>
-              <p className="mt-1 text-[13px] leading-5 text-blue-900/70">
-                See the model lineup and subscribe from the OpenWork Models page.
-              </p>
-            </div>
-            <DenButton onClick={() => router.push(getInferenceRoute(activeOrg?.slug))}>
-              View OpenWork Models
-            </DenButton>
-          </div>
-        )}
-      </section>
+        <DenActionList className="mt-5">
+          {aiActive ? (
+            <DenActionRow
+              description={
+                aiCancelling
+                  ? `Cancellation is scheduled. Access continues until ${aiRenewsOn ?? "the end of the period"}, and you can resume from Stripe before then.`
+                  : "Opens Stripe. Change your card, download invoices, or cancel. Access continues until the end of the period you already paid for."
+              }
+              action={
+                <DenButton
+                  variant={aiPaymentFailed ? "primary" : "secondary"}
+                 
+                  disabled={!canManageBillingSettings}
+                  loading={stripeActionBusy === "portal"}
+                  onClick={openStripePortal}
+                >
+                  {aiPaymentFailed ? "Update payment method" : "Manage subscription"}
+                </DenButton>
+              }
+            />
+          ) : (
+            <DenActionRow
+              description={
+                aiConfigured
+                  ? `Turning this on costs ${aiChargeLabel} per ${stripeBilling.interval} for your ${activeMemberCount} ${activeMemberCount === 1 ? "member" : "members"}, not ${stripePrice}. You subscribe from the OpenWork Models page.`
+                  : "See which models OpenWork ships with and how your team connects their own provider keys."
+              }
+              action={
+                <DenButton onClick={() => router.push(getInferenceRoute(activeOrg?.slug))}>
+                  View OpenWork Models
+                </DenButton>
+              }
+            />
+          )}
+          {aiActive ? (
+            <DenActionRow
+              description="To lower this bill, remove members you are no longer working with. There is no way to buy model access for only some of your team."
+              action={<DenButton variant="secondary" onClick={goToMembers}>Manage members</DenButton>}
+            />
+          ) : null}
+        </DenActionList>
+      </DenCard>
         </>
       )}
       </DashboardPageTemplate>

--- a/evals/flows/billing-seats-vs-ai.flow.mjs
+++ b/evals/flows/billing-seats-vs-ai.flow.mjs
@@ -1,0 +1,384 @@
+/**
+ * User-facing proof: the Billing page distinguishes Team seats from AI model
+ * access instead of showing two lookalike $10 cards, and every action states
+ * when to use it.
+ *
+ * Local runbook:
+ *   1. pnpm evals --stack-down
+ *   2. OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3005 OPENWORK_EVAL_WEB_CDP_ADMIN=http://127.0.0.1:9855 pnpm fraimz --flow billing-seats-vs-ai --stack den
+ *      (the stack exports OPENWORK_EVAL_DEN_API_URL and OPENWORK_EVAL_DEN_TOKEN)
+ *   3. In another shell, run den-web against the stack API:
+ *      DEN_WEB_PORT=3005 DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://127.0.0.1:3005 DEN_AUTH_FALLBACK_BASE=http://127.0.0.1:8790 pnpm --filter @openwork-ee/den-web dev:local
+ *   4. In another shell, run Chrome for screenshots:
+ *      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --remote-debugging-port=9855 --user-data-dir="$(mktemp -d)" --window-size=1440,1400 about:blank
+ */
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denWebUrl } from "./lib/den-web.mjs";
+
+const FLOW_ID = "billing-seats-vs-ai";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = denWebUrl();
+const ADMIN_CDP_URL = (process.env.OPENWORK_EVAL_WEB_CDP_ADMIN ?? "").trim().replace(/\/+$/, "");
+const ADMIN_TOKEN = (process.env.OPENWORK_EVAL_DEN_TOKEN ?? "").trim();
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const state = {
+  adminBrowserSignedIn: false,
+  billing: null,
+};
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+function adminAuthOrigins() {
+  const origins = [];
+  if (DEN_WEB_URL) origins.push(new URL(DEN_WEB_URL).origin);
+  if (DEN_API_URL) {
+    const apiUrl = new URL(DEN_API_URL);
+    if (apiUrl.hostname === "127.0.0.1") {
+      const localhostUrl = new URL(apiUrl.toString());
+      localhostUrl.hostname = "localhost";
+      origins.push(localhostUrl.origin);
+    }
+    origins.push(apiUrl.origin);
+  }
+  return [...new Set(origins)];
+}
+
+function sessionCookiePair(setCookie) {
+  const match = String(setCookie ?? "").match(/better-auth\.session_token=([^;,\s]+)/);
+  return match ? `better-auth.session_token=${match[1]}` : "";
+}
+
+async function createAdminBrowserSession(ctx) {
+  let last = null;
+  for (const origin of adminAuthOrigins()) {
+    const response = await fetch(`${DEN_API_URL}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+    });
+    const text = await response.text();
+    let body = text;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {}
+    const cookie = sessionCookiePair(response.headers.get("set-cookie"));
+    last = { origin, status: response.status, cookie: cookie ? "<present>" : null };
+    if (response.ok && typeof body?.token === "string" && cookie) {
+      witness(ctx, true, "Admin API sign-in minted a den-web browser session", { origin, status: response.status });
+      return { token: body.token, cookie };
+    }
+  }
+  witness(ctx, false, "Admin API sign-in minted a den-web browser session", last);
+  return null;
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) return page;
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) response = await fetch(`${base}/json/new?about:blank`);
+  if (!response.ok) throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) return created;
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  return nextPage;
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    try {
+      client.close();
+    } catch {}
+  }
+}
+
+async function goToDenWeb(ctx, path) {
+  const url = path.startsWith("http") ? path : `${DEN_WEB_URL}${path}`;
+  await ctx.eval(`location.assign(${JSON.stringify(url)})`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `den-web loaded ${path}` });
+}
+
+async function signInAdminBrowser(ctx) {
+  if (state.adminBrowserSignedIn) return;
+  const session = await createAdminBrowserSession(ctx);
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(`(() => {
+    document.cookie = 'better-auth.session_token=; Max-Age=0; Path=/';
+    document.cookie = ${JSON.stringify(`${session.cookie}; Path=/; SameSite=Lax`)};
+    localStorage.setItem('openwork:web:auth-token', ${JSON.stringify(session.token)});
+    sessionStorage.clear();
+    return true;
+  })()`);
+  await goToDenWeb(ctx, "/");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "den-web dashboard after admin sign-in" });
+  state.adminBrowserSignedIn = true;
+}
+
+async function openBillingPage(ctx) {
+  await signInAdminBrowser(ctx);
+  await goToDenWeb(ctx, "/dashboard/billing");
+  await ctx.waitFor("location.pathname.includes('/dashboard/billing')", { timeoutMs: 30_000, label: "billing route" });
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"billing-summary-card\"]'))", {
+    timeoutMs: 30_000,
+    label: "billing summary card rendered",
+  });
+}
+
+async function loadBilling(ctx) {
+  const response = await fetch(`${DEN_API_URL}/v1/billing`, {
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}`, origin: DEN_WEB_URL || DEN_API_URL },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {}
+  witness(ctx, response.ok, "Admin token can load the organization billing summary", { status: response.status });
+  return body?.billing?.stripe ?? null;
+}
+
+/** Reads a card's rendered text so assertions witness what the user actually sees. */
+function cardTextExpression(testId) {
+  return `(document.querySelector('[data-testid=${JSON.stringify(testId)}]')?.innerText ?? '')`;
+}
+
+async function cardText(ctx, testId) {
+  return ctx.eval(cardTextExpression(testId));
+}
+
+async function scrollCardIntoView(ctx, testId) {
+  await ctx.eval(`(() => {
+    document.querySelector('[data-testid=${JSON.stringify(testId)}]')?.scrollIntoView({ block: 'center' });
+    return true;
+  })()`);
+  await ctx.eval("new Promise((resolve) => setTimeout(resolve, 250))", { awaitPromise: true });
+}
+
+/** Money strings as the page renders them, e.g. "$40.00" -> 4000 minor units. */
+function parseMoney(text) {
+  const match = String(text ?? "").match(/\$([\d,]+)\.(\d{2})/);
+  if (!match) return null;
+  return Number.parseInt(match[1].replace(/,/g, ""), 10) * 100 + Number.parseInt(match[2], 10);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Billing separates Team seats from AI model access and explains every action",
+  kind: "user-facing",
+  requiresApp: false,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_WEB_CDP_ADMIN"],
+  steps: [
+    {
+      name: "Frame 1 — One statement, two named line items, one total",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("Billing opens on a single statement that lists Team seats and AI model access as separate line items and sums them into one total", {
+            voiceover: vo[0],
+            assert: async () => {
+              state.billing = await loadBilling(ctx);
+              witness(ctx, state.billing !== null, "Billing payload exposes the stripe summary", {
+                configured: state.billing?.configured,
+                seatsConfigured: state.billing?.seats?.configured,
+                memberCount: state.billing?.memberCount,
+              });
+
+              await openBillingPage(ctx);
+              const summary = await cardText(ctx, "billing-summary-card");
+
+              witness(ctx, summary.includes("Team seats"), "The statement names the Team seats line item", summary.slice(0, 300));
+              witness(ctx, summary.includes("AI model access"), "The statement names the AI model access line item", summary.slice(0, 300));
+              witness(ctx, summary.includes("Total"), "The statement carries a Total row", summary.slice(0, 300));
+
+              // The two line items must sum to the displayed total, so the page can
+              // never show a charge the user cannot account for.
+              const amounts = await ctx.eval(`(() => {
+                const card = document.querySelector('[data-testid="billing-summary-card"]');
+                if (!card) return null;
+                const rows = [...card.querySelectorAll('div')].filter((el) => {
+                  const text = el.innerText ?? '';
+                  return /per (month|year)/.test(text) && el.children.length === 4;
+                });
+                return rows.map((row) => ({
+                  title: (row.children[1]?.innerText ?? '').split('\\n')[0].trim(),
+                  value: (row.children[2]?.innerText ?? '').split('\\n')[0].trim(),
+                }));
+              })()`);
+              witness(ctx, Array.isArray(amounts) && amounts.length === 3, "The statement renders exactly three rows: seats, AI, and the total", amounts);
+
+              const seatsMinor = parseMoney(amounts?.[0]?.value);
+              const aiMinor = parseMoney(amounts?.[1]?.value);
+              const totalMinor = parseMoney(amounts?.[2]?.value);
+              witness(
+                ctx,
+                seatsMinor !== null && aiMinor !== null && totalMinor !== null && seatsMinor + aiMinor === totalMinor,
+                "The Total equals Team seats plus AI model access",
+                { seatsMinor, aiMinor, totalMinor, amounts },
+              );
+
+              ctx.output("billing-summary", JSON.stringify({
+                stripeConfigured: state.billing?.configured,
+                seatsConfigured: state.billing?.seats?.configured,
+                memberCount: state.billing?.memberCount,
+                freeSeatCount: state.billing?.seats?.freeSeatCount,
+                billableSeatCount: state.billing?.seats?.billableSeatCount,
+                renderedRows: amounts,
+              }, null, 2));
+
+              await scrollCardIntoView(ctx, "billing-summary-card");
+            },
+            screenshot: {
+              name: "billing-statement",
+              // "OpenWork Users" was the old seats card title; the sidebar still
+              // links to OpenWork Models, so only the retired card name is rejected.
+              requireText: ["Your subscriptions", "Team seats", "AI model access", "Total"],
+              rejectText: ["OpenWork Users"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2 — The seats card states what seats do and do not include",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("The Team seats card explains this deployment's seat charge in plain language and never implies that seats include model access", {
+            voiceover: vo[1],
+            assert: async () => {
+              await openBillingPage(ctx);
+              const seatsCard = await cardText(ctx, "billing-seats-card");
+
+              witness(ctx, seatsCard.startsWith("Team seats"), "The card is titled Team seats", seatsCard.slice(0, 120));
+
+              // Whatever the deployment's Stripe state, the card must tell the user
+              // that seats and model access are different purchases.
+              const separatesProducts = seatsCard.includes("AI model access") || seatsCard.includes("model access");
+              witness(ctx, separatesProducts, "The seats card explicitly distinguishes itself from AI model access", seatsCard.slice(0, 400));
+
+              const seatsConfigured = state.billing?.seats?.configured === true;
+              if (seatsConfigured) {
+                witness(ctx, seatsCard.includes("Free seats used") || seatsCard.includes("free"), "A configured deployment shows how much of the free allowance is used", seatsCard.slice(0, 400));
+              } else {
+                witness(
+                  ctx,
+                  seatsCard.includes("not set up") && seatsCard.includes("no member limit"),
+                  "An unconfigured deployment says seat billing is not set up and there is no member limit",
+                  seatsCard.slice(0, 400),
+                );
+                witness(
+                  ctx,
+                  !seatsCard.includes("Add paid seats"),
+                  "An unconfigured deployment never offers a seat checkout the operator cannot complete",
+                  seatsCard.slice(0, 400),
+                );
+              }
+
+              ctx.output("seats-card", seatsCard);
+              await scrollCardIntoView(ctx, "billing-seats-card");
+            },
+            screenshot: {
+              name: "seats-card",
+              requireText: ["Team seats", "Manage members"],
+              rejectText: ["OpenWork Users"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Every action says when to use it",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("The AI model access card names who is billed, and every button on the page is paired with a sentence describing when to press it", {
+            voiceover: vo[2],
+            assert: async () => {
+              await openBillingPage(ctx);
+              const aiCard = await cardText(ctx, "billing-ai-card");
+
+              witness(ctx, aiCard.startsWith("AI model access"), "The card is titled AI model access", aiCard.slice(0, 120));
+              witness(
+                ctx,
+                aiCard.includes("Separate from seats"),
+                "The AI card states that it is separate from seats",
+                aiCard.slice(0, 400),
+              );
+
+              const aiConfigured = state.billing?.configured === true;
+              if (aiConfigured) {
+                witness(
+                  ctx,
+                  aiCard.includes("every active member"),
+                  "A configured deployment warns that every active member is billed",
+                  aiCard.slice(0, 400),
+                );
+              } else {
+                witness(
+                  ctx,
+                  aiCard.includes("not set up") && aiCard.includes("own provider keys"),
+                  "An unconfigured deployment says model billing is not set up and the team brings its own keys",
+                  aiCard.slice(0, 400),
+                );
+              }
+
+              // The regression this change guarantees: no button stands alone.
+              const unexplainedActions = await ctx.eval(`(() => {
+                const cards = ['billing-seats-card', 'billing-ai-card'];
+                const orphans = [];
+                for (const id of cards) {
+                  const card = document.querySelector('[data-testid="' + id + '"]');
+                  if (!card) { orphans.push({ card: id, reason: 'card missing' }); continue; }
+                  for (const button of card.querySelectorAll('button')) {
+                    const row = button.closest('div')?.parentElement;
+                    const description = row?.querySelector('p')?.innerText?.trim() ?? '';
+                    if (description.length < 20) {
+                      orphans.push({ card: id, button: button.innerText.trim(), description });
+                    }
+                  }
+                }
+                return orphans;
+              })()`);
+              witness(
+                ctx,
+                Array.isArray(unexplainedActions) && unexplainedActions.length === 0,
+                "Every action button in the seats and AI cards is paired with guidance text",
+                unexplainedActions,
+              );
+
+              ctx.output("ai-card", aiCard);
+              await scrollCardIntoView(ctx, "billing-ai-card");
+            },
+            screenshot: {
+              name: "ai-card-actions",
+              requireText: ["AI model access", "Separate from seats"],
+            },
+          });
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/billing-seats-vs-ai.md
+++ b/evals/voiceovers/billing-seats-vs-ai.md
@@ -1,0 +1,9 @@
+# billing-seats-vs-ai — Billing tells you which of the two things you are paying for
+
+This user-facing demo follows Alex, an admin opening the Billing page. Team seats and AI model access cost the same ten dollars per user and used to be presented as two near-identical cards, so people bought one believing they had bought the other. The page now names each purchase, states who is billed for it, and totals them.
+
+1. Alex opens Billing and sees one statement instead of two lookalike cards. Team seats and AI model access are listed as separate line items, each with its own status and its own price, and the two add up to a single total.
+
+2. Alex reads the Team seats card. It says in plain language what this deployment charges for seats, and it never promises that seats include model access.
+
+3. Alex scrolls to AI model access. Every action on the page now comes with a sentence saying when to use it, so no button can be pressed without knowing what it does or who gets billed.


### PR DESCRIPTION
## Why

Seats and AI model access both cost \$10 per user and were rendered as two near-identical cards. The two products bill completely differently:

- **Team seats** — Stripe `mode: "setup"`. Charges \$0 today; only bills for users beyond the free 5.
- **AI model access** — Stripe `mode: "subscription"`. Bills immediately for *every* active member.

The page never said this, so a user could buy model access believing they had bought "5 seats" and be surprised by the charge. Nothing on the page stated the whole-team total before checkout.

## What changed

**One statement instead of two lookalike cards.** Billing now opens on `Your subscriptions`, listing Team seats and AI model access as separate line items — each with its own status badge and price — summed into a `Total`. The fraimz asserts the two rows arithmetically equal the total, so no charge can appear unaccounted for.

**Every action says when to use it.** Bare buttons are replaced by action rows pairing each control with a plain-language sentence, e.g. `Add paid seats` now reads "Only needed once you pass 5 users. Saves a card now, then charges \$10.00 per extra user each month" — which is the honest description of Stripe setup mode.

**The whole-team price is stated before checkout.** When model access is off, the CTA guidance reads "Turning this on costs \$20.00 per month for your 2 members, not \$10.00."

**Unconfigured deployments no longer lie.** Without Stripe keys the page previously still quoted \$10/user and offered a seat checkout the operator could never complete. It now says seat billing is not set up and there is no member limit.

**Seat usage is visual.** A segmented meter replaces the flat "1 free seat left" sentence, with overflow shown proportionally once a team passes the free tier.

## New primitives

Built on existing Den primitives (`DenCard`, `DenBadge`, `DenSectionHeader`, `DenButton`); added where none existed:

- `DenUsageMeter` — segmented allowance meter for "x of y included" limits
- `DenActionRow` / `DenActionList` — control paired with when-to-use guidance
- `DenLineItemRow` / `DenMarkTile` — read-only statement rows (the counterpart to `DenSelectableRow`)
- `DenNotice` extended with `neutral` and `warning` tones

The page also drops its custom `rounded-2xl` + drop-shadow sections for `DenCard`, which forbids shadows.

## Tests

- `pnpm typecheck` (den-web) — clean, no `any`/casts added
- `pnpm fraimz --flow billing-seats-vs-ai --stack den` — **PASSED**, 3/3 frames, driven through the real den stack (MySQL + den-api + den-web) via CDP against the seeded `alex@acme.test` org

Proof posted as a follow-up comment.

## Reviewer note

The guidance copy asserts two Stripe behaviors I inferred from `stripe-billing.ts` but did not exercise against live Stripe: that cancelling model access runs to period end, and that removing a member lowers the AI bill at renewal rather than immediately. Both are worth confirming against actual proration settings before this ships to hosted.

Made with [Cursor](https://cursor.com)