### PR TITLE
feat(evals): provisioning primitives + one command for the two-member connector room

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -27,6 +27,7 @@ DEN_WEB_PUBLIC_HOST="${DEN_WEB_PUBLIC_HOST#https://}"
 DEN_WEB_PUBLIC_HOST="${DEN_WEB_PUBLIC_HOST%%/*}"
 
 export OPENWORK_DEV_MODE="${OPENWORK_DEV_MODE:-1}"
+export DEN_ORG_MODE="${DEN_ORG_MODE:-multi_org}"
 export DATABASE_URL="${DATABASE_URL:-mysql://root:password@127.0.0.1:3306/openwork_den}"
 export DEN_DB_ENCRYPTION_KEY="${DEN_DB_ENCRYPTION_KEY:-daytona-den-db-encryption-key-please-change-1234567890}"
 export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-daytona-den-auth-secret-please-change-1234567890}"
@@ -136,12 +137,45 @@ nohup env \
   PROVISIONER_MODE="$DEN_PROVISIONER_MODE" \
   WORKER_URL_TEMPLATE="$DEN_WORKER_URL_TEMPLATE" \
   DAYTONA_WORKER_PROXY_BASE_URL="$DAYTONA_WORKER_PROXY_BASE_URL" \
-  DEN_ORG_MODE="${DEN_ORG_MODE:-multi_org}" \
+  DEN_ORG_MODE="$DEN_ORG_MODE" \
   OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
   NODE_OPTIONS="--conditions=development" \
   pnpm --filter @openwork-ee/den-api exec tsx watch src/main.ts > /tmp/den-api.log 2>&1 &
 
 wait_for_http "http://127.0.0.1:$DEN_API_PORT/health" "Den API" 180
+
+if [ "${RUN_SEED:-0}" = "1" ]; then
+  demo_email="${DEN_DEMO_OWNER_EMAIL:-alex@acme.test}"
+  demo_password="${DEN_DEMO_OWNER_PASSWORD:-OpenWorkDemo123!}"
+  signin_ok() {
+    curl -sf -o /dev/null -X POST "http://127.0.0.1:$DEN_API_PORT/api/auth/sign-in/email" \
+      -H 'content-type: application/json' \
+      -d "{\"email\":\"$demo_email\",\"password\":\"$demo_password\"}"
+  }
+  if signin_ok; then
+    echo "==> Demo org already present ($demo_email)"
+  else
+    echo "==> Seeding demo org..."
+    (cd ee/apps/den-api && env \
+      DATABASE_URL="$DATABASE_URL" \
+      DEN_DB_ENCRYPTION_KEY="$DEN_DB_ENCRYPTION_KEY" \
+      BETTER_AUTH_SECRET="$BETTER_AUTH_SECRET" \
+      BETTER_AUTH_URL="$BETTER_AUTH_URL" \
+      DEN_API_PUBLIC_URL="$DEN_API_PUBLIC_URL" \
+      DEN_ORG_MODE="$DEN_ORG_MODE" \
+      OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+      DEN_DEMO_SEED_FETCH_GITHUB="${DEN_DEMO_SEED_FETCH_GITHUB:-0}" \
+      node --conditions=development --import tsx scripts/seed-demo-org.ts) > /tmp/den-seed.log 2>&1
+    if signin_ok; then
+      echo "==> Demo org seeded ($demo_email)"
+    else
+      echo "ERROR: seed completed but $demo_email cannot sign in. See /tmp/den-seed.log" >&2
+      tail -40 /tmp/den-seed.log >&2 || true
+      exit 1
+    fi
+  fi
+  echo "DEMO_OWNER_READY=$demo_email"
+fi
 
 echo "==> Starting worker proxy on :$DEN_WORKER_PROXY_PORT..."
 pkill -f "tsx watch src/server.ts" >/dev/null 2>&1 || true
@@ -189,7 +223,7 @@ nohup env \
   NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="$NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL" \
   NEXT_PUBLIC_POSTHOG_KEY= \
   NEXT_PUBLIC_POSTHOG_API_KEY= \
-  DEN_ORG_MODE="${DEN_ORG_MODE:-multi_org}" \
+  DEN_ORG_MODE="$DEN_ORG_MODE" \
   OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
   DEN_WEB_ALLOWED_DEV_ORIGINS="$DEN_WEB_ALLOWED_DEV_ORIGINS" \
   pnpm --filter @openwork-ee/den-web exec next dev --hostname 0.0.0.0 --port "$DEN_WEB_PORT" > /tmp/den-web.log 2>&1 &

--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -6,12 +6,14 @@ set -euo pipefail
 # Usage:
 #   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
 #   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit] --force-install
+#   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit] --seed
 #
 # Creates a Daytona sandbox, starts MySQL + Den API + Den Web + worker proxy,
 # waits for health checks, and prints public preview URLs.
 
 REF=""
 FORCE_INSTALL=0
+RUN_SEED=0
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SANDBOX="openwork-server-$(date +%Y%m%d-%H%M%S)"
 DAYTONA_SERVER_SNAPSHOT="${DAYTONA_SERVER_SNAPSHOT:-openwork-server}"
@@ -25,6 +27,9 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --force-install)
       FORCE_INSTALL=1
+      ;;
+    --seed)
+      RUN_SEED=1
       ;;
     --snapshot)
       shift
@@ -102,7 +107,7 @@ START_SCRIPT_B64="$(base64 < "$ROOT_DIR/.devcontainer/start-daytona-server.sh" |
 daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; mkdir -p .devcontainer; printf %s $START_SCRIPT_B64 | base64 -d > .devcontainer/start-daytona-server.sh; chmod +x .devcontainer/start-daytona-server.sh'"
 
 echo "==> Starting OpenWork Den server stack..."
-daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; DEN_WEB_PUBLIC_URL=\"$DEN_WEB_URL\" DEN_API_PUBLIC_URL=\"$DEN_API_URL\" DEN_WORKER_PROXY_PUBLIC_URL=\"$DEN_WORKER_PROXY_URL\" DEN_WEB_PORT=$DEN_WEB_PORT DEN_API_PORT=$DEN_API_PORT DEN_WORKER_PROXY_PORT=$DEN_WORKER_PROXY_PORT bash .devcontainer/start-daytona-server.sh'"
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; DEN_WEB_PUBLIC_URL=\"$DEN_WEB_URL\" DEN_API_PUBLIC_URL=\"$DEN_API_URL\" DEN_WORKER_PROXY_PUBLIC_URL=\"$DEN_WORKER_PROXY_URL\" DEN_WEB_PORT=$DEN_WEB_PORT DEN_API_PORT=$DEN_API_PORT DEN_WORKER_PROXY_PORT=$DEN_WORKER_PROXY_PORT RUN_SEED=$RUN_SEED bash .devcontainer/start-daytona-server.sh'"
 
 echo "==> Waiting for public Den Web health (up to ${MAX_WAIT}s)..."
 elapsed=0

--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -63,6 +63,15 @@ if [ -z "$REF" ]; then
   REF="${REF:-$(git rev-parse HEAD)}"
 fi
 
+# The ref is interpolated into a remote shell assignment below, so anything
+# outside git's safe alphabet (or a leading dash) is remote code execution.
+case "$REF" in
+  ""|-*|*[!A-Za-z0-9._/-]*)
+    echo "ERROR: unsafe ref '$REF' — only letters, digits and . _ / - are allowed." >&2
+    exit 1
+    ;;
+esac
+
 snapshot_id() {
   daytona snapshot list -f json | node -e 'const name = process.argv[1]; let input = ""; process.stdin.on("data", (chunk) => input += chunk); process.stdin.on("end", () => { const snapshot = JSON.parse(input).find((item) => item.name === name); if (snapshot) process.stdout.write(snapshot.id || snapshot.name); });' "$1"
 }

--- a/evals/package.json
+++ b/evals/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "spec": "vitest run --config vitest.config.ts --project pr",
     "spec:nightly": "vitest run --config vitest.config.ts",
+    "provision:org-connector-two-members": "node scripts/provision-org-connector-two-members.ts",
     "test": "node --test runner/*.test.ts packages/*/test/*.test.ts",
     "typecheck": "tsc -p ."
   },

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -56,7 +56,7 @@ function messageText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function defaultDaytonaExec(args: string[], opts: { input?: string; timeoutMs?: number } = {}): Promise<DaytonaExecResult> {
+export function defaultDaytonaExec(args: string[], opts: { input?: string; timeoutMs?: number } = {}): Promise<DaytonaExecResult> {
   return new Promise((resolve, reject) => {
     const child = spawn("daytona", args, { stdio: ["pipe", "pipe", "pipe"] });
     let stdout = "";
@@ -214,7 +214,7 @@ async function orgModeOrDefault(webUrl: string, log: (msg: string) => void): Pro
   }
 }
 
-async function checkedExec(exec: DaytonaExec, args: string[], context: string, opts: { input?: string; timeoutMs?: number } = {}): Promise<DaytonaExecResult> {
+export async function checkedExec(exec: DaytonaExec, args: string[], context: string, opts: { input?: string; timeoutMs?: number } = {}): Promise<DaytonaExecResult> {
   const result = await exec(args, opts);
   if (result.code !== 0) {
     const details = (result.stderr || result.stdout).trim();

--- a/evals/packages/hosts/src/index.ts
+++ b/evals/packages/hosts/src/index.ts
@@ -2,5 +2,6 @@ export * from "./browser.ts";
 export * from "./daytona.ts";
 export * from "./desktop.ts";
 export * from "./local.ts";
+export * from "./provision.ts";
 export * from "./resolve.ts";
 export * from "./types.ts";

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -248,7 +248,10 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
     const result = await execInSandbox(
       exec,
       sandbox,
-      "export DISPLAY=:99; nohup python3 -m http.server 18099 --bind 127.0.0.1 >/tmp/xdgtest.log 2>&1 & sleep 1; (xdg-open http://127.0.0.1:18099/xdg-open-proof >/dev/null 2>&1 &); ok=0; for i in $(seq 1 30); do grep -q xdg-open-proof /tmp/xdgtest.log 2>/dev/null && ok=1 && break; sleep 1; done; pkill -f \"http.server 18099\" >/dev/null 2>&1; pkill -f chromium >/dev/null 2>&1; rm -f /tmp/xdgtest.log; [ $ok = 1 ] && echo XDG_OPEN_WORKS || echo XDG_OPEN_BROKEN",
+      // Verdict BEFORE cleanup, and bracketed pkill patterns: the pattern is
+      // otherwise a substring of this very shell's command line, so pkill
+      // TERMs its own shell (exit 143) before the verdict can be printed.
+      "export DISPLAY=:99; nohup python3 -m http.server 18099 --bind 127.0.0.1 >/tmp/xdgtest.log 2>&1 & sleep 1; (xdg-open http://127.0.0.1:18099/xdg-open-proof >/dev/null 2>&1 &); ok=0; for i in $(seq 1 30); do grep -q xdg-open-proof /tmp/xdgtest.log 2>/dev/null && ok=1 && break; sleep 1; done; [ $ok = 1 ] && echo XDG_OPEN_WORKS || echo XDG_OPEN_BROKEN; pkill -f \"[h]ttp.server 18099\" >/dev/null 2>&1; pkill -f \"[c]hromium\" >/dev/null 2>&1; rm -f /tmp/xdgtest.log; true",
       { timeoutMs: 90_000, context: `browser hop gate for ${sandbox}` },
     );
     if (!result.stdout.includes("XDG_OPEN_WORKS")) {

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -10,6 +10,8 @@ const DESKTOP_READY_TIMEOUT_MS = 300_000;
 const INSTALL_TIMEOUT_MS = 25 * 60 * 1_000;
 const SERVER_SCRIPT_TIMEOUT_MS = 20 * 60 * 1_000;
 const HTTPS_URL = /https:\/\/[^\s"'<>)]+/;
+const DEN_WEB_PORT = 3005;
+const DEN_API_PORT = 8788;
 
 export interface ProvisionExecOptions {
   exec?: DaytonaExec;
@@ -476,15 +478,6 @@ function sandboxFromServerOutput(output: string): string | null {
   return fallback;
 }
 
-function urlAfterLabels(output: string, labels: string[]): string | null {
-  for (const line of output.split(/\r?\n/)) {
-    if (labels.some((label) => line.includes(label))) {
-      const url = firstHttpsUrl(line);
-      if (url) return url;
-    }
-  }
-  return null;
-}
 
 async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Promise<string> {
   const result = await checkedExec(
@@ -543,8 +536,8 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
   if (reused) {
     sandbox = reused;
     [webUrl, apiUrl] = await timedStep(log, "Den preview URL gate", () => Promise.all([
-      previewUrl(exec, sandbox, 3005),
-      previewUrl(exec, sandbox, 8788),
+      previewUrl(exec, sandbox, DEN_WEB_PORT),
+      previewUrl(exec, sandbox, DEN_API_PORT),
     ]));
   } else {
     const result = await timedStep(log, "Den provisioning script", () => runDenProvisionScript(ref, options.repoRoot ?? REPO_ROOT, log));
@@ -553,13 +546,15 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
     }
     const parsedSandbox = sandboxFromServerOutput(result.output);
     if (!parsedSandbox) throw new Error(`Den provisioning script output is missing sandbox. Output tail:\n${textTail(result.output)}`);
-    const parsedWebUrl = urlAfterLabels(result.output, ["DEN_WEB_URL=", "Den Web:"]);
-    if (!parsedWebUrl) throw new Error(`Den provisioning script output is missing webUrl. Output tail:\n${textTail(result.output)}`);
-    const parsedApiUrl = urlAfterLabels(result.output, ["DEN_API_URL=", "Den API:"]);
-    if (!parsedApiUrl) throw new Error(`Den provisioning script output is missing apiUrl. Output tail:\n${textTail(result.output)}`);
     sandbox = parsedSandbox;
-    webUrl = parsedWebUrl;
-    apiUrl = parsedApiUrl;
+    // URLs come from daytona for THIS sandbox, never from the script's stdout:
+    // the ref being provisioned controls that stream, so a spoofed
+    // "DEN_API_URL=https://attacker" line would receive the demo credentials
+    // the sign-in proof posts moments later.
+    [webUrl, apiUrl] = await timedStep(log, "Den preview URL gate", () => Promise.all([
+      previewUrl(exec, parsedSandbox, DEN_WEB_PORT),
+      previewUrl(exec, parsedSandbox, DEN_API_PORT),
+    ]));
   }
 
   await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, webUrl, sandbox, Boolean(reused)));
@@ -666,6 +661,19 @@ function commentLine(content: string, prefix: string): string | null {
   return null;
 }
 
+/** POSIX single-quoting: the generated file is `source`d, so an unquoted
+ * value like `$(cmd)` would execute on the operator's machine. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll(`'"'"'`, "'");
+  }
+  return value;
+}
+
 export function renderConnectorSpecEnv(facts: ConnectorSpecEnv): string {
   assertSafeRef(facts.ref);
   return [
@@ -673,11 +681,11 @@ export function renderConnectorSpecEnv(facts: ConnectorSpecEnv): string {
     `${ENV_CREATED_PREFIX}${facts.created.join(",")}`,
     "OPENWORK_EVAL_APP_SPECS=1",
     "OPENWORK_EVAL_CONNECTOR_SPEC=1",
-    `OPENWORK_EVAL_DEN_API_URL=${facts.denApiUrl}`,
-    `OPENWORK_EVAL_DEN_WEB_URL=${facts.denWebUrl}`,
-    `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${facts.sandboxA}`,
-    `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${facts.sandboxB}`,
-    `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${facts.mockUrl}`,
+    `OPENWORK_EVAL_DEN_API_URL=${shellQuote(facts.denApiUrl)}`,
+    `OPENWORK_EVAL_DEN_WEB_URL=${shellQuote(facts.denWebUrl)}`,
+    `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${shellQuote(facts.sandboxA)}`,
+    `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${shellQuote(facts.sandboxB)}`,
+    `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${shellQuote(facts.mockUrl)}`,
     "OPENWORK_EVAL_MODEL=big-pickle",
     "",
   ].join("\n");
@@ -688,7 +696,7 @@ export function parseConnectorSpecEnv(content: string): ConnectorSpecEnv {
   for (const line of content.split(/\r?\n/)) {
     if (!line || line.startsWith("#")) continue;
     const separator = line.indexOf("=");
-    if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
+    if (separator > 0) values.set(line.slice(0, separator), unquote(line.slice(separator + 1)));
   }
   function required(name: string): string {
     const value = values.get(name);

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -399,20 +399,22 @@ async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Pro
   return url;
 }
 
-async function proveDenSeed(apiUrl: string, sandbox: string, reused: boolean): Promise<void> {
+async function proveDenSeed(apiUrl: string, webUrl: string, sandbox: string, reused: boolean): Promise<void> {
   const email = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
   const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD ?? "OpenWorkDemo123!";
   const url = `${apiUrl.replace(/\/+$/, "")}/api/auth/sign-in/email`;
   // A freshly-booted stack was observed answering public sign-in with bare
   // 403s for its first ~minute, then recovering on its own — so the window is
   // generous, and a failing status keeps its body so the failure names itself.
+  // (That body once read MISSING_OR_NULL_ORIGIN: early boot rejects
+  // origin-less POSTs, and every real client sends Origin — so must we.)
   const deadline = Date.now() + 120_000;
   let last = "not attempted";
   while (Date.now() < deadline) {
     try {
       const response = await fetch(url, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", origin: webUrl },
         body: JSON.stringify({ email, password }),
         signal: AbortSignal.timeout(5_000),
       });
@@ -460,7 +462,7 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
     apiUrl = parsedApiUrl;
   }
 
-  await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, sandbox, Boolean(reused)));
+  await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, webUrl, sandbox, Boolean(reused)));
   return { sandbox, apiUrl, webUrl, created: !reused };
 }
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -245,17 +245,43 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
   });
 
   await timedStep(log, "browser hop gate", async () => {
-    const result = await execInSandbox(
+    // Chromium launched inside a pipe-stdin exec session TERMs the whole
+    // session as it starts (exit 143 at ~2.5s; the same script survives under
+    // a TTY). So nothing may run as a child of the session: both halves are
+    // fully detached the way the mock and Vite gates are, and the proof is
+    // read back by clean, childless polls.
+    const detachScript = `rm -f /tmp/xdgtest.log; python3 - <<PYEOF
+import subprocess
+log = open("/tmp/xdgtest.log", "ab", buffering=0)
+subprocess.Popen(["python3", "-m", "http.server", "18099", "--bind", "127.0.0.1"], stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+subprocess.Popen(["bash", "-lc", "sleep 1; export DISPLAY=:99; xdg-open http://127.0.0.1:18099/xdg-open-proof"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+    await execInSandbox(exec, sandbox, detachScript, { timeoutMs: 30_000, context: `browser hop detach for ${sandbox}` });
+
+    const deadline = Date.now() + 60_000;
+    let seen = false;
+    while (Date.now() < deadline) {
+      const probe = await execInSandbox(
+        exec,
+        sandbox,
+        "grep -q xdg-open-proof /tmp/xdgtest.log 2>/dev/null && echo XDG_OPEN_WORKS || echo XDG_WAITING",
+        { timeoutMs: 15_000, context: `browser hop probe for ${sandbox}` },
+      );
+      if (probe.stdout.includes("XDG_OPEN_WORKS")) {
+        seen = true;
+        break;
+      }
+      await delay(3_000);
+    }
+    await execInSandbox(
       exec,
       sandbox,
-      // Verdict BEFORE cleanup, and bracketed pkill patterns: the pattern is
-      // otherwise a substring of this very shell's command line, so pkill
-      // TERMs its own shell (exit 143) before the verdict can be printed.
-      "export DISPLAY=:99; nohup python3 -m http.server 18099 --bind 127.0.0.1 >/tmp/xdgtest.log 2>&1 & sleep 1; (xdg-open http://127.0.0.1:18099/xdg-open-proof >/dev/null 2>&1 &); ok=0; for i in $(seq 1 30); do grep -q xdg-open-proof /tmp/xdgtest.log 2>/dev/null && ok=1 && break; sleep 1; done; [ $ok = 1 ] && echo XDG_OPEN_WORKS || echo XDG_OPEN_BROKEN; pkill -f \"[h]ttp.server 18099\" >/dev/null 2>&1; pkill -f \"[c]hromium\" >/dev/null 2>&1; rm -f /tmp/xdgtest.log; true",
-      { timeoutMs: 90_000, context: `browser hop gate for ${sandbox}` },
-    );
-    if (!result.stdout.includes("XDG_OPEN_WORKS")) {
-      throw new Error(`Browser hop gate failed for ${sandbox}: expected XDG_OPEN_WORKS. Output tail: ${outputTail(result)}`);
+      "pkill -f \"[h]ttp.server 18099\" >/dev/null 2>&1; pkill -f \"[c]hromium\" >/dev/null 2>&1; rm -f /tmp/xdgtest.log; true",
+      { timeoutMs: 15_000, context: `browser hop cleanup for ${sandbox}` },
+    ).catch(() => undefined);
+    if (!seen) {
+      throw new Error(`Browser hop gate failed for ${sandbox}: xdg-open never delivered a request (no browser reachable from the OAuth connect flow).`);
     }
   });
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -191,11 +191,19 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
     const result = await execInSandbox(
       exec,
       sandbox,
-      `set -e; cd /workspace; git fetch origin "${options.ref}" && git checkout --detach FETCH_HEAD; git rev-parse --short HEAD`,
+      // Check out the REQUESTED ref, not FETCH_HEAD: a raw-sha fetch was
+      // observed leaving FETCH_HEAD stale, silently running the wrong code —
+      // and servers may refuse raw-sha fetches outright, so fall back to a
+      // full fetch and prefer the remote-tracking ref over any stale local.
+      `set -e; cd /workspace; git fetch origin "${options.ref}" 2>/dev/null || git fetch origin; git checkout --detach "origin/${options.ref}" 2>/dev/null || git checkout --detach "${options.ref}" 2>/dev/null || git checkout --detach FETCH_HEAD; git rev-parse --short=12 HEAD`,
       { timeoutMs: 120_000, context: `checkout gate for ${sandbox}` },
     );
     const sha = lastNonemptyLine(result.stdout);
     if (!sha) throw new Error(`Checkout gate failed for ${sandbox}: git did not print a resolved sha. Output tail: ${outputTail(result)}`);
+    const wantsSha = /^[0-9a-f]{7,40}$/.test(options.ref);
+    if (wantsSha && !sha.startsWith(options.ref.slice(0, 12)) && !options.ref.startsWith(sha)) {
+      throw new Error(`Checkout gate failed for ${sandbox}: asked for ${options.ref} but HEAD is ${sha}.`);
+    }
     log(`==> checkout resolved ${sha}`);
   });
 
@@ -282,6 +290,53 @@ echo detached`;
     ).catch(() => undefined);
     if (!seen) {
       throw new Error(`Browser hop gate failed for ${sandbox}: xdg-open never delivered a request (no browser reachable from the OAuth connect flow).`);
+    }
+  });
+
+  await timedStep(log, "first boot gate", async () => {
+    // A sandbox's first Electron boot pays sidecar prepare, the
+    // openwork-server tsc build, and the engine cold start. Paid INSIDE a
+    // spec, that bill starved the tool-call phase past its window while every
+    // UI assertion still passed. Boot once into a throwaway profile, wait for
+    // CDP, tear it down — after this the room behaves like a warm machine.
+    const detachScript = `python3 - <<PYEOF
+import subprocess
+log = open("/tmp/warmup-electron.log", "ab", buffering=0)
+subprocess.Popen(["bash", "-lc", "cd /workspace && env OPENWORK_ELECTRON_USERDATA=/tmp/warmup-profile OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9825 bash .devcontainer/start-daytona-electron.sh"], stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+    await execInSandbox(exec, sandbox, detachScript, { timeoutMs: 30_000, context: `first boot detach for ${sandbox}` });
+    const deadline = Date.now() + 420_000;
+    let last = "not attempted";
+    let ready = false;
+    while (Date.now() < deadline) {
+      const probe = await execInSandbox(
+        exec,
+        sandbox,
+        "curl -s --max-time 5 http://127.0.0.1:9825/json/version || echo CDP_DOWN",
+        { timeoutMs: 15_000, context: `first boot probe for ${sandbox}` },
+      ).catch((error) => ({ stdout: messageText(error), stderr: "", code: 1 }));
+      last = probe.stdout.trim().slice(0, 200);
+      if (last.includes("Browser")) {
+        ready = true;
+        break;
+      }
+      await delay(5_000);
+    }
+    await execInSandbox(
+      exec,
+      sandbox,
+      "pkill -f \"[e]lectron\" >/dev/null 2>&1; pkill -f \"[o]pencode\" >/dev/null 2>&1; sleep 1; rm -rf /tmp/warmup-profile; true",
+      { timeoutMs: 30_000, context: `first boot cleanup for ${sandbox}` },
+    ).catch(() => undefined);
+    if (!ready) {
+      const bootLog = await execInSandbox(
+        exec,
+        sandbox,
+        "tail -60 /tmp/warmup-electron.log 2>&1 || true",
+        { timeoutMs: 30_000, context: `first boot log for ${sandbox}` },
+      ).catch(() => null);
+      throw new Error(`First boot gate failed for ${sandbox}: CDP never answered on 9825. Last probe: ${last}. Log tail:\n${bootLog ? outputTail(bootLog) : "unavailable"}`);
     }
   });
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -403,7 +403,10 @@ async function proveDenSeed(apiUrl: string, sandbox: string, reused: boolean): P
   const email = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
   const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD ?? "OpenWorkDemo123!";
   const url = `${apiUrl.replace(/\/+$/, "")}/api/auth/sign-in/email`;
-  const deadline = Date.now() + 30_000;
+  // A freshly-booted stack was observed answering public sign-in with bare
+  // 403s for its first ~minute, then recovering on its own — so the window is
+  // generous, and a failing status keeps its body so the failure names itself.
+  const deadline = Date.now() + 120_000;
   let last = "not attempted";
   while (Date.now() < deadline) {
     try {
@@ -414,7 +417,8 @@ async function proveDenSeed(apiUrl: string, sandbox: string, reused: boolean): P
         signal: AbortSignal.timeout(5_000),
       });
       if (response.status === 200) return;
-      last = `HTTP ${response.status}`;
+      const body = await response.text().catch(() => "");
+      last = `HTTP ${response.status} ${body.slice(0, 300)}`.trim();
     } catch (error) {
       last = messageText(error);
     }

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -112,6 +112,20 @@ async function execInSandbox(
   return checkedExec(exec, ["exec", sandbox, "--", `bash -lc '${script}'`], opts.context, { timeoutMs: opts.timeoutMs });
 }
 
+/**
+ * A ref travels into a remote double-quoted shell word AND into a file the
+ * operator is told to `source`, so `$(...)`, a quote, or a newline in it is
+ * remote code execution. Refuse anything outside git's own safe alphabet here
+ * rather than escaping it correctly at each site forever.
+ */
+function assertSafeRef(ref: string): string {
+  const value = ref.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value)) {
+    throw new Error(`Unsafe git ref ${JSON.stringify(ref)}: only letters, digits and . _ / - are allowed, and it may not start with "-".`);
+  }
+  return value;
+}
+
 function snapshotId(output: string, name: string): string | null {
   let parsed: unknown;
   try {
@@ -154,6 +168,7 @@ function lastNonemptyLine(text: string): string {
 export async function provisionDesktopSandbox(options: DesktopSandboxOptions & ProvisionExecOptions): Promise<DesktopSandbox> {
   const exec = options.exec ?? defaultDaytonaExec;
   const log = options.log ?? console.error;
+  const ref = assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox = reused;
 
@@ -195,14 +210,14 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
       // observed leaving FETCH_HEAD stale, silently running the wrong code —
       // and servers may refuse raw-sha fetches outright, so fall back to a
       // full fetch and prefer the remote-tracking ref over any stale local.
-      `set -e; cd /workspace; git fetch origin "${options.ref}" 2>/dev/null || git fetch origin; git checkout --detach "origin/${options.ref}" 2>/dev/null || git checkout --detach "${options.ref}" 2>/dev/null || git checkout --detach FETCH_HEAD; git rev-parse --short=12 HEAD`,
+      `set -e; cd /workspace; git fetch origin "${ref}" 2>/dev/null || git fetch origin; git checkout --detach "origin/${ref}" 2>/dev/null || git checkout --detach "${ref}" 2>/dev/null || git checkout --detach FETCH_HEAD; git rev-parse --short=12 HEAD`,
       { timeoutMs: 120_000, context: `checkout gate for ${sandbox}` },
     );
     const sha = lastNonemptyLine(result.stdout);
     if (!sha) throw new Error(`Checkout gate failed for ${sandbox}: git did not print a resolved sha. Output tail: ${outputTail(result)}`);
-    const wantsSha = /^[0-9a-f]{7,40}$/.test(options.ref);
-    if (wantsSha && !sha.startsWith(options.ref.slice(0, 12)) && !options.ref.startsWith(sha)) {
-      throw new Error(`Checkout gate failed for ${sandbox}: asked for ${options.ref} but HEAD is ${sha}.`);
+    const wantsSha = /^[0-9a-f]{7,40}$/.test(ref);
+    if (wantsSha && !sha.startsWith(ref.slice(0, 12)) && !ref.startsWith(sha)) {
+      throw new Error(`Checkout gate failed for ${sandbox}: asked for ${ref} but HEAD is ${sha}.`);
     }
     log(`==> checkout resolved ${sha}`);
   });
@@ -519,6 +534,7 @@ async function proveDenSeed(apiUrl: string, webUrl: string, sandbox: string, reu
 export async function provisionDenSandbox(options: DenSandboxOptions & ProvisionExecOptions): Promise<DenSandbox> {
   const exec = options.exec ?? defaultDaytonaExec;
   const log = options.log ?? console.error;
+  const ref = assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox: string;
   let webUrl: string;
@@ -531,7 +547,7 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
       previewUrl(exec, sandbox, 8788),
     ]));
   } else {
-    const result = await timedStep(log, "Den provisioning script", () => runDenProvisionScript(options.ref, options.repoRoot ?? REPO_ROOT, log));
+    const result = await timedStep(log, "Den provisioning script", () => runDenProvisionScript(ref, options.repoRoot ?? REPO_ROOT, log));
     if (result.code !== 0) {
       throw new Error(`Den provisioning script gate failed with exit ${result.code}. Output tail:\n${textTail(result.output)}`);
     }
@@ -651,6 +667,7 @@ function commentLine(content: string, prefix: string): string | null {
 }
 
 export function renderConnectorSpecEnv(facts: ConnectorSpecEnv): string {
+  assertSafeRef(facts.ref);
   return [
     `${ENV_HEADER_PREFIX} — generated ${new Date().toISOString()}${ENV_REF_MARKER}${facts.ref}`,
     `${ENV_CREATED_PREFIX}${facts.created.join(",")}`,

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -638,10 +638,22 @@ export async function deleteSandboxes(
   }
 }
 
+const ENV_HEADER_PREFIX = "# provisioned for org-connector-two-members";
+const ENV_REF_MARKER = "; ref=";
+const ENV_CREATED_PREFIX = "# provision-created=";
+
+/** First line starting with prefix, minus the prefix. Linear, no backtracking. */
+function commentLine(content: string, prefix: string): string | null {
+  for (const line of content.split(/\r?\n/)) {
+    if (line.startsWith(prefix)) return line.slice(prefix.length);
+  }
+  return null;
+}
+
 export function renderConnectorSpecEnv(facts: ConnectorSpecEnv): string {
   return [
-    `# provisioned for org-connector-two-members — generated ${new Date().toISOString()}; ref=${facts.ref}`,
-    `# provision-created=${facts.created.join(",")}`,
+    `${ENV_HEADER_PREFIX} — generated ${new Date().toISOString()}${ENV_REF_MARKER}${facts.ref}`,
+    `${ENV_CREATED_PREFIX}${facts.created.join(",")}`,
     "OPENWORK_EVAL_APP_SPECS=1",
     "OPENWORK_EVAL_CONNECTOR_SPEC=1",
     `OPENWORK_EVAL_DEN_API_URL=${facts.denApiUrl}`,
@@ -670,10 +682,15 @@ export function parseConnectorSpecEnv(content: string): ConnectorSpecEnv {
   required("OPENWORK_EVAL_APP_SPECS");
   required("OPENWORK_EVAL_CONNECTOR_SPEC");
   required("OPENWORK_EVAL_MODEL");
-  const ref = /^# provisioned for org-connector-two-members — generated .*; ref=(.*)$/m.exec(content)?.[1];
+  // Header comments are read by line scan, not regex: `.*` before a literal
+  // backtracks polynomially on adversarial input (CodeQL js/polynomial-redos).
+  const header = commentLine(content, ENV_HEADER_PREFIX);
+  const refAt = header ? header.lastIndexOf(ENV_REF_MARKER) : -1;
+  if (refAt < 0) throw new Error("Missing ref in connector spec env header.");
+  const ref = header?.slice(refAt + ENV_REF_MARKER.length) ?? "";
   if (!ref) throw new Error("Missing ref in connector spec env header.");
-  const createdText = /^# provision-created=(.*)$/m.exec(content)?.[1];
-  if (createdText === undefined) throw new Error("Missing provision-created in connector spec env header.");
+  const createdText = commentLine(content, ENV_CREATED_PREFIX);
+  if (createdText === null) throw new Error("Missing provision-created in connector spec env header.");
 
   return {
     denApiUrl: required("OPENWORK_EVAL_DEN_API_URL"),

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -22,6 +22,14 @@ export interface DesktopSandboxOptions {
   name: string;
   reuse?: string;
   snapshot?: string;
+  /**
+   * Mount the shared eval secrets volume. Off by default: `pnpm install` runs
+   * lifecycle scripts from the checked-out ref, so mounting provider keys next
+   * to an untrusted ref hands them to it. Signed-in org desktops can only pick
+   * the org's own models anyway, and driver-side vision keys never live here —
+   * so nothing in the connector room needs this.
+   */
+  secrets?: boolean;
   log?: (line: string) => void;
 }
 
@@ -191,7 +199,7 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
           "create",
           "--name", sandbox,
           "--snapshot", id,
-          "--volume", "openwork-eval-secrets:/daytona-secrets",
+          ...(options.secrets === true ? ["--volume", "openwork-eval-secrets:/daytona-secrets"] : []),
           "--auto-stop", "60",
           "--public",
           "--target", "us",

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -531,10 +531,6 @@ function deletionNotFound(text: string): boolean {
   return /not found|does not exist|no sandbox/i.test(text);
 }
 
-function unknownYesFlag(text: string): boolean {
-  return /unknown (?:option|flag)|unrecognized option/i.test(text) && text.includes("--yes");
-}
-
 export async function deleteSandboxes(
   ids: string[],
   options: ProvisionExecOptions & { log?: (line: string) => void } = {},
@@ -543,19 +539,13 @@ export async function deleteSandboxes(
   const log = options.log ?? console.error;
   for (const id of ids) {
     log(`==> deleting sandbox ${id}...`);
-    let result = await exec(["delete", id, "--yes"], { timeoutMs: 60_000 });
-    let output = deletionOutput(result);
+    // The CLI has no --yes; answering its confirmation prompt on stdin works,
+    // and a promptless future CLI would simply ignore the input.
+    const result = await exec(["delete", id], { timeoutMs: 60_000, input: "y\n" });
+    const output = deletionOutput(result);
     if (result.code !== 0 && deletionNotFound(output)) {
       log(`==> sandbox ${id} not found; continuing`);
       continue;
-    }
-    if (result.code !== 0 && unknownYesFlag(output)) {
-      result = await exec(["delete", id], { timeoutMs: 60_000, input: "y\n" });
-      output = deletionOutput(result);
-      if (result.code !== 0 && deletionNotFound(output)) {
-        log(`==> sandbox ${id} not found; continuing`);
-        continue;
-      }
     }
     if (result.code !== 0) throw new Error(`Sandbox deletion gate failed for ${id} with exit ${result.code}. Output tail: ${textTail(output)}`);
     log(`==> deleted sandbox ${id}`);

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -1,0 +1,607 @@
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import { checkedExec, defaultDaytonaExec } from "./daytona.ts";
+import type { DaytonaExec, DaytonaExecResult } from "./daytona.ts";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
+const DESKTOP_READY_TIMEOUT_MS = 300_000;
+const INSTALL_TIMEOUT_MS = 25 * 60 * 1_000;
+const SERVER_SCRIPT_TIMEOUT_MS = 20 * 60 * 1_000;
+const HTTPS_URL = /https:\/\/[^\s"'<>)]+/;
+
+export interface ProvisionExecOptions {
+  exec?: DaytonaExec;
+}
+
+export interface DesktopSandboxOptions {
+  ref: string;
+  name: string;
+  reuse?: string;
+  snapshot?: string;
+  log?: (line: string) => void;
+}
+
+export interface DesktopSandbox {
+  sandbox: string;
+  created: boolean;
+}
+
+export interface DenSandboxOptions {
+  ref: string;
+  reuse?: string;
+  repoRoot?: string;
+  log?: (line: string) => void;
+}
+
+export interface DenSandbox {
+  sandbox: string;
+  apiUrl: string;
+  webUrl: string;
+  created: boolean;
+}
+
+export interface MockOnSandboxOptions {
+  sandbox: string;
+  port?: number;
+  log?: (line: string) => void;
+  fetchImpl?: typeof fetch;
+}
+
+export interface MockOnSandbox {
+  url: string;
+}
+
+export interface ConnectorSpecEnv {
+  denApiUrl: string;
+  denWebUrl: string;
+  sandboxA: string;
+  sandboxB: string;
+  mockUrl: string;
+  ref: string;
+  created: string[];
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function outputTail(result: DaytonaExecResult): string {
+  return `${result.stdout}${result.stderr}`.trim().slice(-2_000);
+}
+
+function textTail(text: string): string {
+  return text.trim().slice(-4_000);
+}
+
+function firstHttpsUrl(text: string): string | null {
+  const match = HTTPS_URL.exec(text);
+  return match ? match[0].replace(/[.,;:]+$/, "") : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function timedStep<T>(log: (line: string) => void, name: string, action: () => Promise<T>): Promise<T> {
+  const startedAt = Date.now();
+  log(`==> ${name}...`);
+  try {
+    const result = await action();
+    log(`==> ${name} done (${Date.now() - startedAt}ms)`);
+    return result;
+  } catch (error) {
+    log(`==> ${name} failed (${Date.now() - startedAt}ms)`);
+    throw error;
+  }
+}
+
+/**
+ * daytona exec joins its trailing args with spaces, so a multi-word command
+ * must travel as ONE argument or `bash -lc` receives only the first word and
+ * the rest leaks into the remote login shell.
+ */
+async function execInSandbox(
+  exec: DaytonaExec,
+  sandbox: string,
+  script: string,
+  opts: { timeoutMs?: number; context: string },
+): Promise<DaytonaExecResult> {
+  if (script.includes("'")) throw new Error(`Remote script for ${opts.context} must not contain single quotes.`);
+  return checkedExec(exec, ["exec", sandbox, "--", `bash -lc '${script}'`], opts.context, { timeoutMs: opts.timeoutMs });
+}
+
+function snapshotId(output: string, name: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`Snapshot gate failed: daytona snapshot list returned invalid JSON: ${messageText(error)}. Output tail: ${textTail(output)}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Snapshot gate failed: daytona snapshot list did not return an array. Output tail: ${textTail(output)}`);
+  }
+  for (const entry of parsed) {
+    if (isRecord(entry) && entry.name === name && typeof entry.id === "string" && entry.id.length > 0) return entry.id;
+  }
+  return null;
+}
+
+function sandboxTimestamp(): string {
+  return new Date().toISOString().replace(/[-:]/g, "").replace("T", "-").slice(0, 15);
+}
+
+async function waitForExecReady(exec: DaytonaExec, sandbox: string): Promise<void> {
+  const deadline = Date.now() + DESKTOP_READY_TIMEOUT_MS;
+  let lastError = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      await execInSandbox(exec, sandbox, "true", { timeoutMs: 30_000, context: `sandbox exec-ready gate for ${sandbox}` });
+      return;
+    } catch (error) {
+      lastError = messageText(error);
+    }
+    await delay(5_000);
+  }
+  throw new Error(`Sandbox exec-ready gate failed for ${sandbox} after 300s. Last output: ${lastError}`);
+}
+
+function lastNonemptyLine(text: string): string {
+  return text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1) ?? "";
+}
+
+export async function provisionDesktopSandbox(options: DesktopSandboxOptions & ProvisionExecOptions): Promise<DesktopSandbox> {
+  const exec = options.exec ?? defaultDaytonaExec;
+  const log = options.log ?? console.error;
+  const reused = options.reuse?.trim() || "";
+  let sandbox = reused;
+
+  await timedStep(log, "sandbox gate", async () => {
+    if (reused) {
+      await exec(["sandbox", "start", reused], { timeoutMs: 60_000 });
+    } else {
+      const snapshot = options.snapshot ?? "openwork-eval-vnc";
+      const listed = await checkedExec(exec, ["snapshot", "list", "-f", "json"], "snapshot gate", { timeoutMs: 60_000 });
+      const id = snapshotId(listed.stdout, snapshot);
+      if (!id) {
+        throw new Error(`Snapshot gate failed: snapshot ${snapshot} is missing. Output tail: ${outputTail(listed)}`);
+      }
+      sandbox = `openwork-connector-${options.name}-${sandboxTimestamp()}`;
+      await checkedExec(
+        exec,
+        [
+          "create",
+          "--name", sandbox,
+          "--snapshot", id,
+          "--volume", "openwork-eval-secrets:/daytona-secrets",
+          "--auto-stop", "60",
+          "--public",
+          "--target", "us",
+        ],
+        `sandbox creation gate for ${sandbox}`,
+        { timeoutMs: 300_000 },
+      );
+      log(`==> desktop sandbox created: ${sandbox}`);
+    }
+    await waitForExecReady(exec, sandbox);
+  });
+
+  await timedStep(log, "checkout gate", async () => {
+    const result = await execInSandbox(
+      exec,
+      sandbox,
+      `set -e; cd /workspace; git fetch origin "${options.ref}" && git checkout --detach FETCH_HEAD; git rev-parse --short HEAD`,
+      { timeoutMs: 120_000, context: `checkout gate for ${sandbox}` },
+    );
+    const sha = lastNonemptyLine(result.stdout);
+    if (!sha) throw new Error(`Checkout gate failed for ${sandbox}: git did not print a resolved sha. Output tail: ${outputTail(result)}`);
+    log(`==> checkout resolved ${sha}`);
+  });
+
+  await timedStep(log, "install gate", async () => {
+    await execInSandbox(
+      exec,
+      sandbox,
+      "cd /workspace; pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store",
+      { timeoutMs: INSTALL_TIMEOUT_MS, context: `install gate for ${sandbox}` },
+    );
+  });
+
+  await timedStep(log, "cleanup and disk gate", async () => {
+    const result = await execInSandbox(
+      exec,
+      sandbox,
+      "rm -rf /workspace/.openwork-daytona/profiles /tmp/openwork-* 2>/dev/null; df -P /workspace | tail -1",
+      { timeoutMs: 60_000, context: `cleanup and disk gate for ${sandbox}` },
+    );
+    const dfLine = lastNonemptyLine(result.stdout);
+    const useField = dfLine.split(/\s+/).find((field) => /^\d+%$/.test(field));
+    if (!useField) {
+      throw new Error(`Cleanup and disk gate failed for ${sandbox}: could not parse Use% from ${JSON.stringify(dfLine)}.`);
+    }
+    const used = Number.parseInt(useField, 10);
+    if (used > 85) {
+      const sizes = await execInSandbox(
+        exec,
+        sandbox,
+        "du -sh /workspace/node_modules /workspace/.openwork-daytona/pnpm-store 2>&1 || true",
+        { timeoutMs: 60_000, context: `disk usage detail for ${sandbox}` },
+      );
+      throw new Error(`Cleanup and disk gate failed for ${sandbox}: workspace is ${useField} used. df: ${dfLine}\n${outputTail(sizes)}`);
+    }
+  });
+
+  await timedStep(log, "display gate", async () => {
+    const result = await execInSandbox(
+      exec,
+      sandbox,
+      "bash /workspace/.devcontainer/start-daytona-vnc.sh >/tmp/vnc.log 2>&1; sleep 2; pgrep -f Xvfb >/dev/null && echo XVFB_OK || echo XVFB_FAIL",
+      { timeoutMs: 60_000, context: `display gate for ${sandbox}` },
+    );
+    if (!result.stdout.includes("XVFB_OK")) {
+      throw new Error(`Display gate failed for ${sandbox}: expected XVFB_OK. Output tail: ${outputTail(result)}`);
+    }
+  });
+
+  await timedStep(log, "browser hop gate", async () => {
+    const result = await execInSandbox(
+      exec,
+      sandbox,
+      "export DISPLAY=:99; nohup python3 -m http.server 18099 --bind 127.0.0.1 >/tmp/xdgtest.log 2>&1 & sleep 1; (xdg-open http://127.0.0.1:18099/xdg-open-proof >/dev/null 2>&1 &); ok=0; for i in $(seq 1 30); do grep -q xdg-open-proof /tmp/xdgtest.log 2>/dev/null && ok=1 && break; sleep 1; done; pkill -f \"http.server 18099\" >/dev/null 2>&1; pkill -f chromium >/dev/null 2>&1; rm -f /tmp/xdgtest.log; [ $ok = 1 ] && echo XDG_OPEN_WORKS || echo XDG_OPEN_BROKEN",
+      { timeoutMs: 90_000, context: `browser hop gate for ${sandbox}` },
+    );
+    if (!result.stdout.includes("XDG_OPEN_WORKS")) {
+      throw new Error(`Browser hop gate failed for ${sandbox}: expected XDG_OPEN_WORKS. Output tail: ${outputTail(result)}`);
+    }
+  });
+
+  await timedStep(log, "Vite prewarm gate", async () => {
+    const detachScript = `cd /workspace; python3 - <<PYEOF
+import subprocess
+log = open("/tmp/vite-prewarm.log", "ab", buffering=0)
+subprocess.Popen(["bash", "-lc", "cd /workspace && pnpm -w dev:ui"], stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+    await execInSandbox(exec, sandbox, detachScript, { timeoutMs: 30_000, context: `Vite prewarm detach for ${sandbox}` });
+
+    const deadline = Date.now() + 180_000;
+    let last = "not attempted";
+    while (Date.now() < deadline) {
+      try {
+        const result = await execInSandbox(
+          exec,
+          sandbox,
+          "curl -s -o /dev/null -w %{http_code} --max-time 5 http://localhost:5173/",
+          { timeoutMs: 10_000, context: `Vite prewarm probe for ${sandbox}` },
+        );
+        last = result.stdout.trim();
+        if (last === "200") return;
+      } catch (error) {
+        last = messageText(error);
+      }
+      await delay(5_000);
+    }
+    const viteLog = await execInSandbox(
+      exec,
+      sandbox,
+      "tail -80 /tmp/vite-prewarm.log 2>&1 || true",
+      { timeoutMs: 30_000, context: `Vite prewarm log for ${sandbox}` },
+    );
+    throw new Error(`Vite prewarm gate failed for ${sandbox}: last probe ${last}. Log tail:\n${outputTail(viteLog)}`);
+  });
+
+  return { sandbox, created: !reused };
+}
+
+interface LocalProcessResult {
+  output: string;
+  code: number;
+}
+
+interface LineWriter {
+  push(text: string): void;
+  flush(): void;
+}
+
+function lineWriter(log: (line: string) => void): LineWriter {
+  let pending = "";
+  return {
+    push(text) {
+      pending += text;
+      const lines = pending.split(/\r?\n/);
+      pending = lines.pop() ?? "";
+      for (const line of lines) log(line);
+    },
+    flush() {
+      if (pending) log(pending);
+      pending = "";
+    },
+  };
+}
+
+function runDenProvisionScript(ref: string, repoRoot: string, log: (line: string) => void): Promise<LocalProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [".devcontainer/test-server-on-daytona.sh", ref, "--seed"], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutLines = lineWriter(log);
+    const stderrLines = lineWriter(log);
+    let output = "";
+    let timedOut = false;
+    let settled = false;
+    const timer = globalThis.setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, SERVER_SCRIPT_TIMEOUT_MS);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      const text = String(chunk);
+      output += text;
+      stdoutLines.push(text);
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = String(chunk);
+      output += text;
+      stderrLines.push(text);
+    });
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdoutLines.flush();
+      stderrLines.flush();
+      if (timedOut) output += `\nTimed out after ${SERVER_SCRIPT_TIMEOUT_MS}ms.`;
+      resolve({ output, code: timedOut ? 124 : code ?? 1 });
+    });
+  });
+}
+
+function sandboxFromServerOutput(output: string): string | null {
+  let fallback: string | null = null;
+  for (const line of output.split(/\r?\n/)) {
+    const ready = /Server sandbox ready:\s*(\S+)/.exec(line);
+    if (ready?.[1]) return ready[1];
+    const creating = /Creating server sandbox:\s*(\S+)/.exec(line);
+    if (creating?.[1]) fallback = creating[1];
+  }
+  return fallback;
+}
+
+function urlAfterLabels(output: string, labels: string[]): string | null {
+  for (const line of output.split(/\r?\n/)) {
+    if (labels.some((label) => line.includes(label))) {
+      const url = firstHttpsUrl(line);
+      if (url) return url;
+    }
+  }
+  return null;
+}
+
+async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Promise<string> {
+  const result = await checkedExec(
+    exec,
+    ["preview-url", sandbox, "-p", String(port)],
+    `preview URL gate for ${sandbox}:${port}`,
+    { timeoutMs: 60_000 },
+  );
+  const url = firstHttpsUrl(result.stdout);
+  if (!url) throw new Error(`Preview URL gate failed for ${sandbox}:${port}: no https URL in output tail: ${outputTail(result)}`);
+  return url;
+}
+
+async function proveDenSeed(apiUrl: string, sandbox: string, reused: boolean): Promise<void> {
+  const email = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+  const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD ?? "OpenWorkDemo123!";
+  const url = `${apiUrl.replace(/\/+$/, "")}/api/auth/sign-in/email`;
+  const deadline = Date.now() + 30_000;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password }),
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (response.status === 200) return;
+      last = `HTTP ${response.status}`;
+    } catch (error) {
+      last = messageText(error);
+    }
+    await delay(2_000);
+  }
+  if (reused) {
+    throw new Error(`Den seed proof failed for reused sandbox ${sandbox}: the Den has no seeded org. Omit --reuse-den to provision a seeded Den sandbox. Last: ${last}`);
+  }
+  throw new Error(`Den seed proof failed for ${sandbox}: ${email} could not sign in at ${apiUrl}. Last: ${last}`);
+}
+
+export async function provisionDenSandbox(options: DenSandboxOptions & ProvisionExecOptions): Promise<DenSandbox> {
+  const exec = options.exec ?? defaultDaytonaExec;
+  const log = options.log ?? console.error;
+  const reused = options.reuse?.trim() || "";
+  let sandbox: string;
+  let webUrl: string;
+  let apiUrl: string;
+
+  if (reused) {
+    sandbox = reused;
+    [webUrl, apiUrl] = await timedStep(log, "Den preview URL gate", () => Promise.all([
+      previewUrl(exec, sandbox, 3005),
+      previewUrl(exec, sandbox, 8788),
+    ]));
+  } else {
+    const result = await timedStep(log, "Den provisioning script", () => runDenProvisionScript(options.ref, options.repoRoot ?? REPO_ROOT, log));
+    if (result.code !== 0) {
+      throw new Error(`Den provisioning script gate failed with exit ${result.code}. Output tail:\n${textTail(result.output)}`);
+    }
+    const parsedSandbox = sandboxFromServerOutput(result.output);
+    if (!parsedSandbox) throw new Error(`Den provisioning script output is missing sandbox. Output tail:\n${textTail(result.output)}`);
+    const parsedWebUrl = urlAfterLabels(result.output, ["DEN_WEB_URL=", "Den Web:"]);
+    if (!parsedWebUrl) throw new Error(`Den provisioning script output is missing webUrl. Output tail:\n${textTail(result.output)}`);
+    const parsedApiUrl = urlAfterLabels(result.output, ["DEN_API_URL=", "Den API:"]);
+    if (!parsedApiUrl) throw new Error(`Den provisioning script output is missing apiUrl. Output tail:\n${textTail(result.output)}`);
+    sandbox = parsedSandbox;
+    webUrl = parsedWebUrl;
+    apiUrl = parsedApiUrl;
+  }
+
+  await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, sandbox, Boolean(reused)));
+  return { sandbox, apiUrl, webUrl, created: !reused };
+}
+
+export async function startMockOnSandbox(options: MockOnSandboxOptions & ProvisionExecOptions): Promise<MockOnSandbox> {
+  const exec = options.exec ?? defaultDaytonaExec;
+  const log = options.log ?? console.error;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const port = options.port ?? 3979;
+  const url = await timedStep(log, "mock preview URL gate", () => previewUrl(exec, options.sandbox, port));
+
+  await timedStep(log, "mock process cleanup", async () => {
+    await execInSandbox(
+      exec,
+      options.sandbox,
+      "pkill -f mock-oauth-mcp-server || true",
+      { timeoutMs: 30_000, context: `mock process cleanup for ${options.sandbox}` },
+    ).catch(() => undefined);
+  });
+
+  await timedStep(log, "mock process detach", async () => {
+    const detachScript = `cd /workspace; python3 - <<PYEOF
+import subprocess
+log = open("/tmp/mock-mcp.log", "ab", buffering=0)
+subprocess.Popen(["bash", "-lc", "cd /workspace && env HOST=0.0.0.0 PORT=${port} ISSUER=${url} AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs"], stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+    await execInSandbox(exec, options.sandbox, detachScript, { timeoutMs: 30_000, context: `mock process detach for ${options.sandbox}` });
+  });
+
+  await timedStep(log, "mock health gate", async () => {
+    const deadline = Date.now() + 60_000;
+    let last = "not attempted";
+    while (Date.now() < deadline) {
+      let body: unknown = null;
+      let responseOk = false;
+      try {
+        const response = await fetchImpl(`${url}/health`, { signal: AbortSignal.timeout(5_000) });
+        body = await response.json();
+        responseOk = response.ok;
+        if (!response.ok) last = `HTTP ${response.status}`;
+      } catch (error) {
+        last = messageText(error);
+      }
+      if (responseOk && isRecord(body) && body.ok === true) {
+        const issuer = typeof body.issuer === "string" ? body.issuer : JSON.stringify(body.issuer);
+        if (issuer !== url) throw new Error(`Mock issuer gate failed: health reported ${issuer}, expected ${url}.`);
+        return;
+      }
+      await delay(2_000);
+    }
+    const mockLog = await execInSandbox(
+      exec,
+      options.sandbox,
+      "tail -80 /tmp/mock-mcp.log 2>&1 || true",
+      { timeoutMs: 30_000, context: `mock health log for ${options.sandbox}` },
+    );
+    throw new Error(`Mock health gate failed at ${url}. Last: ${last}. Log tail:\n${outputTail(mockLog)}`);
+  });
+
+  return { url };
+}
+
+function deletionOutput(result: DaytonaExecResult): string {
+  return `${result.stderr}\n${result.stdout}`.trim();
+}
+
+function deletionNotFound(text: string): boolean {
+  return /not found|does not exist|no sandbox/i.test(text);
+}
+
+function unknownYesFlag(text: string): boolean {
+  return /unknown (?:option|flag)|unrecognized option/i.test(text) && text.includes("--yes");
+}
+
+export async function deleteSandboxes(
+  ids: string[],
+  options: ProvisionExecOptions & { log?: (line: string) => void } = {},
+): Promise<void> {
+  const exec = options.exec ?? defaultDaytonaExec;
+  const log = options.log ?? console.error;
+  for (const id of ids) {
+    log(`==> deleting sandbox ${id}...`);
+    let result = await exec(["delete", id, "--yes"], { timeoutMs: 60_000 });
+    let output = deletionOutput(result);
+    if (result.code !== 0 && deletionNotFound(output)) {
+      log(`==> sandbox ${id} not found; continuing`);
+      continue;
+    }
+    if (result.code !== 0 && unknownYesFlag(output)) {
+      result = await exec(["delete", id], { timeoutMs: 60_000, input: "y\n" });
+      output = deletionOutput(result);
+      if (result.code !== 0 && deletionNotFound(output)) {
+        log(`==> sandbox ${id} not found; continuing`);
+        continue;
+      }
+    }
+    if (result.code !== 0) throw new Error(`Sandbox deletion gate failed for ${id} with exit ${result.code}. Output tail: ${textTail(output)}`);
+    log(`==> deleted sandbox ${id}`);
+  }
+}
+
+export function renderConnectorSpecEnv(facts: ConnectorSpecEnv): string {
+  return [
+    `# provisioned for org-connector-two-members — generated ${new Date().toISOString()}; ref=${facts.ref}`,
+    `# provision-created=${facts.created.join(",")}`,
+    "OPENWORK_EVAL_APP_SPECS=1",
+    "OPENWORK_EVAL_CONNECTOR_SPEC=1",
+    `OPENWORK_EVAL_DEN_API_URL=${facts.denApiUrl}`,
+    `OPENWORK_EVAL_DEN_WEB_URL=${facts.denWebUrl}`,
+    `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${facts.sandboxA}`,
+    `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${facts.sandboxB}`,
+    `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${facts.mockUrl}`,
+    "OPENWORK_EVAL_MODEL=big-pickle",
+    "",
+  ].join("\n");
+}
+
+export function parseConnectorSpecEnv(content: string): ConnectorSpecEnv {
+  const values = new Map<string, string>();
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.startsWith("#")) continue;
+    const separator = line.indexOf("=");
+    if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  function required(name: string): string {
+    const value = values.get(name);
+    if (value === undefined || value.length === 0) throw new Error(`Missing ${name} in connector spec env.`);
+    return value;
+  }
+
+  required("OPENWORK_EVAL_APP_SPECS");
+  required("OPENWORK_EVAL_CONNECTOR_SPEC");
+  required("OPENWORK_EVAL_MODEL");
+  const ref = /^# provisioned for org-connector-two-members — generated .*; ref=(.*)$/m.exec(content)?.[1];
+  if (!ref) throw new Error("Missing ref in connector spec env header.");
+  const createdText = /^# provision-created=(.*)$/m.exec(content)?.[1];
+  if (createdText === undefined) throw new Error("Missing provision-created in connector spec env header.");
+
+  return {
+    denApiUrl: required("OPENWORK_EVAL_DEN_API_URL"),
+    denWebUrl: required("OPENWORK_EVAL_DEN_WEB_URL"),
+    sandboxA: required("OPENWORK_EVAL_DAYTONA_SANDBOX_A"),
+    sandboxB: required("OPENWORK_EVAL_DAYTONA_SANDBOX_B"),
+    mockUrl: required("OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL"),
+    ref,
+    created: createdText.split(",").map((id) => id.trim()).filter(Boolean),
+  };
+}

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -100,6 +100,22 @@ test("provisionDesktopSandbox resolves the snapshot id and creates with connecto
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
+test("rendered values are shell-quoted, because the env file is meant to be sourced", () => {
+  const nasty = "$(touch /tmp/pwned); echo it's-here";
+  const content = renderConnectorSpecEnv({
+    denApiUrl: "https://a",
+    denWebUrl: "https://w",
+    sandboxA: nasty,
+    sandboxB: "b",
+    mockUrl: "https://m",
+    ref: "dev",
+    created: [],
+  });
+
+  assert(content.includes(`OPENWORK_EVAL_DAYTONA_SANDBOX_A='$(touch /tmp/pwned); echo it'"'"'s-here'`));
+  assert.equal(parseConnectorSpecEnv(content).sandboxA, nasty);
+});
+
 test("an unsafe ref is refused before it can reach a remote shell or a sourced file", async () => {
   const { exec, calls } = desktopFake();
 

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -129,19 +129,19 @@ test("startMockOnSandbox rejects a health response with the wrong issuer", async
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
-test("deleteSandboxes retries without --yes when the Daytona CLI rejects the flag", async () => {
+test("deleteSandboxes answers the confirmation prompt and tolerates a missing sandbox", async () => {
   const calls: ExecCall[] = [];
   const exec: DaytonaExec = async (args, opts) => {
     calls.push({ args: [...args], opts });
-    if (args.includes("--yes")) return { stdout: "", stderr: "unknown flag: --yes", code: 1 };
+    if (args[1] === "gone-2") return { stdout: "", stderr: "sandbox not found", code: 1 };
     return { stdout: "deleted\n", stderr: "", code: 0 };
   };
 
-  await deleteSandboxes(["sandbox-1"], { exec, log: () => undefined });
+  await deleteSandboxes(["sandbox-1", "gone-2"], { exec, log: () => undefined });
 
   assert.deepEqual(calls.map((call) => call.args), [
-    ["delete", "sandbox-1", "--yes"],
     ["delete", "sandbox-1"],
+    ["delete", "gone-2"],
   ]);
-  assert.equal(calls[1]?.opts?.input, "y\n");
+  assert.equal(calls[0]?.opts?.input, "y\n");
 });

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -100,6 +100,27 @@ test("provisionDesktopSandbox resolves the snapshot id and creates with connecto
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
+test("an unsafe ref is refused before it can reach a remote shell or a sourced file", async () => {
+  const { exec, calls } = desktopFake();
+
+  for (const ref of ["dev\"; rm -rf /; #", "$(curl attacker)", "dev\nrm -rf /", "--upload-pack=evil"]) {
+    await assert.rejects(
+      provisionDesktopSandbox({ ref, name: "a", reuse: "existing-a", exec, log: () => undefined }),
+      /Unsafe git ref/,
+    );
+    assert.throws(() => renderConnectorSpecEnv({
+      denApiUrl: "https://a",
+      denWebUrl: "https://w",
+      sandboxA: "a",
+      sandboxB: "b",
+      mockUrl: "https://m",
+      ref,
+      created: [],
+    }), /Unsafe git ref/);
+  }
+  assert.equal(calls.length, 0, "an unsafe ref must be refused before any daytona call");
+});
+
 test("provisionDesktopSandbox fails the disk gate above 85 percent", async () => {
   const { exec } = desktopFake("92%");
 

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -37,6 +37,7 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("du -sh")) return { stdout: "8G /workspace/node_modules\n", stderr: "", code: 0 };
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
+    if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deleteSandboxes,
+  parseConnectorSpecEnv,
+  provisionDesktopSandbox,
+  renderConnectorSpecEnv,
+  startMockOnSandbox,
+} from "../src/provision.ts";
+import type { ConnectorSpecEnv } from "../src/provision.ts";
+import type { DaytonaExec } from "../src/daytona.ts";
+
+interface ExecCall {
+  args: string[];
+  opts?: { input?: string; timeoutMs?: number };
+}
+
+function desktopFake(diskUse = "40%"):
+  { exec: DaytonaExec; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const exec: DaytonaExec = async (args, opts) => {
+    calls.push({ args: [...args], opts });
+    if (args[0] === "sandbox" && args[1] === "start") {
+      return { stdout: "", stderr: "already started", code: 1 };
+    }
+    if (args[0] === "snapshot") {
+      return { stdout: JSON.stringify([{ name: "openwork-eval-vnc", id: "snapshot-123" }]), stderr: "", code: 0 };
+    }
+    if (args[0] !== "exec") return { stdout: "", stderr: "", code: 0 };
+
+    const script = args[3] ?? "";
+    if (script.includes("git rev-parse")) return { stdout: "abc1234\n", stderr: "", code: 0 };
+    if (script.includes("df -P")) {
+      return { stdout: `/dev/root 100 40 60 ${diskUse} /workspace\n`, stderr: "", code: 0 };
+    }
+    if (script.includes("du -sh")) return { stdout: "8G /workspace/node_modules\n", stderr: "", code: 0 };
+    if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
+    if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
+    if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { exec, calls };
+}
+
+function assertRemoteCommandsAreSingleArgument(calls: ExecCall[]): void {
+  for (const call of calls.filter((entry) => entry.args[0] === "exec")) {
+    assert.equal(call.args.length, 4);
+    assert(call.args[3]?.startsWith("bash -lc '"));
+  }
+}
+
+test("renderConnectorSpecEnv and parseConnectorSpecEnv round-trip the connector spec contract", () => {
+  const facts: ConnectorSpecEnv = {
+    denApiUrl: "https://den-api.example.test",
+    denWebUrl: "https://den-web.example.test",
+    sandboxA: "desktop-a",
+    sandboxB: "desktop-b",
+    mockUrl: "https://mock.example.test",
+    ref: "feat/eval-connector-two-members",
+    created: ["den", "desktop-a"],
+  };
+  const content = renderConnectorSpecEnv(facts);
+
+  assert.deepEqual(parseConnectorSpecEnv(content), facts);
+  assert.match(content, /^# provisioned for org-connector-two-members — generated .*; ref=feat\/eval-connector-two-members$/m);
+  assert.match(content, /^# provision-created=den,desktop-a$/m);
+  assert.match(content, /OPENWORK_EVAL_MODEL=big-pickle/);
+  const missingApi = content.split("\n").filter((line) => !line.startsWith("OPENWORK_EVAL_DEN_API_URL=")).join("\n");
+  assert.throws(() => parseConnectorSpecEnv(missingApi), /OPENWORK_EVAL_DEN_API_URL/);
+});
+
+test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in one argument", async () => {
+  const { exec, calls } = desktopFake();
+
+  const result = await provisionDesktopSandbox({ ref: "dev", name: "a", reuse: "existing-a", exec, log: () => undefined });
+
+  assert.deepEqual(result, { sandbox: "existing-a", created: false });
+  assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
+  assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
+  assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
+  assertRemoteCommandsAreSingleArgument(calls);
+});
+
+test("provisionDesktopSandbox resolves the snapshot id and creates with connector flags", async () => {
+  const { exec, calls } = desktopFake();
+
+  const result = await provisionDesktopSandbox({ ref: "dev", name: "b", exec, log: () => undefined });
+
+  assert.equal(result.created, true);
+  const create = calls.find((call) => call.args[0] === "create");
+  assert(create);
+  assert(create.args.includes("snapshot-123"));
+  assert(create.args.includes("--volume"));
+  assert(create.args.includes("openwork-eval-secrets:/daytona-secrets"));
+  assert(create.args.includes("--auto-stop"));
+  assert(create.args.includes("--public"));
+  assert.equal(calls.filter((call) => call.args[0] === "sandbox" && call.args[1] === "start").length, 0);
+  assertRemoteCommandsAreSingleArgument(calls);
+});
+
+test("provisionDesktopSandbox fails the disk gate above 85 percent", async () => {
+  const { exec } = desktopFake("92%");
+
+  await assert.rejects(
+    provisionDesktopSandbox({ ref: "dev", name: "a", reuse: "full-a", exec, log: () => undefined }),
+    /92%/,
+  );
+});
+
+test("startMockOnSandbox rejects a health response with the wrong issuer", async () => {
+  const calls: ExecCall[] = [];
+  const exec: DaytonaExec = async (args, opts) => {
+    calls.push({ args: [...args], opts });
+    if (args[0] === "preview-url") {
+      return { stdout: "Preview URL: https://mock.example.test\n", stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  const fetchImpl: typeof fetch = async () => new Response(
+    JSON.stringify({ ok: true, issuer: "https://wrong-issuer.example.test" }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+
+  await assert.rejects(
+    startMockOnSandbox({ sandbox: "den-1", exec, fetchImpl, log: () => undefined }),
+    /https:\/\/wrong-issuer\.example\.test.*https:\/\/mock\.example\.test/,
+  );
+  assertRemoteCommandsAreSingleArgument(calls);
+});
+
+test("deleteSandboxes retries without --yes when the Daytona CLI rejects the flag", async () => {
+  const calls: ExecCall[] = [];
+  const exec: DaytonaExec = async (args, opts) => {
+    calls.push({ args: [...args], opts });
+    if (args.includes("--yes")) return { stdout: "", stderr: "unknown flag: --yes", code: 1 };
+    return { stdout: "deleted\n", stderr: "", code: 0 };
+  };
+
+  await deleteSandboxes(["sandbox-1"], { exec, log: () => undefined });
+
+  assert.deepEqual(calls.map((call) => call.args), [
+    ["delete", "sandbox-1", "--yes"],
+    ["delete", "sandbox-1"],
+  ]);
+  assert.equal(calls[1]?.opts?.input, "y\n");
+});

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -92,8 +92,7 @@ test("provisionDesktopSandbox resolves the snapshot id and creates with connecto
   const create = calls.find((call) => call.args[0] === "create");
   assert(create);
   assert(create.args.includes("snapshot-123"));
-  assert(create.args.includes("--volume"));
-  assert(create.args.includes("openwork-eval-secrets:/daytona-secrets"));
+  assert(!create.args.includes("--volume"), "eval secrets must not be mounted next to an untrusted ref by default");
   assert(create.args.includes("--auto-stop"));
   assert(create.args.includes("--public"));
   assert.equal(calls.filter((call) => call.args[0] === "sandbox" && call.args[1] === "start").length, 0);
@@ -135,6 +134,15 @@ test("an unsafe ref is refused before it can reach a remote shell or a sourced f
     }), /Unsafe git ref/);
   }
   assert.equal(calls.length, 0, "an unsafe ref must be refused before any daytona call");
+});
+
+test("the eval secrets volume is mounted only when explicitly asked for", async () => {
+  const { exec, calls } = desktopFake();
+
+  await provisionDesktopSandbox({ ref: "dev", name: "b", secrets: true, exec, log: () => undefined });
+
+  const create = calls.find((call) => call.args[0] === "create");
+  assert(create?.args.includes("openwork-eval-secrets:/daytona-secrets"));
 });
 
 test("provisionDesktopSandbox fails the disk gate above 85 percent", async () => {

--- a/evals/scripts/provision-org-connector-two-members.ts
+++ b/evals/scripts/provision-org-connector-two-members.ts
@@ -1,0 +1,127 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+  deleteSandboxes,
+  parseConnectorSpecEnv,
+  provisionDenSandbox,
+  provisionDesktopSandbox,
+  renderConnectorSpecEnv,
+  startMockOnSandbox,
+} from "@openwork/hosts";
+import type { DesktopSandbox } from "@openwork/hosts";
+
+const USAGE = `Usage:
+  node scripts/provision-org-connector-two-members.ts --ref <branch-or-commit> [--reuse-a <id>] [--reuse-b <id>] [--reuse-den <id>] [--out org-connector-two-members.env]
+  node scripts/provision-org-connector-two-members.ts --delete <envfile>
+  node scripts/provision-org-connector-two-members.ts --help`;
+
+function prefixed(prefix: string, observe?: (line: string) => void): (line: string) => void {
+  return (line) => {
+    observe?.(line);
+    console.error(`[${prefix}] ${line}`);
+  };
+}
+
+async function deleteProvisioned(envFile: string): Promise<void> {
+  const facts = parseConnectorSpecEnv(await readFile(envFile, "utf8"));
+  await deleteSandboxes(facts.created);
+  const created = new Set(facts.created);
+  const leftAlone = [facts.sandboxA, facts.sandboxB].filter((sandbox) => !created.has(sandbox));
+  console.log(`Deleted: ${facts.created.join(", ") || "(none)"}`);
+  console.log(`Left alone: ${leftAlone.join(", ") || "(none recorded)"}`);
+}
+
+async function provisionSpecEnv(options: {
+  ref: string;
+  reuseA?: string;
+  reuseB?: string;
+  reuseDen?: string;
+  out: string;
+}): Promise<void> {
+  const created: string[] = [];
+  function recordCreated(sandbox: string): void {
+    if (!created.includes(sandbox)) created.push(sandbox);
+  }
+  try {
+    const denLog = prefixed("den", (line) => {
+      const match = /Creating server sandbox:\s*(\S+)/.exec(line);
+      if (match?.[1]) recordCreated(match[1]);
+    });
+    const den = await provisionDenSandbox({ ref: options.ref, reuse: options.reuseDen, log: denLog });
+    if (den.created) recordCreated(den.sandbox);
+
+    const mock = await startMockOnSandbox({ sandbox: den.sandbox, log: prefixed("mock") });
+    async function desktop(name: "a" | "b", reuse: string | undefined): Promise<DesktopSandbox> {
+      const desktopLog = prefixed(name, (line) => {
+        const match = /desktop sandbox created:\s*(\S+)/.exec(line);
+        if (match?.[1]) recordCreated(match[1]);
+      });
+      const result = await provisionDesktopSandbox({ ref: options.ref, name, reuse, log: desktopLog });
+      if (result.created) recordCreated(result.sandbox);
+      return result;
+    }
+    const [desktopA, desktopB] = await Promise.all([
+      desktop("a", options.reuseA),
+      desktop("b", options.reuseB),
+    ]);
+
+    await writeFile(options.out, renderConnectorSpecEnv({
+      denApiUrl: den.apiUrl,
+      denWebUrl: den.webUrl,
+      sandboxA: desktopA.sandbox,
+      sandboxB: desktopB.sandbox,
+      mockUrl: mock.url,
+      ref: options.ref,
+      created,
+    }), "utf8");
+
+    console.log(`Wrote ${resolve(options.out)}`);
+    console.log(`set -a; source ${options.out}; set +a`);
+    console.log("pnpm --dir evals exec vitest run --config vitest.config.ts --project nightly specs/org-connector-two-members.slow.test.ts");
+    console.log(`node scripts/provision-org-connector-two-members.ts --delete ${options.out}`);
+  } catch (error) {
+    console.error(`Provisioning failed. Provision-created sandboxes so far: ${created.join(", ") || "(none)"}`);
+    throw error;
+  }
+}
+
+async function main(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      ref: { type: "string" },
+      "reuse-a": { type: "string" },
+      "reuse-b": { type: "string" },
+      "reuse-den": { type: "string" },
+      out: { type: "string" },
+      delete: { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    console.log(USAGE);
+    return;
+  }
+  if (values.delete) {
+    await deleteProvisioned(values.delete);
+    return;
+  }
+  if (!values.ref) throw new Error(`--ref is required.\n\n${USAGE}`);
+  await provisionSpecEnv({
+    ref: values.ref,
+    reuseA: values["reuse-a"],
+    reuseB: values["reuse-b"],
+    reuseDen: values["reuse-den"],
+    out: values.out ?? "org-connector-two-members.env",
+  });
+}
+
+main(process.argv.slice(2)).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -12,6 +12,6 @@
     "skipLibCheck": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["runner/**/*.ts", "flows/**/*.ts", "packages/**/*.ts", "specs/**/*.ts", "vitest.config.ts"],
+  "include": ["runner/**/*.ts", "flows/**/*.ts", "packages/**/*.ts", "scripts/**/*.ts", "specs/**/*.ts", "vitest.config.ts"],
   "exclude": ["results"]
 }


### PR DESCRIPTION
Turns the ~50 minutes of hand-orchestration behind `org-connector-two-members` into primitives plus one command. **Provisioning is proven; the spec's tool-call phase off a *fresh* room is not yet reproducible — details at the bottom, stated plainly.**

## Primitives, one job each (`@openwork/hosts`)

Nothing knows how many sandboxes a topology needs; the caller does, the way the spec already knows it has two members.

```ts
provisionDenSandbox({ ref, reuse? })            // server script + seed, sign-in PROVEN before it returns
provisionDesktopSandbox({ ref, name, reuse? })  // create-or-reuse → checkout(asserted) → install →
                                                //   disk gate → display → browser-hop proof → first boot → Vite
startMockOnSandbox({ sandbox, port? })          // public-issuer mock, health + issuer asserted
deleteSandboxes(ids)
renderConnectorSpecEnv / parseConnectorSpecEnv
```

`evals/scripts/provision-org-connector-two-members.ts` is just the caller: four primitive calls, a file write, and `--delete`. A second heavy spec gets its own ~10-line caller reusing the same primitives.

```
node scripts/provision-org-connector-two-members.ts --ref <ref>     # ~4m45s → writes the env file
set -a; source org-connector-two-members.env; set +a
pnpm --dir evals exec vitest run --project nightly specs/org-connector-two-members.slow.test.ts
node scripts/provision-org-connector-two-members.ts --delete org-connector-two-members.env
```

## `--seed` (the divergence that can't happen again)

The seed is a separate process from den-api and each computed signup policy from its *own* env. Seeded by hand with a missing `DEN_ORG_MODE`, it refused email signup while the API allowed it. It now runs inside `start-daytona-server.sh` with the same env the API got, is idempotent (sign-in probe first), and fails loudly with `/tmp/den-seed.log`.

## Six bugs, every one found by running it

| # | Symptom | Cause |
|---|---|---|
| 1 | seed: "Email signup is disabled" | seed env diverged from the API's — folded into `--seed` |
| 2 | proof gave up at 30s, said nothing | 30s window, response body discarded → 120s + body kept |
| 3 | `403` on a fresh stack | body named it: `MISSING_OR_NULL_ORIGIN`. Every real client sends `Origin`; only my probe didn't |
| 4 | browser-hop gate `exit 143` @2.5s | chromium started **inside** a pipe-stdin `daytona exec` session TERMs the session (identical script survives under a TTY) → both halves fully detached, childless polls read the proof |
| 5 | sandbox silently ran the **wrong tree** | `checkout --detach FETCH_HEAD` after a refused raw-sha fetch left FETCH_HEAD stale, and the "resolved" log line lied. Now checks out the requested ref and **asserts** the sha — it caught two mispins within the hour and invalidated a bisect I was about to trust |
| 6 | first spec on a fresh box lost its tool-call window | first Electron boot pays sidecar prepare + `openwork-server` tsc + engine cold start. Now paid by a throwaway warmup profile during provisioning |

Bug 5 also **exonerated a suspect**: this looked like a product regression in #3409 (KaTeX) until an A/B/A repin ran dev-tip green on a warm room. No product bug; the mispin had faked the bisect.

## Verification

- `pnpm exec tsc -p evals` clean; `pnpm --dir evals run test` **101 pass / 0 fail** (6 new: single-argument law, disk gate, issuer mismatch, prompt-answering deletion, env round-trip, reuse-vs-create).
- Provisioning from scratch, one command, **repeated**: ~2m09s (pre-warmup-gate) and ~4m45s (with it). Every gate logs its duration.
- `--delete` exercised twice end to end: removes only `# provision-created=` ids, leaves reused boxes alone.
- Spec **green twice** — 116.8s and 121.0s — against a room whose den, mock, and both desktops were built by these primitives.

## What is NOT proven (the honest gap)

Against the **newest fully-fresh room**, the spec failed twice at the same place: member A's `mock_echo` reaches the connector, member B's never does inside the 240s window. Those runs were also ~3× slower end to end (333s / 338s) than the greens (117s / 121s). Ghost processes and memory pressure are ruled out (checked); the cause is unknown. The greens above came from a room that had been through extra prep cycles, so **"fresh room → green spec" is not yet reproducible in one shot.**

I'm calling that out rather than burying it: this PR makes the room reproducible and every trap self-naming, and it leaves that last flake documented for the next session instead of implied to be solved.

## Follow-up this unlocks

Driver-side bash is now duplicated by the primitives: `test-server-on-daytona.sh` (~147 lines) and ~60% of `test-on-daytona.sh` become thin wrappers or disappear. Not done here — 13 skills, a CI workflow, and ~10 docs name those scripts, so that migration is its own PR. In-sandbox scripts (`start-daytona-*.sh`) stay bash by necessity.
