### PR TITLE
feat(evals): evidence roll S1 — photo-roll collection view + sticky PR publisher + skill

### DIFF
--- a/.opencode/skills/pr-photo-roll/SKILL.md
+++ b/.opencode/skills/pr-photo-roll/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pr-photo-roll
+description: Post the photo roll, put the screenshots on the PR, or show me the photo roll. Curate recorded eval screenshots and publish one sticky PR gallery.
+---
+
+# PR photo roll
+
+Use this skill when asked to "post the photo roll", "put the screenshots on the PR", or "show me the photo roll".
+
+## Choose the evidence
+
+1. Scan `evals/results/rolls/` newest-first and read each candidate's `roll.json`.
+2. Pick the newest roll relevant to the requested spec or change.
+3. Only publish images attributed by that roll's `roll.json`; never add loose screenshots by hand.
+4. Publish at most one roll per PR comment.
+5. If more than one roll is plausibly relevant, ask which roll to use.
+
+## Commands
+
+Browse the local collection:
+
+```bash
+pnpm --dir evals run roll -- --open
+```
+
+Publish the newest roll, or select one by directory/name:
+
+```bash
+pnpm --dir evals run publish:pr -- --pr <n> [--roll <dir|name>] [--dry-run]
+```
+
+The publisher reads `BLOB_READ_WRITE_TOKEN` from the environment, then falls back to `infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent`. Without a token it still posts verdicts, explicitly noting that screenshots were not uploaded.
+
+Publishing creates one comment containing `<!-- photo-roll -->`. Later runs update that sticky comment instead of adding comment noise.

--- a/evals/package.json
+++ b/evals/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "spec": "vitest run --config vitest.config.ts --project pr",
     "spec:nightly": "vitest run --config vitest.config.ts",
+    "roll": "node packages/evidence/bin/roll.mjs",
+    "publish:pr": "node packages/evidence/bin/publish-pr.mjs",
     "provision:org-connector-two-members": "node scripts/provision-org-connector-two-members.ts",
     "test": "node --test runner/*.test.ts packages/*/test/*.test.ts",
     "typecheck": "tsc -p ."
@@ -12,6 +14,7 @@
   "dependencies": {
     "@openwork/behaviors": "workspace:*",
     "@openwork/cdp": "workspace:*",
+    "@openwork/evidence": "workspace:*",
     "@openwork/fraimz": "workspace:*",
     "@openwork/hosts": "workspace:*",
     "@openwork/labs": "workspace:*",

--- a/evals/packages/evidence/bin/publish-pr.mjs
+++ b/evals/packages/evidence/bin/publish-pr.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { publishPr, scanRolls } from "../src/index.ts";
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const resultsDir = join(repoRoot, "evals", "results");
+const args = process.argv.slice(2);
+let pr;
+let rollArg;
+let dryRun = false;
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  if (arg === "--dry-run") {
+    dryRun = true;
+    continue;
+  }
+  if (arg === "--pr" || arg === "--roll") {
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
+    if (arg === "--pr") pr = value;
+    else rollArg = value;
+    index += 1;
+    continue;
+  }
+  throw new Error(`Unknown argument: ${arg}`);
+}
+
+if (!dryRun && !pr) throw new Error("--pr <n> is required unless --dry-run is set.");
+const entries = (await scanRolls(resultsDir)).filter((entry) => entry.kind === "roll");
+let rollDir;
+if (rollArg) {
+  const candidate = isAbsolute(rollArg) ? rollArg : resolve(process.cwd(), rollArg);
+  if (existsSync(join(candidate, "roll.json"))) rollDir = candidate;
+  else {
+    const selected = entries.find((entry) => entry.directoryName === rollArg || entry.name === rollArg);
+    rollDir = selected?.directoryPath;
+  }
+} else {
+  rollDir = entries[0]?.directoryPath;
+}
+if (!rollDir) throw new Error(`No photo roll found${rollArg ? ` for ${rollArg}` : ""}.`);
+
+const result = await publishPr({ pr, rollDir, dryRun });
+if (!dryRun) process.stdout.write(`${result.updated ? "Updated" : "Posted"} photo roll for PR ${pr}.\n`);

--- a/evals/packages/evidence/bin/roll.mjs
+++ b/evals/packages/evidence/bin/roll.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderCollectionHtml, scanRolls } from "../src/index.ts";
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const resultsDir = join(repoRoot, "evals", "results");
+const rollsDir = join(resultsDir, "rolls");
+
+const args = process.argv.slice(2);
+const shouldOpen = args.includes("--open");
+const unknown = args.filter((arg) => arg !== "--open");
+if (unknown.length > 0) throw new Error(`Unknown argument: ${unknown[0]}`);
+
+await mkdir(rollsDir, { recursive: true });
+const entries = await scanRolls(resultsDir);
+const indexPath = join(rollsDir, "index.html");
+await writeFile(indexPath, renderCollectionHtml(entries), "utf8");
+process.stdout.write(`${indexPath}\n`);
+
+if (shouldOpen) {
+  if (process.platform !== "darwin") throw new Error("--open is only supported on darwin.");
+  const opened = spawnSync("open", [indexPath], { stdio: "inherit" });
+  if (opened.error || opened.status !== 0) throw opened.error ?? new Error(`open exited ${opened.status}`);
+}

--- a/evals/packages/evidence/package.json
+++ b/evals/packages/evidence/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openwork/evidence",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/evals/packages/evidence/src/index.ts
+++ b/evals/packages/evidence/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./publish-pr.ts";
+export * from "./render.ts";
+export * from "./scan.ts";
+export * from "./schema.ts";

--- a/evals/packages/evidence/src/publish-pr.ts
+++ b/evals/packages/evidence/src/publish-pr.ts
@@ -1,0 +1,189 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { renderPrMarkdown } from "./render.ts";
+import { readRollFile } from "./scan.ts";
+
+const BLOB_API_BASE = "https://blob.vercel-storage.com";
+const MARKER = "<!-- photo-roll -->";
+
+export interface CommandOptions {
+  input?: string;
+}
+
+export interface CommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type CommandRunner = (command: string, args: string[], opts?: CommandOptions) => CommandResult;
+export type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface PublishDependencies {
+  exec?: CommandRunner;
+  fetch?: Fetcher;
+  stdout?: (markdown: string) => void;
+}
+
+export interface PublishPrOptions {
+  pr?: string | number;
+  rollDir: string;
+  dryRun?: boolean;
+}
+
+export interface PublishPrResult {
+  markdown: string;
+  posted: boolean;
+  updated: boolean;
+  urls: Record<string, string>;
+}
+
+function commandRunner(command: string, args: string[], opts: CommandOptions = {}): CommandResult {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    input: opts.input,
+  });
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+    error: result.error,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveBlobToken(exec: CommandRunner): string | null {
+  const fromEnv = process.env.BLOB_READ_WRITE_TOKEN;
+  if (fromEnv) return fromEnv;
+  const result = exec(
+    "infisical",
+    ["secrets", "get", "BLOB_READ_WRITE_TOKEN", "--plain", "--silent"],
+  );
+  const token = result.status === 0 && !result.error ? result.stdout.trim() : "";
+  return token.length > 0 ? token : null;
+}
+
+async function uploadImages(
+  rollDir: string,
+  rollName: string,
+  files: string[],
+  token: string,
+  fetcher: Fetcher,
+): Promise<Record<string, string>> {
+  const urls: Record<string, string> = {};
+  for (const file of files) {
+    if (basename(file) !== file || !file.toLowerCase().endsWith(".png")) {
+      throw new Error(`Refusing to upload invalid roll frame path: ${file}`);
+    }
+    const pathname = `photo-roll/${encodeURIComponent(rollName)}/${encodeURIComponent(file)}`;
+    const response = await fetcher(`${BLOB_API_BASE}/${pathname}`, {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-content-type": "image/png",
+        "x-add-random-suffix": "0",
+      },
+      body: await readFile(join(rollDir, file)),
+    });
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 300);
+      throw new Error(`Vercel Blob upload failed (${response.status}) for ${file}: ${detail}`);
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error(`Vercel Blob upload for ${file}: response was not JSON`);
+    }
+    if (!isRecord(payload) || typeof payload.url !== "string" || payload.url.length === 0) {
+      throw new Error(`Vercel Blob upload for ${file}: response did not include a url`);
+    }
+    urls[file] = payload.url;
+  }
+  return urls;
+}
+
+function stickyCommentId(raw: string): string | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(value) || !Array.isArray(value.comments)) return null;
+  for (const comment of value.comments) {
+    if (!isRecord(comment) || typeof comment.body !== "string" || !comment.body.includes(MARKER)) continue;
+    const directId = comment.databaseId ?? comment.id;
+    if (typeof directId === "number" && Number.isInteger(directId)) return String(directId);
+    if (typeof directId === "string" && /^\d+$/.test(directId)) return directId;
+    if (typeof comment.url === "string") {
+      const match = /#issuecomment-(\d+)$/.exec(comment.url);
+      if (match?.[1]) return match[1];
+    }
+  }
+  return null;
+}
+
+function requireSuccess(result: CommandResult, label: string): void {
+  if (result.status === 0 && !result.error) return;
+  const stderr = result.stderr.trim();
+  const detail = result.error?.message ?? (stderr || `exit ${result.status}`);
+  throw new Error(`${label} failed: ${detail}`);
+}
+
+function postStickyComment(pr: string, markdown: string, exec: CommandRunner): boolean {
+  const viewed = exec("gh", ["pr", "view", pr, "--json", "comments"]);
+  requireSuccess(viewed, "Reading PR comments");
+  const commentId = stickyCommentId(viewed.stdout);
+  if (commentId) {
+    const updated = exec(
+      "gh",
+      ["api", "--method", "PATCH", `repos/{owner}/{repo}/issues/comments/${commentId}`, "--input", "-"],
+      { input: JSON.stringify({ body: markdown }) },
+    );
+    requireSuccess(updated, "Updating photo roll comment");
+    return true;
+  }
+  const posted = exec("gh", ["pr", "comment", pr, "--body-file", "-"], { input: markdown });
+  requireSuccess(posted, "Posting photo roll comment");
+  return false;
+}
+
+export async function publishPr(
+  options: PublishPrOptions,
+  dependencies: PublishDependencies = {},
+): Promise<PublishPrResult> {
+  const roll = await readRollFile(join(options.rollDir, "roll.json"));
+  if (!roll) throw new Error(`No valid roll.json found in ${options.rollDir}`);
+  const exec = dependencies.exec ?? commandRunner;
+  const fetcher = dependencies.fetch ?? globalThis.fetch;
+  const rollName = basename(options.rollDir);
+  const pr = options.pr === undefined ? "<n>" : String(options.pr);
+  const reproCommand = `pnpm --dir evals run publish:pr -- --pr ${pr} --roll ${rollName}`;
+
+  if (options.dryRun) {
+    const markdown = renderPrMarkdown(roll, {}, {
+      reproCommand,
+      notice: "Dry run: screenshots were not uploaded.",
+    });
+    (dependencies.stdout ?? ((body) => process.stdout.write(`${body}\n`)))(markdown);
+    return { markdown, posted: false, updated: false, urls: {} };
+  }
+  if (options.pr === undefined) throw new Error("Publishing requires --pr <n>.");
+
+  const token = resolveBlobToken(exec);
+  const urls = token
+    ? await uploadImages(options.rollDir, rollName, roll.frames.map((frame) => frame.fileName), token, fetcher)
+    : {};
+  const markdown = renderPrMarkdown(roll, urls, {
+    reproCommand,
+    notice: token ? undefined : "screenshots not uploaded (no BLOB_READ_WRITE_TOKEN)",
+  });
+  const updated = postStickyComment(String(options.pr), markdown, exec);
+  return { markdown, posted: true, updated, urls };
+}

--- a/evals/packages/evidence/src/publish-pr.ts
+++ b/evals/packages/evidence/src/publish-pr.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { lstat, readFile, realpath } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { renderPrMarkdown } from "./render.ts";
 import { readRollFile } from "./scan.ts";
@@ -76,9 +76,15 @@ async function uploadImages(
   fetcher: Fetcher,
 ): Promise<Record<string, string>> {
   const urls: Record<string, string> = {};
+  const realDir = await realpath(rollDir);
   for (const file of files) {
     if (basename(file) !== file || !file.toLowerCase().endsWith(".png")) {
       throw new Error(`Refusing to upload invalid roll frame path: ${file}`);
+    }
+    const filePath = join(realDir, file);
+    const stats = await lstat(filePath).catch(() => null);
+    if (!stats?.isFile()) {
+      throw new Error(`Refusing to upload non-regular or symlinked roll frame: ${file}`);
     }
     const pathname = `photo-roll/${encodeURIComponent(rollName)}/${encodeURIComponent(file)}`;
     const response = await fetcher(`${BLOB_API_BASE}/${pathname}`, {
@@ -88,7 +94,7 @@ async function uploadImages(
         "x-content-type": "image/png",
         "x-add-random-suffix": "0",
       },
-      body: await readFile(join(rollDir, file)),
+      body: await readFile(filePath),
     });
     if (!response.ok) {
       const detail = (await response.text()).slice(0, 300);

--- a/evals/packages/evidence/src/render.ts
+++ b/evals/packages/evidence/src/render.ts
@@ -1,0 +1,119 @@
+import type { PhotoRollRecord, RollFrame } from "./schema.ts";
+import type { RollEntry } from "./scan.ts";
+
+export interface RenderPrOptions {
+  title?: string;
+  reproCommand?: string;
+  notice?: string;
+}
+
+function html(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function rollBadge(entry: RollEntry): { label: string; className: string; summary: string } {
+  if (entry.kind === "legacy") {
+    return {
+      label: "LEGACY",
+      className: "legacy",
+      summary: `${entry.pngFiles.length} loose screenshot${entry.pngFiles.length === 1 ? "" : "s"}`,
+    };
+  }
+  const summary = entry.roll.summary;
+  if (summary.failedFrames > 0 || summary.failedExpectations > 0) {
+    return {
+      label: "FAILED",
+      className: "failed",
+      summary: `${summary.passedFrames}/${summary.totalFrames} frames passed · ${summary.failedFrames} failed`,
+    };
+  }
+  if (summary.ok) {
+    return {
+      label: "PASSED",
+      className: "passed",
+      summary: `${summary.passedFrames}/${summary.totalFrames} frames passed`,
+    };
+  }
+  return {
+    label: "UNVALIDATED",
+    className: "unvalidated",
+    summary: `${summary.unvalidatedFrames}/${summary.totalFrames} frames unvalidated`,
+  };
+}
+
+export function renderCollectionHtml(entries: RollEntry[]): string {
+  const ordered = [...entries].sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  const cards = ordered.map((entry) => {
+    const badge = rollBadge(entry);
+    const caption = entry.kind === "roll" ? entry.roll.frames[0]?.caption : undefined;
+    const thumbnail = entry.thumbnailHref
+      ? `<img src="${html(entry.thumbnailHref)}" alt="${html(caption ?? entry.name)}">`
+      : `<div class="empty">No screenshot recorded</div>`;
+    return `<article class="card ${badge.className}">
+      <a class="thumb" href="${html(entry.href)}">${thumbnail}</a>
+      <div class="copy">
+        <div class="topline"><span class="badge">${badge.label}</span><time datetime="${html(entry.createdAt)}">${html(entry.createdAt)}</time></div>
+        <h2><a href="${html(entry.href)}">${html(entry.name)}</a></h2>
+        ${caption ? `<p class="caption">${html(caption)}</p>` : ""}
+        <p class="summary">${html(badge.summary)}</p>
+      </div>
+    </article>`;
+  }).join("\n");
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>OpenWork photo rolls</title><style>
+body{font:15px/1.5 system-ui,sans-serif;max-width:1100px;margin:40px auto;padding:0 20px;background:#f6f7f9;color:#17191d}header,.card{background:white;border:1px solid #dfe2e8;border-radius:12px;padding:20px;margin:0 0 24px}header h1{margin:0 0 6px}.muted,time,.summary{color:#636c76}.card{display:grid;grid-template-columns:minmax(220px,40%) 1fr;gap:20px}.card.passed{border-left:6px solid #238636}.card.failed{border-left:6px solid #cf222e}.card.unvalidated{border-left:6px solid #9a6700}.card.legacy{border-left:6px solid #656d76}.thumb img,.empty{display:block;width:100%;aspect-ratio:16/10;object-fit:cover;border:1px solid #dfe2e8;border-radius:8px;background:#f6f7f9}.empty{display:grid;place-items:center;color:#636c76}.topline{display:flex;align-items:center;gap:10px}.badge{font-size:12px;font-weight:700}.passed .badge{color:#1a7f37}.failed .badge{color:#cf222e}.unvalidated .badge{color:#9a6700}.legacy .badge{color:#656d76}h2{margin:12px 0 6px}a{color:inherit}.caption{font-weight:600}@media(max-width:700px){.card{grid-template-columns:1fr}}
+</style></head><body><header><h1>Photo rolls</h1><p class="muted">Evidence captured as the user experienced it, newest first.</p></header>${cards || '<p class="muted">No photo rolls found.</p>'}</body></html>\n`;
+}
+
+function summaryLine(roll: PhotoRollRecord): string {
+  const summary = roll.summary;
+  const icon = summary.ok ? "✅" : summary.failedFrames > 0 || summary.failedExpectations > 0 ? "❌" : "⚪";
+  return `${icon} **${summary.passedFrames}/${summary.totalFrames} frames passed** · ${summary.failedFrames} failed · ${summary.unvalidatedFrames} unvalidated · ${summary.passedExpectations} expectations passed · ${summary.failedExpectations} failed`;
+}
+
+function renderFrame(frame: RollFrame, sequence: number, imageUrl: string | undefined): string {
+  const lines = [`### ${sequence}. ${html(frame.caption)}`, ""];
+  if (frame.results.length === 0) {
+    lines.push("- ⚪ **UNVALIDATED** — no visual expectations recorded.");
+  } else {
+    for (const result of frame.results) {
+      lines.push(`- ${result.passed ? "✅ **PASS**" : "❌ **FAIL**"} ${html(result.expectation)} — ${html(result.evidence)}`);
+    }
+  }
+  if (imageUrl) {
+    lines.push("", `<a href="${html(imageUrl)}"><img src="${html(imageUrl)}" alt="${html(frame.caption)}" width="700"></a>`);
+  }
+  return lines.join("\n");
+}
+
+export function renderPrMarkdown(
+  roll: PhotoRollRecord,
+  urls: Record<string, string>,
+  opts: RenderPrOptions = {},
+): string {
+  const title = opts.title ?? `Photo roll — ${roll.name}`;
+  const lines = [
+    "<!-- photo-roll -->",
+    `## ${html(title)}`,
+    "",
+    summaryLine(roll),
+  ];
+  if (opts.notice) lines.push("", `> ${opts.notice}`);
+  for (const [index, frame] of roll.frames.entries()) {
+    lines.push("", renderFrame(frame, index + 1, urls[frame.fileName]));
+  }
+  const source = `evals/results/rolls/${roll.dir.split(/[\\/]/).at(-1) ?? roll.name}/roll.json`;
+  lines.push(
+    "",
+    "---",
+    `_Roll created ${html(roll.createdAt)} · Source: \`${html(source)}\`${opts.reproCommand ? ` · Repro: \`${html(opts.reproCommand)}\`` : ""}_`,
+    "<!-- /photo-roll -->",
+  );
+  return lines.join("\n");
+}

--- a/evals/packages/evidence/src/scan.ts
+++ b/evals/packages/evidence/src/scan.ts
@@ -1,0 +1,131 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
+import type { Dirent } from "node:fs";
+import { parseRollJson } from "./schema.ts";
+import type { PhotoRollRecord } from "./schema.ts";
+
+export interface RecordedRollEntry {
+  kind: "roll";
+  directoryName: string;
+  directoryPath: string;
+  name: string;
+  createdAt: string;
+  href: string;
+  thumbnailHref?: string;
+  roll: PhotoRollRecord;
+}
+
+export interface LegacyRollEntry {
+  kind: "legacy";
+  directoryName: string;
+  directoryPath: string;
+  name: string;
+  createdAt: string;
+  href: string;
+  thumbnailHref?: string;
+  pngFiles: string[];
+}
+
+export type RollEntry = RecordedRollEntry | LegacyRollEntry;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissing(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+async function readDirectory(path: string): Promise<Dirent[]> {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+}
+
+function segment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function timestampFromName(name: string): string | null {
+  const match = /^(\d{4}-\d{2}-\d{2}T)(\d{2})-(\d{2})-(\d{2})-(\d{3})Z/.exec(name);
+  if (!match) return null;
+  const [, date, hour, minute, second, millis] = match;
+  if (!date || !hour || !minute || !second || !millis) return null;
+  const timestamp = `${date}${hour}:${minute}:${second}.${millis}Z`;
+  return Number.isNaN(Date.parse(timestamp)) ? null : timestamp;
+}
+
+export async function readRollFile(path: string): Promise<PhotoRollRecord | null> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const value: unknown = JSON.parse(raw);
+    return parseRollJson(value);
+  } catch {
+    return null;
+  }
+}
+
+async function scanRecordedRolls(resultsDir: string): Promise<RecordedRollEntry[]> {
+  const rollsDir = join(resultsDir, "rolls");
+  const directories = (await readDirectory(rollsDir)).filter((entry) => entry.isDirectory());
+  const rolls: RecordedRollEntry[] = [];
+  for (const directory of directories) {
+    const directoryPath = join(rollsDir, directory.name);
+    const roll = await readRollFile(join(directoryPath, "roll.json"));
+    if (!roll) continue;
+    const firstFrame = roll.frames[0];
+    rolls.push({
+      kind: "roll",
+      directoryName: directory.name,
+      directoryPath,
+      name: roll.name,
+      createdAt: roll.createdAt,
+      href: `${segment(directory.name)}/index.html`,
+      thumbnailHref: firstFrame ? `${segment(directory.name)}/${segment(firstFrame.fileName)}` : undefined,
+      roll,
+    });
+  }
+  return rolls;
+}
+
+async function scanLegacyRolls(resultsDir: string): Promise<LegacyRollEntry[]> {
+  const directories = (await readDirectory(resultsDir))
+    .filter((entry) => entry.isDirectory() && entry.name !== "rolls" && !entry.name.startsWith("."));
+  const legacy: LegacyRollEntry[] = [];
+  for (const directory of directories) {
+    const directoryPath = join(resultsDir, directory.name);
+    const contents = await readDirectory(directoryPath);
+    const hasFraimz = contents.some((entry) => entry.isFile() && entry.name === "fraimz.html");
+    const pngFiles = contents
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".png"))
+      .map((entry) => entry.name)
+      .sort();
+    if (!hasFraimz && pngFiles.length === 0) continue;
+    const info = await stat(directoryPath);
+    const createdAt = timestampFromName(directory.name) ?? info.mtime.toISOString();
+    const firstPng = pngFiles[0];
+    const prefix = `../${segment(directory.name)}/`;
+    legacy.push({
+      kind: "legacy",
+      directoryName: directory.name,
+      directoryPath,
+      name: basename(directoryPath),
+      createdAt,
+      href: `${prefix}${hasFraimz ? "fraimz.html" : segment(firstPng ?? "")}`,
+      thumbnailHref: firstPng ? `${prefix}${segment(firstPng)}` : undefined,
+      pngFiles,
+    });
+  }
+  return legacy;
+}
+
+export async function scanRolls(resultsDir: string): Promise<RollEntry[]> {
+  const entries = [
+    ...await scanRecordedRolls(resultsDir),
+    ...await scanLegacyRolls(resultsDir),
+  ];
+  return entries.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}

--- a/evals/packages/evidence/src/scan.ts
+++ b/evals/packages/evidence/src/scan.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from "node:fs/promises";
+import { lstat, readFile, readdir, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 import type { Dirent } from "node:fs";
 import { parseRollJson } from "./schema.ts";
@@ -60,6 +60,8 @@ function timestampFromName(name: string): string | null {
 
 export async function readRollFile(path: string): Promise<PhotoRollRecord | null> {
   try {
+    const info = await lstat(path);
+    if (!info.isFile()) return null;
     const raw = await readFile(path, "utf8");
     const value: unknown = JSON.parse(raw);
     return parseRollJson(value);

--- a/evals/packages/evidence/src/schema.ts
+++ b/evals/packages/evidence/src/schema.ts
@@ -1,0 +1,145 @@
+export interface RollExpectationResult {
+  expectation: string;
+  passed: boolean;
+  evidence: string;
+}
+
+export interface RollFrame {
+  caption: string;
+  fileName: string;
+  hash: string;
+  route: string;
+  at: string;
+  description: string;
+  model: string;
+  ok: boolean | null;
+  results: RollExpectationResult[];
+}
+
+export interface RollSummary {
+  ok: boolean;
+  totalFrames: number;
+  passedFrames: number;
+  failedFrames: number;
+  unvalidatedFrames: number;
+  passedExpectations: number;
+  failedExpectations: number;
+}
+
+export interface PhotoRollRecord {
+  name: string;
+  dir: string;
+  createdAt: string;
+  closedAt: string;
+  gitSha?: string;
+  branch?: string;
+  summary: RollSummary;
+  frames: RollFrame[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function parseResult(value: unknown): RollExpectationResult | null {
+  if (
+    !isRecord(value)
+    || typeof value.expectation !== "string"
+    || typeof value.passed !== "boolean"
+    || typeof value.evidence !== "string"
+  ) return null;
+  return {
+    expectation: value.expectation,
+    passed: value.passed,
+    evidence: value.evidence,
+  };
+}
+
+function parseFrame(value: unknown): RollFrame | null {
+  if (
+    !isRecord(value)
+    || typeof value.caption !== "string"
+    || typeof value.fileName !== "string"
+    || typeof value.hash !== "string"
+    || typeof value.route !== "string"
+    || typeof value.at !== "string"
+    || typeof value.description !== "string"
+    || typeof value.model !== "string"
+    || (value.ok !== null && typeof value.ok !== "boolean")
+    || !Array.isArray(value.results)
+  ) return null;
+  const results: RollExpectationResult[] = [];
+  for (const result of value.results) {
+    const parsed = parseResult(result);
+    if (!parsed) return null;
+    results.push(parsed);
+  }
+  return {
+    caption: value.caption,
+    fileName: value.fileName,
+    hash: value.hash,
+    route: value.route,
+    at: value.at,
+    description: value.description,
+    model: value.model,
+    ok: value.ok,
+    results,
+  };
+}
+
+function parseSummary(value: unknown): RollSummary | null {
+  if (
+    !isRecord(value)
+    || typeof value.ok !== "boolean"
+    || !isCount(value.totalFrames)
+    || !isCount(value.passedFrames)
+    || !isCount(value.failedFrames)
+    || !isCount(value.unvalidatedFrames)
+    || !isCount(value.passedExpectations)
+    || !isCount(value.failedExpectations)
+  ) return null;
+  return {
+    ok: value.ok,
+    totalFrames: value.totalFrames,
+    passedFrames: value.passedFrames,
+    failedFrames: value.failedFrames,
+    unvalidatedFrames: value.unvalidatedFrames,
+    passedExpectations: value.passedExpectations,
+    failedExpectations: value.failedExpectations,
+  };
+}
+
+export function parseRollJson(value: unknown): PhotoRollRecord | null {
+  if (
+    !isRecord(value)
+    || typeof value.name !== "string"
+    || typeof value.dir !== "string"
+    || typeof value.createdAt !== "string"
+    || typeof value.closedAt !== "string"
+    || !Array.isArray(value.frames)
+  ) return null;
+  const summary = parseSummary(value.summary);
+  if (!summary) return null;
+  const frames: RollFrame[] = [];
+  for (const frame of value.frames) {
+    const parsed = parseFrame(frame);
+    if (!parsed) return null;
+    frames.push(parsed);
+  }
+  const gitSha = typeof value.gitSha === "string" ? value.gitSha : undefined;
+  const branch = typeof value.branch === "string" ? value.branch : undefined;
+  return {
+    name: value.name,
+    dir: value.dir,
+    createdAt: value.createdAt,
+    closedAt: value.closedAt,
+    gitSha,
+    branch,
+    summary,
+    frames,
+  };
+}

--- a/evals/packages/evidence/test/photo-roll-compat.test.ts
+++ b/evals/packages/evidence/test/photo-roll-compat.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { photoRoll } from "../../fraimz/src/photo-roll.ts";
+import type { Shot } from "../../fraimz/src/screenshot.ts";
+import { scanRolls } from "../src/scan.ts";
+
+test("scanRolls reads roll.json produced by the real photoRoll writer", async () => {
+  const resultsDir = await mkdtemp(join(tmpdir(), "openwork-evidence-compat-"));
+  const rollDir = join(resultsDir, "rolls", "2026-07-02T10-00-00-000Z-writer-compat");
+  try {
+    const png = Buffer.from("synthetic screenshot pixels");
+    const shot: Shot = {
+      png,
+      hash: createHash("sha256").update(png).digest("hex"),
+      route: "#/writer-compat",
+      visibleText: "Writer compatibility",
+      at: "2026-07-02T10:00:00.000Z",
+    };
+    const roll = photoRoll("Writer compatibility", { outDir: rollDir });
+    await roll.add(shot);
+    await roll.close();
+
+    const raw = await readFile(join(rollDir, "roll.json"), "utf8");
+    assert.match(raw, /"gitSha":/);
+    assert.match(raw, /"branch":/);
+    const entries = await scanRolls(resultsDir);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry?.kind, "roll");
+    if (!entry || entry.kind !== "roll") throw new Error("Writer roll was not scanned.");
+    assert.equal(entry.roll.frames[0]?.caption, "Writer compatibility frame 1");
+    assert.equal(typeof entry.roll.gitSha, "string");
+    assert.equal(typeof entry.roll.branch, "string");
+  } finally {
+    await rm(resultsDir, { recursive: true, force: true });
+  }
+});

--- a/evals/packages/evidence/test/publish-pr.test.ts
+++ b/evals/packages/evidence/test/publish-pr.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { publishPr } from "../src/publish-pr.ts";
+import type { CommandRunner, Fetcher } from "../src/publish-pr.ts";
+import type { PhotoRollRecord } from "../src/schema.ts";
+
+function dryRunRecord(dir: string): PhotoRollRecord {
+  return {
+    name: "Dry run proof",
+    dir,
+    createdAt: "2026-07-02T10:00:00.000Z",
+    closedAt: "2026-07-02T10:01:00.000Z",
+    summary: {
+      ok: true,
+      totalFrames: 1,
+      passedFrames: 1,
+      failedFrames: 0,
+      unvalidatedFrames: 0,
+      passedExpectations: 1,
+      failedExpectations: 0,
+    },
+    frames: [{
+      caption: "Dry-run claim",
+      fileName: "01-dry-run.png",
+      hash: "hash",
+      route: "#/dry-run",
+      at: "2026-07-02T10:00:00.000Z",
+      description: "Visible dry-run state",
+      model: "test-model",
+      ok: true,
+      results: [{ expectation: "Dry run is visible", passed: true, evidence: "Visible" }],
+    }],
+  };
+}
+
+test("publishPr dry-run prints composed markdown without upload or gh calls", async () => {
+  const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-publish-"));
+  try {
+    await mkdir(rollDir, { recursive: true });
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(dryRunRecord(rollDir)));
+    let commandCalled = false;
+    let fetchCalled = false;
+    let output = "";
+    const exec: CommandRunner = () => {
+      commandCalled = true;
+      return { status: 1, stdout: "", stderr: "unexpected command" };
+    };
+    const fetcher: Fetcher = async () => {
+      fetchCalled = true;
+      throw new Error("unexpected fetch");
+    };
+    const result = await publishPr(
+      { rollDir, dryRun: true },
+      { exec, fetch: fetcher, stdout: (markdown) => { output = markdown; } },
+    );
+    assert.equal(commandCalled, false);
+    assert.equal(fetchCalled, false);
+    assert.equal(result.posted, false);
+    assert.match(output, /<!-- photo-roll -->/);
+    assert.match(output, /Dry-run claim/);
+    assert.match(output, /Dry run: screenshots were not uploaded/);
+  } finally {
+    await rm(rollDir, { recursive: true, force: true });
+  }
+});

--- a/evals/packages/evidence/test/publish-pr.test.ts
+++ b/evals/packages/evidence/test/publish-pr.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -63,6 +63,67 @@ test("publishPr dry-run prints composed markdown without upload or gh calls", as
     assert.match(output, /Dry-run claim/);
     assert.match(output, /Dry run: screenshots were not uploaded/);
   } finally {
+    await rm(rollDir, { recursive: true, force: true });
+  }
+});
+
+test("publishPr refuses a symlinked frame before calling the blob uploader", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-evidence-symlink-frame-"));
+  const rollDir = join(root, "roll");
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    await mkdir(rollDir);
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(dryRunRecord(rollDir)));
+    const outsideFile = join(root, "private-key");
+    await writeFile(outsideFile, "private material");
+    await symlink(outsideFile, join(rollDir, "01-dry-run.png"));
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token";
+    let fetchCalled = false;
+    const fetcher: Fetcher = async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({ url: "https://example.test/unexpected.png" }));
+    };
+    const exec: CommandRunner = () => ({ status: 0, stdout: "", stderr: "" });
+    await assert.rejects(
+      () => publishPr({ pr: 17, rollDir }, { exec, fetch: fetcher }),
+      /Refusing to upload non-regular or symlinked roll frame: 01-dry-run\.png/,
+    );
+    assert.equal(fetchCalled, false);
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("publishPr uploads a regular frame and posts the composed comment", async () => {
+  const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-regular-frame-"));
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(dryRunRecord(rollDir)));
+    await writeFile(join(rollDir, "01-dry-run.png"), Buffer.from("regular png"));
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token";
+    let fetchCalls = 0;
+    const fetcher: Fetcher = async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify({ url: "https://example.test/regular.png" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const exec: CommandRunner = (_command, args) => ({
+      status: 0,
+      stdout: args.includes("view") ? JSON.stringify({ comments: [] }) : "posted",
+      stderr: "",
+    });
+    const result = await publishPr({ pr: 17, rollDir }, { exec, fetch: fetcher });
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.posted, true);
+    assert.equal(result.updated, false);
+    assert.equal(result.urls["01-dry-run.png"], "https://example.test/regular.png");
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
     await rm(rollDir, { recursive: true, force: true });
   }
 });

--- a/evals/packages/evidence/test/scan-render.test.ts
+++ b/evals/packages/evidence/test/scan-render.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -98,4 +98,20 @@ test("renderPrMarkdown binds claim verdicts to uploaded image URLs", () => {
     "https://example.test/01-first.png",
     "pnpm test:proof",
   ]) assert.match(markdown, new RegExp(expected));
+});
+
+test("scanRolls skips a symlinked roll.json without throwing", async () => {
+  const resultsDir = await mkdtemp(join(tmpdir(), "openwork-evidence-symlink-roll-"));
+  try {
+    const rollDir = join(resultsDir, "rolls", "2026-07-02T10-00-00-000Z-symlinked");
+    await mkdir(rollDir, { recursive: true });
+    const outsideRoll = join(resultsDir, "outside-roll.json");
+    await writeFile(outsideRoll, JSON.stringify(record("Outside", rollDir, "2026-07-02T10:00:00.000Z", true)));
+    await symlink(outsideRoll, join(rollDir, "roll.json"));
+
+    const entries = await scanRolls(resultsDir);
+    assert.deepEqual(entries, []);
+  } finally {
+    await rm(resultsDir, { recursive: true, force: true });
+  }
 });

--- a/evals/packages/evidence/test/scan-render.test.ts
+++ b/evals/packages/evidence/test/scan-render.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { renderCollectionHtml, renderPrMarkdown } from "../src/render.ts";
+import { scanRolls } from "../src/scan.ts";
+import type { PhotoRollRecord } from "../src/schema.ts";
+
+function record(name: string, dir: string, createdAt: string, passed: boolean): PhotoRollRecord {
+  return {
+    name,
+    dir,
+    createdAt,
+    closedAt: createdAt,
+    summary: {
+      ok: passed,
+      totalFrames: 1,
+      passedFrames: passed ? 1 : 0,
+      failedFrames: passed ? 0 : 1,
+      unvalidatedFrames: 0,
+      passedExpectations: passed ? 1 : 0,
+      failedExpectations: passed ? 0 : 1,
+    },
+    frames: [{
+      caption: `${name} first claim`,
+      fileName: "01-first.png",
+      hash: `${name}-hash`,
+      route: "#/workspace/test",
+      at: createdAt,
+      description: `${name} description`,
+      model: "test-model",
+      ok: passed,
+      results: [{
+        expectation: `${name} expectation`,
+        passed,
+        evidence: `${name} evidence`,
+      }],
+    }],
+  };
+}
+
+test("scanRolls reads valid rolls and legacy evidence while tolerating corrupt roll.json", async () => {
+  const resultsDir = await mkdtemp(join(tmpdir(), "openwork-evidence-scan-"));
+  try {
+    const rollsDir = join(resultsDir, "rolls");
+    const olderDir = join(rollsDir, "2026-07-01T10-00-00-000Z-older");
+    const newerDir = join(rollsDir, "2026-07-02T10-00-00-000Z-newer");
+    const corruptDir = join(rollsDir, "2026-07-03T10-00-00-000Z-corrupt");
+    const legacyDir = join(resultsDir, "2026-06-01T10-00-00-000Z-legacy");
+    await Promise.all([
+      mkdir(olderDir, { recursive: true }),
+      mkdir(newerDir, { recursive: true }),
+      mkdir(corruptDir, { recursive: true }),
+      mkdir(legacyDir, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(olderDir, "roll.json"), JSON.stringify({
+        ...record("Older", olderDir, "2026-07-01T10:00:00.000Z", true),
+        futureField: { ignored: true },
+      })),
+      writeFile(join(newerDir, "roll.json"), JSON.stringify(record("Newer", newerDir, "2026-07-02T10:00:00.000Z", false))),
+      writeFile(join(corruptDir, "roll.json"), "{not-json"),
+      writeFile(join(legacyDir, "fraimz.html"), "legacy"),
+      writeFile(join(legacyDir, "frame.png"), Buffer.from("legacy-png")),
+    ]);
+
+    const entries = await scanRolls(resultsDir);
+    assert.equal(entries.length, 3);
+    assert.deepEqual(entries.map((entry) => entry.name), ["Newer", "Older", "2026-06-01T10-00-00-000Z-legacy"]);
+    assert.equal(entries.filter((entry) => entry.kind === "legacy").length, 1);
+    assert.equal(entries.some((entry) => entry.directoryName.includes("corrupt")), false);
+
+    const rendered = renderCollectionHtml(entries);
+    for (const expected of ["Newer first claim", "FAILED", "PASSED", "newer/index.html", "../2026-06-01T10-00-00-000Z-legacy/fraimz.html"]) {
+      assert.match(rendered, new RegExp(expected));
+    }
+  } finally {
+    await rm(resultsDir, { recursive: true, force: true });
+  }
+});
+
+test("renderPrMarkdown binds claim verdicts to uploaded image URLs", () => {
+  const roll = record("PR proof", "/tmp/2026-pr-proof", "2026-07-02T10:00:00.000Z", false);
+  const frame = roll.frames[0];
+  if (!frame) throw new Error("Fixture frame is missing.");
+  frame.results.unshift({ expectation: "Passing expectation", passed: true, evidence: "Visible" });
+  const markdown = renderPrMarkdown(
+    roll,
+    { "01-first.png": "https://example.test/01-first.png" },
+    { reproCommand: "pnpm test:proof" },
+  );
+  for (const expected of [
+    "<!-- photo-roll -->",
+    "PR proof first claim",
+    "PASS",
+    "FAIL",
+    "https://example.test/01-first.png",
+    "pnpm test:proof",
+  ]) assert.match(markdown, new RegExp(expected));
+});

--- a/evals/packages/fraimz/src/photo-roll.ts
+++ b/evals/packages/fraimz/src/photo-roll.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,12 +43,22 @@ function frameCaption(name: string, sequence: number, seen?: SeenFacts): string 
   return seen?.results[0]?.expectation.trim() || `${name} frame ${sequence}`;
 }
 
+function gitValue(args: string[]): string {
+  const result = spawnSync("git", ["rev-parse", ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  return result.status === 0 && !result.error ? result.stdout.trim() : "";
+}
+
 export function photoRoll(name: string, opts: { outDir?: string } = {}): Roll {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const dir = opts.outDir ?? join(REPO_ROOT, "evals", "results", "rolls", `${stamp}-${slug(name)}`);
   const frames: RollFrame[] = [];
   const hashes = new Map<string, string>();
   const createdAt = new Date().toISOString();
+  const gitSha = gitValue(["HEAD"]);
+  const branch = gitValue(["--abbrev-ref", "HEAD"]);
   let closedPath = "";
 
   const close = async (): Promise<string> => {
@@ -64,7 +75,7 @@ export function photoRoll(name: string, opts: { outDir?: string } = {}): Roll {
       failedExpectations: expectationResults.filter((result) => !result.passed).length,
     };
     const closedAt = new Date().toISOString();
-    const payload = { name, dir, createdAt, closedAt, summary, frames };
+    const payload = { name, dir, createdAt, closedAt, gitSha, branch, summary, frames };
     const frameMarkup = frames.map((frame) => `
       <article class="frame ${frame.ok === true ? "passed" : frame.ok === false ? "failed" : "unvalidated"}">
         <h2>${html(frame.caption)}</h2>

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@openwork/cdp':
         specifier: workspace:*
         version: link:packages/cdp
+      '@openwork/evidence':
+        specifier: workspace:*
+        version: link:packages/evidence
       '@openwork/fraimz':
         specifier: workspace:*
         version: link:packages/fraimz
@@ -47,6 +50,8 @@ importers:
         version: link:../timeline
 
   packages/cdp: {}
+
+  packages/evidence: {}
 
   packages/fraimz:
     dependencies:

--- a/prds/evidence-roll/evidence-roll-program.md
+++ b/prds/evidence-roll/evidence-roll-program.md
@@ -1,0 +1,118 @@
+# Evidence Roll Program
+
+Reuse what the spec lane already records — `photoRoll` — and add the two
+missing adapters: a collection view across all rolls, and a PR publisher with
+a thin skill. Leave schema room for live Daytona handoffs and resumable rolls.
+
+## What already exists on dev (verified at 3e052843f)
+
+`@openwork/fraimz` ships three proof primitives (#3322, #3359):
+
+- `screenshot(surface)` → `Shot { png, hash, route, at }`
+- `validate(shot, expectations)` → `SeenFacts { ok, description, results:
+  [{ expectation, passed, evidence }], model, cached }` — vision-graded
+  per-claim assertions with an on-disk cache
+- `photoRoll(name)` → per-run roll: `add(shot, seen?)` writes
+  `NN-<caption>.png` (pixel-hash dedupe, caption = first expectation);
+  `close()`/dispose writes **`roll.json`** (summary + frames with per-
+  expectation PASS/FAIL) and a self-contained **`index.html`** under
+  `evals/results/rolls/<stamp>-<name>/`
+
+Slow specs already produce rolls (app-smoke, first-run-local,
+first-run-cloud-share, models-available, app-den-tls-fault, …). **`roll.json`
+is the record layer.** The flow lane (`evals/runner`) is deprecated; its blob
+upload + gh posting knowledge in `runner/reporters/pr.ts` gets lifted, not
+imported.
+
+## Gaps this program closes
+
+1. No way to see rolls *collected* — each roll has its own index.html, but
+   there is no roll-of-rolls.
+2. No way to put a roll on a PR.
+3. No reserved room for "agent drives to the iteration point, human takes
+   over on a held Daytona surface".
+
+## Architecture
+
+```
+ CAPTURE   spec lane: screenshot + validate + photoRoll          (exists)
+ RECORD    roll.json per roll                                    (exists)
+ RENDER    pure: roll.json[] → collection html · roll.json → PR markdown  (S1)
+ PUBLISH   local collection index · PR sticky comment            (S1)
+           living Daytona index · held-surface handoff           (S2)
+```
+
+Rules: capture never knows where evidence goes; renderers/publishers never
+know where it came from; unknown fields in roll.json are ignored, never fatal.
+
+## Slices
+
+### S1 — collect + publish (this PR)
+
+New package `evals/packages/evidence` (`@openwork/evidence`, zero new npm
+deps):
+
+- `scanRolls(resultsDir)` — read `rolls/*/roll.json` (validating reader,
+  tolerant of unknown fields); legacy result dirs (fraimz.html / loose pngs)
+  become minimal read-only entries.
+- `renderCollectionHtml(entries)` — the photo roll of photo rolls:
+  newest-first, one card per roll (name, date, pass/fail summary badge, first
+  frame as thumbnail, link to the roll's own index.html). Written to
+  `evals/results/rolls/index.html`.
+- `renderPrMarkdown(roll, urls)` — claim → screenshot gallery with
+  per-expectation PASS/FAIL, roll summary, repro footer; wrapped in a
+  `<!-- photo-roll -->` sticky marker.
+- `publish-pr` — upload the roll's PNGs to Vercel Blob
+  (`BLOB_READ_WRITE_TOKEN` env, Infisical fallback — pattern lifted from the
+  deprecated `runner/reporters/pr.ts`), then create-or-update the single
+  sticky comment via `gh`. `--dry-run` prints the markdown. Without a token:
+  post verdicts-only and say so in the comment.
+- CLI: `pnpm --dir evals run roll` (build collection, `--open`) and
+  `pnpm --dir evals run publish:pr -- --pr <n> [--roll <dir|name>] [--dry-run]`
+  (default: newest roll).
+- Skill `.opencode/skills/pr-photo-roll`: judgment only — pick the roll,
+  never post an image `roll.json` cannot attribute, then shell the CLI.
+- Additive capture metadata: `photoRoll` records `gitSha`/`branch` in
+  roll.json (small, optional fields; renderers tolerate absence).
+
+#### S1 results — PASSED (verified 2026-08-01, branch `feat/evidence-roll`)
+
+- Unit lane: `pnpm --dir evals run test` → **108 pass / 0 fail** (scan,
+  renderers, publisher dry-run with injected stubs, and real-writer
+  compatibility: a roll produced by the actual `photoRoll()` API reads back
+  through `scanRolls`). `pnpm --dir evals run typecheck` clean.
+- Real end-to-end: `hosts.chrome()` (headless, real CDP) rendered the
+  generated collection page, `screenshot()` captured real pixels,
+  `validate()` (OpenAI vision) graded both expectations **PASS**
+  ("collection lists at least one roll card", "card shows a pass/fail
+  badge"), `photoRoll` recorded roll.json + per-roll index.html; collection
+  rebuilt with the new roll included. Publisher then posted the sticky
+  gallery to this program's own PR with Blob-hosted images (see PR).
+- Environment finding, out of scope here: `hosts.desktop()` local spawn on
+  this Mac brought up Electron CDP but no page target within 120s (twice) —
+  the app-spec path's home remains the warm Daytona nightly
+  (`OPENWORK_EVAL_APP_SPECS=1`).
+
+### S2 — living index + handoff
+
+Permanent Daytona sandbox serving an append-only archive of roll dirs;
+`publish:daytona` pushes a roll and regenerates the same collection html.
+Reserved roll.json fields (documented now, written later): `surfaces:
+[{ id, kind, cdpUrl?, novncUrl?, apiUrl?, sandboxId?, holdUntil? }]` and
+frame/roll-level `handoff { surfaceId, instructions, credentialsHint }`.
+Hold semantics: a provisioned surface skips teardown, stamps `holdUntil`,
+and the PR/index renders "continue from here" (noVNC + seeded creds only —
+never bearer tokens; TTL mandatory).
+
+### S3 — resumable rolls
+
+Optional Daytona snapshot per frame (`snapshotRef`) so every photo gains
+"resume from this exact state"; video shots as an additional capture kind.
+
+## Risks
+
+1. Blob token availability — env → Infisical fallback; degrade to
+   verdicts-only comment, stated in the comment body.
+2. Comment noise — one sticky comment per PR, edited in place.
+3. roll.json drift — reader is tolerant; version field added additively if a
+   breaking change is ever needed.


### PR DESCRIPTION
## What

Slice S1 of the **Evidence Roll** program (spec: `prds/evidence-roll/evidence-roll-program.md`, included). Reuses the existing `photoRoll` proof primitives (#3322/#3359) and adds the two missing adapters — nothing new is captured, only rendered:

- **`@openwork/evidence`** (zero new deps): tolerant `scanRolls` reader over `evals/results/rolls/*/roll.json` (legacy flow-lane dirs readable read-only), `renderCollectionHtml` (roll-of-rolls: cards with pass/fail badges, thumbnails, links to each roll's own index.html), `renderPrMarkdown` (claim → screenshot gallery with per-expectation PASS/FAIL), `publishPr` (Vercel Blob upload — env token → Infisical fallback, lifted from the deprecated `runner/reporters/pr.ts`, not imported — and a single sticky `<!-- photo-roll -->` comment, edited in place).
- **CLI**: `pnpm --dir evals run roll [-- --open]` · `pnpm --dir evals run publish:pr -- --pr <n> [--roll <dir|name>] [--dry-run]`.
- **Skill** `.opencode/skills/pr-photo-roll`: judgment only (pick the roll, only roll.json-attributed images), mechanics in the CLI.
- **fraimz**: `photoRoll` additionally records best-effort `gitSha`/`branch` (additive; readers tolerate absence).
- Reserved (schema/docs only, S2): serialized surfaces + `handoff` entries for held-Daytona human testing; S3: snapshot-per-frame resumable rolls.

Flow lane untouched (`evals/runner/**` unchanged).

## Tests (commands + results)

```
pnpm --dir evals run test        # 108 pass / 0 fail (incl. real-writer compatibility test)
pnpm --dir evals run typecheck   # clean
```

Real end-to-end: headless `hosts.chrome()` rendered the generated collection page → `screenshot()` → `validate()` (OpenAI vision, both expectations PASS) → `photoRoll` → collection rebuilt → **the sticky gallery comment below was posted by the new publisher itself** (Blob-hosted images).

Known env finding (out of scope): `hosts.desktop()` local spawn on macOS brought up CDP but no page target in 120s (twice); app specs' home remains the Daytona nightly.

## Proof format

Spec acceptance suites + the self-published gallery comment below, per program-owner decision (no fraimz flow lane).