### PR TITLE
feat(den): team access visibility — what can this team use, edge by edge (P3 PR1)

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -102,6 +102,8 @@ import {
   pluginParamsSchema,
   pluginUpdateSchema,
   resourceAccessGrantWriteSchema,
+  teamParamsSchema,
+  teamPluginAccessListResponseSchema,
 } from "./schemas.js"
 
 type EndpointMethod = "DELETE" | "GET" | "PATCH" | "POST"
@@ -167,6 +169,7 @@ export const pluginArchRoutePaths = {
   pluginReleases: `${orgBasePath}/plugins/:pluginId/releases`,
   pluginAccess: `${orgBasePath}/plugins/:pluginId/access`,
   pluginAccessGrant: `${orgBasePath}/plugins/:pluginId/access/:grantId`,
+  teamPluginAccess: `${orgBasePath}/teams/:teamId/plugin-access`,
   pluginGithubMcpImportPreview: `${orgBasePath}/plugins/import-mcps-from-github-url/preview`,
   pluginGithubMcpImport: `${orgBasePath}/plugins/import-mcps-from-github-url`,
   marketplaces: `${orgBasePath}/marketplaces`,
@@ -464,6 +467,15 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
     path: pluginArchRoutePaths.pluginAccess,
     request: { params: pluginParamsSchema },
     response: { description: "Plugin access grants.", schema: accessGrantListResponseSchema, status: 200 },
+    tag: "Plugins",
+  },
+  listTeamPluginAccess: {
+    audience: "member",
+    description: "List the plugins a team can use through direct, marketplace, and organization-wide access.",
+    method: "GET",
+    path: pluginArchRoutePaths.teamPluginAccess,
+    request: { params: teamParamsSchema },
+    response: { description: "Effective plugin access for the team.", schema: teamPluginAccessListResponseSchema, status: 200 },
     tag: "Plugins",
   },
   grantPluginAccess: {

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -106,6 +106,8 @@ import {
   pluginParamsSchema,
   pluginUpdateSchema,
   resourceAccessGrantWriteSchema,
+  teamParamsSchema,
+  teamPluginAccessListResponseSchema,
 } from "./schemas.js"
 import { isPluginArchOrgAdmin, requirePluginArchCapability, type PluginArchActorContext, PluginArchAuthorizationError } from "./access.js"
 import { pluginArchRoutePaths } from "./contracts.js"
@@ -154,6 +156,7 @@ import {
   listPluginMemberships,
   listPlugins,
   listResourceAccess,
+  listTeamEffectivePluginAccess,
   attachPluginToMarketplace,
   completeGithubConnectorInstall,
   applyGithubConnectorDiscovery,
@@ -996,6 +999,32 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       try {
         const params = validParam<any>(c)
         return c.json(await listResourceAccess({ context: actorContext(c), resourceId: params.pluginId, resourceKind: "plugin" }))
+      } catch (error) {
+        return routeErrorResponse(c, error)
+      }
+    })
+
+  withPluginArchOrgContext(app, "get", pluginArchRoutePaths.teamPluginAccess,
+    paramValidator(teamParamsSchema),
+    describeRoute({
+      tags: ["Plugins"],
+      summary: "List effective team plugin access",
+      description: "Lists plugins available to a team through direct grants, marketplace grants, and organization-wide grants.",
+      responses: {
+        200: jsonResponse("Effective team plugin access returned successfully.", teamPluginAccessListResponseSchema),
+        400: jsonResponse("The team access path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to view team plugin access.", unauthorizedSchema),
+        403: jsonResponse("The caller lacks permission to view this team's plugin access.", forbiddenSchema),
+        404: jsonResponse("The team could not be found.", notFoundSchema),
+      },
+    }),
+    async (c: OrgContext) => {
+      try {
+        const params = validParam<z.infer<typeof teamParamsSchema>>(c)
+        return c.json(await listTeamEffectivePluginAccess({
+          context: actorContext(c),
+          teamId: normalizeDenTypeId("team", params.teamId),
+        }))
       } catch (error) {
         return routeErrorResponse(c, error)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -156,6 +156,7 @@ export const pluginAccessGrantParamsSchema = pluginParamsSchema.extend(idParamSc
 export const marketplaceParamsSchema = idParamSchema("marketplaceId", "marketplace")
 export const marketplacePluginParamsSchema = marketplaceParamsSchema.extend(idParamSchema("pluginId", "plugin").shape)
 export const marketplaceAccessGrantParamsSchema = marketplaceParamsSchema.extend(idParamSchema("grantId", "marketplaceAccessGrant").shape)
+export const teamParamsSchema = idParamSchema("teamId", "team")
 export const connectorAccountParamsSchema = idParamSchema("connectorAccountId", "connectorAccount")
 export const connectorInstanceParamsSchema = idParamSchema("connectorInstanceId", "connectorInstance")
 export const connectorInstanceAccessGrantParamsSchema = connectorInstanceParamsSchema.extend(idParamSchema("grantId", "connectorInstanceAccessGrant").shape)
@@ -464,6 +465,26 @@ export const accessGrantSchema = z.object({
   createdAt: z.string().datetime({ offset: true }),
   removedAt: nullableTimestampSchema,
 }).meta({ ref: "PluginArchAccessGrant" })
+
+export const teamPluginAccessSchema = z.object({
+  plugin: z.object({
+    id: pluginIdSchema,
+    name: z.string().trim().min(1).max(255),
+    componentCount: z.number().int().nonnegative(),
+  }),
+  edge: z.enum(["direct_team", "via_catalog", "org_wide"]),
+  marketplace: z.object({
+    id: marketplaceIdSchema,
+    name: z.string().trim().min(1).max(255),
+  }).nullable(),
+  role: accessRoleSchema,
+  grantedBy: z.object({
+    orgMembershipId: memberIdSchema,
+    name: z.string().trim().min(1).max(255),
+  }).nullable(),
+  grantedAt: z.string().datetime({ offset: true }),
+  grantId: pluginAccessGrantIdSchema.nullable(),
+}).meta({ ref: "PluginArchTeamPluginAccess" })
 
 export const configObjectVersionSchema = z.object({
   id: configObjectVersionIdSchema,
@@ -944,6 +965,7 @@ export const marketplacePluginListResponseSchema = pluginArchListResponseSchema(
 export const marketplacePluginMutationResponseSchema = pluginArchMutationResponseSchema("PluginArchMarketplacePluginMutationResponse", marketplacePluginSchema)
 export const accessGrantListResponseSchema = pluginArchListResponseSchema("PluginArchAccessGrantListResponse", accessGrantSchema)
 export const accessGrantMutationResponseSchema = pluginArchMutationResponseSchema("PluginArchAccessGrantMutationResponse", accessGrantSchema)
+export const teamPluginAccessListResponseSchema = pluginArchListResponseSchema("PluginArchTeamPluginAccessListResponse", teamPluginAccessSchema).omit({ nextCursor: true })
 export const connectorAccountListResponseSchema = pluginArchListResponseSchema("PluginArchConnectorAccountListResponse", connectorAccountSchema)
 export const connectorAccountDetailResponseSchema = pluginArchDetailResponseSchema("PluginArchConnectorAccountDetailResponse", connectorAccountSchema)
 export const connectorAccountMutationResponseSchema = pluginArchMutationResponseSchema("PluginArchConnectorAccountMutationResponse", connectorAccountSchema)

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1,5 +1,6 @@
 import { and, asc, count, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
+  AuthUserTable,
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
   ConfigObjectVersionTable,
@@ -1874,6 +1875,209 @@ export async function listResourceAccess(input: { context: PluginArchActorContex
   }
   const rows = await db.select().from(ConnectorInstanceAccessGrantTable).where(eq(ConnectorInstanceAccessGrantTable.connectorInstanceId, input.resourceId)).orderBy(desc(ConnectorInstanceAccessGrantTable.createdAt))
   return { items: rows.map((row) => serializeAccessGrant(row)), nextCursor: null }
+}
+
+type TeamPluginAccessEdge = "direct_team" | "via_catalog" | "org_wide"
+
+type TeamPluginAccessCandidate = {
+  createdAt: Date
+  createdByOrgMembershipId: MemberId
+  edge: TeamPluginAccessEdge
+  grantId: PluginAccessGrantId | null
+  marketplace: { id: MarketplaceId; name: string } | null
+  pluginId: PluginId
+  pluginName: string
+  role: PluginArchRole
+}
+
+const teamPluginAccessEdgeOrder: Record<TeamPluginAccessEdge, number> = {
+  direct_team: 1,
+  via_catalog: 2,
+  org_wide: 3,
+}
+
+const teamPluginAccessRolePriority: Record<PluginArchRole, number> = {
+  viewer: 1,
+  editor: 2,
+  manager: 3,
+}
+
+export async function listTeamEffectivePluginAccess(input: { context: PluginArchActorContext; teamId: TeamId }) {
+  const organizationId = input.context.organizationContext.organization.id
+  const teams = await db
+    .select({ id: TeamTable.id })
+    .from(TeamTable)
+    .where(and(eq(TeamTable.id, input.teamId), eq(TeamTable.organizationId, organizationId)))
+    .limit(1)
+
+  if (!teams[0]) {
+    throw new PluginArchRouteFailure(404, "team_not_found", "Team not found.")
+  }
+  if (!isPluginArchOrgAdmin(input.context) && !input.context.memberTeams.some((team) => team.id === input.teamId)) {
+    throw new PluginArchAuthorizationError(403, "forbidden", "Only organization admins and team members can view this team's plugin access.")
+  }
+
+  const [directRows, marketplaceRows, orgWideRows] = await Promise.all([
+    db
+      .select({
+        createdAt: PluginAccessGrantTable.createdAt,
+        createdByOrgMembershipId: PluginAccessGrantTable.createdByOrgMembershipId,
+        grantId: PluginAccessGrantTable.id,
+        pluginId: PluginTable.id,
+        pluginName: PluginTable.name,
+        role: PluginAccessGrantTable.role,
+      })
+      .from(PluginAccessGrantTable)
+      .innerJoin(PluginTable, eq(PluginAccessGrantTable.pluginId, PluginTable.id))
+      .where(and(
+        eq(PluginAccessGrantTable.organizationId, organizationId),
+        eq(PluginAccessGrantTable.teamId, input.teamId),
+        isNull(PluginAccessGrantTable.removedAt),
+        eq(PluginTable.organizationId, organizationId),
+        eq(PluginTable.status, "active"),
+        isNull(PluginTable.deletedAt),
+      ))
+      .orderBy(asc(PluginAccessGrantTable.createdAt), asc(PluginAccessGrantTable.id)),
+    db
+      .select({
+        createdAt: MarketplaceAccessGrantTable.createdAt,
+        createdByOrgMembershipId: MarketplaceAccessGrantTable.createdByOrgMembershipId,
+        marketplaceId: MarketplaceTable.id,
+        marketplaceName: MarketplaceTable.name,
+        pluginId: PluginTable.id,
+        pluginName: PluginTable.name,
+        role: MarketplaceAccessGrantTable.role,
+      })
+      .from(MarketplaceAccessGrantTable)
+      .innerJoin(MarketplaceTable, eq(MarketplaceAccessGrantTable.marketplaceId, MarketplaceTable.id))
+      .innerJoin(MarketplacePluginTable, eq(MarketplacePluginTable.marketplaceId, MarketplaceTable.id))
+      .innerJoin(PluginTable, eq(MarketplacePluginTable.pluginId, PluginTable.id))
+      .where(and(
+        eq(MarketplaceAccessGrantTable.organizationId, organizationId),
+        eq(MarketplaceAccessGrantTable.teamId, input.teamId),
+        isNull(MarketplaceAccessGrantTable.removedAt),
+        eq(MarketplaceTable.organizationId, organizationId),
+        eq(MarketplaceTable.status, "active"),
+        isNull(MarketplaceTable.deletedAt),
+        eq(MarketplacePluginTable.organizationId, organizationId),
+        isNull(MarketplacePluginTable.removedAt),
+        eq(PluginTable.organizationId, organizationId),
+        eq(PluginTable.status, "active"),
+        isNull(PluginTable.deletedAt),
+      ))
+      .orderBy(asc(MarketplaceAccessGrantTable.createdAt), asc(MarketplaceAccessGrantTable.id), asc(MarketplaceTable.name)),
+    db
+      .select({
+        createdAt: PluginAccessGrantTable.createdAt,
+        createdByOrgMembershipId: PluginAccessGrantTable.createdByOrgMembershipId,
+        pluginId: PluginTable.id,
+        pluginName: PluginTable.name,
+        role: PluginAccessGrantTable.role,
+      })
+      .from(PluginAccessGrantTable)
+      .innerJoin(PluginTable, eq(PluginAccessGrantTable.pluginId, PluginTable.id))
+      .where(and(
+        eq(PluginAccessGrantTable.organizationId, organizationId),
+        eq(PluginAccessGrantTable.orgWide, true),
+        isNull(PluginAccessGrantTable.removedAt),
+        eq(PluginTable.organizationId, organizationId),
+        eq(PluginTable.status, "active"),
+        isNull(PluginTable.deletedAt),
+      ))
+      .orderBy(asc(PluginAccessGrantTable.createdAt), asc(PluginAccessGrantTable.id)),
+  ])
+
+  const candidates: TeamPluginAccessCandidate[] = []
+  for (const row of directRows) {
+    candidates.push({
+      ...row,
+      edge: "direct_team",
+      marketplace: null,
+    })
+  }
+  for (const row of marketplaceRows) {
+    candidates.push({
+      createdAt: row.createdAt,
+      createdByOrgMembershipId: row.createdByOrgMembershipId,
+      edge: "via_catalog",
+      grantId: null,
+      marketplace: { id: row.marketplaceId, name: row.marketplaceName },
+      pluginId: row.pluginId,
+      pluginName: row.pluginName,
+      role: row.role,
+    })
+  }
+  for (const row of orgWideRows) {
+    candidates.push({
+      ...row,
+      edge: "org_wide",
+      grantId: null,
+      marketplace: null,
+    })
+  }
+
+  const effectiveByPluginEdge = new Map<string, TeamPluginAccessCandidate>()
+  for (const candidate of candidates) {
+    const key = `${candidate.pluginId}:${candidate.edge}`
+    const current = effectiveByPluginEdge.get(key)
+    if (!current || teamPluginAccessRolePriority[candidate.role] > teamPluginAccessRolePriority[current.role]) {
+      effectiveByPluginEdge.set(key, candidate)
+    }
+  }
+
+  const effective = [...effectiveByPluginEdge.values()]
+  const pluginIds = uniqueIds(effective.map((candidate) => candidate.pluginId))
+  const creatorIds = uniqueIds(effective.map((candidate) => candidate.createdByOrgMembershipId))
+  const componentCountRows = pluginIds.length === 0
+    ? []
+    : await db
+      .select({ pluginId: PluginConfigObjectTable.pluginId, componentCount: count() })
+      .from(PluginConfigObjectTable)
+      .where(and(
+        eq(PluginConfigObjectTable.organizationId, organizationId),
+        inArray(PluginConfigObjectTable.pluginId, pluginIds),
+        isNull(PluginConfigObjectTable.removedAt),
+      ))
+      .groupBy(PluginConfigObjectTable.pluginId)
+  const creatorRows = creatorIds.length === 0
+    ? []
+    : await db
+      .select({ orgMembershipId: MemberTable.id, name: AuthUserTable.name })
+      .from(MemberTable)
+      .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+      .where(and(eq(MemberTable.organizationId, organizationId), inArray(MemberTable.id, creatorIds)))
+
+  const componentCounts = new Map(componentCountRows.map((row) => [row.pluginId, row.componentCount]))
+  const creatorNames = new Map(creatorRows.flatMap((row) => row.name === null ? [] : [[row.orgMembershipId, row.name]]))
+
+  effective.sort((left, right) => {
+    const byName = left.pluginName.localeCompare(right.pluginName)
+    if (byName !== 0) return byName
+    const byEdge = teamPluginAccessEdgeOrder[left.edge] - teamPluginAccessEdgeOrder[right.edge]
+    if (byEdge !== 0) return byEdge
+    return left.pluginId.localeCompare(right.pluginId)
+  })
+
+  return {
+    items: effective.map((candidate) => {
+      const creatorName = creatorNames.get(candidate.createdByOrgMembershipId)
+      return {
+        plugin: {
+          id: candidate.pluginId,
+          name: candidate.pluginName,
+          componentCount: componentCounts.get(candidate.pluginId) ?? 0,
+        },
+        edge: candidate.edge,
+        marketplace: candidate.marketplace,
+        role: candidate.role,
+        grantedBy: creatorName
+          ? { orgMembershipId: candidate.createdByOrgMembershipId, name: creatorName }
+          : null,
+        grantedAt: candidate.createdAt.toISOString(),
+        grantId: candidate.grantId,
+      }
+    }),
+  }
 }
 
 export async function createResourceAccessGrant(input: { context: PluginArchActorContext; value: AccessGrantWrite } & ResourceTarget) {

--- a/ee/apps/den-api/test/plugin-system-team-access.test.ts
+++ b/ee/apps/den-api/test/plugin-system-team-access.test.ts
@@ -1,0 +1,350 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { eq, inArray } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthUserTable,
+  ConfigObjectTable,
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  OrganizationRoleTable,
+  OrganizationTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+  TeamMemberTable,
+  TeamTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { Hono, type MiddlewareHandler } from "hono"
+import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
+import type { OrgRouteVariables } from "../src/routes/org/shared.js"
+
+const API_ORIGIN = "http://127.0.0.1:8790"
+
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_teamaccess"
+process.env.DB_MODE ??= "mysql"
+process.env.DEN_DB_ENCRYPTION_KEY ??= "team-access-test-encryption-key-1234567890"
+process.env.BETTER_AUTH_SECRET ??= "team-access-test-secret-123456789"
+process.env.BETTER_AUTH_URL ??= API_ORIGIN
+process.env.CORS_ORIGINS ??= API_ORIGIN
+
+let app: Hono<{ Variables: OrgRouteVariables }>
+let teamPluginAccessListResponseSchema: typeof import("../src/routes/org/plugin-system/schemas.js").teamPluginAccessListResponseSchema
+let db: typeof import("../src/db.js").db
+
+const organizationId = createDenTypeId("organization")
+const otherOrganizationId = createDenTypeId("organization")
+const teamId = createDenTypeId("team")
+const otherOrganizationTeamId = createDenTypeId("team")
+const unknownTeamId = createDenTypeId("team")
+
+const adminUserId = createDenTypeId("user")
+const caseyUserId = createDenTypeId("user")
+const novaUserId = createDenTypeId("user")
+const adminMemberId = createDenTypeId("member")
+const caseyMemberId = createDenTypeId("member")
+const novaMemberId = createDenTypeId("member")
+
+const pluginAId = createDenTypeId("plugin")
+const pluginBId = createDenTypeId("plugin")
+const pluginCId = createDenTypeId("plugin")
+const pluginDId = createDenTypeId("plugin")
+const pluginEId = createDenTypeId("plugin")
+const marketplaceId = createDenTypeId("marketplace")
+const configObjectId = createDenTypeId("configObject")
+
+const directGrantId = createDenTypeId("pluginAccessGrant")
+const marketplaceGrantId = createDenTypeId("marketplaceAccessGrant")
+const orgWideGrantId = createDenTypeId("pluginAccessGrant")
+const directGrantedAt = new Date("2026-01-01T10:00:00.000Z")
+const marketplaceGrantedAt = new Date("2026-01-02T10:00:00.000Z")
+const orgWideGrantedAt = new Date("2026-01-03T10:00:00.000Z")
+
+async function cleanup() {
+  await db.delete(PluginConfigObjectTable).where(eq(PluginConfigObjectTable.organizationId, organizationId))
+  await db.delete(PluginAccessGrantTable).where(eq(PluginAccessGrantTable.organizationId, organizationId))
+  await db.delete(MarketplacePluginTable).where(eq(MarketplacePluginTable.organizationId, organizationId))
+  await db.delete(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.organizationId, organizationId))
+  await db.delete(ConfigObjectTable).where(eq(ConfigObjectTable.organizationId, organizationId))
+  await db.delete(PluginTable).where(eq(PluginTable.organizationId, organizationId))
+  await db.delete(MarketplaceTable).where(eq(MarketplaceTable.organizationId, organizationId))
+  await db.delete(TeamMemberTable).where(inArray(TeamMemberTable.teamId, [teamId, otherOrganizationTeamId]))
+  await db.delete(TeamTable).where(inArray(TeamTable.organizationId, [organizationId, otherOrganizationId]))
+  await db.delete(OrganizationRoleTable).where(inArray(OrganizationRoleTable.organizationId, [organizationId, otherOrganizationId]))
+  await db.delete(MemberTable).where(inArray(MemberTable.organizationId, [organizationId, otherOrganizationId]))
+  await db.delete(OrganizationTable).where(inArray(OrganizationTable.id, [organizationId, otherOrganizationId]))
+  await db.delete(AuthUserTable).where(inArray(AuthUserTable.id, [adminUserId, caseyUserId, novaUserId]))
+}
+
+function actorContext(input: {
+  memberId: typeof adminMemberId
+  role: string
+  teamMember: boolean
+  userId: typeof adminUserId
+}): PluginArchActorContext {
+  const now = new Date()
+  return {
+    memberTeams: input.teamMember
+      ? [{ id: teamId, organizationId, name: "Product", createdAt: now, updatedAt: now }]
+      : [],
+    organizationContext: {
+      organization: {
+        id: organizationId,
+        name: "Team Access Test",
+        slug: `team-access-${organizationId}`,
+        logo: null,
+        allowedEmailDomains: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      currentMember: {
+        id: input.memberId,
+        userId: input.userId,
+        role: input.role,
+        createdAt: now,
+        joinedAt: now,
+        isOwner: false,
+      },
+      invitations: [],
+      members: [],
+      roles: [],
+      teams: [],
+    },
+    session: undefined,
+  }
+}
+
+const adminContext = actorContext({ memberId: adminMemberId, role: "admin", teamMember: false, userId: adminUserId })
+const caseyContext = actorContext({ memberId: caseyMemberId, role: "member", teamMember: true, userId: caseyUserId })
+const novaContext = actorContext({ memberId: novaMemberId, role: "member", teamMember: false, userId: novaUserId })
+
+function requestContext(actor: string | undefined) {
+  if (actor === "casey") return caseyContext
+  if (actor === "nova") return novaContext
+  return adminContext
+}
+
+beforeAll(async () => {
+  mock.restore()
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  db = realDb
+  mock.module("../src/db.js", () => ({ db: realDb }))
+  const middleware = await import("../src/middleware/index.js")
+  const passThroughMiddleware: MiddlewareHandler = async (_c, next) => {
+    await next()
+  }
+  mock.module("../src/middleware/index.js", () => ({
+    ...middleware,
+    orgMemberRoute: () => passThroughMiddleware,
+    resolveMemberTeamsMiddleware: passThroughMiddleware,
+  }))
+  const { registerPluginArchRoutes } = await import("../src/routes/org/plugin-system/routes.js")
+  teamPluginAccessListResponseSchema = (await import("../src/routes/org/plugin-system/schemas.js")).teamPluginAccessListResponseSchema
+  app = new Hono<{ Variables: OrgRouteVariables }>()
+  app.use("*", async (c, next) => {
+    const context = requestContext(c.req.header("x-test-actor"))
+    c.set("organizationContext", context.organizationContext)
+    c.set("memberTeams", context.memberTeams)
+    await next()
+  })
+  registerPluginArchRoutes(app)
+
+  await cleanup()
+  await db.insert(AuthUserTable).values([
+    { id: adminUserId, name: "Avery Admin", email: `${adminUserId}@team-access.test`, emailVerified: true },
+    { id: caseyUserId, name: "Casey Collaborator", email: `${caseyUserId}@team-access.test`, emailVerified: true },
+    { id: novaUserId, name: "Nova Nonmember", email: `${novaUserId}@team-access.test`, emailVerified: true },
+  ])
+  await db.insert(OrganizationTable).values([
+    { id: organizationId, name: "Team Access Test", slug: `team-access-${organizationId}` },
+    { id: otherOrganizationId, name: "Other Team Access Test", slug: `other-team-access-${otherOrganizationId}` },
+  ])
+  await db.insert(MemberTable).values([
+    { id: adminMemberId, organizationId, userId: adminUserId, role: "admin" },
+    { id: caseyMemberId, organizationId, userId: caseyUserId, role: "member" },
+    { id: novaMemberId, organizationId, userId: novaUserId, role: "member" },
+  ])
+  await db.insert(TeamTable).values([
+    { id: teamId, organizationId, name: "Product" },
+    { id: otherOrganizationTeamId, organizationId: otherOrganizationId, name: "Other Product" },
+  ])
+  await db.insert(TeamMemberTable).values({
+    id: createDenTypeId("teamMember"),
+    teamId,
+    orgMembershipId: caseyMemberId,
+  })
+  await db.insert(MarketplaceTable).values({
+    id: marketplaceId,
+    organizationId,
+    name: "Curated Catalog",
+    description: "Team catalog",
+    status: "active",
+    createdByOrgMembershipId: adminMemberId,
+  })
+  await db.insert(PluginTable).values([
+    { id: pluginAId, organizationId, name: "Alpha", status: "active", createdByOrgMembershipId: caseyMemberId },
+    { id: pluginBId, organizationId, name: "Beta", status: "active", createdByOrgMembershipId: adminMemberId },
+    { id: pluginCId, organizationId, name: "Charlie", status: "active", createdByOrgMembershipId: adminMemberId },
+    { id: pluginDId, organizationId, name: "Delta", status: "archived", createdByOrgMembershipId: adminMemberId },
+    { id: pluginEId, organizationId, name: "Echo", status: "active", createdByOrgMembershipId: adminMemberId },
+  ])
+  await db.insert(ConfigObjectTable).values({
+    id: configObjectId,
+    organizationId,
+    objectType: "skill",
+    sourceMode: "cloud",
+    title: "Alpha Skill",
+    status: "active",
+    createdByOrgMembershipId: caseyMemberId,
+  })
+  await db.insert(PluginConfigObjectTable).values({
+    id: createDenTypeId("pluginConfigObject"),
+    organizationId,
+    pluginId: pluginAId,
+    configObjectId,
+    membershipSource: "manual",
+    createdByOrgMembershipId: caseyMemberId,
+  })
+  await db.insert(MarketplacePluginTable).values({
+    id: createDenTypeId("marketplacePlugin"),
+    organizationId,
+    marketplaceId,
+    pluginId: pluginBId,
+    membershipSource: "manual",
+    createdByOrgMembershipId: adminMemberId,
+  })
+  await db.insert(MarketplaceAccessGrantTable).values({
+    id: marketplaceGrantId,
+    organizationId,
+    marketplaceId,
+    orgMembershipId: null,
+    teamId,
+    orgWide: false,
+    role: "editor",
+    createdByOrgMembershipId: adminMemberId,
+    createdAt: marketplaceGrantedAt,
+  })
+  await db.insert(PluginAccessGrantTable).values([
+    {
+      id: directGrantId,
+      organizationId,
+      pluginId: pluginAId,
+      orgMembershipId: null,
+      teamId,
+      orgWide: false,
+      role: "viewer",
+      createdByOrgMembershipId: caseyMemberId,
+      createdAt: directGrantedAt,
+    },
+    {
+      id: orgWideGrantId,
+      organizationId,
+      pluginId: pluginCId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      role: "viewer",
+      createdByOrgMembershipId: adminMemberId,
+      createdAt: orgWideGrantedAt,
+    },
+    {
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId,
+      pluginId: pluginDId,
+      orgMembershipId: null,
+      teamId,
+      orgWide: false,
+      role: "viewer",
+      createdByOrgMembershipId: adminMemberId,
+    },
+    {
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId,
+      pluginId: pluginEId,
+      orgMembershipId: null,
+      teamId,
+      orgWide: false,
+      role: "viewer",
+      createdByOrgMembershipId: adminMemberId,
+      removedAt: new Date("2026-01-04T10:00:00.000Z"),
+    },
+  ])
+})
+
+afterAll(async () => {
+  await cleanup()
+  mock.restore()
+})
+
+function requestTeamAccess(actor: "admin" | "casey" | "nova", requestedTeamId = teamId) {
+  return app.fetch(new Request(`${API_ORIGIN}/v1/teams/${requestedTeamId}/plugin-access`, {
+    headers: { "x-test-actor": actor },
+  }))
+}
+
+const expectedItems = [
+  {
+    plugin: { id: pluginAId, name: "Alpha", componentCount: 1 },
+    edge: "direct_team",
+    marketplace: null,
+    role: "viewer",
+    grantedBy: { orgMembershipId: caseyMemberId, name: "Casey Collaborator" },
+    grantedAt: directGrantedAt.toISOString(),
+    grantId: directGrantId,
+  },
+  {
+    plugin: { id: pluginBId, name: "Beta", componentCount: 0 },
+    edge: "via_catalog",
+    marketplace: { id: marketplaceId, name: "Curated Catalog" },
+    role: "editor",
+    grantedBy: { orgMembershipId: adminMemberId, name: "Avery Admin" },
+    grantedAt: marketplaceGrantedAt.toISOString(),
+    grantId: null,
+  },
+  {
+    plugin: { id: pluginCId, name: "Charlie", componentCount: 0 },
+    edge: "org_wide",
+    marketplace: null,
+    role: "viewer",
+    grantedBy: { orgMembershipId: adminMemberId, name: "Avery Admin" },
+    grantedAt: orgWideGrantedAt.toISOString(),
+    grantId: null,
+  },
+]
+
+test("an org admin sees the team's effective plugin access", async () => {
+  const response = await requestTeamAccess("admin")
+  expect(response.status).toBe(200)
+  const payload = teamPluginAccessListResponseSchema.parse(await response.json())
+  expect(payload).toEqual({ items: expectedItems })
+})
+
+test("a non-admin team member sees the same effective plugin access", async () => {
+  const response = await requestTeamAccess("casey")
+  expect(response.status).toBe(200)
+  const payload = teamPluginAccessListResponseSchema.parse(await response.json())
+  expect(payload).toEqual({ items: expectedItems })
+})
+
+test("a non-member cannot view the team's plugin access", async () => {
+  const response = await requestTeamAccess("nova")
+  expect(response.status).toBe(403)
+  expect(await response.json()).toMatchObject({ error: "forbidden" })
+})
+
+test("an unknown team returns not found", async () => {
+  const response = await requestTeamAccess("admin", unknownTeamId)
+  expect(response.status).toBe(404)
+  expect(await response.json()).toMatchObject({ error: "team_not_found" })
+})
+
+test("a team from another organization returns not found", async () => {
+  const response = await requestTeamAccess("admin", otherOrganizationTeamId)
+  expect(response.status).toBe(404)
+  expect(await response.json()).toMatchObject({ error: "team_not_found" })
+})

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -519,6 +519,10 @@ export function getMembersRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/members`;
 }
 
+export function getTeamRoute(orgSlug: string | null | undefined, teamId: string): string {
+  return `${getMembersRoute(orgSlug)}/teams/${encodeURIComponent(teamId)}`;
+}
+
 export function getBackgroundAgentsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/background-agents`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/members/teams/[teamId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/members/teams/[teamId]/page.tsx
@@ -1,0 +1,10 @@
+import { TeamDetailScreen } from "../../../../_components/team-detail-screen";
+
+export default async function TeamDetailPage({
+  params,
+}: {
+  params: Promise<{ teamId: string }>;
+}) {
+  const { teamId } = await params;
+  return <TeamDetailScreen teamId={teamId} />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { type ElementType, useEffect, useMemo, useState } from "react";
 import {
   CheckCircle2,
   Circle,
-  Link,
+  Link as LinkIcon,
   Lock,
   MoreHorizontal,
   Pencil,
@@ -24,6 +25,7 @@ import {
   getOrgAccessFlags,
   isAssignableOrgRole,
   getMembersRoute,
+  getTeamRoute,
   splitRoleString,
   type DenOrgMember,
 } from "../../_lib/den-org";
@@ -127,6 +129,7 @@ function SummaryCard({
 export function ManageMembersScreen() {
   const {
     activeOrg,
+    orgSlug,
     orgContext,
     orgBusy,
     orgError,
@@ -786,7 +789,7 @@ export function ManageMembersScreen() {
                   <DenButton
                     data-testid="copy-install-link"
                     variant="secondary"
-                    icon={Link}
+                    icon={LinkIcon}
                     onClick={() => void handleCopyInstallLink()}
                     loading={installLinkBusy || mutationBusy === "copy-install-link"}
                   >
@@ -903,7 +906,7 @@ export function ManageMembersScreen() {
                                 }}
                                 className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50"
                               >
-                                <Link className="h-3.5 w-3.5" />
+                                <LinkIcon className="h-3.5 w-3.5" />
                                 Copy invite link
                               </button>
                             ) : null}
@@ -1132,9 +1135,12 @@ export function ManageMembersScreen() {
                 >
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-[13px] font-medium text-gray-900">
+                      <Link
+                        href={getTeamRoute(orgSlug, team.id)}
+                        className="text-[13px] font-medium text-gray-900 hover:underline"
+                      >
                         {team.name}
-                      </span>
+                      </Link>
                       {team.managedByScim ? (
                         <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-cyan-700">
                           Managed by SCIM

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-access-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-access-data.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+export type TeamPluginAccessEdge = "direct_team" | "via_catalog" | "org_wide";
+export type TeamPluginAccessRole = "viewer" | "editor" | "manager";
+
+export type TeamPluginAccessItem = {
+  plugin: {
+    id: string;
+    name: string;
+    componentCount: number;
+  };
+  edge: TeamPluginAccessEdge;
+  marketplace: {
+    id: string;
+    name: string;
+  } | null;
+  role: TeamPluginAccessRole;
+  grantedBy: {
+    orgMembershipId: string;
+    name: string;
+  } | null;
+  grantedAt: string;
+  grantId: string | null;
+};
+
+export const teamAccessQueryKeys = {
+  all: ["team-access"],
+  detail: (teamId: string) => ["team-access", "detail", teamId],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseEdge(value: unknown): TeamPluginAccessEdge | null {
+  if (value === "direct_team" || value === "via_catalog" || value === "org_wide") {
+    return value;
+  }
+  return null;
+}
+
+function parseRole(value: unknown): TeamPluginAccessRole | null {
+  if (value === "viewer" || value === "editor" || value === "manager") {
+    return value;
+  }
+  return null;
+}
+
+function parseTeamPluginAccessItem(entry: unknown): TeamPluginAccessItem | null {
+  if (!isRecord(entry) || !isRecord(entry.plugin)) return null;
+
+  const pluginId = asString(entry.plugin.id);
+  const pluginName = asString(entry.plugin.name);
+  const componentCount = entry.plugin.componentCount;
+  const edge = parseEdge(entry.edge);
+  const role = parseRole(entry.role);
+  const grantedAt = asString(entry.grantedAt);
+  if (
+    !pluginId
+    || !pluginName
+    || typeof componentCount !== "number"
+    || !Number.isFinite(componentCount)
+    || componentCount < 0
+    || !edge
+    || !role
+    || !grantedAt
+  ) {
+    return null;
+  }
+
+  let marketplace: TeamPluginAccessItem["marketplace"] = null;
+  if (entry.marketplace !== null) {
+    if (!isRecord(entry.marketplace)) return null;
+    const id = asString(entry.marketplace.id);
+    const name = asString(entry.marketplace.name);
+    if (!id || !name) return null;
+    marketplace = { id, name };
+  }
+  if (edge === "via_catalog" && !marketplace) return null;
+
+  let grantedBy: TeamPluginAccessItem["grantedBy"] = null;
+  if (entry.grantedBy !== null) {
+    if (!isRecord(entry.grantedBy)) return null;
+    const orgMembershipId = asString(entry.grantedBy.orgMembershipId);
+    const name = asString(entry.grantedBy.name);
+    if (!orgMembershipId || !name) return null;
+    grantedBy = { orgMembershipId, name };
+  }
+
+  const grantId = entry.grantId === null ? null : asString(entry.grantId);
+  if (entry.grantId !== null && !grantId) return null;
+
+  return {
+    plugin: { id: pluginId, name: pluginName, componentCount },
+    edge,
+    marketplace,
+    role,
+    grantedBy,
+    grantedAt,
+    grantId,
+  };
+}
+
+export function useTeamPluginAccess(teamId: string) {
+  return useQuery({
+    queryKey: teamAccessQueryKeys.detail(teamId),
+    queryFn: async (): Promise<TeamPluginAccessItem[]> => {
+      const { response, payload } = await requestJson(
+        `/v1/teams/${encodeURIComponent(teamId)}/plugin-access`,
+        { method: "GET" },
+        15000,
+      );
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, `Failed to load team access (${response.status}).`));
+      }
+
+      const items = isRecord(payload) && Array.isArray(payload.items) ? payload.items : [];
+      return items
+        .map(parseTeamPluginAccessItem)
+        .filter((item): item is TeamPluginAccessItem => item !== null);
+    },
+  });
+}
+
+export function useRevokeTeamPluginAccess() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { teamId: string; pluginId: string; grantId: string }) => {
+      await runReauthableAction("revoke-team-plugin-access", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/plugins/${encodeURIComponent(input.pluginId)}/access/${encodeURIComponent(input.grantId)}`,
+          { method: "DELETE" },
+          15000,
+        );
+        if (response.status !== 204 && !response.ok) {
+          throw getRequestError(payload, response, `Failed to revoke access (${response.status}).`);
+        }
+      });
+      return input.teamId;
+    },
+    onSuccess: (teamId) => {
+      queryClient.invalidateQueries({ queryKey: teamAccessQueryKeys.detail(teamId) });
+    },
+  });
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { ArrowLeft, ShieldCheck, Users } from "lucide-react";
+import { DenBadge } from "../../_components/ui/badge";
+import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
+import { type TabItem, UnderlineTabs } from "../../_components/ui/tabs";
+import { getMarketplaceRoute, getMembersRoute } from "../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { OrgMemberIdentity } from "./org-member-identity";
+import {
+  type TeamPluginAccessItem,
+  useRevokeTeamPluginAccess,
+  useTeamPluginAccess,
+} from "./team-access-data";
+
+type TeamDetailTab = "overview" | "access";
+
+function formatGrantedDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function AccessViaBadge({ item }: { item: TeamPluginAccessItem }) {
+  if (item.edge === "direct_team") {
+    return <DenBadge tone="success">direct team grant</DenBadge>;
+  }
+  if (item.edge === "via_catalog") {
+    return <DenBadge tone="info">via catalog: {item.marketplace?.name}</DenBadge>;
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-medium text-emerald-600">
+      org-wide
+    </span>
+  );
+}
+
+function RoleBadge({ role }: { role: TeamPluginAccessItem["role"] }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-1 text-[12px] font-medium ${
+        role === "editor"
+          ? "border border-amber-200 bg-amber-50 text-amber-700"
+          : "bg-gray-100 text-gray-600"
+      }`}
+    >
+      {role}
+    </span>
+  );
+}
+
+export function TeamDetailScreen({ teamId }: { teamId: string }) {
+  const { orgContext, orgSlug } = useOrgDashboard();
+  const [activeTab, setActiveTab] = useState<TeamDetailTab>("access");
+  const accessQuery = useTeamPluginAccess(teamId);
+  const revokeAccess = useRevokeTeamPluginAccess();
+  const team = orgContext?.teams.find((entry) => entry.id === teamId);
+  const membersById = new Map((orgContext?.members ?? []).map((member) => [member.id, member]));
+  const teamMembers = (team?.memberIds ?? []).flatMap((memberId) => {
+    const member = membersById.get(memberId);
+    return member ? [member] : [];
+  });
+  const memberCount = team?.memberIds.length ?? 0;
+  const tabs: readonly TabItem<TeamDetailTab>[] = [
+    { value: "overview", label: "Overview", icon: Users },
+    { value: "access", label: "Access", icon: ShieldCheck },
+  ];
+
+  return (
+    <div className="mx-auto max-w-[860px] px-6 py-8 md:px-8">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <Link
+          href={getMembersRoute(orgSlug)}
+          className="inline-flex items-center gap-1.5 text-[13px] text-gray-400 transition hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Link>
+      </div>
+
+      <header className="flex flex-wrap items-center gap-3">
+        <h1 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-950">
+          {team?.name ?? "Team"}
+        </h1>
+        <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[12px] font-medium text-gray-600">
+          {memberCount} {memberCount === 1 ? "member" : "members"}
+        </span>
+      </header>
+
+      <UnderlineTabs
+        className="mt-6"
+        tabs={tabs}
+        activeTab={activeTab}
+        onChange={setActiveTab}
+      />
+
+      <div className="mt-6">
+        {activeTab === "overview" ? (
+          <div role="tabpanel" aria-label="Overview">
+            {teamMembers.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
+                <p className="text-[14px] font-medium text-gray-800">This team has no members yet.</p>
+              </div>
+            ) : (
+              <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
+                {teamMembers.map((member) => (
+                  <div key={member.id} className="px-6 py-4">
+                    <OrgMemberIdentity member={member} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        {activeTab === "access" ? (
+          <div role="tabpanel" aria-label="Access">
+            {accessQuery.isLoading ? (
+              <div className="rounded-2xl border border-gray-100 bg-white px-6 py-8 text-[13px] text-gray-400">
+                Loading team access…
+              </div>
+            ) : accessQuery.error ? (
+              <DenNotice
+                tone="error"
+                message={accessQuery.error instanceof Error ? accessQuery.error.message : "Could not load team access."}
+              />
+            ) : accessQuery.data?.length ? (
+              <div className="overflow-x-auto rounded-2xl border border-gray-100 bg-white">
+                <div className="min-w-[760px]">
+                  <div className="grid grid-cols-[minmax(0,1fr)_210px_100px_230px_110px] border-b border-gray-100 px-6 py-3 text-[11px] uppercase tracking-[0.14em] text-gray-400">
+                    <span>Plugin</span>
+                    <span>Access via</span>
+                    <span>Role</span>
+                    <span>Granted by</span>
+                    <span />
+                  </div>
+                  <div className="divide-y divide-gray-100">
+                    {accessQuery.data.map((item) => {
+                      const revoking = revokeAccess.isPending && revokeAccess.variables?.grantId === item.grantId;
+                      return (
+                        <div
+                          key={`${item.plugin.id}-${item.edge}-${item.grantId ?? item.marketplace?.id ?? "org"}`}
+                          className={`grid grid-cols-[minmax(0,1fr)_210px_100px_230px_110px] items-center px-6 py-3.5 ${item.role === "editor" ? "bg-amber-50/40" : ""}`}
+                        >
+                          <div className="min-w-0 pr-4">
+                            <p className="truncate text-[14px] font-semibold text-gray-900">{item.plugin.name}</p>
+                            <p className="mt-0.5 text-[12px] text-gray-400">
+                              {item.plugin.componentCount} {item.plugin.componentCount === 1 ? "component" : "components"}
+                            </p>
+                          </div>
+                          <div className="pr-4">
+                            <AccessViaBadge item={item} />
+                          </div>
+                          <div>
+                            <RoleBadge role={item.role} />
+                          </div>
+                          <p className="pr-4 text-[13px] text-gray-500">
+                            {item.grantedBy?.name ?? "—"} · {formatGrantedDate(item.grantedAt)}
+                          </p>
+                          <div className="flex justify-end">
+                            {item.edge === "direct_team" ? (
+                              <DenButton
+                                variant="destructive"
+                                size="sm"
+                                disabled={!item.grantId}
+                                loading={revoking}
+                                onClick={() => {
+                                  if (!item.grantId) return;
+                                  revokeAccess.mutate({
+                                    teamId,
+                                    pluginId: item.plugin.id,
+                                    grantId: item.grantId,
+                                  });
+                                }}
+                              >
+                                Revoke
+                              </DenButton>
+                            ) : item.edge === "via_catalog" && item.marketplace ? (
+                              <DenButton
+                                href={getMarketplaceRoute(orgSlug, item.marketplace.id)}
+                                variant="secondary"
+                                size="sm"
+                              >
+                                Open catalog
+                              </DenButton>
+                            ) : null}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
+                <p className="text-[14px] font-medium text-gray-800">This team has no plugin access yet.</p>
+              </div>
+            )}
+
+            {revokeAccess.error ? (
+              <DenNotice
+                className="mt-4"
+                tone="error"
+                message={revokeAccess.error instanceof Error ? revokeAccess.error.message : "Could not revoke plugin access."}
+              />
+            ) : null}
+
+            <p className="mt-4 text-[12px] text-gray-500">
+              direct = revocable here; via catalog = manage in the catalog; org-wide = org setting.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -269,6 +269,10 @@ export async function evaluate(
   return isRecord(result) ? result.value : undefined;
 }
 
+export async function navigate(client: CdpClient, url: string): Promise<void> {
+  await client.send("Page.navigate", { url });
+}
+
 export async function captureScreenshot(client: CdpClient): Promise<Buffer> {
   const payload = await client.send("Page.captureScreenshot", { format: "png" });
   if (!isRecord(payload) || typeof payload.data !== "string") {

--- a/evals/specs/team-access-view.slow.test.ts
+++ b/evals/specs/team-access-view.slow.test.ts
@@ -1,6 +1,7 @@
 import { expect, onTestFinished, test } from "vitest";
 import { denFetch, ensureMemberSession, evalIn, fill, signIn, waitFor } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
 import { photoRoll, screenshot, validate } from "@openwork/fraimz";
 import { chrome } from "@openwork/hosts";
 
@@ -228,7 +229,7 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
   expect(tokenStored).toBe(true);
 
   const teamUrl = `${webUrl}/dashboard/members/teams/${encodeURIComponent(teamId)}`;
-  await evalIn(browser, `(() => { location.href = ${JSON.stringify(teamUrl)}; return true; })()`);
+  await navigate(browser.client, teamUrl);
   const teamAccessReady = `document.body.innerText.includes(${JSON.stringify(teamName)})
     && document.body.innerText.includes("direct team grant")`;
   let handoffError: unknown;
@@ -276,7 +277,7 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
       timeoutMs: 60_000,
       label: "Den Web dashboard after form sign-in",
     });
-    await evalIn(browser, `(() => { location.href = ${JSON.stringify(teamUrl)}; return true; })()`);
+    await navigate(browser.client, teamUrl);
     await waitFor(browser, teamAccessReady, { timeoutMs: 60_000, label: "team name and direct team grant after form sign-in" });
   }
 

--- a/evals/specs/team-access-view.slow.test.ts
+++ b/evals/specs/team-access-view.slow.test.ts
@@ -1,0 +1,291 @@
+import { expect, onTestFinished, test } from "vitest";
+import { denFetch, ensureMemberSession, evalIn, fill, signIn, waitFor } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { photoRoll, screenshot, validate } from "@openwork/fraimz";
+import { chrome } from "@openwork/hosts";
+
+const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
+const webUrl = process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim().replace(/\/+$/, "") ?? "";
+const title = !apiUrl
+  ? "team access view skipped: set OPENWORK_EVAL_DEN_API_URL to a running Den API"
+  : !webUrl
+    ? "team access view skipped: set OPENWORK_EVAL_DEN_WEB_URL to a running Den Web"
+    : "team members can inspect effective plugin access while non-members are denied";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = orgs.find((entry) => entry.slug === "acme-robotics-demo")
+    ?? orgs.find((entry) => entry.name === "Acme Robotics")
+    ?? orgs[0];
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function selectOrganization(session: DenSession, orgId: string): Promise<void> {
+  const result = await denFetch(session, "/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${session.token}` },
+    body: JSON.stringify({ organizationId: orgId }),
+  });
+  if (!result.response.ok) {
+    throw new Error(`Selecting Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+}
+
+async function organizationMemberIdByEmail(session: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(session, "/v1/org", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const memberId = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !memberId.startsWith("om_")) {
+    throw new Error(`Resolving ${email} in the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return memberId;
+}
+
+function accessItems(body: unknown): Record<string, unknown>[] {
+  return isRecord(body) && Array.isArray(body.items) ? body.items.filter(isRecord) : [];
+}
+
+function pluginIdForAccessItem(item: Record<string, unknown>): string {
+  return isRecord(item.plugin) && typeof item.plugin.id === "string" ? item.plugin.id : "";
+}
+
+test.skipIf(!apiUrl || !webUrl)(title, async () => {
+  const den = { apiUrl, webUrl };
+  const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+  const admin = await signIn(den, {
+    email: process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test",
+    password,
+  });
+  const orgId = await organizationId(admin);
+  await selectOrganization(admin, orgId);
+
+  const stamp = Date.now();
+  const teamName = `Spec Access Team ${stamp}`;
+  const createdTeam = await denFetch(admin, "/v1/teams", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${admin.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ name: teamName }),
+  });
+  const team = isRecord(createdTeam.body) && isRecord(createdTeam.body.team) ? createdTeam.body.team : null;
+  const teamId = team && typeof team.id === "string" ? team.id : "";
+  if (createdTeam.response.status !== 201 || !teamId) {
+    throw new Error(`Creating the spec access team failed: HTTP ${createdTeam.response.status} ${createdTeam.text.slice(0, 500)}`);
+  }
+
+  let caseySession: DenSession | undefined;
+  let pluginId = "";
+  onTestFinished(async () => {
+    const creator = caseySession;
+    const createdPluginId = pluginId;
+    if (creator && createdPluginId) {
+      await denFetch(creator, `/v1/plugins/${encodeURIComponent(createdPluginId)}/archive`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${creator.token}`,
+          "x-openwork-org-id": orgId,
+        },
+      }).catch(() => undefined);
+    }
+    await denFetch(admin, `/v1/teams/${encodeURIComponent(teamId)}`, {
+      method: "DELETE",
+      headers: {
+        authorization: `Bearer ${admin.token}`,
+        "x-openwork-org-id": orgId,
+      },
+    }).catch(() => undefined);
+  });
+
+  const caseyEmail = process.env.OPENWORK_EVAL_CREATOR_EMAIL?.trim() || "casey.spec@acme.test";
+  caseySession = await ensureMemberSession(den, admin, {
+    email: caseyEmail,
+    password: process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || password,
+    name: "Casey Spec",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  const casey = caseySession;
+  await selectOrganization(casey, orgId);
+  const caseyMemberId = await organizationMemberIdByEmail(admin, orgId, caseyEmail);
+  const updatedTeam = await denFetch(admin, `/v1/teams/${encodeURIComponent(teamId)}`, {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${admin.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ memberIds: [caseyMemberId] }),
+  });
+  if (!updatedTeam.response.ok) {
+    throw new Error(`Adding Casey to the spec access team failed: HTTP ${updatedTeam.response.status} ${updatedTeam.text.slice(0, 500)}`);
+  }
+
+  const pluginName = `Spec Team Access Plugin ${stamp}`;
+  const skillName = `spec-team-access-${stamp}`;
+  const rawSourceText = `---\nname: ${skillName}\ndescription: Proves effective team plugin access.\n---\n\nReturn the team access proof phrase.`;
+  const createdPlugin = await denFetch(casey, "/v1/plugins", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({
+      name: pluginName,
+      components: [{ type: "skill", input: { rawSourceText } }],
+    }),
+  });
+  const plugin = isRecord(createdPlugin.body) && isRecord(createdPlugin.body.item) ? createdPlugin.body.item : null;
+  pluginId = plugin && typeof plugin.id === "string" ? plugin.id : "";
+  if (createdPlugin.response.status !== 201 || !pluginId) {
+    throw new Error(`Creating the team access plugin failed: HTTP ${createdPlugin.response.status} ${createdPlugin.text.slice(0, 500)}`);
+  }
+
+  const granted = await denFetch(casey, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ teamId, role: "viewer" }),
+  });
+  if (granted.response.status !== 201) {
+    throw new Error(`Granting team access failed: HTTP ${granted.response.status} ${granted.text.slice(0, 500)}`);
+  }
+
+  const adminAccess = await denFetch(admin, `/v1/teams/${encodeURIComponent(teamId)}/plugin-access`, {
+    headers: {
+      authorization: `Bearer ${admin.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  expect(adminAccess.response.status).toBe(200);
+  const adminItems = accessItems(adminAccess.body);
+  const directAccess = adminItems.find((item) => item.edge === "direct_team" && pluginIdForAccessItem(item) === pluginId);
+  expect(directAccess).toBeDefined();
+  if (!directAccess) throw new Error(`Admin response omitted the direct team access row: ${adminAccess.text.slice(0, 500)}`);
+  expect(directAccess.role).toBe("viewer");
+  expect(typeof directAccess.grantId === "string" && directAccess.grantId.length > 0).toBe(true);
+  const grantedBy = isRecord(directAccess.grantedBy) ? directAccess.grantedBy : null;
+  expect(grantedBy && typeof grantedBy.name === "string" && grantedBy.name.includes("Casey")).toBe(true);
+  expect(adminItems.some((item) => item.edge === "org_wide")).toBe(true);
+
+  const caseyAccess = await denFetch(casey, `/v1/teams/${encodeURIComponent(teamId)}/plugin-access`, {
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  expect(caseyAccess.response.status).toBe(200);
+  expect(
+    accessItems(caseyAccess.body).some((item) => item.edge === "direct_team" && pluginIdForAccessItem(item) === pluginId && item.role === "viewer"),
+  ).toBe(true);
+
+  const nova = await ensureMemberSession(den, admin, {
+    email: process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "nova.spec@acme.test",
+    password: process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || password,
+    name: "Nova Spec",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  await selectOrganization(nova, orgId);
+  const novaAccess = await denFetch(nova, `/v1/teams/${encodeURIComponent(teamId)}/plugin-access`, {
+    headers: {
+      authorization: `Bearer ${nova.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  expect(novaAccess.response.status).toBe(403);
+
+  await using browser = await chrome({ name: "p3-team-access", startUrl: webUrl, headless: true });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin before auth token handoff",
+  });
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+
+  const teamUrl = `${webUrl}/dashboard/members/teams/${encodeURIComponent(teamId)}`;
+  await evalIn(browser, `(() => { location.href = ${JSON.stringify(teamUrl)}; return true; })()`);
+  const teamAccessReady = `document.body.innerText.includes(${JSON.stringify(teamName)})
+    && document.body.innerText.includes("direct team grant")`;
+  let handoffError: unknown;
+  try {
+    await waitFor(browser, teamAccessReady, { timeoutMs: 60_000, label: "team name and direct team grant" });
+  } catch (error) {
+    handoffError = error;
+  }
+
+  if (handoffError) {
+    const hasAuthInput = await evalIn(
+      browser,
+      `Boolean(document.querySelector('input[type="email"], input[name="email"], input[type="password"]'))`,
+    );
+    if (hasAuthInput !== true) throw handoffError;
+
+    const hasEmailInput = await evalIn(browser, `Boolean(document.querySelector('input[type="email"], input[name="email"]'))`);
+    const hasPasswordInput = await evalIn(browser, `Boolean(document.querySelector('input[type="password"]'))`);
+    if (hasEmailInput === true) {
+      await fill(browser, 'input[type="email"], input[name="email"]', admin.email);
+    }
+    if (hasEmailInput === true && hasPasswordInput !== true) {
+      const nextClicked = await evalIn(browser, `(() => {
+        const button = [...document.querySelectorAll("button")]
+          .find((entry) => (entry.textContent ?? "").trim() === "Next");
+        button?.click();
+        return Boolean(button);
+      })()`);
+      expect(nextClicked).toBe(true);
+      await waitFor(browser, `Boolean(document.querySelector('input[type="password"]'))`, {
+        timeoutMs: 30_000,
+        label: "Den Web password step",
+      });
+    }
+    await fill(browser, 'input[type="password"]', password);
+    const signInClicked = await evalIn(browser, `(() => {
+      const button = [...document.querySelectorAll("button")]
+        .reverse()
+        .find((entry) => (entry.textContent ?? "").trim() === "Sign in");
+      button?.click();
+      return Boolean(button);
+    })()`);
+    expect(signInClicked).toBe(true);
+    await waitFor(browser, `location.pathname.startsWith("/dashboard") && !document.querySelector('input[type="password"]')`, {
+      timeoutMs: 60_000,
+      label: "Den Web dashboard after form sign-in",
+    });
+    await evalIn(browser, `(() => { location.href = ${JSON.stringify(teamUrl)}; return true; })()`);
+    await waitFor(browser, teamAccessReady, { timeoutMs: 60_000, label: "team name and direct team grant after form sign-in" });
+  }
+
+  const shot = await screenshot(browser);
+  const seen = await validate(shot, [
+    "A team access table lists a plugin with a direct team grant badge",
+    "A role pill reading viewer is visible",
+  ]);
+  await using roll = photoRoll("p3-team-access");
+  await roll.add(shot, seen);
+  expect(seen.ok, seen.why).toBe(true);
+});

--- a/prds/skill-sharing/grant-native-skill-sharing.md
+++ b/prds/skill-sharing/grant-native-skill-sharing.md
@@ -234,6 +234,19 @@ non-manager denial, recipient cannot re-share.
 
 ### P3 — Library UI + provenance
 
+#### P3 PR1 — team access view (shipped from this branch)
+
+Design source: Paper file "P3 — Access Visibility" (screens annotated with
+den-web primitive mappings and NEW rationale). Shipped: `GET
+/v1/teams/:teamId/plugin-access` (direct_team / via_catalog / org_wide edges,
+server-side grantor names, admin-or-team-member gated) + den-web team detail
+page (Members ▸ Teams ▸ team name) with Overview and Access tabs — the
+members-grid pattern, edge badges on DenBadge tones, amber editor rows,
+Revoke for direct grants, Open catalog for inherited ones. Proof:
+`test/plugin-system-team-access.test.ts` (route-level, real MySQL) +
+`evals/specs/team-access-view.slow.test.ts` (API leg + headless-Chrome
+browser leg with vision-validated photo roll of the real screen).
+
 Dashboard library: Mine / Shared with me / Team / Everyone, one row per
 plugin, provenance chips (Yours / Shared by N / Team T / catalog M /
 built-in), per-skill access list, revoke, delete blast-radius warning.


### PR DESCRIPTION
## What

PR1 of P3 from the **Grant-Native Skill Sharing** program — built to the Paper design ("P3 — Access Visibility", den-primitive-annotated): the admin answer to *what can this team use, and via which edge*.

**den-api** — `GET /v1/teams/:teamId/plugin-access`: one item per (plugin, edge) — `direct_team` (with grantId for revoke), `via_catalog` (with marketplace), `org_wide` — role, server-resolved grantor names, grantedAt. Gated: org admin or member of the team; 404 unknown/foreign team. Active plugins only, componentCounts included.

**den-web** — team names in Members ▸ Teams now link to a new team detail page (`members/teams/[teamId]`): Overview (OrgMemberIdentity rows) + **Access** tab — members-grid pattern, edge badges on DenBadge tones, amber rows + bordered pill for editor grants (the 'this team can change it for everyone' warning), Revoke for direct grants (existing DELETE route), Open catalog for inherited ones, dashed empty state, edge legend. Hand-rolled Den* primitives only, per house rules (no shadows, UnderlineTabs, bracketed text sizes).

## Tests (commands + results)

```
cd ee/apps/den-api
bun test test/plugin-system-team-access.test.ts test/plugin-system-access.test.ts \
  test/plugin-system-member-create.test.ts test/grant-native-capabilities.test.ts
# → 21 pass / 0 fail; pnpm exec tsc --noEmit clean
cd ee/apps/den-web && pnpm run build   # clean, new route generated
pnpm --dir evals exec vitest run --project nightly specs/team-access-view.slow.test.ts
# → 3× pass (executor 2× + orchestrator rerun) against live den-api + den-web from this branch:
#   admin/team-member 200 with direct_team row (grantor name), non-member 403,
#   then headless Chrome loads the real screen — vision validated 2/2 expectations
pnpm --dir evals run typecheck   # clean
```

Photo roll of the real screen follows as the sticky `photo-roll` comment (published via the evidence publisher). One test-infra fix rode along: the new bun suite seeded env after a hoisted value-import — made the schema import dynamic so the file is order-independent.