### PR TITLE
feat(den-web): plugin access panel — who has this plugin, share with role choice, blast-radius confirm (P3 PR2)

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-access-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-access-data.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+export type PluginAccessRole = "viewer" | "editor" | "manager";
+
+export type PluginAccessGrant = {
+  id: string;
+  orgMembershipId: string | null;
+  teamId: string | null;
+  orgWide: boolean;
+  role: PluginAccessRole;
+  createdByOrgMembershipId: string;
+  createdAt: string;
+  removedAt: string | null;
+};
+
+export const pluginAccessQueryKeys = {
+  all: ["plugin-access"],
+  detail: (pluginId: string) => [...pluginAccessQueryKeys.all, pluginId],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  const parsed = readString(value);
+  return parsed ?? undefined;
+}
+
+function readRole(value: unknown): PluginAccessRole | null {
+  if (value === "viewer" || value === "editor" || value === "manager") return value;
+  return null;
+}
+
+function parsePluginAccessGrant(value: unknown): PluginAccessGrant | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value.id);
+  const orgMembershipId = readNullableString(value.orgMembershipId);
+  const teamId = readNullableString(value.teamId);
+  const role = readRole(value.role);
+  const createdByOrgMembershipId = readString(value.createdByOrgMembershipId);
+  const createdAt = readString(value.createdAt);
+  const removedAt = readNullableString(value.removedAt);
+  const targetCount = (orgMembershipId ? 1 : 0) + (teamId ? 1 : 0) + (value.orgWide === true ? 1 : 0);
+  if (
+    !id
+    || orgMembershipId === undefined
+    || teamId === undefined
+    || typeof value.orgWide !== "boolean"
+    || !role
+    || !createdByOrgMembershipId
+    || !createdAt
+    || removedAt === undefined
+    || targetCount !== 1
+  ) {
+    return null;
+  }
+  return {
+    id,
+    orgMembershipId,
+    teamId,
+    orgWide: value.orgWide,
+    role,
+    createdByOrgMembershipId,
+    createdAt,
+    removedAt,
+  };
+}
+
+export function usePluginAccess(pluginId: string) {
+  return useQuery({
+    enabled: Boolean(pluginId),
+    queryKey: pluginAccessQueryKeys.detail(pluginId),
+    queryFn: async (): Promise<PluginAccessGrant[]> => {
+      const { response, payload } = await requestJson(
+        `/v1/plugins/${encodeURIComponent(pluginId)}/access`,
+        { method: "GET" },
+        15000,
+      );
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, `Failed to load plugin access (${response.status}).`));
+      }
+      const items = isRecord(payload) && Array.isArray(payload.items) ? payload.items : [];
+      return items
+        .map(parsePluginAccessGrant)
+        .filter((grant): grant is PluginAccessGrant => grant !== null && grant.removedAt === null);
+    },
+  });
+}
+
+type GrantPluginAccessBody =
+  | { orgMembershipId: string; teamId?: never; orgWide?: never; role: PluginAccessRole }
+  | { orgMembershipId?: never; teamId: string; orgWide?: never; role: PluginAccessRole }
+  | { orgMembershipId?: never; teamId?: never; orgWide: true; role: PluginAccessRole };
+
+export function useGrantPluginAccess() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { pluginId: string; body: GrantPluginAccessBody }) => {
+      await runReauthableAction("grant-plugin-access", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/plugins/${encodeURIComponent(input.pluginId)}/access`,
+          { method: "POST", body: JSON.stringify(input.body) },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to grant plugin access (${response.status}).`);
+        }
+      });
+      return input.pluginId;
+    },
+    onSuccess: (pluginId) => {
+      queryClient.invalidateQueries({ queryKey: pluginAccessQueryKeys.detail(pluginId) });
+    },
+  });
+}
+
+export function useRevokePluginAccess() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { pluginId: string; grantId: string }) => {
+      await runReauthableAction("revoke-plugin-access", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/plugins/${encodeURIComponent(input.pluginId)}/access/${encodeURIComponent(input.grantId)}`,
+          { method: "DELETE" },
+          15000,
+        );
+        if (response.status !== 204 && !response.ok) {
+          throw getRequestError(payload, response, `Failed to revoke plugin access (${response.status}).`);
+        }
+      });
+      return input.pluginId;
+    },
+    onSuccess: (pluginId) => {
+      queryClient.invalidateQueries({ queryKey: pluginAccessQueryKeys.detail(pluginId) });
+    },
+  });
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-access-section.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-access-section.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Check, Globe, Plus, Users } from "lucide-react";
+
+import { getOrgAccessFlags } from "../../_lib/den-org";
+import { DenButton } from "../../_components/ui/button";
+import { DenInput } from "../../_components/ui/input";
+import { DenNotice } from "../../_components/ui/notice";
+import { DenSelect } from "../../_components/ui/select";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  type PluginAccessGrant,
+  type PluginAccessRole,
+  useGrantPluginAccess,
+  useRevokePluginAccess,
+} from "./plugin-access-data";
+import { OrgMemberIdentity } from "./org-member-identity";
+
+type PluginAccessSectionProps = {
+  pluginId: string;
+  pluginCreatedByOrgMembershipId: string | null;
+  grants: PluginAccessGrant[];
+  isLoading: boolean;
+  error: unknown;
+};
+
+type AccessCandidate = {
+  id: string;
+  searchText: string;
+  content: ReactNode;
+};
+
+function formatAccessDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "recently";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function roleLabel(role: PluginAccessRole) {
+  if (role === "viewer") return "Viewer";
+  if (role === "editor") return "Editor";
+  return "Manager";
+}
+
+function AccessRolePill({ role }: { role: PluginAccessRole }) {
+  return (
+    <span
+      className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium ${
+        role === "editor"
+          ? "border border-amber-200 bg-amber-50 text-amber-700"
+          : "bg-gray-100 text-gray-600"
+      }`}
+    >
+      {roleLabel(role)}
+    </span>
+  );
+}
+
+function TeamIdentity({ name, memberCount }: { name: string; memberCount: number }) {
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] bg-gray-100 text-gray-500">
+        <Users className="h-4 w-4" aria-hidden />
+      </div>
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-medium text-gray-900">{name}</p>
+        <p className="truncate text-[12px] text-gray-400">
+          {memberCount} {memberCount === 1 ? "member" : "members"}, future members included
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AccessAddPicker({
+  kind,
+  candidates,
+  disabled,
+  onGrant,
+}: {
+  kind: "person" | "team";
+  candidates: AccessCandidate[];
+  disabled: boolean;
+  onGrant: (id: string, role: "viewer" | "editor") => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [role, setRole] = useState<"viewer" | "editor">("viewer");
+  const [submitting, setSubmitting] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(event: MouseEvent) {
+      if (ref.current && !event.composedPath().includes(ref.current)) {
+        setOpen(false);
+        setQuery("");
+        setSelectedId(null);
+        setRole("viewer");
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [open]);
+
+  const filteredCandidates = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return candidates;
+    return candidates.filter((candidate) => candidate.searchText.includes(normalized));
+  }, [candidates, query]);
+
+  function resetAndClose() {
+    setOpen(false);
+    setQuery("");
+    setSelectedId(null);
+    setRole("viewer");
+  }
+
+  async function handleGrant() {
+    if (!selectedId) return;
+    setSubmitting(true);
+    try {
+      await onGrant(selectedId, role);
+      resetAndClose();
+    } catch {
+      // The mutation error is rendered below the access container.
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const label = kind === "person" ? "person" : "team";
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        disabled={disabled || candidates.length === 0}
+        onClick={() => {
+          if (open) {
+            resetAndClose();
+          } else {
+            setOpen(true);
+          }
+        }}
+        className="inline-flex items-center gap-1 rounded-full border border-dashed border-gray-300 px-3 py-1.5 text-[11.5px] text-gray-500 transition hover:border-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Plus className="h-3 w-3" aria-hidden />
+        Add {label}
+      </button>
+
+      {open ? (
+        <div className="absolute left-0 top-[calc(100%+6px)] z-20 w-[340px] rounded-2xl border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 p-3">
+            <DenInput
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={`Search ${kind === "person" ? "people" : "teams"}...`}
+              autoFocus
+            />
+          </div>
+          <div className="max-h-[220px] divide-y divide-gray-100 overflow-y-auto">
+            {filteredCandidates.length === 0 ? (
+              <p className="px-4 py-5 text-center text-[12px] text-gray-400">No matches</p>
+            ) : (
+              filteredCandidates.map((candidate) => {
+                const selected = candidate.id === selectedId;
+                return (
+                  <button
+                    key={candidate.id}
+                    type="button"
+                    onClick={() => setSelectedId(candidate.id)}
+                    className={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${selected ? "bg-gray-50" : "hover:bg-gray-50/70"}`}
+                  >
+                    <div className="min-w-0 flex-1">{candidate.content}</div>
+                    <Check className={`h-4 w-4 shrink-0 ${selected ? "text-emerald-600" : "text-transparent"}`} aria-hidden />
+                  </button>
+                );
+              })
+            )}
+          </div>
+          <div className="border-t border-gray-100 p-3">
+            <div className="flex items-center gap-2">
+              <DenSelect
+                aria-label={`Access role for ${label}`}
+                value={role}
+                onChange={(event) => setRole(event.target.value === "editor" ? "editor" : "viewer")}
+                className="min-w-0 flex-1"
+                disabled={submitting}
+              >
+                <option value="viewer">Can view (use in chat)</option>
+                <option value="editor">Can edit</option>
+              </DenSelect>
+              <DenButton
+                size="sm"
+                loading={submitting}
+                disabled={!selectedId}
+                onClick={() => void handleGrant()}
+              >
+                Grant
+              </DenButton>
+            </div>
+            {role === "editor" ? (
+              <p className="mt-2 text-[11.5px] leading-5 text-amber-700">
+                Can change this skill for everyone who has it.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function PluginAccessSection({
+  pluginId,
+  pluginCreatedByOrgMembershipId,
+  grants,
+  isLoading,
+  error,
+}: PluginAccessSectionProps) {
+  const { orgContext } = useOrgDashboard();
+  const grantMutation = useGrantPluginAccess();
+  const revokeMutation = useRevokePluginAccess();
+  const access = getOrgAccessFlags(
+    orgContext?.currentMember.role ?? "member",
+    orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles ?? [],
+  );
+  const members = orgContext?.members ?? [];
+  const teams = orgContext?.teams ?? [];
+  const membersById = new Map(members.map((member) => [member.id, member]));
+  const teamsById = new Map(teams.map((team) => [team.id, team]));
+  const orgWideGrant = grants.find((grant) => grant.orgWide) ?? null;
+  const memberGrants = grants.filter((grant) => grant.orgMembershipId !== null);
+  const teamGrants = grants.filter((grant) => grant.teamId !== null);
+  const hasGrantsBeyondCreator = grants.some(
+    (grant) => grant.orgMembershipId !== pluginCreatedByOrgMembershipId,
+  );
+  const busy = grantMutation.isPending || revokeMutation.isPending;
+
+  const memberCandidates: AccessCandidate[] = members
+    .filter((member) => !memberGrants.some((grant) => grant.orgMembershipId === member.id))
+    .map((member) => ({
+      id: member.id,
+      searchText: `${member.user.name} ${member.user.email}`.toLowerCase(),
+      content: <OrgMemberIdentity member={member} />,
+    }));
+  const teamCandidates: AccessCandidate[] = teams
+    .filter((team) => !teamGrants.some((grant) => grant.teamId === team.id))
+    .map((team) => ({
+      id: team.id,
+      searchText: team.name.toLowerCase(),
+      content: <TeamIdentity name={team.name} memberCount={team.memberIds.length} />,
+    }));
+
+  async function handleToggleOrgWide() {
+    try {
+      if (orgWideGrant) {
+        await revokeMutation.mutateAsync({ pluginId, grantId: orgWideGrant.id });
+      } else {
+        await grantMutation.mutateAsync({ pluginId, body: { orgWide: true, role: "viewer" } });
+      }
+    } catch {
+      // The mutation error is rendered below the access container.
+    }
+  }
+
+  async function handleRevoke(grantId: string) {
+    try {
+      await revokeMutation.mutateAsync({ pluginId, grantId });
+    } catch {
+      // The mutation error is rendered below the access container.
+    }
+  }
+
+  function grantPerson(memberId: string, role: "viewer" | "editor") {
+    return grantMutation.mutateAsync({
+      pluginId,
+      body: { orgMembershipId: memberId, role },
+    }).then(() => undefined);
+  }
+
+  function grantTeam(teamId: string, role: "viewer" | "editor") {
+    return grantMutation.mutateAsync({
+      pluginId,
+      body: { teamId, role },
+    }).then(() => undefined);
+  }
+
+  const mutationError = grantMutation.error ?? revokeMutation.error;
+
+  return (
+    <section>
+      <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+        Who can access this
+      </h2>
+
+      {error ? (
+        <DenNotice
+          tone="error"
+          message={error instanceof Error ? error.message : "Failed to load plugin access."}
+        />
+      ) : (
+        <div className="rounded-2xl border border-gray-100 bg-white">
+          {isLoading ? (
+            <p className="px-6 py-4 text-[13px] text-gray-400">Loading access…</p>
+          ) : (
+            <>
+              {access.isAdmin ? (
+                <button
+                  type="button"
+                  onClick={() => void handleToggleOrgWide()}
+                  disabled={busy}
+                  className="flex w-full items-center gap-4 rounded-t-2xl px-6 py-4 text-left transition hover:bg-gray-50/60 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] ${orgWideGrant ? "bg-emerald-50 text-emerald-600" : "bg-gray-100 text-gray-500"}`}>
+                    <Globe className="h-4 w-4" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[14px] font-semibold tracking-[-0.01em] text-gray-900">
+                      Everyone in the organization
+                    </p>
+                    <p className="mt-0.5 text-[12.5px] leading-[1.55] text-gray-500">
+                      {orgWideGrant
+                        ? "All organization members can use this plugin in chat."
+                        : "Only people and teams you add below can use this plugin in chat."}
+                    </p>
+                  </div>
+                  <div
+                    role="switch"
+                    aria-checked={Boolean(orgWideGrant)}
+                    className={`relative inline-flex h-6 w-[42px] shrink-0 items-center rounded-full transition-colors ${orgWideGrant ? "bg-[#0f172a]" : "bg-gray-200"}`}
+                  >
+                    <span className={`inline-block h-5 w-5 rounded-full bg-white transition-transform ${orgWideGrant ? "translate-x-[18px]" : "translate-x-0.5"}`} />
+                  </div>
+                </button>
+              ) : null}
+
+              <div className={`${access.isAdmin ? "border-t" : ""} divide-y divide-gray-100 border-gray-100`}>
+                {memberGrants.map((grant) => {
+                  const member = grant.orgMembershipId ? membersById.get(grant.orgMembershipId) : null;
+                  const creatorGrant = grant.orgMembershipId === pluginCreatedByOrgMembershipId;
+                  const sharedBy = grant.createdByOrgMembershipId === orgContext?.currentMember.id
+                    ? "you"
+                    : membersById.get(grant.createdByOrgMembershipId)?.user.name ?? "an organization member";
+                  return (
+                    <div key={grant.id} className="flex flex-wrap items-center gap-3 px-6 py-3.5">
+                      <div className="min-w-[220px] flex-1">
+                        {member ? (
+                          <OrgMemberIdentity member={member} />
+                        ) : (
+                          <p className="text-[13px] font-medium text-gray-500">Removed member</p>
+                        )}
+                      </div>
+                      <AccessRolePill role={grant.role} />
+                      {creatorGrant ? (
+                        <span className="text-[12px] font-medium text-gray-400">creator</span>
+                      ) : (
+                        <>
+                          <p className="text-[11.5px] text-gray-400">
+                            shared by {sharedBy} · {formatAccessDate(grant.createdAt)}
+                          </p>
+                          <DenButton
+                            size="sm"
+                            variant="destructive"
+                            disabled={busy}
+                            onClick={() => void handleRevoke(grant.id)}
+                          >
+                            Revoke
+                          </DenButton>
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {teamGrants.map((grant) => {
+                  const team = grant.teamId ? teamsById.get(grant.teamId) : null;
+                  const sharedBy = grant.createdByOrgMembershipId === orgContext?.currentMember.id
+                    ? "you"
+                    : membersById.get(grant.createdByOrgMembershipId)?.user.name ?? "an organization member";
+                  return (
+                    <div key={grant.id} className="flex flex-wrap items-center gap-3 px-6 py-3.5">
+                      <div className="min-w-[220px] flex-1">
+                        {team ? (
+                          <TeamIdentity name={team.name} memberCount={team.memberIds.length} />
+                        ) : (
+                          <p className="text-[13px] font-medium text-gray-500">Removed team</p>
+                        )}
+                      </div>
+                      <AccessRolePill role={grant.role} />
+                      <p className="text-[11.5px] text-gray-400">
+                        shared by {sharedBy} · {formatAccessDate(grant.createdAt)}
+                      </p>
+                      <DenButton
+                        size="sm"
+                        variant="destructive"
+                        disabled={busy}
+                        onClick={() => void handleRevoke(grant.id)}
+                      >
+                        Revoke
+                      </DenButton>
+                    </div>
+                  );
+                })}
+
+                {!hasGrantsBeyondCreator ? (
+                  <div className="px-6 py-3.5">
+                    <div className="rounded-xl border border-dashed border-gray-200 px-5 py-5 text-center">
+                      <p className="text-[13px] font-medium text-gray-900">Only you can use this plugin</p>
+                      <p className="mt-1 text-[12px] text-gray-500">
+                        Share it with a person or a team to give them instant access in chat.
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-wrap items-center gap-2 px-6 py-3.5">
+                  <AccessAddPicker
+                    kind="person"
+                    candidates={memberCandidates}
+                    disabled={busy}
+                    onGrant={grantPerson}
+                  />
+                  <AccessAddPicker
+                    kind="team"
+                    candidates={teamCandidates}
+                    disabled={busy}
+                    onGrant={grantTeam}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {mutationError ? (
+        <DenNotice
+          tone="error"
+          className="mt-3"
+          message={mutationError instanceof Error ? mutationError.message : "Failed to update plugin access."}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
@@ -112,6 +112,8 @@ export type DenPlugin = {
   mcps: PluginMcp[];
   agents: PluginAgent[];
   commands: PluginCommand[];
+  createdAt: string;
+  createdByOrgMembershipId: string | null;
   updatedAt: string;
   /**
    * Opt-in gating: which connected integration provider exposes this plugin.
@@ -234,6 +236,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     commands: [
       { id: "cmd_gh_pr", name: "/gh:pr", description: "Create a pull request from the current branch." },
     ],
+    createdAt: "2026-04-10T12:00:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-04-10T12:00:00Z",
     requiresProvider: "github",
   },
@@ -260,6 +264,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
       { id: "cmd_cc_push", name: "/push", description: "Push current branch and track upstream." },
       { id: "cmd_cc_pr", name: "/pr", description: "Open a pull request." },
     ],
+    createdAt: "2026-04-07T09:00:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-04-07T09:00:00Z",
     requiresProvider: "any",
   },
@@ -294,6 +300,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     ],
     agents: [],
     commands: [],
+    createdAt: "2026-03-28T16:45:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-03-28T16:45:00Z",
     requiresProvider: "any",
   },
@@ -327,6 +335,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     commands: [
       { id: "cmd_lin_new", name: "/linear:new", description: "File a new issue from the current context." },
     ],
+    createdAt: "2026-04-02T18:12:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-04-02T18:12:00Z",
     requiresProvider: "any",
   },
@@ -360,6 +370,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     commands: [
       { id: "cmd_ow_release", name: "/release", description: "Run the standardized release workflow." },
     ],
+    createdAt: "2026-04-14T08:30:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-04-14T08:30:00Z",
     requiresProvider: "github",
   },
@@ -389,6 +401,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     ],
     agents: [],
     commands: [],
+    createdAt: "2026-03-20T11:00:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-03-20T11:00:00Z",
     requiresProvider: "any",
   },
@@ -415,6 +429,8 @@ const MOCK_PLUGINS: DenPlugin[] = [
     mcps: [],
     agents: [],
     commands: [],
+    createdAt: "2026-03-12T14:22:00Z",
+    createdByOrgMembershipId: null,
     updatedAt: "2026-03-12T14:22:00Z",
     requiresProvider: "any",
   },
@@ -618,6 +634,8 @@ async function fetchResolvedPlugin(id: string): Promise<DenPlugin | null> {
     author: "Connected repository",
     category: derivePluginCategory({ agents, commands, hooks, mcps, skills }),
     commands,
+    createdAt: asString(pluginItem.createdAt) ?? new Date().toISOString(),
+    createdByOrgMembershipId: asString(pluginItem.createdByOrgMembershipId),
     description: asString(pluginItem.description) ?? "Imported from a connected repository.",
     hooks,
     id: pluginId,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
@@ -23,11 +23,14 @@ import {
   useUpdatePlugin,
 } from "./plugin-data";
 import { CatalogIdentityTile } from "./catalog-identity-tile";
+import { type PluginAccessGrant, usePluginAccess } from "./plugin-access-data";
+import { PluginAccessSection } from "./plugin-access-section";
 
 export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   const router = useRouter();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: plugin, isLoading, error, refetch } = usePlugin(pluginId);
+  const pluginAccessQuery = usePluginAccess(pluginId);
   const archivePlugin = useArchivePlugin();
   const [actionsOpen, setActionsOpen] = useState(false);
   const [editPlugin, setEditPlugin] = useState<{ name: string; description: string } | null>(null);
@@ -71,6 +74,12 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   }
 
   const marketplaces = plugin.marketplaces ?? [];
+  const creator = orgContext?.members.find((member) => member.id === plugin.createdByOrgMembershipId) ?? null;
+  const accessBlastRadius = getPluginAccessBlastRadius(
+    pluginAccessQuery.data ?? [],
+    orgContext?.teams ?? [],
+    orgContext?.currentMember.id ?? null,
+  );
   const missingLabels: string[] = [];
   if (plugin.agents.length === 0) missingLabels.push("agents");
   if (plugin.commands.length === 0) missingLabels.push("commands");
@@ -166,6 +175,9 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
           {plugin.description ? (
             <p className="mt-1 text-[13px] leading-[1.55] text-gray-500">{plugin.description}</p>
           ) : null}
+          <p className="mt-1.5 text-[11.5px] text-gray-400">
+            Added by {creator?.user.name ?? "Unknown member"} · {formatPluginTimestamp(plugin.createdAt)}
+          </p>
           <p className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-[11.5px] text-gray-400">
             {marketplaces.length > 0 ? (
               <>
@@ -182,6 +194,13 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
       </article>
 
       <div className="mt-6 space-y-6">
+        <PluginAccessSection
+          pluginId={plugin.id}
+          pluginCreatedByOrgMembershipId={plugin.createdByOrgMembershipId}
+          grants={pluginAccessQuery.data ?? []}
+          isLoading={pluginAccessQuery.isLoading}
+          error={pluginAccessQuery.error}
+        />
         <SkillsSection orgSlug={orgSlug} plugin={plugin} />
         <PrimitiveSection icon={Users} label="Agents" items={plugin.agents} render={renderAgentRow} />
         <PrimitiveSection icon={Terminal} label="Commands" items={plugin.commands} render={renderCommandRow} />
@@ -210,6 +229,8 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
       <ArchivePluginDialog
         open={archiveOpen}
         pluginName={plugin.name}
+        affectedPeopleCount={accessBlastRadius.peopleCount}
+        affectedTeamCount={accessBlastRadius.teamCount}
         busy={archivePlugin.isPending}
         error={archivePlugin.error}
         onClose={() => {
@@ -315,6 +336,8 @@ function EditPluginDialog({
 function ArchivePluginDialog({
   open,
   pluginName,
+  affectedPeopleCount,
+  affectedTeamCount,
   busy,
   error,
   onClose,
@@ -322,6 +345,8 @@ function ArchivePluginDialog({
 }: {
   open: boolean;
   pluginName: string;
+  affectedPeopleCount: number;
+  affectedTeamCount: number;
   busy: boolean;
   error: unknown;
   onClose: () => void;
@@ -345,6 +370,11 @@ function ArchivePluginDialog({
         <p id="archive-plugin-description" className="mt-2 text-[13px] leading-6 text-gray-500">
           This removes the plugin from active Den lists without deleting its historical skills, marketplace relationships, or audit trail.
         </p>
+        {affectedPeopleCount > 0 ? (
+          <p className="mt-3 text-[12.5px] font-medium text-amber-700">
+            This removes it for {affectedPeopleCount} people across {affectedTeamCount} {affectedTeamCount === 1 ? "team" : "teams"}.
+          </p>
+        ) : null}
         {error ? (
           <p className="mt-3 text-[12.5px] text-red-600">
             {error instanceof Error ? error.message : "Failed to archive plugin."}
@@ -361,6 +391,29 @@ function ArchivePluginDialog({
       </div>
     </div>
   );
+}
+
+function getPluginAccessBlastRadius(
+  grants: PluginAccessGrant[],
+  teams: Array<{ id: string; memberIds: string[] }>,
+  currentMemberId: string | null,
+) {
+  const people = new Set<string>();
+  const teamIds = new Set<string>();
+  const teamsById = new Map(teams.map((team) => [team.id, team]));
+
+  for (const grant of grants) {
+    if (grant.orgMembershipId) people.add(grant.orgMembershipId);
+    if (grant.teamId) teamIds.add(grant.teamId);
+  }
+  for (const teamId of teamIds) {
+    for (const memberId of teamsById.get(teamId)?.memberIds ?? []) {
+      people.add(memberId);
+    }
+  }
+  if (currentMemberId) people.delete(currentMemberId);
+
+  return { peopleCount: people.size, teamCount: teamIds.size };
 }
 
 function formatMissingList(labels: string[]) {

--- a/evals/specs/plugin-access-panel.slow.test.ts
+++ b/evals/specs/plugin-access-panel.slow.test.ts
@@ -1,0 +1,283 @@
+import { expect, onTestFinished, test } from "vitest";
+import { denFetch, ensureMemberSession, evalIn, fill, signIn, waitFor } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
+import { photoRoll, screenshot, validate } from "@openwork/fraimz";
+import { chrome } from "@openwork/hosts";
+
+const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "") ?? "";
+const webUrl = process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim().replace(/\/+$/, "") ?? "";
+const title = !apiUrl
+  ? "plugin access panel skipped: set OPENWORK_EVAL_DEN_API_URL to a running Den API"
+  : !webUrl
+    ? "plugin access panel skipped: set OPENWORK_EVAL_DEN_WEB_URL to a running Den Web"
+    : "plugin creators can inspect person and team access grants in Den Web";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = orgs.find((entry) => entry.slug === "acme-robotics-demo")
+    ?? orgs.find((entry) => entry.name === "Acme Robotics")
+    ?? orgs[0];
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function selectOrganization(session: DenSession, orgId: string): Promise<void> {
+  const result = await denFetch(session, "/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${session.token}` },
+    body: JSON.stringify({ organizationId: orgId }),
+  });
+  if (!result.response.ok) {
+    throw new Error(`Selecting Acme Robotics failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+}
+
+async function organizationMemberIdByEmail(session: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(session, "/v1/org", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const memberId = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !memberId.startsWith("om_")) {
+    throw new Error(`Resolving ${email} in the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return memberId;
+}
+
+function accessItems(body: unknown): Record<string, unknown>[] {
+  return isRecord(body) && Array.isArray(body.items) ? body.items.filter(isRecord) : [];
+}
+
+test.skipIf(!apiUrl || !webUrl)(title, async () => {
+  const den = { apiUrl, webUrl };
+  const password = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+  const admin = await signIn(den, {
+    email: process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test",
+    password,
+  });
+  const orgId = await organizationId(admin);
+  await selectOrganization(admin, orgId);
+
+  let caseySession: DenSession | undefined;
+  let pluginId = "";
+  let teamId = "";
+  onTestFinished(async () => {
+    const creator = caseySession;
+    const createdPluginId = pluginId;
+    const createdTeamId = teamId;
+    if (creator && createdPluginId) {
+      await denFetch(creator, `/v1/plugins/${encodeURIComponent(createdPluginId)}/archive`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${creator.token}`,
+          "x-openwork-org-id": orgId,
+        },
+      }).catch(() => undefined);
+    }
+    if (createdTeamId) {
+      await denFetch(admin, `/v1/teams/${encodeURIComponent(createdTeamId)}`, {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${admin.token}`,
+          "x-openwork-org-id": orgId,
+        },
+      }).catch(() => undefined);
+    }
+  });
+
+  const caseyEmail = process.env.OPENWORK_EVAL_CREATOR_EMAIL?.trim() || "casey.spec@acme.test";
+  caseySession = await ensureMemberSession(den, admin, {
+    email: caseyEmail,
+    password: process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || password,
+    name: "Casey Spec",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  const casey = caseySession;
+  await selectOrganization(casey, orgId);
+
+  const novaEmail = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "nova.spec@acme.test";
+  const nova = await ensureMemberSession(den, admin, {
+    email: novaEmail,
+    password: process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || password,
+    name: "Nova Spec",
+    markVerifiedCmd: process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim(),
+  });
+  await selectOrganization(nova, orgId);
+
+  const stamp = Date.now();
+  const pluginName = `spec-access-panel-${stamp}`;
+  const rawSourceText = `---\nname: ${pluginName}\ndescription: Proves the plugin access panel.\n---\n\nReturn the plugin access panel proof phrase.`;
+  const createdPlugin = await denFetch(casey, "/v1/plugins", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({
+      name: pluginName,
+      components: [{ type: "skill", input: { rawSourceText } }],
+    }),
+  });
+  const plugin = isRecord(createdPlugin.body) && isRecord(createdPlugin.body.item) ? createdPlugin.body.item : null;
+  pluginId = plugin && typeof plugin.id === "string" ? plugin.id : "";
+  if (createdPlugin.response.status !== 201 || !pluginId) {
+    throw new Error(`Creating the plugin access panel fixture failed: HTTP ${createdPlugin.response.status} ${createdPlugin.text.slice(0, 500)}`);
+  }
+
+  const caseyMemberId = await organizationMemberIdByEmail(casey, orgId, caseyEmail);
+  const novaMemberId = await organizationMemberIdByEmail(casey, orgId, novaEmail);
+  const grantedNova = await denFetch(casey, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ orgMembershipId: novaMemberId, role: "viewer" }),
+  });
+  if (grantedNova.response.status !== 201) {
+    throw new Error(`Granting Nova plugin access failed: HTTP ${grantedNova.response.status} ${grantedNova.text.slice(0, 500)}`);
+  }
+
+  const teamName = `Spec Plugin Access Team ${stamp}`;
+  const createdTeam = await denFetch(admin, "/v1/teams", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${admin.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ name: teamName }),
+  });
+  const team = isRecord(createdTeam.body) && isRecord(createdTeam.body.team) ? createdTeam.body.team : null;
+  teamId = team && typeof team.id === "string" ? team.id : "";
+  if (createdTeam.response.status !== 201 || !teamId) {
+    throw new Error(`Creating the plugin access team failed: HTTP ${createdTeam.response.status} ${createdTeam.text.slice(0, 500)}`);
+  }
+
+  const grantedTeam = await denFetch(casey, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ teamId, role: "viewer" }),
+  });
+  if (grantedTeam.response.status !== 201) {
+    throw new Error(`Granting team plugin access failed: HTTP ${grantedTeam.response.status} ${grantedTeam.text.slice(0, 500)}`);
+  }
+
+  const listedAccess = await denFetch(casey, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {
+    headers: {
+      authorization: `Bearer ${casey.token}`,
+      "x-openwork-org-id": orgId,
+    },
+  });
+  expect(listedAccess.response.status).toBe(200);
+  const activeGrants = accessItems(listedAccess.body).filter((grant) => grant.removedAt === null);
+  expect(activeGrants).toHaveLength(3);
+  expect(activeGrants.some((grant) => grant.orgMembershipId === caseyMemberId && grant.role === "manager")).toBe(true);
+  expect(activeGrants.some((grant) => grant.orgMembershipId === novaMemberId && grant.role === "viewer")).toBe(true);
+  expect(activeGrants.some((grant) => grant.teamId === teamId && grant.role === "viewer")).toBe(true);
+
+  // Members are redirected from this admin route after seeing "Your workspace is ready" and
+  // "This setting is managed by workspace admins. Taking you back to your dashboard."
+  await using browser = await chrome({ name: "p3-plugin-access", startUrl: webUrl, headless: true });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin before auth token handoff",
+  });
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+
+  const pluginUrl = `${webUrl}/dashboard/plugins/${encodeURIComponent(pluginId)}`;
+  await navigate(browser.client, pluginUrl);
+  const accessPanelReady = `document.body.innerText.toUpperCase().includes("WHO CAN ACCESS THIS")
+    && document.body.innerText.includes("Nova Spec")
+    && document.body.innerText.toLowerCase().includes("viewer")
+    && document.body.innerText.includes(${JSON.stringify(teamName)})
+    && document.body.innerText.includes("Revoke")`;
+  let handoffError: unknown;
+  try {
+    await waitFor(browser, accessPanelReady, { timeoutMs: 60_000, label: "plugin access heading, Nova, and viewer role" });
+  } catch (error) {
+    handoffError = error;
+  }
+
+  if (handoffError) {
+    const hasAuthInput = await evalIn(
+      browser,
+      `Boolean(document.querySelector('input[type="email"], input[name="email"], input[type="password"]'))`,
+    );
+    if (hasAuthInput !== true) throw handoffError;
+
+    const hasEmailInput = await evalIn(browser, `Boolean(document.querySelector('input[type="email"], input[name="email"]'))`);
+    const hasPasswordInput = await evalIn(browser, `Boolean(document.querySelector('input[type="password"]'))`);
+    if (hasEmailInput === true) {
+      await fill(browser, 'input[type="email"], input[name="email"]', admin.email);
+    }
+    if (hasEmailInput === true && hasPasswordInput !== true) {
+      const nextClicked = await evalIn(browser, `(() => {
+        const button = [...document.querySelectorAll("button")]
+          .find((entry) => (entry.textContent ?? "").trim() === "Next");
+        button?.click();
+        return Boolean(button);
+      })()`);
+      expect(nextClicked).toBe(true);
+      await waitFor(browser, `Boolean(document.querySelector('input[type="password"]'))`, {
+        timeoutMs: 30_000,
+        label: "Den Web password step",
+      });
+    }
+    await fill(browser, 'input[type="password"]', password);
+    const signInClicked = await evalIn(browser, `(() => {
+      const button = [...document.querySelectorAll("button")]
+        .reverse()
+        .find((entry) => (entry.textContent ?? "").trim() === "Sign in");
+      button?.click();
+      return Boolean(button);
+    })()`);
+    expect(signInClicked).toBe(true);
+    await waitFor(browser, `location.pathname.startsWith("/dashboard") && !document.querySelector('input[type="password"]')`, {
+      timeoutMs: 60_000,
+      label: "Den Web dashboard after form sign-in",
+    });
+    await navigate(browser.client, pluginUrl);
+    await waitFor(browser, accessPanelReady, { timeoutMs: 60_000, label: "plugin access panel after form sign-in" });
+  }
+
+  const orgWideTogglePresent = await evalIn(
+    browser,
+    `document.body.innerText.includes("Everyone in the organization")`,
+  );
+  expect(orgWideTogglePresent).toBe(true);
+
+  const shot = await screenshot(browser);
+  const seen = await validate(shot, [
+    "An access section lists a person and a team with viewer role pills",
+    "A revoke button is visible next to a shared row",
+  ]);
+  await using roll = photoRoll("p3-plugin-access");
+  await roll.add(shot, seen);
+  expect(seen.ok, seen.why).toBe(true);
+});

--- a/prds/skill-sharing/grant-native-skill-sharing.md
+++ b/prds/skill-sharing/grant-native-skill-sharing.md
@@ -234,6 +234,23 @@ non-manager denial, recipient cannot re-share.
 
 ### P3 — Library UI + provenance
 
+#### P3 PR2 — plugin access panel (shipped)
+
+Design: Paper file page "PR2 — Skill access panel" (user-approved). Shipped:
+"WHO CAN ACCESS THIS" section on plugin detail (stacked section, no tabs) —
+people/team rows with role pills and shared-by provenance, AccessAddPicker
+share flow with plain-words role choice ("Can view" default, "Can edit"
+behind a select with an amber consequence line), org-wide switch rendered
+ONLY for admins (server 403s members — hide, don't disable), creator
+provenance under the header, and a computed blast-radius line on the archive
+confirm. No new API (existing grant routes; serializer already exposed
+creator fields). Proof: `evals/specs/plugin-access-panel.slow.test.ts` — API
+leg (creator grants person + team; grant list asserted) + browser leg with
+vision-validated photo roll; org-wide toggle asserted PRESENT for admin.
+Known limitation discovered: the den-web `(admin)` route group redirects
+plain members away from plugin detail — member-facing surfaces are a PR3
+decision (the member library cannot live behind the admin gate).
+
 #### P3 PR1 — team access view (shipped from this branch)
 
 Design source: Paper file "P3 — Access Visibility" (screens annotated with


### PR DESCRIPTION
## What

PR2 of P3 (program: `prds/skill-sharing/`; design: Paper page "PR2 — Skill access panel", user-approved with PRIMITIVES/NEW annotations). The other direction of PR1's team view: **who can access THIS plugin**, editable in place.

- "WHO CAN ACCESS THIS" section on plugin detail (stacked section under the header — no tabs, per design decision): people rows via OrgMemberIdentity + team rows, role pills (editor = amber + border), shared-by provenance from grant fields, Revoke per row (creator's manager grant exempt).
- Share via the AccessAddPicker pattern with a **role choice at share time**: "Can view (use in chat)" default, "Can edit" behind a DenSelect with the amber consequence line.
- **Org-wide switch rendered only for admins** — hide-not-disable, because the server 403s member org-wide grants (#3411).
- Archive confirm gains a computed **blast-radius line** ("removes it for N people across M teams") — client-side from grants already fetched, zero extra requests.
- No new API: existing `GET/POST/DELETE /v1/plugins/:id/access`; plugin serializer already exposed creator fields.

## Tests (commands + results)

```
cd ee/apps/den-web && pnpm exec tsc --noEmit && pnpm run build          # clean
pnpm --dir evals exec vitest run --project nightly specs/plugin-access-panel.slow.test.ts
# → 3× pass (executor 2× + orchestrator rerun) against live stack from this branch:
#   creator grants person + team via API (3 active grants asserted),
#   browser leg loads the real panel — vision validated 2/2 (role pills + revoke visible),
#   org-wide toggle PRESENT for admin
pnpm --dir evals run typecheck                                           # clean
```

Photo roll of the real panel follows as the sticky photo-roll comment.

## Honest finding (feeds PR3)

The den-web `(admin)` route group redirects plain members away from plugin detail — a member creator cannot yet manage sharing in the web dashboard (they share via chat, P2). The member library (PR3 / Screen C) therefore cannot live behind the admin gate; that placement decision is now explicitly on PR3's plate.