### PR TITLE
fix(den-api): rank create routes findable in /mcp/agent capability search

### DIFF
--- a/ee/apps/den-api/src/mcp/README.md
+++ b/ee/apps/den-api/src/mcp/README.md
@@ -74,3 +74,12 @@ Untagged operations are excluded by default. Today these are OAuth/MCP discovery
 - `/register`
 
 They are required for OAuth/MCP setup, but should not appear as callable MCP tools.
+
+## Ranking
+
+Search scores exact name tokens +5, name prefixes +3, summary tokens +2, and extra path tokens +1.
+HTTP methods and route shapes add name-level verb tokens such as `create`, `list`, and `update`.
+Exact token equality is plural-insensitive, while prefix matching continues to use raw tokens.
+An exact case-insensitive operation-name query receives a +100 short-circuit bonus.
+Ties prefer connection statuses, then score, fewer path parameters, shorter names, and alphabetical order.
+`test/mcp-search-golden.test.ts` is the behavioral contract; scoring changes must keep it green.

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -42,7 +42,11 @@ export type CapabilityMatch = {
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {
   const statusPriority = Number("kind" in b && b.kind === "connection_status")
     - Number("kind" in a && a.kind === "connection_status")
-  return statusPriority || (b.score - a.score) || a.name.localeCompare(b.name)
+  return statusPriority
+    || (b.score - a.score)
+    || (a.pathParams.length - b.pathParams.length)
+    || (a.name.length - b.name.length)
+    || a.name.localeCompare(b.name)
 }
 
 export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {
@@ -63,6 +67,10 @@ export function tokenize(value: string): string[] {
     .filter((token) => token.length > 0)
 }
 
+function singularize(token: string): string {
+  return token.length > 3 && token.endsWith("s") ? token.slice(0, -1) : token
+}
+
 export function scoreText(
   nameTokens: string[],
   summaryTokens: string[],
@@ -71,15 +79,16 @@ export function scoreText(
 ): number {
   let score = 0
   for (const queryToken of queryTokens) {
-    if (nameTokens.includes(queryToken)) {
+    const singularQueryToken = singularize(queryToken)
+    if (nameTokens.some((token) => singularize(token) === singularQueryToken)) {
       score += 5
     } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
       score += 3
     }
-    if (summaryTokens.includes(queryToken)) {
+    if (summaryTokens.some((token) => singularize(token) === singularQueryToken)) {
       score += 2
     }
-    if (extraTokens.includes(queryToken)) {
+    if (extraTokens.some((token) => singularize(token) === singularQueryToken)) {
       score += 1
     }
   }
@@ -104,7 +113,27 @@ function scoreOperation(operation: McpToolOperation, queryTokens: string[]): num
     return 0
   }
 
-  const nameTokens = tokenizeToolName(operation.name)
+  const method = operation.method.toUpperCase()
+  const collectionRoute = !operation.path.endsWith("}")
+  // These action words derive from the closed world of HTTP methods and route shapes.
+  const verbTokens = method === "POST"
+    ? ["create", "add", "new", "register"]
+    : method === "GET"
+      ? collectionRoute ? ["list"] : ["get", "read"]
+      : method === "PUT" || method === "PATCH"
+        ? ["update", "edit", "set"]
+        : method === "DELETE"
+          ? ["delete", "remove", "revoke"]
+          : []
+  const pathSegments = operation.path.split("/").filter(Boolean)
+  const lastSegment = pathSegments.at(-1)
+  const itemActionTokens = method === "POST"
+    && lastSegment !== undefined
+    && !lastSegment.endsWith("}")
+    && pathSegments.slice(0, -1).some((segment) => segment.endsWith("}"))
+    ? tokenize(lastSegment)
+    : []
+  const nameTokens = [...tokenizeToolName(operation.name), ...verbTokens, ...itemActionTokens]
   const summaryTokens = tokenize(summaryFor(operation))
   const pathTokens = tokenize(operation.path)
   return scoreText(nameTokens, summaryTokens, queryTokens, pathTokens)
@@ -116,6 +145,7 @@ export function searchCapabilities(
   limit = 5,
 ): CapabilityMatch[] {
   const queryTokens = tokenize(query)
+  const normalizedQuery = query.trim().toLowerCase()
   const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
 
   return catalog
@@ -123,7 +153,8 @@ export function searchCapabilities(
       name: operation.name,
       method: operation.method,
       path: operation.path,
-      score: scoreOperation(operation, queryTokens),
+      score: scoreOperation(operation, queryTokens)
+        + (normalizedQuery === operation.name.toLowerCase() ? 100 : 0),
       summary: summaryFor(operation),
       pathParams: pathParameterNamesFromTemplate(operation.path),
       queryParams: getParameters(operation.operation, "query").map((parameter) => parameter.name as string),

--- a/ee/apps/den-api/test/mcp-search-golden.test.ts
+++ b/ee/apps/den-api/test/mcp-search-golden.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import { z } from "zod"
+import type { McpToolOperation } from "../src/mcp/catalog.js"
+import { compareCapabilityMatches, searchCapabilities, type CapabilityMatch } from "../src/mcp/search.js"
+
+function catalogOperation(name: string, summary: string, method: string, path: string): McpToolOperation {
+  return {
+    name,
+    method,
+    path,
+    operation: { summary },
+    inputSchema: z.object({}),
+  }
+}
+
+const catalog = [
+  catalogOperation("getMarketplaces", "List marketplaces", "GET", "/v1/marketplaces"),
+  catalogOperation("postMarketplaces", "Create marketplace", "POST", "/v1/marketplaces"),
+  catalogOperation("getMarketplaces_rvevs7", "Get marketplace", "GET", "/v1/marketplaces/{marketplaceId}"),
+  catalogOperation("deleteMarketplacesAccess", "Revoke marketplace access", "DELETE", "/v1/marketplaces/{marketplaceId}/access/{grantId}"),
+  catalogOperation("deleteMarketplacesPlugins", "Remove marketplace plugin", "DELETE", "/v1/marketplaces/{marketplaceId}/plugins/{pluginId}"),
+  catalogOperation("getMarketplacesAccess", "List marketplace access grants", "GET", "/v1/marketplaces/{marketplaceId}/access"),
+  catalogOperation("getMarketplacesPlugins", "List marketplace plugins", "GET", "/v1/marketplaces/{marketplaceId}/plugins"),
+  catalogOperation("postMarketplacesPlugins", "Add marketplace plugin", "POST", "/v1/marketplaces/{marketplaceId}/plugins"),
+  catalogOperation("postPluginsArchive", "archive plugin", "POST", "/v1/plugins/{pluginId}/archive"),
+  catalogOperation("postMcpConnections", "Register a new External MCP Connection for the org", "POST", "/v1/mcp-connections"),
+  catalogOperation("postCapabilitiesGoogleWorkspaceCalendarEvents", "Create a Google Calendar event as the calling member", "POST", "/v1/capabilities/google-workspace/calendar/events"),
+  catalogOperation("getOrganizations", "List organizations", "GET", "/v1/organizations"),
+  catalogOperation("patchWorkers", "Update worker", "PATCH", "/v1/workers/{workerId}"),
+]
+
+function names(query: string, limit = 5): string[] {
+  return searchCapabilities(catalog, query, limit).map((match) => match.name)
+}
+
+describe("MCP capability search ranking", () => {
+  test("ranks marketplace creation first", () => {
+    expect(names("create marketplace")[0]).toBe("postMarketplaces")
+  })
+
+  test("finds marketplace creation through the new synonym", () => {
+    expect(names("new marketplace").slice(0, 3)).toContain("postMarketplaces")
+  })
+
+  test("ranks an exact lowercase operation name first", () => {
+    expect(names("postmarketplaces")[0]).toBe("postMarketplaces")
+  })
+
+  test("ranks collection listing first", () => {
+    expect(names("list marketplaces")[0]).toBe("getMarketplaces")
+  })
+
+  test("ranks POST item actions first", () => {
+    expect(names("archive plugin")[0]).toBe("postPluginsArchive")
+  })
+
+  test("finds MCP connection registration through add", () => {
+    expect(names("add mcp connection").slice(0, 3)).toContain("postMcpConnections")
+  })
+
+  test("returns deterministic ordering", () => {
+    expect(names("create marketplace")).toEqual(names("create marketplace"))
+  })
+
+  test("prefers fewer path parameters when scores tie", () => {
+    const base: CapabilityMatch = {
+      name: "sameLengthA",
+      method: "GET",
+      path: "/v1/items",
+      score: 5,
+      summary: "List items",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false,
+    }
+    const parameterized: CapabilityMatch = {
+      ...base,
+      name: "sameLengthB",
+      path: "/v1/items/{itemId}",
+      pathParams: ["itemId"],
+    }
+
+    expect([parameterized, base].sort(compareCapabilityMatches)).toEqual([base, parameterized])
+  })
+})


### PR DESCRIPTION
## What

`search_capabilities` on `/mcp/agent` could not surface REST create routes. Discovered live: an org admin asking for "create marketplace" got **zero** results pointing at `postMarketplaces` across four query variants, concluded the capability didn't exist, and was told (wrongly) it was dashboard-only. `execute_capability("postMarketplaces")` worked the whole time — the route was in the catalog; ranking buried it.

## Root causes (reproduced with the production scorer)

| Live query (limit) | Score | Result |
|---|---|---|
| `create marketplace` (4) | 7 | rank 5 — lost a tie to `mcp:…slack_create_conversation` **alphabetically**, cut by one slot |
| `new marketplace register` (6) | 5 | rank 8 — six-way tie, alphabet orders `delete… < get… < post…`, cut |
| `marketplace management admin` (8) | 5 | rank 9 — same tie shape, cut |
| `postMarketplaces` (6) | 3 | buried — query tokenizer doesn't split camelCase, so it prefix-ties with every `post*` route and loses the alphabet |

1. **Verb vocabulary gap** — humans say create/new/add/register; operation names say `post`. The +5 name hit can never fire for creation intent.
2. **Plural mismatch** — query `marketplace` vs name token `marketplaces` earns prefix +3 instead of exact +5, deflating the whole resource family.
3. **Adversarial tiebreak** — equal scores broke by `localeCompare`, so `post*` structurally loses to `delete*`/`get*`/`mcp:*`/`skill:*`.
4. **No exact-name fast path** — searching the literal capability name scored 3.

The hard-coded "fast path" capability tables in `builtin-skills.ts` ("Skip broad search…") are the existing workaround for this recall problem.

## Fix (index-time structure, no dictionaries)

- **Verb tokens derived from the closed world of HTTP methods** (POST→create/add/new/register, GET→list | get/read, PUT/PATCH→update/edit/set, DELETE→delete/remove/revoke) plus static POST item-action segments (`…/{id}/archive` → `archive`), added as name-level tokens at scoring time. New routes get correct tokens automatically; the mapping cannot grow.
- **Plural-insensitive exact equality** (`marketplace` == `marketplaces`) for name/summary/extra matches; prefix logic untouched.
- **Exact-name short-circuit**: query == operation name (case-insensitive) → +100.
- **Meaningful tiebreak**: score, then fewer path params, then shorter name, alphabetical last (kept for determinism).
- `test/mcp-search-golden.test.ts` is the new behavioral contract for ranking; `src/mcp/README.md` documents it.

Deliberately **not** query-side synonym dictionaries (unbounded curation, silent reordering regressions) and **not** embeddings (self-hosted/air-gapped deployments, per-org live catalogs, non-deterministic rankings).

## After (real catalog, 170 operations, via `buildMcpCatalog(openapi.json)`)

```
QUERY "create marketplace"                 QUERY "add github plugin to marketplace"
 1. 15 POST postMarketplaces   <<<<         1. 23 POST postPluginsImportMcpsFromGithubUrlPreview
 2. 13 POST postMarketplacesAccess          2. 23 POST postMarketplacesPlugins
 3. 13 POST postMarketplacesDelete          3. 21 POST postPluginsImportMcpsFromGithubUrl
 ...                                        ...
```

## Tests run

From `ee/apps/den-api` (bun 1.3.10, deps via `pnpm install --filter "@openwork-ee/den-api..."` + workspace builds `den-db`, `enterprise-mcp-client`, `connect-link`, `email`, `install-config`):

| Command | Result |
|---|---|
| `bun test test/mcp-search-golden.test.ts` | 8 pass |
| `bun test test/mcp-url-guard.test.ts` | 53 pass |
| `bun test test/external-capabilities-search-divergence.test.ts` | 23 pass |
| `bun test test/mcp-catalog-parameter-refs.test.ts test/mcp-agent-timeouts.test.ts test/mcp-agent-config-policy.test.ts` | 31 pass / 1 fail — **pre-existing**: identical 15/1 on pristine `origin/dev` with the same deps built (assertion expects `marketplaceId` in `required` for the GitHub import body; the live schema has it optional) |
| `pnpm exec tsc --noEmit` | clean |
| `git stash` A/B on the failing suite | failure present without this diff |

`test/google-workspace-capabilities.test.ts` was not run to green: it needs a live MySQL (`DATABASE_URL`), unrelated to this diff.

## Validation status (honest)

Scoring-function change verified by unit contract + a live-catalog diagnostic (table above) rather than a full fraimz; this is a **draft** — before marking ready I'll attach the fraimz driving `search_capabilities("create marketplace")` against a running Den and asserting `postMarketplaces` is returned (`pnpm fraimz --flow <id> --pr`). Reviewer repro without a stack:

```bash
cd ee/apps/den-api
bun test test/mcp-search-golden.test.ts
```

Discovered while wiring a real org's MCP connection through the agent surface; the failing queries in the table are verbatim from that session.
