### PR TITLE
polish(den-web): library matches the approved Paper design — and the spec now pins fidelity

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
@@ -38,7 +38,9 @@ export type DashboardPageTemplateProps = {
    */
   colors: [string, string, string, string];
   /** `compact` shrinks the hero for setup/onboarding pages. */
-  size?: "default" | "compact";
+  size?: "default" | "compact" | "responsive";
+  /** Places the supporting copy inside the gradient hero instead of below it. */
+  descriptionPlacement?: "below" | "hero";
   children?: React.ReactNode;
 };
 
@@ -49,18 +51,24 @@ export function DashboardPageTemplate({
   description,
   colors,
   size = "default",
+  descriptionPlacement = "below",
   children,
 }: DashboardPageTemplateProps) {
   const compact = size === "compact";
+  const responsive = size === "responsive";
+  const descriptionInHero = descriptionPlacement === "hero";
   const webGlSupported = useWebGlSupported();
 
   return (
-    <div className={`mx-auto max-w-[860px] ${compact ? "p-6 md:p-8" : "p-8"}`}>
+    <div className={`mx-auto max-w-[860px] ${compact || responsive ? "p-6 md:p-8" : "p-8"}`}>
       {/* ── Gradient hero card ── */}
       <div
+        data-dashboard-hero
         className={`relative flex items-center overflow-hidden border border-gray-100 ${
           compact
             ? "mb-5 h-[88px] rounded-2xl px-6 sm:h-[96px] sm:px-8"
+            : responsive
+              ? "mb-5 h-[88px] rounded-2xl px-6 sm:h-[96px] sm:px-8 md:mb-8 md:h-[200px] md:rounded-3xl md:px-10"
             : "mb-8 h-[200px] rounded-3xl px-10"
         }`}
       >
@@ -104,6 +112,8 @@ export function DashboardPageTemplate({
             className={`absolute z-10 flex items-center justify-center rounded-xl border border-white/30 bg-white/20 backdrop-blur-md ${
               compact
                 ? "right-5 top-1/2 h-9 w-9 -translate-y-1/2"
+                : responsive
+                  ? "right-5 top-1/2 h-9 w-9 -translate-y-1/2 md:right-8 md:top-8 md:h-12 md:w-12 md:translate-y-0"
                 : "right-8 top-8 h-12 w-12"
             }`}
           >
@@ -111,31 +121,66 @@ export function DashboardPageTemplate({
           </div>
         ) : null}
 
-        {/* Badge (optional) + Title */}
-        <div
-          className={`absolute z-10 flex flex-col items-start gap-2 ${
-            compact ? "left-6 top-1/2 -translate-y-1/2 sm:left-8" : "bottom-8 left-10"
-          }`}
-        >
-          {badgeLabel ? (
-            <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
-              {badgeLabel}
-            </span>
-          ) : null}
-          <h1
-            className={`font-medium text-white ${
-              compact
-                ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
-                : "text-[28px] tracking-[-0.5px]"
+        {descriptionInHero ? (
+          <div
+            className={`absolute z-10 ${
+              responsive
+                ? "inset-y-0 left-6 right-16 flex flex-col justify-center gap-1.5 sm:left-8 md:inset-y-auto md:bottom-8 md:left-10 md:right-20 md:items-start md:gap-2"
+                : compact
+                  ? "inset-y-0 left-6 right-16 flex flex-col justify-center gap-1.5 sm:left-8"
+                  : "bottom-8 left-10 right-20 flex flex-col items-start gap-2"
             }`}
           >
-            {title}
-          </h1>
-        </div>
+            <div className={responsive ? "flex items-center gap-2 md:flex-col md:items-start" : "flex flex-col items-start gap-2"}>
+              {badgeLabel ? (
+                <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
+                  {badgeLabel}
+                </span>
+              ) : null}
+              <h1
+                className={`font-medium text-white ${
+                  responsive
+                    ? "text-[20px] tracking-[-0.03em] sm:text-[22px] md:text-[28px] md:tracking-[-0.5px]"
+                    : compact
+                      ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
+                      : "text-[28px] tracking-[-0.5px]"
+                }`}
+              >
+                {title}
+              </h1>
+            </div>
+            <p className="line-clamp-2 max-w-[650px] text-[11px] leading-4 text-white/85 md:line-clamp-none md:text-[13px] md:leading-5">
+              {description}
+            </p>
+          </div>
+        ) : (
+          <div
+            className={`absolute z-10 flex flex-col items-start gap-2 ${
+              compact ? "left-6 top-1/2 -translate-y-1/2 sm:left-8" : "bottom-8 left-10"
+            }`}
+          >
+            {badgeLabel ? (
+              <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
+                {badgeLabel}
+              </span>
+            ) : null}
+            <h1
+              className={`font-medium text-white ${
+                compact
+                  ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
+                  : "text-[28px] tracking-[-0.5px]"
+              }`}
+            >
+              {title}
+            </h1>
+          </div>
+        )}
       </div>
 
       {/* ── Description ── */}
-      <p className={`text-[14px] text-gray-500 ${compact ? "mb-5" : "mb-6"}`}>{description}</p>
+      {!descriptionInHero ? (
+        <p className={`text-[14px] text-gray-500 ${compact ? "mb-5" : "mb-6"}`}>{description}</p>
+      ) : null}
 
       {/* ── Page content ── */}
       {children}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
@@ -52,42 +52,53 @@ function sourceRepositoryName(value: string | null): string | null {
 
 function EdgeChip({ edge }: { edge: LibraryAccessEdge }) {
   if (edge.kind === "mine") {
-    return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11.5px] font-medium text-emerald-700">Yours</span>;
+    return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-700">Yours</span>;
   }
   if (edge.kind === "person") {
-    return <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[11.5px] font-medium text-blue-700">Shared by {edge.sharedBy?.name ?? "someone"}</span>;
+    return (
+      <span className="inline-flex max-w-full items-center rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-medium text-blue-700">
+        <span className="shrink-0">Shared by&nbsp;</span>
+        <span className="min-w-0 max-w-[220px] truncate">{edge.sharedBy?.name ?? "someone"}</span>
+      </span>
+    );
   }
   if (edge.kind === "team") {
-    return <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[11.5px] font-medium text-gray-600">Team: {edge.team.name}</span>;
+    return (
+      <span className="inline-flex max-w-full items-center rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-600">
+        <span className="shrink-0">Team:&nbsp;</span>
+        <span className="min-w-0 max-w-[220px] truncate">{edge.team.name}</span>
+      </span>
+    );
   }
   if (edge.kind === "catalog") {
-    return <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[11.5px] font-medium text-blue-700">Catalog: {edge.marketplace.name}</span>;
+    return (
+      <span className="inline-flex max-w-full items-center rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-medium text-blue-700">
+        <span className="shrink-0">Catalog:&nbsp;</span>
+        <span className="min-w-0 max-w-[220px] truncate">{edge.marketplace.name}</span>
+      </span>
+    );
   }
-  return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11.5px] font-medium text-emerald-700">Everyone</span>;
+  return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">Everyone</span>;
 }
 
 function LibraryCard({ item, isAdmin, orgSlug }: { item: LibraryPluginAccessItem; isAdmin: boolean; orgSlug: string | null }) {
   const sourceName = sourceRepositoryName(item.plugin.sourceRepositoryUrl);
   const content = (
-    <>
-      <div className="flex items-start justify-between gap-4">
-        <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-gray-950">{item.plugin.name}</h2>
-        <span className="shrink-0 text-[11.5px] text-gray-400">
-          {item.plugin.componentCount} {item.plugin.componentCount === 1 ? "component" : "components"}
-        </span>
-      </div>
-      <p className="mt-2 line-clamp-2 min-h-10 text-[13px] leading-5 text-gray-500">
+    <div className="flex flex-col gap-2.5">
+      <h2 className="text-[15px] font-semibold text-gray-950">{item.plugin.name}</h2>
+      <p className="line-clamp-2 text-[13px] leading-5 text-gray-500">
         {item.plugin.description ?? "No description provided."}
       </p>
-      <div className="mt-4 flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-1.5">
         {item.edges.map((edge, index) => <EdgeChip key={`${edge.kind}-${index}`} edge={edge} />)}
         {sourceName ? (
-          <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[11.5px] font-medium text-gray-600">
-            From {sourceName}
+          <span className="inline-flex max-w-full items-center rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-600">
+            <span className="shrink-0">From&nbsp;</span>
+            <span className="min-w-0 max-w-[220px] truncate">{sourceName}</span>
           </span>
         ) : null}
       </div>
-    </>
+    </div>
   );
   const className = `block rounded-2xl border border-gray-200 bg-white p-5 ${isAdmin ? "transition-colors hover:border-gray-400" : ""}`;
 
@@ -124,25 +135,28 @@ export function LibraryScreen() {
   return (
     <DashboardPageTemplate
       icon={LibraryBig}
+      badgeLabel="Member library"
       title="Library"
       description="Everything you can use in chat — yours, shared with you, from your teams, and org-wide."
+      descriptionPlacement="hero"
       colors={["#DBEAFE", "#1E3A8A", "#2563EB", "#A7F3D0"]}
+      size="responsive"
     >
-      <div className="mb-6 space-y-4">
-        <div className="overflow-x-auto">
-          <UnderlineTabs
-            className="min-w-max [&>nav]:flex-nowrap"
-            tabs={LIBRARY_TABS}
-            activeTab={activeTab}
-            onChange={setActiveTab}
-          />
-        </div>
+      <div className="mb-5 w-full max-w-[340px]">
         <DenInput
           type="search"
           icon={Search}
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search your library..."
+          placeholder="Search your library"
+        />
+      </div>
+      <div className="mb-6 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <UnderlineTabs
+          className="min-w-max [&>nav]:flex-nowrap"
+          tabs={LIBRARY_TABS}
+          activeTab={activeTab}
+          onChange={setActiveTab}
         />
       </div>
 
@@ -165,7 +179,7 @@ export function LibraryScreen() {
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div data-library-grid className="grid grid-cols-1 items-start gap-3 md:grid-cols-2">
           {visibleItems.map((item) => (
             <LibraryCard key={item.plugin.id} item={item} isAdmin={access.isAdmin} orgSlug={orgSlug} />
           ))}

--- a/evals/specs/library-view.slow.test.ts
+++ b/evals/specs/library-view.slow.test.ts
@@ -274,7 +274,9 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
       browser,
       `document.body.innerText.includes("Library")
         && document.body.innerText.includes(${JSON.stringify(pluginName)})
-        && document.body.innerText.includes("Shared by Casey")`,
+        && [...document.querySelectorAll("[data-library-grid] span")].some((entry) =>
+          (entry.textContent ?? "").replace(/\\s+/g, " ").includes("Shared by Casey")
+        )`,
       { timeoutMs: 60_000, label: "member library, shared plugin, and Casey provenance" },
     );
   } catch (error) {
@@ -287,12 +289,37 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
     `[...document.querySelectorAll("aside, nav")].some((entry) => (entry.textContent ?? "").includes("Library"))`,
   );
   expect(libraryNavPresent).toBe(true);
+  const heroContainsDescription = await evalIn(browser, `(() => {
+    const heading = [...document.querySelectorAll("h1")].find((entry) => entry.textContent?.trim() === "Library");
+    const hero = heading?.closest("[data-dashboard-hero]");
+    return Boolean(hero?.textContent?.includes("Everything you can use in chat"));
+  })()`);
+  expect(heroContainsDescription).toBe(true);
+  const descriptionBeforeTabs = await evalIn(browser, `(() => {
+    const text = document.body.innerText;
+    const descriptionIndex = text.indexOf("Everything you can use in chat");
+    const firstTab = [...document.querySelectorAll('[role="tab"]')].find((entry) => entry.textContent?.trim() === "All");
+    const tabIndex = firstTab ? text.indexOf(firstTab.textContent ?? "") : -1;
+    return descriptionIndex >= 0 && tabIndex >= 0 && descriptionIndex < tabIndex;
+  })()`);
+  expect(descriptionBeforeTabs).toBe(true);
+  const gridHasNoComponentCount = await evalIn(
+    browser,
+    `!(/\\bcomponents?\\b/i.test(document.querySelector("[data-library-grid]")?.textContent ?? ""))`,
+  );
+  expect(gridHasNoComponentCount).toBe(true);
+  const searchBeforeTabs = await evalIn(browser, `(() => {
+    const search = document.querySelector('input[placeholder="Search your library"]');
+    const firstTab = [...document.querySelectorAll('[role="tab"]')].find((entry) => entry.textContent?.trim() === "All");
+    return Boolean(search && firstTab && (search.compareDocumentPosition(firstTab) & Node.DOCUMENT_POSITION_FOLLOWING));
+  })()`);
+  expect(searchBeforeTabs).toBe(true);
 
   await using roll = photoRoll("p3-library");
   const desktopShot = await screenshot(browser);
   const desktopSeen = await validate(desktopShot, [
-    "A library page lists plugin cards with provenance chips",
-    "A chip reading Shared by is visible",
+    "A gradient hero card titled Library contains the description text inside it",
+    "Plugin cards show name, description and small provenance pills with no component counts",
   ]);
   await roll.add(desktopShot, desktopSeen);
   expect(desktopSeen.ok, desktopSeen.why).toBe(true);
@@ -307,6 +334,7 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
   const mobileSeen = await validate(mobileShot, [
     "A narrow mobile layout shows library cards in a single column",
     "Provenance chips wrap and remain readable",
+    "the hero is short and does not dominate the screen",
   ]);
   await roll.add(mobileShot, mobileSeen);
   expect(mobileSeen.ok, mobileSeen.why).toBe(true);


### PR DESCRIPTION
## What

Follow-up to #3429 after design review: the shipped library drifted from the approved canvas (Paper pages "PR3 — Member library placement" + "Mobile treatment"). Fixed, exactly per the canvas:

- **Hero**: description + "Member library" badge INSIDE the DashboardPageTemplate (was a floating paragraph below); compact hero below md so it stops dominating phones.
- **Layout order**: hero → constrained search (max-w-[340px], icon) → tabs → grid (search was a full-width orphan under the tabs).
- **Cards**: canvas anatomy — name, 2-line description, then small provenance pills directly after; the top-right "N components" label (never in the design) removed; no bottom-pinned chips.
- **Chips**: 11px pills with exact canvas tones; long team/catalog values truncate instead of wrapping into blobs.
- Tab scrollbar hidden on mobile.

## The process fix that matters

`library-view.slow.test.ts` now pins **design fidelity**, not just function: DOM-order assertions (description renders inside the hero and before the tabs; search precedes tabs; no "component" counts inside cards) + tightened vision expectations ("hero contains the description inside it", "small provenance pills with no component counts", "hero is short on mobile"). 2 runs green, 5/5 vision expectations. Drift of this kind now fails the spec instead of reaching a human eye.

## Tests
```
den-web tsc + next build — clean
library-view.slow.test.ts — 2× green (17.7s / 18.8s), roll 2 frames, vision 5/5
evals typecheck — clean
```
Before/after: #3429's photo-roll comment is the before; the sticky roll below is the after.