### PR TITLE
feat(den-web): Google Workspace as a repeatable quick-add connector (multi-domain admin UI)

### DIFF
--- a/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
@@ -37,13 +37,15 @@ describe("native provider connections", () => {
     expect(isNativeProviderConnectionId("google-workspace")).toBe(true);
     expect(isNativeProviderConnectionId("microsoft-365")).toBe(true);
     expect(isNativeProviderConnectionId("emc_google_workspace")).toBe(false);
+    expect(isNativeProviderConnectionId("emc_google_workspace", "google-workspace")).toBe(true);
   });
 
   test("shows disconnect only for the connected calling member", () => {
     expect(canDisconnectNativeProviderAccount({ id: "google-workspace", connectedForMe: true })).toBe(true);
     expect(canDisconnectNativeProviderAccount({ id: "microsoft-365", connectedForMe: true })).toBe(true);
     expect(canDisconnectNativeProviderAccount({ id: "google-workspace", connectedForMe: false })).toBe(false);
-    expect(canDisconnectNativeProviderAccount({ id: "emc_google_workspace", connectedForMe: true })).toBe(false);
+    expect(canDisconnectNativeProviderAccount({ id: "emc_google_workspace", nativeProviderKey: "google-workspace", connectedForMe: true })).toBe(true);
+    expect(canDisconnectNativeProviderAccount({ id: "emc_external", nativeProviderKey: null, connectedForMe: true })).toBe(false);
   });
 
   test("allows members to disconnect their own per-member account", () => {

--- a/apps/app/src/react-app/domains/connections/native-provider-connections.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.ts
@@ -1,5 +1,6 @@
 export type NativeProviderDisconnectableConnection = {
   id: string;
+  nativeProviderKey?: string | null;
   connectedForMe: boolean;
 };
 
@@ -22,12 +23,12 @@ export function connectionNeedsReconnect(connection: ReconnectableConnection): b
   return connection.needsReconnect === true || (connection.missingFeatures?.length ?? 0) > 0;
 }
 
-export function isNativeProviderConnectionId(id: string): boolean {
-  return id === "google-workspace" || id === "microsoft-365";
+export function isNativeProviderConnectionId(id: string, nativeProviderKey?: string | null): boolean {
+  return nativeProviderKey != null || id === "google-workspace" || id === "microsoft-365";
 }
 
 export function canDisconnectNativeProviderAccount(connection: NativeProviderDisconnectableConnection): boolean {
-  return connection.connectedForMe && isNativeProviderConnectionId(connection.id);
+  return connection.connectedForMe && isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
 }
 
 /** Reconnect/repair is owned by an org admin, not the member. */

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -29,12 +29,16 @@ async function openAuthorizationUrl(url: string) {
   }
 }
 
-async function disconnectMemberAccount(client: DenClient, orgId: string, connectionId: string): Promise<void> {
-  if (isNativeProviderConnectionId(connectionId)) {
-    await client.disconnectOauthProviderAccount(orgId, connectionId);
+async function disconnectMemberAccount(
+  client: DenClient,
+  orgId: string,
+  connection: Pick<DenExternalMcpConnection, "id" | "nativeProviderKey">,
+): Promise<void> {
+  if (isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)) {
+    await client.disconnectOauthProviderAccount(orgId, connection.id);
     return;
   }
-  await client.disconnectMyMcpConnectionAccount(orgId, connectionId);
+  await client.disconnectMyMcpConnectionAccount(orgId, connection.id);
 }
 
 export type OrgMcpConnectionCardState = {
@@ -213,7 +217,7 @@ export function useOrgMcpConnections() {
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
       if (options?.forceFreshAuthorization === true && previous?.connectedForMe) {
-        await disconnectMemberAccount(client, orgId, connectionId);
+        await disconnectMemberAccount(client, orgId, previous);
         if (!isActionScopeCurrent(pollScope)) return;
       }
       const result = await client.startMcpConnectionConnect(orgId, connectionId);
@@ -295,7 +299,8 @@ export function useOrgMcpConnections() {
     setError(null);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
-      await disconnectMemberAccount(client, orgId, connectionId);
+      const connection = connectionsRef.current.find((entry) => entry.id === connectionId);
+      await disconnectMemberAccount(client, orgId, connection ?? { id: connectionId });
       if (!isActionScopeCurrent(actionScope)) return;
       await refresh(actionScope);
       if (!isActionScopeCurrent(actionScope)) return;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
@@ -18,7 +18,6 @@ export function ConnectorQuickAddGrid({
   telegramConnected: boolean;
   onSelect: (id: string) => void;
 }) {
-  const googleConfigured = connections.some((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID);
   const microsoftConfigured = connections.some((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID);
 
   return (
@@ -37,9 +36,7 @@ export function ConnectorQuickAddGrid({
             </p>
           </div>
         </div>
-        <p className="mt-2 text-[12px] font-medium text-gray-900">
-          {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
-        </p>
+        <p className="mt-2 text-[12px] font-medium text-gray-900">Tap to add</p>
       </button>
 
       <button

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -56,6 +56,7 @@ export type ExternalMcpConnection = {
   reconnectActionOwner?: "member" | "organization_admin" | null;
   missingFeatures?: string[];
   externalAccountId?: string | null;
+  nativeProviderKey?: string | null;
   grantedScopes?: string[];
   tenantId?: string | null;
   requiredBy: ExternalMcpRequiredBy[];
@@ -217,12 +218,12 @@ export type CreatedMcpConnection = ExternalMcpConnection & {
   };
 };
 
-export function isNativeProviderConnectionId(id: string): boolean {
-  return id === "google-workspace" || id === "microsoft-365";
+export function isNativeProviderConnectionId(id: string, nativeProviderKey?: string | null): boolean {
+  return nativeProviderKey != null || id === "google-workspace" || id === "microsoft-365";
 }
 
-export function canDisconnectMyConnectionAccount(connection: Pick<ExternalMcpConnection, "id" | "credentialMode" | "connectedForMe">): boolean {
-  return connection.connectedForMe && (isNativeProviderConnectionId(connection.id) || connection.credentialMode === "per_member");
+export function canDisconnectMyConnectionAccount(connection: Pick<ExternalMcpConnection, "id" | "nativeProviderKey" | "credentialMode" | "connectedForMe">): boolean {
+  return connection.connectedForMe && (isNativeProviderConnectionId(connection.id, connection.nativeProviderKey) || connection.credentialMode === "per_member");
 }
 
 export const mcpConnectionQueryKeys = {
@@ -532,6 +533,16 @@ export type CreateMcpConnectionInput = {
   access: McpConnectionAccessInput;
 };
 
+export type CreateNativeProviderConnectionInput = {
+  nativeProviderKey: string;
+  name: string;
+  oauthClient: {
+    clientId: string;
+    clientSecret?: string;
+    features: string[];
+  };
+};
+
 export type UpdateMcpConnectionInput = {
   connectionId: string;
   expectedUpdatedAt: string;
@@ -632,6 +643,37 @@ export function useCreateMcpConnection() {
         created = payload as CreatedMcpConnection;
       });
       if (!created) throw new Error("Create MCP connection response was incomplete.");
+      return created;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
+export function useCreateNativeProviderConnection() {
+  const queryClient = useQueryClient();
+  const { orgId, runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: CreateNativeProviderConnectionInput): Promise<CreatedMcpConnection> => {
+      let created: CreatedMcpConnection | null = null;
+      await runReauthableAction("create-mcp-connection", async () => {
+        const { response, payload } = await requestJson(
+          "/v1/mcp-connections",
+          {
+            method: "POST",
+            headers: getOrgScopeHeaders(requireOrgId(orgId)),
+            body: JSON.stringify({ kind: "native_provider", ...input }),
+          },
+          20000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to add native provider connection (${response.status}).`);
+        }
+        created = payload as CreatedMcpConnection;
+      });
+      if (!created) throw new Error("Create native provider connection response was incomplete.");
       return created;
     },
     onSuccess: () => {
@@ -770,10 +812,10 @@ export function useDisconnectMyProviderAccount() {
   const { orgId } = useOrgDashboard();
 
   return useMutation({
-    mutationFn: async (providerId: string): Promise<string> => {
-      const path = isNativeProviderConnectionId(providerId)
-        ? `/v1/oauth-providers/${encodeURIComponent(providerId)}/disconnect`
-        : `/v1/mcp-connections/${encodeURIComponent(providerId)}/disconnect-my-account`;
+    mutationFn: async (connection: Pick<ExternalMcpConnection, "id" | "nativeProviderKey">): Promise<string> => {
+      const path = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)
+        ? `/v1/oauth-providers/${encodeURIComponent(connection.id)}/disconnect`
+        : `/v1/mcp-connections/${encodeURIComponent(connection.id)}/disconnect-my-account`;
       const { response, payload } = await requestJson(
         path,
         { method: "POST", headers: getOrgScopeHeaders(requireOrgId(orgId)) },
@@ -782,7 +824,7 @@ export function useDisconnectMyProviderAccount() {
       if (!response.ok) {
         throw getRequestError(payload, response, `Failed to disconnect account (${response.status}).`);
       }
-      return providerId;
+      return connection.id;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -46,8 +46,10 @@ import {
   type UpdatedMcpConnection,
   type UpdateMcpConnectionInput,
   formatMcpConnectedTimestamp,
+  isNativeProviderConnectionId,
   mcpConnectionQueryKeys,
   useCreateMcpConnection,
+  useCreateNativeProviderConnection,
   useDeleteMcpConnection,
   useDisconnectMcpConnection,
   useDiscoverMcpConnectionRequirements,
@@ -252,8 +254,10 @@ export function McpConnectionsScreen() {
   const searchParams = useSearchParams();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
+  const { data: usableConnections = [], isLoading: usableConnectionsLoading } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
+  const createNativeConnection = useCreateNativeProviderConnection();
   const updateConnection = useUpdateMcpConnection();
   const startOAuth = useStartMcpConnectionOAuth();
   const disconnectConnection = useDisconnectMcpConnection();
@@ -267,7 +271,7 @@ export function McpConnectionsScreen() {
   const [configuringOAuthClient, setConfiguringOAuthClient] = useState(false);
   const [issuerReviewConnection, setIssuerReviewConnection] = useState<ExternalMcpConnection | null>(null);
   const [issuerReviewPreview, setIssuerReviewPreview] = useState<McpIssuerReview | null>(null);
-  const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
+  const [googleDialogMode, setGoogleDialogMode] = useState<"create" | "legacy" | null>(null);
   const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
   const [telegramDialogOpen, setTelegramDialogOpen] = useState(false);
   const telegramConnection = useTelegramConnection(true);
@@ -282,7 +286,8 @@ export function McpConnectionsScreen() {
 
   function openQuickAdd(id: string) {
     if (id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
-      setGoogleDialogOpen(true);
+      createNativeConnection.reset();
+      setGoogleDialogMode("create");
       return;
     }
     if (id === MICROSOFT_365_QUICK_ADD_ID) {
@@ -317,6 +322,11 @@ export function McpConnectionsScreen() {
       if (pollTimer.current) clearInterval(pollTimer.current);
     };
   }, []);
+
+  const legacyGoogleConnection = usableConnections.find((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID);
+  const listedConnections = legacyGoogleConnection && !connections.some((connection) => connection.id === legacyGoogleConnection.id)
+    ? [legacyGoogleConnection, ...connections]
+    : connections;
 
   function stopPolling() {
     if (pollTimer.current) {
@@ -528,17 +538,17 @@ export function McpConnectionsScreen() {
       </div>
 
       <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Your connectors</h3>
-      {isLoading ? (
+      {isLoading || usableConnectionsLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
           Loading MCP connectors…
         </div>
-      ) : connections.length === 0 ? (
+      ) : listedConnections.length === 0 ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500">
           No MCP connectors yet.
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
-          {connections.map((connection) => {
+          {listedConnections.map((connection) => {
             const connectAttemptRequiresConfiguration = oauthClientConfigurationRequiredIds.includes(connection.id);
             const needsOAuthClientConfiguration = connectionNeedsOAuthClientConfiguration(
               connection,
@@ -557,6 +567,11 @@ export function McpConnectionsScreen() {
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
               errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
               onEdit={() => {
+                if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
+                  saveNativeClient.reset();
+                  setGoogleDialogMode("legacy");
+                  return;
+                }
                 updateConnection.reset();
                 setConfiguringOAuthClient(false);
                 setEditingConnection(connection);
@@ -620,13 +635,26 @@ export function McpConnectionsScreen() {
       />
 
       <GoogleWorkspaceDialog
-        open={googleDialogOpen}
-        submitting={saveNativeClient.isPending}
-        error={saveNativeClient.error}
-        onClose={() => setGoogleDialogOpen(false)}
-        onSubmit={async (input) => {
+        open={googleDialogMode !== null}
+        mode={googleDialogMode ?? "create"}
+        submitting={googleDialogMode === "legacy" ? saveNativeClient.isPending : createNativeConnection.isPending}
+        error={googleDialogMode === "legacy" ? saveNativeClient.error : createNativeConnection.error}
+        onClose={() => setGoogleDialogMode(null)}
+        onCreate={async (input) => {
+          await createNativeConnection.mutateAsync({
+            nativeProviderKey: "google-workspace",
+            name: input.name,
+            oauthClient: {
+              clientId: input.clientId,
+              clientSecret: input.clientSecret,
+              features: input.features,
+            },
+          });
+          setGoogleDialogMode(null);
+        }}
+        onSaveLegacy={async (input) => {
           await saveNativeClient.mutateAsync({ providerId: "google-workspace", ...input });
-          setGoogleDialogOpen(false);
+          setGoogleDialogMode(null);
         }}
       />
 
@@ -978,18 +1006,23 @@ function ImportPluginConnectionDialog({
 
 function GoogleWorkspaceDialog({
   open,
+  mode,
   submitting,
   error,
   onClose,
-  onSubmit,
+  onCreate,
+  onSaveLegacy,
 }: {
   open: boolean;
+  mode: "create" | "legacy";
   submitting: boolean;
   error: unknown;
   onClose: () => void;
-  onSubmit: (input: { clientId?: string; clientSecret?: string; features: string[] }) => void;
+  onCreate: (input: { name: string; clientId: string; clientSecret: string; features: string[] }) => void;
+  onSaveLegacy: (input: { clientId?: string; clientSecret?: string; features: string[] }) => void;
 }) {
   const clientConfig = useNativeProviderClient("google-workspace", open);
+  const [name, setName] = useState("Google Workspace");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [features, setFeatures] = useState<string[]>([]);
@@ -999,33 +1032,36 @@ function GoogleWorkspaceDialog({
 
   useEffect(() => {
     if (!open) return;
+    setName("Google Workspace");
     setClientId("");
     setClientSecret("");
     setFeatures(GOOGLE_WORKSPACE_DEFAULT_FEATURES);
     setCopiedRedirectUri(false);
     setReplacingCredentials(false);
     featuresPrefilled.current = false;
-  }, [open]);
+  }, [mode, open]);
 
   useEffect(() => {
-    if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
+    if (mode !== "legacy" || !open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
     setFeatures(clientConfig.data.features);
     featuresPrefilled.current = true;
-  }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
+  }, [mode, open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
   if (!open) {
     return null;
   }
 
-  const configured = clientConfig.data?.configured ?? false;
+  const configured = mode === "legacy" && (clientConfig.data?.configured ?? false);
   const savedClientId = clientConfig.data?.clientId;
   const redirectUri = clientConfig.data?.redirectUri ?? "";
   const loadingConfig = clientConfig.isLoading;
   const formError = error ?? clientConfig.error;
+  const trimmedName = name.trim();
   const trimmedClientId = clientId.trim();
   const trimmedClientSecret = clientSecret.trim();
   const showCredentialFields = !loadingConfig && (!configured || replacingCredentials);
-  const saveDisabled = loadingConfig || (showCredentialFields && (!trimmedClientId || !trimmedClientSecret));
+  const saveDisabled = loadingConfig || (mode === "create" && !trimmedName)
+    || (showCredentialFields && (!trimmedClientId || !trimmedClientSecret));
 
   function toggleFeature(feature: string) {
     setFeatures((current) => current.includes(feature) ? current.filter((entry) => entry !== feature) : [...current, feature]);
@@ -1049,13 +1085,27 @@ function GoogleWorkspaceDialog({
         onClick={(event) => event.stopPropagation()}
       >
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
-          {configured ? "Update Google Workspace" : "Set up Google Workspace"}
+          {mode === "legacy" ? "Update Google Workspace" : "Add Google Workspace"}
         </h2>
         <p className="mt-1 text-[13px] leading-6 text-gray-600">
-          Use one Google OAuth web app for your org. Members then connect their own Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
+          Use a Google OAuth web app for this connector. Members then connect their own Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
         </p>
 
         <div className="mt-5 space-y-4">
+          {mode === "create" ? (
+            <div>
+              <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Name</label>
+              <DenInput
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Google Workspace"
+                required
+              />
+              <p className="mt-1.5 text-[12px] leading-5 text-gray-500">
+                Name it so people recognize it — e.g. Acme Labs.
+              </p>
+            </div>
+          ) : null}
           <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
             <p className="text-[13px] font-semibold text-gray-900">How to set it up</p>
             <ol className="mt-2 list-decimal space-y-2 pl-4 text-[12px] leading-5 text-gray-600">
@@ -1186,12 +1236,29 @@ function GoogleWorkspaceDialog({
             variant="primary"
             loading={submitting}
             disabled={saveDisabled}
-            onClick={() => onSubmit({
-              ...(showCredentialFields ? { clientId: trimmedClientId, clientSecret: trimmedClientSecret } : {}),
-              features,
-            })}
+            onClick={() => {
+              if (mode === "create") {
+                onCreate({
+                  name: trimmedName,
+                  clientId: trimmedClientId,
+                  clientSecret: trimmedClientSecret,
+                  features,
+                });
+                return;
+              }
+              onSaveLegacy({
+                ...(showCredentialFields ? { clientId: trimmedClientId, clientSecret: trimmedClientSecret } : {}),
+                features,
+              });
+            }}
           >
-            {configured && !replacingCredentials ? "Save permissions" : replacingCredentials ? "Save new credentials" : "Save setup"}
+            {mode === "create"
+              ? "Add connector"
+              : configured && !replacingCredentials
+                ? "Save permissions"
+                : replacingCredentials
+                  ? "Save new credentials"
+                  : "Save setup"}
           </DenButton>
         </div>
       </div>
@@ -1360,15 +1427,17 @@ function ConnectionRow({
   onToggleTools: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
+  const isNativeProvider = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
+  const isLegacyGoogleConnection = connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID;
   const creatorAttribution = formatConnectionCreatorAttribution(connection.createdByName);
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement>(null);
   const actionsTriggerRef = useRef<HTMLButtonElement>(null);
   const setupRequired = needsPluginSetup || needsOAuthClientConfiguration;
   const displayedConnected = connection.connected && !setupRequired;
-  const canConnectOAuth = !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
+  const canConnectOAuth = !isLegacyGoogleConnection && !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
     && (isPerMember ? !connection.connectedForMe : !connection.connected);
-  const canInspectTools = !setupRequired && !connection.issuerReviewRequired
+  const canInspectTools = !isNativeProvider && !setupRequired && !connection.issuerReviewRequired
     && (connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe);
 
   useEffect(() => {
@@ -1440,7 +1509,7 @@ function ConnectionRow({
             <p className="mt-0.5 truncate text-[12px] text-gray-500">
               {connection.url}{setupRequired ? "" : ` · ${formatMcpConnectedTimestamp(connection.connectedAt)}`}{creatorAttribution ? ` · ${creatorAttribution}` : ""}
             </p>
-            {connection.authType === "oauth" ? (
+            {connection.authType === "oauth" && !isNativeProvider ? (
               <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
                 {connection.authorizationServerIssuer ? <span className="max-w-full truncate">Issuer: {connection.authorizationServerIssuer}</span> : null}
                 {(connection.requestedScopes?.length ?? 0) > 0 ? <span>Scopes: {connection.requestedScopes?.join(", ")}</span> : null}
@@ -1476,7 +1545,7 @@ function ConnectionRow({
               Connect
             </DenButton>
           ) : null}
-          {displayedConnected ? (
+          {displayedConnected && !isLegacyGoogleConnection ? (
             <DenButton
               variant="secondary"
               size="sm"
@@ -1514,7 +1583,7 @@ function ConnectionRow({
                     setActionsOpen(false);
                     onEdit();
                   }}
-                  disabled={!connection.updatedAt}
+                  disabled={!connection.updatedAt && !isLegacyGoogleConnection}
                   className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
                   aria-label={`Edit ${connection.name}`}
                   data-testid={`edit-mcp-connection-${connection.id}`}
@@ -1536,21 +1605,25 @@ function ConnectionRow({
                   {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" /> : <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
                   {toolsOpen ? "Hide tools" : "View tools"}
                 </button>
-                <div className="my-1 border-t border-gray-100" />
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    setActionsOpen(false);
-                    onRemove();
-                  }}
-                  disabled={removing}
-                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  aria-label={`Remove ${connection.name}`}
-                >
-                  {removing ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />}
-                  Remove
-                </button>
+                {!isLegacyGoogleConnection ? (
+                  <>
+                    <div className="my-1 border-t border-gray-100" />
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setActionsOpen(false);
+                        onRemove();
+                      }}
+                      disabled={removing}
+                      className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      aria-label={`Remove ${connection.name}`}
+                    >
+                      {removing ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />}
+                      Remove
+                    </button>
+                  </>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -65,14 +65,14 @@ export function YourConnectionsScreen() {
     focusedRowRef.current.focus({ preventScroll: true });
   }, [focusConnectionId, visibleConnections.length]);
 
-  async function handleDisconnectMyAccount(connectionId: string) {
+  async function handleDisconnectMyAccount(connection: ExternalMcpConnection) {
     setRowError(null);
     try {
-      await disconnectProvider.mutateAsync(connectionId);
+      await disconnectProvider.mutateAsync(connection);
       void refetch();
     } catch (disconnectError) {
       setRowError({
-        connectionId,
+        connectionId: connection.id,
         message: disconnectError instanceof Error ? disconnectError.message : "Failed to disconnect account.",
       });
     }
@@ -117,7 +117,7 @@ export function YourConnectionsScreen() {
               rowRef={focusConnectionId === connection.id ? focusedRowRef : undefined}
               polling={authorization.pollingConnectionId === connection.id}
               connecting={authorization.connectingConnectionId === connection.id}
-              disconnecting={disconnectProvider.isPending && disconnectProvider.variables === connection.id}
+              disconnecting={disconnectProvider.isPending && disconnectProvider.variables?.id === connection.id}
               errorMessage={
                 rowError?.connectionId === connection.id
                   ? rowError.message
@@ -126,7 +126,7 @@ export function YourConnectionsScreen() {
                     : null
               }
               onConnect={() => void authorization.connect(connection.id)}
-              onDisconnect={() => void handleDisconnectMyAccount(connection.id)}
+              onDisconnect={() => void handleDisconnectMyAccount(connection)}
             />;
           })}
         </div>
@@ -184,10 +184,11 @@ function YourConnectionRow({
   const needsMyConnect = !needsAdminSetup && !needsAdminRecovery && isPerMember && !connection.connectedForMe;
   const needsAdminConnect = !needsAdminSetup && !needsAdminRecovery && isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
   const canDisconnect = !needsAdminSetup && canDisconnectMyConnectionAccount(connection);
+  const isNativeProvider = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
   const canTestTools = !needsAdminSetup && !needsAdminRecovery && isAdmin
-    && !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
+    && !isNativeProvider && connection.connectedForMe && !needsReconnect;
   const [toolRunnerOpen, setToolRunnerOpen] = useState(false);
-  const microsoftScopes = connection.id === "microsoft-365"
+  const microsoftScopes = (connection.nativeProviderKey === "microsoft-365" || connection.id === "microsoft-365")
     ? (connection.grantedScopes ?? []).filter((scope) => MICROSOFT_365_DISPLAY_SCOPES.has(scope))
     : [];
   const requiredByLabel = formatRequiredBy(connection.requiredBy);
@@ -246,10 +247,13 @@ function YourConnectionRow({
             {requiredByLabel ? (
               <p className="mt-1 text-[12px] font-medium text-gray-700">{requiredByLabel}</p>
             ) : null}
-            {connection.id === "microsoft-365" && connection.tenantId ? (
+            {isNativeProvider && (connection.tenantId || connection.externalAccountId) ? (
               <p className="mt-1 text-[11px] text-gray-500">
-                Tenant <span className="font-mono text-gray-700">{connection.tenantId}</span>
-                {connection.externalAccountId ? <> · {connection.externalAccountId}</> : null}
+                {connection.tenantId ? (
+                  <>Tenant <span className="font-mono text-gray-700">{connection.tenantId}</span>{connection.externalAccountId ? <> · {connection.externalAccountId}</> : null}</>
+                ) : (
+                  <span className="font-mono text-gray-700">{connection.externalAccountId}</span>
+                )}
               </p>
             ) : null}
             {microsoftScopes.length > 0 ? (


### PR DESCRIPTION
Admin UI for multi-Google-connector orgs (follow-up to #3427, which shipped server+desktop only — the dashboard could not create a second connector).

- Quick-add Google tile: always addable (singleton state removed)
- Google dialog: required Name field; submit creates a native connector row ({kind:"native_provider"}); orgs with the legacy alias keep editing it from its row
- Disconnect routing (web + desktop): by nativeProviderKey payload field, id-check kept as fallback — connector rows now hit /v1/oauth-providers/:id/disconnect
- Your Connections: shows the connected Google account email (generalized from the Microsoft block)

Tests: den-web full suite 103/103; den-web typecheck + build green; apps/app tsc green; apps/app native-provider-connections tests updated for key-based routing (17 pass). Not fraimz-proven end-to-end in a browser — reviewer repro: dashboard → Connections → quick-add Google twice with different names, both rows listed, member connects each. Enacts frames 1–2 of evals/voiceovers/google-workspace-multi-account.md.