### PR TITLE
fix(app): sidebar Library row icon weight matches its neighbors (70% idle, full on hover/active)

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-destination.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-destination.tsx
@@ -23,6 +23,7 @@ export function SidebarDestination({ active, icon: Icon, label, labelContent, on
         aria-current={active ? "page" : undefined}
         aria-label={label}
         tooltip={label}
+        className="text-sidebar-foreground/70"
         onClick={onSelect}
       >
         <Icon />

--- a/apps/app/tests/extensions-sidebar-header.test.tsx
+++ b/apps/app/tests/extensions-sidebar-header.test.tsx
@@ -38,6 +38,9 @@ describe("Extensions sidebar destination", () => {
     expect(html).toContain('aria-current="page"');
     expect(html).toContain("data-active");
     expect(html).toContain(">Library<");
+    // Idle weight matches the neighboring Search row (70% foreground) so the
+    // sidebar header reads as one family; active/hover restore full strength.
+    expect(html).toContain("text-sidebar-foreground/70");
   });
 
   test("sits below Search and above Pinned sessions", () => {


### PR DESCRIPTION
Follow-up to #3434 from design review: the sidebar header's Search row idles at `text-sidebar-foreground/70`, but the Library destination row passed no class — its Puzzle icon+label rendered full-strength black directly beneath a muted neighbor. One-class fix on `SidebarDestination`; hover/active still restore full strength via the base button's `data-active`/hover variants, so the active state is unchanged.

Tests: extensions-sidebar-header suite extended to pin the idle weight (9 tests green), apps/app typecheck clean. Visual-only change; nightly desktop spec covers the surface.