### PR TITLE
fix(ci): sign automated model update commits

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 1
+          token: ${{ github.token }}
+          persist-credentials: true
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -153,18 +155,34 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Open pull request
+      - name: Commit model update
         if: steps.changes.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SIGNING_KEY: ${{ secrets.COMMIT_SIGNING_KEY }}
         run: |
           set -euo pipefail
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          signing_key="$RUNNER_TEMP/commit-signing-key"
+          trap 'rm -f "$signing_key"' EXIT
+          umask 077
+          printf '%s\n' "$COMMIT_SIGNING_KEY" > "$signing_key"
+          chmod 600 "$signing_key"
+
+          git config --local user.email "11430621+benjaminshafii@users.noreply.github.com"
+          git config --local user.name "benjaminshafii"
+          git config --local gpg.format ssh
+          git config --local user.signingkey "$signing_key"
           git switch -c "$BRANCH_NAME"
           git add "$MODELS_PATH"
-          git commit -m "chore: update models snapshot"
+          git commit -S -m "chore: update models snapshot"
+
+      - name: Open pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
           git push --set-upstream origin "$BRANCH_NAME"
           pr_url="$(gh pr create \
             --base "$BASE_BRANCH" \


### PR DESCRIPTION
Configures the model update workflow to create SSH-signed commits using the COMMIT_SIGNING_KEY repository secret.

The existing automation PR #3435 was blocked because its commit was unsigned.