### PR TITLE
feat(den-web): trim dashboard page headers

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
@@ -2,7 +2,6 @@
 
 import type { ElementType, ReactNode } from "react";
 import { PaperMeshGradient } from "@openwork/ui/react";
-import { Dithering } from "@paper-design/shaders-react";
 import { useWebGlSupported } from "../../_lib/use-webgl-supported";
 
 /**
@@ -10,23 +9,23 @@ import { useWebGlSupported } from "../../_lib/use-webgl-supported";
  *
  * A consistent page shell for all org dashboard pages.
  * Provides:
- *  - A gradient hero card (icon + badge + title)
+ *  - A compact gradient hero card (badge + title)
  *  - A description line below the card
  *  - A children slot for page-specific content
  *
  * Caller controls only the gradient `colors` tuple — everything else
- * (distortion, swirl, grain, speed, frame, dithering overlay) is fixed
+ * (distortion, swirl, grain, speed, frame) is fixed
  * so every page looks coherent.
  */
 
 export type DashboardPageTemplateProps = {
-  /** Lucide (or any) icon component rendered inside the frosted glass icon box. Omit to hide. */
+  /** Retained for compatibility; the shared Trim header does not render an icon. */
   icon?: ElementType<{
     size?: number;
     className?: string;
     strokeWidth?: number;
   }>;
-  /** Short label rendered as a frosted pill badge above the title. Omit to hide. */
+  /** Short label rendered as a frosted pill badge beside the title. Omit to hide. */
   badgeLabel?: string;
   /** Page heading rendered large inside the card */
   title: string;
@@ -37,150 +36,63 @@ export type DashboardPageTemplateProps = {
    * Tip: vary hue across pages so each section feels distinct at a glance.
    */
   colors: [string, string, string, string];
-  /** `compact` shrinks the hero for setup/onboarding pages. */
+  /** Retained for compatibility; all pages use the shared Trim header size. */
   size?: "default" | "compact" | "responsive";
-  /** Places the supporting copy inside the gradient hero instead of below it. */
+  /** Retained for compatibility; supporting copy always renders below the header. */
   descriptionPlacement?: "below" | "hero";
   children?: React.ReactNode;
 };
 
 export function DashboardPageTemplate({
-  icon: Icon,
   badgeLabel,
   title,
   description,
   colors,
-  size = "default",
-  descriptionPlacement = "below",
   children,
 }: DashboardPageTemplateProps) {
-  const compact = size === "compact";
-  const responsive = size === "responsive";
-  const descriptionInHero = descriptionPlacement === "hero";
   const webGlSupported = useWebGlSupported();
 
   return (
-    <div className={`mx-auto max-w-[860px] ${compact || responsive ? "p-6 md:p-8" : "p-8"}`}>
+    <div className="mx-auto max-w-[860px] p-4 sm:p-6 md:p-8">
       {/* ── Gradient hero card ── */}
       <div
         data-dashboard-hero
-        className={`relative flex items-center overflow-hidden border border-gray-100 ${
-          compact
-            ? "mb-5 h-[88px] rounded-2xl px-6 sm:h-[96px] sm:px-8"
-            : responsive
-              ? "mb-5 h-[88px] rounded-2xl px-6 sm:h-[96px] sm:px-8 md:mb-8 md:h-[200px] md:rounded-3xl md:px-10"
-            : "mb-8 h-[200px] rounded-3xl px-10"
-        }`}
+        className="relative mb-4 flex h-[104px] items-center overflow-hidden rounded-lg border border-gray-100 px-6"
       >
-        {/* Background layers: mesh gradient wrapped in a dithering texture */}
-        <div className="absolute inset-0 z-0">
+        <div className="absolute -top-[90px] inset-x-0 z-0 h-[280px]">
           {webGlSupported ? (
-            <Dithering
-              speed={0}
-              shape="warp"
-              type="4x4"
-              size={2.5}
+            <PaperMeshGradient
+              speed={0.08}
               scale={1}
-              frame={41112.4}
-              colorBack="#00000000"
-              colorFront="#FEFEFE"
-              style={{
-                backgroundColor: "#0f172a",
-                width: "100%",
-                height: "100%",
-              }}
-            >
-              <PaperMeshGradient
-                speed={0.1}
-                distortion={0.8}
-                swirl={0.1}
-                grainMixer={0}
-                grainOverlay={0}
-                frame={176868.9}
-                colors={colors}
-                style={{ width: "100%", height: "100%" }}
-              />
-            </Dithering>
+              distortion={0.8}
+              swirl={0.1}
+              grainMixer={0}
+              grainOverlay={0}
+              frame={176868.9}
+              colors={colors}
+              style={{ width: "100%", height: "100%" }}
+            />
           ) : (
             <div className="h-full w-full" style={{ background: `linear-gradient(135deg, ${colors.join(", ")})` }} />
           )}
         </div>
+        <div
+          className="absolute inset-0 z-[1]"
+          style={{ background: "linear-gradient(90deg, rgba(11,20,32,.52) 0%, rgba(11,20,32,.18) 55%, rgba(11,20,32,.04) 100%)" }}
+        />
 
-        {/* Icon — top right */}
-        {Icon ? (
-          <div
-            className={`absolute z-10 flex items-center justify-center rounded-xl border border-white/30 bg-white/20 backdrop-blur-md ${
-              compact
-                ? "right-5 top-1/2 h-9 w-9 -translate-y-1/2"
-                : responsive
-                  ? "right-5 top-1/2 h-9 w-9 -translate-y-1/2 md:right-8 md:top-8 md:h-12 md:w-12 md:translate-y-0"
-                : "right-8 top-8 h-12 w-12"
-            }`}
-          >
-            <Icon size={compact ? 18 : 24} className="text-white" strokeWidth={1.5} />
-          </div>
-        ) : null}
-
-        {descriptionInHero ? (
-          <div
-            className={`absolute z-10 ${
-              responsive
-                ? "inset-y-0 left-6 right-16 flex flex-col justify-center gap-1.5 sm:left-8 md:inset-y-auto md:bottom-8 md:left-10 md:right-20 md:items-start md:gap-2"
-                : compact
-                  ? "inset-y-0 left-6 right-16 flex flex-col justify-center gap-1.5 sm:left-8"
-                  : "bottom-8 left-10 right-20 flex flex-col items-start gap-2"
-            }`}
-          >
-            <div className={responsive ? "flex items-center gap-2 md:flex-col md:items-start" : "flex flex-col items-start gap-2"}>
-              {badgeLabel ? (
-                <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
-                  {badgeLabel}
-                </span>
-              ) : null}
-              <h1
-                className={`font-medium text-white ${
-                  responsive
-                    ? "text-[20px] tracking-[-0.03em] sm:text-[22px] md:text-[28px] md:tracking-[-0.5px]"
-                    : compact
-                      ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
-                      : "text-[28px] tracking-[-0.5px]"
-                }`}
-              >
-                {title}
-              </h1>
-            </div>
-            <p className="line-clamp-2 max-w-[650px] text-[11px] leading-4 text-white/85 md:line-clamp-none md:text-[13px] md:leading-5">
-              {description}
-            </p>
-          </div>
-        ) : (
-          <div
-            className={`absolute z-10 flex flex-col items-start gap-2 ${
-              compact ? "left-6 top-1/2 -translate-y-1/2 sm:left-8" : "bottom-8 left-10"
-            }`}
-          >
-            {badgeLabel ? (
-              <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
-                {badgeLabel}
-              </span>
-            ) : null}
-            <h1
-              className={`font-medium text-white ${
-                compact
-                  ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
-                  : "text-[28px] tracking-[-0.5px]"
-              }`}
-            >
-              {title}
-            </h1>
-          </div>
-        )}
+        <div className="relative z-10 flex min-w-0 items-center gap-2">
+          <h1 className="truncate text-[24px] font-semibold leading-[30px] tracking-[-0.02em] text-white">{title}</h1>
+          {badgeLabel ? (
+            <span className="shrink-0 rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
+              {badgeLabel}
+            </span>
+          ) : null}
+        </div>
       </div>
 
       {/* ── Description ── */}
-      {!descriptionInHero ? (
-        <p className={`text-[14px] text-gray-500 ${compact ? "mb-5" : "mb-6"}`}>{description}</p>
-      ) : null}
+      <p className="mb-6 text-[14px] text-gray-500">{description}</p>
 
       {/* ── Page content ── */}
       {children}

--- a/evals/flows/den-trim-page-headers.flow.ts
+++ b/evals/flows/den-trim-page-headers.flow.ts
@@ -1,0 +1,345 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import { denWebUrl, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "den-trim-page-headers";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const ORGANIZATION_NAME = "Acme Robotics";
+const SCREENSHOT_REJECT_TEXT = [
+  "Something went wrong",
+  "Failed to fetch",
+  "Loading...",
+  "Loading…",
+  "Loading members",
+  "Loading plugins",
+  "Loading connectors",
+  "Loading settings",
+  "Error loading",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertMeasurement(ctx: FlowContext, value: unknown, assertion: string): void {
+  ctx.assert(
+    isRecord(value) && value.passed === true,
+    `${assertion}. Observed: ${JSON.stringify(value)}`,
+  );
+}
+
+async function setViewport(ctx: FlowContext, width: number, height: number): Promise<void> {
+  ctx.assert(Boolean(ctx.client), "A browser CDP client is required.");
+  await ctx.client?.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height,
+    deviceScaleFactor: 1,
+    mobile: width < 768,
+  });
+}
+
+async function navigateTo(ctx: FlowContext, path: string, title: string): Promise<void> {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor(
+    `(() => {
+      if (location.pathname !== ${JSON.stringify(path)} || document.readyState !== "complete") return false;
+      const text = document.body?.innerText ?? "";
+      if (/Something went wrong|Failed to fetch|Loading(?:\.\.\.|…| members| plugins| connectors| settings)|Error loading/i.test(text)) return false;
+      const heroes = [...document.querySelectorAll("[data-dashboard-hero]")]
+        .filter((entry) => {
+          const rect = entry.getBoundingClientRect();
+          const style = getComputedStyle(entry);
+          return rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+        });
+      return heroes.length === 1
+        && [...heroes[0].querySelectorAll("h1")].some((entry) => (entry.textContent ?? "").trim() === ${JSON.stringify(title)});
+    })()`,
+    { timeoutMs: 180_000, label: `${title} Trim header at ${path}` },
+  );
+}
+
+async function measureRouteHeader(ctx: FlowContext): Promise<unknown> {
+  return ctx.eval(`(() => {
+    const heroes = [...document.querySelectorAll("[data-dashboard-hero]")]
+      .filter((entry) => {
+        const rect = entry.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0 && getComputedStyle(entry).visibility !== "hidden";
+      });
+    const hero = heroes[0];
+    const heading = hero?.querySelector("h1");
+    const meshSlot = hero ? [...hero.children].find((entry) => {
+      const style = getComputedStyle(entry);
+      return Math.abs(parseFloat(style.height) - 280) <= 1 && Math.abs(parseFloat(style.top) + 90) <= 1;
+    }) : null;
+    const surfaces = meshSlot ? [...meshSlot.querySelectorAll("div, canvas")] : [];
+    const hasGradientSurface = surfaces.some((entry) => {
+      if (entry instanceof HTMLCanvasElement) return entry.width > 0 && entry.height > 0;
+      const image = getComputedStyle(entry).backgroundImage;
+      return image.includes("gradient");
+    });
+    const rect = hero?.getBoundingClientRect();
+    return {
+      passed: heroes.length === 1
+        && Boolean(rect && Math.abs(rect.height - 104) <= 1)
+        && Boolean(heading)
+        && hasGradientSurface,
+      path: location.pathname,
+      title: heading?.textContent?.trim() ?? null,
+      heroCount: heroes.length,
+      heroHeight: rect?.height ?? null,
+      hasGradientSurface,
+    };
+  })()`);
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Den dashboard pages share a compact, readable Trim header",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Members uses the compact Trim header",
+      run: async (ctx) => {
+        await ctx.prove("Members has one 104-pixel Trim header with a plain white title", {
+          voiceover: vo[0],
+          action: async () => {
+            await setViewport(ctx, 1440, 1000);
+            await signInViaBrowser(ctx, EMAIL, PASSWORD, ORGANIZATION_NAME);
+            await navigateTo(ctx, "/dashboard/members", "Members");
+          },
+          assert: async () => {
+            const measurement = await ctx.eval(`(() => {
+              const heroes = [...document.querySelectorAll("[data-dashboard-hero]")]
+                .filter((entry) => {
+                  const rect = entry.getBoundingClientRect();
+                  const style = getComputedStyle(entry);
+                  return rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+                });
+              const hero = heroes[0];
+              const heading = hero?.querySelector("h1");
+              const heroRect = hero?.getBoundingClientRect();
+              const headingStyle = heading ? getComputedStyle(heading) : null;
+              const titleIsWhite = headingStyle
+                ? headingStyle.color === "rgb(255, 255, 255)" || headingStyle.color === "rgba(255, 255, 255, 1)"
+                : false;
+              return {
+                passed: heroes.length === 1
+                  && Boolean(heroRect && Math.abs(heroRect.height - 104) <= 1)
+                  && heading?.textContent?.trim() === "Members"
+                  && headingStyle?.fontSize === "24px"
+                  && titleIsWhite
+                  && hero?.querySelectorAll("svg").length === 0,
+                heroCount: heroes.length,
+                heroHeight: heroRect?.height ?? null,
+                title: heading?.textContent?.trim() ?? null,
+                titleSize: headingStyle?.fontSize ?? null,
+                titleColor: headingStyle?.color ?? null,
+                svgOrIconChipCount: hero?.querySelectorAll("svg").length ?? null,
+              };
+            })()`);
+            assertMeasurement(ctx, measurement, "Members should show exactly one 104px hero, a white 24px h1, and no SVG/icon chip");
+          },
+          screenshot: {
+            name: "members-compact-trim-header",
+            requireText: ["Members", "Invite teammates, adjust roles, and keep access clean."],
+            rejectText: SCREENSHOT_REJECT_TEXT,
+          },
+        });
+      },
+    },
+    {
+      name: "The mesh and ink scrim remain visible",
+      run: async (ctx) => {
+        await ctx.prove("The Trim header preserves the mesh palette and applies the expected readability scrim", {
+          voiceover: vo[1],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/members", "Members");
+            await ctx.waitFor(
+              `(() => {
+                const hero = document.querySelector("[data-dashboard-hero]");
+                return Boolean(hero && (hero.querySelector("canvas") || [...hero.querySelectorAll("div")].some((entry) => getComputedStyle(entry).backgroundImage.includes("gradient"))));
+              })()`,
+              { timeoutMs: 30_000, label: "Members mesh canvas or CSS fallback" },
+            );
+          },
+          assert: async () => {
+            const measurement = await ctx.eval(`(() => {
+              const hero = document.querySelector("[data-dashboard-hero]");
+              const layers = hero ? [...hero.children] : [];
+              const meshSlot = layers.find((entry) => {
+                const style = getComputedStyle(entry);
+                return Math.abs(parseFloat(style.height) - 280) <= 1 && Math.abs(parseFloat(style.top) + 90) <= 1;
+              });
+              const scrim = layers.find((entry) => {
+                const image = getComputedStyle(entry).backgroundImage;
+                return image.includes("linear-gradient") && image.includes("0.52") && image.includes("0.18") && image.includes("0.04");
+              });
+              const fallback = meshSlot ? [...meshSlot.querySelectorAll("div")].find((entry) => getComputedStyle(entry).backgroundImage.includes("gradient")) : null;
+              const canvas = meshSlot?.querySelector("canvas");
+              const slotStyle = meshSlot ? getComputedStyle(meshSlot) : null;
+              return {
+                passed: Boolean(meshSlot && scrim && (canvas || fallback)),
+                slotHeight: slotStyle?.height ?? null,
+                slotTop: slotStyle?.top ?? null,
+                scrimBackground: scrim ? getComputedStyle(scrim).backgroundImage : null,
+                renderSurface: canvas ? "canvas" : fallback ? "css-gradient" : null,
+              };
+            })()`);
+            assertMeasurement(ctx, measurement, "The mesh/fallback slot should be 280px high at -90px with all three ink-scrim opacity stops");
+          },
+          screenshot: {
+            name: "members-mesh-and-scrim",
+            requireText: ["Members", "Invite teammates, adjust roles, and keep access clean."],
+            rejectText: SCREENSHOT_REJECT_TEXT,
+          },
+        });
+      },
+    },
+    {
+      name: "Description and tabs follow the header",
+      run: async (ctx) => {
+        await ctx.prove("Members keeps its description outside the hero and before its tabs", {
+          voiceover: vo[2],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/members", "Members");
+            await ctx.waitFor(
+              `(() => ["Members", "Teams", "Roles"].every((label) => [...document.querySelectorAll('[role="tab"]')].some((entry) => (entry.textContent ?? "").includes(label))))()`,
+              { timeoutMs: 60_000, label: "Members, Teams, and Roles tabs" },
+            );
+          },
+          assert: async () => {
+            const measurement = await ctx.eval(`(() => {
+              const hero = document.querySelector("[data-dashboard-hero]");
+              const description = [...document.querySelectorAll("p")]
+                .find((entry) => (entry.textContent ?? "").trim() === "Invite teammates, adjust roles, and keep access clean.");
+              const tabs = [...document.querySelectorAll('[role="tab"]')]
+                .filter((entry) => ["Members", "Teams", "Roles"].some((label) => (entry.textContent ?? "").includes(label)));
+              const firstTab = tabs[0];
+              const heroBeforeDescription = Boolean(hero && description && (hero.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING));
+              const descriptionBeforeTabs = Boolean(description && firstTab && (description.compareDocumentPosition(firstTab) & Node.DOCUMENT_POSITION_FOLLOWING));
+              return {
+                passed: Boolean(hero && description && !hero.contains(description) && heroBeforeDescription && descriptionBeforeTabs && tabs.length === 3),
+                descriptionOutsideHero: Boolean(hero && description && !hero.contains(description)),
+                heroBeforeDescription,
+                descriptionBeforeTabs,
+                tabs: tabs.map((entry) => (entry.textContent ?? "").replace(/\\s+/g, " ").trim()),
+              };
+            })()`);
+            assertMeasurement(ctx, measurement, "The description should be after and outside the hero, before all three Members tabs");
+          },
+          screenshot: {
+            name: "members-description-and-tabs",
+            requireText: ["Invite teammates, adjust roles, and keep access clean.", "Members", "Teams", "Roles", "Add member"],
+            rejectText: SCREENSHOT_REJECT_TEXT,
+          },
+        });
+      },
+    },
+    {
+      name: "Trim headers stay consistent across dashboard routes",
+      run: async (ctx) => {
+        await ctx.prove("Members, Plugins, Connectors, and Org settings use the same compact gradient shell", {
+          voiceover: vo[3],
+          action: async () => {
+            const routes = [
+              { path: "/dashboard/members", title: "Members" },
+              { path: "/dashboard/plugins", title: "Plugins" },
+              { path: "/dashboard/mcp-connections", title: "Connectors" },
+              { path: "/dashboard/org-settings", title: "Org settings" },
+            ];
+            for (const route of routes) {
+              await navigateTo(ctx, route.path, route.title);
+              const measurement = await measureRouteHeader(ctx);
+              const correctRoute = isRecord(measurement)
+                && measurement.path === route.path
+                && measurement.title === route.title;
+              ctx.assert(correctRoute, `${route.path} should render the ${route.title} h1. Observed: ${JSON.stringify(measurement)}`);
+              assertMeasurement(ctx, measurement, `${route.title} should have one 104px hero and a gradient surface`);
+              ctx.recordEvidence({
+                type: "assertion",
+                status: "passed",
+                assertion: `${route.title} route has the shared 104px gradient Trim header`,
+                actual: measurement,
+              });
+            }
+          },
+          assert: async () => {
+            const finalHeader = await measureRouteHeader(ctx);
+            assertMeasurement(ctx, finalHeader, "The route sequence should finish on a valid non-Members Trim header");
+            ctx.assert(
+              isRecord(finalHeader) && finalHeader.path === "/dashboard/org-settings" && finalHeader.title === "Org settings",
+              `Expected the screenshot route to finish on Org settings. Observed: ${JSON.stringify(finalHeader)}`,
+            );
+          },
+          screenshot: {
+            name: "org-settings-shared-trim-header",
+            requireText: ["Org settings", "Control your organization's settings."],
+            rejectText: SCREENSHOT_REJECT_TEXT,
+          },
+        });
+      },
+    },
+    {
+      name: "Members remains usable at a narrow viewport",
+      run: async (ctx) => {
+        await ctx.prove("The Members Trim header, tabs, and Add member action fit a 375-pixel viewport", {
+          voiceover: vo[4],
+          action: async () => {
+            await setViewport(ctx, 375, 480);
+            await navigateTo(ctx, "/dashboard/members", "Members");
+            await ctx.eval("(() => { scrollTo(0, 0); return true; })()");
+            await ctx.waitFor(
+              `(() => [...document.querySelectorAll("button")].some((entry) => (entry.textContent ?? "").trim() === "Add member"))()`,
+              { timeoutMs: 60_000, label: "narrow Add member action" },
+            );
+          },
+          assert: async () => {
+            const measurement = await ctx.eval(`(() => {
+              const hero = document.querySelector("[data-dashboard-hero]");
+              const title = hero?.querySelector("h1");
+              const tabs = document.querySelector('[role="tablist"]');
+              const addMember = [...document.querySelectorAll("button")]
+                .find((entry) => (entry.textContent ?? "").trim() === "Add member");
+              const heroRect = hero?.getBoundingClientRect();
+              const titleRect = title?.getBoundingClientRect();
+              const tabsRect = tabs?.getBoundingClientRect();
+              const actionRect = addMember?.getBoundingClientRect();
+              const horizontallyContained = (rect) => Boolean(rect && rect.left >= -1 && rect.right <= innerWidth + 1);
+              const visiblySized = (rect) => Boolean(rect && rect.width > 0 && rect.height > 0);
+              return {
+                passed: Boolean(
+                  heroRect && heroRect.top >= 0 && heroRect.bottom <= innerHeight
+                  && visiblySized(titleRect) && visiblySized(tabsRect) && visiblySized(actionRect)
+                  && horizontallyContained(heroRect) && horizontallyContained(titleRect)
+                  && horizontallyContained(tabsRect) && horizontallyContained(actionRect)
+                  && document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1
+                ),
+                viewport: { width: innerWidth, height: innerHeight },
+                hero: heroRect ? { left: heroRect.left, right: heroRect.right, top: heroRect.top, bottom: heroRect.bottom } : null,
+                titleVisible: visiblySized(titleRect),
+                tabsVisible: visiblySized(tabsRect),
+                addMemberVisible: visiblySized(actionRect),
+                addMemberBounds: actionRect ? { left: actionRect.left, right: actionRect.right } : null,
+                pageScrollWidth: document.documentElement.scrollWidth,
+                pageClientWidth: document.documentElement.clientWidth,
+              };
+            })()`);
+            assertMeasurement(ctx, measurement, "At 375x480 the hero should be in view with visible, horizontally contained title, tabs, and Add member action and no page overflow");
+          },
+          screenshot: {
+            name: "members-trim-header-mobile",
+            requireText: ["Members", "Teams", "Roles", "Add member"],
+            rejectText: SCREENSHOT_REJECT_TEXT,
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/den-trim-page-headers.flow.ts
+++ b/evals/flows/den-trim-page-headers.flow.ts
@@ -44,7 +44,8 @@ async function setViewport(ctx: FlowContext, width: number, height: number): Pro
 
 async function navigateTo(ctx: FlowContext, path: string, title: string): Promise<void> {
   const url = new URL(path, denWebUrl()).toString();
-  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  ctx.assert(Boolean(ctx.page), "A browser page is required.");
+  await ctx.page?.goto(url, { waitUntil: "domcontentloaded" });
   await ctx.waitFor(
     `(() => {
       if (location.pathname !== ${JSON.stringify(path)} || document.readyState !== "complete") return false;

--- a/evals/specs/library-view.slow.test.ts
+++ b/evals/specs/library-view.slow.test.ts
@@ -289,12 +289,13 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
     `[...document.querySelectorAll("aside, nav")].some((entry) => (entry.textContent ?? "").includes("Library"))`,
   );
   expect(libraryNavPresent).toBe(true);
-  const heroContainsDescription = await evalIn(browser, `(() => {
+  const descriptionOutsideHero = await evalIn(browser, `(() => {
     const heading = [...document.querySelectorAll("h1")].find((entry) => entry.textContent?.trim() === "Library");
     const hero = heading?.closest("[data-dashboard-hero]");
-    return Boolean(hero?.textContent?.includes("Everything you can use in chat"));
+    const description = [...document.querySelectorAll("p")].find((entry) => entry.textContent?.includes("Everything you can use in chat"));
+    return Boolean(hero && description && !hero.contains(description));
   })()`);
-  expect(heroContainsDescription).toBe(true);
+  expect(descriptionOutsideHero).toBe(true);
   const descriptionBeforeTabs = await evalIn(browser, `(() => {
     const text = document.body.innerText;
     const descriptionIndex = text.indexOf("Everything you can use in chat");
@@ -318,7 +319,7 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
   await using roll = photoRoll("p3-library");
   const desktopShot = await screenshot(browser);
   const desktopSeen = await validate(desktopShot, [
-    "A gradient hero card titled Library contains the description text inside it",
+    "A compact gradient header is titled Library, with its description immediately below and before the tabs",
     "Plugin cards show name, description and small provenance pills with no component counts",
   ]);
   await roll.add(desktopShot, desktopSeen);

--- a/evals/voiceovers/den-trim-page-headers.md
+++ b/evals/voiceovers/den-trim-page-headers.md
@@ -1,0 +1,11 @@
+# den-trim-page-headers — Compact shared gradient headers across Den
+
+1. I open a Den dashboard page and see its oversized hero replaced by a compact 104-pixel gradient header with a clear white title and no icon chip.
+
+2. The mesh gradient keeps that page’s existing colors, while a subtle dark scrim makes every title consistently readable.
+
+3. Descriptions, tabs, actions, and page content remain directly below the header without changing their behavior.
+
+4. As I move between Members, Plugins, Connectors, Settings, and other dashboard pages, the same compact treatment appears with each page’s own palette.
+
+5. At narrower widths, the header and surrounding controls adapt without clipping or hiding essential actions.


### PR DESCRIPTION
## Summary
- apply Paper’s 01 · Trim treatment to every shared Den dashboard gradient header
- preserve per-page palettes and badges while removing icon chips and moving descriptions below headers
- add an approved five-frame voice-over and fraimz flow

## Verification
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --dir ee/apps/den-web exec bun test tests/cloud-super-admins-role-hierarchy.test.ts` — 6 passed
- `pnpm evals:typecheck`
- `pnpm fraimz --flow den-trim-page-headers --stack den --cdp-url http://127.0.0.1:9334` — passed 5/5 frames

## Evidence
- Local artifact: `evals/results/2026-08-02T21-05-45-327Z/fraimz.html`
- Frame proof will be posted in a follow-up PR comment.