### PR TITLE
feat(den-api): binary-safe capability content + MCP image delivery lanes

### DIFF
--- a/ee/apps/den-api/src/capability-sources/binary-content.ts
+++ b/ee/apps/den-api/src/capability-sources/binary-content.ts
@@ -1,0 +1,26 @@
+export type DecodedFileContent =
+  | { kind: "text"; content: string; truncated: boolean }
+  | { kind: "binary"; contentBase64: string; byteSize: number }
+  | { kind: "too_large"; byteSize: number }
+
+export function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {
+  if (text.length <= maxCharacters) {
+    return { text, truncated: false }
+  }
+  return { text: text.slice(0, maxCharacters), truncated: true }
+}
+
+export function decodeFileContent(
+  bytes: Uint8Array,
+  options: { maxTextCharacters: number; maxBinaryBytes: number },
+): DecodedFileContent {
+  try {
+    const decoded = truncateText(new TextDecoder("utf-8", { fatal: true }).decode(bytes), options.maxTextCharacters)
+    return { kind: "text", content: decoded.text, truncated: decoded.truncated }
+  } catch {
+    if (bytes.length > options.maxBinaryBytes) {
+      return { kind: "too_large", byteSize: bytes.length }
+    }
+    return { kind: "binary", contentBase64: Buffer.from(bytes).toString("base64"), byteSize: bytes.length }
+  }
+}

--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -1,3 +1,7 @@
+import { truncateText } from "./binary-content.js"
+
+export { truncateText } from "./binary-content.js"
+
 export type GoogleWorkspaceAttachment = {
   attachmentId: string
   filename: string
@@ -213,13 +217,6 @@ export function extractGmailThreadQuoteInput(json: unknown): { from: string; dat
     date: headers.get("date") ?? "",
     body: state.plain,
   }
-}
-
-export function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {
-  if (text.length <= maxCharacters) {
-    return { text, truncated: false }
-  }
-  return { text: text.slice(0, maxCharacters), truncated: true }
 }
 
 export function buildDriveSearchQuery(text: string): string {

--- a/ee/apps/den-api/src/capability-sources/microsoft-graph.ts
+++ b/ee/apps/den-api/src/capability-sources/microsoft-graph.ts
@@ -1,6 +1,8 @@
+import { decodeFileContent, truncateText } from "./binary-content.js"
+
 const DEFAULT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 const DEFAULT_TIMEOUT_MS = 30_000
-const DEFAULT_MAX_DOWNLOAD_BYTES = 5_000_000
+const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 const DEFAULT_MAX_JSON_RESPONSE_BYTES = 5_000_000
 const DEFAULT_MAX_CONTENT_CHARACTERS = 200_000
 
@@ -56,9 +58,11 @@ export type Microsoft365DriveItem = {
 
 export type Microsoft365DriveItemWithContent = Microsoft365DriveItem & {
   content: string | null
+  contentBase64: string | null
+  encoding: "text" | "base64" | "none"
   contentType: string | null
   truncated: boolean
-  contentUnavailableReason: "folder" | "file_too_large" | "unsupported_content_type" | null
+  contentUnavailableReason: "folder" | "file_too_large" | null
 }
 
 export type Microsoft365TeamsChat = {
@@ -133,15 +137,8 @@ function readEmailAddresses(record: Record<string, unknown>, key: string): Micro
   return addresses
 }
 
-function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {
-  if (text.length <= maxCharacters) {
-    return { text, truncated: false }
-  }
-  return { text: text.slice(0, maxCharacters), truncated: true }
-}
-
-async function readTextWithByteLimit(response: Response, maxBytes: number): Promise<{ text: string; limitExceeded: boolean }> {
-  if (!response.body) return { text: "", limitExceeded: false }
+async function readBytesWithByteLimit(response: Response, maxBytes: number): Promise<{ bytes: Uint8Array; limitExceeded: boolean }> {
+  if (!response.body) return { bytes: new Uint8Array(), limitExceeded: false }
 
   const reader = response.body.getReader()
   const chunks: Uint8Array[] = []
@@ -168,7 +165,7 @@ async function readTextWithByteLimit(response: Response, maxBytes: number): Prom
     bytes.set(chunk, offset)
     offset += chunk.byteLength
   }
-  return { text: new TextDecoder().decode(bytes), limitExceeded }
+  return { bytes, limitExceeded }
 }
 
 function extractMailMessage(value: unknown): Microsoft365MailMessage {
@@ -335,16 +332,6 @@ export function extractMicrosoftTeamsMessages(json: unknown): Microsoft365TeamsM
     .filter((message) => Boolean(message.id))
 }
 
-function isTextContentType(contentType: string): boolean {
-  const normalized = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? ""
-  return normalized.startsWith("text/")
-    || normalized === "application/json"
-    || normalized === "application/xml"
-    || normalized === "application/yaml"
-    || normalized === "application/x-yaml"
-    || normalized === "application/javascript"
-}
-
 function escapeGraphSearch(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
 }
@@ -404,21 +391,21 @@ export class MicrosoftGraphClient {
       signal: init?.signal ?? AbortSignal.timeout(this.timeoutMs),
     })
     if (!response.ok) {
-      const responseBody = await readTextWithByteLimit(response, this.maxJsonResponseBytes)
+      const responseBody = await readBytesWithByteLimit(response, this.maxJsonResponseBytes)
       const suffix = responseBody.limitExceeded ? " [response truncated]" : ""
-      throw new MicrosoftGraphRequestError(operation, response.status, `${responseBody.text}${suffix}`)
+      throw new MicrosoftGraphRequestError(operation, response.status, `${new TextDecoder().decode(responseBody.bytes)}${suffix}`)
     }
     return response
   }
 
   private async requestJson(operation: string, url: URL, init?: RequestInit): Promise<unknown> {
     const response = await this.request(operation, url, init)
-    const responseBody = await readTextWithByteLimit(response, this.maxJsonResponseBytes)
+    const responseBody = await readBytesWithByteLimit(response, this.maxJsonResponseBytes)
     if (responseBody.limitExceeded) {
       throw new MicrosoftGraphRequestError(operation, 502, `Microsoft Graph response exceeded ${this.maxJsonResponseBytes} bytes.`)
     }
     try {
-      const body: unknown = JSON.parse(responseBody.text)
+      const body: unknown = JSON.parse(new TextDecoder().decode(responseBody.bytes))
       return body
     } catch {
       throw new MicrosoftGraphRequestError(operation, 502, "Microsoft Graph returned invalid JSON.")
@@ -523,13 +510,10 @@ export class MicrosoftGraphClient {
   async getDriveItemWithContent(itemId: string): Promise<Microsoft365DriveItemWithContent> {
     const item = await this.getDriveItem(itemId)
     if (item.kind === "folder") {
-      return { ...item, content: null, contentType: null, truncated: false, contentUnavailableReason: "folder" }
+      return { ...item, content: null, contentBase64: null, encoding: "none", contentType: null, truncated: false, contentUnavailableReason: "folder" }
     }
     if (item.size !== null && item.size > this.maxDownloadBytes) {
-      return { ...item, content: null, contentType: item.mimeType || null, truncated: false, contentUnavailableReason: "file_too_large" }
-    }
-    if (item.mimeType && !isTextContentType(item.mimeType)) {
-      return { ...item, content: null, contentType: item.mimeType, truncated: false, contentUnavailableReason: "unsupported_content_type" }
+      return { ...item, content: null, contentBase64: null, encoding: "none", contentType: item.mimeType || null, truncated: false, contentUnavailableReason: "file_too_large" }
     }
 
     const contentUrl = this.url(`me/drive/items/${encodeURIComponent(itemId)}/content`)
@@ -537,20 +521,36 @@ export class MicrosoftGraphClient {
     const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim() || item.mimeType || null
     const contentLength = Number(response.headers.get("content-length"))
     if (Number.isFinite(contentLength) && contentLength > this.maxDownloadBytes) {
-      return { ...item, content: null, contentType, truncated: false, contentUnavailableReason: "file_too_large" }
-    }
-    if (contentType && !isTextContentType(contentType)) {
-      return { ...item, content: null, contentType, truncated: false, contentUnavailableReason: "unsupported_content_type" }
+      return { ...item, content: null, contentBase64: null, encoding: "none", contentType, truncated: false, contentUnavailableReason: "file_too_large" }
     }
 
-    const downloaded = await readTextWithByteLimit(response, this.maxDownloadBytes)
+    const downloaded = await readBytesWithByteLimit(response, this.maxDownloadBytes)
     if (downloaded.limitExceeded) {
-      return { ...item, content: null, contentType, truncated: false, contentUnavailableReason: "file_too_large" }
+      return { ...item, content: null, contentBase64: null, encoding: "none", contentType, truncated: false, contentUnavailableReason: "file_too_large" }
     }
-    const content = truncateText(downloaded.text, this.maxContentCharacters)
+    const content = decodeFileContent(downloaded.bytes, {
+      maxTextCharacters: this.maxContentCharacters,
+      maxBinaryBytes: this.maxDownloadBytes,
+    })
+    if (content.kind === "too_large") {
+      return { ...item, content: null, contentBase64: null, encoding: "none", contentType, truncated: false, contentUnavailableReason: "file_too_large" }
+    }
+    if (content.kind === "binary") {
+      return {
+        ...item,
+        content: null,
+        contentBase64: content.contentBase64,
+        encoding: "base64",
+        contentType,
+        truncated: false,
+        contentUnavailableReason: null,
+      }
+    }
     return {
       ...item,
-      content: content.text,
+      content: content.content,
+      contentBase64: null,
+      encoding: "text",
       contentType,
       truncated: content.truncated,
       contentUnavailableReason: null,

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -27,6 +27,9 @@ import {
   searchBuiltinSkillCapabilities,
 } from "./builtin-skills.js"
 import { executeNativeCapability, searchNativeCapabilities } from "./native-capabilities.js"
+import { externalToolContent, type AgentToolContentPart } from "./tool-content.js"
+
+export { externalToolContent } from "./tool-content.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
 const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
@@ -167,7 +170,7 @@ const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = `The capability call exceeded ${EXECU
 
 export type ExecuteCapabilityToolResult = {
   isError?: boolean
-  content: { text: string; type: "text" }[]
+  content: AgentToolContentPart[]
 }
 
 function textContent(text: string): { text: string; type: "text" }[] {
@@ -214,22 +217,6 @@ function unknownCapabilityText(name: string): string {
     error: "unknown_capability",
     message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
   })
-}
-
-function isTextContent(value: unknown): value is { type: "text"; text: string } {
-  return typeof value === "object"
-    && value !== null
-    && "type" in value
-    && value.type === "text"
-    && "text" in value
-    && typeof value.text === "string"
-}
-
-function externalToolContent(result: unknown): { type: "text"; text: string }[] {
-  if (typeof result === "object" && result !== null && "content" in result && Array.isArray(result.content) && result.content.every(isTextContent)) {
-    return result.content
-  }
-  return textContent(JSON.stringify(result))
 }
 
 export function externalCapabilitySuccessToolResult(

--- a/ee/apps/den-api/src/mcp/invoke.ts
+++ b/ee/apps/den-api/src/mcp/invoke.ts
@@ -3,6 +3,7 @@ import { createInternalCapabilityConnectorHeader, createInternalMcpPrincipalHead
 import type { McpPrincipal } from "./auth.js"
 import type { McpToolOperation } from "./catalog.js"
 import { requiredScopeForMethod } from "./policy.js"
+import { buildRestToolContent } from "./tool-content.js"
 
 type ToolInput = {
   path?: Record<string, unknown>
@@ -141,10 +142,9 @@ export async function invokeMcpOperation(input: {
   const response = await input.app.fetch(request, input.env)
   const contentType = response.headers.get("content-type") ?? ""
   const payload = contentType.includes("application/json") ? await response.json() : await response.text()
-  const text = typeof payload === "string" ? payload : JSON.stringify(payload, null, 2)
 
   return {
     isError: response.status >= 400,
-    content: [{ type: "text" as const, text }],
+    content: await buildRestToolContent(payload),
   }
 }

--- a/ee/apps/den-api/src/mcp/native-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/native-capabilities.ts
@@ -2,6 +2,7 @@ import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { listNativeProviderUsableEntries, type NativeProviderConnectionEntry } from "../capability-sources/native-provider-connections.js"
 import type { McpPrincipal } from "./auth.js"
+import type { AgentToolContentPart } from "./tool-content.js"
 import {
   getJsonRequestBodySchema,
   getParameters,
@@ -161,7 +162,7 @@ async function resolveNativeCapability(input: {
 
 type NativeCapabilityToolResult = {
   isError?: boolean
-  content: { type: "text"; text: string }[]
+  content: AgentToolContentPart[]
 }
 
 export async function executeNativeCapability(input: {

--- a/ee/apps/den-api/src/mcp/tool-content.ts
+++ b/ee/apps/den-api/src/mcp/tool-content.ts
@@ -1,0 +1,95 @@
+import sharp from "sharp"
+
+export type AgentToolContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string }
+
+const MAX_INLINE_IMAGE_BYTES = 1024 * 1024
+const MAX_IMAGE_DIMENSION = 1568
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isImagePayload(value: unknown): value is Record<string, unknown> & {
+  contentBase64: string
+  mimeType: string
+} {
+  return isRecord(value)
+    && typeof value.contentBase64 === "string"
+    && typeof value.mimeType === "string"
+    && value.mimeType.startsWith("image/")
+}
+
+export function isKnownToolContentPart(value: unknown): value is AgentToolContentPart {
+  if (!isRecord(value) || typeof value.type !== "string") return false
+  if (value.type === "text") return typeof value.text === "string"
+  if (value.type === "image") {
+    return typeof value.data === "string" && typeof value.mimeType === "string"
+  }
+  return false
+}
+
+export function externalToolContent(result: unknown): AgentToolContentPart[] {
+  if (isRecord(result) && Array.isArray(result.content) && result.content.every(isKnownToolContentPart)) {
+    return result.content
+  }
+  return [{ type: "text", text: JSON.stringify(result) }]
+}
+
+export async function buildRestToolContent(payload: unknown): Promise<AgentToolContentPart[]> {
+  if (typeof payload === "string") return [{ type: "text", text: payload }]
+
+  const payloadRecord = isRecord(payload) ? payload : undefined
+  let imagePayload: (Record<string, unknown> & { contentBase64: string; mimeType: string }) | undefined
+  let imagePayloadKey: string | undefined
+  if (isImagePayload(payload)) {
+    imagePayload = payload
+  } else if (payloadRecord) {
+    for (const [key, value] of Object.entries(payloadRecord)) {
+      if (isImagePayload(value)) {
+        imagePayload = value
+        imagePayloadKey = key
+        break
+      }
+    }
+  }
+
+  if (!imagePayload) {
+    return [{ type: "text", text: JSON.stringify(payload, null, 2) }]
+  }
+
+  const byteSize = Buffer.byteLength(imagePayload.contentBase64, "base64")
+  const placeholder = `<${byteSize} bytes delivered as image content>`
+  const redactedImagePayload = { ...imagePayload, contentBase64: placeholder }
+  const redactedPayload = imagePayloadKey === undefined || payloadRecord === undefined
+    ? redactedImagePayload
+    : { ...payloadRecord, [imagePayloadKey]: redactedImagePayload }
+  const textPart: AgentToolContentPart = {
+    type: "text",
+    text: JSON.stringify(redactedPayload, null, 2),
+  }
+
+  if (byteSize <= MAX_INLINE_IMAGE_BYTES) {
+    return [textPart, {
+      type: "image",
+      data: imagePayload.contentBase64,
+      mimeType: imagePayload.mimeType,
+    }]
+  }
+
+  try {
+    const image = await sharp(Buffer.from(imagePayload.contentBase64, "base64"))
+      .resize({
+        width: MAX_IMAGE_DIMENSION,
+        height: MAX_IMAGE_DIMENSION,
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality: 80 })
+      .toBuffer()
+    return [textPart, { type: "image", data: image.toString("base64"), mimeType: "image/jpeg" }]
+  } catch {
+    return [textPart]
+  }
+}

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -7,6 +7,7 @@ import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { env } from "../../env.js"
 import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { decodeFileContent } from "../../capability-sources/binary-content.js"
 import { buildGmailDraftRaw, gmailDraftUrl, gmailThreadUrl, readGmailDraftIds } from "../../capability-sources/gmail.js"
 import type { GmailDraftAttachment } from "../../capability-sources/gmail.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
@@ -39,6 +40,7 @@ const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
 const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
 const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
+const MAX_DRIVE_FILE_CONTENT_BYTES = 10 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENTS_TOTAL_BYTES = 20 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENT_BASE64_LENGTH = Math.ceil(MAX_GMAIL_ATTACHMENT_BYTES / 3) * 4
@@ -289,8 +291,11 @@ const uploadDriveFileResponseSchema = z.object({
 const driveFileResponseSchema = z.object({
   ok: z.literal(true),
   file: driveFileSummarySchema.extend({
-    content: z.string(),
+    content: z.string().nullable(),
+    contentBase64: z.string().nullable().describe("Standard base64-encoded file bytes for binary files; decode locally. Same encoding as the gmail-attachment capability's dataBase64 — it can be passed directly to the Drive upload capability's dataBase64 field."),
+    encoding: z.enum(["text", "base64", "none"]),
     truncated: z.boolean(),
+    contentUnavailableReason: z.enum(["file_too_large"]).nullable(),
   }),
 }).meta({ ref: "GoogleWorkspaceDriveFileResponse" })
 
@@ -922,8 +927,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     "/v1/capabilities/google-workspace/drive-file/:fileId",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Read a Google Drive file's text content as the calling member",
-      description: "Reads text from one Google Drive file, exporting Google Docs editors files as plain text and downloading other files as UTF-8 text with truncation.",
+      summary: "Read a Google Drive file's text or binary content as the calling member",
+      description: "Reads one Google Drive file, exporting Google Docs editors files as plain text. Downloaded files are content-sniffed with strict UTF-8 detection, so text is returned regardless of MIME type; binary content is returned as standard base64 up to 10 MiB.",
       responses: {
         200: jsonResponse("Google Drive file returned.", driveFileResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -964,10 +969,25 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "google_api_error", message: "Google Drive returned no file id." }, 502)
       }
 
-      const contentUrl = file.mimeType.startsWith("application/vnd.google-apps")
+      const isGoogleAppsFile = file.mimeType.startsWith("application/vnd.google-apps")
+      if (!isGoogleAppsFile && file.size !== null && Number(file.size) > MAX_DRIVE_FILE_CONTENT_BYTES) {
+        return c.json({
+          ok: true,
+          file: {
+            ...file,
+            content: null,
+            contentBase64: null,
+            encoding: "none",
+            truncated: false,
+            contentUnavailableReason: "file_too_large",
+          },
+        })
+      }
+
+      const contentUrl = isGoogleAppsFile
         ? new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}/export`)
         : new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
-      if (file.mimeType.startsWith("application/vnd.google-apps")) {
+      if (isGoogleAppsFile) {
         contentUrl.searchParams.set("mimeType", "text/plain")
       } else {
         contentUrl.searchParams.set("alt", "media")
@@ -980,13 +1000,61 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json(await googleApiError("Google Drive file content", contentResponse), 502)
       }
 
-      const content = truncateText(await contentResponse.text(), 200_000)
+      if (isGoogleAppsFile) {
+        const content = truncateText(await contentResponse.text(), 200_000)
+        return c.json({
+          ok: true,
+          file: {
+            ...file,
+            content: content.text,
+            contentBase64: null,
+            encoding: "text",
+            truncated: content.truncated,
+            contentUnavailableReason: null,
+          },
+        })
+      }
+
+      const bytes = new Uint8Array(await contentResponse.arrayBuffer())
+      const content = decodeFileContent(bytes, {
+        maxTextCharacters: 200_000,
+        maxBinaryBytes: MAX_DRIVE_FILE_CONTENT_BYTES,
+      })
+      if (content.kind === "text") {
+        return c.json({
+          ok: true,
+          file: {
+            ...file,
+            content: content.content,
+            contentBase64: null,
+            encoding: "text",
+            truncated: content.truncated,
+            contentUnavailableReason: null,
+          },
+        })
+      }
+      if (content.kind === "binary") {
+        return c.json({
+          ok: true,
+          file: {
+            ...file,
+            content: null,
+            contentBase64: content.contentBase64,
+            encoding: "base64",
+            truncated: false,
+            contentUnavailableReason: null,
+          },
+        })
+      }
       return c.json({
         ok: true,
         file: {
           ...file,
-          content: content.text,
-          truncated: content.truncated,
+          content: null,
+          contentBase64: null,
+          encoding: "none",
+          truncated: false,
+          contentUnavailableReason: "file_too_large",
         },
       })
     },

--- a/ee/apps/den-api/src/routes/org/microsoft-365.ts
+++ b/ee/apps/den-api/src/routes/org/microsoft-365.ts
@@ -143,9 +143,11 @@ const driveFileResponseSchema = z.object({
   ok: z.literal(true),
   file: driveItemSchema.extend({
     content: z.string().nullable(),
+    contentBase64: z.string().nullable().describe("Standard base64-encoded file bytes for binary files; decode locally."),
+    encoding: z.enum(["text", "base64", "none"]),
     contentType: z.string().nullable(),
     truncated: z.boolean(),
-    contentUnavailableReason: z.enum(["folder", "file_too_large", "unsupported_content_type"]).nullable(),
+    contentUnavailableReason: z.enum(["folder", "file_too_large"]).nullable(),
   }),
 }).meta({ ref: "Microsoft365DriveFileResponse" })
 
@@ -478,8 +480,8 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
     "/v1/capabilities/microsoft-365/drive-file/:itemId",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Read a OneDrive text file as the calling member",
-      description: "Returns OneDrive metadata, source link, and bounded UTF-8 text content. Folders, large files, and binary Office files return metadata with an explicit contentUnavailableReason instead of decoding unsafe binary data.",
+      summary: "Read a OneDrive text or binary file as the calling member",
+      description: "Returns OneDrive metadata and content using strict-UTF-8 content sniffing: text is returned regardless of MIME type, while binary files are returned as standard base64 up to 10 MiB. Folders and oversized files return metadata with an explicit contentUnavailableReason.",
       responses: {
         200: jsonResponse("OneDrive file returned.", driveFileResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -101,6 +101,7 @@ let calendarCreateCount = 0
 let lastDraftPayload: unknown = null
 let lastGmailThreadUrl: string | null = null
 let forceDriveUploadError = false
+let largeDriveContentHitCount = 0
 
 function resetFakeGoogle() {
   lastAuthorization = null
@@ -120,10 +121,13 @@ function resetFakeGoogle() {
   lastDraftPayload = null
   lastGmailThreadUrl = null
   forceDriveUploadError = false
+  largeDriveContentHitCount = 0
 }
 
 // Trailing high bytes force base64url output ("-"/"_") to differ from standard base64 ("+"/"/").
 const attachmentBytes = Buffer.concat([Buffer.from("%PDF-1.4 fake attachment", "utf8"), Buffer.from([0xfb, 0xef, 0xbe, 0xff])])
+const binaryDriveBytes = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xfb, 0xef, 0xbe, 0xff]), Buffer.from("binary fixture", "utf8")])
+const dxfDriveText = "0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
 
 function gmailMessagePayload() {
   return {
@@ -315,6 +319,56 @@ const fakeGoogleServer = Bun.serve({
         modifiedTime: "2026-07-08T11:00:00Z",
         webViewLink: "https://drive.google.com/file/d/file_1/view",
         size: "42",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/binary_file" && url.searchParams.get("alt") === "media") {
+      return new Response(binaryDriveBytes, { headers: { "content-type": "application/octet-stream" } })
+    }
+    if (url.pathname === "/drive/v3/files/binary_file") {
+      return json({
+        id: "binary_file",
+        name: "fixture.png",
+        mimeType: "application/octet-stream",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/binary_file/view",
+        size: String(binaryDriveBytes.byteLength),
+      })
+    }
+    if (url.pathname === "/drive/v3/files/dxf_file" && url.searchParams.get("alt") === "media") {
+      return new Response(dxfDriveText, { headers: { "content-type": "image/vnd.dxf" } })
+    }
+    if (url.pathname === "/drive/v3/files/dxf_file") {
+      return json({
+        id: "dxf_file",
+        name: "drawing.dxf",
+        mimeType: "image/vnd.dxf",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/dxf_file/view",
+        size: String(Buffer.byteLength(dxfDriveText)),
+      })
+    }
+    if (url.pathname === "/drive/v3/files/large_file" && url.searchParams.get("alt") === "media") {
+      largeDriveContentHitCount += 1
+      return new Response("should not be fetched")
+    }
+    if (url.pathname === "/drive/v3/files/large_file") {
+      return json({
+        id: "large_file",
+        name: "large.bin",
+        mimeType: "application/octet-stream",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/large_file/view",
+        size: "20971520",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/doc_1") {
+      return json({
+        id: "doc_1",
+        name: "Project Doc",
+        mimeType: "application/vnd.google-apps.document",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://docs.google.com/document/d/doc_1/edit",
+        size: null,
       })
     }
     if (url.pathname === "/drive/v3/files/doc_1/export") {
@@ -889,6 +943,62 @@ test("drive search returns mapped files", async () => {
       },
     ],
   })
+})
+
+test("drive file read returns strict UTF-8 text metadata", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/file_1")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "drive text response")
+  expect(responseBody.ok).toBe(true)
+  const file = expectRecord(responseBody.file, "drive text file")
+  expect(file.content).toBe("Drive file text")
+  expect(file.encoding).toBe("text")
+  expect(file.contentBase64).toBeNull()
+  expect(file.contentUnavailableReason).toBeNull()
+})
+
+test("drive file read preserves binary bytes through standard base64", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/binary_file")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "drive binary response")
+  expect(responseBody.ok).toBe(true)
+  const file = expectRecord(responseBody.file, "drive binary file")
+  expect(file.encoding).toBe("base64")
+  expect(file.content).toBeNull()
+  expect(Buffer.compare(Buffer.from(expectString(file.contentBase64, "drive binary content"), "base64"), binaryDriveBytes)).toBe(0)
+})
+
+test("drive file read sniffs text independently of MIME type", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/dxf_file")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  const file = expectRecord(expectRecord(body, "drive DXF response").file, "drive DXF file")
+  expect(file.encoding).toBe("text")
+  expect(file.content).toBe(dxfDriveText)
+})
+
+test("drive file read skips content fetch when metadata exceeds the binary limit", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/large_file")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  const file = expectRecord(expectRecord(body, "large drive response").file, "large drive file")
+  expect(file.contentUnavailableReason).toBe("file_too_large")
+  expect(file.encoding).toBe("none")
+  expect(file.content).toBeNull()
+  expect(file.contentBase64).toBeNull()
+  expect(file.truncated).toBe(false)
+  expect(largeDriveContentHitCount).toBe(0)
+})
+
+test("drive file read keeps the Google Apps text export branch", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/doc_1")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  const file = expectRecord(expectRecord(body, "Google Apps response").file, "Google Apps file")
+  expect(file.encoding).toBe("text")
+  expect(file.content).toBe("Exported doc text")
 })
 
 test("drive upload stores decoded bytes as multipart and returns the user-facing Drive link", async () => {

--- a/ee/apps/den-api/test/mcp-tool-content.test.ts
+++ b/ee/apps/den-api/test/mcp-tool-content.test.ts
@@ -1,0 +1,87 @@
+import { randomBytes } from "node:crypto"
+import { expect, test } from "bun:test"
+import sharp from "sharp"
+import { buildRestToolContent, externalToolContent, isKnownToolContentPart } from "../src/mcp/tool-content.js"
+
+test("buildRestToolContent returns a plain object as one text part", async () => {
+  const payload = { ok: true, count: 2 }
+  expect(await buildRestToolContent(payload)).toEqual([{
+    type: "text",
+    text: JSON.stringify(payload, null, 2),
+  }])
+})
+
+test("buildRestToolContent emits a small image and redacts its base64 from text", async () => {
+  const data = (await sharp({
+    create: { width: 2, height: 2, channels: 4, background: "red" },
+  }).png().toBuffer()).toString("base64")
+  const content = await buildRestToolContent({
+    ok: true,
+    file: { contentBase64: data, mimeType: "image/png", name: "x.png" },
+  })
+
+  expect(content).toHaveLength(2)
+  expect(content[0]?.type).toBe("text")
+  if (content[0]?.type === "text") {
+    expect(content[0].text).toContain("bytes delivered as image content")
+    expect(content[0].text).not.toContain(data)
+  }
+  expect(content[1]).toEqual({ type: "image", data, mimeType: "image/png" })
+})
+
+test("buildRestToolContent downscales large images to bounded JPEG content", async () => {
+  const width = 1600
+  const height = 1600
+  const png = await sharp(randomBytes(width * height * 3), {
+    raw: { width, height, channels: 3 },
+  }).png().toBuffer()
+  expect(png.byteLength).toBeGreaterThan(1024 * 1024)
+
+  const data = png.toString("base64")
+  const content = await buildRestToolContent({
+    file: { contentBase64: data, mimeType: "image/png" },
+  })
+  const textPart = content[0]
+  const imagePart = content[1]
+  expect(textPart?.type).toBe("text")
+  if (textPart?.type === "text") {
+    expect(textPart.text).toContain("bytes delivered as image content")
+    expect(textPart.text).not.toContain(data)
+  }
+  expect(imagePart?.type).toBe("image")
+  if (imagePart?.type === "image") {
+    expect(imagePart.mimeType).toBe("image/jpeg")
+    const metadata = await sharp(Buffer.from(imagePart.data, "base64")).metadata()
+    expect(metadata.width).toBeLessThanOrEqual(1568)
+    expect(metadata.height).toBeLessThanOrEqual(1568)
+  }
+})
+
+test("buildRestToolContent leaves non-image binary payloads unchanged", async () => {
+  const payload = { file: { dataBase64: "AAAA", mimeType: "application/pdf" } }
+  expect(await buildRestToolContent(payload)).toEqual([{
+    type: "text",
+    text: JSON.stringify(payload, null, 2),
+  }])
+})
+
+test("known content validation and external content passthrough preserve text and images", () => {
+  const textResult = { content: [{ type: "text", text: "hello" }] }
+  const imageResult = {
+    content: [
+      { type: "text", text: "preview" },
+      { type: "image", data: "AAAA", mimeType: "image/png" },
+    ],
+  }
+  const unknownResult = { content: [{ type: "audio", data: "AAAA", mimeType: "audio/wav" }] }
+
+  expect(isKnownToolContentPart(textResult.content[0])).toBe(true)
+  expect(isKnownToolContentPart(imageResult.content[1])).toBe(true)
+  expect(isKnownToolContentPart(unknownResult.content[0])).toBe(false)
+  expect(externalToolContent(textResult)).toBe(textResult.content)
+  expect(externalToolContent(imageResult)).toBe(imageResult.content)
+  expect(externalToolContent(unknownResult)).toEqual([{
+    type: "text",
+    text: JSON.stringify(unknownResult),
+  }])
+})

--- a/ee/apps/den-api/test/microsoft-365-routes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-routes.test.ts
@@ -54,6 +54,26 @@ function contextMiddleware(context: OrganizationContext): MiddlewareHandler<{ Va
   }
 }
 
+function driveFileApp(graphFetch: typeof fetch): Hono<{ Variables: OrgRouteVariables }> {
+  const app = new Hono<{ Variables: OrgRouteVariables }>()
+  routes.registerMicrosoft365Routes(app, {
+    graphBaseUrl: "https://graph.example.test/v1.0",
+    fetch: graphFetch,
+    memberRoute: contextMiddleware(organizationContext()),
+    resolveAccessToken: async () => ({
+      kind: "ok",
+      accessToken: "delegated-member-token",
+      scopes: ["Files.Read"],
+      enabledFeatures: ["filesRead"],
+    }),
+  })
+  return app
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 describe("Microsoft 365 injected routes", () => {
   test("maps Graph mail for the calling member and blocks disconnected or under-scoped accounts", async () => {
     const context = organizationContext()
@@ -298,5 +318,122 @@ describe("Microsoft 365 injected routes", () => {
       message: "Your connected Microsoft account is missing the Outlook mail read/write permission. An admin can enable it on the Microsoft 365 connector in OpenWork Cloud -> Connectors; then reconnect your account.",
     })
     expect(graphCalls).toBe(1)
+  })
+
+  test("returns OneDrive binary file bytes as byte-exact base64", async () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xfb, 0xef, 0xbe, 0xff])
+    const graphFetch: typeof fetch = async (input, init) => {
+      const request = new Request(input, init)
+      const pathname = new URL(request.url).pathname
+      if (pathname.endsWith("/content")) {
+        return new Response(binary, { headers: { "content-type": "application/octet-stream" } })
+      }
+      return Response.json({
+        id: "binary_1",
+        name: "image.png",
+        size: binary.byteLength,
+        file: { mimeType: "application/octet-stream" },
+      })
+    }
+
+    const response = await driveFileApp(graphFetch).request("http://den-api.local/v1/capabilities/microsoft-365/drive-file/binary_1")
+    expect(response.status).toBe(200)
+    const payload: unknown = await response.json()
+    expect(payload).toMatchObject({
+      ok: true,
+      file: {
+        encoding: "base64",
+        content: null,
+        contentUnavailableReason: null,
+      },
+    })
+    if (!isRecord(payload) || !isRecord(payload.file) || typeof payload.file.contentBase64 !== "string") {
+      throw new Error("Expected a base64-encoded file response.")
+    }
+    expect(Buffer.compare(Buffer.from(payload.file.contentBase64, "base64"), binary)).toBe(0)
+  })
+
+  test("returns OneDrive text files with text encoding", async () => {
+    const content = "OneDrive text remains readable."
+    const graphFetch: typeof fetch = async (input, init) => {
+      const pathname = new URL(new Request(input, init).url).pathname
+      if (pathname.endsWith("/content")) {
+        return new Response(content, { headers: { "content-type": "text/plain; charset=utf-8" } })
+      }
+      return Response.json({ id: "text_1", name: "notes.txt", size: content.length, file: { mimeType: "text/plain" } })
+    }
+
+    const response = await driveFileApp(graphFetch).request("http://den-api.local/v1/capabilities/microsoft-365/drive-file/text_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      file: {
+        content,
+        contentBase64: null,
+        encoding: "text",
+        truncated: false,
+        contentUnavailableReason: null,
+      },
+    })
+  })
+
+  test("returns strict UTF-8 text even when the OneDrive MIME type looks binary", async () => {
+    const content = "0\nSECTION\n2\nENTITIES\n0\nEOF\n"
+    const graphFetch: typeof fetch = async (input, init) => {
+      const pathname = new URL(new Request(input, init).url).pathname
+      if (pathname.endsWith("/content")) {
+        return new Response(content, { headers: { "content-type": "image/vnd.dxf" } })
+      }
+      return Response.json({ id: "drawing_1", name: "drawing.dxf", size: content.length, file: { mimeType: "image/vnd.dxf" } })
+    }
+
+    const response = await driveFileApp(graphFetch).request("http://den-api.local/v1/capabilities/microsoft-365/drive-file/drawing_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      file: { content, contentBase64: null, encoding: "text", contentUnavailableReason: null },
+    })
+  })
+
+  test("returns folder metadata with no content encoding", async () => {
+    const graphFetch: typeof fetch = async () => Response.json({ id: "folder_1", name: "Projects", size: 0, folder: {} })
+
+    const response = await driveFileApp(graphFetch).request("http://den-api.local/v1/capabilities/microsoft-365/drive-file/folder_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      file: {
+        content: null,
+        contentBase64: null,
+        encoding: "none",
+        contentUnavailableReason: "folder",
+      },
+    })
+  })
+
+  test("rejects oversized OneDrive metadata without downloading content", async () => {
+    let contentCalls = 0
+    const graphFetch: typeof fetch = async (input, init) => {
+      const pathname = new URL(new Request(input, init).url).pathname
+      if (pathname.endsWith("/content")) {
+        contentCalls += 1
+        return new Response("unexpected")
+      }
+      return Response.json({
+        id: "oversized_1",
+        name: "archive.bin",
+        size: 10 * 1024 * 1024 + 1,
+        file: { mimeType: "application/octet-stream" },
+      })
+    }
+
+    const response = await driveFileApp(graphFetch).request("http://den-api.local/v1/capabilities/microsoft-365/drive-file/oversized_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      file: {
+        content: null,
+        contentBase64: null,
+        encoding: "none",
+        contentUnavailableReason: "file_too_large",
+      },
+    })
+    expect(contentCalls).toBe(0)
   })
 })


### PR DESCRIPTION
## Problem

`execute_capability` runs on Den; results ride back to agents as JSON text. The Drive read capability fetches raw bytes correctly (`alt=media`) and then destroys them:

```ts
// google-workspace.ts (before)
const content = truncateText(await contentResponse.text(), 200_000)
```

`.text()` UTF-8-decodes binary, replacing invalid sequences with U+FFFD — measured live this session: a 52,223-byte PNG came back as 49,126 characters of unrecoverable mush. OneDrive reads refused binary outright (`unsupported_content_type`). And even clean base64 could never reach an agent as an *image*: the MCP wrapper hard-codes text-only parts and stringifies any downstream result containing image content.

## What changed

**L1 — shared dual-lane decoder** (`capability-sources/binary-content.ts`)
Strict UTF-8 sniffing (`TextDecoder(..., { fatal: true })`) → text lane (existing truncation); otherwise base64 lane capped at 10 MiB. Content sniffing beats MIME checking: DXF (`image/vnd.dxf`, actually ASCII) stays text.

- **Google Drive** `drive-file/{fileId}`: response gains `contentBase64`, `encoding: "text"|"base64"|"none"`, `contentUnavailableReason: "file_too_large"|null`; metadata size pre-gate skips the content fetch entirely for oversized files. `content` unchanged for text files.
- **OneDrive** `drive-file/{itemId}`: same contract; binary now *returned* instead of refused; byte-limited streaming kept; cap raised 5 MB → 10 MiB for parity.

**L2 — MCP wrapper image lanes** (`mcp/tool-content.ts`, used by `invoke.ts` + `agent.ts`)
- Native lane: REST payloads carrying `contentBase64` + `mimeType: image/*` emit a real MCP `{type:"image"}` part; >1 MiB images are downscaled with sharp (≤1568px, JPEG q80; sharp already a dep); the base64 is redacted from the text part (never double-shipped).
- External lane: downstream MCP content arrays of known text/image parts pass through **verbatim** instead of being stringified — org-connected MCPs (Paper screenshots, future Drive MCPs) can now show agents actual images.

Upload symmetry note: the platform already accepts `dataBase64` (Gmail attachments, Drive upload); this PR makes the read side match. Signed upload/download URLs for >10 MiB are a deliberate follow-up.

## Tests run (all from `ee/apps/den-api`, `bun test --conditions=development ...`)

| Suite | Result |
|---|---|
| `test/google-workspace-capabilities.test.ts` | 34 pass / 0 fail (5 new: binary byte-exact roundtrip, DXF text-sniffing, size pre-gate with zero content hits, text lane, Google Apps export unchanged) |
| `test/microsoft-365-routes.test.ts` | 8 pass / 0 fail (5 new incl. byte-exact roundtrip, MIME-lies-text, folder/too-large) |
| `test/mcp-tool-content.test.ts` (new) | 5 pass / 0 fail (small image passthrough+redaction, >1 MiB sharp downscale verified by decoding output, non-image untouched, external passthrough/fallback) |
| `test/mcp-invoke-body.test.ts` | 9 pass / 0 fail |
| `test/mcp-agent-timeouts.test.ts` + `test/agent-mcp-routes.test.ts` | 17 pass / 0 fail |
| `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` | clean |

**Known pre-existing failures (not this PR — verified via `git stash -u` baseline on dev tip `06225346f`):**
- `test/mcp-agent-config-policy.test.ts`: 14 pass / 2 fail on clean baseline and identically with this diff (expectations drifted from the import-mcps body schema, e.g. `marketplaceId` no longer required — the live API confirms).
- Multi-file combined `bun test` runs of DB-backed suites intermittently fail with mysql2 pool errors on baseline too (shared-process collision); every suite above passes solo.

## Validation scope

Server-API change only — no UI surface, so no video; runtime behavior is proven by the HTTP-level integration tests above (real Hono app, fake Google/Graph upstreams, byte-exact assertions). After deploy to OpenWork Cloud, the end-to-end demo this was built for becomes runnable live: *draw on a Daylight tablet → PNG syncs to Drive → agent says "use my latest drawing" → sees it → recreates it in Paper*. Happy to record that as follow-up proof once deployed.

## Follow-ups (deliberately out of scope)
- Signed download/upload URLs for >10 MiB (bytes around the model, not through it)
- `admin-capabilities.ts` image-part parity
- Fix the two pre-existing `mcp-agent-config-policy` expectations
