### PR TITLE
fix(den-api): preserve Gmail draft formatting

### DIFF
--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -29,6 +29,30 @@ function base64MimeContent(content: Buffer): string {
   return content.toString("base64").match(/.{1,76}/g)?.join("\r\n") ?? ""
 }
 
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+function draftBodyHtml(body: string): string {
+  return body.split("\n").map((line) => `<div>${line.length === 0 ? "<br>" : escapeHtml(line)}</div>`).join("")
+}
+
+function alternativeMimeParts(boundary: string, body: string): string[] {
+  return [
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    base64MimeContent(Buffer.from(body, "utf8")),
+    `--${boundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    base64MimeContent(Buffer.from(draftBodyHtml(body), "utf8")),
+    `--${boundary}--`,
+  ]
+}
+
 // Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
 // literal breaks become visible after send, especially on narrow screens.
 function normalizeDraftBody(body: string): string {
@@ -99,34 +123,34 @@ export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: strin
   ].filter((line) => typeof line === "string")
   const attachments = input.attachments ?? []
   const body = normalizeDraftBody(input.body)
+  const alternativeBoundary = `openwork-alternative-${randomUUID()}`
   const message = attachments.length === 0 ? [
     ...headers,
     "MIME-Version: 1.0",
-    'Content-Type: text/plain; charset="UTF-8"',
-    "Content-Transfer-Encoding: base64",
+    `Content-Type: multipart/alternative; boundary="${alternativeBoundary}"`,
     "",
-    Buffer.from(body, "utf8").toString("base64"),
+    ...alternativeMimeParts(alternativeBoundary, body),
+    "",
   ].join("\r\n") : (() => {
-    const boundary = `openwork-${randomUUID()}`
+    const mixedBoundary = `openwork-mixed-${randomUUID()}`
     return [
       ...headers,
       "MIME-Version: 1.0",
-      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      `Content-Type: multipart/mixed; boundary="${mixedBoundary}"`,
       "",
-      `--${boundary}`,
-      'Content-Type: text/plain; charset="UTF-8"',
-      "Content-Transfer-Encoding: base64",
+      `--${mixedBoundary}`,
+      `Content-Type: multipart/alternative; boundary="${alternativeBoundary}"`,
       "",
-      Buffer.from(body, "utf8").toString("base64"),
+      ...alternativeMimeParts(alternativeBoundary, body),
       ...attachments.flatMap((attachment) => [
-        `--${boundary}`,
+        `--${mixedBoundary}`,
         `Content-Type: ${attachment.mimeType}; name="${encodeMimeParameter(attachment.filename)}"`,
         `Content-Disposition: attachment; filename="${encodeMimeParameter(attachment.filename)}"`,
         "Content-Transfer-Encoding: base64",
         "",
         base64MimeContent(attachment.content),
       ]),
-      `--${boundary}--`,
+      `--${mixedBoundary}--`,
       "",
     ].join("\r\n")
   })()

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -26,15 +26,33 @@ function decodeRawBody(raw: string): string {
   return Buffer.from(encoded.replace(/\r\n/g, ""), "base64").toString("utf8")
 }
 
+function decodeAlternativeBodies(raw: string): { plain: string; html: string } {
+  const decoded = decodeRaw(raw)
+  const parts = [...decoded.matchAll(/Content-Type: text\/(plain|html); charset="UTF-8"\r\nContent-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+)/g)]
+  const decodePart = (kind: string) => {
+    const encoded = parts.find((part) => part[1] === kind)?.[2] ?? ""
+    return Buffer.from(encoded.replace(/\r\n/g, ""), "base64").toString("utf8")
+  }
+  return { plain: decodePart("plain"), html: decodePart("html") }
+}
+
+function expectFoldedBase64Payloads(decoded: string) {
+  const payloads = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+)/g)]
+  expect(payloads.length).toBeGreaterThan(0)
+  for (const payload of payloads) {
+    expect(payload[1]!.split("\r\n").every((line) => line.length <= 76)).toBe(true)
+  }
+}
+
 describe("buildGmailDraftRaw", () => {
-  test("encodes a plain-ASCII draft as base64url RFC 822 with the body base64-encoded", () => {
+  test("encodes a plain-ASCII draft as base64url multipart/alternative", () => {
     const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
     const decoded = Buffer.from(raw, "base64url").toString("utf8")
     expect(decoded).toContain("To: sam@acme.test\r\n")
     expect(decoded).toContain("Subject: Follow up\r\n")
-    expect(decoded).toContain('Content-Type: text/plain; charset="UTF-8"')
-    const bodyPart = decoded.split("\r\n\r\n")[1]
-    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Hello Sam")
+    expect(decoded).toContain("Content-Type: multipart/alternative;")
+    expect(decoded.indexOf('Content-Type: text/plain; charset="UTF-8"')).toBeLessThan(decoded.indexOf('Content-Type: text/html; charset="UTF-8"'))
+    expect(decodeAlternativeBodies(raw)).toEqual({ plain: "Hello Sam", html: "<div>Hello Sam</div>" })
     // base64url alphabet only — Gmail rejects standard base64 for `raw`.
     expect(raw).not.toMatch(/[+/=]/)
   })
@@ -45,18 +63,17 @@ describe("buildGmailDraftRaw", () => {
     const subjectLine = decoded.split("\r\n").find((line) => line.startsWith("Subject: "))
     expect(subjectLine).toMatch(/^Subject: =\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/)
     expect(Buffer.from(subjectLine!.slice("Subject: =?UTF-8?B?".length, -2), "base64").toString("utf8")).toBe("Résumé — próxima reunión")
-    const bodyPart = decoded.split("\r\n\r\n")[1]
-    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Grüße aus Zürich ✅")
+    expect(decodeAlternativeBodies(raw)).toEqual({ plain: "Grüße aus Zürich ✅", html: "<div>Grüße aus Zürich ✅</div>" })
   })
 
-  test("unwraps hard-wrapped prose without changing paragraphs, short breaks, or lists", () => {
+  test("unwraps long prose and preserves blank lines, lists, and escaped text in equivalent alternatives", () => {
     const body = [
       "Thanks again for the conversation today. As promised, I have attached",
       "a revised indicative pricing proposal for the air-gapped on-premises",
       "deployment, covering both the minimal self-managed path and a",
       "full-support option.",
       "",
-      "Options:",
+      "Options for <Sam> & team:",
       "- Self-managed deployment",
       "- Full-support deployment",
       "",
@@ -64,19 +81,23 @@ describe("buildGmailDraftRaw", () => {
       "",
       "Ben",
     ].join("\n")
-    const decoded = decodeRaw(gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body }))
-    const bodyPart = decoded.split("\r\n\r\n")[1]
-    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe([
+    const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body })
+    const expectedPlain = [
       "Thanks again for the conversation today. As promised, I have attached a revised indicative pricing proposal for the air-gapped on-premises deployment, covering both the minimal self-managed path and a full-support option.",
       "",
-      "Options:",
+      "Options for <Sam> & team:",
       "- Self-managed deployment",
       "- Full-support deployment",
       "",
       "Thanks again!",
       "",
       "Ben",
-    ].join("\n"))
+    ].join("\n")
+    expect(decodeAlternativeBodies(raw)).toEqual({
+      plain: expectedPlain,
+      html: "<div>Thanks again for the conversation today. As promised, I have attached a revised indicative pricing proposal for the air-gapped on-premises deployment, covering both the minimal self-managed path and a full-support option.</div><div><br></div><div>Options for &lt;Sam&gt; &amp; team:</div><div>- Self-managed deployment</div><div>- Full-support deployment</div><div><br></div><div>Thanks again!</div><div><br></div><div>Ben</div>",
+    })
+    expectFoldedBase64Payloads(decodeRaw(raw))
   })
 
   test("strips conservative markdown from prose while preserving structure", () => {
@@ -113,17 +134,12 @@ describe("buildGmailDraftRaw", () => {
     ].join("\n"))
   })
 
-  test("keeps legacy draft output unchanged when optional fields are absent", () => {
+  test("closes the top-level alternative boundary when optional fields are absent", () => {
     const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
-    expect(decodeRaw(raw)).toBe([
-      "To: sam@acme.test",
-      "Subject: Follow up",
-      "MIME-Version: 1.0",
-      'Content-Type: text/plain; charset="UTF-8"',
-      "Content-Transfer-Encoding: base64",
-      "",
-      Buffer.from("Hello Sam", "utf8").toString("base64"),
-    ].join("\r\n"))
+    const decoded = decodeRaw(raw)
+    const boundary = decoded.match(/Content-Type: multipart\/alternative; boundary="([^"]+)"/)?.[1]
+    expect(boundary).toStartWith("openwork-alternative-")
+    expect(decoded).toEndWith(`--${boundary}--\r\n`)
   })
 
   test("emits Cc and Bcc header lines exactly when provided", () => {
@@ -186,12 +202,15 @@ describe("buildGmailDraftRaw", () => {
       }],
     }))
     const boundary = decoded.match(/boundary="([^"]+)"/)?.[1]
-    expect(boundary).toStartWith("openwork-")
+    expect(boundary).toStartWith("openwork-mixed-")
     expect(decoded).toContain("Content-Type: multipart/mixed;")
+    expect(decoded).toMatch(/Content-Type: multipart\/mixed;[^]*?\r\n\r\n--openwork-mixed-[^\r\n]+\r\nContent-Type: multipart\/alternative;/)
+    expect(decoded.indexOf('Content-Type: text/plain; charset="UTF-8"')).toBeLessThan(decoded.indexOf('Content-Type: text/html; charset="UTF-8"'))
     expect(decoded).toContain('Content-Type: application/pdf; name="invoice \\"final\\".pdf"')
     expect(decoded).toContain('Content-Disposition: attachment; filename="invoice \\"final\\".pdf"')
     expect(decoded).toContain(Buffer.from("%PDF attachment bytes", "utf8").toString("base64"))
     expect(decoded).toContain(`--${boundary}--\r\n`)
+    expectFoldedBase64Payloads(decoded)
   })
 })
 

--- a/evals/packages/labs/src/mock-google-server.ts
+++ b/evals/packages/labs/src/mock-google-server.ts
@@ -409,19 +409,26 @@ function decodeBase64Body(body: string): string {
   }
 }
 
-function draftBody(headers: string, body: string): string {
+function mimeTextBody(headers: string, body: string): string | null {
   const contentType = headerValue(headers, "content-type");
   const boundary = /boundary="?([^";]+)"?/i.exec(contentType)?.[1] ?? null;
   if (boundary) {
-    const firstPart = body.split(`--${boundary}`).find((part) => part.trim() && !part.trim().startsWith("--")) ?? "";
-    const split = splitMessage(firstPart.replace(/^\r?\n/, ""));
-    return headerValue(split.headers, "content-transfer-encoding").toLowerCase() === "base64"
-      ? decodeBase64Body(split.body)
-      : split.body.trimEnd();
+    for (const part of body.split(`--${boundary}`).slice(1)) {
+      if (!part.trim() || part.trim().startsWith("--")) continue;
+      const split = splitMessage(part.replace(/^\r?\n/, ""));
+      const decoded = mimeTextBody(split.headers, split.body);
+      if (decoded !== null) return decoded;
+    }
+    return null;
   }
+  if (contentType && !contentType.toLowerCase().startsWith("text/plain")) return null;
   return headerValue(headers, "content-transfer-encoding").toLowerCase() === "base64"
     ? decodeBase64Body(body)
     : body.trimEnd();
+}
+
+function draftBody(headers: string, body: string): string {
+  return mimeTextBody(headers, body) ?? "";
 }
 
 function draftInput(value: unknown): { raw: string; threadId?: string } {

--- a/evals/packages/labs/test/mock-google.test.ts
+++ b/evals/packages/labs/test/mock-google.test.ts
@@ -152,6 +152,24 @@ async function userinfo(google: MockGoogleHandle, accessToken: string): Promise<
   return body;
 }
 
+async function submitDraft(
+  google: MockGoogleHandle,
+  accessToken: string,
+  message: string,
+  threadId?: string,
+): Promise<void> {
+  const requestMessage: { raw: string; threadId?: string } = {
+    raw: Buffer.from(message, "utf8").toString("base64url"),
+  };
+  if (threadId) requestMessage.threadId = threadId;
+  const response = await fetch(`${google.apiUrl}/gmail/v1/users/me/drafts`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ message: requestMessage }),
+  });
+  assert.equal(response.status, 200);
+}
+
 async function createDraft(
   google: MockGoogleHandle,
   accessToken: string,
@@ -168,16 +186,7 @@ async function createDraft(
     "",
     Buffer.from(body, "utf8").toString("base64"),
   ].join("\r\n");
-  const requestMessage: { raw: string; threadId?: string } = {
-    raw: Buffer.from(message, "utf8").toString("base64url"),
-  };
-  if (threadId) requestMessage.threadId = threadId;
-  const response = await fetch(`${google.apiUrl}/gmail/v1/users/me/drafts`, {
-    method: "POST",
-    headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
-    body: JSON.stringify({ message: requestMessage }),
-  });
-  assert.equal(response.status, 200);
+  await submitDraft(google, accessToken, message, threadId);
 }
 
 test("mock Google issues independent account identities and credential fingerprints", async () => {
@@ -226,4 +235,48 @@ test("mock Google attributes drafts to one mailbox and returns an empty mailbox 
     tokenId: tokenFingerprint(tokensA.accessToken),
     at: draftsA[0]?.at,
   });
+});
+
+test("mock Google decodes text/plain nested inside mixed and alternative MIME", async () => {
+  const account = "jordan@acme.test";
+  await using google = await startMockGoogle({ accounts: [account], port: 0, autoApprove: false });
+  await using callback = await startCallbackLab();
+  const tokens = await authorize(google, callback, account, "client-nested-mime");
+  const plainBody = "Nested multipart body marker";
+  const mixedBoundary = "fixture-mixed";
+  const alternativeBoundary = "fixture-alternative";
+  const message = [
+    "To: archive@acme.test",
+    "Subject: Nested MIME witness",
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${mixedBoundary}"`,
+    "",
+    `--${mixedBoundary}`,
+    `Content-Type: multipart/alternative; boundary="${alternativeBoundary}"`,
+    "",
+    `--${alternativeBoundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from(plainBody, "utf8").toString("base64"),
+    `--${alternativeBoundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from(`<div>${plainBody}</div>`, "utf8").toString("base64"),
+    `--${alternativeBoundary}--`,
+    `--${mixedBoundary}`,
+    'Content-Type: application/octet-stream; name="witness.bin"',
+    'Content-Disposition: attachment; filename="witness.bin"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from("attachment bytes", "utf8").toString("base64"),
+    `--${mixedBoundary}--`,
+    "",
+  ].join("\r\n");
+
+  await submitDraft(google, tokens.accessToken, message);
+
+  const drafts = await google.draftsFor(account);
+  assert.equal(drafts[0]?.body, plainBody);
 });

--- a/evals/voiceovers/gmail-draft-formatting.md
+++ b/evals/voiceovers/gmail-draft-formatting.md
@@ -1,0 +1,9 @@
+# gmail-draft-formatting — Gmail desktop preserves OpenWork draft formatting
+
+1. OpenWork creates a Gmail draft containing long paragraphs, blank lines, and a short list.
+
+2. The draft opens in Gmail desktop with the intended spacing and readable paragraphs.
+
+3. Sending it from Gmail desktop preserves every intentional paragraph break without adding mid-sentence or blank lines.
+
+4. The resulting MIME contains equivalent plain-text and HTML alternatives, while attachments and threaded replies still work.


### PR DESCRIPTION
## Summary
- emit Gmail drafts as multipart/alternative with equivalent plain-text and escaped HTML bodies
- nest alternatives under multipart/mixed when drafts include attachments
- fold base64 MIME payloads to 76 characters and teach the Google test witness to decode nested MIME

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/gmail-draft.test.ts` — 17 passed
- `pnpm --filter @openwork-ee/den-api exec bun test test/google-workspace-capabilities.test.ts` — 34 passed
- `pnpm --dir evals exec node --test packages/labs/test/mock-google.test.ts` — 3 passed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm evals:spec` — 6 passed, 1 skipped (`skill-grant-access`, requires configured Infisical service token)
- `pnpm evals:typecheck` — pre-existing failure on `origin/dev`: `evals/flows/den-trim-page-headers.flow.ts` references missing `FlowContext.page`

## Evidence
This server MIME change has deterministic raw-message, route, and nested Google witness coverage. A live Gmail desktop send was not run because that requires a real external mailbox; the MIME assertions cover the exact serialization boundary changed here.