### PR TITLE
feat(app): Library inside the Settings pane

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -86,6 +86,8 @@ type SuggestedPlugin = {
 
 export type ExtensionsViewProps = {
   busy: boolean;
+  /** Hide the view's own description line (the settings shell already shows the tab description in-pane). */
+  hideDescription?: boolean;
   selectedWorkspaceRoot: string;
   isRemoteWorkspace: boolean;
   canEditPlugins: boolean;
@@ -141,11 +143,13 @@ export function ExtensionsView(props: ExtensionsViewProps) {
   return (
     <section className="space-y-6 max-w-3xl w-full animate-in fade-in duration-300">
       <div className="flex items-center justify-between">
-        <div className="flex min-w-0 flex-col gap-1">
-          <p className="text-sm text-dls-secondary">
-            {t("extensions.inventory_description")}
-          </p>
-        </div>
+        {props.hideDescription === true ? <div /> : (
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className="text-sm text-dls-secondary">
+              {t("extensions.inventory_description")}
+            </p>
+          </div>
+        )}
         <Button variant="outline" onClick={props.onRefresh}>
           {t("common.refresh")}
         </Button>

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -184,7 +184,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["preferences", "permissions", "advanced"];
+  return ["preferences", "permissions", "extensions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2339,6 +2339,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return (
           <ExtensionsView
             busy={busy}
+            hideDescription={props.standaloneExtensions !== true}
             selectedWorkspaceRoot={selectedWorkspaceRoot}
             isRemoteWorkspace={isRemoteWorkspace}
             canEditPlugins={canWriteWorkspacePlugins}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2210,14 +2210,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }
   };
 
-  if (!props.embedded && !props.standaloneExtensions && route.tab === "extensions") {
-    const extensionPath = extensionsPathForRoute(route);
-    const target = selectedWorkspaceId
-      ? workspaceExtensionsRoute(selectedWorkspaceId, extensionPath)
-      : globalExtensionsRoute(extensionPath);
-    return <Navigate to={target} replace state={location.state} />;
-  }
-
   if (route.redirectPath && !props.embedded) {
     const target = props.standaloneExtensions
       ? selectedWorkspaceId

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -7,6 +7,7 @@ import {
   settingsPathForRoute,
 } from "../src/react-app/shell/settings-route";
 import {
+  getSettingsTabLabel,
   getWorkspaceSettingsTabs,
   isSettingsTabActive,
 } from "../src/react-app/domains/settings/shell/settings-page";
@@ -20,7 +21,6 @@ describe("settings route parsing", () => {
     expect(parseExtensionsPath(pathname)).toEqual(route);
     expect(isSettingsTabActive(route.tab, "extensions")).toBe(true);
     expect(isSettingsTabActive(route.tab, "general")).toBe(false);
-    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "advanced"]);
   });
 
   test("preserves top-level Extensions section and detail deep links", () => {
@@ -95,5 +95,12 @@ describe("settings route parsing", () => {
       extensionsSection: "all",
       extensionDetailId: "skill:briefing",
     });
+  });
+});
+
+describe("settings navigation", () => {
+  test("includes Library in workspace settings", () => {
+    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "extensions", "advanced"]);
+    expect(getSettingsTabLabel("extensions")).toBe("Library");
   });
 });

--- a/evals/specs/library-state-tabs.slow.test.ts
+++ b/evals/specs/library-state-tabs.slow.test.ts
@@ -46,6 +46,11 @@ test.skipIf(!appSpecsEnabled)(title, async () => {
     return /apps? connected/i.test(description?.parentElement?.textContent ?? "");
   })()`);
   expect(headerHasConnectedCount).toBe(false);
+  const descriptionRenderedOnce = await evalIn(
+    app,
+    `document.body.innerText.split("Skills, connections, and tools your agent can use.").length - 1`,
+  );
+  expect(descriptionRenderedOnce).toBe(1);
 
   const clickedReady = await evalIn(app, `(() => {
     const tab = [...document.querySelectorAll('[role="tab"]')]

--- a/evals/specs/library-state-tabs.slow.test.ts
+++ b/evals/specs/library-state-tabs.slow.test.ts
@@ -14,12 +14,26 @@ test.skipIf(!appSpecsEnabled)(title, async () => {
   await using app = await desktop({ name: "library-state-tabs" });
   await createAndSelectWorkspace(app, { path: repoRoot });
   await evalIn(app, `(() => {
-    window.location.hash = "#/settings/extensions";
+    window.location.hash = "#/settings/general";
     return true;
   })()`);
   await waitFor(
     app,
-    `[...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")
+    `[...document.querySelectorAll("button")].some((button) => button.textContent?.trim() === "Library")`,
+    { timeoutMs: 60_000, label: "Library settings navigation entry" },
+  );
+  const openedLibrary = await evalIn(app, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((entry) => entry.textContent?.trim() === "Library");
+    if (!(button instanceof HTMLElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(openedLibrary).toBe(true);
+  await waitFor(
+    app,
+    `window.location.hash.includes("/settings/extensions")
+      && [...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")
       && Boolean(document.querySelector('[role="tablist"][aria-label="Library state"]'))
       && [...document.querySelectorAll('[role="tab"]')].some((tab) => tab.textContent?.trim() === "All")
       && [...document.querySelectorAll('[role="tab"]')].some((tab) => (tab.textContent ?? "").includes("Ready to use"))`,


### PR DESCRIPTION
## Summary
The Library was only reachable as a main-content takeover from the chat sidebar / command palette. Now it's also a first-class Settings section:
- **Nav entry**: `extensions` ("Library") added to the workspace settings tabs (sidebar + compact section menu) — the tab, icon, label, and in-pane renderer all already existed.
- **Redirect removed**: `/settings/extensions…` no longer bounces to the standalone route; it renders inside the settings shell. The standalone route, chat-sidebar row, and command palette are untouched and keep working.
- **Deduped intro**: in-pane, the view hides its own description line (the settings shell already shows the tab description); standalone keeps it (`hideDescription` prop).
- Spec now enters through the Settings nav, asserts single description, Ready deep-link (`…/extensions/ready`), and group-pure rows.

## Verification
- `pnpm --filter @openwork/app typecheck` — pass
- `bun test tests/settings-route.test.ts` — 8 passed (incl. new nav-entry assertion)
- `OPENWORK_EVAL_APP_SPECS=1` stack spec `library-state-tabs.slow.test.ts` — passed 2× consecutively at head SHA driving the real app (one earlier run flaked immediately post-rebuild before passing twice unchanged; noting for transparency)

## Evidence
Photo roll in follow-up comment.