### PR TITLE
feat: Open in Den — desktop library deep-links to the web library element

### DIFF
--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -310,6 +310,7 @@ export default {
   "extensions.plugin_count_other": "{count} plugins",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "Skills, connexions i eines que el teu agent pot utilitzar.",
+  "extensions.open_in_den": "Obre a Den",
   "extensions.title": "Biblioteca",
   "mcp.add_modal_subtitle": "Connecta un servidor MCP personalitzat mitjançant una URL o una comanda local.",
   "mcp.add_modal_title": "Afegeix una aplicació personalitzada",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -648,6 +648,7 @@ export default {
   "extensions.state_needs_signin": "Needs your sign-in",
   "extensions.state_needs_signin_caption": "These come from {org} — connect your own account to use them.",
   "extensions.subtitle": "Skills, connections, and tools your agent can use.",
+  "extensions.open_in_den": "Open in Den",
   "extensions.title": "Library",
   "extensions.update_all_button": "Update all",
   "extensions.update_all_progress": "Updating {current} of {total}...",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -310,6 +310,7 @@ export default {
   "extensions.plugin_count_other": "Plugins {count}",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "Skills, conexiones y herramientas que tu agente puede usar.",
+  "extensions.open_in_den": "Abrir en Den",
   "extensions.title": "Biblioteca",
   "mcp.add_modal_subtitle": "Conecta un servidor MCP personalizado mediante URL o un Command local.",
   "mcp.add_modal_title": "Añadir aplicación personalizada",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -310,6 +310,7 @@ export default {
   "extensions.plugin_count_other": "{count} plugins",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "Les skills, connexions et outils que votre agent peut utiliser.",
+  "extensions.open_in_den": "Ouvrir dans Den",
   "extensions.title": "Bibliothèque",
   "mcp.add_modal_subtitle": "Connectez un serveur MCP personnalisé par URL ou commande locale.",
   "mcp.add_modal_title": "Ajouter une application personnalisée",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -303,6 +303,7 @@ export default {
   "extensions.plugin_count": "{count}件のプラグイン",
   "extensions.plugins_opencode_header": "プラグイン（OpenCode）",
   "extensions.subtitle": "エージェントが使用できるスキル、接続、ツール。",
+  "extensions.open_in_den": "Den で開く",
   "extensions.title": "ライブラリ",
   "mcp.add_modal_subtitle": "URLまたはローカルコマンドでカスタムMCPサーバーを接続します。",
   "mcp.add_modal_title": "カスタムアプリを追加",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -308,6 +308,7 @@ export default {
   "extensions.plugin_count_other": "{count} plugins",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "Skills, conexões e ferramentas que seu agente pode usar.",
+  "extensions.open_in_den": "Abrir no Den",
   "extensions.title": "Biblioteca",
   "mcp.add_modal_subtitle": "Conecte um servidor MCP personalizado por URL ou comando local.",
   "mcp.add_modal_title": "Adicionar App Personalizado",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -1264,5 +1264,6 @@ export default {
   "extensions.plugin_count_other": "{count} плагинов",
   "extensions.plugins_opencode_header": "Плагины (OpenCode)",
   "extensions.subtitle": "Навыки, подключения и инструменты, которые может использовать ваш агент.",
+  "extensions.open_in_den": "Открыть в Den",
   "extensions.title": "Библиотека",
 } as const;

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -304,6 +304,7 @@ export default {
   "extensions.plugin_count": "{count} ปลั๊กอิน",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "ทักษะ การเชื่อมต่อ และเครื่องมือที่เอเจนต์ของคุณใช้ได้",
+  "extensions.open_in_den": "เปิดใน Den",
   "extensions.title": "ไลบรารี",
   "mcp.add_modal_subtitle": "เชื่อมต่อ MCP server กำหนดเองด้วย URL หรือคำสั่งภายในเครื่อง",
   "mcp.add_modal_title": "เพิ่มแอปกำหนดเอง",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -304,6 +304,7 @@ export default {
   "extensions.plugin_count": "{count} plugins",
   "extensions.plugins_opencode_header": "Plugins (OpenCode)",
   "extensions.subtitle": "Kỹ năng, kết nối và công cụ mà agent của bạn có thể sử dụng.",
+  "extensions.open_in_den": "Mở trong Den",
   "extensions.title": "Thư viện",
   "mcp.add_modal_subtitle": "Kết nối MCP server tùy chỉnh bằng URL hoặc lệnh nội bộ.",
   "mcp.add_modal_title": "Thêm ứng dụng tùy chỉnh",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -307,6 +307,7 @@ export default {
   "extensions.plugin_count": "{count}个插件",
   "extensions.plugins_opencode_header": "插件（OpenCode）",
   "extensions.subtitle": "智能体可使用的技能、连接和工具。",
+  "extensions.open_in_den": "在 Den 中打开",
   "extensions.title": "资料库",
   "mcp.add_modal_subtitle": "通过URL或本地命令连接自定义MCP服务器。",
   "mcp.add_modal_title": "添加自定义应用",

--- a/apps/app/src/react-app/domains/settings/open-in-den.ts
+++ b/apps/app/src/react-app/domains/settings/open-in-den.ts
@@ -1,0 +1,39 @@
+export type DenLibraryTarget = {
+  id: string;
+  pluginId?: string;
+};
+
+export function denLibraryFocus(target: DenLibraryTarget): string | null {
+  if (target.id.startsWith("org-mcp:")) {
+    const connectionId = target.id.slice("org-mcp:".length);
+    return connectionId ? `connection-${connectionId}` : null;
+  }
+  if (target.pluginId) return `plugin-${target.pluginId}`;
+  if (target.id.startsWith("openwork-connect:")) {
+    const pluginId = target.id.split(":")[1];
+    return pluginId ? `plugin-${pluginId}` : null;
+  }
+  if (target.id.startsWith("openwork-connect://")) {
+    const pluginId = target.id.slice("openwork-connect://".length).split("/")[1];
+    return pluginId ? `plugin-${pluginId}` : null;
+  }
+  if (target.id.startsWith("marketplace:")) {
+    const pluginId = target.id.split(":").at(-1);
+    return pluginId ? `plugin-${pluginId}` : null;
+  }
+  return null;
+}
+
+export function openInDenLibraryUrl(baseUrl: string, target: DenLibraryTarget): string | null {
+  const focus = denLibraryFocus(target);
+  if (!baseUrl.trim() || !focus) return null;
+  return new URL(`/dashboard/library?focus=${encodeURIComponent(focus)}`, baseUrl).toString();
+}
+
+export function shouldShowOpenInDenAction(
+  baseUrl: string,
+  hasCloudSession: boolean,
+  target: DenLibraryTarget,
+): boolean {
+  return hasCloudSession && Boolean(baseUrl.trim()) && denLibraryFocus(target) !== null;
+}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useReducer, useRef, useState, type ReactNode, type SetStateAction } from "react";
 import {
   BookOpen,
+  ArrowUpRight,
   CheckCircle2,
   ChevronDown,
   ChevronLeft,
@@ -50,11 +51,13 @@ import {
 import { SettingsGroupHeader } from "../settings-section";
 import { SettingsListSearchInput } from "../settings-list";
 import {
+  openDesktopUrl,
   openDesktopPath,
   readOpencodeConfig,
   revealDesktopItemInDir,
   type OpencodeConfigFile,
 } from "../../../../app/lib/desktop";
+import { readDenSettings } from "../../../../app/lib/den";
 import {
   getMcpIdentityKey,
   normalizeMcpSlug,
@@ -88,6 +91,12 @@ import {
   type ConfigScope,
   type McpViewLocalState,
 } from "./mcp-view-state";
+import { useCloudSession } from "../cloud/cloud-session-provider";
+import {
+  openInDenLibraryUrl,
+  shouldShowOpenInDenAction,
+  type DenLibraryTarget,
+} from "../open-in-den";
 
 export type ReactMcpStatus =
   | "connected"
@@ -346,6 +355,8 @@ function resolveExtensionDetailTarget(
 }
 
 export function McpView(props: McpViewProps) {
+  const cloudSession = useCloudSession();
+  const denBaseUrl = readDenSettings().baseUrl;
   const skillCount = props.installedSkills?.length ?? 0;
   const useRoutedDetail = typeof props.onDetailIdChange === "function";
   const [detailTarget, setDetailTarget] = useState<ExtensionDetailTarget | null>(null);
@@ -413,6 +424,22 @@ export function McpView(props: McpViewProps) {
   const installedPlugins = props.installedPlugins ?? [];
   const orgMcpItems = props.orgMcpItems ?? [];
   const detailPresentation = useRoutedDetail ? "page" : "dialog";
+  const openInDenAction = (target: DenLibraryTarget): ReactNode => {
+    if (!shouldShowOpenInDenAction(denBaseUrl, cloudSession.isSignedIn, target)) return null;
+    const url = openInDenLibraryUrl(denBaseUrl, target);
+    if (!url) return null;
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-fit"
+        onClick={() => void openDesktopUrl(url)}
+      >
+        {t("extensions.open_in_den")}
+        <ArrowUpRight size={13} />
+      </Button>
+    );
+  };
   const setInventoryFilter = (nextFilter: ExtensionInventoryFilter) => {
     setFilter(nextFilter);
     props.onFilterChange?.(nextFilter);
@@ -801,6 +828,7 @@ export function McpView(props: McpViewProps) {
             path={detailSkill.origin === "openwork-connect" ? undefined : detailSkill.path}
             trigger={detailSkill.trigger}
             contentPreview={detailSkillContent ?? undefined}
+            configSlot={openInDenAction({ id: detailSkill.path })}
             onReveal={detailSkill.path && detailSkill.origin !== "openwork-connect" ? () => {
               void revealDesktopItemInDir(detailSkill.path);
             } : undefined}
@@ -835,6 +863,7 @@ export function McpView(props: McpViewProps) {
           url={detailConnectMcp.config.type === "remote" ? detailConnectMcp.config.url : undefined}
           oauth={detailConnectMcp.config.type === "remote"}
           showEnablementCard
+          configSlot={openInDenAction({ id: detailConnectMcp.id ?? detailConnectMcp.name })}
         />
       ) : null}
 
@@ -851,6 +880,7 @@ export function McpView(props: McpViewProps) {
             taxonomy="plugin"
             connected={true}
             hidden={hidden}
+            configSlot={openInDenAction({ id: `marketplace:installed:${detailPlugin.pluginId}`, pluginId: detailPlugin.pluginId })}
             onUninstall={props.removeCloudPlugin ? () => {
               void props.removeCloudPlugin?.(detailPlugin.pluginId);
               closeDetail();
@@ -893,9 +923,12 @@ export function McpView(props: McpViewProps) {
             closeOnUninstall={false}
             showEnablementCard={false}
             configSlot={(
-              <div className="flex flex-wrap gap-2">
-                <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">Shared by your organization</span>
-                <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">{connection.credentialMode === "shared" ? "Org account" : "Your account"}</span>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap gap-2">
+                  <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">Shared by your organization</span>
+                  <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">{connection.credentialMode === "shared" ? "Org account" : "Your account"}</span>
+                </div>
+                {openInDenAction({ id: detailOrgMcpItem.id })}
               </div>
             )}
           />

--- a/apps/app/tests/open-in-den.test.ts
+++ b/apps/app/tests/open-in-den.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  openInDenLibraryUrl,
+  shouldShowOpenInDenAction,
+} from "../src/react-app/domains/settings/open-in-den";
+
+describe("Open in Den", () => {
+  test("builds a focused connection URL for an organization MCP item", () => {
+    expect(openInDenLibraryUrl("https://den.example/", { id: "org-mcp:conn_123" })).toBe(
+      "https://den.example/dashboard/library?focus=connection-conn_123",
+    );
+  });
+
+  test("builds a focused plugin URL for a plugin item", () => {
+    expect(openInDenLibraryUrl("https://den.example", {
+      id: "marketplace:marketplace-1:plg_123",
+      pluginId: "plg_123",
+    })).toBe("https://den.example/dashboard/library?focus=plugin-plg_123");
+  });
+
+  test("hides the action without a Den base URL or cloud session", () => {
+    const target = { id: "org-mcp:connection-123" };
+    expect(shouldShowOpenInDenAction("", true, target)).toBe(false);
+    expect(shouldShowOpenInDenAction("https://den.example", false, target)).toBe(false);
+  });
+
+  test("shows the action with a Den base URL and cloud session", () => {
+    expect(shouldShowOpenInDenAction("https://den.example", true, {
+      id: "marketplace:installed:plugin-123",
+      pluginId: "plugin-123",
+    })).toBe(true);
+  });
+});

--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { type ReactNode, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { LibraryBig, Search } from "lucide-react";
 
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
@@ -222,11 +223,12 @@ function LibraryRowContent({ item, orgName, action }: { item: LibraryItem; orgNa
   );
 }
 
-function LibraryRow({ item, isAdmin, orgName, orgSlug }: { item: LibraryItem; isAdmin: boolean; orgName: string; orgSlug: string | null }) {
+function LibraryRow({ item, isAdmin, isFocused, orgName, orgSlug }: { item: LibraryItem; isAdmin: boolean; isFocused: boolean; orgName: string; orgSlug: string | null }) {
   const sectionState = getSectionState(item);
-  const rowClassName = sectionState === "ready"
+  const rowClassName = `${sectionState === "ready"
     ? "block h-[52px] border-b border-[#f0f1f3] bg-transparent"
-    : "block h-[52px] rounded-[10px] border border-[#fde9c3] bg-[#fffbeb]";
+    : "block h-[52px] rounded-[10px] border border-[#fde9c3] bg-[#fffbeb]"} ${isFocused ? "ring-2 ring-blue-300 ring-offset-2 transition-shadow" : ""}`;
+  const rowKey = `${item.type}-${item.id}`;
   const connectionHref = item.type === "connection"
     ? `${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(item.id)}`
     : null;
@@ -251,6 +253,8 @@ function LibraryRow({ item, isAdmin, orgName, orgSlug }: { item: LibraryItem; is
         href={getPluginRoute(orgSlug, item.id)}
         className={`${rowClassName} hover:bg-gray-50`}
         data-library-item-type={item.type}
+        data-library-item-key={rowKey}
+        data-library-focused={isFocused ? "" : undefined}
       >
         <LibraryRowContent item={item} orgName={orgName} action={action} />
       </Link>
@@ -262,6 +266,8 @@ function LibraryRow({ item, isAdmin, orgName, orgSlug }: { item: LibraryItem; is
       className={rowClassName}
       data-library-item-type={item.type}
       data-library-item-state={item.type === "connection" ? item.state : undefined}
+      data-library-item-key={rowKey}
+      data-library-focused={isFocused ? "" : undefined}
     >
       <LibraryRowContent item={item} orgName={orgName} action={action} />
     </div>
@@ -280,6 +286,7 @@ function LibrarySection({
   isAdmin,
   orgName,
   orgSlug,
+  focusedKey,
   onToggle,
 }: {
   state: LibrarySectionState;
@@ -288,6 +295,7 @@ function LibrarySection({
   isAdmin: boolean;
   orgName: string;
   orgSlug: string | null;
+  focusedKey: string | null;
   onToggle: () => void;
 }) {
   const visibleItems = expanded ? items : items.slice(0, 6);
@@ -313,6 +321,7 @@ function LibrarySection({
             key={`${item.type}-${item.id}`}
             item={item}
             isAdmin={isAdmin}
+            isFocused={focusedKey === `${item.type}-${item.id}`}
             orgName={orgName}
             orgSlug={orgSlug}
           />
@@ -334,10 +343,13 @@ function LibrarySection({
 export function LibraryScreen() {
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: items = [], isLoading, error } = useLibrary();
+  const searchParams = useSearchParams();
   const [activeState, setActiveState] = useState<LibraryStateTab>("all");
   const [activeKind, setActiveKind] = useState<KindFilter>("all");
   const [activeFrom, setActiveFrom] = useState<FromFilter>("anyone");
   const [query, setQuery] = useState("");
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  const handledFocusRef = useRef<string | null>(null);
   const [expandedSections, setExpandedSections] = useState<Record<LibrarySectionState, boolean>>({
     needs_signin: false,
     needs_admin_setup: false,
@@ -349,6 +361,31 @@ export function LibraryScreen() {
     orgContext?.roles,
   );
   const orgName = orgContext?.organization.name ?? "your organization";
+  const requestedFocus = searchParams.get("focus");
+
+  useEffect(() => {
+    if (!requestedFocus || handledFocusRef.current === requestedFocus) return;
+    if (!/^(plugin|connection)-.+$/.test(requestedFocus)) return;
+    const item = items.find((candidate) => `${candidate.type}-${candidate.id}` === requestedFocus);
+    if (!item) return;
+    handledFocusRef.current = requestedFocus;
+    setActiveState("all");
+    setActiveKind("all");
+    setActiveFrom("anyone");
+    setQuery("");
+    setExpandedSections((current) => ({ ...current, [getSectionState(item)]: true }));
+    setFocusedKey(requestedFocus);
+  }, [items, requestedFocus]);
+
+  useEffect(() => {
+    if (!focusedKey) return;
+    const row = [...document.querySelectorAll<HTMLElement>("[data-library-item-key]")]
+      .find((candidate) => candidate.dataset.libraryItemKey === focusedKey);
+    if (!row) return;
+    row.scrollIntoView({ block: "center" });
+    const timeout = window.setTimeout(() => setFocusedKey(null), 2_000);
+    return () => window.clearTimeout(timeout);
+  }, [focusedKey]);
   const normalizedQuery = query.trim().toLowerCase();
   const kindCounts = useMemo(() => {
     const counts: Record<Exclude<KindFilter, "all">, number> = {
@@ -531,6 +568,7 @@ export function LibraryScreen() {
                 isAdmin={access.isAdmin}
                 orgName={orgName}
                 orgSlug={orgSlug}
+                focusedKey={focusedKey}
                 onToggle={() => setExpandedSections((current) => ({ ...current, [state]: !current[state] }))}
               />
             ) : null

--- a/evals/specs/library-view.slow.test.ts
+++ b/evals/specs/library-view.slow.test.ts
@@ -534,4 +534,13 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
   ]);
   await roll.add(mobileShot, mobileSeen);
   expect(mobileSeen.ok, mobileSeen.why).toBe(true);
+
+  await navigate(browser.client, `${webUrl}/dashboard/library?focus=${encodeURIComponent(`connection-${connection.id}`)}`);
+  await waitFor(browser, `(() => {
+    const row = document.querySelector('[data-library-focused][data-library-item-type="connection"]');
+    return Boolean(row && (row.textContent ?? "").includes(${JSON.stringify(connection.name)}));
+  })()`, {
+    timeoutMs: 60_000,
+    label: "focused connection row from the library deep link",
+  });
 });


### PR DESCRIPTION
## Summary
- **Desktop**: cloud-sourced Library detail surfaces (skills, plugins, org MCP connections, connect capabilities) gain an "Open in Den" action (ArrowUpRight, all locales). Follows the agent-access-card pattern: `new URL(…, readDenSettings().baseUrl)` + `openDesktopUrl`. Gated on cloud session + den base URL + a mappable den entity. Pure helpers in `open-in-den.ts`: `org-mcp:{id}` → `connection-{id}`; plugin/connect/marketplace ids → `plugin-{pluginId}`.
- **Web**: `/dashboard/library?focus=plugin-{id}|connection-{id}` resets filters, expands the target section, scrolls the row to center and highlights it for 2s (`data-library-focused`).

## Verification
- `pnpm --filter @openwork/app typecheck` + `pnpm --filter @openwork-ee/den-web typecheck` — pass
- `open-in-den.test.ts` — 4 passed (URL formats, visibility gating)
- stack spec `library-view.slow.test.ts` — passed at head SHA incl. new deep-link assertion (navigate with `?focus=connection-{spec fixture id}` → focused row)
- Desktop-side e2e of the external-open is not feasible in the spec host (no cloud session there) — covered by the pure-function tests + gating; noted for the den-connected Daytona lane.

## Evidence
Photo roll in follow-up comment.