### PR TITLE
fix: dev red — library page Suspense boundary + stale extensions nav test

### DIFF
--- a/apps/app/tests/extensions-sidebar-header.test.tsx
+++ b/apps/app/tests/extensions-sidebar-header.test.tsx
@@ -14,9 +14,7 @@ const appSidebarPath = fileURLToPath(
 const sessionPagePath = fileURLToPath(
   new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),
 );
-const generalSettingsPath = fileURLToPath(
-  new URL("../src/react-app/domains/settings/pages/general-view.tsx", import.meta.url),
-);
+
 
 describe("Extensions sidebar destination", () => {
   test("exposes its label, keyboard button, and active page state", () => {
@@ -59,13 +57,13 @@ describe("Extensions sidebar destination", () => {
 });
 
 describe("Extensions main page", () => {
-  test("uses the main content header and is absent from Settings navigation", () => {
+  test("uses the main content header and is listed in Settings navigation", () => {
     const sessionPageSource = readFileSync(sessionPagePath, "utf8");
-    const generalSettingsSource = readFileSync(generalSettingsPath, "utf8");
 
     expect(sessionPageSource).toContain("props.mainContentTitle");
     expect(sessionPageSource).toContain("<h1");
-    expect(getWorkspaceSettingsTabs()).not.toContain("extensions");
-    expect(generalSettingsSource).not.toContain('{ tab: "extensions"');
+    // The Library is intentionally reachable both standalone and inside the
+    // Settings pane (feat: Library inside the Settings pane).
+    expect(getWorkspaceSettingsTabs()).toContain("extensions");
   });
 });

--- a/ee/apps/den-web/app/(den)/dashboard/library/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/library/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import { LibraryScreen } from "../_components/library-screen";
 
 export default function LibraryPage() {
-  return <LibraryScreen />;
+  return (
+    <Suspense fallback={null}>
+      <LibraryScreen />
+    </Suspense>
+  );
 }

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
Two dev breakages from the library PR train (#3452, #3454), both caught post-merge on non-required checks:
1. **`Build openwork-den-web` / Vercel**: `useSearchParams()` in LibraryScreen (added by #3454's `?focus=` deep link) needs a Suspense boundary for prerender. Wrapped `/dashboard/library/page.tsx` in `<Suspense fallback={null}>` — the repo's own pattern (`install`, `reauth/complete` pages).
2. **`openwork-tests`**: `extensions-sidebar-header.test.tsx` asserted Library is *absent* from Settings navigation — #3452 deliberately inverted that. Updated the test to assert presence (the new intent).

## Verification
- `pnpm --filter @openwork-ee/den-web build` — production build passes, 0 suspense errors (was failing on dev)
- `bun test --isolate tests/` (apps/app) — 593 pass / 2 fail: the 2 are the documented pre-existing `message-list-loading` full-suite-ordering flake (passes in isolation, passed on CI); the extensions test now passes
- `bun test tests/extensions-sidebar-header.test.tsx tests/message-list-loading.test.tsx` — 6 pass / 0 fail