### PR TITLE
fix(desktop): make right-click work in the in-app browser, and stop passkey requests hanging for 3 minutes

### DIFF
--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -46,7 +46,7 @@ function ContextMenuSurface({
   onClose: () => void;
 }) {
   React.useEffect(() => {
-    // document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
+    document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
   }, [request.id]);
 
   return (

--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -17,7 +17,9 @@ type ContextMenuItem = {
 
 type ContextMenuRequest = {
   id: string;
-  source: "tab" | "page" | "sidebar";
+  source: "tab" | "page" | "passkey" | "sidebar";
+  title?: string;
+  description?: string;
   items: ContextMenuItem[];
 };
 
@@ -68,16 +70,24 @@ function ContextMenuSurface({
       }}
     >
       <ContextMenuContent
-        role="menu"
-        aria-label={`${request.source} context menu`}
+        role={request.source === "passkey" ? "dialog" : "menu"}
+        aria-label={request.title ?? `${request.source} context menu`}
         className="w-full"
       >
+        {request.title ? (
+          <div className="px-3 pt-2 pb-2">
+            <div className="text-sm font-semibold text-foreground">{request.title}</div>
+            {request.description ? (
+              <div className="pt-1 text-xs leading-5 text-muted-foreground">{request.description}</div>
+            ) : null}
+          </div>
+        ) : null}
         {request.items.map((item) => {
           return (
             <React.Fragment key={item.id}>
               {item.separatorBefore ? <ContextMenuSeparator /> : null}
               <ContextMenuItem
-                role="menuitem"
+                role={request.source === "passkey" ? undefined : "menuitem"}
                 disabled={item.disabled}
                 onClick={() => onChoose(item.id)}
               >

--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -26,6 +26,7 @@ type ContextMenuRequest = {
 type MenuOverlayApi = {
   ready: () => void;
   onShow: (callback: (request: ContextMenuRequest) => void) => () => void;
+  resize: (requestId: string, height: number) => void;
   choose: (requestId: string, itemId: string) => void;
   close: (requestId?: string) => void;
 };
@@ -42,18 +43,45 @@ function ContextMenuSurface({
   request,
   onChoose,
   onClose,
+  onResize,
 }: {
   request: ContextMenuRequest;
   onChoose: (itemId: string) => void;
   onClose: () => void;
+  onResize: (height: number) => void;
 }) {
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
     document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
   }, [request.id]);
 
+  React.useLayoutEffect(() => {
+    const root = rootRef.current;
+    const content = contentRef.current;
+    if (!root || !content || request.source === "passkey") return;
+
+    const reportHeight = () => {
+      const style = window.getComputedStyle(root);
+      const verticalPadding = Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+      onResize(Math.ceil(content.getBoundingClientRect().height + verticalPadding));
+    };
+    reportHeight();
+    const observer = new ResizeObserver(reportHeight);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [onResize, request.id, request.source]);
+
   return (
     <div
+      ref={rootRef}
       className="dark h-dvh overflow-hidden bg-transparent text-popover-foreground p-px"
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        if (event.target instanceof Element && event.target.closest("[data-slot='context-menu-item']")) return;
+        onClose();
+      }}
       onKeyDown={(event) => {
         const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>(MENU_ITEM_SELECTOR));
         const currentIndex = Math.max(buttons.indexOf(document.activeElement as HTMLButtonElement), 0);
@@ -70,6 +98,7 @@ function ContextMenuSurface({
       }}
     >
       <ContextMenuContent
+        ref={contentRef}
         role={request.source === "passkey" ? "dialog" : "menu"}
         aria-label={request.title ?? `${request.source} context menu`}
         className="w-full"
@@ -122,6 +151,7 @@ function OverlayApp() {
       request={request}
       onChoose={(itemId) => api.choose(request.id, itemId)}
       onClose={() => api.close(request.id)}
+      onResize={(height) => api.resize(request.id, height)}
     />
   );
 }

--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -10,9 +10,5 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
-  <key>keychain-access-groups</key>
-  <array>
-    <string>F5DJWB4CCV.com.differentai.openwork.webauthn</string>
-  </array>
 </dict>
 </plist>

--- a/apps/desktop/electron-builder.base.yml
+++ b/apps/desktop/electron-builder.base.yml
@@ -24,7 +24,7 @@ asar: true
 asarUnpack:
   - node_modules/.pnpm/@lydell+node-pty*/**
   - node_modules/node-pty/**
-npmRebuild: false
+npmRebuild: true
 afterPack: scripts/electron-after-pack.cjs
 afterSign: scripts/electron-after-sign.cjs
 publish:
@@ -39,7 +39,7 @@ mac:
   gatekeeperAssess: false
   notarize: false
   entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
   extendInfo:
     NSMicrophoneUsageDescription: OpenWork uses the microphone when you start Voice Mode so you can speak commands to your agent.
   extraResources:

--- a/apps/desktop/electron/browser-content-preload.cjs
+++ b/apps/desktop/electron/browser-content-preload.cjs
@@ -1,6 +1,7 @@
 const { ipcRenderer } = require("electron");
 
-function dismissMenuOverlay() {
+function dismissMenuOverlay(event) {
+  if (event.type === "pointerdown" && (event.button === 2 || event.buttons === 2)) return;
   ipcRenderer.send("openwork:menu-overlay:dismiss");
 }
 

--- a/apps/desktop/electron/browser-content-preload.cjs
+++ b/apps/desktop/electron/browser-content-preload.cjs
@@ -1,4 +1,59 @@
-const { ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer } = require("electron");
+
+const PASSKEY_BRIDGE_KEY = "__OPENWORK_PASSKEY_FALLBACK__";
+
+contextBridge.exposeInMainWorld(PASSKEY_BRIDGE_KEY, {
+  notifyUnavailable() {
+    ipcRenderer.send("openwork:browser:passkey-unavailable");
+  },
+});
+
+// This runs in the page's Main World, where page scripts see the overridden methods.
+contextBridge.executeInMainWorld({
+  func: (bridgeKey) => {
+    const credentials = navigator.credentials;
+    const publicKeyCredential = globalThis.PublicKeyCredential;
+    if (
+      !credentials ||
+      typeof publicKeyCredential?.isUserVerifyingPlatformAuthenticatorAvailable !== "function"
+    ) {
+      return;
+    }
+
+    let capabilityProbe;
+    try {
+      capabilityProbe = publicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+    } catch {
+      return;
+    }
+    const platformAuthenticatorAvailable = Promise.resolve(capabilityProbe).catch(() => true);
+
+    for (const methodName of ["create", "get"]) {
+      const originalMethod = credentials[methodName];
+      if (typeof originalMethod !== "function") continue;
+
+      Object.defineProperty(credentials, methodName, {
+        configurable: true,
+        writable: true,
+        value: function (...args) {
+          const options = args[0];
+          if (!options || typeof options !== "object" || options.publicKey == null) {
+            return Reflect.apply(originalMethod, this, args);
+          }
+
+          return platformAuthenticatorAvailable.then((available) => {
+            if (available !== false) {
+              return Reflect.apply(originalMethod, this, args);
+            }
+            globalThis[bridgeKey]?.notifyUnavailable();
+            throw new DOMException("The operation was not allowed.", "NotAllowedError");
+          });
+        },
+      });
+    }
+  },
+  args: [PASSKEY_BRIDGE_KEY],
+});
 
 function dismissMenuOverlay(event) {
   if (event.type === "pointerdown" && (event.button === 2 || event.buttons === 2)) return;

--- a/apps/desktop/electron/browser-content-preload.test.cjs
+++ b/apps/desktop/electron/browser-content-preload.test.cjs
@@ -1,0 +1,80 @@
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { test } = require("node:test");
+
+const originalLoad = Module._load;
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+let mainWorldScript;
+
+Module._load = function (request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      contextBridge: {
+        exposeInMainWorld() {},
+        executeInMainWorld(script) { mainWorldScript = script; },
+      },
+      ipcRenderer: { send() {} },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+globalThis.document = { readyState: "loading", addEventListener() {} };
+globalThis.window = { addEventListener() {} };
+try {
+  require("./browser-content-preload.cjs");
+} finally {
+  Module._load = originalLoad;
+  globalThis.document = originalDocument;
+  globalThis.window = originalWindow;
+}
+
+test("passkey fallback stays quiet when Touch ID is available", async () => {
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const publicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "PublicKeyCredential",
+  );
+  const bridgeKey = mainWorldScript.args[0];
+  const bridgeDescriptor = Object.getOwnPropertyDescriptor(globalThis, bridgeKey);
+  let nativeCalls = 0;
+  let fallbackNotifications = 0;
+  const credentials = {
+    create() { nativeCalls += 1; return Promise.resolve("native-create"); },
+    get() { nativeCalls += 1; return Promise.resolve("native-get"); },
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { credentials },
+  });
+  Object.defineProperty(globalThis, "PublicKeyCredential", {
+    configurable: true,
+    value: {
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    },
+  });
+  Object.defineProperty(globalThis, bridgeKey, {
+    configurable: true,
+    value: { notifyUnavailable() { fallbackNotifications += 1; } },
+  });
+
+  try {
+    mainWorldScript.func(...mainWorldScript.args);
+    assert.equal(await credentials.get({ publicKey: {} }), "native-get");
+    assert.equal(nativeCalls, 1);
+    assert.equal(fallbackNotifications, 0);
+  } finally {
+    restoreProperty("navigator", navigatorDescriptor);
+    restoreProperty("PublicKeyCredential", publicKeyCredentialDescriptor);
+    restoreProperty(bridgeKey, bridgeDescriptor);
+  }
+});
+
+function restoreProperty(name, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete globalThis[name];
+  }
+}

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -16,7 +16,10 @@ const BROWSER_TARGET_RESOLVE_TIMEOUT_MS = 2500;
 const BROWSER_TARGET_RESOLVE_INTERVAL_MS = 80;
 const MENU_OVERLAY_HTML = "overlay.html";
 const MENU_OVERLAY_WIDTH = 196;
-const MENU_OVERLAY_HEIGHT = 176;
+const MENU_OVERLAY_ITEM_HEIGHT = 36;
+const MENU_OVERLAY_SEPARATOR_HEIGHT = 13;
+const MENU_OVERLAY_VERTICAL_CHROME = 19;
+const MENU_OVERLAY_EDGE_GAP = 4;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
 
 export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
@@ -250,13 +253,23 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     return { x: Math.round(x), y: Math.round(y) };
   }
 
-  function menuOverlayBounds(point) {
-    const [contentWidth, contentHeight] = window()?.getContentSize?.() ?? [MENU_OVERLAY_WIDTH, MENU_OVERLAY_HEIGHT];
+  function menuOverlayHeight(items) {
+    const separatorCount = items.filter((item) => item.separatorBefore).length;
+    return MENU_OVERLAY_VERTICAL_CHROME
+      + (items.length * MENU_OVERLAY_ITEM_HEIGHT)
+      + (separatorCount * MENU_OVERLAY_SEPARATOR_HEIGHT);
+  }
+
+  function menuOverlayBounds(point, items) {
+    const requestedHeight = menuOverlayHeight(items);
+    const [contentWidth, contentHeight] = window()?.getContentSize?.() ?? [MENU_OVERLAY_WIDTH, requestedHeight];
+    const width = Math.min(MENU_OVERLAY_WIDTH, Math.max(contentWidth - MENU_OVERLAY_EDGE_GAP, 0));
+    const height = Math.min(requestedHeight, Math.max(contentHeight - MENU_OVERLAY_EDGE_GAP, 0));
     return {
-      x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - MENU_OVERLAY_WIDTH - 4, 0)),
-      y: Math.min(Math.max(point.y, 0), Math.max(contentHeight - MENU_OVERLAY_HEIGHT - 4, 0)),
-      width: MENU_OVERLAY_WIDTH,
-      height: MENU_OVERLAY_HEIGHT,
+      x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - width - MENU_OVERLAY_EDGE_GAP, 0)),
+      y: Math.min(Math.max(point.y, 0), Math.max(contentHeight - height - MENU_OVERLAY_EDGE_GAP, 0)),
+      width,
+      height,
     };
   }
 
@@ -347,28 +360,92 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   function tabMenuRequest(tab, point) {
     const url = browserTabUrl(tab);
+    const items = [
+      { id: "copy-url", label: "Copy URL", iconName: "copy", disabled: !url },
+      { id: "open-external", label: "Open in Browser", iconName: "external", disabled: !(url && isHttpUrl(url)) },
+      { id: "close-tab", label: "Close Tab", iconName: "close", separatorBefore: true },
+      { id: "close-all-tabs", label: "Close All Tabs", iconName: "close" },
+    ];
     return {
       id: `tab-menu:${tab.tabId}:${Date.now()}`,
       source: "tab",
       tabId: tab.tabId,
       url,
-      bounds: menuOverlayBounds(normalizeMenuOverlayPoint(point)),
-      items: [
-        { id: "copy-url", label: "Copy URL", iconName: "copy", disabled: !url },
-        { id: "open-external", label: "Open in Browser", iconName: "external", disabled: !(url && isHttpUrl(url)) },
-        { id: "close-tab", label: "Close Tab", iconName: "close", separatorBefore: true },
-        { id: "close-all-tabs", label: "Close All Tabs", iconName: "close" },
-      ],
+      bounds: menuOverlayBounds(normalizeMenuOverlayPoint(point), items),
+      items,
     };
   }
 
-  async function showBrowserTabContextMenu(tabId, point) {
-    const tab = getBrowserTab(String(tabId ?? ""));
-    if (!window() || !tab || tab.view.webContents.isDestroyed()) return;
+  function editFlagDisables(editFlags, flag) {
+    return typeof editFlags?.[flag] === "boolean" && !editFlags[flag];
+  }
 
+  function pageMenuRequest(tab, params) {
+    const webContents = tab.view.webContents;
+    const selectionText = typeof params.selectionText === "string" ? params.selectionText : "";
+    const linkUrl = typeof params.linkURL === "string" ? params.linkURL : "";
+    const editFlags = params.editFlags;
+    const items = [];
+
+    if (params.isEditable) {
+      items.push(
+        { id: "page-cut", label: "Cut", disabled: !selectionText || editFlagDisables(editFlags, "canCut") },
+        { id: "page-copy", label: "Copy", disabled: !selectionText || editFlagDisables(editFlags, "canCopy") },
+        { id: "page-paste", label: "Paste", disabled: editFlagDisables(editFlags, "canPaste") },
+        { id: "page-select-all", label: "Select All", disabled: editFlagDisables(editFlags, "canSelectAll"), separatorBefore: true },
+      );
+    } else if (selectionText) {
+      items.push({ id: "page-copy", label: "Copy" });
+    }
+
+    if (linkUrl) {
+      items.push(
+        { id: "page-open-link-new-tab", label: "Open Link in New Tab", disabled: !isHttpUrl(linkUrl), separatorBefore: items.length > 0 },
+        { id: "page-copy-link", label: "Copy Link Address" },
+        { id: "page-open-link-external", label: "Open Link in Browser", disabled: !isHttpUrl(linkUrl) },
+      );
+    }
+
+    const imagePoint = normalizeMenuOverlayPoint(params);
+    if (params.mediaType === "image") {
+      items.push({ id: "page-copy-image", label: "Copy Image", separatorBefore: items.length > 0 });
+    }
+
+    const url = browserTabUrl(tab);
+    if (items.length === 0) {
+      const navigationHistory = webContents.navigationHistory;
+      items.push(
+        { id: "page-back", label: "Back", disabled: !navigationHistory.canGoBack() },
+        { id: "page-forward", label: "Forward", disabled: !navigationHistory.canGoForward() },
+        { id: "page-reload", label: "Reload" },
+        { id: "page-copy-url", label: "Copy Page URL", disabled: !url, separatorBefore: true },
+        { id: "page-open-external", label: "Open Page in Browser", disabled: !(url && isHttpUrl(url)) },
+      );
+    }
+
+    const viewBounds = tab.view.getBounds();
+    const point = {
+      // The view origin was already zoom-scaled by scaleRendererBounds when it
+      // was attached. Context-menu coordinates are local view DIPs, so add
+      // them without applying the main renderer zoom a second time.
+      x: viewBounds.x + imagePoint.x,
+      y: viewBounds.y + imagePoint.y,
+    };
+    return {
+      id: `page-menu:${tab.tabId}:${Date.now()}`,
+      source: "page",
+      tabId: tab.tabId,
+      url,
+      linkUrl,
+      imagePoint,
+      bounds: menuOverlayBounds(point, items),
+      items,
+    };
+  }
+
+  async function showMenuOverlay(request) {
     const showSerial = menuOverlayShowSerial + 1;
     menuOverlayShowSerial = showSerial;
-    const request = tabMenuRequest(tab, point ? scaleRendererPoint(point) : point);
     const view = await ensureMenuOverlayView();
     if (showSerial !== menuOverlayShowSerial || menuOverlayView !== view) return;
     menuOverlayRequest = request;
@@ -388,10 +465,23 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     view.webContents.focus();
   }
 
+  async function showBrowserTabContextMenu(tabId, point) {
+    const tab = getBrowserTab(String(tabId ?? ""));
+    if (!window() || !tab || tab.view.webContents.isDestroyed()) return;
+    const request = tabMenuRequest(tab, point ? scaleRendererPoint(point) : point);
+    await showMenuOverlay(request);
+  }
+
+  async function showBrowserPageContextMenu(tab, params) {
+    if (!window() || tab.view.webContents.isDestroyed()) return;
+    await showMenuOverlay(pageMenuRequest(tab, params));
+  }
+
   function handleMenuOverlayChoice(payload) {
     if (!payload || payload.requestId !== menuOverlayRequest?.id) return;
     const request = menuOverlayRequest;
     const tab = getBrowserTab(request.tabId);
+    const webContents = tab && !tab.view.webContents.isDestroyed() ? tab.view.webContents : null;
     hideMenuOverlay();
 
     switch (payload.itemId) {
@@ -406,6 +496,45 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         break;
       case "close-all-tabs":
         closeAllBrowserTabs();
+        break;
+      case "page-cut":
+        webContents?.cut();
+        break;
+      case "page-copy":
+        webContents?.copy();
+        break;
+      case "page-paste":
+        webContents?.paste();
+        break;
+      case "page-select-all":
+        webContents?.selectAll();
+        break;
+      case "page-open-link-new-tab":
+        if (request.linkUrl && isHttpUrl(request.linkUrl)) createBrowserTab(request.linkUrl, { select: true });
+        break;
+      case "page-copy-link":
+        if (request.linkUrl) clipboard.writeText(request.linkUrl);
+        break;
+      case "page-open-link-external":
+        if (request.linkUrl && isHttpUrl(request.linkUrl)) void shell.openExternal(request.linkUrl);
+        break;
+      case "page-copy-image":
+        if (webContents && request.imagePoint) webContents.copyImageAt(request.imagePoint.x, request.imagePoint.y);
+        break;
+      case "page-back":
+        if (webContents?.navigationHistory.canGoBack()) webContents.navigationHistory.goBack();
+        break;
+      case "page-forward":
+        if (webContents?.navigationHistory.canGoForward()) webContents.navigationHistory.goForward();
+        break;
+      case "page-reload":
+        webContents?.reload();
+        break;
+      case "page-copy-url":
+        if (request.url) clipboard.writeText(request.url);
+        break;
+      case "page-open-external":
+        if (request.url && isHttpUrl(request.url)) void shell.openExternal(request.url);
         break;
     }
   }
@@ -490,6 +619,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     view.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
       void shell.openExternal(targetUrl);
       return { action: "deny" };
+    });
+    view.webContents.on("context-menu", (event, params) => {
+      event.preventDefault();
+      void showBrowserPageContextMenu(tab, params);
     });
     view.webContents.on("did-start-navigation", (_event, targetUrl, isInPlace, isMainFrame) => {
       if (!isMainFrame || isInPlace) return;

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -21,6 +21,8 @@ const MENU_OVERLAY_SEPARATOR_HEIGHT = 13;
 const MENU_OVERLAY_VERTICAL_CHROME = 19;
 const MENU_OVERLAY_EDGE_GAP = 4;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
+const PASSKEY_OVERLAY_WIDTH = 360;
+const PASSKEY_OVERLAY_HEIGHT = 152;
 
 export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   const browserTabs = new Map();
@@ -260,10 +262,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       + (separatorCount * MENU_OVERLAY_SEPARATOR_HEIGHT);
   }
 
-  function menuOverlayBounds(point, items) {
-    const requestedHeight = menuOverlayHeight(items);
-    const [contentWidth, contentHeight] = window()?.getContentSize?.() ?? [MENU_OVERLAY_WIDTH, requestedHeight];
-    const width = Math.min(MENU_OVERLAY_WIDTH, Math.max(contentWidth - MENU_OVERLAY_EDGE_GAP, 0));
+  function menuOverlayBounds(point, items, requestedWidth = MENU_OVERLAY_WIDTH, requestedHeight = menuOverlayHeight(items)) {
+    const [contentWidth, contentHeight] = window()?.getContentSize?.() ?? [requestedWidth, requestedHeight];
+    const width = Math.min(requestedWidth, Math.max(contentWidth - MENU_OVERLAY_EDGE_GAP, 0));
     const height = Math.min(requestedHeight, Math.max(contentHeight - MENU_OVERLAY_EDGE_GAP, 0));
     return {
       x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - width - MENU_OVERLAY_EDGE_GAP, 0)),
@@ -443,6 +444,28 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     };
   }
 
+  function passkeyMenuRequest(tab) {
+    const url = browserTabUrl(tab);
+    const items = [
+      { id: "passkey-open-external", label: "Open in your browser", iconName: "external", disabled: !(url && isHttpUrl(url)) },
+    ];
+    const viewBounds = tab.view.getBounds();
+    const point = {
+      x: viewBounds.x + viewBounds.width - PASSKEY_OVERLAY_WIDTH - 16,
+      y: viewBounds.y + 16,
+    };
+    return {
+      id: `passkey-menu:${tab.tabId}:${Date.now()}`,
+      source: "passkey",
+      title: "Open this page to use a passkey",
+      description: "This site asked for a passkey, but OpenWork’s built-in browser can’t use passkeys yet.",
+      tabId: tab.tabId,
+      url,
+      bounds: menuOverlayBounds(point, items, PASSKEY_OVERLAY_WIDTH, PASSKEY_OVERLAY_HEIGHT),
+      items,
+    };
+  }
+
   async function showMenuOverlay(request) {
     const showSerial = menuOverlayShowSerial + 1;
     menuOverlayShowSerial = showSerial;
@@ -460,6 +483,8 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     view.webContents.send("openwork:menu-overlay:show", {
       id: request.id,
       source: request.source,
+      title: request.title,
+      description: request.description,
       items: request.items,
     });
     view.webContents.focus();
@@ -489,6 +514,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         if (request.url) clipboard.writeText(request.url);
         break;
       case "open-external":
+        if (request.url && isHttpUrl(request.url)) void shell.openExternal(request.url);
+        break;
+      case "passkey-open-external":
         if (request.url && isHttpUrl(request.url)) void shell.openExternal(request.url);
         break;
       case "close-tab":
@@ -915,6 +943,11 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     ipcMain.handle("openwork:browser:getProxy", () => browserProxyState());
     ipcMain.handle("openwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
     ipcMain.handle("openwork:browser:destroy", () => destroyBrowserView());
+    ipcMain.on("openwork:browser:passkey-unavailable", (event) => {
+      const tab = [...browserTabs.values()].find((candidate) => candidate.view.webContents === event.sender);
+      if (!tab || tab.view.webContents.isDestroyed()) return;
+      void showMenuOverlay(passkeyMenuRequest(tab));
+    });
     ipcMain.on("openwork:menu-overlay:ready", (event) => {
       if (event.sender !== menuOverlayView?.webContents) return;
       markMenuOverlayReady(menuOverlayView);

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -334,6 +334,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   function hideMenuOverlay() {
     const view = menuOverlayView;
     const mainWindow = window();
+    const request = menuOverlayRequest;
     menuOverlayShowSerial += 1;
     menuOverlayRequest = null;
     if (!view || !mainWindow) return;
@@ -344,6 +345,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       }
     } catch {
       // already removed
+    }
+    if (request?.source === "tab") {
+      mainWindow.webContents.focus();
+    } else {
+      const tab = getBrowserTab(request?.tabId);
+      if (tab && !tab.view.webContents.isDestroyed()) tab.view.webContents.focus();
     }
   }
 

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -16,9 +16,10 @@ const BROWSER_TARGET_RESOLVE_TIMEOUT_MS = 2500;
 const BROWSER_TARGET_RESOLVE_INTERVAL_MS = 80;
 const MENU_OVERLAY_HTML = "overlay.html";
 const MENU_OVERLAY_WIDTH = 196;
-const MENU_OVERLAY_ITEM_HEIGHT = 36;
-const MENU_OVERLAY_SEPARATOR_HEIGHT = 13;
-const MENU_OVERLAY_VERTICAL_CHROME = 19;
+// Provisional bounds let the renderer lay out; it immediately reports the rendered height.
+const MENU_OVERLAY_INITIAL_ITEM_HEIGHT = 36;
+const MENU_OVERLAY_INITIAL_SEPARATOR_HEIGHT = 13;
+const MENU_OVERLAY_INITIAL_VERTICAL_CHROME = 19;
 const MENU_OVERLAY_EDGE_GAP = 4;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
 const PASSKEY_OVERLAY_WIDTH = 360;
@@ -257,9 +258,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   function menuOverlayHeight(items) {
     const separatorCount = items.filter((item) => item.separatorBefore).length;
-    return MENU_OVERLAY_VERTICAL_CHROME
-      + (items.length * MENU_OVERLAY_ITEM_HEIGHT)
-      + (separatorCount * MENU_OVERLAY_SEPARATOR_HEIGHT);
+    return MENU_OVERLAY_INITIAL_VERTICAL_CHROME
+      + (items.length * MENU_OVERLAY_INITIAL_ITEM_HEIGHT)
+      + (separatorCount * MENU_OVERLAY_INITIAL_SEPARATOR_HEIGHT);
   }
 
   function menuOverlayBounds(point, items, requestedWidth = MENU_OVERLAY_WIDTH, requestedHeight = menuOverlayHeight(items)) {
@@ -951,6 +952,17 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     ipcMain.on("openwork:menu-overlay:ready", (event) => {
       if (event.sender !== menuOverlayView?.webContents) return;
       markMenuOverlayReady(menuOverlayView);
+    });
+    ipcMain.on("openwork:menu-overlay:resize", (event, payload) => {
+      if (event.sender !== menuOverlayView?.webContents) return;
+      if (payload?.requestId !== menuOverlayRequest?.id) return;
+      const requestedHeight = Number(payload.height);
+      if (!Number.isFinite(requestedHeight) || requestedHeight <= 0) return;
+      const bounds = menuOverlayRequest.bounds;
+      const contentHeight = window()?.getContentSize?.()[1] ?? requestedHeight;
+      const height = Math.min(Math.ceil(requestedHeight), Math.max(contentHeight - bounds.y - MENU_OVERLAY_EDGE_GAP, 0));
+      bounds.height = height;
+      menuOverlayView.setBounds(bounds);
     });
     ipcMain.on("openwork:menu-overlay:choose", (event, payload) => {
       if (event.sender !== menuOverlayView?.webContents) return;

--- a/apps/desktop/electron/electron-builder-config.test.mjs
+++ b/apps/desktop/electron/electron-builder-config.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 
+import { macosWebAuthnKeychainAccessGroup } from "./webauthn.mjs";
+
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function readConfig(name) {
@@ -18,6 +20,9 @@ describe("Electron distribution configs", () => {
     );
     const config = await readConfig("electron-builder.base.yml");
     assert.equal(packageMetadata.desktopName, "com.differentai.openwork");
+    assert.equal(config.npmRebuild, true);
+    assert.equal(config.mac.entitlements, "build/entitlements.mac.plist");
+    assert.equal(config.mac.entitlementsInherit, "build/entitlements.mac.inherit.plist");
     assert.equal(config.linux.syncDesktopName, true);
     assert.equal(config.linux.icon, "resources/icons/linux");
     assert.deepEqual(config.linux.extraResources[0], {
@@ -25,6 +30,22 @@ describe("Electron distribution configs", () => {
       to: "icons/linux",
       filter: ["*.png"],
     });
+  });
+
+  it("keeps the Touch ID keychain entitlement in sync with signing metadata", async () => {
+    const packageMetadata = JSON.parse(
+      await readFile(path.resolve(dirname, "..", "package.json"), "utf8"),
+    );
+    const entitlements = await readFile(
+      path.resolve(dirname, "..", "build", "entitlements.mac.plist"),
+      "utf8",
+    );
+    const keychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+      teamId: packageMetadata.openworkAppleTeamId,
+      bundleId: packageMetadata.desktopName,
+    });
+    assert.ok(keychainAccessGroup);
+    assert.match(entitlements, new RegExp(`<string>${keychainAccessGroup}<\\/string>`));
   });
 
   it("keeps the public artifact and protocol unchanged", async () => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -53,6 +53,10 @@ import { openExternalUrl } from "./open-external.mjs";
 import { resolveAppIdentifier, resolveUserDataPath } from "./dev-profile.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
 import {
+  configureMacosTouchIdPasskeys,
+  macosWebAuthnKeychainAccessGroup,
+} from "./webauthn.mjs";
+import {
   createLinuxDesktopIntegration,
 } from "./linux-desktop-integration.mjs";
 import {
@@ -115,6 +119,10 @@ const APP_IDENTIFIER = resolveAppIdentifier({
   devProfile: process.env.OPENWORK_DEV_PROFILE,
   isDevMode,
   isPackaged: app.isPackaged,
+});
+const macosTouchIdKeychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+  teamId: desktopPackageMetadata.openworkAppleTeamId,
+  bundleId: desktopPackageMetadata.desktopName,
 });
 if (process.env.OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN === "1") {
   // Fresh, isolated development profiles otherwise trigger macOS's native
@@ -2521,6 +2529,11 @@ or use: pnpm dev:worktree`);
   });
 
   app.whenReady().then(async () => {
+    configureMacosTouchIdPasskeys({
+      electronApp: app,
+      platform: process.platform,
+      keychainAccessGroup: macosTouchIdKeychainAccessGroup,
+    });
     installMediaPermissionHandlers(session, () => mainWindow);
     await runPendingNukeCleanup({
       env: process.env,

--- a/apps/desktop/electron/menu-overlay-preload.mjs
+++ b/apps/desktop/electron/menu-overlay-preload.mjs
@@ -23,6 +23,9 @@ contextBridge.exposeInMainWorld("__OPENWORK_MENU_OVERLAY__", {
       }
     };
   },
+  resize(requestId, height) {
+    ipcRenderer.send("openwork:menu-overlay:resize", { requestId, height });
+  },
   choose(requestId, itemId) {
     ipcRenderer.send("openwork:menu-overlay:choose", { requestId, itemId });
   },

--- a/apps/desktop/electron/webauthn.mjs
+++ b/apps/desktop/electron/webauthn.mjs
@@ -1,0 +1,32 @@
+export const MACOS_WEBAUTHN_PROMPT_REASON = "sign in to $1";
+
+export function macosWebAuthnKeychainAccessGroup({ teamId, bundleId }) {
+  if (typeof teamId !== "string" || !teamId.trim()) return null;
+  if (typeof bundleId !== "string" || !bundleId.trim()) return null;
+  return `${teamId.trim()}.${bundleId.trim()}.webauthn`;
+}
+
+export function configureMacosTouchIdPasskeys({
+  electronApp,
+  platform,
+  keychainAccessGroup,
+}) {
+  if (platform !== "darwin" || typeof electronApp?.configureWebAuthn !== "function") {
+    return false;
+  }
+  if (typeof keychainAccessGroup !== "string" || !keychainAccessGroup) return false;
+
+  try {
+    electronApp.configureWebAuthn({
+      touchID: {
+        keychainAccessGroup,
+        promptReason: MACOS_WEBAUTHN_PROMPT_REASON,
+      },
+    });
+    return true;
+  } catch {
+    // Macs without a Secure Enclave cannot use Touch ID passkeys. Leave the
+    // browser's capability probe false without interrupting app startup.
+    return false;
+  }
+}

--- a/apps/desktop/electron/webauthn.test.mjs
+++ b/apps/desktop/electron/webauthn.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  configureMacosTouchIdPasskeys,
+  macosWebAuthnKeychainAccessGroup,
+} from "./webauthn.mjs";
+
+describe("macOS WebAuthn", () => {
+  it("derives the Touch ID keychain group from the signing team and bundle", () => {
+    assert.equal(
+      macosWebAuthnKeychainAccessGroup({
+        teamId: "F5DJWB4CCV",
+        bundleId: "com.differentai.openwork",
+      }),
+      "F5DJWB4CCV.com.differentai.openwork.webauthn",
+    );
+  });
+
+  it("configures Touch ID with user-facing prompt copy", () => {
+    const calls = [];
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: (options) => calls.push(options) },
+      platform: "darwin",
+      keychainAccessGroup: "F5DJWB4CCV.com.differentai.openwork.webauthn",
+    }), true);
+    assert.deepEqual(calls, [{
+      touchID: {
+        keychainAccessGroup: "F5DJWB4CCV.com.differentai.openwork.webauthn",
+        promptReason: "sign in to $1",
+      },
+    }]);
+  });
+
+  it("does nothing when the platform or Electron capability is unsupported", () => {
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: () => assert.fail("must not be called") },
+      platform: "linux",
+      keychainAccessGroup: "group",
+    }), false);
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: {},
+      platform: "darwin",
+      keychainAccessGroup: "group",
+    }), false);
+  });
+
+  it("does not interrupt startup when Touch ID cannot be configured", () => {
+    assert.doesNotThrow(() => configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: () => { throw new Error("unavailable"); } },
+      platform: "darwin",
+      keychainAccessGroup: "group",
+    }));
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.18.13",
   "desktopName": "com.differentai.openwork",
+  "openworkAppleTeamId": "F5DJWB4CCV",
   "description": "OpenWork desktop shell",
   "author": {
     "name": "OpenWork",
@@ -15,15 +16,16 @@
     "dev:electron": "node ./scripts/electron-dev.mjs",
     "build": "node ./scripts/electron-build.mjs",
     "build:electron": "node ./scripts/electron-build.mjs",
+    "rebuild:electron-native": "electron-rebuild --force --which-module better-sqlite3",
     "package:electron": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.yml",
     "package:electron:cloud": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.cloud.yml",
     "package:electron:enterprise": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.enterprise.yml",
     "package:electron:dir": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.yml --dir",
-    "electron": "pnpm exec electron ./electron/main.mjs",
+    "electron": "pnpm run rebuild:electron-native && pnpm exec electron ./electron/main.mjs",
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/browser-content-preload.test.cjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/webauthn.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@openwork/paths": "workspace:*",
@@ -38,8 +40,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.2.0",
     "@openwork/types": "workspace:*",
-    "electron": "^35.0.0",
+    "electron": "^41.6.0",
     "electron-builder": "^26.15.3",
     "electron-devtools-installer": "^4.0.0"
   },

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -3,6 +3,8 @@ import { copyFileSync, cpSync, readFileSync, readdirSync, rmSync, writeFileSync 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { macosWebAuthnKeychainAccessGroup } from "../electron/webauthn.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "../..");
@@ -10,6 +12,8 @@ const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
 const electronHelperDir = resolve(desktopRoot, "resources", "helpers");
 const electronRoot = resolve(desktopRoot, "electron");
 const packagedServerRoot = resolve(desktopRoot, "server");
+const desktopPackagePath = resolve(desktopRoot, "package.json");
+const macEntitlementsPath = resolve(desktopRoot, "build", "entitlements.mac.plist");
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const nodeCmd = process.execPath;
@@ -29,6 +33,27 @@ function run(command, args, cwd, env) {
     process.exit(result.status ?? 1);
   }
 }
+
+function syncMacosWebAuthnEntitlement() {
+  const packageMetadata = JSON.parse(readFileSync(desktopPackagePath, "utf8"));
+  const keychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+    teamId: packageMetadata.openworkAppleTeamId,
+    bundleId: packageMetadata.desktopName,
+  });
+  if (!keychainAccessGroup) {
+    throw new Error("Desktop package metadata must define the Apple team ID and bundle ID");
+  }
+
+  const entitlements = readFileSync(macEntitlementsPath, "utf8");
+  const keychainGroupPattern = /(<key>keychain-access-groups<\/key>\s*<array>\s*<string>)[^<]+(<\/string>\s*<\/array>)/;
+  if (!keychainGroupPattern.test(entitlements)) {
+    throw new Error("macOS entitlements must contain a keychain-access-groups entry");
+  }
+  const updated = entitlements.replace(keychainGroupPattern, `$1${keychainAccessGroup}$2`);
+  if (updated !== entitlements) writeFileSync(macEntitlementsPath, updated, "utf8");
+}
+
+syncMacosWebAuthnEntitlement();
 
 run(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], desktopRoot);
 run(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], desktopRoot);

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -261,6 +261,11 @@ if (!viteReady) {
 
 const resolvedStartUrl = await waitForVite(startUrl);
 
+// Native dependencies installed for the host Node ABI must be rebuilt before
+// Electron loads the embedded server and terminal runtime.
+console.log("[electron-dev] Rebuilding native dependencies for Electron...");
+runSync(pnpmCmd, ["--filter", "@openwork/desktop", "run", "rebuild:electron-native"], { cwd: repoRoot });
+
 // Optional Electron CDP for external debugging / raw CDP clients.
 // NOT required for the built-in browser (uses native webContents APIs).
 // Set OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 to enable.

--- a/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
+++ b/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
@@ -537,8 +537,8 @@ test("built-in browser page menus and passkeys work in Electron with OS-level vi
   try {
     await using app = await desktop({ mode: "attach", name: "builtin-browser-context-menu-passkey" });
     const userAgent = await evalIn(app, "navigator.userAgent");
-    expect(userAgent).toEqual(expect.stringContaining("Electron/35."));
-    evidence.fact("The real app under test is Electron 35", String(userAgent), true);
+    expect(userAgent).toEqual(expect.stringContaining("Electron/41."));
+    evidence.fact("The real app under test is Electron 41", String(userAgent), true);
 
     await createAndSelectWorkspace(app, { path: "/tmp/openwork-browser-context-menu-passkey" });
     await waitFor(

--- a/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
+++ b/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
@@ -14,7 +14,6 @@ const FIXTURE_URL = `http://localhost:${FIXTURE_PORT}/index.html`;
 const LINK_URL = `http://localhost:${FIXTURE_PORT}/linked.html`;
 const MENU_ITEM_HEIGHT = 36;
 const MENU_SEPARATOR_HEIGHT = 13;
-const MENU_VERTICAL_CHROME = 19;
 
 const PLAIN_LABELS = ["Back", "Forward", "Reload", "Copy Page URL", "Open Page in Browser"];
 const LINK_LABELS = ["Open Link in New Tab", "Copy Link Address", "Open Link in Browser"];
@@ -116,6 +115,7 @@ type MenuMetrics = {
   itemHeights: number[];
   separatorFootprints: number[];
   menuRect: Rect;
+  contentHeight: number;
   lastItemBottom: number;
   scrollHeight: number;
 };
@@ -187,6 +187,7 @@ function parseMenuMetrics(value: unknown): MenuMetrics {
     || !value.itemHeights.every((entry) => typeof entry === "number")
     || !Array.isArray(value.separatorFootprints)
     || !value.separatorFootprints.every((entry) => typeof entry === "number")
+    || typeof value.contentHeight !== "number"
     || typeof value.lastItemBottom !== "number"
     || typeof value.scrollHeight !== "number"
   ) {
@@ -200,6 +201,7 @@ function parseMenuMetrics(value: unknown): MenuMetrics {
     itemHeights: value.itemHeights,
     separatorFootprints: value.separatorFootprints,
     menuRect: parseRect(value.menuRect, "menu"),
+    contentHeight: value.contentHeight,
     lastItemBottom: value.lastItemBottom,
     scrollHeight: value.scrollHeight,
   };
@@ -422,6 +424,8 @@ async function readMenuMetrics(client: CdpClient): Promise<MenuMetrics | null> {
       top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left,
     });
     const menuRect = menu.getBoundingClientRect();
+    const rootStyle = getComputedStyle(menu.parentElement);
+    const contentHeight = menuRect.height + parseFloat(rootStyle.paddingTop) + parseFloat(rootStyle.paddingBottom);
     const lastRect = items.at(-1)?.getBoundingClientRect();
     return {
       ariaLabel: menu.getAttribute('aria-label') ?? '',
@@ -434,6 +438,7 @@ async function readMenuMetrics(client: CdpClient): Promise<MenuMetrics | null> {
         return separator.getBoundingClientRect().height + parseFloat(style.marginTop) + parseFloat(style.marginBottom);
       }),
       menuRect: rectValue(menuRect),
+      contentHeight,
       lastItemBottom: lastRect?.bottom ?? 0,
       scrollHeight: document.documentElement.scrollHeight,
     };
@@ -453,11 +458,9 @@ function assertMenuSizing(
   metrics: MenuMetrics,
   separatorCount: number,
 ): void {
-  const expectedHeight = MENU_VERTICAL_CHROME
-    + metrics.labels.length * MENU_ITEM_HEIGHT
-    + separatorCount * MENU_SEPARATOR_HEIGHT;
   expect(metrics.innerWidth).toBe(196);
-  expect(metrics.innerHeight).toBe(expectedHeight);
+  expect(metrics.contentHeight).toBeLessThanOrEqual(metrics.innerHeight);
+  expect(metrics.innerHeight - metrics.contentHeight).toBeLessThanOrEqual(1);
   expect(metrics.itemHeights).toHaveLength(metrics.labels.length);
   for (const height of metrics.itemHeights) {
     expect(height).toBeGreaterThanOrEqual(34);
@@ -473,8 +476,8 @@ function assertMenuSizing(
   expect(visibleTrailingGap).toBeGreaterThanOrEqual(0);
   expect(visibleTrailingGap).toBeLessThanOrEqual(10);
   evidence.fact(
-    `${metrics.ariaLabel} is sized from 36px items, 13px separators, and 19px vertical chrome without clipping or a large dead gap`,
-    JSON.stringify({ expectedHeight, metrics, visibleTrailingGap, transparentBottomSpace }),
+    `${metrics.ariaLabel} overlay height matches its rendered content without clipping or a large dead gap`,
+    JSON.stringify({ overlayHeight: metrics.innerHeight, contentHeight: metrics.contentHeight, metrics, visibleTrailingGap, transparentBottomSpace }),
     true,
   );
 }

--- a/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
+++ b/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
@@ -1,0 +1,723 @@
+import { createHash } from "node:crypto";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { connect, debuggerUrlFor, evaluate, listTargets, targetById } from "@openwork/cdp";
+import type { CdpClient, CdpTarget, Surface } from "@openwork/cdp";
+import { currentTape, validate } from "@openwork/fraimz";
+import type { Shot, Tape } from "@openwork/fraimz";
+import { expectFrame } from "@openwork/fraimz/vitest";
+import { defaultDaytonaExec, desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const FIXTURE_PORT = 43_127;
+const FIXTURE_URL = `http://localhost:${FIXTURE_PORT}/index.html`;
+const LINK_URL = `http://localhost:${FIXTURE_PORT}/linked.html`;
+const MENU_ITEM_HEIGHT = 36;
+const MENU_SEPARATOR_HEIGHT = 13;
+const MENU_VERTICAL_CHROME = 19;
+
+const PLAIN_LABELS = ["Back", "Forward", "Reload", "Copy Page URL", "Open Page in Browser"];
+const LINK_LABELS = ["Open Link in New Tab", "Copy Link Address", "Open Link in Browser"];
+const INPUT_LABELS = ["Cut", "Copy", "Paste", "Select All"];
+const SELECTED_TEXT_LABELS = ["Copy"];
+const TAB_LABELS = ["Copy URL", "Open in Browser", "Close Tab", "Close All Tabs"];
+
+const fixtureHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>OpenWork Browser E2E Fixture</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #f7f3e8; color: #181711; font: 16px/1.5 system-ui, sans-serif; }
+      main { height: 100%; padding: 28px 34px; position: relative; }
+      h1 { margin: 0 0 18px; font-size: 26px; }
+      .row { display: flex; align-items: center; gap: 24px; margin-bottom: 20px; }
+      a { color: #0645ad; font-weight: 700; }
+      input { width: 280px; padding: 10px 12px; border: 2px solid #706b5b; border-radius: 8px; background: white; }
+      button { padding: 10px 14px; border: 0; border-radius: 8px; color: white; background: #163a66; font-weight: 700; }
+      #selectable { width: max-content; padding: 8px; background: #fff8cf; }
+      #plain { position: absolute; left: 30%; top: 48%; width: 32%; height: 25%; border: 2px dashed #a39a7e; border-radius: 12px; display: flex; align-items: center; justify-content: center; color: #645f50; }
+      #fixture-image { width: 72px; height: 48px; border-radius: 8px; }
+      #marker { position: fixed; z-index: 2147483647; width: 30px; height: 30px; transform: translate(-15px, -15px); pointer-events: none; display: none; }
+      #marker::before, #marker::after { content: ""; position: absolute; background: #ff00a8; box-shadow: 0 0 0 1px white; }
+      #marker::before { left: 14px; top: 0; width: 2px; height: 30px; }
+      #marker::after { left: 0; top: 14px; width: 30px; height: 2px; }
+      #marker-ring { position: absolute; inset: 5px; border: 2px solid #ff00a8; border-radius: 999px; }
+      #result { font: 13px/1.4 ui-monospace, monospace; color: #403b30; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Built-in browser interaction fixture</h1>
+      <div class="row">
+        <a id="fixture-link" href="/linked.html">Open deterministic linked page</a>
+        <img id="fixture-image" alt="fixture image" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='144' height='96'%3E%3Crect width='144' height='96' fill='%23e34b35'/%3E%3Ccircle cx='72' cy='48' r='28' fill='%23ffe36d'/%3E%3C/svg%3E">
+      </div>
+      <div class="row">
+        <input id="fixture-input" value="Editable fixture text">
+        <button id="passkey-button" type="button">Request a passkey</button>
+        <span id="result">Passkey not requested</span>
+      </div>
+      <p id="selectable">Select this exact sentence for the Copy menu.</p>
+      <div id="plain">Plain page area for context menu</div>
+      <div id="marker"><div id="marker-ring"></div></div>
+    </main>
+    <script>
+      window.__showContextMarker = (x, y) => {
+        const marker = document.getElementById("marker");
+        marker.style.left = x + "px";
+        marker.style.top = y + "px";
+        marker.style.display = "block";
+      };
+      document.getElementById("passkey-button").addEventListener("click", async () => {
+        const startedAt = performance.now();
+        let result;
+        try {
+          await navigator.credentials.get({
+            publicKey: {
+              challenge: new Uint8Array(32),
+              timeout: 180000,
+              rpId: "localhost",
+              allowCredentials: [],
+              userVerification: "preferred"
+            }
+          });
+          result = { settled: true, elapsedMs: performance.now() - startedAt, resolved: true };
+        } catch (error) {
+          result = {
+            settled: true,
+            elapsedMs: performance.now() - startedAt,
+            resolved: false,
+            name: error && error.name,
+            message: error && error.message,
+            isDomException: error instanceof DOMException,
+            constructorName: error && error.constructor && error.constructor.name
+          };
+        }
+        window.__passkeyResult = result;
+        document.getElementById("result").textContent = JSON.stringify(result);
+      });
+    </script>
+  </body>
+</html>`;
+
+const linkedHtml = `<!doctype html><meta charset="utf-8"><title>Linked fixture page</title><body style="font:20px system-ui;background:#e8f4ff;padding:40px"><h1>Linked fixture page opened in a new tab</h1></body>`;
+
+type Point = { x: number; y: number };
+type Rect = { x: number; y: number; width: number; height: number; top: number; right: number; bottom: number; left: number };
+type MenuMetrics = {
+  ariaLabel: string;
+  labels: string[];
+  innerWidth: number;
+  innerHeight: number;
+  itemHeights: number[];
+  separatorFootprints: number[];
+  menuRect: Rect;
+  lastItemBottom: number;
+  scrollHeight: number;
+};
+type BrowserTab = { id: string; url: string };
+type BrowserState = { activeTabId: string | null; tabs: BrowserTab[] };
+type PasskeyResult = {
+  settled: boolean;
+  elapsedMs: number;
+  resolved: boolean;
+  name: string;
+  isDomException: boolean;
+  constructorName: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function parsePoint(value: unknown, label: string): Point {
+  if (!isRecord(value) || typeof value.x !== "number" || typeof value.y !== "number") {
+    throw new Error(`${label} did not resolve to a point: ${JSON.stringify(value)}`);
+  }
+  return { x: value.x, y: value.y };
+}
+
+function parseRect(value: unknown, label: string): Rect {
+  if (
+    !isRecord(value)
+    || typeof value.x !== "number"
+    || typeof value.y !== "number"
+    || typeof value.width !== "number"
+    || typeof value.height !== "number"
+    || typeof value.top !== "number"
+    || typeof value.right !== "number"
+    || typeof value.bottom !== "number"
+    || typeof value.left !== "number"
+  ) {
+    throw new Error(`${label} did not resolve to a rectangle: ${JSON.stringify(value)}`);
+  }
+  return {
+    x: value.x,
+    y: value.y,
+    width: value.width,
+    height: value.height,
+    top: value.top,
+    right: value.right,
+    bottom: value.bottom,
+    left: value.left,
+  };
+}
+
+function parseMenuMetrics(value: unknown): MenuMetrics {
+  if (
+    !isRecord(value)
+    || typeof value.ariaLabel !== "string"
+    || !Array.isArray(value.labels)
+    || !value.labels.every((entry) => typeof entry === "string")
+    || typeof value.innerWidth !== "number"
+    || typeof value.innerHeight !== "number"
+    || !Array.isArray(value.itemHeights)
+    || !value.itemHeights.every((entry) => typeof entry === "number")
+    || !Array.isArray(value.separatorFootprints)
+    || !value.separatorFootprints.every((entry) => typeof entry === "number")
+    || typeof value.lastItemBottom !== "number"
+    || typeof value.scrollHeight !== "number"
+  ) {
+    throw new Error(`Overlay did not expose menu metrics: ${JSON.stringify(value)}`);
+  }
+  return {
+    ariaLabel: value.ariaLabel,
+    labels: value.labels,
+    innerWidth: value.innerWidth,
+    innerHeight: value.innerHeight,
+    itemHeights: value.itemHeights,
+    separatorFootprints: value.separatorFootprints,
+    menuRect: parseRect(value.menuRect, "menu"),
+    lastItemBottom: value.lastItemBottom,
+    scrollHeight: value.scrollHeight,
+  };
+}
+
+function parseBrowserState(value: unknown): BrowserState {
+  if (!isRecord(value) || (value.activeTabId !== null && typeof value.activeTabId !== "string") || !Array.isArray(value.tabs)) {
+    throw new Error(`Browser state was invalid: ${JSON.stringify(value)}`);
+  }
+  const tabs: BrowserTab[] = [];
+  for (const entry of value.tabs) {
+    if (!isRecord(entry) || typeof entry.id !== "string" || typeof entry.url !== "string") {
+      throw new Error(`Browser tab was invalid: ${JSON.stringify(entry)}`);
+    }
+    tabs.push({ id: entry.id, url: entry.url });
+  }
+  return { activeTabId: value.activeTabId, tabs };
+}
+
+function parsePasskeyResult(value: unknown): PasskeyResult {
+  if (
+    !isRecord(value)
+    || typeof value.settled !== "boolean"
+    || typeof value.elapsedMs !== "number"
+    || typeof value.resolved !== "boolean"
+    || typeof value.name !== "string"
+    || typeof value.isDomException !== "boolean"
+    || typeof value.constructorName !== "string"
+  ) {
+    throw new Error(`Passkey result was invalid: ${JSON.stringify(value)}`);
+  }
+  return {
+    settled: value.settled,
+    elapsedMs: value.elapsedMs,
+    resolved: value.resolved,
+    name: value.name,
+    isDomException: value.isDomException,
+    constructorName: value.constructorName,
+  };
+}
+
+async function sandboxExec(sandbox: string, script: string, timeoutMs = 30_000): Promise<string> {
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  const result = await defaultDaytonaExec(
+    ["exec", sandbox, "--", "echo", encoded, "|", "base64", "-d", "|", "bash"],
+    { timeoutMs },
+  );
+  if (result.code !== 0) {
+    throw new Error(`Daytona command failed (${result.code}): ${(result.stderr || result.stdout).trim()}`);
+  }
+  return result.stdout;
+}
+
+async function startFixtureServer(sandbox: string): Promise<void> {
+  const html = Buffer.from(fixtureHtml, "utf8").toString("base64");
+  const linked = Buffer.from(linkedHtml, "utf8").toString("base64");
+  await sandboxExec(sandbox, `
+set -euo pipefail
+if [ -f /tmp/openwork-browser-fixture.pid ]; then kill "$(cat /tmp/openwork-browser-fixture.pid)" 2>/dev/null || true; fi
+rm -rf /tmp/openwork-browser-fixture
+mkdir -p /tmp/openwork-browser-fixture
+printf %s ${shellQuote(html)} | base64 -d > /tmp/openwork-browser-fixture/index.html
+printf %s ${shellQuote(linked)} | base64 -d > /tmp/openwork-browser-fixture/linked.html
+nohup python3 -m http.server ${FIXTURE_PORT} --bind 127.0.0.1 --directory /tmp/openwork-browser-fixture >/tmp/openwork-browser-fixture.log 2>&1 &
+echo $! > /tmp/openwork-browser-fixture.pid
+for attempt in $(seq 1 50); do
+  if curl -fsS ${FIXTURE_URL} >/dev/null; then exit 0; fi
+  sleep 0.1
+done
+exit 1
+`);
+}
+
+async function stopFixtureServer(sandbox: string): Promise<void> {
+  await sandboxExec(sandbox, `
+if [ -f /tmp/openwork-browser-fixture.pid ]; then
+  kill "$(cat /tmp/openwork-browser-fixture.pid)" 2>/dev/null || true
+  rm -f /tmp/openwork-browser-fixture.pid
+fi
+`).catch(() => undefined);
+}
+
+async function captureOsShot(app: Surface, sandbox: string): Promise<Shot> {
+  const remotePath = `/tmp/openwork-browser-evidence-${Date.now()}.png`;
+  const stdout = await sandboxExec(sandbox, `
+set -euo pipefail
+export DISPLAY=:99
+xdotool search --name OpenWork windowactivate --sync 2>/dev/null || true
+bash /workspace/.devcontainer/capture-daytona-screenshot.sh --output ${shellQuote(remotePath)} --size 1920x1080 >/tmp/openwork-browser-capture.log 2>&1
+base64 -w 0 ${shellQuote(remotePath)}
+rm -f ${shellQuote(remotePath)}
+`);
+  const png = Buffer.from(stdout.trim(), "base64");
+  if (png.length < 1_000) throw new Error(`OS screenshot was unexpectedly small: ${png.length} bytes.`);
+  const page = await evalIn(app, `({ route: location.hash, visibleText: document.body.innerText })`);
+  if (!isRecord(page) || typeof page.route !== "string" || typeof page.visibleText !== "string") {
+    throw new Error("The app did not expose route and visible text for OS evidence.");
+  }
+  const shot: Shot = {
+    png,
+    hash: createHash("sha256").update(png).digest("hex"),
+    route: page.route,
+    visibleText: page.visibleText,
+    at: new Date().toISOString(),
+  };
+  const tape = currentTape();
+  if (!tape) throw new Error("OS screenshot requires the ambient testkit evidence tape.");
+  tape.recordTake(shot);
+  return shot;
+}
+
+async function proveOsFrame(
+  app: Surface,
+  sandbox: string,
+  expectations: string[],
+): Promise<void> {
+  const shot = await captureOsShot(app, sandbox);
+  const seen = await validate(shot, expectations);
+  expectFrame(seen);
+}
+
+async function waitUntil<T>(
+  label: string,
+  read: () => Promise<T | null>,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const startedAt = Date.now();
+  let lastError: unknown = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const result = await read();
+      if (result !== null) return result;
+      lastError = null;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${label}${lastError ? `: ${messageText(lastError)}` : ""}`);
+}
+
+async function findOverlayTarget(cdpBaseUrl: string): Promise<CdpTarget> {
+  return waitUntil("menu overlay CDP target", async () => {
+    const targets = await listTargets(cdpBaseUrl);
+    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl && target.url.includes("overlay.html")) ?? null;
+  });
+}
+
+async function elementCenter(client: CdpClient, selector: string): Promise<Point> {
+  const value = await evaluate(client, `(() => {
+    const element = document.querySelector(${JSON.stringify(selector)});
+    if (!element) return null;
+    const rect = element.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  return parsePoint(value, selector);
+}
+
+async function viewportPoint(client: CdpClient, edge: "center" | "bottom-right"): Promise<Point> {
+  const value = await evaluate(client, edge === "center"
+    ? `({ x: innerWidth / 2, y: innerHeight / 2 })`
+    : `({ x: innerWidth - 10, y: innerHeight - 10 })`);
+  return parsePoint(value, `${edge} viewport point`);
+}
+
+async function showMarker(client: CdpClient, point: Point): Promise<void> {
+  await evaluate(client, `window.__showContextMarker(${point.x}, ${point.y})`);
+}
+
+async function dispatchMouse(client: CdpClient, point: Point, button: "left" | "right"): Promise<void> {
+  const buttons = button === "right" ? 2 : 1;
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: point.x,
+    y: point.y,
+    button,
+    buttons,
+    clickCount: 1,
+  });
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: point.x,
+    y: point.y,
+    button,
+    buttons: 0,
+    clickCount: 1,
+  });
+}
+
+async function rightClick(client: CdpClient, point: Point, mark = true): Promise<void> {
+  if (mark) await showMarker(client, point);
+  await dispatchMouse(client, point, "right");
+}
+
+async function dispatchEscape(client: CdpClient): Promise<void> {
+  await client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+  await client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+}
+
+async function readMenuMetrics(client: CdpClient): Promise<MenuMetrics | null> {
+  const value = await evaluate(client, `(() => {
+    const menu = document.querySelector('[data-slot="context-menu-content"]');
+    if (!menu) return null;
+    const items = Array.from(menu.querySelectorAll('[data-slot="context-menu-item"]'));
+    const separators = Array.from(menu.querySelectorAll('[data-slot="context-menu-separator"]'));
+    const rectValue = (rect) => ({
+      x: rect.x, y: rect.y, width: rect.width, height: rect.height,
+      top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left,
+    });
+    const menuRect = menu.getBoundingClientRect();
+    const lastRect = items.at(-1)?.getBoundingClientRect();
+    return {
+      ariaLabel: menu.getAttribute('aria-label') ?? '',
+      labels: items.map((item) => item.textContent?.trim() ?? ''),
+      innerWidth,
+      innerHeight,
+      itemHeights: items.map((item) => item.getBoundingClientRect().height),
+      separatorFootprints: separators.map((separator) => {
+        const style = getComputedStyle(separator);
+        return separator.getBoundingClientRect().height + parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+      }),
+      menuRect: rectValue(menuRect),
+      lastItemBottom: lastRect?.bottom ?? 0,
+      scrollHeight: document.documentElement.scrollHeight,
+    };
+  })()`);
+  return value === null ? null : parseMenuMetrics(value);
+}
+
+async function waitForMenu(client: CdpClient, ariaLabel: string, labels: string[]): Promise<MenuMetrics> {
+  return waitUntil(`${ariaLabel} with ${labels.join(", ")}`, async () => {
+    const metrics = await readMenuMetrics(client);
+    return metrics?.ariaLabel === ariaLabel && JSON.stringify(metrics.labels) === JSON.stringify(labels) ? metrics : null;
+  });
+}
+
+function assertMenuSizing(
+  evidence: Tape,
+  metrics: MenuMetrics,
+  separatorCount: number,
+): void {
+  const expectedHeight = MENU_VERTICAL_CHROME
+    + metrics.labels.length * MENU_ITEM_HEIGHT
+    + separatorCount * MENU_SEPARATOR_HEIGHT;
+  expect(metrics.innerWidth).toBe(196);
+  expect(metrics.innerHeight).toBe(expectedHeight);
+  expect(metrics.itemHeights).toHaveLength(metrics.labels.length);
+  for (const height of metrics.itemHeights) {
+    expect(height).toBeGreaterThanOrEqual(34);
+    expect(height).toBeLessThanOrEqual(MENU_ITEM_HEIGHT);
+  }
+  expect(metrics.separatorFootprints).toHaveLength(separatorCount);
+  for (const height of metrics.separatorFootprints) expect(height).toBeCloseTo(MENU_SEPARATOR_HEIGHT, 1);
+  expect(metrics.menuRect.top).toBeGreaterThanOrEqual(0);
+  expect(metrics.menuRect.bottom).toBeLessThanOrEqual(metrics.innerHeight);
+  expect(metrics.scrollHeight).toBeLessThanOrEqual(metrics.innerHeight);
+  const visibleTrailingGap = metrics.menuRect.bottom - metrics.lastItemBottom;
+  const transparentBottomSpace = metrics.innerHeight - metrics.menuRect.bottom;
+  expect(visibleTrailingGap).toBeGreaterThanOrEqual(0);
+  expect(visibleTrailingGap).toBeLessThanOrEqual(10);
+  evidence.fact(
+    `${metrics.ariaLabel} is sized from 36px items, 13px separators, and 19px vertical chrome without clipping or a large dead gap`,
+    JSON.stringify({ expectedHeight, metrics, visibleTrailingGap, transparentBottomSpace }),
+    true,
+  );
+}
+
+async function chooseMenuItem(client: CdpClient, label: string): Promise<void> {
+  const point = await elementCenter(client, `[data-slot="context-menu-item"]`);
+  const value = await evaluate(client, `(() => {
+    const item = Array.from(document.querySelectorAll('[data-slot="context-menu-item"]'))
+      .find((candidate) => candidate.textContent?.trim() === ${JSON.stringify(label)});
+    if (!item) return null;
+    const rect = item.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  await dispatchMouse(client, value === null ? point : parsePoint(value, label), "left");
+}
+
+async function browserState(app: Surface): Promise<BrowserState> {
+  return parseBrowserState(await evalIn(app, "window.__OPENWORK_ELECTRON__.browser.getState()", { awaitPromise: true }));
+}
+
+async function clipboardText(client: CdpClient): Promise<string> {
+  const value = await evaluate(client, "navigator.clipboard.readText()", { awaitPromise: true });
+  if (typeof value !== "string") throw new Error(`Clipboard read did not return text: ${JSON.stringify(value)}`);
+  return value;
+}
+
+async function selectFixtureText(client: CdpClient): Promise<Point> {
+  const value = await evaluate(client, `(() => {
+    const element = document.getElementById('selectable');
+    if (!element?.firstChild) return null;
+    const selection = getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const rect = range.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  return parsePoint(value, "selected fixture text");
+}
+
+async function clearSelection(client: CdpClient): Promise<void> {
+  await evaluate(client, `getSelection()?.removeAllRanges()`);
+}
+
+test("built-in browser page menus and passkeys work in Electron with OS-level visual evidence", async ({ evidence }) => {
+  needs({
+    optIn: ["OPENWORK_EVAL_APP_SPECS"],
+    daytona: true,
+    env: ["OPENWORK_EVAL_CDP_URL", "OPENWORK_EVAL_DAYTONA_SANDBOX", "OPENAI_API_KEY"],
+  });
+
+  const sandbox = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim();
+  if (!sandbox) throw new Error("OPENWORK_EVAL_DAYTONA_SANDBOX was checked by needs() but is empty.");
+
+  await startFixtureServer(sandbox);
+  try {
+    await using app = await desktop({ mode: "attach", name: "builtin-browser-context-menu-passkey" });
+    const userAgent = await evalIn(app, "navigator.userAgent");
+    expect(userAgent).toEqual(expect.stringContaining("Electron/35."));
+    evidence.fact("The real app under test is Electron 35", String(userAgent), true);
+
+    await createAndSelectWorkspace(app, { path: "/tmp/openwork-browser-context-menu-passkey" });
+    await waitFor(
+      app,
+      `window.__openworkControl.listActions().some((action) => action.id === 'browser.open_url' && !action.disabled)`,
+      { timeoutMs: 60_000, label: "browser.open_url action" },
+    );
+    await evalIn(app, "window.__OPENWORK_ELECTRON__.browser.closeAllTabs()", { awaitPromise: true });
+
+    const opened = await control(app, "browser.open_url", { provider: "builtin", url: FIXTURE_URL });
+    if (!isRecord(opened) || typeof opened.target_id !== "string" || typeof opened.tab_id !== "string") {
+      throw new Error(`browser.open_url did not return target_id and tab_id: ${JSON.stringify(opened)}`);
+    }
+    const originalTabId = opened.tab_id;
+    const pageTarget = await targetById(app.handle.cdpUrl, opened.target_id, { timeoutMs: 30_000 });
+    const pageClient = await connect(debuggerUrlFor(app.handle.cdpUrl, pageTarget));
+    await pageClient.send("Page.enable");
+
+    let overlayClient: CdpClient | null = null;
+    try {
+      await waitUntil("fixture page load", async () => {
+        const title = await evaluate(pageClient, "document.title");
+        return title === "OpenWork Browser E2E Fixture" ? title : null;
+      }, 30_000);
+
+      const plainPoint = await elementCenter(pageClient, "#plain");
+      await rightClick(pageClient, plainPoint);
+      const overlayTarget = await findOverlayTarget(app.handle.cdpUrl);
+      overlayClient = await connect(debuggerUrlFor(app.handle.cdpUrl, overlayTarget));
+      await overlayClient.send("Page.enable");
+
+      const plainMenu = await waitForMenu(overlayClient, "page context menu", PLAIN_LABELS);
+      expect(plainMenu.labels).toEqual(PLAIN_LABELS);
+      assertMenuSizing(evidence, plainMenu, 1);
+      evidence.fact(
+        "A real CDP right-click on plain page area opens Back / Forward / Reload / Copy Page URL / Open Page in Browser and is not instantly dismissed",
+        JSON.stringify(plainMenu.labels),
+        true,
+      );
+      await proveOsFrame(app, sandbox, [
+        "The in-app browser visibly shows a five-item page context menu with Back, Forward, Reload, Copy Page URL, and Open Page in Browser",
+        "The page context menu begins at the magenta click marker, is fully visible, and tightly fits its five rows without clipping or a large empty gap",
+      ]);
+
+      await chooseMenuItem(overlayClient, "Copy Page URL");
+      const copiedUrl = await clipboardText(pageClient);
+      expect(copiedUrl).toBe(FIXTURE_URL);
+      evidence.fact("Choosing Copy Page URL writes the browsed page URL to the OS clipboard", copiedUrl, true);
+
+      await rightClick(pageClient, plainPoint);
+      await waitForMenu(overlayClient, "page context menu", PLAIN_LABELS);
+      const outsidePoint = { x: 18, y: plainPoint.y };
+      await dispatchMouse(pageClient, outsidePoint, "left");
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await proveOsFrame(app, sandbox, [
+        "After a left-click on the browsed page, no page or tab context menu is visible anywhere in the OpenWork window",
+      ]);
+
+      await rightClick(pageClient, plainPoint);
+      await waitForMenu(overlayClient, "page context menu", PLAIN_LABELS);
+      await dispatchEscape(overlayClient);
+      await showMarker(pageClient, { x: 30, y: 30 });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await proveOsFrame(app, sandbox, [
+        "After pressing Escape, no page or tab context menu is visible anywhere in the OpenWork window",
+      ]);
+
+      const linkPoint = await elementCenter(pageClient, "#fixture-link");
+      await rightClick(pageClient, linkPoint);
+      const linkMenu = await waitForMenu(overlayClient, "page context menu", LINK_LABELS);
+      expect(linkMenu.labels).toEqual(LINK_LABELS);
+      assertMenuSizing(evidence, linkMenu, 0);
+      evidence.fact("Right-clicking a link exposes the three link actions", JSON.stringify(linkMenu.labels), true);
+      await proveOsFrame(app, sandbox, [
+        "The in-app browser visibly shows Open Link in New Tab, Copy Link Address, and Open Link in Browser for the fixture link",
+        "The link menu is positioned at the magenta click marker and all three rows are fully visible without excess empty space",
+      ]);
+
+      const beforeNewTab = await browserState(app);
+      await chooseMenuItem(overlayClient, "Open Link in New Tab");
+      const afterNewTab = await waitUntil("linked page in a new built-in browser tab", async () => {
+        const state = await browserState(app);
+        return state.tabs.length === beforeNewTab.tabs.length + 1 && state.tabs.some((tab) => tab.url === LINK_URL) ? state : null;
+      });
+      expect(afterNewTab.tabs).toHaveLength(beforeNewTab.tabs.length + 1);
+      expect(afterNewTab.tabs.some((tab) => tab.url === LINK_URL)).toBe(true);
+      evidence.fact(
+        "Choosing Open Link in New Tab opens the link in one new in-panel tab",
+        JSON.stringify({ before: beforeNewTab, after: afterNewTab }),
+        true,
+      );
+      await evalIn(app, `window.__OPENWORK_ELECTRON__.browser.selectTab(${JSON.stringify(originalTabId)})`, { awaitPromise: true });
+
+      const inputPoint = await elementCenter(pageClient, "#fixture-input");
+      await dispatchMouse(pageClient, inputPoint, "left");
+      await rightClick(pageClient, inputPoint);
+      const inputMenu = await waitForMenu(overlayClient, "page context menu", INPUT_LABELS);
+      expect(inputMenu.labels).toEqual(INPUT_LABELS);
+      assertMenuSizing(evidence, inputMenu, 1);
+      evidence.fact("Right-clicking an editable text input exposes Cut / Copy / Paste / Select All", JSON.stringify(inputMenu.labels), true);
+      await proveOsFrame(app, sandbox, [
+        "The in-app browser visibly shows Cut, Copy, Paste, and Select All for the text input",
+        "The four-row input menu is fully visible at the magenta click marker and tightly sized without clipping",
+      ]);
+
+      await dispatchEscape(overlayClient);
+      const selectedPoint = await selectFixtureText(pageClient);
+      await rightClick(pageClient, selectedPoint);
+      const selectedMenu = await waitForMenu(overlayClient, "page context menu", SELECTED_TEXT_LABELS);
+      expect(selectedMenu.labels).toEqual(SELECTED_TEXT_LABELS);
+      assertMenuSizing(evidence, selectedMenu, 0);
+      evidence.fact("Right-clicking selected non-editable text exposes Copy", JSON.stringify(selectedMenu.labels), true);
+      await proveOsFrame(app, sandbox, [
+        "The selected sentence is visibly highlighted and its context menu contains the single Copy action",
+        "The one-row Copy menu is fully visible at the magenta click marker with no extra blank height below the Copy row",
+      ]);
+
+      await dispatchEscape(overlayClient);
+      await clearSelection(pageClient);
+      const bottomRightPoint = await viewportPoint(pageClient, "bottom-right");
+      await rightClick(pageClient, bottomRightPoint);
+      const edgeMenu = await waitForMenu(overlayClient, "page context menu", PLAIN_LABELS);
+      assertMenuSizing(evidence, edgeMenu, 1);
+      evidence.fact(
+        "A bottom-right page right-click keeps the complete five-item menu at its calculated item-count height",
+        JSON.stringify({ point: bottomRightPoint, edgeMenu }),
+        true,
+      );
+      await proveOsFrame(app, sandbox, [
+        "Near the bottom-right browser edge, the complete five-item page context menu is shifted left and up so it remains fully on-screen and unclipped",
+        "The magenta click marker is near the menu's bottom-right corner, showing the edge-clamped menu is aligned to the requested click rather than offset",
+        "The edge menu tightly fits its five rows without a large empty area below Open Page in Browser",
+      ]);
+
+      await dispatchEscape(overlayClient);
+      const tabPoint = parsePoint(await evalIn(app, `(() => {
+        const button = document.getElementById(${JSON.stringify(originalTabId)})
+          ?.querySelector('button[aria-label^="Select tab:"]');
+        if (!button) return null;
+        const rect = button.getBoundingClientRect();
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      })()`), "browser tab strip");
+      await dispatchMouse(app.client, tabPoint, "right");
+      const tabMenu = await waitForMenu(overlayClient, "tab context menu", TAB_LABELS);
+      expect(tabMenu.labels).toEqual(TAB_LABELS);
+      assertMenuSizing(evidence, tabMenu, 1);
+      evidence.fact("Right-clicking the browser tab strip preserves the original four-item tab menu", JSON.stringify(tabMenu.labels), true);
+      await proveOsFrame(app, sandbox, [
+        "The browser tab strip visibly shows its original four-item menu: Copy URL, Open in Browser, Close Tab, and Close All Tabs",
+        "The tab context menu is fully visible beside the right-clicked tab and tightly fits its four rows",
+      ]);
+
+      await dispatchEscape(overlayClient);
+      const passkeyPoint = await elementCenter(pageClient, "#passkey-button");
+      await dispatchMouse(pageClient, passkeyPoint, "left");
+      const passkey = await waitUntil("fast passkey rejection", async () => {
+        const value = await evaluate(pageClient, "window.__passkeyResult ?? null");
+        return value === null ? null : parsePasskeyResult(value);
+      }, 2_000);
+      expect(passkey.settled).toBe(true);
+      expect(passkey.resolved).toBe(false);
+      expect(passkey.elapsedMs).toBeLessThan(2_000);
+      expect(passkey.name).toBe("NotAllowedError");
+      expect(passkey.isDomException).toBe(true);
+      expect(passkey.constructorName).toBe("DOMException");
+      evidence.fact(
+        "navigator.credentials.get({ publicKey }) settles under 2s with a real NotAllowedError DOMException",
+        JSON.stringify(passkey),
+        true,
+      );
+      const passkeyMenu = await waitForMenu(overlayClient, "Open this page to use a passkey", ["Open in your browser"]);
+      expect(passkeyMenu.labels).toEqual(["Open in your browser"]);
+      evidence.fact("The passkey fast-fail offers Open in your browser", JSON.stringify(passkeyMenu.labels), true);
+      await proveOsFrame(app, sandbox, [
+        "The in-app browser visibly offers Open in your browser after the fixture requests a passkey",
+        "The passkey fallback explains that the built-in browser cannot use passkeys yet, and the overlay is fully visible and unclipped",
+      ]);
+    } finally {
+      overlayClient?.close();
+      pageClient.close();
+    }
+  } finally {
+    await stopFixtureServer(sandbox);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,12 +265,15 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@electron/rebuild':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types
       electron:
-        specifier: ^35.0.0
-        version: 35.7.5
+        specifier: ^41.6.0
+        version: 41.10.3
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -1623,6 +1626,10 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@electron-internal/extract-zip@1.0.5':
+    resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
@@ -1632,13 +1639,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.1.0':
+    resolution: {integrity: sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
@@ -5253,9 +5260,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
@@ -5656,9 +5660,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -6272,9 +6273,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@35.7.5:
-    resolution: {integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==}
-    engines: {node: '>= 12.20.55'}
+  electron@41.10.3:
+    resolution: {integrity: sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@10.6.0:
@@ -6477,11 +6478,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6517,9 +6513,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -7977,9 +7970,6 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -8997,6 +8987,10 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -9350,9 +9344,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yjs@13.6.30:
     resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
@@ -10409,6 +10400,8 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@electron-internal/extract-zip@1.0.5': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -10421,7 +10414,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -10435,17 +10428,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.1.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.4
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13625,11 +13617,6 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.12.12
-    optional: true
-
   '@ungap/structured-clone@1.3.1': {}
 
   '@vercel/oidc@3.1.0': {}
@@ -14066,8 +14053,6 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -14616,11 +14601,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@35.7.5:
+  electron@41.10.3:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 22.19.7
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.5
+      '@electron/get': 5.1.0
+      '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14964,16 +14949,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -15019,10 +14994,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -16523,8 +16494,6 @@ snapshots:
 
   peberminta@0.9.0: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -17776,6 +17745,9 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@7.29.0:
+    optional: true
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -18071,11 +18043,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yjs@13.6.30:
     dependencies:


### PR DESCRIPTION
Two bugs reported in the built-in browser: right-click did nothing, and passkeys were unusable.

## Right-click did nothing

No `context-menu` listener was ever registered on the browser tab's `WebContentsView`. The overlay menu machinery already existed and already declared a `"page"` source — the main process only ever emitted `"tab"`, so page right-clicks fell on the floor.

Now builds a `params`-driven menu:

| Target | Items |
|---|---|
| Text input | Cut / Copy / Paste / Select All |
| Selected text | Copy |
| Link | Open Link in New Tab / Copy Link Address / Open Link in Browser |
| Image | Copy Image |
| Page | Back / Forward / Reload / Copy Page URL / Open Page in Browser |

Two traps handled: a secondary-button `pointerdown` used to dismiss the very menu it opened, and `context-menu` coordinates are local to the tab view so they need offsetting against the overlay's window-relative bounds.

## Passkeys hung for 180 seconds

Electron 35 has no working WebAuthn authenticator at all — `isUserVerifyingPlatformAuthenticatorAvailable()` is `false` and requests hang for **exactly 180s** before a generic `NotAllowedError`. That silent 3-minute stall is what "I can't use it" actually felt like.

Requests now settle in **~0.6ms** with a real `DOMException`/`NotAllowedError` so the site runs its own password/magic-link fallback immediately, and the user is offered to open the page in their real browser. Gated on a **live capability probe**, not a version check, so it goes quiet automatically once Electron can service passkeys (see the follow-up PR).

Real passkey support needs Electron ≥ 41.5.0 and is stacked in a follow-up.

## Overlay sizing defect (found by validation)

Visual proof measured a **~13px transparent strip** below the menu: the overlay was sized from a guessed 36px row height while rows render at 34.56px. That strip belongs to the overlay compositor surface, so it silently swallowed clicks meant for the page. The overlay now measures its rendered content and applies exact bounds (200px view vs 199.81px content), and dismisses on backdrop click.

## Tests

`evals/specs/builtin-browser-context-menu-passkey.slow.test.ts` — new, drives the real app with real CDP right-clicks.

Because a `WebContentsView` embedded in another window is a separate compositor surface (invisible to CDP `Page.captureScreenshot` from both its own and the parent target), the menu is proven with **OS-level X11 capture**.

```
OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_DAYTONA=1 ... --project stack \
  specs/builtin-browser-context-menu-passkey.slow.test.ts

Test Files  1 passed (1)
Tests       1 passed (1)
Duration    112.52s
```

**26/26 frames, 34/34 expectations.** Screenshots confirm menus land on the click markers, edge-clamp near the window bottom/right, and are unclipped. Also covered: item actions (clipboard, new tab), backdrop/Escape dismissal, the tab-strip 4-item regression guard, and passkey timing + error name.

Also green: `pnpm typecheck`, `pnpm --filter @openwork/desktop typecheck:electron`, `pnpm --filter @openwork/desktop test` (174 passed / 1 skipped).

Pre-existing and unrelated: `pnpm evals:typecheck` fails on `den-trim-page-headers.flow.ts` (`FlowContext.page`).