### PR TITLE
feat(desktop): upgrade to Electron 41 and enable macOS Touch ID passkeys

### DIFF
--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -10,9 +10,5 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
-  <key>keychain-access-groups</key>
-  <array>
-    <string>F5DJWB4CCV.com.differentai.openwork.webauthn</string>
-  </array>
 </dict>
 </plist>

--- a/apps/desktop/electron-builder.base.yml
+++ b/apps/desktop/electron-builder.base.yml
@@ -24,7 +24,7 @@ asar: true
 asarUnpack:
   - node_modules/.pnpm/@lydell+node-pty*/**
   - node_modules/node-pty/**
-npmRebuild: false
+npmRebuild: true
 afterPack: scripts/electron-after-pack.cjs
 afterSign: scripts/electron-after-sign.cjs
 publish:
@@ -39,7 +39,7 @@ mac:
   gatekeeperAssess: false
   notarize: false
   entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
   extendInfo:
     NSMicrophoneUsageDescription: OpenWork uses the microphone when you start Voice Mode so you can speak commands to your agent.
   extraResources:

--- a/apps/desktop/electron/browser-content-preload.test.cjs
+++ b/apps/desktop/electron/browser-content-preload.test.cjs
@@ -1,0 +1,80 @@
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { test } = require("node:test");
+
+const originalLoad = Module._load;
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+let mainWorldScript;
+
+Module._load = function (request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      contextBridge: {
+        exposeInMainWorld() {},
+        executeInMainWorld(script) { mainWorldScript = script; },
+      },
+      ipcRenderer: { send() {} },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+globalThis.document = { readyState: "loading", addEventListener() {} };
+globalThis.window = { addEventListener() {} };
+try {
+  require("./browser-content-preload.cjs");
+} finally {
+  Module._load = originalLoad;
+  globalThis.document = originalDocument;
+  globalThis.window = originalWindow;
+}
+
+test("passkey fallback stays quiet when Touch ID is available", async () => {
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const publicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "PublicKeyCredential",
+  );
+  const bridgeKey = mainWorldScript.args[0];
+  const bridgeDescriptor = Object.getOwnPropertyDescriptor(globalThis, bridgeKey);
+  let nativeCalls = 0;
+  let fallbackNotifications = 0;
+  const credentials = {
+    create() { nativeCalls += 1; return Promise.resolve("native-create"); },
+    get() { nativeCalls += 1; return Promise.resolve("native-get"); },
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { credentials },
+  });
+  Object.defineProperty(globalThis, "PublicKeyCredential", {
+    configurable: true,
+    value: {
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true),
+    },
+  });
+  Object.defineProperty(globalThis, bridgeKey, {
+    configurable: true,
+    value: { notifyUnavailable() { fallbackNotifications += 1; } },
+  });
+
+  try {
+    mainWorldScript.func(...mainWorldScript.args);
+    assert.equal(await credentials.get({ publicKey: {} }), "native-get");
+    assert.equal(nativeCalls, 1);
+    assert.equal(fallbackNotifications, 0);
+  } finally {
+    restoreProperty("navigator", navigatorDescriptor);
+    restoreProperty("PublicKeyCredential", publicKeyCredentialDescriptor);
+    restoreProperty(bridgeKey, bridgeDescriptor);
+  }
+});
+
+function restoreProperty(name, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete globalThis[name];
+  }
+}

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -334,6 +334,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   function hideMenuOverlay() {
     const view = menuOverlayView;
     const mainWindow = window();
+    const request = menuOverlayRequest;
     menuOverlayShowSerial += 1;
     menuOverlayRequest = null;
     if (!view || !mainWindow) return;
@@ -344,6 +345,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       }
     } catch {
       // already removed
+    }
+    if (request?.source === "tab") {
+      mainWindow.webContents.focus();
+    } else {
+      const tab = getBrowserTab(request?.tabId);
+      if (tab && !tab.view.webContents.isDestroyed()) tab.view.webContents.focus();
     }
   }
 

--- a/apps/desktop/electron/electron-builder-config.test.mjs
+++ b/apps/desktop/electron/electron-builder-config.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 
+import { macosWebAuthnKeychainAccessGroup } from "./webauthn.mjs";
+
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function readConfig(name) {
@@ -18,6 +20,9 @@ describe("Electron distribution configs", () => {
     );
     const config = await readConfig("electron-builder.base.yml");
     assert.equal(packageMetadata.desktopName, "com.differentai.openwork");
+    assert.equal(config.npmRebuild, true);
+    assert.equal(config.mac.entitlements, "build/entitlements.mac.plist");
+    assert.equal(config.mac.entitlementsInherit, "build/entitlements.mac.inherit.plist");
     assert.equal(config.linux.syncDesktopName, true);
     assert.equal(config.linux.icon, "resources/icons/linux");
     assert.deepEqual(config.linux.extraResources[0], {
@@ -25,6 +30,22 @@ describe("Electron distribution configs", () => {
       to: "icons/linux",
       filter: ["*.png"],
     });
+  });
+
+  it("keeps the Touch ID keychain entitlement in sync with signing metadata", async () => {
+    const packageMetadata = JSON.parse(
+      await readFile(path.resolve(dirname, "..", "package.json"), "utf8"),
+    );
+    const entitlements = await readFile(
+      path.resolve(dirname, "..", "build", "entitlements.mac.plist"),
+      "utf8",
+    );
+    const keychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+      teamId: packageMetadata.openworkAppleTeamId,
+      bundleId: packageMetadata.desktopName,
+    });
+    assert.ok(keychainAccessGroup);
+    assert.match(entitlements, new RegExp(`<string>${keychainAccessGroup}<\\/string>`));
   });
 
   it("keeps the public artifact and protocol unchanged", async () => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -53,6 +53,10 @@ import { openExternalUrl } from "./open-external.mjs";
 import { resolveAppIdentifier, resolveUserDataPath } from "./dev-profile.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
 import {
+  configureMacosTouchIdPasskeys,
+  macosWebAuthnKeychainAccessGroup,
+} from "./webauthn.mjs";
+import {
   createLinuxDesktopIntegration,
 } from "./linux-desktop-integration.mjs";
 import {
@@ -115,6 +119,10 @@ const APP_IDENTIFIER = resolveAppIdentifier({
   devProfile: process.env.OPENWORK_DEV_PROFILE,
   isDevMode,
   isPackaged: app.isPackaged,
+});
+const macosTouchIdKeychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+  teamId: desktopPackageMetadata.openworkAppleTeamId,
+  bundleId: desktopPackageMetadata.desktopName,
 });
 if (process.env.OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN === "1") {
   // Fresh, isolated development profiles otherwise trigger macOS's native
@@ -2521,6 +2529,11 @@ or use: pnpm dev:worktree`);
   });
 
   app.whenReady().then(async () => {
+    configureMacosTouchIdPasskeys({
+      electronApp: app,
+      platform: process.platform,
+      keychainAccessGroup: macosTouchIdKeychainAccessGroup,
+    });
     installMediaPermissionHandlers(session, () => mainWindow);
     await runPendingNukeCleanup({
       env: process.env,

--- a/apps/desktop/electron/webauthn.mjs
+++ b/apps/desktop/electron/webauthn.mjs
@@ -1,0 +1,32 @@
+export const MACOS_WEBAUTHN_PROMPT_REASON = "sign in to $1";
+
+export function macosWebAuthnKeychainAccessGroup({ teamId, bundleId }) {
+  if (typeof teamId !== "string" || !teamId.trim()) return null;
+  if (typeof bundleId !== "string" || !bundleId.trim()) return null;
+  return `${teamId.trim()}.${bundleId.trim()}.webauthn`;
+}
+
+export function configureMacosTouchIdPasskeys({
+  electronApp,
+  platform,
+  keychainAccessGroup,
+}) {
+  if (platform !== "darwin" || typeof electronApp?.configureWebAuthn !== "function") {
+    return false;
+  }
+  if (typeof keychainAccessGroup !== "string" || !keychainAccessGroup) return false;
+
+  try {
+    electronApp.configureWebAuthn({
+      touchID: {
+        keychainAccessGroup,
+        promptReason: MACOS_WEBAUTHN_PROMPT_REASON,
+      },
+    });
+    return true;
+  } catch {
+    // Macs without a Secure Enclave cannot use Touch ID passkeys. Leave the
+    // browser's capability probe false without interrupting app startup.
+    return false;
+  }
+}

--- a/apps/desktop/electron/webauthn.test.mjs
+++ b/apps/desktop/electron/webauthn.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  configureMacosTouchIdPasskeys,
+  macosWebAuthnKeychainAccessGroup,
+} from "./webauthn.mjs";
+
+describe("macOS WebAuthn", () => {
+  it("derives the Touch ID keychain group from the signing team and bundle", () => {
+    assert.equal(
+      macosWebAuthnKeychainAccessGroup({
+        teamId: "F5DJWB4CCV",
+        bundleId: "com.differentai.openwork",
+      }),
+      "F5DJWB4CCV.com.differentai.openwork.webauthn",
+    );
+  });
+
+  it("configures Touch ID with user-facing prompt copy", () => {
+    const calls = [];
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: (options) => calls.push(options) },
+      platform: "darwin",
+      keychainAccessGroup: "F5DJWB4CCV.com.differentai.openwork.webauthn",
+    }), true);
+    assert.deepEqual(calls, [{
+      touchID: {
+        keychainAccessGroup: "F5DJWB4CCV.com.differentai.openwork.webauthn",
+        promptReason: "sign in to $1",
+      },
+    }]);
+  });
+
+  it("does nothing when the platform or Electron capability is unsupported", () => {
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: () => assert.fail("must not be called") },
+      platform: "linux",
+      keychainAccessGroup: "group",
+    }), false);
+    assert.equal(configureMacosTouchIdPasskeys({
+      electronApp: {},
+      platform: "darwin",
+      keychainAccessGroup: "group",
+    }), false);
+  });
+
+  it("does not interrupt startup when Touch ID cannot be configured", () => {
+    assert.doesNotThrow(() => configureMacosTouchIdPasskeys({
+      electronApp: { configureWebAuthn: () => { throw new Error("unavailable"); } },
+      platform: "darwin",
+      keychainAccessGroup: "group",
+    }));
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.18.13",
   "desktopName": "com.differentai.openwork",
+  "openworkAppleTeamId": "F5DJWB4CCV",
   "description": "OpenWork desktop shell",
   "author": {
     "name": "OpenWork",
@@ -15,15 +16,16 @@
     "dev:electron": "node ./scripts/electron-dev.mjs",
     "build": "node ./scripts/electron-build.mjs",
     "build:electron": "node ./scripts/electron-build.mjs",
+    "rebuild:electron-native": "electron-rebuild --force --which-module better-sqlite3",
     "package:electron": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.yml",
     "package:electron:cloud": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.cloud.yml",
     "package:electron:enterprise": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.enterprise.yml",
     "package:electron:dir": "pnpm run build:electron && pnpm exec electron-builder --config electron-builder.yml --dir",
-    "electron": "pnpm exec electron ./electron/main.mjs",
+    "electron": "pnpm run rebuild:electron-native && pnpm exec electron ./electron/main.mjs",
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/browser-content-preload.test.cjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/webauthn.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@openwork/paths": "workspace:*",
@@ -38,8 +40,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.2.0",
     "@openwork/types": "workspace:*",
-    "electron": "^35.0.0",
+    "electron": "^41.6.0",
     "electron-builder": "^26.15.3",
     "electron-devtools-installer": "^4.0.0"
   },

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -3,6 +3,8 @@ import { copyFileSync, cpSync, readFileSync, readdirSync, rmSync, writeFileSync 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { macosWebAuthnKeychainAccessGroup } from "../electron/webauthn.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "../..");
@@ -10,6 +12,8 @@ const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
 const electronHelperDir = resolve(desktopRoot, "resources", "helpers");
 const electronRoot = resolve(desktopRoot, "electron");
 const packagedServerRoot = resolve(desktopRoot, "server");
+const desktopPackagePath = resolve(desktopRoot, "package.json");
+const macEntitlementsPath = resolve(desktopRoot, "build", "entitlements.mac.plist");
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const nodeCmd = process.execPath;
@@ -29,6 +33,27 @@ function run(command, args, cwd, env) {
     process.exit(result.status ?? 1);
   }
 }
+
+function syncMacosWebAuthnEntitlement() {
+  const packageMetadata = JSON.parse(readFileSync(desktopPackagePath, "utf8"));
+  const keychainAccessGroup = macosWebAuthnKeychainAccessGroup({
+    teamId: packageMetadata.openworkAppleTeamId,
+    bundleId: packageMetadata.desktopName,
+  });
+  if (!keychainAccessGroup) {
+    throw new Error("Desktop package metadata must define the Apple team ID and bundle ID");
+  }
+
+  const entitlements = readFileSync(macEntitlementsPath, "utf8");
+  const keychainGroupPattern = /(<key>keychain-access-groups<\/key>\s*<array>\s*<string>)[^<]+(<\/string>\s*<\/array>)/;
+  if (!keychainGroupPattern.test(entitlements)) {
+    throw new Error("macOS entitlements must contain a keychain-access-groups entry");
+  }
+  const updated = entitlements.replace(keychainGroupPattern, `$1${keychainAccessGroup}$2`);
+  if (updated !== entitlements) writeFileSync(macEntitlementsPath, updated, "utf8");
+}
+
+syncMacosWebAuthnEntitlement();
 
 run(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], desktopRoot);
 run(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], desktopRoot);

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -261,6 +261,11 @@ if (!viteReady) {
 
 const resolvedStartUrl = await waitForVite(startUrl);
 
+// Native dependencies installed for the host Node ABI must be rebuilt before
+// Electron loads the embedded server and terminal runtime.
+console.log("[electron-dev] Rebuilding native dependencies for Electron...");
+runSync(pnpmCmd, ["--filter", "@openwork/desktop", "run", "rebuild:electron-native"], { cwd: repoRoot });
+
 // Optional Electron CDP for external debugging / raw CDP clients.
 // NOT required for the built-in browser (uses native webContents APIs).
 // Set OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 to enable.

--- a/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
+++ b/evals/specs/builtin-browser-context-menu-passkey.slow.test.ts
@@ -537,8 +537,8 @@ test("built-in browser page menus and passkeys work in Electron with OS-level vi
   try {
     await using app = await desktop({ mode: "attach", name: "builtin-browser-context-menu-passkey" });
     const userAgent = await evalIn(app, "navigator.userAgent");
-    expect(userAgent).toEqual(expect.stringContaining("Electron/35."));
-    evidence.fact("The real app under test is Electron 35", String(userAgent), true);
+    expect(userAgent).toEqual(expect.stringContaining("Electron/41."));
+    evidence.fact("The real app under test is Electron 41", String(userAgent), true);
 
     await createAndSelectWorkspace(app, { path: "/tmp/openwork-browser-context-menu-passkey" });
     await waitFor(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,12 +265,15 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@electron/rebuild':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types
       electron:
-        specifier: ^35.0.0
-        version: 35.7.5
+        specifier: ^41.6.0
+        version: 41.10.3
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -1623,6 +1626,10 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@electron-internal/extract-zip@1.0.5':
+    resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
@@ -1632,13 +1639,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.1.0':
+    resolution: {integrity: sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
@@ -5253,9 +5260,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
@@ -5656,9 +5660,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -6272,9 +6273,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@35.7.5:
-    resolution: {integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==}
-    engines: {node: '>= 12.20.55'}
+  electron@41.10.3:
+    resolution: {integrity: sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@10.6.0:
@@ -6477,11 +6478,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6517,9 +6513,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -7977,9 +7970,6 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -8997,6 +8987,10 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -9350,9 +9344,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yjs@13.6.30:
     resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
@@ -10409,6 +10400,8 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@electron-internal/extract-zip@1.0.5': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -10421,7 +10414,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -10435,17 +10428,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.1.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.4
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13625,11 +13617,6 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.12.12
-    optional: true
-
   '@ungap/structured-clone@1.3.1': {}
 
   '@vercel/oidc@3.1.0': {}
@@ -14066,8 +14053,6 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -14616,11 +14601,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@35.7.5:
+  electron@41.10.3:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 22.19.7
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.5
+      '@electron/get': 5.1.0
+      '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14964,16 +14949,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -15019,10 +14994,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -16523,8 +16494,6 @@ snapshots:
 
   peberminta@0.9.0: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -17776,6 +17745,9 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@7.29.0:
+    optional: true
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -18071,11 +18043,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yjs@13.6.30:
     dependencies:


### PR DESCRIPTION
Stacked on #3459 — review/merge that first.

## Why an upgrade is required

Electron gained a working WebAuthn platform authenticator only in **41.5.0**, via `app.configureWebAuthn`. Verified by diffing `docs/api/app.md` across tags: absent in 40.x and 41.0.0, present from 41.5.0. OpenWork was on 35.7.5, which has no authenticator at all — its `ElectronWebAuthenticationDelegate` implements only `SupportsResidentKeys()`. No Chromium feature flag changes this.

**35.7.5 → 41.10.3** (Chromium 146, Node 24, native ABI 141 → 145). Picked ≥ 41.6.0 because 41.6.0 fixed a Touch ID prompt crash.

## Read this before promising users anything

Touch ID credentials are **device-bound**, stored in the macOS keychain and **not synced via iCloud**. So:

- ❌ existing iCloud Keychain passkeys — still unusable
- ❌ 1Password / third-party passkeys — still unusable
- ❌ "use your phone" / QR hybrid — still unusable
- ❌ USB security keys — still unusable
- ❌ Windows / Linux — unsupported by the API
- ✅ a **new** passkey registered per-site inside OpenWork, on a Secure Enclave Mac

The fast-fail fallback from #3459 therefore stays, and covers every case above.

## Changes

- forced native rebuilds so `better-sqlite3` and `node-pty` match ABI 145
- `keychain-access-groups` entitlement, kept in sync with the signing Team ID from a single source of truth in `package.json`
- separate inherit entitlements so the keychain group stays off child binaries
- `configureWebAuthn` called **first inside `whenReady()`** — calling it earlier trips a native `SIGTRAP`
- guarded on `darwin` + API existence + try/catch, so non-Secure-Enclave Macs and Windows/Linux degrade silently

## Breaking changes that actually bit

1. **Native ABI 141 → 145** — fixed with forced Electron rebuild.
2. **`configureWebAuthn` before app-ready → native SIGTRAP** — fixed by calling it first in `whenReady()`.
3. **Chromium 146 enforces focused-document clipboard writes** — exposed that hiding the context-menu overlay never returned focus to the page, so page-menu Copy silently failed. Fixed and runtime-proven.

No removed v36–v41 Electron API applied to this codebase.

## Regression sweep

Every failure was classified against an Electron 35 baseline (parent commit `658f842ef`) rather than assumed.

| Spec | Verdict |
|---|---|
| `app-smoke` | PASS |
| `first-run-local` | PASS |
| `app-den-tls-fault` | PASS |
| `models-available` | PASS |
| `library-state-tabs` | PASS |
| `builtin-browser-context-menu-passkey` | PASS (after the focus fix) |
| `skills-local` | FAIL — **pre-existing**, identical timeout on the Electron 35 baseline |
| `testkit-app-boot`, `testkit-selftest` | FAIL — **pre-existing**, both revisions reject empty `DATABASE_HOST` |
| Den/cloud/multi-desktop lanes | SKIP — need `OPENWORK_EVAL_DEN_API_URL` etc. |

Runtime probes on Electron 41: **node-pty** spawned/resized a real PTY and exited 0; **better-sqlite3** opened and queried; **browser panel** loaded, navigated back/forward/reload with all menus working. Two further failures (blueprint materialization `Too many parameter values`, cookie persistence across restart) reproduce identically on Electron 35 — pre-existing, not ABI regressions.

`pnpm --filter @openwork/desktop test` 180 passed / 1 skipped; both typechecks exit 0.

## Unproven — needs a human

**Signed packaging and Touch ID itself are not proven.** Local `codesign` failed with `errSecInternalComponent` accessing the private key. Someone must, on a Secure Enclave Mac with the signing cert:

1. produce a signed build and confirm the `keychain-access-groups` entitlement is present,
2. register and then sign in with a passkey in the in-app browser,
3. confirm the #3459 fallback prompt stays absent.

Given the upgrade's blast radius, I'd suggest an alpha build before this reaches everyone.