### PR TITLE
fix(app): stop session loading indicator from sticking after runs complete

### DIFF
--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -10,6 +10,7 @@ type SessionMessageRole = "assistant" | "system" | "user";
 type SessionActivityRecord = {
   status: SessionActivityStatus;
   runActive: boolean;
+  runStatusAt: number;
   assistantOutput: boolean;
   errorActive: boolean;
   errorMessage: string | null;
@@ -33,7 +34,13 @@ type SessionActivityStore = {
   getStatus: (workspaceId: string, sessionId: string) => SessionActivityStatus;
   getSessionError: (workspaceId: string, sessionId: string) => string | null;
   seedWorkspaceSessions: (workspaceId: string, sessions: SessionLike[]) => void;
-  seedSessionRun: (workspaceId: string, sessionId: string, status: unknown, assistantOutput: boolean) => void;
+  seedSessionRun: (
+    workspaceId: string,
+    sessionId: string,
+    status: unknown,
+    assistantOutput: boolean | undefined,
+    options?: { snapshotStartedAt?: number },
+  ) => void;
   setRunStatus: (workspaceId: string, sessionId: string, status: unknown) => void;
   markMessageRole: (workspaceId: string, sessionId: string, messageId: string, role: SessionMessageRole) => void;
   markAssistantOutput: (workspaceId: string, sessionId: string, messageId?: string, options?: { allowUnknownMessageRole?: boolean }) => void;
@@ -48,6 +55,7 @@ type SessionActivityStore = {
 const createRecord = (): SessionActivityRecord => ({
   status: "idle",
   runActive: false,
+  runStatusAt: 0,
   assistantOutput: false,
   errorActive: false,
   errorMessage: null,
@@ -185,18 +193,23 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       return nextState;
     });
   },
-  seedSessionRun: (workspaceId, sessionId, status, assistantOutput) => {
+  seedSessionRun: (workspaceId, sessionId, status, assistantOutput, options) => {
     const workspace = workspaceId.trim();
     const session = sessionId.trim();
     if (!workspace || !session) return;
     set((state) => updateRecord(state, workspace, session, (record) => {
       const normalized = normalizeRunStatus(status);
       const runActive = normalized === "running" || normalized === "retry";
-      if (!runActive && record.status !== "idle") return record;
+      const snapshotStartedAt = options?.snapshotStartedAt;
+      // Order snapshot seeds against live writes so stale idle cannot kill a
+      // live spinner and stale busy cannot resurrect a run that already ended.
+      if (typeof snapshotStartedAt === "number" && snapshotStartedAt < record.runStatusAt) return record;
+      if (typeof snapshotStartedAt !== "number" && !runActive && record.status !== "idle") return record;
       return {
         ...record,
         runActive,
-        assistantOutput: runActive && assistantOutput,
+        runStatusAt: snapshotStartedAt ?? record.runStatusAt,
+        assistantOutput: runActive && (assistantOutput ?? record.assistantOutput),
         errorActive: runActive ? false : record.errorActive,
         errorMessage: runActive ? null : record.errorMessage,
         compacting: runActive ? record.compacting : false,
@@ -215,6 +228,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       return {
         ...record,
         runActive,
+        runStatusAt: Date.now(),
         assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
         errorActive: runActive ? false : record.errorActive,
         errorMessage: runActive ? null : record.errorMessage,
@@ -281,6 +295,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       errorActive: true,
       errorMessage: message ? message : "Session failed",
       runActive: false,
+      runStatusAt: Date.now(),
       assistantOutput: false,
       compacting: false,
     })));

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -67,6 +67,7 @@ import { QueuedMessagesPanel } from "@/react-app/domains/session/modals/queued-m
 import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
+  markSessionSnapshotFetchStart,
   seedSessionState,
   snapshotKey as reactSnapshotKey,
   statusKey as reactStatusKey,
@@ -741,7 +742,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
-    queryFn: async () => (await props.client.getSessionSnapshot(props.workspaceId, props.sessionId, { limit: 140 })).item,
+    queryFn: async () => {
+      const startedAt = Date.now();
+      const item = (await props.client.getSessionSnapshot(props.workspaceId, props.sessionId, { limit: 140 })).item;
+      markSessionSnapshotFetchStart(item, startedAt);
+      return item;
+    },
     staleTime: 500,
   });
 

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -62,6 +62,7 @@ type SyncEntry = {
 
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
+const sessionSnapshotFetchStarts = new WeakMap<OpenworkSessionSnapshot, number>();
 const workspaceSyncDisposeGraceMs = 2_000;
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
@@ -72,13 +73,31 @@ type SyncSubscriptionFactory = (
   signal: AbortSignal,
 ) => Promise<AsyncIterable<unknown>>;
 
+type SessionStatusFetcher = (
+  baseUrl: string,
+  openworkToken: string,
+  signal: AbortSignal,
+) => Promise<Record<string, SessionStatus>>;
+
 const defaultSyncSubscriptionFactory: SyncSubscriptionFactory = async (baseUrl, openworkToken, signal) => {
   const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
   const subscription = await client.event.subscribe(undefined, { signal });
   return subscription.stream;
 };
 
+const defaultSessionStatusFetcher: SessionStatusFetcher = async (baseUrl, openworkToken, signal) => {
+  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const result = await client.session.status(undefined, { signal });
+  if (result.data !== undefined) return result.data;
+  throw result.error;
+};
+
 let syncSubscriptionFactory = defaultSyncSubscriptionFactory;
+let sessionStatusFetcher = defaultSessionStatusFetcher;
+
+export function markSessionSnapshotFetchStart(snapshot: OpenworkSessionSnapshot, startedAt: number) {
+  sessionSnapshotFetchStarts.set(snapshot, startedAt);
+}
 
 export const snapshotKey = (workspaceId: string, sessionId: string) =>
   ["react-session-snapshot", workspaceId, sessionId] as const;
@@ -1100,6 +1119,7 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
       const stream = await syncSubscriptionFactory(input.baseUrl, entry.openworkToken, connectionController.signal);
       retryDelayMs = 1_000;
       lastEventAt = Date.now();
+      void reconcileSessionRunStatuses(entry, input, connectionController.signal);
       for await (const raw of stream) {
         if (controller.signal.aborted || connectionController.signal.aborted) return;
         lastEventAt = Date.now();
@@ -1137,6 +1157,29 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
     activeConnectionController?.abort();
     controller.abort();
   };
+}
+
+async function reconcileSessionRunStatuses(entry: SyncEntry, input: SyncOptions, signal: AbortSignal) {
+  const startedAt = Date.now();
+  let statuses: Record<string, SessionStatus>;
+  try {
+    statuses = await sessionStatusFetcher(input.baseUrl, entry.openworkToken, signal);
+  } catch {
+    return;
+  }
+  if (signal.aborted) return;
+
+  const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId];
+  if (!records) return;
+  for (const sessionId of Object.keys(records)) {
+    useSessionActivityStore.getState().seedSessionRun(
+      input.workspaceId,
+      sessionId,
+      statuses[sessionId] ?? idleStatus,
+      undefined,
+      { snapshotStartedAt: startedAt },
+    );
+  }
 }
 
 export function ensureWorkspaceSessionSync(input: SyncOptions) {
@@ -1204,12 +1247,20 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const incoming = snapshotToUIMessages(snapshot);
   const existing = queryClient.getQueryData<UIMessage[]>(key);
 
-  useSessionActivityStore.getState().seedSessionRun(
-    workspaceId,
-    snapshot.session.id,
-    snapshot.status,
-    assistantOutputAfterLatestUser(incoming),
-  );
+  const snapshotStartedAt = sessionSnapshotFetchStarts.get(snapshot);
+  if (typeof snapshotStartedAt === "number") {
+    const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[snapshot.session.id];
+    useSessionActivityStore.getState().seedSessionRun(
+      workspaceId,
+      snapshot.session.id,
+      snapshot.status,
+      assistantOutputAfterLatestUser(incoming),
+      { snapshotStartedAt },
+    );
+    if (snapshotStartedAt >= (record?.runStatusAt ?? 0)) {
+      queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
+    }
+  }
 
   // The snapshot's revert cursor is authoritative: messages at/after it are
   // reverted server-side, so the cache must not keep them alive (a later
@@ -1223,7 +1274,6 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     snapshot.session.revert?.messageID ?? null,
   ));
 
-  queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
   queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);
 }
 
@@ -1340,4 +1390,8 @@ export function __applySessionSyncEventForTest(input: SyncOptions, event: Openco
 
 export function __setWorkspaceSessionSyncSubscriptionFactoryForTest(factory: SyncSubscriptionFactory | null) {
   syncSubscriptionFactory = factory ?? defaultSyncSubscriptionFactory;
+}
+
+export function __setWorkspaceSessionSyncStatusFetcherForTest(fetcher: SessionStatusFetcher | null) {
+  sessionStatusFetcher = fetcher ?? defaultSessionStatusFetcher;
 }

--- a/apps/app/tests/session-sync-lifecycle.test.ts
+++ b/apps/app/tests/session-sync-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, jest, setSystemTime, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, jest, setSystemTime, test } from "bun:test";
 
 type SyncInput = {
   workspaceId: string;
@@ -18,6 +18,7 @@ const subscriptions: Subscription[] = [];
 const {
   __disposeWorkspaceSessionSyncForTest,
   __hasWorkspaceSessionSyncForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
   __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
 } = await import("../src/react-app/domains/session/sync/session-sync");
@@ -56,12 +57,17 @@ async function waitForSubscriptions(count: number) {
   expect(subscriptions).toHaveLength(count);
 }
 
+beforeEach(() => {
+  __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+});
+
 afterEach(() => {
   jest.useRealTimers();
   for (const syncInput of inputs) __disposeWorkspaceSessionSyncForTest(syncInput);
   inputs.length = 0;
   subscriptions.length = 0;
   __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
+  __setWorkspaceSessionSyncStatusFetcherForTest(null);
   setSystemTime();
   Object.defineProperty(globalThis, "setInterval", {
     configurable: true,

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, jest, setSystemTime, test } from "bun:test";
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import {
+  __applySessionSyncEventForTest,
+  __createWorkspaceSessionSyncForTest,
+  __disposeWorkspaceSessionSyncForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest,
+  ensureWorkspaceSessionSync,
+  markSessionSnapshotFetchStart,
+  seedSessionState,
+  statusKey,
+  trackWorkspaceSessionSync,
+} from "../src/react-app/domains/session/sync/session-sync";
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
+
+type SyncInput = {
+  workspaceId: string;
+  baseUrl: string;
+  openworkToken: string;
+};
+
+type Subscription = {
+  signal: AbortSignal;
+  end: () => void;
+};
+
+const workspaceId = "workspace-run-status";
+const sessionId = "session-run-status";
+const syncInputs: SyncInput[] = [];
+const subscriptions: Subscription[] = [];
+
+function createSnapshot(status: SessionStatus): OpenworkSessionSnapshot {
+  return {
+    session: {
+      id: sessionId,
+      slug: sessionId,
+      projectID: "project-run-status",
+      directory: "/tmp/project-run-status",
+      title: "Run status test",
+      version: "1",
+      time: { created: 1, updated: 1 },
+    },
+    messages: [],
+    todos: [],
+    status,
+  };
+}
+
+function createSyncInput(): SyncInput {
+  const input = {
+    workspaceId,
+    baseUrl: "https://run-status.example/opencode",
+    openworkToken: "token",
+  };
+  syncInputs.push(input);
+  return input;
+}
+
+function createTestSync() {
+  const input = createSyncInput();
+  const cleanup = __createWorkspaceSessionSyncForTest(input);
+  const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+  return { input, cleanup, releaseSession };
+}
+
+async function createSubscription(_baseUrl: string, _token: string, signal: AbortSignal) {
+  let end = () => {};
+  const ended = new Promise<void>((resolve) => {
+    end = resolve;
+  });
+  signal.addEventListener("abort", end, { once: true });
+  async function* stream() {
+    await ended;
+  }
+  subscriptions.push({ signal, end });
+  return stream();
+}
+
+async function waitForSubscriptions(count: number) {
+  const deadline = Date.now() + 2_000;
+  while (subscriptions.length < count && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+  expect(subscriptions).toHaveLength(count);
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+function applyStatus(input: SyncInput, status: SessionStatus) {
+  __applySessionSyncEventForTest(input, {
+    type: "session.status",
+    properties: { sessionID: sessionId, status },
+  });
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+  for (const input of syncInputs) __disposeWorkspaceSessionSyncForTest(input);
+  syncInputs.length = 0;
+  subscriptions.length = 0;
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
+  __setWorkspaceSessionSyncStatusFetcherForTest(null);
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  getReactQueryClient().clear();
+  setSystemTime();
+});
+
+describe("session run status ordering", () => {
+  test("does not resurrect a finished run from a stale busy snapshot", () => {
+    const { input, cleanup, releaseSession } = createTestSync();
+    const snapshot = createSnapshot({ type: "busy" });
+    markSessionSnapshotFetchStart(snapshot, 100);
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    setSystemTime(300);
+    __applySessionSyncEventForTest(input, {
+      type: "session.idle",
+      properties: { sessionID: sessionId },
+    });
+    seedSessionState(workspaceId, snapshot);
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("idle");
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("does not let an older idle snapshot stop a live run", () => {
+    setSystemTime(200);
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
+
+    useSessionActivityStore.getState().seedSessionRun(
+      workspaceId,
+      sessionId,
+      { type: "idle" },
+      false,
+      { snapshotStartedAt: 100 },
+    );
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+  });
+
+  test("lets a newer idle snapshot heal a stale active record", () => {
+    setSystemTime(100);
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
+
+    useSessionActivityStore.getState().seedSessionRun(
+      workspaceId,
+      sessionId,
+      { type: "idle" },
+      false,
+      { snapshotStartedAt: 200 },
+    );
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("idle");
+  });
+
+  test("ignores run state from unmarked snapshot objects", () => {
+    setSystemTime(100);
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "idle" });
+    getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), { type: "idle" });
+
+    seedSessionState(workspaceId, createSnapshot({ type: "busy" }));
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("idle");
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+  });
+
+  test("preserves assistant output when an active seed omits it", () => {
+    setSystemTime(100);
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
+    useSessionActivityStore.getState().markAssistantOutput(workspaceId, sessionId);
+
+    useSessionActivityStore.getState().seedSessionRun(
+      workspaceId,
+      sessionId,
+      { type: "busy" },
+      undefined,
+      { snapshotStartedAt: 200 },
+    );
+
+    const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+    expect(record?.assistantOutput).toBe(true);
+    expect(record?.status).toBe("responding");
+  });
+});
+
+describe("session run status reconnect reconciliation", () => {
+  test("heals an active record when a reconnect reports no active run", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    jest.useFakeTimers();
+    subscriptions[0]?.end();
+    await flushMicrotasks();
+    jest.advanceTimersByTime(1_000);
+    await flushMicrotasks();
+
+    expect(subscriptions).toHaveLength(2);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("idle");
+  });
+
+  test("keeps the stream and run state intact when reconciliation fails", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      throw new Error("status unavailable");
+    });
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    jest.useFakeTimers();
+    subscriptions[0]?.end();
+    await flushMicrotasks();
+    jest.advanceTimersByTime(1_000);
+    await flushMicrotasks();
+
+    expect(subscriptions).toHaveLength(2);
+    expect(subscriptions[1]?.signal.aborted).toBe(false);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+  });
+});

--- a/evals/specs/session-loading-idle.slow.test.ts
+++ b/evals/specs/session-loading-idle.slow.test.ts
@@ -1,0 +1,228 @@
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor, waitForText } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "session-loading-idle-mock";
+const modelId = "session-loading-idle-model";
+const reply = "session loading idle proof";
+const renamedTitle = "Session loading stays idle";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "completed session loading stays idle after snapshot refetch and rename"
+  : "session loading idle skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function newestSessionId(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0 || !isRecord(value[0]) || typeof value[0].sessionId !== "string") {
+    throw new Error(`session.list_sessions did not return a newest session: ${JSON.stringify(value)}`);
+  }
+  return value[0].sessionId;
+}
+
+function indicatorExpression(sessionId: string, present: boolean): string {
+  return `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${sessionId}"]`)});
+    const indicator = row?.querySelector("[data-session-loading-indicator]");
+    return ${present ? "Boolean(indicator)" : "!indicator"};
+  })()`;
+}
+
+const stopDisabledExpression = `(() => {
+  const stop = window.__openworkControl.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop?.disabled);
+})()`;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { body += chunk; });
+      request.on("end", () => {
+        const delayMs = body.includes("Reply with exactly") ? 8_000 : 0;
+        setTimeout(() => {
+          const chunks = [
+            { id: "chatcmpl-session-loading-idle", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+            { id: "chatcmpl-session-loading-idle", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: reply }, finish_reason: null }] },
+            { id: "chatcmpl-session-loading-idle", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+          ];
+          response.writeHead(200, {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          });
+          for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          response.write("data: [DONE]\n\n");
+          response.end();
+        }, delayMs);
+      });
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  await using app = await desktop({ name: "session-loading-idle" });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-session-loading-idle-${Date.now()}`,
+  });
+
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Session loading idle mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-session-loading-idle" },
+              models: {
+                [${JSON.stringify(modelId)}]: { name: "Session loading idle model" },
+              },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  await control(app, "session.create_task");
+  const parkingSessionId = newestSessionId(await control(app, "session.list_sessions"));
+  await control(app, "session.create_task");
+  const mainSessionId = newestSessionId(await control(app, "session.list_sessions"));
+  expect(mainSessionId).not.toBe(parkingSessionId);
+
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "main session composer text action enabled",
+  });
+  await control(app, "composer.set_text", { text: `Reply with exactly: ${reply}` });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "main session composer send action enabled",
+  });
+  await control(app, "composer.send");
+  await waitFor(app, indicatorExpression(mainSessionId, true), {
+    timeoutMs: 30_000,
+    label: "main session sidebar activity indicator active",
+  });
+  evidence.fact(
+    "The sidebar session row shows a loading indicator while the run is active",
+    "[data-session-loading-indicator] appeared under the main session row after composer.send.",
+    true,
+  );
+  const runningShot = await screenshot(app);
+  await control(app, "session.open", { sessionId: parkingSessionId });
+  await control(app, "session.open", { sessionId: mainSessionId });
+  await waitFor(app, `(() => {
+    if (!window.location.hash.includes(${JSON.stringify(mainSessionId)})) return false;
+    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${mainSessionId}"]`)});
+    return Boolean(row?.querySelector("[data-session-loading-indicator]"));
+  })()`, {
+    timeoutMs: 10_000,
+    label: "main session reopened while sidebar activity remains active",
+  });
+  await sleep(500);
+  {
+    const seen = await validate(runningShot, [
+      `The user's message asking to reply with '${reply}' is visible in the conversation, with no completed assistant reply below it yet`,
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  await waitForText(app, reply, { timeoutMs: 120_000 });
+  await waitFor(app, indicatorExpression(mainSessionId, false), {
+    timeoutMs: 30_000,
+    label: "completed main session sidebar activity indicator cleared",
+  });
+  await waitFor(app, stopDisabledExpression, {
+    timeoutMs: 30_000,
+    label: "completed main session stop action disabled",
+  });
+
+  await sleep(3_000);
+  await control(app, "session.rename", { sessionId: mainSessionId, title: renamedTitle });
+
+  for (let second = 1; second <= 8; second += 1) {
+    await sleep(1_000);
+    expect(
+      await evalIn(app, indicatorExpression(mainSessionId, false)),
+      `activity indicator returned ${second}s after rename`,
+    ).toBe(true);
+  }
+  expect(await evalIn(app, stopDisabledExpression), "composer.stop became enabled after rename").toBe(true);
+  evidence.fact(
+    "The completed session's activity indicator stays idle after a mid-run snapshot refetch and a post-idle rename",
+    "The sidebar indicator remained absent for eight consecutive one-second checks after the completed session was renamed, and composer.stop remained disabled.",
+    true,
+  );
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The session row for the renamed session shows no activity spinner",
+      `The assistant reply '${reply}' is visible in the conversation`,
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+});


### PR DESCRIPTION
## Problem

The per-session loading indicator (sidebar spinner, "Thinking…" card, reload blocking) often stayed active after the run had finished — until app restart.

## Root cause

Session run-state in `useSessionActivityStore` had two racing writers with no ordering: live SSE events (`session.status`/`session.idle`) and snapshot seeds (snapshot query refetches on mount/focus, `staleTime: 500`). A one-sided guard from 2ec41540a let seeds upgrade to active but never downgrade — so a snapshot fetched while busy that resolved *after* `session.idle` re-raised `runActive` with no event left to ever clear it. Missed idle events during SSE gaps (sleep/reconnect) hit the same terminal state; the watchdog reconnects without reconciling statuses.

## Fix

- Records track `runStatusAt` (stamped by live writers `setRunStatus`/`setError`). Snapshot seeds carry their fetch-start time and apply only when not older than the last live write — and fresh seeds may now downgrade to idle (both race directions handled symmetrically; the 2ec41540a behavior is preserved for genuinely stale idle seeds).
- Derived snapshot cache rewrites (from `session.updated` etc.) are unmarked and no longer seed run state at all.
- On every SSE (re)connect, best-effort `GET /session/status` reconciliation heals records stuck by events missed during the gap. Injectable for tests; failures never affect the stream.

## Tests

- `pnpm --dir apps/app test` — **600 pass, 2 fail**: both failures are `message-list-loading.test.tsx`, pre-existing on base (verified by stash-run baseline; file passes in isolation — suite-order pollution, untouched by this diff).
- `pnpm --dir apps/app typecheck` — green.
- New unit tests `apps/app/tests/session-sync-run-status.test.ts` (7 tests) encode the exact races: stale-busy seed after live idle stays idle (the bug), stale-idle seed during live run stays busy (2ec41540a preserved), fresh idle heals stuck records, unmarked snapshots are inert, reconnect reconciliation heals/fails-safe.
- New e2e spec `evals/specs/session-loading-idle.slow.test.ts` (`OPENWORK_EVAL_APP_SPECS=1`, stack lane) drives the real app with a deterministic mock provider: sidebar indicator on during the run → clears on completion → **stays idle** through a mid-run snapshot refetch, a post-idle rename (`session.updated`), and an 8s soak — **passed** at this head; testkit evidence tape published below.

Honest scoping: the e2e spec proves the user-visible contract (the app self-heals the rename path via post-idle refetch even on old code); the unit suite is the deterministic regression discriminator for the races.