### PR TITLE
fix(den-api): consolidate seat prorations onto the monthly invoice

### DIFF
--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -611,7 +611,10 @@ export async function syncInferenceSubscriptionQuantityAfterMemberChange(input: 
   const quantity = Math.max(1, input.memberCount)
   await stripe().subscriptionItems.update(row.stripe_subscription_item_id, {
     quantity,
-    proration_behavior: "always_invoice",
+    // Accrue prorations onto the next monthly invoice instead of charging
+    // (and invoicing) every quantity change immediately. Customers get one
+    // consolidated invoice per cycle; add/remove churn nets out.
+    proration_behavior: "create_prorations",
   })
 }
 
@@ -628,7 +631,9 @@ export async function syncSeatSubscriptionQuantityAfterMemberChange(input: { org
   const seatCounts = await getOrganizationSeatBillingCounts(input)
   await stripe().subscriptionItems.update(row.stripe_subscription_item_id, {
     quantity: seatCounts.chargeable,
-    proration_behavior: "always_invoice",
+    // See syncInferenceSubscriptionQuantityAfterMemberChange: one invoice per
+    // cycle instead of a card charge per seat change.
+    proration_behavior: "create_prorations",
   })
 }
 

--- a/ee/apps/den-api/test/stripe-seat-proration.test.ts
+++ b/ee/apps/den-api/test/stripe-seat-proration.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, expect, mock, test } from "bun:test"
+
+// Regression guard for OpenWork seat billing: quantity syncs must accrue
+// prorations onto the next monthly invoice ("create_prorations") instead of
+// invoicing and charging the card on every seat change ("always_invoice"),
+// which produced a separate bank charge per added/removed member.
+
+type UpdateCall = { itemId: string; params: Record<string, unknown> }
+
+const updateCalls: UpdateCall[] = []
+const selectResults: Array<Array<Record<string, unknown>>> = []
+
+class FakeStripe {
+  subscriptionItems = {
+    update: (itemId: string, params: Record<string, unknown>) => {
+      updateCalls.push({ itemId, params })
+      return Promise.resolve({ id: itemId })
+    },
+  }
+}
+
+function queryChain() {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(selectResults.shift() ?? []),
+  }
+  return chain
+}
+
+mock.module("stripe", () => ({ default: FakeStripe }))
+
+mock.module("../src/db.js", () => ({
+  db: { select: () => queryChain() },
+}))
+
+mock.module("../src/env.js", () => ({
+  env: {
+    stripe: {
+      secretKey: "sk_test_fake",
+      webhookSecret: undefined,
+      inferencePriceId: "price_inference_fake",
+      seatPriceId: "price_seat_fake",
+      billingSuccessUrl: undefined,
+      billingCancelUrl: undefined,
+    },
+  },
+}))
+
+mock.module("../src/inference.js", () => ({
+  setInferenceEnabled: () => Promise.resolve(),
+}))
+
+const loggerStub = {
+  child: () => loggerStub,
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+mock.module("../src/observability/logger.js", () => ({ appLogger: loggerStub }))
+
+const {
+  syncInferenceSubscriptionQuantityAfterMemberChange,
+  syncSeatSubscriptionQuantityAfterMemberChange,
+} = await import("../src/stripe-billing.js")
+
+beforeEach(() => {
+  updateCalls.length = 0
+  selectResults.length = 0
+})
+
+test("seat quantity sync accrues prorations instead of invoicing each change", async () => {
+  // 1st select: active seat subscription; 2nd select: organization metadata.
+  selectResults.push(
+    [{ status: "active", stripe_subscription_item_id: "si_seat_item" }],
+    [{ metadata: null }],
+  )
+
+  await syncSeatSubscriptionQuantityAfterMemberChange({ organizationId: "org_test", memberCount: 8 })
+
+  expect(updateCalls).toHaveLength(1)
+  expect(updateCalls[0]?.itemId).toBe("si_seat_item")
+  // 8 members minus 5 included free seats.
+  expect(updateCalls[0]?.params.quantity).toBe(3)
+  expect(updateCalls[0]?.params.proration_behavior).toBe("create_prorations")
+})
+
+test("inference quantity sync accrues prorations instead of invoicing each change", async () => {
+  selectResults.push([{ status: "active", stripe_subscription_item_id: "si_inference_item" }])
+
+  await syncInferenceSubscriptionQuantityAfterMemberChange({ organizationId: "org_test", memberCount: 4 })
+
+  expect(updateCalls).toHaveLength(1)
+  expect(updateCalls[0]?.itemId).toBe("si_inference_item")
+  expect(updateCalls[0]?.params.quantity).toBe(4)
+  expect(updateCalls[0]?.params.proration_behavior).toBe("create_prorations")
+})
+
+test("no Stripe call when the seat subscription is not active", async () => {
+  selectResults.push([{ status: "canceled", stripe_subscription_item_id: "si_seat_item" }])
+
+  await syncSeatSubscriptionQuantityAfterMemberChange({ organizationId: "org_test", memberCount: 8 })
+
+  expect(updateCalls).toHaveLength(0)
+})


### PR DESCRIPTION
## Problem

Seat and inference quantity syncs call `subscriptionItems.update` with `proration_behavior: "always_invoice"`, so **every member add/remove immediately finalizes an invoice and charges the card**. A real customer (Go Autonomous) adjusted seats one at a time and collected **26 invoices in ~7 weeks** — four separate $10.00 charges in one day, then $9.07, $8.08, and 14 netted-out $0 proration invoices in July alone. Their bookkeeper asked us what was going on.

## Fix

Switch both syncs to `proration_behavior: "create_prorations"` (2 lines in `ee/apps/den-api/src/stripe-billing.ts`). Prorations accrue as pending invoice items and roll into the next `subscription_cycle` invoice:

- one consolidated invoice per month, seat changes itemized as proration lines
- add-then-remove churn cancels out before any money moves
- quantity updates (and access) still apply immediately
- payment failure risk moves to the renewal charge, already handled by the existing `invoice.payment_failed` webhook

Trade-off to be aware of: cash for mid-cycle seat adds is now collected at the next renewal instead of immediately (≤1 month of float on $10/seat amounts).

## Validation

- `bun test test/stripe-seat-proration.test.ts` (from `ee/apps/den-api`, after `pnpm run build:den-db`) — **3 pass, 0 fail**. New unit test mocks the Stripe SDK + db and asserts the exact `subscriptionItems.update` params for the seat sync (5 free seats → quantity 3 for 8 members), the inference sync, and the inactive-subscription no-op guard.
- `pnpm exec tsc --noEmit` in `ee/apps/den-api` — clean.
- No `@openwork/testkit` evidence tape: proving this end to end requires a Stripe provider witness (no existing one covers billing). The unit test asserts the only observable boundary (the Stripe API params). Repro: flip the param back to `always_invoice` and the test fails.

Follow-up candidates (not in this PR): backfill note for affected orgs, and a Stripe witness for testkit billing coverage.