### PR TITLE
fix(app): restore per-session agent selection when switching between …

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
@@ -1,0 +1,74 @@
+// Per-conversation agent memory. Each session can pick its own agent from
+// the composer; the choice is remembered in localStorage so returning to a
+// conversation restores the agent it last used. Sessions without a remembered
+// choice fall back to the global default agent preference.
+import { create } from "zustand";
+
+const STORAGE_KEY = "openwork.sessionAgents.v1";
+const MAX_REMEMBERED_SESSIONS = 200;
+
+function readStoredAgents(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const entries: Record<string, string> = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      if (typeof value === "string" && value.trim()) {
+        entries[sessionId] = value;
+      }
+    }
+    return entries;
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredAgents(bySessionId: Record<string, string>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bySessionId));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function capAgents(bySessionId: Record<string, string>) {
+  const keys = Object.keys(bySessionId);
+  if (keys.length <= MAX_REMEMBERED_SESSIONS) return bySessionId;
+  const trimmed: Record<string, string> = {};
+  for (const key of keys.slice(keys.length - MAX_REMEMBERED_SESSIONS)) {
+    trimmed[key] = bySessionId[key]!;
+  }
+  return trimmed;
+}
+
+type SessionAgentStore = {
+  bySessionId: Record<string, string>;
+  setAgent: (sessionId: string, agent: string | null) => void;
+};
+
+export const useSessionAgentStore = create<SessionAgentStore>((set) => ({
+  bySessionId: readStoredAgents(),
+  setAgent: (sessionId, agent) =>
+    set((state) => {
+      const trimmed = agent?.trim() ?? "";
+      if (!trimmed) {
+        const { [sessionId]: _removed, ...rest } = state.bySessionId;
+        writeStoredAgents(rest);
+        return { bySessionId: rest };
+      }
+      const previous = state.bySessionId[sessionId];
+      if (previous === trimmed) return state;
+      const { [sessionId]: _replaced, ...rest } = state.bySessionId;
+      const bySessionId = capAgents({ ...rest, [sessionId]: trimmed });
+      writeStoredAgents(bySessionId);
+      return { bySessionId };
+    }),
+}));
+
+export function getSessionAgent(sessionId: string): string | null {
+  return useSessionAgentStore.getState().bySessionId[sessionId] ?? null;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -108,6 +108,7 @@ import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { getSessionModelSelection, useSessionModelStore } from "@/react-app/domains/session/surface/session-model-store";
+import { getSessionAgent, useSessionAgentStore } from "@/react-app/domains/session/surface/session-agent-store";
 import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { decodeComposerMentionValue } from "@/react-app/domains/session/surface/composer/mention-encoding";
@@ -574,14 +575,24 @@ export function SessionRoute() {
   const effectiveCloudMcpSubmissionState = cloudMcpAppSubmissionBlocked(cloudMcpAppSubmissionState)
     ? cloudMcpAppSubmissionState
     : cloudMcpSubmissionState;
-  // Agent selection is persisted in local prefs (like the model variant) so
-  // it survives reloads instead of silently falling back to "build" (#2101).
-  const selectedAgent = local.prefs.selectedAgent;
+  // Agent selection is per-session (keyed by sessionId in localStorage) so
+  // switching between sessions restores each session's own agent (#3461).
+  // When no session is selected (empty-state new-task composer), fall back to
+  // the global pref so the user's last new-session choice is preserved across
+  // reloads (#2101).
+  const sessionAgentMap = useSessionAgentStore((state) => state.bySessionId);
+  const selectedAgent = selectedSessionId
+    ? (sessionAgentMap[selectedSessionId] ?? null)
+    : local.prefs.selectedAgent;
   const setSelectedAgent = useCallback(
     (agent: string | null) => {
-      local.setPrefs((previous) => ({ ...previous, selectedAgent: agent }));
+      if (selectedSessionId) {
+        useSessionAgentStore.getState().setAgent(selectedSessionId, agent);
+      } else {
+        local.setPrefs((previous) => ({ ...previous, selectedAgent: agent }));
+      }
     },
-    [local.setPrefs],
+    [selectedSessionId, local.setPrefs],
   );
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.


### PR DESCRIPTION
…sessions

## Summary
-

## Why
-

## Issue
- Closes #

## Scope
-

## Out of scope
-

## Testing
### Ran
- `...`

### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
