### PR TITLE
ci(changelog): auto-generate release notes on stable releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,193 @@
+name: Changelog
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Stable release tag to document (e.g. v0.18.13)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: changelog-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  changelog:
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    env:
+      BASE_BRANCH: dev
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      BRANCH_NAME: automation/changelog-${{ github.event.release.tag_name || inputs.tag }}-${{ github.run_id }}
+
+    steps:
+      - name: Validate tag
+        id: guard
+        run: |
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping changelog automation because $TAG is not a stable release tag."
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.stable == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Skip if already documented
+        if: steps.guard.outputs.stable == 'true'
+        id: dedupe
+        run: |
+          if grep -Fq "[$TAG](https://github.com/different-ai/openwork/compare/" packages/docs/changelog.mdx; then
+            echo "documented=true" >> "$GITHUB_OUTPUT"
+            echo "$TAG is already documented; skipping changelog automation."
+          else
+            echo "documented=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gather release facts
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        id: facts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUBLISHED_AT_EVENT: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse --verify "refs/tags/$TAG^{commit}" >/dev/null; then
+            echo "Release tag $TAG does not exist in the fetched repository." >&2
+            exit 1
+          fi
+
+          PREV="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | grep -x -B1 "$TAG" | head -n1)"
+          if [[ -z "$PREV" || "$PREV" == "$TAG" ]]; then
+            echo "Could not determine the stable release immediately before $TAG." >&2
+            exit 1
+          fi
+
+          PUBLISHED_AT="$PUBLISHED_AT_EVENT"
+          if [[ -z "$PUBLISHED_AT" ]]; then
+            PUBLISHED_AT="$(gh release view "$TAG" --json publishedAt -q .publishedAt)"
+          fi
+          if [[ -z "$PUBLISHED_AT" ]]; then
+            echo "Could not determine the published-at timestamp for $TAG." >&2
+            exit 1
+          fi
+
+          COMMIT8="$(git rev-list -n1 "$TAG" | cut -c1-8)"
+          SHORTSTAT="$(git diff --shortstat "$PREV".."$TAG")"
+          INSERTIONS="$(grep -oE '[0-9]+ insertion' <<< "$SHORTSTAT" | grep -oE '[0-9]+' || true)"
+          DELETIONS="$(grep -oE '[0-9]+ deletion' <<< "$SHORTSTAT" | grep -oE '[0-9]+' || true)"
+          INSERTIONS="${INSERTIONS:-0}"
+          DELETIONS="${DELETIONS:-0}"
+          TOTAL=$((INSERTIONS + DELETIONS))
+          LOC_LINE="$TOTAL lines changed since \`$PREV\` ($INSERTIONS insertions, $DELETIONS deletions)."
+
+          IFS=$'\t' read -r DATE_LABEL TRACKER_FILE < <(node -e '
+            const publishedAt = new Date(process.argv[1]);
+            if (Number.isNaN(publishedAt.valueOf())) throw new Error("Invalid published-at timestamp");
+            const day = publishedAt.getUTCDate();
+            const mod100 = day % 100;
+            const suffix = mod100 >= 11 && mod100 <= 13 ? "th" : ({ 1: "st", 2: "nd", 3: "rd" }[day % 10] || "th");
+            const month = publishedAt.toLocaleString("en-US", { month: "long", timeZone: "UTC" });
+            const date = publishedAt.toISOString().slice(0, 10);
+            process.stdout.write(month + " " + day + suffix + "\tchangelog/release-tracker-" + date + ".md\n");
+          ' "$PUBLISHED_AT")
+
+          git log --no-merges --format='%h %s' "$PREV".."$TAG" | head -400 > /tmp/commits.txt
+          cat > /tmp/changelog_prompt.txt <<PROMPT_EOF
+          Document OpenWork release $TAG in the changelog. Use these facts exactly; do not invent or recompute any of them.
+
+          - version: $TAG
+          - previous version: $PREV
+          - release commit (short): $COMMIT8
+          - published at (UTC): $PUBLISHED_AT
+          - docs date label: $DATE_LABEL
+          - tracker file: $TRACKER_FILE
+          - loc line (copy verbatim into the tracker): $LOC_LINE
+          - compare url: https://github.com/different-ai/openwork/compare/$PREV...$TAG
+
+          Commits between $PREV and $TAG (hash subject):
+          PROMPT_EOF
+          cat /tmp/commits.txt >> /tmp/changelog_prompt.txt
+          echo "PREV=$PREV" >> "$GITHUB_ENV"
+
+      - name: Setup Node
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install opencode
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        run: |
+          version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version" --no-modify-path
+
+      - name: Draft changelog entries
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        run: opencode run --agent changelog "$(cat /tmp/changelog_prompt.txt)"
+
+      - name: Discard opencode runtime churn
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        run: |
+          git checkout -- .opencode/
+          git clean -fd .opencode/
+
+      - name: Verify generated output
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        run: node scripts/check-changelog-output.mjs "$TAG" "$PREV"
+
+      - name: Commit release notes
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        env:
+          COMMIT_SIGNING_KEY: ${{ secrets.COMMIT_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+
+          signing_key="$RUNNER_TEMP/commit-signing-key"
+          trap 'rm -f "$signing_key"' EXIT
+          umask 077
+          printf '%s\n' "$COMMIT_SIGNING_KEY" > "$signing_key"
+          chmod 600 "$signing_key"
+
+          git config --local user.email "11430621+benjaminshafii@users.noreply.github.com"
+          git config --local user.name "benjaminshafii"
+          git config --local gpg.format ssh
+          git config --local user.signingkey "$signing_key"
+          git switch -c "$BRANCH_NAME"
+          git add packages/docs/changelog.mdx changelog/
+          git commit -S -m "docs(changelog): release notes for $TAG"
+
+      - name: Open pull request
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git push --set-upstream origin "$BRANCH_NAME"
+          printf '%s\n\n%s\n' \
+            "These release notes were auto-generated from the commits between \`$PREV\` and \`$TAG\` by the changelog agent and verified by \`scripts/check-changelog-output.mjs\`." \
+            "This is a docs-only change with no runtime surface." > /tmp/pr_body.txt
+          pr_url="$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH_NAME" \
+            --title "docs(changelog): release notes for $TAG" \
+            --body-file /tmp/pr_body.txt)"
+          gh pr merge "$pr_url" --auto --squash --delete-branch

--- a/.opencode/agents/changelog.md
+++ b/.opencode/agents/changelog.md
@@ -1,0 +1,77 @@
+---
+mode: primary
+hidden: true
+model: opencode/claude-sonnet-4-5
+color: "#7C6FF0"
+tools:
+  "*": false
+  read: true
+  glob: true
+  grep: true
+  edit: true
+  write: true
+---
+
+You write OpenWork release changelogs. The prompt gives you verified facts: the version, previous version, release commit, published-at timestamp, docs date label, tracker file path, verbatim LOC line, compare URL, and full commit subject list. Use only these facts. Never invent features, numbers, or dates, and never recompute the LOC line.
+
+Before writing, read `packages/docs/changelog.mdx` and the most recent `changelog/release-tracker-*.md` file to match their formats exactly.
+
+Modify only these two files:
+
+1. The tracker file named in the prompt. If it does not exist, create it with this standard header:
+
+   ```markdown
+   # Release Changelog Tracker
+
+   Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+   ```
+
+   Otherwise, append the new section. Keep `## vX.Y.Z` sections within a tracker file in ascending version order. Never edit or reflow existing entries.
+2. `packages/docs/changelog.mdx`. Never edit or reflow existing entries.
+
+Do not modify any other file.
+
+## Tracker section format
+
+Use this exact heading sequence and content:
+
+1. `## vX.Y.Z`
+2. `#### Commit` — the short hash in backticks
+3. `#### Released at` — the UTC ISO timestamp in backticks
+4. `#### Title` — one outcome-focused sentence fragment with no trailing period
+5. `#### One-line summary`
+6. `#### Main changes` — 3–5 bullets, or a short paragraph for a tiny release
+7. `#### Lines of code changed since previous release` — the provided LOC line verbatim
+8. `#### Release importance` — `Major release: …` or `Minor release: …` with a one-line justification
+9. `#### Major improvements` — `True` or `False`
+10. `#### Number of major improvements`
+11. `#### Major improvement details` — bullets or `None.`
+12. `#### Major bugs resolved` — `True` or `False`
+13. `#### Number of major bugs resolved`
+14. `#### Major bug fix details` — bullets or `None.`
+15. `#### Deprecated features` — `True` or `False`
+16. `#### Number of deprecated features`
+17. `#### Deprecated details` — bullets or `None.`
+
+All counts must match the number of detail bullets.
+
+## Docs entry format
+
+```mdx
+<Update label="<docs date label>" tags={[...]}>
+
+  ## [<version>](<compare url>): <Title>
+
+  - bullet
+  - bullet
+
+</Update>
+```
+
+Choose tags from `"🚀 New Features"`, `"🐛 Bug Fixes"`, and `"🏗️ Refactoring"`, ordered by prominence in the release. Write 2–5 bullets with two-space indentation inside the block, and leave one blank line between blocks.
+
+Docs entries are ordered newest-version-first. If the new version is higher than every documented version, insert it directly after the frontmatter ending on line 3 (`---`). For a backfill, insert it directly below the entry of the lowest documented version that is higher than the new version, so the new entry sits immediately after its closest newer version even when undated or unversioned entries appear elsewhere in the file.
+
+Write for non-technical users and lead with user-visible outcomes, such as “X now does Y” or “Fixed X so Y.” Use plain language and no PR numbers in docs bullets. Fold internal tooling (evals, testkit, CI), release plumbing, and dependency bumps into at most one bullet, or omit them entirely when the release has enough user-facing changes. If a release is mostly internal, say so plainly. Titles should read like the existing titles, such as “Linux installs repair themselves” and “Managed provider credentials reach the engine.”
+
+Do not use bash. When done, briefly state which two files you changed.

--- a/scripts/check-changelog-output.mjs
+++ b/scripts/check-changelog-output.mjs
@@ -1,0 +1,134 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const [tag, previousTag] = process.argv.slice(2);
+
+function fail(message) {
+  console.error(`Changelog output check failed: ${message}`);
+  process.exit(1);
+}
+
+if (!tag || !previousTag) {
+  fail("usage: node scripts/check-changelog-output.mjs <tag> <prev>");
+}
+
+const cwd = process.cwd();
+const docsPath = "packages/docs/changelog.mdx";
+const trackerPattern = /^changelog\/release-tracker-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$/;
+const status = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" }).trimEnd();
+
+if (!status) {
+  fail("no changes found; the changelog agent did not modify any files");
+}
+
+const changedPaths = status.split("\n").map((line) => line.slice(3));
+const unexpectedPaths = changedPaths.filter((path) => path !== docsPath && !trackerPattern.test(path));
+if (unexpectedPaths.length > 0) {
+  fail(`unexpected changed path(s): ${unexpectedPaths.join(", ")}`);
+}
+if (!changedPaths.includes(docsPath)) {
+  fail(`${docsPath} was not changed`);
+}
+if (!changedPaths.some((path) => trackerPattern.test(path))) {
+  fail("no release tracker file was changed");
+}
+console.log("Changed paths are limited to the changelog docs and release tracker files.");
+
+const docs = readFileSync(resolve(cwd, docsPath), "utf8");
+const openingUpdates = docs.match(/<Update /g)?.length ?? 0;
+const closingUpdates = docs.match(/<\/Update>/g)?.length ?? 0;
+if (openingUpdates !== closingUpdates) {
+  fail(`unbalanced Update tags: found ${openingUpdates} opening and ${closingUpdates} closing tags`);
+}
+
+const compareLink = `[${tag}](https://github.com/different-ai/openwork/compare/${previousTag}...${tag})`;
+const compareLinkCount = docs.split(compareLink).length - 1;
+if (compareLinkCount !== 1) {
+  fail(`expected the exact compare link ${compareLink} once, found ${compareLinkCount}`);
+}
+
+const versions = [...docs.matchAll(/^\s*## \[(v[0-9]+\.[0-9]+\.[0-9]+)\]\(/gm)].map((match) => match[1]);
+function compareVersions(left, right) {
+  const leftParts = left.slice(1).split(".").map(Number);
+  const rightParts = right.slice(1).split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+for (let index = 1; index < versions.length; index += 1) {
+  if (compareVersions(versions[index - 1], versions[index]) <= 0) {
+    fail(`docs versions are not strictly descending at ${versions[index - 1]} then ${versions[index]}`);
+  }
+}
+console.log("Changelog Update tags, compare link, and version ordering are valid.");
+
+const trackerDirectory = resolve(cwd, "changelog");
+const trackerFiles = readdirSync(trackerDirectory)
+  .filter((name) => /^release-tracker-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$/.test(name))
+  .sort();
+const tagHeading = `## ${tag}`;
+const containingTrackers = [];
+
+for (const trackerFile of trackerFiles) {
+  const path = resolve(trackerDirectory, trackerFile);
+  const contents = readFileSync(path, "utf8");
+  const headingCount = contents.split("\n").filter((line) => line === tagHeading).length;
+  for (let count = 0; count < headingCount; count += 1) {
+    containingTrackers.push({ path, contents });
+  }
+}
+
+if (containingTrackers.length !== 1) {
+  fail(`expected ${tagHeading} exactly once across release trackers, found ${containingTrackers.length}`);
+}
+
+const shortstat = execFileSync("git", ["diff", "--shortstat", `${previousTag}..${tag}`], {
+  cwd,
+  encoding: "utf8",
+});
+const insertions = Number(shortstat.match(/([0-9]+) insertion/)?.[1] ?? 0);
+const deletions = Number(shortstat.match(/([0-9]+) deletion/)?.[1] ?? 0);
+const locLine = `${insertions + deletions} lines changed since \`${previousTag}\` (${insertions} insertions, ${deletions} deletions).`;
+const trackerContents = containingTrackers[0].contents;
+if (!trackerContents.includes(locLine)) {
+  fail(`tracker section is missing the exact LOC line: ${locLine}`);
+}
+
+const sectionStart = trackerContents.split("\n").findIndex((line) => line === tagHeading);
+const sectionLines = trackerContents.split("\n").slice(sectionStart + 1);
+const nextSection = sectionLines.findIndex((line) => line.startsWith("## "));
+const section = (nextSection === -1 ? sectionLines : sectionLines.slice(0, nextSection)).join("\n");
+const requiredHeadings = [
+  "#### Commit",
+  "#### Released at",
+  "#### Title",
+  "#### One-line summary",
+  "#### Main changes",
+  "#### Lines of code changed since previous release",
+  "#### Release importance",
+  "#### Major improvements",
+  "#### Number of major improvements",
+  "#### Major improvement details",
+  "#### Major bugs resolved",
+  "#### Number of major bugs resolved",
+  "#### Major bug fix details",
+  "#### Deprecated features",
+  "#### Number of deprecated features",
+  "#### Deprecated details",
+];
+let previousHeadingIndex = -1;
+for (const heading of requiredHeadings) {
+  const headingIndex = section.indexOf(heading);
+  if (headingIndex === -1) {
+    fail(`${tagHeading} section is missing ${heading}`);
+  }
+  if (headingIndex <= previousHeadingIndex) {
+    fail(`${tagHeading} section has ${heading} out of order`);
+  }
+  previousHeadingIndex = headingIndex;
+}
+console.log(`${tagHeading} appears once with the exact LOC line and all required headings in order.`);


### PR DESCRIPTION
## What

Automates the changelog workflow we just did by hand for v0.18.9–v0.18.13. On every stable release (`release: published`, tags matching `vX.Y.Z` — alphas and signpath tags skipped), a new **Changelog** workflow:

1. **Gathers deterministic facts by script** — previous stable tag, commit list (`git log --no-merges prev..tag`), `git diff --shortstat` LOC line, publish timestamp, docs date label, tracker filename. The LLM never computes numbers or dates.
2. **Drafts the prose with a new `changelog` agent** (`.opencode/agents/changelog.md`, same pattern as the existing `triage`/`duplicate-pr` CI agents): one `<Update>` entry in `packages/docs/changelog.mdx` + a structured section in `changelog/release-tracker-<date>.md`, following the exact formats already in those files.
3. **Verifies the output with `scripts/check-changelog-output.mjs`** — only the two allowed paths changed, balanced `<Update>` tags, exact compare link exactly once, strictly descending version order, tracker LOC line recomputed independently and matched verbatim, all 16 tracker headings present in order.
4. **Opens a signed, auto-merging PR against `dev`** (same signing + auto-merge pattern as `update-models.yml`). Mintlify/warden checks remain the merge gate.

Also dispatchable manually (`workflow_dispatch` with a `tag` input) for backfills; it exits cleanly when the tag is already documented (idempotent) or not a stable tag.

## Testing

CI/agent-config change; the workflow itself cannot run pre-merge, so it was rehearsed end-to-end locally in a worktree:

- Built the exact CI prompt for **v0.18.8** with the workflow's own shell logic, ran the real `changelog` agent, then the guardrail: all checks green, entry inserted in the correct backfill position (directly below v0.18.9), tracker format exact, LOC line verbatim.
- Guardrail negative tests: clean tree → fails with "no changes"; removed one `</Update>` → fails on tag balance; unexpected changed paths → fails and names them (this caught real `.opencode/package-lock.json` runtime churn, now discarded by a dedicated workflow step before verification).
- Guardrail positive test against the real historical v0.18.13 docs diff → pass.
- `node --check scripts/check-changelog-output.mjs` and `actionlint` (clean apart from the expected unknown Blacksmith runner label).

**Post-merge proof**: I will dispatch `changelog.yml` with `tag=v0.18.8` (the one undocumented version below the new entries) — the run doubles as a real backfill and the end-to-end CI validation of the full pipeline including the auto-merge PR.