### PR TITLE
ci(desktop): gate PRs on the packaged macOS app actually launching

### DIFF
--- a/.github/workflows/ci-macos-packaged-launch.yml
+++ b/.github/workflows/ci-macos-packaged-launch.yml
@@ -1,0 +1,77 @@
+name: macOS Packaged Launch
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - apps/desktop/build/entitlements*.plist
+      - apps/desktop/electron-builder*.yml
+      - apps/desktop/package.json
+      - apps/desktop/electron/**
+      - apps/desktop/scripts/electron-build.mjs
+      - apps/desktop/scripts/electron-after-pack.cjs
+      - apps/desktop/scripts/electron-after-sign.cjs
+      - apps/desktop/scripts/macos-launch-gate.sh
+      - pnpm-lock.yaml
+      - .github/workflows/ci-macos-packaged-launch.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-packaged-launch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  packaged-launch:
+    name: Ad-hoc signed app survives launch
+    runs-on: macos-14
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.4.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
+        with:
+          bun-version: 1.3.10
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: macos-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            macos-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Package Electron desktop (unsigned directory)
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          set -euo pipefail
+          rm -rf apps/desktop/dist-electron
+          pnpm --filter @openwork/desktop package:electron:dir
+
+      - name: Ad-hoc sign and launch packaged app
+        run: bash apps/desktop/scripts/macos-launch-gate.sh

--- a/apps/desktop/scripts/macos-launch-gate.sh
+++ b/apps/desktop/scripts/macos-launch-gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly entitlements="apps/desktop/build/entitlements.mac.plist"
+readonly survival_seconds=10
+
+shopt -s nullglob
+apps=(apps/desktop/dist-electron/mac*/OpenWork.app)
+if [[ ${#apps[@]} -ne 1 ]]; then
+  echo "Expected exactly one packaged macOS app, found ${#apps[@]} under apps/desktop/dist-electron." >&2
+  exit 1
+fi
+
+readonly app_path="${apps[0]}"
+readonly executable="$app_path/Contents/MacOS/OpenWork"
+if [[ ! -x "$executable" ]]; then
+  echo "Packaged app executable is missing or not executable: $executable" >&2
+  exit 1
+fi
+
+echo "Ad-hoc signing $app_path with $entitlements"
+codesign --force --deep --sign - --entitlements "$entitlements" "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+readonly user_data="$(mktemp -d "${TMPDIR:-/tmp}/openwork-launch-gate.XXXXXX")"
+readonly stdout_log="$user_data/stdout.log"
+readonly stderr_log="$user_data/stderr.log"
+app_pid=""
+
+cleanup() {
+  if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+    kill -TERM "$app_pid" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$app_pid" 2>/dev/null || true
+    wait "$app_pid" 2>/dev/null || true
+  fi
+  rm -rf "$user_data"
+}
+trap cleanup EXIT
+
+echo "Launching packaged app and requiring it to survive for ${survival_seconds}s"
+readonly launch_started="$(date '+%Y-%m-%d %H:%M:%S')"
+OPENWORK_ELECTRON_USERDATA="$user_data/profile" \
+OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN=1 \
+OPENWORK_ELECTRON_DISABLE_PROTOCOL_REGISTRATION=1 \
+ELECTRON_EXTRA_LAUNCH_ARGS="--headless --disable-gpu" \
+  "$executable" >"$stdout_log" 2>"$stderr_log" &
+app_pid=$!
+
+sleep "$survival_seconds"
+if kill -0 "$app_pid" 2>/dev/null; then
+  echo "PASS: packaged app survived launch for ${survival_seconds}s (pid $app_pid)."
+  exit 0
+fi
+
+set +e
+wait "$app_pid"
+status=$?
+set -e
+app_pid=""
+
+signal_message=""
+if [[ $status -gt 128 ]]; then
+  signal_number=$((status - 128))
+  signal_name="$(kill -l "$signal_number" 2>/dev/null || echo UNKNOWN)"
+  signal_message=", signal $signal_number SIG${signal_name#SIG}"
+fi
+
+echo "FAIL: packaged app exited before ${survival_seconds}s (exit $status${signal_message})." >&2
+if [[ $status -eq 137 ]]; then
+  echo "Exit 137 / SIGKILL is consistent with macOS AMFI rejecting a restricted entitlement." >&2
+fi
+
+echo "--- packaged app stdout ---" >&2
+cat "$stdout_log" >&2 || true
+echo "--- packaged app stderr ---" >&2
+cat "$stderr_log" >&2 || true
+echo "--- signed app entitlements ---" >&2
+codesign --display --entitlements :- "$app_path" >&2 || true
+echo "--- recent AMFI system log entries ---" >&2
+/usr/bin/log show --start "$launch_started" --style compact \
+  --predicate '(process == "amfid" OR subsystem == "com.apple.AMFI" OR eventMessage CONTAINS[c] "AMFI") AND (eventMessage CONTAINS[c] "OpenWork.app" OR eventMessage CONTAINS[c] "Restricted entitlements" OR eventMessage CONTAINS[c] "provisioning profile")' \
+  >&2 || true
+
+exit 1


### PR DESCRIPTION
Closes the hole that let the Electron 41 revert happen.

## What went wrong

Adding the restricted `keychain-access-groups` entitlement made the signed app **fail to launch** — macOS AMFI killed it at exec:

```
Disallowing com.differentai.openwork because no eligible provisioning profiles found
Restricted entitlements not validated
AMFI: Code=-413 "No matching profile found"
→ exit 137 / SIGKILL, before stderr, before any JS
```

`codesign --verify`, `spctl` and `stapler validate` all **passed**. Signing succeeded; runtime entitlement authorization failed. So no build-time check could see it.

## Why every check was green

| Lane | Result | Why blind |
|---|---|---|
| `evals/specs` (Daytona) | green | Linux — AMFI doesn't exist |
| `ci-tests.yml` on `macos-14` | green | never packages, signs, or launches Electron |
| local `pnpm dev` | healthy | unsigned → entitlements unenforced |
| local unsigned package | boots | unsigned → entitlements unenforced |
| **signed artifact** | **SIGKILL** | only built on `push: dev`, i.e. **after merge** |

Nothing in the pipeline ever launched the artifact a user receives, before merge. `build-electron-desktop.yml` can sign+notarize but only triggers on `workflow_dispatch` or a branch named `electron-notary-test` — never on PRs.

Also worth noting: the test added alongside that entitlement asserted the plist *contained* the keychain group. It tested shape, never effect — the more correctly the fatal entitlement was wired, the greener it went.

## The gate

`.github/workflows/ci-macos-packaged-launch.yml` + `apps/desktop/scripts/macos-launch-gate.sh`: package the app, **ad-hoc sign it with the repo's real entitlements plist**, launch it, require it to survive 10s.

Key point: **ad-hoc signing reproduces the failure**, so this needs no Developer ID cert, no notarization, and no repository secrets — it works on fork PRs and stays fast.

- Path-filtered to the packaging/startup surface (`entitlements*.plist`, `electron-builder*.yml`, `apps/desktop/electron/**`, packaging scripts, lockfile)
- On failure, prints exit code + signal, app stdout/stderr, the signed entitlements, and the matching AMFI log lines, so the cause is obvious from the red check
- Third-party actions pinned to SHAs, per existing convention

## Verified both directions locally

```
rm -rf apps/desktop/dist-electron \
  && CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --filter @openwork/desktop package:electron:dir \
  && bash apps/desktop/scripts/macos-launch-gate.sh
```

| Case | Result |
|---|---|
| `dev`'s current entitlements | **exit 0** — survived 10s (67s cold) |
| exact `keychain-access-groups` entitlement restored | **exit 1** — app exit 137, signal 9 SIGKILL, AMFI `Restricted entitlements not validated` (31s) |

Entitlement reverted afterwards. Electron stays on **35** — this PR is the gate only, no re-land.

Also green: `pnpm --filter @openwork/desktop test` (174 passed, 1 skipped), `actionlint`, `bash -n`.

## What this does NOT catch

Developer ID credential problems, provisioning-profile *correctness*, notarization/stapling/Gatekeeper failures, non-arm64 architectures, and anything that only breaks after the 10s window. It catches launch-blocking entitlement and startup-crash regressions — the class that just bit us.