### PR TITLE
fix(app): restore per-session agent selection when switching between sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
@@ -1,7 +1,8 @@
 // Per-conversation agent memory. Each session can pick its own agent from
 // the composer; the choice is remembered in localStorage so returning to a
-// conversation restores the agent it last used. Sessions without a remembered
-// choice fall back to the global default agent preference.
+// conversation restores the agent it last used. A session with no stored
+// choice has no entry here and falls back to the default agent. The global
+// agent preference is only used outside of any session (the new-task composer).
 import { create } from "zustand";
 
 const STORAGE_KEY = "openwork.sessionAgents.v1";
@@ -68,7 +69,3 @@ export const useSessionAgentStore = create<SessionAgentStore>((set) => ({
       return { bySessionId };
     }),
 }));
-
-export function getSessionAgent(sessionId: string): string | null {
-  return useSessionAgentStore.getState().bySessionId[sessionId] ?? null;
-}

--- a/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-agent-store.ts
@@ -1,0 +1,74 @@
+// Per-conversation agent memory. Each session can pick its own agent from
+// the composer; the choice is remembered in localStorage so returning to a
+// conversation restores the agent it last used. Sessions without a remembered
+// choice fall back to the global default agent preference.
+import { create } from "zustand";
+
+const STORAGE_KEY = "openwork.sessionAgents.v1";
+const MAX_REMEMBERED_SESSIONS = 200;
+
+function readStoredAgents(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const entries: Record<string, string> = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      if (typeof value === "string" && value.trim()) {
+        entries[sessionId] = value;
+      }
+    }
+    return entries;
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredAgents(bySessionId: Record<string, string>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bySessionId));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function capAgents(bySessionId: Record<string, string>) {
+  const keys = Object.keys(bySessionId);
+  if (keys.length <= MAX_REMEMBERED_SESSIONS) return bySessionId;
+  const trimmed: Record<string, string> = {};
+  for (const key of keys.slice(keys.length - MAX_REMEMBERED_SESSIONS)) {
+    trimmed[key] = bySessionId[key]!;
+  }
+  return trimmed;
+}
+
+type SessionAgentStore = {
+  bySessionId: Record<string, string>;
+  setAgent: (sessionId: string, agent: string | null) => void;
+};
+
+export const useSessionAgentStore = create<SessionAgentStore>((set) => ({
+  bySessionId: readStoredAgents(),
+  setAgent: (sessionId, agent) =>
+    set((state) => {
+      const trimmed = agent?.trim() ?? "";
+      if (!trimmed) {
+        const { [sessionId]: _removed, ...rest } = state.bySessionId;
+        writeStoredAgents(rest);
+        return { bySessionId: rest };
+      }
+      const previous = state.bySessionId[sessionId];
+      if (previous === trimmed) return state;
+      const { [sessionId]: _replaced, ...rest } = state.bySessionId;
+      const bySessionId = capAgents({ ...rest, [sessionId]: trimmed });
+      writeStoredAgents(bySessionId);
+      return { bySessionId };
+    }),
+}));
+
+export function getSessionAgent(sessionId: string): string | null {
+  return useSessionAgentStore.getState().bySessionId[sessionId] ?? null;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -125,6 +125,7 @@ import {
   nextFavoriteModel,
   useModelCollectionsStore,
 } from "@/react-app/domains/session/models/model-collections-store";
+import { useSessionAgentStore } from "@/react-app/domains/session/surface/session-agent-store";
 import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
 import { markComposerAutoSend } from "@/react-app/domains/session/surface/composer-auto-send";
 import { sendWithRevertRollback } from "@/react-app/domains/session/surface/safe-edit-resend";
@@ -542,14 +543,24 @@ export function SessionRoute() {
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     providerModel: cloudMcpProviderModel,
   });
-  // Agent selection is persisted in local prefs (like the model variant) so
-  // it survives reloads instead of silently falling back to "build" (#2101).
-  const selectedAgent = local.prefs.selectedAgent;
+  // Agent selection is per-session (keyed by sessionId in localStorage) so
+  // switching between sessions restores each session's own agent (#3461).
+  // When no session is selected (empty-state new-task composer), fall back to
+  // the global pref so the user's last new-session choice is preserved across
+  // reloads (#2101).
+  const sessionAgentMap = useSessionAgentStore((state) => state.bySessionId);
+  const selectedAgent = selectedSessionId
+    ? (sessionAgentMap[selectedSessionId] ?? null)
+    : local.prefs.selectedAgent;
   const setSelectedAgent = useCallback(
     (agent: string | null) => {
-      local.setPrefs((previous) => ({ ...previous, selectedAgent: agent }));
+      if (selectedSessionId) {
+        useSessionAgentStore.getState().setAgent(selectedSessionId, agent);
+      } else {
+        local.setPrefs((previous) => ({ ...previous, selectedAgent: agent }));
+      }
     },
-    [local.setPrefs],
+    [selectedSessionId, local.setPrefs],
   );
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.


### PR DESCRIPTION
## Summary
- Agent selection lived in one global slot (`local.prefs.selectedAgent`) shared by every session, so picking an agent in one conversation overwrote it for all of them
- Adds `session-agent-store.ts`, a localStorage store keyed by session ID, mirroring the existing `session-model-store.ts`
- `session-route.tsx` reads/writes the active session's agent; the new-task composer still uses the global pref

## Why
- Returning to a conversation silently changed its agent, so the next message ran under the wrong one
- Per-session model choice already works this way; agent selection was the outlier

## Issue
- Closes #3461

## Scope
- `session-agent-store.ts` (new): per-session agent map under `openwork.sessionAgents.v1`, capped at 200 entries, tolerant of missing or malformed storage
- `session-route.tsx`: `selectedAgent` derives from the active session; `setSelectedAgent` writes per-session, or to the global pref when no session is selected

## Out of scope
- `local.prefs.selectedAgent` stays as the new-task composer's source of truth, preserving the reload persistence from `#2101`
- New sessions start at the default agent rather than inheriting the composer's choice — `session-model-store.ts` behaves the same way today, so this keeps the two consistent rather than changing one in a bugfix
- No server, schema, or sync changes — local UI state only

## Testing
### Ran
- `pnpm typecheck`
- `bun test --isolate tests/` (apps/app unit suite)
- `pnpm test:session-switch`
- `pnpm test:sessions`
- `pnpm test:health`

### Result
- pass/fail: pass
- if fail, exact files/errors: `tests/message-list-loading.test.tsx` has 2 failures (`Invalid hook call` / `TypeError: null is not an object (evaluating 'resolveDispatcher().useState')` in `renderToStringImpl`). These are pre-existing on `dev` — I re-ran that file with this branch's two files reverted to their `dev` state and got the identical 2 failures, so they are unrelated to this change. Everything else is green: 600 pass in the unit suite, 7/7 steps in `test:session-switch`, `ok: true` for `test:sessions` and `test:health`.

## CI status
- pass: typecheck, session-switch, sessions, health
- code-related failures: none from this change
- external/env/auth blockers: none

## Manual verification
1. Set the `build` agent on session A and `plan` on session B
2. Switch back to session A — the picker shows `build` (before this change it showed `plan`)
3. Reload the app and switch between both sessions — each still restores its own agent
4. With no session selected, pick an agent in the new-task composer and reload — the choice is restored
5. Clear a session's agent back to default — the entry is removed and the session falls back to the default agent
