### PR TITLE
feat(examples): add Tenki Cloud sandbox TypeScript example

### DIFF
--- a/examples/tenki-openwork-ts/README.md
+++ b/examples/tenki-openwork-ts/README.md
@@ -1,0 +1,40 @@
+# Tenki OpenWork TypeScript Example
+
+Small standalone TypeScript example that boots the headless OpenWork server inside a [Tenki Cloud](https://tenki.cloud) sandbox with the [`@tenkicloud/sandbox`](https://www.npmjs.com/package/@tenkicloud/sandbox) SDK, exposes it on a public preview URL, verifies `/health`, checks that `/workspaces` is `401` without a token and `200` with the client token, creates an OpenCode session through `/w/:workspaceId/opencode/session` and reads it back, prints startup timings, then terminates the sandbox.
+
+Unlike the [microsandbox example](../microsandbox-openwork-rust), no local Docker image build is required: the sandbox installs the published [`openwork-server`](https://www.npmjs.com/package/openwork-server) npm package (which ships a compiled Linux binary) and downloads the OpenCode release pinned in the repo-root `constants.json`.
+
+## Run
+
+```bash
+cd examples/tenki-openwork-ts
+pnpm install --ignore-workspace
+TENKI_API_KEY=tk_your_api_key pnpm start
+```
+
+`--ignore-workspace` keeps the install local to this directory; the example is intentionally not part of the repo's pnpm workspace, mirroring the standalone Rust example.
+
+Requires Node.js 20+ and a Tenki API key from [tenki.cloud](https://tenki.cloud). The sandbox is ephemeral: it is terminated when the run finishes, fails, or is interrupted with `Ctrl+C`, and carries `maxDurationMs` / `idleTimeoutMinutes` backstops in case the process is killed outright.
+
+To keep the sandbox running and connect the OpenWork desktop app (`Add a worker` -> `Connect remote`) to the printed URL and client token:
+
+```bash
+TENKI_API_KEY=tk_your_api_key OPENWORK_TENKI_KEEP_ALIVE=1 pnpm start
+```
+
+Useful environment overrides:
+
+- `OPENWORK_SERVER_VERSION` - `openwork-server` npm version to install. Defaults to `latest`.
+- `OPENCODE_VERSION` - OpenCode release tag to download (for example `v1.17.11`). Defaults to the `opencodeVersion` pin in the repo-root `constants.json`.
+- `OPENWORK_PORT` - port the server listens on inside the sandbox. Defaults to `8787`.
+- `OPENWORK_TOKEN` - remote-connect client token. Defaults to a random UUID; the preview URL is publicly reachable, so keep this secret.
+- `OPENWORK_HOST_TOKEN` - host/admin token. Defaults to a random UUID.
+- `OPENWORK_TENKI_KEEP_ALIVE` - set to `1` to keep the sandbox alive until `Ctrl+C` instead of terminating after the checks.
+- `TENKI_PREVIEW_SLUG` - optional stable slug for the preview URL.
+- `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` - forwarded into the server environment when set, so the managed OpenCode engine can run prompts.
+
+## Typecheck
+
+```bash
+pnpm typecheck
+```

--- a/examples/tenki-openwork-ts/README.md
+++ b/examples/tenki-openwork-ts/README.md
@@ -33,6 +33,8 @@ Useful environment overrides:
 - `TENKI_PREVIEW_SLUG` - optional stable slug for the preview URL.
 - `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` - forwarded into the server environment when set, so the managed OpenCode engine can run prompts.
 
+Security note: the server runs with `OPENWORK_APPROVAL_MODE=auto`, so anyone holding the client token gets auto-approved command execution inside the sandbox - including use of any forwarded provider keys. The preview URL is publicly reachable; treat the printed tokens as secrets (for example, don't run this in CI where stdout is a public log).
+
 ## Typecheck
 
 ```bash

--- a/examples/tenki-openwork-ts/package.json
+++ b/examples/tenki-openwork-ts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tenki-openwork-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Boot the OpenWork server inside a Tenki Cloud sandbox and verify it end to end",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@tenkicloud/sandbox": "^0.5.4"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/examples/tenki-openwork-ts/pnpm-lock.yaml
+++ b/examples/tenki-openwork-ts/pnpm-lock.yaml
@@ -1,0 +1,387 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tenkicloud/sandbox':
+        specifier: ^0.5.4
+        version: 0.5.4
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.5
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+
+packages:
+
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
+  '@connectrpc/connect-node@2.1.2':
+    resolution: {integrity: sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tenkicloud/sandbox@0.5.4':
+    resolution: {integrity: sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==}
+    engines: {node: '>=18'}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  tsx@4.23.5:
+    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@bufbuild/protobuf@2.12.1': {}
+
+  '@connectrpc/connect-node@2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@tenkicloud/sandbox@0.5.4':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-node': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  tsx@4.23.5:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
+
+  ws@8.21.1: {}

--- a/examples/tenki-openwork-ts/src/main.ts
+++ b/examples/tenki-openwork-ts/src/main.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 
-import { TenkiSandbox, type ProcessRunHandle, type Session } from "@tenkicloud/sandbox";
+import {
+  TenkiSandbox,
+  WaitReadyFailedError,
+  type ProcessRunHandle,
+  type Session,
+} from "@tenkicloud/sandbox";
 
 // Guest layout. Tenki sandboxes run as the `tenki` user with this home directory.
 const GUEST_HOME = "/home/tenki";
@@ -34,12 +39,22 @@ async function resolveConfig(): Promise<Config> {
   return {
     serverVersion: process.env.OPENWORK_SERVER_VERSION?.trim() || "latest",
     opencodeVersion: process.env.OPENCODE_VERSION?.trim() || (await repoOpencodeVersion()),
-    port: Number(process.env.OPENWORK_PORT ?? "8787"),
+    port: resolvePort(),
     clientToken: process.env.OPENWORK_TOKEN?.trim() || randomUUID(),
     hostToken: process.env.OPENWORK_HOST_TOKEN?.trim() || randomUUID(),
     keepAlive: process.env.OPENWORK_TENKI_KEEP_ALIVE === "1",
     previewSlug: process.env.TENKI_PREVIEW_SLUG?.trim() || undefined,
   };
+}
+
+function resolvePort(): number {
+  const raw = process.env.OPENWORK_PORT?.trim();
+  if (!raw) return 8787;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`invalid OPENWORK_PORT: "${raw}"`);
+  }
+  return port;
 }
 
 /** Default OpenCode version comes from the repo-root constants.json pin. */
@@ -73,18 +88,37 @@ function request(url: string, init?: RequestInit): Promise<Response> {
   return fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
 }
 
+/**
+ * Local deadline for guest commands: @tenkicloud/sandbox 0.5.4 declares
+ * ExecOptions.timeoutMs but does not apply it, so we enforce one here. On
+ * timeout the guest process may keep running, which is fine because the
+ * sandbox is terminated right after.
+ */
+async function withDeadline<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms} ms`)), ms);
+  });
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function provisionScript(config: Config): string {
   return `
 set -eu
 mkdir -p '${GUEST_DIR}/bin' '${WORKSPACE_DIR}'
-npm install --prefix '${GUEST_DIR}' --no-fund --no-audit 'openwork-server@${config.serverVersion}'
 arch="$(uname -m)"
-case "$arch" in
-  x86_64) asset="opencode-linux-x64-baseline.tar.gz" ;;
-  aarch64) asset="opencode-linux-arm64.tar.gz" ;;
-  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
-esac
+if [ "$arch" != "x86_64" ]; then
+  # The published openwork-server npm package ships a single x86_64 binary.
+  echo "unsupported architecture: $arch" >&2
+  exit 1
+fi
+npm install --prefix '${GUEST_DIR}' --no-fund --no-audit 'openwork-server@${config.serverVersion}'
 tmpdir="$(mktemp -d)"
+asset="opencode-linux-x64-baseline.tar.gz"
 curl -fsSL "https://github.com/anomalyco/opencode/releases/download/${config.opencodeVersion}/$asset" -o "$tmpdir/$asset"
 tar -xzf "$tmpdir/$asset" -C "$tmpdir"
 binary="$(find "$tmpdir" -type f -name opencode | head -n 1)"
@@ -121,14 +155,20 @@ function streamLogs(handle: ProcessRunHandle): void {
   const pump = async (stream: ReadableStream<Uint8Array>, sink: NodeJS.WriteStream): Promise<void> => {
     const decoder = new TextDecoder();
     const reader = stream.getReader();
+    let pending = "";
+    const emit = (line: string): void => {
+      if (line.trim().length > 0) sink.write(`[openwork] ${line}\n`);
+    };
     try {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        for (const line of decoder.decode(value).split("\n")) {
-          if (line.trim().length > 0) sink.write(`[openwork] ${line}\n`);
-        }
+        pending += decoder.decode(value, { stream: true });
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) emit(line);
       }
+      emit(pending + decoder.decode());
     } finally {
       reader.releaseLock();
     }
@@ -201,28 +241,30 @@ async function main(): Promise<void> {
   const config = await resolveConfig();
   const sandbox = new TenkiSandbox(); // reads TENKI_API_KEY / TENKI_AUTH_TOKEN
 
-  const startedAt = Date.now();
-  console.log("Creating Tenki sandbox...");
-  const session: Session = await sandbox.create({
-    name: "openwork-example",
-    cpuCores: 2,
-    memoryMb: 4096,
-    diskSizeGb: 10,
-    allowInbound: true,
-    allowOutbound: true,
-    maxDurationMs: (config.keepAlive ? 120 : 30) * 60 * 1000,
-    idleTimeoutMinutes: config.keepAlive ? 60 : 15,
-    tags: ["openwork-example"],
-  });
-  const sandboxReadyMs = Date.now() - startedAt;
-  console.log(`Sandbox ${session.id} running (${sandboxReadyMs} ms).`);
-
+  let pendingCreate: Promise<Session> | undefined;
+  let session: Session | undefined;
   let serverHandle: ProcessRunHandle | undefined;
-  const shutdown = async (): Promise<void> => {
-    await serverHandle?.kill().catch(() => undefined);
-    await session.closeIfOpen();
-    console.log(`Sandbox ${session.id} terminated.`);
+  let shuttingDown = false;
+
+  // Memoized so the signal handlers and the finally block never double-terminate.
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      shuttingDown = true;
+      if (serverHandle) await serverHandle.kill().catch(() => undefined);
+      const active = session ?? (await pendingCreate?.then(
+        (created) => created,
+        () => undefined,
+      ));
+      if (active) {
+        await active.closeIfOpen();
+        console.log(`Sandbox ${active.id} terminated.`);
+      }
+    })();
+    return shutdownPromise;
   };
+
+  // Installed before create() so Ctrl+C during sandbox creation still cleans up.
   process.once("SIGINT", () => {
     console.log("\nInterrupted; terminating sandbox...");
     void shutdown().finally(() => process.exit(130));
@@ -232,15 +274,43 @@ async function main(): Promise<void> {
   });
 
   try {
+    const startedAt = Date.now();
+    console.log("Creating Tenki sandbox...");
+    pendingCreate = sandbox.create({
+      name: "openwork-example",
+      cpuCores: 2,
+      memoryMb: 4096,
+      diskSizeGb: 10,
+      allowInbound: true,
+      allowOutbound: true,
+      maxDurationMs: (config.keepAlive ? 120 : 30) * 60 * 1000,
+      idleTimeoutMinutes: config.keepAlive ? 60 : 15,
+      tags: ["openwork-example"],
+    });
+    try {
+      session = await pendingCreate;
+    } catch (error) {
+      // A readiness-wait failure still carries a live session; terminate it.
+      if (error instanceof WaitReadyFailedError && error.session) {
+        await error.session.closeIfOpen().catch(() => undefined);
+      }
+      throw error;
+    }
+    const sandboxReadyMs = Date.now() - startedAt;
+    console.log(`Sandbox ${session.id} running (${sandboxReadyMs} ms).`);
+
     console.log(`Installing openwork-server@${config.serverVersion} and OpenCode ${config.opencodeVersion}...`);
     const provisionStartedAt = Date.now();
-    const provision = await session.exec("bash", {
-      args: ["-c", provisionScript(config)],
-      timeoutMs: PROVISION_TIMEOUT_MS,
-      onOutput: (output) => {
-        (output.isStderr ? process.stderr : process.stdout).write(output.data);
-      },
-    });
+    const provision = await withDeadline(
+      session.exec("bash", {
+        args: ["-c", provisionScript(config)],
+        onOutput: (output) => {
+          (output.isStderr ? process.stderr : process.stdout).write(output.data);
+        },
+      }),
+      PROVISION_TIMEOUT_MS,
+      "provisioning",
+    );
     if (provision.exitCode !== 0) {
       throw new Error(`provisioning failed with exit code ${provision.exitCode}`);
     }
@@ -249,8 +319,21 @@ async function main(): Promise<void> {
     console.log("Starting OpenWork server...");
     const serverStartedAt = Date.now();
     serverHandle = session.run([SERVER_BIN, "--verbose"], { env: serverEnv(config) });
-    void Promise.resolve(serverHandle).catch(() => undefined);
     streamLogs(serverHandle);
+
+    // Surfaces a crashed or terminated server instead of hanging on health
+    // polls (or forever in keep-alive mode). Quiet once shutdown started.
+    const serverExitMessage: Promise<string> = Promise.resolve(serverHandle).then(
+      (result) => `openwork-server exited early with code ${result.exitCode}${result.reason ? ` (${result.reason})` : ""}`,
+      (error) => `openwork-server run stream failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    const failOnServerExit = <T>(work: Promise<T>): Promise<T> => {
+      const failure = serverExitMessage.then(async (message) => {
+        if (shuttingDown) return new Promise<never>(() => {});
+        throw new Error(message);
+      });
+      return Promise.race([work, failure]);
+    };
 
     const exposed = await session.exposePort(config.port, {
       ...(config.previewSlug ? { slug: config.previewSlug } : {}),
@@ -258,10 +341,10 @@ async function main(): Promise<void> {
     const baseUrl = exposed.previewUrl.replace(/\/+$/, "");
     console.log(`Port ${config.port} exposed at ${baseUrl}`);
 
-    await waitForHealth(baseUrl);
+    await failOnServerExit(waitForHealth(baseUrl));
     const serverReadyMs = Date.now() - serverStartedAt;
 
-    await runSmokeChecks(baseUrl, config.clientToken);
+    await failOnServerExit(runSmokeChecks(baseUrl, config.clientToken));
     const totalMs = Date.now() - startedAt;
 
     console.log("");
@@ -279,9 +362,11 @@ async function main(): Promise<void> {
     if (config.keepAlive) {
       console.log("");
       console.log("Keep-alive mode: press Ctrl+C to terminate the sandbox.");
-      await new Promise<never>(() => {
-        // Resolved never; SIGINT/SIGTERM handlers terminate the sandbox.
-      });
+      await failOnServerExit(
+        new Promise<never>(() => {
+          // Resolved never; SIGINT/SIGTERM handlers terminate the sandbox.
+        }),
+      );
     }
   } finally {
     await shutdown();

--- a/examples/tenki-openwork-ts/src/main.ts
+++ b/examples/tenki-openwork-ts/src/main.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { TenkiSandbox, type ProcessRunHandle, type Session } from "@tenkicloud/sandbox";
+
+// Guest layout. Tenki sandboxes run as the `tenki` user with this home directory.
+const GUEST_HOME = "/home/tenki";
+const GUEST_DIR = `${GUEST_HOME}/openwork`;
+const SERVER_BIN = `${GUEST_DIR}/node_modules/.bin/openwork-server`;
+const OPENCODE_BIN = `${GUEST_DIR}/bin/opencode`;
+const WORKSPACE_DIR = `${GUEST_DIR}/workspace`;
+
+const PROVISION_TIMEOUT_MS = 10 * 60 * 1000;
+const HEALTH_DEADLINE_MS = 4 * 60 * 1000;
+const SMOKE_DEADLINE_MS = 60 * 1000;
+const FETCH_TIMEOUT_MS = 30 * 1000;
+
+// Provider keys forwarded into the server environment when set, so the managed
+// OpenCode engine can actually run prompts. Never printed or persisted.
+const FORWARDED_PROVIDER_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"];
+
+interface Config {
+  serverVersion: string;
+  opencodeVersion: string;
+  port: number;
+  clientToken: string;
+  hostToken: string;
+  keepAlive: boolean;
+  previewSlug: string | undefined;
+}
+
+async function resolveConfig(): Promise<Config> {
+  return {
+    serverVersion: process.env.OPENWORK_SERVER_VERSION?.trim() || "latest",
+    opencodeVersion: process.env.OPENCODE_VERSION?.trim() || (await repoOpencodeVersion()),
+    port: Number(process.env.OPENWORK_PORT ?? "8787"),
+    clientToken: process.env.OPENWORK_TOKEN?.trim() || randomUUID(),
+    hostToken: process.env.OPENWORK_HOST_TOKEN?.trim() || randomUUID(),
+    keepAlive: process.env.OPENWORK_TENKI_KEEP_ALIVE === "1",
+    previewSlug: process.env.TENKI_PREVIEW_SLUG?.trim() || undefined,
+  };
+}
+
+/** Default OpenCode version comes from the repo-root constants.json pin. */
+async function repoOpencodeVersion(): Promise<string> {
+  const constantsUrl = new URL("../../../constants.json", import.meta.url);
+  const parsed: unknown = JSON.parse(await readFile(constantsUrl, "utf8"));
+  return getString(parsed, "opencodeVersion");
+}
+
+function getProperty(value: unknown, key: string): unknown {
+  if (typeof value === "object" && value !== null) {
+    const record: Record<string, unknown> = Object.fromEntries(Object.entries(value));
+    return record[key];
+  }
+  throw new Error(`expected a JSON object with a "${key}" field`);
+}
+
+function getString(value: unknown, key: string): string {
+  const found = getProperty(value, key);
+  if (typeof found === "string" && found.length > 0) return found;
+  throw new Error(`expected a non-empty string "${key}" field`);
+}
+
+function firstListItem(value: unknown, key: string): unknown {
+  const found = getProperty(value, key);
+  if (Array.isArray(found) && found.length > 0) return found[0];
+  throw new Error(`expected a non-empty "${key}" array`);
+}
+
+function request(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+}
+
+function provisionScript(config: Config): string {
+  return `
+set -eu
+mkdir -p '${GUEST_DIR}/bin' '${WORKSPACE_DIR}'
+npm install --prefix '${GUEST_DIR}' --no-fund --no-audit 'openwork-server@${config.serverVersion}'
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) asset="opencode-linux-x64-baseline.tar.gz" ;;
+  aarch64) asset="opencode-linux-arm64.tar.gz" ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+tmpdir="$(mktemp -d)"
+curl -fsSL "https://github.com/anomalyco/opencode/releases/download/${config.opencodeVersion}/$asset" -o "$tmpdir/$asset"
+tar -xzf "$tmpdir/$asset" -C "$tmpdir"
+binary="$(find "$tmpdir" -type f -name opencode | head -n 1)"
+test -n "$binary"
+install -m 0755 "$binary" '${OPENCODE_BIN}'
+rm -rf "$tmpdir"
+# The published npm package ships the compiled binary without the executable bit.
+chmod +x '${GUEST_DIR}/node_modules/openwork-server/dist/bin/openwork-server'
+'${SERVER_BIN}' --version
+'${OPENCODE_BIN}' --version
+`;
+}
+
+function serverEnv(config: Config): Record<string, string> {
+  const env: Record<string, string> = {
+    OPENWORK_HOST: "0.0.0.0",
+    OPENWORK_PORT: String(config.port),
+    OPENWORK_TOKEN: config.clientToken,
+    OPENWORK_HOST_TOKEN: config.hostToken,
+    OPENWORK_APPROVAL_MODE: "auto",
+    OPENWORK_CORS_ORIGINS: "*",
+    OPENWORK_WORKSPACES: WORKSPACE_DIR,
+    OPENWORK_MANAGE_OPENCODE: "1",
+    OPENWORK_OPENCODE_BIN: OPENCODE_BIN,
+  };
+  for (const key of FORWARDED_PROVIDER_KEYS) {
+    const value = process.env[key];
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
+function streamLogs(handle: ProcessRunHandle): void {
+  const pump = async (stream: ReadableStream<Uint8Array>, sink: NodeJS.WriteStream): Promise<void> => {
+    const decoder = new TextDecoder();
+    const reader = stream.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        for (const line of decoder.decode(value).split("\n")) {
+          if (line.trim().length > 0) sink.write(`[openwork] ${line}\n`);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  };
+  void pump(handle.stdout, process.stdout).catch(() => undefined);
+  void pump(handle.stderr, process.stderr).catch(() => undefined);
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + HEALTH_DEADLINE_MS;
+  for (;;) {
+    try {
+      const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(5000) });
+      if (response.ok) return;
+    } catch {
+      // Not reachable yet; the preview URL returns errors until the server listens.
+    }
+    if (Date.now() > deadline) throw new Error(`server did not become healthy at ${baseUrl}/health`);
+    await sleep(2000);
+  }
+}
+
+async function runSmokeChecks(baseUrl: string, clientToken: string): Promise<void> {
+  const unauthenticated = await request(`${baseUrl}/workspaces`);
+  if (unauthenticated.status !== 401) {
+    throw new Error(`expected unauthenticated /workspaces to return 401, got ${unauthenticated.status}`);
+  }
+
+  const auth = { Authorization: `Bearer ${clientToken}` };
+  const workspacesResponse = await request(`${baseUrl}/workspaces`, { headers: auth });
+  if (!workspacesResponse.ok) {
+    throw new Error(`expected authenticated /workspaces to succeed, got ${workspacesResponse.status}`);
+  }
+  const workspaces: unknown = await workspacesResponse.json();
+  const workspaceId = getString(firstListItem(workspaces, "items"), "id");
+  console.log(`Workspace registered: ${workspaceId}`);
+
+  // The managed OpenCode engine can finish booting slightly after /health goes
+  // green, so retry session creation until the smoke deadline.
+  const deadline = Date.now() + SMOKE_DEADLINE_MS;
+  let sessionId = "";
+  for (;;) {
+    const created = await request(`${baseUrl}/w/${workspaceId}/opencode/session`, {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Tenki sandbox smoke test" }),
+    });
+    if (created.ok) {
+      const payload: unknown = await created.json();
+      sessionId = getString(payload, "id");
+      break;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`expected opencode session create to succeed, got ${created.status}`);
+    }
+    await sleep(3000);
+  }
+  console.log(`OpenCode session created: ${sessionId}`);
+
+  const fetched = await request(`${baseUrl}/w/${workspaceId}/opencode/session/${sessionId}`, { headers: auth });
+  if (!fetched.ok) throw new Error(`expected opencode session get to succeed, got ${fetched.status}`);
+
+  const messages = await request(`${baseUrl}/w/${workspaceId}/opencode/session/${sessionId}/message?limit=10`, {
+    headers: auth,
+  });
+  if (!messages.ok) throw new Error(`expected opencode session messages to succeed, got ${messages.status}`);
+}
+
+async function main(): Promise<void> {
+  const config = await resolveConfig();
+  const sandbox = new TenkiSandbox(); // reads TENKI_API_KEY / TENKI_AUTH_TOKEN
+
+  const startedAt = Date.now();
+  console.log("Creating Tenki sandbox...");
+  const session: Session = await sandbox.create({
+    name: "openwork-example",
+    cpuCores: 2,
+    memoryMb: 4096,
+    diskSizeGb: 10,
+    allowInbound: true,
+    allowOutbound: true,
+    maxDurationMs: (config.keepAlive ? 120 : 30) * 60 * 1000,
+    idleTimeoutMinutes: config.keepAlive ? 60 : 15,
+    tags: ["openwork-example"],
+  });
+  const sandboxReadyMs = Date.now() - startedAt;
+  console.log(`Sandbox ${session.id} running (${sandboxReadyMs} ms).`);
+
+  let serverHandle: ProcessRunHandle | undefined;
+  const shutdown = async (): Promise<void> => {
+    await serverHandle?.kill().catch(() => undefined);
+    await session.closeIfOpen();
+    console.log(`Sandbox ${session.id} terminated.`);
+  };
+  process.once("SIGINT", () => {
+    console.log("\nInterrupted; terminating sandbox...");
+    void shutdown().finally(() => process.exit(130));
+  });
+  process.once("SIGTERM", () => {
+    void shutdown().finally(() => process.exit(143));
+  });
+
+  try {
+    console.log(`Installing openwork-server@${config.serverVersion} and OpenCode ${config.opencodeVersion}...`);
+    const provisionStartedAt = Date.now();
+    const provision = await session.exec("bash", {
+      args: ["-c", provisionScript(config)],
+      timeoutMs: PROVISION_TIMEOUT_MS,
+      onOutput: (output) => {
+        (output.isStderr ? process.stderr : process.stdout).write(output.data);
+      },
+    });
+    if (provision.exitCode !== 0) {
+      throw new Error(`provisioning failed with exit code ${provision.exitCode}`);
+    }
+    const provisionMs = Date.now() - provisionStartedAt;
+
+    console.log("Starting OpenWork server...");
+    const serverStartedAt = Date.now();
+    serverHandle = session.run([SERVER_BIN, "--verbose"], { env: serverEnv(config) });
+    void Promise.resolve(serverHandle).catch(() => undefined);
+    streamLogs(serverHandle);
+
+    const exposed = await session.exposePort(config.port, {
+      ...(config.previewSlug ? { slug: config.previewSlug } : {}),
+    });
+    const baseUrl = exposed.previewUrl.replace(/\/+$/, "");
+    console.log(`Port ${config.port} exposed at ${baseUrl}`);
+
+    await waitForHealth(baseUrl);
+    const serverReadyMs = Date.now() - serverStartedAt;
+
+    await runSmokeChecks(baseUrl, config.clientToken);
+    const totalMs = Date.now() - startedAt;
+
+    console.log("");
+    console.log("All checks passed.");
+    console.log(`- sandbox ready:  ${sandboxReadyMs} ms`);
+    console.log(`- provisioning:   ${provisionMs} ms`);
+    console.log(`- server ready:   ${serverReadyMs} ms`);
+    console.log(`- total:          ${totalMs} ms`);
+    console.log("");
+    console.log(`OpenWork URL:  ${baseUrl}`);
+    console.log(`Client token:  ${config.clientToken}`);
+    console.log(`Host token:    ${config.hostToken}`);
+    console.log("Connect the OpenWork desktop app via Add a worker -> Connect remote.");
+
+    if (config.keepAlive) {
+      console.log("");
+      console.log("Keep-alive mode: press Ctrl+C to terminate the sandbox.");
+      await new Promise<never>(() => {
+        // Resolved never; SIGINT/SIGTERM handlers terminate the sandbox.
+      });
+    }
+  } finally {
+    await shutdown();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/tenki-openwork-ts/tsconfig.json
+++ b/examples/tenki-openwork-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Adds `examples/tenki-openwork-ts`: a small standalone TypeScript example that boots the headless OpenWork server inside a [Tenki Cloud](https://tenki.cloud) sandbox using the [`@tenkicloud/sandbox`](https://www.npmjs.com/package/@tenkicloud/sandbox) SDK, exposes it on a public preview URL, and verifies it end to end.

It mirrors the smoke flow of `examples/microsandbox-openwork-rust`:

1. Create an ephemeral sandbox (2 vCPU / 4 GB / 10 GB).
2. Install the published `openwork-server` npm package (compiled Linux binary — no in-sandbox build) and the OpenCode release pinned in the repo-root `constants.json` (`v1.17.11`).
3. Start the server with `OPENWORK_MANAGE_OPENCODE=1`, same contract as `packaging/docker/microsandbox-entrypoint.sh`.
4. Expose port 8787 via a Tenki preview URL and verify from outside the sandbox: `/health`, unauthenticated `/workspaces` → 401, authenticated → 200, `POST /w/:id/opencode/session`, session + message reads.
5. Print startup timings, then terminate the sandbox.

`OPENWORK_TENKI_KEEP_ALIVE=1` keeps it running for the desktop app's **Add a worker → Connect remote** flow; Ctrl+C terminates the sandbox.

## Sandbox lifecycle

Ephemeral by default. Termination is guaranteed via a memoized shutdown shared by `finally` and SIGINT/SIGTERM handlers (installed before sandbox creation), with `maxDurationMs`/`idleTimeoutMinutes` backstops if the process is killed outright. Verified after all test runs below by listing sessions by tag: 6 sessions total, **0 alive** (including failed and interrupted runs).

## Tests run

- `pnpm typecheck` — clean (strict, no `any`/`as`).
- `pnpm start` e2e against real Tenki sandboxes — 3 clean runs, all checks passed. Representative run: sandbox ready 2043 ms, provisioning 7000 ms, server ready 3385 ms, total 23133 ms (`server ready` = server spawn → `/health` 200 through the public preview URL; total includes the ~9 s first `POST .../opencode/session`).
- Keep-alive run: reached steady state, SIGINT → exit 130, sandbox terminated.
- SIGINT 1 s in (during sandbox creation): exit 130, sandbox terminated.

The branch also went through an adversarial review pass before submission (second commit): a provisioning deadline enforced locally (the Tenki SDK's declared `ExecOptions.timeoutMs` is a no-op in 0.5.4 — reported to Tenki as a bug), fail-fast when the server process exits early instead of hanging on health polls, signal handlers installed before sandbox creation, UTF-8-safe log line buffering, port validation, and a documented `OPENWORK_APPROVAL_MODE=auto` trust model in the README.

Testkit evidence tape: not applicable — this is a standalone example outside the pnpm workspace (like the Rust microsandbox example); it does not touch app/server runtime code. The example itself is the executable end-to-end check; validation needs a `TENKI_API_KEY`, so it cannot run in CI. Repro steps are in the example README.

## Note: packaging bug found while testing

`openwork-server@0.18.13` on npm ships `dist/bin/openwork-server` **without the executable bit**, so the `bin/openwork-server.mjs` wrapper fails with `EACCES` on Linux after a plain `npm install` — the README quick start (`npm install -g openwork-server && openwork-server ...`) hits this too. The example works around it with a `chmod +x` after install (commented in the provision script). Happy to file/fix separately — likely a publish-pipeline fix (`chmod` before `npm publish` or an install script).