### PR TITLE
Give the sidebar a New task row and move notifications into it

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -57,7 +57,6 @@ import { SessionEmptyHero } from "./session-empty-hero";
 import type { NewTaskComposerContext } from "./new-task-composer";
 import type { SessionCloudMcpMaintenanceState } from "../../connections/use-session-mcp-maintenance";
 import { OwDotTicker } from "../../../shell/dot-ticker";
-import { NotificationBell } from "../../../shell/notification-center";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
@@ -1128,7 +1127,6 @@ export function SessionPage(props: SessionPageProps) {
                   <TooltipContent>Find in conversation (⌘F)</TooltipContent>
                 </Tooltip>
               ) : null}
-              <NotificationBell />
               <Tooltip>
                 <TooltipTrigger
                   render={

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -9,12 +9,12 @@ import {
   ChevronRight,
   Columns2,
   FolderPlus,
+  LayoutGrid,
   MoreHorizontal,
   Pencil,
   Pin,
   PinOff,
   Plus,
-  Puzzle,
   Search,
   Share2,
   Trash2,
@@ -22,6 +22,7 @@ import {
   RotateCcw,
   Settings,
   FolderOpen,
+  SquarePen,
   Tag,
   X,
 } from "lucide-react";
@@ -30,6 +31,7 @@ import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
 import { OpenWorkDenHelpLink } from "../../workspace/openwork-den-help-link";
+import { NotificationBell } from "../../../shell/notification-center";
 import type {
   WorkspaceConnectionState,
   WorkspaceSessionGroup,
@@ -1108,6 +1110,19 @@ export function AppSidebar(props: AppSidebarProps) {
         ) : null}
         <SidebarHeader className="pb-0 pe-0">
           <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                type="button"
+                data-sidebar-new-chat
+                aria-label={t("session.new_task")}
+                tooltip={t("session.new_task")}
+                disabled={props.newTaskDisabled}
+                onClick={() => props.onCreateTaskInWorkspace(props.selectedWorkspaceId)}
+              >
+                <SquarePen />
+                <span className="flex-1 truncate">{t("session.new_task")}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
             {props.onOpenSessionSearch ? (
               <SidebarMenuItem>
                 <SidebarMenuButton
@@ -1125,10 +1140,13 @@ export function AppSidebar(props: AppSidebarProps) {
             ) : null}
             <SidebarDestination
               active={props.extensionsActive === true}
-              icon={Puzzle}
+              icon={LayoutGrid}
               label={t("settings.tab_extensions")}
               onSelect={props.onOpenExtensions}
             />
+            <SidebarMenuItem>
+              <NotificationBell variant="sidebar-row" />
+            </SidebarMenuItem>
           </SidebarMenu>
         </SidebarHeader>
         <SidebarSplitPill

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -11,6 +11,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { SidebarMenuButton } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import { t } from "@/i18n";
 import {
@@ -52,11 +53,11 @@ function formatTimeAgo(timestamp: number): string {
 }
 
 /**
- * Notification bell with unread badge + popover panel. Mounted in the
- * session and settings headers; hidden via the `notifications` shell flag.
- * Closing the panel marks everything read.
+ * Notification bell with unread badge + popover panel. Mounted as a labelled
+ * row in the main sidebar and as an icon in the settings header; hidden via
+ * the `notifications` shell flag. Closing the panel marks everything read.
  */
-export function NotificationBell() {
+export function NotificationBell({ variant = "icon" }: { variant?: "icon" | "sidebar-row" }) {
   const { config } = useShellConfig();
   const [open, setOpen] = useState(false);
   const notifications = useNotificationStore((state) => state.notifications);
@@ -90,6 +91,9 @@ export function NotificationBell() {
     () => notifications.filter((notification) => notification.readAt === null).length,
     [notifications],
   );
+  const label = unreadCount > 0
+    ? `${t("notifications.title")} (${unreadCount})`
+    : t("notifications.title");
 
   useEffect(() => {
     const handler = () => setOpen(true);
@@ -130,27 +134,45 @@ export function NotificationBell() {
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
         render={
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground"
-            title={t("notifications.title")}
-            aria-label={
-              unreadCount > 0
-                ? `${t("notifications.title")} (${unreadCount})`
-                : t("notifications.title")
-            }
-          >
-            <Bell size={17} />
-            {unreadCount > 0 ? (
-              <span className="absolute right-0.5 top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-3 text-primary-foreground">
-                {unreadCount > 9 ? "9+" : unreadCount}
-              </span>
-            ) : null}
-          </Button>
+          variant === "sidebar-row" ? (
+            <SidebarMenuButton
+              type="button"
+              className="text-sidebar-foreground/70"
+              tooltip={label}
+              aria-label={label}
+            >
+              <Bell />
+              <span className="flex-1 truncate">{t("notifications.title")}</span>
+              {unreadCount > 0 ? (
+                <span className="ml-auto flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-4 text-primary-foreground">
+                  {unreadCount > 9 ? "9+" : unreadCount}
+                </span>
+              ) : null}
+            </SidebarMenuButton>
+          ) : (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground"
+              title={t("notifications.title")}
+              aria-label={label}
+            >
+              <Bell size={17} />
+              {unreadCount > 0 ? (
+                <span className="absolute right-0.5 top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-3 text-primary-foreground">
+                  {unreadCount > 9 ? "9+" : unreadCount}
+                </span>
+              ) : null}
+            </Button>
+          )
         }
       />
-      <PopoverContent align="end" sideOffset={8} className="w-96 gap-0 p-0">
+      <PopoverContent
+        align={variant === "sidebar-row" ? "start" : "end"}
+        side={variant === "sidebar-row" ? "right" : "bottom"}
+        sideOffset={8}
+        className="w-96 gap-0 p-0"
+      >
         <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
           <p className="text-sm font-semibold">{t("notifications.title")}</p>
           {notifications.length > 0 ? (

--- a/evals/specs/sidebar-primary-actions.slow.test.ts
+++ b/evals/specs/sidebar-primary-actions.slow.test.ts
@@ -1,0 +1,138 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "the sidebar offers New task and Notifications as primary actions, and the bell is not duplicated in the session header"
+  : "sidebar primary actions skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+/** Labels of the top-level rows, which all live in the sidebar header block. */
+const primaryActionLabels = `(() => {
+  const header = document.querySelector('[data-slot="sidebar-header"]');
+  if (!header) return null;
+  return [...header.querySelectorAll("button")]
+    .map((button) => (button.textContent ?? "").replace(/\\s+/g, " ").trim())
+    .filter((label) => label.length > 0);
+})()`;
+
+/**
+ * The bell used to sit in the session header too. Counting every notifications
+ * control on the page proves it moved rather than merely being added.
+ */
+const notificationControls = `(() => {
+  const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+  const all = [...document.querySelectorAll("button")]
+    .filter((button) => (button.getAttribute("aria-label") ?? "").startsWith("Notifications"));
+  return {
+    total: all.length,
+    inSidebar: all.filter((button) => Boolean(sidebar && sidebar.contains(button))).length,
+  };
+})()`;
+
+function labels(value: unknown): string[] {
+  if (!Array.isArray(value)) throw new Error(`Sidebar header rows were not readable: ${JSON.stringify(value)}`);
+  return value.map((entry) => (typeof entry === "string" ? entry : ""));
+}
+
+function counts(value: unknown): { total: number; inSidebar: number } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Notification control counts were not an object: ${JSON.stringify(value)}`);
+  }
+  const total = Reflect.get(value, "total");
+  const inSidebar = Reflect.get(value, "inSidebar");
+  if (typeof total !== "number" || typeof inSidebar !== "number") {
+    throw new Error(`Notification control counts were not numbers: ${JSON.stringify(value)}`);
+  }
+  return { total, inSidebar };
+}
+
+function sessionCount(value: unknown): number {
+  if (!Array.isArray(value)) throw new Error(`session.list_sessions did not return a list: ${JSON.stringify(value)}`);
+  return value.length;
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using app = await desktop({ name: "sidebar-primary-actions" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-sidebar-primary-actions-${Date.now()}`,
+  });
+
+  await waitFor(app, `Boolean(document.querySelector('[data-slot="sidebar-header"] [data-sidebar-new-chat]'))`, {
+    timeoutMs: 60_000,
+    label: "sidebar New task row",
+  });
+
+  const rows = labels(await evalIn(app, primaryActionLabels));
+  for (const expected of ["New task", "Library", "Notifications"]) {
+    expect(rows.some((row) => row.includes(expected)), `sidebar header rows: ${JSON.stringify(rows)}`).toBe(true);
+  }
+  evidence.fact(
+    "New task and Notifications are top-level sidebar rows alongside search and Library",
+    `The sidebar header renders these rows: ${JSON.stringify(rows)}.`,
+    true,
+  );
+
+  const bells = counts(await evalIn(app, notificationControls));
+  expect(bells.total).toBe(1);
+  expect(bells.inSidebar).toBe(1);
+  evidence.fact(
+    "The notification bell lives only in the sidebar, not duplicated in the session header",
+    `Exactly ${bells.total} notifications control exists on the page and ${bells.inSidebar} of them is inside the sidebar.`,
+    true,
+  );
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The sidebar lists New task, Search sessions, Library and Notifications as rows above the workspaces section",
+      "No notification bell icon is visible in the header bar above the conversation area",
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  const before = sessionCount(await control(app, "session.list_sessions"));
+  await evalIn(app, `document.querySelector('[data-sidebar-new-chat]')?.click()`);
+  await waitFor(app, `window.location.hash.includes("/session/ses_")`, {
+    timeoutMs: 60_000,
+    label: "session created from the sidebar New task row",
+  });
+  const after = sessionCount(await control(app, "session.list_sessions"));
+  expect(after).toBeGreaterThan(before);
+  evidence.fact(
+    "Clicking the sidebar New task row starts a new session",
+    `Sessions went from ${before} to ${after} after clicking the New task row, and the route moved to the new session.`,
+    true,
+  );
+
+  await evalIn(app, `(() => {
+    const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+    const bell = [...(sidebar?.querySelectorAll("button") ?? [])]
+      .find((button) => (button.getAttribute("aria-label") ?? "").startsWith("Notifications"));
+    bell?.click();
+  })()`);
+  await waitFor(app, `document.body.innerText.includes("No notifications yet")
+    || Boolean(document.querySelector('[role="dialog"], [data-popup-open]'))`, {
+    timeoutMs: 30_000,
+    label: "notification panel opened from the sidebar row",
+  });
+  evidence.fact(
+    "The sidebar Notifications row opens the notification panel",
+    "Clicking the sidebar notifications control revealed the notification panel.",
+    true,
+  );
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The notification panel is open beside the sidebar and reports that there are no notifications yet",
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary

- **New task** is now the first sidebar row. There was previously no way to start a task from the top level — only a hover `+` on a workspace header.
- **Notifications** moves out of the session header and into the sidebar as a labelled row with its unread badge. `NotificationBell` gains a `variant` so it renders either as the old header icon or as a sidebar row; the session header drops its copy so the bell moves rather than duplicates. Settings keeps its own bell, since the main sidebar is not visible on that screen.
- **Library** trades its puzzle glyph for a grid, which reads as a destination rather than a plugin.

Design reference is the normalized sidebar artboard in Paper.

## Test plan

- `pnpm typecheck` — clean.
- `pnpm --filter @openwork/app test` — 596 pass / 2 fail, identical to a stashed clean tree. Both failures are pre-existing and unrelated: `opencode-stream-timeout.test.ts` aborts the batch run, and two `message-list loading feedback` tests fail only in batch from cross-test pollution (each passes in isolation).
- New spec `evals/specs/sidebar-primary-actions.slow.test.ts` — green. It asserts the primary-action rows, that exactly one notifications control exists on the page and it lives inside the sidebar (the negative half proving the bell moved rather than being added), that clicking New task increases the session count, and that the row opens the notification panel.

```
OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run \
  --config vitest.config.ts --project stack specs/sidebar-primary-actions.slow.test.ts
```

Photo roll follows in a comment.

Made with [Cursor](https://cursor.com)