### PR TITLE
fix(desktop): ship runtime window icon in packaged Windows builds

### DIFF
--- a/apps/desktop/electron-builder.base.yml
+++ b/apps/desktop/electron-builder.base.yml
@@ -82,6 +82,8 @@ linux:
 win:
   icon: resources/icons/icon.ico
   extraResources:
+    - from: resources/icons/icon.png
+      to: icons/icon.png
     - from: resources/sidecars
       to: sidecars
       filter:

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -218,8 +218,7 @@ function resolveAppIconPath() {
       : []),
     // Repo-relative path to the Electron resource icon set.
     path.resolve(__dirname, "../resources/icons/icon.png"),
-    // Packaged: electron-builder copies extraResources but we fall back to this
-    // if custom packaging ever exposes the icon here.
+    // Packaged Windows and Linux builds ship runtime icons via extraResources.
     path.join(process.resourcesPath ?? "", "icons", "linux", "512x512.png"),
     path.join(process.resourcesPath ?? "", "icons", "icon.png"),
   ];


### PR DESCRIPTION
## What

4 user reports over 3 weeks (v0.18.0 → v0.18.12): the running app's Windows taskbar button shows the generic blank icon while the desktop shortcut / exe icon is correct.

Packaged Windows builds have **no reachable runtime icon**: `resources/` is not in the asar (`files:` list) and `win.extraResources` shipped sidecars only, so every candidate in `resolveAppIconPath()` misses → `APP_ICON_IMAGE === null` → `new BrowserWindow` gets no `icon:` and nothing calls `setIcon` on the stock Windows path. Invisible until #2636 added the `skipTaskbar: true` → `setSkipTaskbar(false)` toggle: the rebuilt taskbar button takes the HWND's own icon, and this window has none — that's why the exe/shortcut icons stayed correct while the live button went blank. #3217 fixed this exact packaging hole for Linux only; this mirrors it for Windows.

- `electron-builder.base.yml`: ship `resources/icons/icon.png` → `resources/icons/icon.png` in `win.extraResources`; the existing `resourcesPath/icons/icon.png` candidate in `resolveAppIconPath()` now resolves.
- Comment fix in `main.mjs`; no logic change. Dev candidates untouched.

## Tests run

- YAML parses (repo `yaml` dep); public/cloud/enterprise flavors all inherit `win` and none overrides `extraResources`.
- `node --check apps/desktop/electron/main.mjs` — clean.
- `resources/icons/icon.png` confirmed 512×512.
- Windows taskbar pixels cannot be verified from macOS: Daytona Windows-sandbox validation of the built artifact is being run and evidence will be posted on this PR.