### PR TITLE
fix(server): make embedded lifecycle cleanup idempotent

### DIFF
--- a/apps/server/src/embedded-lifecycle.test.ts
+++ b/apps/server/src/embedded-lifecycle.test.ts
@@ -1,0 +1,401 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { startEmbeddedServer, type EmbeddedServerHandle, type EmbeddedServerOptions } from "./embedded.js";
+import * as managedOpencodeModule from "./managed-opencode.js";
+import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import * as serverModule from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const HOST = "127.0.0.1";
+const SERVER_TOKEN = "server-token";
+const HOST_TOKEN = "host-token";
+const PROVIDER_ID = "lifecycle_anthropic";
+const PROVIDER = { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] };
+const ENV_NAMES: string[] = [
+  "HOME",
+  "OPENWORK_DEV_MODE",
+  "OPENWORK_RUNTIME_DB",
+  "OPENWORK_OPENCODE_BASE_URL",
+  "OPENWORK_LIFECYCLE_LOG",
+  "OPENCODE_MODELS_URL",
+];
+
+type Fixture = {
+  root: string;
+  opencodeBin: string;
+  logPath: string;
+  handles: EmbeddedServerHandle[];
+  restore: () => Promise<void>;
+};
+
+function restoreProcessEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function writeFakeOpencodeBin(root: string): Promise<string> {
+  const binPath = join(root, "fake-opencode.mjs");
+  await writeFile(binPath, [
+    "#!/usr/bin/env bun",
+    "import { appendFileSync } from 'node:fs';",
+    "const portIndex = process.argv.indexOf('--port');",
+    "const requestedPort = Number(process.argv[portIndex + 1] ?? 0);",
+    "const logPath = process.env.OPENWORK_LIFECYCLE_LOG;",
+    "const append = (line) => { if (logPath) appendFileSync(logPath, `${line}\\n`); };",
+    "const server = Bun.serve({",
+    "  hostname: '127.0.0.1',",
+    "  port: requestedPort,",
+    "  fetch(request) { append(new URL(request.url).pathname); return Response.json({}); },",
+    "});",
+    "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
+    "process.on('SIGTERM', () => { append('SIGTERM'); server.stop(true); process.exit(0); });",
+  ].join("\n"));
+  await chmod(binPath, 0o755);
+  return binPath;
+}
+
+async function writeUnreadyOpencodeBin(root: string): Promise<string> {
+  const binPath = join(root, "unready-opencode.mjs");
+  await writeFile(binPath, [
+    "#!/usr/bin/env bun",
+    "import { appendFileSync } from 'node:fs';",
+    "const logPath = process.env.OPENWORK_LIFECYCLE_LOG;",
+    "process.on('SIGTERM', () => { if (logPath) appendFileSync(logPath, 'SIGTERM\\n'); process.exit(0); });",
+    "if (logPath) appendFileSync(logPath, 'READY\\n');",
+    "setInterval(() => undefined, 1000);",
+  ].join("\n"));
+  await chmod(binPath, 0o755);
+  return binPath;
+}
+
+async function createFixture(): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-embedded-lifecycle-"));
+  const previousEnv = new Map(ENV_NAMES.map((name) => [name, process.env[name]]));
+  const logPath = join(root, "managed-opencode.log");
+  const opencodeBin = await writeFakeOpencodeBin(root);
+  const handles: EmbeddedServerHandle[] = [];
+
+  process.env.HOME = join(root, "home");
+  process.env.OPENWORK_DEV_MODE = "1";
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_LIFECYCLE_LOG = logPath;
+  process.env.OPENCODE_MODELS_URL = "https://catalog.example.test/models";
+  delete process.env.OPENWORK_OPENCODE_BASE_URL;
+
+  return {
+    root,
+    opencodeBin,
+    logPath,
+    handles,
+    async restore() {
+      const errors: unknown[] = [];
+      for (const handle of handles.reverse()) {
+        try {
+          await handle.stop();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      for (const name of ENV_NAMES) restoreProcessEnv(name, previousEnv.get(name));
+      try {
+        await rm(root, { recursive: true, force: true });
+      } catch (error) {
+        errors.push(error);
+      }
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "Failed to clean up embedded lifecycle test");
+      }
+    },
+  };
+}
+
+async function startManaged(fixture: Fixture, name: string): Promise<EmbeddedServerHandle> {
+  const workspace = join(fixture.root, `${name}-workspace`);
+  await mkdir(workspace, { recursive: true });
+  const handle = await startEmbeddedServer({
+    configPath: join(fixture.root, `${name}-server.json`),
+    host: HOST,
+    port: 0,
+    token: SERVER_TOKEN,
+    hostToken: HOST_TOKEN,
+    workspaces: [workspace],
+    manageOpencode: true,
+    opencodeBin: fixture.opencodeBin,
+    opencodeCwd: workspace,
+  });
+  fixture.handles.push(handle);
+  return handle;
+}
+
+function managedOptions(fixture: Fixture, name: string): EmbeddedServerOptions {
+  const workspace = join(fixture.root, `${name}-workspace`);
+  return {
+    configPath: join(fixture.root, `${name}-server.json`),
+    host: HOST,
+    port: 0,
+    token: SERVER_TOKEN,
+    hostToken: HOST_TOKEN,
+    workspaces: [workspace],
+    manageOpencode: true,
+    opencodeBin: fixture.opencodeBin,
+    opencodeCwd: workspace,
+  };
+}
+
+function workspaceId(config: ServerConfig): string {
+  const id = config.workspaces[0]?.id;
+  if (!id) throw new Error("Expected an embedded workspace");
+  return id;
+}
+
+async function mutateWorkspace(config: ServerConfig, id: string, label: string): Promise<void> {
+  await writeRuntimeOpencodeConfig(config, id, (current) => ({
+    ...current,
+    mcp: { [label]: { type: "remote", url: `https://${label}.example.test/mcp` } },
+  }));
+}
+
+async function patchProviders(handle: EmbeddedServerHandle): Promise<Record<string, unknown>> {
+  const response = await fetch(`${handle.url}/runtime-config/providers`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-openwork-host-token": HOST_TOKEN,
+    },
+    body: JSON.stringify({ provider: { [PROVIDER_ID]: PROVIDER } }),
+  });
+  expect(response.status).toBe(200);
+  const body: unknown = await response.json();
+  if (!isRecord(body)) {
+    throw new Error("Expected a runtime provider response");
+  }
+  return body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function logLines(path: string): Promise<string[]> {
+  const content = await readFile(path, "utf8").catch(() => "");
+  return content.split("\n").filter(Boolean);
+}
+
+describe("embedded server lifecycle", () => {
+  test.serial("managed OpenCode readiness failure closes the spawned child", async () => {
+    const fixture = await createFixture();
+    try {
+      const bin = await writeUnreadyOpencodeBin(fixture.root);
+      await expect(managedOpencodeModule.createManagedOpencodeServer({
+        bin,
+        cwd: fixture.root,
+        timeoutMs: 500,
+        env: { OPENWORK_LIFECYCLE_LOG: fixture.logPath },
+      })).rejects.toThrow("Timeout waiting for OpenCode server");
+      expect(await logLines(fixture.logPath)).toContain("READY");
+      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(1);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test.serial("a stopped server no longer writes generated runtime configuration", async () => {
+    const fixture = await createFixture();
+    try {
+      const serverA = await startManaged(fixture, "server-a");
+      const id = workspaceId(serverA.config);
+      await serverA.stop();
+
+      await mutateWorkspace(serverA.config, id, "stopped-server");
+      const barrier = await writeOpenworkRuntimeConfigFile(serverA.config, id);
+
+      // The explicit barrier is the first writer only when the stopped
+      // server's subscription did not enqueue a write ahead of it.
+      expect(barrier.changed).toBe(true);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test.serial("only the replacement server responds to shared runtime database changes", async () => {
+    const fixture = await createFixture();
+    try {
+      const serverA = await startManaged(fixture, "server-a");
+      const serverAWorkspace = workspaceId(serverA.config);
+      await serverA.stop();
+      const serverB = await startManaged(fixture, "server-b");
+      const serverBWorkspace = workspaceId(serverB.config);
+
+      await mutateWorkspace(serverA.config, serverAWorkspace, "stale-server");
+      const afterStoppedServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config, serverBWorkspace);
+      expect(afterStoppedServerMutation.changed).toBe(false);
+
+      await mutateWorkspace(serverB.config, serverBWorkspace, "active-server");
+      const afterActiveServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config, serverBWorkspace);
+      expect(afterActiveServerMutation.changed).toBe(false);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test.serial("an identical provider update after replacement is inert", async () => {
+    const fixture = await createFixture();
+    try {
+      const serverA = await startManaged(fixture, "server-a");
+      const serverAWorkspace = workspaceId(serverA.config);
+      await serverA.stop();
+      const serverB = await startManaged(fixture, "server-b");
+
+      const first = await patchProviders(serverB);
+      expect(first).toMatchObject({ changed: true, reload: "reloaded" });
+      const fileAfterFirstPatch = await readFile(join(fixture.root, "runtime-opencode-config.json"));
+      const disposalsAfterFirstPatch = (await logLines(fixture.logPath)).filter((line) => line === "/instance/dispose").length;
+
+      await mutateWorkspace(serverA.config, serverAWorkspace, "stale-server");
+      const second = await patchProviders(serverB);
+
+      expect(second).toMatchObject({ changed: false, reload: "skipped" });
+      expect(await readFile(join(fixture.root, "runtime-opencode-config.json"))).toEqual(fileAfterFirstPatch);
+      expect((await logLines(fixture.logPath)).filter((line) => line === "/instance/dispose")).toHaveLength(disposalsAfterFirstPatch);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test.serial("stop shares one shutdown operation and releases each resource once", async () => {
+    const fixture = await createFixture();
+    const originalStartServer = serverModule.startServer;
+    let httpStopCalls = 0;
+    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async (config) => {
+      const server = await originalStartServer(config);
+      return {
+        ...server,
+        async stop() {
+          httpStopCalls += 1;
+          await server.stop();
+        },
+      };
+    });
+    const clearTrustedSpy = spyOn(serverModule, "clearTrustedOpencodeProcess");
+
+    try {
+      const handle = await startManaged(fixture, "idempotent");
+      const firstStop = handle.stop();
+      const secondStop = handle.stop();
+      expect(secondStop).toBe(firstStop);
+      await Promise.all([firstStop, secondStop]);
+
+      expect(httpStopCalls).toBe(1);
+      expect(clearTrustedSpy).toHaveBeenCalledTimes(1);
+      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(1);
+      expect(handle.managedOpencode?.isAlive()).toBe(false);
+      await expect(fetch(handle.url)).rejects.toThrow();
+      await expect(handle.stop()).resolves.toBeUndefined();
+    } finally {
+      clearTrustedSpy.mockRestore();
+      startSpy.mockRestore();
+      await fixture.restore();
+    }
+  });
+
+  test.serial("startup failure after subscription registration unwinds acquired resources", async () => {
+    const fixture = await createFixture();
+    const startupError = new Error("forced HTTP startup failure");
+    let failedConfig: ServerConfig | null = null;
+    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async (config) => {
+      failedConfig = config;
+      throw startupError;
+    });
+    const clearTrustedSpy = spyOn(serverModule, "clearTrustedOpencodeProcess");
+
+    try {
+      const options = managedOptions(fixture, "startup-failure");
+      await mkdir(options.opencodeCwd ?? "", { recursive: true });
+      await expect(startEmbeddedServer(options)).rejects.toBe(startupError);
+      if (!failedConfig) throw new Error("Expected startup to reach the HTTP server");
+
+      const config = failedConfig;
+      const id = workspaceId(config);
+      await mutateWorkspace(config, id, "after-startup-failure");
+      const barrier = await writeOpenworkRuntimeConfigFile(config, id);
+
+      expect(barrier.changed).toBe(true);
+      expect(clearTrustedSpy).toHaveBeenCalledTimes(1);
+      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(1);
+    } finally {
+      clearTrustedSpy.mockRestore();
+      startSpy.mockRestore();
+      await fixture.restore();
+    }
+  });
+
+  test.serial("shutdown errors remain observable while every later resource is released", async () => {
+    const fixture = await createFixture();
+    const managedError = new Error("forced managed OpenCode shutdown failure");
+    const httpError = new Error("forced HTTP shutdown failure");
+    const originalCreateManagedOpencodeServer = managedOpencodeModule.createManagedOpencodeServer;
+    const originalStartServer = serverModule.startServer;
+    let managedCloseCalls = 0;
+    let httpStopCalls = 0;
+    const managedSpy = spyOn(managedOpencodeModule, "createManagedOpencodeServer").mockImplementation(async (options) => {
+      const managed = await originalCreateManagedOpencodeServer(options);
+      return {
+        ...managed,
+        async close() {
+          managedCloseCalls += 1;
+          await managed.close();
+          throw managedError;
+        },
+      };
+    });
+    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async (config) => {
+      const server = await originalStartServer(config);
+      return {
+        ...server,
+        async stop() {
+          httpStopCalls += 1;
+          await server.stop();
+          throw httpError;
+        },
+      };
+    });
+
+    try {
+      const handle = await startManaged(fixture, "shutdown-failure");
+      const id = workspaceId(handle.config);
+      const firstStop = handle.stop();
+      const secondStop = handle.stop();
+      expect(secondStop).toBe(firstStop);
+
+      let observed: unknown;
+      try {
+        await firstStop;
+      } catch (error) {
+        observed = error;
+      }
+      expect(observed).toBeInstanceOf(AggregateError);
+      if (!(observed instanceof AggregateError)) throw new Error("Expected aggregate shutdown failure");
+      expect(observed.errors).toEqual([managedError, httpError]);
+
+      await mutateWorkspace(handle.config, id, "after-shutdown-failure");
+      const barrier = await writeOpenworkRuntimeConfigFile(handle.config, id);
+      expect(barrier.changed).toBe(true);
+      expect(managedCloseCalls).toBe(1);
+      expect(httpStopCalls).toBe(1);
+      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(1);
+      await expect(fetch(handle.url)).rejects.toThrow();
+      fixture.handles.splice(fixture.handles.indexOf(handle), 1);
+    } finally {
+      managedSpy.mockRestore();
+      startSpy.mockRestore();
+      await fixture.restore();
+    }
+  });
+});

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -53,92 +53,155 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
   let managedOpencode: ManagedOpencodeServer | null = null;
   let managedOpencodeIdentity: string | null = null;
+  let stopRuntimeConfigFileRefresh: (() => void) | null = null;
+  let server: ServeResult | null = null;
+  let stopPromise: Promise<void> | null = null;
 
-  if (!config.readOnly) {
-    await ensureLocalWorkspaceFiles(config.workspaces);
-  }
+  const releaseResources = async (): Promise<void> => {
+    const errors: unknown[] = [];
 
-  if (!config.opencodeBaseUrl && options.manageOpencode) {
-    const workspace = findManagedEngineWorkspace(config.workspaces);
-    if (workspace) {
-      // Server-managed config file: the engine re-reads it from disk on every
-      // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
-      // on every runtime-DB write — so disposes always pick up current state.
-      const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-      keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
-      const cwd = options.opencodeCwd
-        || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
-        || workspace.path;
-      await mkdir(cwd, { recursive: true });
-      await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
-      const opencodeModelsUrl = await resolveOpencodeModelsUrl();
-
-      managedOpencode = await createManagedOpencodeServer({
-        bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
-        cwd,
-        excludedPorts: [config.port],
-        env: {
-          ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
-          ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
-          OPENWORK_SERVER_URL: serverUrl,
-          OPENWORK_SERVER_TOKEN: config.token,
-          OPENCODE_CONFIG: runtimeConfigPath,
-          OPENCODE_MODELS_URL: opencodeModelsUrl,
-        },
-      });
-
-      config.opencodeBaseUrl = managedOpencode.url;
-      config.opencodeUsername = managedOpencode.username;
-      config.opencodePassword = managedOpencode.password;
-      for (const entry of config.workspaces) {
-        if (entry.workspaceType === "remote") {
-          entry.baseUrl ??= managedOpencode.url;
-          entry.opencodeUsername ??= managedOpencode.username;
-          entry.opencodePassword ??= managedOpencode.password;
-          entry.directory ??= entry.path;
-          continue;
-        }
-        entry.baseUrl = managedOpencode.url;
-        entry.opencodeUsername = managedOpencode.username;
-        entry.opencodePassword = managedOpencode.password;
-        entry.directory = entry.path;
+    const identity = managedOpencodeIdentity;
+    managedOpencodeIdentity = null;
+    if (identity) {
+      try {
+        clearTrustedOpencodeProcess(config, identity);
+      } catch (error) {
+        errors.push(error);
       }
-      managedOpencodeIdentity = [
-        managedOpencode.pid ?? "unknown",
-        managedOpencode.username,
-        managedOpencode.password,
-      ].join(":");
-      registerTrustedOpencodeProcess(config, {
-        baseUrl: managedOpencode.url,
-        identity: managedOpencodeIdentity,
-        isAlive: managedOpencode.isAlive,
-      });
     }
-  }
 
-  const server = await startServer(config);
-
-  // The runtime config file above only covers workspaces[0]. Push every
-  // workspace's runtime-DB MCPs into the engine so they aren't invisible
-  // until a manual reload. Best-effort.
-  if (managedOpencode) {
-    void syncAllWorkspacesRuntimeMcpToEngine(config);
-  }
-
-  return {
-    port: server.port,
-    url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
-    config,
-    managedOpencodeExecution: managedOpencode?.execution ?? null,
-    managedOpencode: managedOpencode
-      ? { pid: managedOpencode.pid ?? null, isAlive: managedOpencode.isAlive }
-      : null,
-    async stop() {
-      if (managedOpencodeIdentity) {
-        clearTrustedOpencodeProcess(config, managedOpencodeIdentity);
+    const opencode = managedOpencode;
+    managedOpencode = null;
+    if (opencode) {
+      try {
+        await opencode.close();
+      } catch (error) {
+        errors.push(error);
       }
-      await managedOpencode?.close();
-      await server.stop();
-    },
+    }
+
+    const httpServer = server;
+    server = null;
+    if (httpServer) {
+      try {
+        await httpServer.stop();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    const unsubscribe = stopRuntimeConfigFileRefresh;
+    stopRuntimeConfigFileRefresh = null;
+    if (unsubscribe) {
+      try {
+        unsubscribe();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Failed to stop embedded OpenWork server");
+    }
   };
+
+  const stop = (): Promise<void> => {
+    stopPromise ??= releaseResources();
+    return stopPromise;
+  };
+
+  try {
+    if (!config.readOnly) {
+      await ensureLocalWorkspaceFiles(config.workspaces);
+    }
+
+    if (!config.opencodeBaseUrl && options.manageOpencode) {
+      const workspace = findManagedEngineWorkspace(config.workspaces);
+      if (workspace) {
+        // Server-managed config file: the engine re-reads it from disk on every
+        // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
+        // on every runtime-DB write — so disposes always pick up current state.
+        const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+        stopRuntimeConfigFileRefresh = keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
+        const cwd = options.opencodeCwd
+          || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
+          || workspace.path;
+        await mkdir(cwd, { recursive: true });
+        await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
+        const opencodeModelsUrl = await resolveOpencodeModelsUrl();
+
+        managedOpencode = await createManagedOpencodeServer({
+          bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
+          cwd,
+          excludedPorts: [config.port],
+          env: {
+            ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+            ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
+            OPENWORK_SERVER_URL: serverUrl,
+            OPENWORK_SERVER_TOKEN: config.token,
+            OPENCODE_CONFIG: runtimeConfigPath,
+            OPENCODE_MODELS_URL: opencodeModelsUrl,
+          },
+        });
+
+        config.opencodeBaseUrl = managedOpencode.url;
+        config.opencodeUsername = managedOpencode.username;
+        config.opencodePassword = managedOpencode.password;
+        for (const entry of config.workspaces) {
+          if (entry.workspaceType === "remote") {
+            entry.baseUrl ??= managedOpencode.url;
+            entry.opencodeUsername ??= managedOpencode.username;
+            entry.opencodePassword ??= managedOpencode.password;
+            entry.directory ??= entry.path;
+            continue;
+          }
+          entry.baseUrl = managedOpencode.url;
+          entry.opencodeUsername = managedOpencode.username;
+          entry.opencodePassword = managedOpencode.password;
+          entry.directory = entry.path;
+        }
+        managedOpencodeIdentity = [
+          managedOpencode.pid ?? "unknown",
+          managedOpencode.username,
+          managedOpencode.password,
+        ].join(":");
+        registerTrustedOpencodeProcess(config, {
+          baseUrl: managedOpencode.url,
+          identity: managedOpencodeIdentity,
+          isAlive: managedOpencode.isAlive,
+        });
+      }
+    }
+
+    server = await startServer(config);
+
+    // The runtime config file above only covers workspaces[0]. Push every
+    // workspace's runtime-DB MCPs into the engine so they aren't invisible
+    // until a manual reload. Best-effort.
+    if (managedOpencode) {
+      void syncAllWorkspacesRuntimeMcpToEngine(config);
+    }
+
+    return {
+      port: server.port,
+      url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
+      config,
+      managedOpencodeExecution: managedOpencode?.execution ?? null,
+      managedOpencode: managedOpencode
+        ? { pid: managedOpencode.pid ?? null, isAlive: managedOpencode.isAlive }
+        : null,
+      stop,
+    };
+  } catch (startupError) {
+    try {
+      await stop();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [startupError, cleanupError],
+        "Embedded OpenWork server startup failed and cleanup was incomplete",
+      );
+    }
+    throw startupError;
+  }
 }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -111,97 +111,101 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     return stopPromise;
   };
 
-  try {
-    if (!config.readOnly) {
-      await ensureLocalWorkspaceFiles(config.workspaces);
-    }
-
-    if (!config.opencodeBaseUrl && options.manageOpencode) {
-      const workspace = findManagedEngineWorkspace(config.workspaces);
-      if (workspace) {
-        // Server-managed config file: the engine re-reads it from disk on every
-        // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
-        // on every runtime-DB write — so disposes always pick up current state.
-        const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-        stopRuntimeConfigFileRefresh = keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
-        const cwd = options.opencodeCwd
-          || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
-          || workspace.path;
-        await mkdir(cwd, { recursive: true });
-        await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
-        const opencodeModelsUrl = await resolveOpencodeModelsUrl();
-
-        managedOpencode = await createManagedOpencodeServer({
-          bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
-          cwd,
-          excludedPorts: [config.port],
-          env: {
-            ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
-            ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
-            OPENWORK_SERVER_URL: serverUrl,
-            OPENWORK_SERVER_TOKEN: config.token,
-            OPENCODE_CONFIG: runtimeConfigPath,
-            OPENCODE_MODELS_URL: opencodeModelsUrl,
-          },
-        });
-
-        config.opencodeBaseUrl = managedOpencode.url;
-        config.opencodeUsername = managedOpencode.username;
-        config.opencodePassword = managedOpencode.password;
-        for (const entry of config.workspaces) {
-          if (entry.workspaceType === "remote") {
-            entry.baseUrl ??= managedOpencode.url;
-            entry.opencodeUsername ??= managedOpencode.username;
-            entry.opencodePassword ??= managedOpencode.password;
-            entry.directory ??= entry.path;
-            continue;
-          }
-          entry.baseUrl = managedOpencode.url;
-          entry.opencodeUsername = managedOpencode.username;
-          entry.opencodePassword = managedOpencode.password;
-          entry.directory = entry.path;
-        }
-        managedOpencodeIdentity = [
-          managedOpencode.pid ?? "unknown",
-          managedOpencode.username,
-          managedOpencode.password,
-        ].join(":");
-        registerTrustedOpencodeProcess(config, {
-          baseUrl: managedOpencode.url,
-          identity: managedOpencodeIdentity,
-          isAlive: managedOpencode.isAlive,
-        });
-      }
-    }
-
-    server = await startServer(config);
-
-    // The runtime config file above only covers workspaces[0]. Push every
-    // workspace's runtime-DB MCPs into the engine so they aren't invisible
-    // until a manual reload. Best-effort.
-    if (managedOpencode) {
-      void syncAllWorkspacesRuntimeMcpToEngine(config);
-    }
-
-    return {
-      port: server.port,
-      url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
-      config,
-      managedOpencodeExecution: managedOpencode?.execution ?? null,
-      managedOpencode: managedOpencode
-        ? { pid: managedOpencode.pid ?? null, isAlive: managedOpencode.isAlive }
-        : null,
-      stop,
-    };
-  } catch (startupError) {
+  const duringStartup = async <T>(operation: () => Promise<T>): Promise<T> => {
     try {
-      await stop();
-    } catch (cleanupError) {
-      throw new AggregateError(
-        [startupError, cleanupError],
-        "Embedded OpenWork server startup failed and cleanup was incomplete",
-      );
+      return await operation();
+    } catch (startupError) {
+      try {
+        await stop();
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [startupError, cleanupError],
+          "Embedded OpenWork server startup failed and cleanup was incomplete",
+        );
+      }
+      throw startupError;
     }
-    throw startupError;
+  };
+
+  if (!config.readOnly) {
+    await ensureLocalWorkspaceFiles(config.workspaces);
   }
+
+  if (!config.opencodeBaseUrl && options.manageOpencode) {
+    const workspace = findManagedEngineWorkspace(config.workspaces);
+    if (workspace) {
+      // Server-managed config file: the engine re-reads it from disk on every
+      // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
+      // on every runtime-DB write — so disposes always pick up current state.
+      const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+      stopRuntimeConfigFileRefresh = keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
+      const cwd = options.opencodeCwd
+        || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
+        || workspace.path;
+      await duringStartup(() => mkdir(cwd, { recursive: true }));
+      await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
+      const opencodeModelsUrl = await duringStartup(() => resolveOpencodeModelsUrl());
+
+      managedOpencode = await duringStartup(() => createManagedOpencodeServer({
+        bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
+        cwd,
+        excludedPorts: [config.port],
+        env: {
+          ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+          ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
+          OPENWORK_SERVER_URL: serverUrl,
+          OPENWORK_SERVER_TOKEN: config.token,
+          OPENCODE_CONFIG: runtimeConfigPath,
+          OPENCODE_MODELS_URL: opencodeModelsUrl,
+        },
+      }));
+
+      config.opencodeBaseUrl = managedOpencode.url;
+      config.opencodeUsername = managedOpencode.username;
+      config.opencodePassword = managedOpencode.password;
+      for (const entry of config.workspaces) {
+        if (entry.workspaceType === "remote") {
+          entry.baseUrl ??= managedOpencode.url;
+          entry.opencodeUsername ??= managedOpencode.username;
+          entry.opencodePassword ??= managedOpencode.password;
+          entry.directory ??= entry.path;
+          continue;
+        }
+        entry.baseUrl = managedOpencode.url;
+        entry.opencodeUsername = managedOpencode.username;
+        entry.opencodePassword = managedOpencode.password;
+        entry.directory = entry.path;
+      }
+      managedOpencodeIdentity = [
+        managedOpencode.pid ?? "unknown",
+        managedOpencode.username,
+        managedOpencode.password,
+      ].join(":");
+      registerTrustedOpencodeProcess(config, {
+        baseUrl: managedOpencode.url,
+        identity: managedOpencodeIdentity,
+        isAlive: managedOpencode.isAlive,
+      });
+    }
+  }
+
+  server = await duringStartup(() => startServer(config));
+
+  // The runtime config file above only covers workspaces[0]. Push every
+  // workspace's runtime-DB MCPs into the engine so they aren't invisible
+  // until a manual reload. Best-effort.
+  if (managedOpencode) {
+    void syncAllWorkspacesRuntimeMcpToEngine(config);
+  }
+
+  return {
+    port: server.port,
+    url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
+    config,
+    managedOpencodeExecution: managedOpencode?.execution ?? null,
+    managedOpencode: managedOpencode
+      ? { pid: managedOpencode.pid ?? null, isAlive: managedOpencode.isAlive }
+      : null,
+    stop,
+  };
 }

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -100,32 +100,58 @@ export async function createManagedOpencodeServer(options: {
     child.once("exit", () => resolve());
   });
 
-  const url = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`)), options.timeoutMs ?? 15000);
-    let output = "";
-    const done = (value: string) => {
-      clearTimeout(timeout);
-      resolve(value);
-    };
-    const fail = (error: Error) => {
-      clearTimeout(timeout);
-      reject(error);
-    };
-    child.stdout?.on("data", (chunk) => {
-      output += chunk.toString();
-      for (const line of output.split("\n")) {
-        if (!line.startsWith("opencode server listening")) continue;
-        const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-        if (!match?.[1]) return fail(new Error(`Failed to parse OpenCode server URL from: ${line}`));
-        done(match[1]);
+  const close = (): Promise<void> => {
+    closePromise ??= (async () => {
+      if (child.exitCode !== null) return;
+      if (!child.killed) child.kill("SIGTERM");
+      const timeout = new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 1000);
+      });
+      await Promise.race([exited, timeout]);
+      if (child.exitCode === null) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Process already exited.
+        }
+        await Promise.race([exited, new Promise<void>((resolve) => setTimeout(() => resolve(), 500))]);
       }
+    })();
+    return closePromise;
+  };
+
+  let url: string;
+  try {
+    url = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`)), options.timeoutMs ?? 15000);
+      let output = "";
+      const done = (value: string) => {
+        clearTimeout(timeout);
+        resolve(value);
+      };
+      const fail = (error: Error) => {
+        clearTimeout(timeout);
+        reject(error);
+      };
+      child.stdout?.on("data", (chunk) => {
+        output += chunk.toString();
+        for (const line of output.split("\n")) {
+          if (!line.startsWith("opencode server listening")) continue;
+          const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+          if (!match?.[1]) return fail(new Error(`Failed to parse OpenCode server URL from: ${line}`));
+          done(match[1]);
+        }
+      });
+      child.stderr?.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+      child.once("error", fail);
+      child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));
     });
-    child.stderr?.on("data", (chunk) => {
-      output += chunk.toString();
-    });
-    child.once("error", fail);
-    child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));
-  });
+  } catch (error) {
+    await close();
+    throw error;
+  }
 
   return {
     url,
@@ -141,24 +167,6 @@ export async function createManagedOpencodeServer(options: {
     isAlive() {
       return child.exitCode === null && child.signalCode === null && !child.killed;
     },
-    close() {
-      closePromise ??= (async () => {
-        if (child.exitCode !== null) return;
-        if (!child.killed) child.kill("SIGTERM");
-        const timeout = new Promise<void>((resolve) => {
-          setTimeout(() => resolve(), 1000);
-        });
-        await Promise.race([exited, timeout]);
-        if (child.exitCode === null) {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // Process already exited.
-          }
-          await Promise.race([exited, new Promise<void>((resolve) => setTimeout(() => resolve(), 500))]);
-        }
-      })();
-      return closePromise;
-    },
+    close,
   };
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1027,6 +1027,8 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     });
   } catch (error) {
     invalidateEngineMcpServerState(config, engineMcpServerState);
+    watcherHandle.close();
+    reloadBaselineRefreshers.delete(config);
     throw error;
   }
 


### PR DESCRIPTION
## Summary

- make the embedded server own its runtime-configuration unsubscribe callback for its full lifetime
- share one ordered shutdown operation across repeated `stop()` calls and startup unwind
- preserve shutdown failures while continuing cleanup and aggregating multiple errors
- close managed OpenCode children that fail before readiness, and release server watcher state when HTTP startup fails

## Lifecycle invariant

Every acquired embedded-server resource is released at most once, in this order where present:

1. trusted-process registration
2. managed OpenCode process
3. HTTP server
4. runtime-configuration listener

The listener is always released even when an earlier shutdown component rejects. A startup failure runs the same cleanup operation for every resource acquired before the failure. Repeated `stop()` calls share the same promise and observe the same result.

## Tests

Added focused real-subscription lifecycle coverage for:

- stopped server A performing no later generated-config write
- replacement server B being the only listener that responds against a shared runtime database and generated path
- identical provider configuration after replacement remaining byte-stable with `changed:false`, skipped reload, and no engine disposal
- concurrent/repeated `stop()` calls releasing managed OpenCode, HTTP, trusted registration, and the listener once
- startup failure after subscription registration unwinding the listener, managed process, and trusted registration
- managed and HTTP shutdown failures remaining observable while later cleanup still completes
- managed OpenCode readiness failure closing the spawned child

### Focused candidate verification

Passed on candidate `67658be12` based on `f058a554a`:

- `bun test src/embedded-lifecycle.test.ts src/opencode-models-url.test.ts src/openwork-runtime-config.test.ts src/runtime-opencode-config-store.test.ts src/runtime-config-global-providers.test.ts src/runtime-config-patch-reload.e2e.test.ts src/runtime-provider-merge.test.ts` — 35 passed, 0 failed
- `pnpm --filter openwork-server typecheck` — passed
- `git diff upstream/dev...HEAD --check` — passed

## Scope and risk

No public API, route, schema, authentication, provider semantic, configuration serialization, or engine reload policy changes. The production change is limited to lifecycle ownership and failure cleanup.

Broader server suites, repository-wide checks, cross-platform verification, and CI are deferred to the verification/hardening pass. This PR does not claim to address unrelated memory pressure or every client abort.
