### PR TITLE
fix(server): keep engine credentials out of the trusted-process identity

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
@@ -75,10 +76,12 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
       entry.opencodePassword ??= managedOpencode.password;
       entry.directory ??= entry.path;
     }
+    // The identity only needs to be unique per managed-process boot; a
+    // random nonce provides that without routing the engine credentials
+    // through the fast identity hash.
     managedOpencodeIdentity = [
       managedOpencode.pid ?? "unknown",
-      managedOpencode.username,
-      managedOpencode.password,
+      randomUUID(),
     ].join(":");
     registerTrustedOpencodeProcess(config, {
       baseUrl: managedOpencode.url,

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -5,6 +5,7 @@
  * in one call -- mirrors what cli.ts does but returns a handle instead
  * of owning the process lifecycle.
  */
+import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
@@ -103,10 +104,12 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         entry.opencodePassword = managedOpencode.password;
         entry.directory = entry.path;
       }
+      // The identity only needs to be unique per managed-process boot; a
+      // random nonce provides that without routing the engine credentials
+      // through the fast identity hash.
       managedOpencodeIdentity = [
         managedOpencode.pid ?? "unknown",
-        managedOpencode.username,
-        managedOpencode.password,
+        randomUUID(),
       ].join(":");
       registerTrustedOpencodeProcess(config, {
         baseUrl: managedOpencode.url,


### PR DESCRIPTION
## Summary

- Stop embedding the managed OpenCode engine's basic-auth username and password in the trusted-process identity string, in both entry points ([embedded.ts](https://github.com/different-ai/openwork/blob/dev/apps/server/src/embedded.ts) and [cli.ts](https://github.com/different-ai/openwork/blob/dev/apps/server/src/cli.ts)).
- The identity is opaque — it is hashed immediately by `registerTrustedOpencodeProcess` and only ever compared, never reported — so it only needs per-boot uniqueness. A `randomUUID()` nonce plus the pid provides that without routing credentials through the fast SHA-256 fingerprint.

## Why

Resolves CodeQL alert #115 (`js/insufficient-password-hash`, open on `dev`): the engine password flowed from the identity join into `hashToken` (plain SHA-256) in `utils.ts`. The alert also blocks the CodeQL check on any PR whose diff touches that flow path (e.g. #3486). This removes the tainted flow at its source rather than dismissing the alert.

## Behavior

No behavior change. Registration and `clearTrustedOpencodeProcess` compare the same opaque string held by the caller; nothing reconstructs the identity from credentials.

## Tests

- `pnpm --filter openwork-server typecheck` — passed
- `bun test src/agent-context-diagnostics.test.ts src/mcp.engine-sync.e2e.test.ts src/cloud-mcp-reconcile.e2e.test.ts` (bun 1.3.10) — 109 passed, 0 failed

## Note

#3486 rewrites the surrounding block in `embedded.ts`; whichever lands second needs a trivial rebase of the identity lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)