### PR TITLE
fix(den-api): launch cloud workers with auto approvals so web writes stop 403ing

### DIFF
--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -465,7 +465,9 @@ export function buildOpenWorkStartCommand(input: ProvisionInput) {
     ` --host 0.0.0.0`,
     ` --port ${shellQuote(String(env.daytona.openworkPort))}`,
     ` --cors '*'`,
-    ` --approval manual`,
+    // This single-user worker's SPA has no approvals responder, so manual mode makes gated writes such as chat-attachment uploads time out to 403.
+    // Auto matches the desktop sidecar's approvalMode; viewer tokens remain blocked by scope checks.
+    ` --approval auto`,
     ` --verbose`,
   ].join("")
   const script = `

--- a/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
+++ b/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
@@ -61,6 +61,8 @@ describe("Daytona OpenWork checkpoint start command", () => {
     expect(command).toContain("tar -C / -xf")
     expect(command).not.toContain("tar -h")
     expect(command).not.toContain("tar -ch")
+    expect(command).toContain("--approval auto")
+    expect(command).not.toContain("--approval manual")
 
     const hydrateCall = command.indexOf("\nhydrate_checkpoint\n")
     const serverStart = command.indexOf(" openwork-server --workspace")


### PR DESCRIPTION
## Problem
Chat image attachments (and every other `requireApproval`-gated write) fail on web.openworklabs.com with `403 write_denied`. den-api launches cloud sandboxes with `openwork-server --approval manual`, but the web SPA has no approvals responder, so each gated write blocks for `DEFAULT_TIMEOUT_MS` (30s) and then denies. Desktop is unaffected because the sidecar launches with `approvalMode: "auto"` (`apps/desktop/electron/runtime.mjs:1607`).

Repro on web: attach an image in the chat composer and send → `POST /workspace/<id>/inbox` → 403 after ~30s.

## Fix
Launch cloud workers with `--approval auto` (desktop parity). Viewer tokens remain read-only via scope checks; the collaborator client token is the signed-in user themself. Wake re-issues the start command, so stopped sandboxes pick this up on their next wake — no recycle needed (requires den-api redeploy).

## Tests
- `pnpm --dir ee/apps/den-api exec bun test test/daytona-checkpoint-command.test.ts test/daytona-provisioning.test.ts` → 14 pass, 0 fail (includes new regression assertions: start command contains `--approval auto`, never `--approval manual`).
- Full den-api suite: 808 pass / 169 fail — failure set byte-identical with the change stashed (pre-existing env issues: missing env values, stale den-db exports), verified by running both ways.

## Validation note
No runtime evidence tape: proving this end-to-end needs a den-api deploy + live Daytona sandbox + gateway upload. Exact repro/verify steps post-deploy: open web.openworklabs.com, wait for instance ready, attach an image in chat, send → upload returns 200 and the attachment badge renders.
