### PR TITLE
polish(app): hide workspace creation on gateway web and ChatGPT sign-in in browser mode

### DIFF
--- a/apps/app/src/app/lib/workspace-creation-policy.ts
+++ b/apps/app/src/app/lib/workspace-creation-policy.ts
@@ -1,0 +1,5 @@
+import { isOpenworkGatewayRuntime } from "./gateway-runtime";
+
+export function canCreateWorkspaces() {
+  return !isOpenworkGatewayRuntime();
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1209,6 +1209,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       if (!isOpenAiProvider) continue;
       merged[id] = providerMethods.filter((method) => {
         if (method.type !== "oauth") return true;
+        // Browser mode can't complete the ChatGPT sign-in flows, so only API keys
+        // are offered off-desktop.
+        if (!isDesktopRuntime()) return false;
         const label = method.label.toLowerCase();
         const isHeadless = /headless|device/.test(label);
         return workerType === "remote" ? isHeadless : !isHeadless;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -45,6 +45,7 @@ import {
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import { useBrandLogoUrl } from "../../cloud/brand-theme";
+import { canCreateWorkspaces } from "../../../../app/lib/workspace-creation-policy";
 
 import {
   Sidebar,
@@ -1170,15 +1171,17 @@ export function AppSidebar(props: AppSidebarProps) {
               <span className={SIDEBAR_SECTION_LABEL}>
                 {t("workspace_list.title")}
               </span>
-              <button
-                type="button"
-                className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-foreground"
-                onClick={props.onOpenCreateWorkspace}
-                aria-label={t("workspace_list.add_workspace")}
-                title={t("workspace_list.add_workspace")}
-              >
-                <Plus className="size-3.5" />
-              </button>
+              {canCreateWorkspaces() ? (
+                <button
+                  type="button"
+                  className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-foreground"
+                  onClick={props.onOpenCreateWorkspace}
+                  aria-label={t("workspace_list.add_workspace")}
+                  title={t("workspace_list.add_workspace")}
+                >
+                  <Plus className="size-3.5" />
+                </button>
+              ) : null}
             </div>
             <Reorder.Group
               as="div"

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -19,6 +19,7 @@ import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
 import { trackSessionActive, trackTaskStarted } from "@/app/lib/den-telemetry";
 import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
+import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -1493,6 +1494,7 @@ export function SessionRoute() {
   ]);
 
   const handleOpenCreateWorkspace = useCallback(() => {
+    if (!canCreateWorkspaces()) return;
     // Respect the org-level `allowMultipleWorkspaces` restriction (dev
     // #1505). If the checker returns true, the admin has disabled
     // adding further workspaces; surface a friendly notice instead of
@@ -2276,6 +2278,8 @@ export function SessionRoute() {
   const handleChatFirstTask = useCallback((prompt: string, attachments?: ComposerAttachment[]) => {
     void (async () => {
       if (!isDesktopRuntime()) {
+        // The cloud workspace is provisioned by Den; boot takeover covers the pre-attach state.
+        if (!canCreateWorkspaces()) return;
         handleOpenCreateWorkspace();
         return;
       }
@@ -2304,6 +2308,7 @@ export function SessionRoute() {
       { name: "projectLabel", type: "string", required: false, description: "Optional project name used to group the workspace's sessions in analytics." },
     ],
     execute: async (args) => {
+      if (!canCreateWorkspaces()) return { ok: false, error: "workspace creation is unavailable" };
       const parsed = args as { path?: string; projectLabel?: string } | undefined;
       const folder = parsed?.path?.trim();
       if (!folder) return { ok: false, error: "path is required" };

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -38,7 +38,6 @@ import type {
   SettingsTab,
   WorkspaceConnectionState,
   WorkspaceDisplay,
-  WorkspacePreset,
   WorkspaceSessionGroup,
 } from "@/app/types";
 import { getWorkspaceTaskLoadErrorDisplay } from "@/app/utils";
@@ -48,9 +47,7 @@ import {
   type RouteWorkspace,
   type RouteSession,
   describeRouteError,
-  describeWorkspaceCreateError,
   downloadWorkspaceJson,
-  folderNameFromPath,
   getSessionStatus,
   isActiveSessionStatus,
   mapDesktopWorkspace,
@@ -117,10 +114,8 @@ import {
   openworkServerRestart,
   engineStart,
   engineRestart,
-  pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
-  workspaceCreateRemote,
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
@@ -150,7 +145,6 @@ import {
   safeStringify,
 } from "@/app/utils";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
-import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { ShareWorkspaceModal } from "@/react-app/domains/workspace/share-workspace-modal";
 import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-workspace-state";
@@ -374,14 +368,6 @@ function writeStoredBoolean(key: string, value: boolean) {
   }
 }
 
-function singlePickedDirectory(selection: string | string[] | null) {
-  return typeof selection === "string"
-    ? selection
-    : Array.isArray(selection)
-      ? selection[0] ?? null
-      : null;
-}
-
 function readNavigationWorkspaceId(state: unknown): string | null {
   if (!state || typeof state !== "object") return null;
   const value = (state as { workspaceId?: unknown }).workspaceId;
@@ -514,11 +500,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [configActionStatus, setConfigActionStatus] = useState<string | null>(null);
   const [revealConfigBusy, setRevealConfigBusy] = useState(false);
   const [resetConfigBusy, setResetConfigBusy] = useState(false);
-  const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
-  const [createWorkspaceBusy, setCreateWorkspaceBusy] = useState(false);
-  const [createWorkspaceError, setCreateWorkspaceError] = useState<string | null>(null);
-  const [createWorkspaceRemoteBusy, setCreateWorkspaceRemoteBusy] = useState(false);
-  const [createWorkspaceRemoteError, setCreateWorkspaceRemoteError] = useState<string | null>(null);
   const [renameWorkspaceId, setRenameWorkspaceId] = useState<string | null>(null);
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
@@ -2021,24 +2002,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     await refreshRouteState();
   };
 
-  const handleOpenCreateWorkspace = () => {
-    if (
-      workspaces.length > 0 &&
-      checkDesktopRestriction({ restriction: "allowMultipleWorkspaces" })
-    ) {
-      restrictionNotice.show({
-        title: "Additional workspaces are restricted",
-        message:
-          "Your organization administrator has restricted access to adding additional workspaces.",
-      });
-      return;
-    }
-
-    setCreateWorkspaceError(null);
-    setCreateWorkspaceRemoteError(null);
-    setCreateWorkspaceOpen(true);
-  };
-
   const handleSelectSettingsWorkspace = useCallback((workspaceId: string) => {
     if (workspaceId === selectedWorkspaceId) return;
     setLegacySelectedWorkspaceId(workspaceId);
@@ -2135,80 +2098,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }
     await refreshRouteState();
   }, [openworkClient, refreshRouteState, selectedWorkspaceId, workspaces]);
-
-  const handleCreateWorkspace = async (preset: WorkspacePreset, folder: string | null) => {
-    if (!folder) return;
-    setCreateWorkspaceBusy(true);
-    setCreateWorkspaceError(null);
-    try {
-      const workspaceName = folderNameFromPath(folder);
-      let list: WorkspaceList | null = null;
-      if (openworkClient) {
-        list = await openworkClient
-          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .catch(() => null);
-      }
-      if (!list) {
-        throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
-      }
-      const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
-      if (createdId) {
-        await workspaceSetSelected(createdId).catch(() => undefined);
-        await workspaceSetRuntimeActive(createdId).catch(() => undefined);
-      }
-      setCreateWorkspaceOpen(false);
-      await refreshRouteState();
-    } catch (error) {
-      setCreateWorkspaceError(describeWorkspaceCreateError(error));
-    } finally {
-      setCreateWorkspaceBusy(false);
-    }
-  };
-
-  const handleCreateRemoteWorkspace = async (input: {
-    openworkHostUrl?: string | null;
-    openworkToken?: string | null;
-    directory?: string | null;
-    displayName?: string | null;
-  }) => {
-    const baseUrlValue = input.openworkHostUrl?.trim() ?? "";
-    if (!baseUrlValue) return false;
-    setCreateWorkspaceRemoteBusy(true);
-    setCreateWorkspaceRemoteError(null);
-    try {
-      const remoteType: "openwork" = "openwork";
-      const payload = {
-        baseUrl: baseUrlValue,
-        openworkHostUrl: baseUrlValue,
-        openworkToken: input.openworkToken?.trim() || null,
-        displayName: input.displayName?.trim() || null,
-        directory: input.directory?.trim() || null,
-        remoteType,
-      };
-      let list: WorkspaceList | null = null;
-      if (isDesktopRuntime()) {
-        list = await workspaceCreateRemote(payload);
-      } else if (openworkClient) {
-        list = await openworkClient.createRemoteWorkspace(payload).catch(() => null);
-      }
-      if (!list) {
-        throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");
-      }
-      const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
-      if (createdId) {
-        await workspaceSetSelected(createdId).catch(() => undefined);
-        await workspaceSetRuntimeActive(createdId).catch(() => undefined);
-      }
-      setCreateWorkspaceOpen(false);
-      await refreshRouteState();
-      return true;
-    } catch (error) {
-      setCreateWorkspaceRemoteError(error instanceof Error ? error.message : t("app.unknown_error"));
-      return false;
-    } finally {
-      setCreateWorkspaceRemoteBusy(false);
-    }
-  };
 
   if (route.redirectPath && !props.embedded) {
     const target = props.standaloneExtensions
@@ -2689,27 +2578,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
         onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
         onClose={() => providerAuthStore.closeProviderAuthModal()}
-      />
-      <CreateWorkspaceModal
-        open={createWorkspaceOpen}
-        onClose={() => {
-          setCreateWorkspaceOpen(false);
-          setCreateWorkspaceError(null);
-        }}
-        onConfirm={handleCreateWorkspace}
-        onConfirmRemote={handleCreateRemoteWorkspace}
-        onPickFolder={async () => singlePickedDirectory(await pickDirectory({ title: t("onboarding.authorize_folder") }))}
-        submitting={createWorkspaceBusy}
-        localError={createWorkspaceError}
-        localDisabled={!platform.capabilities.nativeFilePicker}
-        localDisabledReason={
-          platform.capabilities.nativeFilePicker
-            ? undefined
-            : t("app.local_disabled_reason")
-        }
-        showProjectLabel={false}
-        remoteSubmitting={createWorkspaceRemoteBusy}
-        remoteError={createWorkspaceRemoteError}
       />
       <RenameWorkspaceModal
         open={renameWorkspaceId !== null}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -13,6 +13,7 @@ import {
   type WorkspaceList,
 } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
+import { canCreateWorkspaces } from "../../app/lib/workspace-creation-policy";
 import { createClient, unwrap } from "../../app/lib/opencode";
 import { useLocal } from "../kernel/local-provider";
 import { usePlatform } from "../kernel/platform";
@@ -370,6 +371,7 @@ export function WelcomeRoute() {
 
   const handleGetStarted = useCallback(async () => {
     if (!isDesktopRuntime()) {
+      if (!canCreateWorkspaces()) return;
       // Non-desktop: fall back to the modal for remote workspace creation.
       dispatch({ type: "open" });
       return;

--- a/apps/app/tests/gateway-workspace-creation.test.ts
+++ b/apps/app/tests/gateway-workspace-creation.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { canCreateWorkspaces } from "../src/app/lib/workspace-creation-policy";
+
+const originalWindow = globalThis.window;
+
+function installWindow(options: {
+  origin: string;
+  gateway?: boolean;
+  electronInfo?: {
+    baseUrl: string;
+    ownerToken: string;
+  };
+}) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      location: { origin: options.origin },
+      __OPENWORK_GATEWAY__: options.gateway ? { version: 1 } : undefined,
+      __OPENWORK_ELECTRON__: options.electronInfo
+        ? {
+            invokeDesktop: async () => ({
+              running: true,
+              baseUrl: options.electronInfo?.baseUrl,
+              ownerToken: options.electronInfo?.ownerToken,
+            }),
+          }
+        : undefined,
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("workspace creation policy", () => {
+  test("disables workspace creation in gateway runtime", () => {
+    installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+    expect(canCreateWorkspaces()).toBe(false);
+  });
+
+  test("allows workspace creation in plain web runtime", () => {
+    installWindow({ origin: "https://self-hosted.example" });
+    expect(canCreateWorkspaces()).toBe(true);
+  });
+
+  test("allows workspace creation in desktop runtime", () => {
+    installWindow({
+      origin: "http://localhost:3000",
+      electronInfo: { baseUrl: "http://localhost:8787", ownerToken: "owner-token" },
+    });
+    expect(canCreateWorkspaces()).toBe(true);
+  });
+});

--- a/apps/app/tests/provider-auth-methods.test.ts
+++ b/apps/app/tests/provider-auth-methods.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createClient } from "../src/app/lib/opencode";
+import type { ProviderListItem, WorkspaceDisplay } from "../src/app/types";
+import { createProviderAuthStore } from "../src/react-app/domains/connections/provider-auth/store";
+
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test");
+
+function installWindow(options: {
+  origin: string;
+  electronInfo?: {
+    baseUrl: string;
+    ownerToken: string;
+  };
+}) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+      location: { origin: options.origin },
+      __OPENWORK_ELECTRON__: options.electronInfo
+        ? {
+            invokeDesktop: async () => ({
+              running: true,
+              baseUrl: options.electronInfo?.baseUrl,
+              ownerToken: options.electronInfo?.ownerToken,
+            }),
+          }
+        : undefined,
+    },
+  });
+}
+
+function installProviderAuthFetch() {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async () =>
+      new Response(
+        JSON.stringify({
+          openai: [
+            { type: "oauth", label: "Sign in with ChatGPT" },
+            { type: "oauth", label: "Headless device flow" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+  });
+}
+
+function createTestStore(workerType: "local" | "remote") {
+  const providers: ProviderListItem[] = [
+    {
+      id: "openai",
+      name: "OpenAI",
+      env: ["OPENAI_API_KEY"],
+      source: "env",
+      models: {},
+    },
+  ];
+  const workspace = {
+    id: "workspace_test",
+    name: "Test workspace",
+    path: "/tmp/workspace_test",
+    preset: "default",
+    workspaceType: workerType,
+  } satisfies WorkspaceDisplay;
+
+  return createProviderAuthStore({
+    client: () => opencodeClient,
+    providers: () => providers,
+    providerDefaults: () => ({}),
+    providerConnectedIds: () => [],
+    disabledProviders: () => [],
+    checkDesktopAppRestriction: () => false,
+    selectedWorkspaceDisplay: () => workspace,
+    providerBaseUrl: () => "https://engine.example",
+    selectedWorkspaceRoot: () => workspace.path,
+    runtimeWorkspaceId: () => workspace.id,
+    openworkServer: {
+      getSnapshot: () => ({
+        openworkServerStatus: "disconnected",
+        openworkServerClient: null,
+        openworkServerCapabilities: null,
+      }),
+    },
+    setProviders: () => undefined,
+    setProviderDefaults: () => undefined,
+    setProviderConnectedIds: () => undefined,
+    setDisabledProviders: () => undefined,
+    markOpencodeConfigReloadRequired: () => undefined,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: originalWindow });
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+});
+
+describe("OpenAI provider auth methods", () => {
+  test("desktop local workers offer non-headless OAuth", async () => {
+    installWindow({
+      origin: "http://localhost:3000",
+      electronInfo: { baseUrl: "http://localhost:8787", ownerToken: "owner-token" },
+    });
+    installProviderAuthFetch();
+    const store = createTestStore("local");
+
+    await store.openProviderAuthModal();
+
+    expect(store.getSnapshot().providerAuthMethods.openai).toEqual([
+      { type: "oauth", label: "Sign in with ChatGPT", methodIndex: 0 },
+      { type: "api", label: "API key" },
+    ]);
+  });
+
+  test("desktop remote workers offer only headless OAuth", async () => {
+    installWindow({
+      origin: "http://localhost:3000",
+      electronInfo: { baseUrl: "http://localhost:8787", ownerToken: "owner-token" },
+    });
+    installProviderAuthFetch();
+    const store = createTestStore("remote");
+
+    await store.openProviderAuthModal();
+
+    expect(store.getSnapshot().providerAuthMethods.openai).toEqual([
+      { type: "oauth", label: "Headless device flow", methodIndex: 1 },
+      { type: "api", label: "API key" },
+    ]);
+  });
+
+  test("browser workers offer API keys without OAuth", async () => {
+    installWindow({ origin: "https://self-hosted.example" });
+    installProviderAuthFetch();
+    const store = createTestStore("local");
+
+    await store.openProviderAuthModal();
+
+    expect(store.getSnapshot().providerAuthMethods.openai).toEqual([
+      { type: "api", label: "API key" },
+    ]);
+  });
+});


### PR DESCRIPTION
Two "web parity" gaps on web.openworklabs.com: the UI offered features that cannot work there.

## Change 1 — no workspace creation in gateway mode
The cloud instance's workspace is provisioned by Den; creating workspaces from the SPA isn't a thing on OpenWork Web. New leaf policy `canCreateWorkspaces()` (= `!isOpenworkGatewayRuntime()`) now gates every entry point: the sidebar "+" button, `handleOpenCreateWorkspace`, the chat-first empty-state fallback, the welcome "Get started" fallback, and the `workspace.create` control action. Desktop and self-hosted browser use are unchanged. Also deletes the settings-route create-workspace modal + handlers, which were unreachable dead code (the only `setCreateWorkspaceOpen(true)` caller was never referenced).

## Change 2 — no "Sign in with ChatGPT" off desktop
Browser mode can't complete the ChatGPT sign-in flows. `buildProviderAuthMethods` now drops all OpenAI `oauth` methods when `!isDesktopRuntime()`, leaving API-key entry. Desktop keeps existing behavior, including the remote-worker headless/device filtering.

## Tests
- New: `apps/app/tests/gateway-workspace-creation.test.ts` (policy: gateway=false, plain web=true, desktop=true) and `apps/app/tests/provider-auth-methods.test.ts` (desktop local → ChatGPT OAuth + API key; desktop remote → headless only; browser → API key only). The browser-mode assertion is red against the old store code and green with this change (verified both ways).
- `bun test tests/gateway-workspace-creation.test.ts tests/provider-auth-methods.test.ts` → 6 pass / 0 fail.
- Full app suite `bun test --isolate tests/` on this branch: 608 pass / 2 fail; on clean dev: 602 pass / same 2 fail (`message-list-loading feedback` ×2 — pre-existing suite-order flake; both pass when the file runs alone on either tree). No regressions introduced.
- `pnpm --filter @openwork/app typecheck` → clean.

## Validation note
Verified at the unit layer with the repo's gateway/desktop window fakes (same pattern as `gateway-runtime.test.ts` / `cloud-provider-sync-gateway.test.ts`). No app-driving testkit spec: exercising real gateway mode end-to-end needs a Den gateway + cloud instance harness. Manual repro post-deploy: open web.openworklabs.com → sidebar shows no "+" next to Workspaces; Settings → AI → Connect OpenAI offers API key only.
