### PR TITLE
ci: dev engine snapshots per dev push (nightly backstop) with DAYTONA_PIN_CHANNEL

### DIFF
--- a/.github/workflows/daytona-snapshot-drift.yml
+++ b/.github/workflows/daytona-snapshot-drift.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout
         if: steps.config.outputs.enabled == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/daytona-snapshot-drift.yml
+++ b/.github/workflows/daytona-snapshot-drift.yml
@@ -38,9 +38,56 @@ jobs:
       - name: Checkout
         if: steps.config.outputs.enabled == 'true'
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Read production snapshot pin
+        if: steps.config.outputs.enabled == 'true'
+        id: current
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pin="$(node scripts/update-daytona-snapshot-pin.mjs \
+            --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" \
+            --read)"
+          base_name="${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}"
+          echo "pin=$pin" >> "$GITHUB_OUTPUT"
+          if [[ "$pin" =~ ^${base_name}-dev-([0-9a-f]{7,})$ ]]; then
+            echo "channel=dev" >> "$GITHUB_OUTPUT"
+            echo "sha=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=release" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check dev channel snapshot pin
+        if: steps.config.outputs.enabled == 'true' && steps.current.outputs.channel == 'dev'
+        shell: bash
+        env:
+          CURRENT_PIN: ${{ steps.current.outputs.pin }}
+          SHORT_SHA: ${{ steps.current.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin dev
+          if ! full_sha="$(git rev-parse --verify "${SHORT_SHA}^{commit}" 2>/dev/null)"; then
+            echo "::error::nightly dev snapshot appears stale/broken: ${SHORT_SHA} does not resolve to a commit"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$full_sha" origin/dev; then
+            echo "::error::nightly dev snapshot appears stale/broken: ${full_sha} is not on origin/dev"
+            exit 1
+          fi
+
+          commit_time="$(git show -s --format=%ct "$full_sha")"
+          if [ "$(( $(date +%s) - commit_time ))" -gt 172800 ]; then
+            echo "::error::nightly dev snapshot appears stale/broken"
+            exit 1
+          fi
+          echo "Dev channel pin healthy: ${CURRENT_PIN}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Resolve expected snapshot from latest release
-        if: steps.config.outputs.enabled == 'true'
+        if: steps.config.outputs.enabled == 'true' && steps.current.outputs.channel == 'release'
         id: expected
         shell: bash
         env:
@@ -62,7 +109,7 @@ jobs:
           echo "Expected snapshot for ${release_tag}: ${snapshot_name}"
 
       - name: Compare production snapshot pin
-        if: steps.config.outputs.enabled == 'true'
+        if: steps.config.outputs.enabled == 'true' && steps.current.outputs.channel == 'release'
         shell: bash
         env:
           EXPECTED_SNAPSHOT_NAME: ${{ steps.expected.outputs.snapshot_name }}

--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -51,7 +51,7 @@ jobs:
       # Every commit on dev has passed PR review (Warden L24-F6Z).
       - name: Checkout dev source at the triggering commit
         if: steps.channel.outputs.enabled == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -130,7 +130,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.channel.outputs.enabled == 'true' && (steps.existing.outputs.exists != 'true' || inputs.force == true)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.9.0
 
       - name: Build and push snapshot
         id: publish
@@ -159,7 +159,7 @@ jobs:
 
       - name: Checkout snapshot pin automation
         if: steps.channel.outputs.enabled == 'true' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.sha }}
           path: .snapshot-pin-automation

--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -1,12 +1,14 @@
 # web.openworklabs.com engine channel:
-# Nightly snapshot from dev HEAD, named <base>-dev-<short-sha>.
-# Releases still re-pin to the release snapshot and the next nightly moves it back
-# to dev. This known ping-pong will be resolved by an explicit channel var later.
+# Per-push snapshot from dev HEAD, named <base>-dev-<short-sha>, with a nightly backstop.
+# DAYTONA_PIN_CHANNEL resolves pin ping-pong: release pinning defers to the dev channel.
+# Set DAYTONA_PIN_CHANNEL=release to stop this pipeline; the next release re-pins.
 # Sandboxes roll forward via the existing stopped+stale recycle.
 
 name: Dev Daytona Snapshot
 
 on:
+  push:
+    branches: ["dev"]
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
@@ -21,6 +23,7 @@ permissions:
   contents: read
 
 concurrency:
+  # Per-push runs queue/batch naturally; in-flight snapshot publishes are never cancelled.
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
@@ -30,7 +33,22 @@ jobs:
     if: github.repository == 'different-ai/openwork'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - name: Check channel
+        id: channel
+        shell: bash
+        env:
+          DAYTONA_PIN_CHANNEL: ${{ vars.DAYTONA_PIN_CHANNEL }}
+        run: |
+          if [ "$DAYTONA_PIN_CHANNEL" != "dev" ]; then
+            echo "::notice::Dev engine channel is disabled; set repository variable DAYTONA_PIN_CHANNEL=dev to enable."
+            echo "Skipped: dev engine channel is disabled (set \`DAYTONA_PIN_CHANNEL=dev\` to enable)." >> "$GITHUB_STEP_SUMMARY"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout dev source
+        if: steps.channel.outputs.enabled == 'true'
         uses: actions/checkout@v6
         with:
           ref: dev
@@ -38,6 +56,7 @@ jobs:
 
       - name: Resolve snapshot name
         id: resolve
+        if: steps.channel.outputs.enabled == 'true'
         shell: bash
         env:
           DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
@@ -55,6 +74,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install Daytona CLI
+        if: steps.channel.outputs.enabled == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -96,6 +116,7 @@ jobs:
 
       - name: Check whether snapshot already exists
         id: existing
+        if: steps.channel.outputs.enabled == 'true'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -126,12 +147,12 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        if: steps.existing.outputs.exists != 'true' || inputs.force == true
+        if: steps.channel.outputs.enabled == 'true' && (steps.existing.outputs.exists != 'true' || inputs.force == true)
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push snapshot
         id: publish
-        if: steps.existing.outputs.exists != 'true' || inputs.force == true
+        if: steps.channel.outputs.enabled == 'true' && (steps.existing.outputs.exists != 'true' || inputs.force == true)
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -155,7 +176,7 @@ jobs:
           ./scripts/create-daytona-openwork-snapshot.sh "${DAYTONA_SNAPSHOT_NAME}"
 
       - name: Checkout snapshot pin automation
-        if: vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
+        if: steps.channel.outputs.enabled == 'true' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
@@ -165,6 +186,7 @@ jobs:
 
       - name: Update production snapshot pin
         id: pin
+        if: steps.channel.outputs.enabled == 'true'
         shell: bash
         env:
           DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
@@ -202,7 +224,7 @@ jobs:
         # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
         # Without this the pin moves but `latestVersion` stays stale and no
         # sandbox ever recycles - observed for real on v0.18.11.
-        if: steps.pin.outcome == 'success'
+        if: steps.channel.outputs.enabled == 'true' && steps.pin.outcome == 'success'
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}

--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -47,11 +47,13 @@ jobs:
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout dev source
+      # Immutable SHA: the pushed commit for push events, or default-branch HEAD at trigger time for schedule/dispatch.
+      # Every commit on dev has passed PR review (Warden L24-F6Z).
+      - name: Checkout dev source at the triggering commit
         if: steps.channel.outputs.enabled == 'true'
         uses: actions/checkout@v6
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Resolve snapshot name
@@ -74,43 +76,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install Daytona CLI
+        # Pinned and checksum-verified because the CLI runs with DAYTONA_API_KEY.
+        # Bump the version and SHA together (Warden MZE-XC3).
         if: steps.channel.outputs.enabled == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          DAYTONA_CLI_VERSION: v0.190.0
+          DAYTONA_CLI_SHA256: 1d3591a1ea61d801696110e1b5f3381f223a56a623a882940d0d85742862fd44
         run: |
           set -euo pipefail
 
-          case "$(uname -s)" in
-            Linux) platform="linux" ;;
-            Darwin) platform="darwin" ;;
-            *)
-              echo "Unsupported OS: $(uname -s)" >&2
-              exit 1
-              ;;
-          esac
-
-          case "$(uname -m)" in
-            x86_64|amd64) arch="amd64" ;;
-            aarch64|arm64) arch="arm64" ;;
-            *)
-              echo "Unsupported architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          asset_name="daytona-${platform}-${arch}"
-          install_dir="$HOME/.local/bin"
-          mkdir -p "$install_dir"
-
-          release_json="$(gh api repos/daytonaio/daytona/releases/latest)"
-          asset_url="$(python3 -c 'import json, sys; data = json.load(sys.stdin); name = sys.argv[1]; print(next(asset["browser_download_url"] for asset in data["assets"] if asset["name"] == name))' "$asset_name" <<<"$release_json")"
-
-          curl -fL "$asset_url" -o "$install_dir/daytona"
-          chmod +x "$install_dir/daytona"
-
-          echo "$install_dir" >> "$GITHUB_PATH"
-          export PATH="$install_dir:$PATH"
+          mkdir -p "$HOME/.local/bin"
+          curl -fL "https://github.com/daytonaio/daytona/releases/download/${DAYTONA_CLI_VERSION}/daytona-linux-amd64" \
+            -o "$HOME/.local/bin/daytona"
+          printf '%s  %s\n' "$DAYTONA_CLI_SHA256" "$HOME/.local/bin/daytona" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/daytona"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
 
           daytona version
 

--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -1,0 +1,233 @@
+# web.openworklabs.com engine channel:
+# Nightly snapshot from dev HEAD, named <base>-dev-<short-sha>.
+# Releases still re-pin to the release snapshot and the next nightly moves it back
+# to dev. This known ping-pong will be resolved by an explicit channel var later.
+# Sandboxes roll forward via the existing stopped+stale recycle.
+
+name: Dev Daytona Snapshot
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Rebuild even if the snapshot for the current dev HEAD already exists"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  publish-daytona-snapshot:
+    name: Build and Push Dev Daytona Snapshot
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout dev source
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Resolve snapshot name
+        id: resolve
+        shell: bash
+        env:
+          DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
+          DEFAULT_SNAPSHOT_REGION: ${{ vars.DAYTONA_SNAPSHOT_REGION }}
+        run: |
+          set -euo pipefail
+
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          snapshot_name="${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}-dev-${short_sha}"
+          snapshot_region="${DEFAULT_SNAPSHOT_REGION:-}"
+          {
+            echo "snapshot_name=$snapshot_name"
+            echo "snapshot_region=$snapshot_region"
+            echo "short_sha=$short_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install Daytona CLI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          case "$(uname -s)" in
+            Linux) platform="linux" ;;
+            Darwin) platform="darwin" ;;
+            *)
+              echo "Unsupported OS: $(uname -s)" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$(uname -m)" in
+            x86_64|amd64) arch="amd64" ;;
+            aarch64|arm64) arch="arm64" ;;
+            *)
+              echo "Unsupported architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          asset_name="daytona-${platform}-${arch}"
+          install_dir="$HOME/.local/bin"
+          mkdir -p "$install_dir"
+
+          release_json="$(gh api repos/daytonaio/daytona/releases/latest)"
+          asset_url="$(python3 -c 'import json, sys; data = json.load(sys.stdin); name = sys.argv[1]; print(next(asset["browser_download_url"] for asset in data["assets"] if asset["name"] == name))' "$asset_name" <<<"$release_json")"
+
+          curl -fL "$asset_url" -o "$install_dir/daytona"
+          chmod +x "$install_dir/daytona"
+
+          echo "$install_dir" >> "$GITHUB_PATH"
+          export PATH="$install_dir:$PATH"
+
+          daytona version
+
+      - name: Check whether snapshot already exists
+        id: existing
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_URL: ${{ vars.DAYTONA_API_URL }}
+          DAYTONA_TARGET: ${{ vars.DAYTONA_TARGET }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+          FORCE_REBUILD: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DAYTONA_API_KEY:-}" ]; then
+            echo "Missing required secret: DAYTONA_API_KEY" >&2
+            exit 1
+          fi
+
+          export DAYTONA_CONFIG_DIR="$RUNNER_TEMP/daytona"
+          mkdir -p "$DAYTONA_CONFIG_DIR"
+          daytona login --api-key "$DAYTONA_API_KEY"
+
+          snapshot_list="$(daytona snapshot list)"
+          if grep -Fq -- "$DAYTONA_SNAPSHOT_NAME" <<<"$snapshot_list"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            if [ "${FORCE_REBUILD:-false}" != "true" ]; then
+              echo "Snapshot already exists; skipping rebuild: ${DAYTONA_SNAPSHOT_NAME}" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.existing.outputs.exists != 'true' || inputs.force == true
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push snapshot
+        id: publish
+        if: steps.existing.outputs.exists != 'true' || inputs.force == true
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_URL: ${{ vars.DAYTONA_API_URL }}
+          DAYTONA_TARGET: ${{ vars.DAYTONA_TARGET }}
+          DAYTONA_SNAPSHOT_REGION: ${{ steps.resolve.outputs.snapshot_region }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DAYTONA_API_KEY:-}" ]; then
+            echo "Missing required secret: DAYTONA_API_KEY" >&2
+            exit 1
+          fi
+
+          export DAYTONA_CONFIG_DIR="$RUNNER_TEMP/daytona"
+          mkdir -p "$DAYTONA_CONFIG_DIR"
+          daytona login --api-key "$DAYTONA_API_KEY"
+
+          echo "Publishing Daytona snapshot: ${DAYTONA_SNAPSHOT_NAME}"
+          ./scripts/create-daytona-openwork-snapshot.sh "${DAYTONA_SNAPSHOT_NAME}"
+
+      - name: Checkout snapshot pin automation
+        if: vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .snapshot-pin-automation
+          sparse-checkout: scripts/update-daytona-snapshot-pin.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Update production snapshot pin
+        id: pin
+        shell: bash
+        env:
+          DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DAYTONA_CLOUD_ENV_GROUP_ID:-}" ]; then
+            echo "::notice::DAYTONA_CLOUD_ENV_GROUP_ID is not configured; skipping production snapshot pin update."
+            {
+              echo "### Daytona snapshot pin"
+              echo
+              echo "Skipped: repository variable \`DAYTONA_CLOUD_ENV_GROUP_ID\` is not configured."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -z "${RENDER_API_KEY:-}" ]; then
+            echo "::error::Missing required secret: RENDER_API_KEY"
+            exit 1
+          fi
+
+          result="$(node .snapshot-pin-automation/scripts/update-daytona-snapshot-pin.mjs \
+            --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" \
+            --snapshot "$DAYTONA_SNAPSHOT_NAME")"
+          echo "$result"
+          {
+            echo "### Daytona snapshot pin"
+            echo
+            echo "$result"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Redeploy den-api so the new pin takes effect
+        # Render does not redeploy services when an env group value changes, so
+        # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
+        # Without this the pin moves but `latestVersion` stays stale and no
+        # sandbox ever recycles - observed for real on v0.18.11.
+        if: steps.pin.outcome == 'success'
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_DEN_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RENDER_DEN_SERVICE_ID:-}" ] || [ -z "${RENDER_API_KEY:-}" ]; then
+            echo "::notice::Render den-api credentials unavailable; skipping redeploy. The pin will take effect on the next den-api deploy."
+            exit 0
+          fi
+
+          response="$(curl -s -w '\n%{http_code}' -X POST \
+            "https://api.render.com/v1/services/${RENDER_DEN_SERVICE_ID}/deploys" \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}')"
+          code="$(printf '%s' "$response" | tail -1)"
+          body="$(printf '%s' "$response" | sed '$d')"
+          if [ "$code" -ge 400 ]; then
+            echo "::error::POST /deploys returned HTTP $code: $body"
+            exit 1
+          fi
+
+          {
+            echo
+            echo "Triggered a den-api deploy so the new pin takes effect."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -107,42 +107,22 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Install Daytona CLI
+        # Pinned and checksum-verified because the CLI runs with DAYTONA_API_KEY.
+        # Bump the version and SHA together (Warden MZE-XC3).
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          DAYTONA_CLI_VERSION: v0.190.0
+          DAYTONA_CLI_SHA256: 1d3591a1ea61d801696110e1b5f3381f223a56a623a882940d0d85742862fd44
         run: |
           set -euo pipefail
 
-          case "$(uname -s)" in
-            Linux) platform="linux" ;;
-            Darwin) platform="darwin" ;;
-            *)
-              echo "Unsupported OS: $(uname -s)" >&2
-              exit 1
-              ;;
-          esac
-
-          case "$(uname -m)" in
-            x86_64|amd64) arch="amd64" ;;
-            aarch64|arm64) arch="arm64" ;;
-            *)
-              echo "Unsupported architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          asset_name="daytona-${platform}-${arch}"
-          install_dir="$HOME/.local/bin"
-          mkdir -p "$install_dir"
-
-          release_json="$(gh api repos/daytonaio/daytona/releases/latest)"
-          asset_url="$(python3 -c 'import json, sys; data = json.load(sys.stdin); name = sys.argv[1]; print(next(asset["browser_download_url"] for asset in data["assets"] if asset["name"] == name))' "$asset_name" <<<"$release_json")"
-
-          curl -fL "$asset_url" -o "$install_dir/daytona"
-          chmod +x "$install_dir/daytona"
-
-          echo "$install_dir" >> "$GITHUB_PATH"
-          export PATH="$install_dir:$PATH"
+          mkdir -p "$HOME/.local/bin"
+          curl -fL "https://github.com/daytonaio/daytona/releases/download/${DAYTONA_CLI_VERSION}/daytona-linux-amd64" \
+            -o "$HOME/.local/bin/daytona"
+          printf '%s  %s\n' "$DAYTONA_CLI_SHA256" "$HOME/.local/bin/daytona" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/daytona"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
 
           daytona version
 

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -98,13 +98,13 @@ jobs:
           echo "Verified tag: ${RELEASE_TAG}"
 
       - name: Checkout release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
           ref: refs/tags/${{ steps.resolve.outputs.release_tag }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.9.0
 
       - name: Install Daytona CLI
         # Pinned and checksum-verified because the CLI runs with DAYTONA_API_KEY.
@@ -159,7 +159,7 @@ jobs:
 
       - name: Checkout snapshot pin automation
         if: steps.publish.outcome == 'success' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != '' && vars.DAYTONA_PIN_CHANNEL != 'dev'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.sha }}
           path: .snapshot-pin-automation

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -170,8 +170,15 @@ jobs:
           echo "Publishing Daytona snapshot: ${DAYTONA_SNAPSHOT_NAME}"
           ./scripts/create-daytona-openwork-snapshot.sh "${DAYTONA_SNAPSHOT_NAME}"
 
+      - name: Note skipped release pin
+        if: vars.DAYTONA_PIN_CHANNEL == 'dev'
+        shell: bash
+        run: |
+          echo "::notice::web engine channel is 'dev'; release snapshot pin skipped (set DAYTONA_PIN_CHANNEL=release to restore release pinning)"
+          echo "Skipped release snapshot pin: web engine channel is \`dev\`. Set \`DAYTONA_PIN_CHANNEL=release\` to restore release pinning." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout snapshot pin automation
-        if: steps.publish.outcome == 'success' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != ''
+        if: steps.publish.outcome == 'success' && vars.DAYTONA_CLOUD_ENV_GROUP_ID != '' && vars.DAYTONA_PIN_CHANNEL != 'dev'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
@@ -181,7 +188,7 @@ jobs:
 
       - name: Update production snapshot pin
         id: pin
-        if: steps.publish.outcome == 'success'
+        if: steps.publish.outcome == 'success' && vars.DAYTONA_PIN_CHANNEL != 'dev'
         shell: bash
         env:
           DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
@@ -219,7 +226,7 @@ jobs:
         # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
         # Without this the pin moves but `latestVersion` stays stale and no
         # sandbox ever recycles - observed for real on v0.18.11.
-        if: steps.pin.outcome == 'success'
+        if: steps.pin.outcome == 'success' && vars.DAYTONA_PIN_CHANNEL != 'dev'
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}

--- a/scripts/update-daytona-snapshot-pin.mjs
+++ b/scripts/update-daytona-snapshot-pin.mjs
@@ -182,12 +182,14 @@ export const USAGE = `Update or check the Daytona sandbox snapshot pin (DAYTONA_
 Usage:
   node scripts/update-daytona-snapshot-pin.mjs --env-group-id <id> --snapshot <name> [--dry-run]
   node scripts/update-daytona-snapshot-pin.mjs --env-group-id <id> --snapshot <name> --compare
+  node scripts/update-daytona-snapshot-pin.mjs --env-group-id <id> --read
 
 Options:
   --env-group-id <id>  Render env group holding DAYTONA_SNAPSHOT (e.g. evg-...).
   --snapshot <name>    Desired snapshot name (e.g. openwork-0.18.11).
   --dry-run            Print the request that would be sent; write nothing.
   --compare            Read-only drift check; exits non-zero when the pin differs.
+  --read               Print the current snapshot pin; write nothing.
   -h, --help           Show this help.
 
 Environment:
@@ -201,6 +203,7 @@ export function parseArgs(args) {
     snapshotName: "",
     dryRun: false,
     compare: false,
+    read: false,
     help: false,
   }
 
@@ -216,6 +219,8 @@ export function parseArgs(args) {
       options.dryRun = true
     } else if (argument === "--compare") {
       options.compare = true
+    } else if (argument === "--read") {
+      options.read = true
     } else if (argument === "--help" || argument === "-h") {
       options.help = true
     } else {
@@ -229,6 +234,9 @@ export function parseArgs(args) {
 
   if (options.dryRun && options.compare) {
     throw new Error("--dry-run and --compare cannot be used together.")
+  }
+  if (options.read && (options.dryRun || options.compare)) {
+    throw new Error("--read cannot be used with --dry-run or --compare.")
   }
 
   return options
@@ -244,6 +252,12 @@ export async function main(args, environment = process.env) {
     envGroupId: options.envGroupId,
     snapshotName: options.snapshotName,
     apiKey: environment.RENDER_API_KEY,
+  }
+
+  if (options.read) {
+    const current = await readDaytonaSnapshotPin(input)
+    console.log(current)
+    return { status: "read", current }
   }
 
   if (options.compare) {

--- a/scripts/update-daytona-snapshot-pin.test.mjs
+++ b/scripts/update-daytona-snapshot-pin.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test"
 
 import {
   compareDaytonaSnapshotPin,
+  main,
   updateDaytonaSnapshotPin,
 } from "./update-daytona-snapshot-pin.mjs"
 
@@ -206,4 +207,30 @@ test("compare mode fails with a clear diff when drift is detected", async () => 
     }),
     /expected DAYTONA_SNAPSHOT=openwork-0\.18\.10, found DAYTONA_SNAPSHOT=openwork-0\.18\.9/,
   )
+})
+
+test("read mode prints the current pin without writing", async () => {
+  const originalFetch = globalThis.fetch
+  const originalLog = console.log
+  const calls = []
+  const messages = []
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options })
+    return jsonResponse({ key: "DAYTONA_SNAPSHOT", value: snapshotName })
+  }
+  console.log = (message) => messages.push(message)
+
+  try {
+    const result = await main(["--env-group-id", envGroupId, "--read"], {
+      RENDER_API_KEY: apiKey,
+    })
+
+    assert.deepEqual(result, { status: "read", current: snapshotName })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].options.method, "GET")
+    assert.deepEqual(messages, [snapshotName])
+  } finally {
+    globalThis.fetch = originalFetch
+    console.log = originalLog
+  }
 })


### PR DESCRIPTION
Makes the cloud ENGINE track dev (nightly), pairing with #3494 (UI images per dev push). Together one commit stream feeds both halves of web.openworklabs.com.

## What
- New `dev-daytona-snapshot.yml`: nightly (03:00 UTC) + manual dispatch. Builds a Daytona snapshot from dev HEAD named `<base>-dev-<short-sha>` using the existing `create-daytona-openwork-snapshot.sh`, updates the production `DAYTONA_SNAPSHOT` pin (same script + env-group guard as the release flow), and redeploys den-api. Skips the build when the snapshot for the current HEAD already exists (`force` input overrides) but still runs the idempotent pin+redeploy to heal half-failed runs. Users roll forward via the existing stopped+stale recycle with checkpoint restore.
- `update-daytona-snapshot-pin.mjs`: new read-only `--read` mode (prints current pin; GET only) + tests.
- `daytona-snapshot-drift.yml` is now channel-aware: dev-channel pins (`<base>-dev-<sha>`) are checked for (a) sha resolvable and an ancestor of origin/dev, (b) commit age ≤ 48h (nightly-broken alarm); release pins keep the exact existing compare.

## Known interaction (intentional, documented in the workflow header)
Releases still re-pin to the release snapshot; the next nightly moves the pin back to dev. Resolving the ping-pong with an explicit channel var is a follow-up.

## Tests
- `node --test scripts/update-daytona-snapshot-pin.test.mjs` → 13 pass / 0 fail (includes `--read`: GET-only, prints pin, no `--snapshot` needed).
- `actionlint` on both workflows: only the pre-existing custom Blacksmith runner-label finding (same as the existing drift/release workflows).

## Validation note
Workflows can't run locally. First observable proof: manually dispatch "Dev Daytona Snapshot" after merge → expect snapshot `openwork-dev-<sha>` in Daytona, pin summary in the run, and den-api redeploy; the drift check's next scheduled run should then report "Dev channel pin healthy".

---
**Amended after live Render inspection:** engine snapshots now build on **every dev push** (nightly stays as backstop; GitHub's concurrency queue batches bursts; skip-if-exists dedupes). New repo variable `DAYTONA_PIN_CHANNEL` (already set to `dev`) gates this pipeline AND makes the release workflow skip its pin+redeploy — pin ping-pong resolved. `DAYTONA_PIN_CHANNEL=release` is the one-flip rollback: this pipeline stops and the next release re-pins. Release snapshots still build/publish unconditionally as rollback artifacts.
