### PR TITLE
feat(provider): add Nexforce Router

### DIFF
--- a/apps/app/src/react-app/design-system/provider-logo-src.ts
+++ b/apps/app/src/react-app/design-system/provider-logo-src.ts
@@ -63,6 +63,7 @@ const PROVIDER_DOMAINS: Record<string, string> = {
   opencode: "opencode.ai",
   openwork: "openworklabs.com",
   abacus: "abacus.ai",
+  nexforce: "router.nexforce.ai",
 };
 
 /**

--- a/packages/docs/cloud/share-with-your-team/custom-llm-provider.mdx
+++ b/packages/docs/cloud/share-with-your-team/custom-llm-provider.mdx
@@ -132,6 +132,80 @@ Pick the model and it's live in the session footer:
 
 Add more entries under `models` to expose other routes the gateway supports (e.g. `openai/gpt-5.4`, `google/gemini-2.5-flash`).
 
+### Functional example: Nexforce Router
+
+[Nexforce Router](https://router.nexforce.ai/docs) is Latin America's largest AI inference router: one OpenAI-compatible endpoint that routes to Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models, with per-key fallback chains and per-key cost control. Fallbacks, rate limits, and spend caps are configured per API key, and response headers `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` disclose exactly which model served each request.
+
+Grab a key from the [API Keys dashboard](https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys). If you don't have an account yet, sign up at [marketplace.nexforce.ai](https://marketplace.nexforce.ai).
+
+Paste the key into `API key / credential` and use this JSON:
+
+```json
+{
+  "id": "nexforce",
+  "name": "Nexforce Router",
+  "npm": "@ai-sdk/openai-compatible",
+  "env": [
+    "NEXFORCE_API_KEY"
+  ],
+  "doc": "https://router.nexforce.ai/docs",
+  "api": "https://router.nexforce.ai/v1",
+  "models": [
+    {
+      "id": "nexforce/smart-route",
+      "name": "Nexforce Smart Route",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      }
+    },
+    {
+      "id": "anthropic/claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "limit": {
+        "context": 1000000,
+        "input": 1000000,
+        "output": 128000
+      },
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      }
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash",
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "open_weights": true,
+      "limit": {
+        "context": 1000000,
+        "input": 1000000,
+        "output": 384000
+      },
+      "modalities": {
+        "input": ["text"],
+        "output": ["text"]
+      }
+    }
+  ]
+}
+```
+
+`nexforce/smart-route` lets the router pick an equivalent model per request while preserving required capabilities — a good default entry that keeps working as Nexforce's catalog grows. Add more entries under `models` (e.g. `openai/gpt-5.4`, `google/gemini-3.6-flash`, `z-ai/glm-5`) to expose other routes.
+
 ## When to use a cloud provider
 
 Use a Cloud provider when the setup is meant to be shared across an org or team. For solo use, configuring it directly in the desktop app is simpler.

--- a/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
@@ -52,4 +52,36 @@ Pull the model first with `ollama pull qwen3:8b`, then make sure the Ollama serv
 
 Open your desktop, change the provider name and voila! You have an fully local LLM running in your machine.
 
+### Functional example: Nexforce Router
+
+[Nexforce Router](https://router.nexforce.ai/docs) is Latin America's largest AI inference router — one OpenAI-compatible endpoint that routes to Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models, with per-key fallback chains and per-key cost control. Grab a key from the [API Keys dashboard](https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys) and set it as `NEXFORCE_API_KEY` in your environment.
+
+```
+{
+  "provider": {
+    "nexforce": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Nexforce Router",
+      "options": {
+        "baseURL": "https://router.nexforce.ai/v1",
+        "apiKey": "{env:NEXFORCE_API_KEY}"
+      },
+      "models": {
+        "nexforce/smart-route": {
+          "name": "Nexforce Smart Route"
+        },
+        "anthropic/claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6"
+        },
+        "deepseek/deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        }
+      }
+    }
+  }
+}
+```
+
+Reload the config and pick a Nexforce model from the model picker. `nexforce/smart-route` lets the router pick an equivalent model per request while preserving required capabilities.
+
 For teams, you can manage the provider in OpenWork Cloud under [LLM Providers](/cloud/share-with-your-team/managed-llm-provider), then import it into each workspace from `Settings -> Cloud`.


### PR DESCRIPTION
## Value proposition

This PR adds **Nexforce Router** — Latin America's largest AI inference router — so OpenWork users get **one API key that reaches Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI**, with automatic fallback and per-key cost control.

OpenWork already supports any OpenAI-compatible provider via config (base URL + key). Nexforce Router is exactly that shape, so the integration is a turnkey catalog entry: point OpenWork at `https://router.nexforce.ai/v1`, drop in your `NEXFORCE_API_KEY`, and every routed model appears in the model picker — including `nexforce/smart-route`, which lets the router pick an equivalent model per request while preserving required capabilities.

## Regional differentiator

Nexforce Router is built for Latin America. Billing and compliance are handled locally for each country in the region: invoicing, taxes, and payment infrastructure are managed in-country, so teams get **compliant, locally-issued invoices** without the FX and foreign-procurement friction of paying an overseas provider. Cost control is per API key — fallback chains, rate limits, and spend caps configured per key, with `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` response headers disclosing exactly which model answered and what it cost.

## What changed

- `packages/docs/cloud/share-with-your-team/custom-llm-provider.mdx` — new "Functional example: Nexforce Router" section with a ready-to-paste provider definition (mirrors the existing Infron gateway example).
- `packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx` — desktop config example for solo use: `nexforce` provider block with `@ai-sdk/openai-compatible`, base URL, and `NEXFORCE_API_KEY`.
- `apps/app/src/react-app/design-system/provider-logo-src.ts` — brand logo catalog entry so the Nexforce Router mark resolves in the model picker instead of falling back to a monogram.

## How to configure

Set the env var:

```bash
export NEXFORCE_API_KEY=nfc_...
```

Then add the provider to your workspace `opencode.json`:

```json
{
  "provider": {
    "nexforce": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "Nexforce Router",
      "options": {
        "baseURL": "https://router.nexforce.ai/v1",
        "apiKey": "{env:NEXFORCE_API_KEY}"
      },
      "models": {
        "nexforce/smart-route": { "name": "Nexforce Smart Route" },
        "anthropic/claude-sonnet-4-6": { "name": "Claude Sonnet 4.6" },
        "deepseek/deepseek-v4-flash": { "name": "DeepSeek V4 Flash" }
      }
    }
  }
}
```

Grab a key at https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys

## Verification done

- **Live `/v1/models` listing**: `GET https://router.nexforce.ai/v1/models` (public, no key) returned the full catalog (139 models across Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI).
- **Live chat roundtrip** against `deepseek/deepseek-v4-flash`: HTTP 200 with a real completion, confirming `X-Nexforce-Requested-Model: deepseek/deepseek-v4-flash` and `X-Nexforce-Served-Model: deepseek-v4-flash` transparency headers.
- **Tool calling**: a function-call request returned `finish_reason: tool_calls` with valid arguments, confirming agentic/tool-calling support.
- **Engine load**: with a temp HOME + `opencode.json` containing the documented `nexforce` provider block, the real OpenCode engine listed all six configured Nexforce models (`opencode models`).
- **Typecheck**: `pnpm --filter @openwork/app typecheck` passes.
- **Tests**: `apps/app` unit tests use `bun test`, and `bun` is not available in this environment, so the `provider-icon` test could not be executed here; the one-line logo-map change is covered by app typecheck. Docs changes carry no test harness. Please run `pnpm --filter @openwork/app test` in CI.
