### PR TITLE
fix(app): recover invited organization bootstrap

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1103,12 +1103,6 @@ export async function ensureDenActiveOrganization(options?: { forceServerSync?: 
     null;
 
   if (!targetOrg) {
-    writeDenSettings({
-      ...settings,
-      activeOrgId: null,
-      activeOrgSlug: null,
-      activeOrgName: null,
-    }, { persistBootstrap: false });
     return null;
   }
 

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -21,6 +21,7 @@ import {
   resolveDenBaseUrls,
   setDenBootstrapConfig,
   type DenBootstrapConfig,
+  type DenOrgSummary,
   type DenUser,
 } from "../../../app/lib/den";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
@@ -54,6 +55,26 @@ export type DenAuthStatus =
 
 export const DEN_AUTH_SIGNAL_RETRY_COOLDOWN_MS = 5_000;
 export const DEN_AUTH_UNAVAILABLE_RETRY_INTERVAL_MS = 30_000;
+const DEN_ORG_RESOLUTION_RETRY_DELAYS_MS = [0, 200, 600];
+
+export async function resolveDenActiveOrganizationWithRetry(
+  resolve: () => Promise<DenOrgSummary | null>,
+  wait: (delayMs: number) => Promise<void> = (delayMs) =>
+    new Promise((resolveWait) => window.setTimeout(resolveWait, delayMs)),
+) {
+  for (const delayMs of DEN_ORG_RESOLUTION_RETRY_DELAYS_MS) {
+    if (delayMs > 0) await wait(delayMs);
+
+    try {
+      const organization = await resolve();
+      if (organization) return organization;
+    } catch {
+      // A newly accepted membership can take a moment to become visible.
+    }
+  }
+
+  return null;
+}
 
 export function resolveDenAuthFailureStatus(
   error: unknown,
@@ -191,10 +212,12 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
 
       if (currentRun !== refreshTokenRef.current) return;
 
-      await ensureDenActiveOrganization({
-        forceServerSync:
-          !settings.activeOrgId?.trim() || !settings.activeOrgSlug?.trim(),
-      }).catch(() => null);
+      await resolveDenActiveOrganizationWithRetry(() =>
+        ensureDenActiveOrganization({
+          forceServerSync:
+            !settings.activeOrgId?.trim() || !settings.activeOrgSlug?.trim(),
+        })
+      );
 
       if (currentRun !== refreshTokenRef.current) return;
 

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -72,6 +72,10 @@ const DESKTOP_CONFIG_ITEMS = [
   "onboardingPromptDescriptions",
 ] as const satisfies readonly (keyof DenDesktopConfig)[];
 
+export function resolveConnectStateToPush(config: DenDesktopConfig): boolean | null {
+  return typeof config.connectEnabled === "boolean" ? config.connectEnabled : null;
+}
+
 type DesktopConfigItem = (typeof DESKTOP_CONFIG_ITEMS)[number];
 type DesktopConfigAction = {
   item: DesktopConfigItem;
@@ -358,10 +362,11 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     };
   }, [desktopConfigHandler, isSignedIn]);
 
-  const connectEnabled = config.connectEnabled === true;
+  const connectEnabled = resolveConnectStateToPush(config);
 
   useEffect(() => {
     if (loading) return;
+    if (connectEnabled === null) return;
     if (lastPushedConnectEnabledRef.current === connectEnabled) return;
     let cancelled = false;
 

--- a/apps/app/tests/den-auth-provider.test.ts
+++ b/apps/app/tests/den-auth-provider.test.ts
@@ -4,9 +4,17 @@ import { DenApiError } from "../src/app/lib/den";
 import {
   DEN_AUTH_SIGNAL_RETRY_COOLDOWN_MS,
   hasRetainedDenSession,
+  resolveDenActiveOrganizationWithRetry,
   resolveDenAuthFailureStatus,
   shouldRetryDenAuthOnSignal,
 } from "../src/react-app/domains/cloud/den-auth-provider";
+
+const resolvedOrganization = {
+  id: "org_invited",
+  name: "Invited organization",
+  slug: "invited-organization",
+  role: "member",
+};
 
 describe("resolveDenAuthFailureStatus", () => {
   test("only treats a confirmed unauthorized response as signed out", () => {
@@ -81,5 +89,28 @@ describe("shouldRetryDenAuthOnSignal", () => {
         lastAttemptAt: 1_000,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveDenActiveOrganizationWithRetry", () => {
+  test("recovers when an invited organization is temporarily unavailable", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+
+    const result = await resolveDenActiveOrganizationWithRetry(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new TypeError("Failed to fetch");
+        if (attempts === 2) return null;
+        return resolvedOrganization;
+      },
+      async (delayMs) => {
+        waits.push(delayMs);
+      },
+    );
+
+    expect(result).toEqual(resolvedOrganization);
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([200, 600]);
   });
 });

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -7,10 +7,17 @@ import {
   selectEffectiveOnboardingPrompts,
 } from "@openwork/types/den/desktop-policies";
 import { createDenClient, normalizeDenDesktopConfig } from "../src/app/lib/den";
+import { resolveConnectStateToPush } from "../src/react-app/domains/cloud/desktop-config-provider";
 
 const originalFetch = globalThis.fetch;
 
 describe("Den desktop config client", () => {
+  test("only pushes an explicit Connect policy", () => {
+    expect(resolveConnectStateToPush({})).toBeNull();
+    expect(resolveConnectStateToPush({ connectEnabled: false })).toBe(false);
+    expect(resolveConnectStateToPush({ connectEnabled: true })).toBe(true);
+  });
+
   afterEach(() => {
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,

--- a/apps/app/tests/den-session-offline-resilience.test.ts
+++ b/apps/app/tests/den-session-offline-resilience.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   DenApiError,
+  ensureDenActiveOrganization,
   isDenSessionRevokedError,
   mergePassiveDenSettings,
   readDenSettings,
@@ -10,6 +11,7 @@ import {
 import { resolveDenAuthFailureStatus } from "../src/react-app/domains/cloud/den-auth-provider";
 
 const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
 
 function memoryStorage(): Storage {
   const map = new Map<string, string>();
@@ -39,6 +41,10 @@ afterEach(() => {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: originalFetch,
   });
 });
 
@@ -147,6 +153,43 @@ describe("mergePassiveDenSettings", () => {
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_stored");
     expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("stored-org");
     expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Stored Org");
+  });
+});
+
+describe("ensureDenActiveOrganization", () => {
+  test("preserves the selected organization when the server temporarily returns none", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: () => true,
+      },
+    });
+    writeDenSettings({
+      baseUrl: "https://den.test",
+      authToken: "tok_stored",
+      activeOrgId: "org_stored",
+      activeOrgSlug: "stored-org",
+      activeOrgName: "Stored Org",
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: (async () => new Response(JSON.stringify({
+        orgs: [],
+        activeOrgId: null,
+        activeOrgSlug: null,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) satisfies typeof fetch,
+    });
+
+    await expect(ensureDenActiveOrganization()).resolves.toBeNull();
+    expect(readDenSettings()).toMatchObject({
+      activeOrgId: "org_stored",
+      activeOrgSlug: "stored-org",
+      activeOrgName: "Stored Org",
+    });
   });
 });
 


### PR DESCRIPTION
## What

Fixes fresh invited-member sign-in when organization discovery is briefly unavailable.

- preserve the last valid organization instead of persisting an empty selection
- retry organization resolution during session restoration
- only mirror Connect state when Den returned an explicit boolean
- preserve explicit organization policy `connectEnabled: false`

## Tests

- `pnpm exec bun test tests/den-auth-provider.test.ts tests/den-desktop-config.test.ts tests/den-session-offline-resilience.test.ts` — Passed: 20 tests, 60 assertions
- `pnpm typecheck` — Passed
- `git diff --check` — Passed

## Evidence

Incomplete: this quick repair has focused executable regression coverage but no `@openwork/testkit` app-driving evidence tape. Manual repro: accept a fresh organization invite while the first `/v1/me/orgs` request fails or returns empty; the app should retry, retain the selected organization, and must not write `connectEnabled:false` until Den returns an explicit policy.