### PR TITLE
fix(deps): repair pnpm lockfile snapshot

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,7 +934,7 @@ importers:
         version: 1.3.14
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## What

Repairs the `packages/automations` tsup peer snapshot after the PostCSS lockfile update. The importer referenced a peer combination that no longer existed in `pnpm-lock.yaml`, causing frozen installs to fail with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`.

## Validation

- `pnpm install --no-frozen-lockfile --prefer-offline` — repaired the snapshot
- `pnpm install --frozen-lockfile --prefer-offline` — passed
- `git diff --check` — passed

Pure lockfile repair; runtime evidence tape is not applicable.