### PR TITLE
fix(den,app): carry org through desktop handoff and heal stranded Connect state

### DIFF
--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -1,5 +1,6 @@
 import {
   createDenClient,
+  readDenSettings,
   writeDenSettings,
   type DenDesktopHandoffExchange,
 } from "./den";
@@ -56,12 +57,18 @@ export async function exchangeHandoffAndSignIn(
         window.sessionStorage.setItem(DEN_HANDOFF_AUTO_CONTINUE_KEY, String(Date.now()));
       } catch {}
     }
+    // Prefer the caller-provided org (install-link bootstrap), then the org the
+    // server resolved for this session. When neither is known, keep whatever is
+    // already stored: overwriting with null strands fresh profiles without an
+    // organization, which disables Connect and skips org onboarding.
+    const activeOrg = options.activeOrg ?? exchange.organization ?? null;
+    const storedSettings = readDenSettings();
     writeDenSettings({
       baseUrl: options.baseUrl,
       authToken: exchange.token,
-      activeOrgId: options.activeOrg?.id ?? null,
-      activeOrgSlug: options.activeOrg?.slug ?? null,
-      activeOrgName: options.activeOrg?.name ?? null,
+      activeOrgId: activeOrg ? activeOrg.id : storedSettings.activeOrgId,
+      activeOrgSlug: activeOrg ? activeOrg.slug ?? null : storedSettings.activeOrgSlug,
+      activeOrgName: activeOrg ? activeOrg.name ?? null : storedSettings.activeOrgName,
     });
 
     dispatchDenSessionUpdated({

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -376,9 +376,16 @@ type DenAuthResult = {
   token: string | null;
 };
 
+export type DenDesktopHandoffExchangeOrganization = {
+  id: string;
+  slug: string | null;
+  name: string | null;
+};
+
 export type DenDesktopHandoffExchange = {
   user: DenUser | null;
   token: string | null;
+  organization: DenDesktopHandoffExchangeOrganization | null;
 };
 
 const defaultBootstrapBaseUrls = resolveDenBaseUrls({
@@ -1175,6 +1182,24 @@ function getToken(payload: unknown): string | null {
     return null;
   }
   return payload.token.trim() || null;
+}
+
+function getExchangeOrganization(payload: unknown): DenDesktopHandoffExchangeOrganization | null {
+  if (!isRecord(payload) || !isRecord(payload.organization)) {
+    return null;
+  }
+
+  const organization = payload.organization;
+  const id = typeof organization.id === "string" ? organization.id.trim() : "";
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    slug: typeof organization.slug === "string" && organization.slug.trim() ? organization.slug.trim() : null,
+    name: typeof organization.name === "string" && organization.name.trim() ? organization.name.trim() : null,
+  };
 }
 
 function getOrgList(payload: unknown): DenOrgSummary[] {
@@ -2253,7 +2278,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         method: "POST",
         body: { grant },
       });
-      return { user: getUser(payload), token: getToken(payload) };
+      return { user: getUser(payload), token: getToken(payload), organization: getExchangeOrganization(payload) };
     },
 
     async listOrgs(): Promise<{ orgs: DenOrgSummary[]; activeOrgId: string | null; activeOrgSlug: string | null; defaultOrgId: string | null }> {

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -55,6 +55,7 @@ export type DenAuthStatus =
 
 export const DEN_AUTH_SIGNAL_RETRY_COOLDOWN_MS = 5_000;
 export const DEN_AUTH_UNAVAILABLE_RETRY_INTERVAL_MS = 30_000;
+export const DEN_AUTH_ORG_REPAIR_INTERVAL_MS = 30_000;
 const DEN_ORG_RESOLUTION_RETRY_DELAYS_MS = [0, 200, 600];
 
 export async function resolveDenActiveOrganizationWithRetry(
@@ -289,10 +290,26 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
       retryUnavailableSession,
       DEN_AUTH_UNAVAILABLE_RETRY_INTERVAL_MS,
     );
+    // A signed-in session without an organization is a stranded first
+    // sign-in (e.g. org discovery was rate limited during a handoff). Keep
+    // repairing in the background until an organization resolves.
+    const repairMissingOrganization = () => {
+      if (statusRef.current !== "signed_in") return;
+      const settings = readDenSettings();
+      if (!settings.authToken?.trim() || settings.activeOrgId?.trim()) return;
+      void resolveDenActiveOrganizationWithRetry(() =>
+        ensureDenActiveOrganization({ forceServerSync: true })
+      );
+    };
+    const orgRepairInterval = window.setInterval(
+      repairMissingOrganization,
+      DEN_AUTH_ORG_REPAIR_INTERVAL_MS,
+    );
     return () => {
       window.removeEventListener("online", retryUnavailableSession);
       window.removeEventListener("focus", retryUnavailableSession);
       window.clearInterval(retryInterval);
+      window.clearInterval(orgRepairInterval);
     };
   }, [refresh]);
 

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -76,6 +76,34 @@ export function resolveConnectStateToPush(config: DenDesktopConfig): boolean | n
   return typeof config.connectEnabled === "boolean" ? config.connectEnabled : null;
 }
 
+export const CONNECT_STATE_PUSH_RETRY_DELAY_MS = 3_000;
+export const CONNECT_STATE_PUSH_MAX_ATTEMPTS = 20;
+
+/**
+ * Push the Connect switch to the local server until it is actually accepted.
+ * On a fresh install the local server (or its host token) may not be ready
+ * when the first push fires; dropping that push would strand the on-disk
+ * default (`connectEnabled: false`) forever. Resolves true once delivered.
+ */
+export async function deliverConnectState(
+  attempt: () => Promise<boolean>,
+  wait: (delayMs: number) => Promise<void>,
+  isCancelled: () => boolean,
+): Promise<boolean> {
+  for (let attemptIndex = 0; attemptIndex < CONNECT_STATE_PUSH_MAX_ATTEMPTS; attemptIndex += 1) {
+    if (isCancelled()) return false;
+    try {
+      if (await attempt()) return true;
+    } catch {
+      // The local server may still be starting; retry below.
+    }
+    if (isCancelled()) return false;
+    await wait(CONNECT_STATE_PUSH_RETRY_DELAY_MS);
+  }
+
+  return false;
+}
+
 type DesktopConfigItem = (typeof DESKTOP_CONFIG_ITEMS)[number];
 type DesktopConfigAction = {
   item: DesktopConfigItem;
@@ -370,16 +398,24 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (lastPushedConnectEnabledRef.current === connectEnabled) return;
     let cancelled = false;
 
-    void (async () => {
-      const connection = await resolveOpenworkConnection();
-      if (cancelled || !connection.normalizedBaseUrl || !connection.resolvedHostToken) return;
-      lastPushedConnectEnabledRef.current = connectEnabled;
-      await createOpenworkServerClient({
-        baseUrl: connection.normalizedBaseUrl,
-        token: connection.resolvedToken,
-        hostToken: connection.resolvedHostToken,
-      }).setConnectState(connectEnabled);
-    })().catch(() => null);
+    void deliverConnectState(
+      async () => {
+        const connection = await resolveOpenworkConnection();
+        if (!connection.normalizedBaseUrl || !connection.resolvedHostToken) return false;
+        await createOpenworkServerClient({
+          baseUrl: connection.normalizedBaseUrl,
+          token: connection.resolvedToken,
+          hostToken: connection.resolvedHostToken,
+        }).setConnectState(connectEnabled);
+        return true;
+      },
+      (delayMs) => new Promise((resolveWait) => window.setTimeout(resolveWait, delayMs)),
+      () => cancelled,
+    ).then((delivered) => {
+      if (delivered && !cancelled) {
+        lastPushedConnectEnabledRef.current = connectEnabled;
+      }
+    }).catch(() => null);
 
     return () => {
       cancelled = true;

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -7,7 +7,12 @@ import {
   selectEffectiveOnboardingPrompts,
 } from "@openwork/types/den/desktop-policies";
 import { createDenClient, normalizeDenDesktopConfig } from "../src/app/lib/den";
-import { resolveConnectStateToPush } from "../src/react-app/domains/cloud/desktop-config-provider";
+import {
+  CONNECT_STATE_PUSH_MAX_ATTEMPTS,
+  CONNECT_STATE_PUSH_RETRY_DELAY_MS,
+  deliverConnectState,
+  resolveConnectStateToPush,
+} from "../src/react-app/domains/cloud/desktop-config-provider";
 
 const originalFetch = globalThis.fetch;
 
@@ -16,6 +21,54 @@ describe("Den desktop config client", () => {
     expect(resolveConnectStateToPush({})).toBeNull();
     expect(resolveConnectStateToPush({ connectEnabled: false })).toBe(false);
     expect(resolveConnectStateToPush({ connectEnabled: true })).toBe(true);
+  });
+
+  test("retries the Connect push until the local server accepts it", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+
+    const delivered = await deliverConnectState(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) return false;
+        if (attempts === 2) throw new Error("local server starting");
+        return true;
+      },
+      async (delayMs) => {
+        waits.push(delayMs);
+      },
+      () => false,
+    );
+
+    expect(delivered).toBe(true);
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([CONNECT_STATE_PUSH_RETRY_DELAY_MS, CONNECT_STATE_PUSH_RETRY_DELAY_MS]);
+  });
+
+  test("stops the Connect push when cancelled or exhausted", async () => {
+    let cancelledAttempts = 0;
+    const cancelled = await deliverConnectState(
+      async () => {
+        cancelledAttempts += 1;
+        return false;
+      },
+      async () => {},
+      () => cancelledAttempts >= 2,
+    );
+    expect(cancelled).toBe(false);
+    expect(cancelledAttempts).toBe(2);
+
+    let exhaustedAttempts = 0;
+    const exhausted = await deliverConnectState(
+      async () => {
+        exhaustedAttempts += 1;
+        return false;
+      },
+      async () => {},
+      () => false,
+    );
+    expect(exhausted).toBe(false);
+    expect(exhaustedAttempts).toBe(CONNECT_STATE_PUSH_MAX_ATTEMPTS);
   });
 
   afterEach(() => {

--- a/apps/app/tests/den-handoff.test.ts
+++ b/apps/app/tests/den-handoff.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { exchangeHandoffAndSignIn } from "../src/app/lib/den-handoff";
+
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function stubWindow() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: memoryStorage(),
+      sessionStorage: memoryStorage(),
+      dispatchEvent: () => true,
+    },
+  });
+}
+
+function stubExchangeResponse(payload: Record<string, unknown>) {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: (async () => new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) satisfies typeof fetch,
+  });
+}
+
+const exchangeUser = { id: "user_invited", email: "invited@example.com", name: "Invited Member" };
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: originalFetch,
+  });
+});
+
+describe("exchangeHandoffAndSignIn", () => {
+  test("persists the organization resolved by the handoff exchange", async () => {
+    stubWindow();
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_invited", slug: "invited-org", name: "Invited Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_invited");
+    expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("invited-org");
+    expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Invited Org");
+  });
+
+  test("prefers the caller-provided organization over the exchange payload", async () => {
+    stubWindow();
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_exchange", slug: "exchange-org", name: "Exchange Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", {
+      baseUrl: "https://den.test",
+      activeOrg: { id: "org_bootstrap", slug: "bootstrap-org", name: "Bootstrap Org" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_bootstrap");
+  });
+
+  test("preserves the stored organization when the exchange has none", async () => {
+    stubWindow();
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_stored");
+    window.localStorage.setItem("openwork.den.activeOrgSlug", "stored-org");
+    window.localStorage.setItem("openwork.den.activeOrgName", "Stored Org");
+    stubExchangeResponse({ token: "tok_handoff", user: exchangeUser });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_stored");
+    expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("stored-org");
+    expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Stored Org");
+  });
+});

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -8,6 +8,7 @@ import { z } from "zod"
 import { authenticatedRoute, jsonValidator, publicRoute } from "../../middleware/index.js"
 import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
+import { resolveUserOrganizations } from "../../orgs.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { enforceRateLimit } from "../../utils/rate-limit.js"
@@ -41,6 +42,11 @@ const desktopHandoffExchangeResponseSchema = z.object({
     email: z.string().email(),
     name: z.string().nullable(),
   }),
+  organization: z.object({
+    id: denTypeIdSchema("organization"),
+    slug: z.string(),
+    name: z.string(),
+  }).nullable(),
 }).meta({ ref: "DesktopHandoffExchangeResponse" })
 
 const desktopHandoffStatusResponseSchema = z.object({
@@ -568,6 +574,7 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
           email: row.user.email,
           name: row.user.name,
         },
+        activeOrganizationId: row.session.activeOrganizationId,
       }
     })
 
@@ -578,7 +585,27 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
       }, 404)
     }
 
-    return c.json(exchange)
+    // Tell the desktop which organization this sign-in belongs to so the app
+    // never has to guess (or race /v1/me/orgs) right after a handoff. Falls
+    // back to null when the session has no resolvable organization; the app
+    // then repairs through its normal org-resolution path.
+    let organization: { id: string; slug: string; name: string } | null = null
+    try {
+      const resolved = await resolveUserOrganizations({
+        userId: normalizeDenTypeId("user", exchange.user.id),
+        activeOrganizationId: exchange.activeOrganizationId,
+      })
+      const activeOrg = resolved.orgs.find((org) => org.id === resolved.activeOrgId) ?? null
+      organization = activeOrg ? { id: activeOrg.id, slug: activeOrg.slug, name: activeOrg.name } : null
+    } catch {
+      organization = null
+    }
+
+    return c.json({
+      token: exchange.token,
+      user: exchange.user,
+      organization,
+    })
     },
   )
 }


### PR DESCRIPTION
## Why

#3503 stopped fresh invited-member profiles from being *poisoned* (null-org persistence, unknown mirrored as Connect=false), but field testing showed it cannot *heal* the state: after an invite deep-link sign-in the app still had no organization and `connect-state.json` stayed at its on-disk default `connectEnabled:false`. Three remaining holes:

1. The deep-link handoff wrote `activeOrgId: null` explicitly — the exchange response never carried the org, so the client had to race `/v1/me/orgs` (which 429s under onboarding-wave rate limits).
2. Org recovery was 3 attempts in ~800ms at sign-in only — useless against 60s rate-limit windows; a signed-in-but-orgless session never retried again.
3. The Connect mirror push was fire-and-forget: a not-ready local server (fresh install!) dropped the push, and a thrown push was marked as delivered (ref set before the await) — either way `connectEnabled:false` was stranded forever.

## What

- **den-api**: `/v1/auth/desktop-handoff/exchange` now returns `organization {id, slug, name} | null`, resolved from the grant's session (single-org fallback via `resolveUserOrganizations`; additive + backward compatible; failures degrade to null and never block sign-in).
- **app**: handoff persists caller org → exchange org → otherwise **preserves** the stored org instead of nulling it.
- **app**: while signed in without an org, a 30s background repair keeps retrying `ensureDenActiveOrganization` until an org resolves.
- **app**: the Connect push retries (3s × up to 20) until the local server accepts it, and only records success after delivery. Explicit `connectEnabled:false` from Den is still pushed.

## Tests (commands + results)

- `pnpm exec bun test tests/den-handoff.test.ts tests/den-desktop-config.test.ts tests/den-auth-provider.test.ts tests/den-session-offline-resilience.test.ts` (apps/app) — **25 pass** (new: exchange-org persistence, caller-org precedence, stored-org preservation, push retry/cancel/exhaustion).
- `pnpm typecheck` (apps/app) — passed.
- `pnpm exec tsc --noEmit` (ee/apps/den-api) — passed.
- den-api bun handoff suites fail locally identically on clean `origin/dev` (`Cannot find module @openwork-ee/den-db/drizzle` — local workspace prereq); CI `openwork-tests` covers them.

## Evidence

Incomplete: quick-repair lane, no `@openwork/testkit` app-driving tape. Manual repro: fresh profile → accept org invite → desktop deep-link sign-in while `/v1/me/orgs` is rate limited. Expected with this PR: org lands from the exchange payload (or repairs within 30s), org onboarding shows, and `GET /experimental/connect/state` flips to `connectEnabled:true` once Den policy is fetched — without sign-out or reinstall.