### PR TITLE
fix(den-web): route invites through org auth method

### DIFF
--- a/ee/apps/den-api/test/sso-resolve-route.test.ts
+++ b/ee/apps/den-api/test/sso-resolve-route.test.ts
@@ -6,6 +6,7 @@ function seedRequiredEnv() {
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "multi_org"
   process.env.OPENWORK_DEV_MODE = "0"
 }
 
@@ -152,5 +153,28 @@ test("login-options also requires BotID before deterministic auth-method routing
   expect(body).toEqual({
     error: "bot_verification_failed",
     message: "Request verification failed.",
+  })
+})
+
+test("login-options returns SSO as the first step for verified SSO domains", async () => {
+  requirement = {
+    organizationId: "organization_sso_invite_test",
+    organizationSlug: "invite-sso",
+    signInPath: "/sso/invite-sso",
+    ssoProviderId: "openwork-sso-organization_sso_invite_test",
+    hasSso: true,
+  }
+
+  const response = await createAuthApp().request("http://den.local/v1/auth/login-options?email=invited@verified.example.test")
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual({
+    email: "invited@verified.example.test",
+    nextStep: "sso",
+    allowPublicSignup: true,
+    organizationSlug: "invite-sso",
+    signInPath: "/sso/invite-sso",
+    signInUrl: "http://127.0.0.1:8790/sso/invite-sso",
   })
 })

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -203,6 +203,7 @@ export function AuthPanel({
   hideEmailField = false,
   hideLockedEmailSummary = false,
   emailFirstFlow = false,
+  resolveEmailFirstOnPrefill = false,
   eyebrow = "Account",
   bare = false,
   signUpContent,
@@ -217,6 +218,7 @@ export function AuthPanel({
   hideEmailField?: boolean;
   hideLockedEmailSummary?: boolean;
   emailFirstFlow?: boolean;
+  resolveEmailFirstOnPrefill?: boolean;
   eyebrow?: string;
   // When true the panel renders without its own `den-frame`/padding, so a parent
   // (the unified split auth card) can own the surface. Defaults to a self-framed
@@ -229,6 +231,7 @@ export function AuthPanel({
   const router = useRouter();
   const pathname = usePathname();
   const prefillRef = useRef<string | null>(null);
+  const resolvedLoginOptionPrefillRef = useRef<string | null>(null);
   const [passwordResetRequested, setPasswordResetRequested] = useState(false);
   const [passwordResetBusy, setPasswordResetBusy] = useState(false);
   const [passwordResetInfo, setPasswordResetInfo] = useState("");
@@ -401,7 +404,62 @@ export function AuthPanel({
     setAuthName("");
     setPassword("");
     setVerificationCode("");
+    resolvedLoginOptionPrefillRef.current = null;
   }, [initialMode, prefillKey, prefilledEmail, setAuthMode, setAuthName, setEmail, setPassword, setVerificationCode]);
+
+  useEffect(() => {
+    const trimmedEmail = prefilledEmail?.trim() ?? "";
+    const key = prefillKey ?? trimmedEmail;
+    if (!emailFirstFlow || !resolveEmailFirstOnPrefill || !trimmedEmail || resolvedLoginOptionPrefillRef.current === key || loginOption || loginOptionBusy) {
+      return;
+    }
+
+    let cancelled = false;
+    resolvedLoginOptionPrefillRef.current = key;
+
+    async function resolvePrefilledLoginOption() {
+      setLoginOptionBusy(true);
+      setLoginOptionError(null);
+      setLoginOption(null);
+      setPassword("");
+      setAuthName("");
+
+      try {
+        const { response, payload } = await requestJson(`/v1/auth/login-options?email=${encodeURIComponent(trimmedEmail)}`, { method: "GET" }, 12000);
+        if (cancelled) {
+          return;
+        }
+        if (!response.ok) {
+          setLoginOptionError(getErrorMessage(payload, response.status === 403 ? "We could not verify this sign-in attempt. Please refresh and try again." : `Could not check sign-in options (${response.status}).`));
+          return;
+        }
+
+        const nextOption = readLoginOption(payload);
+        if (!nextOption) {
+          setLoginOptionError("The sign-in options response was incomplete. Try again.");
+          return;
+        }
+
+        setEmail(trimmedEmail);
+        setAuthMode(nextOption.nextStep === "new_account" ? "sign-up" : "sign-in");
+        setLoginOption(nextOption);
+      } catch (error) {
+        if (!cancelled) {
+          setLoginOptionError(error instanceof Error ? error.message : "Could not check sign-in options.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoginOptionBusy(false);
+        }
+      }
+    }
+
+    void resolvePrefilledLoginOption();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [emailFirstFlow, loginOption, loginOptionBusy, prefillKey, prefilledEmail, resolveEmailFirstOnPrefill, setAuthMode, setAuthName, setEmail, setPassword]);
 
   const switchMode = (mode: AuthMode) => {
     if (mode === authMode && !passwordResetRequested) {
@@ -534,6 +592,7 @@ export function AuthPanel({
   const signedInEmail = user?.email?.trim() || "";
   const emailFirstPanelActive = emailFirstFlow && !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
   const emailFirstFormBusy = loginOptionBusy || authBusy || desktopRedirectBusy;
+  const waitingForPrefilledLoginOption = resolveEmailFirstOnPrefill && Boolean(prefilledEmail?.trim()) && !loginOption;
 
   if (isSignedInWithDesktopHandoff) {
     return (
@@ -603,7 +662,13 @@ export function AuthPanel({
           />
         ) : null}
 
-        {emailFirstStep === "email" ? (
+        {waitingForPrefilledLoginOption ? (
+          <div className="den-frame-inset rounded-[1.5rem] px-4 py-3 text-center text-sm text-[var(--dls-text-secondary)]" aria-live="polite">
+            {loginOptionBusy ? "Checking the workspace sign-in method..." : "Could not check the workspace sign-in method. Refresh and try again."}
+          </div>
+        ) : null}
+
+        {!waitingForPrefilledLoginOption && emailFirstStep === "email" ? (
           <form className="grid gap-4" onSubmit={resolveEmailFirstStep}>
             <label className="grid gap-2">
               <span className="den-label">Email</span>
@@ -627,7 +692,7 @@ export function AuthPanel({
           </form>
         ) : null}
 
-        {emailFirstStep === "sso" ? (
+        {!waitingForPrefilledLoginOption && emailFirstStep === "sso" ? (
           <button
             type="button"
             className="den-button-primary w-full"
@@ -639,7 +704,7 @@ export function AuthPanel({
           </button>
         ) : null}
 
-        {emailFirstStep === "google" ? (
+        {!waitingForPrefilledLoginOption && emailFirstStep === "google" ? (
           <SocialButton
             onClick={() => void beginSocialAuth("google")}
             disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
@@ -649,7 +714,7 @@ export function AuthPanel({
           </SocialButton>
         ) : null}
 
-        {emailFirstStep === "github" ? (
+        {!waitingForPrefilledLoginOption && emailFirstStep === "github" ? (
           <SocialButton
             onClick={() => void beginSocialAuth("github")}
             disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
@@ -659,7 +724,7 @@ export function AuthPanel({
           </SocialButton>
         ) : null}
 
-        {emailFirstStep === "password" ? (
+        {!waitingForPrefilledLoginOption && emailFirstStep === "password" ? (
           <form
             className="grid gap-4"
             onSubmit={async (event) => {
@@ -699,7 +764,7 @@ export function AuthPanel({
           </form>
         ) : null}
 
-        {emailFirstStep === "new_account" ? (
+        {!waitingForPrefilledLoginOption && emailFirstStep === "new_account" ? (
           <form
             className="grid gap-4"
             onSubmit={async (event) => {
@@ -707,17 +772,21 @@ export function AuthPanel({
               await handleAuthNavigation(next);
             }}
           >
-            <label className="grid gap-2">
-              <span className="den-label">Email</span>
-              <input
-                className="den-input"
-                type="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                autoComplete="email"
-                required
-              />
-            </label>
+            {!hideEmailField ? (
+              <label className="grid gap-2">
+                <span className="den-label">Email</span>
+                <input
+                  className="den-input disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500"
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  autoComplete="email"
+                  readOnly={lockEmail}
+                  disabled={lockEmail}
+                  required
+                />
+              </label>
+            ) : null}
             <label className="grid gap-2">
               <span className="den-label">Name</span>
               <input
@@ -729,16 +798,20 @@ export function AuthPanel({
                 required
               />
             </label>
-            <div className="den-divider" aria-hidden="true">
-              <span>or</span>
-            </div>
-            <SocialButton
-              onClick={() => void beginSocialAuth("google")}
-              disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
-            >
-              <GoogleLogo />
-              <span>Sign up with Google</span>
-            </SocialButton>
+            {!hideSocialAuth ? (
+              <>
+                <div className="den-divider" aria-hidden="true">
+                  <span>or</span>
+                </div>
+                <SocialButton
+                  onClick={() => void beginSocialAuth("google")}
+                  disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+                >
+                  <GoogleLogo />
+                  <span>Sign up with Google</span>
+                </SocialButton>
+              </>
+            ) : null}
             <label className="grid gap-2">
               <span className="den-label">Password</span>
               <input

--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -209,6 +209,8 @@ function InviteAuthPanel({
         hideEmailField
         hideLockedEmailSummary
         hideSocialAuth
+        emailFirstFlow
+        resolveEmailFirstOnPrefill
         signUpContent={{
           title: "Create your account.",
           copy: "Choose a password for your invited email.",

--- a/ee/apps/den-web/tests/join-org-invite-clean.test.ts
+++ b/ee/apps/den-web/tests/join-org-invite-clean.test.ts
@@ -101,6 +101,8 @@ describe("join organization invite clean layout contract", () => {
     expect(source).toMatch(/<AuthPanel[\s\S]*?\blockEmail\b/);
     expect(source).toMatch(/<AuthPanel[\s\S]*?\bhideEmailField\b/);
     expect(source).toMatch(/<AuthPanel[\s\S]*?\bhideLockedEmailSummary\b/);
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\bemailFirstFlow\b/);
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\bresolveEmailFirstOnPrefill\b/);
     expect(source).toContain('title: "Create your account."');
     expect(source).toContain('title: "Sign in to continue."');
     expect(source).not.toContain("title: `Join ${preview.organization.name}.`");
@@ -110,6 +112,22 @@ describe("join organization invite clean layout contract", () => {
     expect(source).toContain('router.replace("/");');
     expect(source).not.toContain("Decline invitation");
     expect(source).not.toContain("Cancel invitation");
+  });
+
+  test("resolves the invited email auth method before showing invite credentials", () => {
+    const source = readJoinOrgScreenSource();
+    const authPanelSource = readFileSync(
+      fileURLToPath(new URL("../app/(den)/_components/auth-panel.tsx", import.meta.url)),
+      "utf8",
+    );
+
+    expect(source).toContain("resolveEmailFirstOnPrefill");
+    expect(authPanelSource).toContain("/v1/auth/login-options?email=");
+    expect(authPanelSource).toContain('emailFirstStep === "sso"');
+    expect(authPanelSource).toContain("startEmailFirstSso");
+    expect(authPanelSource).toContain("resolvedLoginOptionPrefillRef");
+    expect(authPanelSource).toMatch(/emailFirstStep === "new_account"[\s\S]*?!hideEmailField/);
+    expect(authPanelSource).toMatch(/emailFirstStep === "new_account"[\s\S]*?!hideSocialAuth/);
   });
 
   test("preserves invitation preview, account switching, status, and accept behavior", () => {


### PR DESCRIPTION
## Summary
- Resolve invite auth using the invited email before showing credentials
- Show the org-selected auth method, including SSO, on join-org invite pages
- Cover SSO login-options resolution and invite auth contract

## Tests
- bun test tests/join-org-invite-clean.test.ts
- pnpm --dir ee/apps/den-web typecheck
- pnpm --filter @openwork-ee/den-db build
- pnpm --filter @openwork/email build
- bun test test/sso-resolve-route.test.ts