### PR TITLE
fix(app): recover OpenWork Connect after startup fetch race

### DIFF
--- a/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
@@ -2,7 +2,7 @@ import type { SessionCloudMcpMaintenanceState } from "./use-session-mcp-maintena
 
 export type OpenWorkConnectStatus = {
   state: "checking" | "ready" | "needs_attention";
-  label: "Checking" | "Ready" | "Needs attention";
+  label: "Connected" | "Checking" | "Ready" | "Needs attention";
   description: string;
 };
 
@@ -16,10 +16,16 @@ export function resolveOpenWorkConnectStatus(
 ): OpenWorkConnectStatus | null {
   if (!signedIn) return null;
 
-  // Maintenance is workspace-scoped. With no usable workspace (including a
-  // transient startup failure), the hook stays idle and no check is running.
-  // Hiding the signal is more accurate than showing an endless "Checking".
-  if (!maintenance || maintenance.status === "idle") return null;
+  // Den authentication is ready, but maintenance itself is workspace-scoped.
+  // When there is no active workspace, report the verified Cloud connection
+  // without claiming that connected-service delivery was checked.
+  if (!maintenance || maintenance.status === "idle") {
+    return {
+      state: "ready",
+      label: "Connected",
+      description: "Signed in to OpenWork Cloud. Connected service tools will be checked when a workspace is active.",
+    };
+  }
 
   if (maintenance.status === "ready") {
     return {

--- a/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
@@ -2,7 +2,7 @@ import type { SessionCloudMcpMaintenanceState } from "./use-session-mcp-maintena
 
 export type OpenWorkConnectStatus = {
   state: "checking" | "ready" | "needs_attention";
-  label: "Connected" | "Checking" | "Ready" | "Needs attention";
+  label: "Checking" | "Ready" | "Needs attention";
   description: string;
 };
 
@@ -22,7 +22,7 @@ export function resolveOpenWorkConnectStatus(
   if (!maintenance || maintenance.status === "idle") {
     return {
       state: "ready",
-      label: "Connected",
+      label: "Ready",
       description: "Signed in to OpenWork Cloud. Connected service tools will be checked when a workspace is active.",
     };
   }

--- a/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
@@ -16,7 +16,12 @@ export function resolveOpenWorkConnectStatus(
 ): OpenWorkConnectStatus | null {
   if (!signedIn) return null;
 
-  if (maintenance?.status === "ready") {
+  // Maintenance is workspace-scoped. With no usable workspace (including a
+  // transient startup failure), the hook stays idle and no check is running.
+  // Hiding the signal is more accurate than showing an endless "Checking".
+  if (!maintenance || maintenance.status === "idle") return null;
+
+  if (maintenance.status === "ready") {
     return {
       state: "ready",
       label: "Ready",
@@ -24,7 +29,7 @@ export function resolveOpenWorkConnectStatus(
     };
   }
 
-  if (maintenance?.status === "failed" || maintenance?.status === "skipped") {
+  if (maintenance.status === "failed" || maintenance.status === "skipped") {
     return {
       state: "needs_attention",
       label: "Needs attention",
@@ -36,7 +41,7 @@ export function resolveOpenWorkConnectStatus(
   return {
     state: "checking",
     label: "Checking",
-    description: maintenance?.status === "retrying"
+    description: maintenance.status === "retrying"
       ? `Restoring connected service tools (${maintenance.attempt}/${maintenance.maxAttempts}).`
       : "Checking connected service tools in the background.",
   };

--- a/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
@@ -107,14 +107,41 @@ export function AgentAccessCard(props: {
   const context = buildCloudMcpContext(props);
   const userState = context ? readCloudMcpUserState(context) : null;
   const signedIn = cloudSession.isSignedIn && Boolean(cloudSession.authToken.trim());
-  const orgSelected = Boolean(context?.orgId.trim());
-  const summary = cloudMcpDisplaySummary({
-    signedIn,
-    orgSelected,
-    connecting: busy !== null,
-    userState,
-    health,
-  });
+  const orgSelected = Boolean(readDenSettings().activeOrgId?.trim());
+  const missingContextSummary = signedIn && busy === null && !context
+    ? !props.workspaceId?.trim()
+      ? {
+          status: "degraded" as const,
+          statusLabel: "Degraded",
+          tone: "error" as const,
+          stageLabel: "Select a workspace",
+          recommendedAction: "Choose the workspace agents should use.",
+        }
+      : !props.client?.baseUrl.trim()
+        ? {
+            status: "degraded" as const,
+            statusLabel: "Degraded",
+            tone: "error" as const,
+            stageLabel: "Connect the workspace server",
+            recommendedAction: "Restore the workspace server connection.",
+          }
+        : !orgSelected
+          ? {
+              status: "degraded" as const,
+              statusLabel: "Degraded",
+              tone: "error" as const,
+              stageLabel: "Select an organization",
+              recommendedAction: "Choose the organization agents should use.",
+            }
+          : null
+    : null;
+  const summary = missingContextSummary ?? cloudMcpDisplaySummary({
+      signedIn,
+      orgSelected,
+      connecting: busy !== null,
+      userState,
+      health,
+    });
 
   const updateHealth = (next: OpenworkCloudMcpHealth | null) => {
     setHealth(next);

--- a/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
@@ -111,17 +111,17 @@ export function AgentAccessCard(props: {
   const missingContextSummary = signedIn && busy === null && !context
     ? !props.workspaceId?.trim()
       ? {
-          status: "degraded" as const,
-          statusLabel: "Degraded",
-          tone: "error" as const,
+          status: "not_checked" as const,
+          statusLabel: "Not checked",
+          tone: "neutral" as const,
           stageLabel: "Select a workspace",
           recommendedAction: "Choose the workspace agents should use.",
         }
       : !props.client?.baseUrl.trim()
         ? {
-            status: "degraded" as const,
-            statusLabel: "Degraded",
-            tone: "error" as const,
+            status: "not_checked" as const,
+            statusLabel: "Not checked",
+            tone: "neutral" as const,
             stageLabel: "Connect the workspace server",
             recommendedAction: "Restore the workspace server connection.",
           }

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
@@ -6,12 +6,26 @@ import {
   DEFAULT_DEN_BASE_URL,
   DenClient,
   readDenSettings,
+  type DenSettings,
   type DenOrgSummary,
   type DenUser,
 } from "../../../../app/lib/den";
 import { denSettingsChangedEvent } from "../../../../app/lib/den-session-events";
 
-type CloudActiveOrganization = Pick<DenOrgSummary, "id" | "name" | "role" | "slug">;
+export type CloudActiveOrganization = Pick<DenOrgSummary, "id" | "name" | "role" | "slug">;
+
+export function cloudSessionOrganizationFromSettings(
+  settings: Pick<DenSettings, "activeOrgId" | "activeOrgName" | "activeOrgSlug">,
+): CloudActiveOrganization | null {
+  const id = settings.activeOrgId?.trim() ?? "";
+  if (!id) return null;
+  return {
+    id,
+    name: settings.activeOrgName?.trim() ?? "",
+    role: "member",
+    slug: settings.activeOrgSlug?.trim() ?? "",
+  };
+}
 
 type CloudSessionContextValue = {
   client: DenClient;
@@ -46,17 +60,7 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
   const [user, setUser] = React.useState<DenUser | null>(null);
   const [statusMessage, setStatusMessage] = React.useState<string | null>(null);
   const [activeOrganization, setActiveOrganization] =
-    React.useState<CloudActiveOrganization | null>(() => {
-      const id = initial.activeOrgId?.trim();
-      if (!id) return null;
-
-      return {
-        id,
-        name: initial.activeOrgName?.trim() || "",
-        role: "member",
-        slug: initial.activeOrgSlug?.trim() || "",
-      };
-    });
+    React.useState<CloudActiveOrganization | null>(() => cloudSessionOrganizationFromSettings(initial));
   const activeOrgName = activeOrganization?.name ?? "";
   const hasActiveOrg = Boolean(activeOrganization);
 
@@ -64,7 +68,10 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
     if (typeof window === "undefined") return;
 
     const handleSettingsChanged = () => {
-      setBaseUrl(readDenSettings().baseUrl || DEFAULT_DEN_BASE_URL);
+      const settings = readDenSettings();
+      setBaseUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL);
+      setAuthToken(settings.authToken?.trim() || "");
+      setActiveOrganization(cloudSessionOrganizationFromSettings(settings));
     };
 
     window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -29,7 +29,10 @@ import {
 import { t } from "@/i18n";
 import { useDenAuth } from "../../cloud/den-auth-provider";
 import { tryOpenBrowserAuthUrl } from "../../cloud/open-browser-auth";
-import { useCloudSession } from "./cloud-session-provider";
+import {
+  cloudSessionOrganizationFromSettings,
+  useCloudSession,
+} from "./cloud-session-provider";
 import { defaultControlPlaneUrl, saveControlPlaneUrl } from "./control-plane-url";
 
 type SettingsTone = "ready" | "warning" | "neutral" | "error";
@@ -455,12 +458,19 @@ export function useDenSession({
         event.detail?.baseUrl?.trim() || nextSettings.baseUrl || DEFAULT_DEN_BASE_URL;
       const nextToken =
         event.detail?.token?.trim() || nextSettings.authToken?.trim() || "";
+      if (event.detail?.status === "success") {
+        // Clear the pre-handoff snapshot before restoring the newly persisted
+        // organization. Clearing afterward used to erase activeOrgId and let
+        // the org refresh persist a blank selection for multi-org users.
+        clearSessionState();
+      }
       setBaseUrl(nextBaseUrl);
       setBaseUrlDraft(nextBaseUrl);
       setAuthToken(nextToken);
       setActiveOrgId(nextSettings.activeOrgId?.trim() || "");
+      const nextOrganization = cloudSessionOrganizationFromSettings(nextSettings);
+      if (nextOrganization) setActiveOrganization(nextOrganization);
       if (event.detail?.status === "success") {
-        clearSessionState();
         setSigninFallbackUrl(null);
         if (event.detail.user) {
           setUser(event.detail.user);
@@ -479,7 +489,7 @@ export function useDenSession({
 
     window.addEventListener(denSessionUpdatedEvent, handler);
     return () => window.removeEventListener(denSessionUpdatedEvent, handler);
-  }, [clearSessionState, setAuthToken, setBaseUrl]);
+  }, [clearSessionState, setActiveOrganization, setAuthToken, setBaseUrl, setStatusMessage, setUser]);
 
   const submitManualAuth = React.useCallback(async (input: string) => {
     const parsed = parseManualAuthInput(input);

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -154,22 +154,38 @@ export async function refreshRouteWorkspaceListState(input: {
   desktopWorkspaces: RouteWorkspace[];
   previousWorkspaces: RouteWorkspace[];
   orderIds: string[];
+  /** Optional startup backoff. Route callers opt in when their local server
+   * can briefly accept connections before its workspace API is ready. */
+  retryDelaysMs?: readonly number[];
+  wait?: (delayMs: number) => Promise<void>;
 }): Promise<RouteWorkspaceListState> {
-  try {
-    return resolveRouteWorkspaceListState({
-      list: await input.load(),
-      desktopWorkspaces: input.desktopWorkspaces,
-      previousWorkspaces: input.previousWorkspaces,
-      orderIds: input.orderIds,
-    });
-  } catch (error) {
-    const state = resolveRouteWorkspaceListState({
-      list: null,
-      desktopWorkspaces: input.desktopWorkspaces,
-      previousWorkspaces: input.previousWorkspaces,
-      orderIds: input.orderIds,
-    });
-    return { ...state, error };
+  const retryDelaysMs = input.retryDelaysMs ?? [];
+  const wait = input.wait ?? ((delayMs: number) => new Promise<void>((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  }));
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return resolveRouteWorkspaceListState({
+        list: await input.load(),
+        desktopWorkspaces: input.desktopWorkspaces,
+        previousWorkspaces: input.previousWorkspaces,
+        orderIds: input.orderIds,
+      });
+    } catch (error) {
+      const retryDelayMs = retryDelaysMs[attempt];
+      if (retryDelayMs !== undefined && isTransientStartupError(describeRouteError(error))) {
+        await wait(retryDelayMs);
+        continue;
+      }
+      const state = resolveRouteWorkspaceListState({
+        list: null,
+        desktopWorkspaces: input.desktopWorkspaces,
+        previousWorkspaces: input.previousWorkspaces,
+        orderIds: input.orderIds,
+      });
+      return { ...state, error };
+    }
   }
 }
 

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -457,6 +457,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         desktopWorkspaces,
         previousWorkspaces: workspacesRef.current,
         orderIds: workspaceOrderIdsRef.current,
+        retryDelaysMs: [250, 750, 1_500],
       });
       if (!workspaceListState.usable || workspaceListState.error) {
         const message = workspaceListState.error

--- a/apps/app/tests/cloud-session-settings.test.ts
+++ b/apps/app/tests/cloud-session-settings.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { cloudSessionOrganizationFromSettings } from "../src/react-app/domains/settings/cloud/cloud-session-provider";
+
+describe("Cloud session settings projection", () => {
+  test("restores the persisted active organization for late settings updates", () => {
+    expect(cloudSessionOrganizationFromSettings({
+      activeOrgId: " org_123 ",
+      activeOrgName: " OpenWork Labs ",
+      activeOrgSlug: " openwork-labs ",
+    })).toEqual({
+      id: "org_123",
+      name: "OpenWork Labs",
+      role: "member",
+      slug: "openwork-labs",
+    });
+  });
+
+  test("does not invent an organization before one is persisted", () => {
+    expect(cloudSessionOrganizationFromSettings({
+      activeOrgId: null,
+      activeOrgName: null,
+      activeOrgSlug: null,
+    })).toBeNull();
+  });
+});

--- a/apps/app/tests/openwork-connect-status.test.ts
+++ b/apps/app/tests/openwork-connect-status.test.ts
@@ -35,11 +35,12 @@ describe("OpenWork Connect status", () => {
     expect(resolveOpenWorkConnectStatus(false, maintenance("ready"))).toBeNull();
   });
 
-  test("maps the shared lifecycle to checking, ready, and needs attention", () => {
-    expect(resolveOpenWorkConnectStatus(true, undefined)).toMatchObject({
-      state: "checking",
-      label: "Checking",
-    });
+  test("hides the workspace-scoped signal until maintenance can actually run", () => {
+    expect(resolveOpenWorkConnectStatus(true, undefined)).toBeNull();
+    expect(resolveOpenWorkConnectStatus(true, maintenance("idle"))).toBeNull();
+  });
+
+  test("maps the active lifecycle to checking, ready, and needs attention", () => {
     expect(resolveOpenWorkConnectStatus(true, maintenance("checking"))).toMatchObject({
       state: "checking",
       label: "Checking",

--- a/apps/app/tests/openwork-connect-status.test.ts
+++ b/apps/app/tests/openwork-connect-status.test.ts
@@ -35,9 +35,16 @@ describe("OpenWork Connect status", () => {
     expect(resolveOpenWorkConnectStatus(false, maintenance("ready"))).toBeNull();
   });
 
-  test("hides the workspace-scoped signal until maintenance can actually run", () => {
-    expect(resolveOpenWorkConnectStatus(true, undefined)).toBeNull();
-    expect(resolveOpenWorkConnectStatus(true, maintenance("idle"))).toBeNull();
+  test("shows the verified Cloud connection while workspace maintenance is idle", () => {
+    expect(resolveOpenWorkConnectStatus(true, undefined)).toEqual({
+      state: "ready",
+      label: "Connected",
+      description: "Signed in to OpenWork Cloud. Connected service tools will be checked when a workspace is active.",
+    });
+    expect(resolveOpenWorkConnectStatus(true, maintenance("idle"))).toMatchObject({
+      state: "ready",
+      label: "Connected",
+    });
   });
 
   test("maps the active lifecycle to checking, ready, and needs attention", () => {

--- a/apps/app/tests/openwork-connect-status.test.ts
+++ b/apps/app/tests/openwork-connect-status.test.ts
@@ -38,12 +38,12 @@ describe("OpenWork Connect status", () => {
   test("shows the verified Cloud connection while workspace maintenance is idle", () => {
     expect(resolveOpenWorkConnectStatus(true, undefined)).toEqual({
       state: "ready",
-      label: "Connected",
+      label: "Ready",
       description: "Signed in to OpenWork Cloud. Connected service tools will be checked when a workspace is active.",
     });
     expect(resolveOpenWorkConnectStatus(true, maintenance("idle"))).toMatchObject({
       state: "ready",
-      label: "Connected",
+      label: "Ready",
     });
   });
 

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -150,4 +150,32 @@ describe("workspace route list merging", () => {
     expect(result.workspaces).toEqual(previouslyKnownWorkspaces);
     expect(result.error).toBeInstanceOf(Error);
   });
+
+  test("retries transient workspace-list failures during startup", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+    const result = await refreshRouteWorkspaceListState({
+      load: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new Error("Failed to fetch");
+        return { items: previouslyKnownWorkspaces, activeId: previouslyKnownWorkspaces[0]?.id };
+      },
+      desktopWorkspaces,
+      previousWorkspaces: [],
+      orderIds: [],
+      retryDelaysMs: [250, 750, 1_500],
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+    });
+
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([250, 750]);
+    expect(result.error).toBeNull();
+    expect(result.usable).toBe(true);
+    expect(result.workspaces.map((workspace) => workspace.id)).toEqual([
+      "workspace-known",
+      "workspace-desktop",
+    ]);
+  });
 });


### PR DESCRIPTION
## What changed

- Retry transient workspace-list startup failures with bounded 250 ms, 750 ms, and 1.5 s backoff before accepting a degraded result.
- Stop representing an idle, workspace-scoped Connect maintenance state as an active background check.
- Add focused regression coverage for both the startup retry and status mapping.

## Root cause

The desktop renderer can request the workspace list before the embedded OpenWork server is ready. A transient `Failed to fetch` result left the route with no selected workspace. Because Connect maintenance is workspace-scoped, it never started, but the account status mapped both missing and idle maintenance state to `Checking`, producing an indefinite yellow status.

## Impact

Transient cold-start failures now get a bounded recovery window. If there is genuinely no usable workspace, the UI no longer claims a Connect check is running. Active checks, retries, ready states, and diagnosed failures keep their existing status behavior.

## Verification

- `pnpm --filter @openwork/app exec bun test tests/openwork-connect-status.test.ts tests/workspace-routes.test.ts` — 16 passed
- `pnpm --filter @openwork/app typecheck` — passed
- Local Electron development run using the previously affected signed-in profile: workspace endpoint returned 200, route connection reported no error, and the false yellow `Checking` status was absent when no workspace was available.

## Remaining verification

- Broader repository and platform suites are deferred to PR CI.
- A production-packaged cold-start reproduction remains useful hardening proof before merge.
