### PR TITLE
polish(app): clarify sidebar create actions

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1185,7 +1185,7 @@ export function AppSidebar(props: AppSidebarProps) {
               {canCreateWorkspaces() ? (
                 <button
                   type="button"
-                  className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-foreground"
+                  className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-[color,background-color,opacity] hover:bg-sidebar-accent hover:text-foreground group-hover/workspaces-header:opacity-100 group-focus-within/workspaces-header:opacity-100"
                   onClick={props.onOpenCreateWorkspace}
                   aria-label={t("workspace_list.add_workspace")}
                   title={t("workspace_list.add_workspace")}
@@ -1472,7 +1472,7 @@ function WorkspaceHeader({
         )}
       </SidebarGlyphSlot>
       <div
-        className="min-w-0 flex-1 cursor-grab touch-none transition-[padding] duration-75 active:cursor-grabbing group-hover/workspace-header:pr-14 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-14 group-has-data-popup-open/workspace-header:pr-10 group-hover/workspace-header:group-has-data-popup-open/workspace-header:pr-14 pr-2"
+        className="min-w-0 flex-1 cursor-grab touch-none pr-14 active:cursor-grabbing"
         onPointerDown={onTitlePointerDown}
       >
         <span className="block ow-fade-truncate">{label}</span>
@@ -1602,7 +1602,7 @@ function WorkspaceSidebarGroup({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="size-5 text-muted-foreground opacity-0 group-hover/workspace-header:opacity-100 group-focus-within/workspace-actions:opacity-100"
+                  className="size-5 text-muted-foreground"
                   onClick={(e) => {
                     e.stopPropagation();
                     ctx.onCreateTaskInWorkspace(workspace.id);
@@ -1611,7 +1611,7 @@ function WorkspaceSidebarGroup({
                   aria-label={t("session.new_task")}
                   title={t("session.new_task")}
                 >
-                  <Plus className="size-4" />
+                  <SquarePen className="size-3.5" />
                 </Button>
                 <WorkspaceActionsMenu
                   workspace={workspace}


### PR DESCRIPTION
## What changed

- hide the section-level **Add workspace** plus until the Workspaces header is hovered or keyboard-focused
- keep the per-workspace **New task** action visible without requiring hover
- use the existing compose icon for New task instead of another plus
- reserve space for the persistent action so long workspace names do not overlap it

## Why

The always-visible workspace-creation plus was easy to mistake for the workspace's new-task action, while the actual new-task action was hidden until hover. This makes the two actions visually distinct and puts the frequent action in the persistent position.

## Validation

- `corepack pnpm --filter @openwork/app typecheck`
- `git diff --check`

## Deferred

- real-app visual acceptance and cross-platform hover/touch verification are deferred to the verification pass
