### PR TITLE
fix(updater): allow stable update checks from alpha builds

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -227,8 +227,11 @@ export function selectStableDesktopUpdate(input: {
   metadata: DenAppVersionMetadata;
   desktopConfig: DenDesktopConfig | null | undefined;
 }): StableDesktopUpdateSelection | null {
-  const currentVersion = normalizeStableDesktopVersion(input.currentVersion);
-  if (!currentVersion) return null;
+  // The installed build may be a prerelease (e.g. returning from the alpha
+  // channel to stable); it only needs to be comparable. The published
+  // inventory below must stay plain-stable x.y.z.
+  const currentVersion = input.currentVersion.trim();
+  if (!parseComparableVersion(currentVersion)) return null;
 
   const publishedVersions = [...new Set(input.metadata.publishedDesktopVersions.flatMap((version) => {
     const normalized = normalizeStableDesktopVersion(version);

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -77,6 +77,42 @@ describe("selectStableDesktopUpdate", () => {
     });
   });
 
+  test("updates an installed alpha build to its published stable release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.24-alpha.2151+5221290",
+      metadata,
+      desktopConfig: {},
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.24",
+      latestPublishedVersion: "0.17.24",
+    });
+  });
+
+  test("does not downgrade an alpha build ahead of every published stable release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.25-alpha.10+abcdef0",
+      metadata,
+      desktopConfig: {},
+    })).toEqual({ kind: "current", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("blocks an alpha build when policy has not approved the newer stable release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.24-alpha.2151+5221290",
+      metadata,
+      desktopConfig: { allowedDesktopVersions: ["0.17.23"] },
+    })).toEqual({ kind: "blocked", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("rejects an unparseable installed version", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "not-a-version",
+      metadata,
+      desktopConfig: {},
+    })).toBeNull();
+  });
+
   test("does not downgrade when the installed version is newer than Den's inventory", () => {
     expect(selectStableDesktopUpdate({
       currentVersion: "0.17.25",


### PR DESCRIPTION
## Summary

Users on an alpha desktop build (e.g. `v0.18.14-alpha.2151+5221290`) who switch the release channel back to **stable** get a hard error on every update check:

> Couldn't check for updates — Den returned an invalid desktop release inventory.

Den's inventory is fine. The manual stable check runs the **installed** version through `normalizeStableDesktopVersion`, which only accepts plain `x.y.z`. Any prerelease/build-metadata version fails that regex, so `selectStableDesktopUpdate` returns `null`, which the settings updater state misreports as a bad Den inventory. Result: alpha users can never move to stable through the UI.

## Fix

In `selectStableDesktopUpdate` (`apps/app/src/app/lib/version-gate.ts`), the installed version now only needs to be *comparable* (`parseComparableVersion` — already handles `v` prefixes, `-alpha.N` tags, `+build` metadata). The published Den inventory entries themselves still require strict plain-stable `x.y.z`; that trust boundary is unchanged.

With semver prerelease ordering (`0.18.14-alpha.2151 < 0.18.14`) the alpha→stable flow now resolves correctly end to end:

- newer published stable exists → targeted update (main-process `targetedStableUpdaterFeed` already accepts it, since the target is newer than the installed prerelease)
- alpha ahead of every published stable → "You're up to date" (no downgrade, matching existing main-process behavior)
- org policy hasn't approved the newer stable → "blocked" with the approval message
- genuinely unparseable installed version → still `null`

The same `null` also silently short-circuited `resolveAutomaticStableDesktopUpdate` and onboarding update staging (`org-onboarding-page.tsx`) for alpha installs; both paths are fixed by the same change.

## Tests

- `apps/app`: `bun test tests/version-gate.test.ts` → **18 pass / 0 fail** (14 existing + 4 new: alpha→published-stable update, no-downgrade "current", policy "blocked", unparseable → null)
- `apps/app`: `bun test --isolate tests/` → 590 pass / 2 fail; the 2 failures (`tests/message-list-loading.test.tsx`, React DOM suite-interaction `TypeError: target.addEventListener is not a function`) reproduce identically on the pristine base (`586 pass / 2 fail` before this change) — pre-existing, unrelated
- `apps/desktop`: `node --test electron/updater.test.mjs` → **11 pass / 0 fail / 1 skipped** (main process untouched; targeted-feed path still green)

## Validation note (no testkit tape)

This is a pure decision-function fix; the affected flow is the packaged-app auto-updater (signed build + GitHub release feeds + Squirrel install), which cannot run inside the `@openwork/testkit` spec harness. Unit tests above are the verifying proof.

Manual repro: install an alpha build (e.g. `0.18.14-alpha.2151`), open Settings → Updates, switch channel to Stable, check for updates. Before: "Den returned an invalid desktop release inventory." After: offers the published stable (`v0.18.14`) for download/install, or reports up-to-date/blocked per inventory and org policy.
