### PR TITLE
feat(app): cloud providers import automatically — no Import button

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -525,7 +525,7 @@ export default {
   "den.cloud_provider_detail": "{count} models · {source} provider",
   "den.cloud_provider_removed_detail": "This imported provider is no longer in cloud. Uninstall the local {providerId} config.",
   "den.cloud_provider_sync_detail": "Cloud provider changed. Sync the {count} model {source} config into this workspace.",
-  "den.cloud_providers_hint": "Import managed LLM providers into this workspace and use the org credential.",
+  "den.cloud_providers_hint": "Providers your organization manages are imported into this workspace automatically using the org credential.",
   "den.cloud_providers_title": "Cloud providers",
   "den.cloud_section_desc": "Sign in and pick an organization to access OpenWork Cloud.",
   "den.cloud_section_title": "OpenWork Cloud",

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -100,6 +100,11 @@ type CloudProviderSyncReason =
   | "settings_cloud_opened"
   | "manual";
 
+export type CloudProviderSyncOutcome =
+  | { outcome: "handled_server_side" }
+  | { outcome: "synced" }
+  | { outcome: "failed"; message: string };
+
 let lastGlobalProviderDisposeRefreshAt = 0;
 const globalCloudProviderSyncByContext = new Map<string, Promise<void>>();
 let loggedGatewayCloudProviderSyncSkip = false;
@@ -258,7 +263,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   let cloudOrgProvidersLoadKey = "";
   let cloudOrgProvidersInFlightKey = "";
   let cloudOrgProvidersInFlight: Promise<DenOrgLlmProvider[]> | null = null;
-  let cloudProviderSyncTail: Promise<void> = Promise.resolve();
+  let cloudProviderSyncTail: Promise<CloudProviderSyncOutcome> = Promise.resolve({ outcome: "synced" });
   let cloudProviderSyncContextKey = "";
 
   const emitChange = () => {
@@ -1745,13 +1750,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return;
     }
 
-    let importedProviders: Record<string, CloudImportedProvider>;
-    try {
-      importedProviders = await refreshImportedCloudProviders({ strict: true });
-    } catch (error) {
-      logCloudProviderSyncError(reason, error);
-      return;
-    }
+    const importedProviders = await refreshImportedCloudProviders({ strict: true });
     const liveProviders = await refreshCloudOrgProviders({ force: true });
     const liveProviderMap = new Map(liveProviders.map((provider) => [provider.id, provider]));
     const failures: string[] = [];
@@ -1836,7 +1835,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
-  async function runCloudProviderSync(reason: CloudProviderSyncReason) {
+  async function runCloudProviderSync(reason: CloudProviderSyncReason): Promise<CloudProviderSyncOutcome> {
     if (getOpenworkGatewayOrigin()) {
       if (!loggedGatewayCloudProviderSyncSkip) {
         loggedGatewayCloudProviderSyncSkip = true;
@@ -1855,11 +1854,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           () => performCloudProviderSync(reason),
         ),
       )
-      .catch((error) => {
+      .then<CloudProviderSyncOutcome>(() => ({ outcome: "synced" }))
+      .catch((error): CloudProviderSyncOutcome => {
         const message = logCloudProviderSyncError(reason, error);
         if (reason === "settings_cloud_opened") {
           setStateField("providerAuthError", message);
         }
+        return { outcome: "failed", message };
       });
 
     cloudProviderSyncTail = request;

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -37,7 +37,7 @@ import {
 import { t } from "@/i18n";
 import { useCloudSession } from "./cloud-session-provider";
 
-type ResourceActionKind = "import" | "remove" | "sync";
+type ResourceActionKind = "remove";
 
 export type CloudProviderRow = {
   key: string;
@@ -154,20 +154,12 @@ interface CloudProviderListItemProps {
   actionId: string | null;
   actionKind: ResourceActionKind | null;
   row: CloudProviderRow;
-  onImport: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onRemove?: (cloudProviderId: string, providerName: string) => void | Promise<void>;
-  onSync: (cloudProviderId: string, providerName: string) => void | Promise<void>;
 }
 
-function CloudProviderListItem({ actionId, actionKind, row, onImport, onRemove, onSync }: CloudProviderListItemProps) {
+function CloudProviderListItem({ actionId, actionKind, row, onRemove }: CloudProviderListItemProps) {
   const actionBusy = actionId === row.cloudProviderId;
-  const actionLabel = !actionBusy
-    ? null
-    : actionKind === "import"
-      ? t("den.importing")
-      : actionKind === "sync"
-        ? t("den.syncing")
-        : t("den.removing");
+  const actionLabel = actionBusy && actionKind === "remove" ? t("den.removing") : null;
   const source = row.provider?.source === "custom" ? "custom" : "managed";
   const modelCount = row.provider?.models.length ?? 0;
   const cloudProviderDetail = modelCount === 0
@@ -207,26 +199,6 @@ function CloudProviderListItem({ actionId, actionKind, row, onImport, onRemove, 
         </SettingsListItemDescription>
       </SettingsListItemContent>
       <SettingsListItemActions>
-        {row.status === "out_of_sync" && row.provider ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void onSync(row.cloudProviderId, row.name)}
-            disabled={actionId !== null}
-          >
-            {actionBusy && actionKind === "sync" ? t("den.syncing") : t("den.sync")}
-          </Button>
-        ) : null}
-        {row.status === "available" && row.provider ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void onImport(row.cloudProviderId, row.name)}
-            disabled={actionId !== null}
-          >
-            {actionBusy ? actionLabel : t("den.import_provider")}
-          </Button>
-        ) : null}
         {row.status !== "available" && onRemove ? (
           <Button
             variant="destructive"
@@ -387,10 +359,8 @@ export interface CloudProvidersSectionProps {
   actionKind: ResourceActionKind | null;
   busy: boolean;
   rows: CloudProviderRow[];
-  onImport: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
   onRemove?: (cloudProviderId: string, providerName: string) => void | Promise<void>;
-  onSync: (cloudProviderId: string, providerName: string) => void | Promise<void>;
 }
 
 export function CloudProvidersSection({
@@ -399,16 +369,14 @@ export function CloudProvidersSection({
   actionKind,
   busy,
   rows,
-  onImport,
   onRefresh,
   onRemove,
-  onSync,
 }: CloudProvidersSectionProps) {
   const { hasActiveOrg } = useCloudSession();
   const [searchQuery, setSearchQuery] = React.useState("");
   const visibleRows = useSearch({ items: rows, keys: nameSearchKeys, query: searchQuery });
   const providerGroups = [
-    { value: "available", label: "Available", rows: visibleRows.filter((row) => row.status === "available") },
+    { value: "available", label: t("den.importing"), rows: visibleRows.filter((row) => row.status === "available") },
     { value: "out_of_sync", label: t("den.out_of_sync_badge"), rows: visibleRows.filter((row) => row.status === "out_of_sync") },
     { value: "imported", label: t("den.imported_badge"), rows: visibleRows.filter((row) => row.status === "imported") },
     { value: "removed_from_cloud", label: t("den.removed_from_cloud_badge"), rows: visibleRows.filter((row) => row.status === "removed_from_cloud") },
@@ -472,9 +440,7 @@ export function CloudProvidersSection({
                           actionId={actionId}
                           actionKind={actionKind}
                           row={row}
-                          onImport={onImport}
                           onRemove={onRemove}
-                          onSync={onSync}
                         />
                       ))}
                     </SettingsList>

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -7,6 +7,7 @@ import type { DenOrgLlmProvider } from "@/app/lib/den";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
+import type { CloudProviderSyncOutcome } from "@/react-app/domains/connections/provider-auth/store";
 import { useCloudSession } from "@/react-app/domains/settings/cloud/cloud-session-provider";
 import { CloudProvidersSection, type CloudProviderRow } from "@/react-app/domains/settings/cloud/sections";
 import type { useDenSession } from "@/react-app/domains/settings/cloud/use-den-session";
@@ -16,11 +17,10 @@ type CloudProvidersSession = Pick<
   ReturnType<typeof useDenSession>,
   "syncCurrentDenSettings"
 >;
-type ProviderActionKind = "import" | "remove" | "sync";
+type ProviderActionKind = "remove";
 
 export type CloudProvidersViewProps = {
   cloudOrgProviders: DenOrgLlmProvider[];
-  connectCloudProvider: (cloudProviderId: string) => Promise<string | void>;
   embedded?: boolean;
   importedCloudProviders: Record<string, CloudImportedProvider>;
   onOpenAccount: () => void;
@@ -28,6 +28,7 @@ export type CloudProvidersViewProps = {
   refreshImportedCloudProviders: () => Promise<Record<string, CloudImportedProvider>>;
   removeCloudProvider: (cloudProviderId: string) => Promise<string | void>;
   session: CloudProvidersSession;
+  syncCloudProviders: (reason: "manual") => Promise<CloudProviderSyncOutcome>;
 };
 
 const sortStrings = (values: string[]) => values.toSorted();
@@ -37,7 +38,6 @@ const sameStringList = (a: string[], b: string[]) =>
 
 export function CloudProvidersView({
   cloudOrgProviders,
-  connectCloudProvider,
   embedded = false,
   importedCloudProviders,
   onOpenAccount,
@@ -45,6 +45,7 @@ export function CloudProvidersView({
   refreshImportedCloudProviders,
   removeCloudProvider,
   session,
+  syncCloudProviders,
 }: CloudProvidersViewProps) {
   const { activeOrganization: activeOrg, authToken, isSignedIn, user } = useCloudSession();
   const [busy, setBusy] = React.useState(false);
@@ -52,6 +53,7 @@ export function CloudProvidersView({
   const [actionKind, setActionKind] = React.useState<ProviderActionKind | null>(null);
   const [actionError, setActionError] = React.useState<string | null>(null);
   const activeOrgId = activeOrg?.id ?? "";
+  const autoSyncKey = React.useRef<string | null>(null);
 
   const rows = React.useMemo<CloudProviderRow[]>(() => {
     const nextRows: CloudProviderRow[] = cloudOrgProviders.map((provider) => {
@@ -99,11 +101,12 @@ export function CloudProvidersView({
 
       try {
         session.syncCurrentDenSettings();
-        const [items] = await Promise.all([
-          refreshCloudOrgProviders({ force: !quiet }),
-          refreshImportedCloudProviders(),
-        ]);
-        if (!quiet) {
+        const result = await syncCloudProviders("manual");
+        const items = await refreshCloudOrgProviders({ force: result.outcome === "handled_server_side" });
+        await refreshImportedCloudProviders();
+        if (result.outcome === "failed") {
+          setActionError(result.message);
+        } else if (!quiet) {
           toast.info(
             items.length > 0
               ? `Loaded ${items.length} cloud provider${items.length === 1 ? "" : "s"} for ${activeOrg?.name ?? t("den.active_org_title")}.`
@@ -111,9 +114,7 @@ export function CloudProvidersView({
           );
         }
       } catch (error) {
-        if (!quiet) {
-          setActionError(error instanceof Error ? error.message : "Failed to load cloud providers.");
-        }
+        setActionError(error instanceof Error ? error.message : "Failed to load cloud providers.");
       } finally {
         setBusy(false);
       }
@@ -125,36 +126,17 @@ export function CloudProvidersView({
       activeOrgId,
       authToken,
       session.syncCurrentDenSettings,
+      syncCloudProviders,
     ],
   );
 
   React.useEffect(() => {
     if (!user || !activeOrgId) return;
+    const key = `${user.id}::${activeOrgId}`;
+    if (autoSyncKey.current === key) return;
+    autoSyncKey.current = key;
     void refresh(true);
   }, [activeOrgId, refresh, user]);
-
-  const importProvider = React.useCallback(
-    async (cloudProviderId: string, providerName: string) => {
-      if (actionId) return;
-
-      setActionId(cloudProviderId);
-      setActionKind("import");
-      setActionError(null);
-
-      try {
-        const message = await connectCloudProvider(cloudProviderId);
-        toast.success(message || t("den.imported_provider", { name: providerName }));
-      } catch (error) {
-        setActionError(
-          error instanceof Error ? error.message : t("den.import_provider_failed", { name: providerName }),
-        );
-      } finally {
-        setActionId(null);
-        setActionKind(null);
-      }
-    },
-    [actionId, connectCloudProvider],
-  );
 
   const removeProvider = React.useCallback(
     async (cloudProviderId: string, providerName: string) => {
@@ -177,29 +159,6 @@ export function CloudProvidersView({
       }
     },
     [actionId, removeCloudProvider],
-  );
-
-  const syncProvider = React.useCallback(
-    async (cloudProviderId: string, providerName: string) => {
-      if (actionId) return;
-
-      setActionId(cloudProviderId);
-      setActionKind("sync");
-      setActionError(null);
-
-      try {
-        await connectCloudProvider(cloudProviderId);
-        toast.success(t("den.synced_provider", { name: providerName }));
-      } catch (error) {
-        setActionError(
-          error instanceof Error ? error.message : t("den.sync_provider_failed", { name: providerName }),
-        );
-      } finally {
-        setActionId(null);
-        setActionKind(null);
-      }
-    },
-    [actionId, connectCloudProvider],
   );
 
   if (!isSignedIn) {
@@ -228,10 +187,8 @@ export function CloudProvidersView({
       actionKind={actionKind}
       busy={busy}
       rows={rows}
-      onImport={importProvider}
       onRefresh={refresh}
       onRemove={undefined}
-      onSync={syncProvider}
     />
   );
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1690,11 +1690,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   useCloudProviderAutoSync(() => connectionsStore.syncCloudControlMcp());
 
   useEffect(() => {
-    if (route.tab !== "cloud-providers") return;
-    void providerAuthStore.runCloudProviderSync("settings_cloud_opened");
-  }, [providerAuthStore, route.tab]);
-
-  useEffect(() => {
     openworkServerStore.syncFromOptions();
     connectionsStore.syncFromOptions();
     providerAuthStore.syncFromOptions();
@@ -2190,13 +2185,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               <CloudProvidersView
                 embedded
                 cloudOrgProviders={providerAuthSnapshot.cloudOrgProviders}
-                connectCloudProvider={providerAuthStore.connectCloudProvider}
                 importedCloudProviders={providerAuthSnapshot.importedCloudProviders}
                 onOpenAccount={openCloudAccountSettings}
                 refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
                 refreshImportedCloudProviders={providerAuthStore.refreshImportedCloudProviders}
                 removeCloudProvider={providerAuthStore.removeCloudProvider}
                 session={denSession}
+                syncCloudProviders={providerAuthStore.runCloudProviderSync}
               />
             }
           />
@@ -2344,13 +2339,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return (
           <CloudProvidersView
             cloudOrgProviders={providerAuthSnapshot.cloudOrgProviders}
-            connectCloudProvider={providerAuthStore.connectCloudProvider}
             importedCloudProviders={providerAuthSnapshot.importedCloudProviders}
             onOpenAccount={openCloudAccountSettings}
             refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
             refreshImportedCloudProviders={providerAuthStore.refreshImportedCloudProviders}
             removeCloudProvider={providerAuthStore.removeCloudProvider}
             session={denSession}
+            syncCloudProviders={providerAuthStore.runCloudProviderSync}
           />
         );
       case "advanced":

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -274,8 +274,9 @@ describe("cloud provider sync in gateway mode", () => {
     installProviderSyncFetch(requests);
     const { store, reloadCount } = createProviderAuthTestStore();
 
-    await store.runCloudProviderSync("settings_cloud_opened");
+    const outcome = await store.runCloudProviderSync("settings_cloud_opened");
 
+    expect(outcome).toEqual({ outcome: "synced" });
     const patchRequests = requests.filter(
       (request) => request.method === "PATCH" && request.url === "https://server.example/workspace/ws_1/config",
     );
@@ -286,5 +287,25 @@ describe("cloud provider sync in gateway mode", () => {
     expect(store.getSnapshot().importedCloudProviders.lpr_test?.providerId).toBe("lpr_test");
     expect(store.getSnapshot().providerAuthError).toBeNull();
     expect(reloadCount()).toBe(0);
+  });
+
+  test("returns a failed outcome instead of rejecting when provider sync fails", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async () => {
+        throw new Error("Den provider fetch failed");
+      },
+    });
+    const { store } = createProviderAuthTestStore();
+
+    const outcome = await store.runCloudProviderSync("manual");
+
+    expect(outcome.outcome).toBe("failed");
+    if (outcome.outcome === "failed") {
+      expect(outcome.message.length).toBeGreaterThan(0);
+      expect(outcome.message).toContain("Den provider fetch failed");
+    }
   });
 });

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -371,6 +371,29 @@ export async function openConnectionsSurface(app: Surface, workspaceId: string):
   throw new Error(`The extensions connections surface never settled. On screen: ${JSON.stringify(seen)}`);
 }
 
+export async function openCloudProvidersSurface(app: Surface, workspaceId: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const settled = await evalIn(
+      app,
+      `window.location.hash.includes("/settings/cloud-providers") && document.body.innerText.includes("Cloud providers")`,
+      { timeoutMs: 8_000 },
+    ).catch(() => false);
+    if (settled === true) return;
+    await go(app, `/workspace/${workspaceId}/settings/cloud-providers`).catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  }
+  // Say what WAS on screen: a bare timeout cannot distinguish a route that
+  // never rewrote from a shell the app steered somewhere else entirely.
+  const seen = await evalIn(app, `({
+    hash: window.location.hash,
+    title: document.title,
+    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\\s+/g, ' ').trim()).filter(Boolean).slice(0, 30),
+    text: (document.body.innerText ?? '').replace(/\\s+/g, ' ').slice(0, 500),
+  })`, { timeoutMs: 10_000 }).catch(() => null);
+  throw new Error(`The cloud providers surface never settled. On screen: ${JSON.stringify(seen)}`);
+}
+
 export async function currentHash(app: Surface): Promise<string> {
   const hash = await resilientRead(app, "window.location.hash", { label: "location hash" });
   if (typeof hash !== "string") throw new Error("CDP did not return window.location.hash as a string.");

--- a/evals/specs/cloud-provider-auto-import.slow.test.ts
+++ b/evals/specs/cloud-provider-auto-import.slow.test.ts
@@ -5,6 +5,7 @@ import {
   denFetch,
   evalIn,
   go,
+  openCloudProvidersSurface,
   readAvailableModels,
   readCurrentOrganizationMemberId,
   selectModel,
@@ -122,7 +123,8 @@ test(title, async ({ evidence, place }) => {
   await using den = await server({ place });
   await selectOrganization(den.admin);
   await deleteProofProviders(den.admin);
-  onTestFinished(async () => deleteProofProviders(den.admin));
+  // Local server() Dens may be disposed first; reused Dens are cleaned here, and stale rows are also deleted up front.
+  onTestFinished(async () => deleteProofProviders(den.admin).catch(() => undefined));
 
   const adminMemberId = await readCurrentOrganizationMemberId(den.admin);
   const created = record(await denRequest(den.admin, "/v1/llm-providers", {
@@ -146,10 +148,9 @@ test(title, async ({ evidence, place }) => {
   expect(providerId, "The assigned organization provider was not created.").not.toBe("");
 
   await using desktopApp = await app({ den, as: "admin", place });
-  const settingsPath = `/workspace/${desktopApp.workspaceId}/settings/cloud-providers`;
 
   // Frame 2: opening settings is the import action; there is nothing to click.
-  await go(desktopApp, settingsPath);
+  await openCloudProvidersSurface(desktopApp, desktopApp.workspaceId);
   await waitForText(desktopApp, providerName, { timeoutMs: 120_000 });
   await waitFor(desktopApp, importedProviderExpression(), {
     timeoutMs: 120_000,
@@ -204,7 +205,7 @@ test(title, async ({ evidence, place }) => {
     }),
   });
 
-  await go(desktopApp, settingsPath);
+  await openCloudProvidersSurface(desktopApp, desktopApp.workspaceId);
   await clickButton(desktopApp, "Refresh");
   await waitFor(
     desktopApp,
@@ -229,11 +230,20 @@ test(title, async ({ evidence, place }) => {
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   await waitForSelectableModel(desktopApp, addedModelId);
   const finalModels = await readAvailableModels(desktopApp);
-  expect(finalModels.some((model) => model.id === addedModelId && model.selectable)).toBe(true);
+  const addedSelectable = finalModels.some((model) => model.id === addedModelId && model.selectable);
+  evidence.fact(
+    "The newly added organization model became selectable without any manual action",
+    `Available after refresh: ${JSON.stringify(finalModels.map((model) => model.id))}`,
+    addedSelectable,
+  );
+  expect(addedSelectable).toBe(true);
+  const selectedAdded = await selectModel(desktopApp, addedModelId);
+  expect(selectedAdded.id).toBe(addedModelId);
+  expect(selectedAdded.selected).toBe(true);
   {
     const shot = await screenshot(desktopApp);
     const seen = await validate(shot, [
-      "The newly added organization model gpt-5.4-mini is visibly selectable in the model picker",
+      "The composer is visibly ready with a model selected",
       "No manual Sync prompt or 'Something went wrong' crash message is visible",
     ]);
     expect(seen.ok, seen.why).toBe(true);

--- a/evals/specs/cloud-provider-auto-import.slow.test.ts
+++ b/evals/specs/cloud-provider-auto-import.slow.test.ts
@@ -1,0 +1,241 @@
+import { expect, onTestFinished } from "vitest";
+import { screenshot, validate } from "@openwork/fraimz";
+import {
+  clickButton,
+  denFetch,
+  evalIn,
+  go,
+  readAvailableModels,
+  readCurrentOrganizationMemberId,
+  selectModel,
+  waitFor,
+  waitForText,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { app, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = { optIn: ["OPENWORK_EVAL_APP_SPECS"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `cloud provider auto import skipped — needs: ${missingRequirements.join(", ")}`
+  : "org providers import themselves — settings never shows an Import button";
+
+const providerName = "Auto Import Proof";
+const modelId = "gpt-5.4";
+const addedModelId = "gpt-5.4-mini";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+async function denRequest(
+  session: DenSession,
+  path: string,
+  init: RequestInit = {},
+  allowedStatuses: number[] = [],
+): Promise<unknown> {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${session.token}`);
+  const result = await denFetch(session, path, { ...init, headers });
+  if (!result.response.ok && !allowedStatuses.includes(result.response.status)) {
+    throw new Error(`${init.method ?? "GET"} ${path} failed with ${result.response.status}: ${result.text.slice(0, 500)}`);
+  }
+  return result.body;
+}
+
+async function selectOrganization(admin: DenSession): Promise<void> {
+  // A reused Den account may belong to several organizations. Explicitly select
+  // one so every provider API call and the desktop sign-in use the same org.
+  const body = record(await denRequest(admin, "/v1/me/orgs"));
+  const organization = records(body.orgs).find((entry) => entry.slug === "default") ?? records(body.orgs)[0];
+  const organizationId = stringField(organization?.id);
+  if (!organizationId) throw new Error("The eval admin has no organization.");
+  await denRequest(admin, "/v1/me/active-organization", {
+    method: "POST",
+    body: JSON.stringify({ organizationId }),
+  });
+}
+
+async function deleteProofProviders(admin: DenSession): Promise<void> {
+  const body = record(await denRequest(admin, "/v1/llm-providers?scope=manageable"));
+  for (const provider of records(body.llmProviders)) {
+    if (provider.name !== providerName || typeof provider.id !== "string") continue;
+    await denRequest(
+      admin,
+      `/v1/llm-providers/${encodeURIComponent(provider.id)}`,
+      { method: "DELETE" },
+      [204, 404],
+    );
+  }
+}
+
+function importedProviderExpression(): string {
+  return `(() => {
+    const name = ${JSON.stringify(providerName)};
+    const title = [...document.querySelectorAll('*')]
+      .find((element) => element.children.length === 0 && (element.textContent ?? '').trim() === name);
+    let row = title;
+    for (let depth = 0; row && depth < 4; depth += 1, row = row.parentElement) {
+      const imported = [...row.querySelectorAll('*')]
+        .some((element) => element.children.length === 0 && (element.textContent ?? '').trim() === 'Imported');
+      if (imported) return true;
+    }
+    return false;
+  })()`;
+}
+
+async function exactButtonLabels(desktopApp: Surface): Promise<string[]> {
+  const value = await evalIn(
+    desktopApp,
+    `[...document.querySelectorAll('button')].map((button) => (button.textContent ?? '').trim())`,
+  );
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+async function waitForSelectableModel(desktopApp: Surface, id: string): Promise<void> {
+  // The engine catalog arrives asynchronously after both app boot and a cloud
+  // provider refresh, so repeatedly reopen/read the real picker rather than
+  // trusting its first paint.
+  await expect.poll(
+    async () => (await readAvailableModels(desktopApp)).some((model) => model.id === id && model.selectable),
+    { timeout: 120_000, interval: 3_000 },
+  ).toBe(true);
+}
+
+test(title, async ({ evidence, place }) => {
+  needs(requirements);
+
+  await using den = await server({ place });
+  await selectOrganization(den.admin);
+  await deleteProofProviders(den.admin);
+  onTestFinished(async () => deleteProofProviders(den.admin));
+
+  const adminMemberId = await readCurrentOrganizationMemberId(den.admin);
+  const created = record(await denRequest(den.admin, "/v1/llm-providers", {
+    method: "POST",
+    body: JSON.stringify({
+      name: providerName,
+      source: "models_dev",
+      providerId: "openai",
+      modelIds: [modelId],
+      apiKey: "sk-openwork-local-eval-only",
+      memberIds: [adminMemberId],
+      teamIds: [],
+    }),
+  }));
+  const providerId = stringField(record(created.llmProvider).id);
+  evidence.fact(
+    "The admin published an organization provider",
+    `${providerName} grants ${modelId} to member ${adminMemberId}.`,
+    Boolean(providerId),
+  );
+  expect(providerId, "The assigned organization provider was not created.").not.toBe("");
+
+  await using desktopApp = await app({ den, as: "admin", place });
+  const settingsPath = `/workspace/${desktopApp.workspaceId}/settings/cloud-providers`;
+
+  // Frame 2: opening settings is the import action; there is nothing to click.
+  await go(desktopApp, settingsPath);
+  await waitForText(desktopApp, providerName, { timeoutMs: 120_000 });
+  await waitFor(desktopApp, importedProviderExpression(), {
+    timeoutMs: 120_000,
+    label: `${providerName} row marked Imported`,
+  });
+  const initialButtons = await exactButtonLabels(desktopApp);
+  const noManualImport = !initialButtons.includes("Import") && !initialButtons.includes("Sync");
+  evidence.fact(
+    "No Import button exists on the Cloud providers surface",
+    `Exact button labels: ${JSON.stringify(initialButtons)}`,
+    noManualImport,
+  );
+  expect(initialButtons).not.toContain("Import");
+  expect(initialButtons).not.toContain("Sync");
+  {
+    const shot = await screenshot(desktopApp);
+    const seen = await validate(shot, [
+      "The organization provider is visibly Imported in Cloud providers settings",
+      "No Import or Sync button is visible in the providers list",
+      "No 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  // Frame 3: the imported model is immediately usable in the composer.
+  await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
+  await waitForSelectableModel(desktopApp, modelId);
+  const selected = await selectModel(desktopApp, modelId);
+  expect(selected.id).toBe(modelId);
+  expect(selected.selectable).toBe(true);
+  expect(selected.selected).toBe(true);
+  {
+    const shot = await screenshot(desktopApp);
+    const seen = await validate(shot, [
+      "The organization's model is selected and selectable in the composer",
+      "No 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  // Frame 4: Den's write route expects the complete provider schema on PATCH.
+  await denRequest(den.admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      name: providerName,
+      source: "models_dev",
+      providerId: "openai",
+      modelIds: [modelId, addedModelId],
+      apiKey: "sk-openwork-local-eval-only",
+      memberIds: [adminMemberId],
+      teamIds: [],
+    }),
+  });
+
+  await go(desktopApp, settingsPath);
+  await clickButton(desktopApp, "Refresh");
+  await waitFor(
+    desktopApp,
+    `(() => {
+      const imported = ${importedProviderExpression()};
+      const labels = [...document.querySelectorAll('button')].map((button) => (button.textContent ?? '').trim());
+      return imported && !document.body.innerText.includes('Out of sync') && !labels.includes('Import') && !labels.includes('Sync');
+    })()`,
+    { timeoutMs: 120_000, label: "provider refresh reconciled without Import, Sync, or Out of sync" },
+  );
+  const refreshedButtons = await exactButtonLabels(desktopApp);
+  const reconciledWithoutSync = !refreshedButtons.includes("Import")
+    && !refreshedButtons.includes("Sync")
+    && await evalIn(desktopApp, "!document.body.innerText.includes('Out of sync')") === true;
+  evidence.fact(
+    "The model list change reconciled without any manual Sync",
+    `The row remained Imported; exact button labels: ${JSON.stringify(refreshedButtons)}.`,
+    reconciledWithoutSync,
+  );
+  expect(reconciledWithoutSync).toBe(true);
+
+  await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
+  await waitForSelectableModel(desktopApp, addedModelId);
+  const finalModels = await readAvailableModels(desktopApp);
+  expect(finalModels.some((model) => model.id === addedModelId && model.selectable)).toBe(true);
+  {
+    const shot = await screenshot(desktopApp);
+    const seen = await validate(shot, [
+      "The newly added organization model gpt-5.4-mini is visibly selectable in the model picker",
+      "No manual Sync prompt or 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+});


### PR DESCRIPTION
## What

Org-managed (cloud) providers now land in the workspace with zero clicks. The silent auto-import machinery (`performCloudProviderSync`) already ran on sign-in/app-launch/app-resume/new-chat/model-picker; this PR makes the settings surface drive that same sync and removes the manual affordances it made redundant:

- **Settings → AI Providers / Cloud Providers** triggers the full sync on mount and on **Refresh** (previously the AI tab never synced and Refresh only refetched lists, stranding providers under "Available" behind an Import button).
- **Import and Sync row buttons are gone.** Rows are status displays; the not-yet-imported group is labeled "Importing…".
- `runCloudProviderSync` now resolves a typed outcome (`synced | failed | handled_server_side`); the view surfaces `failed` inline in the section error notice, and Refresh retries.
- Mount sync is guarded by a per-`user.id::orgId` key so snapshot-driven re-renders can't re-trigger it; the sync callback is passed as a stable store method.
- Section hint copy updated to describe automatic import.

Approved voice-over (demo-driven): admin publishes a provider in OpenWork Cloud → member's desktop shows it **Imported** with nothing to click → its models are immediately usable → later model-list changes reconcile automatically (no Sync button, Refresh just re-runs the sync).

## Evidence

`evals/specs/cloud-provider-auto-import.slow.test.ts` (new, `@openwork/testkit`) encodes the narration end-to-end against a cold-booted local Den + Electron: provider created via Den API → settings shows the row **Imported** with an exact-match assertion that **no button labeled "Import" or "Sync" exists** → `gpt-5.4` selectable in the composer → admin PATCHes the model list → after Refresh the row is still Imported, "Out of sync" never demands action, and `gpt-5.4-mini` becomes selectable. Tape: **7/7 frames, 11/11 expectations passed** (published as a comment below).

Narration frame 5 (a genuinely blocked import explains itself) is covered by the inline error surface + a unit test asserting `runCloudProviderSync` resolves `{ outcome: "failed", message }`; deterministically faulting Den mid-session for an e2e frame isn't in the tape.

## Tests run

- `bun test --isolate tests/cloud-provider-sync-{gateway,triggers}.test.ts tests/cloud-provider-{reimport,credentials}.test.ts` (apps/app) — **16 pass, 0 fail** (includes new synced/failed outcome coverage; gateway `handled_server_side` shape unchanged)
- `pnpm typecheck` (apps/app) — **pass**
- `OPENWORK_EVAL_APP_SPECS=1 vitest --project stack specs/cloud-provider-auto-import.slow.test.ts` — **1 passed** (76.7s, cold local `server()` + Docker MySQL)
- `pnpm run spec` (evals PR lane) — **3 passed, 1 skipped** (`skill-grant-access` env skip)

## Notes for review

- `connectCloudProvider` (store) is untouched and still powers the provider-auth modal's cloud method.
- Now-unused i18n keys (e.g. `den.import_provider` for providers) are left in place per existing precedent (`den.import_all`); `den.import_provider` is still used by plugin import.
- New shared behavior `openCloudProvidersSurface` mirrors `openConnectionsSurface` (settings route-rewrite race).