### PR TITLE
fix(den-api): keep SKILL.md frontmatter when deriving GitHub connector skill projections

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -5915,6 +5915,31 @@ function importedObjectMetadata(input: { objectType: ConnectorMappingRow["object
   }
 }
 
+export function deriveGithubImportedObjectProjection(input: { objectType: ConnectorMappingRow["objectType"]; path: string; rawSourceText: string }) {
+  const metadata = importedObjectMetadata({ objectType: input.objectType, path: input.path, rawSourceText: input.rawSourceText })
+  const frontmatterRecord = metadata.metadata && typeof metadata.metadata.frontmatter === "object"
+    ? metadata.metadata.frontmatter as Record<string, unknown>
+    : null
+  const hasFrontmatter = frontmatterRecord && Object.keys(frontmatterRecord).length > 0
+  // Skill projections need the full SKILL.md: deriveSkillProjection parses and
+  // validates the frontmatter itself, so stripping it here made every GitHub
+  // connector skill import fail with invalid_skill_frontmatter.
+  const projectionRawSource = input.objectType !== "skill" && hasFrontmatter
+    ? parseMarkdownFrontmatter(input.rawSourceText).body
+    : input.rawSourceText
+  return {
+    metadata,
+    projection: deriveProjection({
+      objectType: input.objectType,
+      value: {
+        metadata: metadata.metadata,
+        normalizedPayloadJson: metadata.normalizedPayloadJson,
+        rawSourceText: projectionRawSource,
+      },
+    }),
+  }
+}
+
 async function findActiveConnectorSourceBinding(input: {
   connectorMappingId: ConnectorMappingId
   externalLocator: string
@@ -5947,25 +5972,10 @@ async function materializeGithubImportedObject(input: {
   const organizationId = input.context.organizationContext.organization.id
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
   const now = new Date()
-  const metadata = importedObjectMetadata({
+  const { metadata, projection } = deriveGithubImportedObjectProjection({
     objectType: input.connectorMapping.objectType,
     path: input.externalLocator,
     rawSourceText: input.rawSourceText,
-  })
-  const frontmatterRecord = metadata.metadata && typeof metadata.metadata.frontmatter === "object"
-    ? metadata.metadata.frontmatter as Record<string, unknown>
-    : null
-  const hasFrontmatter = frontmatterRecord && Object.keys(frontmatterRecord).length > 0
-  const projectionRawSource = hasFrontmatter
-    ? parseMarkdownFrontmatter(input.rawSourceText).body
-    : input.rawSourceText
-  const projection = deriveProjection({
-    objectType: input.connectorMapping.objectType,
-    value: {
-      metadata: metadata.metadata,
-      normalizedPayloadJson: metadata.normalizedPayloadJson,
-      rawSourceText: projectionRawSource,
-    },
   })
   const fileName = input.externalLocator.split("/").filter(Boolean).at(-1) ?? input.externalLocator
   const fileExtension = fileName.includes(".") ? fileName.split(".").at(-1) ?? null : null

--- a/ee/apps/den-api/test/github-import-projection.test.ts
+++ b/ee/apps/den-api/test/github-import-projection.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let store: typeof import("../src/routes/org/plugin-system/store.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.module("../src/db.js", () => ({ db: {} }))
+  store = await import("../src/routes/org/plugin-system/store.js")
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+function expectProbeProjection(rawSourceText: string) {
+  const { projection } = store.deriveGithubImportedObjectProjection({
+    objectType: "skill",
+    path: "probe-plugin/skills/probe/SKILL.md",
+    rawSourceText,
+  })
+  expect(projection.title).toBe("probe")
+  expect(projection.description).toBe("Probe connector import")
+  expect(projection.searchText).toContain("Run the probe checklist.")
+}
+
+test("derives a GitHub-imported skill projection from valid SKILL.md", () => {
+  expectProbeProjection("---\nname: probe\ndescription: Probe connector import\n---\n\nRun the probe checklist.\n")
+})
+
+test("derives a GitHub-imported skill projection with CRLF line endings", () => {
+  expectProbeProjection("---\r\nname: probe\r\ndescription: Probe connector import\r\n---\r\n\r\nRun the probe checklist.\r\n")
+})
+
+test("rejects a GitHub-imported skill without frontmatter", () => {
+  try {
+    store.deriveGithubImportedObjectProjection({
+      objectType: "skill",
+      path: "probe-plugin/skills/probe/SKILL.md",
+      rawSourceText: "# No frontmatter\n\nBody.",
+    })
+    throw new Error("Expected skill projection to fail")
+  } catch (error) {
+    expect(error).toHaveProperty("error", "invalid_skill_frontmatter")
+    expect(error).toHaveProperty("status", 400)
+  }
+})
+
+test("strips frontmatter before deriving a GitHub-imported command projection", () => {
+  const { projection } = store.deriveGithubImportedObjectProjection({
+    objectType: "command",
+    path: "probe-plugin/commands/run.md",
+    rawSourceText: "---\nname: Run Probe\ndescription: Runs it\n---\nBody text.\n",
+  })
+  expect(projection.title).toBe("Run Probe")
+  expect(projection.description).toBe("Runs it")
+  expect(projection.searchText).not.toContain("name: Run Probe")
+  expect(projection.searchText).toContain("Body text.")
+})


### PR DESCRIPTION
Fixes #3521

## Root cause

`materializeGithubImportedObject` (`ee/apps/den-api/src/routes/org/plugin-system/store.ts`) stripped YAML frontmatter from the fetched file before deriving the projection. For `objectType === "skill"`, `deriveProjection` dispatches to `deriveSkillProjection`, which re-parses the text and **requires** frontmatter — so:

- skill file **with** valid frontmatter → frontmatter stripped → `invalid_skill_frontmatter`
- skill file **without** frontmatter → `invalid_skill_frontmatter`

Every GitHub-connector skill import failed (first apply and webhook re-sync), no matter how clean the SKILL.md was — exactly the user report: discovery succeeds, `importPlansByPluginKey` lists the right path with a valid blob sha, apply always 400s.

## Fix

Extracted the projection derivation into exported `deriveGithubImportedObjectProjection`, which keeps the **full SKILL.md** for skills (`deriveSkillProjection` parses and validates the frontmatter itself) and preserves the existing frontmatter-stripping behavior for all other object types (command/agent/hook/mcp), whose generic projection intentionally avoids frontmatter lines in fallback heuristics. Smallest-diff behavior change: one condition.

## Validation

Commands run (all from repo root, workspace installed, `den-db`/workspace packages built):

- `bun test ee/apps/den-api/test/github-import-projection.test.ts ee/apps/den-api/test/github-connector-app.test.ts ee/apps/den-api/test/plugin-system-create-bundle.test.ts ee/apps/den-api/test/github-discovery.test.ts ee/apps/den-api/test/github-webhook.test.ts` → **24 pass, 0 fail** on this branch.
- **Red-proof**: with only the fix condition reverted to the old stripping behavior, the two valid-SKILL.md regression tests fail with `invalid_skill_frontmatter` (the reporter's exact symptom, incl. a CRLF variant); with the fix, all green.

New regression tests (`ee/apps/den-api/test/github-import-projection.test.ts`) cover: the reporter's minimal probe SKILL.md (LF), a CRLF variant, a no-frontmatter skill still rejected with `invalid_skill_frontmatter`/400, and a command file keeping the frontmatter-stripped projection.

No `@openwork/testkit` evidence tape: exercising this end-to-end requires a live GitHub App installation; the deterministic witness for this module is the established mocked-`fetchFn`/mocked-db bun suite, which these tests extend.

## Follow-up (out of scope)

`deriveSkillProjection` enforces strict kebab-case names and one invalid skill file still aborts the whole apply — per-file resilience for connector imports tracked in #3521 discussion.