### PR TITLE
fix(den-api,den-web): list all GitHub installation repositories, not just the first 30

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -79,6 +79,8 @@ export type GithubInstallStatePayload = {
 
 const GITHUB_API_BASE = "https://api.github.com"
 const GITHUB_API_VERSION = "2022-11-28"
+const GITHUB_REPOSITORY_MAX_PAGES = 30
+const GITHUB_REPOSITORY_PAGE_SIZE = 100
 
 function base64UrlEncode(value: unknown) {
   const buffer = typeof value === "string"
@@ -358,38 +360,54 @@ function normalizeGithubRepository(entry: unknown): GithubRepositorySummary | nu
 
 export async function listGithubInstallationRepositories(input: { config: GithubConnectorAppConfig; fetchFn?: GithubFetch; installationId: number }) {
   const token = await createGithubInstallationAccessToken(input)
-  const response = await requestGithubJson<{ repositories?: unknown[] }>({
-    fetchFn: input.fetchFn,
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    path: "/installation/repositories",
-  })
-
-  if (!Array.isArray(response.body.repositories)) {
-    return []
-  }
-
-  const repositories: GithubRepositorySummary[] = []
-  for (const entry of response.body.repositories) {
-    const normalized = normalizeGithubRepository(entry)
-    if (!normalized) {
-      continue
+  const normalizedRepositories: GithubRepositorySummary[] = []
+  for (let page = 1; page <= GITHUB_REPOSITORY_MAX_PAGES; page += 1) {
+    const response = await requestGithubJson<{ repositories?: unknown[] }>({
+      fetchFn: input.fetchFn,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      path: `/installation/repositories?per_page=${GITHUB_REPOSITORY_PAGE_SIZE}&page=${page}`,
+    })
+    const pageRepositories = response.body.repositories
+    if (!Array.isArray(pageRepositories) || pageRepositories.length === 0) {
+      break
     }
 
-    const manifest = await detectRepositoryManifest({
-      fetchFn: input.fetchFn,
-      ownerAndRepo: normalized.fullName,
-      token,
-    })
-
-    repositories.push({
-      ...normalized,
-      hasPluginManifest: manifest.manifestKind !== null,
-      manifestKind: manifest.manifestKind,
-      marketplacePluginCount: manifest.marketplacePluginCount,
-    })
+    for (const entry of pageRepositories) {
+      const normalized = normalizeGithubRepository(entry)
+      if (normalized) {
+        normalizedRepositories.push(normalized)
+      }
+    }
+    if (pageRepositories.length < GITHUB_REPOSITORY_PAGE_SIZE) {
+      break
+    }
   }
+
+  const repositories = new Array<GithubRepositorySummary>(normalizedRepositories.length)
+  let nextIndex = 0
+  const workerCount = Math.max(1, Math.min(8, normalizedRepositories.length))
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < normalizedRepositories.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const normalized = normalizedRepositories[index]
+      const manifest = await detectRepositoryManifest({
+        fetchFn: input.fetchFn,
+        ownerAndRepo: normalized.fullName,
+        token,
+      })
+
+      repositories[index] = {
+        ...normalized,
+        hasPluginManifest: manifest.manifestKind !== null,
+        manifestKind: manifest.manifestKind,
+        marketplacePluginCount: manifest.marketplacePluginCount,
+      }
+    }
+  })
+  await Promise.all(workers)
 
   return repositories
 }

--- a/ee/apps/den-api/test/github-connector-app.test.ts
+++ b/ee/apps/den-api/test/github-connector-app.test.ts
@@ -77,17 +77,69 @@ describe("github connector app helpers", () => {
       installationId: 777,
     })
 
-    expect(requests.map((request) => request.url)).toEqual([
+    const requestUrls = requests.map((request) => request.url)
+    expect(requestUrls.slice(0, 2)).toEqual([
       "https://api.github.com/app/installations/777/access_tokens",
-      "https://api.github.com/installation/repositories",
+      "https://api.github.com/installation/repositories?per_page=100&page=1",
+    ])
+    expect(requestUrls.slice(2).sort()).toEqual([
       "https://api.github.com/repos/different-ai/openwork/contents/.claude-plugin/marketplace.json",
       "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/marketplace.json",
       "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/plugin.json",
+    ].sort())
+    expect(requestUrls.filter((url) => url.includes("/repos/different-ai/opencode/contents/"))).toEqual([
+      "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/marketplace.json",
+      "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/plugin.json",
     ])
+    expect(requestUrls).not.toContain("https://api.github.com/installation/repositories?per_page=100&page=2")
     expect(repositories).toEqual([
       { defaultBranch: "main", fullName: "different-ai/openwork", hasPluginManifest: true, id: 42, manifestKind: "marketplace", marketplacePluginCount: 3, private: true },
       { defaultBranch: "dev", fullName: "different-ai/opencode", hasPluginManifest: true, id: 99, manifestKind: "plugin", marketplacePluginCount: null, private: false },
     ])
+  })
+
+  test("follows pagination when an installation exposes more than one page of repositories", async () => {
+    const requestUrls: string[] = []
+    const repositories = await listGithubInstallationRepositories({
+      config: { appId: "123456", privateKey: privateKeyPem },
+      fetchFn: async (url) => {
+        const requestUrl = String(url)
+        requestUrls.push(requestUrl)
+
+        if (requestUrl.endsWith("/access_tokens")) {
+          return new Response(JSON.stringify({ token: "installation-token" }), { status: 201 })
+        }
+
+        const parsedUrl = new URL(requestUrl)
+        if (parsedUrl.pathname === "/installation/repositories") {
+          const page = parsedUrl.searchParams.get("page")
+          const firstId = page === "1" ? 1 : page === "2" ? 101 : null
+          const count = page === "1" ? 100 : page === "2" ? 30 : 0
+          return new Response(JSON.stringify({
+            repositories: firstId === null
+              ? []
+              : Array.from({ length: count }, (_, index) => {
+                  const id = firstId + index
+                  return { default_branch: "main", full_name: `different-ai/repo-${id}`, id, private: false }
+                }),
+          }), { status: 200 })
+        }
+
+        if (requestUrl.includes("/contents/.claude-plugin/")) {
+          return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
+        }
+
+        return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
+      },
+      installationId: 777,
+    })
+
+    expect(repositories).toHaveLength(130)
+    expect(repositories[0]?.id).toBe(1)
+    expect(repositories[129]?.id).toBe(130)
+    expect(requestUrls).toContain("https://api.github.com/installation/repositories?per_page=100&page=1")
+    expect(requestUrls).toContain("https://api.github.com/installation/repositories?per_page=100&page=2")
+    expect(requestUrls).not.toContain("https://api.github.com/installation/repositories?per_page=100&page=3")
   })
 
   test("builds install URLs and validates signed state tokens", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integration-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integration-data.tsx
@@ -529,17 +529,7 @@ export function useGithubAccountRepositories(connectorAccountId: string | null) 
     enabled: Boolean(connectorAccountId),
     queryKey: [...integrationQueryKeys.repos("github", connectorAccountId), "connected-account"] as const,
     queryFn: async (): Promise<IntegrationRepo[]> => {
-      const { response, payload } = await requestJson(
-        `/v1/connectors/github/accounts/${encodeURIComponent(connectorAccountId ?? "")}/repositories?limit=100`,
-        { method: "GET" },
-        20000,
-      );
-
-      if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to load GitHub repositories (${response.status}).`));
-      }
-
-      return isRecord(payload) && Array.isArray(payload.items)
+      const parseRepositories = (payload: unknown): IntegrationRepo[] => isRecord(payload) && Array.isArray(payload.items)
         ? payload.items.flatMap((entry) => {
             if (!isRecord(entry)) {
               return [];
@@ -573,6 +563,27 @@ export function useGithubAccountRepositories(connectorAccountId: string | null) 
             } satisfies IntegrationRepo];
           })
         : [];
+      const repositories: IntegrationRepo[] = [];
+      let cursor: string | null = null;
+      for (let page = 0; page < 30; page += 1) {
+        const { response, payload } = await requestJson(
+          `/v1/connectors/github/accounts/${encodeURIComponent(connectorAccountId ?? "")}/repositories?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+          { method: "GET" },
+          20000,
+        );
+
+        if (!response.ok) {
+          throw new Error(getErrorMessage(payload, `Failed to load GitHub repositories (${response.status}).`));
+        }
+
+        repositories.push(...parseRepositories(payload));
+        const nextCursor = isRecord(payload) ? asString(payload.nextCursor) : null;
+        if (!nextCursor) {
+          break;
+        }
+        cursor = nextCursor;
+      }
+      return repositories;
     },
   });
 }


### PR DESCRIPTION
Fixes #3522

## Root cause

Two missing pagination layers:

1. **Server** — `listGithubInstallationRepositories` (`ee/apps/den-api/src/routes/org/plugin-system/github-app.ts`) called `GET /installation/repositories` exactly once with no `per_page`/`page` params; GitHub's default page size is 30, so at most 30 repositories were ever fetched — the user report: installation with **all repositories** selected shows only the first 30.
2. **Web** — `useGithubAccountRepositories` (`ee/apps/den-web/app/(den)/dashboard/_components/integration-data.tsx`) requested `?limit=100` once and never followed `nextCursor`, so >100 repos would still truncate after the server fix.

## Fix

- Server pages through `/installation/repositories?per_page=100&page=N` (safety cap 30 pages), stopping when a page comes back short/empty. Per-repo manifest detection now runs through an **order-preserving bounded worker pool** (8 workers, same pattern as `fetchGithubImportFilesWithRevisionGuard`) instead of strictly sequentially, since installations can now surface hundreds of repositories. Return shape unchanged.
- Web hook follows `nextCursor` (limit 100 per request, same 30-page cap) and aggregates pages; per-page error handling and timeout unchanged.

## Validation

Commands run (repo root, workspace installed, workspace packages built):

- `bun test ee/apps/den-api/test/github-connector-app.test.ts ee/apps/den-api/test/github-webhook.test.ts ee/apps/den-api/test/github-discovery.test.ts` → **15 pass, 0 fail** on this branch.
- New test `follows pagination when an installation exposes more than one page of repositories`: 130-repo installation served as 100 + 30 across two pages → all 130 returned in order, `page=1` and `page=2` requested, no `page=3`. Against the old implementation this test received **0/130** (verified red first).
- Existing single-page test updated for the new URL and made robust to concurrent manifest probes (token → list ordering still asserted, per-repo probe ordering still asserted, single list call asserted).
- `pnpm --filter @openwork-ee/den-web typecheck` → clean.

No `@openwork/testkit` evidence tape: the flow requires a live GitHub App installation; the deterministic witness for this module is the established mocked-`fetchFn` bun suite, which these tests extend.