### PR TITLE
feat(server,app): gateway-style server-side provider sync on the local server

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -15,7 +15,7 @@ import { isOpenworkGatewayRuntime } from "./gateway-runtime";
 import { isDesktopRuntime } from "./runtime-env";
 import type { ExecResult, OpencodeConfigFile, WorkspaceInfo, WorkspaceList } from "./desktop";
 import type { DenOrgMarketplace, DenOrgPluginResolved, DenResourceSnapshot } from "./den-types";
-import type { CloudImportedMarketplace, CloudImportedPlugin } from "../cloud/import-state";
+import type { CloudImportedMarketplace, CloudImportedPlugin, CloudImportedProvider } from "../cloud/import-state";
 
 export type OpenworkServerCapabilities = {
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
@@ -23,6 +23,7 @@ export type OpenworkServerCapabilities = {
   mcp: { read: boolean; write: boolean };
   commands: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
+  providerSync?: boolean;
   sandbox?: { enabled: boolean; backend: "none" | "docker" | "container" };
   proxy?: { opencode: boolean };
   toolProviders?: {
@@ -40,6 +41,69 @@ export type OpenworkServerCapabilities = {
     };
   };
 };
+
+export type OpenworkCloudProviderSyncRun = {
+  status: "applied" | "noop" | "failed" | "no_session";
+  message?: string;
+};
+
+export type OpenworkCloudProviderSyncStatus = {
+  hasSession: boolean;
+  lastRun: { at: string | number; status: OpenworkCloudProviderSyncRun["status"]; message?: string } | null;
+  providers: CloudImportedProvider[];
+};
+
+function parseCloudProviderSyncRun(value: unknown): OpenworkCloudProviderSyncRun {
+  if (!value || typeof value !== "object" || !("status" in value)) throw new Error("Invalid cloud provider sync response.");
+  const status = value.status;
+  if (status !== "applied" && status !== "noop" && status !== "failed" && status !== "no_session") {
+    throw new Error("Invalid cloud provider sync status.");
+  }
+  const message = "message" in value && typeof value.message === "string" ? value.message : undefined;
+  return { status, message };
+}
+
+function parseCloudImportedProvider(value: unknown): CloudImportedProvider | null {
+  if (!value || typeof value !== "object") return null;
+  if (
+    !("cloudProviderId" in value) || typeof value.cloudProviderId !== "string" ||
+    !("providerId" in value) || typeof value.providerId !== "string" ||
+    !("sourceProviderId" in value) || typeof value.sourceProviderId !== "string" ||
+    !("name" in value) || typeof value.name !== "string" ||
+    !("modelIds" in value) || !Array.isArray(value.modelIds) || !value.modelIds.every((item) => typeof item === "string")
+  ) return null;
+  return {
+    cloudProviderId: value.cloudProviderId,
+    providerId: value.providerId,
+    sourceProviderId: value.sourceProviderId,
+    name: value.name,
+    source: "source" in value && typeof value.source === "string" ? value.source : null,
+    updatedAt: "updatedAt" in value && typeof value.updatedAt === "string" ? value.updatedAt : null,
+    modelIds: value.modelIds,
+    importedAt: "importedAt" in value && typeof value.importedAt === "number" ? value.importedAt : null,
+  };
+}
+
+function parseCloudProviderSyncStatus(value: unknown): OpenworkCloudProviderSyncStatus {
+  if (!value || typeof value !== "object" || !("hasSession" in value) || typeof value.hasSession !== "boolean" || !("providers" in value) || !Array.isArray(value.providers)) {
+    throw new Error("Invalid cloud provider sync status response.");
+  }
+  const providers: CloudImportedProvider[] = [];
+  for (const rawProvider of value.providers) {
+    const provider = parseCloudImportedProvider(rawProvider);
+    if (!provider) throw new Error("Invalid cloud provider sync provider response.");
+    providers.push(provider);
+  }
+  let lastRun: OpenworkCloudProviderSyncStatus["lastRun"] = null;
+  if ("lastRun" in value && value.lastRun !== null) {
+    if (!value.lastRun || typeof value.lastRun !== "object" || !("at" in value.lastRun) || (typeof value.lastRun.at !== "string" && typeof value.lastRun.at !== "number")) {
+      throw new Error("Invalid cloud provider sync last-run response.");
+    }
+    const run = parseCloudProviderSyncRun(value.lastRun);
+    lastRun = { at: value.lastRun.at, status: run.status, message: run.message };
+  }
+  return { hasSession: value.hasSession, lastRun, providers };
+}
 
 export type OpenworkServerStatus = "connected" | "disconnected" | "limited";
 
@@ -1334,6 +1398,24 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       const suffix = query.size ? `?${query.toString()}` : "";
       return requestJson<OpenworkConnectState>(baseUrl, `/experimental/connect/state${suffix}`, { token, hostToken, timeoutMs: timeouts.config });
     },
+    putDenSession: async (body: { baseUrl: string; token: string; orgId: string }) => {
+      await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "PUT", body, timeoutMs: timeouts.config });
+    },
+    deleteDenSession: async () => {
+      await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "DELETE", timeoutMs: timeouts.config });
+    },
+    runCloudProviderSyncNow: async (reason?: string) =>
+      parseCloudProviderSyncRun(await requestJson<unknown>(baseUrl, "/cloud-provider-sync/run", {
+        hostToken,
+        method: "POST",
+        body: reason ? { reason } : {},
+        timeoutMs: timeouts.cloudMcpReconcile,
+      })),
+    getCloudProviderSyncStatus: async () =>
+      parseCloudProviderSyncStatus(await requestJson<unknown>(baseUrl, "/cloud-provider-sync/status", {
+        token,
+        timeoutMs: timeouts.config,
+      })),
     setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),
     callExtensionAction: (payload: OpenworkExtensionActionCall) =>
       requestJson<OpenworkExtensionActionResult>(baseUrl, "/experimental/extensions/call", {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -10,6 +10,7 @@ import { t } from "../../../../i18n";
 import {
   createDenClient,
   readDenSettings,
+  resolveDenBaseUrls,
   type DenOrgLlmProvider,
   type DenOrgLlmProviderConnection,
 } from "../../../../app/lib/den";
@@ -50,7 +51,8 @@ export type ProviderAuthOpenworkServer = {
     OpenworkServerStoreSnapshot,
     "openworkServerStatus" | "openworkServerClient"
   > & {
-    openworkServerCapabilities: { config?: { read?: boolean; write?: boolean } } | null;
+    openworkServerAuth?: { token?: string; hostToken?: string };
+    openworkServerCapabilities: { config?: { read?: boolean; write?: boolean }; providerSync?: boolean } | null;
   };
 };
 import {
@@ -268,6 +270,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   let cloudOrgProvidersInFlight: Promise<DenOrgLlmProvider[]> | null = null;
   let cloudProviderSyncTail: Promise<void> = Promise.resolve();
   let cloudProviderSyncContextKey = "";
+  let lastDenSessionPushKey = "";
+  let denSessionPushKey = "";
+  let denSessionPushInFlight: Promise<void> | null = null;
 
   const emitChange = () => {
     for (const listener of listeners) listener();
@@ -340,6 +345,42 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       hasOpenworkTarget,
       canUseOpenworkServer,
     };
+  };
+
+  const serverHandlesProviderSync = () => {
+    const openworkSnapshot = options.openworkServer.getSnapshot();
+    return Boolean(
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      openworkSnapshot.openworkServerCapabilities?.providerSync === true &&
+      openworkSnapshot.openworkServerAuth?.hostToken?.trim() &&
+      openworkSnapshot.openworkServerClient,
+    );
+  };
+
+  const pushDenSession = (force = false): Promise<void> => {
+    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    const settings = readDenSettings();
+    const apiBaseUrl = settings.apiBaseUrl ?? resolveDenBaseUrls(settings).apiBaseUrl;
+    const token = settings.authToken?.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!serverHandlesProviderSync() || !openworkClient || !token || !orgId) return Promise.resolve();
+    const key = `${apiBaseUrl}::${orgId}::${token}`;
+    if (!force && key === lastDenSessionPushKey) return Promise.resolve();
+    if (key === denSessionPushKey && denSessionPushInFlight) return denSessionPushInFlight;
+    denSessionPushKey = key;
+    const request = openworkClient.putDenSession({ baseUrl: apiBaseUrl, token, orgId });
+    denSessionPushInFlight = request;
+    request.then(
+      () => { lastDenSessionPushKey = key; },
+      () => undefined,
+    ).finally(() => {
+      if (denSessionPushInFlight === request) {
+        denSessionPushInFlight = null;
+        denSessionPushKey = "";
+      }
+    });
+    return request;
   };
 
   const refreshSnapshot = () => {
@@ -465,6 +506,14 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
   const refreshImportedCloudProviders = async (refreshOptions?: { strict?: boolean }) => {
     try {
+      if (serverHandlesProviderSync()) {
+        const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
+        if (!openworkClient) throw new Error("OpenWork server unavailable.");
+        const status = await openworkClient.getCloudProviderSyncStatus();
+        const next = Object.fromEntries(status.providers.map((provider) => [provider.cloudProviderId, provider]));
+        setStateField("importedCloudProviders", next);
+        return next;
+      }
       const config = await readWorkspaceOpenworkConfigRecord();
       const cloudImports = readWorkspaceCloudImports(config);
       const next = cloudImports.providers;
@@ -1902,6 +1951,38 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return { outcome: "handled_server_side" };
     }
 
+    if (serverHandlesProviderSync()) {
+      try {
+        const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
+        if (!openworkClient) throw new Error("OpenWork server unavailable.");
+        let result = await openworkClient.runCloudProviderSyncNow(reason);
+        if (result.status === "no_session") {
+          await pushDenSession(true);
+          result = await openworkClient.runCloudProviderSyncNow(reason);
+        }
+        if (result.status === "failed" || result.status === "no_session") {
+          const message = logCloudProviderSyncError(
+            reason,
+            new Error(result.message ?? "Cloud provider sync failed."),
+          );
+          if (reason === "settings_cloud_opened") {
+            setStateField("providerAuthError", message);
+          }
+          return;
+        }
+        if (result.status === "applied") {
+          await refreshProviders({ force: true });
+        }
+        return { outcome: "handled_server_side" };
+      } catch (error) {
+        const message = logCloudProviderSyncError(reason, error);
+        if (reason === "settings_cloud_opened") {
+          setStateField("providerAuthError", message);
+        }
+        return;
+      }
+    }
+
     const request = cloudProviderSyncTail
       .catch(() => undefined)
       .then(() =>
@@ -2059,6 +2140,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       setStateField("lastSyncError", {});
       void refreshImportedCloudProviders();
     }
+    if (serverHandlesProviderSync()) {
+      const nextSyncContextKey = getCloudProviderSyncContextKey();
+      if (nextSyncContextKey === cloudProviderSyncContextKey) return;
+      cloudProviderSyncContextKey = nextSyncContextKey;
+      void pushDenSession().then(() => runCloudProviderSync("app_launch"));
+      return;
+    }
     if (!hasCloudProviderSyncPrerequisites()) {
       cloudProviderSyncContextKey = "";
       return;
@@ -2093,8 +2181,12 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             providerAuthMethods: {},
             lastSyncError: {},
           }));
-          void runCloudProviderSync("sign_in");
+          void pushDenSession().then(() => runCloudProviderSync("sign_in"));
         } else {
+          if (serverHandlesProviderSync()) {
+            lastDenSessionPushKey = "";
+            void options.openworkServer.getSnapshot().openworkServerClient?.deleteDenSession().catch(() => undefined);
+          }
           // Sign-out or error: remove all cloud-imported providers from the workspace
           // Capture the full import records BEFORE clearing state
           const importedProviders = { ...state.importedCloudProviders };

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -108,7 +108,7 @@ function installCloudSession(storage: Storage) {
 }
 
 function createProviderAuthTestStore(
-  configCapabilities: { read: boolean; write: boolean } = { read: true, write: true },
+  configCapabilities: { read: boolean; write: boolean; providerSync?: boolean } = { read: true, write: true },
 ) {
   const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test", {
     token: "engine-token",
@@ -117,6 +117,7 @@ function createProviderAuthTestStore(
   const openworkClient = createOpenworkServerClient({
     baseUrl: "https://server.example",
     token: "server-token",
+    hostToken: "host-token",
   });
   const workspace = {
     id: "workspace_test",
@@ -146,7 +147,11 @@ function createProviderAuthTestStore(
       getSnapshot: () => ({
         openworkServerStatus: "connected",
         openworkServerClient: openworkClient,
-        openworkServerCapabilities: { config: configCapabilities },
+        openworkServerAuth: { token: "server-token", hostToken: "host-token" },
+        openworkServerCapabilities: {
+          config: configCapabilities,
+          providerSync: configCapabilities.providerSync,
+        },
       }),
     },
     setProviders: (value) => {
@@ -174,8 +179,13 @@ function createProviderAuthTestStore(
 
 function installProviderSyncFetch(
   requests: RecordedRequest[],
-  options: { conflict?: boolean } = {},
+  options: {
+    conflict?: boolean;
+    runStatuses?: Array<{ status: "applied" | "noop" | "failed" | "no_session"; message?: string }>;
+    statusProviders?: Array<Record<string, unknown>>;
+  } = {},
 ) {
+  let runIndex = 0;
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -195,6 +205,18 @@ function installProviderSyncFetch(
       }
       if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/config" && method === "GET") {
         return jsonResponse({ opencode: {}, openwork: {} });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/den-session" && method === "PUT") {
+        return new Response(null, { status: 204 });
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/cloud-provider-sync/run" && method === "POST") {
+        const statuses = options.runStatuses ?? [{ status: "noop" }];
+        const result = statuses[Math.min(runIndex, statuses.length - 1)];
+        runIndex += 1;
+        return jsonResponse(result);
+      }
+      if (url.origin === "https://server.example" && url.pathname === "/cloud-provider-sync/status" && method === "GET") {
+        return jsonResponse({ hasSession: true, lastRun: null, providers: options.statusProviders ?? [] });
       }
       if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/config" && method === "PATCH") {
         return jsonResponse({ updatedAt: 1 });
@@ -333,5 +355,103 @@ describe("cloud provider sync in gateway mode", () => {
       (request) => request.url === "https://den.example/api/den/v1/llm-providers/lpr_test/connect",
     ).length;
     expect(secondConnectCount).toBe(firstConnectCount);
+  });
+});
+
+describe("cloud provider sync in server-capability mode", () => {
+  beforeEach(() => {
+    process.env.VITE_OPENWORK_DEPLOYMENT = "web";
+    console.info = () => undefined;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", { configurable: true, value: originalWindow });
+    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    console.info = originalConsoleInfo;
+    if (originalDeployment === undefined) delete process.env.VITE_OPENWORK_DEPLOYMENT;
+    else process.env.VITE_OPENWORK_DEPLOYMENT = originalDeployment;
+  });
+
+  test("posts run-now without fetching Den providers in the renderer", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, { runStatuses: [{ status: "applied" }] });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toEqual({ outcome: "handled_server_side" });
+    expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(1);
+    expect(requests.filter((request) => request.url.includes("/v1/llm-providers"))).toHaveLength(0);
+  });
+
+  test("resolves noop as handled server-side", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, { runStatuses: [{ status: "noop" }] });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toEqual({ outcome: "handled_server_side" });
+  });
+
+  test("exposes server failure in settings", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, { runStatuses: [{ status: "failed", message: "Provider import failed" }] });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toBeUndefined();
+    expect(store.getSnapshot().providerAuthError).toContain("Provider import failed");
+  });
+
+  test("pushes the resolved Den API session and retries once when missing", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, { runStatuses: [{ status: "no_session" }, { status: "noop" }] });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toEqual({ outcome: "handled_server_side" });
+    const sessionRequests = requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session");
+    expect(sessionRequests).toHaveLength(1);
+    expect(sessionRequests[0]?.body).toBe(JSON.stringify({
+      baseUrl: "https://den.example/api/den",
+      token: "den-token",
+      orgId: "org_test",
+    }));
+    expect(requests.filter((request) => request.method === "POST" && new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(2);
+  });
+
+  test("maps imported provider status by cloud provider id", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, {
+      statusProviders: [{
+        cloudProviderId: "cloud_1",
+        providerId: "lpr_cloud_1",
+        sourceProviderId: "openai",
+        name: "Team OpenAI",
+        source: "custom",
+        updatedAt: "2026-08-04T00:00:00.000Z",
+        modelIds: ["gpt-test"],
+        importedAt: 123,
+      }],
+    });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    await store.refreshImportedCloudProviders();
+
+    expect(store.getSnapshot().importedCloudProviders.cloud_1).toEqual({
+      cloudProviderId: "cloud_1",
+      providerId: "lpr_cloud_1",
+      sourceProviderId: "openai",
+      name: "Team OpenAI",
+      source: "custom",
+      updatedAt: "2026-08-04T00:00:00.000Z",
+      modelIds: ["gpt-test"],
+      importedAt: 123,
+    });
   });
 });

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EnvService } from "./env-file.js";
+import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
+import {
+  readGlobalRuntimeOpencodeConfig,
+  readRuntimeOpencodeConfig,
+  runtimeProviderMap,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const clientToken = "owt_cloud_provider_client";
+const hostToken = "owt_cloud_provider_host";
+const roots: string[] = [];
+const stops: Array<() => void | Promise<void>> = [];
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const previousEnvStore = process.env.OPENWORK_ENV_STORE;
+const previousInterval = process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS;
+
+type FakeModel = {
+  id: string;
+  name: string;
+  config: Record<string, unknown>;
+};
+
+type FakeProvider = {
+  id: string;
+  providerId: string;
+  name: string;
+  source: string;
+  updatedAt: string;
+  providerConfig: Record<string, unknown>;
+  apiKey: string;
+  apiKeys: Record<string, string> | null;
+  models: FakeModel[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`Expected ${label}`);
+  return value;
+}
+
+function clientHeaders() {
+  return { authorization: `Bearer ${clientToken}`, "content-type": "application/json" };
+}
+
+function hostHeaders() {
+  return { "x-openwork-host-token": hostToken, "content-type": "application/json" };
+}
+
+async function responseRecord(response: Response, label: string): Promise<Record<string, unknown>> {
+  return expectRecord(await response.json(), label);
+}
+
+async function createRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-cloud-provider-sync-"));
+  roots.push(root);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_ENV_STORE = join(root, "env.json");
+  process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS = "3600000";
+  return root;
+}
+
+function buildProvider(models: FakeModel[]): FakeProvider {
+  return {
+    id: "lpr_test",
+    providerId: "openai-compatible",
+    name: "Test provider",
+    source: "custom",
+    updatedAt: "2026-08-04T10:00:00.000Z",
+    providerConfig: {
+      env: ["TEST_PROVIDER_API_KEY"],
+      npm: "@ai-sdk/openai-compatible",
+      api: "https://models.example.test/api/v1",
+      options: { baseURL: "https://models.example.test/api/v1" },
+      whitelist: ["allowed-model"],
+      blacklist: ["blocked-model"],
+    },
+    apiKey: "sk-test-provider",
+    apiKeys: null,
+    models,
+  };
+}
+
+function serverConfig(root: string, engineBaseUrl: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: clientToken,
+    hostToken,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_1",
+      name: "Workspace",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: engineBaseUrl,
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function waitForLastRun(base: string, expectedStatus: string): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const response = await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() });
+    expect(response.status).toBe(200);
+    const status = await responseRecord(response, "provider sync status");
+    const lastRun = isRecord(status.lastRun) ? status.lastRun : null;
+    if (lastRun?.status === expectedStatus) return status;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for provider sync status ${expectedStatus}`);
+}
+
+async function runSync(base: string, reason: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${base}/cloud-provider-sync/run`, {
+    method: "POST",
+    headers: hostHeaders(),
+    body: JSON.stringify({ reason }),
+  });
+  expect(response.status).toBe(200);
+  return responseRecord(response, "provider sync run response");
+}
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+  if (previousEnvStore === undefined) delete process.env.OPENWORK_ENV_STORE;
+  else process.env.OPENWORK_ENV_STORE = previousEnvStore;
+  if (previousInterval === undefined) delete process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS;
+  else process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS = previousInterval;
+});
+
+describe("cloud provider sync gateway", () => {
+  test("materializes Den providers globally, reconciles changes, and sweeps the session", async () => {
+    const root = await createRoot();
+    const engineRequests: string[] = [];
+    const engine = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        engineRequests.push(`${request.method} ${url.pathname}`);
+        return Response.json({ ok: true });
+      },
+    });
+    stops.push(() => engine.stop(true));
+
+    let denFailure = false;
+    let denProviders = [
+      buildProvider([
+        { id: "model-z", name: "Model Z", config: { reasoning: true } },
+        { id: "model-a", name: "Model A", config: { family: "test" } },
+      ]),
+    ];
+    const denRequests: Array<{ path: string; authorization: string | null; orgId: string | null }> = [];
+    const den = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        denRequests.push({
+          path: url.pathname,
+          authorization: request.headers.get("authorization"),
+          orgId: request.headers.get("x-openwork-legacy-org-id"),
+        });
+        if (denFailure) return Response.json({ error: "unavailable" }, { status: 503 });
+        if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: denProviders });
+        const match = url.pathname.match(/^\/v1\/llm-providers\/([^/]+)\/connect$/);
+        const provider = match ? denProviders.find((entry) => entry.id === decodeURIComponent(match[1] ?? "")) : null;
+        return provider
+          ? Response.json({ llmProvider: provider })
+          : Response.json({ error: "not_found" }, { status: 404 });
+      },
+    });
+    stops.push(() => den.stop(true));
+
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+      provider: {
+        lpr_stale: { id: "stale", name: "Stale", env: ["STALE_KEY"] },
+        local_provider: { id: "local", name: "Local" },
+      },
+    }));
+    await writeOpenworkWorkspaceConfig(config, "ws_1", () => ({
+      cloudImports: {
+        providers: { lpr_stale: { cloudProviderId: "lpr_stale" } },
+        marketplaces: { mkp_keep: { name: "Keep" } },
+      },
+    }));
+
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+
+    const capabilitiesResponse = await fetch(`${base}/capabilities`, { headers: clientHeaders() });
+    expect(capabilitiesResponse.status).toBe(200);
+    expect((await responseRecord(capabilitiesResponse, "capabilities")).providerSync).toBe(true);
+
+    expect(await runSync(base, "before-session")).toEqual({ status: "no_session" });
+
+    const sessionResponse = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({
+        baseUrl: `http://127.0.0.1:${den.port}`,
+        token: "den-token",
+        orgId: "org_test",
+      }),
+    });
+    expect(sessionResponse.status).toBe(204);
+
+    const firstStatus = await waitForLastRun(base, "applied");
+    expect(firstStatus.hasSession).toBe(true);
+    const statusProviders = Array.isArray(firstStatus.providers) ? firstStatus.providers : [];
+    expect(statusProviders).toHaveLength(1);
+    const statusProvider = expectRecord(statusProviders[0], "materialized provider status");
+    expect(statusProvider).toMatchObject({
+      cloudProviderId: "lpr_test",
+      providerId: "lpr_test",
+      sourceProviderId: "openai-compatible",
+      name: "Test provider",
+      source: "custom",
+      updatedAt: "2026-08-04T10:00:00.000Z",
+      modelIds: ["model-a", "model-z"],
+    });
+    expect(typeof statusProvider.importedAt).toBe("number");
+    const firstImportedAt = statusProvider.importedAt;
+
+    expect(denRequests.every((request) => request.authorization === "Bearer den-token")).toBe(true);
+    expect(denRequests.every((request) => request.orgId === "org_test")).toBe(true);
+    expect(denRequests.map((request) => request.path)).toContain("/v1/llm-providers/lpr_test/connect");
+
+    const globalProviders = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config));
+    const globalProvider = expectRecord(globalProviders.lpr_test, "global runtime provider");
+    const globalModels = expectRecord(globalProvider.models, "global runtime provider models");
+    expect(Object.keys(globalModels).sort()).toEqual(["model-a", "model-z"]);
+    expect(expectRecord(globalModels["model-z"], "model-z runtime config").reasoning).toBe(true);
+    expect((await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list()).find(
+      (entry) => entry.key === "TEST_PROVIDER_API_KEY",
+    )?.value).toBe("sk-test-provider");
+
+    const workspaceProviders = runtimeProviderMap(await readRuntimeOpencodeConfig(config, "ws_1"));
+    expect(workspaceProviders.lpr_stale).toBeUndefined();
+    expect(workspaceProviders.local_provider).toBeDefined();
+    const openwork = await readOpenworkWorkspaceConfig(config, "ws_1");
+    const cloudImports = expectRecord(openwork.cloudImports, "workspace cloud imports");
+    expect(cloudImports.providers).toEqual({});
+    expect(cloudImports.marketplaces).toEqual({ mkp_keep: { name: "Keep" } });
+
+    expect(await runSync(base, "idempotency")).toEqual({ status: "noop" });
+
+    denProviders = [buildProvider([{ id: "model-b", name: "Model B", config: { tool_call: true } }])];
+    expect(await runSync(base, "models-changed")).toEqual({ status: "applied" });
+    const updatedGlobal = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config));
+    expect(Object.keys(expectRecord(updatedGlobal.lpr_test, "updated global provider").models ?? {})).toEqual(["model-b"]);
+    const updatedStatusResponse = await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() });
+    const updatedStatus = await responseRecord(updatedStatusResponse, "updated status");
+    const updatedProviders = Array.isArray(updatedStatus.providers) ? updatedStatus.providers : [];
+    expect(expectRecord(updatedProviders[0], "updated provider status").importedAt).toBe(firstImportedAt);
+
+    denProviders = [];
+    expect(await runSync(base, "provider-removed")).toEqual({ status: "applied" });
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeUndefined();
+    const removedStatusResponse = await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() });
+    expect((await responseRecord(removedStatusResponse, "removed status")).providers).toEqual([]);
+
+    denProviders = [buildProvider([{ id: "model-c", name: "Model C", config: {} }])];
+    expect(await runSync(base, "provider-restored")).toEqual({ status: "applied" });
+    const deleteResponse = await fetch(`${base}/den-session`, { method: "DELETE", headers: hostHeaders() });
+    expect(deleteResponse.status).toBe(204);
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeUndefined();
+    expect((await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list()).find(
+      (entry) => entry.key === "TEST_PROVIDER_API_KEY",
+    )).toBeUndefined();
+    const clearedStatusResponse = await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() });
+    expect(await responseRecord(clearedStatusResponse, "cleared status")).toEqual({
+      hasSession: false,
+      lastRun: null,
+      providers: [],
+    });
+    expect(engineRequests).toContain("DELETE /auth/lpr_test");
+    expect(await runSync(base, "after-delete")).toEqual({ status: "no_session" });
+
+    denFailure = true;
+    const failedSessionResponse = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({
+        baseUrl: `http://127.0.0.1:${den.port}`,
+        token: "den-token",
+        orgId: "org_test",
+      }),
+    });
+    expect(failedSessionResponse.status).toBe(204);
+    const failedRun = await runSync(base, "den-failure");
+    expect(failedRun.status).toBe("failed");
+    expect(typeof failedRun.message).toBe("string");
+    const failedStatus = await waitForLastRun(base, "failed");
+    const failedLastRun = expectRecord(failedStatus.lastRun, "failed last run");
+    expect(failedLastRun.status).toBe("failed");
+    expect(failedLastRun.message).toBe(failedRun.message);
+  });
+});

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -1,0 +1,734 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type { EnvService } from "./env-file.js";
+import { syncManagedProviderAuth } from "./managed-provider-auth.js";
+import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
+import {
+  hasOpenworkWorkspaceConfig,
+  readOpenworkWorkspaceConfig,
+  writeOpenworkWorkspaceConfig,
+} from "./openwork-workspace-config-store.js";
+import {
+  mergeRuntimeProviderUpdate,
+  readGlobalRuntimeOpencodeConfig,
+  readRuntimeOpencodeConfig,
+  runtimeProviderMap,
+  writeGlobalRuntimeOpencodeConfig,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+import { openworkConfigPath } from "./workspace-files.js";
+import { findManagedEngineWorkspace } from "./workspaces.js";
+
+type JsonRecord = Record<string, unknown>;
+
+export type CloudProviderDenSession = {
+  /** Resolved Den API base URL, including any required `/api/den` prefix. */
+  baseUrl: string;
+  token: string;
+  orgId: string;
+};
+
+export type CloudProviderSyncRunResult = {
+  status: "applied" | "noop" | "failed" | "no_session";
+  message?: string;
+};
+
+export type CloudProviderSyncStatusProvider = {
+  cloudProviderId: string;
+  providerId: string;
+  sourceProviderId: string;
+  name: string;
+  source: string | null;
+  updatedAt: string | null;
+  modelIds: string[];
+  importedAt: number;
+};
+
+export type CloudProviderSyncStatus = {
+  hasSession: boolean;
+  lastRun: {
+    at: string;
+    status: "applied" | "noop" | "failed";
+    message?: string;
+  } | null;
+  providers: CloudProviderSyncStatusProvider[];
+};
+
+type DenProviderModel = {
+  id: string;
+  name: string;
+  config: JsonRecord;
+};
+
+type DenProvider = {
+  id: string;
+  providerId: string;
+  name: string;
+  source: string | null;
+  updatedAt: string | null;
+  providerConfig: JsonRecord;
+  models: DenProviderModel[];
+};
+
+type DenProviderConnection = DenProvider & {
+  apiKey: string | null;
+  apiKeys: Record<string, string> | null;
+};
+
+type EnvEntry = {
+  key: string;
+  value: string;
+};
+
+type MaterializedProvider = {
+  provider: DenProviderConnection;
+  runtimeProviderId: string;
+  config: JsonRecord;
+  envEntries: EnvEntry[];
+};
+
+type PreparedMaterialization = {
+  fingerprint: string;
+  providers: MaterializedProvider[];
+  envEntries: EnvEntry[];
+};
+
+type CloudProviderSyncLogger = {
+  warn: (message: string, metadata?: JsonRecord) => void;
+  error: (message: string, metadata?: JsonRecord) => void;
+};
+
+export type CloudProviderSyncOptions = {
+  config: ServerConfig;
+  env: EnvService;
+  reloadEngine: () => Promise<void>;
+  fetchImpl?: typeof globalThis.fetch;
+  logger?: CloudProviderSyncLogger;
+  intervalMs?: number;
+};
+
+const requestTimeoutMs = 8_000;
+const defaultIntervalMs = 5 * 60 * 1_000;
+const modelConfigPassthroughKeys = [
+  "family",
+  "release_date",
+  "attachment",
+  "reasoning",
+  "temperature",
+  "tool_call",
+  "interleaved",
+  "cost",
+  "limit",
+  "modalities",
+  "status",
+  "options",
+  "headers",
+  "provider",
+  "variants",
+];
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : [];
+}
+
+function parseJsonRecord(value: unknown): JsonRecord {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return {};
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseApiKeys(value: unknown): Record<string, string> | null {
+  if (!isRecord(value)) return null;
+  const entries: Array<[string, string]> = [];
+  for (const [key, credential] of Object.entries(value)) {
+    if (typeof credential === "string" && credential.trim().length > 0) {
+      entries.push([key, credential]);
+    }
+  }
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function parseModel(value: unknown): DenProviderModel | null {
+  if (!isRecord(value)) return null;
+  const id = readRequiredString(value.id);
+  const name = readRequiredString(value.name);
+  if (!id || !name || (!isRecord(value.config) && typeof value.config !== "string")) return null;
+  return { id, name, config: parseJsonRecord(value.config) };
+}
+
+function parseProvider(value: unknown): DenProvider | null {
+  if (!isRecord(value)) return null;
+  const id = readRequiredString(value.id);
+  const providerId = readRequiredString(value.providerId);
+  const name = readRequiredString(value.name);
+  if (!id || !/^lpr_/i.test(id) || !providerId || !name || !Array.isArray(value.models)) return null;
+
+  const models: DenProviderModel[] = [];
+  for (const modelValue of value.models) {
+    const model = parseModel(modelValue);
+    if (!model) return null;
+    models.push(model);
+  }
+
+  return {
+    id,
+    providerId,
+    name,
+    source: readOptionalString(value.source),
+    updatedAt: readOptionalString(value.updatedAt),
+    providerConfig: parseJsonRecord(value.providerConfig),
+    models,
+  };
+}
+
+function parseProviderList(payload: unknown): DenProvider[] {
+  if (!isRecord(payload) || !Array.isArray(payload.llmProviders)) {
+    throw new Error("den_llm_provider_list_invalid_response");
+  }
+  const providers: DenProvider[] = [];
+  for (const value of payload.llmProviders) {
+    const provider = parseProvider(value);
+    if (!provider) throw new Error("den_llm_provider_list_invalid_response");
+    providers.push(provider);
+  }
+  return providers;
+}
+
+function parseProviderConnection(payload: unknown, expectedId: string): DenProviderConnection {
+  if (!isRecord(payload) || !isRecord(payload.llmProvider)) {
+    throw new Error(`den_llm_provider_connect_invalid_response_${expectedId}`);
+  }
+  const provider = parseProvider(payload.llmProvider);
+  if (!provider || provider.id !== expectedId) {
+    throw new Error(`den_llm_provider_connect_invalid_response_${expectedId}`);
+  }
+  return {
+    ...provider,
+    apiKey: typeof payload.llmProvider.apiKey === "string" ? payload.llmProvider.apiKey : null,
+    apiKeys: parseApiKeys(payload.llmProvider.apiKeys),
+  };
+}
+
+export function parseCloudProviderDenSession(value: unknown): CloudProviderDenSession | null {
+  if (!isRecord(value)) return null;
+  const baseUrl = readRequiredString(value.baseUrl);
+  const token = readRequiredString(value.token);
+  const orgId = readRequiredString(value.orgId);
+  if (!baseUrl || !token || !orgId) return null;
+  try {
+    const url = new URL(baseUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  } catch {
+    return null;
+  }
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), token, orgId };
+}
+
+async function requestJson(
+  fetchImpl: typeof globalThis.fetch,
+  session: CloudProviderDenSession,
+  path: string,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImpl(`${session.baseUrl}${path}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${session.token}`,
+        "x-openwork-legacy-org-id": session.orgId,
+      },
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
+  } catch (error) {
+    throw new Error(error instanceof Error ? `den_request_failed: ${error.message}` : "den_request_failed");
+  }
+  if (!response.ok) throw new Error(`den_request_failed_${response.status}`);
+  try {
+    const payload: unknown = await response.json();
+    return payload;
+  } catch {
+    throw new Error("den_request_invalid_json");
+  }
+}
+
+async function fetchProviders(
+  fetchImpl: typeof globalThis.fetch,
+  session: CloudProviderDenSession,
+): Promise<DenProviderConnection[]> {
+  const providers = parseProviderList(await requestJson(fetchImpl, session, "/v1/llm-providers"));
+  return Promise.all(
+    providers.map(async (provider) =>
+      parseProviderConnection(
+        await requestJson(fetchImpl, session, `/v1/llm-providers/${encodeURIComponent(provider.id)}/connect`),
+        provider.id,
+      )),
+  );
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableValue(value[key])]),
+  );
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(stableValue(value));
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function runtimeProviderId(provider: DenProvider): string {
+  return provider.source === "openwork" ? "openwork" : provider.id;
+}
+
+function isCloudManagedProviderKey(providerId: string): boolean {
+  return /^lpr_/i.test(providerId) || providerId.trim() === "openwork";
+}
+
+function readProviderEnvNames(providerConfig: JsonRecord): string[] {
+  return readStringList(providerConfig.env);
+}
+
+function upsertEnvEntry(entries: EnvEntry[], key: string, value: string): void {
+  const trimmedKey = key.trim();
+  const trimmedValue = value.trim();
+  if (!trimmedKey || !trimmedValue) return;
+  const existing = entries.find((entry) => entry.key === trimmedKey);
+  if (existing) existing.value = trimmedValue;
+  else entries.push({ key: trimmedKey, value: trimmedValue });
+}
+
+function readOpenWorkInferenceBaseUrl(providerConfig: JsonRecord): string | null {
+  const options = providerConfig.options;
+  if (isRecord(options)) {
+    const baseUrl = readRequiredString(options.baseURL);
+    if (baseUrl) return baseUrl.replace(/\/api\/v1\/?$/, "");
+  }
+  const api = readRequiredString(providerConfig.api);
+  return api ? api.replace(/\/api\/v1\/?$/, "") : null;
+}
+
+// Ported from ee/apps/den-api/src/llm/cloud-provider-materialization.ts.
+// Keep local: the open-source server must never depend on ee modules.
+function providerEnvEntries(provider: DenProviderConnection): EnvEntry[] {
+  const entries: EnvEntry[] = [];
+  const envNames = readProviderEnvNames(provider.providerConfig);
+  if (provider.apiKeys) {
+    const keys = Object.keys(provider.apiKeys);
+    const orderedNames = [
+      ...envNames.filter((name) => keys.includes(name)),
+      ...keys.filter((name) => !envNames.includes(name)),
+    ];
+    for (const name of orderedNames) upsertEnvEntry(entries, name, provider.apiKeys[name] ?? "");
+  }
+  if (provider.apiKey && envNames[0]) upsertEnvEntry(entries, envNames[0], provider.apiKey);
+
+  const primaryCredential = provider.apiKey?.trim() || entries[0]?.value || "";
+  if (provider.source === "openwork" && primaryCredential) {
+    upsertEnvEntry(entries, "OPENWORK_API_KEY", primaryCredential);
+    const baseUrl = readOpenWorkInferenceBaseUrl(provider.providerConfig);
+    if (baseUrl) upsertEnvEntry(entries, "OPENWORK_INFERENCE_BASE_URL", baseUrl);
+  }
+  return entries;
+}
+
+function buildModelConfig(model: DenProviderModel): JsonRecord {
+  const next: JsonRecord = { id: model.id, name: model.name };
+  for (const key of modelConfigPassthroughKeys) {
+    const value = model.config[key];
+    if (value !== undefined) next[key] = value;
+  }
+  return next;
+}
+
+function buildProviderConfig(provider: DenProviderConnection): JsonRecord {
+  const models: JsonRecord = {};
+  for (const model of [...provider.models].sort((left, right) => left.id.localeCompare(right.id))) {
+    models[model.id] = buildModelConfig(model);
+  }
+  const config: JsonRecord = {
+    id: provider.providerId,
+    name: provider.name,
+    env: readProviderEnvNames(provider.providerConfig),
+  };
+  if (Object.keys(models).length > 0 || provider.source !== "openwork") config.models = models;
+
+  const npm = readRequiredString(provider.providerConfig.npm);
+  if (npm) config.npm = npm;
+  const api = readRequiredString(provider.providerConfig.api);
+  if (api) config.api = api;
+  if (isRecord(provider.providerConfig.options)) config.options = provider.providerConfig.options;
+  const whitelist = readStringList(provider.providerConfig.whitelist);
+  if (whitelist.length > 0) config.whitelist = whitelist;
+  const blacklist = readStringList(provider.providerConfig.blacklist);
+  if (blacklist.length > 0) config.blacklist = blacklist;
+  return config;
+}
+
+function prepareMaterialization(providers: DenProviderConnection[]): PreparedMaterialization {
+  const materialized: MaterializedProvider[] = [];
+  for (const provider of providers) {
+    const envEntries = providerEnvEntries(provider);
+    const envNames = readProviderEnvNames(provider.providerConfig);
+    if (envNames.length > 0 && !envEntries.some((entry) => envNames.includes(entry.key))) continue;
+    materialized.push({
+      provider,
+      runtimeProviderId: runtimeProviderId(provider),
+      config: buildProviderConfig(provider),
+      envEntries,
+    });
+  }
+  materialized.sort((left, right) => left.runtimeProviderId.localeCompare(right.runtimeProviderId));
+
+  const envEntries: EnvEntry[] = [];
+  for (const provider of materialized) {
+    for (const entry of provider.envEntries) upsertEnvEntry(envEntries, entry.key, entry.value);
+  }
+
+  // Preserve den-api's stable, secret-safe owp:v1 fingerprint format.
+  const fingerprintPayload = materialized.map((entry) => ({
+    id: entry.provider.id,
+    runtimeProviderId: entry.runtimeProviderId,
+    source: entry.provider.source,
+    providerId: entry.provider.providerId,
+    config: entry.config,
+    keyHashes: entry.envEntries
+      .map((envEntry) => ({ key: envEntry.key, hash: hashString(envEntry.value) }))
+      .sort((left, right) => left.key.localeCompare(right.key)),
+  }));
+  return {
+    fingerprint: `owp:v1:${hashString(stableJson(fingerprintPayload))}`,
+    providers: materialized,
+    envEntries,
+  };
+}
+
+function desiredProviderMap(prepared: PreparedMaterialization): JsonRecord {
+  return Object.fromEntries(prepared.providers.map((provider) => [provider.runtimeProviderId, provider.config]));
+}
+
+function managedProviderMap(providers: Record<string, Record<string, unknown>>): JsonRecord {
+  return Object.fromEntries(Object.entries(providers).filter(([providerId]) => isCloudManagedProviderKey(providerId)));
+}
+
+function removeCloudProviderImportBaselines(openwork: JsonRecord): JsonRecord | null {
+  if (!isRecord(openwork.cloudImports) || !isRecord(openwork.cloudImports.providers)) return null;
+  if (Object.keys(openwork.cloudImports.providers).length === 0) return null;
+  return {
+    ...openwork,
+    cloudImports: {
+      ...openwork.cloudImports,
+      providers: {},
+    },
+  };
+}
+
+async function readLegacyOpenworkConfig(path: string): Promise<JsonRecord | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function configuredIntervalMs(): number {
+  const configured = Number(process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS ?? "");
+  return Number.isFinite(configured) && configured > 0 ? configured : defaultIntervalMs;
+}
+
+export class CloudProviderSync {
+  private readonly config: ServerConfig;
+  private readonly env: EnvService;
+  private readonly reloadEngine: () => Promise<void>;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly logger?: CloudProviderSyncLogger;
+  private readonly intervalMs: number;
+  private session: CloudProviderDenSession | null = null;
+  private lastRun: CloudProviderSyncStatus["lastRun"] = null;
+  private providers: CloudProviderSyncStatusProvider[] = [];
+  private fingerprint: string | null = null;
+  private ownedEnvKeys = new Set<string>();
+  private managedProviderIds = new Set<string>();
+  private importedAtByCloudProviderId = new Map<string, number>();
+  private reloadPending = false;
+  private queue: Promise<void> = Promise.resolve();
+  private interval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: CloudProviderSyncOptions) {
+    this.config = options.config;
+    this.env = options.env;
+    this.reloadEngine = options.reloadEngine;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.logger = options.logger;
+    this.intervalMs = options.intervalMs ?? configuredIntervalMs();
+  }
+
+  setSession(session: CloudProviderDenSession): void {
+    this.session = session;
+    this.startInterval();
+    void this.run("den_session_updated");
+  }
+
+  async clearSession(): Promise<void> {
+    this.session = null;
+    this.stopInterval();
+    await this.enqueue(async () => {
+      try {
+        await this.sweep();
+      } catch (error) {
+        this.logger?.error("cloud provider sweep failed", {
+          message: error instanceof Error ? error.message : "cloud_provider_sweep_failed",
+        });
+      } finally {
+        this.lastRun = null;
+        this.providers = [];
+        this.fingerprint = null;
+        this.ownedEnvKeys.clear();
+        this.managedProviderIds.clear();
+        this.importedAtByCloudProviderId.clear();
+      }
+    });
+  }
+
+  run(reason?: string): Promise<CloudProviderSyncRunResult> {
+    if (!this.session) return Promise.resolve({ status: "no_session" });
+    return this.enqueue(() => this.runPass(reason));
+  }
+
+  status(): CloudProviderSyncStatus {
+    return {
+      hasSession: this.session !== null,
+      lastRun: this.lastRun ? { ...this.lastRun } : null,
+      providers: this.providers.map((provider) => ({ ...provider, modelIds: [...provider.modelIds] })),
+    };
+  }
+
+  stop(): void {
+    this.stopInterval();
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(operation, operation);
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private startInterval(): void {
+    this.stopInterval();
+    this.interval = setInterval(() => {
+      if (this.session) void this.run("interval");
+    }, this.intervalMs);
+    this.interval.unref();
+  }
+
+  private stopInterval(): void {
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+  }
+
+  private async runPass(reason?: string): Promise<CloudProviderSyncRunResult> {
+    const session = this.session;
+    if (!session) return { status: "no_session" };
+    try {
+      const prepared = prepareMaterialization(await fetchProviders(this.fetchImpl, session));
+      const changed = await this.apply(prepared);
+      this.updateProviderStatus(prepared);
+      this.fingerprint = prepared.fingerprint;
+      const status = changed ? "applied" : "noop";
+      this.lastRun = { at: new Date().toISOString(), status };
+      return { status };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "cloud_provider_sync_failed";
+      this.lastRun = { at: new Date().toISOString(), status: "failed", message };
+      this.logger?.warn("cloud provider sync failed", { reason, message });
+      return { status: "failed", message };
+    }
+  }
+
+  private async apply(prepared: PreparedMaterialization): Promise<boolean> {
+    const desiredProviders = desiredProviderMap(prepared);
+    const globalRuntime = await readGlobalRuntimeOpencodeConfig(this.config);
+    const currentManagedProviders = managedProviderMap(runtimeProviderMap(globalRuntime));
+    const providerStateChanged = stableJson(currentManagedProviders) !== stableJson(desiredProviders);
+
+    if (providerStateChanged) {
+      const patch: JsonRecord = {};
+      for (const providerId of Object.keys(currentManagedProviders)) {
+        if (!(providerId in desiredProviders)) patch[providerId] = null;
+      }
+      for (const [providerId, providerConfig] of Object.entries(desiredProviders)) patch[providerId] = providerConfig;
+      await writeGlobalRuntimeOpencodeConfig(this.config, (current) => ({
+        ...current,
+        provider: mergeRuntimeProviderUpdate(current.provider, patch),
+      }));
+    }
+    for (const providerId of Object.keys(desiredProviders)) this.managedProviderIds.add(providerId);
+
+    const storedEnv = new Map((await this.env.list()).map((entry) => [entry.key, entry.value]));
+    const envUpserts = prepared.envEntries.filter((entry) => storedEnv.get(entry.key) !== entry.value);
+    if (envUpserts.length > 0) {
+      await this.env.upsertMany(envUpserts);
+      for (const entry of envUpserts) this.ownedEnvKeys.add(entry.key);
+    }
+    const desiredEnvKeys = new Set(prepared.envEntries.map((entry) => entry.key));
+    const envDeletes = [...this.ownedEnvKeys].filter((key) => !desiredEnvKeys.has(key));
+    for (const key of envDeletes) {
+      await this.env.delete(key);
+      this.ownedEnvKeys.delete(key);
+    }
+
+    const workspaceCleanup = await this.cleanupWorkspaceTakeovers();
+    const engineWorkspace = findManagedEngineWorkspace(this.config.workspaces) ?? this.config.workspaces[0];
+    if (!engineWorkspace) throw new Error("workspace_missing");
+    const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
+    this.reloadPending = this.reloadPending
+      || providerStateChanged
+      || workspaceCleanup.runtimeChanged
+      || fileResult.changed;
+    let reloadError: unknown;
+    if (this.reloadPending) {
+      try {
+        await this.reloadEngine();
+        this.reloadPending = false;
+      } catch (error) {
+        reloadError = error;
+      }
+    }
+    await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    if (reloadError) throw reloadError;
+
+    this.managedProviderIds = new Set(Object.keys(desiredProviders));
+    return this.fingerprint !== prepared.fingerprint
+      || providerStateChanged
+      || envUpserts.length > 0
+      || envDeletes.length > 0
+      || workspaceCleanup.changed
+      || fileResult.changed;
+  }
+
+  private async cleanupWorkspaceTakeovers(): Promise<{ changed: boolean; runtimeChanged: boolean }> {
+    let changed = false;
+    let runtimeChanged = false;
+    for (const workspace of this.config.workspaces) {
+      const runtime = await readRuntimeOpencodeConfig(this.config, workspace.id);
+      const providerPatch: JsonRecord = {};
+      for (const providerId of Object.keys(runtimeProviderMap(runtime))) {
+        if (isCloudManagedProviderKey(providerId)) providerPatch[providerId] = null;
+      }
+      if (Object.keys(providerPatch).length > 0) {
+        const result = await writeRuntimeOpencodeConfig(this.config, workspace.id, (current) => ({
+          ...current,
+          provider: mergeRuntimeProviderUpdate(current.provider, providerPatch),
+        }));
+        changed = changed || result.changed;
+        runtimeChanged = runtimeChanged || result.changed;
+      }
+
+      const hasStoredConfig = await hasOpenworkWorkspaceConfig(this.config, workspace.id);
+      const openwork = hasStoredConfig
+        ? await readOpenworkWorkspaceConfig(this.config, workspace.id)
+        : workspace.workspaceType !== "remote" && workspace.path.trim().length > 0
+          ? await readLegacyOpenworkConfig(openworkConfigPath(workspace.path))
+          : null;
+      if (!openwork) continue;
+      const next = removeCloudProviderImportBaselines(openwork);
+      if (!next) continue;
+      await writeOpenworkWorkspaceConfig(this.config, workspace.id, () => next);
+      changed = true;
+    }
+    return { changed, runtimeChanged };
+  }
+
+  private updateProviderStatus(prepared: PreparedMaterialization): void {
+    const desiredCloudIds = new Set(prepared.providers.map((entry) => entry.provider.id));
+    for (const cloudId of [...this.importedAtByCloudProviderId.keys()]) {
+      if (!desiredCloudIds.has(cloudId)) this.importedAtByCloudProviderId.delete(cloudId);
+    }
+    const now = Date.now();
+    this.providers = prepared.providers.map((entry) => {
+      const importedAt = this.importedAtByCloudProviderId.get(entry.provider.id) ?? now;
+      this.importedAtByCloudProviderId.set(entry.provider.id, importedAt);
+      return {
+        cloudProviderId: entry.provider.id,
+        providerId: entry.runtimeProviderId,
+        sourceProviderId: entry.provider.providerId,
+        name: entry.provider.name,
+        source: entry.provider.source,
+        updatedAt: entry.provider.updatedAt,
+        modelIds: entry.provider.models.map((model) => model.id).sort(),
+        importedAt,
+      };
+    });
+  }
+
+  private async sweep(): Promise<void> {
+    const providerPatch = Object.fromEntries([...this.managedProviderIds].map((providerId) => [providerId, null]));
+    let providerChanged = false;
+    if (Object.keys(providerPatch).length > 0) {
+      const result = await writeGlobalRuntimeOpencodeConfig(this.config, (current) => ({
+        ...current,
+        provider: mergeRuntimeProviderUpdate(current.provider, providerPatch),
+      }));
+      providerChanged = result.changed;
+    }
+    for (const key of this.ownedEnvKeys) await this.env.delete(key);
+
+    const engineWorkspace = findManagedEngineWorkspace(this.config.workspaces) ?? this.config.workspaces[0];
+    if (engineWorkspace) {
+      const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
+      this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
+    }
+    let reloadError: unknown;
+    if (this.reloadPending) {
+      try {
+        await this.reloadEngine();
+        this.reloadPending = false;
+      } catch (error) {
+        reloadError = error;
+      }
+    }
+    await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    if (reloadError) throw reloadError;
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -96,6 +96,7 @@ import {
 import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { readLegacyConfigSweepState } from "./legacy-config-sweep.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
+import { CloudProviderSync, parseCloudProviderDenSession } from "./cloud-provider-sync.js";
 import pkg from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
 
@@ -851,6 +852,12 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
   };
   const engineMcpServerState = beginEngineMcpServerState(config);
+  const cloudProviderSync = new CloudProviderSync({
+    config,
+    env,
+    reloadEngine: () => reloadOpencodeEngine(config, resolveEngineRuntimeWorkspace(config), engineMcpServerState),
+    logger: toManagedProviderAuthLogger(logger),
+  });
   const routes = createRoutes(
     config,
     approvals,
@@ -859,6 +866,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     restartReloadWatchers,
     engineMcpServerState,
     logger,
+    cloudProviderSync,
   );
 
   const serverOptions: {
@@ -1026,6 +1034,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
       idleTimeout: 120,
     });
   } catch (error) {
+    cloudProviderSync.stop();
     invalidateEngineMcpServerState(config, engineMcpServerState);
     watcherHandle.close();
     reloadBaselineRefreshers.delete(config);
@@ -1042,6 +1051,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   return {
     ...server,
     stop: async () => {
+      cloudProviderSync.stop();
       invalidateEngineMcpServerState(config, engineMcpServerState);
       watcherHandle.close();
       reloadBaselineRefreshers.delete(config);
@@ -1277,6 +1287,7 @@ function buildCapabilities(config: ServerConfig): Capabilities {
     schemaVersion,
     serverVersion: SERVER_VERSION,
     opencodeVersion: OPENCODE_VERSION,
+    providerSync: true,
     skills: { read: true, write: writeEnabled, source: "openwork" },
     plugins: { read: true, write: writeEnabled },
     mcp: { read: true, write: writeEnabled },
@@ -1530,6 +1541,7 @@ function createRoutes(
   onWorkspacesChanged: () => void,
   engineMcpServerState: EngineMcpServerState,
   logger: ServerLogger,
+  cloudProviderSync: CloudProviderSync,
 ): Route[] {
   const routes: Route[] = [];
   registerCoreRoutes({
@@ -2046,6 +2058,33 @@ function createRoutes(
   addRoute(routes, "GET", "/runtime-config/providers", "host-token", async () => {
     const runtime = await readGlobalRuntimeOpencodeConfig(config);
     return jsonResponse({ provider: runtimeProviderMap(runtime) });
+  });
+
+  addRoute(routes, "PUT", "/den-session", "host-token", async (ctx) => {
+    ensureWritable(config);
+    const session = parseCloudProviderDenSession(await readJsonBody(ctx.request));
+    if (!session) throw new ApiError(400, "invalid_payload", "baseUrl, token, and orgId are required");
+    cloudProviderSync.setSession(session);
+    return new Response(null, { status: 204 });
+  });
+
+  addRoute(routes, "DELETE", "/den-session", "host-token", async () => {
+    ensureWritable(config);
+    await cloudProviderSync.clearSession();
+    return new Response(null, { status: 204 });
+  });
+
+  addRoute(routes, "POST", "/cloud-provider-sync/run", "host-token", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    if (body.reason !== undefined && typeof body.reason !== "string") {
+      throw new ApiError(400, "invalid_payload", "reason must be a string");
+    }
+    return jsonResponse(await cloudProviderSync.run(typeof body.reason === "string" ? body.reason : undefined));
+  });
+
+  addRoute(routes, "GET", "/cloud-provider-sync/status", "client", async () => {
+    return jsonResponse(cloudProviderSync.status());
   });
 
   addRoute(routes, "PATCH", "/runtime-config/providers", "host-token", async (ctx) => {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -107,6 +107,7 @@ export interface Capabilities {
   schemaVersion: number;
   serverVersion: string;
   opencodeVersion: string;
+  providerSync: true;
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
   plugins: { read: boolean; write: boolean };
   mcp: { read: boolean; write: boolean };


### PR DESCRIPTION
## What

**Rebuilt on `dev` after #3525 merged** — single commit on top of it. #3525 removed the Import concept but kept materialization in the renderer; this PR moves it **server-side for local workspaces, the same way gateway/cloud instances work**: the server materializes, the client displays.

### Server (`apps/server`)
- New `cloud-provider-sync.ts` — local sibling of den-api's cloud worker materializer (ported pure logic; never imports `ee/**`):
  - Minimal Den client (`GET /v1/llm-providers`, `GET /v1/llm-providers/:id/connect`; Bearer + org header; bounded fetches).
  - Materializes providers **engine-global** (the #3255 layer), upserts env, one engine reload per changed pass, credential delivery via `syncManagedProviderAuth`.
  - den-api's `owp:v1:` fingerprint noop-cache; serialized passes; 5-min interval (env-overridable) + run-now.
  - **Takeover cleanup:** renderer-era per-workspace `lpr_*` rows and `openwork.cloudImports.providers` baselines are cleared so they can't shadow the fresh global layer.
  - Sign-out sweep removes everything it materialized (global rows, owned env keys, auth withdrawal).
- Routes: `PUT/DELETE /den-session` (host-token; body carries the **resolved Den API base**), `POST /cloud-provider-sync/run` (host-token), `GET /cloud-provider-sync/status` (client). `GET /capabilities` advertises `providerSync: true`.
- Den session is held **in memory only** — nothing persisted; the app re-pushes on connect/sign-in/org switch and any trigger self-heals via `no_session` (push + one retry).

### App (`apps/app`) — minimal delta on #3525's merged store
- When the connected server advertises `providerSync` **and** the app holds its host token: sync triggers ping run-now and return the same `handled_server_side` outcome gateway mode uses; `refreshImportedCloudProviders` reads the status endpoint, feeding #3525's status-only rows ("Connected") with **zero view changes**.
- #3525's renderer materialization, per-provider `lastSyncError`, and conflict terminality are untouched and remain the fallback for servers without the capability. Gateway short-circuit unchanged.

## Evidence

- **Live e2e:** dev's merged spec `evals/specs/cloud-provider-auto-import.slow.test.ts` (#3525's own demo — member sees Connected, no Import button, models in the picker) passes unchanged on this branch against a cold local Den + Electron (tape published below).
- **Live activation of the server path** was proven during development by a red/green pair on the pre-rebase branch: the settings UI displayed `den_request_failed_404` — an error string that exists only in the new server module — confirming capability → session push → run-now → server Den client end-to-end; the only change before green was fixing the pushed base URL to the resolved `/api/den` API base (that fix ships here, with a unit test pinning the pushed URL).
- **Server:** `cloud-provider-sync.e2e.test.ts` (real `startServer`, fake Den): apply/noop fingerprint, drift rewrite, upstream removal, per-workspace takeover cleanup, sign-out sweep, `no_session`, Den-failure reporting, status shape.
- **App:** capability-mode tests — run-now POSTed with zero renderer Den fetches, `no_session` push-retry with the `/api/den` base asserted, failure mapping, status→`importedCloudProviders` mapping; all #3525 tests pass unchanged.

## Tests run

- `apps/server`: `bun test src/` — **629 pass, 2 skip, 0 fail** · `pnpm typecheck` pass
- `apps/app`: `bun test --isolate` (sync-gateway, sync-triggers, reimport, credentials, cloud-providers-view, composer-model-controls) — **34 pass, 0 fail** · `pnpm typecheck` pass
- `OPENWORK_EVAL_APP_SPECS=1 vitest --project stack specs/cloud-provider-auto-import.slow.test.ts` — **passed** (96s, cold local `server()` + Docker MySQL)

## Notes for review

- Engine-global write scope is deliberate (matches cloud semantics from #3255): org providers are org-level — one definition per engine, one auth delivery path.
- In server mode #3525's per-provider `lastSyncError` stays empty; a persistent server-side Den failure is visible via the status endpoint's `lastRun` and surfaces as `providerAuthError` on settings open — richer per-provider mapping is a natural follow-up.
- The renderer's desktop-policy pre-import guard doesn't run on the server path; Den's per-member provider assignment (fetched with the member's own token) is the access control.