### PR TITLE
fix(den-api): build @openwork/types and @openwork/automations in the native build

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -6,6 +6,8 @@
     "dev": "pnpm run build:email && pnpm run build:install-config && pnpm run build:connect-link && pnpm run build:enterprise-mcp-client && OPENWORK_DEV_MODE=1 tsx watch src/main.ts",
     "dev:local": "pnpm run build:email && pnpm run build:install-config && pnpm run build:connect-link && pnpm run build:enterprise-mcp-client && OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/main.ts",
     "build": "node ./scripts/build.mjs",
+    "build:types": "pnpm --filter @openwork/types build",
+    "build:automations": "pnpm --filter @openwork/automations build",
     "build:email": "pnpm --filter @openwork/email build",
     "build:install-config": "pnpm --filter @openwork/install-config build",
     "build:connect-link": "pnpm --filter @openwork/connect-link build",

--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -109,6 +109,8 @@ function main() {
   writeGeneratedVersionFile(process.env.DEN_API_LATEST_APP_VERSION)
   cleanDist()
 
+  run(pnpmCommand, ["run", "build:types"])
+  run(pnpmCommand, ["run", "build:automations"])
   run(pnpmCommand, ["run", "build:connect-link"])
   run(pnpmCommand, ["run", "build:email"])
   run(pnpmCommand, ["run", "build:install-config"])


### PR DESCRIPTION
## Problem

Production den-api (Render native build, `/opt/render/project/src/...`) crashes at boot since #3466 shipped:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ee/apps/den-api/node_modules/@openwork/types/dist/automations.js'
imported from .../ee/apps/den-api/dist/routes/automations/index.js
```

This is why Automations is currently unusable in prod.

## Cause

#3466 added the `./automations` subpath to `@openwork/types` and the new `@openwork/automations` package. Both resolve their `node`/`default` export conditions to tsup-built `dist/` files — the first exports in these packages that require a build step. `packaging/docker/Dockerfile.den` was correctly updated to build them, but Render does not use that Dockerfile: it runs the native build (`ee/apps/den-api/scripts/build.mjs`), which pre-builds email/install-config/connect-link/enterprise-mcp-client/den-db but not these two packages. `tsc` cannot catch it (it resolves the `types` condition to `src/`), and bun/tsx tests resolve `bun`/`development` to `src/` — the failure only exists at plain-Node boot.

## Fix

Build `@openwork/types` then `@openwork/automations` (types first — automations depends on it) in `build.mjs`, with matching `build:*` scripts following the existing pattern. 4-line diff. Redundant-but-harmless for the Docker path.

## Validation

Build-tooling change — no app-runtime behavior change, so no testkit tape; verified by running the production build path directly:

- `pnpm install` — passed
- `rm -rf packages/types/dist packages/automations/dist && pnpm --dir ee/apps/den-api run build` — exit 0, both tsup builds ran
- `packages/types/dist/automations.js` and `packages/automations/dist/index.js` exist after build
- From `ee/apps/den-api`: `node --input-type=module -e "await import('@openwork/types/automations'); await import('@openwork/automations')"` — prints `resolve-ok` (reproduces the exact prod resolution; fails on current `dev`)

## After merge

Redeploy den-api on Render (manual redeploy lever added in `be9a95cea`). A follow-up draft PR adds a CI job so this class of break is caught on PRs.

cc @reachjalil
