### PR TITLE
ci: smoke den-api native build output (catches unbuilt workspace dist exports)

### DIFF
--- a/.github/workflows/den-api-native-build.yml
+++ b/.github/workflows/den-api-native-build.yml
@@ -1,0 +1,82 @@
+name: Den API Native Build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/den-api-native-build.yml"
+      - "ee/apps/den-api/**"
+      - "ee/packages/den-db/**"
+      - "packages/automations/**"
+      - "packages/connect-link/**"
+      - "packages/email/**"
+      - "packages/enterprise-mcp-client/**"
+      - "packages/install-config/**"
+      - "packages/types/**"
+      - "pnpm-lock.yaml"
+  push:
+    branches:
+      - "dev"
+    paths:
+      - ".github/workflows/den-api-native-build.yml"
+      - "ee/apps/den-api/**"
+      - "ee/packages/den-db/**"
+      - "packages/automations/**"
+      - "packages/connect-link/**"
+      - "packages/email/**"
+      - "packages/enterprise-mcp-client/**"
+      - "packages/install-config/**"
+      - "packages/types/**"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: den-api-native-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  native-build:
+    name: Build and smoke native output
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Den API native output
+        run: pnpm --dir ee/apps/den-api run build
+
+      - name: Smoke Node-condition workspace imports
+        working-directory: ee/apps/den-api
+        run: node --input-type=module -e "await import('@openwork/types/automations'); await import('@openwork/automations'); console.log('den-api node-condition imports resolve')"
+
+      - name: Assert built entry exists
+        run: test -s ee/apps/den-api/dist/main.js


### PR DESCRIPTION
## What / why

#3466 broke prod den-api at boot (`ERR_MODULE_NOT_FOUND` for `@openwork/types/dist/automations.js`) while every PR check stayed green:

- typecheck resolves the `types` export condition → `src/*.ts`
- bun tests resolve `bun` → `src/*.ts`
- tsx/dev + eval harness resolve `development` → `src/*.ts`
- the "Build openwork-den-api" job builds the **Docker** image, whose Dockerfile was patched in the same PR

Prod deploys via Render's **native** build (`scripts/build.mjs`), which nothing in CI exercises — and only a plain-Node boot resolves the `node` condition → `dist/*.js`. This job closes that gap: it runs the native build, then resolves `@openwork/types/automations` and `@openwork/automations` under Node's `node` condition from den-api's package context, and asserts `dist/main.js` exists.

## ⚠️ This job is red on this branch — by design

This branch is plain `dev`, which still has the live breakage. The failing run here **is the demonstration** that the backstop catches exactly this failure class. It goes green once #3527 (the prod fix) merges and this branch rebases.

## Open questions for review (cc @reachjalil)

1. Is the import-smoke approach right, or would you rather boot `dist/main.js` against a health check (heavier, needs env/DB stubs)?
2. Should the smoke enumerate dist-condition workspace deps dynamically instead of hardcoding the two current packages?
3. Path filters / triggers reasonable?

## Validation

Workflow-only change (no app runtime): `actionlint` passes (sole warning is the custom `blacksmith-4vcpu-ubuntu-2204` runner label, shared by existing workflows); every `uses:` action+version and the runner label are copied verbatim from `ci-tests.yml` / `den-db-check.yml`; concurrency follows the repo's `cancel-in-progress: true` convention.
