### PR TITLE
feat(testkit): resilience primitives for fresh-profile first sign-in coverage

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -78,6 +78,11 @@ export function selectStickyOpenworkPortWorkspace(requestedWorkspacePaths = [], 
   return "";
 }
 
+export function resolveEvalLocalServerDelayMs(env = process.env) {
+  const delayMs = Number(env.OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS);
+  return Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
+}
+
 export function commandMatchesPackagedSidecar(command, sidecarDirs = []) {
   const value = String(command ?? "");
   if (!sidecarDirs.some((dir) => String(dir ?? "").trim() && value.includes(dir))) {
@@ -1545,6 +1550,10 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   let inProcessServer = null;
 
   async function startOpenworkServer(options) {
+    const evalDelayMs = resolveEvalLocalServerDelayMs();
+    if (evalDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, evalDelayMs));
+    }
     const currentPort = openworkServerState.port;
     // Stop any previously running in-process server
     if (inProcessServer) {

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -9,6 +9,7 @@ import {
   commandMatchesPackagedSidecar,
   embeddedServerImportUrl,
   prioritizeWorkspacePaths,
+  resolveEvalLocalServerDelayMs,
   resolveOpenworkServerConfigPath,
   seedWorkspacePathsForEmbeddedServer,
   selectStickyOpenworkPortWorkspace,
@@ -60,6 +61,16 @@ describe("selectStickyOpenworkPortWorkspace", () => {
       selectStickyOpenworkPortWorkspace([], ["/workspace/from-server"]),
       "/workspace/from-server",
     );
+  });
+});
+
+describe("resolveEvalLocalServerDelayMs", () => {
+  it("enables only positive finite eval delays", () => {
+    assert.equal(resolveEvalLocalServerDelayMs({ OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS: "3000" }), 3000);
+    assert.equal(resolveEvalLocalServerDelayMs({ OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS: "0" }), 0);
+    assert.equal(resolveEvalLocalServerDelayMs({ OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS: "-1" }), 0);
+    assert.equal(resolveEvalLocalServerDelayMs({ OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS: "Infinity" }), 0);
+    assert.equal(resolveEvalLocalServerDelayMs({ OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS: "invalid" }), 0);
   });
 });
 

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -33,6 +33,8 @@ export interface DesktopOptions {
     requireSignin?: boolean;
   };
   env?: Record<string, string>;
+  /** Exact caller-owned Electron profile root, for restart scenarios. */
+  profileDir?: string;
   timeoutMs?: number;
 }
 
@@ -108,6 +110,7 @@ export async function desktop(opts: DesktopOptions = {}): Promise<DesktopHandle>
     host = opts.host ?? await resolveHost();
     handle = await host.spawnElectron(opts.name ?? "spec", {
       profile: "fresh",
+      profileDir: opts.profileDir,
       bootstrap: opts.bootstrap,
       env: opts.env,
     });

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -525,7 +525,14 @@ function surfacePorts(handle: SurfaceHandle): number[] {
 }
 
 export function createLocalHost(options: LocalHostOptions): DisposableHost {
-  const rootDir = options.rootDir ?? join(options.repoRoot, "evals", "results", ".surfaces");
+  // Surface profiles become the Electron process HOME. node-gyp/electron-rebuild
+  // generate Makefiles with unquoted include paths under that HOME, so a repo
+  // checkout on a path containing spaces breaks every native rebuild. The env
+  // override lets such machines park surfaces on a space-free path (e.g. /tmp).
+  const surfacesRootOverride = process.env.OPENWORK_EVAL_SURFACES_DIR?.trim();
+  const rootDir = options.rootDir ?? (surfacesRootOverride
+    ? surfacesRootOverride
+    : join(options.repoRoot, "evals", "results", ".surfaces"));
   const log = options.log;
   const spawnedSurfaces = new Set<SurfaceHandle>();
   const denPorts = new Set<number>();
@@ -629,8 +636,12 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
       const spawnEnvForChecks: NodeJS.ProcessEnv = { ...process.env, ...opts.env };
       if (insideContainerSandbox() && (spawnEnvForChecks.DISPLAY ?? "").trim().length === 0) spawnEnvForChecks.DISPLAY = ":99";
       await ensureDisplay(options.repoRoot, spawnEnvForChecks, log);
-      await clearStaleSurfaces(rootDir, log);
-      const profileRoot = join(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
+      if (opts.profileDir !== undefined && !opts.profileDir.trim()) {
+        throw new Error("Electron profileDir must not be empty.");
+      }
+      const callerOwnedProfile = opts.profileDir !== undefined;
+      if (!callerOwnedProfile) await clearStaleSurfaces(rootDir, log);
+      const profileRoot = opts.profileDir ?? join(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
       const paths = electronProfilePaths(profileRoot);
       await ensureElectronProfile(paths);
       await writeBootstrap(paths.bootstrapPath, opts.bootstrap);
@@ -671,7 +682,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         cdpUrl,
         pid: spawned.pid,
         profileDir: profileRoot,
-        meta: { vitePort: String(port), cdpPort: String(cdpPort), log: logPath },
+        meta: { vitePort: String(port), cdpPort: String(cdpPort), log: logPath, profileOwner: callerOwnedProfile ? "caller" : "host" },
       };
       spawnedSurfaces.add(handle);
       return handle;
@@ -751,7 +762,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         await killLocalPid(handle.pid, { log });
       }
       await disposeKnownPorts(handle);
-      if (handle.kind === "electron" && handle.profileDir) {
+      if (handle.kind === "electron" && handle.profileDir && handle.meta?.profileOwner !== "caller") {
         await rm(handle.profileDir, { recursive: true, force: true });
       }
       spawnedSurfaces.delete(handle);

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -4,6 +4,8 @@ export type { SurfaceHandle, SurfaceKind } from "@openwork/cdp";
 
 export interface ElectronSurfaceOptions {
   profile?: "fresh" | "shared";
+  /** Exact caller-owned profile root. Local hosts preserve it on disposal. */
+  profileDir?: string;
   bootstrap?: {
     baseUrl: string;
     apiBaseUrl?: string;

--- a/evals/packages/testkit/src/app.ts
+++ b/evals/packages/testkit/src/app.ts
@@ -10,8 +10,13 @@ export interface AppOptions {
   place: Place;
   host?: Host;
   model?: string;
+  /** Reuse this caller-owned local Electron profile root instead of creating one. */
+  profileDir?: string;
+  /** Eval-only delay before the desktop starts its embedded OpenWork server. */
+  localServerDelayMs?: number;
 }
 
+/** A signed-in desktop; its Electron profile root is available at handle.profileDir. */
 export interface App extends DesktopHandle {
   workspaceId: string;
 }
@@ -22,15 +27,21 @@ export async function app(options: AppOptions): Promise<App> {
     const available = ["admin", ...Object.keys(options.den.members)].join(", ");
     throw new Error(`Unknown Den member ${JSON.stringify(options.as)}. Available: ${available}`);
   }
+  const env: Record<string, string> = {};
+  if (options.model) env.OPENWORK_EVAL_MODEL = options.model;
+  if (options.localServerDelayMs !== undefined) {
+    env.OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS = String(options.localServerDelayMs);
+  }
   const surface = await desktop({
     name: `testkit-${options.as}`,
     host: options.host ?? options.place.host(),
+    profileDir: options.profileDir,
     bootstrap: {
       baseUrl: options.den.ref.webUrl,
       apiBaseUrl: options.den.ref.webUrl,
       requireSignin: false,
     },
-    env: options.model ? { OPENWORK_EVAL_MODEL: options.model } : undefined,
+    env: Object.keys(env).length > 0 ? env : undefined,
   });
   try {
     // Workspace first, then the org sign-in: the signed-in org shell offers no

--- a/evals/packages/testkit/src/eventually.ts
+++ b/evals/packages/testkit/src/eventually.ts
@@ -1,0 +1,51 @@
+export interface EventuallyOptions<T> {
+  within: number;
+  intervalMs?: number;
+  label?: string;
+  until?: (value: T) => boolean;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describe(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}
+
+export async function eventually<T>(
+  probe: () => Promise<T> | T,
+  options: EventuallyOptions<T>,
+): Promise<T> {
+  const intervalMs = options.intervalMs ?? 500;
+  const until = options.until ?? ((value: T) => Boolean(value));
+  const deadline = Date.now() + options.within;
+  let lastValue: T | undefined;
+  let lastError: unknown;
+  let hasValue = false;
+
+  while (true) {
+    try {
+      lastValue = await probe();
+      hasValue = true;
+      lastError = undefined;
+      if (until(lastValue)) return lastValue;
+    } catch (error) {
+      lastError = error;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const label = options.label ?? "condition";
+      const valueDetail = hasValue ? `; last value: ${describe(lastValue)}` : "";
+      const errorDetail = lastError === undefined ? "" : `; last error: ${describe(lastError instanceof Error ? lastError.message : lastError)}`;
+      throw new Error(`Timed out waiting for ${label} after ${options.within}ms${valueDetail}${errorDetail}`);
+    }
+    await sleep(Math.min(intervalMs, remaining));
+  }
+}

--- a/evals/packages/testkit/src/faults.ts
+++ b/evals/packages/testkit/src/faults.ts
@@ -94,20 +94,28 @@ function forward(
   requests: FaultRequest[],
 ): void {
   const path = incoming.url ?? "/";
-  const target = new URL(path, upstream);
   const onResponse = (response: IncomingMessage): void => {
     const status = response.statusCode ?? 502;
     requests.push({ method: incoming.method ?? "GET", path, status, faulted, at: Date.now() });
     writeUpstreamResponse(client, status, response.statusMessage, forwardedHeaders(response.headers));
     response.pipe(client);
   };
+  // Pin the upstream origin and take only the path from the caller. An
+  // absolute-form request target (legal for proxy requests) would otherwise
+  // steer this fetch at an arbitrary host, because `new URL(absolute, base)`
+  // discards the base.
+  const requested = new URL(path, "http://request-target.invalid");
   const options = {
+    protocol: upstream.protocol,
+    hostname: upstream.hostname,
+    port: upstream.port,
+    path: `${requested.pathname}${requested.search}`,
     method: incoming.method ?? "GET",
-    headers: forwardedHeaders(incoming.headers, target.host),
+    headers: forwardedHeaders(incoming.headers, upstream.host),
   };
-  const outbound = target.protocol === "https:"
-    ? httpsRequest(target, options, onResponse)
-    : httpRequest(target, options, onResponse);
+  const outbound = upstream.protocol === "https:"
+    ? httpsRequest(options, onResponse)
+    : httpRequest(options, onResponse);
   outbound.on("error", (error) => {
     if (client.headersSent) {
       client.destroy(error);

--- a/evals/packages/testkit/src/faults.ts
+++ b/evals/packages/testkit/src/faults.ts
@@ -1,0 +1,181 @@
+import { createServer, request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { setTimeout as delay } from "node:timers/promises";
+import { allocateFreePort } from "@openwork/cdp";
+import type { IncomingHttpHeaders, IncomingMessage, OutgoingHttpHeaders, Server, ServerResponse } from "node:http";
+import type { DenRef } from "@openwork/behaviors";
+
+export interface FaultRequest {
+  method: string;
+  path: string;
+  status: number;
+  faulted: boolean;
+  at: number;
+}
+
+export interface FaultProxy extends AsyncDisposable {
+  ref: DenRef;
+  faults: {
+    status(pathPrefix: string, statusCode: number, opts?: { times?: number; body?: unknown }): void;
+    latency(pathPrefix: string, delayMs: number, opts?: { times?: number }): void;
+    clear(): void;
+  };
+  requests: FaultRequest[];
+}
+
+interface RuleBase {
+  pathPrefix: string;
+  remaining: number;
+}
+
+type FaultRule =
+  | (RuleBase & { kind: "status"; statusCode: number; body: unknown })
+  | (RuleBase & { kind: "latency"; delayMs: number });
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function headerText(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value.join(",") : value ?? "";
+}
+
+function forwardedHeaders(source: IncomingHttpHeaders, host?: string): OutgoingHttpHeaders {
+  const nominated = new Set(headerText(source.connection).split(",").map((name) => name.trim().toLowerCase()).filter(Boolean));
+  const headers: OutgoingHttpHeaders = {};
+  for (const [name, value] of Object.entries(source)) {
+    if (value === undefined || HOP_BY_HOP_HEADERS.has(name) || nominated.has(name)) continue;
+    headers[name] = value;
+  }
+  if (host) headers.host = host;
+  return headers;
+}
+
+function times(value: number | undefined): number {
+  if (value === undefined) return 1;
+  if (!Number.isInteger(value) || value < 0) throw new Error(`Fault times must be a non-negative integer, got ${value}.`);
+  return value;
+}
+
+function takeRule(rules: FaultRule[], path: string): FaultRule | null {
+  for (const rule of rules) {
+    if (rule.remaining <= 0 || !path.startsWith(rule.pathPrefix)) continue;
+    rule.remaining -= 1;
+    return rule;
+  }
+  return null;
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+    server.closeAllConnections();
+  });
+}
+
+function writeUpstreamResponse(client: ServerResponse, status: number, message: string | undefined, headers: OutgoingHttpHeaders): void {
+  if (message) client.writeHead(status, message, headers);
+  else client.writeHead(status, headers);
+}
+
+function forward(
+  incoming: IncomingMessage,
+  client: ServerResponse,
+  upstream: URL,
+  faulted: boolean,
+  requests: FaultRequest[],
+): void {
+  const path = incoming.url ?? "/";
+  const target = new URL(path, upstream);
+  const onResponse = (response: IncomingMessage): void => {
+    const status = response.statusCode ?? 502;
+    requests.push({ method: incoming.method ?? "GET", path, status, faulted, at: Date.now() });
+    writeUpstreamResponse(client, status, response.statusMessage, forwardedHeaders(response.headers));
+    response.pipe(client);
+  };
+  const options = {
+    method: incoming.method ?? "GET",
+    headers: forwardedHeaders(incoming.headers, target.host),
+  };
+  const outbound = target.protocol === "https:"
+    ? httpsRequest(target, options, onResponse)
+    : httpRequest(target, options, onResponse);
+  outbound.on("error", (error) => {
+    if (client.headersSent) {
+      client.destroy(error);
+      return;
+    }
+    requests.push({ method: incoming.method ?? "GET", path, status: 502, faulted, at: Date.now() });
+    client.writeHead(502, { "content-type": "application/json" });
+    client.end(JSON.stringify({ error: error.message }));
+  });
+  incoming.on("aborted", () => outbound.destroy());
+  incoming.pipe(outbound);
+}
+
+export async function faultProxy(ref: DenRef): Promise<FaultProxy> {
+  const upstream = new URL(ref.webUrl);
+  const port = await allocateFreePort();
+  const rules: FaultRule[] = [];
+  const requests: FaultRequest[] = [];
+  const server = createServer((incoming, response) => {
+    void (async () => {
+      const path = incoming.url ?? "/";
+      const rule = takeRule(rules, path);
+      if (rule?.kind === "status") {
+        const body = JSON.stringify(rule.body ?? { error: `Injected HTTP ${rule.statusCode}` });
+        requests.push({ method: incoming.method ?? "GET", path, status: rule.statusCode, faulted: true, at: Date.now() });
+        response.writeHead(rule.statusCode, {
+          "access-control-allow-origin": "*",
+          "content-length": Buffer.byteLength(body),
+          "content-type": "application/json",
+        });
+        response.end(body);
+        return;
+      }
+      if (rule?.kind === "latency") await delay(rule.delayMs);
+      forward(incoming, response, upstream, rule !== null, requests);
+    })().catch((error: unknown) => {
+      if (response.headersSent) {
+        response.destroy(error instanceof Error ? error : undefined);
+        return;
+      }
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  const url = `http://127.0.0.1:${port}`;
+  let disposed = false;
+  return {
+    ref: { apiUrl: `${url}/api/den`, webUrl: url },
+    faults: {
+      status(pathPrefix, statusCode, opts = {}) {
+        rules.push({ kind: "status", pathPrefix, statusCode, body: opts.body, remaining: times(opts.times) });
+      },
+      latency(pathPrefix, delayMs, opts = {}) {
+        rules.push({ kind: "latency", pathPrefix, delayMs, remaining: times(opts.times) });
+      },
+      clear() {
+        rules.length = 0;
+      },
+    },
+    requests,
+    async [Symbol.asyncDispose](): Promise<void> {
+      if (disposed) return;
+      disposed = true;
+      await closeServer(server);
+    },
+  };
+}

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -46,8 +46,13 @@ function wrapTestApi<T extends (...args: never[]) => unknown>(api: T): T {
 
 export const test = wrapTestApi(fixtureTest);
 
+export { createDesktopHandoffGrant, signInDesktopAs } from "@openwork/behaviors";
+export type { DesktopHandle } from "@openwork/hosts";
 export * from "./app.ts";
+export * from "./eventually.ts";
+export * from "./faults.ts";
 export * from "./mock.ts";
 export * from "./needs.ts";
 export * from "./place.ts";
 export * from "./server.ts";
+export * from "./state.ts";

--- a/evals/packages/testkit/src/server.ts
+++ b/evals/packages/testkit/src/server.ts
@@ -277,6 +277,13 @@ async function createMember(
   return member;
 }
 
+export async function inviteMember(den: Den, key: string, person?: PersonShape): Promise<DenSession> {
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const member = await createMember(den.ref, den.admin, personDefaults(key, person, runId), den.database?.url);
+  den.members[key] = member;
+  return member;
+}
+
 async function provisionOrganization(
   ref: DenRef,
   shape: OrgShape,

--- a/evals/packages/testkit/src/state.ts
+++ b/evals/packages/testkit/src/state.ts
@@ -1,0 +1,144 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { evalIn } from "@openwork/behaviors";
+import { electronProfilePaths } from "@openwork/hosts";
+import type { Surface } from "@openwork/cdp";
+
+export interface DenClientState {
+  authTokenPresent: boolean;
+  activeOrgId: string | null;
+  activeOrgSlug: string | null;
+  activeOrgName: string | null;
+}
+
+export interface ConnectState {
+  ok: boolean;
+  connectEnabled: boolean | null;
+  raw: unknown;
+}
+
+export interface ConnectStateFile {
+  status: "missing" | "available" | "invalid";
+  connectEnabled: boolean | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function errorCode(error: unknown): string | null {
+  return isRecord(error) && typeof error.code === "string" ? error.code : null;
+}
+
+export async function readDenClientState(app: Surface): Promise<DenClientState> {
+  const value = await evalIn(app, `(() => ({
+    authTokenPresent: Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim()),
+    activeOrgId: (localStorage.getItem("openwork.den.activeOrgId") ?? "").trim() || null,
+    activeOrgSlug: (localStorage.getItem("openwork.den.activeOrgSlug") ?? "").trim() || null,
+    activeOrgName: (localStorage.getItem("openwork.den.activeOrgName") ?? "").trim() || null,
+  }))()`);
+  if (!isRecord(value)) throw new Error("The desktop returned an invalid Den client state.");
+  return {
+    authTokenPresent: value.authTokenPresent === true,
+    activeOrgId: nullableString(value.activeOrgId),
+    activeOrgSlug: nullableString(value.activeOrgSlug),
+    activeOrgName: nullableString(value.activeOrgName),
+  };
+}
+
+export async function readConnectState(app: Surface): Promise<ConnectState> {
+  const value = await evalIn(app, `(async () => {
+    // Resolve the local server the same way the app does: live runtime info
+    // from the Electron bridge first (loopback port + token are ephemeral per
+    // boot), then the web-mode localStorage overrides as a fallback.
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    if (!baseUrl || !token) {
+      return { ok: false, connectEnabled: null, raw: { error: "Local server credentials are unavailable." } };
+    }
+    try {
+      const response = await fetch(
+        baseUrl + "/experimental/connect/state",
+        { headers: { Authorization: "Bearer " + token } },
+      );
+      const text = await response.text();
+      let raw = text;
+      try { raw = text ? JSON.parse(text) : null; } catch {}
+      return {
+        ok: response.ok,
+        connectEnabled: raw && typeof raw === "object" && typeof raw.connectEnabled === "boolean"
+          ? raw.connectEnabled
+          : null,
+        raw,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        connectEnabled: null,
+        raw: { error: error instanceof Error ? error.message : String(error) },
+      };
+    }
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value)) throw new Error("The desktop returned an invalid Connect state.");
+  return {
+    ok: value.ok === true,
+    connectEnabled: typeof value.connectEnabled === "boolean" ? value.connectEnabled : null,
+    raw: value.raw,
+  };
+}
+
+/** Reads the caller-visible profile filesystem; remote-hosted apps are unsupported. */
+export async function readConnectStateFile(app: Surface): Promise<ConnectStateFile> {
+  if (app.handle.hostKind !== "local") {
+    throw new Error(`readConnectStateFile only supports local app profiles; received ${app.handle.hostKind}.`);
+  }
+  if (!app.handle.profileDir) throw new Error("The local app did not expose its profile directory.");
+  // The local server persists runtime state next to its config file
+  // (`openworkConfigDir()`). The dev-mode desktop redirects that XDG config
+  // root under its Electron userData dir (`<userData>/openwork-dev-data/xdg/config`),
+  // so probe the known layouts in order.
+  const paths = electronProfilePaths(app.handle.profileDir);
+  const candidates = [
+    join(paths.userDataDir, "openwork-dev-data", "xdg", "config", "openwork", "connect-state.json"),
+    join(paths.configHome, "openwork", "connect-state.json"),
+    join(paths.homeDir, ".config", "openwork", "connect-state.json"),
+  ];
+  let text: string | null = null;
+  for (const path of candidates) {
+    try {
+      text = await readFile(path, "utf8");
+      break;
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+  }
+  if (text === null) return { status: "missing", connectEnabled: null };
+  try {
+    const value: unknown = JSON.parse(text);
+    if (!isRecord(value) || typeof value.connectEnabled !== "boolean") {
+      return { status: "invalid", connectEnabled: null };
+    }
+    return { status: "available", connectEnabled: value.connectEnabled };
+  } catch {
+    return { status: "invalid", connectEnabled: null };
+  }
+}

--- a/evals/packages/testkit/test/eventually.test.ts
+++ b/evals/packages/testkit/test/eventually.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { eventually, sleep } from "../src/eventually.ts";
+
+test("eventually polls until the default truthy condition passes", async () => {
+  let attempts = 0;
+  const value = await eventually(() => {
+    attempts += 1;
+    return attempts >= 3 ? "ready" : "";
+  }, { within: 100, intervalMs: 1 });
+
+  assert.equal(value, "ready");
+  assert.equal(attempts, 3);
+});
+
+test("eventually supports custom conditions and asynchronous probes", async () => {
+  let value = 0;
+  const result = await eventually(async () => {
+    await sleep(1);
+    value += 1;
+    return value;
+  }, { within: 100, intervalMs: 1, until: (candidate) => candidate === 2 });
+
+  assert.equal(result, 2);
+});
+
+test("eventually reports its label and last value on timeout", async () => {
+  await assert.rejects(
+    eventually(() => ({ ready: false }), {
+      within: 5,
+      intervalMs: 1,
+      label: "fake readiness",
+      until: (value) => value.ready,
+    }),
+    /Timed out waiting for fake readiness.*last value: \{"ready":false\}/,
+  );
+});
+
+test("eventually reports the last probe error on timeout", async () => {
+  await assert.rejects(
+    eventually(() => {
+      throw new Error("fake failure");
+    }, { within: 5, intervalMs: 1, label: "erroring probe" }),
+    /Timed out waiting for erroring probe.*last error: "fake failure"/,
+  );
+});

--- a/evals/packages/testkit/test/faults.test.ts
+++ b/evals/packages/testkit/test/faults.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import { denFetch } from "@openwork/behaviors";
+import { faultProxy } from "../src/faults.ts";
+import type { Server } from "node:http";
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address !== null) resolve(address.port);
+      else reject(new Error("Upstream test server did not expose a port."));
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}
+
+test("faultProxy consumes status and latency rules before passing through", async () => {
+  const upstream = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "application/json", "x-upstream": "yes" });
+    response.end(JSON.stringify({ method: request.method, path: request.url }));
+  });
+  const port = await listen(upstream);
+  try {
+    await using proxy = await faultProxy({
+      apiUrl: `http://127.0.0.1:${port}`,
+      webUrl: `http://127.0.0.1:${port}`,
+    });
+    proxy.faults.status("/api/den/flaky", 429, { times: 2, body: { error: "slow down" } });
+
+    const first = await fetch(`${proxy.ref.webUrl}/api/den/flaky`);
+    const second = await fetch(`${proxy.ref.webUrl}/api/den/flaky`);
+    const passed = await fetch(`${proxy.ref.webUrl}/api/den/flaky`);
+
+    assert.equal(first.status, 429);
+    assert.deepEqual(await first.json(), { error: "slow down" });
+    assert.equal(second.status, 429);
+    assert.equal(passed.status, 200);
+    assert.equal(passed.headers.get("x-upstream"), "yes");
+    assert.deepEqual(await passed.json(), { method: "GET", path: "/api/den/flaky" });
+
+    proxy.faults.latency("/delayed", 25);
+    const startedAt = Date.now();
+    const delayed = await fetch(`${proxy.ref.webUrl}/delayed`);
+    assert.equal(delayed.status, 200);
+    assert(Date.now() - startedAt >= 15);
+    assert.equal((await fetch(`${proxy.ref.webUrl}/delayed`)).status, 200);
+    const behaviorResult = await denFetch(proxy.ref, "/behavior");
+    assert.equal(behaviorResult.response.status, 200);
+    assert.deepEqual(behaviorResult.body, { method: "GET", path: "/api/den/behavior" });
+
+    assert.deepEqual(
+      proxy.requests.map(({ path, status, faulted }) => ({ path, status, faulted })),
+      [
+        { path: "/api/den/flaky", status: 429, faulted: true },
+        { path: "/api/den/flaky", status: 429, faulted: true },
+        { path: "/api/den/flaky", status: 200, faulted: false },
+        { path: "/delayed", status: 200, faulted: true },
+        { path: "/delayed", status: 200, faulted: false },
+        { path: "/api/den/behavior", status: 200, faulted: false },
+      ],
+    );
+  } finally {
+    await close(upstream);
+  }
+});
+
+test("faultProxy clear removes pending rules", async () => {
+  const upstream = createServer((_request, response) => {
+    response.writeHead(204);
+    response.end();
+  });
+  const port = await listen(upstream);
+  try {
+    await using proxy = await faultProxy({
+      apiUrl: `http://127.0.0.1:${port}`,
+      webUrl: `http://127.0.0.1:${port}`,
+    });
+    proxy.faults.status("/", 500, { times: 3 });
+    proxy.faults.clear();
+
+    assert.equal((await fetch(proxy.ref.webUrl)).status, 204);
+    assert.equal(proxy.requests[0]?.faulted, false);
+  } finally {
+    await close(upstream);
+  }
+});

--- a/evals/specs/first-signin-fresh-profile.slow.test.ts
+++ b/evals/specs/first-signin-fresh-profile.slow.test.ts
@@ -1,0 +1,106 @@
+import { expect } from "vitest";
+import {
+  app,
+  eventually,
+  faultProxy,
+  inviteMember,
+  localMysqlIsRunning,
+  needs,
+  readConnectState,
+  readConnectStateFile,
+  readDenClientState,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const orgsPath = "/api/den/v1/me/orgs";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "fresh-profile first sign-in healing skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "fresh-profile first sign-in healing skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "fresh-profile first sign-in healing skipped — needs MySQL on 127.0.0.1:3306"
+      : "fresh-profile first sign-in heals organization and Connect state after transient faults";
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({
+    place,
+    org: {
+      name: "First Signin Heal",
+      admin: {
+        email: `first-signin-admin-${Date.now()}@openwork.test`,
+        name: "First Signin Admin",
+        password: "OpenWorkEval123!",
+      },
+    },
+  });
+  await inviteMember(den, "fresh", {
+    email: `first-signin-member-${Date.now()}@openwork.test`,
+    name: "Fresh Profile Member",
+    password: "OpenWorkEval123!",
+  });
+  await using proxy = await faultProxy(den.ref);
+  proxy.faults.status(orgsPath, 429, { times: 3 });
+
+  await using freshApp = await app({
+    den: { ...den, ref: proxy.ref },
+    as: "fresh",
+    place,
+    localServerDelayMs: 3_000,
+  });
+
+  const denState = await eventually(() => readDenClientState(freshApp), {
+    within: 60_000,
+    label: "fresh profile active organization",
+    until: (state) => Boolean(state.activeOrgId),
+  });
+  expect(denState.authTokenPresent).toBe(true);
+  expect(denState.activeOrgId).toBeTruthy();
+  evidence.fact(
+    "The fresh profile converged on an active organization",
+    `The handoff persisted an auth token and active organization ${denState.activeOrgId}.`,
+    true,
+  );
+
+  const connectState = await eventually(() => readConnectState(freshApp), {
+    within: 90_000,
+    label: "local server Connect state",
+    until: (state) => state.connectEnabled === true,
+  });
+  expect(connectState.ok).toBe(true);
+  evidence.fact(
+    "Connect converged after the delayed local server start",
+    "The authenticated local-server state endpoint reported connectEnabled=true.",
+    true,
+  );
+
+  if (freshApp.handle.hostKind === "local") {
+    const fileState = await eventually(() => readConnectStateFile(freshApp), {
+      within: 30_000,
+      label: "persisted Connect state file",
+      until: (state) => state.status === "available" && state.connectEnabled === true,
+    });
+    expect(fileState).toEqual({ status: "available", connectEnabled: true });
+    evidence.fact(
+      "Connect persisted to the fresh profile",
+      "The profile's connect-state.json reports connectEnabled=true.",
+      true,
+    );
+  }
+
+  const faultedRequests = await eventually(
+    () => proxy.requests.filter((request) => request.path.startsWith(orgsPath) && request.status === 429 && request.faulted),
+    { within: 60_000, label: "faulted organization request", until: (requests) => requests.length > 0 },
+  );
+  expect(faultedRequests.length).toBeGreaterThan(0);
+  evidence.fact(
+    "The organization request fault burst was exercised",
+    `${faultedRequests.length} observed ${orgsPath} request(s) received the injected HTTP 429.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Why

The Go Autonomous onboarding incident (fresh invited member → no org, Connect stranded false) was invisible to our test infrastructure: no spec could express "fresh profile + transient fault + convergence." These primitives make that whole bug class testable by agents in ~30 lines.

## What

New `@openwork/testkit` surface:
- **`eventually(probe, { within, until, intervalMs, label })`** — bounded convergence assertion with last-value/error diagnostics; plus `sleep`.
- **`faultProxy(den.ref)`** — reverse proxy in front of a real Den: `faults.status(prefix, 429, {times})`, `faults.latency(prefix, ms)`, full request log with `faulted` attribution; hand `{...den, ref: proxy.ref}` to `app()`.
- **State readers** — `readDenClientState(app)` (den localStorage), `readConnectState(app)` (authenticated local-server `GET /experimental/connect/state`, resolved through the same Electron bridge the app uses), `readConnectStateFile(app)` (persisted `connect-state.json` on disk, dev-mode + XDG layouts).
- **`inviteMember(den, key)`** — real invitation flow post-boot; result usable with `app({ as: key })`.
- **`app({ profileDir })`** — boot on a caller-owned profile (restart scenarios); caller-owned profiles survive disposal. **`app({ localServerDelayMs })`** — opens the local-server cold-start window via an eval-only, guard-tested product env knob (`OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS`, inert unless set).
- **`OPENWORK_EVAL_SURFACES_DIR`** — surfaces root override; node-gyp/electron-rebuild break on checkout paths containing spaces, this parks profiles on a space-free path.
- Re-exports `signInDesktopAs` / `createDesktopHandoffGrant`.

## Proof spec

`evals/specs/first-signin-fresh-profile.slow.test.ts` — fresh profile + 429 burst on `/api/den/v1/me/orgs` + 3s delayed local server → invited member's first sign-in converges: active org persisted, Connect true via authenticated endpoint AND on-disk `connect-state.json`, and the fault burst provably fired (negative half via proxy request log). This directly regression-guards #3503/#3507.

## Tests (commands + results)

- `OPENWORK_EVAL_SURFACES_DIR=/tmp/openwork-eval-surfaces OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/first-signin-fresh-profile.slow.test.ts` — **PASSED 1/1** (61s, real Den on local MySQL + real Electron). Evidence tape recorded by the run.
- `pnpm --dir evals test` — 147/147 pass (incl. new eventually + faults unit suites).
- `pnpm --dir evals run spec` (pr lane) — 6 passed, 1 skipped.
- `apps/desktop`: `pnpm test` — 178 pass, 1 skip (incl. new delay-guard test).
- Stack-lane collection compiles all 30 spec files.