### PR TITLE
fix(desktop): clearing the Den brand icon never resets the macOS dock icon

### DIFF
--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -26,7 +26,7 @@ import {
   setDenBootstrapConfig,
   type DenDesktopConfig,
 } from "../../../app/lib/den";
-import { applyBrandAppName, applyBrandIcon } from "../../../app/lib/desktop";
+import { applyBrandAppName, applyBrandIcon, getBrandIconState } from "../../../app/lib/desktop";
 import { createOpenworkServerClient } from "../../../app/lib/openwork-server";
 import {
   denSessionUpdatedEvent,
@@ -38,6 +38,7 @@ import { useDenAuth } from "./den-auth-provider";
 import {
   bootstrapBrandingFromDesktopConfig,
   bootstrapBrandingNeedsSync,
+  brandIconReconcileAction,
 } from "./workspace-branding-restart";
 
 export type DesktopConfigStore = {
@@ -178,6 +179,44 @@ type DesktopConfigProviderProps = {
   children: ReactNode;
 };
 
+// Rewrites desktop-bootstrap.json branding to match `normalizedConfig` so a
+// cleared wordmark/icon cannot resurrect from the install/connect snapshot on
+// the next relaunch. No-op when the bootstrap already matches.
+function syncBootstrapBranding(normalizedConfig: DenDesktopConfig): void {
+  if (!isDesktopRuntime()) return;
+  const bootstrap = readDenBootstrapConfig();
+  if (!bootstrapBrandingNeedsSync(bootstrap, normalizedConfig)) return;
+  const branding = bootstrapBrandingFromDesktopConfig(normalizedConfig);
+  void setDenBootstrapConfig(
+    {
+      ...bootstrap,
+      brandAppName: branding.brandAppName,
+      brandLogoUrl: branding.brandLogoUrl,
+      brandIconUrl: branding.brandIconUrl,
+    },
+    { dispatchSettingsChanged: false },
+  ).catch(() => undefined);
+}
+
+// Level-based safety net behind the edge-triggered config diff: the shell
+// (Electron main) restores its cached/bootstrap brand icon on every launch,
+// so when a clear's edge is missed (stale localStorage cache, failed IPC,
+// org/base-URL switch changing the cache key), nothing would ever tell the
+// shell to reset and the branded icon would persist forever. After every
+// fresh config fetch, compare the shell's applied state to the config and
+// re-assert the expected icon plus the bootstrap branding snapshot.
+async function reconcileShellBranding(latestConfig: DenDesktopConfig): Promise<void> {
+  if (!isDesktopRuntime()) return;
+  const normalizedConfig = normalizeDenDesktopConfig(latestConfig);
+  syncBootstrapBranding(normalizedConfig);
+  const action = brandIconReconcileAction(normalizedConfig, await getBrandIconState());
+  if (!action) return;
+  const result = await applyBrandIcon(action.apply);
+  if (!result.ok) {
+    console.warn(`[brand-icon] Desktop icon reconcile was not applied: ${result.reason ?? "unknown failure"}`);
+  }
+}
+
 type DesktopConfigState = {
   config: DenDesktopConfig;
   loading: boolean;
@@ -245,20 +284,8 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     const shouldSyncBootstrapBranding = actions.some((action) =>
       isBootstrapBrandingActionItem(action.item),
     );
-    if (shouldSyncBootstrapBranding && isDesktopRuntime()) {
-      const bootstrap = readDenBootstrapConfig();
-      if (bootstrapBrandingNeedsSync(bootstrap, normalizedConfig)) {
-        const branding = bootstrapBrandingFromDesktopConfig(normalizedConfig);
-        void setDenBootstrapConfig(
-          {
-            ...bootstrap,
-            brandAppName: branding.brandAppName,
-            brandLogoUrl: branding.brandLogoUrl,
-            brandIconUrl: branding.brandIconUrl,
-          },
-          { dispatchSettingsChanged: false },
-        ).catch(() => undefined);
-      }
+    if (shouldSyncBootstrapBranding) {
+      syncBootstrapBranding(normalizedConfig);
     }
 
     currentDesktopConfigRef.current = normalizedConfig;
@@ -273,6 +300,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (import.meta.env.DEV && requireFresh && devRefreshDesktopConfigRef.current) {
       const nextConfig = devRefreshDesktopConfigRef.current;
       applyDesktopConfigActions(nextConfig);
+      void reconcileShellBranding(nextConfig).catch(() => undefined);
       return nextConfig;
     }
 
@@ -307,6 +335,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
       writeCachedDesktopConfig(cacheKey, nextConfig);
       applyDesktopConfigActions(nextConfig);
+      void reconcileShellBranding(nextConfig).catch(() => undefined);
       return nextConfig;
     } catch (error) {
       if (currentRun !== refreshRunRef.current) {

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
@@ -9,6 +9,7 @@ declare const expect: (value: unknown) => {
 import {
   bootstrapBrandingFromDesktopConfig,
   bootstrapBrandingNeedsSync,
+  brandIconReconcileAction,
   hasWorkspaceBranding,
   workspaceBrandingFingerprint,
 } from "./workspace-branding-restart";
@@ -61,5 +62,29 @@ describe("workspace branding restart", () => {
       {},
       { brandLogoUrl: "https://example.com/logo.png" },
     )).toBe(true);
+  });
+
+  test("reconcile clears a shell icon the org no longer configures", () => {
+    expect(brandIconReconcileAction({}, { applied: true })).toEqual({ apply: null });
+  });
+
+  test("reconcile applies a configured icon the shell never applied", () => {
+    expect(brandIconReconcileAction(
+      { brandIconUrl: "https://example.com/icon.png" },
+      { applied: false },
+    )).toEqual({ apply: "https://example.com/icon.png" });
+  });
+
+  test("reconcile is a no-op when the shell already matches the config", () => {
+    expect(brandIconReconcileAction({}, { applied: false })).toBe(null);
+    expect(brandIconReconcileAction(
+      { brandIconUrl: "https://example.com/icon.png" },
+      { applied: true },
+    )).toBe(null);
+  });
+
+  test("reconcile is a no-op without a shell bridge", () => {
+    expect(brandIconReconcileAction({}, null)).toBe(null);
+    expect(brandIconReconcileAction({ brandIconUrl: "https://example.com/icon.png" }, null)).toBe(null);
   });
 });

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
@@ -1,3 +1,4 @@
+import type { BrandIconState } from "../../../app/lib/desktop-types";
 import type { DenBootstrapConfig, DenDesktopConfig } from "../../../app/lib/den";
 
 const BRANDING_KEYS = [
@@ -55,4 +56,27 @@ export function bootstrapBrandingNeedsSync(
 ): boolean {
   const next = bootstrapBrandingFromDesktopConfig(config);
   return BOOTSTRAP_BRANDING_KEYS.some((key) => (bootstrap[key] ?? null) !== next[key]);
+}
+
+/**
+ * Level-based reconcile between a fresh org desktop config and the shell's
+ * applied brand-icon state. The provider's config diff is edge-triggered, but
+ * the shell restores its cached/bootstrap icon at every launch — so a clear
+ * whose edge was missed (stale localStorage cache, failed IPC, org switch)
+ * would otherwise never be retried and the branded icon would stick forever.
+ *
+ * Returns the URL to apply (`{ apply: string | null }`, where null means
+ * "reset to the stock icon"), or null when the shell already matches. A
+ * mismatch between two applied URLs is left to the edge diff, which owns
+ * config-change transitions.
+ */
+export function brandIconReconcileAction(
+  config: Pick<DenDesktopConfig, "brandIconUrl">,
+  state: Pick<BrandIconState, "applied"> | null,
+): { apply: string | null } | null {
+  if (!state) return null;
+  const configuredIconUrl = typeof config.brandIconUrl === "string" ? config.brandIconUrl : null;
+  if (configuredIconUrl !== null && !state.applied) return { apply: configuredIconUrl };
+  if (configuredIconUrl === null && state.applied) return { apply: null };
+  return null;
 }

--- a/apps/desktop/electron/brand-icon-darwin.mjs
+++ b/apps/desktop/electron/brand-icon-darwin.mjs
@@ -1,0 +1,14 @@
+// macOS dock icon reset for cleared organization brand icons.
+//
+// Packaged macOS builds ship the application icon only inside the .app bundle
+// (electron-builder `mac.icon`), so unlike dev/Linux/Windows there is no loose
+// image file on disk to re-apply when an organization clears its brand icon.
+// Electron's dock.setIcon treats `null` as "restore the bundle icon from
+// Info.plist" (browser_mac.mm handles IsNull() explicitly), which is exactly
+// the stock icon we want back.
+export function resetMacDockIcon(dock, defaultImage) {
+  if (!dock) return { ok: false, reason: "dock-unavailable" };
+  const image = defaultImage && !defaultImage.isEmpty() ? defaultImage : null;
+  dock.setIcon(image);
+  return { ok: true };
+}

--- a/apps/desktop/electron/brand-icon-darwin.test.mjs
+++ b/apps/desktop/electron/brand-icon-darwin.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resetMacDockIcon } from "./brand-icon-darwin.mjs";
+
+function fakeDock() {
+  const calls = [];
+  return {
+    calls,
+    setIcon(image) {
+      calls.push(image);
+    },
+  };
+}
+
+test("re-applies the loose default icon when one exists (dev builds)", () => {
+  const dock = fakeDock();
+  const image = { isEmpty: () => false };
+
+  assert.deepEqual(resetMacDockIcon(dock, image), { ok: true });
+  assert.deepEqual(dock.calls, [image]);
+});
+
+test("restores the bundle icon via setIcon(null) when no loose default icon ships (packaged builds)", () => {
+  const dock = fakeDock();
+
+  assert.deepEqual(resetMacDockIcon(dock, null), { ok: true });
+  assert.deepEqual(dock.calls, [null]);
+});
+
+test("treats an empty default image like a missing one", () => {
+  const dock = fakeDock();
+
+  assert.deepEqual(resetMacDockIcon(dock, { isEmpty: () => true }), { ok: true });
+  assert.deepEqual(dock.calls, [null]);
+});
+
+test("reports when the dock is unavailable instead of throwing", () => {
+  assert.deepEqual(resetMacDockIcon(null, null), { ok: false, reason: "dock-unavailable" });
+  assert.deepEqual(resetMacDockIcon(undefined, { isEmpty: () => false }), {
+    ok: false,
+    reason: "dock-unavailable",
+  });
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
 import net from "node:net";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import {
   cp,
   mkdir,
@@ -656,6 +656,17 @@ async function readBrandIconSidecar() {
   }
 }
 
+function readBrandIconSidecarSourceUrlSync() {
+  try {
+    const parsed = JSON.parse(readFileSync(brandIconSidecarPath(), "utf8"));
+    return parsed && typeof parsed === "object" && typeof parsed.sourceUrl === "string"
+      ? parsed.sourceUrl
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 async function clearBrandIconCache() {
   await Promise.all([
     rm(brandIconCachePath(), { force: true }),
@@ -860,7 +871,18 @@ async function getBrandIconState() {
   return { ...brandIconRuntimeState };
 }
 
-const INITIAL_APP_ICON_IMAGE = resolveBrandIconImage() ?? APP_ICON_IMAGE;
+const INITIAL_BRAND_ICON_IMAGE = resolveBrandIconImage();
+const INITIAL_APP_ICON_IMAGE = INITIAL_BRAND_ICON_IMAGE ?? APP_ICON_IMAGE;
+if (INITIAL_BRAND_ICON_IMAGE) {
+  // The renderer's level-based reconcile compares getBrandIconState() with
+  // the fresh org config. Record that a cached brand icon is restored at
+  // boot so a clear whose edge the renderer missed still resets the icon.
+  brandIconRuntimeState = {
+    applied: true,
+    sourceUrl: readBrandIconSidecarSourceUrlSync(),
+    reason: null,
+  };
+}
 if (process.platform === "darwin" && INITIAL_APP_ICON_IMAGE && !INITIAL_APP_ICON_IMAGE.isEmpty() && app.dock) {
   app.dock.setIcon(INITIAL_APP_ICON_IMAGE);
 }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -71,6 +71,7 @@ import {
   writeWindowsBrandShortcut,
   windowsIconFromNativeImage,
 } from "./brand-icon-windows.mjs";
+import { resetMacDockIcon } from "./brand-icon-darwin.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = path.resolve(__dirname, "../../..");
@@ -542,6 +543,20 @@ async function applyAppIconImage(image, { taskbarIconPath = null, taskbarAppId =
 async function applyDefaultAppIconImage(expectedSequence = null) {
   let image = APP_ICON_IMAGE;
   let taskbarIconPath = null;
+  if (process.platform === "darwin") {
+    // Packaged macOS builds have no loose default icon file (APP_ICON_IMAGE
+    // is null), so reset the dock via dock.setIcon(null) to restore the
+    // bundle icon instead of silently leaving the branded icon in place.
+    if (expectedSequence !== null && expectedSequence !== brandIconApplySequence) {
+      return { ok: false, reason: "stale" };
+    }
+    try {
+      const result = resetMacDockIcon(app.dock, image);
+      return result.ok ? result : brandIconFailure(result.reason);
+    } catch (error) {
+      return brandIconFailure("os-apply-failed", error);
+    }
+  }
   if (process.platform === "win32") {
     try {
       await removeWindowsBrandShortcut();
@@ -567,8 +582,8 @@ async function applyDefaultAppIconImage(expectedSequence = null) {
     }
   }
   if (!image || image.isEmpty()) {
-    // Preserve the pre-existing no-op fallback on platforms whose packaged
-    // application icon is managed entirely by the bundle.
+    // Linux: the packaged window/launcher icon is managed by the desktop
+    // integration, so a missing loose icon is a safe no-op.
     return process.platform === "win32" ? brandIconFailure("stock-icon-unavailable") : { ok: true };
   }
   if (process.platform === "win32" && taskbarIconPath) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-darwin.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@openwork/paths": "workspace:*",


### PR DESCRIPTION
## Problem

Clearing the organization brand icon in Den **never** resets the macOS dock icon — not live, and not across relaunches. Two compounding defects:

### 1. Packaged macOS reset is a silent no-op

The clear path (`applyBrandIconUrl(null)` → `applyDefaultAppIconImage`) resets by re-applying `APP_ICON_IMAGE`, resolved from loose icon files that only exist in dev (`resources/icons/dev/*`) or Linux/Windows resource layouts. Packaged macOS ships the icon **only inside the .app bundle** (`electron-builder.base.yml` `mac.icon`; mac `extraResources` has no icons), so `APP_ICON_IMAGE` is `null` and the old fallback branch returned `{ ok: true }` **without touching the dock**. Even when the clear signal arrived, the dock stayed branded.

### 2. The clear signal itself is edge-triggered and easily lost forever

The shell (Electron main) is level-based: it **re-applies its cached brand icon on every launch** — from `brand-icon.png`/sidecar at module load and from `desktop-bootstrap.json` right before window creation. But the renderer only sends `applyBrandIcon(null)` when its config **diff** sees `brandIconUrl` go `string → absent`. If that edge is ever missed — stale localStorage config cache, org/base-URL switch changing the cache key, the fire-and-forget IPC failing, or the bootstrap sync being swallowed by its `.catch(() => undefined)` — **nothing ever retries the clear**, while the shell re-brands the dock at every boot. Branded icon forever.

Neither boot re-apply path recorded `brandIconRuntimeState`, so even `getBrandIconState()` claimed no icon was applied.

## Fix

**macOS reset (`brand-icon-darwin.mjs` + `main.mjs`):** `resetMacDockIcon(dock, defaultImage)` re-applies the loose default icon when one exists (dev builds) and otherwise calls `app.dock.setIcon(null)` — Electron's `browser_mac.mm` `DockSetIcon` explicitly handles `IsNull()` and restores the bundle icon from Info.plist. Failures surface through `brandIconFailure` telemetry instead of no-opping.

**Level-based reconcile (`desktop-config-provider.tsx` + `workspace-branding-restart.ts` + `main.mjs`):**
- `main.mjs` now records `brandIconRuntimeState` (`applied` + sidecar `sourceUrl`) when it restores a cached brand icon at boot, so `getBrandIconState()` reflects reality.
- New pure helper `brandIconReconcileAction(config, state)` decides: clear when the shell has an icon the config no longer configures, apply when the config has one the shell never applied, no-op otherwise (URL-change transitions stay owned by the existing edge diff — avoids re-staging churn on Windows).
- After **every successful fresh** `/me/desktop-config` fetch (and the dev-refresh bridge path), `reconcileShellBranding` re-asserts the icon via that helper and re-syncs the `desktop-bootstrap.json` branding snapshot (`syncBootstrapBranding`, extracted from the edge handler). Reconcile runs only on fresh configs, so a stale cache or an offline fallback can never resurrect cleared branding.

So even if every edge is missed, the next fresh config fetch clears the dock icon, the brand-icon cache, and the bootstrap snapshot — the icon converges to the org config instead of depending on catching a one-shot transition.

## Windows check (as requested)

Audited the same clear path on win32: packaged Windows also has `APP_ICON_IMAGE === null`, but the win32 branch already falls back to `app.getFileIcon(process.execPath)` (exe-embedded stock icon) plus AppUserModelID + Start Menu shortcut reset and taskbar re-staging, and a missing stock icon is a hard failure rather than a silent no-op. Windows' *reset* works; the lost-edge problem (defect 2) affected Windows/Linux too and is fixed by the same reconcile.

## Tests

Ran (commands + result):

- `pnpm --dir apps/desktop test` — **181 pass, 0 fail, 1 skip** (pre-existing macOS-conditional skip). Includes new `electron/brand-icon-darwin.test.mjs` (4 tests), wired into the package test script.
- `bun test src/react-app/domains/cloud/workspace-branding-restart.test.ts` (apps/app) — **8 pass** (4 new `brandIconReconcileAction` tests: clear, apply, matching no-op, no-bridge no-op).
- `bun test --isolate tests/den-desktop-config.test.ts` (apps/app) — **9 pass** (provider module untouched behavior).
- `pnpm --dir apps/app run typecheck` — clean.
- `pnpm --dir apps/desktop run typecheck:electron` — clean.
- `node --check apps/desktop/electron/main.mjs` — clean.

### Why no testkit evidence tape

The full defect is only observable on a **packaged** macOS build (dev builds resolve the loose dev icon) and the observable surface is the OS dock icon, which the spec harness cannot assert. Packaged repro:

1. Install a packaged macOS build connected to a Den org with a brand icon (dock branded).
2. In Den web: Dashboard → Brand appearance → clear the icon → Save.
3. Before: the dock icon never resets — not when the config refresh lands (silent no-op) and not across relaunches once the renderer's diff edge is missed (shell re-brands from its own caches at every boot). After: the dock resets when the fresh config lands, and every subsequent fresh fetch re-asserts the cleared state against the shell's caches and bootstrap snapshot.

The unit tests pin both new decision surfaces (`resetMacDockIcon`, `brandIconReconcileAction`); Electron's `setIcon(null)` handling is upstream-verified in `shell/browser/browser_mac.mm::DockSetIcon`.