### PR TITLE
fix(den-api): preserve sessions on role upgrades

### DIFF
--- a/ee/apps/den-api/src/organization-role-hierarchy.ts
+++ b/ee/apps/den-api/src/organization-role-hierarchy.ts
@@ -72,6 +72,23 @@ export function organizationRoleValueSatisfies(input: {
   return roles.some((role) => organizationRoleSatisfies(role, input.requiredRole))
 }
 
+export function shouldRevokeSessionsForRoleChange(previousRole: string, nextRole: string) {
+  if (previousRole === nextRole) {
+    return false
+  }
+
+  const previousRoles = splitOrganizationRoles(previousRole)
+  const nextRoles = splitOrganizationRoles(nextRole)
+  // Only single built-in roles have a provable ordering; ambiguous changes fail closed.
+  if (previousRoles.length !== 1 || nextRoles.length !== 1) {
+    return true
+  }
+
+  const previousLevel = builtInRoleLevel(previousRoles[0] ?? "")
+  const nextLevel = builtInRoleLevel(nextRoles[0] ?? "")
+  return previousLevel === null || nextLevel === null || nextLevel <= previousLevel
+}
+
 export function isProtectedOrganizationRoleName(role: string) {
   return BUILT_IN_ORGANIZATION_ROLES.some((builtInRole) => builtInRole === role)
 }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -40,7 +40,7 @@ import {
   type OrganizationPermissionRecord,
 } from "./organization-access.js"
 import { ensureDefaultDesktopPolicyForOrganization } from "./desktop-policies.js"
-import { isProtectedOrganizationRoleName } from "./organization-role-hierarchy.js"
+import { isProtectedOrganizationRoleName, shouldRevokeSessionsForRoleChange } from "./organization-role-hierarchy.js"
 import { isSingleOrgOwnerEmailEligible, resolveSingleOrgMembershipRole } from "./single-org-policy.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -1774,10 +1774,14 @@ export async function updateOrganizationMemberRole(input: {
       orgMembershipId: updated.member.id,
       userId: updated.member.userId,
     })
-    await revokeMembershipSessionCredentials({
-      organizationId: input.organizationId,
-      userId: updated.member.userId,
-    })
+    // Revocation prevents a live session from retaining access it just lost.
+    // An upgrade removes no access, so there is nothing to revoke.
+    if (shouldRevokeSessionsForRoleChange(updated.previousRole, updated.nextRole)) {
+      await revokeMembershipSessionCredentials({
+        organizationId: input.organizationId,
+        userId: updated.member.userId,
+      })
+    }
   }
 
   return updated

--- a/ee/apps/den-api/test/organization-role-session-revocation.test.ts
+++ b/ee/apps/den-api/test/organization-role-session-revocation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { shouldRevokeSessionsForRoleChange } from "../src/organization-role-hierarchy.js"
+
+describe("organization role change session revocation", () => {
+  test("preserves sessions only for unchanged roles and unambiguous built-in upgrades", () => {
+    expect(shouldRevokeSessionsForRoleChange("member", "admin")).toBe(false)
+    expect(shouldRevokeSessionsForRoleChange("member", "member")).toBe(false)
+
+    expect(shouldRevokeSessionsForRoleChange("admin", "member")).toBe(true)
+    expect(shouldRevokeSessionsForRoleChange("owner", "admin")).toBe(true)
+  })
+
+  test("fails closed for custom, multi-role, and unknown role changes", () => {
+    expect(shouldRevokeSessionsForRoleChange("qa", "admin")).toBe(true)
+    expect(shouldRevokeSessionsForRoleChange("admin", "admin,qa")).toBe(true)
+    expect(shouldRevokeSessionsForRoleChange("garbage", "unknown")).toBe(true)
+  })
+})

--- a/evals/specs/role-change-session-survival.slow.test.ts
+++ b/evals/specs/role-change-session-survival.slow.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "vitest";
+import { denFetch, freshSession } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { eventually, localMysqlIsRunning, needs, server, test } from "@openwork/testkit";
+
+const ORGANIZATION_NAME = "Role Change Session Survival";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "role change session survival skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "role change session survival skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "role change session survival skipped — needs MySQL on 127.0.0.1:3306"
+      : "role upgrades preserve live sessions while demotions revoke them";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(admin: DenSession): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: auth(admin) });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function memberIdByEmail(admin: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/org", {
+    headers: {
+      ...auth(admin),
+      "x-openwork-org-id": orgId,
+    },
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const id = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the teammate membership failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function updateMemberRole(admin: DenSession, orgId: string, memberId: string, role: "admin" | "member"): Promise<void> {
+  const privilegedAdmin = await freshSession(admin);
+  const result = await denFetch(privilegedAdmin, `/v1/members/${encodeURIComponent(memberId)}/role`, {
+    method: "POST",
+    headers: {
+      ...auth(privilegedAdmin),
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ role }),
+  });
+  expect(result.response.status).toBe(200);
+}
+
+async function sessionStatus(member: DenSession): Promise<number> {
+  const result = await denFetch(member, "/v1/me", { headers: auth(member) });
+  return result.response.status;
+}
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      members: {
+        teammate: { name: "Role Change Teammate" },
+      },
+    },
+  });
+  const teammate = den.members.teammate;
+  if (!teammate) throw new Error("The testkit did not provision the teammate session.");
+
+  expect(await sessionStatus(teammate)).toBe(200);
+  const orgId = await organizationId(den.admin);
+  const teammateMemberId = await memberIdByEmail(den.admin, orgId, teammate.email);
+
+  await updateMemberRole(den.admin, orgId, teammateMemberId, "admin");
+  const promotedSessionStatus = await eventually(() => sessionStatus(teammate), {
+    within: 10_000,
+    label: "original member session after promotion",
+    until: (status) => status === 200,
+  });
+  expect(promotedSessionStatus).toBe(200);
+  evidence.fact(
+    "A privilege upgrade preserves the member's live session",
+    "The original member bearer token still returned HTTP 200 from /v1/me after promotion to admin.",
+    promotedSessionStatus === 200,
+  );
+
+  await updateMemberRole(den.admin, orgId, teammateMemberId, "member");
+  const demotedSessionStatus = await eventually(() => sessionStatus(teammate), {
+    within: 10_000,
+    label: "original member session revocation after demotion",
+    until: (status) => status === 401,
+  });
+  expect(demotedSessionStatus).toBe(401);
+  evidence.fact(
+    "A privilege demotion revokes the member's live session",
+    "The original member bearer token returned HTTP 401 from /v1/me after demotion to member.",
+    demotedSessionStatus === 401,
+  );
+});


### PR DESCRIPTION
## What
- Add a pure role-change decision that preserves sessions only for unchanged roles or provable, strictly increasing built-in privilege.
- Keep session revocation for demotions and fail closed for custom, unknown, or multi-role changes.
- Apply the decision only to member role changes; API-key revocation remains unchanged.

## Why
Session revocation prevents a live session from retaining access it just lost. A privilege upgrade removes no access, so revoking every user session only creates collateral logout and rate-limit risk without improving security.

## Tests
- `pnpm --dir ee/apps/den-api exec bun test test/organization-role-session-revocation.test.ts` — passed: 2 tests, 7 assertions.
- `pnpm --dir ee/apps/den-api exec tsc --noEmit` — passed with no output.
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project stack --reporter=basic --testNamePattern=__nomatch__` — passed compile/collection: 31 files skipped, 36 tests skipped.

## Evidence
Incomplete pending orchestrator runtime execution. `evals/specs/role-change-session-survival.slow.test.ts` is authored with promotion-survival and demotion-revocation witnesses, but was intentionally not run because another process owns Electron/ports/Den on this machine.

## Follow-up
`organization-role-credential-revocation.ts` remains unchanged. Role-permission-edit revocation should receive a separate scope-safety review.