### PR TITLE
fix(auth): expand handoff into a first-run bootstrap contract

### DIFF
--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -1,6 +1,7 @@
 import {
   createDenClient,
   readDenSettings,
+  seedDenDesktopConfigConnectPolicy,
   writeDenSettings,
   type DenDesktopHandoffExchange,
 } from "./den";
@@ -70,6 +71,12 @@ export async function exchangeHandoffAndSignIn(
       activeOrgSlug: activeOrg ? activeOrg.slug ?? null : storedSettings.activeOrgSlug,
       activeOrgName: activeOrg ? activeOrg.name ?? null : storedSettings.activeOrgName,
     });
+    if (exchange.organization) {
+      seedDenDesktopConfigConnectPolicy({
+        organizationId: exchange.organization.id,
+        connectEnabled: exchange.connectEnabled,
+      });
+    }
 
     dispatchDenSessionUpdated({
       status: "success",

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -53,6 +53,7 @@ const STORAGE_AUTH_TOKEN = "openwork.den.authToken";
 const STORAGE_ACTIVE_ORG_ID = "openwork.den.activeOrgId";
 const STORAGE_ACTIVE_ORG_SLUG = "openwork.den.activeOrgSlug";
 const STORAGE_ACTIVE_ORG_NAME = "openwork.den.activeOrgName";
+const DESKTOP_CONFIG_CACHE_PREFIX = "openwork.den.desktopConfig:";
 export const CLOUD_MCP_SYNC_MARKER_STORAGE_KEY = "openwork.den.mcp.sync";
 const ORG_PROXY_HEADER = "x-openwork-legacy-org-id";
 const DEFAULT_DEN_TIMEOUT_MS = 12_000;
@@ -386,6 +387,7 @@ export type DenDesktopHandoffExchange = {
   user: DenUser | null;
   token: string | null;
   organization: DenDesktopHandoffExchangeOrganization | null;
+  connectEnabled: boolean | null;
 };
 
 const defaultBootstrapBaseUrls = resolveDenBaseUrls({
@@ -967,6 +969,54 @@ export function readDenSettings(): DenSettings {
   };
 }
 
+export function getDenDesktopConfigCacheKey(): string {
+  const settings = readDenSettings();
+  const baseUrl = settings.baseUrl.trim();
+  const activeOrgId = settings.activeOrgId?.trim() ?? "";
+  if (!baseUrl) return "";
+  return `${DESKTOP_CONFIG_CACHE_PREFIX}${baseUrl}::${activeOrgId}`;
+}
+
+export function readCachedDenDesktopConfig(key: string): DenDesktopConfig | null {
+  if (typeof window === "undefined" || !key) return null;
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    return normalizeDenDesktopConfig(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedDenDesktopConfig(key: string, config: DenDesktopConfig) {
+  if (typeof window === "undefined" || !key) return;
+  try {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify(normalizeDenDesktopConfig(config)),
+    );
+  } catch {
+    // Quota / private-browsing failures are non-fatal — we just miss the cache next boot.
+  }
+}
+
+export function seedDenDesktopConfigConnectPolicy(input: {
+  organizationId: string;
+  connectEnabled: boolean | null;
+}): boolean {
+  if (input.connectEnabled === null) return false;
+
+  const organizationId = input.organizationId.trim();
+  const activeOrgId = readDenSettings().activeOrgId?.trim() ?? "";
+  if (!organizationId || activeOrgId !== organizationId) return false;
+
+  const key = getDenDesktopConfigCacheKey();
+  const cached = readCachedDenDesktopConfig(key) ?? {};
+  writeCachedDenDesktopConfig(key, { ...cached, connectEnabled: input.connectEnabled });
+  return true;
+}
+
 function mergePassiveDenField(
   current: string | null | undefined,
   next: string | null | undefined,
@@ -1200,6 +1250,13 @@ function getExchangeOrganization(payload: unknown): DenDesktopHandoffExchangeOrg
     slug: typeof organization.slug === "string" && organization.slug.trim() ? organization.slug.trim() : null,
     name: typeof organization.name === "string" && organization.name.trim() ? organization.name.trim() : null,
   };
+}
+
+function getExchangeConnectEnabled(payload: unknown): boolean | null {
+  if (!isRecord(payload) || typeof payload.connectEnabled !== "boolean") {
+    return null;
+  }
+  return payload.connectEnabled;
 }
 
 function getOrgList(payload: unknown): DenOrgSummary[] {
@@ -2278,7 +2335,12 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         method: "POST",
         body: { grant },
       });
-      return { user: getUser(payload), token: getToken(payload), organization: getExchangeOrganization(payload) };
+      return {
+        user: getUser(payload),
+        token: getToken(payload),
+        organization: getExchangeOrganization(payload),
+        connectEnabled: getExchangeConnectEnabled(payload),
+      };
     },
 
     async listOrgs(): Promise<{ orgs: DenOrgSummary[]; activeOrgId: string | null; activeOrgSlug: string | null; defaultOrgId: string | null }> {

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -20,10 +20,13 @@ import {
   createDenClient,
   DenApiError,
   ensureDenActiveOrganization,
+  getDenDesktopConfigCacheKey,
   normalizeDenDesktopConfig,
+  readCachedDenDesktopConfig,
   readDenBootstrapConfig,
   readDenSettings,
   setDenBootstrapConfig,
+  writeCachedDenDesktopConfig,
   type DenDesktopConfig,
 } from "../../../app/lib/den";
 import { applyBrandAppName, applyBrandIcon } from "../../../app/lib/desktop";
@@ -59,7 +62,6 @@ const DesktopConfigContext = createContext<DesktopConfigStore | undefined>(
 
 const DEFAULT_DESKTOP_CONFIG: DenDesktopConfig = {};
 const DESKTOP_CONFIG_REFRESH_MS = 60 * 60 * 1000;
-const DESKTOP_CONFIG_CACHE_PREFIX = "openwork.den.desktopConfig:";
 const DESKTOP_CONFIG_ITEMS = [
   ...desktopPolicyKeys,
   "allowedDesktopVersions",
@@ -113,38 +115,6 @@ type DesktopConfigAction = {
 
 function isBootstrapBrandingActionItem(item: DesktopConfigItem): boolean {
   return item === "brandAppName" || item === "brandLogoUrl" || item === "brandIconUrl";
-}
-
-function getDesktopConfigCacheKey(): string {
-  const settings = readDenSettings();
-  const baseUrl = settings.baseUrl.trim();
-  const activeOrgId = settings.activeOrgId?.trim() ?? "";
-  if (!baseUrl) return "";
-  return `${DESKTOP_CONFIG_CACHE_PREFIX}${baseUrl}::${activeOrgId}`;
-}
-
-function readCachedDesktopConfig(key: string): DenDesktopConfig | null {
-  if (typeof window === "undefined" || !key) return null;
-
-  try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) return null;
-    return normalizeDenDesktopConfig(JSON.parse(raw));
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedDesktopConfig(key: string, config: DenDesktopConfig) {
-  if (typeof window === "undefined" || !key) return;
-  try {
-    window.localStorage.setItem(
-      key,
-      JSON.stringify(normalizeDenDesktopConfig(config)),
-    );
-  } catch {
-    // Quota / private-browsing failures are non-fatal — we just miss the cache next boot.
-  }
 }
 
 function desktopConfigItemMatches(
@@ -280,7 +250,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
     const activeOrgId = settings.activeOrgId?.trim() ?? "";
-    const cacheKey = getDesktopConfigCacheKey();
+    const cacheKey = getDenDesktopConfigCacheKey();
 
     if (!isSignedIn || !token || !activeOrgId) {
       applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
@@ -288,7 +258,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       return DEFAULT_DESKTOP_CONFIG;
     }
 
-    const cached = readCachedDesktopConfig(cacheKey);
+    const cached = readCachedDenDesktopConfig(cacheKey);
     if (cached) {
       applyDesktopConfigActions(cached);
     }
@@ -305,7 +275,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
       if (currentRun !== refreshRunRef.current) return nextConfig;
 
-      writeCachedDesktopConfig(cacheKey, nextConfig);
+      writeCachedDenDesktopConfig(cacheKey, nextConfig);
       applyDesktopConfigActions(nextConfig);
       return nextConfig;
     } catch (error) {
@@ -361,8 +331,8 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       return;
     }
 
-    const cacheKey = getDesktopConfigCacheKey();
-    const cached = readCachedDesktopConfig(cacheKey);
+    const cacheKey = getDenDesktopConfigCacheKey();
+    const cached = readCachedDenDesktopConfig(cacheKey);
     applyDesktopConfigActions(cached ?? DEFAULT_DESKTOP_CONFIG);
     setDesktopConfigState((current) => ({ ...current, loading: !cached }));
     void desktopConfigHandler();

--- a/apps/app/tests/den-handoff.test.ts
+++ b/apps/app/tests/den-handoff.test.ts
@@ -70,14 +70,19 @@ describe("exchangeHandoffAndSignIn", () => {
       token: "tok_handoff",
       user: exchangeUser,
       organization: { id: "org_invited", slug: "invited-org", name: "Invited Org" },
+      connectEnabled: false,
     });
 
     const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
 
     expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_invited");
     expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("invited-org");
     expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Invited Org");
+    expect(result.exchange.connectEnabled).toBe(false);
+    expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_invited"))
+      .toBe(JSON.stringify({ connectEnabled: false }));
   });
 
   test("prefers the caller-provided organization over the exchange payload", async () => {
@@ -95,6 +100,7 @@ describe("exchangeHandoffAndSignIn", () => {
 
     expect(result.ok).toBe(true);
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_bootstrap");
+    expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_bootstrap")).toBeNull();
   });
 
   test("preserves the stored organization when the exchange has none", async () => {
@@ -107,8 +113,12 @@ describe("exchangeHandoffAndSignIn", () => {
     const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
 
     expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_stored");
     expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("stored-org");
     expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Stored Org");
+    expect(result.exchange.connectEnabled).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_stored"))
+      .toBeNull();
   });
 });

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -5,6 +5,7 @@ import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { authenticatedRoute, jsonValidator, publicRoute } from "../../middleware/index.js"
 import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
@@ -47,6 +48,7 @@ const desktopHandoffExchangeResponseSchema = z.object({
     slug: z.string(),
     name: z.string(),
   }).nullable(),
+  connectEnabled: z.boolean().nullable(),
 }).meta({ ref: "DesktopHandoffExchangeResponse" })
 
 const desktopHandoffStatusResponseSchema = z.object({
@@ -590,6 +592,7 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
     // back to null when the session has no resolvable organization; the app
     // then repairs through its normal org-resolution path.
     let organization: { id: string; slug: string; name: string } | null = null
+    let organizationMetadata: string | null = null
     try {
       const resolved = await resolveUserOrganizations({
         userId: normalizeDenTypeId("user", exchange.user.id),
@@ -597,14 +600,27 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
       })
       const activeOrg = resolved.orgs.find((org) => org.id === resolved.activeOrgId) ?? null
       organization = activeOrg ? { id: activeOrg.id, slug: activeOrg.slug, name: activeOrg.name } : null
+      organizationMetadata = activeOrg?.metadata ?? null
     } catch {
       organization = null
+    }
+
+    let connectEnabled: boolean | null = null
+    if (organization) {
+      try {
+        connectEnabled = memberFacingMcpConnectionsEnabled(organizationMetadata, {
+          gatingEnabled: env.mcpConnectionsGatingEnabled,
+        })
+      } catch {
+        connectEnabled = null
+      }
     }
 
     return c.json({
       token: exchange.token,
       user: exchange.user,
       organization,
+      connectEnabled,
     })
     },
   )

--- a/evals/specs/first-run-bootstrap-contract.slow.test.ts
+++ b/evals/specs/first-run-bootstrap-contract.slow.test.ts
@@ -1,0 +1,92 @@
+import { expect } from "vitest";
+import {
+  app,
+  eventually,
+  faultProxy,
+  inviteMember,
+  localMysqlIsRunning,
+  needs,
+  readConnectState,
+  readDenClientState,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const desktopConfigPath = "/api/den/v1/me/desktop-config";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "first-run bootstrap contract skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "first-run bootstrap contract skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "first-run bootstrap contract skipped — needs MySQL on 127.0.0.1:3306"
+      : "first-run handoff bootstraps Connect while desktop config is rate limited";
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({
+    place,
+    org: {
+      name: "First Run Bootstrap",
+      admin: {
+        email: `first-run-bootstrap-admin-${Date.now()}@openwork.test`,
+        name: "First Run Bootstrap Admin",
+        password: "OpenWorkEval123!",
+      },
+    },
+  });
+  await inviteMember(den, "member", {
+    email: `first-run-bootstrap-member-${Date.now()}@openwork.test`,
+    name: "First Run Bootstrap Member",
+    password: "OpenWorkEval123!",
+  });
+  await using proxy = await faultProxy(den.ref);
+  proxy.faults.status(desktopConfigPath, 429, { times: 5 });
+
+  await using memberApp = await app({
+    den: { ...den, ref: proxy.ref },
+    as: "member",
+    place,
+  });
+
+  const denState = await eventually(() => readDenClientState(memberApp), {
+    within: 60_000,
+    label: "first-run active organization",
+    until: (state) => Boolean(state.activeOrgId),
+  });
+  expect(denState.authTokenPresent).toBe(true);
+  expect(denState.activeOrgId).toBeTruthy();
+  evidence.fact(
+    "The handoff bootstrapped the invited member's organization",
+    `The first-run profile persisted an auth token and active organization ${denState.activeOrgId}.`,
+    true,
+  );
+
+  const connectState = await eventually(() => readConnectState(memberApp), {
+    until: (state) => state.connectEnabled === true,
+    within: 90_000,
+    label: "handoff-bootstrapped Connect state",
+  });
+  expect(connectState.ok).toBe(true);
+  evidence.fact(
+    "Connect enabled from the handoff bootstrap contract",
+    "The local server reported connectEnabled=true without a successful desktop-config response.",
+    true,
+  );
+
+  const faultedRequests = await eventually(
+    () => proxy.requests.filter((request) =>
+      request.path.startsWith(desktopConfigPath) && request.status === 429 && request.faulted
+    ),
+    { within: 60_000, label: "faulted desktop-config request", until: (requests) => requests.length > 0 },
+  );
+  expect(faultedRequests.length).toBeGreaterThan(0);
+  evidence.fact(
+    "The desktop-config failure condition was exercised",
+    `${faultedRequests.length} observed ${desktopConfigPath} request(s) received the injected HTTP 429.`,
+    true,
+  );
+});


### PR DESCRIPTION
## What
- Return nullable `connectEnabled` with the resolved organization from desktop handoff exchange.
- Parse and seed that policy into the signed-in organization desktop-config cache so the existing Connect mirror delivers it immediately.
- Add unit coverage and a first-run fault-proxy slow spec.

## Why
Fresh invited members should not depend on a second `/v1/me/desktop-config` round-trip to learn Connect policy during onboarding-wave rate limits.

## Tests
- `pnpm --dir apps/app exec bun test tests/den-handoff.test.ts` — passed: 3 tests, 0 failures.
- `pnpm --dir apps/app typecheck` — passed.
- `pnpm --dir ee/apps/den-api exec tsc --noEmit` — passed.
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project stack --reporter=basic --testNamePattern=__nomatch__` — passed collection: 31 files / 36 tests skipped by the non-matching pattern.

## Evidence
`evals/specs/first-run-bootstrap-contract.slow.test.ts` is authored with active-org, Connect, and injected-429 assertions. Per task ownership, the slow spec was not executed; the orchestrator will execute it.