### PR TITLE
fix(app): add rogue active-org writer tripwire

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -47,6 +47,12 @@ import type {
   OpenWorkExtensionSourceFormat,
 } from "../extensions";
 
+declare global {
+  interface Window {
+    __openworkOrgDropWarnings?: string[];
+  }
+}
+
 export const STORAGE_BASE_URL = "openwork.den.baseUrl";
 const LEGACY_STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
 const STORAGE_AUTH_TOKEN = "openwork.den.authToken";
@@ -995,7 +1001,34 @@ export function mergePassiveDenSettings(current: DenSettings, next: DenSettings)
   };
 }
 
-export function writeDenSettings(next: DenSettings, options?: { persistBootstrap?: boolean }) {
+function warnOnUnexpectedActiveOrgDrop(input: {
+  previousActiveOrgId: string | null | undefined;
+  nextActiveOrgId: string | null | undefined;
+  intentionalActiveOrgClear?: boolean;
+}) {
+  if (!import.meta.env.DEV || typeof window === "undefined" || input.intentionalActiveOrgClear) {
+    return;
+  }
+
+  const previousActiveOrgId = input.previousActiveOrgId?.trim() ?? "";
+  const nextActiveOrgId = input.nextActiveOrgId?.trim() ?? "";
+  if (!previousActiveOrgId || nextActiveOrgId) return;
+
+  const message = `[den-settings] activeOrgId dropped unexpectedly from ${previousActiveOrgId}`;
+  const stack = new Error(message).stack ?? message;
+  try {
+    window.__openworkOrgDropWarnings ??= [];
+    window.__openworkOrgDropWarnings.push(stack);
+    console.warn(stack);
+  } catch {
+    // Diagnostics must never block the settings write they observe.
+  }
+}
+
+export function writeDenSettings(
+  next: DenSettings,
+  options?: { persistBootstrap?: boolean; intentionalActiveOrgClear?: boolean },
+) {
   if (typeof window === "undefined") {
     return;
   }
@@ -1020,6 +1053,12 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
   ) {
     return;
   }
+
+  warnOnUnexpectedActiveOrgDrop({
+    previousActiveOrgId: previous.activeOrgId,
+    nextActiveOrgId: activeOrgId,
+    intentionalActiveOrgClear: options?.intentionalActiveOrgClear,
+  });
 
   if (isDesktopRuntime()) {
     window.localStorage.removeItem(STORAGE_BASE_URL);
@@ -1078,6 +1117,14 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
 export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
   if (typeof window === "undefined") {
     return;
+  }
+
+  if (import.meta.env.DEV) {
+    warnOnUnexpectedActiveOrgDrop({
+      previousActiveOrgId: readDenSettings().activeOrgId,
+      nextActiveOrgId: null,
+      intentionalActiveOrgClear: true,
+    });
   }
 
   if (options?.includeBaseUrls) {

--- a/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
+++ b/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
@@ -52,7 +52,7 @@ export async function saveControlPlaneUrl(value: string) {
       activeOrgSlug: null,
       activeOrgName: null,
     },
-    { persistBootstrap: false },
+    { persistBootstrap: false, intentionalActiveOrgClear: true },
   );
 
   return persisted;

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -336,7 +336,7 @@ export function useDenSession({
           activeOrgSlug: null,
           activeOrgName: null,
         },
-        { persistBootstrap: false },
+        { persistBootstrap: false, intentionalActiveOrgClear: true },
       );
       setBaseUrl(resolved.baseUrl);
       setBaseUrlDraft(resolved.baseUrl);

--- a/apps/app/tests/den-session-offline-resilience.test.ts
+++ b/apps/app/tests/den-session-offline-resilience.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
+  clearDenSession,
   DenApiError,
   ensureDenActiveOrganization,
   isDenSessionRevokedError,
@@ -12,6 +13,7 @@ import { resolveDenAuthFailureStatus } from "../src/react-app/domains/cloud/den-
 
 const originalWindow = globalThis.window;
 const originalFetch = globalThis.fetch;
+const originalDev = process.env.DEV;
 
 function memoryStorage(): Storage {
   const map = new Map<string, string>();
@@ -45,6 +47,81 @@ afterEach(() => {
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: originalFetch,
+  });
+  if (originalDev === undefined) {
+    delete process.env.DEV;
+  } else {
+    process.env.DEV = originalDev;
+  }
+});
+
+function stubWindow() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: memoryStorage(),
+      dispatchEvent: () => true,
+    },
+  });
+}
+
+describe("active organization drop tripwire", () => {
+  test("warns with a recorded stack for an unflagged drop", () => {
+    process.env.DEV = "true";
+    stubWindow();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: "org_stored" }, { persistBootstrap: false });
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: null }, { persistBootstrap: false });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(window.__openworkOrgDropWarnings).toHaveLength(1);
+    expect(window.__openworkOrgDropWarnings?.[0]).toContain("activeOrgId dropped unexpectedly from org_stored");
+    expect(window.__openworkOrgDropWarnings?.[0]).toContain("\n");
+    warn.mockRestore();
+  });
+
+  test("stays silent for opted-out clears and sign-out", () => {
+    process.env.DEV = "true";
+    stubWindow();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: "org_stored" }, { persistBootstrap: false });
+    writeDenSettings(
+      { baseUrl: "https://den.test", activeOrgId: null },
+      { persistBootstrap: false, intentionalActiveOrgClear: true },
+    );
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: "org_stored" }, { persistBootstrap: false });
+    clearDenSession();
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(window.__openworkOrgDropWarnings).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  test("stays silent when no organization was set", () => {
+    process.env.DEV = "true";
+    stubWindow();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: null }, { persistBootstrap: false });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(window.__openworkOrgDropWarnings).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  test("is inert outside development builds", () => {
+    delete process.env.DEV;
+    stubWindow();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: "org_stored" }, { persistBootstrap: false });
+    writeDenSettings({ baseUrl: "https://den.test", activeOrgId: null }, { persistBootstrap: false });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(window.__openworkOrgDropWarnings).toBeUndefined();
+    warn.mockRestore();
   });
 });
 


### PR DESCRIPTION
## What
- Add a dev/eval-only warning with a captured stack when `writeDenSettings` unexpectedly drops a non-empty active organization.
- Record warnings on `window.__openworkOrgDropWarnings` for automated inspection.
- Add an explicit `intentionalActiveOrgClear` opt-out and use it for known control-plane clears; sign-out is explicitly exempted.

## Why
A future writer that silently erases the active organization should become visible in development and CI before it strands a customer.

## Tests
- `pnpm --dir apps/app exec bun test tests/den-session-offline-resilience.test.ts` — passed: 11 tests, 0 failures.
- `pnpm --dir apps/app typecheck` — passed.

## Evidence
Unit coverage verifies an unflagged drop warns and records a stack, intentional clears/sign-out remain silent, an initially empty org remains silent, and production mode is inert.