### PR TITLE
fix(den-api): remove shared domain login limits

### DIFF
--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -482,20 +482,18 @@ function sha256Hex(value: string) {
   return createHash("sha256").update(value).digest("hex")
 }
 
-function readEmailDomain(email: string) {
-  const atIndex = email.lastIndexOf("@")
-  return atIndex > 0 && atIndex < email.length - 1 ? email.slice(atIndex + 1) : "unknown"
+export function loginOptionsRateLimitKeys(headers: Headers, email: string) {
+  // Per-domain limiting was removed: shared corporate domains and NAT made it a coworker-vs-coworker limiter, not an abuse boundary.
+  return [
+    `auth-login-options:ip:${sha256Hex(readRequestAddress(headers))}`,
+    `auth-login-options:email:${sha256Hex(email)}`,
+  ]
 }
 
 async function checkLoginOptionsRateLimit(headers: Headers, email: string) {
   const now = Date.now()
-  const keys = [
-    `auth-login-options:ip:${sha256Hex(readRequestAddress(headers))}`,
-    `auth-login-options:email:${sha256Hex(email)}`,
-    `auth-login-options:domain:${sha256Hex(readEmailDomain(email))}`,
-  ]
 
-  for (const key of keys) {
+  for (const key of loginOptionsRateLimitKeys(headers, email)) {
     const retryAfter = await checkRateLimit(key, 20, 60_000, now)
     if (retryAfter !== null) {
       return retryAfter

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -206,22 +206,19 @@ function normalizeResolveEmail(email: string) {
   return email.trim().toLowerCase()
 }
 
-function getResolveEmailDomain(email: string) {
-  const normalized = normalizeResolveEmail(email)
-  const atIndex = normalized.lastIndexOf("@")
-  return atIndex > 0 && atIndex < normalized.length - 1 ? normalized.slice(atIndex + 1) : "unknown"
+export function ssoResolveRateLimitKeys(headers: Headers, email: string) {
+  const normalizedEmail = normalizeResolveEmail(email)
+  // Per-domain limiting was removed: shared corporate domains and NAT made it a coworker-vs-coworker limiter, not an abuse boundary.
+  return [
+    `org-sso-resolve:ip:${sha256Hex(getRequestAddress(headers))}`,
+    `org-sso-resolve:email:${sha256Hex(normalizedEmail)}`,
+  ]
 }
 
 async function checkSsoResolveRateLimit(headers: Headers, email: string) {
-  const normalizedEmail = normalizeResolveEmail(email)
   const now = Date.now()
-  const keys = [
-    `org-sso-resolve:ip:${sha256Hex(getRequestAddress(headers))}`,
-    `org-sso-resolve:email:${sha256Hex(normalizedEmail)}`,
-    `org-sso-resolve:domain:${sha256Hex(getResolveEmailDomain(normalizedEmail))}`,
-  ]
 
-  for (const key of keys) {
+  for (const key of ssoResolveRateLimitKeys(headers, email)) {
     const retryAfter = await checkRateLimit(key, 20, 60_000, now)
     if (retryAfter !== null) {
       return retryAfter

--- a/ee/apps/den-api/test/login-rate-limit-keys.test.ts
+++ b/ee/apps/den-api/test/login-rate-limit-keys.test.ts
@@ -1,0 +1,60 @@
+import { createHash } from "node:crypto"
+import { beforeAll, expect, test } from "bun:test"
+
+let loginOptionsRateLimitKeys: typeof import("../src/routes/auth/index.js").loginOptionsRateLimitKeys
+let ssoResolveRateLimitKeys: typeof import("../src/routes/org/core.js").ssoResolveRateLimitKeys
+
+function sha256Hex(value: string) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+
+  const [authRoutes, orgRoutes] = await Promise.all([
+    import("../src/routes/auth/index.js"),
+    import("../src/routes/org/core.js"),
+  ])
+  loginOptionsRateLimitKeys = authRoutes.loginOptionsRateLimitKeys
+  ssoResolveRateLimitKeys = orgRoutes.ssoResolveRateLimitKeys
+})
+
+test("login options rate-limit keys include only the IP and email", () => {
+  const headers = new Headers({ "x-forwarded-for": "203.0.113.42, 10.0.0.1" })
+  const keys = loginOptionsRateLimitKeys(headers, "jordan@company.test")
+
+  expect(keys).toEqual([
+    `auth-login-options:ip:${sha256Hex("203.0.113.42")}`,
+    `auth-login-options:email:${sha256Hex("jordan@company.test")}`,
+  ])
+  expect(keys.some((key) => key.includes(":domain:"))).toBe(false)
+})
+
+test("SSO resolution rate-limit keys include only the IP and normalized email", () => {
+  const headers = new Headers({ "x-real-ip": "203.0.113.43" })
+  const keys = ssoResolveRateLimitKeys(headers, " Jordan@Company.Test ")
+
+  expect(keys).toEqual([
+    `org-sso-resolve:ip:${sha256Hex("203.0.113.43")}`,
+    `org-sso-resolve:email:${sha256Hex("jordan@company.test")}`,
+  ])
+  expect(keys.some((key) => key.includes(":domain:"))).toBe(false)
+})
+
+test("coworkers at one domain have distinct endpoint key sets", () => {
+  const headers = new Headers({ "x-forwarded-for": "203.0.113.44" })
+  const firstLoginKeys = loginOptionsRateLimitKeys(headers, "first@company.test")
+  const secondLoginKeys = loginOptionsRateLimitKeys(headers, "second@company.test")
+  const firstSsoKeys = ssoResolveRateLimitKeys(headers, "first@company.test")
+  const secondSsoKeys = ssoResolveRateLimitKeys(headers, "second@company.test")
+
+  expect(firstLoginKeys).not.toEqual(secondLoginKeys)
+  expect(firstSsoKeys).not.toEqual(secondSsoKeys)
+  expect(firstLoginKeys[0]).toBe(secondLoginKeys[0])
+  expect(firstSsoKeys[0]).toBe(secondSsoKeys[0])
+  expect(firstLoginKeys[1]).not.toBe(secondLoginKeys[1])
+  expect(firstSsoKeys[1]).not.toBe(secondSsoKeys[1])
+})

--- a/evals/specs/login-rate-limit-shared-domain.slow.test.ts
+++ b/evals/specs/login-rate-limit-shared-domain.slow.test.ts
@@ -1,0 +1,70 @@
+import { denFetch } from "@openwork/behaviors";
+import { expect } from "vitest";
+import { localMysqlIsRunning, needs, server, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "shared-domain login rate limit skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "shared-domain login rate limit skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "shared-domain login rate limit skipped — needs MySQL on 127.0.0.1:3306"
+      : "coworkers sharing an email domain keep independent login-option rate limits";
+
+function statusDistribution(statuses: number[]): string {
+  const counts = new Map<number, number>();
+  for (const status of statuses) counts.set(status, (counts.get(status) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort(([first], [second]) => first - second)
+    .map(([status, count]) => `${status}: ${count}`)
+    .join(", ");
+}
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({ place });
+  const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const domain = `shared-${unique}.example.test`;
+  const coworkerStatuses: number[] = [];
+
+  // The route uses the first forwarded address, so give each coworker a stable IP to isolate the former domain bucket.
+  for (let request = 0; request < 25; request += 1) {
+    const coworker = request % 5;
+    const result = await denFetch(
+      den.ref,
+      `/v1/auth/login-options?email=${encodeURIComponent(`coworker-${coworker}@${domain}`)}`,
+      { headers: { "x-forwarded-for": `198.51.100.${coworker + 1}` } },
+    );
+    coworkerStatuses.push(result.response.status);
+  }
+
+  expect(coworkerStatuses).not.toContain(429);
+  expect(coworkerStatuses.every((status) => status === 200)).toBe(true);
+  evidence.fact(
+    "Coworkers at one domain do not exhaust a shared domain bucket",
+    `Observed 25 requests across 5 emails with status distribution ${statusDistribution(coworkerStatuses)}.`,
+    !coworkerStatuses.includes(429),
+  );
+
+  const singleEmail = `single-${unique}@positive-control.test`;
+  const singleEmailStatuses: number[] = [];
+  // Vary the forwarded address so only the per-email bucket can trigger this positive control.
+  for (let request = 0; request < 25; request += 1) {
+    const result = await denFetch(
+      den.ref,
+      `/v1/auth/login-options?email=${encodeURIComponent(singleEmail)}`,
+      { headers: { "x-forwarded-for": `203.0.113.${request + 1}` } },
+    );
+    singleEmailStatuses.push(result.response.status);
+  }
+
+  expect(singleEmailStatuses).toContain(429);
+  evidence.fact(
+    "The per-email abuse limiter remains active",
+    `Observed 25 requests for one email from distinct forwarded addresses with status distribution ${statusDistribution(singleEmailStatuses)}.`,
+    singleEmailStatuses.includes(429),
+  );
+});


### PR DESCRIPTION
## What
- remove per-domain buckets from login-options and organization SSO resolution
- preserve the existing 20/minute per-IP and per-email buckets unchanged
- add pure key-construction coverage and a Den-only shared-domain regression spec

## Why
A live customer onboarding incident was materially worsened when repeated forced re-logins exhausted one shared company-domain bucket. Coworkers at the same corporate domain were rate limiting each other even when their individual email buckets were below the limit.

## Tests
- `pnpm --dir ee/apps/den-api exec bun test test/login-rate-limit-keys.test.ts` — passed (3 tests)
- `pnpm --dir ee/apps/den-api exec tsc --noEmit` — passed
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project stack --reporter=basic --testNamePattern=__nomatch__` — passed (31 files / 36 tests skipped by the no-match pattern; compile/collection only)

## Evidence
`evals/specs/login-rate-limit-shared-domain.slow.test.ts` is authored but intentionally not run on this machine because another process owns the Den ports. The orchestrator will run it. The spec varies the trusted first `x-forwarded-for` address so the per-IP limiter does not mask the removed domain behavior, then varies addresses for a single-email positive control so the retained email limiter is observable.