### PR TITLE
feat(evidence): publish multi-spec PR tapes

### DIFF
--- a/evals/packages/evidence/bin/publish-pr.mjs
+++ b/evals/packages/evidence/bin/publish-pr.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { formatRollAge, publishPr, readRollFile, scanRolls } from "../src/index.ts";
+import { formatRollAge, publishPr, publishPrRolls, readRollFile, scanRolls } from "../src/index.ts";
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
 const resultsDir = join(repoRoot, "evals", "results");
@@ -13,6 +14,7 @@ let rollArg;
 let dryRun = false;
 let force = false;
 let shouldOpen = false;
+let all = false;
 
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index];
@@ -29,6 +31,10 @@ for (let index = 0; index < args.length; index += 1) {
     shouldOpen = true;
     continue;
   }
+  if (arg === "--all") {
+    all = true;
+    continue;
+  }
   if (arg === "--pr" || arg === "--roll") {
     const value = args[index + 1];
     if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
@@ -41,7 +47,25 @@ for (let index = 0; index < args.length; index += 1) {
 }
 
 if (!dryRun && !shouldOpen && !pr) throw new Error("--pr <n> is required unless --dry-run or --open is set.");
-if (shouldOpen && (pr || dryRun || force)) throw new Error("--open cannot be combined with --pr, --dry-run, or --force.");
+if (shouldOpen && (pr || dryRun || force || all)) throw new Error("--open cannot be combined with --pr, --dry-run, --force, or --all.");
+if (all && rollArg) throw new Error("--all cannot be combined with --roll.");
+if (all && dryRun) throw new Error("--all cannot be combined with --dry-run.");
+if (all && force) throw new Error("--all cannot be combined with --force; it only publishes rolls matching the PR head.");
+
+if (all) {
+  const rollsDir = join(resultsDir, "rolls");
+  const rollDirs = existsSync(rollsDir)
+    ? (await readdir(rollsDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(rollsDir, entry.name))
+      .sort()
+    : [];
+  if (rollDirs.length === 0) throw new Error("No photo roll directories found.");
+  const result = await publishPrRolls({ pr, rollDirs });
+  process.stdout.write(`${result.updated ? "Updated" : "Posted"} ${Object.keys(result.urls).length} photo rolls for PR ${pr}.\n`);
+  process.exit(0);
+}
+
 const entries = (await scanRolls(resultsDir)).filter((entry) => entry.kind === "roll");
 let rollDir;
 let selectedRoll;

--- a/evals/packages/evidence/src/publish-pr.ts
+++ b/evals/packages/evidence/src/publish-pr.ts
@@ -3,9 +3,13 @@ import { lstat, readFile, realpath } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { renderPrMarkdown } from "./render.ts";
 import { readRollFile } from "./scan.ts";
+import type { PhotoRollRecord } from "./schema.ts";
 
 const BLOB_API_BASE = "https://blob.vercel-storage.com";
 const MARKER = "<!-- photo-roll -->";
+const FRAIMZ_MARKER = "<!-- fraimz -->";
+const END_MARKER = "<!-- /photo-roll -->";
+const SECTION_PATTERN = /<!-- photo-roll-section slug=([^ ]+) createdAt=([^ ]+) verdict=([^ ]+) name=([^ ]*) -->\n([\s\S]*?)\n<!-- \/photo-roll-section -->/g;
 
 export interface CommandOptions {
   input?: string;
@@ -41,6 +45,29 @@ export interface PublishPrResult {
   urls: Record<string, string>;
 }
 
+export type EvidenceVerdict = "passed" | "failed" | "unvalidated";
+
+export interface PrEvidenceSection {
+  slug: string;
+  name: string;
+  createdAt: string;
+  verdict: EvidenceVerdict;
+  markdown: string;
+}
+
+export interface PublishPrRollsOptions {
+  pr: string | number;
+  rollDirs: string[];
+}
+
+export interface PublishPrRollsResult {
+  markdown: string;
+  posted: boolean;
+  updated: boolean;
+  urls: Record<string, Record<string, string>>;
+  skipped: string[];
+}
+
 function commandRunner(command: string, args: string[], opts: CommandOptions = {}): CommandResult {
   const result = spawnSync(command, args, {
     encoding: "utf8",
@@ -58,6 +85,112 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function html(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function evidenceSlug(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 80) || "roll";
+}
+
+function isVerdict(value: string): value is EvidenceVerdict {
+  return value === "passed" || value === "failed" || value === "unvalidated";
+}
+
+function decode(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function stripCommentMarkers(markdown: string): string {
+  return markdown
+    .split("\n")
+    .filter((line) => line !== MARKER && line !== FRAIMZ_MARKER && line !== END_MARKER)
+    .join("\n")
+    .trim();
+}
+
+function parseSections(body: string): PrEvidenceSection[] {
+  const sections: PrEvidenceSection[] = [];
+  for (const match of body.matchAll(SECTION_PATTERN)) {
+    const [, slug, encodedCreatedAt, verdict, encodedName, markdown] = match;
+    if (!slug || !encodedCreatedAt || !verdict || encodedName === undefined || !markdown || !isVerdict(verdict)) continue;
+    const createdAt = decode(encodedCreatedAt);
+    const name = decode(encodedName);
+    if (createdAt === null || name === null) continue;
+    sections.push({ slug, name, createdAt, verdict, markdown });
+  }
+  return sections;
+}
+
+function legacySection(body: string): PrEvidenceSection | null {
+  if (!body.includes(MARKER)) return null;
+  const markdown = stripCommentMarkers(body);
+  if (!markdown) return null;
+  const title = /^## Photo roll — (.+?) — /m.exec(markdown)?.[1];
+  const directoryName = /Source: `evals\/results\/rolls\/([^/`]+)\/roll\.json`/.exec(markdown)?.[1];
+  const directorySlug = directoryName?.replace(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-/, "");
+  const createdAt = /_Roll created ([^ ·]+)/.exec(markdown)?.[1] ?? "0000-00-00T00:00:00.000Z";
+  const icon = /^(✅|❌|⚪) \*\*/m.exec(markdown)?.[1];
+  const verdict: EvidenceVerdict = icon === "✅" ? "passed" : icon === "❌" ? "failed" : "unvalidated";
+  return {
+    slug: directorySlug || evidenceSlug(title ?? "previous-evidence"),
+    name: title ?? directorySlug ?? "Previous evidence",
+    createdAt,
+    verdict,
+    markdown,
+  };
+}
+
+function verdictLabel(verdict: EvidenceVerdict): string {
+  if (verdict === "passed") return "✅ PASSED";
+  if (verdict === "failed") return "❌ FAILED";
+  return "⚪ UNVALIDATED";
+}
+
+function renderSection(section: PrEvidenceSection): string {
+  const marker = `<!-- photo-roll-section slug=${section.slug} createdAt=${encodeURIComponent(section.createdAt)} verdict=${section.verdict} name=${encodeURIComponent(section.name)} -->`;
+  return `${marker}\n${section.markdown.trim()}\n<!-- /photo-roll-section -->`;
+}
+
+export function composePrComment(
+  existingBody: string | null | undefined,
+  incoming: PrEvidenceSection | PrEvidenceSection[],
+): string {
+  const existing = existingBody ? parseSections(existingBody) : [];
+  if (existingBody && existing.length === 0) {
+    const legacy = legacySection(existingBody);
+    if (legacy) existing.push(legacy);
+  }
+  const sections = new Map<string, PrEvidenceSection>();
+  for (const section of [...existing, ...(Array.isArray(incoming) ? incoming : [incoming])]) {
+    sections.set(section.slug, section);
+  }
+  const ordered = [...sections.values()].sort((left, right) => (
+    left.createdAt.localeCompare(right.createdAt) || left.slug.localeCompare(right.slug)
+  ));
+  const summary = ordered.map((section) => `- ${verdictLabel(section.verdict)} — **${html(section.name)}**`).join("\n");
+  const details = ordered.map(renderSection).join("\n\n");
+  return [
+    MARKER,
+    FRAIMZ_MARKER,
+    "## Testkit evidence",
+    "",
+    summary,
+    "",
+    details,
+    END_MARKER,
+  ].join("\n");
+}
+
 export function formatRollAge(createdAt: string, now = Date.now()): string {
   const elapsed = Math.max(0, now - Date.parse(createdAt));
   const minutes = Math.floor(elapsed / 60_000);
@@ -69,6 +202,25 @@ export function formatRollAge(createdAt: string, now = Date.now()): string {
 
 function shortSha(sha: string): string {
   return sha.slice(0, 7);
+}
+
+function rollVerdict(roll: PhotoRollRecord): EvidenceVerdict {
+  if (roll.summary.ok) return "passed";
+  if (roll.summary.failedFrames > 0 || roll.summary.failedExpectations > 0) return "failed";
+  return "unvalidated";
+}
+
+function evidenceSection(
+  roll: PhotoRollRecord,
+  markdown: string,
+): PrEvidenceSection {
+  return {
+    slug: evidenceSlug(roll.name),
+    name: roll.name,
+    createdAt: roll.createdAt,
+    verdict: rollVerdict(roll),
+    markdown: stripCommentMarkers(markdown),
+  };
 }
 
 function resolveBlobToken(exec: CommandRunner): string | null {
@@ -128,7 +280,12 @@ async function uploadImages(
   return urls;
 }
 
-function stickyCommentId(raw: string): string | null {
+interface StickyComment {
+  id: string;
+  body: string;
+}
+
+function stickyComment(raw: string): StickyComment | null {
   let value: unknown;
   try {
     value = JSON.parse(raw);
@@ -139,11 +296,11 @@ function stickyCommentId(raw: string): string | null {
   for (const comment of value.comments) {
     if (!isRecord(comment) || typeof comment.body !== "string" || !comment.body.includes(MARKER)) continue;
     const directId = comment.databaseId ?? comment.id;
-    if (typeof directId === "number" && Number.isInteger(directId)) return String(directId);
-    if (typeof directId === "string" && /^\d+$/.test(directId)) return directId;
+    if (typeof directId === "number" && Number.isInteger(directId)) return { id: String(directId), body: comment.body };
+    if (typeof directId === "string" && /^\d+$/.test(directId)) return { id: directId, body: comment.body };
     if (typeof comment.url === "string") {
       const match = /#issuecomment-(\d+)$/.exec(comment.url);
-      if (match?.[1]) return match[1];
+      if (match?.[1]) return { id: match[1], body: comment.body };
     }
   }
   return null;
@@ -156,7 +313,7 @@ function requireSuccess(result: CommandResult, label: string): void {
   throw new Error(`${label} failed: ${detail}`);
 }
 
-function resolvePrHeadSha(pr: string, exec: CommandRunner): string {
+export function resolvePrHeadSha(pr: string, exec: CommandRunner = commandRunner): string {
   const viewed = exec("gh", ["pr", "view", pr, "--json", "headRefOid"]);
   if (viewed.status !== 0 || viewed.error) {
     const detail = viewed.error?.message ?? viewed.stderr.trim();
@@ -174,22 +331,57 @@ function resolvePrHeadSha(pr: string, exec: CommandRunner): string {
   return payload.headRefOid;
 }
 
-function postStickyComment(pr: string, markdown: string, exec: CommandRunner): boolean {
+function postStickyComment(
+  pr: string,
+  sections: PrEvidenceSection[],
+  exec: CommandRunner,
+): { markdown: string; updated: boolean } {
   const viewed = exec("gh", ["pr", "view", pr, "--json", "comments"]);
   requireSuccess(viewed, "Reading PR comments");
-  const commentId = stickyCommentId(viewed.stdout);
-  if (commentId) {
+  const comment = stickyComment(viewed.stdout);
+  const markdown = composePrComment(comment?.body, sections);
+  if (comment) {
     const updated = exec(
       "gh",
-      ["api", "--method", "PATCH", `repos/{owner}/{repo}/issues/comments/${commentId}`, "--input", "-"],
+      ["api", "--method", "PATCH", `repos/{owner}/{repo}/issues/comments/${comment.id}`, "--input", "-"],
       { input: JSON.stringify({ body: markdown }) },
     );
     requireSuccess(updated, "Updating photo roll comment");
-    return true;
+    return { markdown, updated: true };
   }
   const posted = exec("gh", ["pr", "comment", pr, "--body-file", "-"], { input: markdown });
   requireSuccess(posted, "Posting photo roll comment");
-  return false;
+  return { markdown, updated: false };
+}
+
+async function prepareEvidenceSection(
+  rollDir: string,
+  roll: PhotoRollRecord,
+  pr: string,
+  token: string | null,
+  fetcher: Fetcher,
+  staleNotice?: string,
+): Promise<{ section: PrEvidenceSection; urls: Record<string, string> }> {
+  const rollName = basename(rollDir);
+  const urls = token
+    ? await uploadImages(
+      rollDir,
+      rollName,
+      [...new Set(roll.frames.map((frame) => frame.fileName).filter((fileName) => fileName.length > 0))],
+      token,
+      fetcher,
+    )
+    : {};
+  const uploadNotice = token ? undefined : "screenshots not uploaded (no BLOB_READ_WRITE_TOKEN)";
+  const markdown = renderPrMarkdown(roll, urls, {
+    reproCommand: `pnpm fraimz:publish -- --pr ${pr} --roll ${rollName}`,
+    notice: [staleNotice, uploadNotice].filter((notice) => notice !== undefined).join(" · ") || undefined,
+  });
+  return { section: evidenceSection(roll, markdown), urls };
+}
+
+function writeMessage(dependencies: PublishDependencies, message: string): void {
+  (dependencies.stdout ?? ((body) => process.stdout.write(`${body}\n`)))(message);
 }
 
 export async function publishPr(
@@ -226,21 +418,69 @@ export async function publishPr(
     ? `⚠ evidence from ${shortSha(roll.gitSha)}, PR head is ${shortSha(prHeadSha)}`
     : undefined;
 
+  const prepared = await prepareEvidenceSection(
+    options.rollDir,
+    roll,
+    String(options.pr),
+    resolveBlobToken(exec),
+    fetcher,
+    staleNotice,
+  );
+  const posted = postStickyComment(String(options.pr), [prepared.section], exec);
+  return { markdown: posted.markdown, posted: true, updated: posted.updated, urls: prepared.urls };
+}
+
+export async function publishPrRolls(
+  options: PublishPrRollsOptions,
+  dependencies: PublishDependencies = {},
+): Promise<PublishPrRollsResult> {
+  const exec = dependencies.exec ?? commandRunner;
+  const fetcher = dependencies.fetch ?? globalThis.fetch;
+  const pr = String(options.pr);
+  const prHeadSha = resolvePrHeadSha(pr, exec);
+  const skipped: string[] = [];
+  const matching: { rollDir: string; roll: PhotoRollRecord }[] = [];
+
+  for (const rollDir of options.rollDirs) {
+    const rollName = basename(rollDir);
+    const roll = await readRollFile(join(rollDir, "roll.json"));
+    let reason: string | undefined;
+    if (!roll) reason = "unreadable or malformed roll.json";
+    else if (!roll.gitSha) reason = "roll.json has no gitSha";
+    else if (roll.gitSha.toLowerCase() !== prHeadSha.toLowerCase()) {
+      reason = `roll SHA ${shortSha(roll.gitSha)} does not match PR head ${shortSha(prHeadSha)}`;
+    }
+    if (reason) {
+      const message = `Skipping ${rollName}: ${reason}.`;
+      skipped.push(message);
+      writeMessage(dependencies, message);
+      continue;
+    }
+    if (roll) matching.push({ rollDir, roll });
+  }
+
+  matching.sort((left, right) => (
+    left.roll.createdAt.localeCompare(right.roll.createdAt)
+    || basename(left.rollDir).localeCompare(basename(right.rollDir))
+  ));
+  if (matching.length === 0) {
+    throw new Error(`No photo rolls match PR head SHA ${prHeadSha}.`);
+  }
+
   const token = resolveBlobToken(exec);
-  const urls = token
-    ? await uploadImages(
-      options.rollDir,
-      rollName,
-      [...new Set(roll.frames.map((frame) => frame.fileName).filter((fileName) => fileName.length > 0))],
-      token,
-      fetcher,
-    )
-    : {};
-  const uploadNotice = token ? undefined : "screenshots not uploaded (no BLOB_READ_WRITE_TOKEN)";
-  const markdown = renderPrMarkdown(roll, urls, {
-    reproCommand,
-    notice: [staleNotice, uploadNotice].filter((notice) => notice !== undefined).join(" · ") || undefined,
-  });
-  const updated = postStickyComment(String(options.pr), markdown, exec);
-  return { markdown, posted: true, updated, urls };
+  const sections: PrEvidenceSection[] = [];
+  const urls: Record<string, Record<string, string>> = {};
+  for (const entry of matching) {
+    const prepared = await prepareEvidenceSection(entry.rollDir, entry.roll, pr, token, fetcher);
+    sections.push(prepared.section);
+    urls[basename(entry.rollDir)] = prepared.urls;
+  }
+  const posted = postStickyComment(pr, sections, exec);
+  return {
+    markdown: posted.markdown,
+    posted: true,
+    updated: posted.updated,
+    urls,
+    skipped,
+  };
 }

--- a/evals/packages/evidence/test/publish-pr.test.ts
+++ b/evals/packages/evidence/test/publish-pr.test.ts
@@ -3,12 +3,71 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { publishPr } from "../src/publish-pr.ts";
-import type { CommandRunner, Fetcher } from "../src/publish-pr.ts";
+import { composePrComment, publishPr, publishPrRolls } from "../src/publish-pr.ts";
+import type { CommandRunner, Fetcher, PrEvidenceSection } from "../src/publish-pr.ts";
 import type { PhotoRollRecord } from "../src/schema.ts";
 
 const ROLL_SHA = "1111111111111111111111111111111111111111";
 const OTHER_SHA = "2222222222222222222222222222222222222222";
+
+function section(
+  slug: string,
+  name: string,
+  createdAt: string,
+  verdict: PrEvidenceSection["verdict"],
+  markdown = `## ${name} details`,
+): PrEvidenceSection {
+  return { slug, name, createdAt, verdict, markdown };
+}
+
+test("composePrComment merges a new spec section into the existing sticky comment", () => {
+  const first = section("alpha-spec", "Alpha spec", "2026-07-02T10:00:00.000Z", "passed");
+  const second = section("beta-spec", "Beta spec", "2026-07-02T11:00:00.000Z", "failed");
+  const existing = composePrComment(undefined, first);
+  const merged = composePrComment(existing, second);
+
+  assert.match(merged, /## Alpha spec details/);
+  assert.match(merged, /## Beta spec details/);
+  assert.match(merged, /- ✅ PASSED — \*\*Alpha spec\*\*/);
+  assert.match(merged, /- ❌ FAILED — \*\*Beta spec\*\*/);
+});
+
+test("composePrComment replaces only a same-slug section and preserves unrelated sections and markers", () => {
+  const existing = composePrComment(undefined, [
+    section("alpha-spec", "Alpha spec", "2026-07-02T10:00:00.000Z", "failed", "old alpha evidence"),
+    section("beta-spec", "Beta spec", "2026-07-02T11:00:00.000Z", "passed", "beta evidence"),
+  ]);
+  const merged = composePrComment(
+    existing,
+    section("alpha-spec", "Alpha spec", "2026-07-02T12:00:00.000Z", "passed", "new alpha evidence"),
+  );
+
+  assert.doesNotMatch(merged, /old alpha evidence/);
+  assert.match(merged, /new alpha evidence/);
+  assert.match(merged, /beta evidence/);
+  assert.equal(merged.match(/<!-- photo-roll -->/g)?.length, 1);
+  assert.equal(merged.match(/<!-- fraimz -->/g)?.length, 1);
+  assert.equal(merged.match(/photo-roll-section slug=alpha-spec/g)?.length, 1);
+  assert.equal(merged.match(/- ✅ PASSED — \*\*Alpha spec\*\*/g)?.length, 1);
+});
+
+test("composePrComment renders a complete summary and stable chronological section order", () => {
+  const body = composePrComment(undefined, [
+    section("zulu-spec", "Zulu spec", "2026-07-02T12:00:00.000Z", "unvalidated"),
+    section("beta-spec", "Beta spec", "2026-07-02T10:00:00.000Z", "failed"),
+    section("alpha-spec", "Alpha spec", "2026-07-02T10:00:00.000Z", "passed"),
+  ]);
+
+  assert.match(body, /## Testkit evidence/);
+  for (const summary of [
+    "- ✅ PASSED — **Alpha spec**",
+    "- ❌ FAILED — **Beta spec**",
+    "- ⚪ UNVALIDATED — **Zulu spec**",
+  ]) assert.ok(body.includes(summary));
+  assert.ok(body.indexOf("slug=alpha-spec") < body.indexOf("slug=beta-spec"));
+  assert.ok(body.indexOf("slug=beta-spec") < body.indexOf("slug=zulu-spec"));
+  assert.ok(body.indexOf("Zulu spec**") < body.indexOf("slug=alpha-spec"));
+});
 
 function dryRunRecord(dir: string): PhotoRollRecord {
   return {
@@ -69,6 +128,59 @@ test("publishPr dry-run prints composed markdown without upload or gh calls", as
     assert.match(output, /Dry run: screenshots were not uploaded/);
   } finally {
     await rm(rollDir, { recursive: true, force: true });
+  }
+});
+
+test("publishPrRolls skips malformed and stale rolls and composes matching rolls chronologically", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-evidence-publish-all-"));
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const olderDir = join(root, "2026-07-02T10-00-00-000Z-older-spec");
+    const newerDir = join(root, "2026-07-02T12-00-00-000Z-newer-spec");
+    const staleDir = join(root, "2026-07-02T11-00-00-000Z-stale-spec");
+    const malformedDir = join(root, "2026-07-02T13-00-00-000Z-malformed-spec");
+    await Promise.all([olderDir, newerDir, staleDir, malformedDir].map((dir) => mkdir(dir)));
+    const older = dryRunRecord(olderDir);
+    older.name = "Older spec";
+    const newer = dryRunRecord(newerDir);
+    newer.name = "Newer spec";
+    newer.createdAt = "2026-07-02T12:00:00.000Z";
+    const stale = dryRunRecord(staleDir);
+    stale.name = "Stale spec";
+    stale.gitSha = OTHER_SHA;
+    await Promise.all([
+      writeFile(join(olderDir, "roll.json"), JSON.stringify(older)),
+      writeFile(join(newerDir, "roll.json"), JSON.stringify(newer)),
+      writeFile(join(staleDir, "roll.json"), JSON.stringify(stale)),
+      writeFile(join(malformedDir, "roll.json"), "{not-json"),
+    ]);
+    let postedMarkdown = "";
+    const messages: string[] = [];
+    const exec: CommandRunner = (_command, args, opts) => {
+      if (args.includes("headRefOid")) return { status: 0, stdout: JSON.stringify({ headRefOid: ROLL_SHA }), stderr: "" };
+      if (args.includes("comments")) return { status: 0, stdout: JSON.stringify({ comments: [] }), stderr: "" };
+      if (args.includes("BLOB_READ_WRITE_TOKEN")) return { status: 1, stdout: "", stderr: "missing" };
+      postedMarkdown = opts?.input ?? "";
+      return { status: 0, stdout: "posted", stderr: "" };
+    };
+    const result = await publishPrRolls(
+      { pr: 17, rollDirs: [malformedDir, newerDir, staleDir, olderDir] },
+      { exec, stdout: (message) => messages.push(message) },
+    );
+
+    assert.deepEqual(Object.keys(result.urls), [
+      "2026-07-02T10-00-00-000Z-older-spec",
+      "2026-07-02T12-00-00-000Z-newer-spec",
+    ]);
+    assert.equal(messages.some((message) => message.includes("unreadable or malformed roll.json")), true);
+    assert.equal(messages.some((message) => message.includes("does not match PR head")), true);
+    assert.ok(postedMarkdown.indexOf("slug=older-spec") < postedMarkdown.indexOf("slug=newer-spec"));
+    assert.match(postedMarkdown, /screenshots not uploaded \(no BLOB_READ_WRITE_TOKEN\)/);
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
+    await rm(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## What
- Merge evidence into one sticky PR comment using deterministic per-spec sections.
- Replace only a republished spec while retaining every other tape and a summary of all verdicts.
- Add `--all` to publish every valid roll matching the PR head in chronological order, skipping malformed, unreadable, missing-SHA, and stale rolls with clear messages.

## Why
A five-spec PR had its five tapes published sequentially, but the single sticky comment was replaced each time. Four tapes were silently overwritten, leaving only the last tape and making multi-spec human verification unreliable.

## Tests
- `pnpm --dir evals test` — PASS (151 passed, 0 failed).
- `pnpm exec tsc --noEmit --strict --module nodenext --moduleResolution nodenext --target es2023 --lib es2023,esnext.disposable --allowImportingTsExtensions --erasableSyntaxOnly --verbatimModuleSyntax --skipLibCheck --types node evals/packages/evidence/src/*.ts evals/packages/evidence/test/*.ts` — PASS.
- `pnpm --dir evals typecheck` — unavailable because the isolated evals workspace does not install `tsc`; root `pnpm exec tsc -p evals` reaches an unrelated pre-existing error in `evals/specs/connectors-quick-add.slow.test.ts:253`.

## Evidence
This changes tooling for the evidence layer itself. The network-free comment composition is covered by pure unit tests, including merge, same-slug replacement, marker preservation, summary rendering, and stable ordering. No real PR was published during implementation; the orchestrator will exercise the publisher live.