### PR TITLE
docs(skills): define two-layer PR verification

### DIFF
--- a/.opencode/skills/daytona-flow-validator/SKILL.md
+++ b/.opencode/skills/daytona-flow-validator/SKILL.md
@@ -8,6 +8,8 @@ description: do e2e tests, validate feature, prove it works, pass/fail, testkit 
 Use this skill to decide whether a Daytona Electron or browser flow actually
 works. Launching the sandbox is separate. This skill owns the feedback loop.
 
+Follow `prove-a-pr` for the repository-wide agent-first and human-verification contract.
+
 ## Core Rule
 
 Never report success from a click, script return value, or recording alone.

--- a/.opencode/skills/daytona-recording-artifacts/SKILL.md
+++ b/.opencode/skills/daytona-recording-artifacts/SKILL.md
@@ -10,6 +10,8 @@ journey. Pass/fail evidence comes from an `@openwork/testkit` spec and its
 ambient tape; use `daytona-flow-validator` and `run-tests` before declaring a
 verdict. Custom screenshots or recordings never replace the tape.
 
+Follow `prove-a-pr` for the repository-wide agent-first and human-verification contract.
+
 ## Default supplementary format: screenshot index
 
 For presentation, use a browseable HTML page with named PNG screenshots for

--- a/.opencode/skills/diagnose-a-red-run/SKILL.md
+++ b/.opencode/skills/diagnose-a-red-run/SKILL.md
@@ -1,19 +1,39 @@
 ---
 name: diagnose-a-red-run
-description: Test is red, flaky, timed out, was this already broken. Use to classify and diagnose a failing @openwork/testkit spec before changing code.
+description: Test is red, typecheck failed, CI job failed, flaky, timed out, was this already broken. Use to classify any failing check before changing code or calling it pre-existing.
 ---
 
 # Skill: Diagnose a Red Run
 
-## First establish ownership
+## Capture the branch failure
 
-The first question is always: is it red on `origin/dev` too? Materialize the
-baseline with `git show origin/dev:<file> > zz-baseline`, run it, then delete
-the baseline. Introduced versus pre-existing determines the response; never
-hand-wave a failure as unrelated.
+- Record the exact command, commit SHA, exit code, and passed/failed/skipped
+  counts. Quote the first actionable failure; do not summarize it away.
+- Classify the check: testkit spec, unit suite, typecheck, build, lint, or CI job.
+
+## Run a clean control
+
+Never call a failure pre-existing from memory or from a modified checkout.
+
+```bash
+git fetch origin dev
+git worktree add /tmp/openwork-dev-control --detach origin/dev
+# In that clean worktree, prepare the same prerequisites and run the exact command.
+git worktree remove /tmp/openwork-dev-control
+```
+
+- Keep tool versions, environment, services, flags, and secrets equivalent.
+- Quote the control command, `origin/dev` SHA, exit code, counts, and matching
+  failure text.
+- Classify as pre-existing only when the clean control demonstrates the same
+  failure. Otherwise classify it as introduced, environment-specific, or
+  unresolved. A non-reproducing control is not proof of flakiness; repeat both
+  sides before using that label.
 
 ## Classify by signature
 
+- Unit/type/CI-only failure: inspect the first failing job and run its exact
+  command locally before broadening scope.
 - Vision disagreement on identical pixels: claim wording or product ambiguity.
   Make the product unambiguous or make the claim factual.
 - Timeout with an On-screen dump: read it. It names the state; for example,
@@ -31,5 +51,6 @@ hand-wave a failure as unrelated.
 - Electron zombies can respawn from a root process; kill the process group.
 - Leaked state pollutes organizations; delete leftover connectors between runs.
 
-The tape ends at the stuck screen. Read its last unclaimed takes before
-touching code.
+For a testkit failure, read the tape's last unclaimed takes before touching
+code. Publish a useful red tape with `publish-evidence`; it remains human audit,
+not a passing verdict.

--- a/.opencode/skills/fraimz/SKILL.md
+++ b/.opencode/skills/fraimz/SKILL.md
@@ -8,6 +8,8 @@ description: DEPRECATED legacy flow compatibility. Load only when a user explici
 This guide exists only to run a user-requested flow that is already present in
 `evals/flows/`. The corpus is frozen.
 
+For current verification, use `prove-a-pr` → `write-a-spec` → `run-tests` → `publish-evidence`.
+
 ## Hard boundary
 
 - Refuse requests to create, scaffold, copy, rename, or modify a legacy flow.

--- a/.opencode/skills/prove-a-pr/SKILL.md
+++ b/.opencode/skills/prove-a-pr/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: prove-a-pr
+description: Prove a PR, prepare merge verification, publish all evidence, check a stacked PR. Use when declaring a PR Passed, Incomplete, or Failed.
+---
+
+# Skill: Prove a PR
+
+## Verify the tree that will land
+
+- Run every check on the PR head after its final rebase or cherry-pick. Re-run
+  and re-publish after any history rewrite; tapes are bound to a commit SHA.
+- Before merging a stacked PR, inspect
+  `gh pr view <n> --json baseRefName,headRefName,headRefOid`. If its base PR
+  merged first, the stack can merge into the feature branch instead of `dev`;
+  GitHub then recreates commits with new SHAs and orphans their tapes.
+- Detect stray commits with `git log --oneline <branch> ^origin/dev`. Remedy a
+  bad stack by cherry-picking only the intended commits onto current `dev`, then
+  re-run every check and re-publish every tape.
+
+## Produce the agent-first verdict
+
+- Use `write-a-spec` and `run-tests`. Prose, screenshots, and recordings never
+  decide pass/fail.
+- Give every claim an observable assertion and a visible testkit tape.
+- Report only `Passed`, `Incomplete`, or `Failed`. Always quote exact commands,
+  exit codes, and passed/failed/skipped counts.
+- Call a failure pre-existing only after the same command demonstrates it in a
+  clean `origin/dev` worktree. Quote the control command and matching failure.
+
+## Satisfy local prerequisites
+
+```bash
+pnpm --filter @openwork/types build
+pnpm --filter @openwork-ee/den-db build
+pnpm --filter @openwork/email build
+pnpm dev:den:mysql
+```
+
+- Local `server()` requires MySQL at `127.0.0.1:3306`; unbuilt workspace
+  dependencies can make den-api imports fail.
+- If the checkout path contains spaces, set `OPENWORK_EVAL_SURFACES_DIR` to a
+  space-free path; node-gyp and electron-rebuild otherwise fail.
+- Set `OPENWORK_EVAL_APP_SPECS=1` for app-driving specs.
+
+## Publish human verification
+
+- The orchestrator owns publishing after the verdict. After a multi-spec run,
+  publish every head-matching tape with:
+
+```bash
+pnpm fraimz:publish -- --pr <n> --all
+```
+
+- Confirm the sticky PR comment shows one section for every claimed spec.
+- Never use `--force` to paper over a SHA mismatch; re-run on the PR head.
+  Reserve it for deliberately publishing a historical or red tape, and call
+  that exception out in the report and PR comment.

--- a/.opencode/skills/publish-evidence/SKILL.md
+++ b/.opencode/skills/publish-evidence/SKILL.md
@@ -1,30 +1,47 @@
 ---
 name: publish-evidence
-description: Publish an existing testkit evidence tape on a PR without rerunning tests.
+description: Publish evidence, publish all tapes, update PR verification, audit a red tape. Use for the human-verification layer after @openwork/testkit runs.
 ---
 
 # Skill: Publish Evidence
 
-Run:
+The orchestrator owns this human-verification step. Publishing makes the
+agent-first verdict inspectable; it never decides pass/fail and never reruns a
+test.
+
+## Make every claim auditable
+
+- Show the spec name and verdict, each claim's assertion or fact, the relevant
+  frames, the source tape, and the reproduction command.
+- Require one sticky-comment section per claimed spec. If a claim has no visible
+  tape section, report the PR `Incomplete`.
+- Keep both `<!-- photo-roll -->` and `<!-- fraimz -->` markers.
+
+## Publish the PR head
+
+After a multi-spec run, publish every tape whose `gitSha` matches the PR head:
 
 ```bash
-pnpm fraimz:publish -- --pr <n> [--roll <dir|name>] [--force] [--open]
+pnpm fraimz:publish -- --pr <n> --all
 ```
 
 `fraimz:publish` is an implementation-compatibility command name. It publishes
-an existing `@openwork/testkit` evidence tape; it does not run a legacy flow.
+existing `@openwork/testkit` tapes, not legacy flows.
 
-## Publishing contract
+- `--all` processes matching rolls chronologically and prints why stale or
+  malformed rolls were skipped.
+- Do not combine `--all` with `--roll`, `--force`, `--dry-run`, or `--open`.
+- Publishing accumulates sections in one sticky comment. Publishing a new spec
+  preserves existing sections; republishing the same spec replaces only that
+  spec's section. Confirm the summary lists every spec and verdict.
+- Use `--roll <dir|name>` only to publish one selected existing tape.
 
-- The publisher selects the newest ambient tape and prints what it selected.
-- Use `--roll <dir|name>` only when needed to select a specific existing tape.
-  This publisher selector is not the prohibited test-author roll-handle API.
-- Test authors do not create, pass, or manage roll handles.
-- It refuses a tape whose SHA differs from the PR head. Use `--force` only when
-  intentional; the published result is annotated.
-- Red tapes are publishable and often should be published.
-- Publishing never reruns tests.
-- Update one sticky PR comment carrying both `<!-- photo-roll -->` and
-  `<!-- fraimz -->` markers.
+## Refuse misleading evidence
+
+- Never use `--force` to hide a SHA mismatch. Re-run the spec on the PR head.
+- Use `--force` only to deliberately publish a historical or red tape. The
+  output is annotated; call the exception out explicitly. Red tapes are valid
+  human-verification artifacts and should be published when they explain a
+  `Failed` or `Incomplete` verdict.
 - Read `BLOB_READ_WRITE_TOKEN` from the environment or the Infisical fallback.
   Without it, still post verdicts with a no-screenshots note.

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -8,6 +8,8 @@ description: DEPRECATED legacy automation runner. Load only when a user explicit
 Use this guide only when the user names a flow that already exists in
 `evals/flows/`. The directory is frozen.
 
+For current verification, use `prove-a-pr` → `write-a-spec` → `run-tests` → `publish-evidence`.
+
 - Refuse to create, scaffold, copy, rename, or modify a legacy flow.
 - If the requested behavior has no existing flow, use `write-a-spec` and
   `run-tests`; new specs import `test` from `@openwork/testkit`.

--- a/.opencode/skills/run-tests/SKILL.md
+++ b/.opencode/skills/run-tests/SKILL.md
@@ -1,27 +1,58 @@
 ---
 name: run-tests
-description: Run the tests, run e2e locally, run on Daytona, why is this skipped. Use for running and interpreting @openwork/testkit specs.
+description: Run the tests, run one spec, run e2e locally or on Daytona, investigate a skipped spec. Use for executing @openwork/testkit agent-first verification.
 ---
 
 # Skill: Run Tests
 
-## Choose the lane
+## Run the landable tree
 
-- `pnpm evals:spec` is the app-less PR lane.
-- App specs require `OPENWORK_EVAL_APP_SPECS=1` and run with
-  `vitest --project stack <file>`.
+- Check out the exact PR head that will land. After any rebase or cherry-pick,
+  discard the old verdict and run again.
+- Run one spec at a time so each failure and ambient tape has one owner.
+
+## Prepare local execution
+
+```bash
+pnpm --filter @openwork/types build
+pnpm --filter @openwork-ee/den-db build
+pnpm --filter @openwork/email build
+pnpm dev:den:mysql
+```
+
+- Local `server()` requires MySQL at `127.0.0.1:3306`.
+- Build those workspace dependencies before local Den; otherwise den-api imports
+  can fail.
+- If the checkout path contains spaces, set `OPENWORK_EVAL_SURFACES_DIR` to a
+  space-free path before app specs. node-gyp and electron-rebuild require it.
+
+## Choose one lane
+
+- Run one app-less PR-lane spec:
+
+```bash
+pnpm evals:spec specs/<name>.test.ts
+```
+
+- Run one app/Den-driving stack-lane spec:
+
+```bash
+OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/<name>.slow.test.ts
+```
+
 - Set `OPENWORK_EVAL_DAYTONA=1` to place resources in sandboxes. Leave it unset
-  for isolated local instances.
-- Local `server()` requires Docker MySQL from `pnpm dev:den:mysql`.
+  for isolated local resources.
 
 ## Read the verdict
 
-Report exactly: passed, failed, or `skipped — needs: X`. A skip must name the
-missing environment requirement. A green suite containing skips is not proof.
+- Record the exact command, exit code, and passed/failed/skipped counts.
+- Report each skip as `skipped — needs: X`; never call it passed. A green command
+  containing skips makes the overall verdict `Incomplete`.
+- Use `Passed`, `Incomplete`, or `Failed` for the overall result.
 
-## Iterate without weakening proof
+## Iterate, then cold-boot
 
-- Run one spec at a time.
 - While iterating, reuse a warm Den with `OPENWORK_EVAL_DEN_API_URL`.
-- Before declaring green, cold-boot through local `server()`.
+- Before declaring `Passed`, remove the reuse override and cold-boot through
+  `server()` on the same commit.
 - Inject secrets with `infisical run --silent --`; never print or echo values.

--- a/.opencode/skills/write-a-spec/SKILL.md
+++ b/.opencode/skills/write-a-spec/SKILL.md
@@ -5,19 +5,33 @@ description: Write a spec, new e2e test, test a feature end to end, add a slow s
 
 # Skill: Write a Spec
 
-Write new tests in `evals/specs/*.test.ts` and import `test` from
+Write new tests in `evals/specs/**/*.test.ts` and import `test` from
 `@openwork/testkit`. App-driving specs use `.slow.test.ts`; the PR lane excludes
 them. Model setup as resources in dependency order: `needs()` → `server()` →
 `app()`.
 
+## Use the testkit primitives
+
+- `server()` boots or reuses Den and provisions isolated organizations.
+- `app()` boots a signed-in desktop. Use `profileDir` for caller-owned profile
+  continuity and `localServerDelayMs` for deterministic startup races.
+- `inviteMember()` adds a named member to an existing Den.
+- `faultProxy()` injects `faults.status()` or `faults.latency()` and exposes the
+  `requests` log for assertions about attempts and recovery.
+- `eventually()` bounds polling and reports its last value or error.
+- `readDenClientState()`, `readConnectState()`, and `readConnectStateFile()`
+  expose client, local-server, and persisted-profile state.
+
 ## Claims and witnesses
 
-- Describe what a human would verify, not incidental layout. Claims such as
-  "side by side" can disagree even when pixels are identical across runs.
+- Make each claim machine-checkable with an observable assertion and its
+  explicit negative half. Assert both the intended effect and what must not
+  happen to another identity, account, request, file, or state.
+- Prose is never proof. Screenshots explain an assertion but cannot replace it.
+- Describe product behavior, not incidental layout. Claims such as "side by
+  side" can disagree even when pixels are identical across runs.
 - Match claims to what the product actually says on screen. If product and
   claim diverge, explicitly change one; never silently bend the claim.
-- The assertion is the witness. Attribute side effects per identity and always
-  assert the negative half: the other mailbox or account must be empty.
 - Never smuggle the answer into the prompt. Assert that the user-facing request
   does not contain connector or resource IDs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,16 +27,24 @@ If you open a PR, you must run tests and report what you ran (commands + result)
 
 For runtime-observable changes, include the `@openwork/testkit` evidence tape.
 Custom screenshots and recordings may supplement that tape, but never determine the
-pass/fail verdict. If validation cannot run, say why and give exact repro steps.
+pass/fail verdict. The orchestrator owns publishing the tape, and a runtime-observable
+change is not done until its tape is visible on the PR. If validation cannot run,
+say why and give exact repro steps.
 
 ## Validate Every Experience
 
 Almost everything we change affects the filesystem, runtime DB, server API,
-provisioning, sessions, config, or UI. New executable end-to-end coverage has
-one path: `evals/specs/**/*.test.ts`, with `test` imported from
-`@openwork/testkit`. Specs that drive the app use `.slow.test.ts`.
+provisioning, sessions, config, or UI. Validation has two layers:
 
-Use the skills in this order: `write-a-spec` → `run-tests` →
+1. **Agent-first verification** produces the verdict. New executable end-to-end
+   coverage has one path: `evals/specs/**/*.test.ts`, with `test` imported from
+   `@openwork/testkit`. Specs that drive the app use `.slow.test.ts`. Prose is
+   never proof.
+2. **Human verification** publishes the testkit tape on the PR so a person can
+   audit the verdict without rerunning it. It never decides pass/fail. The
+   orchestrator owns this step.
+
+Use the skills in this order: `prove-a-pr` → `write-a-spec` → `run-tests` →
 `diagnose-a-red-run` when failing → `publish-evidence` for an existing ambient
 evidence tape. Evidence is ambient: do not create or pass roll handles. Report
 `Passed` only when every claim has an observable assertion in the tape;


### PR DESCRIPTION
## What

- Add the orchestrator-facing `prove-a-pr` skill for landable-tree, stacked-PR, control-run, prerequisite, verdict, and publication checks.
- Rewrite the authoring, execution, diagnosis, and publication skills around agent-first verdicts and human-auditable tapes.
- Name both layers in `AGENTS.md` and point deprecated/overlapping skills at the new contract without deleting or rewriting their compatibility guidance.

## Why

Make one concise verification path explicit: machines decide the verdict from observable assertions; humans audit the accumulated tape on the PR.

This PR documents the contract implemented in #3546 (`feat/evidence-multi-tape`), expected to land before or with this PR: per-spec sticky-comment accumulation, chronological `--all` publication for PR-head tapes, stale-roll skip reasons, and annotated deliberate forced publication.

## Validation

- `git diff --check origin/dev...HEAD` — passed.
- `pnpm evals:spec specs/testkit-evidence.test.ts` — 1 file passed, 2 tests passed; command-syntax sanity check only.
- Docs and inert agent config; no runtime evidence applies.

## Skill summary

| Action | Skills |
| --- | --- |
| Added | `prove-a-pr` |
| Rewritten | `write-a-spec`, `run-tests`, `diagnose-a-red-run`, `publish-evidence` |
| Pointed at | `fraimz`, `run-evals`, `daytona-flow-validator`, `daytona-recording-artifacts` |