### PR TITLE
fix(den-web): drop amber background on non-ready library rows

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
@@ -241,7 +241,6 @@ function LibraryRow({ item, isAdmin, isFocused, orgName, orgSlug }: { item: Libr
       ) : undefined}
       action={action}
       href={rowHref}
-      tone={sectionState === "ready" ? "default" : "warning"}
       focused={isFocused}
       dataAttributes={{
         "data-library-item-type": item.type,

--- a/evals/specs/library-view.slow.test.ts
+++ b/evals/specs/library-view.slow.test.ts
@@ -521,7 +521,7 @@ test.skipIf(!apiUrl || !webUrl)(title, async () => {
   const desktopShot = await screenshot(browser);
   const desktopSeen = await validate(desktopShot, [
     "Rows show a logo tile, a title with chips beside it, and one meta line inside a hairline-divided card",
-    "An amber needs-sign-in row shows a dark Sign in button under a NEEDS YOUR SIGN-IN caption",
+    "A white needs-sign-in row shows an amber Connect your account chip and a dark Sign in button under a NEEDS YOUR SIGN-IN caption",
   ]);
   await roll.add(desktopShot, desktopSeen);
   expect(desktopSeen.ok, desktopSeen.why).toBe(true);


### PR DESCRIPTION
## What

The Library screen tinted every row in the **NEEDS YOUR SIGN-IN** and **NEEDS ADMIN SETUP** sections with an amber background (`DenListRow tone="warning"` → `bg-amber-50/40`). Rows now stay white like the rest of the list (and like Your Connections); the amber status chip ("Connect your account" / "Waiting on your admin") still carries the state.

- `ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx`: stop passing `tone="warning"` to the row.
- `evals/specs/library-view.slow.test.ts`: update the vision claim to expect a white row with an amber chip.

## Validation

Ran the den-web library spec against a fresh local Den stack (multi-org, seeded Acme Robotics demo):

- `vitest run --project stack specs/library-view.slow.test.ts` — **passed** (includes the updated vision claim "A white needs-sign-in row shows an amber Connect your account chip and a dark Sign in button under a NEEDS YOUR SIGN-IN caption").
- `pnpm --filter @openwork-ee/den-web typecheck` — passed.
- `specs/library-state-tabs.slow.test.ts` (desktop Electron Library view) fails at its first navigation step in this environment; it exercises `apps/app`, which this den-web-only diff does not touch — pre-existing/environmental, unrelated to this change.

Evidence tape published in the sticky comment below.