### PR TITLE
feat(automations): propose an Automation from chat

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -35,6 +35,10 @@ import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
 import { GlobTool } from "@/components/tools/glob"
 import { GrepTool } from "@/components/tools/grep"
 import { LspTool } from "@/components/tools/lsp"
+import {
+  isAutomationProposalToolPart,
+  OpenWorkAutomationProposalTool,
+} from "@/components/tools/openwork-automation-proposal"
 import { OpenWorkSessionCreateTool } from "@/components/tools/openwork-session-create"
 import { QuestionTool } from "@/components/tools/question"
 import { SkillTool } from "@/components/tools/skill"
@@ -224,6 +228,10 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (part.type === "dynamic-tool" && part.toolName === "openwork_session_create") {
     return <OpenWorkSessionCreateTool part={part} />
+  }
+
+  if (part.type === "dynamic-tool" && isAutomationProposalToolPart(part)) {
+    return <OpenWorkAutomationProposalTool part={part} />
   }
 
   if (isTaskToolPart(part)) {

--- a/apps/app/src/components/tools/openwork-automation-proposal.tsx
+++ b/apps/app/src/components/tools/openwork-automation-proposal.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, CalendarClock, Check } from "lucide-react"
+import type { DynamicToolUIPart } from "ai"
+import { useNavigate } from "react-router-dom"
+import { toast } from "sonner"
+
+import { automationProposalSchema, AUTOMATION_FREE_MODEL, type AutomationProposal } from "@openwork/types/automations"
+
+import { createDenClient, readDenSettings } from "@/app/lib/den"
+import { Button } from "@/components/ui/button"
+import { Tool } from "@/components/ui/tool"
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { formatAutomationSchedule } from "@/react-app/domains/automations/automation-format"
+import { useFeatureFlagsPreferences } from "@/react-app/domains/settings/state/feature-flags-preferences"
+import { automationsRoute } from "@/react-app/shell/workspace-routes"
+
+function parseOutputValue(output: unknown): unknown {
+  if (typeof output !== "string") return output
+  try {
+    return JSON.parse(output)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reads an `automation.propose` affordance result out of an openwork_execute
+ * tool part. Returns null for every other affordance so the generic capability
+ * line keeps rendering them.
+ */
+export function parseAutomationProposal(output: unknown): AutomationProposal | null {
+  const envelope = parseOutputValue(output)
+  if (envelope === null || typeof envelope !== "object" || Array.isArray(envelope)) return null
+  const record = envelope as Record<string, unknown>
+  if (record.ok !== true || record.id !== "automation.propose") return null
+  const result = record.result
+  if (result === null || typeof result !== "object" || Array.isArray(result)) return null
+  const parsed = automationProposalSchema.safeParse((result as Record<string, unknown>).proposal)
+  return parsed.success ? parsed.data : null
+}
+
+export function isAutomationProposalToolPart(part: DynamicToolUIPart): boolean {
+  return part.toolName === "openwork_execute"
+    && part.state === "output-available"
+    && parseAutomationProposal(part.output) !== null
+}
+
+export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPart }) {
+  const navigate = useNavigate()
+  const denAuth = useDenAuth()
+  const { automationsEnabled } = useFeatureFlagsPreferences()
+  const [created, setCreated] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const proposal = part.state === "output-available" ? parseAutomationProposal(part.output) : null
+  if (!proposal) {
+    return <Tool toolPart={part} title="Proposed an Automation" />
+  }
+
+  const settings = readDenSettings()
+  const token = settings.authToken?.trim() ?? ""
+  const organizationId = settings.activeOrgId?.trim() ?? ""
+  const signedIn = denAuth.isSignedIn && Boolean(token) && Boolean(organizationId)
+  const blocker = !automationsEnabled
+    ? "Turn on the Automations preview in Settings → Preferences to create this."
+    : !signedIn
+      ? "Sign in to OpenWork Cloud to create this Automation."
+      : null
+
+  const create = async () => {
+    setBusy(true)
+    try {
+      const client = createDenClient({ baseUrl: settings.baseUrl, token })
+      const detail = await client.createAutomation(organizationId, {
+        name: proposal.name,
+        instructions: proposal.instructions,
+        schedule: proposal.schedule,
+        model: proposal.model ?? {
+          providerId: AUTOMATION_FREE_MODEL.providerId,
+          modelId: AUTOMATION_FREE_MODEL.modelId,
+        },
+      })
+      setCreated(detail.automation.id)
+      toast.success("Automation created and active")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not create the Automation")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="not-prose w-full max-w-2xl overflow-hidden rounded-2xl border border-dls-border bg-dls-surface/95 shadow-sm"
+      data-openwork-automation-proposal
+      data-automation-created={created ?? undefined}
+    >
+      <div className="flex items-start gap-3 border-b border-dls-border px-4 py-3">
+        <div className={created
+          ? "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-green-6/35 bg-green-3/30 text-green-11"
+          : "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-dls-border bg-dls-hover text-dls-secondary"
+        }>
+          {created ? <Check className="size-4" /> : <CalendarClock className="size-4" />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-dls-primary">
+            {created ? "Automation created and active" : "Suggested Automation"}
+          </h3>
+          <p className="mt-0.5 text-xs text-dls-secondary">
+            {created
+              ? "It runs on the schedule below while this desktop is connected."
+              : "Nothing was created yet. Review it, then create it if it looks right."}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3 px-4 py-3">
+        <div>
+          <p className="truncate text-sm font-medium text-dls-primary" title={proposal.name}>{proposal.name}</p>
+          <p className="text-xs text-dls-secondary">{formatAutomationSchedule(proposal.schedule)}</p>
+        </div>
+        <p className="whitespace-pre-wrap text-sm text-dls-secondary">{proposal.instructions}</p>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-dls-border px-4 py-3">
+        <p className="min-w-0 flex-1 text-xs text-dls-secondary">
+          {blocker ?? "Automations run on this desktop while it is connected."}
+        </p>
+        {created ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            data-open-automation={created}
+            onClick={() => navigate(automationsRoute())}
+          >
+            Open Automation
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            className="shrink-0"
+            disabled={busy || blocker !== null}
+            data-create-automation
+            onClick={() => void create()}
+          >
+            {busy ? "Creating…" : "Create Automation"}
+          </Button>
+        )}
+      </div>
+
+      {blocker && !created ? (
+        <div className="flex items-center gap-2 border-t border-dls-border px-4 py-2 text-xs text-amber-11">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1">{blocker}</span>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/app/src/react-app/domains/automations/automation-format.ts
+++ b/apps/app/src/react-app/domains/automations/automation-format.ts
@@ -1,3 +1,5 @@
+import type { AutomationSchedule } from "@openwork/types/automations";
+
 const SUNDAY_UTC = Date.UTC(2024, 0, 7);
 
 export function formatAutomationWeekdays(daysOfWeek: number[], locales?: Intl.LocalesArgument) {
@@ -9,4 +11,17 @@ export function formatAutomationWeekdays(daysOfWeek: number[], locales?: Intl.Lo
   return daysOfWeek
     .map((day) => formatter.format(new Date(SUNDAY_UTC + day * 24 * 60 * 60 * 1_000)))
     .join(", ");
+}
+
+export function formatAutomationTime(value: number | null | undefined) {
+  return typeof value === "number" ? new Date(value).toLocaleString() : "—";
+}
+
+export function formatAutomationSchedule(schedule: AutomationSchedule) {
+  if (schedule.kind === "once") {
+    return `Once · ${formatAutomationTime(schedule.at)} · ${schedule.timezone}`;
+  }
+  const time = `${String(schedule.hour).padStart(2, "0")}:${String(schedule.minute).padStart(2, "0")}`;
+  if (schedule.kind === "daily") return `Daily · ${time} · ${schedule.timezone}`;
+  return `Weekly · ${formatAutomationWeekdays(schedule.daysOfWeek)} · ${time} · ${schedule.timezone}`;
 }

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -46,21 +46,10 @@ import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal"
 import { AutomationEditor } from "./automation-editor"
 import { automationExecutionThreadRoute, automationExecutionIdentity } from "./automation-cloud-thread"
-import { formatAutomationWeekdays } from "./automation-format"
+import { formatAutomationSchedule, formatAutomationTime } from "./automation-format"
 import { automationModelOptions } from "./automation-model-options"
 
 const ACTIVE_RUN_STATUSES = new Set<AutomationRun["status"]>(["queued", "claimed", "running"])
-
-function formatTime(value: number | null | undefined) {
-  return typeof value === "number" ? new Date(value).toLocaleString() : "—"
-}
-
-function scheduleLabel(schedule: AutomationSchedule) {
-  if (schedule.kind === "once") return `Once · ${formatTime(schedule.at)} · ${schedule.timezone}`
-  const time = `${String(schedule.hour).padStart(2, "0")}:${String(schedule.minute).padStart(2, "0")}`
-  if (schedule.kind === "daily") return `Daily · ${time} · ${schedule.timezone}`
-  return `Weekly · ${formatAutomationWeekdays(schedule.daysOfWeek)} · ${time} · ${schedule.timezone}`
-}
 
 function stateLabel(state: AutomationState) {
   if (state === "needs_attention") return "Needs attention"
@@ -362,7 +351,7 @@ export function AutomationsPage() {
                 <h2 className="truncate text-xl font-semibold">{task.name}</h2>
                 <Badge variant={stateVariant(task.state)}>{stateLabel(task.state)}</Badge>
               </div>
-              <p className="mt-1 text-sm text-muted-foreground">{scheduleLabel(detail.revision.schedule)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{formatAutomationSchedule(detail.revision.schedule)}</p>
             </div>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -431,7 +420,7 @@ export function AutomationsPage() {
               </CardHeader>
               <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
                 <div><span className="text-muted-foreground">Model</span><p>{detail.revision.model.providerId}/{detail.revision.model.modelId}</p></div>
-                <div><span className="text-muted-foreground">Next run</span><p>{formatTime(task.nextDueAt)}</p></div>
+                <div><span className="text-muted-foreground">Next run</span><p>{formatAutomationTime(task.nextDueAt)}</p></div>
                 <div><span className="text-muted-foreground">Runtime limit</span><p>{Math.round(detail.revision.maximumRuntimeMs / 60_000)} minutes</p></div>
                 <div><span className="text-muted-foreground">Integrations</span><p>Your available OpenWork Connect tools</p></div>
               </CardContent>
@@ -460,7 +449,7 @@ export function AutomationsPage() {
                           </span>
                         ) : null}
                       </span>
-                      <span className="mt-1 block truncate text-xs text-muted-foreground">{formatTime(run.startedAt ?? run.createdAt)}</span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">{formatAutomationTime(run.startedAt ?? run.createdAt)}</span>
                     </span>
                     <span className="flex items-center gap-2">
                       {!ACTIVE_RUN_STATUSES.has(run.status) ? <span className="text-xs text-muted-foreground">{usageLabel(run)}</span> : null}
@@ -530,7 +519,7 @@ export function AutomationsPage() {
                         <span className="absolute -start-[1.2rem] top-1.5 size-2 rounded-full bg-muted-foreground" />
                         <div className="flex items-center justify-between gap-2">
                           <span className="text-xs font-medium">{event.type.replaceAll("_", " ")}</span>
-                          <time className="text-xs text-muted-foreground">{formatTime(event.createdAt)}</time>
+                          <time className="text-xs text-muted-foreground">{formatAutomationTime(event.createdAt)}</time>
                         </div>
                         <p className="mt-1 break-words text-xs text-muted-foreground">{eventSummary(event)}</p>
                       </li>
@@ -601,8 +590,8 @@ export function AutomationsPage() {
                 <Badge variant={stateVariant(item.automation.state)}>{stateLabel(item.automation.state)}</Badge>
               </div>
               <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-                <span>{scheduleLabel(item.revision.schedule)}</span>
-                <span>{item.latestRun ? `Last run: ${item.latestRun.status}` : `Next: ${formatTime(item.automation.nextDueAt)}`}</span>
+                <span>{formatAutomationSchedule(item.revision.schedule)}</span>
+                <span>{item.latestRun ? `Last run: ${item.latestRun.status}` : `Next: ${formatAutomationTime(item.automation.nextDueAt)}`}</span>
               </div>
             </button>
           ))}

--- a/apps/app/tests/automation-proposal-card.test.ts
+++ b/apps/app/tests/automation-proposal-card.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAutomationProposal } from "../src/components/tools/openwork-automation-proposal";
+
+const dailyProposal = {
+  ok: true,
+  id: "automation.propose",
+  result: {
+    ok: true,
+    kind: "automation-proposal",
+    created: false,
+    proposal: {
+      name: "Morning Slack check",
+      instructions: "Summarize my most recent Slack message.",
+      schedule: { kind: "daily", timezone: "Europe/Berlin", hour: 9, minute: 0 },
+    },
+  },
+};
+
+describe("Automation proposal card", () => {
+  test("reads a proposal out of an openwork_execute result, string or object", () => {
+    const fromObject = parseAutomationProposal(dailyProposal);
+    const fromString = parseAutomationProposal(JSON.stringify(dailyProposal));
+
+    expect(fromObject).toEqual(fromString);
+    expect(fromObject?.name).toBe("Morning Slack check");
+    expect(fromObject?.schedule).toEqual({
+      kind: "daily",
+      timezone: "Europe/Berlin",
+      hour: 9,
+      minute: 0,
+    });
+    expect(fromObject?.model).toBeUndefined();
+  });
+
+  test("ignores results that are not Automation proposals", () => {
+    expect(parseAutomationProposal({ ...dailyProposal, id: "session.create" })).toBeNull();
+    expect(parseAutomationProposal({ ...dailyProposal, ok: false })).toBeNull();
+    expect(parseAutomationProposal("not json")).toBeNull();
+    expect(parseAutomationProposal(null)).toBeNull();
+  });
+
+  test("refuses a proposal whose schedule or fields fail the shared contract", () => {
+    const badSchedule = {
+      ...dailyProposal,
+      result: {
+        ...dailyProposal.result,
+        proposal: {
+          ...dailyProposal.result.proposal,
+          schedule: { kind: "interval", timezone: "Europe/Berlin", everyMinutes: 5 },
+        },
+      },
+    };
+    const emptyName = {
+      ...dailyProposal,
+      result: {
+        ...dailyProposal.result,
+        proposal: { ...dailyProposal.result.proposal, name: "   " },
+      },
+    };
+
+    expect(parseAutomationProposal(badSchedule)).toBeNull();
+    expect(parseAutomationProposal(emptyName)).toBeNull();
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -112,4 +112,22 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(read).not.toContain("JWKS");
     expect(read).not.toContain("~/.cursor/mcp.json");
   });
+
+  test("teaches Automations as the product feature for recurring work", async () => {
+    const plugin = await OpenWorkCapabilitiesKnowledge();
+    const output = { system: [] };
+
+    await plugin["experimental.chat.system.transform"]({}, output);
+
+    const knowledge = output.system.join("\n");
+    expect(knowledge).toContain("## Automations");
+    expect(knowledge).toContain("openwork_execute");
+    expect(knowledge).toContain("automation.propose");
+    // Scheduling OpenWork work through the OS is the exact failure this guidance prevents.
+    expect(knowledge).toContain("Never write a cron entry, a launchd or systemd unit, a Task Scheduler job");
+    expect(knowledge).toContain("Proposing is not creating");
+    expect(knowledge).toContain("There is no interval schedule");
+    expect(knowledge).toContain("durably recorded as missed");
+    expect(knowledge).toContain("0=Sunday through 6=Saturday");
+  });
 });

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -94,6 +94,14 @@ Here is what you can help users with:
 - Manageable via Settings > Skills.
 - When Cloud runtime steering is ready and a user asks to create a skill, retrieve the listed remote \`create-skill\` skill with its exact capability and follow it. Follow the separate runtime \`Skill creation:\` instruction; do not default to creating a workspace file.
 
+## Automations
+- OpenWork has first-class Automations: OpenWork Cloud keeps the schedule and run history, and each occurrence runs on the signed-in desktop as a normal visible chat thread with the usual tools and OpenWork Connect integrations.
+- When someone asks for recurring or scheduled work, propose an Automation with \`openwork_execute\` id \`automation.propose\`. Never write a cron entry, a launchd or systemd unit, a Task Scheduler job, or a workspace script to schedule OpenWork work — those are not Automations and the user cannot manage them from the app.
+- Proposing is not creating. The proposal appears in the chat for the person to review and create themselves; you cannot create, activate, or run an Automation, and you must not claim you did.
+- Schedules are \`{ kind: "once", timezone, at }\`, \`{ kind: "daily", timezone, hour, minute }\`, or \`{ kind: "weekly", timezone, daysOfWeek, hour, minute }\`. Hours are 0-23, minutes are 0-59, weekdays are 0=Sunday through 6=Saturday, and the timezone is an IANA name such as \`Europe/Berlin\`.
+- There is no interval schedule. If someone asks for "every 5 minutes" or any sub-daily cadence, say plainly that Automations do not support intervals, then offer the closest supported schedule and mention that Run now triggers an Automation immediately whenever they want another run.
+- An Automation only runs while a signed-in desktop with the Automations preview enabled is connected. If no desktop is connected when an occurrence is due, that occurrence is durably recorded as missed. Never claim an Automation runs with the app closed, as an OS background service, or in the cloud.
+
 ## Creating Plugins
 - Plugins extend OpenWork/OpenCode with custom tools.
 - Create a file in \`.opencode/plugins/my-plugin.ts\` and add it to the \`plugin\` array in \`opencode.json\`.

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -51,6 +51,19 @@ const createResultSchema = z.object({
   })),
 });
 
+const automationProposalResultSchema = z.object({
+  ok: z.literal(true),
+  kind: z.literal("automation-proposal"),
+  created: z.literal(false),
+  limitation: z.string(),
+  proposal: z.object({
+    name: z.string(),
+    instructions: z.string(),
+    schedule: z.record(z.string(), z.unknown()),
+    model: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
 const affordanceResultSchema = <T extends z.ZodTypeAny>(id: string, result: T) => z.object({
   ok: z.literal(true),
   id: z.literal(id),
@@ -253,6 +266,7 @@ describe("OpenWorkExtensionsPreview session tools", () => {
 
     expect(contributions.map((contribution) => contribution.featureId)).toEqual([
       "sessions",
+      "automations",
       "extensions",
       "mcp:notion",
       "connect",
@@ -483,5 +497,47 @@ describe("OpenWorkExtensionsPreview semantic tool surface", () => {
     expect(system).toContain("Use openwork_context");
     expect(system).toContain("session.search");
     expect(system).toContain("browser.open_url");
+  });
+
+  test("proposes an Automation without creating anything or calling a backend", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+
+    const output = await plugin.tool.openwork_execute.execute({
+      id: "automation.propose",
+      args: {
+        name: "Morning Slack check",
+        instructions: "Summarize my most recent Slack message.",
+        schedule: { kind: "daily", timezone: "Europe/Berlin", hour: 9, minute: 0 },
+      },
+    }, { sessionID: "ses_origin" });
+    const parsed = affordanceResultSchema("automation.propose", automationProposalResultSchema)
+      .parse(JSON.parse(output));
+
+    expect(parsed.result.created).toBe(false);
+    expect(parsed.result.proposal.name).toBe("Morning Slack check");
+    expect(parsed.result.proposal.schedule).toEqual({
+      kind: "daily",
+      timezone: "Europe/Berlin",
+      hour: 9,
+      minute: 0,
+    });
+    // The whole point of proposal-only: an agent never reaches Den or the
+    // local server, so it cannot bring an Automation into existence.
+    expect(fake.requests).toHaveLength(0);
+    expect(parsed.effects).toEqual({ data: "none", ui: "none", external: false });
+  });
+
+  test("rejects a proposal whose schedule is not a supported kind", async () => {
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+
+    await expect(plugin.tool.openwork_execute.execute({
+      id: "automation.propose",
+      args: {
+        name: "Every five minutes",
+        instructions: "Say hello.",
+        schedule: { kind: "interval", timezone: "Europe/Berlin", everyMinutes: 5 },
+      },
+    }, { sessionID: "ses_origin" })).rejects.toThrow();
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { homedir, platform } from "node:os";
 import { z } from "zod";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
+import { automationProposalSchema } from "@openwork/types/automations";
 import {
   combineInstructionSections,
   composeAgentInstructions,
@@ -191,6 +192,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const affordanceReadEffects: OpenworkAffordanceEffects = { data: "read", ui: "none", external: false };
 const affordanceWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: false };
 const affordanceExternalWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: true };
+// A proposal writes nothing anywhere: it is rendered for a person to act on.
+const affordanceProposalEffects: OpenworkAffordanceEffects = { data: "none", ui: "none", external: false };
 
 function affordanceResult(
   id: string,
@@ -451,6 +454,13 @@ async function executeOpenworkAffordance(
       request.id,
       await createOpenWorkSessions(request.args ?? {}, context),
       affordanceWriteEffects,
+    );
+  }
+  if (request.id === "automation.propose") {
+    return affordanceResult(
+      request.id,
+      proposeAutomation(request.args ?? {}),
+      affordanceProposalEffects,
     );
   }
   if (request.id === "extension.call") {
@@ -829,6 +839,24 @@ async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext
     workspace: workspaceLabel(workspace),
     created,
     failures,
+  };
+}
+
+/**
+ * Validates a proposed Automation and hands it back for the renderer to show.
+ *
+ * Deliberately does no I/O. Automations are active from the moment they exist,
+ * and the Den credential lives in the renderer, so an agent can describe an
+ * Automation but only a person can create one.
+ */
+function proposeAutomation(rawArgs: unknown): object {
+  const proposal = automationProposalSchema.parse(rawArgs);
+  return {
+    ok: true,
+    kind: "automation-proposal",
+    proposal,
+    created: false,
+    limitation: "Automations run only while a signed-in desktop runner is connected.",
   };
 }
 

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
@@ -9,6 +9,7 @@ describe("OpenWork provider adapters", () => {
 
     expect(contributions.map((contribution) => contribution.featureId)).toEqual([
       "sessions",
+      "automations",
       "extensions",
     ]);
     expect(
@@ -67,17 +68,38 @@ describe("OpenWork provider adapters", () => {
 
     expect(contributions.map((contribution) => contribution.featureId)).toEqual([
       "sessions",
+      "automations",
       "extensions",
       "mcp:notion",
       "connect",
     ]);
-    expect(contributions[2]).toMatchObject({
+    expect(contributions[3]).toMatchObject({
       provider: { id: "notion", kind: "mcp" },
       affordances: [],
     });
-    expect(contributions[3]?.affordances.map((affordance) => affordance.id)).toEqual([
+    expect(contributions[4]?.affordances.map((affordance) => affordance.id)).toEqual([
       "connect.capabilities.search",
       "connect.capability.execute",
     ]);
+  });
+
+  test("exposes an Automations proposal affordance that writes nothing", () => {
+    const proposal = buildOpenworkProviderContributions([])
+      .flatMap((contribution) => contribution.affordances)
+      .find((affordance) => affordance.id === "automation.propose");
+
+    expect(proposal).toMatchObject({
+      kind: "command",
+      // No data effect: a proposal is rendered for a person, never persisted.
+      effects: { data: "none", ui: "none", external: false },
+      executor: { kind: "openwork" },
+    });
+    expect(proposal?.arguments.map((argument) => argument.name)).toEqual([
+      "name",
+      "instructions",
+      "schedule",
+      "model",
+    ]);
+    expect(proposal?.arguments.find((argument) => argument.name === "model")?.required).toBe(false);
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
@@ -117,6 +117,31 @@ function sessionContribution(): OpenworkFeatureContribution {
   };
 }
 
+function automationContribution(): OpenworkFeatureContribution {
+  const provider: OpenworkProviderRef = { id: "openwork-automations", kind: "builtin" };
+  return {
+    featureId: "automations",
+    provider,
+    affordances: [
+      affordance({
+        id: "automation.propose",
+        kind: "command",
+        title: "Propose an Automation",
+        description: "Offer a scheduled Automation for the person to review and create. This only renders a proposal in the chat; it cannot create, activate, or run anything.",
+        provider,
+        arguments: [
+          argument("name", "string", true, "Short Automation name, at most 120 characters."),
+          argument("instructions", "string", true, "Self-contained instructions the Automation runs on its schedule."),
+          argument("schedule", "object", true, "once/daily/weekly schedule with an IANA timezone. Intervals are not supported."),
+          argument("model", "object", false, "Optional providerId and modelId. Omit to use the person's default."),
+        ],
+        effects: noEffects,
+      }),
+    ],
+    guidance: [],
+  };
+}
+
 function extensionContribution(): OpenworkFeatureContribution {
   const provider: OpenworkProviderRef = { id: "openwork-extensions", kind: "extension" };
   return {
@@ -219,6 +244,7 @@ export function buildOpenworkProviderContributions(
   const connect = connectContribution(skills, cloudMcp);
   return [
     sessionContribution(),
+    automationContribution(),
     extensionContribution(),
     ...mcps
       .filter((mcp) => mcp.name !== "openwork-cloud")

--- a/packages/types/src/automations.ts
+++ b/packages/types/src/automations.ts
@@ -272,6 +272,22 @@ export const createAutomationSchema = z.object({
 })
 export type CreateAutomation = z.infer<typeof createAutomationSchema>
 
+/**
+ * What an in-app agent may hand back when a person describes recurring work.
+ *
+ * A proposal is inert: it names the Automation the person could create, and
+ * nothing more. Automations are active the moment they exist, so creation stays
+ * behind an explicit human action in the renderer, which owns the Den session.
+ * The model is optional because the renderer resolves the person's own default.
+ */
+export const automationProposalSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  instructions: z.string().trim().min(1).max(100_000),
+  schedule: automationScheduleSchema,
+  model: automationModelSchema.optional(),
+})
+export type AutomationProposal = z.infer<typeof automationProposalSchema>
+
 export const updateAutomationSchema = createAutomationSchema.partial().refine(
   (input) => Object.keys(input).length > 0,
   "At least one behavior-changing field is required",


### PR DESCRIPTION
## Why

Asked to "create a test automation that prints hello every 5 minutes," the in-app agent had no idea Automations exist. It read the workspace, found leftover shell scripts, said *"I see the existing pattern — they use `launchd` plists"*, and started writing one. Nothing in the product told it there is a scheduler, so it improvised an OS-level cron the user cannot see or manage from the app.

This teaches the agent the feature and gives it a safe way to hand one over.

## What changed

Three layers, following the shape closed PR #3236 used for Scheduled Tasks:

**Knowledge** — an `## Automations` section in the capabilities prompt: what Automations are, that recurring work goes through `openwork_execute` id `automation.propose`, and an explicit prohibition on scheduling OpenWork work with cron, launchd, systemd, or Task Scheduler. It carries the exact `once`/`daily`/`weekly` shapes (hours 0-23, minutes 0-59, weekdays 0=Sunday), says there is **no interval schedule** and to offer the closest supported cadence plus Run now instead, and states the two honesty constraints: proposing is not creating, and an occurrence is durably missed when no desktop runner is connected.

**Affordance** — a new `automations` feature contribution exposing `automation.propose`. It validates arguments against the shared contract and returns the proposal. **It does no I/O at all** — no Den call, no local server call, `{ data: "none", ui: "none", external: false }`. Automations are active from the moment they exist and the Den credential lives in the renderer, so an agent can describe an Automation but only a person can create one. A test asserts zero requests reach the fake backend.

**Card** — the proposal renders in the thread with its schedule and instructions behind a **Create Automation** button that uses the renderer's own Den session and active org, then links to the Automations view. It explains itself when the preview flag is off or Cloud is signed out rather than failing on click.

`scheduleLabel`/`formatTime` move out of `automations-page.tsx` into `automation-format.ts` so the card and the page label schedules identically.

## Trying it

With the Automations preview on and Cloud signed in, ask a thread for something recurring — *"check my Slack every morning and summarize the last message."* The agent proposes; you create.

Asking for "every 5 minutes" now gets an honest answer about intervals instead of a launchd plist.

## Checks

Run on `477ff9b82`:

- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --dir apps/server typecheck` — passed
- Server plugin suites (adapters, capabilities knowledge, extensions preview) — 23 passed
- App Automations suites incl. the new proposal-card test — 4 passed
- Full app suite — 646 passed, 2 failed; both are `message-list-loading` failures that reproduce identically on unmodified `dev` (645 tests, same 2 failures) and only under full-suite `--isolate`. Not introduced here, and not claimed as passing.

No dependency changes, so `pnpm-lock.yaml` is untouched.

## Notes for review

- The card detects `automation.propose` by parsing the `openwork_execute` result rather than adding a dedicated tool, so no new tool surface appears in the model's tool list.
- Proposal-only is a deliberate boundary, not a v1 shortcut: chat-created *active* automations would let any content an agent reads schedule recurring work. Worth keeping even if Automations later gain a draft state.
- Follow-up worth considering: the card's copy is hardcoded English, matching the existing Automations UI, which is outside the i18n audit's key inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
