### PR TITLE
Require PR branches to rebase onto current dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,27 @@ OpenWork is a practical control surface for agentic work:
 
 If you open a PR, you must run tests and report what you ran (commands + result).
 
+### Keep PR branches current with `dev`
+
+Immediately before opening or updating a PR, and again before handing it off
+as ready to review or merge:
+
+1. Fetch canonical `dev` and rebase the owned feature branch onto the exact
+   fetched `upstream/dev` head. Do not merge `dev` into the feature branch.
+2. Verify that fetched `upstream/dev` commit is the branch's merge base and
+   record the exact base and head SHAs in the PR handoff.
+3. If the feature branch is already published, update only that branch with
+   `git push --force-with-lease`. Prefer an explicit expected remote-head lease
+   when available. If the lease fails, fetch and reconcile again rather than
+   overwriting unexpected remote work.
+4. Resolve rebase conflicts for the intended feature on top of current `dev`
+   and rerun the checks affected by those resolutions.
+
+Never use plain `--force`, rewrite another contributor's branch without
+explicit coordination, or force-push `dev`, `main`, or another shared base.
+Here, forced rebasing means rewriting only the owned feature branch and
+publishing it safely with `--force-with-lease`.
+
 For runtime-observable changes, include the `@openwork/testkit` evidence tape.
 Custom screenshots and recordings may supplement that tape, but never determine the
 pass/fail verdict. If validation cannot run, say why and give exact repro steps.


### PR DESCRIPTION
## Summary

- require OpenWork feature branches to rebase onto freshly fetched canonical `upstream/dev` before PR publication or update
- repeat the freshness check before ready-for-review or merge handoff
- require `--force-with-lease` for already-published feature branches and stop on lease failure
- prohibit plain force pushes, merging `dev` into feature branches, and rewriting shared or uncoordinated branches

## Why

Keeping feature history linear and based on current `dev` reduces avoidable integration conflicts and makes the exact reviewed base explicit.

## Verification

- `git diff --check`
- rebased branch onto `upstream/dev@ee1c5a67588e3c3aa1dce60a11cd8a9e2548e8f4`
- verified `upstream/dev` is the branch merge base
- docs-only instruction change; runtime proof skipped

Head: `038fb8bef475808586918f9551b2965529b45b74`