### PR TITLE
ci(warden): review desktop↔den contract drift, gate clearance on blocking findings only

### DIFF
--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -1,9 +1,10 @@
 # Warden security clearance.
 #
-# Grants or revokes a "security clearance" review on PRs based on the Warden
-# diff-security-review verdict. Humans still review and merge; the clearance
-# only satisfies the required-review gate in the branch ruleset for clean
-# diffs.
+# Grants or revokes a "security clearance" review on PRs based on blocking
+# findings from the Warden skills: all security findings plus high desktop↔den
+# sync findings. Advisory sync findings never withhold clearance. Humans still
+# review and merge; the clearance only satisfies the required-review gate in
+# the branch ruleset for clean diffs.
 #
 # Why workflow_run: this file always executes from the default branch, so a
 # PR cannot tamper with the clearance logic. The verdict step additionally
@@ -74,7 +75,9 @@ jobs:
           verdict() { echo "verdict=$1" >> "$GITHUB_OUTPUT"; exit 0; }
 
           summary_sha="$(jq -r '.head_sha' warden-summary.json)"
-          count="$(jq -r '.findings_count' warden-summary.json)"
+          blocking="$(jq -r '.blocking_count // .findings_count' warden-summary.json)"
+          advisory="$(jq -r '.sync_advisory_count // 0' warden-summary.json)"
+          echo "advisory=$advisory" >> "$GITHUB_OUTPUT"
 
           if [ "$summary_sha" != "$HEAD_SHA" ]; then
             echo "Summary SHA ($summary_sha) does not match analyzed SHA ($HEAD_SHA); skipping."
@@ -103,11 +106,11 @@ jobs:
             verdict guarded
           fi
 
-          if [ "$count" = "0" ]; then
-            echo "No new security issues found for $HEAD_SHA."
+          if [ "$blocking" = "0" ]; then
+            echo "No blocking findings for $HEAD_SHA."
             verdict clear
           else
-            echo "$count finding(s) on $HEAD_SHA."
+            echo "$blocking blocking finding(s) on $HEAD_SHA."
             verdict flagged
           fi
 
@@ -127,12 +130,18 @@ jobs:
           PR: ${{ steps.verdict.outputs.pr }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ADVISORY: ${{ steps.verdict.outputs.advisory }}
         run: |
           set -euo pipefail
+          BODY="**Warden security clearance: clear.** No blocking findings (security or desktop↔den sync) in this diff (\`$HEAD_SHA\`)."
+          if [[ "$ADVISORY" =~ ^[0-9]+$ ]] && [ "$ADVISORY" -gt 0 ]; then
+            BODY="$BODY $ADVISORY advisory desktop↔den sync note(s) were posted as review comments; they do not affect clearance."
+          fi
+          BODY="$BODY Automated clearance satisfies the required-review gate only — a human still reviews and merges. [Analysis run]($RUN_URL)"
           gh api "repos/$REPO/pulls/$PR/reviews" \
             -f event=APPROVE \
             -f commit_id="$HEAD_SHA" \
-            -f body="**Warden security clearance: clear.** No new security issues found in this diff (\`$HEAD_SHA\`). Automated clearance satisfies the required-review gate only — a human still reviews and merges. [Analysis run]($RUN_URL)"
+            -f body="$BODY"
 
       - name: Revoke stale clearance
         if: steps.verdict.outputs.verdict == 'flagged'
@@ -147,7 +156,7 @@ jobs:
             --jq "[.[] | select(.user.login == \"${APP_SLUG}[bot]\" and .state == \"APPROVED\")] | last | .id // empty")"
           if [ -n "$rid" ]; then
             gh api -X PUT "repos/$REPO/pulls/$PR/reviews/$rid/dismissals" \
-              -f message="Warden found new security findings on the latest diff; clearance revoked." \
+              -f message="Warden found new blocking findings (security or desktop↔den sync) on the latest diff; clearance revoked." \
               || echo "Could not dismiss review $rid (may already be dismissed)."
           else
             echo "No active clearance to revoke."

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -51,21 +51,54 @@ jobs:
           mode: report
           findings-file: ${{ steps.analyze.outputs.findings-file }}
 
-      # Consumed by warden-clearance.yml (workflow_run). The clearance
-      # workflow refuses to act on PRs that touch review machinery, so this
-      # artifact cannot be forged without tripping that guard.
+      # Consumed by warden-clearance.yml (workflow_run). blocking_count excludes
+      # advisory desktop↔den sync findings so they notify without withholding
+      # clearance. The clearance workflow refuses to act on PRs that touch review
+      # machinery, so this artifact cannot be forged without tripping that guard.
       - name: Write clearance summary
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           FINDINGS_COUNT: ${{ steps.analyze.outputs.findings-count }}
           HIGH_COUNT: ${{ steps.analyze.outputs.high-count }}
+          FINDINGS_FILE: ${{ steps.analyze.outputs.findings-file }}
         run: |
           set -euo pipefail
+
+          if [ -n "$FINDINGS_FILE" ] && [ -f "$FINDINGS_FILE" ] && counts="$(jq -ce '
+            {
+              security_count: ([.skills[] | select(.name == "diff-security-review") | .findings | length] | add // 0),
+              sync_blocking_count: ([.skills[] | select(.name == "desktop-den-sync-review") | .findings[] | select(.severity != "medium" and .severity != "low")] | length),
+              sync_advisory_count: ([.skills[] | select(.name == "desktop-den-sync-review") | .findings[] | select(.severity == "medium" or .severity == "low")] | length)
+            }
+          ' "$FINDINGS_FILE" 2>/dev/null)"; then
+            security_count="$(jq -r '.security_count' <<< "$counts")"
+            sync_blocking_count="$(jq -r '.sync_blocking_count' <<< "$counts")"
+            sync_advisory_count="$(jq -r '.sync_advisory_count' <<< "$counts")"
+            blocking_count="$((security_count + sync_blocking_count))"
+          else
+            security_count="$FINDINGS_COUNT"
+            sync_blocking_count=0
+            sync_advisory_count=0
+            blocking_count="$FINDINGS_COUNT"
+          fi
+
           jq -n \
             --arg sha "$HEAD_SHA" \
             --arg count "$FINDINGS_COUNT" \
             --arg high "$HIGH_COUNT" \
-            '{head_sha: $sha, findings_count: ($count | tonumber), high_count: ($high | tonumber)}' \
+            --arg blocking "$blocking_count" \
+            --arg security "$security_count" \
+            --arg sync_blocking "$sync_blocking_count" \
+            --arg sync_advisory "$sync_advisory_count" \
+            '{
+              head_sha: $sha,
+              findings_count: ($count | tonumber),
+              high_count: ($high | tonumber),
+              blocking_count: ($blocking | tonumber),
+              security_count: ($security | tonumber),
+              sync_blocking_count: ($sync_blocking | tonumber),
+              sync_advisory_count: ($sync_advisory | tonumber)
+            }' \
             > warden-summary.json
           cat warden-summary.json
 

--- a/.warden/skills/desktop-den-sync-review/SKILL.md
+++ b/.warden/skills/desktop-den-sync-review/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: desktop-den-sync-review
+description: Flag desktop<->den contract drift introduced by this diff. High findings gate Warden clearance; medium findings are advisory only.
+allowed-tools: Read Grep Glob
+---
+
+You are reviewing a diff to answer exactly one question: does this change
+break or drift the contract between the desktop app and den (the cloud API)?
+
+Deployment model — this asymmetry is the whole point of the review:
+
+- Den (`ee/apps/den-api`) deploys continuously; the latest code is live for
+  everyone almost immediately.
+- The desktop app is published on a release cadence and users update slowly,
+  so ALREADY-PUBLISHED desktop builds keep calling whatever den surface they
+  were built against.
+
+Contract surfaces:
+
+- Desktop/client side: `apps/app/src/app/lib/den.ts` (hand-written den API
+  client), `apps/app/src/app/lib/den-types.ts` and the other
+  `apps/app/src/app/lib/den-*.ts` helpers, `apps/app/src/react-app/domains/cloud/`,
+  and `apps/desktop/`.
+- Den side: `ee/apps/den-api/src/routes/`.
+- Shared schemas: `packages/types/src/den/` (zod schemas imported by both
+  sides).
+
+Severity is the gating contract. Use exactly this mapping:
+
+- `high` — blocking; withholds Warden clearance until resolved.
+- `medium` — advisory; posted as a comment but never blocks clearance.
+- Never report `low` findings from this skill.
+
+Report a HIGH (blocking) finding only in these two cases:
+
+1. Breaking den change that can brick published desktop builds. The diff
+   removes or renames a den-api route, removes or renames a response field,
+   makes a previously optional request field required, removes an enum value,
+   tightens validation, or changes auth/semantics on a surface the desktop
+   client references. Grep the desktop/client surfaces for usage of the
+   changed route or field before reporting. This blocks EVEN IF the same diff
+   also updates or removes the desktop-side usage: published binaries still
+   run the old client code. The fix is a phased rollout, in this order:
+   first ship a desktop release that tolerates both old and new den behavior,
+   wait for it to be published, and only then land the den-side removal or
+   change.
+2. Desktop-ahead dependency. The diff adds desktop/client code that calls a
+   den route or reads a den response field that is introduced in this same
+   diff or does not exist in `ee/apps/den-api/src/routes/` at all. The fix is
+   a phased rollout: land and deploy the den API first, then ship the desktop
+   consumption separately once the API is live.
+
+Report a MEDIUM (advisory) finding only in this case:
+
+3. Additive den-ahead drift. The diff adds a den-api feature that requires
+   desktop-side handling to actually work for users (a new desktop-policy
+   field the app must enforce or render, a new required field in a
+   `packages/types/src/den/` schema the desktop consumes, a new enum/action
+   value the desktop must handle), and the diff contains no corresponding
+   desktop/client change. Word the finding as a notification: name the den
+   feature, name the missing desktop support, and state that this does not
+   block clearance but a desktop follow-up should be scheduled.
+
+Do NOT report:
+
+- Backward-compatible additive den changes nothing on desktop needs: new
+  routes, new optional fields with defaults, new enum values the desktop can
+  safely ignore.
+- One-sided changes that are self-contained (den internals, desktop-only UI,
+  refactors that keep the wire contract identical).
+- Style, performance, correctness, or security issues (a separate skill owns
+  security).
+- Pre-existing drift in unchanged code.
+- Tests, mocks, fixtures, seed data, or docs.
+
+For each finding, report:
+
+- The exact file and changed lines that introduce the drift.
+- Which published-vs-deployed pair breaks: what the published desktop calls
+  or expects, and what den now serves (or vice versa).
+- Severity per the mapping above.
+- The concrete rollout fix: what ships first, what waits, and what change in
+  this diff should be split out.
+
+If the diff introduces no desktop<->den drift, report nothing. Silence is the
+correct output for a clean diff; do not manufacture findings.

--- a/warden.toml
+++ b/warden.toml
@@ -1,8 +1,9 @@
 version = 1
 
-# Warden gates "security clearance" on a single question: does this diff
-# introduce a new security issue? See .warden/skills/diff-security-review.
-# The clearance itself is granted by .github/workflows/warden-clearance.yml.
+# Warden gates clearance on blocking findings from two skills:
+# diff-security-review (all findings block) and desktop-den-sync-review (only
+# high findings block; medium findings are advisory). The clearance itself is
+# granted by .github/workflows/warden-clearance.yml.
 
 [defaults]
 reportOn = "low"
@@ -31,5 +32,22 @@ actions = ["opened", "synchronize", "reopened"]
 draft = false
 
 # Lets developers run `warden` locally on uncommitted changes before pushing.
+[[skills.triggers]]
+type = "local"
+
+[[skills]]
+name = "desktop-den-sync-review"
+paths = [
+  "apps/app/**",
+  "apps/desktop/**",
+  "ee/apps/den-api/**",
+  "packages/types/**",
+]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+draft = false
+
 [[skills.triggers]]
 type = "local"


### PR DESCRIPTION
## What

Extends Warden beyond security review with a second skill, `desktop-den-sync-review`, that checks every PR diff for desktop↔den contract drift — and rewires clearance so advisory findings notify without blocking.

**Blocking (`high`, withholds Warden clearance):**
1. **Breaking den change that can brick published desktop builds** — removing/renaming a den-api route or response field, making a request field required, removing enum values, or changing auth/semantics on a surface the desktop client references. Blocks *even if the same diff updates the desktop side*, because already-published binaries still run the old client. Fix guidance is always the phased rollout: ship desktop tolerance → publish → land den change.
2. **Desktop-ahead dependency** — desktop/client code calling a den API introduced in the same diff (or absent from `ee/apps/den-api/src/routes/`). Fix: deploy den first, ship desktop consumption separately.

**Advisory (`medium`, notifies only):**
3. **Additive den-ahead drift** — den adds a feature that needs desktop-side handling (new desktop-policy field, new required shared-schema field, new enum/action value) with no desktop change in the diff. Posted as a review comment; clearance is still granted.

## How

- `.warden/skills/desktop-den-sync-review/SKILL.md` — new skill; severity is the gating contract (`high` blocks, `medium` advises, never `low`). Scoped in `warden.toml` via `paths` to `apps/app/**`, `apps/desktop/**`, `ee/apps/den-api/**`, `packages/types/**`.
- `.github/workflows/warden.yml` — the clearance summary now parses the analyze findings-file per skill and adds `blocking_count` (= all security findings + high sync findings), `security_count`, `sync_blocking_count`, `sync_advisory_count`. Falls back to the old every-finding-blocks behavior if the findings file is missing/unparseable.
- `.github/workflows/warden-clearance.yml` — verdict gates on `.blocking_count // .findings_count` (fallback keeps in-flight PRs built on the old summary format safe, since this workflow runs from the default branch). The approval body mentions advisory note count when clearing.

Advisory findings still surface as review threads (ruleset requires resolving them), so "notify" = acknowledge-and-resolve; clearance is never withheld for them.

## Validation

CI/review-machinery config only — no app runtime behavior changes, so no `@openwork/testkit` spec / evidence tape applies (per AGENTS.md, inert config may skip runtime proof).

What I ran instead:
- `warden.toml` parses (smol-toml) and registers both skills: `toml ok: diff-security-review, desktop-den-sync-review`.
- Both workflow YAMLs parse (PyYAML): `yaml ok`.
- Extracted the **actual** "Write clearance summary" `run` script from the workflow YAML and executed it against fixture findings files:
  - mixed (security high ×1, sync high ×1, sync medium ×1) → `{"blocking_count":2,"security_count":1,"sync_blocking_count":1,"sync_advisory_count":1}` ✅
  - advisory-only (sync medium ×1) → `{"blocking_count":0,...,"sync_advisory_count":1}` ✅
  - missing findings file, `FINDINGS_COUNT=4` → `{"blocking_count":4,...}` (old behavior fallback) ✅
- Clearance jq fallbacks: old-format summary → `3,0`; new summary with `blocking_count:0` → `0,2` (jq `//` keeps `0`, since `0` is truthy in jq) ✅

Note: this PR touches `.github/`, `warden.toml`, and `.warden/`, so warden-clearance will (correctly) return the `guarded` verdict on it — human review required by design.