### PR TITLE
chore(release): v0.18.15

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.14",
+  "version": "0.18.15",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.14",
+  "version": "0.18.15",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.15",
   "0.18.14",
   "0.18.13",
   "0.18.12",


### PR DESCRIPTION
Backfills the v0.18.15 version bump into dev. The release tag v0.18.15 was cut from dev + this commit (tag-ruleset admin bypass); merging this PR brings dev level with the released version so the next release:review passes.

Bump touches: apps/app, apps/desktop, apps/server package.json + regenerated ee/apps/den-api/src/generated/desktop-versions.ts.

Needs one approval from a maintainer other than reachjalil (last-push rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)