### PR TITLE
fix(server): sqlite v13 on Bun+Node, Daytona toolchain, and v0.18.15 version backfill

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.14",
+  "version": "0.18.15",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.14",
+  "version": "0.18.15",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/apps/server/src/opencode-db.test.ts
+++ b/apps/server/src/opencode-db.test.ts
@@ -41,22 +41,11 @@ async function createDb(): Promise<{ path: string; dispose: () => void }> {
   };
 }
 
-// seedOpencodeSessionMessages requires better-sqlite3, whose native binding
-// does not load under bun (oven-sh/bun#4290). Skip gracefully instead of
-// failing the suite in bun-driven environments like CI.
-const betterSqliteAvailable = await import("better-sqlite3").then(
-  (mod) => {
-    try {
-      new mod.default(":memory:").close();
-      return true;
-    } catch {
-      return false;
-    }
-  },
-  () => false,
-);
-
-describe.skipIf(!betterSqliteAvailable)("seedOpencodeSessionMessages", () => {
+// opencode-db selects its sqlite driver at call time: bun:sqlite under Bun
+// (better-sqlite3's N-API binding panics the Bun runtime), better-sqlite3
+// under Node/Electron. Under bun test the bun:sqlite path is always
+// available, so these tests run unconditionally.
+describe("seedOpencodeSessionMessages", () => {
   test("writes seeded transcript messages into the OpenCode db", async () => {
     const fixture = await createDb();
     const result = seedOpencodeSessionMessages({

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -1,9 +1,48 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { isAbsolute, join } from "node:path";
 import { opencodeDataDirs as defaultOpencodeDataDirs } from "@openwork/paths";
 
-import Database from "better-sqlite3";
+// better-sqlite3's N-API binding hard-crashes Bun (panic: "NAPI FATAL ERROR:
+// Error::New napi_get_last_error_info"), and the Daytona worker runtime ships
+// openwork-server as a bun-compiled binary. Use Bun's built-in bun:sqlite
+// driver under Bun and better-sqlite3 under Node/Electron; both expose the
+// better-sqlite3-style API surface used here (prepare/get/run, exec,
+// transaction, close). Loading is lazy so merely importing this module never
+// touches a native binding.
+type SqliteStatement = {
+  get(...params: unknown[]): unknown;
+  run(...params: unknown[]): unknown;
+};
+
+type SqliteDatabase = {
+  prepare(sql: string): SqliteStatement;
+  exec(sql: string): void;
+  transaction<T>(fn: () => T): () => T;
+  close(): void;
+};
+
+type SqliteConstructor = new (dbPath: string, options?: { readonly?: boolean }) => SqliteDatabase;
+
+const requireModule = createRequire(import.meta.url);
+
+let sqliteConstructor: SqliteConstructor | null = null;
+
+function loadSqliteConstructor(): SqliteConstructor {
+  if (!sqliteConstructor) {
+    sqliteConstructor =
+      typeof (globalThis as { Bun?: unknown }).Bun === "undefined"
+        ? (requireModule("better-sqlite3") as SqliteConstructor)
+        : ((requireModule("bun:sqlite") as { Database: SqliteConstructor }).Database);
+  }
+  return sqliteConstructor;
+}
+
+function openDatabase(dbPath: string, options?: { readonly?: boolean }): SqliteDatabase {
+  const Database = loadSqliteConstructor();
+  return new Database(dbPath, options);
+}
 
 type SeedMessage = {
   role: "assistant" | "user";
@@ -92,9 +131,9 @@ export function resolveOpencodeDbPath(): string {
 function findOpencodeSessionDbPath(sessionId: string, inputPath?: string): string | null {
   const candidates = (inputPath ? [inputPath] : candidateOpencodeDbPaths()).filter((candidate) => existsSync(candidate));
   for (const dbPath of candidates) {
-    const db = new Database(dbPath, { readonly: true });
+    const db = openDatabase(dbPath, { readonly: true });
     try {
-      const session = db.prepare("select id from session where id = ?1").get(sessionId);
+      const session = db.prepare("select id from session where id = ?").get(sessionId);
       if (session) return dbPath;
     } catch {
       // ignore non-matching dbs
@@ -147,28 +186,28 @@ export function seedOpencodeSessionMessages(input: {
     throw new Error(`OpenCode database not found at ${dbPath}`);
   }
 
-  const db = new Database(dbPath);
+  const db = openDatabase(dbPath);
   db.exec("PRAGMA foreign_keys = ON");
 
   try {
     const run = db.transaction(() => {
-      const session = db.prepare("select id from session where id = ?1").get(sessionId);
+      const session = db.prepare("select id from session where id = ?").get(sessionId);
       if (!session) {
         throw new Error(`OpenCode session not found: ${sessionId}`);
       }
 
-      const existing = db.prepare("select count(1) as count from message where session_id = ?1").get(sessionId) as { count?: number } | null;
+      const existing = db.prepare("select count(1) as count from message where session_id = ?").get(sessionId) as { count?: number } | null;
       if ((existing?.count ?? 0) > 0) {
         return { inserted: 0, skipped: true };
       }
 
       const insertMessage = db.prepare(
-        "insert into message (id, session_id, time_created, time_updated, data) values (?1, ?2, ?3, ?4, ?5)",
+        "insert into message (id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?)",
       );
       const insertPart = db.prepare(
-        "insert into part (id, message_id, session_id, time_created, time_updated, data) values (?1, ?2, ?3, ?4, ?5, ?6)",
+        "insert into part (id, message_id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?, ?)",
       );
-      const updateSession = db.prepare("update session set time_updated = ?2 where id = ?1");
+      const updateSession = db.prepare("update session set time_updated = ? where id = ?");
 
       const startedAt = input.now ?? Date.now();
       let counter = 0;
@@ -218,7 +257,7 @@ export function seedOpencodeSessionMessages(input: {
         }
       });
 
-      updateSession.run(sessionId, startedAt + messages.length);
+      updateSession.run(startedAt + messages.length, sessionId);
       return { inserted: messages.length, skipped: false };
     });
 

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.15",
   "0.18.14",
   "0.18.13",
   "0.18.12",

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -8,12 +8,16 @@ WORKDIR /src
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
+    python3 make g++ \
   && npm install -g bun \
   && corepack enable \
   && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 
+# python3/make/g++ above: better-sqlite3 v13 has no install script, but pnpm's
+# implicit node-gyp build for packages with a binding.gyp still compiles it
+# from source here, which needs a toolchain (v12 downloaded prebuilds instead).
 RUN pnpm install --frozen-lockfile --filter openwork-server... --filter @openwork/app...
 
 ARG TARGETARCH


### PR DESCRIPTION
**One PR to bring dev fully level for v0.18.16.** Combines the sqlite runtime fixes with the v0.18.15 version backfill (#3562 closed in favor of this).

## Commit 1 — sqlite v13 fixes (the regressions #3561 introduced)

1. **Bun panic** — v13's N-API binding hard-crashes Bun (`NAPI FATAL ERROR: Error::New napi_get_last_error_info`); `bun test` died suite-wide, and the Daytona worker runtime ships openwork-server as a **bun-compiled binary**, so runtime sandboxes would crash too. `opencode-db` now picks its driver lazily at call time: `bun:sqlite` under Bun, `better-sqlite3` under Node/Electron (same API surface; the test fixture already used bun:sqlite).
2. **Latent Node bug bun-CI can't see** — v13 under Node rejects `?N` numbered params bound positionally (`RangeError: Too many parameter values were provided`); bun:sqlite accepts them, so tests stayed green while the desktop/Node path would break. All statements normalized to anonymous `?`, verified against both drivers.
3. **Daytona snapshot build** — pnpm's implicit node-gyp build compiles better-sqlite3 from source in `node:22-bookworm-slim` (no toolchain): `gyp ERR! Could not find any Python installation`. Builder stage now installs `python3 make g++`.

## Commit 2 — v0.18.15 version backfill

The bump commit the v0.18.15 tag was cut from (tag-ruleset admin bypass): apps/app, apps/desktop, apps/server package.json + regenerated `ee/apps/den-api/src/generated/desktop-versions.ts`. Merging keeps dev's version math correct for the next release.

## Verification

- `bun test` in apps/server: 625 pass (panic reproduced on unpatched dev with the same suite)
- `bun test src/opencode-db.test.ts`: 5/5, availability-skip removed
- Node smoke of every statement shape against better-sqlite3 v13, including the arg-order-sensitive `update`
- v0.18.15 run validated the electron matrix on v13: 16/18 green incl. all Linux variants (only Daytona red — fixed here)

After merge, v0.18.16 gets tagged from dev and the release publishes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)