### PR TITLE
perf(den-api): bound GitHub reconciliation sweep cost and cache installation tokens

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -32,6 +32,8 @@ const EnvSchema = z.object({
   GITHUB_SYNC_RETRY_BASE_MS: z.string().optional(),
   GITHUB_SYNC_MAX_ATTEMPTS: z.string().optional(),
   GITHUB_RECONCILE_INTERVAL_MS: z.string().optional(),
+  GITHUB_RECONCILE_BATCH_SIZE: z.string().optional(),
+  GITHUB_RECONCILE_MIN_AGE_MS: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   EMAIL_FROM: z.string().optional(),
@@ -482,6 +484,8 @@ export const env = {
     retryBaseMs: Number(parsed.GITHUB_SYNC_RETRY_BASE_MS ?? "30000"),
     maxAttempts: Number(parsed.GITHUB_SYNC_MAX_ATTEMPTS ?? "5"),
     reconcileIntervalMs: Number(parsed.GITHUB_RECONCILE_INTERVAL_MS ?? "900000"),
+    reconcileBatchSize: Number(parsed.GITHUB_RECONCILE_BATCH_SIZE ?? "25"),
+    reconcileMinAgeMs: Number(parsed.GITHUB_RECONCILE_MIN_AGE_MS ?? "21600000"),
   },
   google: {
     clientId: optionalString(parsed.GOOGLE_CLIENT_ID),

--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -78,8 +78,14 @@ export type GithubInstallStatePayload = {
 }
 
 const GITHUB_API_VERSION = "2022-11-28"
+const GITHUB_INSTALLATION_TOKEN_CACHE_TTL_MS = 55 * 60_000
 const GITHUB_REPOSITORY_MAX_PAGES = 30
 const GITHUB_REPOSITORY_PAGE_SIZE = 100
+const githubInstallationTokenCache = new Map<string, { token: string; expiresAtMs: number }>()
+
+export function clearGithubInstallationTokenCache() {
+  githubInstallationTokenCache.clear()
+}
 
 // Overridable so @openwork/testkit specs can point the connector at a mock GitHub witness.
 function githubApiBase(): string {
@@ -330,8 +336,25 @@ async function createGithubInstallationAccessToken(input: { config: GithubConnec
   return token
 }
 
-export async function getGithubInstallationAccessToken(input: { config: GithubConnectorAppConfig; fetchFn?: GithubFetch; installationId: number }) {
-  return createGithubInstallationAccessToken(input)
+export async function getGithubInstallationAccessToken(input: {
+  config: GithubConnectorAppConfig
+  fetchFn?: GithubFetch
+  installationId: number
+  nowMs?: number
+}) {
+  const nowMs = input.nowMs ?? Date.now()
+  const cacheKey = `${input.config.appId}:${input.installationId}`
+  const cached = githubInstallationTokenCache.get(cacheKey)
+  if (cached && cached.expiresAtMs > nowMs) {
+    return cached.token
+  }
+
+  const token = await createGithubInstallationAccessToken(input)
+  githubInstallationTokenCache.set(cacheKey, {
+    expiresAtMs: nowMs + GITHUB_INSTALLATION_TOKEN_CACHE_TTL_MS,
+    token,
+  })
+  return token
 }
 
 function normalizeGithubRepository(entry: unknown): GithubRepositorySummary | null {
@@ -364,7 +387,7 @@ function normalizeGithubRepository(entry: unknown): GithubRepositorySummary | nu
 }
 
 export async function listGithubInstallationRepositories(input: { config: GithubConnectorAppConfig; fetchFn?: GithubFetch; installationId: number }) {
-  const token = await createGithubInstallationAccessToken(input)
+  const token = await getGithubInstallationAccessToken(input)
   const normalizedRepositories: GithubRepositorySummary[] = []
   for (let page = 1; page <= GITHUB_REPOSITORY_MAX_PAGES; page += 1) {
     const response = await requestGithubJson<{ repositories?: unknown[] }>({
@@ -488,7 +511,7 @@ export async function getGithubRepositoryTextFile(input: {
     throw new GithubConnectorRequestError("GitHub repository full name is invalid.", 400)
   }
 
-  const token = input.token ?? await createGithubInstallationAccessToken(input)
+  const token = input.token ?? await getGithubInstallationAccessToken(input)
   const response = await requestGithubJson<{ content?: string; encoding?: string }>({
     allowStatuses: [404],
     fetchFn: input.fetchFn,
@@ -570,7 +593,7 @@ export async function getGithubRepositoryHeadSha(input: {
     throw new GithubConnectorRequestError("GitHub repository full name is invalid.", 400)
   }
 
-  const token = input.token ?? await createGithubInstallationAccessToken(input)
+  const token = input.token ?? await getGithubInstallationAccessToken(input)
   const commitResponse = await requestGithubJson<{ sha?: string }>({
     fetchFn: input.fetchFn,
     headers: {
@@ -599,7 +622,7 @@ export async function getGithubRepositoryTree(input: {
     throw new GithubConnectorRequestError("GitHub repository full name is invalid.", 400)
   }
 
-  const token = input.token ?? await createGithubInstallationAccessToken(input)
+  const token = input.token ?? await getGithubInstallationAccessToken(input)
   const authHeaders = {
     Authorization: `Bearer ${token}`,
   }
@@ -681,7 +704,7 @@ export async function validateGithubInstallationTarget(input: {
     }
   }
 
-  const token = input.token ?? await createGithubInstallationAccessToken(input)
+  const token = input.token ?? await getGithubInstallationAccessToken(input)
   const authHeaders = {
     Authorization: `Bearer ${token}`,
   }

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -337,8 +337,9 @@ export class PluginArchRouteFailure extends Error {
     readonly status: 400 | 404 | 409 | 502,
     readonly error: string,
     message: string,
+    options?: ErrorOptions,
   ) {
-    super(message)
+    super(message, options)
     this.name = "PluginArchRouteFailure"
   }
 }
@@ -4144,7 +4145,7 @@ function wrapGithubConnectorError(error: unknown): never {
   }
 
   if (error instanceof GithubConnectorRequestError) {
-    throw new PluginArchRouteFailure(409, "github_connector_request_failed", error.message)
+    throw new PluginArchRouteFailure(409, "github_connector_request_failed", error.message, { cause: error })
   }
 
   throw error

--- a/ee/apps/den-api/src/workers/github-sync.ts
+++ b/ee/apps/den-api/src/workers/github-sync.ts
@@ -19,6 +19,41 @@ import { executeGithubConnectorSyncEvent } from "../routes/org/plugin-system/sto
 
 const logger = appLogger.child({ component: "github_sync_worker" })
 const MAX_BACKOFF_MS = 15 * 60_000
+// This bounds one process; multi-replica dedup/leadership is deliberately deferred to #3568.
+const githubReconcileLastProbedAtMs = new Map<string, number>()
+
+export function resetGithubReconcileProbeStateForTests() {
+  githubReconcileLastProbedAtMs.clear()
+}
+
+export function selectGithubReconcileCandidates(input: {
+  batchSize: number
+  minAgeMs: number
+  now: Date
+  targets: Array<{ targetId: string; createdAtMs: number }>
+  lastProbedAtMs: ReadonlyMap<string, number>
+}): string[] {
+  const nowMs = input.now.getTime()
+  return [...input.targets]
+    .filter((target) => {
+      const lastProbedAtMs = input.lastProbedAtMs.get(target.targetId)
+      return lastProbedAtMs === undefined || nowMs - lastProbedAtMs >= input.minAgeMs
+    })
+    .sort((left, right) => {
+      const leftLastProbedAtMs = input.lastProbedAtMs.get(left.targetId)
+      const rightLastProbedAtMs = input.lastProbedAtMs.get(right.targetId)
+      if (leftLastProbedAtMs === undefined && rightLastProbedAtMs !== undefined) return -1
+      if (leftLastProbedAtMs !== undefined && rightLastProbedAtMs === undefined) return 1
+      if (leftLastProbedAtMs !== undefined && rightLastProbedAtMs !== undefined) {
+        const probedAtOrder = leftLastProbedAtMs - rightLastProbedAtMs
+        if (probedAtOrder !== 0) return probedAtOrder
+      }
+      const createdAtOrder = left.createdAtMs - right.createdAtMs
+      return createdAtOrder || left.targetId.localeCompare(right.targetId)
+    })
+    .slice(0, Math.max(0, Math.floor(input.batchSize)))
+    .map((target) => target.targetId)
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -48,7 +83,11 @@ export function isTransientGithubSyncError(error: unknown) {
   if (error instanceof GithubConnectorRequestError) {
     return error.status === 429 || error.status >= 500
   }
-  return error instanceof TypeError || (error instanceof Error && error.name === "AbortError")
+  if (error instanceof TypeError || (error instanceof Error && error.name === "AbortError")) return true
+  if (error instanceof Error && error.cause !== undefined && error.cause !== error) {
+    return isTransientGithubSyncError(error.cause)
+  }
+  return false
 }
 
 export async function processDueGithubSyncEvents(now = new Date()) {
@@ -187,7 +226,7 @@ export async function reconcileGithubConnectorTargets() {
     ))
     .orderBy(asc(ConnectorTargetTable.createdAt), asc(ConnectorTargetTable.id))
 
-  let enqueued = 0
+  const candidateTargets: typeof targets = []
   for (const row of targets) {
     const activeEvents = await db
       .select({ id: ConnectorSyncEventTable.id })
@@ -199,6 +238,26 @@ export async function reconcileGithubConnectorTargets() {
       .limit(1)
     if (activeEvents[0]) continue
 
+    candidateTargets.push(row)
+  }
+
+  const now = new Date()
+  const selectedTargetIds = selectGithubReconcileCandidates({
+    batchSize: env.githubSync.reconcileBatchSize,
+    lastProbedAtMs: githubReconcileLastProbedAtMs,
+    minAgeMs: env.githubSync.reconcileMinAgeMs,
+    now,
+    targets: candidateTargets.map((row) => ({
+      createdAtMs: row.target.createdAt.getTime(),
+      targetId: row.target.id,
+    })),
+  })
+
+  let enqueued = 0
+  for (const targetId of selectedTargetIds) {
+    const row = candidateTargets.find((candidate) => candidate.target.id === targetId)
+    if (!row) continue
+    githubReconcileLastProbedAtMs.set(row.target.id, now.getTime())
     try {
       const targetConfig = githubTargetConfig(row.target)
       const installationId = githubInstallationId(row.instance, row.account)
@@ -249,7 +308,7 @@ export async function reconcileGithubConnectorTargets() {
     }
   }
 
-  return { checked: targets.length, enqueued }
+  return { checked: selectedTargetIds.length, enqueued }
 }
 
 let workerTickRunning = false
@@ -296,14 +355,18 @@ export function startGithubSyncWorker(
   const reconcileTimer = Number.isFinite(reconcileIntervalMs) && reconcileIntervalMs > 0
     ? setInterval(runReconcile, reconcileIntervalMs)
     : null
+  const reconcileInitialTimer = reconcileTimer
+    ? setTimeout(runReconcile, Math.floor(Math.random() * Math.min(reconcileIntervalMs, 60_000)))
+    : null
   workerTimer?.unref()
   reconcileTimer?.unref()
+  reconcileInitialTimer?.unref()
   if (workerTimer) runWorkerTick()
-  if (reconcileTimer) runReconcile()
 
   return async () => {
     if (workerTimer) clearInterval(workerTimer)
     if (reconcileTimer) clearInterval(reconcileTimer)
+    if (reconcileInitialTimer) clearTimeout(reconcileInitialTimer)
     await Promise.all([workerTickPromise, reconcilePromise])
   }
 }

--- a/ee/apps/den-api/test/github-connector-app.test.ts
+++ b/ee/apps/den-api/test/github-connector-app.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from "bun:test"
+import { beforeEach, describe, expect, test } from "bun:test"
 import { generateKeyPairSync } from "node:crypto"
 import {
   buildGithubAppInstallUrl,
+  clearGithubInstallationTokenCache,
   createGithubInstallStateToken,
   createGithubAppJwt,
   fetchGithubImportFilesWithRevisionGuard,
   getGithubAppSummary,
   getGithubConnectorAppConfig,
   getGithubInstallationSummary,
+  getGithubInstallationAccessToken,
   getGithubRepositoryTextFile,
   GithubConnectorRequestError,
   listGithubInstallationRepositories,
@@ -20,6 +22,10 @@ const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
 const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString()
 
 describe("github connector app helpers", () => {
+  beforeEach(() => {
+    clearGithubInstallationTokenCache()
+  })
+
   test("normalizes escaped private keys and produces a signed app JWT", () => {
     const escapedKey = privateKeyPem.replace(/\n/g, "\\n")
     expect(normalizeGithubPrivateKey(escapedKey)).toBe(privateKeyPem)
@@ -140,6 +146,46 @@ describe("github connector app helpers", () => {
     expect(requestUrls).toContain("https://api.github.com/installation/repositories?per_page=100&page=1")
     expect(requestUrls).toContain("https://api.github.com/installation/repositories?per_page=100&page=2")
     expect(requestUrls).not.toContain("https://api.github.com/installation/repositories?per_page=100&page=3")
+  })
+
+  test("caches installation tokens within the TTL and clears them on demand", async () => {
+    let mintCount = 0
+    const fetchFn: typeof fetch = async () => {
+      mintCount += 1
+      return new Response(JSON.stringify({ token: `installation-token-${mintCount}` }), { status: 201 })
+    }
+    const input = {
+      config: { appId: "123456", privateKey: privateKeyPem },
+      fetchFn,
+      installationId: 777,
+    }
+
+    expect(await getGithubInstallationAccessToken({ ...input, nowMs: 1_000 })).toBe("installation-token-1")
+    expect(await getGithubInstallationAccessToken({ ...input, nowMs: 55 * 60_000 })).toBe("installation-token-1")
+    expect(mintCount).toBe(1)
+
+    clearGithubInstallationTokenCache()
+    expect(await getGithubInstallationAccessToken({ ...input, nowMs: 55 * 60_000 })).toBe("installation-token-2")
+    expect(mintCount).toBe(2)
+  })
+
+  test("expires installation tokens after 55 minutes and isolates installations", async () => {
+    let mintCount = 0
+    const fetchFn: typeof fetch = async () => {
+      mintCount += 1
+      return new Response(JSON.stringify({ token: `installation-token-${mintCount}` }), { status: 201 })
+    }
+    const config = { appId: "123456", privateKey: privateKeyPem }
+
+    expect(await getGithubInstallationAccessToken({ config, fetchFn, installationId: 777, nowMs: 1_000 })).toBe("installation-token-1")
+    expect(await getGithubInstallationAccessToken({ config, fetchFn, installationId: 888, nowMs: 1_000 })).toBe("installation-token-2")
+    expect(await getGithubInstallationAccessToken({
+      config,
+      fetchFn,
+      installationId: 777,
+      nowMs: 1_000 + 55 * 60_000 + 1,
+    })).toBe("installation-token-3")
+    expect(mintCount).toBe(3)
   })
 
   test("builds install URLs and validates signed state tokens", async () => {

--- a/ee/apps/den-api/test/github-sync-worker.test.ts
+++ b/ee/apps/den-api/test/github-sync-worker.test.ts
@@ -28,9 +28,65 @@ test("GitHub sync transient error classification covers rate limits, server fail
   expect(workerModule.isTransientGithubSyncError(new githubModule.GithubConnectorRequestError("unavailable", 503))).toBe(true)
   expect(workerModule.isTransientGithubSyncError(new githubModule.GithubConnectorRequestError("bad request", 400))).toBe(false)
   expect(workerModule.isTransientGithubSyncError(new TypeError("fetch failed"))).toBe(true)
+  expect(workerModule.isTransientGithubSyncError(new Error("wrapped", {
+    cause: new githubModule.GithubConnectorRequestError("rate limited", 429),
+  }))).toBe(true)
 
   const abortError = new Error("aborted")
   abortError.name = "AbortError"
   expect(workerModule.isTransientGithubSyncError(abortError)).toBe(true)
   expect(workerModule.isTransientGithubSyncError(new Error("permanent"))).toBe(false)
+})
+
+test("GitHub reconcile selection prioritizes never-probed targets, orders old probes, and respects the batch cap deterministically", () => {
+  const input = {
+    batchSize: 4,
+    lastProbedAtMs: new Map([
+      ["probed-new", 3_000],
+      ["probed-old-b", 1_000],
+      ["probed-old-a", 1_000],
+    ]),
+    minAgeMs: 0,
+    now: new Date(10_000),
+    targets: [
+      { createdAtMs: 20, targetId: "never-b" },
+      { createdAtMs: 30, targetId: "probed-old-b" },
+      { createdAtMs: 10, targetId: "never-a" },
+      { createdAtMs: 30, targetId: "probed-old-a" },
+      { createdAtMs: 5, targetId: "probed-new" },
+    ],
+  }
+
+  expect(workerModule.selectGithubReconcileCandidates(input)).toEqual([
+    "never-a",
+    "never-b",
+    "probed-old-a",
+    "probed-old-b",
+  ])
+  expect(workerModule.selectGithubReconcileCandidates({
+    ...input,
+    targets: input.targets.toReversed(),
+  })).toEqual([
+    "never-a",
+    "never-b",
+    "probed-old-a",
+    "probed-old-b",
+  ])
+})
+
+test("GitHub reconcile selection excludes probes newer than the minimum age and includes the boundary", () => {
+  expect(workerModule.selectGithubReconcileCandidates({
+    batchSize: 10,
+    lastProbedAtMs: new Map([
+      ["at-boundary", 8_000],
+      ["too-recent", 8_001],
+    ]),
+    minAgeMs: 2_000,
+    now: new Date(10_000),
+    targets: [
+      { createdAtMs: 20, targetId: "too-recent" },
+      { createdAtMs: 10, targetId: "at-boundary" },
+      { createdAtMs: 30, targetId: "never-probed" },
+    ],
+  })).toEqual(["never-probed", "at-boundary"])
 })

--- a/evals/specs/github-sync-self-healing.slow.test.ts
+++ b/evals/specs/github-sync-self-healing.slow.test.ts
@@ -307,6 +307,7 @@ test.skipIf(!localPlacement || !mysqlOpen)(title, async ({ evidence, place }) =>
     GITHUB_SYNC_RETRY_BASE_MS: "500",
     GITHUB_SYNC_MAX_ATTEMPTS: "5",
     GITHUB_RECONCILE_INTERVAL_MS: "2000",
+    GITHUB_RECONCILE_MIN_AGE_MS: "0",
   });
 
   try {


### PR DESCRIPTION
Part of #3568 (interim mitigation — the deliveries-API redesign completes it). Context: the sweep shipped in #3536 probed **every** active GitHub target every 15 min, minting a fresh installation token per probe, on every replica — ~40k GitHub calls/hour at 5k targets. Webhooks are the primary signal; the sweep is a safety net and now costs like one.

## Changes

- **Installation token cache** (`github-app.ts`): 55-min TTL per app+installation (GitHub tokens live 60), used by every connector call site (repo listing, discovery, materialization, probes). Injectable `nowMs` + exported clear helper keep unit tests deterministic and still prove cold-cache minting.
- **Bounded sweep** (`workers/github-sync.ts`): new knobs `GITHUB_RECONCILE_BATCH_SIZE` (default **25**/tick) and `GITHUB_RECONCILE_MIN_AGE_MS` (default **6h** per target); pure exported selector (never-probed first by creation, then oldest-probed, deterministic tiebreaks); jittered cancellable initial run instead of probing at boot; probe timestamps recorded for **attempted** probes so a broken target can't hot-loop. Steady-state: ≤25 probes/15 min per replica regardless of fleet size (5k targets: ~40k/hr → ~100/hr, and each probe is now 1 call instead of 2).
- **Retry classification through cause chains** (`store.ts` + worker): found by the spec — cached tokens shifted a mocked 429 onto a path where `wrapGithubConnectorError` re-wrapped it as `PluginArchRouteFailure`, silently losing transient classification. `PluginArchRouteFailure` now carries `cause`, and `isTransientGithubSyncError` walks the chain (self-reference guarded).
- Spec env: `GITHUB_RECONCILE_MIN_AGE_MS: "0"` so frame 5 (lost-webhook healing) still exercises an immediate re-probe.

Multi-replica leadership + deliveries-API reconciliation deliberately deferred to #3568 (commented in code).

## Validation

- `bun test` across 6 den-api suites → **30 pass, 0 fail** (new: selector semantics, token-cache TTL/expiry/isolation, cause-chain transient classification).
- `pnpm exec tsc --noEmit -p ee/apps/den-api` → clean.
- Both stack specs green (`github-sync-self-healing` — bounded sweep exercised end-to-end via the lost-webhook frame — and `github-connector-import` — token-identity assertions undisturbed), including a run at this exact HEAD.

Evidence tape published as the sticky comment.