### PR TITLE
fix: update OpenCode sidecar for LongCat free model

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.17.11"
+  "opencodeVersion": "v1.18.13"
 }


### PR DESCRIPTION
## Summary

- Update the bundled OpenCode sidecar from v1.17.11 to v1.18.13.
- Include the longcat-2.0-free model in OpenWork model discovery.

## Validation

- node --check apps/desktop/scripts/prepare-sidecar.mjs
- Prepared the sidecar and verified that opencode models opencode lists opencode/longcat-2.0-free.

Closes #3555