### PR TITLE
fix(automations): recognize desktop runners across Den replicas

### DIFF
--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -581,6 +581,15 @@ export class DenAutomationRepository implements AutomationRepository {
       ))
   }
 
+  async hasRecentDesktopRunner(input: { organizationId: string; ownerMemberId: string; seenAfter: number }) {
+    const rows = await db.select({ id: AutomationRunnerTable.id }).from(AutomationRunnerTable).where(and(
+      eq(AutomationRunnerTable.organization_id, normalizeOrganizationId(input.organizationId)),
+      eq(AutomationRunnerTable.owner_member_id, normalizeMemberId(input.ownerMemberId)),
+      gt(AutomationRunnerTable.last_seen_at, new Date(input.seenAfter)),
+    )).limit(1)
+    return rows.length > 0
+  }
+
   async discoverDesktopWork(input: { organizationId: string; ownerMemberId: string; now: number; limit: number }) {
     const rows = await db.select({ runId: AutomationRunTable.id, executionTarget: AutomationRunTable.execution_target })
       .from(AutomationRunTable)

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -11,7 +11,6 @@ export type AutomationRunnerIdentity = {
 }
 
 export class AutomationRunnerAuth {
-  private readonly connections = new Map<string, number>()
   constructor(private readonly secret = env.betterAuthSecret) {}
 
   private sign(payload: string) {
@@ -64,23 +63,6 @@ export class AutomationRunnerAuth {
     }
   }
 
-  private connectionKey(scope: Pick<AutomationRunnerIdentity, "organizationId" | "ownerMemberId">) {
-    return `${scope.organizationId}:${scope.ownerMemberId}`
-  }
-
-  connected(scope: AutomationRunnerIdentity) {
-    const key = this.connectionKey(scope)
-    this.connections.set(key, (this.connections.get(key) ?? 0) + 1)
-    return () => {
-      const remaining = (this.connections.get(key) ?? 1) - 1
-      if (remaining > 0) this.connections.set(key, remaining)
-      else this.connections.delete(key)
-    }
-  }
-
-  hasConnected(scope: Pick<AutomationRunnerIdentity, "organizationId" | "ownerMemberId">) {
-    return (this.connections.get(this.connectionKey(scope)) ?? 0) > 0
-  }
 }
 
 export const automationRunnerAuth = new AutomationRunnerAuth()

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -12,6 +12,7 @@ import { isActiveAutomationOwner, resolveAutomationModelAccess } from "./authori
 import { automationRepository } from "./repository.js"
 
 const schedulerOwner = `den:${process.pid}:${randomUUID()}`
+const DESKTOP_RUNNER_ONLINE_WINDOW_MS = 45_000
 
 type OwnerScope = { organizationId: string; ownerMemberId: string }
 export type DesktopRunnerScope = OwnerScope & { runnerId: string }
@@ -137,6 +138,14 @@ export class AutomationService {
 
   touchDesktopRunner(scope: DesktopRunnerScope) {
     return automationRepository.touchDesktopRunner({ ...scope, now: Date.now() })
+  }
+
+  hasOnlineDesktopRunner(scope: OwnerScope) {
+    const now = Date.now()
+    return automationRepository.hasRecentDesktopRunner({
+      ...scope,
+      seenAfter: now - DESKTOP_RUNNER_ONLINE_WINDOW_MS,
+    })
   }
 
   async discoverDesktopRunnerWork(scope: DesktopRunnerScope) {

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -108,37 +108,32 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     const requestedCursor = Number(c.req.header("Last-Event-ID") ?? "0")
     let cursor = Number.isSafeInteger(requestedCursor) && requestedCursor >= 0 ? requestedCursor : 0
     return streamSSE(c, async (stream) => {
-      const disconnected = automationRunnerAuth.connected(identity)
       let lastKeepaliveAt = 0
       let lastOwnerCheckAt = Date.now()
-      try {
-        while (!stream.aborted) {
-          // A held-open stream must not outlive the credential or membership.
-          if (Date.now() >= identity.expiresAt) break
-          if (Date.now() - lastOwnerCheckAt >= 15_000) {
-            if (!(await service.isActiveRunnerOwner(identity))) break
-            lastOwnerCheckAt = Date.now()
-          }
-          const notifications = await service.runnerNotifications(identity, cursor)
-          for (const notification of notifications) {
-            cursor = notification.id
-            const payload = automationRunnerNotificationSchema.parse({
-              type: notification.event_type === "work_available"
-                ? "automation_work_available"
-                : "automation_cancellation_available",
-              cursor: String(notification.id),
-            })
-            await stream.writeSSE({ id: payload.cursor, event: payload.type, data: JSON.stringify(payload) })
-          }
-          if (notifications.length === 0 && Date.now() - lastKeepaliveAt >= 15_000) {
-            await service.touchDesktopRunner(identity)
-            await stream.writeSSE({ event: "keepalive", data: "{}" })
-            lastKeepaliveAt = Date.now()
-          }
-          await stream.sleep(1_000)
+      while (!stream.aborted) {
+        // A held-open stream must not outlive the credential or membership.
+        if (Date.now() >= identity.expiresAt) break
+        if (Date.now() - lastOwnerCheckAt >= 15_000) {
+          if (!(await service.isActiveRunnerOwner(identity))) break
+          lastOwnerCheckAt = Date.now()
         }
-      } finally {
-        disconnected()
+        const notifications = await service.runnerNotifications(identity, cursor)
+        for (const notification of notifications) {
+          cursor = notification.id
+          const payload = automationRunnerNotificationSchema.parse({
+            type: notification.event_type === "work_available"
+              ? "automation_work_available"
+              : "automation_cancellation_available",
+            cursor: String(notification.id),
+          })
+          await stream.writeSSE({ id: payload.cursor, event: payload.type, data: JSON.stringify(payload) })
+        }
+        if (notifications.length === 0 && Date.now() - lastKeepaliveAt >= 15_000) {
+          await service.touchDesktopRunner(identity)
+          await stream.writeSSE({ event: "keepalive", data: "{}" })
+          lastKeepaliveAt = Date.now()
+        }
+        await stream.sleep(1_000)
       }
     })
   })
@@ -324,7 +319,7 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     orgMemberRoute(), paramValidator(idParamsSchema),
     async (c) => {
       const owner = scope(c)
-      if (!automationRunnerAuth.hasConnected(owner)) {
+      if (!(await service.hasOnlineDesktopRunner(owner))) {
         return c.json({ error: "runner_unavailable", message: "No desktop runner is online" }, 409)
       }
       try {

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -140,6 +140,18 @@ test("every runner endpoint re-checks that the token owner is still an active me
   assert.match(sse, /if \(!\(await service\.isActiveRunnerOwner\(identity\)\)\) break/)
 })
 
+test("manual runs use durable runner presence across Den API replicas", () => {
+  const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
+  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
+  const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
+
+  assert.match(routesSource, /await service\.hasOnlineDesktopRunner\(owner\)/)
+  assert.doesNotMatch(routesSource, /automationRunnerAuth\.hasConnected/)
+  assert.match(serviceSource, /DESKTOP_RUNNER_ONLINE_WINDOW_MS = 45_000/)
+  assert.match(serviceSource, /automationRepository\.hasRecentDesktopRunner\(/)
+  assert.match(repositorySource, /gt\(AutomationRunnerTable\.last_seen_at, new Date\(input\.seenAfter\)\)/)
+})
+
 test("every dispatch path revalidates the owner's model access", () => {
   const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const tick = serviceSource.slice(serviceSource.indexOf("async tick"), serviceSource.indexOf("async stop"))

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -144,9 +144,11 @@ test("manual runs use durable runner presence across Den API replicas", () => {
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
   const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
+  const runnerAuthSource = readFileSync(join(import.meta.dir, "../src/automations/runner-auth.ts"), "utf8")
 
   assert.match(routesSource, /await service\.hasOnlineDesktopRunner\(owner\)/)
   assert.doesNotMatch(routesSource, /automationRunnerAuth\.hasConnected/)
+  assert.doesNotMatch(runnerAuthSource, /connections = new Map/)
   assert.match(serviceSource, /DESKTOP_RUNNER_ONLINE_WINDOW_MS = 45_000/)
   assert.match(serviceSource, /automationRepository\.hasRecentDesktopRunner\(/)
   assert.match(repositorySource, /gt\(AutomationRunnerTable\.last_seen_at, new Date\(input\.seenAfter\)\)/)


### PR DESCRIPTION
## Summary

Use the durable `automation_runner.last_seen_at` heartbeat to decide whether Run Now has an online desktop runner.

## Root cause

Runner presence was stored in an in-memory map owned by one Den API process. The desktop SSE stream could be connected to replica A while the manual-run request reached replica B, which then returned `No desktop runner is online`.

## What changed

- query the existing indexed runner heartbeat by organization and owner
- treat a runner heartbeat from the last 45 seconds as online
- remove the process-local connection map
- add a regression contract covering the replica-safe presence path

## Impact

An open, connected desktop is now recognized regardless of which Den API replica handles Run Now. Offline runs retain the existing explicit `runner_unavailable` response after the heartbeat window expires.

## Verification

Passed:

- `bun test ee/apps/den-api/test/automation-runner-protocol.test.ts` — 12 passed, 0 failed
- `git diff --check`

Deferred:

- Den Automations typecheck: the clean worktree reused an older installed workspace dependency graph and reported existing `model_variant` schema/type mismatches unrelated to this diff; PR CI should run against a coherent install.
- runtime evidence tape and multi-replica deployment proof
