### PR TITLE
fix(app): keep failed organization MCP OAuth modal open

### DIFF
--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -54,6 +54,8 @@ export type ExtensionDetailModalProps = {
   beta?: boolean;
   /** Reason this item is visible but unavailable. */
   disabledReason?: string | null;
+  /** Actionable error from the most recent connection attempt. */
+  errorInfo?: string | null;
   /** Remote URL if applicable. */
   url?: string;
   /** Declarative setup instructions from an extension manifest. */
@@ -198,6 +200,7 @@ export function ExtensionDetailModal({
   preview = false,
   beta = false,
   disabledReason = null,
+  errorInfo = null,
   url,
   setupInstructions,
   resourceLabels = [],
@@ -303,6 +306,12 @@ export function ExtensionDetailModal({
       <div className="text-sm leading-relaxed text-card-foreground">
         {description}
       </div>
+
+      {errorInfo ? (
+        <div role="alert" className="rounded-lg border border-red-6 bg-red-2 px-3 py-2 text-sm text-red-11">
+          {errorInfo}
+        </div>
+      ) : null}
 
       {setupInstructions ? (
         <Card variant="outline" size="sm">

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -19,6 +19,22 @@ import { connectionNeedsReconnect, isNativeProviderConnectionId } from "./native
 const CONNECT_POLL_INTERVAL_MS = 2_000;
 const CONNECT_TIMEOUT_MS = 90_000;
 
+export type OrgMcpConnectFailure =
+  | "missing_context"
+  | "missing_authorization_url"
+  | "timeout";
+
+export function orgMcpConnectFailureMessage(failure: OrgMcpConnectFailure): string {
+  switch (failure) {
+    case "missing_context":
+      return "Sign in to OpenWork Cloud and select an organization before connecting.";
+    case "missing_authorization_url":
+      return "The connection did not return a sign-in URL. Check its OAuth configuration and try again.";
+    case "timeout":
+      return "Sign-in did not complete. Check the provider window for an OAuth error, then verify the provider redirect URI and try again.";
+  }
+}
+
 async function openAuthorizationUrl(url: string) {
   if (isDesktopRuntime()) {
     await openDesktopUrl(url);
@@ -202,7 +218,10 @@ export function useOrgMcpConnections() {
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
     const orgId = settings.activeOrgId?.trim() ?? "";
-    if (!token || !orgId) return;
+    if (!token || !orgId) {
+      setError(orgMcpConnectFailureMessage("missing_context"));
+      return;
+    }
 
     const previous = connectionsRef.current.find((entry) => entry.id === connectionId);
     const previousConnectedAt = previous?.connectedAt ?? null;
@@ -214,6 +233,7 @@ export function useOrgMcpConnections() {
     };
     setDisconnectingId(null);
     setConnectingId(connectionId);
+    setError(null);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
       if (options?.forceFreshAuthorization === true && previous?.connectedForMe) {
@@ -229,6 +249,7 @@ export function useOrgMcpConnections() {
         return;
       }
       if (!result.authorizeUrl) {
+        setError(orgMcpConnectFailureMessage("missing_authorization_url"));
         setConnectingId(null);
         return;
       }
@@ -241,6 +262,7 @@ export function useOrgMcpConnections() {
         if (!isActionScopeCurrent(pollScope)) return;
         if (Date.now() - startedAt >= CONNECT_TIMEOUT_MS) {
           stopPolling();
+          setError(orgMcpConnectFailureMessage("timeout"));
           setConnectingId(null);
           return;
         }

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -167,6 +167,7 @@ export type McpViewProps = {
   /** Connected org-level External MCP Connections rendered in My Extensions. */
   orgMcpItems?: ExtensionItem[];
   organizationName?: string | null;
+  orgMcpError?: string | null;
   orgMcpConnectingId?: string | null;
   connectOrgMcp?: (connectionId: string) => void;
   reconnectOrgMcp?: (connectionId: string) => void;
@@ -912,6 +913,7 @@ export function McpView(props: McpViewProps) {
             connecting={connectingBusy || disconnectingBusy}
             connectingLabel={disconnectingBusy ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_waiting_browser")}
             beta
+            errorInfo={props.orgMcpError}
             url={connection.url}
             oauth={connection.authType === "oauth"}
             connectLabel={orgMcpConnectionActionLabel(connection)}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2315,6 +2315,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 installedPlugins={extensionItems.installedCloudPlugins}
                 orgMcpItems={orgMcpConnectionItems}
                 organizationName={cloudSession.activeOrgName}
+                orgMcpError={orgMcpConnections.error}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
                 orgMcpConnectingId={orgMcpConnections.connectingId}

--- a/apps/app/tests/extension-detail-modal-error.test.tsx
+++ b/apps/app/tests/extension-detail-modal-error.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ExtensionDetailModal } from "../src/react-app/design-system/extension-detail-modal";
+
+describe("ExtensionDetailModal connection errors", () => {
+  test("keeps the connection detail visible and shows the failed OAuth attempt", () => {
+    const html = renderToStaticMarkup(
+      <ExtensionDetailModal
+        open
+        presentation="page"
+        onClose={() => {}}
+        name="BigQuery"
+        description="Connect BigQuery to your organization."
+        taxonomy="connection"
+        oauth
+        errorInfo="Sign-in did not complete. Check the provider window for an OAuth error."
+        onConnect={() => {}}
+      />,
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Sign-in did not complete");
+    expect(html).toContain("Connect");
+  });
+});

--- a/apps/app/tests/org-mcp-connections.test.ts
+++ b/apps/app/tests/org-mcp-connections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   isOrgMcpPollScopeCurrent,
+  orgMcpConnectFailureMessage,
   resolveOrgMcpConnectionCardState,
 } from "../src/react-app/domains/connections/use-org-mcp-connections";
 
@@ -68,6 +69,12 @@ describe("resolveOrgMcpConnectionCardState", () => {
 });
 
 describe("organization MCP OAuth polling", () => {
+  test("terminal connection failures provide actionable feedback", () => {
+    expect(orgMcpConnectFailureMessage("missing_context")).toContain("Sign in");
+    expect(orgMcpConnectFailureMessage("missing_authorization_url")).toContain("OAuth configuration");
+    expect(orgMcpConnectFailureMessage("timeout")).toContain("provider redirect URI");
+  });
+
   test("an in-flight response cannot apply org A rows after switching to org B", async () => {
     let releaseResponse = () => {};
     const responsePending = new Promise<void>((resolve) => {


### PR DESCRIPTION
## What changed

- keep the organization MCP connection detail modal visible when OAuth does not complete
- show the failure inside that modal instead of silently clearing the connecting state
- report missing authorization URLs and polling timeouts with actionable guidance
- clear stale modal errors when a member retries

## Root cause

Organization-managed MCPs use a newer Den polling flow instead of the existing local MCP OAuth modal. That flow silently cleared its busy state when Den returned no authorization URL or when the 90-second poll expired. Its stored connection error also was not wired into the organization MCP detail modal.

## User impact

After Connect fails, the connection detail remains open and displays the error in context. No alert is added to the Extensions inventory list.

## Validation

- `bun test apps/app/tests/org-mcp-connections.test.ts apps/app/tests/extension-detail-modal-error.test.tsx` — 11 passed
- modal regression coverage verifies the open connection detail renders the OAuth error and retry action
- Bun compilation of the three changed UI entry points
- `git diff --check upstream/dev...HEAD`

This PR improves modal feedback only; OAuth provider redirect URI configuration remains an operational requirement.