### PR TITLE
fix(automations): hide preview on web

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
@@ -42,6 +42,7 @@ export type PreferencesViewProps = {
   onDesktopNotificationsChange: (value: DesktopNotificationPreference) => void;
   memoryEnabled: boolean;
   onToggleMemory: () => void;
+  showAutomations: boolean;
   automationsEnabled: boolean;
   onToggleAutomations: () => void;
 };
@@ -191,27 +192,29 @@ export function PreferencesView(props: PreferencesViewProps) {
         </LayoutSectionItem>
       </LayoutSection>
 
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>{t("automations.preferences_title")}</LayoutSectionTitle>
-          <LayoutSectionDescription>{t("automations.preferences_section_desc")}</LayoutSectionDescription>
-        </LayoutSectionHeader>
+      {props.showAutomations ? (
+        <LayoutSection>
+          <LayoutSectionHeader>
+            <LayoutSectionTitle>{t("automations.preferences_title")}</LayoutSectionTitle>
+            <LayoutSectionDescription>{t("automations.preferences_section_desc")}</LayoutSectionDescription>
+          </LayoutSectionHeader>
 
-        <LayoutSectionItem>
-          <LayoutSectionItemHeader>
-            <LayoutSectionItemTitle>{t("automations.preferences_toggle")}</LayoutSectionItemTitle>
-            <LayoutSectionItemDescription>{t("automations.preferences_toggle_desc")}</LayoutSectionItemDescription>
-            <LayoutSectionItemHeaderActions>
-              <Switch
-                aria-label={t("automations.preferences_toggle")}
-                checked={props.automationsEnabled}
-                disabled={props.busy}
-                onCheckedChange={props.onToggleAutomations}
-              />
-            </LayoutSectionItemHeaderActions>
-          </LayoutSectionItemHeader>
-        </LayoutSectionItem>
-      </LayoutSection>
+          <LayoutSectionItem>
+            <LayoutSectionItemHeader>
+              <LayoutSectionItemTitle>{t("automations.preferences_toggle")}</LayoutSectionItemTitle>
+              <LayoutSectionItemDescription>{t("automations.preferences_toggle_desc")}</LayoutSectionItemDescription>
+              <LayoutSectionItemHeaderActions>
+                <Switch
+                  aria-label={t("automations.preferences_toggle")}
+                  checked={props.automationsEnabled}
+                  disabled={props.busy}
+                  onCheckedChange={props.onToggleAutomations}
+                />
+              </LayoutSectionItemHeaderActions>
+            </LayoutSectionItemHeader>
+          </LayoutSectionItem>
+        </LayoutSection>
+      ) : null}
     </LayoutStack>
   );
 }

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -49,12 +49,10 @@ export type LocalPreferences = {
   featureFlags: {
     microsandboxCreateSandbox: boolean;
     /**
-     * Automations preview. Client-only and per-device. Gates every desktop
-     * Automations affordance — the sidebar entry, the /automations route, and
-     * the Den availability probe — until the user opts into the preview. The
-     * Den APIs stay callable (owner-scoped + authz'd), but this desktop only
-     * registers as an execution runner while the preview is enabled. Off by
-     * default.
+     * Automations preview. Client-only and per-device. Hidden entirely on web;
+     * desktop gates the sidebar entry, /automations route, Den availability
+     * probe, and runner registration until the user opts in. The Den APIs stay
+     * callable (owner-scoped + authz'd). Off by default.
      */
     automations: boolean;
     /**

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { isDesktopRuntime } from "@/app/utils";
 import type {
   OpenworkAffordanceDescriptor,
   OpenworkAffordanceEffects,
@@ -813,7 +814,9 @@ export function OpenworkRouteControlActions() {
           { id: "code", label: "Write and run code", description: "Generate, edit, and execute code with full tool access." },
           { id: "computer-use", label: "Computer use", description: "Control your computer with screenshots and mouse/keyboard actions." },
           { id: "skills", label: "Skills", description: "Install specialized skill packs for specific workflows." },
-          { id: "automations", label: "Automations", description: "Schedule recurring tasks and background agents." },
+          ...(isDesktopRuntime()
+            ? [{ id: "automations", label: "Automations", description: "Schedule recurring tasks and background agents." }]
+            : []),
           { id: "sharing", label: "Share sessions", description: "Share workspace sessions with collaborators via OpenWork Cloud." },
         ],
         hint: "Use settings.panel.open for settings such as AI providers, and route.extensions.skills to browse Library.",

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -50,7 +50,11 @@ type AppProvidersProps = {
 
 function AutomationRunnerBridgeGate() {
   const { prefs } = useLocal();
-  return <AutomationRunnerBridge enabled={prefs.featureFlags?.automations === true} />;
+  return (
+    <AutomationRunnerBridge
+      enabled={isDesktopRuntime() && prefs.featureFlags?.automations === true}
+    />
+  );
 }
 
 function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -462,7 +462,8 @@ export function SessionRoute() {
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
   const local = useLocal();
-  const automationsEnabled = local.prefs.featureFlags?.automations === true;
+  const automationsEnabled =
+    isDesktopRuntime() && local.prefs.featureFlags?.automations === true;
   const automationsRouteActive = automationsEnabled && automationsRouteRequested;
   const denSettings = readDenSettings();
   const [automationsSupported, setAutomationsSupported] = useState(false);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2227,6 +2227,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             }}
             memoryEnabled={memoryEnabled}
             onToggleMemory={toggleMemory}
+            showAutomations={isDesktopRuntime()}
             automationsEnabled={automationsEnabled}
             onToggleAutomations={toggleAutomations}
           />

--- a/apps/app/tests/automation-feature-flag.test.ts
+++ b/apps/app/tests/automation-feature-flag.test.ts
@@ -23,21 +23,32 @@ describe("Automations feature flag", () => {
     expect(source).toContain("toggleAutomations")
   })
 
-  test("the shell gates route, Den probe, navigation, and runner registration on the flag", () => {
+  test("the shell gates route, Den probe, navigation, and runner registration on desktop and the flag", () => {
     const source = read("src/react-app/shell/session-route.tsx")
-    expect(source).toContain("local.prefs.featureFlags?.automations === true")
+    expect(source).toMatch(/isDesktopRuntime\(\)\s*&&\s*local\.prefs\.featureFlags\?\.automations === true/)
     expect(source).toContain("automationsEnabled && automationsRouteRequested")
     expect(source).toContain("!automationsEnabled || !denAuth.isSignedIn")
     expect(source).toContain("automationsEnabled && automationsSupported")
 
     const providers = read("src/react-app/shell/providers.tsx")
-    expect(providers).toContain("prefs.featureFlags?.automations === true")
-    expect(providers).toContain("<AutomationRunnerBridge enabled=")
+    expect(providers).toMatch(/isDesktopRuntime\(\)\s*&&\s*prefs\.featureFlags\?\.automations === true/)
+    expect(providers).toContain("<AutomationRunnerBridge")
 
     const bridge = read("src/react-app/domains/automations/automation-runner-bridge.tsx")
     expect(bridge).toContain("!enabled || status !== \"signed_in\"")
     expect(bridge).toContain("[enabled, status]")
     expect(bridge).toContain('automationRunnerConfigure", null')
+  })
+
+  test("web hides the Automations preferences and capability affordances", () => {
+    const settings = read("src/react-app/shell/settings-route.tsx")
+    expect(settings).toContain("showAutomations={isDesktopRuntime()}")
+
+    const preferences = read("src/react-app/domains/settings/pages/preferences-view.tsx")
+    expect(preferences).toContain("props.showAutomations ?")
+
+    const controls = read("src/react-app/shell/control/control-provider.tsx")
+    expect(controls).toContain("...(isDesktopRuntime()")
   })
 
   test("every locale carries the shared Automations preferences copy", () => {


### PR DESCRIPTION
## Summary

- keep the Automations preview available only in the desktop runtime
- hide its preferences toggle and capability advertisement on web
- redirect direct web `/automations` requests through the existing disabled-feature guard
- prevent web clients from registering an automation runner
- leave Den scheduling and API behavior unchanged

## Why

The current preview flag is stored client-side and can also be enabled in a web client. That exposes an Automations surface which depends on desktop runner infrastructure that is not ready for web yet.

## Verification

- `bun test apps/app/tests/automation-feature-flag.test.ts` (5 passed)
- `git diff --check`

## Scope

Focused UI/runtime gating only. Broad app and desktop packaging checks are deferred to PR CI.