### PR TITLE
fix(den-web): surface Your Connections OAuth popup failures

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-account-authorization-state.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-account-authorization-state.ts
@@ -1,0 +1,19 @@
+export const MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE =
+  "The sign-in window closed before OpenWork confirmed the connection. Review the provider error, then try again.";
+
+export const MCP_AUTHORIZATION_TIMEOUT_MESSAGE =
+  "OpenWork could not confirm the connection. Review the provider error in this window, then try again.";
+
+export type McpAuthorizationPollOutcome = "connected" | "window_closed" | "timeout" | "pending";
+
+export function resolveMcpAuthorizationPollOutcome(input: {
+  connected: boolean;
+  authorizationWindowClosed: boolean;
+  elapsedMs: number;
+  timeoutMs: number;
+}): McpAuthorizationPollOutcome {
+  if (input.connected) return "connected";
+  if (input.authorizationWindowClosed) return "window_closed";
+  if (input.elapsedMs >= input.timeoutMs) return "timeout";
+  return "pending";
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
@@ -3,6 +3,11 @@
 import { useEffect, useRef, useState } from "react";
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
 import {
+  MCP_AUTHORIZATION_TIMEOUT_MESSAGE,
+  MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE,
+  resolveMcpAuthorizationPollOutcome,
+} from "./mcp-account-authorization-state";
+import {
   McpOAuthStartError,
   useMcpConnections,
   useStartMcpConnectionOAuth,
@@ -42,19 +47,35 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
     onConnectedRef.current?.();
   }
 
-  function pollUntilConnected(connectionId: string) {
+  function finishFailed(
+    connectionId: string,
+    authorizationWindow: Window,
+    message: string,
+  ) {
+    stopPolling();
+    showMcpAuthorizationError(authorizationWindow, { message });
+    setError({ connectionId, message });
+  }
+
+  function pollUntilConnected(connectionId: string, authorizationWindow: Window) {
     stopPolling();
     setPollingConnectionId(connectionId);
     const startedAt = Date.now();
     pollTimer.current = setInterval(async () => {
       const result = await refetch();
       const connection = result.data?.find((entry) => entry.id === connectionId);
-      if (connection?.connectedForMe && connection.needsReconnect !== true) {
+      const outcome = resolveMcpAuthorizationPollOutcome({
+        connected: Boolean(connection?.connectedForMe && connection.needsReconnect !== true),
+        authorizationWindowClosed: authorizationWindow.closed,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: OAUTH_POLL_TIMEOUT_MS,
+      });
+      if (outcome === "connected") {
         finishConnected();
-        return;
-      }
-      if (Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
-        stopPolling();
+      } else if (outcome === "window_closed") {
+        finishFailed(connectionId, authorizationWindow, MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE);
+      } else if (outcome === "timeout") {
+        finishFailed(connectionId, authorizationWindow, MCP_AUTHORIZATION_TIMEOUT_MESSAGE);
       }
     }, OAUTH_POLL_INTERVAL_MS);
   }
@@ -75,7 +96,7 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
         throw new Error("The MCP provider did not return an authorization URL.");
       }
       authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
-      pollUntilConnected(connectionId);
+      pollUntilConnected(connectionId, authorizationWindow);
     } catch (connectError) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect account.";
       showMcpAuthorizationError(authorizationWindow, {

--- a/ee/apps/den-web/tests/mcp-account-authorization-state.test.ts
+++ b/ee/apps/den-web/tests/mcp-account-authorization-state.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MCP_AUTHORIZATION_TIMEOUT_MESSAGE,
+  MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE,
+  resolveMcpAuthorizationPollOutcome,
+} from "../app/(den)/dashboard/_components/mcp-account-authorization-state";
+
+describe("resolveMcpAuthorizationPollOutcome", () => {
+  test("treats a confirmed connection as success even when the provider window has closed", () => {
+    expect(resolveMcpAuthorizationPollOutcome({
+      connected: true,
+      authorizationWindowClosed: true,
+      elapsedMs: 2_000,
+      timeoutMs: 90_000,
+    })).toBe("connected");
+  });
+
+  test("reports an unconfirmed provider window closing instead of failing silently", () => {
+    expect(resolveMcpAuthorizationPollOutcome({
+      connected: false,
+      authorizationWindowClosed: true,
+      elapsedMs: 2_000,
+      timeoutMs: 90_000,
+    })).toBe("window_closed");
+    expect(MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE).toContain("closed");
+  });
+
+  test("reports timeout and otherwise keeps polling", () => {
+    expect(resolveMcpAuthorizationPollOutcome({
+      connected: false,
+      authorizationWindowClosed: false,
+      elapsedMs: 90_000,
+      timeoutMs: 90_000,
+    })).toBe("timeout");
+    expect(MCP_AUTHORIZATION_TIMEOUT_MESSAGE).toContain("provider error");
+    expect(resolveMcpAuthorizationPollOutcome({
+      connected: false,
+      authorizationWindowClosed: false,
+      elapsedMs: 89_999,
+      timeoutMs: 90_000,
+    })).toBe("pending");
+  });
+});


### PR DESCRIPTION
## What changed

- preserve the Den **Your Connections** OAuth popup on timeout and render the existing failure document when the browser still permits access
- detect an unconfirmed provider popup closing and surface an immediate error beside the affected connection
- keep confirmed connections successful even when the provider closes its window after completion
- add focused state-machine coverage for connected, closed, timeout, and pending outcomes

## Root cause

The previous fix targeted the desktop Extensions connection flow. The reported page at `/dashboard/your-connections` uses a separate Den hook introduced earlier. That hook silently called `stopPolling()` after 90 seconds and did not retain the popup reference while polling, so it could neither render the timeout failure page nor report an early popup close.

## User impact

BigQuery and other organization MCP connections no longer return silently to Connect when their provider window closes or authorization never completes. The Den row receives an actionable error, and an accessible popup failure page remains visible whenever same-origin browser access is available.

## Validation

- authenticated local verification of the BigQuery row at `http://localhost:3005/dashboard/your-connections`
- `bun test ee/apps/den-web/tests/mcp-account-authorization-state.test.ts ee/apps/den-web/tests/mcp-authorization-url.test.ts` — 13 passed
- `pnpm --dir ee/apps/den-web typecheck`
- `git diff --check upstream/dev...HEAD`

The local in-app test browser does not retain provider popups as controllable tabs, so provider-window rendering is additionally covered through the existing authorization-document tests and the new poll-outcome tests.