### PR TITLE
chore(release): v0.18.17

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.16",
+  "version": "0.18.17",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.16",
+  "version": "0.18.17",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.16",
+  "version": "0.18.17",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.17",
   "0.18.16",
   "0.18.15",
   "0.18.14",


### PR DESCRIPTION
Backfills the `v0.18.17` version bump into `dev` after the stable tag was cut from exact `dev@6fc60ffec3869fb515b17a5f96184ba0d68fc341`.

Changes:
- bump app, desktop, and openwork-server to `0.18.17`
- add `0.18.17` to the published desktop version inventory

Verification:
- `node scripts/release/review.mjs --strict` — passed
- `node scripts/release/verify-tag.mjs --tag v0.18.17` — passed
- `git diff --check` — passed

The release tag points to exact commit `1dc372488ced16803e90f349714ca43daa0fa787`. The release workflow is building updater artifacts separately.