### PR TITLE
fix(den): complete MCP OAuth before closing popup

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-account-authorization-state.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-account-authorization-state.ts
@@ -4,6 +4,9 @@ export const MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE =
 export const MCP_AUTHORIZATION_TIMEOUT_MESSAGE =
   "OpenWork could not confirm the connection. Review the provider error in this window, then try again.";
 
+export const MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE =
+  "The provider responded, but OpenWork could not confirm this account connection. Review the provider configuration, then try again.";
+
 export type McpAuthorizationPollOutcome = "connected" | "window_closed" | "timeout" | "pending";
 
 export function resolveMcpAuthorizationPollOutcome(input: {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
 import {
   MCP_AUTHORIZATION_TIMEOUT_MESSAGE,
+  MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE,
   MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE,
   resolveMcpAuthorizationPollOutcome,
 } from "./mcp-account-authorization-state";
@@ -87,9 +88,18 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
       authorizationWindow = openMcpAuthorizationWindow();
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
-        authorizationWindow.close();
-        void refetch();
-        finishConnected();
+        const refreshed = await refetch();
+        const connection = refreshed.data?.find((entry) => entry.id === connectionId);
+        if (connection?.connectedForMe && connection.needsReconnect !== true) {
+          authorizationWindow.close();
+          finishConnected();
+        } else {
+          finishFailed(
+            connectionId,
+            authorizationWindow,
+            MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE,
+          );
+        }
         return;
       }
       if (!result.authorizeUrl) {

--- a/ee/apps/den-web/tests/mcp-account-authorization-state.test.ts
+++ b/ee/apps/den-web/tests/mcp-account-authorization-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   MCP_AUTHORIZATION_TIMEOUT_MESSAGE,
+  MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE,
   MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE,
   resolveMcpAuthorizationPollOutcome,
 } from "../app/(den)/dashboard/_components/mcp-account-authorization-state";
@@ -39,5 +40,10 @@ describe("resolveMcpAuthorizationPollOutcome", () => {
       elapsedMs: 89_999,
       timeoutMs: 90_000,
     })).toBe("pending");
+  });
+
+  test("explains when the start response cannot be confirmed for the member", () => {
+    expect(MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE).toContain("could not confirm");
+    expect(MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE).toContain("provider configuration");
   });
 });

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -1,5 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { auth, UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
 import { z } from "zod"
@@ -65,6 +65,7 @@ const optionsSchema = z.object({
 type Session = {
   client: Client
   transport: StreamableHTTPClientTransport
+  serverUrl: URL
   oauthProvider?: EnterpriseMcpOAuthProvider
   observer: EnterpriseMcpRequestObserver
   controller: AbortController
@@ -280,6 +281,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
     return {
       client,
       transport,
+      serverUrl,
       oauthProvider,
       observer,
       controller,
@@ -464,6 +466,9 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
         operationPhase: "connection-handshake",
         operation: async (session) => {
           try {
+            const hadOAuthCredential = session.oauthProvider
+              ? Boolean(await session.oauthProvider.tokens())
+              : false
             await connectWithProtocolVersionFallback({
               session,
               connectionId: input.connection.id,
@@ -482,6 +487,29 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             // implementing tools/list at all.
             if (session.client.getServerCapabilities()?.tools) {
               await session.client.listTools(undefined, session.requestOptions)
+            }
+            // OAuth connections must not be treated as member-connected merely
+            // because a provider exposes initialize and tools/list publicly.
+            // When no member credential exists, proactively run OAuth discovery
+            // so providers such as BigQuery can return an authorization URL
+            // without first issuing an MCP-level 401 challenge.
+            if (session.oauthProvider && !hadOAuthCredential) {
+              const authResult = await auth(session.oauthProvider, {
+                serverUrl: session.serverUrl,
+                fetchFn: session.observer.fetch,
+              })
+              const authorizeUrl = session.oauthProvider.authorizeUrl
+              if (authResult === "REDIRECT") {
+                if (!authorizeUrl) {
+                  throw new Error("The OAuth provider requested authorization without an authorization URL.")
+                }
+                try {
+                  await closeWithinDeadline(() => session.client.close(), closeTimeoutMs)
+                } catch {
+                  // The bounded cleanup attempt must not discard a valid authorization URL.
+                }
+                return { status: "needs_auth", authorizeUrl }
+              }
             }
             try {
               await closeWithinDeadline(() => session.client.close(), closeTimeoutMs)

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -1479,6 +1479,89 @@ describe("enterprise MCP OAuth persistence contract", () => {
     assert.equal(persistence.registration?.source, "client-metadata")
   })
 
+  it("starts OAuth when initialize and tool discovery are both public but no member credential exists", async () => {
+    const resourceOrigin = "https://bigquery.googleapis.test"
+    const authorizationOrigin = "https://accounts.google.test"
+    const mcpMethods: string[] = []
+    const fetch: EnterpriseMcpFetch = async (url, init) => {
+      const target = new URL(url)
+      if (target.href === `${resourceOrigin}/.well-known/oauth-protected-resource/mcp`) {
+        return Response.json({
+          resource: `${resourceOrigin}/mcp`,
+          authorization_servers: [`${authorizationOrigin}/`],
+          scopes_supported: ["https://www.googleapis.test/auth/bigquery"],
+          bearer_methods_supported: ["header"],
+        })
+      }
+      if (target.href === `${authorizationOrigin}/.well-known/oauth-authorization-server`) {
+        return Response.json({
+          issuer: authorizationOrigin,
+          authorization_endpoint: `${authorizationOrigin}/o/oauth2/v2/auth`,
+          token_endpoint: `${authorizationOrigin}/token`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+          code_challenge_methods_supported: ["plain", "S256"],
+        })
+      }
+      if (target.href === `${resourceOrigin}/mcp`) {
+        const body = typeof init?.body === "string" ? init.body : ""
+        if (!body) return new Response(null, { status: 202 })
+        const request = rpcRequestSchema.parse(JSON.parse(body))
+        mcpMethods.push(request.method)
+        if (request.method === "notifications/initialized") return new Response(null, { status: 202 })
+        if (request.method === "initialize") {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: {} },
+              serverInfo: { name: "bigquery-style-test", version: "1.0.0" },
+            },
+          })
+        }
+        if (request.method === "tools/list") {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: { tools: [{ name: "execute_sql", inputSchema: { type: "object" } }] },
+          })
+        }
+      }
+      return new Response(null, { status: 404 })
+    }
+    const persistence = new MemoryOAuthPersistence()
+    persistence.seedRegistration({
+      client_id: "pre-registered-google-client",
+      client_secret: "test-client-secret",
+      token_endpoint_auth_method: "client_secret_post",
+    })
+    const client = createEnterpriseMcpClient({ fetch })
+    const connection: EnterpriseMcpConnection = {
+      id: "oauth-public-bigquery-style",
+      serverUrl: `${resourceOrigin}/mcp`,
+      authorization: { type: "oauth", persistence },
+    }
+
+    const started = await client.connect({
+      connection,
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      authorizationId: "signed-bigquery-state",
+    })
+
+    assert.equal(started.status, "needs_auth")
+    if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
+    const authorizeUrl = new URL(started.authorizeUrl)
+    assert.equal(authorizeUrl.origin, authorizationOrigin)
+    assert.equal(authorizeUrl.searchParams.get("client_id"), "pre-registered-google-client")
+    assert.equal(authorizeUrl.searchParams.get("scope"), "https://www.googleapis.test/auth/bigquery")
+    assert.equal(authorizeUrl.searchParams.get("state"), "signed-bigquery-state")
+    assert.ok(mcpMethods.includes("initialize"))
+    assert.ok(mcpMethods.includes("tools/list"))
+    assert.equal(persistence.credential, undefined)
+  })
+
   it("refreshes an expired enterprise OAuth credential and persists the replacement", async () => {
     const server = await startOAuthMcpServer()
     try {


### PR DESCRIPTION
## What changed

- verify connectedForMe after connect/start reports protocol-level connected
- close the OAuth popup only when the refreshed member connection confirms success
- otherwise keep the popup open and render the existing failure document
- when an OAuth MCP exposes initialize and tools/list publicly but the member has no saved credential, proactively run OAuth discovery and return the provider authorization URL

## Root cause

The connect flow treated a successful MCP initialize/tools-list handshake as proof that the member account was connected. BigQuery exposes those MCP operations before user authorization, so Den returned connected without saving a member credential. The UI then closed the popup even though connectedForMe remained false.

This PR now fixes both sides of that gap: the modal stays open for an unconfirmed connection, and the enterprise MCP client starts OAuth when the configured connection has no member credential instead of waiting for a provider 401 that may never arrive.

## Validation

- enterprise MCP client tests: 52 passed, including a BigQuery-style public-handshake regression
- enterprise MCP client typecheck
- focused Den Web tests: 14 passed
- Den Web typecheck
- git diff check against current dev

Current base: 6fc60ffec3869fb515b17a5f96184ba0d68fc341
Current head: 3d5d73c0c504845406be8da789af631fe78ee12a
