### PR TITLE
fix(den): keep access lists readable after auth ages

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -69,7 +69,10 @@ type ResourceLookupInput =
   | MarketplaceResourceLookupInput
   | ConfigObjectResourceLookupInput
 
-type RequireResourceRoleInput = ResourceLookupInput & { role: PluginArchRole }
+type RequireResourceRoleInput = ResourceLookupInput & {
+  requireFreshSession?: boolean
+  role: PluginArchRole
+}
 
 export class PluginArchAuthorizationError extends Error {
   constructor(
@@ -383,11 +386,12 @@ export async function requirePluginArchCapability(context: PluginArchActorContex
 
 export async function requirePluginArchResourceRole(input: {
   context: PluginArchActorContext
+  requireFreshSession?: boolean
   resourceId: ConfigObjectId | ConnectorInstanceId | MarketplaceId | PluginId
   resourceKind: PluginArchResourceKind
   role: PluginArchRole
 }) {
-  if (input.role !== "viewer") {
+  if (input.role !== "viewer" && input.requireFreshSession !== false) {
     ensureFreshPluginArchAdmin(input.context)
   }
 

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1864,7 +1864,13 @@ export async function removeConfigObjectFromPlugin(input: { context: PluginArchA
 
 export async function listResourceAccess(input: { context: PluginArchActorContext } & ResourceTarget) {
   await ensureResourceInOrganization(input.context, input)
-  await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
+  await requirePluginArchResourceRole({
+    context: input.context,
+    requireFreshSession: false,
+    resourceId: input.resourceId,
+    resourceKind: input.resourceKind,
+    role: "manager",
+  })
 
   if (input.resourceKind === "config_object") {
     const rows = await db.select().from(ConfigObjectAccessGrantTable).where(eq(ConfigObjectAccessGrantTable.configObjectId, input.resourceId)).orderBy(desc(ConfigObjectAccessGrantTable.createdAt))

--- a/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
+++ b/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { expect, test } from "bun:test"
+
+const accessSource = readFileSync(
+  fileURLToPath(new URL("../src/routes/org/plugin-system/access.ts", import.meta.url)),
+  "utf8",
+)
+const storeSource = readFileSync(
+  fileURLToPath(new URL("../src/routes/org/plugin-system/store.ts", import.meta.url)),
+  "utf8",
+)
+
+test("access-list reads keep manager authorization without requiring a fresh session", () => {
+  const listAccess = storeSource.slice(
+    storeSource.indexOf("export async function listResourceAccess"),
+    storeSource.indexOf("type TeamPluginAccessEdge"),
+  )
+
+  expect(listAccess).toContain('requireFreshSession: false')
+  expect(listAccess).toContain('role: "manager"')
+  expect(accessSource).toContain('input.role !== "viewer" && input.requireFreshSession !== false')
+})
+
+test("access mutations retain the default fresh-session requirement", () => {
+  const mutations = storeSource.slice(
+    storeSource.indexOf("export async function createResourceAccessGrant"),
+    storeSource.indexOf("async function collectPluginMarketplaces"),
+  )
+
+  expect(mutations).toContain("export async function createResourceAccessGrant")
+  expect(mutations).toContain("export async function deleteResourceAccessGrant")
+  expect(mutations).not.toContain("requireFreshSession: false")
+})


### PR DESCRIPTION
## Summary

- keep plugin, marketplace, config-object, and connector access lists readable after an admin's 15-minute privileged-session window expires
- preserve manager authorization on those reads
- preserve fresh-session step-up authentication for grant and revoke mutations

## Root cause

The shared access-list path required the `manager` role through the same helper used by privileged mutations. That helper also enforced fresh-session step-up for every non-viewer role, so an authorized admin with an older session received `fresh_auth_required` while merely loading the access panel. The UI rendered that read failure as a dead-end notice because only mutations participate in the queued reauthentication dialog.

## Verification

- Passed: `pnpm --filter @openwork-ee/den-api exec bun test test/plugin-system-access-list-freshness.test.ts test/plugin-system-access.test.ts` — 6 passed, 0 failed
- Passed: `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
- Passed: `git diff --check upstream/dev...HEAD`
- Deferred: cold-boot testkit proof did not reach product assertions because Den API startup evaluated `sharp/lib/index.d.ts` through `tsx` and crashed with `ReferenceError: sharp is not defined`; no runtime pass is claimed and no tape was published

Base: `1102535b2336279a3071bf93288613769011d929`

Head: `eeac18a2347b448d2bf316e6919fbf947e98d51f`
