### PR TITLE
feat(settings): add default model selector to workspace preferences

### DIFF
--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -823,6 +823,8 @@ export default {
   "settings.model_behavior_desc": "Obre el selector de models predeterminat per triar perfils de raonament quan estiguin disponibles.",
   "settings.model_section_desc": "Tria el model de xat predeterminat i revisa com raona.",
   "settings.model_title": "Model",
+  "settings.default_model": "Model predeterminat",
+  "settings.default_model_desc": "Tria el model predeterminat per als nous xats.",
   "settings.no_active_workspace": "No hi ha workspace local actiu.",
   "settings.no_audit_entries": "Encara no hi ha entrades d'auditoria.",
   "settings.no_custom_path_set": "No s'ha definit cap camí personalitzat",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1332,6 +1332,8 @@ export default {
   "settings.model_behavior_unavailable": "Model behavior configuration is not yet available.",
   "settings.model_section_desc": "Pick the default chat model and review how it reasons.",
   "settings.model_title": "Model",
+  "settings.default_model": "Default model",
+  "settings.default_model_desc": "Pick the default model used for new chats.",
   "settings.no_active_workspace": "No active local workspace.",
   "settings.no_providers_connected": "No providers connected yet.",
   "settings.no_audit_entries": "No audit entries yet.",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -823,6 +823,8 @@ export default {
   "settings.model_behavior_desc": "Abre el selector del modelo predeterminado para elegir perfiles de razonamiento cuando estén disponibles.",
   "settings.model_section_desc": "Elige el modelo de chat predeterminado y revisa cómo razona.",
   "settings.model_title": "Modelo",
+  "settings.default_model": "Modelo predeterminado",
+  "settings.default_model_desc": "Elige el modelo predeterminado para los nuevos chats.",
   "settings.no_active_workspace": "No hay espacio de trabajo local activo.",
   "settings.no_audit_entries": "Aún no hay entradas de auditoría.",
   "settings.no_custom_path_set": "No se ha establecido ninguna ruta personalizada",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -823,6 +823,8 @@ export default {
   "settings.model_behavior_desc": "Ouvrez le sélecteur du modèle par défaut pour choisir des profils de raisonnement lorsqu'ils sont disponibles.",
   "settings.model_section_desc": "Choisissez le modèle de chat par défaut et examinez sa manière de raisonner.",
   "settings.model_title": "Modèle",
+  "settings.default_model": "Modèle par défaut",
+  "settings.default_model_desc": "Choisissez le modèle par défaut pour les nouvelles discussions.",
   "settings.no_active_workspace": "Aucun espace de travail local actif.",
   "settings.no_audit_entries": "Aucune entrée d'audit pour le moment.",
   "settings.no_custom_path_set": "Aucun chemin personnalisé défini",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -815,6 +815,8 @@ export default {
   "settings.model_behavior_desc": "デフォルトモデルピッカーを開いて、利用可能な場合に推論プロファイルを選択します。",
   "settings.model_section_desc": "デフォルトのチャットモデルを選択し、推論方法を確認します。",
   "settings.model_title": "モデル",
+  "settings.default_model": "デフォルトモデル",
+  "settings.default_model_desc": "新しいチャットに使用するデフォルトのモデルを選択します。",
   "settings.no_active_workspace": "アクティブなローカルワークスペースがありません。",
   "settings.no_audit_entries": "まだ監査エントリがありません。",
   "settings.no_custom_path_set": "カスタムパスが設定されていません",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -821,6 +821,8 @@ export default {
   "settings.model_behavior_desc": "Abra o seletor de modelo padrão para escolher perfis de raciocínio quando disponíveis.",
   "settings.model_section_desc": "Escolha o modelo de chat padrão e veja como ele raciocina.",
   "settings.model_title": "Modelo",
+  "settings.default_model": "Modelo padrão",
+  "settings.default_model_desc": "Escolha o modelo padrão para novos chats.",
   "settings.no_active_workspace": "Nenhum workspace local ativo.",
   "settings.no_audit_entries": "Nenhuma entrada de auditoria ainda.",
   "settings.no_custom_path_set": "Nenhum caminho personalizado definido",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -927,6 +927,8 @@ export default {
   "settings.model_behavior_desc": "Откройте выбор модели по умолчанию, чтобы выбрать профили рассуждений, когда они доступны.",
   "settings.model_section_desc": "Выберите модель чата по умолчанию и посмотрите, как она рассуждает.",
   "settings.model_title": "Модель",
+  "settings.default_model": "Модель по умолчанию",
+  "settings.default_model_desc": "Выберите модель по умолчанию для новых чатов.",
   "settings.no_active_workspace": "Нет активного локального workspace.",
   "settings.no_providers_connected": "Пока нет подключенных провайдеров.",
   "settings.no_audit_entries": "Пока нет записей аудита.",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -816,6 +816,8 @@ export default {
   "settings.model_behavior_desc": "เปิดตัวเลือกโมเดลเริ่มต้นเพื่อเลือก reasoning profiles เมื่อมีให้ใช้",
   "settings.model_section_desc": "เลือกโมเดลแชทเริ่มต้นและตรวจสอบวิธีการใช้เหตุผล",
   "settings.model_title": "โมเดล",
+  "settings.default_model": "โมเดลเริ่มต้น",
+  "settings.default_model_desc": "เลือกโมเดลเริ่มต้นที่จะใช้สำหรับแชทใหม่",
   "settings.no_active_workspace": "ไม่มีพื้นที่ทำงานภายในเครื่องที่ใช้งาน",
   "settings.no_audit_entries": "ยังไม่มีรายการตรวจสอบ",
   "settings.no_custom_path_set": "ยังไม่ได้ตั้งเส้นทางกำหนดเอง",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -816,6 +816,8 @@ export default {
   "settings.model_behavior_desc": "Mở bộ chọn model mặc định để chọn hồ sơ suy luận khi có sẵn.",
   "settings.model_section_desc": "Chọn model trò chuyện mặc định và xem xét cách nó suy luận.",
   "settings.model_title": "Model",
+  "settings.default_model": "Model mặc định",
+  "settings.default_model_desc": "Chọn model mặc định cho các cuộc trò chuyện mới.",
   "settings.no_active_workspace": "Không có workspace nội bộ đang hoạt động.",
   "settings.no_audit_entries": "Chưa có mục kiểm toán.",
   "settings.no_custom_path_set": "Chưa đặt đường dẫn tùy chỉnh",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -819,6 +819,8 @@ export default {
   "settings.model_behavior_desc": "打开默认模型选择器，选择可用的推理配置。",
   "settings.model_section_desc": "选择默认对话模型并查看其推理方式。",
   "settings.model_title": "模型",
+  "settings.default_model": "默认模型",
+  "settings.default_model_desc": "选择用于新对话的默认模型。",
   "settings.no_active_workspace": "没有活动的本地工作区。",
   "settings.no_audit_entries": "暂无审计记录。",
   "settings.no_custom_path_set": "未设置自定义路径",

--- a/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
@@ -1,4 +1,12 @@
 /** @jsxImportSource react */
+import { useState } from "react";
+import type { ModelRef } from "@/app/types";
+import { ModelSelect } from "@/components/model-select";
+
+const DEFAULT_MODEL: ModelRef = {
+  providerID: "opencode",
+  modelID: "big-pickle",
+};
 import {
   Select,
   SelectContent,
@@ -45,6 +53,8 @@ export type PreferencesViewProps = {
   showAutomations: boolean;
   automationsEnabled: boolean;
   onToggleAutomations: () => void;
+  defaultModel: ModelRef | null;
+  onDefaultModelChange: (model: ModelRef) => void;
 };
 
 function desktopNotificationPreferenceLabel(value: DesktopNotificationPreference) {
@@ -59,10 +69,14 @@ function desktopNotificationPreferenceLabel(value: DesktopNotificationPreference
 }
 
 export function PreferencesView(props: PreferencesViewProps) {
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+
   const desktopNotificationItems = DESKTOP_NOTIFICATION_PREFERENCE_VALUES.map((value) => ({
     value,
     label: desktopNotificationPreferenceLabel(value),
   }));
+
+  const activeModel = props.defaultModel ?? DEFAULT_MODEL;
 
   return (
     <LayoutStack>
@@ -71,6 +85,25 @@ export function PreferencesView(props: PreferencesViewProps) {
           <LayoutSectionTitle>{t("settings.model_title")}</LayoutSectionTitle>
           <LayoutSectionDescription>{t("settings.model_section_desc")}</LayoutSectionDescription>
         </LayoutSectionHeader>
+
+        {/* Default model */}
+        <LayoutSectionItem>
+          <LayoutSectionItemHeader>
+            <LayoutSectionItemTitle>{t("settings.default_model")}</LayoutSectionItemTitle>
+            <LayoutSectionItemDescription>{t("settings.default_model_desc")}</LayoutSectionItemDescription>
+            <LayoutSectionItemHeaderActions>
+              <div className="flex h-7 items-center">
+                <ModelSelect
+                  open={modelPickerOpen}
+                  value={activeModel}
+                  onOpenChange={setModelPickerOpen}
+                  onChange={props.onDefaultModelChange}
+                  disabled={props.busy}
+                />
+              </div>
+            </LayoutSectionItemHeaderActions>
+          </LayoutSectionItemHeader>
+        </LayoutSectionItem>
 
         {/* Show reasoning */}
         <LayoutSectionItem>

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -73,6 +73,7 @@ import "@/react-app/domains/settings/openwork-voice-config";
 import { useSettingsExtensionController } from "@/react-app/domains/settings/settings-extension-controller";
 import { buildExtensionItems } from "@/react-app/domains/settings/extension-items";
 import { isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
+import { WorkspaceProvider } from "./workspace-provider";
 import { PreferencesView } from "@/react-app/domains/settings/pages/preferences-view";
 import { GeneralSettingsView } from "@/react-app/domains/settings/pages/general-view";
 import { AuthorizedFoldersPanel } from "@/react-app/domains/settings/panels/authorized-folders-panel";
@@ -155,6 +156,7 @@ import {
   testRemoteWorkspaceConnection,
 } from "@/react-app/domains/workspace/remote-workspace-diagnostics";
 import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
+import { openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
 import type { ModelRef } from "@/app/types";
 import { workspaceSwatchColor } from "@/react-app/domains/session/sidebar/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
@@ -899,7 +901,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     await providerAuthStore.refreshProviders();
   }, [providerAuthStore]);
 
-  const handleOpenProviderAuth = useCallback(() => {
+  const handleOpenProviderAuthModal = useCallback(() => {
     if (providerAuthStore.isProviderAddRestricted()) {
       restrictionNotice.show({
         title: t("restrictions.add_custom_providers_disabled_title"),
@@ -910,6 +912,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
     void providerAuthStore.openProviderAuthModal();
   }, [providerAuthStore, restrictionNotice]);
+
+  const handleOpenProviderAuth = useCallback(() => {
+    navigateSettingsPath("ai");
+  }, [navigateSettingsPath]);
+
+  useEffect(() => {
+    const handler = () => handleOpenProviderAuth();
+    window.addEventListener(openProviderAuthEvent, handler);
+    return () => window.removeEventListener(openProviderAuthEvent, handler);
+  }, [handleOpenProviderAuth]);
 
   useEffect(() => {
     if (!activeClient || !selectedWorkspaceId) return;
@@ -2164,7 +2176,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             providerConnectError={providerAuthSnapshot.providerAuthError}
             providerDisconnectStatus={configActionStatus}
             providerDisconnectError={null}
-            onOpenProviderAuth={handleOpenProviderAuth}
+            onOpenProviderAuth={handleOpenProviderAuthModal}
             onDisconnectProvider={async (providerId) => {
               const message = await providerAuthStore.disconnectProvider(providerId);
               if (typeof message === "string" && message.trim()) {
@@ -2208,29 +2220,39 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         );
       case "preferences":
         return (
-          <PreferencesView
-            busy={busy}
-            showThinking={local.prefs.showThinking}
-            onToggleShowThinking={() => {
-              local.setPrefs((previous) => ({ ...previous, showThinking: !previous.showThinking }));
-            }}
-            autoCompactContext={autoCompactContext}
-            autoCompactContextBusy={autoCompactContextBusy}
-            onToggleAutoCompactContext={toggleAutoCompactContext}
-            analyticsEnabled={local.prefs.analyticsEnabled}
-            onToggleAnalytics={() => {
-              local.setPrefs((previous) => ({ ...previous, analyticsEnabled: !previous.analyticsEnabled }));
-            }}
-            desktopNotifications={local.prefs.desktopNotifications}
-            onDesktopNotificationsChange={(desktopNotifications) => {
-              local.setPrefs((previous) => ({ ...previous, desktopNotifications }));
-            }}
-            memoryEnabled={memoryEnabled}
-            onToggleMemory={toggleMemory}
-            showAutomations={isDesktopRuntime()}
-            automationsEnabled={automationsEnabled}
-            onToggleAutomations={toggleAutomations}
-          />
+          <WorkspaceProvider
+            client={activeClient}
+            opencodeBaseUrl={opencodeBaseUrl}
+            selectedWorkspaceRoot={selectedWorkspaceRoot}
+          >
+            <PreferencesView
+              busy={busy}
+              showThinking={local.prefs.showThinking}
+              onToggleShowThinking={() => {
+                local.setPrefs((previous) => ({ ...previous, showThinking: !previous.showThinking }));
+              }}
+              autoCompactContext={autoCompactContext}
+              autoCompactContextBusy={autoCompactContextBusy}
+              onToggleAutoCompactContext={toggleAutoCompactContext}
+              analyticsEnabled={local.prefs.analyticsEnabled}
+              onToggleAnalytics={() => {
+                local.setPrefs((previous) => ({ ...previous, analyticsEnabled: !previous.analyticsEnabled }));
+              }}
+              desktopNotifications={local.prefs.desktopNotifications}
+              onDesktopNotificationsChange={(desktopNotifications) => {
+                local.setPrefs((previous) => ({ ...previous, desktopNotifications }));
+              }}
+              defaultModel={local.prefs.defaultModel}
+              onDefaultModelChange={(defaultModel) => {
+                local.setPrefs((previous) => ({ ...previous, defaultModel }));
+              }}
+              memoryEnabled={memoryEnabled}
+              onToggleMemory={toggleMemory}
+              showAutomations={isDesktopRuntime()}
+              automationsEnabled={automationsEnabled}
+              onToggleAutomations={toggleAutomations}
+            />
+          </WorkspaceProvider>
         );
       case "extensions":
         return (
@@ -2675,7 +2697,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           modelPicker.setOpen(false);
         }}
         onBehaviorChange={() => {}}
-        onOpenSettings={() => {}}
+        onOpenSettings={() => {
+          modelPicker.setOpen(false);
+          handleOpenProviderAuth();
+        }}
         onClose={() => modelPicker.setOpen(false)}
       />
     </>


### PR DESCRIPTION

## Summary
- Restored the missing **Default model** picker inside the Workspace Preferences page using the `ModelSelect` component.
- Declared the fallback `DEFAULT_MODEL` locally in `preferences-view.tsx` to resolve a circular dependency runtime crash.
- Wrapped `<PreferencesView>` in `<WorkspaceProvider>` inside `settings-route.tsx` to supply the necessary workspace context (`activeClient`, `opencodeBaseUrl`, `selectedWorkspaceRoot`) that `ModelSelect` relies on.
- Wired up picker modal redirection events (`openProviderAuthEvent` and `onOpenSettings`) to close the picker modal and navigate directly to the **AI Providers** settings tab.
- Disentangled the connection modal triggers in `settings-route.tsx` by splitting the page redirection handler (`handleOpenProviderAuth`) from the direct connection dialog handler (`handleOpenProviderAuthModal`), ensuring the **"Connect provider"** button on the AI Providers page launches the connection modal correctly.
- Added localization entries for `settings.default_model` and `settings.default_model_desc` to all 10 supported locale files.

## Why
- Closes the feature gap where users could not select their default chat model in the UI settings (Preferences tab).
- Fixes several runtime crashes (circular imports, missing context, and inactive event hooks) associated with settings-to-picker navigation loops.

## Issue
- Closes #3579

## Scope
- Workspace Preferences settings page UI and State wiring.
- Localization files for all 10 languages.

## Out of scope
- Session-specific model overrides and composer-side picker UI modifications.

## Testing
### Ran
- `pnpm typecheck`
- `pnpm build`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: pass

## Manual verification
1. Go to **Workspace/Preferences**.
2. Click **Default model** dropdown list, select any model, and observe the new default model selection state saves successfully.
3. Open model picker popover, click **"Add your keys"** or **"Connect a provider"** in the empty state, and verify it navigates you to the **AI Providers** settings page.
4. On the **AI Providers** page, click **"Connect provider"** and verify that it opens the provider connection modal dialog.

## Evidence
- N/A

## Risk
- Low. Changes are scoped locally to settings rendering and preferences state bindings.

## Rollback
- Revert commits on settings routes and preferences view.

<img width="1087" height="747" alt="image" src="https://github.com/user-attachments/assets/1ec70b75-7e35-4d90-a97b-e8d4ae43dd2d" />
