### PR TITLE
fix(cloud): keep the sandbox alive while a task is running, even with the web tab closed

### DIFF
--- a/apps/server/src/worker-activity-heartbeat.test.ts
+++ b/apps/server/src/worker-activity-heartbeat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildWorkerActivityHeartbeatPayload,
+  countBusySessions,
   parseSessionActivityAt,
   postWorkerActivityHeartbeat,
   resolveWorkerActivityHeartbeatConfig,
@@ -81,20 +82,52 @@ describe("worker activity heartbeat", () => {
     expect(parseSessionActivityAt({ time: { created: 1000 } })).toBe(1000);
   });
 
+  test("counts busy and retry sessions, ignoring idle and malformed entries", () => {
+    expect(countBusySessions({
+      a: { type: "busy" },
+      b: { type: "retry", attempt: 1, message: "again", next: 123 },
+      c: { type: "idle" },
+      d: "garbage",
+      e: null,
+    })).toBe(2);
+    expect(countBusySessions(undefined)).toBe(0);
+    expect(countBusySessions("nope")).toBe(0);
+  });
+
   test("sets isActiveRecently on both sides of the active window boundary", () => {
     const now = 10_000;
     const windowMs = 1000;
-    expect(buildWorkerActivityHeartbeatPayload([{ time: { updated: now - windowMs } }], now, windowMs).isActiveRecently).toBe(true);
-    expect(buildWorkerActivityHeartbeatPayload([{ time: { updated: now - windowMs - 1 } }], now, windowMs).isActiveRecently).toBe(false);
+    const payloadFor = (updated: number) =>
+      buildWorkerActivityHeartbeatPayload({ sessions: [{ time: { updated } }], busySessionCount: 0 }, now, windowMs);
+    expect(payloadFor(now - windowMs).isActiveRecently).toBe(true);
+    expect(payloadFor(now - windowMs - 1).isActiveRecently).toBe(false);
+  });
+
+  test("reports active with lastActivityAt=now while any session is busy, even when timestamps are stale", () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const staleUpdated = now - 60 * 60_000;
+    const payload = buildWorkerActivityHeartbeatPayload(
+      { sessions: [{ time: { updated: staleUpdated } }], busySessionCount: 1 },
+      now,
+      1000,
+    );
+    expect(payload).toEqual({
+      sentAt: "2026-01-01T00:00:00.000Z",
+      isActiveRecently: true,
+      lastActivityAt: "2026-01-01T00:00:00.000Z",
+      openSessionCount: 1,
+      busySessionCount: 1,
+    });
   });
 
   test("uses null lastActivityAt when there are no sessions", () => {
     const now = Date.UTC(2026, 0, 1, 0, 0, 0);
-    expect(buildWorkerActivityHeartbeatPayload([], now, 1000)).toEqual({
+    expect(buildWorkerActivityHeartbeatPayload({ sessions: [], busySessionCount: 0 }, now, 1000)).toEqual({
       sentAt: "2026-01-01T00:00:00.000Z",
       isActiveRecently: false,
       lastActivityAt: null,
       openSessionCount: 0,
+      busySessionCount: 0,
     });
   });
 
@@ -108,7 +141,10 @@ describe("worker activity heartbeat", () => {
 
     await postWorkerActivityHeartbeat({
       config: heartbeatConfig({ DEN_ACTIVITY_WINDOW_SECONDS: "60" }),
-      sessions: [{ time: { updated: now - 30_000 } }, { time: { created: now - 120_000 } }],
+      activity: {
+        sessions: [{ time: { updated: now - 30_000 } }, { time: { created: now - 120_000 } }],
+        busySessionCount: 0,
+      },
       fetchImpl,
       now: () => now,
     });
@@ -123,6 +159,7 @@ describe("worker activity heartbeat", () => {
       isActiveRecently: true,
       lastActivityAt: "2025-12-31T23:59:30.000Z",
       openSessionCount: 2,
+      busySessionCount: 0,
     });
   });
 
@@ -143,7 +180,7 @@ describe("worker activity heartbeat", () => {
     const handle = startWorkerActivityHeartbeat(serverConfig(), logger, {
       env: { ...enabledEnv, DEN_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS: "60" },
       fetchImpl: async () => new Response("nope", { status: 503 }),
-      listSessions: async () => [],
+      collectActivity: async () => ({ sessions: [], busySessionCount: 0 }),
       now: () => Date.UTC(2026, 0, 1, 0, 0, 0),
     });
 

--- a/apps/server/src/worker-activity-heartbeat.ts
+++ b/apps/server/src/worker-activity-heartbeat.ts
@@ -27,6 +27,12 @@ export type WorkerActivityHeartbeatPayload = {
   isActiveRecently: boolean;
   lastActivityAt: string | null;
   openSessionCount: number;
+  busySessionCount: number;
+};
+
+export type WorkerActivitySnapshot = {
+  sessions: readonly unknown[];
+  busySessionCount: number;
 };
 
 type HeartbeatEnv = Record<string, string | undefined>;
@@ -51,6 +57,19 @@ export function parseSessionActivityAt(session: unknown): number | null {
   const created = session.time.created;
   if (typeof created === "number" && Number.isFinite(created) && created > 0) return created;
   return null;
+}
+
+// A session that is busy (or retrying a step) has an in-flight task even when
+// its `time.updated` is stale — e.g. one long silent tool call. Counting these
+// keeps the sandbox alive for the entire run instead of only while the session
+// record keeps changing.
+export function countBusySessions(statuses: unknown): number {
+  if (!isRecord(statuses)) return 0;
+  let busy = 0;
+  for (const status of Object.values(statuses)) {
+    if (isRecord(status) && (status.type === "busy" || status.type === "retry")) busy += 1;
+  }
+  return busy;
 }
 
 export function resolveWorkerActivityHeartbeatConfig(env: HeartbeatEnv = process.env): WorkerActivityHeartbeatConfig {
@@ -92,34 +111,41 @@ export function resolveWorkerActivityHeartbeatConfig(env: HeartbeatEnv = process
 }
 
 export function buildWorkerActivityHeartbeatPayload(
-  sessions: readonly unknown[],
+  activity: WorkerActivitySnapshot,
   now: number,
   activeWindowMs: number,
 ): WorkerActivityHeartbeatPayload {
   let latestActivityAt = 0;
-  for (const session of sessions) {
+  for (const session of activity.sessions) {
     const activityAt = parseSessionActivityAt(session);
     if (activityAt && activityAt > latestActivityAt) latestActivityAt = activityAt;
   }
 
+  // Busy sessions are active right now, regardless of session timestamps.
+  // Report `now` so Den keeps advancing `last_active_at` and the idle-stop
+  // reaper never kills a sandbox mid-task.
+  const busy = activity.busySessionCount > 0;
+  const lastActivityAt = busy ? now : latestActivityAt;
+
   return {
     sentAt: new Date(now).toISOString(),
-    isActiveRecently: latestActivityAt > 0 && now - latestActivityAt <= activeWindowMs,
-    lastActivityAt: latestActivityAt > 0 ? new Date(latestActivityAt).toISOString() : null,
-    openSessionCount: sessions.length,
+    isActiveRecently: busy || (latestActivityAt > 0 && now - latestActivityAt <= activeWindowMs),
+    lastActivityAt: lastActivityAt > 0 ? new Date(lastActivityAt).toISOString() : null,
+    openSessionCount: activity.sessions.length,
+    busySessionCount: activity.busySessionCount,
   };
 }
 
 export async function postWorkerActivityHeartbeat(input: {
   config: WorkerActivityHeartbeatConfig;
-  sessions: readonly unknown[];
+  activity: WorkerActivitySnapshot;
   fetchImpl?: HeartbeatFetch;
   now?: () => number;
 }): Promise<WorkerActivityHeartbeatPayload | null> {
   if (!input.config.enabled) return null;
 
   const payload = buildWorkerActivityHeartbeatPayload(
-    input.sessions,
+    input.activity,
     input.now ? input.now() : Date.now(),
     input.config.activeWindowMs,
   );
@@ -137,14 +163,39 @@ export async function postWorkerActivityHeartbeat(input: {
   return payload;
 }
 
-async function listOpenSessions(config: ServerConfig): Promise<readonly unknown[]> {
-  const workspace = config.workspaces[0];
-  if (!workspace) return [];
-  const opencode = createWorkspaceOpencodeClient(config, workspace);
-  const result = await opencode.session.list({ limit: 200 });
-  if (result.data != null) return result.data;
-  if (result.error === undefined) throw new Error("opencode_empty_response");
-  throw new Error(`opencode_request_failed:${result.response.status}`);
+async function collectWorkerActivity(config: ServerConfig): Promise<WorkerActivitySnapshot> {
+  const results = await Promise.allSettled(
+    config.workspaces.map(async (workspace): Promise<WorkerActivitySnapshot> => {
+      const opencode = createWorkspaceOpencodeClient(config, workspace);
+      const [sessions, statuses] = await Promise.all([
+        opencode.session.list({ limit: 200 }).then((result) => {
+          if (result.data != null) return result.data;
+          if (result.error === undefined) throw new Error("opencode_empty_response");
+          throw new Error(`opencode_request_failed:${result.response.status}`);
+        }),
+        // Missing/failed status route degrades to timestamp-only activity so
+        // heartbeats keep flowing against older opencode engines.
+        opencode.session
+          .status()
+          .then((result) => result.data ?? {})
+          .catch(() => ({})),
+      ]);
+      return { sessions, busySessionCount: countBusySessions(statuses) };
+    }),
+  );
+
+  const fulfilled = results.filter(
+    (result): result is PromiseFulfilledResult<WorkerActivitySnapshot> => result.status === "fulfilled",
+  );
+  const firstRejection = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  // Tolerate partial workspace failures so one broken workspace cannot hide a
+  // busy task in another; surface the error only when nothing succeeded.
+  if (fulfilled.length === 0 && firstRejection) throw firstRejection.reason;
+
+  return {
+    sessions: fulfilled.flatMap((result) => result.value.sessions),
+    busySessionCount: fulfilled.reduce((total, result) => total + result.value.busySessionCount, 0),
+  };
 }
 
 function errorMessage(error: unknown): string {
@@ -157,7 +208,7 @@ export function startWorkerActivityHeartbeat(
   options?: {
     env?: HeartbeatEnv;
     fetchImpl?: HeartbeatFetch;
-    listSessions?: () => Promise<readonly unknown[]>;
+    collectActivity?: () => Promise<WorkerActivitySnapshot>;
     now?: () => number;
   },
 ): WorkerActivityHeartbeatHandle | null {
@@ -170,12 +221,12 @@ export function startWorkerActivityHeartbeat(
     activeWindowMs: heartbeatConfig.activeWindowMs,
   });
 
-  const listSessions = options?.listSessions ?? (() => listOpenSessions(config));
+  const collectActivity = options?.collectActivity ?? (() => collectWorkerActivity(config));
   const runHeartbeat = () => {
-    void listSessions()
-      .then((sessions) => postWorkerActivityHeartbeat({
+    void collectActivity()
+      .then((activity) => postWorkerActivityHeartbeat({
         config: heartbeatConfig,
-        sessions,
+        activity,
         fetchImpl: options?.fetchImpl,
         now: options?.now,
       }))

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -47,6 +47,7 @@ export const activityHeartbeatSchema = z.object({
   isActiveRecently: z.boolean(),
   lastActivityAt: z.string().datetime().optional().nullable(),
   openSessionCount: z.number().int().min(0).optional(),
+  busySessionCount: z.number().int().min(0).optional(),
 })
 
 export const workerIdParamSchema = z.object({


### PR DESCRIPTION
## Problem

Long-running tasks on OpenWork Cloud die when the user leaves the web interface.

Root cause chain:

1. The in-sandbox activity heartbeat (`apps/server/src/worker-activity-heartbeat.ts`) infers liveness **only** from `session.time.updated` being <5 min old, and only for `workspaces[0]`. A task that is actively running but quiet at the session level (one long tool call, a subagent build) reports `isActiveRecently: false`.
2. Den's idle reaper (`ee/apps/den-api/src/workers/cloud-lifecycle.ts`) stops any healthy cloud worker whose `last_active_at` is >30 min old — with no busy-check — killing the in-flight task.
3. While the browser tab is open, the SPA's 60s `GET /v1/cloud/instance` poll re-wakes the stopped sandbox, masking the kill. Close the tab and nothing wakes it again: the user returns to a dead task.

The browser was never keeping the sandbox alive — it was only waking it back up after it had already been killed.

## Fix (server-driven, no browser dependency)

opencode already exposes the real signal: `session.status()` returns `busy`/`retry`/`idle` per session. The heartbeat now:

- reports `isActiveRecently: true` with `lastActivityAt = now` while **any session is busy or retrying**, so `last_active_at` keeps advancing for the entire run and the idle reaper never fires mid-task
- aggregates sessions + statuses across **all workspaces** (was: first workspace only), tolerating partial workspace failures
- degrades to the previous timestamp-only behavior when the status route is unavailable (older engines)
- reports `busySessionCount` in the payload; den-api accepts it (optional field, backwards compatible both directions)

Sandboxes still idle-stop 30 min after work actually finishes, so idle cost behavior is unchanged.

## Tests run

- `apps/server`: `bun test src/worker-activity-heartbeat.test.ts` — 13 pass, 0 fail (new coverage: busy forces active with stale timestamps; busy/retry counting ignores idle/malformed; payload includes `busySessionCount`)
- `apps/server`: full `bun test` (same as CI's `pnpm --filter openwork-server test`) — **627 pass, 8 skip, 0 fail**
- `apps/server`: `pnpm typecheck` — clean
- `ee/apps/den-api`: `bun test test/cloud-lifecycle.test.ts` — 10 pass, 0 fail; `tsc --noEmit` — clean
- `ee/apps/den-api`: `test/route-guard-policy.test.ts` fails locally with `ReferenceError: sharp is not defined` — **pre-existing**: fails identically on a clean `dev` checkout in this environment (missing sharp native binding); unrelated to this diff

## Runtime evidence

A full e2e tape for this needs a live Daytona cloud worker held past the 30-minute idle threshold mid-task, which cannot run in this environment. Exact repro:

1. Provision a cloud worker (`DEN_ACTIVITY_HEARTBEAT_ENABLED=1`, `CLOUD_IDLE_STOP_MINUTES=30` defaults).
2. Start a session with a single long-running tool call (e.g. `sleep 2400` via bash) and close the browser tab.
3. Before: den-api logs `cloud idle stop` for the worker ~35 min in; worker row flips to `stopped`; the task is dead on return.
4. After: heartbeats keep posting `isActiveRecently: true` with `busySessionCount >= 1`; `last_active_at` keeps advancing; the worker stays `healthy` until the tool call completes, then idles out 30 min later.

Not included: regenerating `packages/docs/openapi.json` (generator also blocked by the same `sharp` env issue; no CI gate enforces the snapshot — can follow up).