### PR TITLE
feat(desktop): seed a chat-first default workspace when none exists

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -129,6 +129,11 @@ if (process.env.OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN === "1") {
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
+// Chat-first global default workspace: when the user has not created or
+// connected any local workspace, the app seeds this one so the engine, model
+// picker, and provider list are available immediately (no "create workspace"
+// empty state). Mirrors the chat-first onboarding folder in the renderer.
+const DEFAULT_WORKSPACE_NAME = "OpenWork Chat";
 const applicationMenu = createApplicationMenu({
   appName: APP_NAME,
   docsUrl: DOCS_PAGE_URL,
@@ -1257,7 +1262,12 @@ function assertOpenworkServerReady(info) {
 }
 
 async function bootRuntimeForSelectedWorkspace() {
-  const list = await workspaceStore.readWorkspaceState();
+  const { state: list, seeded } = await workspaceStore.ensureDefaultLocalWorkspace({
+    name: DEFAULT_WORKSPACE_NAME,
+  });
+  if (seeded) {
+    console.info("[runtime] seeded default workspace", { name: DEFAULT_WORKSPACE_NAME });
+  }
   const selectedId = list.selectedId || list.activeId || list.workspaces[0]?.id || "";
   const workspace = selectedId
     ? list.workspaces.find((entry) => entry?.id === selectedId)

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -1048,6 +1048,32 @@ export function createWorkspaceStore({
     });
   }
 
+  /**
+   * Ensure at least one local workspace exists so the app is immediately
+   * usable ("chat-first"): the engine, model picker, and provider list only
+   * come up when a local workspace boots the server. When the user has not
+   * created or connected any local workspace, seed a global default under the
+   * user's home. Remote-only setups are left untouched (they boot their own
+   * engine remotely). Returns the workspace state after the (maybe no-op)
+   * seed, plus whether a new workspace was created.
+   */
+  async function ensureDefaultLocalWorkspace(input = {}) {
+    const current = await readWorkspaceState();
+    // Seed only when the user has no workspace at all. A remote-only setup is
+    // a deliberate choice to run workers remotely (no local engine needed), so
+    // it must not gain a local default.
+    if (current.workspaces.length > 0) {
+      return { state: current, seeded: false };
+    }
+    const name = String(input.name ?? "OpenWork Chat");
+    const folderValue = String(input.folderPath ?? "").trim();
+    const folderPath = folderValue
+      ? await normalizeLocalWorkspacePath(folderValue)
+      : path.join(os.homedir(), name);
+    const state = await createWorkspace({ folderPath, name });
+    return { state, seeded: true };
+  }
+
   async function createRemoteWorkspace(input = {}) {
     const baseUrl = String(input.baseUrl ?? "").trim();
     if (!baseUrl) throw new Error("baseUrl is required");
@@ -1285,6 +1311,7 @@ export function createWorkspaceStore({
     clearDesktopBootstrapConfig,
     debugDesktopBootstrapConfig,
     defaultWorkspaceOpenworkConfig,
+    ensureDefaultLocalWorkspace,
     exportConfig,
     forgetWorkspace,
     getDesktopBootstrapConfig,

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -205,6 +205,116 @@ test("does not create a default workspace when desktop state is absent", async (
   }
 });
 
+test("ensures a chat-first default workspace is seeded when no local workspace exists", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  const previousHome = process.env.HOME;
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
+  const previousServerConfig = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.HOME = path.join(root, "home");
+  process.env.OPENWORK_DEV_MODE = "1";
+  process.env.OPENWORK_SERVER_CONFIG = path.join(root, "missing-server.json");
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+
+    const { state, seeded } = await store.ensureDefaultLocalWorkspace({ name: "OpenWork Chat" });
+    assert.equal(seeded, true);
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].name, "OpenWork Chat");
+    assert.equal(state.workspaces[0].workspaceType, "local");
+    assert.equal(state.selectedId, state.workspaces[0].id);
+    assert.ok(String(state.workspaces[0].path).trim().endsWith("Open Work Chat") || String(state.workspaces[0].path).trim().length > 0);
+
+    // A second call is a no-op: the seeded default already satisfies the invariant.
+    const again = await store.ensureDefaultLocalWorkspace({ name: "OpenWork Chat" });
+    assert.equal(again.seeded, false);
+    assert.equal(again.state.workspaces.length, 1);
+  } finally {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
+    restoreEnv("OPENWORK_SERVER_CONFIG", previousServerConfig);
+  }
+});
+
+test("does not seed a default workspace when a local workspace already exists", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  const existing = path.join(root, "existing-project");
+  await mkdir(existing, { recursive: true });
+  await mkdir(userData, { recursive: true });
+  await writeFile(
+    path.join(userData, "openwork-workspaces.json"),
+    JSON.stringify({
+      selectedId: "ws_existing",
+      activeId: "ws_existing",
+      watchedId: "ws_existing",
+      workspaces: [{ id: "ws_existing", path: existing, name: "Existing", workspaceType: "local" }],
+    }),
+    "utf8",
+  );
+
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
+  const previousServerConfig = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.OPENWORK_DEV_MODE = "1";
+  process.env.OPENWORK_SERVER_CONFIG = path.join(root, "missing-server.json");
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+    const { state, seeded } = await store.ensureDefaultLocalWorkspace({ name: "OpenWork Chat" });
+    assert.equal(seeded, false);
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].id, "ws_existing");
+  } finally {
+    restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
+    restoreEnv("OPENWORK_SERVER_CONFIG", previousServerConfig);
+  }
+});
+
+test("does not seed a default workspace for a remote-only setup", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  await mkdir(userData, { recursive: true });
+  await writeFile(
+    path.join(userData, "openwork-workspaces.json"),
+    JSON.stringify({
+      selectedId: "rem_ws",
+      activeId: "rem_ws",
+      watchedId: "rem_ws",
+      workspaces: [{ id: "rem_ws", path: "", name: "Remote", workspaceType: "remote", baseUrl: "https://worker.example.com" }],
+    }),
+    "utf8",
+  );
+
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
+  const previousServerConfig = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.OPENWORK_DEV_MODE = "1";
+  process.env.OPENWORK_SERVER_CONFIG = path.join(root, "missing-server.json");
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+    const { state, seeded } = await store.ensureDefaultLocalWorkspace({ name: "OpenWork Chat" });
+    assert.equal(seeded, false);
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].id, "rem_ws");
+  } finally {
+    restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
+    restoreEnv("OPENWORK_SERVER_CONFIG", previousServerConfig);
+  }
+});
+
 test("normalizes recovered remote OpenWork entries before persisting", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
   const userData = path.join(root, "userData");

--- a/evals/specs/default-workspace.slow.test.ts
+++ b/evals/specs/default-workspace.slow.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "vitest";
+import type { Surface } from "@openwork/cdp";
+import { photoRoll, screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import {
+  evalIn,
+  go,
+  readAvailableModels,
+  readComposerState,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+  waitForAssistantReply,
+  waitForText,
+  waitUntilTextStable,
+} from "@openwork/behaviors";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "a fresh desktop seeds a global default workspace so models and chat work without creating a workspace"
+  : "default-workspace skipped: set OPENWORK_EVAL_APP_SPECS=1 to opt in";
+const prompt = "Tell me in one sentence what OpenWork is.";
+
+interface DefaultWorkspaceFacts {
+  workspaceSelected: boolean;
+  noWorkspaceEmptyState: boolean;
+  routeHasWorkspace: boolean;
+  workspaceNameVisible: string;
+}
+
+async function readDefaultWorkspaceState(app: Surface): Promise<DefaultWorkspaceFacts> {
+  const value = await evalIn(app, `(() => {
+    const text = document.body.innerText;
+    return {
+      workspaceSelected: Boolean(localStorage.getItem("openwork.react.activeWorkspace"))
+        || /\\/workspace\\/[^/?#]+/.test(window.location.hash),
+      noWorkspaceEmptyState: text.includes("Create or connect a workspace"),
+      routeHasWorkspace: /\\/workspace\\/[^/?#]+/.test(window.location.hash),
+      workspaceNameVisible: text.includes("OpenWork Chat") ? "OpenWork Chat" : "",
+    };
+  })()`);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Default workspace state was not an object.");
+  }
+  return {
+    workspaceSelected: Reflect.get(value, "workspaceSelected") === true,
+    noWorkspaceEmptyState: Reflect.get(value, "noWorkspaceEmptyState") === true,
+    routeHasWorkspace: Reflect.get(value, "routeHasWorkspace") === true,
+    workspaceNameVisible: String(Reflect.get(value, "workspaceNameVisible") ?? ""),
+  };
+}
+
+test.skipIf(!appSpecsEnabled)(title, async () => {
+  await using app = await desktop({ name: "default-workspace" });
+  await using roll = photoRoll("default-workspace");
+
+  // Frame 1: no "Create or connect a workspace" empty state. A fresh profile
+  // with no user-created workspace lands directly in a usable default
+  // workspace that the desktop main process seeded at boot.
+  let state = await readDefaultWorkspaceState(app);
+  const bodyText = String(await evalIn(app, "document.body.innerText"));
+  expect(state.workspaceSelected, `active workspace should be present. Body text: ${bodyText.slice(0, 300)}`).toBe(true);
+  expect(state.noWorkspaceEmptyState, "no Create or connect a workspace empty state").toBe(false);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A workspace is selected with no 'Create or connect a workspace' empty state",
+      "No generic error or 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  // Frame 2: the model picker lists selectable models without binding a
+  // project, because the managed engine is up and reading the provider list.
+  let models = await readAvailableModels(app);
+  const catalogDeadline = Date.now() + 90_000;
+  while (models.length === 0 && Date.now() < catalogDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    models = await readAvailableModels(app);
+  }
+  expect(models.length).toBeGreaterThan(0);
+  expect(models.some((model) => model.selectable)).toBe(true);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The Models picker visibly lists selectable models without binding a workspace",
+      "No empty-model failure or 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  const model = models.find((candidate) => candidate.selectable);
+  expect(model).toBeTruthy();
+  if (!model) throw new Error("No selectable model was returned.");
+  const selected = await selectModel(app, model.id);
+  expect(selected.id).toBe(model.id);
+
+  // Frame 3: a direct question runs in the default workspace and streams a
+  // reply, not blocked by any workspace-selection requirement.
+  const composer = await readComposerState(app);
+  expect(composer.route).toContain("/workspace/");
+  expect(composer.runTaskVisible).toBe(true);
+  const sent = await sendComposerMessage(app, prompt);
+  expect(sent.userMessageCount).toBeGreaterThan(0);
+  await waitForText(app, prompt, { timeoutMs: 30_000 });
+  const reply = await waitForAssistantReply(app, { timeoutMs: 180_000 });
+  expect(reply.assistantMessageCount).toBeGreaterThan(0);
+  expect(reply.text.trim().length).toBeGreaterThan(0);
+  await waitUntilTextStable(app, { quietMs: 8_000, timeoutMs: 240_000 });
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A direct chat in the default workspace produced a substantive assistant reply",
+      "No response failure or 'Something went wrong' crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await roll.add(shot, seen);
+  }
+
+  // Frame 4: Settings -> AI Providers shows connected providers because the
+  // engine is running, without a manually-created workspace.
+  const workspaceId = state.routeHasWorkspace
+    ? (await evalIn(app, `(() => { const m = /\\/workspace\\/([^/?#]+)/.exec(window.location.hash); return m?.[1] ?? ""; })()`))
+    : "";
+  if (workspaceId) {
+    await go(app, `/workspace/${workspaceId}/settings/ai`);
+    await waitFor(app, `document.body.innerText.includes("AI Providers")`, {
+      timeoutMs: 60_000,
+      label: "AI Providers settings page",
+    });
+    await waitFor(app, `(() => {
+      const text = document.body.innerText;
+      return !text.includes("No providers") && /providers?\\b/i.test(text);
+    })()`, { timeoutMs: 60_000, label: "connected providers listed" });
+    const providersState = await evalIn(app, `({
+      hasTitle: document.body.innerText.includes("AI Providers"),
+      hasProviders: /\\d+ providers?\\b/i.test(document.body.innerText),
+      empty: document.body.innerText.includes("No providers"),
+    })`);
+    const ok = typeof providersState === "object" && providersState !== null
+      && Reflect.get(providersState, "hasTitle") === true
+      && Reflect.get(providersState, "hasProviders") === true
+      && Reflect.get(providersState, "empty") !== true;
+    expect(ok, `AI Providers page should list providers: ${JSON.stringify(providersState)}`).toBe(true);
+    {
+      const shot = await screenshot(app);
+      const seen = await validate(shot, [
+        "The AI Providers settings page lists connected providers without a created workspace",
+        "No 'No providers' empty state or 'Something went wrong' crash message is visible",
+      ]);
+      expect(seen.ok, seen.why).toBe(true);
+      await roll.add(shot, seen);
+    }
+  }
+});


### PR DESCRIPTION
## What
When a fresh desktop has no local workspace, the engine (and with it the model picker and provider list) never boots, leaving the app stuck on a "create workspace" empty state. This seeds a chat-first global default workspace — `OpenWork Chat` under the user's home — so models, providers, and ordinary chat are immediately usable without creating a workspace. Mirrors the chat-first onboarding folder in the renderer.

## How
- `apps/desktop/electron/workspace-store.mjs`: new `ensureDefaultLocalWorkspace({name, folderPath})` — returns `{state, seeded}`. Seeds only when the workspace list is **completely empty**; remote-only setups are left untouched (they boot their own engine remotely).
- `apps/desktop/electron/main.mjs`: `bootRuntimeForSelectedWorkspace` calls it before starting the server+engine and logs when a new default is seeded.
- No server-side change: the engine is started by the desktop main process, which is the branch point when no workspace is selected.

## Tests run
- `pnpm --dir apps/desktop test` → **185 pass / 1 skip (pre-existing macOS gate) / 0 fail**. 3 new cases: empty-list seeds, existing-local no-ops, remote-only no-ops.
- `pnpm --dir evals typecheck` → new `default-workspace` spec compiles clean; only pre-existing `connectors-quick-add.slow.test.ts:253` error remains (untouched).

## E2E note
Wrote `evals/specs/default-workspace.slow.test.ts` (stack lane, `OPENWORK_EVAL_APP_SPECS=1`). A local run booted the app, seeded the default workspace, and passed the frame-1 DOM assertions (no empty state, straight into the default workspace) before the screenshot-vision layer required a vision API key that isn't available in this sandbox. Full vision tape deferred until a key is available (CI/Daytona). Functional assertions are the gate; per AGENTS.md the tape is human-verification evidence.