### PR TITLE
feat(headless-threads): drive native OpenWork threads from code

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -56,6 +56,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@openwork/headless-threads": "workspace:*",
     "@openwork/paths": "workspace:*",
     "@openwork/types": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",

--- a/apps/server/src/headless-threads.e2e.test.ts
+++ b/apps/server/src/headless-threads.e2e.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createHeadlessThreadClient } from "@openwork/headless-threads";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+const SESSION_ID = "ses_headless";
+const FIRST_ANSWER = "The refund window closed after 30 days.";
+const SECOND_ANSWER = "Without a receipt, use the order lookup.";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+function message(id: string, role: string, text: string) {
+  return {
+    info: { id, sessionID: SESSION_ID, role, time: { created: 100 } },
+    parts: [{ id: `prt_${id}`, messageID: id, sessionID: SESSION_ID, type: "text", text }],
+  };
+}
+
+const USER_1 = message("msg_1", "user", "A customer wants a refund after 40 days.");
+const ASSISTANT_1 = message("msg_2", "assistant", FIRST_ANSWER);
+const USER_2 = message("msg_3", "user", "They also lost the receipt.");
+const ASSISTANT_2 = message("msg_4", "assistant", SECOND_ANSWER);
+
+/**
+ * What the engine looks like at each step of two turns. Beat 0 and beat 3 are
+ * the moments that matter: the thread has accepted a prompt but has not
+ * started, so it reads idle with no new reply. A client that settles there
+ * reports a turn finished before it began.
+ */
+const BEATS = [
+  { busy: false, messages: [USER_1] },
+  { busy: true, messages: [USER_1] },
+  { busy: false, messages: [USER_1, ASSISTANT_1] },
+  { busy: false, messages: [USER_1, ASSISTANT_1, USER_2] },
+  { busy: true, messages: [USER_1, ASSISTANT_1, USER_2] },
+  { busy: false, messages: [USER_1, ASSISTANT_1, USER_2, ASSISTANT_2] },
+];
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-headless-threads-"));
+  await mkdir(join(root, ".opencode"), { recursive: true });
+  roots.push(root);
+  return root;
+}
+
+/**
+ * A managed-OpenCode stand-in. It only moves to the next beat when `advance()`
+ * is called, which the test wires to the client's sleep — so the whole journey
+ * is deterministic and needs no wall-clock waiting.
+ */
+function startMockOpencode() {
+  const prompts: Array<Record<string, unknown>> = [];
+  let aborted = 0;
+  let beat = 0;
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const current = BEATS[Math.min(beat, BEATS.length - 1)];
+      const session = {
+        id: SESSION_ID,
+        title: "Refund policy",
+        slug: "refund-policy",
+        directory: request.headers.get("x-opencode-directory"),
+        time: { created: 100, updated: 100 },
+      };
+
+      if (url.pathname === "/session" && request.method === "POST") return Response.json(session);
+      if (url.pathname === "/session" && request.method === "GET") return Response.json([session]);
+      if (url.pathname === `/session/${SESSION_ID}`) return Response.json(session);
+      if (url.pathname === `/session/${SESSION_ID}/message`) return Response.json(current.messages);
+      if (url.pathname === `/session/${SESSION_ID}/todo`) return Response.json([]);
+      if (url.pathname === "/session/status") {
+        return Response.json(current.busy ? { [SESSION_ID]: { type: "busy" } } : {});
+      }
+      if (url.pathname === `/session/${SESSION_ID}/prompt_async` && request.method === "POST") {
+        prompts.push(await request.json());
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname === `/session/${SESSION_ID}/abort` && request.method === "POST") {
+        aborted += 1;
+        return Response.json(true);
+      }
+      return Response.json({ code: "not_found", message: `Not found: ${request.method} ${url.pathname}` }, { status: 404 });
+    },
+  }) as Served;
+  stops.push(() => server.stop(true));
+
+  return {
+    server,
+    prompts,
+    advance: () => {
+      beat += 1;
+    },
+    abortCount: () => aborted,
+  };
+}
+
+async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      {
+        id: "ws_1",
+        name: "Workspace",
+        path: input.workspaceRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: input.opencodeBaseUrl,
+      },
+    ],
+    authorizedRoots: [input.workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { server, token: config.token };
+}
+
+test("drives two headless turns on a native OpenWork thread", async () => {
+  const workspaceRoot = await createWorkspaceRoot();
+  const engine = startMockOpencode();
+  const openwork = await startOpenworkServer({
+    workspaceRoot,
+    opencodeBaseUrl: `http://127.0.0.1:${engine.server.port}`,
+  });
+
+  let clock = 0;
+  const threads = createHeadlessThreadClient({
+    baseUrl: `http://127.0.0.1:${openwork.server.port}`,
+    workspaceId: "ws_1",
+    token: openwork.token,
+    defaultModel: { providerId: "anthropic", modelId: "claude-sonnet-5" },
+    now: () => clock,
+    // Each poll gap moves the engine exactly one beat, so the journey below is
+    // reproducible and never waits on real time.
+    sleep: async (ms) => {
+      clock += ms;
+      engine.advance();
+    },
+  });
+
+  const thread = await threads.createThread({
+    title: "Refund policy",
+    prompt: "A customer wants a refund after 40 days.",
+  });
+
+  expect(thread.id).toBe(SESSION_ID);
+  expect(thread.started).toBe(true);
+  expect(thread.directory).toBe(workspaceRoot);
+  expect(engine.prompts).toHaveLength(1);
+  expect(engine.prompts[0]).toEqual({
+    parts: [{ type: "text", text: "A customer wants a refund after 40 days." }],
+    model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+  });
+
+  const firstWait = await threads.waitForThread(thread.id, { timeoutMs: 60_000, pollIntervalMs: 10 });
+
+  expect(firstWait.outcome).toBe("settled");
+  expect(firstWait.observedRunning).toBe(true);
+  // Beat 0 was idle with no reply yet: settling there would have been wrong.
+  expect(firstWait.polls).toBe(3);
+
+  const firstTranscript = await threads.exportTranscript(thread.id);
+  expect(firstTranscript.finalAssistantText).toBe(FIRST_ANSWER);
+  expect(firstTranscript.messages.map((entry) => entry.role)).toEqual(["user", "assistant"]);
+
+  const followUp = await threads.sendTurn(thread.id, { prompt: "They also lost the receipt." });
+
+  expect(followUp.messageCountBefore).toBe(2);
+  expect(engine.prompts).toHaveLength(2);
+  expect(engine.prompts[1]).toEqual({
+    parts: [{ type: "text", text: "They also lost the receipt." }],
+    model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+  });
+
+  const secondWait = await threads.waitForThread(thread.id, {
+    timeoutMs: 60_000,
+    pollIntervalMs: 10,
+    since: followUp,
+  });
+
+  expect(secondWait.outcome).toBe("settled");
+  expect(secondWait.observedRunning).toBe(true);
+  // The first answer was already in the thread; only the new one settles it.
+  expect(secondWait.polls).toBe(4);
+
+  const transcript = await threads.exportTranscript(thread.id);
+  expect(transcript.finalAssistantText).toBe(SECOND_ANSWER);
+  expect(transcript.messages.map((entry) => entry.text)).toEqual([
+    "A customer wants a refund after 40 days.",
+    FIRST_ANSWER,
+    "They also lost the receipt.",
+    SECOND_ANSWER,
+  ]);
+
+  await expect(threads.abortThread(thread.id)).resolves.toEqual({ threadId: thread.id, accepted: true });
+  expect(engine.abortCount()).toBe(1);
+});
+
+test("leaves the thread readable through the session surface the app uses", async () => {
+  const workspaceRoot = await createWorkspaceRoot();
+  const engine = startMockOpencode();
+  const openwork = await startOpenworkServer({
+    workspaceRoot,
+    opencodeBaseUrl: `http://127.0.0.1:${engine.server.port}`,
+  });
+  const base = `http://127.0.0.1:${openwork.server.port}`;
+
+  const thread = await createHeadlessThreadClient({
+    baseUrl: base,
+    workspaceId: "ws_1",
+    token: openwork.token,
+  }).createThread({ title: "Refund policy" });
+
+  // The app lists and opens sessions through these routes. A headless thread
+  // is an ordinary session, so it has to be visible here with the same id.
+  const listed = await fetch(`${base}/workspace/ws_1/sessions`, {
+    headers: { Authorization: `Bearer ${openwork.token}` },
+  });
+  expect(listed.status).toBe(200);
+  const listedBody = await listed.json();
+  expect(listedBody.items.map((item: { id: string }) => item.id)).toContain(thread.id);
+
+  const opened = await fetch(`${base}/workspace/ws_1/sessions/${thread.id}`, {
+    headers: { Authorization: `Bearer ${openwork.token}` },
+  });
+  expect(opened.status).toBe(200);
+  await expect(opened.json()).resolves.toMatchObject({ item: { id: thread.id, title: "Refund policy" } });
+});

--- a/packages/headless-threads/README.md
+++ b/packages/headless-threads/README.md
@@ -1,0 +1,97 @@
+# @openwork/headless-threads
+
+Drive a native OpenWork thread from code, without rendering the app.
+
+A "thread" here is an ordinary OpenWork session. Same workspace, same managed
+OpenCode engine, same session id, same persisted messages, tool activity, and
+final state the desktop UI shows. A thread this package creates can be opened
+in the app afterwards, because there is no separate headless thread type.
+
+This is a client, not a runtime. It adds no chat engine, no session store, no
+model gateway, and no new server route — it is a typed shape over session
+surfaces the OpenWork server already serves.
+
+## Why
+
+Anything that drives OpenWork without a UI — a load check, an automation
+harness, an agent-quality benchmark — currently re-implements the same
+sequence by hand against raw HTTP: create a session, submit `prompt_async`,
+poll `/session/status`, poll messages, work out when the turn actually
+finished, then dig text back out of message parts.
+[`evals/flows/windows-workspace-session-performance.flow.mjs`](../../evals/flows/windows-workspace-session-performance.flow.mjs)
+is one such copy. This package is that sequence, typed and tested once.
+
+Note what the hand-rolled version has to get right, and what this package now
+owns: a thread is still `idle` in the gap between accepting a prompt and
+starting work, so waiting for "not busy" alone reports a turn finished before
+it began. Settling requires a non-running status **and** an assistant message
+that was not there when the turn was submitted.
+
+## Use
+
+```ts
+import { createHeadlessThreadClient } from "@openwork/headless-threads";
+
+const threads = createHeadlessThreadClient({
+  baseUrl: "http://127.0.0.1:8787",
+  workspaceId: "ws_1",
+  token: process.env.OPENWORK_TOKEN,
+  defaultModel: { providerId: "anthropic", modelId: "claude-sonnet-5" },
+});
+
+const thread = await threads.createThread({
+  title: "Refund policy",
+  prompt: "A customer wants a refund after 40 days. What are their options?",
+});
+
+await threads.waitForThread(thread.id, { timeoutMs: 120_000 });
+
+const followUp = await threads.sendTurn(thread.id, {
+  prompt: "They also lost the receipt.",
+});
+const waited = await threads.waitForThread(thread.id, {
+  timeoutMs: 120_000,
+  since: followUp,
+});
+
+if (waited.outcome === "settled") {
+  const transcript = await threads.exportTranscript(thread.id);
+  console.log(transcript.finalAssistantText);
+}
+```
+
+`thread.id` is the native session id. Opening OpenWork on the same workspace
+shows this conversation in the sidebar.
+
+## Contract
+
+| Function | Does |
+| --- | --- |
+| `createThread` | Creates a thread, optionally with its first turn and a model. |
+| `sendTurn` | Submits a turn and returns an acceptance that records the pre-turn message count. |
+| `waitForThread` | Polls to a bounded deadline. Returns `settled`, `timeout`, or `aborted` — never throws on a slow thread. |
+| `getThreadSnapshot` | Status, messages, and todos as OpenWork stores them. |
+| `abortThread` | Requests a stop. Acceptance is not proof the run ended; wait afterwards to observe idle. |
+| `exportTranscript` | Flattens a snapshot into per-message text, reasoning, and tool calls. |
+
+`waitForThread` reports an outcome rather than throwing, so a caller running
+many threads can record a timeout as a result instead of losing the run.
+Transport and payload failures throw `HeadlessThreadError`, which carries
+`code`, `status`, `method`, `path`, and the server's body.
+
+Deterministic by construction: inject `fetch`, `now`, and `sleep` to run the
+whole contract against fixtures with no wall-clock dependency.
+
+## Test
+
+```bash
+pnpm --filter @openwork/headless-threads test
+```
+
+The end-to-end proof lives with the server it drives, in
+`apps/server/src/headless-threads.e2e.test.ts`, and runs against a real
+OpenWork server:
+
+```bash
+pnpm --filter openwork-server test src/headless-threads.e2e.test.ts
+```

--- a/packages/headless-threads/package.json
+++ b/packages/headless-threads/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openwork/headless-threads",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test src"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.6",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/headless-threads/src/client.test.ts
+++ b/packages/headless-threads/src/client.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, test } from "bun:test";
+
+import { createHeadlessThreadClient } from "./client.js";
+import { HeadlessThreadError } from "./errors.js";
+import type { HeadlessFetch, HeadlessThreadStatus } from "./types.js";
+
+type RecordedRequest = { method: string; path: string; body: unknown };
+type MessageWire = { info: { id: string; role: string; time?: { created: number } }; parts: unknown[] };
+/** One poll's worth of thread state, consumed in order by snapshot reads. */
+type Beat = { status: HeadlessThreadStatus; messages: MessageWire[] };
+
+const SESSION_ID = "ses_1";
+const BASE_URL = "http://openwork.test";
+
+function reply(id: string, role: string, text?: string): MessageWire {
+  return {
+    info: { id, role, time: { created: 1 } },
+    parts: text === undefined ? [] : [{ id: `prt_${id}`, type: "text", text }],
+  };
+}
+
+/**
+ * A stand-in for the OpenWork server's session routes. `beats` scripts what
+ * successive snapshot reads observe, so a wait can be tested without a clock
+ * or an engine.
+ */
+function createOpenworkDouble(input?: { beats?: Beat[]; messages?: MessageWire[] }) {
+  const requests: RecordedRequest[] = [];
+  const beats = input?.beats ?? [];
+  const messages = input?.messages ?? [];
+  let beatIndex = 0;
+
+  const session = { id: SESSION_ID, title: "Refund policy", directory: "/workspace", time: { created: 1 } };
+
+  const fetchImpl: HeadlessFetch = async (url, init) => {
+    const parsed = new URL(url);
+    const method = init?.method ?? "GET";
+    const body: unknown = init?.body === undefined ? undefined : JSON.parse(init.body);
+    requests.push({ method, path: `${parsed.pathname}${parsed.search}`, body });
+
+    if (method === "POST" && parsed.pathname === "/workspace/ws_1/sessions") {
+      const started = typeof body === "object" && body !== null && "prompt" in body;
+      return Response.json({ item: session, started }, { status: 201 });
+    }
+    if (method === "GET" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/messages`) {
+      return Response.json({ items: messages });
+    }
+    if (method === "GET" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/snapshot`) {
+      const beat = beats[Math.min(beatIndex, beats.length - 1)];
+      beatIndex += 1;
+      return Response.json({
+        item: {
+          session,
+          messages: beat === undefined ? messages : beat.messages,
+          todos: [],
+          status: beat === undefined ? { type: "idle" } : beat.status,
+        },
+      });
+    }
+    if (method === "POST" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}/prompt_async`) {
+      return new Response(null, { status: 204 });
+    }
+    if (method === "POST" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/abort`) {
+      return Response.json({ ok: true });
+    }
+    return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
+  };
+
+  return { fetchImpl, requests, snapshotReads: () => beatIndex };
+}
+
+/** A clock that only moves when the client sleeps, so waits are instant. */
+function createClock() {
+  let clock = 0;
+  return {
+    now: () => clock,
+    sleep: async (ms: number) => {
+      clock += ms;
+    },
+    elapsed: () => clock,
+  };
+}
+
+function createClient(double: ReturnType<typeof createOpenworkDouble>, clock = createClock()) {
+  return createHeadlessThreadClient({
+    baseUrl: BASE_URL,
+    workspaceId: "ws_1",
+    token: "owt_test",
+    fetch: double.fetchImpl,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+}
+
+describe("createThread", () => {
+  test("sends the title, prompt, and model in OpenWork's casing", async () => {
+    const double = createOpenworkDouble();
+    const thread = await createClient(double).createThread({
+      title: "Refund policy",
+      prompt: "A customer wants a refund after 40 days.",
+      model: { providerId: "anthropic", modelId: "claude-sonnet-5", variant: "thinking" },
+    });
+
+    expect(double.requests[0]).toEqual({
+      method: "POST",
+      path: "/workspace/ws_1/sessions",
+      body: {
+        title: "Refund policy",
+        prompt: "A customer wants a refund after 40 days.",
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        variant: "thinking",
+      },
+    });
+    expect(thread).toEqual({
+      id: SESSION_ID,
+      workspaceId: "ws_1",
+      title: "Refund policy",
+      directory: "/workspace",
+      createdAt: 1,
+      started: true,
+    });
+  });
+
+  test("normalizes a base URL that ends in slashes", async () => {
+    const double = createOpenworkDouble();
+    const client = createHeadlessThreadClient({
+      baseUrl: `${BASE_URL}///`,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      fetch: double.fetchImpl,
+    });
+
+    await client.createThread({ title: "Refund policy" });
+
+    expect(double.requests[0]?.path).toBe("/workspace/ws_1/sessions");
+  });
+
+  test("omits the prompt and model when none were given", async () => {
+    const double = createOpenworkDouble();
+    const thread = await createClient(double).createThread({ title: "Empty" });
+
+    expect(double.requests[0]?.body).toEqual({ title: "Empty" });
+    expect(thread.started).toBe(false);
+  });
+});
+
+describe("sendTurn", () => {
+  test("records the pre-turn message count and prompts in OpenCode's casing", async () => {
+    const double = createOpenworkDouble({ messages: [reply("msg_1", "user"), reply("msg_2", "assistant", "hi")] });
+    const acceptance = await createClient(double).sendTurn(SESSION_ID, {
+      prompt: "They also lost the receipt.",
+      model: { providerId: "anthropic", modelId: "claude-sonnet-5" },
+    });
+
+    expect(acceptance).toEqual({ threadId: SESSION_ID, acceptedAt: 0, messageCountBefore: 2 });
+    expect(double.requests.map((request) => request.path)).toEqual([
+      "/workspace/ws_1/sessions/ses_1/messages",
+      "/workspace/ws_1/opencode/session/ses_1/prompt_async",
+    ]);
+    expect(double.requests[1]?.body).toEqual({
+      parts: [{ type: "text", text: "They also lost the receipt." }],
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    });
+  });
+
+  test("falls back to the client's default model", async () => {
+    const double = createOpenworkDouble({ messages: [] });
+    const client = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      fetch: double.fetchImpl,
+      defaultModel: { providerId: "openai", modelId: "gpt-5" },
+    });
+
+    await client.sendTurn(SESSION_ID, { prompt: "hello" });
+
+    expect(double.requests[1]?.body).toEqual({
+      parts: [{ type: "text", text: "hello" }],
+      model: { providerID: "openai", modelID: "gpt-5" },
+    });
+  });
+});
+
+describe("waitForThread", () => {
+  test("does not call an idle thread finished before the engine has started", async () => {
+    // The first beat is the gap between accepting a prompt and starting work:
+    // the thread is idle and has no new reply. Settling there would report a
+    // turn finished before it began.
+    const double = createOpenworkDouble({
+      beats: [
+        { status: { type: "idle" }, messages: [reply("msg_1", "user")] },
+        { status: { type: "busy" }, messages: [reply("msg_1", "user")] },
+        { status: { type: "retry", attempt: 1, message: "rate limited", next: 5 }, messages: [reply("msg_1", "user")] },
+        { status: { type: "idle" }, messages: [reply("msg_1", "user"), reply("msg_2", "assistant", "Answer.")] },
+      ],
+    });
+
+    const result = await createClient(double).waitForThread(SESSION_ID, { timeoutMs: 10_000, pollIntervalMs: 100 });
+
+    expect(result.outcome).toBe("settled");
+    expect(result.polls).toBe(4);
+    expect(result.observedRunning).toBe(true);
+    expect(result.waitedMs).toBe(300);
+    expect(result.snapshot.status).toEqual({ type: "idle" });
+  });
+
+  test("ignores an assistant reply that predates the turn being waited on", async () => {
+    const before = [reply("msg_1", "user"), reply("msg_2", "assistant", "First answer.")];
+    const double = createOpenworkDouble({
+      beats: [
+        { status: { type: "idle" }, messages: before },
+        { status: { type: "idle" }, messages: [...before, reply("msg_3", "user")] },
+        { status: { type: "idle" }, messages: [...before, reply("msg_3", "user"), reply("msg_4", "assistant", "Second.")] },
+      ],
+    });
+
+    const result = await createClient(double).waitForThread(SESSION_ID, {
+      timeoutMs: 10_000,
+      pollIntervalMs: 100,
+      since: { messageCountBefore: 2 },
+    });
+
+    expect(result.outcome).toBe("settled");
+    expect(result.polls).toBe(3);
+    expect(result.snapshot.messages.at(-1)?.id).toBe("msg_4");
+  });
+
+  test("reports a timeout instead of throwing when the thread never answers", async () => {
+    const clock = createClock();
+    const double = createOpenworkDouble({
+      beats: [{ status: { type: "busy" }, messages: [reply("msg_1", "user")] }],
+    });
+
+    const result = await createClient(double, clock).waitForThread(SESSION_ID, {
+      timeoutMs: 1_000,
+      pollIntervalMs: 400,
+    });
+
+    expect(result.outcome).toBe("timeout");
+    expect(result.observedRunning).toBe(true);
+    expect(clock.elapsed()).toBe(1_000);
+    expect(result.waitedMs).toBe(1_000);
+  });
+
+  test("stops on an aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const double = createOpenworkDouble({
+      beats: [{ status: { type: "busy" }, messages: [] }],
+    });
+
+    const result = await createClient(double).waitForThread(SESSION_ID, {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+
+    expect(result.outcome).toBe("aborted");
+    expect(result.polls).toBe(1);
+  });
+});
+
+describe("failures", () => {
+  test("surfaces the server's error code and status", async () => {
+    const double = createOpenworkDouble();
+    const client = createClient(double);
+
+    const error = await client.getThreadSnapshot("ses_missing").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HeadlessThreadError);
+    if (!(error instanceof HeadlessThreadError)) throw new Error("expected a HeadlessThreadError");
+    expect(error.code).toBe("not_found");
+    expect(error.status).toBe(404);
+    expect(error.method).toBe("GET");
+    expect(error.path).toBe("/workspace/ws_1/sessions/ses_missing/snapshot");
+  });
+
+  test("rejects a payload that does not match the session read model", async () => {
+    const fetchImpl: HeadlessFetch = async () => Response.json({ item: { session: { id: 7 } } });
+    const client = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      fetch: fetchImpl,
+    });
+
+    const error = await client.getThreadSnapshot(SESSION_ID).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HeadlessThreadError);
+    if (!(error instanceof HeadlessThreadError)) throw new Error("expected a HeadlessThreadError");
+    expect(error.code).toBe("invalid_response");
+  });
+});
+
+describe("abortThread", () => {
+  test("reports acceptance without claiming the run stopped", async () => {
+    const double = createOpenworkDouble();
+
+    await expect(createClient(double).abortThread(SESSION_ID)).resolves.toEqual({
+      threadId: SESSION_ID,
+      accepted: true,
+    });
+  });
+});
+
+describe("exportTranscript", () => {
+  test("flattens the current snapshot", async () => {
+    const double = createOpenworkDouble({
+      beats: [
+        {
+          status: { type: "idle" },
+          messages: [reply("msg_1", "user", "Why?"), reply("msg_2", "assistant", "Because.")],
+        },
+      ],
+    });
+
+    const transcript = await createClient(double).exportTranscript(SESSION_ID);
+
+    expect(transcript.threadId).toBe(SESSION_ID);
+    expect(transcript.finalAssistantText).toBe("Because.");
+    expect(transcript.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+  });
+});

--- a/packages/headless-threads/src/client.ts
+++ b/packages/headless-threads/src/client.ts
@@ -1,0 +1,202 @@
+/**
+ * A function-driven client for native OpenWork threads.
+ *
+ * Every call goes to an OpenWork server surface that already exists:
+ *
+ * - `POST   /workspace/:id/sessions`                        create a thread
+ * - `GET    /workspace/:id/sessions/:threadId/messages`     read messages
+ * - `GET    /workspace/:id/sessions/:threadId/snapshot`     read status + messages + todos
+ * - `POST   /workspace/:id/sessions/:threadId/abort`        stop a run
+ * - `POST   /workspace/:id/opencode/session/:threadId/prompt_async`  submit a turn
+ *
+ * The last one is the workspace OpenCode mount the desktop app itself prompts
+ * through. Routing turns through it — rather than adding a parallel prompt
+ * route — is what keeps a headless thread indistinguishable from a thread the
+ * user typed into. Callers depend on the functions below, not on those paths,
+ * so the transport can move without breaking them.
+ */
+import { z } from "zod";
+
+import { HeadlessThreadError } from "./errors.js";
+import { hasAssistantReplySince, toTranscript } from "./transcript.js";
+import type {
+  CreateThreadInput,
+  HeadlessAbortResult,
+  HeadlessThread,
+  HeadlessThreadClient,
+  HeadlessThreadClientOptions,
+  HeadlessThreadSnapshot,
+  HeadlessThreadTranscript,
+  HeadlessThreadTurnInput,
+  HeadlessThreadWaitInput,
+  HeadlessThreadWaitResult,
+  HeadlessTurnAcceptance,
+} from "./types.js";
+import {
+  abortResponseSchema,
+  createThreadResponseSchema,
+  isRunning,
+  threadMessagesResponseSchema,
+  threadSnapshotResponseSchema,
+  toSnapshot,
+  toThread,
+} from "./wire.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+const errorBodySchema = z
+  .object({ code: z.string().optional(), message: z.string().optional() })
+  .passthrough();
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Scanned rather than matched with `/\/+$/`: the anchored form backtracks
+ * quadratically on a long run of slashes, which CodeQL flags.
+ */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
+export function createHeadlessThreadClient(options: HeadlessThreadClientOptions): HeadlessThreadClient {
+  const baseUrl = stripTrailingSlashes(options.baseUrl);
+  const workspaceId = options.workspaceId;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const workspacePath = `/workspace/${encodeURIComponent(workspaceId)}`;
+
+  function threadPath(threadId: string, suffix: string): string {
+    return `${workspacePath}/sessions/${encodeURIComponent(threadId)}${suffix}`;
+  }
+
+  async function send(method: string, path: string, body?: unknown): Promise<{ status: number; payload: unknown }> {
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const text = await response.text().catch(() => "");
+    const payload = text === "" ? undefined : safeJsonParse(text);
+    if (response.ok) return { status: response.status, payload };
+
+    const detail = errorBodySchema.safeParse(payload);
+    throw new HeadlessThreadError({
+      code: detail.success && detail.data.code !== undefined ? detail.data.code : "request_failed",
+      message: detail.success && detail.data.message !== undefined
+        ? detail.data.message
+        : `OpenWork returned ${response.status} for ${method} ${path}`,
+      method,
+      path,
+      status: response.status,
+      body: payload,
+    });
+  }
+
+  async function requestJson<T>(schema: z.ZodType<T>, method: string, path: string, body?: unknown): Promise<T> {
+    const response = await send(method, path, body);
+    const parsed = schema.safeParse(response.payload);
+    if (parsed.success) return parsed.data;
+    throw new HeadlessThreadError({
+      code: "invalid_response",
+      message: `OpenWork returned an unexpected payload for ${method} ${path}`,
+      method,
+      path,
+      status: response.status,
+      body: parsed.error.issues,
+    });
+  }
+
+  async function countMessages(threadId: string): Promise<number> {
+    const body = await requestJson(threadMessagesResponseSchema, "GET", threadPath(threadId, "/messages"));
+    return body.items.length;
+  }
+
+  async function getThreadSnapshot(threadId: string): Promise<HeadlessThreadSnapshot> {
+    const body = await requestJson(threadSnapshotResponseSchema, "GET", threadPath(threadId, "/snapshot"));
+    return toSnapshot(body.item);
+  }
+
+  async function createThread(input: CreateThreadInput): Promise<HeadlessThread> {
+    const model = input.model ?? options.defaultModel;
+    const body = await requestJson(createThreadResponseSchema, "POST", `${workspacePath}/sessions`, {
+      title: input.title,
+      ...(input.prompt === undefined ? {} : { prompt: input.prompt }),
+      ...(model === undefined ? {} : { providerId: model.providerId, modelId: model.modelId }),
+      ...(model?.variant === undefined ? {} : { variant: model.variant }),
+    });
+    return toThread(body.item, workspaceId, body.started);
+  }
+
+  async function sendTurn(threadId: string, input: HeadlessThreadTurnInput): Promise<HeadlessTurnAcceptance> {
+    const model = input.model ?? options.defaultModel;
+    // Read the message count first: it is the only way a later wait can tell a
+    // reply to this turn apart from replies already in the thread.
+    const messageCountBefore = await countMessages(threadId);
+    await send("POST", `${workspacePath}/opencode/session/${encodeURIComponent(threadId)}/prompt_async`, {
+      parts: [{ type: "text", text: input.prompt }],
+      ...(model === undefined ? {} : { model: { providerID: model.providerId, modelID: model.modelId } }),
+      ...(model?.variant === undefined ? {} : { variant: model.variant }),
+    });
+    return { threadId, acceptedAt: now(), messageCountBefore };
+  }
+
+  async function waitForThread(threadId: string, input: HeadlessThreadWaitInput): Promise<HeadlessThreadWaitResult> {
+    const startedAt = now();
+    const deadline = startedAt + input.timeoutMs;
+    const interval = input.pollIntervalMs ?? pollIntervalMs;
+    const messageCountBefore = input.since?.messageCountBefore ?? 0;
+    let polls = 0;
+    let observedRunning = false;
+
+    for (;;) {
+      const snapshot = await getThreadSnapshot(threadId);
+      polls += 1;
+      const finish = (outcome: HeadlessThreadWaitResult["outcome"]): HeadlessThreadWaitResult => ({
+        outcome,
+        snapshot,
+        waitedMs: now() - startedAt,
+        polls,
+        observedRunning,
+      });
+
+      if (isRunning(snapshot.status)) {
+        observedRunning = true;
+      } else if (hasAssistantReplySince(snapshot.messages, messageCountBefore)) {
+        return finish("settled");
+      }
+
+      if (input.signal?.aborted) return finish("aborted");
+      const remaining = deadline - now();
+      if (remaining <= 0) return finish("timeout");
+      await sleep(Math.min(interval, remaining));
+    }
+  }
+
+  async function abortThread(threadId: string): Promise<HeadlessAbortResult> {
+    const body = await requestJson(abortResponseSchema, "POST", threadPath(threadId, "/abort"), {});
+    return { threadId, accepted: body.ok };
+  }
+
+  async function exportTranscript(threadId: string): Promise<HeadlessThreadTranscript> {
+    return toTranscript(await getThreadSnapshot(threadId));
+  }
+
+  return { createThread, sendTurn, waitForThread, getThreadSnapshot, abortThread, exportTranscript };
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/headless-threads/src/errors.ts
+++ b/packages/headless-threads/src/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * A single error type for every headless thread failure, so a caller running
+ * many threads can classify failures without string matching.
+ */
+export class HeadlessThreadError extends Error {
+  readonly code: string;
+  readonly method: string;
+  readonly path: string;
+  readonly status: number | null;
+  readonly body: unknown;
+
+  constructor(input: {
+    code: string;
+    message: string;
+    method: string;
+    path: string;
+    status?: number;
+    body?: unknown;
+  }) {
+    super(input.message);
+    this.name = "HeadlessThreadError";
+    this.code = input.code;
+    this.method = input.method;
+    this.path = input.path;
+    this.status = input.status ?? null;
+    this.body = input.body;
+  }
+}

--- a/packages/headless-threads/src/index.ts
+++ b/packages/headless-threads/src/index.ts
@@ -1,0 +1,26 @@
+export { createHeadlessThreadClient } from "./client.js";
+export { HeadlessThreadError } from "./errors.js";
+export { hasAssistantReplySince, toTranscript, toTranscriptMessage } from "./transcript.js";
+export { isRunning } from "./wire.js";
+export type {
+  CreateThreadInput,
+  HeadlessAbortResult,
+  HeadlessFetch,
+  HeadlessThread,
+  HeadlessThreadClient,
+  HeadlessThreadClientOptions,
+  HeadlessThreadMessage,
+  HeadlessThreadMessagePart,
+  HeadlessThreadModel,
+  HeadlessThreadSnapshot,
+  HeadlessThreadStatus,
+  HeadlessThreadTodo,
+  HeadlessThreadTranscript,
+  HeadlessThreadTurnInput,
+  HeadlessThreadWaitInput,
+  HeadlessThreadWaitOutcome,
+  HeadlessThreadWaitResult,
+  HeadlessTranscriptMessage,
+  HeadlessTranscriptToolCall,
+  HeadlessTurnAcceptance,
+} from "./types.js";

--- a/packages/headless-threads/src/transcript.test.ts
+++ b/packages/headless-threads/src/transcript.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasAssistantReplySince, toTranscript } from "./transcript.js";
+import type { HeadlessThreadMessage, HeadlessThreadSnapshot } from "./types.js";
+
+function message(input: Partial<HeadlessThreadMessage> & { id: string; role: string }): HeadlessThreadMessage {
+  return { createdAt: null, parts: [], ...input };
+}
+
+function snapshot(messages: HeadlessThreadMessage[]): HeadlessThreadSnapshot {
+  return {
+    threadId: "ses_1",
+    title: "Refund policy",
+    directory: "/workspace",
+    status: { type: "idle" },
+    messages,
+    todos: [],
+  };
+}
+
+describe("toTranscript", () => {
+  test("joins text parts, keeps reasoning separate, and lists tool calls", () => {
+    const transcript = toTranscript(
+      snapshot([
+        message({ id: "msg_1", role: "user", parts: [{ id: "prt_1", type: "text", text: "  Why? " }] }),
+        message({
+          id: "msg_2",
+          role: "assistant",
+          createdAt: 200,
+          parts: [
+            { id: "prt_2", type: "reasoning", text: "check the policy" },
+            { id: "prt_3", type: "tool", tool: "read", callId: "call_1", toolStatus: "completed" },
+            { id: "prt_4", type: "text", text: "Because " },
+            { id: "prt_5", type: "text", text: "the window closed." },
+          ],
+        }),
+      ]),
+    );
+
+    expect(transcript.messages).toEqual([
+      { id: "msg_1", role: "user", createdAt: null, text: "Why?", reasoning: "", toolCalls: [] },
+      {
+        id: "msg_2",
+        role: "assistant",
+        createdAt: 200,
+        text: "Because the window closed.",
+        reasoning: "check the policy",
+        toolCalls: [{ partId: "prt_3", name: "read", callId: "call_1", status: "completed" }],
+      },
+    ]);
+    expect(transcript.finalAssistantText).toBe("Because the window closed.");
+  });
+
+  test("drops synthetic and ignored parts the app also hides", () => {
+    const transcript = toTranscript(
+      snapshot([
+        message({
+          id: "msg_1",
+          role: "assistant",
+          parts: [
+            { id: "prt_1", type: "text", text: "<system reminder>", synthetic: true },
+            { id: "prt_2", type: "text", text: "stale", ignored: true },
+            { id: "prt_3", type: "text", text: "kept" },
+          ],
+        }),
+      ]),
+    );
+
+    expect(transcript.messages[0]?.text).toBe("kept");
+  });
+
+  test("reports an empty final answer rather than falling back to an earlier turn", () => {
+    const transcript = toTranscript(
+      snapshot([
+        message({ id: "msg_1", role: "assistant", parts: [{ id: "prt_1", type: "text", text: "first" }] }),
+        message({ id: "msg_2", role: "user", parts: [{ id: "prt_2", type: "text", text: "and now?" }] }),
+      ]),
+    );
+
+    expect(transcript.finalAssistantText).toBe("first");
+  });
+
+  test("has no final answer when the thread never answered", () => {
+    const transcript = toTranscript(
+      snapshot([message({ id: "msg_1", role: "user", parts: [{ id: "prt_1", type: "text", text: "hi" }] })]),
+    );
+
+    expect(transcript.finalAssistantText).toBe("");
+  });
+});
+
+describe("hasAssistantReplySince", () => {
+  const thread = [
+    message({ id: "msg_1", role: "user" }),
+    message({ id: "msg_2", role: "assistant" }),
+    message({ id: "msg_3", role: "user" }),
+  ];
+
+  test("ignores assistant replies that predate the turn", () => {
+    expect(hasAssistantReplySince(thread, 3)).toBe(false);
+  });
+
+  test("sees an assistant reply appended after the turn", () => {
+    expect(hasAssistantReplySince([...thread, message({ id: "msg_4", role: "assistant" })], 3)).toBe(true);
+  });
+
+  test("treats a fresh thread as having no reply until one arrives", () => {
+    expect(hasAssistantReplySince([], 0)).toBe(false);
+    expect(hasAssistantReplySince([message({ id: "msg_1", role: "assistant" })], 0)).toBe(true);
+  });
+});

--- a/packages/headless-threads/src/transcript.ts
+++ b/packages/headless-threads/src/transcript.ts
@@ -1,0 +1,70 @@
+/**
+ * Transcript projection.
+ *
+ * A snapshot carries the thread exactly as OpenWork stores it. A transcript is
+ * the flattened, comparable view of the same data: what each side said, what
+ * it reasoned about, and which tools it called. Deriving it here keeps every
+ * consumer from re-implementing part handling the way the desktop UI does.
+ */
+import type {
+  HeadlessThreadMessage,
+  HeadlessThreadSnapshot,
+  HeadlessThreadTranscript,
+  HeadlessTranscriptMessage,
+  HeadlessTranscriptToolCall,
+} from "./types.js";
+
+function joinPartText(message: HeadlessThreadMessage, type: string): string {
+  return message.parts
+    .filter((part) => part.type === type && typeof part.text === "string")
+    // Synthetic and ignored parts are engine bookkeeping; the UI hides them
+    // and a transcript comparison must not see them either.
+    .filter((part) => part.synthetic !== true && part.ignored !== true)
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
+function toToolCalls(message: HeadlessThreadMessage): HeadlessTranscriptToolCall[] {
+  return message.parts
+    .filter((part) => part.type === "tool")
+    .map((part) => ({
+      partId: part.id,
+      name: part.tool ?? "",
+      callId: part.callId ?? null,
+      status: part.toolStatus ?? null,
+    }));
+}
+
+export function toTranscriptMessage(message: HeadlessThreadMessage): HeadlessTranscriptMessage {
+  return {
+    id: message.id,
+    role: message.role,
+    createdAt: message.createdAt,
+    text: joinPartText(message, "text"),
+    reasoning: joinPartText(message, "reasoning"),
+    toolCalls: toToolCalls(message),
+  };
+}
+
+export function toTranscript(snapshot: HeadlessThreadSnapshot): HeadlessThreadTranscript {
+  const messages = snapshot.messages.map(toTranscriptMessage);
+  const lastAssistant = messages.filter((message) => message.role === "assistant" && message.text).at(-1);
+  return {
+    threadId: snapshot.threadId,
+    title: snapshot.title,
+    status: snapshot.status,
+    messages,
+    finalAssistantText: lastAssistant ? lastAssistant.text : "",
+  };
+}
+
+/**
+ * True once the thread holds an assistant message that did not exist when a
+ * turn was submitted. Paired with a non-running status this is what makes a
+ * turn "finished" — a status read alone is ambiguous, because a thread is
+ * still idle in the moment between accepting a prompt and starting work.
+ */
+export function hasAssistantReplySince(messages: HeadlessThreadMessage[], messageCountBefore: number): boolean {
+  return messages.slice(messageCountBefore).some((message) => message.role === "assistant");
+}

--- a/packages/headless-threads/src/types.ts
+++ b/packages/headless-threads/src/types.ts
@@ -1,0 +1,179 @@
+/**
+ * The Headless Threads contract.
+ *
+ * A "thread" is a native OpenWork session: the same workspace, the same
+ * managed OpenCode engine, the same session id, the same persisted messages
+ * and tool activity the desktop UI shows. Nothing here introduces a second
+ * chat engine, a second session store, or a second model gateway — the types
+ * below only describe the session surface OpenWork already serves.
+ */
+
+/** Model selection, in OpenWork's server casing (`providerId`/`modelId`). */
+export interface HeadlessThreadModel {
+  providerId: string;
+  modelId: string;
+  /** Optional engine variant, e.g. a reasoning configuration. */
+  variant?: string;
+}
+
+export type HeadlessThreadStatus =
+  | { type: "idle" }
+  | { type: "busy" }
+  | { type: "retry"; attempt: number; message: string; next: number };
+
+export interface HeadlessThreadTodo {
+  content: string;
+  status: string;
+  priority: string;
+}
+
+export interface HeadlessThreadMessagePart {
+  id: string;
+  type?: string;
+  text?: string;
+  tool?: string;
+  callId?: string;
+  toolStatus?: string;
+  synthetic?: boolean;
+  ignored?: boolean;
+}
+
+export interface HeadlessThreadMessage {
+  id: string;
+  role: string;
+  createdAt: number | null;
+  parts: HeadlessThreadMessagePart[];
+}
+
+export interface CreateThreadInput {
+  title: string;
+  /** Optional first turn. When present the thread starts running immediately. */
+  prompt?: string;
+  model?: HeadlessThreadModel;
+}
+
+export interface HeadlessThread {
+  /**
+   * The native OpenCode session id. It is the same id the OpenWork UI uses,
+   * so a headless thread can be opened in the app afterwards.
+   */
+  id: string;
+  workspaceId: string;
+  title: string | null;
+  directory: string | null;
+  createdAt: number | null;
+  /** True when `createThread` was given a prompt and the engine accepted it. */
+  started: boolean;
+}
+
+export interface HeadlessThreadTurnInput {
+  prompt: string;
+  model?: HeadlessThreadModel;
+}
+
+/**
+ * Proof that the engine accepted a turn, plus the message count observed just
+ * before submitting it. `waitForThread` uses that count to tell a fresh
+ * assistant reply apart from the replies already in the thread.
+ */
+export interface HeadlessTurnAcceptance {
+  threadId: string;
+  acceptedAt: number;
+  messageCountBefore: number;
+}
+
+export interface HeadlessThreadWaitInput {
+  timeoutMs: number;
+  pollIntervalMs?: number;
+  /** The turn being waited on. Omit to wait on a thread's first reply. */
+  since?: Pick<HeadlessTurnAcceptance, "messageCountBefore">;
+  signal?: AbortSignal;
+}
+
+export type HeadlessThreadWaitOutcome = "settled" | "timeout" | "aborted";
+
+export interface HeadlessThreadWaitResult {
+  outcome: HeadlessThreadWaitOutcome;
+  snapshot: HeadlessThreadSnapshot;
+  waitedMs: number;
+  polls: number;
+  /** True when a busy or retry status was seen while waiting. */
+  observedRunning: boolean;
+}
+
+export interface HeadlessThreadSnapshot {
+  threadId: string;
+  title: string | null;
+  directory: string | null;
+  status: HeadlessThreadStatus;
+  messages: HeadlessThreadMessage[];
+  todos: HeadlessThreadTodo[];
+}
+
+export interface HeadlessAbortResult {
+  threadId: string;
+  /**
+   * The server accepted the abort request. Acceptance is not proof the run
+   * stopped — call `waitForThread` afterwards to observe the thread go idle.
+   */
+  accepted: boolean;
+}
+
+export interface HeadlessTranscriptToolCall {
+  partId: string;
+  name: string;
+  callId: string | null;
+  status: string | null;
+}
+
+export interface HeadlessTranscriptMessage {
+  id: string;
+  role: string;
+  createdAt: number | null;
+  text: string;
+  reasoning: string;
+  toolCalls: HeadlessTranscriptToolCall[];
+}
+
+export interface HeadlessThreadTranscript {
+  threadId: string;
+  title: string | null;
+  status: HeadlessThreadStatus;
+  messages: HeadlessTranscriptMessage[];
+  /** Text of the last assistant message, or an empty string when there is none. */
+  finalAssistantText: string;
+}
+
+export interface HeadlessThreadClient {
+  createThread(input: CreateThreadInput): Promise<HeadlessThread>;
+  sendTurn(threadId: string, input: HeadlessThreadTurnInput): Promise<HeadlessTurnAcceptance>;
+  waitForThread(threadId: string, input: HeadlessThreadWaitInput): Promise<HeadlessThreadWaitResult>;
+  getThreadSnapshot(threadId: string): Promise<HeadlessThreadSnapshot>;
+  abortThread(threadId: string): Promise<HeadlessAbortResult>;
+  exportTranscript(threadId: string): Promise<HeadlessThreadTranscript>;
+}
+
+/**
+ * The narrow slice of `fetch` this client uses. `globalThis.fetch` satisfies
+ * it, and so does a test double, without dragging in a runtime's own `fetch`
+ * type (Bun's carries `preconnect`, Node's does not).
+ */
+export type HeadlessFetch = (
+  input: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<Response>;
+
+export interface HeadlessThreadClientOptions {
+  /** OpenWork server base URL, e.g. `http://127.0.0.1:8787`. */
+  baseUrl: string;
+  workspaceId: string;
+  /** A collaborator-scoped OpenWork client token. */
+  token: string;
+  /** Model used when a call does not name one. */
+  defaultModel?: HeadlessThreadModel;
+  /** Default `waitForThread` poll interval. Defaults to 500ms. */
+  pollIntervalMs?: number;
+  fetch?: HeadlessFetch;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}

--- a/packages/headless-threads/src/wire.ts
+++ b/packages/headless-threads/src/wire.ts
@@ -1,0 +1,156 @@
+/**
+ * The wire boundary: schemas for what the OpenWork server already returns on
+ * its session routes, plus the mapping into the headless thread types.
+ *
+ * Every schema is permissive about fields it does not name, so an engine or
+ * server that grows a field does not break a benchmark run mid-campaign.
+ */
+import { z } from "zod";
+
+import type {
+  HeadlessThread,
+  HeadlessThreadMessage,
+  HeadlessThreadMessagePart,
+  HeadlessThreadSnapshot,
+  HeadlessThreadStatus,
+  HeadlessThreadTodo,
+} from "./types.js";
+
+const timeSchema = z
+  .object({
+    created: z.number().optional(),
+    updated: z.number().optional(),
+  })
+  .passthrough();
+
+export const threadStatusSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("idle") }),
+  z.object({ type: z.literal("busy") }),
+  z.object({ type: z.literal("retry"), attempt: z.number(), message: z.string(), next: z.number() }),
+]);
+
+const sessionSchema = z
+  .object({
+    id: z.string(),
+    title: z.string().nullish(),
+    directory: z.string().nullish(),
+    time: timeSchema.optional(),
+  })
+  .passthrough();
+
+const partSchema = z
+  .object({
+    id: z.string(),
+    type: z.string().optional(),
+    text: z.string().optional(),
+    tool: z.string().optional(),
+    callID: z.string().optional(),
+    state: z.object({ status: z.string().optional() }).passthrough().optional(),
+    synthetic: z.boolean().optional(),
+    ignored: z.boolean().optional(),
+  })
+  .passthrough();
+
+const messageSchema = z
+  .object({
+    info: z
+      .object({
+        id: z.string(),
+        role: z.string(),
+        time: timeSchema.optional(),
+      })
+      .passthrough(),
+    parts: z.array(partSchema),
+  })
+  .passthrough();
+
+const todoSchema = z
+  .object({
+    content: z.string(),
+    status: z.string(),
+    priority: z.string(),
+  })
+  .passthrough();
+
+export const createThreadResponseSchema = z.object({
+  item: sessionSchema,
+  started: z.boolean(),
+});
+
+export const threadSnapshotResponseSchema = z.object({
+  item: z.object({
+    session: sessionSchema,
+    messages: z.array(messageSchema),
+    todos: z.array(todoSchema),
+    status: threadStatusSchema,
+  }),
+});
+
+export const threadMessagesResponseSchema = z.object({
+  items: z.array(messageSchema),
+});
+
+export const abortResponseSchema = z.object({
+  ok: z.boolean(),
+});
+
+type SessionWire = z.infer<typeof sessionSchema>;
+type MessageWire = z.infer<typeof messageSchema>;
+type PartWire = z.infer<typeof partSchema>;
+type TodoWire = z.infer<typeof todoSchema>;
+
+function optionalString(value: string | null | undefined): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function toPart(part: PartWire): HeadlessThreadMessagePart {
+  const mapped: HeadlessThreadMessagePart = { id: part.id };
+  if (part.type !== undefined) mapped.type = part.type;
+  if (part.text !== undefined) mapped.text = part.text;
+  if (part.tool !== undefined) mapped.tool = part.tool;
+  if (part.callID !== undefined) mapped.callId = part.callID;
+  if (part.state?.status !== undefined) mapped.toolStatus = part.state.status;
+  if (part.synthetic !== undefined) mapped.synthetic = part.synthetic;
+  if (part.ignored !== undefined) mapped.ignored = part.ignored;
+  return mapped;
+}
+
+export function toThreadMessage(message: MessageWire): HeadlessThreadMessage {
+  return {
+    id: message.info.id,
+    role: message.info.role,
+    createdAt: message.info.time?.created ?? null,
+    parts: message.parts.map(toPart),
+  };
+}
+
+function toTodo(todo: TodoWire): HeadlessThreadTodo {
+  return { content: todo.content, status: todo.status, priority: todo.priority };
+}
+
+export function toThread(session: SessionWire, workspaceId: string, started: boolean): HeadlessThread {
+  return {
+    id: session.id,
+    workspaceId,
+    title: optionalString(session.title),
+    directory: optionalString(session.directory),
+    createdAt: session.time?.created ?? null,
+    started,
+  };
+}
+
+export function toSnapshot(item: z.infer<typeof threadSnapshotResponseSchema>["item"]): HeadlessThreadSnapshot {
+  return {
+    threadId: item.session.id,
+    title: optionalString(item.session.title),
+    directory: optionalString(item.session.directory),
+    status: item.status,
+    messages: item.messages.map(toThreadMessage),
+    todos: item.todos.map(toTodo),
+  };
+}
+
+/** Busy and retry both mean the engine still owns the turn. */
+export function isRunning(status: HeadlessThreadStatus): boolean {
+  return status.type === "busy" || status.type === "retry";
+}

--- a/packages/headless-threads/tsconfig.json
+++ b/packages/headless-threads/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@openwork/headless-threads':
+        specifier: workspace:*
+        version: link:../../packages/headless-threads
       '@openwork/paths':
         specifier: workspace:*
         version: link:../../packages/paths
@@ -1042,6 +1045,19 @@ importers:
         version: 5.9.3
 
   packages/handsfree: {}
+
+  packages/headless-threads:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      bun-types:
+        specifier: ^1.3.6
+        version: 1.3.14
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
 
   packages/install-config:
     dependencies:


### PR DESCRIPTION
Adds `@openwork/headless-threads`: a typed, function-driven client for driving a **native OpenWork thread from code**, without rendering the app.

## Why

Anything that exercises OpenWork without a UI re-implements the same sequence by hand against raw HTTP: create a session, submit `prompt_async`, poll `/session/status`, poll messages, work out when the turn actually finished, then dig text back out of message parts. `evals/flows/windows-workspace-session-performance.flow.mjs` is one such copy — ~150 lines of it. This package is that sequence, typed and tested once.

The subtle part it now owns: **a thread still reads `idle` in the gap between accepting a prompt and starting work.** Waiting for "not busy" alone reports a turn finished before it began. Settling requires a non-running status *and* an assistant message that was not present when the turn was submitted. That is easy to get wrong per-consumer and is exactly the kind of thing worth writing down once.

## What it is not

This is a client, not a runtime. No new chat engine, no second session store, no alternative React state, no new model gateway, no benchmark-only thread type — and **no new server route**.

Every call goes to a session surface the server already serves:

| Call | Surface |
| --- | --- |
| `createThread` | `POST /workspace/:id/sessions` |
| `sendTurn` | `POST /workspace/:id/opencode/session/:threadId/prompt_async` |
| `getThreadSnapshot` | `GET /workspace/:id/sessions/:threadId/snapshot` |
| `waitForThread` | bounded polling over the snapshot route |
| `abortThread` | `POST /workspace/:id/sessions/:threadId/abort` |
| `exportTranscript` | snapshot, flattened |

Turns go through the workspace OpenCode mount **because that is what the desktop app prompts through** — same engine, same path, same result. Adding a parallel server-side prompt route that the app would not use seemed like the wrong trade; the package encapsulates the transport, so if OpenWork later grows a first-class route, only this package changes and callers do not.

Consequence: a headless thread is an ordinary session with an ordinary native id. It lists and opens in the app like any other thread. There is no headless thread type.

## Contract

```ts
const threads = createHeadlessThreadClient({ baseUrl, workspaceId, token, defaultModel });

const thread = await threads.createThread({ title, prompt });
await threads.waitForThread(thread.id, { timeoutMs: 120_000 });

const turn = await threads.sendTurn(thread.id, { prompt: "..." });
const waited = await threads.waitForThread(thread.id, { timeoutMs: 120_000, since: turn });

if (waited.outcome === "settled") {
  console.log((await threads.exportTranscript(thread.id)).finalAssistantText);
}
```

`waitForThread` returns `settled` / `timeout` / `aborted` rather than throwing, so a caller running many threads records a slow thread as a result instead of losing the run. Transport and payload failures throw `HeadlessThreadError` carrying `code`, `status`, `method`, `path`, and the server's body. `fetch`, `now`, and `sleep` are injectable, so the whole contract runs against fixtures with no wall-clock dependency.

## Tests

`apps/server/src/headless-threads.e2e.test.ts` drives the client against a **real OpenWork server** with a mock OpenCode engine. The engine only advances when the client sleeps, so a two-turn journey is fully deterministic — and it scripts the idle-but-not-started beat explicitly, asserting `polls === 3` so a client that settled early would fail rather than silently pass.

```
$ pnpm --filter @openwork/headless-threads test
 19 pass  0 fail  42 expect() calls

$ pnpm --filter @openwork/headless-threads typecheck
 (clean)

$ pnpm --filter openwork-server test
 627 pass  8 skip  1 fail  1 error

$ pnpm --filter openwork-server build      # after rm -rf packages/types/dist
 (clean — tsc + plugin bundle)

$ pnpm check:outbound-access
 Outbound access manifest covers 35 hosts. No stale fetched entries.
```

The `openwork-server` suite gains 2 tests (625 → 627 pass). The 1 fail / 1 error is **pre-existing on `dev`** and unrelated: `src/workspace-kv-store.node.test.ts` cannot resolve `node:sqlite` on the local Bun 1.3.4. Verified by stashing this branch's changes and re-running at the base commit — identical `625 pass / 8 skip / 1 fail / 1 error`. CI installs Bun via `oven-sh/setup-bun@v2`, where `node:sqlite` is available.

No runtime-observable UI change, so there is no testkit tape: this adds a package plus a server-side test and changes no product surface. The "a headless thread opens in the app" claim is proven at the server surface the app reads (`GET /workspace/:id/sessions` and `.../sessions/:id`), not by driving Electron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
