### PR TITLE
fix(ci): restore Den DB migration rollout

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -134,25 +134,15 @@ jobs:
             done
             return 1
           }
-          read_safe_migrations_state() {
-            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
-          }
-          if ! state="$(read_safe_migrations_state)"; then
-            state=""
-          fi
-          echo "safe_migrations before run: $state"
-          if [ "$state" = "true" ]; then
-            if ! pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"; then
-              echo "::error::Could not disable safe migrations for $DATABASE_NAME/$PLANETSCALE_BRANCH."
-              exit 1
-            fi
-            echo "Safe migrations disabled for the duration of this run."
-          elif [ "$state" = "false" ]; then
-            echo "Safe migrations already disabled; will re-enable at the end of this run."
-          else
-            echo "::error::Could not read safe_migrations state for $DATABASE_NAME/$PLANETSCALE_BRANCH."
+          if ! state="$(pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json)"; then
+            echo "::error::Could not disable safe migrations for $DATABASE_NAME/$PLANETSCALE_BRANCH."
             exit 1
           fi
+          if ! jq -e '.safe_migrations == false' >/dev/null <<<"$state"; then
+            echo "::error::PlanetScale did not confirm safe migrations were disabled."
+            exit 1
+          fi
+          echo "Safe migrations disabled for the duration of this run."
 
           # The toggle propagates to the connection gateways asynchronously and
           # per edge node, so require several consecutive successful DDL probes
@@ -269,33 +259,22 @@ jobs:
             done
             return 1
           }
-          read_safe_migrations_state() {
-            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
-          }
-
           confirmed="false"
           for attempt in $(seq 1 5); do
             echo "Enabling safe migrations (attempt $attempt/5)."
-            if output="$(pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" 2>&1)"; then
-              if [ -n "$output" ]; then
-                printf '%s\n' "$output"
+            if output="$(pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json 2>&1)"; then
+              if jq -e '.safe_migrations == true' >/dev/null <<<"$output"; then
+                confirmed="true"
+                echo "PlanetScale confirmed safe migrations are enabled."
+                break
               fi
+              echo "PlanetScale enable response did not confirm safe migrations: $output" >&2
             else
               status=$?
               if [ -n "$output" ]; then
                 printf '%s\n' "$output" >&2
               fi
-              echo "pscale enable failed (attempt $attempt/5, exit $status); checking branch state." >&2
-            fi
-
-            if state="$(read_safe_migrations_state)"; then
-              echo "safe_migrations after run: $state"
-              if [ "$state" = "true" ]; then
-                confirmed="true"
-                break
-              fi
-            else
-              echo "Could not verify safe_migrations state after enable attempt $attempt." >&2
+              echo "pscale enable failed (attempt $attempt/5, exit $status)." >&2
             fi
 
             if [ "$attempt" -lt 5 ]; then

--- a/ee/packages/den-db/test/migration-readiness.test.ts
+++ b/ee/packages/den-db/test/migration-readiness.test.ts
@@ -88,9 +88,12 @@ describe("Den DB migration readiness wiring", () => {
     assert.match(workflow, /name: Den DB Migrate/)
     assert.match(workflow, /branches:\n\s+- dev/)
     assert.match(workflow, /paths:\n\s+- "ee\/packages\/den-db\/drizzle\/\*\*"/)
-    assert.match(workflow, /pscale branch safe-migrations disable/)
+    assert.match(workflow, /pscale branch safe-migrations disable[^\n]+--format json/)
+    assert.match(workflow, /jq -e '\.safe_migrations == false'/)
     assert.match(workflow, /run_with_ddl_retry pnpm --filter @openwork-ee\/den-db db:migrate/)
-    assert.match(workflow, /pscale branch safe-migrations enable/)
+    assert.match(workflow, /pscale branch safe-migrations enable[^\n]+--format json/)
+    assert.match(workflow, /jq -e '\.safe_migrations == true'/)
+    assert.doesNotMatch(workflow, /pscale branch show/)
   })
 
   test("PR guardrails run readiness tests and smoke Den DB assets in the Den API image", () => {

--- a/ee/packages/den-db/test/migration-schema-parity.test.ts
+++ b/ee/packages/den-db/test/migration-schema-parity.test.ts
@@ -255,6 +255,27 @@ async function migrationOwnedIndexes() {
   return indexes
 }
 
+async function migrationAddedColumns() {
+  const entries = await readdir(migrationsFolder)
+  const columns = new Map<string, Set<string>>()
+  const addColumnRegex = /ALTER\s+TABLE\s+`([^`]+)`\s+ADD(?:\s+COLUMN)?\s+`([^`]+)`/gi
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".sql")) continue
+
+    const sql = await readFile(join(migrationsFolder, entry), "utf8")
+    let match = addColumnRegex.exec(sql)
+    while (match) {
+      const tableColumns = columns.get(match[1]) ?? new Set<string>()
+      tableColumns.add(match[2])
+      columns.set(match[1], tableColumns)
+      match = addColumnRegex.exec(sql)
+    }
+  }
+
+  return columns
+}
+
 function exportTableNames(statements: string[]) {
   return statements
     .map(createTableName)
@@ -262,15 +283,42 @@ function exportTableNames(statements: string[]) {
     .sort()
 }
 
-function statementForSeed(statement: string) {
-  if (createTableName(statement) !== "worker") {
-    return statement
-  }
+function statementForSeed(statement: string, addedColumns: Map<string, Set<string>>) {
+  const tableName = createTableName(statement)
+  if (!tableName) return statement
+
+  const columns = addedColumns.get(tableName)
+  if (!columns?.size) return statement
 
   return statement
-    .replace(/\n\s*`last_heartbeat_at` timestamp\(3\),/i, "")
-    .replace(/\n\s*`last_active_at` timestamp\(3\),/i, "")
+    .split("\n")
+    .filter((line) => {
+      const columnName = /^\s*`([^`]+)`/.exec(line)?.[1]
+      return !columnName || !columns.has(columnName)
+    })
+    .join("\n")
 }
+
+test("seed schema excludes columns supplied by committed migrations", () => {
+  const statement = [
+    "CREATE TABLE `oauthAccessToken` (",
+    "  `id` varchar(64) NOT NULL,",
+    "  `authorization_code_id` varchar(64),",
+    "  `token` text NOT NULL",
+    ")",
+  ].join("\n")
+  const addedColumns = new Map([["oauthAccessToken", new Set(["authorization_code_id"])]])
+
+  assert.equal(
+    statementForSeed(statement, addedColumns),
+    [
+      "CREATE TABLE `oauthAccessToken` (",
+      "  `id` varchar(64) NOT NULL,",
+      "  `token` text NOT NULL",
+      ")",
+    ].join("\n"),
+  )
+})
 
 function seedShouldSkipIndex(statement: string) {
   return /^CREATE\s+INDEX\s+`worker_last_(?:heartbeat|active)_at`\s+ON\s+`worker`/i.test(statement)
@@ -281,15 +329,16 @@ async function seedNonMigrationOwnedTables(
   exportStatements: string[],
   nonMigrationOwnedTables: Set<string>,
   migrationCreatedIndexes: Set<string>,
+  migrationColumns: Map<string, Set<string>>,
 ) {
   // The committed migrations start after the original auth/system schema. They do not
   // create the export tables in nonMigrationOwnedTables, so those tables are seeded
-  // before replay. The worker table is seeded from export with the two columns that
-  // 0002 adds removed, letting the full migration chain replay deterministically.
+  // before replay. Columns added by committed ALTER TABLE migrations are removed from
+  // the current export first, letting the full migration chain replay deterministically.
   for (const statement of exportStatements) {
     const tableName = createTableName(statement)
     if (tableName && nonMigrationOwnedTables.has(tableName)) {
-      await connection.query(statementForSeed(statement))
+      await connection.query(statementForSeed(statement, migrationColumns))
     }
   }
 
@@ -444,13 +493,14 @@ test("migrations replay to exported schema and config object version inserts", {
     const exportStatements = splitSqlStatements(exportSql)
     const ownedTables = await migrationOwnedTables()
     const ownedIndexes = await migrationOwnedIndexes()
+    const addedColumns = await migrationAddedColumns()
     const nonMigrationOwnedTableNames = exportTableNames(exportStatements).filter((tableName) => !ownedTables.has(tableName))
     const nonMigrationOwnedTables = new Set(nonMigrationOwnedTableNames)
 
     migratedConnection = await mysql.createConnection(mysqlConnectionConfigFor(mysqlUrl, migratedDatabase))
     exportedConnection = await mysql.createConnection(mysqlConnectionConfigFor(mysqlUrl, exportedDatabase))
 
-    await seedNonMigrationOwnedTables(migratedConnection, exportStatements, nonMigrationOwnedTables, ownedIndexes)
+    await seedNonMigrationOwnedTables(migratedConnection, exportStatements, nonMigrationOwnedTables, ownedIndexes, addedColumns)
 
     const migratedDb = drizzle(migratedConnection)
     await migrate(migratedDb, { migrationsFolder })


### PR DESCRIPTION
## Summary

Restore the production Den DB migration rollout after PlanetScale branch metadata reads began failing under the CI service token, and repair the migration parity test exposed by the new OAuth columns.

## What changed

- validate safe-migration state from the authorized `safe-migrations disable/enable --format json` mutation responses
- remove the separate `branch show` dependency that masked the real error as `null`
- keep the DDL propagation probes and mandatory re-enable guard
- derive migration-added columns when seeding the parity database so the migration chain can replay without duplicate columns
- add focused workflow and seed-schema contract assertions

## Why

The OAuth schema fix in #3603 deployed at `dev@75f02c3e4`, but its production migration stopped before DDL because `pscale branch show` was not authorized. The service token can perform the safe-migration mutations, and those commands return the resulting branch state directly. After that repair, the parity check exposed that its baseline seed already included the new OAuth columns before replaying migration 0056.

## Verification

- Passed: production `Den DB Migrate` run 31174511748; migration applied and safe migrations re-enabled
- Passed: production OAuth client registration probe returned HTTP 201
- Passed: `Den DB Check` run 31174806869, including schema/migration parity
- Passed: focused workflow-owner test (1/1)
- Passed: `git diff --check`
- Base: `0cb93f4885f8ec18fd1c83f152e17468fb1dc119`
- Candidate: `65ca5d3d30a271234d91c1ab7963f94ede4da95c`

No merge is included in this handoff.