### PR TITLE
fix(den): seed MCP resources into the better-auth 1.7 resource registry (unblocks third-party MCP auth)

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -994,6 +994,11 @@ export const auth = betterAuth({
       consentPage: `${env.betterAuthUrl}/mcp/select-organization`,
       scopes: [...DEN_MCP_SCOPES],
       validAudiences: DEN_MCP_OAUTH_VALID_AUDIENCES,
+      // better-auth 1.7 gates every token-request `resource` parameter on the
+      // oauthResource registry (invalid_target "is not configured" otherwise;
+      // validAudiences no longer whitelists issuance). Seed all accepted MCP
+      // resource aliases at startup — seeding is idempotent (insertOnly).
+      resources: [...DEN_MCP_RESOURCES],
       allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,


### PR DESCRIPTION
## Summary
- With migration 0056 applied (#3603 + the dispatched migrate run), third-party MCP auth now gets past registration — and hits the *next* better-auth 1.7 behavior change: the token endpoint validates every `resource` parameter against the new `oauthResource` registry, and `validAudiences` no longer whitelists issuance. The registry is empty, so the authorization-code exchange fails with `invalid_target: requested resource https://api.openworklabs.com/mcp/agent is not configured`.
- Reproduced end to end against prod with `opencode mcp auth openwork`: registration 201 → authorize URL opens → consent → token exchange fails with exactly that error (this is the "different error" Ben reported after the migration landed).
- Fix: pass the full accepted alias set (`DEN_MCP_RESOURCES` — canonical agent resource, `/mcp`, betterAuthUrl and public-API aliases, `mcpAdditionalResources`, local aliases, and the agent/admin endpoint aliases) as the oauthProvider `resources` option. The plugin seeds the registry idempotently at startup (`insertOnly` — rows are never mutated afterward, and re-deploys are no-ops). Rows carry no TTL/scope overrides, so issuance policy is otherwise unchanged from 1.6 behavior.

## Validation
- `pnpm --filter @openwork-ee/den-api build` (typechecks the `resources` option against @better-auth/oauth-provider 1.7.0-beta.10)
- Mechanism verified in plugin source: `seedResources` runs in plugin `init`, inserts one `oauthResource` row per configured identifier, skips existing rows and RFC 8707-invalid identifiers with a warning.
- Post-deploy verification plan: full `opencode mcp auth openwork` round-trip against prod + confirm `oauthResource` rows exist.

Part of the better-auth 1.7 upgrade fallout (#3584/#3588 → #3603 → this). Remaining known gap after this: none reproduced — the opencode flow reaches token exchange cleanly once the resource is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)