### PR TITLE
fix(den): generate ids for oauthResource seeds and disable per-client resource ACL (P0 follow-up)

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -777,6 +777,15 @@ export const auth = betterAuth({
             return createDenTypeId("oauthRefreshToken");
           case "oauthConsent":
             return createDenTypeId("oauthConsent");
+          // better-auth 1.7 oauth-provider models with no den typeid: without
+          // an id the drizzle adapter emits `insert ... values (default, ...)`
+          // and MySQL rejects it (no default on `id`) — the oauthResource seed
+          // storm of 2026-08-07. oauthClientResource/oauthClientAssertion use
+          // forceAllowId, but cover them for any future non-forced create.
+          case "oauthResource":
+          case "oauthClientResource":
+          case "oauthClientAssertion":
+            return crypto.randomUUID();
           case "rateLimit":
             return createDenTypeId("rateLimit");
           case "organization":
@@ -999,6 +1008,11 @@ export const auth = betterAuth({
       // validAudiences no longer whitelists issuance). Seed all accepted MCP
       // resource aliases at startup — seeding is idempotent (insertOnly).
       resources: [...DEN_MCP_RESOURCES],
+      // 1.7 defaults to requiring an oauthClientResource link per client per
+      // resource. Dynamically registered MCP clients never request resources
+      // at registration, so enforcement would invalid_target every DCR client.
+      // Keep pre-1.7 behavior: registry + audience validation, no per-client ACL.
+      enforcePerClientResources: false,
       allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,


### PR DESCRIPTION
## Summary
Two urgent follow-ups to #3607 (1.7 resource registry seed), both verified against prod behavior:

1. **Seed inserts fail → 500 storm (live now, DEN-API-1G/1H, 125+ events since 12:42Z).** den-api's `generateId` returns `false` for models without a den typeid, and the (patched) drizzle adapter then emits `INSERT INTO oauthResource (id, ...) VALUES (default, ...)` — MySQL rejects it because `id` has no default. The lazy seed retries on every better-auth request, so even `GET /api/auth/.well-known/openid-configuration` 500s. Fix: generate UUIDs for `oauthResource` / `oauthClientResource` / `oauthClientAssertion` (the latter two normally use forceAllowId; covered defensively).
2. **`enforcePerClientResources` defaults to `true` in 1.7** — once seeding works, every token exchange from a dynamically-registered client would fail `invalid_target` because DCR clients never request resources at registration and therefore hold no `oauthClientResource` links. Pin to `false` to keep pre-1.7 semantics (registry + audience validation, no per-client ACL). Verified default in plugin source (`resolveEnforcePerClientResources` → `value: true, source: "default"`).

## Validation
- `pnpm --filter @openwork-ee/den-api run build` green.
- Adapter behavior reproduced in a standalone better-auth 1.7.0-beta.10 harness (registration + seeding path, SQL logged).
- Post-deploy: `oauthResource` rows appear once, discovery/registration return 200/201, full `opencode mcp auth openwork` round-trip.

Chain: #3584/#3588 (upgrade) → #3603 (schema) → #3606 (CI) → #3607 (registry seed) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)