### PR TITLE
fix(den): generate ids for oauthResource seeds and disable per-client resource ACL (hotfix for #3607)

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -777,6 +777,15 @@ export const auth = betterAuth({
             return createDenTypeId("oauthRefreshToken");
           case "oauthConsent":
             return createDenTypeId("oauthConsent");
+          // better-auth 1.7 oauth-provider models with no den typeid: without
+          // an id the drizzle adapter emits `insert ... values (default, ...)`
+          // and MySQL rejects it (no default on `id`) — the oauthResource seed
+          // storm of 2026-08-07. oauthClientResource/oauthClientAssertion use
+          // forceAllowId, but cover them for any future non-forced create.
+          case "oauthResource":
+          case "oauthClientResource":
+          case "oauthClientAssertion":
+            return crypto.randomUUID();
           case "rateLimit":
             return createDenTypeId("rateLimit");
           case "organization":
@@ -999,6 +1008,11 @@ export const auth = betterAuth({
       // validAudiences no longer whitelists issuance). Seed all accepted MCP
       // resource aliases at startup — seeding is idempotent (insertOnly).
       resources: [...DEN_MCP_RESOURCES],
+      // 1.7 defaults to requiring an oauthClientResource link per client per
+      // resource. Dynamically registered MCP clients never request resources
+      // at registration, so enforcement would invalid_target every DCR client.
+      // Keep pre-1.7 behavior: registry + audience validation, no per-client ACL.
+      enforcePerClientResources: false,
       allowPublicClientPrelogin: true,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,


### PR DESCRIPTION
## Summary
- **Urgent follow-up to #3607** — its resource seeding fails in prod: den-api's `generateId` returns `false` for models outside its switch, so the seed INSERT into `oauthResource` goes out with `id = default` and MySQL rejects it (`Field 'id' doesn't have a default value`, errno 1364). The lazy-seed wrapper retries on every resource lookup, so this currently 500s OAuth discovery (`/.well-known/oauth-authorization-server`, issue DEN-API-1G, growing) and dynamic client registration — a regression beyond the original outage.
- Fix 1: `generateId` cases for the three 1.7 oauth-provider models with no den typeid (`oauthResource`, `oauthClientResource`, `oauthClientAssertion`) → `crypto.randomUUID()` (fits the varchar(64) id columns; the latter two normally use forceAllowId, covered defensively).
- Fix 2: `enforcePerClientResources: false` — 1.7 defaults to requiring an `oauthClientResource` link per client per resource; dynamically registered MCP clients never request resources at registration, so enforcement would `invalid_target` every DCR client even after seeding. This preserves pre-1.7 behavior (registry + audience validation, no per-client ACL).

## Validation
- `pnpm --filter @openwork-ee/den-api build` green.
- Post-deploy: expect discovery 200, registration 201, `oauthResource` rows seeded on first lookup, and a full `opencode mcp auth openwork` round-trip.

Fallout chain: #3584/#3588 (better-auth 1.7-beta bump) → #3603 (schema) → #3607 (registry seed config) → this (seed id generation + ACL default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)