### PR TITLE
Fix idle automation runner notification polling

### DIFF
--- a/docs/features/automations-desktop-runner/README.md
+++ b/docs/features/automations-desktop-runner/README.md
@@ -13,6 +13,12 @@ resumable notification cursor. After connecting or receiving a wake-up, the
 desktop discovers work over HTTP, atomically claims one occurrence, and reports
 attempt-bound heartbeats, ordered events, cancellation, usage, and completion.
 
+When a runner has no pending notifications, Den exponentially backs its cursor
+query off from one second to 15 seconds. The poll resets to one second after
+activity, and its sleep is capped by the existing 15-second presence keepalive.
+This preserves the resumable SSE and bounded claim protocol while reducing an
+idle runner's steady-state notification queries from 60 to four per minute.
+
 The claimed Automation runs as a normal visible local OpenWork thread in the
 desktop's active workspace. It uses the selected model and the same local
 OpenCode tool and integration experience as a thread started by the user.

--- a/ee/apps/den-api/src/automations/runner-notification-poll.ts
+++ b/ee/apps/den-api/src/automations/runner-notification-poll.ts
@@ -1,0 +1,22 @@
+export const RUNNER_NOTIFICATION_POLL_MIN_MS = 1_000
+export const RUNNER_NOTIFICATION_POLL_MAX_MS = 15_000
+export const RUNNER_KEEPALIVE_INTERVAL_MS = 15_000
+
+export function nextRunnerNotificationPollDelay(
+  currentDelayMs: number,
+  receivedNotifications: boolean,
+): number {
+  if (receivedNotifications) return RUNNER_NOTIFICATION_POLL_MIN_MS
+  return Math.min(
+    RUNNER_NOTIFICATION_POLL_MAX_MS,
+    Math.max(RUNNER_NOTIFICATION_POLL_MIN_MS, currentDelayMs) * 2,
+  )
+}
+
+export function capRunnerNotificationPollDelayForKeepalive(
+  pollDelayMs: number,
+  elapsedSinceKeepaliveMs: number,
+): number {
+  const untilKeepaliveMs = RUNNER_KEEPALIVE_INTERVAL_MS - elapsedSinceKeepaliveMs
+  return Math.min(pollDelayMs, Math.max(RUNNER_NOTIFICATION_POLL_MIN_MS, untilKeepaliveMs))
+}

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -29,6 +29,12 @@ import {
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
 import { automationRunnerAuth } from "../../automations/runner-auth.js"
+import {
+  RUNNER_KEEPALIVE_INTERVAL_MS,
+  RUNNER_NOTIFICATION_POLL_MIN_MS,
+  capRunnerNotificationPollDelayForKeepalive,
+  nextRunnerNotificationPollDelay,
+} from "../../automations/runner-notification-poll.js"
 
 const idParamsSchema = z.object({ id: z.string().min(1).max(160) })
 const automationRunParamsSchema = z.object({ id: z.string().min(1).max(160) })
@@ -110,6 +116,7 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     return streamSSE(c, async (stream) => {
       let lastKeepaliveAt = 0
       let lastOwnerCheckAt = Date.now()
+      let notificationPollDelayMs = RUNNER_NOTIFICATION_POLL_MIN_MS
       while (!stream.aborted) {
         // A held-open stream must not outlive the credential or membership.
         if (Date.now() >= identity.expiresAt) break
@@ -128,12 +135,22 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
           })
           await stream.writeSSE({ id: payload.cursor, event: payload.type, data: JSON.stringify(payload) })
         }
-        if (notifications.length === 0 && Date.now() - lastKeepaliveAt >= 15_000) {
+        if (notifications.length === 0 && Date.now() - lastKeepaliveAt >= RUNNER_KEEPALIVE_INTERVAL_MS) {
           await service.touchDesktopRunner(identity)
           await stream.writeSSE({ event: "keepalive", data: "{}" })
           lastKeepaliveAt = Date.now()
         }
-        await stream.sleep(1_000)
+        notificationPollDelayMs = nextRunnerNotificationPollDelay(
+          notificationPollDelayMs,
+          notifications.length > 0,
+        )
+        // Idle runners need only a bounded recovery scan. Keep the sleep short
+        // enough to preserve the existing presence heartbeat, and return to
+        // the low-latency interval as soon as this stream observes activity.
+        await stream.sleep(capRunnerNotificationPollDelayForKeepalive(
+          notificationPollDelayMs,
+          Date.now() - lastKeepaliveAt,
+        ))
       }
     })
   })

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -10,6 +10,12 @@ import {
 } from "@openwork/types/automations"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
+import {
+  RUNNER_NOTIFICATION_POLL_MAX_MS,
+  RUNNER_NOTIFICATION_POLL_MIN_MS,
+  capRunnerNotificationPollDelayForKeepalive,
+  nextRunnerNotificationPollDelay,
+} from "../src/automations/runner-notification-poll.js"
 import { automationUpdateChangedRows } from "../src/automations/update-result.js"
 import { isMcpOperationAllowed } from "../src/mcp/policy.js"
 
@@ -138,6 +144,25 @@ test("every runner endpoint re-checks that the token owner is still an active me
   )
   assert.match(sse, /Date\.now\(\) >= identity\.expiresAt\) break/)
   assert.match(sse, /if \(!\(await service\.isActiveRunnerOwner\(identity\)\)\) break/)
+})
+
+test("idle runner notification polling backs off without delaying keepalives", () => {
+  let delay = RUNNER_NOTIFICATION_POLL_MIN_MS
+  delay = nextRunnerNotificationPollDelay(delay, false)
+  assert.equal(delay, 2_000)
+  delay = nextRunnerNotificationPollDelay(delay, false)
+  assert.equal(delay, 4_000)
+  delay = nextRunnerNotificationPollDelay(delay, false)
+  assert.equal(delay, 8_000)
+  delay = nextRunnerNotificationPollDelay(delay, false)
+  assert.equal(delay, RUNNER_NOTIFICATION_POLL_MAX_MS)
+  assert.equal(nextRunnerNotificationPollDelay(delay, false), RUNNER_NOTIFICATION_POLL_MAX_MS)
+
+  assert.equal(
+    capRunnerNotificationPollDelayForKeepalive(delay, 14_000),
+    RUNNER_NOTIFICATION_POLL_MIN_MS,
+  )
+  assert.equal(nextRunnerNotificationPollDelay(delay, true), RUNNER_NOTIFICATION_POLL_MIN_MS)
 })
 
 test("manual runs use durable runner presence across Den API replicas", () => {


### PR DESCRIPTION
## Summary

Reduce the high-volume automation_runner_notification cursor query shown in PlanetScale Query Insights. The existing owner/cursor index is correct; the volume comes from each connected desktop querying once per second while idle.

## What changed

- exponentially back off empty SSE notification scans from 1s to 15s
- reset the interval to 1s as soon as notifications are observed
- cap sleeps so the existing 15s runner-presence keepalive is preserved
- document the operational behavior and expected steady-state reduction from 60 to 4 queries per minute per idle runner

The tradeoff is a maximum 15s wake-up delay after a runner has been idle, still inside the existing 60s claim window. Cursor resumability, authorization checks, notification payloads, and claim semantics are unchanged.

## Verification

Passed:
- corepack pnpm --filter @openwork-ee/den-api typecheck:automations
- corepack pnpm --filter @openwork-ee/den-api exec bun test test/automation-runner-protocol.test.ts (13 passed, 0 failed)
- git diff --check

Deferred:
- production Query Insights confirmation after deployment
- broader repository and CI suites

Base: e62d01897a9d2a0cb5855e3d409f4ab2b580350a
Head: 4a7c1ae7799f227ffb42a94050a7bbbbb1694d41