### PR TITLE
Fix managed model refresh getting stuck until restart

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
@@ -86,6 +86,12 @@ export const IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE: CloudMcpSubmissionGateState =
   maxAttempts: 1 + CLOUD_MCP_SUBMISSION_RETRY_DELAYS_MS.length,
 };
 
+export function clearCloudMcpSubmissionFailure(
+  state: CloudMcpSubmissionGateState,
+): CloudMcpSubmissionGateState {
+  return state.status === "failed" ? IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE : state;
+}
+
 function normalize(value: string | null | undefined): string {
   return value?.trim().replace(/\/+$/, "") ?? "";
 }

--- a/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
@@ -5,12 +5,19 @@ declare const expect: (value: unknown) => {
   toEqual: (expected: unknown) => void;
 };
 
+import { readFileSync } from "node:fs";
+
 import {
   isOrganizationModelsEmpty,
   refreshOrganizationModels,
   shouldAutoOpenUnavailableModelPicker,
   shouldWaitForCloudProviderSyncBeforePolicyReconcile,
 } from "./managed-models-recovery";
+
+const sessionProviderAuthSource = readFileSync(
+  new URL("./use-session-provider-auth.ts", import.meta.url),
+  "utf8",
+);
 
 describe("managed model sync ordering", () => {
   test("waits to reconcile policy until the first signed-in cloud provider sync settles", () => {
@@ -68,5 +75,32 @@ describe("managed model recovery", () => {
     });
 
     expect(calls).toEqual(["sync:manual", "providers"]);
+  });
+
+  test("returns the refreshed provider snapshot for lifecycle and product triggers", async () => {
+    const calls: string[] = [];
+    const snapshot = { connected: ["openwork"], all: [] };
+
+    const result = await refreshOrganizationModels({
+      runCloudProviderSync: async (reason) => {
+        calls.push(`sync:${reason}`);
+      },
+      refreshProviders: async () => {
+        calls.push("providers");
+        return snapshot;
+      },
+    }, "app_resume");
+
+    expect(calls).toEqual(["sync:app_resume", "providers"]);
+    expect(result).toBe(snapshot);
+  });
+
+  test("publishes automatic sync results into the live session snapshot", () => {
+    expect(sessionProviderAuthSource.includes(
+      "useCloudProviderAutoSync(refreshCloudProviderSync)",
+    )).toBe(true);
+    expect(sessionProviderAuthSource.includes(
+      "useCloudProviderAutoSync(store.runCloudProviderSync)",
+    )).toBe(false);
   });
 });

--- a/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.ts
@@ -55,14 +55,23 @@ export function shouldWaitForCloudProviderSyncBeforePolicyReconcile(
   );
 }
 
-export type OrganizationModelsRefreshInput = {
-  runCloudProviderSync: (reason: "manual") => Promise<unknown>;
-  refreshProviders: () => Promise<unknown> | unknown;
+export type OrganizationModelsRefreshInput<T> = {
+  runCloudProviderSync: (reason: OrganizationModelsRefreshReason) => Promise<unknown>;
+  refreshProviders: () => Promise<T> | T;
 };
 
-export async function refreshOrganizationModels(
-  input: OrganizationModelsRefreshInput,
-) {
-  await input.runCloudProviderSync("manual");
-  await input.refreshProviders();
+export type OrganizationModelsRefreshReason =
+  | "sign_in"
+  | "app_launch"
+  | "app_resume"
+  | "model_picker_open"
+  | "new_chat"
+  | "manual";
+
+export async function refreshOrganizationModels<T>(
+  input: OrganizationModelsRefreshInput<T>,
+  reason: OrganizationModelsRefreshReason = "manual",
+): Promise<T> {
+  await input.runCloudProviderSync(reason);
+  return input.refreshProviders();
 }

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -15,7 +15,11 @@ import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-pr
 import { useReloadCoordinator } from "@/react-app/shell/reload-coordinator";
 import { type RouteWorkspace, workspaceLabel } from "@/react-app/shell/route-workspaces";
 import { reconcilePolicyDisabledProviders } from "@/react-app/domains/connections/policy-provider-reconcile";
-import { shouldWaitForCloudProviderSyncBeforePolicyReconcile } from "./managed-models-recovery";
+import {
+  refreshOrganizationModels,
+  shouldWaitForCloudProviderSyncBeforePolicyReconcile,
+  type OrganizationModelsRefreshReason,
+} from "./managed-models-recovery";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "./store";
 
 const emptyWorkspaceDisplay: WorkspaceDisplay = {
@@ -169,11 +173,13 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
       ? completedCloudProviderSync
       : null;
   const cloudProviderSyncReady = Boolean(currentCloudProviderSync);
-  const loadCloudProviderSync = useCallback(async (reason: "app_launch" | "manual") => {
-    await store.runCloudProviderSync(reason);
-    return store.refreshProviders({ force: true });
-  }, [store]);
-  const refreshCloudProviderSync = useCallback(async (reason: "manual") => {
+  const loadCloudProviderSync = useCallback((reason: OrganizationModelsRefreshReason) => (
+    refreshOrganizationModels({
+      runCloudProviderSync: store.runCloudProviderSync,
+      refreshProviders: () => store.refreshProviders({ force: true }),
+    }, reason)
+  ), [store]);
+  const refreshCloudProviderSync = useCallback(async (reason: OrganizationModelsRefreshReason) => {
     const providerList = await loadCloudProviderSync(reason);
     setCompletedCloudProviderSync({ context: cloudProviderSyncContext, providerList });
     return providerList;
@@ -289,7 +295,10 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
 
   // Session is where forced sign-in lands. Keep org-managed cloud providers in
   // sync here so sign-in applies opencode.json changes before Settings opens.
-  useCloudProviderAutoSync(store.runCloudProviderSync);
+  // Route every lifecycle trigger through the snapshot-publishing wrapper:
+  // refreshing only the engine leaves selected-model availability stale until
+  // this route is recreated by a restart or sign-out.
+  useCloudProviderAutoSync(refreshCloudProviderSync);
   const snapshot = useProviderAuthStoreSnapshot(store);
 
   return {

--- a/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
@@ -14,6 +14,7 @@ import {
 } from "./cloud-mcp-user-state";
 import {
   createCloudMcpSubmissionCoordinator,
+  clearCloudMcpSubmissionFailure,
   decideCloudMcpSubmissionGate,
   ensureCloudMcpSubmissionReadiness,
   IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
@@ -48,6 +49,7 @@ type CloudMcpSubmitInput = {
 export type CloudMcpSubmitReadiness = {
   state: CloudMcpSubmissionGateState;
   submit: (input: CloudMcpSubmitInput) => Promise<CloudMcpSubmissionResult>;
+  clearFailure: () => void;
 };
 
 function missingContextIssue(input: {
@@ -338,5 +340,9 @@ export function useCloudMcpSubmitReadiness(
     });
   }, [waitForAuthResolution]);
 
-  return { state, submit };
+  const clearFailure = useCallback(() => {
+    setState(clearCloudMcpSubmissionFailure);
+  }, []);
+
+  return { state, submit, clearFailure };
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -595,6 +595,7 @@ export function SessionRoute() {
   const {
     state: cloudMcpSubmissionState,
     submit: submitWithCloudMcpReadiness,
+    clearFailure: clearCloudMcpSubmissionFailure,
   } = useCloudMcpSubmitReadiness({
     cloudAuthStatus: denAuth.status,
     client: selectedWorkspaceEndpoint?.client ?? null,
@@ -868,8 +869,8 @@ export function SessionRoute() {
     };
   }, [denAuth.isSignedIn, denAuth.status, denSessionVersion]);
   const handleModelPickerOpen = useCallback(() => {
-    void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
-  }, [sessionProviderAuthStore]);
+    void refreshCloudProviderSync("model_picker_open");
+  }, [refreshCloudProviderSync]);
   const openWorkModelsEntitled = useMemo(() => {
     if (!denAuth.isSignedIn) return false;
     const fromOrg = sessionProviderAuthSnapshot.cloudOrgProviders.some(
@@ -893,6 +894,10 @@ export function SessionRoute() {
   const refreshOrganizationModelAccess = useCallback(async () => {
     await refreshCloudProviderSync("manual");
   }, [refreshCloudProviderSync]);
+  useEffect(() => {
+    if (!cloudProviderSyncReady || !cloudProviderList) return;
+    clearCloudMcpSubmissionFailure();
+  }, [clearCloudMcpSubmissionFailure, cloudProviderList, cloudProviderSyncReady]);
   const refreshOpenWorkModels = useCallback(async () => {
     await refreshOrganizationModelAccess();
   }, [refreshOrganizationModelAccess]);
@@ -1207,7 +1212,7 @@ export function SessionRoute() {
       onModelPickerOpenChange: (open: boolean) => {
         modelPicker.setCompactOpen(open);
         if (open) {
-          void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+          void refreshCloudProviderSync("model_picker_open");
         }
       },
       onModelChange: (model: ModelRef) => {
@@ -1417,6 +1422,7 @@ export function SessionRoute() {
     navigate,
     providerCatalog,
     openWorkModelsEntitled,
+    refreshCloudProviderSync,
     refreshOrganizationModelAccess,
     opencodeBaseUrl,
     opencodeClient,
@@ -1427,7 +1433,6 @@ export function SessionRoute() {
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
-    sessionProviderAuthStore,
     sessionsByWorkspaceId,
     submitWithCloudMcpReadiness,
     token,
@@ -1465,7 +1470,7 @@ export function SessionRoute() {
       onModelPickerOpenChange: (open: boolean) => {
         modelPicker.setCompactOpen(open);
         if (open) {
-          void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+          void refreshCloudProviderSync("model_picker_open");
         }
       },
       onModelChange: (model: ModelRef) => {
@@ -1524,13 +1529,13 @@ export function SessionRoute() {
     opencodeClient,
     openWorkModelsEntitled,
     organizationModelsEmpty,
+    refreshCloudProviderSync,
     refreshOrganizationModelAccess,
     selectedAgent,
     selectedModelUnavailable,
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
-    sessionProviderAuthStore,
     setSelectedAgent,
   ]);
 
@@ -1682,7 +1687,7 @@ export function SessionRoute() {
         await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
       );
       if (workspaceId === selectedWorkspaceId) {
-        void sessionProviderAuthStore.runCloudProviderSync("new_chat");
+        void refreshCloudProviderSync("new_chat");
       }
       captureAnalyticsEvent("task_created", {
         source: "new_task",
@@ -1731,7 +1736,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [endpointForWorkspace, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, sessionProviderAuthStore, workspaces]);
+  }, [endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we
@@ -2611,7 +2616,7 @@ export function SessionRoute() {
                 await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
               );
               if (workspaceId === selectedWorkspaceId) {
-                void sessionProviderAuthStore.runCloudProviderSync("new_chat");
+                void refreshCloudProviderSync("new_chat");
               }
               const firstTaskPrompt = prompt.trim();
               if (firstTaskPrompt) {

--- a/apps/app/tests/cloud-mcp-submit-readiness.test.ts
+++ b/apps/app/tests/cloud-mcp-submit-readiness.test.ts
@@ -6,8 +6,10 @@ import type {
 } from "../src/app/lib/openwork-server";
 import {
   createCloudMcpSubmissionCoordinator,
+  clearCloudMcpSubmissionFailure,
   decideCloudMcpSubmissionGate,
   ensureCloudMcpSubmissionReadiness,
+  IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
   resolveCloudMcpSubmissionAuth,
   type CloudMcpSubmissionGateDecision,
   type CloudMcpSubmissionPreparationResult,
@@ -158,6 +160,19 @@ function preparation(input: {
 }
 
 describe("Cloud MCP pre-send readiness", () => {
+  test("a successful provider refresh clears only a stale failure", () => {
+    const failed = {
+      status: "failed" as const,
+      issue: failure({ code: "provider_tool_projection_missing" }),
+      attempt: 3,
+      maxAttempts: 3,
+    };
+    const checking = { ...failed, status: "checking" as const };
+
+    expect(clearCloudMcpSubmissionFailure(failed)).toEqual(IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE);
+    expect(clearCloudMcpSubmissionFailure(checking)).toBe(checking);
+  });
+
   test("ready projected tools send immediately", async () => {
     const coordinator = createCloudMcpSubmissionCoordinator();
     const decision = requiredDecision();


### PR DESCRIPTION
## Summary

Fix the stale managed-model state that could leave the composer blocked with “Model no longer available” and a provider-catalog Cloud tools error until users restarted OpenWork or signed out completely.

## Root cause

Lifecycle and product triggers such as sign-in, app resume, model-picker open, and new-chat creation refreshed the OpenCode engine through the provider-auth store, but did not replace the session route’s completed cloud-provider snapshot. The engine could therefore have the current managed model catalog while the renderer continued evaluating model availability against an older snapshot. A previous Cloud readiness failure also remained visible after the catalog recovered. Restarting or signing out recreated the route and incidentally cleared both stale states.

## What changed

- route app-launch, sign-in, resume, model-picker, new-chat, and manual syncs through one refresh path that rereads and publishes the current provider catalog
- preserve the startup cancellation guard while making later lifecycle syncs update live session state
- clear only a failed Cloud readiness banner after a non-null provider catalog refresh; active checking, repairing, and sending states are preserved
- add regression coverage for lifecycle snapshot publication and selective failure clearing

## Verification

Passed:
- corepack pnpm --filter @openwork/app exec bun test src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts tests/cloud-mcp-submit-readiness.test.ts (17 passed, 0 failed, 41 expectations)
- corepack pnpm --filter @openwork/app typecheck
- git diff --check

Live diagnosis:
- the installed app was on 0.18.16
- after restart, its OpenCode provider catalog and stored default were healthy, consistent with reports that route recreation clears the defect

Deferred:
- packaged desktop reproduction of an entitlement change without restart
- broader repository and CI suites

Base: ace4afbd5c26c92f217a2120b0ab1494400c92c5
Head: b015b83442e08a35566cf408ef8d4959829878a8