### PR TITLE
Fix Agent Access model recovery in Settings

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
@@ -18,6 +18,10 @@ const sessionProviderAuthSource = readFileSync(
   new URL("./use-session-provider-auth.ts", import.meta.url),
   "utf8",
 );
+const providerAuthStoreSource = readFileSync(
+  new URL("./store.ts", import.meta.url),
+  "utf8",
+);
 
 describe("managed model sync ordering", () => {
   test("waits to reconcile policy until the first signed-in cloud provider sync settles", () => {
@@ -102,5 +106,14 @@ describe("managed model recovery", () => {
     expect(sessionProviderAuthSource.includes(
       "useCloudProviderAutoSync(store.runCloudProviderSync)",
     )).toBe(false);
+  });
+
+  test("reconciles the stored default after server-managed provider syncs", () => {
+    expect(providerAuthStoreSource.includes(
+      "preselectEntitledOrgDefaultModel(providerList)",
+    )).toBe(true);
+    expect(providerAuthStoreSource.includes(
+      "await refreshProvidersAfterCloudSync({ force: true });",
+    )).toBe(true);
   });
 });

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1791,6 +1791,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     if (replacement) writeStoredDefaultModel(replacement);
   };
 
+  const refreshProvidersAfterCloudSync = async (optionsArg: {
+    dispose?: boolean;
+    force?: boolean;
+  }) => {
+    const providerList = await refreshProviders(optionsArg);
+    preselectEntitledOrgDefaultModel(providerList);
+    return providerList;
+  };
+
   async function performCloudProviderSync(reason: CloudProviderSyncReason) {
     if (!hasCloudProviderSyncPrerequisites()) {
       return;
@@ -1921,10 +1930,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       }
     }
 
-    const syncedProviderList = configChanged
-      ? await refreshProviders({ dispose: true }).catch(() => null)
-      : await refreshProviders({ force: true }).catch(() => null);
-    preselectEntitledOrgDefaultModel(syncedProviderList);
+    await refreshProvidersAfterCloudSync(
+      configChanged ? { dispose: true } : { force: true },
+    ).catch(() => null);
 
     // Notify the UI about newly imported providers so the global toast
     // can be shown regardless of which route is active.
@@ -1970,9 +1978,11 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           }
           return;
         }
-        if (result.status === "applied") {
-          await refreshProviders({ force: true });
-        }
+        // The server may already be synchronized while this route still holds
+        // a removed managed-model default. Always reread the live catalog and
+        // reconcile that preference so Settings diagnostics recover in place,
+        // including after a noop server sync.
+        await refreshProvidersAfterCloudSync({ force: true });
         return { outcome: "handled_server_side" };
       } catch (error) {
         const message = logCloudProviderSyncError(reason, error);


### PR DESCRIPTION
## Summary

Agent Access diagnostics now recover in place when an organization-managed model is removed or replaced. A successful server-managed provider sync always rereads the live provider catalog and reconciles an unavailable stored default, including when the server reports that its own configuration was already synchronized.

## Why

PR #3611 fixed live catalog publication in the session/composer route, but Settings could continue testing the removed model from local preferences. Users could therefore remain stuck on **Current model can’t use Cloud tools** until they navigated away, selected another model, restarted, or signed out.

## Verification

- Passed: 9 focused tests, 14 assertions
- Passed: `pnpm typecheck` in `apps/app`
- Passed: `git diff --check`
- Deferred: packaged desktop entitlement-change reproduction and broad CI

Base: `b4566b8210c4ca0a5cbcc5b40085bd37be285bb4`
Candidate: `c99ad22e0e30c0edef495a8d0dad1c8e347a7816`