### PR TITLE
docs: prefer Daytona for PR verification

### DIFF
--- a/.opencode/skills/prove-a-pr/SKILL.md
+++ b/.opencode/skills/prove-a-pr/SKILL.md
@@ -21,13 +21,19 @@ description: Prove a PR, prepare merge verification, publish all evidence, check
 
 - Use `write-a-spec` and `run-tests`. Prose, screenshots, and recordings never
   decide pass/fail.
+- Prefer Daytona for agent-first verification. Attempt the Daytona lane first
+  when its credentials and service access are available; otherwise run the same
+  checks locally. Missing Daytona credentials, tooling, or service access is an
+  expected OSS contributor fallback, not a failed check.
+- Record whether each check ran on Daytona or locally. When falling back, state
+  the unavailable Daytona prerequisite without exposing secret values.
 - Give every claim an observable assertion and a visible testkit tape.
 - Report only `Passed`, `Incomplete`, or `Failed`. Always quote exact commands,
   exit codes, and passed/failed/skipped counts.
 - Call a failure pre-existing only after the same command demonstrates it in a
   clean `origin/dev` worktree. Quote the control command and matching failure.
 
-## Satisfy local prerequisites
+## Satisfy local fallback prerequisites
 
 ```bash
 pnpm --filter @openwork/types build

--- a/.opencode/skills/run-tests/SKILL.md
+++ b/.opencode/skills/run-tests/SKILL.md
@@ -11,7 +11,17 @@ description: Run the tests, run one spec, run e2e locally or on Daytona, investi
   discard the old verdict and run again.
 - Run one spec at a time so each failure and ambient tape has one owner.
 
-## Prepare local execution
+## Choose the execution environment
+
+- Prefer Daytona when Daytona credentials, tooling, and service access are
+  available. Set `OPENWORK_EVAL_DAYTONA=1` for that run.
+- If Daytona is unavailable, run the same spec locally with
+  `OPENWORK_EVAL_DAYTONA` unset. Missing Daytona access is an expected path for
+  OSS contributors and does not make the verdict fail or incomplete.
+- Record the selected lane. For local fallback, report which Daytona
+  prerequisite was unavailable without printing secret values.
+
+## Prepare local fallback
 
 ```bash
 pnpm --filter @openwork/types build
@@ -40,8 +50,8 @@ pnpm evals:spec specs/<name>.test.ts
 OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/<name>.slow.test.ts
 ```
 
-- Set `OPENWORK_EVAL_DAYTONA=1` to place resources in sandboxes. Leave it unset
-  for isolated local resources.
+- The commands above use Daytona when `OPENWORK_EVAL_DAYTONA=1` is set and
+  isolated local resources when it is unset.
 
 ## Read the verdict
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ evidence tape. Evidence is ambient: do not create or pass roll handles. Report
 otherwise report `Incomplete` or `Failed` with repro steps. Pure docs/comments,
 types-only changes, and inert agent config may skip runtime proof, but say so.
 
+Run agent-first verification through Daytona first when Daytona credentials and
+access are available. If Daytona is unavailable, run the same verification
+locally instead; missing Daytona access is an expected OSS contributor path,
+not a test failure. Report which execution lane was used and why local fallback
+was necessary when applicable.
+
 ## Demo-Driven Development (the paved path)
 
 Feature work starts with the demo, not a PRD:


### PR DESCRIPTION
## Summary
- prefer Daytona for agent-first PR verification when access is available
- fall back to equivalent local verification for OSS contributors
- require reporting the selected execution lane and fallback reason

## Verification
- `git diff --check origin/dev...HEAD`
- Runtime tests not run: documentation and inert agent-skill guidance only; no runtime behavior changed.