### PR TITLE
fix(chat): add assistant copy context menu

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -421,6 +421,7 @@ type AssistantMessageProps = {
 const AssistantMessage = React.memo(
   ({ message, hideReasoning }: AssistantMessageProps) => {
     const { showThinking, highlightQuery } = useMessageList()
+    const messageText = React.useMemo(() => getMessagesText([message]), [message])
     const assistantRenderGroups = React.useMemo(
       () => {
         const groups = getAssistantRenderGroups(message.parts, showThinking)
@@ -428,6 +429,11 @@ const AssistantMessage = React.memo(
       },
       [hideReasoning, message.parts, showThinking]
     )
+    const copyRenderedText = React.useCallback(() => {
+      const selection = window.getSelection()?.toString() ?? ""
+      const text = selection.trim() ? selection : messageText
+      if (text) void navigator.clipboard.writeText(text)
+    }, [messageText])
 
     return (
       <Message
@@ -435,54 +441,77 @@ const AssistantMessage = React.memo(
         data-message-id={message.id}
         data-message-role={message.role}
       >
-        <div className="group flex w-full flex-col gap-0 space-y-2">
-          {assistantRenderGroups.map((group, index) => {
-            if (group.kind === "text") {
-              return (
-                <MessageContent
-                  key={`text-${index}`}
-                  className="text-foreground prose w-full min-w-0 flex-1 rounded-lg bg-transparent p-0"
-                  markdown
-                  highlightQuery={highlightQuery}
-                >
-                  {group.text}
-                </MessageContent>
-              )
-            }
+        <ContextMenu>
+          <ContextMenuTrigger
+            className="!select-text"
+            render={
+              <div
+                className="group flex w-full flex-col gap-0 space-y-2 !select-text"
+                style={{ userSelect: "text" }}
+              >
+                {assistantRenderGroups.map((group, index) => {
+                  if (group.kind === "text") {
+                    return (
+                      <MessageContent
+                        key={`text-${index}`}
+                        className="text-foreground prose w-full min-w-0 flex-1 rounded-lg bg-transparent p-0 !select-text"
+                        style={{ userSelect: "text" }}
+                        markdown
+                        highlightQuery={highlightQuery}
+                      >
+                        {group.text}
+                      </MessageContent>
+                    )
+                  }
 
-            if (group.kind === "reasoning") {
-              return (
-                <ReasoningBlock
-                  key={`reasoning-${index}`}
-                  text={group.text}
-                  isStreaming={group.isStreaming}
-                />
-              )
-            }
+                  if (group.kind === "reasoning") {
+                    return (
+                      <ReasoningBlock
+                        key={`reasoning-${index}`}
+                        text={group.text}
+                        isStreaming={group.isStreaming}
+                      />
+                    )
+                  }
 
-            if (group.kind === "file") {
-              return (
-                <div key={`file-${index}`} className="w-fit max-w-full">
-                  <FileMessage part={group.part} tone="assistant" />
-                </div>
-              )
-            }
+                  if (group.kind === "file") {
+                    return (
+                      <div key={`file-${index}`} className="w-fit max-w-full">
+                        <FileMessage part={group.part} tone="assistant" />
+                      </div>
+                    )
+                  }
 
-            if (group.kind === "tool-aggregate") {
-              return (
-                <div key={`tool-aggregate-${index}`} className="w-full">
-                  <ToolAggregateGroup parts={group.parts} />
-                </div>
-              )
-            }
+                  if (group.kind === "tool-aggregate") {
+                    return (
+                      <div key={`tool-aggregate-${index}`} className="w-full">
+                        <ToolAggregateGroup parts={group.parts} />
+                      </div>
+                    )
+                  }
 
-            return (
-              <div key={`tool-${index}`} className="w-full">
-                <ToolMessage part={group.part} />
+                  return (
+                    <div key={`tool-${index}`} className="w-full">
+                      <ToolMessage part={group.part} />
+                    </div>
+                  )
+                })}
               </div>
-            )
-          })}
-        </div>
+            }
+          />
+          <ContextMenuContent className="w-56">
+            <ContextMenuItem onClick={copyRenderedText}>
+              <Copy className="size-4" />
+              Copy
+            </ContextMenuItem>
+            {messageText ? (
+              <ContextMenuItem onClick={() => void navigator.clipboard.writeText(messageText)}>
+                <Copy className="size-4" />
+                Copy as Markdown
+              </ContextMenuItem>
+            ) : null}
+          </ContextMenuContent>
+        </ContextMenu>
       </Message>
     )
   }

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -148,9 +148,7 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
     if (!(editor instanceof HTMLElement)) return "missing editor";
     editor.focus();
-    const data = new DataTransfer();
-    data.setData("text/plain", ${JSON.stringify(prompt)});
-    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    document.execCommand("insertText", false, ${JSON.stringify(prompt)});
     return editor.innerText;
   })()`);
   expect(composed).toBe(prompt);

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -160,6 +160,10 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     });
   }
 
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "new task action enabled",
+  });
   await control(app, "session.create_task");
   await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
     timeoutMs: 30_000,

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -1,0 +1,242 @@
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "copy-message-markdown-mock";
+const modelId = "copy-message-markdown-model";
+const selectedText = "selected rich phrase";
+const markdownReply = `# Clipboard proof
+
+Rendered **${selectedText}** with \`inline code\`.
+
+- first item
+- second item`;
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "assistant messages copy rendered selections and exact raw Markdown"
+  : "copy message Markdown skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForClipboard(app: Surface, expected: string): Promise<void> {
+  let last = "";
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const value = await evalIn(app, "navigator.clipboard.readText()", { awaitPromise: true });
+    last = typeof value === "string" ? value : String(value);
+    if (last === expected) return;
+    await sleep(100);
+  }
+  throw new Error(`Clipboard did not equal ${JSON.stringify(expected)}; last value was ${JSON.stringify(last)}`);
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      request.resume();
+      request.on("end", () => {
+        const chunks = [
+          { id: "chatcmpl-copy-markdown", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: "chatcmpl-copy-markdown", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: markdownReply }, finish_reason: null }] },
+          { id: "chatcmpl-copy-markdown", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.end("data: [DONE]\n\n");
+      });
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  await using app = await desktop({ name: "copy-message-markdown" });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-copy-message-markdown-${Date.now()}`,
+  });
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Copy message Markdown mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-copy-message-markdown" },
+              models: { [${JSON.stringify(modelId)}]: { name: "Copy message Markdown model" } },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  await control(app, "session.create_task");
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer text action enabled",
+  });
+  await control(app, "composer.set_text", { text: "Show the deterministic Markdown reply." });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer send action enabled",
+  });
+  await control(app, "composer.send");
+
+  await waitFor(app, `(() => {
+    const message = document.querySelector('[data-message-role="assistant"]');
+    return message?.querySelector("h1")?.textContent === "Clipboard proof"
+      && message.querySelector("strong")?.textContent === ${JSON.stringify(selectedText)}
+      && message.querySelector("code")?.textContent === "inline code"
+      && message.querySelectorAll("li").length === 2;
+  })()`, { timeoutMs: 120_000, label: "rich assistant Markdown rendered" });
+  evidence.fact(
+    "The assistant Markdown renders as rich text while remaining selectable",
+    "Observed an h1, strong text, inline code, and two list items in the assistant message.",
+    true,
+  );
+
+  const opened = await evalIn(app, `(() => {
+    const message = document.querySelector('[data-message-role="assistant"]');
+    const strong = message?.querySelector("strong");
+    if (!message || !strong) return false;
+    const range = document.createRange();
+    range.selectNodeContents(strong);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    message.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: 400,
+      clientY: 300,
+    }));
+    return selection?.toString() === ${JSON.stringify(selectedText)};
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `(() => {
+    const labels = [...document.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent?.trim());
+    return labels.includes("Copy") && labels.includes("Copy as Markdown")
+      && window.getSelection()?.toString() === ${JSON.stringify(selectedText)};
+  })()`, { timeoutMs: 10_000, label: "assistant context menu actions and preserved selection" });
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A rich Markdown assistant reply is visible with a context menu containing Copy and Copy as Markdown",
+      "The reply visibly includes a heading, bold text, inline code, and a list",
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  const copiedSelection = await evalIn(app, `(() => {
+    const item = [...document.querySelectorAll('[role="menuitem"]')]
+      .find((entry) => entry.textContent?.trim() === "Copy");
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(copiedSelection).toBe(true);
+  await waitForClipboard(app, selectedText);
+  evidence.fact(
+    "Copy writes the active rendered-text selection",
+    `Clipboard exactly matched ${JSON.stringify(selectedText)} rather than the whole raw message.`,
+    true,
+  );
+
+  await waitFor(app, `!document.querySelector('[role="menuitem"]')`, {
+    timeoutMs: 10_000,
+    label: "context menu closed after Copy",
+  });
+  const reopened = await evalIn(app, `(() => {
+    const message = document.querySelector('[data-message-role="assistant"]');
+    if (!message) return false;
+    message.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: 400,
+      clientY: 300,
+    }));
+    return true;
+  })()`);
+  expect(reopened).toBe(true);
+  await waitFor(app, `[...document.querySelectorAll('[role="menuitem"]')]
+    .some((entry) => entry.textContent?.trim() === "Copy as Markdown")`, {
+    timeoutMs: 10_000,
+    label: "Copy as Markdown action reopened",
+  });
+  const copiedMarkdown = await evalIn(app, `(() => {
+    const item = [...document.querySelectorAll('[role="menuitem"]')]
+      .find((entry) => entry.textContent?.trim() === "Copy as Markdown");
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(copiedMarkdown).toBe(true);
+  await waitForClipboard(app, markdownReply);
+  evidence.fact(
+    "Copy as Markdown writes the exact raw assistant source",
+    `Clipboard exactly preserved heading, bold, inline-code, and list syntax: ${JSON.stringify(markdownReply)}`,
+    true,
+  );
+});

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -144,14 +144,18 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     label: "composer editor ready",
   });
   const prompt = "Show the deterministic Markdown reply.";
-  const composed = await evalIn(app, `(() => {
+  const focused = await evalIn(app, `(() => {
     const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
-    if (!(editor instanceof HTMLElement)) return "missing editor";
+    if (!(editor instanceof HTMLElement)) return false;
     editor.focus();
-    document.execCommand("insertText", false, ${JSON.stringify(prompt)});
-    return editor.innerText;
+    return true;
   })()`);
-  expect(composed).toBe(prompt);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text: prompt });
+  await waitFor(app, `document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText === ${JSON.stringify(prompt)}`, {
+    timeoutMs: 10_000,
+    label: "prompt entered in composer",
+  });
   await clickButton(app, "Run task", { timeoutMs: 30_000 });
 
   await waitFor(app, `(() => {

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -130,6 +130,13 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     return "ok";
   })()`, { awaitPromise: true, timeoutMs: 30_000 });
   expect(configured).toBe("ok");
+  if (process.env.OPENWORK_EVAL_CDP_URL?.trim()) {
+    await evalIn(app, "location.reload(); true");
+    await waitFor(app, "Boolean(window.__openworkControl)", {
+      timeoutMs: 30_000,
+      label: "attached app reloaded with mock provider preferences",
+    });
+  }
 
   await control(app, "session.create_task");
   await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
 import { expect, onTestFinished } from "vitest";
-import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
 import { screenshot, validate } from "@openwork/fraimz";
 import { desktop } from "@openwork/hosts";
@@ -139,16 +139,22 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
   }
 
   await control(app, "session.create_task");
-  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+  await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
     timeoutMs: 30_000,
-    label: "composer text action enabled",
+    label: "composer editor ready",
   });
-  await control(app, "composer.set_text", { text: "Show the deterministic Markdown reply." });
-  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
-    timeoutMs: 30_000,
-    label: "composer send action enabled",
-  });
-  await control(app, "composer.send");
+  const prompt = "Show the deterministic Markdown reply.";
+  const composed = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return "missing editor";
+    editor.focus();
+    const data = new DataTransfer();
+    data.setData("text/plain", ${JSON.stringify(prompt)});
+    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    return editor.innerText;
+  })()`);
+  expect(composed).toBe(prompt);
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
 
   await waitFor(app, `(() => {
     const message = document.querySelector('[data-message-role="assistant"]');

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -22,6 +22,28 @@ const title = appSpecsEnabled
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function rightClick(app: Surface, selector: string): Promise<void> {
+  const rawPoint = await evalIn(app, `(() => {
+    const target = document.querySelector(${JSON.stringify(selector)});
+    if (!(target instanceof HTMLElement)) return "";
+    target.scrollIntoView({ block: "center" });
+    const rect = target.getBoundingClientRect();
+    return JSON.stringify({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+  })()`);
+  if (typeof rawPoint !== "string") throw new Error(`Right-click target did not return coordinates: ${String(rawPoint)}`);
+  const point: unknown = JSON.parse(rawPoint);
+  if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") {
+    throw new Error(`Right-click target did not return valid coordinates: ${rawPoint}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "right", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "right", clickCount: 1 });
+}
+
 async function waitForClipboard(app: Surface, expected: string): Promise<void> {
   let last = "";
   for (let attempt = 0; attempt < 50; attempt += 1) {
@@ -180,16 +202,10 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     const selection = window.getSelection();
     selection?.removeAllRanges();
     selection?.addRange(range);
-    message.dispatchEvent(new MouseEvent("contextmenu", {
-      bubbles: true,
-      cancelable: true,
-      button: 2,
-      clientX: 400,
-      clientY: 300,
-    }));
     return selection?.toString() === ${JSON.stringify(selectedText)};
   })()`);
   expect(opened).toBe(true);
+  await rightClick(app, '[data-message-role="assistant"] strong');
   await waitFor(app, `(() => {
     const labels = [...document.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent?.trim());
     return labels.includes("Copy") && labels.includes("Copy as Markdown")
@@ -225,19 +241,7 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     timeoutMs: 10_000,
     label: "context menu closed after Copy",
   });
-  const reopened = await evalIn(app, `(() => {
-    const message = document.querySelector('[data-message-role="assistant"]');
-    if (!message) return false;
-    message.dispatchEvent(new MouseEvent("contextmenu", {
-      bubbles: true,
-      cancelable: true,
-      button: 2,
-      clientX: 400,
-      clientY: 300,
-    }));
-    return true;
-  })()`);
-  expect(reopened).toBe(true);
+  await rightClick(app, '[data-message-role="assistant"] strong');
   await waitFor(app, `[...document.querySelectorAll('[role="menuitem"]')]
     .some((entry) => entry.textContent?.trim() === "Copy as Markdown")`, {
     timeoutMs: 10_000,

--- a/evals/specs/copy-message-markdown.slow.test.ts
+++ b/evals/specs/copy-message-markdown.slow.test.ts
@@ -77,7 +77,10 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
   if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
   const baseUrl = `http://127.0.0.1:${address.port}/v1`;
 
-  await using app = await desktop({ name: "copy-message-markdown" });
+  await using app = await desktop({
+    name: "copy-message-markdown",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+  });
   const workspace = await createAndSelectWorkspace(app, {
     path: `/tmp/openwork-copy-message-markdown-${Date.now()}`,
   });


### PR DESCRIPTION
## Summary
- add a right-click context menu to assistant messages
- copy the active rendered-text selection with Copy
- copy the exact source Markdown with Copy as Markdown
- add a deterministic desktop spec covering rich rendering and both clipboard paths

## Feedback
Addresses David's report from OpenWork 0.18.6 on macOS that rendered message text had no right-click copy menu or source-Markdown copy path.

## Verification
- Passed: `pnpm --filter @openwork/app typecheck` (Daytona, exit 0)
- Passed: `pnpm --filter @openwork/app build` (Daytona, exit 0)
- Passed: `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_CDP_URL=http://127.0.0.1:9825 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/copy-message-markdown.slow.test.ts` (Daytona, 1 passed)