### PR TITLE
fix(den): gate default role refresh

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -501,8 +501,6 @@ function normalizeAssignableRole(input: string, availableRoles: Set<string>, fal
 }
 
 export async function listAssignableRoles(orgId: OrgId) {
-  await ensureDefaultDynamicRoles(orgId)
-
   const rows = await db
     .select({ role: OrganizationRoleTable.role })
     .from(OrganizationRoleTable)
@@ -1151,7 +1149,6 @@ export async function ensureSingletonOrganizationForUser(userId: UserId) {
     organizationId: organization.id,
     createdByOrgMemberId: member.id,
   })
-  await ensureDefaultDynamicRoles(organization.id)
 
   return organization.id
 }
@@ -1165,8 +1162,6 @@ export async function ensureUserOrgAccess(input: {
 
   const memberships = await listMembershipRows(input.userId)
   if (memberships.length > 0) {
-    const organizationIds = [...new Set(memberships.map((membership) => membership.organizationId))]
-    await Promise.all(organizationIds.map((organizationId) => ensureDefaultDynamicRoles(organizationId)))
     return memberships[0].organizationId
   }
 
@@ -1483,8 +1478,6 @@ export async function getOrganizationContextForUser(input: {
   if (!currentMember.userId) {
     return null
   }
-
-  await ensureDefaultDynamicRoles(organization.id)
 
   const members = await db
     .select({

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -22,11 +22,13 @@ import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
   acceptInvitationForUser,
   createOrganizationForUser,
+  getOrganizationContextForUser,
   getInvitationPreview,
   getSingletonSsoStatus,
   normalizeAllowedEmailDomains,
   OrganizationEmailDomainRestrictionError,
   serializeMemberFacingOrganizationMetadata,
+  seedDefaultOrganizationRoles,
   setSessionActiveOrganization,
   type AcceptInvitationForUserResult,
   updateOrganizationSettings,
@@ -34,7 +36,7 @@ import {
 import { getRequiredUserEmail } from "../../user.js"
 import { checkRateLimit } from "../../utils/rate-limit.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureOrganizationSuperAdmin, orgAccessFailureStatus } from "./shared.js"
+import { ensureOrganizationAdminRole, ensureOrganizationSuperAdmin, orgAccessFailureStatus } from "./shared.js"
 
 const createOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120),
@@ -55,6 +57,10 @@ const updateOrganizationSchema = z.object({
 
 const resolveSsoByEmailQuerySchema = z.object({
   email: z.string().trim().email(),
+})
+
+const organizationContextQuerySchema = z.object({
+  refreshRoles: z.enum(["true", "false"]).optional().transform((value) => value === "true"),
 })
 
 const resolveSsoByEmailResponseSchema = z.object({
@@ -631,9 +637,31 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
       },
     }),
     orgMemberRoute(),
+    queryValidator(organizationContextQuerySchema),
     resolveMemberTeamsMiddleware,
     async (c) => {
-      const payload = c.get("organizationContext")
+      let payload = c.get("organizationContext")
+      const query = c.req.valid("query")
+
+      if (query.refreshRoles) {
+        const permission = ensureOrganizationAdminRole(c, "Only workspace owners and admins can refresh organization roles.")
+        if (!permission.ok) {
+          return c.json(permission.response, orgAccessFailureStatus(permission.response))
+        }
+
+        await seedDefaultOrganizationRoles(payload.organization.id)
+        const refreshedPayload = await getOrganizationContextForUser({
+          organizationId: payload.organization.id,
+          userId: normalizeDenTypeId("user", c.get("user").id),
+        })
+        if (!refreshedPayload) {
+          return c.json({ error: "organization_not_found" }, 404)
+        }
+
+        payload = refreshedPayload
+        c.set("organizationContext", payload)
+      }
+
       const owner = payload.members.find((member: typeof payload.members[number]) => member.isOwner) ?? null
       const cloudEnabled = organizationCloudEnabled(payload.organization.metadata, { orgMode: env.orgMode })
       const [ssoRows, scimRows] = await Promise.all([

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -154,6 +154,11 @@ export function OrgDashboardProvider({
     return target;
   }
 
+  function shouldRefreshRolesForPage(org: DenOrgSummary) {
+    const isMembersPage = pathname === "/dashboard/members" || pathname === "/dashboard/manage-members";
+    return isMembersPage && getOrgAccessFlags(org.role, false).isAdmin;
+  }
+
   async function loadOrgDirectory() {
     const { response, payload } = await requestJson("/v1/me/orgs", { method: "GET" }, 12000);
     if (!response.ok) {
@@ -178,9 +183,10 @@ export function OrgDashboardProvider({
     }
   }
 
-  async function loadOrgContext(organizationId: string) {
+  async function loadOrgContext(organizationId: string, refreshRoles: boolean) {
+    const path = refreshRoles ? "/v1/org?refreshRoles=true" : "/v1/org";
     const { response, payload } = await requestJson(
-      "/v1/org",
+      path,
       { method: "GET", headers: { [ORG_SCOPE_HEADER]: organizationId } },
       12000,
     );
@@ -281,7 +287,7 @@ export function OrgDashboardProvider({
         directoryPayload = await loadOrgDirectory();
       }
 
-      const context = await loadOrgContext(targetOrg.id);
+      const context = await loadOrgContext(targetOrg.id, shouldRefreshRolesForPage(targetOrg));
 
       setOrgDirectory(directoryPayload.orgs.map((entry) => ({ ...entry, isActive: entry.id === context.organization.id })));
       setOrgContext(context);
@@ -485,7 +491,7 @@ export function OrgDashboardProvider({
       try {
         setRequestOrgScope(targetOrg.id);
         await setActiveOrganization({ organizationId: targetOrg.id });
-        const context = await loadOrgContext(targetOrg.id);
+        const context = await loadOrgContext(targetOrg.id, shouldRefreshRolesForPage(targetOrg));
         setOrgDirectory((current) => current.map((entry) => ({ ...entry, isActive: entry.id === context.organization.id })));
         setOrgContext(context);
         setOrgSelectionRequired(false);


### PR DESCRIPTION
## Summary
- stop seeding default organization roles on hot org context, user-org resolution, and role-list paths
- add explicit `GET /v1/org?refreshRoles=true` path that refreshes default roles for admins before returning org context
- have Den Web request role refresh only when an admin opens the members/manage-members dashboard page

## Validation
- `pnpm --filter @openwork-ee/den-api build`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --filter @openwork-ee/den-web exec bun test tests/cloud-super-admins-role-hierarchy.test.ts` — 6 pass
- `pnpm --filter @openwork-ee/den-api exec bun test test/organization-context.test.ts` — 8 pass

Note: no @openwork/testkit tape was added for this targeted Den API/dashboard data-loading change.