### PR TITLE
test(evals): preserve Electron readiness logs

### DIFF
--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { timed } from "@openwork/timeline";
 import { attachSurface, describeAppState, dumpScreenState, isInteractive, probeAppState } from "@openwork/cdp";
 import { resolveHost } from "./resolve.ts";
@@ -15,6 +16,19 @@ function messageText(error: unknown): string {
 
 function logCleanupError(name: string, error: unknown): void {
   console.warn(`[openwork/evals] Desktop ${name} cleanup failed: ${messageText(error)}`);
+}
+
+async function appendDesktopLog(error: unknown, handle: SurfaceHandle): Promise<unknown> {
+  const logPath = handle.meta?.log;
+  if (!logPath) return error;
+  try {
+    const log = await readFile(logPath, "utf8");
+    if (!log.trim()) return error;
+    const tail = log.trimEnd().split(/\r?\n/).slice(-40).join("\n");
+    return new Error(`${messageText(error)}\n\nLast 40 lines of ${logPath}:\n${tail}`, { cause: error });
+  } catch {
+    return error;
+  }
 }
 
 export interface DesktopOptions {
@@ -139,8 +153,9 @@ export async function desktop(opts: DesktopOptions = {}): Promise<DesktopHandle>
       [Symbol.asyncDispose]: dispose,
     };
   } catch (error) {
+    const readinessError = attached ? await appendDesktopLog(error, handle) : error;
     await closeSpawnedSurface(attached, host, handle)
       .catch((cleanupError: unknown) => logCleanupError(handle.name, cleanupError));
-    throw error;
+    throw readinessError;
   }
 }


### PR DESCRIPTION
## Summary
- read the spawned Electron log before failed desktop readiness cleanup removes its profile
- append only the final 40 lines to the readiness error
- preserve the original error unchanged when the log is absent, empty, or unreadable

## Why
While verifying #3615, Electron exposed CDP but Vite had failed, so the renderer stayed blank for three minutes. The test host then deleted the profile and reported only an empty-screen timeout. This change keeps the actionable Vite/Electron failure in the test output for the next run.

## Verification
- Passed: `pnpm exec node --test packages/hosts/test/*.test.ts` from `evals/` (24 passed)
- Focused TypeScript check passed
- Full `pnpm evals:typecheck` reports `MockMcpHandle.handshakes` at `evals/specs/connectors-quick-add.slow.test.ts:253`

Infrastructure-only test harness change; no runtime evidence tape required.