### PR TITLE
fix(server): materialize cloud providers before the first workspace exists

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -47,7 +47,22 @@ export DEN_WEB_ALLOWED_DEV_ORIGINS="${DEN_WEB_ALLOWED_DEV_ORIGINS:-$DEN_WEB_PUBL
 
 DEFAULT_ORIGINS="$DEN_WEB_PUBLIC_URL,$DEN_API_PUBLIC_URL,$DEN_WORKER_PROXY_PUBLIC_URL,http://localhost:$DEN_WEB_PORT,http://127.0.0.1:$DEN_WEB_PORT,http://localhost:$DEN_API_PORT,http://127.0.0.1:$DEN_API_PORT,http://localhost:$DEN_WORKER_PROXY_PORT,http://127.0.0.1:$DEN_WORKER_PROXY_PORT"
 export CORS_ORIGINS="${CORS_ORIGINS:-$DEFAULT_ORIGINS}"
-export DEN_BETTER_AUTH_TRUSTED_ORIGINS="${DEN_BETTER_AUTH_TRUSTED_ORIGINS:-$CORS_ORIGINS}"
+
+# Daytona mints a fresh preview hostname on every preview-url call, so any
+# origin baked at boot goes stale immediately. Trust the preview proxy domain
+# by wildcard (better-auth supports wildcard trusted origins) so rotated
+# preview URLs keep working. Local hosts produce no wildcard.
+PREVIEW_PROXY_HOST="${DEN_WEB_PUBLIC_URL#http://}"
+PREVIEW_PROXY_HOST="${PREVIEW_PROXY_HOST#https://}"
+PREVIEW_PROXY_HOST="${PREVIEW_PROXY_HOST%%/*}"
+PREVIEW_PROXY_WILDCARD=""
+case "$PREVIEW_PROXY_HOST" in
+  localhost*|127.*|0.0.0.0*|\[*) ;;
+  *.*.*)
+    PREVIEW_PROXY_WILDCARD="https://*.${PREVIEW_PROXY_HOST#*.}"
+    ;;
+esac
+export DEN_BETTER_AUTH_TRUSTED_ORIGINS="${DEN_BETTER_AUTH_TRUSTED_ORIGINS:-$CORS_ORIGINS${PREVIEW_PROXY_WILDCARD:+,$PREVIEW_PROXY_WILDCARD}}"
 
 run_root() {
   if [ "$(id -u)" -eq 0 ]; then

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { EnvService } from "./env-file.js";
+import { CloudProviderSync } from "./cloud-provider-sync.js";
 import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
 import {
   readGlobalRuntimeOpencodeConfig,
@@ -155,6 +156,70 @@ afterEach(async () => {
 });
 
 describe("cloud provider sync gateway", () => {
+  test("materializes providers before the first workspace exists and finishes setup later", async () => {
+    const root = await createRoot();
+    const config = serverConfig(root, "https://engine.example.test");
+    config.workspaces = [];
+    let reloads = 0;
+    const engineRequests: string[] = [];
+    const engine = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        engineRequests.push(`${request.method} ${url.pathname}`);
+        return Response.json({ ok: true });
+      },
+    });
+    stops.push(() => engine.stop(true));
+    const den = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/v1/llm-providers") {
+          return Response.json({
+            llmProviders: [buildProvider([{ id: "model-a", name: "Model A", config: {} }])],
+          });
+        }
+        return Response.json({
+          llmProvider: buildProvider([{ id: "model-a", name: "Model A", config: {} }]),
+        });
+      },
+    });
+    stops.push(() => den.stop(true));
+    const sync = new CloudProviderSync({
+      config,
+      env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }),
+      reloadEngine: async () => {
+        reloads += 1;
+      },
+      intervalMs: 3_600_000,
+    });
+    stops.push(() => sync.stop());
+
+    sync.setSession({
+      baseUrl: `http://127.0.0.1:${den.port}`,
+      token: "den-token",
+      orgId: "org_test",
+    });
+    expect((await sync.run("before-workspace")).status).toBe("noop");
+    expect(sync.status().lastRun?.status).toBe("noop");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
+    expect(reloads).toBe(0);
+    expect(engineRequests).toEqual([]);
+
+    config.workspaces.push({
+      id: "ws_1",
+      name: "Workspace",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: `http://127.0.0.1:${engine.port}`,
+    });
+    expect(await sync.run("workspace-created")).toEqual({ status: "applied" });
+    expect(reloads).toBe(1);
+    expect(engineRequests).toContain("PUT /auth/lpr_test");
+  });
+
   test("materializes Den providers globally, reconciles changes, and sweeps the session", async () => {
     const root = await createRoot();
     const engineRequests: string[] = [];

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -610,14 +610,15 @@ export class CloudProviderSync {
 
     const workspaceCleanup = await this.cleanupWorkspaceTakeovers();
     const engineWorkspace = findManagedEngineWorkspace(this.config.workspaces) ?? this.config.workspaces[0];
-    if (!engineWorkspace) throw new Error("workspace_missing");
-    const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
+    const runtimeFileChanged = engineWorkspace
+      ? (await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id)).changed
+      : false;
     this.reloadPending = this.reloadPending
       || providerStateChanged
       || workspaceCleanup.runtimeChanged
-      || fileResult.changed;
+      || runtimeFileChanged;
     let reloadError: unknown;
-    if (this.reloadPending) {
+    if (engineWorkspace && this.reloadPending) {
       try {
         await this.reloadEngine();
         this.reloadPending = false;
@@ -639,7 +640,7 @@ export class CloudProviderSync {
       || envUpserts.length > 0
       || envDeletes.length > 0
       || workspaceCleanup.changed
-      || fileResult.changed;
+      || runtimeFileChanged;
   }
 
   private async cleanupWorkspaceTakeovers(): Promise<{ changed: boolean; runtimeChanged: boolean }> {

--- a/ee/apps/den-api/tsconfig.json
+++ b/ee/apps/den-api/tsconfig.json
@@ -11,10 +11,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "inlineSources": true,
-    "resolveJsonModule": true,
-    "paths": {
-      "sharp": ["./node_modules/sharp/lib/index.d.ts"]
-    }
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/evals/specs/cloud-provider-before-workspace.slow.test.ts
+++ b/evals/specs/cloud-provider-before-workspace.slow.test.ts
@@ -1,0 +1,193 @@
+import { expect, onTestFinished } from "vitest";
+import { denFetch, evalIn, go, readAvailableModels, waitFor, waitForText } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { eventually, needs, server, signInDesktopAs, test } from "@openwork/testkit";
+
+const ORGANIZATION_NAME = "Cloud Provider Before Workspace";
+const PROVIDER_NAME = "First Workspace Models";
+const PROVIDER_KEY = "first-workspace-models";
+const MODEL_ID = "first-workspace-proof-model";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = result.body;
+  const organizations = isRecord(body) && Array.isArray(body.orgs) ? body.orgs.filter(isRecord) : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) throw new Error(`Finding the test organization failed with HTTP ${result.response.status}.`);
+  return id;
+}
+
+async function createProvider(admin: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: ["FIRST_WORKSPACE_PROVIDER_API_KEY"],
+        models: [{ id: MODEL_ID, name: "First Workspace Proof Model" }],
+      },
+      apiKey: "sk-openwork-first-workspace-eval-only",
+      allMembers: true,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = result.body;
+  const provider = isRecord(body) && isRecord(body.llmProvider) ? body.llmProvider : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  if (result.response.status !== 201 || !id) throw new Error(`Creating the provider failed with HTTP ${result.response.status}.`);
+  return id;
+}
+
+async function localServerRequest(
+  app: Parameters<typeof evalIn>[0],
+  path: string,
+  input: { method?: string; body?: Record<string, unknown>; host?: boolean } = {},
+): Promise<Record<string, unknown>> {
+  const result = await evalIn(app, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
+    const headers = { "content-type": "application/json" };
+    if (${input.host === true}) headers["x-openwork-host-token"] = String(info.hostToken ?? "");
+    else headers.authorization = "Bearer " + String(info.ownerToken ?? info.clientToken ?? "");
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + ${JSON.stringify(path)}, {
+      method: ${JSON.stringify(input.method ?? "GET")},
+      headers,
+      body: ${input.body ? JSON.stringify(JSON.stringify(input.body)) : "undefined"},
+    });
+    const text = await response.text();
+    let body = text;
+    try { body = text ? JSON.parse(text) : null; } catch {}
+    return { status: response.status, body };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  if (!isRecord(result)) throw new Error(`Invalid local server response: ${JSON.stringify(result)}`);
+  return result;
+}
+
+test("managed models survive sign-in before the first workspace exists", async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      admin: { name: "Provider Admin" },
+      members: { member: { name: "Provider Member" } },
+    },
+  });
+  const member = den.members.member;
+  if (!member) throw new Error("The testkit did not provision the organization member.");
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId);
+  onTestFinished(async () => {
+    await denFetch(den.admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+      method: "DELETE",
+      headers: { ...auth(den.admin), "x-openwork-org-id": orgId },
+    }).catch(() => undefined);
+  });
+
+  await using desktopApp = await desktop({
+    name: "provider-before-workspace",
+    host: place.host(),
+    bootstrap: {
+      baseUrl: den.ref.webUrl,
+      apiBaseUrl: den.ref.webUrl,
+      requireSignin: false,
+    },
+  });
+  await signInDesktopAs(desktopApp, den.ref, member);
+
+  const initialStatus = await eventually(
+    () => localServerRequest(desktopApp, "/cloud-provider-sync/status"),
+    {
+      within: 120_000,
+      intervalMs: 2_000,
+      label: "provider sync before workspace creation",
+      until: (value) => {
+        const body = isRecord(value.body) ? value.body : {};
+        const lastRun = isRecord(body.lastRun) ? body.lastRun : {};
+        return value.status === 200 && typeof lastRun.status === "string";
+      },
+    },
+  );
+  const initialBody = isRecord(initialStatus.body) ? initialStatus.body : {};
+  const initialLastRun = isRecord(initialBody.lastRun) ? initialBody.lastRun : {};
+  const initialProviders = Array.isArray(initialBody.providers) ? initialBody.providers.filter(isRecord) : [];
+  const initialSucceeded = initialLastRun.status !== "failed"
+    && initialLastRun.message !== "workspace_missing"
+    && initialProviders.some((provider) => provider.name === PROVIDER_NAME);
+  evidence.fact(
+    "Provider sync succeeds before a workspace exists",
+    `Sync status: ${JSON.stringify(initialBody)}`,
+    initialSucceeded,
+  );
+  expect(initialSucceeded).toBe(true);
+
+  const workspacePath = `/tmp/openwork-provider-before-workspace-${Date.now()}`;
+  const created = await localServerRequest(desktopApp, "/workspaces/local", {
+    method: "POST",
+    host: true,
+    body: { folderPath: workspacePath, name: "First Workspace", preset: "starter" },
+  });
+  const createdBody = isRecord(created.body) ? created.body : {};
+  const workspaceId = typeof createdBody.activeId === "string" ? createdBody.activeId : "";
+  expect(created.status).toBe(201);
+  expect(workspaceId).not.toBe("");
+
+  // The workspace was created through the server API, not the renderer, so
+  // reload once to re-hydrate the app's workspace list before navigating.
+  await evalIn(desktopApp, "(() => { window.location.reload(); return true; })()");
+  await waitFor(desktopApp, "Boolean(document.body && document.body.innerText.trim().length > 0)", {
+    timeoutMs: 60_000,
+    label: "renderer back after reload",
+  });
+  await go(desktopApp, `/workspace/${workspaceId}/session`);
+  await waitForText(desktopApp, "Power your first task", { timeoutMs: 120_000 });
+  const models = await eventually(
+    () => readAvailableModels(desktopApp),
+    {
+      within: 120_000,
+      intervalMs: 3_000,
+      label: "managed model after first workspace creation",
+      until: (candidates) => candidates.some((candidate) => candidate.id === MODEL_ID && candidate.selectable),
+    },
+  );
+  const model = models.find((candidate) => candidate.id === MODEL_ID && candidate.selectable);
+  evidence.fact(
+    "The first workspace receives the already-synced model without restarting",
+    `Selectable model: ${JSON.stringify(model)}`,
+    model?.id === MODEL_ID && model.selectable,
+  );
+  expect(model?.id).toBe(MODEL_ID);
+  expect(model?.selectable).toBe(true);
+
+  const finalStatus = await localServerRequest(desktopApp, "/cloud-provider-sync/status");
+  const finalBody = isRecord(finalStatus.body) ? finalStatus.body : {};
+  const finalLastRun = isRecord(finalBody.lastRun) ? finalBody.lastRun : {};
+  const noWorkspaceFailure = finalLastRun.status !== "failed" && finalLastRun.message !== "workspace_missing";
+  evidence.fact(
+    "Workspace creation does not reintroduce the sync failure",
+    `Final sync status: ${JSON.stringify(finalBody)}`,
+    noWorkspaceFailure,
+  );
+  expect(noWorkspaceFailure).toBe(true);
+});

--- a/evals/specs/cloud-provider-before-workspace.slow.test.ts
+++ b/evals/specs/cloud-provider-before-workspace.slow.test.ts
@@ -1,5 +1,5 @@
 import { expect, onTestFinished } from "vitest";
-import { denFetch, evalIn, go, readAvailableModels } from "@openwork/behaviors";
+import { createAndSelectWorkspace, denFetch, evalIn, readAvailableModels } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
 import { desktop } from "@openwork/hosts";
 import { eventually, needs, server, signInDesktopAs, test } from "@openwork/testkit";
@@ -165,36 +165,12 @@ test("managed models survive sign-in before the first workspace exists", async (
   );
   expect(initialSucceeded).toBe(true);
 
+  // The first workspace is created through the product itself: organization
+  // onboarding plus the app's workspace.create action, the same journey a
+  // person takes right after this sign-in.
   const workspacePath = `/tmp/openwork-provider-before-workspace-${Date.now()}`;
-  const created = await localServerRequest(desktopApp, "/workspaces/local", {
-    method: "POST",
-    host: true,
-    body: { folderPath: workspacePath, name: "First Workspace", preset: "starter" },
-  });
-  const createdBody = isRecord(created.body) ? created.body : {};
-  const workspaceId = typeof createdBody.activeId === "string" ? createdBody.activeId : "";
-  expect(created.status).toBe(201);
+  const { workspaceId } = await createAndSelectWorkspace(desktopApp, { path: workspacePath });
   expect(workspaceId).not.toBe("");
-
-  // The workspace was created through the server API, not the renderer. The
-  // route store refreshes on workspace changes, so steer to the session route
-  // until the composer surface appears (bounded, re-navigating each probe).
-  await eventually(
-    async () => {
-      await go(desktopApp, `/workspace/${workspaceId}/session`);
-      const seen = await evalIn(
-        desktopApp,
-        `document.body.innerText.includes("Power your first task")`,
-        { timeoutMs: 8_000 },
-      ).catch(() => false);
-      return seen === true;
-    },
-    {
-      within: 120_000,
-      intervalMs: 5_000,
-      label: "session route for the first workspace",
-    },
-  );
   const models = await eventually(
     () => readAvailableModels(desktopApp),
     {

--- a/evals/specs/cloud-provider-before-workspace.slow.test.ts
+++ b/evals/specs/cloud-provider-before-workspace.slow.test.ts
@@ -116,10 +116,33 @@ test("managed models survive sign-in before the first workspace exists", async (
   });
   await signInDesktopAs(desktopApp, den.ref, member);
 
+  // Deliver the Den session to the local server the same way the desktop
+  // runtime does (PUT /den-session), while zero workspaces exist. This is the
+  // exact state that used to fail every sync with workspace_missing.
+  const sessionPush = await localServerRequest(desktopApp, "/den-session", {
+    method: "PUT",
+    host: true,
+    body: { baseUrl: den.ref.apiUrl, token: member.token, orgId },
+  });
+  expect(sessionPush.status).toBe(204);
+  const syncRun = await localServerRequest(desktopApp, "/cloud-provider-sync/run", {
+    method: "POST",
+    host: true,
+    body: { reason: "eval_before_workspace" },
+  });
+  const syncRunBody = isRecord(syncRun.body) ? syncRun.body : {};
+  evidence.fact(
+    "A sync with zero workspaces no longer fails with workspace_missing",
+    `Run result: ${JSON.stringify(syncRunBody)}`,
+    syncRun.status === 200 && (syncRunBody.status === "applied" || syncRunBody.status === "noop"),
+  );
+  expect(syncRun.status).toBe(200);
+  expect(syncRunBody.status === "applied" || syncRunBody.status === "noop", JSON.stringify(syncRunBody)).toBe(true);
+
   const initialStatus = await eventually(
     () => localServerRequest(desktopApp, "/cloud-provider-sync/status"),
     {
-      within: 120_000,
+      within: 60_000,
       intervalMs: 2_000,
       label: "provider sync before workspace creation",
       until: (value) => {

--- a/evals/specs/cloud-provider-before-workspace.slow.test.ts
+++ b/evals/specs/cloud-provider-before-workspace.slow.test.ts
@@ -1,5 +1,5 @@
 import { expect, onTestFinished } from "vitest";
-import { denFetch, evalIn, go, readAvailableModels, waitFor, waitForText } from "@openwork/behaviors";
+import { denFetch, evalIn, go, readAvailableModels } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
 import { desktop } from "@openwork/hosts";
 import { eventually, needs, server, signInDesktopAs, test } from "@openwork/testkit";
@@ -176,15 +176,25 @@ test("managed models survive sign-in before the first workspace exists", async (
   expect(created.status).toBe(201);
   expect(workspaceId).not.toBe("");
 
-  // The workspace was created through the server API, not the renderer, so
-  // reload once to re-hydrate the app's workspace list before navigating.
-  await evalIn(desktopApp, "(() => { window.location.reload(); return true; })()");
-  await waitFor(desktopApp, "Boolean(document.body && document.body.innerText.trim().length > 0)", {
-    timeoutMs: 60_000,
-    label: "renderer back after reload",
-  });
-  await go(desktopApp, `/workspace/${workspaceId}/session`);
-  await waitForText(desktopApp, "Power your first task", { timeoutMs: 120_000 });
+  // The workspace was created through the server API, not the renderer. The
+  // route store refreshes on workspace changes, so steer to the session route
+  // until the composer surface appears (bounded, re-navigating each probe).
+  await eventually(
+    async () => {
+      await go(desktopApp, `/workspace/${workspaceId}/session`);
+      const seen = await evalIn(
+        desktopApp,
+        `document.body.innerText.includes("Power your first task")`,
+        { timeoutMs: 8_000 },
+      ).catch(() => false);
+      return seen === true;
+    },
+    {
+      within: 120_000,
+      intervalMs: 5_000,
+      label: "session route for the first workspace",
+    },
+  );
   const models = await eventually(
     () => readAvailableModels(desktopApp),
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   fast-uri@>=3.0.0 <3.1.5: 3.1.5
   fast-xml-parser@>=5.0.0 <5.7.0: 5.7.0
   form-data@>=4.0.0 <4.0.6: 4.0.6
-  esbuild: 0.28.1
+  esbuild: 0.25.12
   better-call: 1.3.7
   hono@<4.12.34: 4.12.34
   ip-address@>=10.0.0 <10.3.1: 10.3.1
@@ -1749,158 +1749,158 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4926,7 +4926,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -5575,10 +5575,10 @@ packages:
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9586,7 +9586,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -9594,82 +9594,82 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.14.0
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -10992,7 +10992,7 @@ snapshots:
 
   '@react-email/ui@6.9.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       next: 16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
@@ -12621,9 +12621,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bundle-require@5.1.0(esbuild@0.28.1):
+  bundle-require@5.1.0(esbuild@0.25.12):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       load-tsconfig: 0.2.5
 
   busboy@1.6.0:
@@ -12987,8 +12987,8 @@ snapshots:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.28.1
-      esbuild-register: 3.6.0(esbuild@0.28.1)
+      esbuild: 0.25.12
+      esbuild-register: 3.6.0(esbuild@0.25.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -13200,41 +13200,41 @@ snapshots:
   es6-error@4.1.1:
     optional: true
 
-  esbuild-register@3.6.0(esbuild@0.28.1):
+  esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
 
-  esbuild@0.28.1:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -15047,7 +15047,7 @@ snapshots:
       conf: 15.1.0
       css-tree: 3.2.1
       debounce: 2.2.0
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       glob: 13.0.6
       jiti: 2.6.1
       log-symbols: 7.0.1
@@ -15948,12 +15948,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.1)
+      bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -15976,7 +15976,7 @@ snapshots:
 
   tsx@4.23.1:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -16141,7 +16141,7 @@ snapshots:
 
   vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
       postcss: 8.5.23
@@ -16158,7 +16158,7 @@ snapshots:
 
   vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
       postcss: 8.5.23

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,10 @@ overrides:
   "fast-uri@>=3.0.0 <3.1.5": 3.1.5
   "fast-xml-parser@>=5.0.0 <5.7.0": 5.7.0
   "form-data@>=4.0.0 <4.0.6": 4.0.6
-  esbuild: 0.28.1
+  # 0.25.12 keeps the >=0.25.0 dev-server CORS fix. Do not bump to 0.28.x:
+  # its browser-name target lists (Vite optimizeDeps defaults) refuse to
+  # lower plain destructuring, which kills `vite dev` on every fresh install.
+  esbuild: 0.25.12
   better-call: 1.3.7
   "hono@<4.12.34": 4.12.34
   "ip-address@>=10.0.0 <10.3.1": 10.3.1


### PR DESCRIPTION
## What

A Den session that lands before any workspace exists (fresh sign-in on a clean profile) failed every cloud provider sync with `workspace_missing` — the exact "Cloud provider sync failed: workspace missing" report from the Enterprise (Grant Hamm) call. Providers and credentials now materialize globally right away; the engine runtime-config write and reload are deferred until the first workspace appears, then complete on the next sync.

Three infrastructure defects blocked proving this end-to-end and are fixed here because the verification lane is unusable without them:

- `ee/apps/den-api/tsconfig.json` still path-mapped `sharp` to a `.d.ts` removed in sharp 0.35, crashing every tsx-run Den API boot (Daytona server sandboxes never became healthy).
- `pnpm-workspace.yaml` pinned esbuild to 0.28.1 (#3588), which refuses to lower plain destructuring for browser-name target lists — Vite's optimizeDeps defaults — so `vite dev` died with ~3000 errors on every **fresh install** since Aug 6 (stale local `node_modules` hid it). Pinned to 0.25.12, which keeps the >=0.25.0 dev-server CORS fix.
- Daytona now mints a fresh preview hostname per `preview-url` call, so Den trusted origins baked at boot went stale immediately and the testkit's seed proof failed with `INVALID_ORIGIN`. The eval Den stack now trusts the preview proxy domain by wildcard.

## Regression coverage

- `apps/server/src/cloud-provider-sync.e2e.test.ts`: sync with zero workspaces materializes providers globally, performs no engine calls, then finishes setup (runtime file, auth delivery, reload) once the first workspace exists.
- `evals/specs/cloud-provider-before-workspace.slow.test.ts`: signs into a fresh desktop **before any workspace exists**, delivers the Den session, asserts the sync run returns `applied|noop` (pre-fix: `failed / workspace_missing`), creates the first workspace through the product's own onboarding, and asserts the managed model is selectable without a restart.

## Verification

- Daytona cold boot (fresh Den + desktop sandboxes from this head):
  `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/cloud-provider-sync-before-first-workspace pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/cloud-provider-before-workspace.slow.test.ts`
  → exit 0, **1 passed / 0 failed / 0 skipped** (204s)
- Server regression: `pnpm --filter openwork-server test -- src/cloud-provider-sync.e2e.test.ts` → **2 pass / 0 fail**
- `pnpm --filter openwork-server typecheck` → clean
- Local `vite dev` serves 200 after the esbuild pin; before it, every fresh install failed the Vite prewarm gate.

Testkit evidence tape published below.