### PR TITLE
fix(release): route command through release scripts

### DIFF
--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -8,14 +8,29 @@ Arguments: `$ARGUMENTS`
 - If empty, default to a patch release.
 - If set to `minor` or `major`, use that bump type.
 
-Do the following, in order, and stop on any failure:
+Load and follow `.opencode/skills/release/SKILL.md`; `docs/RELEASING.md` is the
+full runbook. Use the tag-first path unless the user explicitly requests
+PR-first.
 
-1. Sync `dev` and ensure the working tree is clean.
-2. Bump app/desktop versions using `pnpm bump:$ARGUMENTS` (or `pnpm bump:patch` if empty).
-3. If any dependencies were pinned or changed, run `pnpm install --lockfile-only`.
-4. Run `pnpm release:review` and resolve any mismatches.
-5. Tag and push: `git tag vX.Y.Z` and `git push origin vX.Y.Z`, then `git push origin dev`.
-6. Watch the Release App GitHub Actions workflow to completion.
-7. If the `openwork-server` version changed, publish that package.
+1. Fetch `origin/dev`. Work only from a clean checkout based on its current
+   tip. If the user's checkout is dirty or `dev` is already checked out, create
+   an isolated release worktree and leave the original checkout untouched.
+2. Run `pnpm release:prepare:dry -- <bump>`, then
+   `pnpm release:prepare -- <bump>`. In an isolated branch worktree, pass
+   `--ci` only after independently confirming the branch is based on current
+   `origin/dev` and the worktree is clean.
+3. Run `pnpm release:ship`. A rejected direct push to protected `dev` is
+   expected: `release:ship` must push a `release/vX.Y.Z-dev-sync` branch and
+   open the backfill PR. Never bypass or force-push `dev`.
+4. Watch the matching `Release App` run through completion. The release is not
+   done until `Publish GitHub Release` succeeds and the release is public.
+5. Get the version backfill PR approved and merged. If the workflow opens an
+   AUR packaging PR, report its URL, wait for it to merge, then rerun Release
+   App with the same tag as described by the release skill.
+6. Verify the public release assets resolve, `npm view openwork-server version`
+   matches the tag, and the latest relevant Daytona snapshot run is green.
 
-Report what you changed, the tag created, and the GHA status.
+Diagnose unexpected failures instead of treating Node runtime deprecation
+warnings or the expected protected-branch rejection as release failures.
+Report the tag, release URL, workflow verdict, merged backfill PR, npm version,
+public asset check, and any non-blocking channel status.


### PR DESCRIPTION
## Summary\n- make /release load the repository release skill and runbook\n- use release:prepare and release:ship instead of manually pushing protected dev\n- require backfill merge, public asset/npm checks, and Daytona status before completion\n\n## Verification\n- pnpm release:review passed during v0.18.18\n- documentation-only command change; runtime testkit proof is not applicable