### PR TITLE
chore(aur): refresh PKGBUILD checksums for 0.18.18

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -20,8 +20,8 @@ pkgbase = openwork
 	depends = hicolor-icon-theme
 	options = !strip
 	source_x86_64 = openwork-0.18.18-x64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.18/openwork-linux-x64-0.18.18.tar.gz
-	sha256sums_x86_64 = 4b77fe7f70cf4f037b4043efa173501a6f18fe7947c33efdfda8e26c59668085
+	sha256sums_x86_64 = 18a0da287d73f90aacf0dc40b847825201440a2112bff95b9dc1da1aa89b2593
 	source_aarch64 = openwork-0.18.18-arm64.tar.gz::https://github.com/different-ai/openwork/releases/download/v0.18.18/openwork-linux-arm64-0.18.18.tar.gz
-	sha256sums_aarch64 = b32da47e16ada6ae8ef9c561db5a5df7af76d3abcf165afa31127c21741b22a0
+	sha256sums_aarch64 = 7c3379cb4751074c4c7dfb17ceeac229b93f4a5b0519f2e7594ce5fa164f1d40
 
 pkgname = openwork

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -10,10 +10,10 @@ options=(!strip)
 
 # Architecture-specific sources and checksums
 source_x86_64=("${pkgname}-${pkgver}-x64.tar.gz::${url}/releases/download/v${pkgver}/openwork-linux-x64-${pkgver}.tar.gz")
-sha256sums_x86_64=('4b77fe7f70cf4f037b4043efa173501a6f18fe7947c33efdfda8e26c59668085')
+sha256sums_x86_64=('18a0da287d73f90aacf0dc40b847825201440a2112bff95b9dc1da1aa89b2593')
 
 source_aarch64=("${pkgname}-${pkgver}-arm64.tar.gz::${url}/releases/download/v${pkgver}/openwork-linux-arm64-${pkgver}.tar.gz")
-sha256sums_aarch64=('b32da47e16ada6ae8ef9c561db5a5df7af76d3abcf165afa31127c21741b22a0')
+sha256sums_aarch64=('7c3379cb4751074c4c7dfb17ceeac229b93f4a5b0519f2e7594ce5fa164f1d40')
 
 package() {
   cd "${srcdir}"


### PR DESCRIPTION
Updates AUR packaging checksums after the v0.18.18 release assets were rebuilt during transient-failure recovery. The workflow branch was rewritten with a verified signed commit because dev requires signed commits and the workflow's GITHUB_TOKEN cannot create pull requests.