### PR TITLE
fix(evals): detach the Daytona install gate from the exec channel

### DIFF
--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -233,12 +233,42 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
   });
 
   await timedStep(log, "install gate", async () => {
-    await execInSandbox(
+    // pnpm's progress stream over a long-lived `daytona exec` session was
+    // observed wedging the session past every local timeout, so the install
+    // runs detached with its output in a file, and childless polls read back
+    // an explicit exit sentinel — the same shape as the boot and Vite gates.
+    const detachScript = `rm -f /tmp/install-gate.log; python3 - <<PYEOF
+import subprocess
+log = open("/tmp/install-gate.log", "ab", buffering=0)
+subprocess.Popen(["bash", "-lc", "cd /workspace && pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store; echo INSTALL_EXIT=$?"], stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+    await execInSandbox(exec, sandbox, detachScript, { timeoutMs: 30_000, context: `install detach for ${sandbox}` });
+    const deadline = Date.now() + INSTALL_TIMEOUT_MS;
+    let exitCode: number | null = null;
+    while (Date.now() < deadline) {
+      const probe = await execInSandbox(
+        exec,
+        sandbox,
+        "grep -o \"INSTALL_EXIT=[0-9]*\" /tmp/install-gate.log 2>/dev/null || echo INSTALL_RUNNING",
+        { timeoutMs: 15_000, context: `install probe for ${sandbox}` },
+      ).catch(() => null);
+      const match = probe ? /INSTALL_EXIT=(\d+)/.exec(probe.stdout) : null;
+      if (match) {
+        exitCode = Number.parseInt(match[1], 10);
+        break;
+      }
+      await delay(10_000);
+    }
+    if (exitCode === 0) return;
+    const installLog = await execInSandbox(
       exec,
       sandbox,
-      "cd /workspace; pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store",
-      { timeoutMs: INSTALL_TIMEOUT_MS, context: `install gate for ${sandbox}` },
-    );
+      "tail -40 /tmp/install-gate.log 2>&1 || true",
+      { timeoutMs: 30_000, context: `install log for ${sandbox}` },
+    ).catch(() => null);
+    const reason = exitCode === null ? `did not finish within ${INSTALL_TIMEOUT_MS}ms` : `exited ${exitCode}`;
+    throw new Error(`Install gate failed for ${sandbox}: pnpm install ${reason}. Log tail:\n${installLog ? outputTail(installLog) : "unavailable"}`);
   });
 
   await timedStep(log, "cleanup and disk gate", async () => {


### PR DESCRIPTION
## Scope change after rebase

The original content of this PR — the `workspace_missing` server fix, the regression test, the testkit spec, the esbuild 0.25.12 pin, the rotated-preview-origin trust, and the den-api tsconfig fix — landed on `dev` via #3621. After rebasing onto current `dev` (`71bc6e7fe`), this PR carries exactly one remaining commit.

## Problem

A long `pnpm install` streaming progress over a single `daytona exec` session was observed wedging past every local timeout — the install gate sat stuck for 40+ minutes on a sandbox whose install had already finished (`INSTALL_TIMEOUT_MS` is 25 minutes and never fired).

## Fix

Run the install detached with its output in a file and poll a childless `INSTALL_EXIT=<code>` sentinel instead — the same shape as the first-boot and Vite prewarm gates in the same file. Timeouts and non-zero exits surface the log tail.

## Verification (agent-first, real Daytona)

Verdict: **Passed** (on PR head `8e76c0eb1` = `dev` + this commit)

- `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/cloud-provider-sync-before-first-workspace pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/cloud-provider-before-workspace.slow.test.ts` → 1 passed; tape 4/4 facts (sticky comment below, SHA-matched). The install gate in this PR is exercised by the desktop-sandbox provisioning of that run.
- The same run re-proves the #3621 fix on current `dev`: sync succeeds with zero workspaces and `/cloud-provider-sync/status` lists the managed provider before the first workspace exists — the exact data source behind the previously persistent “Syncing” badge in Settings → AI providers (`cloud-providers-view.tsx` maps empty `status.providers` to a perpetual `syncing` row state).

Historical evidence from before the rebase (same spec, prior head `3f1b9c715`): RED counterfactual on the unfixed ref failed exactly with `{"status":"failed","message":"workspace_missing"}`; GREEN passed 4/4 tape facts.
