### PR TITLE
fix(evals): bootstrap the isolated Den instead of pushing its schema

### DIFF
--- a/evals/scripts/dev-den.ts
+++ b/evals/scripts/dev-den.ts
@@ -15,8 +15,8 @@ const USAGE = `Usage:
   pnpm --dir evals dev:den -- up [--port <port>] [--database <name>] [--seed]
   pnpm --dir evals dev:den -- down --port <port> [--drop-database]
 
-The up command creates an isolated database, pushes the current schema with
-db:push, starts den-api in multi-org dev mode, waits for /health, and prints the
+The up command creates an isolated database, initializes it with
+db:bootstrap, starts den-api in multi-org dev mode, waits for /health, and prints the
 OPENWORK_EVAL_DEN_* exports. The generated trusted origins always include the
 printed web URL; omitting it causes Better Auth 403 INVALID_ORIGIN responses.`;
 
@@ -191,9 +191,19 @@ async function createDatabase(database: string): Promise<void> {
   ]);
 }
 
-async function pushSchema(state: DevDenState): Promise<void> {
-  console.log(`Pushing schema to ${state.database} with db:push...`);
-  await run("pnpm", ["--filter", "@openwork-ee/den-db", "db:push"], denEnvironment(state));
+async function applySchema(state: DevDenState): Promise<void> {
+  // Uses db:bootstrap, the same entrypoint a real Den install runs, rather than
+  // re-deriving DDL with db:push.
+  //
+  // push regenerates a prefix-length index as ``token`(191)`` — doubled
+  // backticks — which MySQL rejects with a 1064 parse error, so an isolated Den
+  // could never finish standing up. bootstrap instead initializes an empty
+  // database from the build-time schema snapshot and records the committed
+  // migrations as its baseline, so the eval Den is built the way a deployment
+  // is. Plain db:migrate is not an option here: the ledger is baselined, so on
+  // an empty database it has nothing to create the base tables from.
+  console.log(`Bootstrapping ${state.database} from the current schema snapshot...`);
+  await run("pnpm", ["--filter", "@openwork-ee/den-db", "db:bootstrap"], denEnvironment(state));
 }
 
 async function seedDemoOrg(state: DevDenState): Promise<void> {
@@ -222,7 +232,7 @@ async function up(portValue: string | undefined, databaseValue: string | undefin
   };
 
   await createDatabase(database);
-  await pushSchema(state);
+  await applySchema(state);
   await ensurePortFree(port);
 
   const logFd = openSync(state.logPath, "w");


### PR DESCRIPTION
`pnpm --dir evals dev:den -- up` cannot finish on a fresh database.

## Problem

`db:push` re-derives DDL from the schema and renders a prefix-length index with doubled backticks:

```sql
CREATE INDEX `oauth_access_token_token` ON `oauthAccessToken` (``token`(191)`);
```

MySQL rejects it, and the helper dies before den-api starts:

```
ER_PARSE_ERROR 1064: ...check the manual... near 'token`(191)`)' at line 1
```

The committed migration for the same index is correct — `drizzle/0046_messy_reaper.sql` has ``ON `oauthAccessToken` (`token`(191))`` — so the defect is in re-deriving the DDL, not in the schema.

## Fix

Use `db:bootstrap`, the entrypoint a real Den install runs. It initializes an empty database from the build-time schema snapshot, then records the committed migrations as its baseline. This avoids the `push` code path entirely, and builds an eval Den the same way a deployment is built.

`db:migrate` alone does not work here: the migration ledger is baselined, so on an empty database there is nothing to create the base tables from and the first `ALTER` fails with `Table 'worker' doesn't exist`.

## Verification

Against a fresh database. Before, `db:push` fails with the 1064 above. After:

```
[den-db] empty database detected; applying current schema snapshot
[den-db] recording 56 committed migrations as baseline
[den-db] running committed migrations
[den-db] ensuring FULLTEXT indexes
[den-db] memory.content FULLTEXT index created
[den-db] ensuring schema repairs
```

One file, evals tooling only. No product or schema changes.

## Known follow-up

This unblocks the database step only. den-api can still fail to start afterwards when tsx compiles sharp's `lib/index.d.ts` as CJS:

```
ReferenceError: sharp is not defined
  at .../sharp@0.35.3/node_modules/sharp/lib/index.d.ts:1999
```

`sharp@0.35.3` exports `dist/index.cjs` for `require`, and `require.resolve("sharp")` from `ee/apps/den-api` resolves there correctly, so this looks like a resolver disagreement rather than a missing build. Separate problem, not addressed here.
