### PR TITLE
test(evidence): fail loudly when frames cannot upload

### DIFF
--- a/.opencode/skills/publish-evidence/SKILL.md
+++ b/.opencode/skills/publish-evidence/SKILL.md
@@ -19,22 +19,20 @@ test.
 
 ## Publish the PR head
 
-After a multi-spec run, publish every tape whose `gitSha` matches the PR head:
+After a multi-spec run, publish each tape whose `gitSha` matches the PR head:
 
 ```bash
-pnpm fraimz:publish -- --pr <n> --all
+pnpm fraimz:publish --pr <n> --roll <roll-directory-name>
 ```
 
 `fraimz:publish` is an implementation-compatibility command name. It publishes
-existing `@openwork/testkit` tapes, not legacy flows.
+existing `@openwork/testkit` tapes, not legacy flows. There is no `--all` flag;
+run the command once per matching roll under `evals/results/rolls/`. Without
+`--roll` it selects the newest roll, which is wrong after a multi-spec run.
 
-- `--all` processes matching rolls chronologically and prints why stale or
-  malformed rolls were skipped.
-- Do not combine `--all` with `--roll`, `--force`, `--dry-run`, or `--open`.
 - Publishing accumulates sections in one sticky comment. Publishing a new spec
   preserves existing sections; republishing the same spec replaces only that
   spec's section. Confirm the summary lists every spec and verdict.
-- Use `--roll <dir|name>` only to publish one selected existing tape.
 
 ## Refuse misleading evidence
 
@@ -43,5 +41,11 @@ existing `@openwork/testkit` tapes, not legacy flows.
   output is annotated; call the exception out explicitly. Red tapes are valid
   human-verification artifacts and should be published when they explain a
   `Failed` or `Incomplete` verdict.
-- Read `BLOB_READ_WRITE_TOKEN` from the environment or the Infisical fallback.
-  Without it, still post verdicts with a no-screenshots note.
+- The publisher reads `BLOB_READ_WRITE_TOKEN` from the environment, then falls
+  back to `infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent`. When
+  a roll has frames and neither source yields a token, publishing fails and the
+  error quotes the fallback's failure; fix the token (see `get-env-var`) and
+  republish instead of retrying blind.
+- Pass `--no-screenshots` only to deliberately post a frameful verdict without
+  its frames, and call that exception out in the report and PR comment.
+  Facts-only rolls publish normally without a token.

--- a/evals/packages/evidence/bin/publish-pr.mjs
+++ b/evals/packages/evidence/bin/publish-pr.mjs
@@ -13,6 +13,7 @@ let rollArg;
 let dryRun = false;
 let force = false;
 let shouldOpen = false;
+let noScreenshots = false;
 
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index];
@@ -27,6 +28,10 @@ for (let index = 0; index < args.length; index += 1) {
   }
   if (arg === "--open") {
     shouldOpen = true;
+    continue;
+  }
+  if (arg === "--no-screenshots") {
+    noScreenshots = true;
     continue;
   }
   if (arg === "--pr" || arg === "--roll") {
@@ -73,5 +78,5 @@ if (shouldOpen) {
   process.exit(0);
 }
 
-const result = await publishPr({ pr, rollDir, dryRun, force });
+const result = await publishPr({ pr, rollDir, dryRun, force, noScreenshots });
 if (!dryRun) process.stdout.write(`${result.updated ? "Updated" : "Posted"} photo roll for PR ${pr}.\n`);

--- a/evals/packages/evidence/src/publish-pr.ts
+++ b/evals/packages/evidence/src/publish-pr.ts
@@ -32,6 +32,8 @@ export interface PublishPrOptions {
   rollDir: string;
   dryRun?: boolean;
   force?: boolean;
+  /** Deliberately publish the verdict without uploading frames. */
+  noScreenshots?: boolean;
 }
 
 export interface PublishPrResult {
@@ -71,15 +73,24 @@ function shortSha(sha: string): string {
   return sha.slice(0, 7);
 }
 
-function resolveBlobToken(exec: CommandRunner): string | null {
+type BlobTokenResolution =
+  | { token: string }
+  | { token: null; detail: string };
+
+function resolveBlobToken(exec: CommandRunner): BlobTokenResolution {
   const fromEnv = process.env.BLOB_READ_WRITE_TOKEN;
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return { token: fromEnv };
   const result = exec(
     "infisical",
     ["secrets", "get", "BLOB_READ_WRITE_TOKEN", "--plain", "--silent"],
   );
-  const token = result.status === 0 && !result.error ? result.stdout.trim() : "";
-  return token.length > 0 ? token : null;
+  if (result.status !== 0 || result.error) {
+    const detail = result.error?.message ?? (result.stderr.trim() || `exit ${result.status}`);
+    return { token: null, detail: `the infisical fallback failed (${detail})` };
+  }
+  const token = result.stdout.trim();
+  if (token.length === 0) return { token: null, detail: "the infisical fallback returned an empty token" };
+  return { token };
 }
 
 async function uploadImages(
@@ -226,17 +237,28 @@ export async function publishPr(
     ? `⚠ evidence from ${shortSha(roll.gitSha)}, PR head is ${shortSha(prHeadSha)}`
     : undefined;
 
-  const token = resolveBlobToken(exec);
-  const urls = token
-    ? await uploadImages(
-      options.rollDir,
-      rollName,
-      [...new Set(roll.frames.map((frame) => frame.fileName).filter((fileName) => fileName.length > 0))],
-      token,
-      fetcher,
-    )
-    : {};
-  const uploadNotice = token ? undefined : "screenshots not uploaded (no BLOB_READ_WRITE_TOKEN)";
+  const frames = [...new Set(roll.frames.map((frame) => frame.fileName).filter((fileName) => fileName.length > 0))];
+  let urls: Record<string, string> = {};
+  let uploadNotice: string | undefined;
+  if (options.noScreenshots) {
+    uploadNotice = "screenshots not uploaded (--no-screenshots)";
+  } else {
+    const resolved = resolveBlobToken(exec);
+    if (resolved.token !== null) {
+      urls = await uploadImages(options.rollDir, rollName, frames, resolved.token, fetcher);
+    } else if (frames.length > 0) {
+      // Posting a frameful roll without its frames silently degrades the
+      // evidence; require the operator to fix the token or opt out explicitly.
+      throw new Error(
+        `Refusing to publish ${frames.length} frame${frames.length === 1 ? "" : "s"} without screenshots: `
+        + `BLOB_READ_WRITE_TOKEN is unset and ${resolved.detail}. `
+        + 'Export it with `export BLOB_READ_WRITE_TOKEN="$(infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent)"`, '
+        + "or pass --no-screenshots to deliberately publish the verdict without frames.",
+      );
+    } else {
+      uploadNotice = "screenshots not uploaded (no BLOB_READ_WRITE_TOKEN)";
+    }
+  }
   const markdown = renderPrMarkdown(roll, urls, {
     reproCommand,
     notice: [staleNotice, uploadNotice].filter((notice) => notice !== undefined).join(" · ") || undefined,

--- a/evals/packages/evidence/test/publish-pr.test.ts
+++ b/evals/packages/evidence/test/publish-pr.test.ts
@@ -262,6 +262,110 @@ test("publishPr renders facts without images, skips fact uploads, marks failures
   }
 });
 
+test("publishPr refuses to publish a frameful roll when no blob token resolves", async () => {
+  const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-token-guard-"));
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(dryRunRecord(rollDir)));
+    await writeFile(join(rollDir, "01-dry-run.png"), Buffer.from("regular png"));
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    let fetchCalled = false;
+    let commentPosted = false;
+    const exec: CommandRunner = (command, args) => {
+      if (command === "infisical") return { status: 1, stdout: "", stderr: "not logged in" };
+      if (args.includes("headRefOid")) return { status: 0, stdout: JSON.stringify({ headRefOid: ROLL_SHA }), stderr: "" };
+      commentPosted = true;
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    await assert.rejects(
+      () => publishPr({ pr: 17, rollDir }, { exec, fetch: async () => { fetchCalled = true; return new Response(); } }),
+      /Refusing to publish 1 frame without screenshots: BLOB_READ_WRITE_TOKEN is unset and the infisical fallback failed \(not logged in\).*--no-screenshots/,
+    );
+    assert.equal(fetchCalled, false);
+    assert.equal(commentPosted, false);
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
+    await rm(rollDir, { recursive: true, force: true });
+  }
+});
+
+test("publishPr --no-screenshots deliberately publishes the verdict without uploads", async () => {
+  const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-no-screenshots-"));
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(dryRunRecord(rollDir)));
+    await writeFile(join(rollDir, "01-dry-run.png"), Buffer.from("regular png"));
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    let fetchCalled = false;
+    let infisicalCalled = false;
+    let postedMarkdown = "";
+    const exec: CommandRunner = (command, args, opts) => {
+      if (command === "infisical") {
+        infisicalCalled = true;
+        return { status: 1, stdout: "", stderr: "not logged in" };
+      }
+      if (args.includes("headRefOid")) return { status: 0, stdout: JSON.stringify({ headRefOid: ROLL_SHA }), stderr: "" };
+      if (args.includes("comments")) return { status: 0, stdout: JSON.stringify({ comments: [] }), stderr: "" };
+      postedMarkdown = opts?.input ?? "";
+      return { status: 0, stdout: "posted", stderr: "" };
+    };
+    const result = await publishPr(
+      { pr: 17, rollDir, noScreenshots: true },
+      { exec, fetch: async () => { fetchCalled = true; return new Response(); } },
+    );
+    assert.equal(result.posted, true);
+    assert.equal(fetchCalled, false);
+    assert.equal(infisicalCalled, false);
+    assert.match(postedMarkdown, /screenshots not uploaded \(--no-screenshots\)/);
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
+    await rm(rollDir, { recursive: true, force: true });
+  }
+});
+
+test("publishPr still publishes a facts-only roll when no blob token resolves", async () => {
+  const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-facts-only-"));
+  const previousToken = process.env.BLOB_READ_WRITE_TOKEN;
+  try {
+    const roll = dryRunRecord(rollDir);
+    roll.frames = [{
+      caption: "API witness",
+      fileName: "",
+      hash: "fact-hash",
+      route: "",
+      at: roll.createdAt,
+      description: "The API returned HTTP 500.",
+      model: "test-model",
+      ok: true,
+      results: [{ expectation: "API witness", passed: true, evidence: "HTTP 500 observed" }],
+    }];
+    await writeFile(join(rollDir, "roll.json"), JSON.stringify(roll));
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    let fetchCalled = false;
+    let postedMarkdown = "";
+    const exec: CommandRunner = (command, args, opts) => {
+      if (command === "infisical") return { status: 1, stdout: "", stderr: "not logged in" };
+      if (args.includes("headRefOid")) return { status: 0, stdout: JSON.stringify({ headRefOid: ROLL_SHA }), stderr: "" };
+      if (args.includes("comments")) return { status: 0, stdout: JSON.stringify({ comments: [] }), stderr: "" };
+      postedMarkdown = opts?.input ?? "";
+      return { status: 0, stdout: "posted", stderr: "" };
+    };
+    const result = await publishPr(
+      { pr: 17, rollDir },
+      { exec, fetch: async () => { fetchCalled = true; return new Response(); } },
+    );
+    assert.equal(result.posted, true);
+    assert.equal(fetchCalled, false);
+    assert.match(postedMarkdown, /screenshots not uploaded \(no BLOB_READ_WRITE_TOKEN\)/);
+  } finally {
+    if (previousToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = previousToken;
+    await rm(rollDir, { recursive: true, force: true });
+  }
+});
+
 test("publishPr reports gh authentication guidance when the PR head cannot be resolved", async () => {
   const rollDir = await mkdtemp(join(tmpdir(), "openwork-evidence-gh-auth-"));
   try {


### PR DESCRIPTION
## Summary
- `publishPr` now refuses to post a frameful tape when `BLOB_READ_WRITE_TOKEN` is unset and the Infisical fallback fails, quoting the fallback's exact failure and the remediation command
- add `--no-screenshots` as the deliberate opt-out for publishing a verdict without frames
- facts-only rolls keep publishing without a token, with the existing note
- fix `publish-evidence` skill: document the token order and remove the nonexistent `--all` flag

## Why
Publishing PR #3615's tape silently degraded to 'screenshots not uploaded' because a transient Infisical failure was collapsed into `null` with no detail. The published evidence lost its frames without anyone deciding that. Nothing in CI publishes tokenless, so failing loudly is safe.

## Verification
- Passed: `pnpm exec node --test packages/evidence/test/*.test.ts` from `evals/` — 14 pass, 0 fail (3 new: token guard throw, `--no-screenshots` opt-out, facts-only unaffected)

Tooling + skill-doc change; no runtime evidence tape applies.