### PR TITLE
feat(app): minimal gateway boot loading + logged-in first load lands on chat

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -61,6 +61,7 @@ import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 import type { SessionNumberShortcutsState } from "../../../shell/session-number-shortcuts";
+import { useBootOverlayVisible } from "../../../shell/boot-state";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
@@ -231,23 +232,6 @@ export type SessionPageProps = {
   onSessionTabsChange?: (tabs: OpenSessionTab[]) => void;
 };
 
-function getSidebarInitialLoading(props: SessionPageSidebarProps) {
-  if (props.workspaceSessionGroups.some((group) => group.sessions.length > 0)) {
-    return false;
-  }
-  if (props.sidebarHydratedFromCache) return false;
-  if (
-    props.startupPhase !== "sessionIndexReady" &&
-    props.startupPhase !== "firstSessionReady" &&
-    props.startupPhase !== "ready"
-  ) {
-    return true;
-  }
-  return props.workspaceSessionGroups.some(
-    (group) => group.status === "loading" || group.status === "idle",
-  );
-}
-
 function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | undefined) {
   if (!id) return "";
   const sessionsById = new Map(groups.flatMap((group) => group.sessions.map((session) => [session.id, session] as const)));
@@ -319,6 +303,7 @@ export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
   const platform = usePlatform();
   const denAuth = useDenAuth();
+  const bootOverlayVisible = useBootOverlayVisible();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
   const sidePanelSessionKey = getSidePanelSessionKey(props.selectedSessionId);
@@ -800,6 +785,7 @@ export function SessionPage(props: SessionPageProps) {
   const hasMainContentTakeover = Boolean(props.mainContentTakeover);
   const showWorkspaceSetupEmptyState = props.workspaces.length === 0 && !props.selectedSessionId;
   const showStartupSkeleton =
+    !bootOverlayVisible &&
     !props.primarySlot &&
     !hasMainContentTakeover &&
     !props.selectedSessionId &&
@@ -807,7 +793,6 @@ export function SessionPage(props: SessionPageProps) {
     props.startupPhase !== "sessionIndexReady" &&
     props.startupPhase !== "firstSessionReady" &&
     props.startupPhase !== "ready";
-  const sidebarInitialLoading = useMemo(() => getSidebarInitialLoading(props.sidebar), [props.sidebar]);
   // Derive the main-pane error from the same data the sidebar uses so the two
   // panes can never disagree. We check (in priority order):
   // 1. selectedWorkspaceError (errorsByWorkspaceId[selectedWorkspaceId])
@@ -854,6 +839,7 @@ export function SessionPage(props: SessionPageProps) {
   // rendered chat with a loading pane (and leaving it there when a refresh
   // hangs) is never correct.
   const showSessionLoadingState =
+    !bootOverlayVisible &&
     !props.primarySlot &&
     Boolean(props.selectedSessionId) &&
     props.sessionLoadingById(props.selectedSessionId) &&
@@ -1026,7 +1012,6 @@ export function SessionPage(props: SessionPageProps) {
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
           developerMode={props.sidebar.developerMode}
           selectedSessionId={props.sidebar.selectedSessionId}
-          showInitialLoading={sidebarInitialLoading}
           showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession || props.onArchiveSession)}
           sessionStatusById={props.sidebar.sessionStatusById}
           connectingWorkspaceId={props.sidebar.connectingWorkspaceId}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -822,7 +822,6 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
 export type AppSidebarProps = {
   sessionNumberShortcuts: SessionNumberShortcutsState;
   workspaceSessionGroups: WorkspaceSessionGroup[];
-  showInitialLoading?: boolean;
   selectedWorkspaceId: string;
   developerMode: boolean;
   selectedSessionId: string | null;
@@ -1206,7 +1205,6 @@ export function AppSidebar(props: AppSidebarProps) {
                   key={group.workspace.id}
                   group={group}
                   className={cn(index === 0 && "mac:pt-0")}
-                  showInitialLoading={props.showInitialLoading}
                   previewCount={previewCount(group.workspace.id)}
                   showMoreSessions={showMoreSessions}
                 />
@@ -1386,7 +1384,6 @@ function GlobalPinnedSessionTree({ group, sessionId }: GlobalPinnedSessionEntry)
 type WorkspaceReorderItemProps = {
   className: string;
   group: WorkspaceSessionGroup;
-  showInitialLoading?: boolean;
   previewCount: number;
   showMoreSessions: (workspaceId: string, totalRoots: number) => void;
 };
@@ -1394,7 +1391,6 @@ type WorkspaceReorderItemProps = {
 function WorkspaceReorderItem({
   className,
   group,
-  showInitialLoading,
   previewCount,
   showMoreSessions,
 }: WorkspaceReorderItemProps) {
@@ -1419,7 +1415,6 @@ function WorkspaceReorderItem({
       <WorkspaceSidebarGroup
         className={className}
         group={group}
-        showInitialLoading={showInitialLoading}
         previewCount={previewCount}
         showMoreSessions={showMoreSessions}
         onWorkspaceTitlePointerDown={(event) => dragControls.start(event)}
@@ -1489,7 +1484,6 @@ function WorkspaceHeader({
 type WorkspaceSidebarGroupProps = {
   className: string;
   group: WorkspaceSessionGroup;
-  showInitialLoading?: boolean;
   previewCount: number;
   showMoreSessions: (workspaceId: string, totalRoots: number) => void;
   onWorkspaceTitlePointerDown: React.PointerEventHandler<HTMLDivElement>;
@@ -1498,7 +1492,6 @@ type WorkspaceSidebarGroupProps = {
 function WorkspaceSidebarGroup({
   className,
   group,
-  showInitialLoading,
   previewCount,
   showMoreSessions,
   onWorkspaceTitlePointerDown,
@@ -1595,7 +1588,7 @@ function WorkspaceSidebarGroup({
                 workspace={workspace}
                 statusLabel={statusLabel}
                 isError={group.status === "error"}
-                isLoading={group.status === "loading" || isConnecting}
+                isLoading={isConnecting}
                 onTitlePointerDown={onWorkspaceTitlePointerDown}
               />
               <div data-workspace-actions className="group/workspace-actions absolute right-8 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
@@ -1653,16 +1646,7 @@ function WorkspaceSidebarGroup({
                       ctx.onEditWorkspaceConnection(workspace.id);
                     }}
                   />
-                ) : showInitialLoading || (group.status === "loading" && group.sessions.length === 0) ? (
-                  <SidebarMenuSubItem>
-                    <SidebarMenuSubButton aria-disabled className={cn("text-muted-foreground text-xs truncate", SIDEBAR_ROW_LANE)}>
-                      <SidebarGlyphSlot>
-                        <SessionDotMatrixLoader label={t("workspace.loading_tasks")} />
-                      </SidebarGlyphSlot>
-                      <span className="truncate">{t("workspace.loading_tasks")}</span>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
-                ) : activeSessions.length > 0 ? (
+                ) : group.status === "loading" && group.sessions.length === 0 ? null : activeSessions.length > 0 ? (
                   <>
                     {wsGroups.length > 0 ? (
                       <GroupedSessionList

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -44,6 +44,7 @@ import { SessionRoute } from "./session-route";
 import { SettingsRoute } from "./settings-route";
 import { ShellConfigProvider } from "./shell-config";
 import { WelcomeRoute } from "./welcome-route";
+import { signedInRoute } from "./den-signin-routing";
 
 
 type DenSigninGateProps = {
@@ -102,8 +103,7 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       if (!denAuth.isSignedIn && !onSignin) {
         navigate("/signin", { replace: true });
       } else if (denAuth.isSignedIn && onSignin) {
-        // Signed in — route to onboarding so the user sees their org resources.
-        navigate("/onboarding", { replace: true });
+        navigate(signedInRoute(readDenSettings().activeOrgId), { replace: true });
       }
     } else if (onSignin) {
       navigate("/session", { replace: true });
@@ -126,9 +126,8 @@ function DenSigninGate({ children }: DenSigninGateProps) {
     requireSignin,
   ]);
 
-  // After a fresh sign-in, navigate to the onboarding page so the user sees
-  // their signed-in org state. Do not wait for an active org: first-run users
-  // may not belong to one yet, and must not remain on the signed-out welcome.
+  // After a fresh sign-in, returning members go straight to chat. Give org
+  // restoration a brief chance to settle before treating the user as new.
   useEffect(() => {
     const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
       if (event.detail?.status !== "success") return;
@@ -136,12 +135,14 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       const check = () => {
         attempts++;
         const settings = readDenSettings();
-        if (settings.authToken?.trim()) {
-          navigate("/onboarding", { replace: true });
+        if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
+          navigate("/session", { replace: true });
         } else if (attempts < 10) {
           // Session persistence should already be done, but retry briefly in
           // case another consumer is still applying the handoff result.
           setTimeout(check, 500);
+        } else if (settings.authToken?.trim()) {
+          navigate(signedInRoute(settings.activeOrgId), { replace: true });
         }
       };
       // First check after a short delay for the auth to settle
@@ -152,7 +153,7 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   }, [navigate]);
 
   if (requireSignin && denAuth.status === "checking") {
-    return <ForcedSigninPage developerMode={false} />;
+    return null;
   }
 
   if (redirectingPreparedWorkspace) return <Navigate to="/onboarding" replace />;

--- a/apps/app/src/react-app/shell/boot-state.tsx
+++ b/apps/app/src/react-app/shell/boot-state.tsx
@@ -57,6 +57,10 @@ const PHASE_MESSAGES: Record<BootPhaseId, string> = {
 
 const BootStateContext = createContext<BootStateContextValue | null>(null);
 
+export function bootOverlayCanHide(phase: BootPhaseId, routeReady: boolean): boolean {
+  return routeReady && (phase === "ready" || phase === "idle");
+}
+
 export function BootStateProvider({ children }: { children: ReactNode }) {
   const [snapshot, setSnapshot] = useState<BootStateSnapshot>(DEFAULT_STATE);
   // Once the main route has finished its first successful refresh (workspaces
@@ -135,7 +139,7 @@ export function useBootOverlayVisible(): boolean {
   // is interactive and can mark itself ready again. Treat `idle + routeReady`
   // the same as `ready + routeReady` so the full-screen boot overlay never
   // becomes a permanent pointer-events blocker during development.
-  const canHide = routeReady && (phase === "ready" || phase === "idle");
+  const canHide = bootOverlayCanHide(phase, routeReady);
   const [visible, setVisible] = useState(!canHide);
 
   useEffect(() => {

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -19,12 +19,14 @@ import {
   formatCloudWorkspaceElapsed,
   mapCloudWorkspaceState,
   shouldAutoUpdateCloudWorkspace,
+  shouldShowCloudWorkspaceStatusPill,
   type CloudWorkspaceBootStage,
   type CloudWorkspaceMainContentDecision,
   type CloudWorkspaceViewModel,
 } from "./cloud-workspace-status";
 import type { DenCloudInstance } from "@/app/lib/den";
 import { OwDotTicker } from "./dot-ticker";
+import { useBootOverlayVisible } from "./boot-state";
 
 type CloudWorkspaceStatusContextValue = {
   gatewayMode: boolean;
@@ -444,10 +446,21 @@ export function CloudWorkspaceStatusPanel(props: {
 
 function CloudWorkspaceOverlayInner() {
   const cloudWorkspace = useCloudWorkspaceStatus();
+  const bootOverlayVisible = useBootOverlayVisible();
   const [open, setOpen] = useState(false);
   const viewModel = cloudWorkspace.viewModel;
 
-  if (!cloudWorkspace.gatewayMode || !cloudWorkspace.visible) return null;
+  if (
+    bootOverlayVisible ||
+    cloudWorkspace.takeoverActive ||
+    !cloudWorkspace.gatewayMode ||
+    !cloudWorkspace.visible ||
+    !shouldShowCloudWorkspaceStatusPill({
+      variant: viewModel.variant,
+      hasInstance: cloudWorkspace.instance !== null,
+      requestFailed: cloudWorkspace.requestFailed,
+    })
+  ) return null;
 
   return (
     <LazyMotion features={domMax}>

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -159,6 +159,15 @@ export function cloudWorkspaceStatusHasReadyContent(variant: CloudWorkspacePillV
   return variant === "ready" || variant === "stale";
 }
 
+export function shouldShowCloudWorkspaceStatusPill(input: {
+  variant: CloudWorkspacePillVariant;
+  hasInstance: boolean;
+  requestFailed: boolean;
+}): boolean {
+  if (!input.hasInstance && !input.requestFailed) return false;
+  return input.variant === "waking" || input.variant === "provisioning" || input.variant === "failed";
+}
+
 export function mapCloudWorkspaceMainContentDecision(input: {
   status: CloudWorkspacePillVariant;
   hasWorkspaces: boolean;

--- a/apps/app/src/react-app/shell/den-signin-routing.ts
+++ b/apps/app/src/react-app/shell/den-signin-routing.ts
@@ -1,0 +1,3 @@
+export function signedInRoute(activeOrgId: string | null | undefined): "/session" | "/onboarding" {
+  return activeOrgId?.trim() ? "/session" : "/onboarding";
+}

--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useBootState, useBootOverlayVisible } from "./boot-state";
+import { bootOverlayCanHide, useBootState, useBootOverlayVisible } from "./boot-state";
 import { OwDotTicker } from "./dot-ticker";
 
 const RELEASES_URL = "https://github.com/different-ai/openwork/releases";
@@ -11,11 +11,11 @@ const RELEASES_URL = "https://github.com/different-ai/openwork/releases";
  */
 export function LoadingOverlay() {
   const visible = useBootOverlayVisible();
-  const { phase, message, error } = useBootState();
+  const { phase, routeReady, message, error } = useBootState();
 
   if (!visible) return null;
 
-  const fading = phase === "ready";
+  const fading = bootOverlayCanHide(phase, routeReady);
 
   return (
     <div

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -171,6 +171,7 @@ import { saveSessionDraft } from "@/react-app/domains/session/sync/draft-store";
 import { useComposerStateStore } from "@/react-app/domains/session/surface/composer-state-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
+import { useBootOverlayVisible } from "./boot-state";
 
 import {
   createDenClient,
@@ -565,6 +566,7 @@ export function SessionRoute() {
     onHostInfo: setOpenworkServerHostInfoState,
   });
   const cloudWorkspace = useCloudWorkspaceStatus();
+  const bootOverlayVisible = useBootOverlayVisible();
   const previousCloudWorkspaceStatusRef = useRef<typeof cloudWorkspace.viewModel.variant | null>(null);
   useEffect(() => {
     const previousStatus = previousCloudWorkspaceStatusRef.current;
@@ -1446,7 +1448,7 @@ export function SessionRoute() {
     !cloudWorkspace.gatewayMode ||
     !cloudWorkspace.visible ||
     cloudWorkspaceStatusHasReadyContent(cloudWorkspace.viewModel.variant);
-  const cloudWorkspaceMainContentTakeover = cloudWorkspaceMainContentDecision === "takeover" ? (
+  const cloudWorkspaceMainContentTakeover = !bootOverlayVisible && cloudWorkspaceMainContentDecision === "takeover" ? (
     <CloudWorkspaceBootTakeover decision={cloudWorkspaceMainContentDecision} />
   ) : null;
   const gatedRouteNotFoundMessage = cloudWorkspaceReadyForRouteErrors ? routeNotFoundMessage : null;

--- a/apps/app/tests/boot-state.test.ts
+++ b/apps/app/tests/boot-state.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+
+import { bootOverlayCanHide } from "../src/react-app/shell/boot-state";
+
+describe("boot overlay visibility", () => {
+  test("waits for both boot and route readiness", () => {
+    expect(bootOverlayCanHide("ready", false)).toBe(false);
+    expect(bootOverlayCanHide("starting-engine", true)).toBe(false);
+    expect(bootOverlayCanHide("ready", true)).toBe(true);
+    expect(bootOverlayCanHide("idle", true)).toBe(true);
+  });
+});

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -18,9 +18,11 @@ import {
   formatCloudWorkspaceElapsed,
   mapCloudWorkspaceMainContentDecision,
   mapCloudWorkspaceState,
+  shouldShowCloudWorkspaceStatusPill,
   shouldRefetchCloudWorkspaceOnReadyTransition,
 } from "../src/react-app/shell/cloud-workspace-status";
 import type { CloudWorkspaceMainContentDecision, CloudWorkspacePillVariant } from "../src/react-app/shell/cloud-workspace-status";
+import { BootStateProvider } from "../src/react-app/shell/boot-state";
 
 const originalWindow = globalThis.window;
 
@@ -35,7 +37,7 @@ function instance(input: Partial<DenCloudInstance> = {}): DenCloudInstance {
 }
 
 describe("cloud workspace overlay state", () => {
-  test("maps ready and current workers to the quiet Cloud pill", () => {
+  test("maps ready and current workers to a quiet status", () => {
     const state = mapCloudWorkspaceState({ instance: instance(), updating: false });
 
     expect(state.variant).toBe("ready");
@@ -89,7 +91,17 @@ describe("cloud workspace overlay state", () => {
     expect(failed.showRetry).toBe(true);
   });
 
-  test("keeps the pill in updating state after the user clicks update", () => {
+  test("shows the corner pill only for resolved degraded states", () => {
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "waking", hasInstance: false, requestFailed: false })).toBe(false);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "waking", hasInstance: true, requestFailed: false })).toBe(true);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "provisioning", hasInstance: true, requestFailed: false })).toBe(true);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "failed", hasInstance: false, requestFailed: true })).toBe(true);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "ready", hasInstance: true, requestFailed: false })).toBe(false);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "stale", hasInstance: true, requestFailed: false })).toBe(false);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "updating", hasInstance: true, requestFailed: false })).toBe(false);
+  });
+
+  test("keeps the workspace status updating after the user clicks update", () => {
     const state = mapCloudWorkspaceState({
       instance: instance({ imageVersion: "openwork-0.18.2", latestVersion: "openwork-0.18.8" }),
       updating: true,
@@ -321,7 +333,11 @@ describe("cloud workspace overlay gateway gating", () => {
       value: { location: { origin: "https://instance.example.test" } },
     });
 
-    expect(renderToStaticMarkup(<CloudWorkspaceOverlay />)).toBe("");
+    expect(renderToStaticMarkup(
+      <BootStateProvider>
+        <CloudWorkspaceOverlay />
+      </BootStateProvider>,
+    )).toBe("");
   });
 });
 

--- a/apps/app/tests/den-signin-routing.test.ts
+++ b/apps/app/tests/den-signin-routing.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { signedInRoute } from "../src/react-app/shell/den-signin-routing";
+
+describe("signed-in routing", () => {
+  test("sends organization members directly to chat", () => {
+    expect(signedInRoute("org-returning")).toBe("/session");
+    expect(signedInRoute("  org-returning  ")).toBe("/session");
+  });
+
+  test("reserves onboarding for users without an organization", () => {
+    expect(signedInRoute(null)).toBe("/onboarding");
+    expect(signedInRoute("  ")).toBe("/onboarding");
+  });
+});


### PR DESCRIPTION
Part of gateway launch prep (1/3). Addresses launch items 1 and 2: fewer simultaneous loaders at startup, and signed-in users landing directly on the chat interface.

## What changed

**One loader at a time during boot**
- While the full-screen boot overlay is visible, secondary loaders no longer render underneath: sidebar dot-matrix "Loading tasks" loader (startup case removed), main-pane startup skeleton, cloud-boot takeover checklist, and the corner cloud status pill are all gated on the overlay being gone.
- After the overlay fades, at most one contextual loader shows (main pane).
- The corner cloud status pill now only appears post-boot and only for degraded states (provisioning/waking/failed) — never during a normal first load (`cloud-workspace-status.ts` decision helper + overlay gating).
- Extracted `bootOverlayCanHide(phase, routeReady)` in `boot-state.tsx` so overlay visibility/fade share one predicate.

**Direct-to-chat first load**
- New `signedInRoute(activeOrgId)` helper: signed-in users with an active org go to `/session` (chat); only genuinely-new users (no org) see `/onboarding`.
- Fresh sign-in handoff (`denSessionUpdatedEvent`) now waits briefly for org restoration and routes returning members straight to `/session`.
- While den auth is still `checking`, the gate renders nothing (boot overlay stays up) instead of flashing `ForcedSigninPage` at returning users.

## Verification

- `pnpm --filter @openwork/app typecheck` — exit 0
- Bun unit tests (boot-state, den-signin-routing, cloud-workspace-overlay + neighbors): 41 passed, 0 failed
  - `apps/app/tests/boot-state.test.ts` — overlay hide predicate
  - `apps/app/tests/den-signin-routing.test.ts` — org-aware signed-in destination
  - `apps/app/tests/cloud-workspace-overlay.test.tsx` — pill shown only for degraded states, hidden during boot

**Status: Incomplete (unit-verified, no runtime tape).** A browser-level testkit spec for the gateway web build was not added: testkit `app()` boots Electron, and the gateway signed-in flow requires a deployed gateway + cloud credentials. Repro steps for manual verification: build `apps/app` with `build:web`, serve via den-gateway, sign in, reload — expect a single boot overlay then chat at `/session`, no onboarding flash, no stacked spinners.