### PR TITLE
fix(app): reduce mobile layout shifts on gateway web

### DIFF
--- a/apps/app/src/components/page.tsx
+++ b/apps/app/src/components/page.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 function Page({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
-      className={cn("relative h-screen bg-background text-foreground", className)}
+      className={cn("relative h-dvh bg-background text-foreground", className)}
       {...props}
     />
   );

--- a/apps/app/src/hooks/use-mobile.ts
+++ b/apps/app/src/hooks/use-mobile.ts
@@ -1,19 +1,26 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+export function getInitialIsMobile(matchMedia?: (query: string) => { matches: boolean }) {
+  return matchMedia?.(MOBILE_MEDIA_QUERY).matches ?? false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState(() =>
+    getInitialIsMobile(typeof window === "undefined" ? undefined : (query) => window.matchMedia(query)),
+  )
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(mql.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    onChange()
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }

--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -218,7 +218,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
     // Paper first-load spec: same centered welcome card as WelcomePage.
     // Forced sign-in only removes the "Use Without Cloud" option.
     return (
-      <div className="relative min-h-screen bg-background text-foreground">
+      <div className="relative min-h-dvh bg-background text-foreground">
         {/* Pixel-dither mosaic background (dark:invert keeps it visible in dark mode) */}
         <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden opacity-[0.1] dark:invert">
           <Dithering
@@ -237,7 +237,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
         {/* Titlebar drag region */}
         <div className="absolute inset-x-0 top-0 z-20 h-10 mac:titlebar-drag" />
 
-        <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-16">
+        <div className="relative z-10 flex min-h-dvh items-center justify-center px-6 py-16">
           <div className="w-full max-w-[720px] rounded-3xl border border-border bg-background px-8 pb-12 pt-10 sm:px-16 sm:pb-16 sm:pt-14">
             <div className="flex items-center gap-2.5">
               <img

--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -26,7 +26,7 @@ export function useEnterpriseActivationRequired() {
 function EnterpriseActivationPage() {
   return (
     <div
-      className="relative min-h-screen bg-background text-foreground"
+      className="relative min-h-dvh bg-background text-foreground"
       data-state="enterprise-activation"
       data-testid="enterprise-activation-root"
     >
@@ -50,7 +50,7 @@ function EnterpriseActivationPage() {
       <div className="absolute inset-x-0 top-0 z-20 h-10 mac:titlebar-drag" />
 
       <div
-        className="relative z-10 flex min-h-screen items-center justify-center px-6 py-16"
+        className="relative z-10 flex min-h-dvh items-center justify-center px-6 py-16"
         data-testid="enterprise-activation-foreground"
       >
         <section

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -59,12 +59,12 @@ export function WelcomePage({
   }, [markRouteReady]);
 
   return (
-    <Page className="min-h-screen">
+    <Page className="min-h-dvh">
       <PageTitlebarRegion />
 
       <ScrollArea className="relative z-10">
         <ScrollAreaViewport>
-          <div className="relative flex min-h-screen items-center justify-center px-6 py-16">
+          <div className="relative flex min-h-dvh items-center justify-center px-6 py-16">
             {/* Paper first-load spec: subtle black pixel-dither mosaic over a
                 near-white ground. `dark:invert` flips the pixels to white so
                 the texture survives dark mode. */}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../../../../app/types";
 import type { ShareWorkspaceModalProps } from "../../workspace/types";
 import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
@@ -319,6 +320,7 @@ export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
   const platform = usePlatform();
   const denAuth = useDenAuth();
+  const isMobile = useIsMobile();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
   const sidePanelSessionKey = getSidePanelSessionKey(props.selectedSessionId);
@@ -385,6 +387,7 @@ export function SessionPage(props: SessionPageProps) {
   const workbenchTabs = useWorkbenchStore((state) => state.tabs);
   const workbenchSplitSessionId = useWorkbenchStore((state) => state.splitSessionId);
   const focusedWorkbenchPane = useWorkbenchStore((state) => state.focusedPane);
+  const activeWorkbenchPane = isMobile ? "primary" : focusedWorkbenchPane;
   const syncWorkbench = useWorkbenchStore((state) => state.sync);
   const openWorkbenchTab = useWorkbenchStore((state) => state.openTab);
   const setWorkbenchSplit = useWorkbenchStore((state) => state.setSplit);
@@ -848,7 +851,7 @@ export function SessionPage(props: SessionPageProps) {
       reactSessionToken &&
       props.surface,
   );
-  const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
+  const canRenderSplitSurface = Boolean(!isMobile && canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
   // Route-level refreshes must only gate the very first paint of a session.
   // Once the surface can mount it owns its own data stream, so replacing a
   // rendered chat with a loading pane (and leaving it there when a refresh
@@ -1092,7 +1095,7 @@ export function SessionPage(props: SessionPageProps) {
             onLayoutChanged={sidePanelOpen ? commitBrowserPanelWidth : undefined}
             className="min-h-0 flex-1 rounded-[14px]"
           >
-            <ResizablePanel minSize="360px" className="min-w-0">
+            <ResizablePanel minSize={isMobile ? "0px" : "360px"} className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
           <header className="z-10 flex h-9 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
@@ -1145,7 +1148,7 @@ export function SessionPage(props: SessionPageProps) {
                       variant="ghost"
                       size="icon-sm"
                       className={cn(
-                        "rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground",
+                        "hidden rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground md:inline-flex",
                         sidePanelOpen && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
                       )}
                       aria-label={sidePanelOpen ? "Close side panel" : "Open side panel"}
@@ -1164,10 +1167,12 @@ export function SessionPage(props: SessionPageProps) {
                 />
                 <TooltipContent>{sidePanelOpen ? "Close side panel" : "Open side panel"}</TooltipContent>
               </Tooltip>
-              {showCloudSignIn ? (
+              {shellConfig.cloudSignin ? (
                 <Button
                   variant="secondary"
                   size="sm"
+                  className={showCloudSignIn ? undefined : "invisible"}
+                  disabled={!showCloudSignIn}
                   onClick={openCloudSignIn}
                   title={t("den.signin_title")}
                   aria-label={t("den.signin_title")}
@@ -1265,10 +1270,10 @@ export function SessionPage(props: SessionPageProps) {
                     className="min-h-0 flex-1"
                   >
                     <ResizablePanel
-                      minSize="320px"
+                      minSize={isMobile ? "0px" : "320px"}
                       className="min-h-0 min-w-0"
                       data-workbench-pane="primary"
-                      data-workbench-pane-focused={focusedWorkbenchPane === "primary" ? "true" : undefined}
+                      data-workbench-pane-focused={activeWorkbenchPane === "primary" ? "true" : undefined}
                       onPointerDown={() => focusWorkbenchPane("primary")}
                       onFocusCapture={() => focusWorkbenchPane("primary")}
                     >
@@ -1284,7 +1289,7 @@ export function SessionPage(props: SessionPageProps) {
                         environmentClient={props.environmentClient}
                         workspaceId={props.runtimeWorkspaceId!}
                         sessionId={props.selectedSessionId!}
-                        isControlTarget={focusedWorkbenchPane === "primary"}
+                        isControlTarget={activeWorkbenchPane === "primary"}
                         opencodeBaseUrl={reactSessionBaseUrl}
                         openworkToken={reactSessionToken}
                         todos={props.todos}
@@ -1305,7 +1310,7 @@ export function SessionPage(props: SessionPageProps) {
                           minSize="320px"
                           className="min-h-0 min-w-0"
                           data-workbench-pane="secondary"
-                          data-workbench-pane-focused={focusedWorkbenchPane === "secondary" ? "true" : undefined}
+                          data-workbench-pane-focused={activeWorkbenchPane === "secondary" ? "true" : undefined}
                           onPointerDown={() => focusWorkbenchPane("secondary")}
                           onFocusCapture={() => focusWorkbenchPane("secondary")}
                         >
@@ -1315,7 +1320,7 @@ export function SessionPage(props: SessionPageProps) {
                             environmentClient={props.environmentClient}
                             workspaceId={props.runtimeWorkspaceId!}
                             sessionId={splitSessionId!}
-                            isControlTarget={focusedWorkbenchPane === "secondary"}
+                            isControlTarget={activeWorkbenchPane === "secondary"}
                             opencodeBaseUrl={reactSessionBaseUrl}
                             openworkToken={reactSessionToken}
                             todos={[]}
@@ -1408,7 +1413,7 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
             </div>
             </ResizablePanel>
-            {props.terminalOpen ? (
+            {props.terminalOpen && !isMobile ? (
               <>
                 <ResizableHandle />
                 <ResizablePanel defaultSize="280px" minSize="160px" maxSize="55%" className="min-h-0">
@@ -1424,7 +1429,7 @@ export function SessionPage(props: SessionPageProps) {
 
               </main>
             </ResizablePanel>
-              {sidePanelOpen ? (
+              {sidePanelOpen && !isMobile ? (
               <>
                 <ResizableHandle className="hidden bg-transparent lg:flex" />
                 <ResizablePanel
@@ -1463,7 +1468,7 @@ export function SessionPage(props: SessionPageProps) {
               </>
             ) : null}
           </ResizablePanelGroup>
-          <aside className="flex w-9 shrink-0 flex-col items-center gap-1 px-0.5 py-2 text-muted-foreground mac:titlebar-no-drag">
+          <aside className="hidden w-9 shrink-0 flex-col items-center gap-1 px-0.5 py-2 text-muted-foreground md:flex mac:titlebar-no-drag">
             {isElectronRuntime() ? (
               <Button
                 variant="ghost"

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -100,7 +100,7 @@ export function SettingsShell(props: SettingsShellProps) {
   }
 
   return (
-    <div className="flex h-dvh min-h-screen w-full overflow-hidden">
+    <div className="flex h-dvh min-h-dvh w-full overflow-hidden">
       <SidebarProvider defaultOpen className="relative min-h-0 flex-1">
         <SettingsSidebar
           activeTab={props.activeTab}

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -98,8 +98,8 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
   if (!info?.mismatch) return <>{children}</>;
 
   return (
-    <main className="min-h-screen bg-[#05070c] text-white">
-      <div className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-6 py-12">
+    <main className="min-h-dvh bg-[#05070c] text-white">
+      <div className="mx-auto flex min-h-dvh w-full max-w-5xl items-center px-6 py-12">
         <section className="w-full overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.04] shadow-2xl shadow-black/40">
           <div className="grid gap-0 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="space-y-8 p-8 sm:p-10 lg:p-12">

--- a/apps/app/tests/use-mobile.test.ts
+++ b/apps/app/tests/use-mobile.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { getInitialIsMobile } from "../src/hooks/use-mobile";
+
+describe("getInitialIsMobile", () => {
+  test("reads the mobile media query synchronously", () => {
+    let receivedQuery = "";
+
+    const isMobile = getInitialIsMobile((query) => {
+      receivedQuery = query;
+      return { matches: true };
+    });
+
+    expect(receivedQuery).toBe("(max-width: 767px)");
+    expect(isMobile).toBe(true);
+  });
+
+  test("defaults to desktop without window matchMedia", () => {
+    expect(getInitialIsMobile()).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of gateway launch prep (2/3). Addresses launch item 3: mobile layout shifts.

## What changed

- **`useIsMobile` no longer flips after first render**: state now initializes synchronously from `matchMedia` instead of `undefined -> false -> effect`, which previously forced a desktop-first paint and reflow on every mobile load. Change listener uses `mql.matches` instead of re-reading `innerWidth`.
- **Dynamic viewport heights**: full-viewport shells moved from `h-screen`/`min-h-screen` to `dvh` equivalents (page shell, den signin surface, enterprise activation gate, welcome page, architecture mismatch gate, settings shell) — kills the jump when the mobile URL bar collapses/expands. No `h-screen` remains in `apps/app/src`.
- **Session page on mobile**: single-pane stack — split/secondary workbench pane disabled below 768px, resizable panel min sizes relaxed so the chat pane isn't squeezed, side-panel toggle hidden on small screens.
- **Reserved header slot**: cloud sign-in button occupies its slot (`invisible`/disabled) before it becomes actionable instead of popping in and shifting the header.

## Verification

- `pnpm --filter @openwork/app typecheck` — exit 0
- `pnpm --filter @openwork/app build:web` — exit 0 (dvh utilities confirmed in generated CSS)
- `apps/app/tests/use-mobile.test.ts` — initial mobile detection + no-window fallback: passed (plus neighboring hook/sidebar tests, 5 passed)

**Status: Incomplete (unit/build-verified, no runtime tape).** No live mobile-browser run: gateway web needs a deployed gateway + cloud sign-in. Manual repro: open the gateway web app in a mobile viewport (<768px), reload — expect no desktop-layout flash, no jump when the URL bar collapses, single-pane chat.