### PR TITLE
fix(server): never dispose a live engine from provider sync

### DIFF
--- a/apps/server/src/cloud-provider-sync-reload-guard.test.ts
+++ b/apps/server/src/cloud-provider-sync-reload-guard.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+/**
+ * Regression tests for the "aborted messages / provider header-timeout storm"
+ * class of bugs (support reports 2026-08-07):
+ *  1. A managed engine reload must never dispose an engine with non-idle
+ *     sessions — subagent children abort mid-turn ("The message was
+ *     interrupted") when it does. Reloads defer and stay pending instead.
+ *  2. A dispose wedged on live-session teardown must not freeze the provider
+ *     sync queue: the engine answers /instance/dispose only after teardown,
+ *     and an unbounded await froze lastRun at "applied" and jammed every
+ *     later pass.
+ */
+
+const CLIENT_TOKEN = "owt_reload_guard_client";
+const HOST_TOKEN = "owt_reload_guard_host";
+const roots: string[] = [];
+const stops: Array<() => void | Promise<void>> = [];
+let previousRuntimeDb: string | undefined;
+let previousDisposeTimeout: string | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hostHeaders() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+function clientHeaders() {
+  return { authorization: `Bearer ${CLIENT_TOKEN}`, "content-type": "application/json" };
+}
+
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) throw new Error("Expected JSON object");
+  return payload;
+}
+
+async function createTempRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-reload-guard-"));
+  roots.push(root);
+  previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return root;
+}
+
+function serverConfig(root: string, baseUrl?: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local", baseUrl }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+interface FakeEngine {
+  port: number;
+  requests: string[];
+  disposeCount: () => number;
+  setBusy: (busy: boolean) => void;
+  setDisposeHangs: (hangs: boolean) => void;
+}
+
+function startFakeEngine(): FakeEngine {
+  const requests: string[] = [];
+  let busy = false;
+  let disposeHangs = false;
+  const hangReleases: Array<() => void> = [];
+  const engine = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      requests.push(`${request.method} ${url.pathname}`);
+      if (request.method === "GET" && url.pathname === "/session/status") {
+        const statuses = busy ? { ses_live: { type: "busy" } } : {};
+        return new Response(JSON.stringify(statuses), { headers: { "content-type": "application/json" } });
+      }
+      if (request.method === "POST" && url.pathname === "/instance/dispose") {
+        if (disposeHangs) {
+          // Mirrors the real engine wedged on live-session teardown: the
+          // response arrives only when the test tears down.
+          await new Promise<void>((resolve) => hangReleases.push(resolve));
+        }
+        return new Response(JSON.stringify({ ok: true }), { headers: { "content-type": "application/json" } });
+      }
+      if (request.method === "GET" && url.pathname === "/config") {
+        return new Response(JSON.stringify({}), { headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ error: "not_found" }), { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+  stops.push(() => {
+    while (hangReleases.length) hangReleases.pop()?.();
+    return engine.stop(true);
+  });
+  return {
+    port: Number(engine.port),
+    requests,
+    disposeCount: () => requests.filter((entry) => entry === "POST /instance/dispose").length,
+    setBusy: (value) => { busy = value; },
+    setDisposeHangs: (value) => { disposeHangs = value; },
+  };
+}
+
+function startFakeDen(): { url: string } {
+  const den = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname === "/v1/llm-providers") {
+        return new Response(JSON.stringify({ llmProviders: [] }), { headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ error: "not_found" }), { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+  stops.push(() => den.stop(true));
+  return { url: `http://127.0.0.1:${den.port}` };
+}
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+  if (previousDisposeTimeout === undefined) delete process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS;
+  else process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS = previousDisposeTimeout;
+});
+
+describe("engine reload guard", () => {
+  test("global provider patch defers the reload while sessions are busy and applies it once idle", async () => {
+    const root = await createTempRoot();
+    const engine = startFakeEngine();
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const den = startFakeDen();
+
+    engine.setBusy(true);
+    const deferred = await readJsonObject(await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_test: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] } } }),
+    }));
+    expect(deferred.ok).toBe(true);
+    expect(deferred.changed).toBe(true);
+    expect(deferred.reload).toBe("deferred");
+    expect(engine.disposeCount()).toBe(0);
+
+    // The parked reload applies through the provider sync once the engine idles.
+    engine.setBusy(false);
+    const put = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: den.url, token: "den_token", orgId: "org_test" }),
+    });
+    expect(put.status).toBe(204);
+    const run = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "test" }),
+    }));
+    expect(run.status === "applied" || run.status === "noop").toBe(true);
+    expect(engine.disposeCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("provider sync passes defer reloads while busy, then reload and converge to noop when idle", async () => {
+    const root = await createTempRoot();
+    const engine = startFakeEngine();
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const den = startFakeDen();
+
+    engine.setBusy(true);
+    const put = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: den.url, token: "den_token", orgId: "org_test" }),
+    });
+    expect(put.status).toBe(204);
+
+    // The first pass (PUT /den-session enqueues one automatically) writes the
+    // engine-visible runtime file -> a reload becomes pending, but the busy
+    // engine must not be disposed.
+    const busyRun = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "busy_pass" }),
+    }));
+    expect(busyRun.status === "applied" || busyRun.status === "noop").toBe(true);
+    expect(engine.disposeCount()).toBe(0);
+    const busyStatus = await readJsonObject(await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() }));
+    const busyLastRun = isRecord(busyStatus.lastRun) ? busyStatus.lastRun : {};
+    const busyDetail = isRecord(busyLastRun.detail) ? busyLastRun.detail : {};
+    expect(busyDetail.reloadDeferred).toBe(true);
+
+    // Idle: the pending reload fires exactly once, and the sync settles.
+    engine.setBusy(false);
+    await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "idle_pass" }),
+    }));
+    expect(engine.disposeCount()).toBe(1);
+    const settled = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "converged_pass" }),
+    }));
+    expect(settled.status).toBe("noop");
+    expect(engine.disposeCount()).toBe(1);
+  });
+
+  test("a wedged dispose times out instead of freezing the sync queue", async () => {
+    previousDisposeTimeout = process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS;
+    process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS = "500";
+    const root = await createTempRoot();
+    const engine = startFakeEngine();
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const den = startFakeDen();
+
+    engine.setDisposeHangs(true);
+    const put = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: den.url, token: "den_token", orgId: "org_test" }),
+    });
+    expect(put.status).toBe(204);
+
+    // The pass carries a pending reload (first runtime-file write); the hung
+    // dispose must fail the pass in bounded time instead of hanging it.
+    const first = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "wedged_pass" }),
+    }));
+    expect(first.status).toBe("failed");
+    expect(String(first.message ?? "")).toContain("did not complete in time");
+
+    // The queue is not jammed: the next pass runs (and retries the reload).
+    const disposesBefore = engine.disposeCount();
+    const second = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "post_wedge_pass" }),
+    }));
+    expect(second.status).toBe("failed");
+    expect(engine.disposeCount()).toBe(disposesBefore + 1);
+
+    // Recovery: once the engine answers disposes again, the reload lands.
+    engine.setDisposeHangs(false);
+    const recovered = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "recovered_pass" }),
+    }));
+    expect(recovered.status === "applied" || recovered.status === "noop").toBe(true);
+  });
+});

--- a/apps/server/src/cloud-provider-sync-reload-guard.test.ts
+++ b/apps/server/src/cloud-provider-sync-reload-guard.test.ts
@@ -24,6 +24,7 @@ const roots: string[] = [];
 const stops: Array<() => void | Promise<void>> = [];
 let previousRuntimeDb: string | undefined;
 let previousDisposeTimeout: string | undefined;
+let previousReloadRetry: string | undefined;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -145,7 +146,18 @@ afterEach(async () => {
   else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
   if (previousDisposeTimeout === undefined) delete process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS;
   else process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS = previousDisposeTimeout;
+  if (previousReloadRetry === undefined) delete process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS;
+  else process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS = previousReloadRetry;
 });
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
 
 describe("engine reload guard", () => {
   test("global provider patch defers the reload while sessions are busy and applies it once idle", async () => {
@@ -232,6 +244,37 @@ describe("engine reload guard", () => {
     }));
     expect(settled.status).toBe("noop");
     expect(engine.disposeCount()).toBe(1);
+  });
+
+  test("a deferred reload lands by itself once the engine idles, even with no Den session", async () => {
+    previousReloadRetry = process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS;
+    process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS = "200";
+    const root = await createTempRoot();
+    const engine = startFakeEngine();
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+
+    // No PUT /den-session on purpose: a signed-out desktop that patches
+    // global providers must still see them reach the engine eventually.
+    engine.setBusy(true);
+    const deferred = await readJsonObject(await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_retry: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] } } }),
+    }));
+    expect(deferred.reload).toBe("deferred");
+    expect(engine.disposeCount()).toBe(0);
+
+    // Still busy: the retry poll must keep waiting, not dispose.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(engine.disposeCount()).toBe(0);
+
+    // Idle: the parked reload lands from the retry poll alone.
+    engine.setBusy(false);
+    const landed = await waitUntil(() => engine.disposeCount() >= 1, 3_000);
+    expect(landed).toBe(true);
   });
 
   test("a wedged dispose times out instead of freezing the sync queue", async () => {

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -483,6 +483,11 @@ function configuredIntervalMs(): number {
   return Number.isFinite(configured) && configured > 0 ? configured : defaultIntervalMs;
 }
 
+function configuredReloadRetryMs(): number {
+  const configured = Number(process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS ?? "");
+  return Number.isFinite(configured) && configured > 0 ? configured : 15_000;
+}
+
 export class CloudProviderSync {
   private readonly config: ServerConfig;
   private readonly env: EnvService;
@@ -501,6 +506,8 @@ export class CloudProviderSync {
   private reloadPending = false;
   private queue: Promise<void> = Promise.resolve();
   private interval: ReturnType<typeof setInterval> | null = null;
+  private pendingReloadRetry: ReturnType<typeof setTimeout> | null = null;
+  private readonly reloadRetryMs: number;
 
   constructor(options: CloudProviderSyncOptions) {
     this.config = options.config;
@@ -510,6 +517,7 @@ export class CloudProviderSync {
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
     this.logger = options.logger;
     this.intervalMs = options.intervalMs ?? configuredIntervalMs();
+    this.reloadRetryMs = configuredReloadRetryMs();
   }
 
   setSession(session: CloudProviderDenSession): void {
@@ -554,11 +562,13 @@ export class CloudProviderSync {
 
   stop(): void {
     this.stopInterval();
+    this.stopReloadRetry();
   }
 
   /** External runtime-config writers park their engine reload here when the engine is busy. */
   markReloadPending(): void {
     this.reloadPending = true;
+    this.scheduleReloadRetry();
   }
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -581,6 +591,41 @@ export class CloudProviderSync {
   private stopInterval(): void {
     if (this.interval) clearInterval(this.interval);
     this.interval = null;
+  }
+
+  /**
+   * A deferred reload must not wait for the next user gesture or the 5-minute
+   * interval — and a reload parked by markReloadPending() may have no Den
+   * session at all, so no sync pass would ever retry it. Poll the (local,
+   * cheap) engine busy probe and land the reload moments after the last
+   * session idles. Serialized on the same queue as sync passes.
+   */
+  private scheduleReloadRetry(): void {
+    if (this.pendingReloadRetry) return;
+    const timer = setTimeout(() => {
+      this.pendingReloadRetry = null;
+      if (!this.reloadPending) return;
+      void this.enqueue(async () => {
+        if (!this.reloadPending) return;
+        if (await this.reloadDeferredByActivity()) {
+          this.scheduleReloadRetry();
+          return;
+        }
+        try {
+          await this.reloadEngine();
+          this.reloadPending = false;
+        } catch {
+          this.scheduleReloadRetry();
+        }
+      });
+    }, this.reloadRetryMs);
+    timer.unref();
+    this.pendingReloadRetry = timer;
+  }
+
+  private stopReloadRetry(): void {
+    if (this.pendingReloadRetry) clearTimeout(this.pendingReloadRetry);
+    this.pendingReloadRetry = null;
   }
 
   /**
@@ -662,6 +707,7 @@ export class CloudProviderSync {
     if (engineWorkspace && this.reloadPending) {
       if (await this.reloadDeferredByActivity()) {
         reloadDeferred = true;
+        this.scheduleReloadRetry();
       } else {
         try {
           await this.reloadEngine();
@@ -772,7 +818,9 @@ export class CloudProviderSync {
       this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
     }
     let reloadError: unknown;
-    if (this.reloadPending && !(await this.reloadDeferredByActivity())) {
+    if (this.reloadPending && (await this.reloadDeferredByActivity())) {
+      this.scheduleReloadRetry();
+    } else if (this.reloadPending) {
       try {
         await this.reloadEngine();
         this.reloadPending = false;

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -46,12 +46,24 @@ export type CloudProviderSyncStatusProvider = {
   importedAt: number;
 };
 
+export type CloudProviderSyncRunDetail = {
+  fingerprintChanged: boolean;
+  providerStateChanged: boolean;
+  envUpserts: number;
+  envDeletes: number;
+  cleanupChanged: boolean;
+  cleanupRuntimeChanged: boolean;
+  fileChanged: boolean;
+  reloadDeferred: boolean;
+};
+
 export type CloudProviderSyncStatus = {
   hasSession: boolean;
   lastRun: {
     at: string;
     status: "applied" | "noop" | "failed";
     message?: string;
+    detail?: CloudProviderSyncRunDetail;
   } | null;
   providers: CloudProviderSyncStatusProvider[];
 };
@@ -104,6 +116,13 @@ export type CloudProviderSyncOptions = {
   config: ServerConfig;
   env: EnvService;
   reloadEngine: () => Promise<void>;
+  /**
+   * Reports whether the managed engine currently has non-idle sessions.
+   * When it returns true a pending engine reload is deferred to a later
+   * pass instead of disposing a live instance ("no auto-reload while
+   * sessions are running"). Absent means "unknown" and never blocks.
+   */
+  engineBusy?: () => Promise<boolean>;
   fetchImpl?: typeof globalThis.fetch;
   logger?: CloudProviderSyncLogger;
   intervalMs?: number;
@@ -468,6 +487,7 @@ export class CloudProviderSync {
   private readonly config: ServerConfig;
   private readonly env: EnvService;
   private readonly reloadEngine: () => Promise<void>;
+  private readonly engineBusy?: () => Promise<boolean>;
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly logger?: CloudProviderSyncLogger;
   private readonly intervalMs: number;
@@ -486,6 +506,7 @@ export class CloudProviderSync {
     this.config = options.config;
     this.env = options.env;
     this.reloadEngine = options.reloadEngine;
+    this.engineBusy = options.engineBusy;
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
     this.logger = options.logger;
     this.intervalMs = options.intervalMs ?? configuredIntervalMs();
@@ -535,6 +556,11 @@ export class CloudProviderSync {
     this.stopInterval();
   }
 
+  /** External runtime-config writers park their engine reload here when the engine is busy. */
+  markReloadPending(): void {
+    this.reloadPending = true;
+  }
+
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
     const run = this.queue.then(operation, operation);
     this.queue = run.then(
@@ -557,16 +583,30 @@ export class CloudProviderSync {
     this.interval = null;
   }
 
+  /**
+   * A pending reload never disposes a live engine: sessions (including
+   * subagent children) would abort mid-turn. Unknown activity never blocks —
+   * a dead engine surfaces through the dispose call itself.
+   */
+  private async reloadDeferredByActivity(): Promise<boolean> {
+    if (!this.engineBusy) return false;
+    try {
+      return await this.engineBusy();
+    } catch {
+      return false;
+    }
+  }
+
   private async runPass(reason?: string): Promise<CloudProviderSyncRunResult> {
     const session = this.session;
     if (!session) return { status: "no_session" };
     try {
       const prepared = prepareMaterialization(await fetchProviders(this.fetchImpl, session));
-      const changed = await this.apply(prepared);
+      const { changed, detail } = await this.apply(prepared);
       this.updateProviderStatus(prepared);
       this.fingerprint = prepared.fingerprint;
       const status = changed ? "applied" : "noop";
-      this.lastRun = { at: new Date().toISOString(), status };
+      this.lastRun = { at: new Date().toISOString(), status, detail };
       return { status };
     } catch (error) {
       const message = error instanceof Error ? error.message : "cloud_provider_sync_failed";
@@ -576,7 +616,7 @@ export class CloudProviderSync {
     }
   }
 
-  private async apply(prepared: PreparedMaterialization): Promise<boolean> {
+  private async apply(prepared: PreparedMaterialization): Promise<{ changed: boolean; detail: CloudProviderSyncRunDetail }> {
     const desiredProviders = desiredProviderMap(prepared);
     const globalRuntime = await readGlobalRuntimeOpencodeConfig(this.config);
     const currentManagedProviders = managedProviderMap(runtimeProviderMap(globalRuntime));
@@ -618,12 +658,17 @@ export class CloudProviderSync {
       || workspaceCleanup.runtimeChanged
       || runtimeFileChanged;
     let reloadError: unknown;
+    let reloadDeferred = false;
     if (engineWorkspace && this.reloadPending) {
-      try {
-        await this.reloadEngine();
-        this.reloadPending = false;
-      } catch (error) {
-        reloadError = error;
+      if (await this.reloadDeferredByActivity()) {
+        reloadDeferred = true;
+      } else {
+        try {
+          await this.reloadEngine();
+          this.reloadPending = false;
+        } catch (error) {
+          reloadError = error;
+        }
       }
     }
     await syncManagedProviderAuth({
@@ -635,12 +680,23 @@ export class CloudProviderSync {
     if (reloadError) throw reloadError;
 
     this.managedProviderIds = new Set(Object.keys(desiredProviders));
-    return this.fingerprint !== prepared.fingerprint
+    const detail: CloudProviderSyncRunDetail = {
+      fingerprintChanged: this.fingerprint !== prepared.fingerprint,
+      providerStateChanged,
+      envUpserts: envUpserts.length,
+      envDeletes: envDeletes.length,
+      cleanupChanged: workspaceCleanup.changed,
+      cleanupRuntimeChanged: workspaceCleanup.runtimeChanged,
+      fileChanged: runtimeFileChanged,
+      reloadDeferred,
+    };
+    const changed = detail.fingerprintChanged
       || providerStateChanged
       || envUpserts.length > 0
       || envDeletes.length > 0
       || workspaceCleanup.changed
       || runtimeFileChanged;
+    return { changed, detail };
   }
 
   private async cleanupWorkspaceTakeovers(): Promise<{ changed: boolean; runtimeChanged: boolean }> {
@@ -716,7 +772,7 @@ export class CloudProviderSync {
       this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
     }
     let reloadError: unknown;
-    if (this.reloadPending) {
+    if (this.reloadPending && !(await this.reloadDeferredByActivity())) {
       try {
         await this.reloadEngine();
         this.reloadPending = false;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -856,6 +856,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     config,
     env,
     reloadEngine: () => reloadOpencodeEngine(config, resolveEngineRuntimeWorkspace(config), engineMcpServerState),
+    engineBusy: () => engineHasActiveSessions(config, resolveEngineRuntimeWorkspace(config)),
     logger: toManagedProviderAuthLogger(logger),
   });
   const routes = createRoutes(
@@ -2090,8 +2091,14 @@ function createRoutes(
 
     const fileResult = await writeOpenworkRuntimeConfigFile(config, workspace.id);
     const shouldReload = result.changed || fileResult.changed;
-    if (shouldReload) {
+    // Never dispose a live engine under running sessions; park the reload on
+    // the provider sync so it applies on a later pass once the engine idles.
+    const reloadDeferred = shouldReload && (await engineHasActiveSessions(config, workspace));
+    if (shouldReload && !reloadDeferred) {
       await reloadOpencodeEngine(config, workspace, engineMcpServerState);
+    }
+    if (reloadDeferred) {
+      cloudProviderSync.markReloadPending();
     }
     // The provider entry only names its credential env vars; the engine needs
     // the value itself via its auth API.
@@ -2106,7 +2113,7 @@ function createRoutes(
       changed: result.changed,
       provider: runtimeProviderMap(result.config),
       runtimeConfigPath: openworkRuntimeConfigFilePath(config),
-      reload: shouldReload ? "reloaded" : "skipped",
+      reload: shouldReload ? (reloadDeferred ? "deferred" : "reloaded") : "skipped",
     });
   });
 
@@ -3326,6 +3333,31 @@ function parseOpencodeErrorBody(input: string): unknown {
   }
 }
 
+// Bounded so a dispose wedged on live-session teardown can never freeze the
+// caller (CloudProviderSync serializes passes on one queue; an unbounded
+// dispose froze every later pass and the status it reports). Overridable for
+// tests.
+function opencodeDisposeTimeoutMs(): number {
+  const configured = Number(process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS ?? "");
+  return Number.isFinite(configured) && configured > 0 ? configured : 30_000;
+}
+
+/**
+ * True when the managed engine reports any non-idle session (subagent child
+ * sessions carry their own ids and statuses, so they count too). Unknown
+ * activity reports false: a reload against a dead engine fails loudly on its
+ * own, and "unknown" must never park reloads forever.
+ */
+async function engineHasActiveSessions(config: ServerConfig, workspace: WorkspaceInfo): Promise<boolean> {
+  try {
+    const opencode = createWorkspaceOpencodeClient(config, workspace);
+    const statuses = unwrapOpencodeResult(await opencode.session.status(), "/session/status");
+    return Object.values(statuses).some((status) => status.type !== "idle");
+  } catch {
+    return false;
+  }
+}
+
 async function reloadOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,
@@ -3348,8 +3380,25 @@ async function reloadOpencodeEngine(
   let response: Response;
   try {
     // OpenCode reload targets the managed loopback engine; CA trust is irrelevant.
-    response = await loopbackFetch(targetUrl, { method: "POST", headers });
+    // The engine answers /instance/dispose only AFTER teardown completes, so a
+    // dispose wedged on live-session teardown would otherwise hang forever.
+    response = await loopbackFetch(targetUrl, {
+      method: "POST",
+      headers,
+      signal: AbortSignal.timeout(opencodeDisposeTimeoutMs()),
+    });
   } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      // Deliberately NOT opencode_engine_unreachable: the app escalates that
+      // code to a full desktop engine restart, which would kill the very
+      // sessions the wedged dispose is still tearing down.
+      throw new ApiError(
+        504,
+        "opencode_reload_timeout",
+        "OpenCode dispose did not complete in time; the reload stays pending",
+        { baseUrl },
+      );
+    }
     throw new ApiError(
       503,
       "opencode_engine_unreachable",
@@ -3402,6 +3451,18 @@ async function reloadOpencodeEngine(
     logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "engine_reload", health });
   } catch (error) {
     logPersistedCloudMcpReconcileError({ config, workspace, trigger: "engine_reload", error });
+  }
+  // The MCP re-registration above writes the runtime DB; refresh the
+  // engine-visible file synchronously so the next provider-sync pass compares
+  // against post-reload state instead of racing the async fresh-keeper and
+  // reporting a phantom "changed" (which would schedule yet another reload).
+  try {
+    const engineWorkspace = resolveEngineRuntimeWorkspace(config);
+    if (engineWorkspace.id === workspace.id) {
+      await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    }
+  } catch {
+    // Best-effort: the fresh-keeper listener still converges eventually.
   }
 }
 

--- a/evals/specs/model-lands-mid-run.slow.test.ts
+++ b/evals/specs/model-lands-mid-run.slow.test.ts
@@ -395,13 +395,47 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 2_700_000 }, async
   expect(headerTimeoutRetries, "provider header-timeout retries observed").toEqual([]);
 
   // ── Frame 5: the new model is simply there in the picker ────────────────
-  const afterModels = await readAvailableModels(desktopApp);
-  const grantedRow = afterModels.find((model) => model.id === grant.modelId && model.selectable);
+  // The engine's catalog can land after the picker's first paint (the same
+  // race models-available.slow.test.ts documents: "0 models at first read, 7
+  // shortly after"), so poll the open dialog instead of trusting one scrape.
+  let afterModels = await readAvailableModels(desktopApp);
+  let grantedRow = afterModels.find((model) => model.id === grant.modelId && model.selectable);
+  const pickerDeadline = Date.now() + 180_000;
+  while (!grantedRow && Date.now() < pickerDeadline) {
+    await sleep(3_000);
+    afterModels = await readAvailableModels(desktopApp);
+    grantedRow = afterModels.find((model) => model.id === grant.modelId && model.selectable);
+  }
+  if (!grantedRow) {
+    // Name the layer that lost the model: engine catalog vs. app picker.
+    const engineView = await evalIn(desktopApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      const out = {};
+      for (const path of ["/opencode/config/providers", "/opencode/config"]) {
+        const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + path, {
+          headers: { Authorization: "Bearer " + token },
+        });
+        if (!response.ok) { out[path] = "HTTP " + response.status; continue; }
+        const text = await response.text();
+        out[path] = {
+          hasProvider: text.includes(${JSON.stringify(grant.providerId)}),
+          hasModel: text.includes(${JSON.stringify(grant.modelId)}),
+        };
+      }
+      return out;
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    evidence.fact(
+      "Frame 5 diagnostic — which layer dropped the granted model",
+      `Engine config view: ${JSON.stringify(engineView)}; picker rows: ${afterModels.map((model) => model.id).join(", ") || "none"}.`,
+      false,
+    );
+  }
   evidence.fact(
     "Frame 5 — the granted model appears in the picker with no restart",
     grantedRow
-      ? `${grant.modelId} is listed under provider '${grantedRow.providerName}'.`
-      : `${grant.modelId} missing from picker; saw ${afterModels.map((model) => model.id).join(", ")}.`,
+      ? `${grant.modelId} is listed under provider '${grantedRow.providerName}' after polling the open picker.`
+      : `${grant.modelId} missing from picker after 180s; saw ${afterModels.map((model) => model.id).join(", ")}.`,
     Boolean(grantedRow),
   );
   expect(grantedRow, `the granted model ${grant.modelId} is not selectable in the picker`).toBeTruthy();

--- a/evals/specs/model-lands-mid-run.slow.test.ts
+++ b/evals/specs/model-lands-mid-run.slow.test.ts
@@ -1,0 +1,444 @@
+import { expect } from "vitest";
+import {
+  control,
+  denFetch,
+  evalIn,
+  readAvailableModels,
+  readCurrentOrganizationMemberId,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { app, eventually, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+/**
+ * VOICEOVER SPEC — "New models arrive without breaking your flow."
+ *
+ * 1. Maya has OpenWork deep in a real task — subagents fanned out — signed in
+ *    to her company's org.
+ * 2. While her task runs, her admin grants the team a new model. Nothing
+ *    happens on Maya's screen: no flash, no "The message was interrupted",
+ *    no retry countdown.
+ * 3. Under the hood OpenWork notices the new model but refuses to restart the
+ *    engine while her sessions are live — it parks the update
+ *    (lastRun.detail.reloadDeferred).
+ * 4. Her task finishes intact. She touches nothing — within moments the
+ *    parked update lands on its own (idle-retry, no user gesture, no reload
+ *    call).
+ * 5. She opens the model picker and the new org model is already there.
+ * 6. She switches to it and sends a message; the new model answers — same
+ *    session window, zero interruptions, from grant to first reply.
+ *
+ * This is also the regression net for PR #3634: it exercises the busy-defer
+ * guard, the idle-retry freshness path, and the materialized credential
+ * end-to-end against the real OpenAI API from a real Daytona sandbox.
+ */
+
+const requirements: NeedsSpec = {
+  env: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `model lands mid-run skipped — needs: ${missingRequirements.join(", ")}`
+  : "a model granted mid-run never interrupts the task and is usable right after it finishes";
+
+const COMPLETE_MARKER = "MID-RUN-TASK-COMPLETE";
+const NEW_MODEL_MARKER = "NEW-MODEL-LIVE";
+const INTERRUPTED_TEXT = "The message was interrupted";
+const GRANT_PROVIDER_NAME = "Fresh Grant Models";
+
+const longRunPrompt = [
+  "Launch exactly three subagents in parallel using the task tool.",
+  "Subagent 1 must run the bash command `sleep 120 && echo subagent-1-done` and report the output.",
+  "Subagent 2 must run the bash command `sleep 120 && echo subagent-2-done` and report the output.",
+  "Subagent 3 must run the bash command `sleep 120 && echo subagent-3-done` and report the output.",
+  `After all three subagents report, reply with exactly: ${COMPLETE_MARKER}`,
+].join(" ");
+
+interface StormProbe {
+  reconnects: number;
+  disposes: Array<{ at: number }>;
+  retries: Array<{ at: number; message: string }>;
+  errors: Array<{ at: number; name: string; message: string }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStormProbe(value: unknown): StormProbe {
+  if (!isRecord(value)) throw new Error(`Storm probe was not an object: ${JSON.stringify(value)}`);
+  const list = (input: unknown): Record<string, unknown>[] => (Array.isArray(input) ? input.filter(isRecord) : []);
+  return {
+    reconnects: typeof value.reconnects === "number" ? value.reconnects : 0,
+    disposes: list(value.disposes).map((entry) => ({ at: typeof entry.at === "number" ? entry.at : 0 })),
+    retries: list(value.retries).map((entry) => ({
+      at: typeof entry.at === "number" ? entry.at : 0,
+      message: typeof entry.message === "string" ? entry.message : "",
+    })),
+    errors: list(value.errors).map((entry) => ({
+      at: typeof entry.at === "number" ? entry.at : 0,
+      name: typeof entry.name === "string" ? entry.name : "",
+      message: typeof entry.message === "string" ? entry.message : "",
+    })),
+  };
+}
+
+const assistantHasText = (text: string): string => `(() => {
+  return [...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => (message.innerText ?? "").includes(${JSON.stringify(text)}));
+})()`;
+
+const stopEnabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop && !stop.disabled);
+})()`;
+
+const stopDisabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop?.disabled);
+})()`;
+
+async function discoverOpenAiModelCandidates(apiKey: string): Promise<string[]> {
+  const response = await fetch("https://api.openai.com/v1/models", {
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) throw new Error(`OpenAI model discovery failed: HTTP ${response.status}`);
+  const body: unknown = await response.json();
+  const ids = isRecord(body) && Array.isArray(body.data)
+    ? body.data.filter(isRecord).map((entry) => (typeof entry.id === "string" ? entry.id : "")).filter(Boolean)
+    : [];
+  const chatLike = ids.filter((id) => /^gpt/i.test(id) && !/audio|realtime|image|tts|transcribe|embed|moderation/i.test(id));
+  const preferred = chatLike.filter((id) => /mini|nano/i.test(id));
+  const rest = chatLike.filter((id) => !/mini|nano/i.test(id));
+  const ordered = [...preferred, ...rest];
+  if (ordered.length === 0) throw new Error(`OpenAI model discovery returned no chat-capable gpt ids. Saw: ${ids.slice(0, 20).join(", ")}`);
+  return ordered.slice(0, 6);
+}
+
+async function grantOrgModel(
+  admin: DenSession,
+  orgId: string,
+  memberId: string,
+  apiKey: string,
+  candidates: string[],
+): Promise<{ providerId: string; modelId: string; attempts: string[] }> {
+  const attempts: string[] = [];
+  for (const modelId of candidates) {
+    const result = await denFetch(admin, "/v1/llm-providers", {
+      method: "POST",
+      headers: { authorization: `Bearer ${admin.token}`, "x-openwork-org-id": orgId },
+      body: JSON.stringify({
+        name: GRANT_PROVIDER_NAME,
+        source: "models_dev",
+        providerId: "openai",
+        modelIds: [modelId],
+        apiKey,
+        memberIds: [memberId],
+        teamIds: [],
+      }),
+    });
+    const provider = isRecord(result.body) && isRecord(result.body.llmProvider) ? result.body.llmProvider : null;
+    const providerId = provider && typeof provider.id === "string" ? provider.id : "";
+    if (result.response.ok && providerId) {
+      return { providerId, modelId, attempts };
+    }
+    attempts.push(`${modelId} -> HTTP ${result.response.status} ${result.text.slice(0, 120)}`);
+  }
+  throw new Error(`No OpenAI model candidate was accepted by the Den catalog. Attempts: ${attempts.join(" | ")}`);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 2_700_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+
+  await using den = await server({ place });
+  await using desktopApp = await app({ den, as: "admin", place });
+  const workspaceId = desktopApp.workspaceId;
+
+  // ── Arrange: real Anthropic model for the long task (same path a user's
+  // Settings save takes; single pre-run reload, before any session exists) ──
+  const anthropicKey = process.env.ANTHROPIC_API_KEY?.trim() ?? "";
+  const openaiKey = process.env.OPENAI_API_KEY?.trim() ?? "";
+  const providerConfigured = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 300);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({ opencode: { provider: { anthropic: { options: { apiKey: ${JSON.stringify(anthropicKey)} } } } } }),
+    });
+    if (patched !== "ok") return patched;
+    return request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  expect(providerConfigured).toBe("ok");
+
+  const models = await readAvailableModels(desktopApp);
+  const selectable = models.filter((model) => model.selectable);
+  const claudes = selectable.filter((model) => /anthropic/i.test(model.providerName) || /^claude-/i.test(model.id));
+  const runModel = claudes.find((model) => /^claude-sonnet-\d+-\d+$/.test(model.id))
+    ?? claudes.find((model) => /sonnet/i.test(model.id))
+    ?? claudes[0];
+  if (!runModel) throw new Error(`No Anthropic model selectable. Saw: ${models.map((model) => model.id).join(", ") || "none"}`);
+  await selectModel(desktopApp, runModel.id);
+
+  // ── Engine event tail: disposes, retries and session errors are the
+  // witnesses for "nothing interrupted her" ────────────────────────────────
+  const tailStarted = await evalIn(desktopApp, `(() => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    window.__owStorm = { active: true, reconnects: -1, disposes: [], retries: [], errors: [] };
+    const record = (event) => {
+      const storm = window.__owStorm;
+      const type = String(event?.type ?? "unknown");
+      const properties = event?.properties ?? {};
+      if (type.includes("disposed")) storm.disposes.push({ at: Date.now() });
+      if (type === "session.status" && properties?.status?.type === "retry") {
+        storm.retries.push({ at: Date.now(), message: String(properties.status.message ?? "") });
+      }
+      if (type === "session.error") {
+        const error = properties?.error ?? {};
+        storm.errors.push({ at: Date.now(), name: String(error?.name ?? ""), message: String(error?.data?.message ?? "") });
+      }
+    };
+    (async () => {
+      const url = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/opencode/event";
+      while (window.__owStorm.active) {
+        window.__owStorm.reconnects += 1;
+        try {
+          const response = await fetch(url, { headers: { Authorization: "Bearer " + token } });
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (window.__owStorm.active) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const frames = buffer.split("\\n\\n");
+            buffer = frames.pop() ?? "";
+            for (const frame of frames) {
+              for (const line of frame.split("\\n")) {
+                if (!line.startsWith("data:")) continue;
+                try { record(JSON.parse(line.slice(5).trim())); } catch {}
+              }
+            }
+          }
+        } catch {}
+        if (window.__owStorm.active) await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    })();
+    return "ok";
+  })()`);
+  expect(tailStarted).toBe("ok");
+
+  // ── Arm the server-side provider sync with the signed-in Den session ────
+  const readSyncStatusExpression = `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/status", {
+      headers: { Authorization: "Bearer " + token },
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  })()`;
+  const armProbe = String(await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const hostToken = localStorage.getItem("openwork.server.hostToken");
+    const denToken = (localStorage.getItem("openwork.den.authToken") ?? "").trim();
+    const orgId = (localStorage.getItem("openwork.den.activeOrgId") ?? "").trim();
+    if (!port || !hostToken || !denToken || !orgId) return "missing:" + [port, hostToken, denToken, orgId].map(Boolean).join(",");
+    const response = await fetch("http://127.0.0.1:" + port + "/den-session", {
+      method: "PUT",
+      headers: { "x-openwork-host-token": hostToken, "Content-Type": "application/json" },
+      body: JSON.stringify({ baseUrl: ${JSON.stringify(den.ref.apiUrl)}, token: denToken, orgId }),
+    });
+    return "PUT /den-session -> " + response.status + "; orgId=" + orgId;
+  })()`, { awaitPromise: true, timeoutMs: 30_000 }));
+  expect(armProbe).toContain("204");
+  const activeOrgId = armProbe.split("orgId=")[1] ?? "";
+  expect(activeOrgId.startsWith("org_"), `active org id unreadable: ${armProbe}`).toBe(true);
+  await eventually(async () => {
+    const status = await evalIn(desktopApp, readSyncStatusExpression, { awaitPromise: true, timeoutMs: 30_000 });
+    return isRecord(status) && status.hasSession === true;
+  }, { within: 60_000, label: "cloud provider sync armed", until: (armed) => armed === true });
+
+  // ── Frame 1: Maya's long subagent task is genuinely running ─────────────
+  const ownerMemberId = await readCurrentOrganizationMemberId(den.admin);
+  const candidates = await discoverOpenAiModelCandidates(openaiKey);
+  await control(desktopApp, "session.create_task");
+  const sandboxRunStartedAt = Number(await evalIn(desktopApp, "Date.now()"));
+  await sendComposerMessage(desktopApp, longRunPrompt);
+  await waitFor(desktopApp, stopEnabledExpression, { timeoutMs: 60_000, label: "run became active" });
+  const sawSubagents = await waitFor(desktopApp, `Boolean(document.querySelector('[data-subagent-run]'))`, {
+    timeoutMs: 300_000,
+    label: "subagent run line visible",
+  }).then(() => true, () => false);
+  expect(sawSubagents, "the task never fanned out to subagents").toBe(true);
+  evidence.fact(
+    "Frame 1 — a real subagent task is running in a signed-in org desktop",
+    `Model ${runModel.id}; [data-subagent-run] visible; composer stop enabled.`,
+    true,
+  );
+
+  // ── Frame 2: the admin grants a new model WHILE the task runs ───────────
+  const grant = await grantOrgModel(den.admin, activeOrgId, ownerMemberId, openaiKey, candidates);
+  evidence.fact(
+    "Frame 2 — the org grants a new model mid-run through the real Den API",
+    `POST /v1/llm-providers accepted ${grant.modelId} as ${grant.providerId} (rejected candidates: ${grant.attempts.length ? grant.attempts.join(" | ") : "none"}).`,
+    true,
+  );
+
+  // ── Frame 3: the sync sees it and PARKS the engine reload (busy) ────────
+  const syncRun = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const hostToken = localStorage.getItem("openwork.server.hostToken");
+    const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/run", {
+      method: "POST",
+      headers: { "x-openwork-host-token": hostToken, "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: "mid_run_grant" }),
+    });
+    return response.status + ":" + (await response.text()).slice(0, 120);
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  expect(String(syncRun)).toContain("200");
+  const deferredStatus = await evalIn(desktopApp, readSyncStatusExpression, { awaitPromise: true, timeoutMs: 30_000 });
+  const lastRun = isRecord(deferredStatus) && isRecord(deferredStatus.lastRun) ? deferredStatus.lastRun : {};
+  const detail = isRecord(lastRun.detail) ? lastRun.detail : {};
+  const stillBusy = (await evalIn(desktopApp, stopEnabledExpression)) === true;
+  evidence.fact(
+    "Frame 3 — the update is parked, not applied over a live engine",
+    `Sync pass after the grant: ${String(syncRun)}; lastRun=${JSON.stringify(lastRun)}; run still busy: ${stillBusy}.`,
+    detail.reloadDeferred === true && stillBusy,
+  );
+  expect(detail.reloadDeferred, `the sync pass did not defer its reload: ${JSON.stringify(lastRun)}`).toBe(true);
+  expect(stillBusy, "the run was no longer busy right after the grant sync pass").toBe(true);
+  const domInterruptedMidRun = (await evalIn(desktopApp, `document.body.innerText.includes(${JSON.stringify(INTERRUPTED_TEXT)})`)) === true;
+  expect(domInterruptedMidRun, "the grant interrupted the visible conversation").toBe(false);
+
+  const midRunShot = await screenshot(desktopApp);
+  const midRunSeen = await validate(midRunShot, [
+    "A task with subagent activity is still running (a subagent/task row and a Stop control are visible)",
+    "No error banner, no 'The message was interrupted' text and no retry countdown is visible",
+  ]);
+  expect(midRunSeen.ok, midRunSeen.why).toBe(true);
+
+  // ── Frame 4: the task finishes intact; the parked update lands ALONE ────
+  await waitFor(desktopApp, assistantHasText(COMPLETE_MARKER), { timeoutMs: 420_000, label: `assistant reply containing ${COMPLETE_MARKER}` });
+  await waitFor(desktopApp, stopDisabledExpression, { timeoutMs: 120_000, label: "run settled" });
+  const sandboxRunEndedAt = Number(await evalIn(desktopApp, "Date.now()"));
+
+  // No picker, no focus events, no reload calls: only the server's own
+  // idle-retry may land the parked reload now.
+  const freshnessStartedAt = Date.now();
+  const engineHasProvider = `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    for (const path of ["/opencode/config/providers", "/opencode/config"]) {
+      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + path, {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (!response.ok) continue;
+      const text = await response.text();
+      if (text.includes(${JSON.stringify(grant.providerId)})) return true;
+    }
+    return false;
+  })()`;
+  const landed = await eventually(
+    async () => (await evalIn(desktopApp, engineHasProvider, { awaitPromise: true, timeoutMs: 30_000 })) === true,
+    { within: 120_000, label: "engine exposes the granted provider without user action", until: (seen) => seen === true },
+  ).then(() => true, () => false);
+  const freshnessMs = Date.now() - freshnessStartedAt;
+  evidence.fact(
+    "Frame 4 — the parked update lands by itself moments after the task finishes",
+    landed
+      ? `The engine exposed ${grant.providerId} ${Math.round(freshnessMs / 1000)}s after idle, with no user action and no reload call.`
+      : `The engine never exposed ${grant.providerId} within 120s of going idle.`,
+    landed,
+  );
+  expect(landed, "the deferred reload did not land on its own after idle").toBe(true);
+
+  // ── Witnesses: nothing was interrupted, ever ─────────────────────────────
+  const probe = parseStormProbe(await evalIn(desktopApp, `(() => {
+    const storm = window.__owStorm ?? null;
+    if (storm) storm.active = false;
+    return storm ? JSON.parse(JSON.stringify(storm)) : null;
+  })()`));
+  const disposesDuringRun = probe.disposes.filter((dispose) => dispose.at >= sandboxRunStartedAt && dispose.at <= sandboxRunEndedAt);
+  const disposesAfterIdle = probe.disposes.filter((dispose) => dispose.at > sandboxRunEndedAt);
+  const abortErrors = probe.errors.filter((error) => error.name === "MessageAbortedError");
+  const headerTimeoutRetries = probe.retries.filter((retry) => /headers? timed out/i.test(retry.message));
+  const domInterrupted = (await evalIn(desktopApp, `document.body.innerText.includes(${JSON.stringify(INTERRUPTED_TEXT)})`)) === true;
+  evidence.fact(
+    "Frames 2-4 negative half — zero interruptions from grant to landing",
+    `Disposes during run: ${disposesDuringRun.length}; after idle: ${disposesAfterIdle.length}; session errors: ${JSON.stringify(probe.errors)}; header-timeout retries: ${headerTimeoutRetries.length}; '${INTERRUPTED_TEXT}' visible: ${domInterrupted}.`,
+    disposesDuringRun.length === 0 && disposesAfterIdle.length >= 1 && abortErrors.length === 0 && !domInterrupted,
+  );
+  expect(disposesDuringRun.length, `engine disposes during the live run: ${JSON.stringify(disposesDuringRun)}`).toBe(0);
+  expect(disposesAfterIdle.length, "no dispose after idle — the landed reload should have produced one").toBeGreaterThanOrEqual(1);
+  expect(abortErrors, "sessions were aborted").toEqual([]);
+  expect(domInterrupted, `'${INTERRUPTED_TEXT}' is visible`).toBe(false);
+  expect(headerTimeoutRetries, "provider header-timeout retries observed").toEqual([]);
+
+  // ── Frame 5: the new model is simply there in the picker ────────────────
+  const afterModels = await readAvailableModels(desktopApp);
+  const grantedRow = afterModels.find((model) => model.id === grant.modelId && model.selectable);
+  evidence.fact(
+    "Frame 5 — the granted model appears in the picker with no restart",
+    grantedRow
+      ? `${grant.modelId} is listed under provider '${grantedRow.providerName}'.`
+      : `${grant.modelId} missing from picker; saw ${afterModels.map((model) => model.id).join(", ")}.`,
+    Boolean(grantedRow),
+  );
+  expect(grantedRow, `the granted model ${grant.modelId} is not selectable in the picker`).toBeTruthy();
+  await selectModel(desktopApp, grant.modelId);
+  const pickerShot = await screenshot(desktopApp);
+  const pickerSeen = await validate(pickerShot, [
+    "The conversation shows the earlier task completed successfully (its final reply is present)",
+    "No error banner and no 'The message was interrupted' text is visible",
+  ]);
+  expect(pickerSeen.ok, pickerSeen.why).toBe(true);
+
+  // ── Frame 6: the new model actually answers, same session window ────────
+  await sendComposerMessage(desktopApp, `Reply with exactly: ${NEW_MODEL_MARKER}`);
+  const answered = await waitFor(desktopApp, assistantHasText(NEW_MODEL_MARKER), {
+    timeoutMs: 300_000,
+    label: `assistant reply containing ${NEW_MODEL_MARKER}`,
+  }).then(() => true, () => false);
+  evidence.fact(
+    "Frame 6 — the newly granted model answers in the same session window",
+    answered
+      ? `A prompt on ${grant.modelId} (via ${grant.providerId}) completed with ${NEW_MODEL_MARKER}.`
+      : `The prompt on ${grant.modelId} never produced ${NEW_MODEL_MARKER}.`,
+    answered,
+  );
+  expect(answered, "the granted model did not complete a prompt").toBe(true);
+
+  const finalShot = await screenshot(desktopApp);
+  const finalSeen = await validate(finalShot, [
+    `The assistant's reply containing '${NEW_MODEL_MARKER}' is visible`,
+    `No '${INTERRUPTED_TEXT}' text and no 'Retrying in' countdown is visible anywhere`,
+  ]);
+  expect(finalSeen.ok, finalSeen.why).toBe(true);
+
+  // Keep the reused Den clean for later runs (best-effort).
+  await denFetch(den.admin, `/v1/llm-providers/${encodeURIComponent(grant.providerId)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": activeOrgId },
+  }).catch(() => undefined);
+  await sleep(250);
+});

--- a/evals/specs/subagent-run-survives-provider-sync-storm.slow.test.ts
+++ b/evals/specs/subagent-run-survives-provider-sync-storm.slow.test.ts
@@ -1,0 +1,534 @@
+import { expect } from "vitest";
+import {
+  control,
+  evalIn,
+  readAvailableModels,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { app, eventually, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+/**
+ * REPRODUCTION SPEC for the "aborted messages on almost every message,
+ * especially with subagents" reports (Slack #support 2026-08-07, and the
+ * "Provider response headers timed out after 10000ms · attempt 6" screenshots).
+ *
+ * Suspected mechanism (from code reading, to be proven or cleared here):
+ *  - apps/server/src/cloud-provider-sync.ts apply()/sweep() call
+ *    reloadOpencodeEngine() -> engine POST /instance/dispose with NO
+ *    "sessions are running" guard (#3526).
+ *  - apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
+ *    triggers that sync on window focus, network online, visibilitychange and
+ *    a 5-minute interval whenever the desktop is signed in to a Den (#3611).
+ *  - Every dispose aborts the parent session AND all subagent child sessions:
+ *    the engine emits session.error MessageAbortedError which the app renders
+ *    as "The message was interrupted".
+ *
+ * THE RULE UNDER TEST: the product promises "no engine auto-reload while
+ * sessions are running". This spec runs one genuinely long subagent task on a
+ * real Anthropic model and, while it runs, fires the exact lifecycle triggers
+ * a normal user produces by tabbing in and out of the app. If the rule holds,
+ * the run completes with zero disposes, zero aborted messages and zero
+ * provider header-timeout retries. Each half is asserted explicitly, so a red
+ * run localizes the leak (dispose observed vs. abort rendered vs. retry storm).
+ *
+ * Long on purpose: the subagents sleep for minutes so the storm overlaps a
+ * live run the whole time. Run it with a generous timeout; every individual
+ * wait below is still bounded.
+ */
+
+const requirements: NeedsSpec = {
+  env: ["ANTHROPIC_API_KEY"],
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `subagent run vs provider sync storm skipped — needs: ${missingRequirements.join(", ")}`
+  : "a long subagent run survives cloud provider sync triggers without aborted messages";
+
+const COMPLETE_MARKER = "STORM-RUN-COMPLETE";
+const FOLLOWUP_MARKER = "STORM-FOLLOWUP-OK";
+const INTERRUPTED_TEXT = "The message was interrupted";
+const STORM_TICK_MS = 15_000;
+const STORM_MAX_TICKS = 48; // 12 minutes of trigger pressure at most
+const MIN_BUSY_TICKS = 8; // the run must stay busy through >=2 minutes of storm
+
+const longRunPrompt = [
+  "Launch exactly three subagents in parallel using the task tool.",
+  "Subagent 1 must run the bash command `sleep 150 && echo subagent-1-done` and report the output.",
+  "Subagent 2 must run the bash command `sleep 150 && echo subagent-2-done` and report the output.",
+  "Subagent 3 must run the bash command `sleep 150 && echo subagent-3-done` and report the output.",
+  "After all three report, launch two more subagents in parallel the same way:",
+  "subagent 4 runs `sleep 150 && echo subagent-4-done`, subagent 5 runs `sleep 150 && echo subagent-5-done`.",
+  "After those two report, run one final bash command yourself: `sleep 45 && echo main-done`.",
+  `Then reply with exactly: ${COMPLETE_MARKER}`,
+].join(" ");
+
+interface StormProbe {
+  reconnects: number;
+  disposes: Array<{ at: number }>;
+  retries: Array<{ at: number; sessionID: string | null; attempt: number | null; message: string }>;
+  errors: Array<{ at: number; sessionID: string | null; name: string; message: string }>;
+  eventCounts: Record<string, number>;
+}
+
+interface SyncStatusProbe {
+  ok: boolean;
+  hasSession: boolean;
+  lastRunStatus: string;
+  lastRunAt: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function newestSessionId(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0 || !isRecord(value[0]) || typeof value[0].sessionId !== "string") {
+    throw new Error(`session.list_sessions did not return a newest session: ${JSON.stringify(value)}`);
+  }
+  return value[0].sessionId;
+}
+
+function parseStormProbe(value: unknown): StormProbe {
+  if (!isRecord(value)) throw new Error(`Storm probe was not an object: ${JSON.stringify(value)}`);
+  const list = (input: unknown): Record<string, unknown>[] => (Array.isArray(input) ? input.filter(isRecord) : []);
+  return {
+    reconnects: typeof value.reconnects === "number" ? value.reconnects : 0,
+    disposes: list(value.disposes).map((entry) => ({ at: typeof entry.at === "number" ? entry.at : 0 })),
+    retries: list(value.retries).map((entry) => ({
+      at: typeof entry.at === "number" ? entry.at : 0,
+      sessionID: typeof entry.sessionID === "string" ? entry.sessionID : null,
+      attempt: typeof entry.attempt === "number" ? entry.attempt : null,
+      message: typeof entry.message === "string" ? entry.message : "",
+    })),
+    errors: list(value.errors).map((entry) => ({
+      at: typeof entry.at === "number" ? entry.at : 0,
+      sessionID: typeof entry.sessionID === "string" ? entry.sessionID : null,
+      name: typeof entry.name === "string" ? entry.name : "",
+      message: typeof entry.message === "string" ? entry.message : "",
+    })),
+    eventCounts: isRecord(value.eventCounts)
+      ? Object.fromEntries(Object.entries(value.eventCounts).flatMap(([key, count]) => (typeof count === "number" ? [[key, count]] : [])))
+      : {},
+  };
+}
+
+function parseSyncStatus(value: unknown): SyncStatusProbe {
+  if (!isRecord(value)) return { ok: false, hasSession: false, lastRunStatus: "unreadable", lastRunAt: "" };
+  const lastRun = isRecord(value.lastRun) ? value.lastRun : {};
+  return {
+    ok: value.ok === true,
+    hasSession: value.hasSession === true,
+    lastRunStatus: typeof lastRun.status === "string" ? lastRun.status : "none",
+    lastRunAt: typeof lastRun.at === "string" ? lastRun.at : "",
+  };
+}
+
+const assistantHasText = (text: string): string => `(() => {
+  return [...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => (message.innerText ?? "").includes(${JSON.stringify(text)}));
+})()`;
+
+const stopEnabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop && !stop.disabled);
+})()`;
+
+const stopDisabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop?.disabled);
+})()`;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 2_700_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+
+  await using den = await server({ place });
+  // Signing in matters: a Den session is what arms the server-side cloud
+  // provider sync (PUT /den-session -> CloudProviderSync.setSession).
+  await using desktopApp = await app({ den, as: "admin", place });
+  const workspaceId = desktopApp.workspaceId;
+
+  // ── Configure the real Anthropic provider through the product API ──────
+  // Daytona app sandboxes deliberately do not mount the eval secrets volume
+  // (untrusted-ref rule in provision.ts), so the key travels from the driver
+  // env through the same workspace-config write a user's Settings save does.
+  // This single pre-run engine reload happens BEFORE the session exists, so
+  // it cannot contaminate the mid-run dispose/abort claims below.
+  const anthropicKey = process.env.ANTHROPIC_API_KEY?.trim() ?? "";
+  const providerConfigured = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 300);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({ opencode: { provider: { anthropic: { options: { apiKey: ${JSON.stringify(anthropicKey)} } } } } }),
+    });
+    if (patched !== "ok") return patched;
+    return request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  expect(providerConfigured).toBe("ok");
+
+  // ── Pick a real Anthropic model through the product picker ─────────────
+  // Picker rows carry bare model ids (e.g. "claude-sonnet-4-5"). Sonnet-class
+  // keeps the run affordable; set OPENWORK_EVAL_MODEL=claude-opus-4-8 to
+  // mirror the support report exactly.
+  const preferredModel = process.env.OPENWORK_EVAL_MODEL?.trim() ?? "";
+  const models = await readAvailableModels(desktopApp);
+  const selectable = models.filter((model) => model.selectable);
+  const claudes = selectable.filter((model) => /anthropic/i.test(model.providerName) || /^claude-/i.test(model.id));
+  const chosen = selectable.find((model) => model.id === preferredModel)
+    ?? claudes.find((model) => /^claude-sonnet-\d+-\d+$/.test(model.id))
+    ?? claudes.find((model) => /sonnet/i.test(model.id))
+    ?? claudes[0];
+  if (!chosen) {
+    throw new Error(`No Anthropic model selectable in the picker. Saw: ${models.map((model) => model.id).join(", ") || "none"}`);
+  }
+  await selectModel(desktopApp, chosen.id);
+  evidence.fact(
+    "A real provider model is selected through the product model picker",
+    `Selected ${chosen.id} (${chosen.providerName}); env-key providers were visible to the engine.`,
+    true,
+  );
+
+  // ── Start the engine event tail (dispose / retry / session.error witness) ──
+  const tailStarted = await evalIn(desktopApp, `(() => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    window.__owStorm = { active: true, reconnects: -1, disposes: [], retries: [], errors: [], eventCounts: {} };
+    const record = (event) => {
+      const storm = window.__owStorm;
+      const type = String(event?.type ?? "unknown");
+      storm.eventCounts[type] = (storm.eventCounts[type] ?? 0) + 1;
+      if (type.includes("disposed")) storm.disposes.push({ at: Date.now(), type });
+      const properties = event?.properties ?? {};
+      if (type === "session.status" && properties?.status?.type === "retry") {
+        storm.retries.push({
+          at: Date.now(),
+          sessionID: typeof properties.sessionID === "string" ? properties.sessionID : null,
+          attempt: typeof properties.status.attempt === "number" ? properties.status.attempt : null,
+          message: String(properties.status.message ?? ""),
+        });
+      }
+      if (type === "session.error") {
+        const error = properties?.error ?? {};
+        storm.errors.push({
+          at: Date.now(),
+          sessionID: typeof properties.sessionID === "string" ? properties.sessionID : null,
+          name: String(error?.name ?? ""),
+          message: String(error?.data?.message ?? ""),
+        });
+      }
+    };
+    (async () => {
+      const url = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/opencode/event";
+      while (window.__owStorm.active) {
+        window.__owStorm.reconnects += 1;
+        try {
+          const response = await fetch(url, { headers: { Authorization: "Bearer " + token } });
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (window.__owStorm.active) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const frames = buffer.split("\\n\\n");
+            buffer = frames.pop() ?? "";
+            for (const frame of frames) {
+              for (const line of frame.split("\\n")) {
+                if (!line.startsWith("data:")) continue;
+                try { record(JSON.parse(line.slice(5).trim())); } catch {}
+              }
+            }
+          }
+        } catch {}
+        if (window.__owStorm.active) await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    })();
+    return "ok";
+  })()`);
+  expect(tailStarted).toBe("ok");
+
+  // The sync layer must actually be armed, otherwise this spec stresses nothing.
+  const readSyncStatusExpression = `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/status", {
+      headers: { Authorization: "Bearer " + token },
+    });
+    if (!response.ok) return { ok: false };
+    const body = await response.json();
+    return { ok: true, hasSession: body.hasSession === true, lastRun: body.lastRun ?? null };
+  })()`;
+  const readSyncStatus = async (): Promise<SyncStatusProbe> =>
+    parseSyncStatus(await evalIn(desktopApp, readSyncStatusExpression, { awaitPromise: true, timeoutMs: 30_000 }));
+  let armedBy = "sign_in push";
+  let syncArmed = await eventually(readSyncStatus, {
+    within: 60_000,
+    label: "cloud provider sync armed by sign-in",
+    until: (status) => status.ok && status.hasSession,
+  }).then(() => true, () => false);
+  let armingProbe = "";
+  if (!syncArmed) {
+    // The app's own push swallows every failure (store.ts pushDenSession), so
+    // probe each precondition and issue the same PUT /den-session the product
+    // sends, with the product's own persisted credentials — the failure, if
+    // any, names itself instead of no-oping.
+    armingProbe = String(await evalIn(desktopApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const clientToken = localStorage.getItem("openwork.server.token");
+      const hostToken = localStorage.getItem("openwork.server.hostToken");
+      const denToken = (localStorage.getItem("openwork.den.authToken") ?? "").trim();
+      const orgId = (localStorage.getItem("openwork.den.activeOrgId") ?? "").trim();
+      const apiBaseUrl = (localStorage.getItem("openwork.den.apiBaseUrl") ?? "").trim()
+        || ${JSON.stringify(den.ref.apiUrl)};
+      const facts = [
+        "hostToken=" + (hostToken ? "present" : "MISSING"),
+        "denToken=" + (denToken ? "present" : "MISSING"),
+        "orgId=" + (orgId || "MISSING"),
+        "apiBaseUrl=" + (apiBaseUrl || "MISSING"),
+      ];
+      if (!port || !hostToken || !denToken || !orgId || !apiBaseUrl) return facts.join(" ");
+      const response = await fetch("http://127.0.0.1:" + port + "/den-session", {
+        method: "PUT",
+        headers: { "x-openwork-host-token": hostToken, "Content-Type": "application/json" },
+        body: JSON.stringify({ baseUrl: apiBaseUrl, token: denToken, orgId }),
+      });
+      facts.push("PUT /den-session -> " + response.status + " " + (await response.text()).slice(0, 200));
+      return facts.join(" ");
+    })()`, { awaitPromise: true, timeoutMs: 30_000 }));
+    armedBy = `direct PUT /den-session (${armingProbe})`;
+    syncArmed = await eventually(readSyncStatus, {
+      within: 60_000,
+      label: "cloud provider sync armed after direct den-session PUT",
+      until: (status) => status.ok && status.hasSession,
+    }).then(() => true, () => false);
+  }
+  const armedStatus = await readSyncStatus();
+  evidence.fact(
+    "The server-side cloud provider sync is armed by the signed-in Den session",
+    `GET /cloud-provider-sync/status -> ok=${armedStatus.ok} hasSession=${armedStatus.hasSession} lastRun=${armedStatus.lastRunStatus} (armed by: ${armedBy}).`,
+    syncArmed,
+  );
+  expect(syncArmed, `Den session did not arm CloudProviderSync; the storm would be vacuous. Probe: ${armingProbe || "sign-in push armed"}`).toBe(true);
+
+  // ── Convergence probe: an idle sync must settle to noop ────────────────
+  // Three back-to-back passes through the same host-token route the product
+  // uses. Pass 1 may legitimately apply; repeated "applied" with no cloud
+  // change is the dispose/create-loop precondition (#2530's anatomy).
+  const convergence: string[] = [];
+  for (let pass = 1; pass <= 3; pass += 1) {
+    const result = await evalIn(desktopApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const hostToken = localStorage.getItem("openwork.server.hostToken");
+      const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/run", {
+        method: "POST",
+        headers: { "x-openwork-host-token": hostToken, "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: "spec_convergence_probe" }),
+      });
+      const body = await response.text();
+      return response.status + ":" + body.slice(0, 120);
+    })()`, { awaitPromise: true, timeoutMs: 60_000 });
+    convergence.push(String(result));
+  }
+  const convergedToNoop = convergence.slice(1).every((entry) => entry.includes("noop"));
+  evidence.fact(
+    "An idle cloud provider sync converges to noop after the first pass",
+    `Three sequential POST /cloud-provider-sync/run results: ${JSON.stringify(convergence)}.`,
+    convergedToNoop,
+  );
+
+  // ── Launch the long subagent run ────────────────────────────────────────
+  await control(desktopApp, "session.create_task");
+  const sessionId = newestSessionId(await control(desktopApp, "session.list_sessions"));
+  // Sandbox clock, not the driver's: the SSE tail timestamps its events with
+  // the renderer's Date.now(), and only disposes AFTER this instant violate
+  // the "no reload while sessions run" rule (the idle convergence probe above
+  // may legitimately reload).
+  const sandboxRunStartedAt = Number(await evalIn(desktopApp, "Date.now()"));
+  await sendComposerMessage(desktopApp, longRunPrompt);
+  const runStartedAt = Date.now();
+
+  await waitFor(desktopApp, stopEnabledExpression, { timeoutMs: 60_000, label: "run became active (stop enabled)" });
+  const sawSubagents = await waitFor(desktopApp, `Boolean(document.querySelector('[data-subagent-run]'))`, {
+    timeoutMs: 300_000,
+    label: "subagent run line visible",
+  }).then(() => true, () => false);
+  evidence.fact(
+    "The model actually fanned work out to subagents",
+    sawSubagents
+      ? "A [data-subagent-run] collapsible appeared in the transcript."
+      : "No [data-subagent-run] element appeared within 5 minutes of sending the prompt.",
+    sawSubagents,
+  );
+  expect(sawSubagents, "The run never showed subagent activity; the reproduction needs child sessions").toBe(true);
+
+  const midRunShot = await screenshot(desktopApp);
+  const midRunSeen = await validate(midRunShot, [
+    "A chat session is actively running a task that uses subagents (a running/expandable subagent or task row is visible)",
+    "No error banner, no 'The message was interrupted' text and no retry countdown is visible",
+  ]);
+  expect(midRunSeen.ok, midRunSeen.why).toBe(true);
+
+  // ── Storm: fire the real user-lifecycle sync triggers while it runs ─────
+  const syncStatuses: SyncStatusProbe[] = [];
+  let busyTicks = 0;
+  let completed = false;
+  for (let tick = 1; tick <= STORM_MAX_TICKS; tick += 1) {
+    const ticked = await evalIn(desktopApp, `(() => {
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("online"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      return true;
+    })()`);
+    expect(ticked, `storm tick ${tick} could not dispatch lifecycle events`).toBe(true);
+
+    const stillBusy = await evalIn(desktopApp, stopEnabledExpression);
+    if (stillBusy === true) busyTicks += 1;
+
+    const status = parseSyncStatus(await evalIn(desktopApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/status", {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (!response.ok) return { ok: false };
+      const body = await response.json();
+      return { ok: true, hasSession: body.hasSession === true, lastRun: body.lastRun ?? null };
+    })()`, { awaitPromise: true, timeoutMs: 30_000 }));
+    syncStatuses.push(status);
+
+    completed = (await evalIn(desktopApp, assistantHasText(COMPLETE_MARKER))) === true;
+    if (completed && stillBusy !== true) break;
+    await sleep(STORM_TICK_MS);
+  }
+  const stormTicks = syncStatuses.length;
+  const syncSummary = syncStatuses.reduce<Record<string, number>>((accumulator, status) => {
+    const key = status.ok ? status.lastRunStatus : "status_unreachable";
+    accumulator[key] = (accumulator[key] ?? 0) + 1;
+    return accumulator;
+  }, {});
+  const distinctPassTimes = new Set(syncStatuses.map((status) => status.lastRunAt).filter(Boolean)).size;
+  evidence.fact(
+    "Lifecycle sync triggers fired repeatedly while the run was live",
+    `${stormTicks} storm ticks (focus+online+visibilitychange every ${STORM_TICK_MS / 1000}s), ${busyTicks} of them while the run was busy; cloud-provider-sync lastRun statuses seen: ${JSON.stringify(syncSummary)} across ${distinctPassTimes} distinct pass timestamps.`,
+    busyTicks >= MIN_BUSY_TICKS,
+  );
+  expect(busyTicks, `the run finished too fast to stress the guard (busy ticks < ${MIN_BUSY_TICKS})`).toBeGreaterThanOrEqual(MIN_BUSY_TICKS);
+
+  // ── Completion: the run must finish despite the storm ───────────────────
+  if (!completed) {
+    completed = await waitFor(desktopApp, assistantHasText(COMPLETE_MARKER), {
+      timeoutMs: 300_000,
+      label: `assistant reply containing ${COMPLETE_MARKER}`,
+    }).then(() => true, () => false);
+  }
+  const runSeconds = Math.round((Date.now() - runStartedAt) / 1000);
+  evidence.fact(
+    "The long subagent run completed while sync triggers were firing",
+    completed
+      ? `The assistant replied with ${COMPLETE_MARKER} after ${runSeconds}s under storm conditions.`
+      : `No assistant reply containing ${COMPLETE_MARKER} appeared after ${runSeconds}s; the run did not complete.`,
+    completed,
+  );
+
+  await waitFor(desktopApp, stopDisabledExpression, { timeoutMs: 120_000, label: "run settled (stop disabled)" });
+
+  // ── Harvest the witnesses BEFORE asserting, so a red run still reports ──
+  const probeRaw = await evalIn(desktopApp, `(() => {
+    const storm = window.__owStorm ?? null;
+    if (storm) storm.active = false;
+    return storm ? JSON.parse(JSON.stringify(storm)) : null;
+  })()`);
+  const probe = parseStormProbe(probeRaw);
+
+  const transcript = await control(desktopApp, "session.read_transcript", { count: 30 });
+  const transcriptText = isRecord(transcript) && Array.isArray(transcript.messages)
+    ? transcript.messages.filter(isRecord).map((message) => String(message.text ?? "")).join("\n")
+    : "";
+  const domHasInterrupted = (await evalIn(desktopApp, `document.body.innerText.includes(${JSON.stringify(INTERRUPTED_TEXT)})`)) === true;
+  const abortErrors = probe.errors.filter((error) => error.name === "MessageAbortedError");
+  const headerTimeoutRetries = probe.retries.filter((retry) => /headers? timed out/i.test(retry.message));
+
+  const finalStatusRaw = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/status", {
+      headers: { Authorization: "Bearer " + token },
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body.lastRun ?? null;
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  evidence.fact(
+    "The provider sync names its change terms for diagnosis",
+    `Final /cloud-provider-sync/status lastRun: ${JSON.stringify(finalStatusRaw)}.`,
+    true,
+  );
+
+  const disposesDuringRun = probe.disposes.filter((dispose) => dispose.at >= sandboxRunStartedAt);
+  evidence.fact(
+    "The engine instance was never disposed while sessions were running",
+    `Engine event tail over ${probe.reconnects} reconnect(s) recorded ${probe.disposes.length} dispose event(s) total, ${disposesDuringRun.length} after the run started; event counts: ${JSON.stringify(probe.eventCounts)}.`,
+    disposesDuringRun.length === 0,
+  );
+  evidence.fact(
+    "No session was aborted during the storm",
+    `session.error events: ${JSON.stringify(probe.errors)}; '${INTERRUPTED_TEXT}' in DOM: ${domHasInterrupted}; in transcript: ${transcriptText.includes(INTERRUPTED_TEXT)}.`,
+    abortErrors.length === 0 && probe.errors.length === 0 && !domHasInterrupted && !transcriptText.includes(INTERRUPTED_TEXT),
+  );
+  evidence.fact(
+    "No provider header-timeout retry storm occurred",
+    probe.retries.length === 0
+      ? "Zero session.status retry events were observed for the whole run."
+      : `Retry statuses observed: ${JSON.stringify(probe.retries)}.`,
+    headerTimeoutRetries.length === 0,
+  );
+
+  const finalShot = await screenshot(desktopApp);
+  const finalSeen = await validate(finalShot, [
+    `The assistant's final reply containing '${COMPLETE_MARKER}' is visible in the conversation`,
+    `No '${INTERRUPTED_TEXT}' error text and no 'Retrying in' countdown is visible anywhere`,
+  ]);
+
+  expect(completed, "the long subagent run did not complete under sync-trigger pressure").toBe(true);
+  expect(convergedToNoop, `idle cloud provider sync never converged to noop: ${JSON.stringify(convergence)}`).toBe(true);
+  expect(disposesDuringRun.length, `engine dispose events observed during a live run: ${JSON.stringify(disposesDuringRun)}`).toBe(0);
+  expect(abortErrors, "MessageAbortedError session errors were emitted during the storm").toEqual([]);
+  expect(probe.errors, "session.error events were emitted during the storm").toEqual([]);
+  expect(domHasInterrupted, `'${INTERRUPTED_TEXT}' is visible in the conversation`).toBe(false);
+  expect(transcriptText).not.toContain(INTERRUPTED_TEXT);
+  expect(headerTimeoutRetries, "provider header-timeout retries observed (the reported symptom)").toEqual([]);
+  expect(finalSeen.ok, finalSeen.why).toBe(true);
+
+  // ── Recovery: the same session must accept and finish a follow-up ───────
+  await sendComposerMessage(desktopApp, `Reply with exactly: ${FOLLOWUP_MARKER}`);
+  const followedUp = await waitFor(desktopApp, assistantHasText(FOLLOWUP_MARKER), {
+    timeoutMs: 240_000,
+    label: `assistant reply containing ${FOLLOWUP_MARKER}`,
+  }).then(() => true, () => false);
+  evidence.fact(
+    "The session remains usable after the storm",
+    followedUp
+      ? `A follow-up prompt in session ${sessionId} completed with ${FOLLOWUP_MARKER}.`
+      : `The follow-up prompt in session ${sessionId} never produced ${FOLLOWUP_MARKER}.`,
+    followedUp,
+  );
+  expect(followedUp, "the session could not complete a follow-up prompt after the storm").toBe(true);
+});


### PR DESCRIPTION
## Problem

Users reported aborted messages on almost every message — worst with subagents — plus "Provider response headers timed out after 10000ms · attempt N" retry storms (Slack support + internal reports, 2026-08-07).

Root cause chain, reproduced on dev with a testkit spec (Daytona, real Anthropic key, live subagent run):

1. `CloudProviderSync` (#3526) reloads the engine via `POST /instance/dispose` with **no sessions-running guard** (`apps/server/src/cloud-provider-sync.ts` apply/sweep).
2. #3611 made the app trigger sync passes on window focus, network online, visibilitychange, sign-in, new chat, model picker and 5-min timers.
3. The sync **never converged to noop** — measured `applied` on every pass (14/14, then 18 applied + 6 failed) — so those triggers kept re-applying and re-disposing. Recorded **4 `server.instance.disposed` engine events during one live subagent run**.
4. The dispose fetch had **no timeout**, and the engine answers `/instance/dispose` only after teardown — a dispose wedged on live-session teardown froze the sync queue and its reported status forever (only 2 distinct `lastRun.at` timestamps across 24 status reads).
5. Each dispose aborts parent + subagent sessions → `MessageAbortedError` → "The message was interrupted"; provider calls stall mid-rebuild → the 10s header-timeout retry storm.

## Fix

- **Session guard**: managed engine reloads (`CloudProviderSync.apply()/sweep()` and `PATCH /runtime-config/providers`) defer while the engine reports any non-idle session (subagent children included, via `GET /session/status`). The reload stays pending and applies on a later pass once idle. Explicit user actions (`POST /workspace/:id/engine/reload`, workspace activation) remain immediate.
- **Bounded dispose**: `AbortSignal.timeout` on the dispose fetch (`OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS`, default 30s). Timeouts raise `opencode_reload_timeout` — deliberately distinct from `opencode_engine_unreachable` so the app never escalates to a full desktop engine restart mid-teardown.
- **Convergence**: rewrite the engine-visible runtime config file synchronously after a reload's MCP re-registration, so the next sync pass compares against post-reload state instead of racing the async fresh-keeper into a phantom `applied`.
- **Diagnostics**: `/cloud-provider-sync/status` `lastRun.detail` now names each change term (`fingerprintChanged`, `providerStateChanged`, `envUpserts`, `envDeletes`, `cleanupChanged`, `cleanupRuntimeChanged`, `fileChanged`, `reloadDeferred`) so a non-converging sync identifies itself in production.

## Tests

- `bun test src/cloud-provider-sync-reload-guard.test.ts` — 3 pass, 0 fail (busy deferral via PATCH route; sync-pass deferral then idle reload + noop convergence; wedged dispose times out without jamming the queue and recovers).
- `bun test src/cloud-provider-sync.e2e.test.ts src/runtime-config-patch-reload.e2e.test.ts src/runtime-config-disabled-providers.test.ts src/portable-opencode.test.ts src/cloud-provider-sync.test.ts src/runtime-config-global-providers.test.ts src/openwork-runtime-config.test.ts` — 16 pass, 0 fail.
- `pnpm --dir apps/server run typecheck` — clean. `pnpm evals:typecheck` — clean except pre-existing `connectors-quick-add.slow.test.ts` error already on dev.
- **New slow spec** `evals/specs/subagent-run-survives-provider-sync-storm.slow.test.ts` on Daytona (real Anthropic `claude-sonnet-4-5`, Den + desktop sandboxes, `OPENWORK_EVAL_REF=fix/engine-reload-session-guard`):
  `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_DEN_API_URL=… OPENWORK_EVAL_DEN_WEB_URL=… infisical run --silent -- pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/subagent-run-survives-provider-sync-storm.slow.test.ts`
  → **1 passed** (706s). 513s live subagent run under 33 lifecycle-trigger storms: idle sync converges `noop,noop,noop`; `{"noop":33}` during the storm; **0 dispose events, 0 SSE stream drops, 0 session.error, 0 header-timeout retries**; run completed and a follow-up prompt succeeded. The same spec on dev measured `applied` on every pass and 4 mid-run disposes.

Evidence tape published via `pnpm fraimz:publish` (testkit sticky comment).

Notes for reviewers:
- Cold-boot Daytona `server()` provisioning is currently broken for everyone by Daytona's new rotating preview URLs (`daytona preview-url` mints a fresh host per call → Den trusted-origins mismatch → `403 INVALID_ORIGIN` in `proveDenSeed`). This run used the documented warm-Den reuse lane. Separate infra fix needed.