### PR TITLE
feat(app): autosave markdown artifacts + right-click formatting menu

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
@@ -9,7 +9,6 @@ import { isElectronRuntime } from "@/app/utils";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { formatFileSize } from "@/lib/utils";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { type ArtifactPanelTab, usePanelTabStore } from "../panel/panel-tab-store";
 import { isCollectibleArtifactTarget, type BinaryData, type Data, type OpenTarget, type TextData } from "./open-target";
@@ -96,6 +95,8 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const lastSyncedRef = useRef<string | null>(null);
+  const failedDraftRef = useRef<string | null>(null);
   const isDirectTextEdit = isTextContent(target) && target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target);
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
   const canUseDesktopFileActions = target.kind === "file" && !isRemoteWorkspace && platform.capabilities.revealInFileManager;
@@ -154,10 +155,13 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   useEffect(() => {
     setEditing(false);
     setDraft("");
+    lastSyncedRef.current = null;
+    failedDraftRef.current = null;
   }, [target.id, workspaceId]);
 
   useEffect(() => {
-    if (data?.kind === "text") {
+    if (data?.kind === "text" && data.data !== lastSyncedRef.current) {
+      lastSyncedRef.current = data.data;
       setDraft(data.data);
     }
   }, [data]);
@@ -183,8 +187,16 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
       );
 
       if (input.kind === "text") {
-        setDraft(input.data);
+        lastSyncedRef.current = input.data;
+        failedDraftRef.current = null;
       }
+    },
+    onError: (cause, input) => {
+      if (input.kind === "text") {
+        failedDraftRef.current = input.data;
+      }
+
+      toast.error(cause instanceof Error ? cause.message : "Could not save changes.");
     },
   });
 
@@ -232,20 +244,27 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     }
   };
 
-  const save = () => {
-    if (target.kind !== "file" || !isTextContent(target) || data?.kind !== "text") {
+  const isTextEditing = data?.kind === "text" && (editing || isDirectTextEdit);
+  const isDirty = data?.kind === "text" && draft !== data.data;
+
+  useEffect(() => {
+    if (
+      target.kind !== "file" ||
+      data?.kind !== "text" ||
+      !(editing || isDirectTextEdit) ||
+      isSaving ||
+      draft === data.data ||
+      draft === failedDraftRef.current
+    ) {
       return;
     }
 
-    mutate(
-      {
-        kind: "text",
-        data: draft,
-        baseUpdatedAt: data.updatedAt,
-      },
-      { onSuccess: () => setEditing(false) },
-    );
-  };
+    const timer = window.setTimeout(() => {
+      mutate({ kind: "text", data: draft, baseUpdatedAt: data.updatedAt });
+    }, 600);
+
+    return () => window.clearTimeout(timer);
+  }, [draft, data, editing, isDirectTextEdit, isSaving, target.kind, mutate]);
 
   const saveSpreadsheetContent = async (payload: Data) => {
     if (target.kind !== "file") {
@@ -270,52 +289,19 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
               {target.name}
             </h3>
             <span className="shrink-0 text-xs text-muted-foreground">
-              {target.exists === false ? "missing" : target.size !== undefined ? `${formatFileSize(target.size)}` : ""}
+              {target.exists === false ? "missing" : isTextEditing ? (isSaving || isDirty ? "Saving\u2026" : "Saved") : ""}
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-          {isTextContent(target) && data?.kind === "text" ? (
-            editing || isDirectTextEdit ? (
-              <>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={(
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          if (data?.kind === "text") {
-                            setDraft(data.data);
-                          }
-                          setEditing(false);
-                        }}
-                        disabled={isSaving}
-                      >
-                        Discard
-                      </Button>
-                    )}
-                  />
-                  <TooltipContent>Discard changes</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={(
-                      <Button variant="default" size="sm" onClick={() => void save()} disabled={isSaving || draft === data.data}>{isSaving ? "Saving" : "Save"}</Button>
-                    )}
-                  />
-                  <TooltipContent>Save changes</TooltipContent>
-                </Tooltip>
-              </>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger
-                  render={(
-                    <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button>
-                  )}
-                />
-                <TooltipContent>Edit artifact</TooltipContent>
-              </Tooltip>
-            )
+          {isTextContent(target) && data?.kind === "text" && !isDirectTextEdit ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="sm" onClick={() => setEditing((value) => !value)}>{editing ? "Done" : "Edit"}</Button>
+                )}
+              />
+              <TooltipContent>{editing ? "Stop editing" : "Edit artifact"}</TooltipContent>
+            </Tooltip>
           ) : null}
           {target.kind === "file" ? (
             <Tooltip>

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
@@ -4,8 +4,47 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { markdownLivePreview } from "./markdown-live-preview";
+
+const LINE_PREFIX_PATTERN = /^(#{1,6}\s+|>\s+|[-*+]\s+(\[[ xX]\]\s+)?|\d+[.)]\s+)/;
+
+function setLinePrefix(view: EditorView, prefix: string | ((index: number) => string)) {
+  const { state } = view;
+  const { from, to } = state.selection.main;
+  const startLine = state.doc.lineAt(from).number;
+  const endLine = state.doc.lineAt(to).number;
+  const changes = [];
+
+  for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
+    const line = state.doc.line(lineNumber);
+    const existing = LINE_PREFIX_PATTERN.exec(line.text);
+    const insert = typeof prefix === "function" ? prefix(lineNumber - startLine) : prefix;
+
+    changes.push({ from: line.from, to: line.from + (existing ? existing[0].length : 0), insert });
+  }
+
+  view.dispatch({ changes });
+  view.focus();
+}
+
+function wrapSelection(view: EditorView, marker: string) {
+  const { from, to } = view.state.selection.main;
+  const text = view.state.sliceDoc(from, to);
+
+  view.dispatch({
+    changes: { from, to, insert: `${marker}${text}${marker}` },
+    selection: { anchor: from + marker.length, head: to + marker.length },
+  });
+  view.focus();
+}
 
 type ArtifactTextEditorProps = {
   className?: string;
@@ -99,5 +138,38 @@ export function ArtifactTextEditor(props: ArtifactTextEditorProps) {
     view.dispatch({ changes: { from: 0, to: current.length, insert: props.value } });
   }, [props.value]);
 
-  return <div ref={rootRef} className={cn("h-full min-h-0 overflow-hidden", props.className)} />;
+  const editor = <div ref={rootRef} className={cn("h-full min-h-0 overflow-hidden", props.className)} />;
+
+  if (props.language !== "markdown") {
+    return editor;
+  }
+
+  const format = (apply: (view: EditorView) => void) => {
+    const view = viewRef.current;
+
+    if (view) {
+      apply(view);
+    }
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger className="block h-full min-h-0">{editor}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, "# "))}>Heading 1</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, "## "))}>Heading 2</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, "### "))}>Heading 3</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, ""))}>Paragraph</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => format((view) => wrapSelection(view, "**"))}>Bold</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => wrapSelection(view, "*"))}>Italic</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => wrapSelection(view, "~~"))}>Strikethrough</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => wrapSelection(view, "`"))}>Inline code</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, "- "))}>Bullet list</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, (index) => `${index + 1}. `))}>Numbered list</ContextMenuItem>
+        <ContextMenuItem onClick={() => format((view) => setLinePrefix(view, "> "))}>Quote</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
 }

--- a/evals/specs/markdown-editor-autosave.slow.test.ts
+++ b/evals/specs/markdown-editor-autosave.slow.test.ts
@@ -1,0 +1,232 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "markdown artifacts autosave without Save/Discard buttons and format from the right-click menu"
+  : "markdown editor autosave skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+const activeArtifactPath = "artifacts/overflow-tab-12.md";
+const untouchedArtifactPath = "artifacts/overflow-tab-11.md";
+const typedSentence = "Autosaved without buttons.";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readFileExpression(workspaceId: string, path: string): string {
+  return `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "";
+    const response = await fetch(
+      "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/files/content?path=" + encodeURIComponent(${JSON.stringify(path)}),
+      { headers: { Authorization: "Bearer " + token } },
+    );
+    if (!response.ok) return "";
+    const json = await response.json();
+    return typeof json.content === "string" ? json.content : "";
+  })()`;
+}
+
+async function waitForFileContent(
+  app: Surface,
+  workspaceId: string,
+  path: string,
+  predicate: (content: string) => boolean,
+  label: string,
+): Promise<string> {
+  let last = "";
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const value = await evalIn(app, readFileExpression(workspaceId, path), { awaitPromise: true });
+    last = typeof value === "string" ? value : "";
+    if (predicate(last)) return last;
+    await sleep(250);
+  }
+  throw new Error(`${label}: file ${path} never matched; last content was ${JSON.stringify(last)}`);
+}
+
+async function rightClick(app: Surface, selector: string): Promise<void> {
+  const rawPoint = await evalIn(app, `(() => {
+    const target = document.querySelector(${JSON.stringify(selector)});
+    if (!(target instanceof HTMLElement)) return "";
+    target.scrollIntoView({ block: "center" });
+    const rect = target.getBoundingClientRect();
+    return JSON.stringify({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+  })()`);
+  if (typeof rawPoint !== "string" || !rawPoint) throw new Error(`Right-click target ${selector} did not return coordinates.`);
+  const point: unknown = JSON.parse(rawPoint);
+  if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") {
+    throw new Error(`Right-click target ${selector} returned invalid coordinates: ${rawPoint}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "right", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "right", clickCount: 1 });
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using app = await desktop({
+    name: "markdown-editor-autosave",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-markdown-editor-autosave-${Date.now()}`,
+  });
+
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "new task action enabled",
+  });
+  await control(app, "session.create_task");
+  await waitFor(app, `String(window.__openworkControl.snapshot().route || "").includes("/session/")`, {
+    timeoutMs: 30_000,
+    label: "session route open",
+  });
+
+  // Mount the side panel so the dev seed action registers, then open markdown artifacts.
+  const seedReady = await evalIn(app, `window.__openworkControl.listActions().some((action) => action.id === "eval.artifact_tabs.seed_overflow" && !action.disabled)`);
+  if (seedReady !== true) {
+    // browser.open_url sets the side panel open before navigating; the
+    // navigation itself can race the internal tab bootstrap, which is fine —
+    // we only need the panel mounted so its dev seed action registers.
+    await control(app, "browser.open_url", { url: "about:blank" }).catch(() => undefined);
+  }
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "eval.artifact_tabs.seed_overflow" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "artifact seed action enabled",
+  });
+  await control(app, "eval.artifact_tabs.seed_overflow", { count: 12 });
+
+  await waitFor(app, "Boolean(window.__artifactEditorView)", {
+    timeoutMs: 30_000,
+    label: "markdown artifact opened directly in the editor",
+  });
+
+  const header = await evalIn(app, `(() => {
+    const buttons = Array.from(document.querySelectorAll("button")).map((button) => (button.textContent ?? "").trim());
+    return JSON.stringify({
+      hasSave: buttons.includes("Save") || buttons.includes("Saving"),
+      hasDiscard: buttons.includes("Discard"),
+      mentionsBytes: /\\d+(\\.\\d+)?\\s*(bytes|KB|MB|GB|TB)/.test(document.body.innerText),
+    });
+  })()`);
+  if (typeof header !== "string") throw new Error("Header probe did not return JSON.");
+  const headerState: unknown = JSON.parse(header);
+  if (!isRecord(headerState)) throw new Error(`Header probe returned invalid JSON: ${header}`);
+  expect(headerState.hasSave).toBe(false);
+  expect(headerState.hasDiscard).toBe(false);
+  expect(headerState.mentionsBytes).toBe(false);
+  evidence.fact(
+    "The markdown editor exposes no Save or Discard buttons and no file byte count",
+    "With a markdown artifact open for direct editing, no button was labelled Save, Saving, or Discard, and no byte/KB size readout was visible.",
+    true,
+  );
+
+  const baseline = await waitForFileContent(
+    app,
+    workspace.workspaceId,
+    activeArtifactPath,
+    (content) => content.startsWith("# Overflow tab 12"),
+    "seeded artifact on disk",
+  );
+  const untouchedBaseline = await waitForFileContent(
+    app,
+    workspace.workspaceId,
+    untouchedArtifactPath,
+    (content) => content.startsWith("# Overflow tab 11"),
+    "sibling artifact on disk",
+  );
+
+  const typed = await evalIn(app, `(() => {
+    const view = window.__artifactEditorView;
+    if (!view) return false;
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "\\n" + ${JSON.stringify(typedSentence)} } });
+    return true;
+  })()`);
+  expect(typed).toBe(true);
+
+  const savedContent = await waitForFileContent(
+    app,
+    workspace.workspaceId,
+    activeArtifactPath,
+    (content) => content.includes(typedSentence),
+    "autosave after typing",
+  );
+  expect(savedContent).toBe(`${baseline}\n${typedSentence}`);
+  await waitFor(app, `document.body.innerText.includes("Saved")`, {
+    timeoutMs: 15_000,
+    label: "Saved indicator after autosave",
+  });
+  evidence.fact(
+    "Typing in the markdown editor persists to disk without pressing any button",
+    `The artifact file content became exactly the baseline plus ${JSON.stringify(typedSentence)} and the header showed Saved.`,
+    true,
+  );
+
+  // Format the first line via the right-click menu.
+  const selected = await evalIn(app, `(() => {
+    const view = window.__artifactEditorView;
+    if (!view) return false;
+    view.dispatch({ selection: { anchor: 0 } });
+    return true;
+  })()`);
+  expect(selected).toBe(true);
+  await rightClick(app, ".cm-line");
+  await waitFor(app, `(() => {
+    const labels = [...document.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent?.trim());
+    return ["Heading 1", "Heading 2", "Heading 3", "Bold", "Bullet list", "Quote"].every((label) => labels.includes(label));
+  })()`, { timeoutMs: 10_000, label: "markdown formatting context menu open" });
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A markdown editor is open with a right-click context menu offering Heading 1, Heading 2, Heading 3 and other formatting options",
+      "The editor header shows a Saved status label and contains no button labelled Save or Discard",
+      "No error dialog or crash message is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  const clickedHeading = await evalIn(app, `(() => {
+    const item = [...document.querySelectorAll('[role="menuitem"]')]
+      .find((entry) => entry.textContent?.trim() === "Heading 2");
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(clickedHeading).toBe(true);
+
+  await waitFor(app, `window.__artifactEditorView?.state.doc.line(1).text.startsWith("## ")`, {
+    timeoutMs: 10_000,
+    label: "first line converted to a level-2 heading",
+  });
+  const headingContent = await waitForFileContent(
+    app,
+    workspace.workspaceId,
+    activeArtifactPath,
+    (content) => content.startsWith("## Overflow tab 12"),
+    "autosave after heading formatting",
+  );
+  expect(headingContent).toBe(`#${baseline}\n${typedSentence}`);
+  evidence.fact(
+    "The right-click menu converts the current line to the chosen heading level and the change autosaves",
+    "Heading 2 rewrote the first line from `# Overflow tab 12` to `## Overflow tab 12`, and the file on disk matched exactly.",
+    true,
+  );
+
+  const untouchedAfter = await evalIn(app, readFileExpression(workspace.workspaceId, untouchedArtifactPath), { awaitPromise: true });
+  expect(untouchedAfter).toBe(untouchedBaseline);
+  evidence.fact(
+    "Autosave only writes the artifact being edited",
+    "A sibling markdown artifact opened in another tab kept byte-identical content after edits and formatting in the active tab.",
+    true,
+  );
+});


### PR DESCRIPTION
## What

- **Always save**: markdown (and text) artifact edits now autosave with a 600ms debounce. The **Discard** and **Save** buttons are gone; the header shows a subtle `Saving…`/`Saved` status instead.
- **No more byte count**: the file-size readout in the artifact header is removed.
- **Richer editing**: right-clicking inside the markdown editor opens a formatting menu — Heading 1/2/3, Paragraph, Bold, Italic, Strikethrough, Inline code, Bullet list, Numbered list, Quote.
- Non-markdown text files keep a single **Edit/Done** toggle (still autosaving while editing).
- Save failures surface as a toast; a failed draft is not retried until the content changes, and external file changes still reload the editor without clobbering unsaved typing.

## Validation

- `pnpm typecheck` (@openwork/app) — passed.
- `evals` typecheck — only pre-existing error in `connectors-quick-add.slow.test.ts` (untouched).
- New spec `evals/specs/markdown-editor-autosave.slow.test.ts` run locally (Daytona unavailable on this machine — OSS/local lane):
  `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/markdown-editor-autosave.slow.test.ts` — **1 passed**.
  It proves: no Save/Discard buttons and no byte readout, typing autosaves byte-exact to disk, Heading 2 from the right-click menu rewrites the line and autosaves, and a sibling artifact stays untouched.

Evidence tape to follow in the sticky comment.