### PR TITLE
fix(attachments): prevent gateway upload hangs

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -255,6 +255,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
       onModelChange={context?.onModelChange ?? noop}
       attachments={attachments}
+      attachmentsUploading={props.busy && attachments.length > 0}
       onAttachFiles={handleAttachFiles}
       onRemoveAttachment={handleRemoveAttachment}
       attachmentsEnabled

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -21,7 +21,7 @@ import { usePlatform } from "@/react-app/kernel/platform";
 import { resolveExtensionIconUrl } from "@/react-app/design-system/extension-icon-src";
 import { ModelBehaviorSelect } from "@/components/model-behavior-select";
 import { ModelSelect } from "@/components/model-select";
-import { LexicalPromptEditor, type LexicalPromptEditorHandle } from "./editor";
+import { LexicalPromptEditor, syncAttachmentChipStatus, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
 import {
@@ -81,6 +81,8 @@ type ComposerProps = {
   onAttachFiles: (files: File[]) => void;
   onRemoveAttachment: (id: string) => void;
   attachmentsEnabled: boolean;
+  /** True while the draft's attachments are being compressed/uploaded during a send; chips show a spinner overlay. */
+  attachmentsUploading?: boolean;
   attachmentsDisabledReason: string | null;
   modelVariantLabel: string;
   modelVariant: string | null;
@@ -122,9 +124,6 @@ type ComposerProps = {
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
 const FOCUS_PROMPT_EVENT = "openwork:focusPrompt";
-const IMAGE_COMPRESS_MAX_PX = 2048;
-const IMAGE_COMPRESS_QUALITY = 0.82;
-const IMAGE_COMPRESS_TARGET_BYTES = 1_500_000;
 const DEFAULT_AGENT_NAME = "openwork";
 
 function isNonDefaultAgent(agent: Agent) {
@@ -158,55 +157,6 @@ function parseClipboardUriList(clipboard: DataTransfer) {
 
 function isImageAttachment(attachment: ComposerAttachment) {
   return attachment.kind === "image" || attachment.mimeType.startsWith("image/");
-}
-
-async function compressImageFile(file: File): Promise<File> {
-  if (file.type === "image/gif" || file.size <= IMAGE_COMPRESS_TARGET_BYTES) {
-    return file;
-  }
-
-  const bitmap = await createImageBitmap(file);
-  const { width, height } = bitmap;
-  const maxDim = Math.max(width, height);
-  const scale = maxDim > IMAGE_COMPRESS_MAX_PX ? IMAGE_COMPRESS_MAX_PX / maxDim : 1;
-  const targetW = Math.round(width * scale);
-  const targetH = Math.round(height * scale);
-
-  let blob: Blob | null = null;
-
-  if (typeof OffscreenCanvas !== "undefined") {
-    const offscreen = new OffscreenCanvas(targetW, targetH);
-    const ctx = offscreen.getContext("2d");
-    if (ctx) {
-      ctx.drawImage(bitmap, 0, 0, targetW, targetH);
-      blob = await offscreen.convertToBlob({
-        type: "image/jpeg",
-        quality: IMAGE_COMPRESS_QUALITY,
-      });
-    }
-  }
-
-  if (!blob) {
-    const canvas = document.createElement("canvas");
-    canvas.width = targetW;
-    canvas.height = targetH;
-    const ctx = canvas.getContext("2d");
-    if (ctx) {
-      ctx.drawImage(bitmap, 0, 0, targetW, targetH);
-      blob = await new Promise<Blob | null>((resolve) =>
-        canvas.toBlob(resolve, "image/jpeg", IMAGE_COMPRESS_QUALITY),
-      );
-    }
-  }
-
-  bitmap.close();
-
-  if (!blob || blob.size >= file.size) {
-    return file;
-  }
-
-  const stem = file.name.replace(/\.[^.]+$/, "") || "image";
-  return new File([blob], `${stem}.jpg`, { type: "image/jpeg" });
 }
 
 function formatMcpStatusLabel(status: McpServerStatus | undefined) {
@@ -1087,6 +1037,14 @@ export function ReactSessionComposer(props: ComposerProps) {
     }
   };
 
+  // Attachment chips are raw Lexical token DOM, so their uploading overlay is
+  // synced by attribute whenever the uploading flag or the chip set changes.
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    syncAttachmentChipStatus(root, props.attachmentsUploading ? "uploading" : "ready");
+  }, [props.attachmentsUploading, props.attachments]);
+
   const addAttachments = async (inputFiles: File[]) => {
     if (!inputFiles.length) return;
     if (!props.attachmentsEnabled) {
@@ -1096,14 +1054,9 @@ export function ReactSessionComposer(props: ComposerProps) {
 
     // No client-side size cap: oversized files are rejected upstream (upload
     // endpoint or provider) with their own errors instead of a composer rule.
-    const accepted: File[] = [];
-    for (const original of inputFiles) {
-      accepted.push(original.type.startsWith("image/") ? await compressImageFile(original) : original);
-    }
-
-    if (accepted.length) {
-      props.onAttachFiles(accepted);
-    }
+    // Oversized images are compressed at send time (see image-compression.ts)
+    // so the chip appears instantly instead of blocking on canvas work here.
+    props.onAttachFiles(inputFiles);
   };
 
   const activeMcpItems = mcpServers.map((entry) => ({

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -457,6 +457,8 @@ function createAttachmentChipDom(attachment: ComposerAttachmentToken) {
   dom.contentEditable = "false";
   dom.setAttribute("spellcheck", "false");
   dom.title = attachment.name;
+  dom.dataset.attachmentId = attachment.id;
+  dom.dataset.attachmentStatus = "ready";
 
   if (attachment.kind === "image" && attachment.previewUrl) {
     const img = document.createElement("img");
@@ -475,6 +477,25 @@ function createAttachmentChipDom(attachment: ComposerAttachmentToken) {
     dom.append(chip);
   }
 
+  // Upload progress overlay: hidden by default, toggled through the chip's
+  // data-attachment-status attribute while the draft's attachments are being
+  // compressed/uploaded at send time (see syncAttachmentChipStatus).
+  const spinner = document.createElement("span");
+  spinner.dataset.attachmentSpinner = "true";
+  spinner.className = "absolute inset-0 hidden items-center justify-center rounded-xl bg-background/60";
+  const spinnerIcon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  spinnerIcon.setAttribute("viewBox", "0 0 24 24");
+  spinnerIcon.setAttribute("fill", "none");
+  spinnerIcon.setAttribute("class", "h-4 w-4 animate-spin text-foreground");
+  const spinnerArc = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  spinnerArc.setAttribute("d", "M12 3a9 9 0 1 0 9 9");
+  spinnerArc.setAttribute("stroke", "currentColor");
+  spinnerArc.setAttribute("stroke-width", "2.5");
+  spinnerArc.setAttribute("stroke-linecap", "round");
+  spinnerIcon.append(spinnerArc);
+  spinner.append(spinnerIcon);
+  dom.append(spinner);
+
   const remove = document.createElement("button");
   remove.type = "button";
   remove.className = "absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-xs leading-none text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground";
@@ -484,6 +505,22 @@ function createAttachmentChipDom(attachment: ComposerAttachmentToken) {
   remove.textContent = "×";
   dom.append(remove);
   return dom;
+}
+
+/**
+ * Toggle the uploading overlay on every attachment chip inside `root`.
+ * Chips are raw Lexical token DOM (not React), so status is synced by
+ * attribute instead of a re-render. Exported for the composer, which flips
+ * this while a draft with attachments is being uploaded/sent.
+ */
+export function syncAttachmentChipStatus(root: HTMLElement, status: "uploading" | "ready") {
+  for (const chip of root.querySelectorAll<HTMLElement>("[data-attachment-id]")) {
+    chip.dataset.attachmentStatus = status;
+    const spinner = chip.querySelector<HTMLElement>("[data-attachment-spinner]");
+    if (!spinner) continue;
+    spinner.classList.toggle("hidden", status !== "uploading");
+    spinner.classList.toggle("flex", status === "uploading");
+  }
 }
 
 function updateAttachmentChipDom(dom: HTMLElement, attachment: ComposerAttachmentToken) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -657,6 +657,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const draft = useComposerStateStore((state) => getComposerDraft(state, props.sessionId));
   const attachments = useComposerStateStore((state) => getComposerAttachments(state, props.sessionId));
+  // True while a send with attachments is in flight (compression + inbox
+  // upload + prompt POST); drives the uploading overlay on composer chips.
+  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
   const mentions = useComposerStateStore((state) => getComposerMentions(state, props.sessionId));
   const pasteParts = useComposerStateStore((state) => getComposerPasteParts(state, props.sessionId));
   const setComposerDraft = useComposerStateStore((state) => state.setDraft);
@@ -1161,6 +1164,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!text && attachments.length === 0) return;
     const nextDraft = buildDraft(text, attachments);
     const sentAttachments = attachments;
+    if (sentAttachments.length) setAttachmentsUploading(true);
     try {
       const result = await sendDraft(nextDraft);
       if (result.outcome === "blocked" || result.outcome === "cancelled") return;
@@ -1177,6 +1181,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
           .forEach(revokeAttachmentPreview);
       }
     } catch {
+    } finally {
+      setAttachmentsUploading(false);
     }
   }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
 
@@ -2069,6 +2075,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onModelChange={handleModelChange}
         sessionId={props.sessionId}
         attachments={attachments}
+        attachmentsUploading={attachmentsUploading}
         onAttachFiles={handleAttachFiles}
         onRemoveAttachment={handleRemoveAttachment}
         attachmentsEnabled={props.attachmentsEnabled}

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -1,6 +1,7 @@
 import type { FilePartInput, TextPartInput } from "@opencode-ai/sdk/v2/client";
 
 import type { ComposerAttachment } from "../../../../app/types";
+import { compressImageFile } from "./image-compression";
 import { joinWorkspaceRelativePath, toFileUrl } from "./prompt-file-parts";
 
 type AttachmentKind = "image" | "file";
@@ -314,7 +315,11 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
 
   const uploaded: UploadedChatAttachment[] = [];
   for (const attachment of input.attachments) {
-    const metadata = resolveAttachmentFileMetadata(attachment.file);
+    // Oversized images are re-encoded here, at send time, so the composer chip
+    // appears instantly at attach time and the canvas work happens while the
+    // chip already shows its uploading state.
+    const file = await compressImageFile(attachment.file);
+    const metadata = resolveAttachmentFileMetadata(file);
     const id = input.createId ? input.createId() : randomAttachmentId();
     const inboxPath = buildChatAttachmentInboxPath({
       sessionId: input.sessionId,
@@ -324,7 +329,7 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
 
     let result: InboxUploadResult;
     try {
-      result = await input.endpoint.client.uploadInbox(workspaceId, attachment.file, { path: inboxPath });
+      result = await input.endpoint.client.uploadInbox(workspaceId, file, { path: inboxPath });
     } catch (error) {
       throw new Error(uploadErrorMessage(metadata.filename, error));
     }
@@ -335,8 +340,8 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
     if (!result.path.trim()) {
       throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: upload did not return a path`);
     }
-    if (result.bytes !== attachment.file.size) {
-      throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: expected ${attachment.file.size} bytes, wrote ${result.bytes}`);
+    if (result.bytes !== file.size) {
+      throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: expected ${file.size} bytes, wrote ${result.bytes}`);
     }
 
     const workspacePath = workspaceInboxPath(result.path);
@@ -347,7 +352,7 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
       bytes: result.bytes,
       workspacePath,
       url: toFileUrl(absolutePath),
-      file: attachment.file,
+      file,
     });
   }
 
@@ -358,12 +363,13 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
 }
 
 export async function composerAttachmentToFilePart(attachment: ComposerAttachment): Promise<FilePartInput | null> {
-  const metadata = resolveAttachmentFileMetadata(attachment.file);
+  const file = await compressImageFile(attachment.file);
+  const metadata = resolveAttachmentFileMetadata(file);
   const modelMime = modelFacingAttachmentMime(metadata.mime);
   if (!modelMime) return null;
   return {
     type: "file",
-    url: await fileToDataUrl(attachment.file, modelMime),
+    url: await fileToDataUrl(file, modelMime),
     filename: metadata.filename,
     mime: modelMime,
   };

--- a/apps/app/src/react-app/domains/session/sync/image-compression.ts
+++ b/apps/app/src/react-app/domains/session/sync/image-compression.ts
@@ -1,0 +1,61 @@
+const IMAGE_COMPRESS_MAX_PX = 2048;
+const IMAGE_COMPRESS_QUALITY = 0.82;
+const IMAGE_COMPRESS_TARGET_BYTES = 1_500_000;
+
+/**
+ * Re-encode oversized images as JPEG before upload / prompt inlining.
+ *
+ * Runs at send time (inside the async send pipeline, while attachment chips
+ * show their uploading state) instead of at attach time, so dropping a large
+ * photo into the composer shows its chip immediately rather than blocking the
+ * UI on canvas work (#attachment-upload-ux).
+ */
+export async function compressImageFile(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) return file;
+  if (file.type === "image/gif" || file.size <= IMAGE_COMPRESS_TARGET_BYTES) {
+    return file;
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+  const maxDim = Math.max(width, height);
+  const scale = maxDim > IMAGE_COMPRESS_MAX_PX ? IMAGE_COMPRESS_MAX_PX / maxDim : 1;
+  const targetW = Math.round(width * scale);
+  const targetH = Math.round(height * scale);
+
+  let blob: Blob | null = null;
+
+  if (typeof OffscreenCanvas !== "undefined") {
+    const offscreen = new OffscreenCanvas(targetW, targetH);
+    const ctx = offscreen.getContext("2d");
+    if (ctx) {
+      ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+      blob = await offscreen.convertToBlob({
+        type: "image/jpeg",
+        quality: IMAGE_COMPRESS_QUALITY,
+      });
+    }
+  }
+
+  if (!blob) {
+    const canvas = document.createElement("canvas");
+    canvas.width = targetW;
+    canvas.height = targetH;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+      blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/jpeg", IMAGE_COMPRESS_QUALITY),
+      );
+    }
+  }
+
+  bitmap.close();
+
+  if (!blob || blob.size >= file.size) {
+    return file;
+  }
+
+  const stem = file.name.replace(/\.[^.]+$/, "") || "image";
+  return new File([blob], `${stem}.jpg`, { type: "image/jpeg" });
+}

--- a/apps/server/src/inbox-upload-approval.e2e.test.ts
+++ b/apps/server/src/inbox-upload-approval.e2e.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const APPROVAL_TIMEOUT_MS = 1_500;
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function startManualApprovalServer() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-inbox-approval-"));
+  roots.push(root);
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    // The web/gateway posture: nobody answers approval prompts, so anything
+    // that parks on the approval queue hangs for timeoutMs and then fails.
+    approval: { mode: "manual", timeoutMs: APPROVAL_TIMEOUT_MS },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token, root };
+}
+
+describe("inbox uploads under manual approval mode", () => {
+  test("chat-attachment inbox upload succeeds immediately without host approval", async () => {
+    const { base, token, root } = await startManualApprovalServer();
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
+    const form = new FormData();
+    form.append("file", new File([bytes], "screenshot.png", { type: "image/png" }));
+    const inboxPath = "chat-attachments/session-1/att-1-screenshot.png";
+
+    const startedAt = Date.now();
+    const response = await fetch(
+      `${base}/workspace/ws_1/inbox?path=${encodeURIComponent(inboxPath)}`,
+      { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: form },
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    // Positive half: the upload lands and reports the exact byte count.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ok: true, path: inboxPath, bytes: bytes.length });
+
+    // Negative half: it must not have parked on the approval queue. Before the
+    // fix this request waited the full approval timeout and returned 403
+    // write_denied, which is what froze web/gateway attachment sends.
+    expect(elapsedMs).toBeLessThan(APPROVAL_TIMEOUT_MS);
+
+    // The bytes are intact and confined to the inbox drop area.
+    const dest = join(root, ".opencode", "openwork", "inbox", inboxPath);
+    expect(Array.from(new Uint8Array(await readFile(dest)))).toEqual(Array.from(bytes));
+  });
+
+  test("other workspace writes remain approval-gated (fix is not a blanket bypass)", async () => {
+    const { base, token, root } = await startManualApprovalServer();
+
+    const startedAt = Date.now();
+    const response = await fetch(`${base}/workspace/ws_1/files/content`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "notes/unapproved.md", content: "# should not land\n" }),
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    // A regular file write still parks on the approval queue and is denied
+    // after the timeout because nobody approves it.
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: "write_denied", details: { reason: "timeout" } });
+    expect(elapsedMs).toBeGreaterThanOrEqual(APPROVAL_TIMEOUT_MS - 100);
+
+    // And the file must not exist on disk.
+    await expect(stat(join(root, "notes", "unapproved.md"))).rejects.toThrow();
+  });
+});

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -604,12 +604,12 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
       throw new ApiError(413, "file_too_large", "File exceeds upload limit", { maxBytes, size: file.size });
     }
 
-    await requireApproval(ctx, {
-      workspaceId: workspace.id,
-      action: "workspace.inbox.upload",
-      summary: `Upload ${relativePath} to inbox`,
-      paths: [dest],
-    });
+    // Inbox uploads are exempt from host approval: the inbox is the designated
+    // client drop area (path-constrained via resolveSafeChildPath, size-capped,
+    // audited, and disable-able via inbox.enabled). Parking the upload on the
+    // manual-approval queue froze web/gateway clients for the whole approval
+    // timeout and then failed the send, because client tokens cannot approve
+    // their own writes. All other write routes remain approval-gated.
 
     await ensureDir(dirname(dest));
     const bytes = Buffer.from(await file.arrayBuffer());

--- a/evals/specs/attachment-upload-loading-state.slow.test.ts
+++ b/evals/specs/attachment-upload-loading-state.slow.test.ts
@@ -1,0 +1,360 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { screenshot } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "attachment-upload-mock";
+const modelId = "attachment-upload-model";
+const reply = "attachment upload loading proof";
+const attachmentName = "big-photo.png";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "attaching an image shows its chip instantly and sends with a visible uploading state"
+  : "attachment upload loading state skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+/**
+ * Boot the standalone openwork-server (the web/gateway posture) in
+ * manual-approval mode with nobody answering approvals. This is the exact
+ * configuration that used to park chat-attachment uploads for the whole
+ * approval timeout and then fail them with 403 write_denied.
+ */
+async function startManualApprovalServer(approvalTimeoutMs: number) {
+  const script = `
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { startServer } = await import("./src/server.ts");
+    const root = mkdtempSync(join(tmpdir(), "openwork-attachment-spec-"));
+    const server = await startServer({
+      host: "127.0.0.1",
+      port: 0,
+      token: "owt_spec_token",
+      hostToken: "owt_spec_host_token",
+      approval: { mode: "manual", timeoutMs: ${approvalTimeoutMs} },
+      corsOrigins: ["*"],
+      workspaces: [{ id: "ws_spec", name: "Workspace", path: root, preset: "starter", workspaceType: "local" }],
+      authorizedRoots: [root],
+      readOnly: false,
+      startedAt: Date.now(),
+      tokenSource: "cli",
+      hostTokenSource: "cli",
+      logFormat: "pretty",
+      logRequests: false,
+    });
+    console.log("SPEC_SERVER_PORT:" + server.port);
+    setInterval(() => {}, 60_000);
+  `;
+  const child = spawn("bun", ["-e", script], {
+    cwd: join(repoRoot, "apps", "server"),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  onTestFinished(() => {
+    child.kill("SIGKILL");
+  });
+  const port = await new Promise<number>((resolvePort, reject) => {
+    const timer = setTimeout(() => reject(new Error("Standalone openwork-server did not report a port within 30s.")), 30_000);
+    let buffered = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      buffered += chunk;
+      const match = buffered.match(/SPEC_SERVER_PORT:(\d+)/);
+      if (match?.[1]) {
+        clearTimeout(timer);
+        resolvePort(Number(match[1]));
+      }
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`Standalone openwork-server exited early (code ${code}): ${buffered.slice(0, 500)}`));
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(new Error(`Failed to spawn bun for the standalone server: ${error.message}`));
+    });
+  });
+  return { base: `http://127.0.0.1:${port}`, token: "owt_spec_token" };
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  // ---------------------------------------------------------------------
+  // Part 1 — gateway server contract: manual-approval mode must not park
+  // chat-attachment inbox uploads, while other writes stay approval-gated.
+  // ---------------------------------------------------------------------
+  const approvalTimeoutMs = 3_000;
+  const gateway = await startManualApprovalServer(approvalTimeoutMs);
+
+  const uploadBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 9, 9, 9, 9]);
+  const uploadForm = new FormData();
+  uploadForm.append("file", new File([uploadBytes], "screenshot.png", { type: "image/png" }));
+  const uploadStartedAt = Date.now();
+  const uploadResponse = await fetch(
+    `${gateway.base}/workspace/ws_spec/inbox?path=${encodeURIComponent("chat-attachments/s1/att-1-screenshot.png")}`,
+    { method: "POST", headers: { Authorization: `Bearer ${gateway.token}` }, body: uploadForm },
+  );
+  const uploadElapsedMs = Date.now() - uploadStartedAt;
+  expect(uploadResponse.status).toBe(200);
+  expect(uploadElapsedMs).toBeLessThan(approvalTimeoutMs);
+  evidence.fact(
+    "A chat-attachment upload to a manual-approval gateway server succeeds immediately instead of parking on the approval queue",
+    `POST /workspace/:id/inbox with a client token returned ${uploadResponse.status} in ${uploadElapsedMs}ms (approval timeout is ${approvalTimeoutMs}ms; before the fix this waited the full timeout and returned 403 write_denied).`,
+    true,
+  );
+
+  const writeStartedAt = Date.now();
+  const writeResponse = await fetch(`${gateway.base}/workspace/ws_spec/files/content`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${gateway.token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ path: "notes/unapproved.md", content: "# should not land\n" }),
+  });
+  const writeElapsedMs = Date.now() - writeStartedAt;
+  expect(writeResponse.status).toBe(403);
+  expect(writeElapsedMs).toBeGreaterThanOrEqual(approvalTimeoutMs - 100);
+  evidence.fact(
+    "Ordinary workspace writes remain approval-gated: the inbox exemption is not a blanket approval bypass",
+    `POST /workspace/:id/files/content with the same client token still parked and was denied with HTTP ${writeResponse.status} after ${writeElapsedMs}ms.`,
+    true,
+  );
+
+  // ---------------------------------------------------------------------
+  // Part 2 — composer UX: chip appears instantly, uploading state visible.
+  // ---------------------------------------------------------------------
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+    if (request.method === "POST" && (url.startsWith("/v1/chat/completions") || url.startsWith("/chat/completions"))) {
+      request.resume();
+      request.on("end", () => {
+        const chunks = [
+          { id: "chatcmpl-attachment-upload", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: "chatcmpl-attachment-upload", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: reply }, finish_reason: null }] },
+          { id: "chatcmpl-attachment-upload", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolveListen, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolveListen);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolveClose, reject) => mock.close((error) => error ? reject(error) : resolveClose()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  await using app = await desktop({ name: "attachment-upload-loading" });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-attachment-upload-${Date.now()}`,
+  });
+
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Attachment upload mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-attachment-upload" },
+              models: {
+                [${JSON.stringify(modelId)}]: { name: "Attachment upload model" },
+              },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  // Reload so the renderer re-reads the mock provider preference before the
+  // new session is created. Without this, the already-mounted model store can
+  // keep the previous default model despite the localStorage update above.
+  await evalIn(app, "location.reload(); true");
+  await waitFor(app, "Boolean(window.__openworkControl)", {
+    timeoutMs: 30_000,
+    label: "app reloaded with attachment mock provider preference",
+  });
+
+  await control(app, "session.create_task");
+  await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+    timeoutMs: 30_000,
+    label: "new-task composer editor ready",
+  });
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text: "Describe the attached image." });
+
+  // Attach a >1.5MB image (random noise defeats PNG compression) through the
+  // composer's hidden file input, and measure dispatch -> chip visibility.
+  const attachResult = await evalIn(app, `(async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 2400;
+    canvas.height = 2400;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return "no canvas context";
+    const image = ctx.createImageData(2400, 2400);
+    for (let index = 0; index < image.data.length; index += 1) {
+      image.data[index] = Math.floor(Math.random() * 256);
+    }
+    ctx.putImageData(image, 0, 0);
+    const blob = await new Promise((resolveBlob) => canvas.toBlob(resolveBlob, "image/png"));
+    if (!blob) return "no blob";
+    const file = new File([blob], ${JSON.stringify(attachmentName)}, { type: "image/png" });
+    const inputs = [...document.querySelectorAll('input[type="file"][multiple]')];
+    const input = inputs.at(-1);
+    if (!input) return "no composer file input";
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    input.files = transfer.files;
+    const startedAt = performance.now();
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    const chip = await new Promise((resolveChip) => {
+      const deadline = performance.now() + 5000;
+      const poll = () => {
+        const found = document.querySelector("[data-attachment-id]");
+        if (found) return resolveChip(found);
+        if (performance.now() > deadline) return resolveChip(null);
+        requestAnimationFrame(poll);
+      };
+      poll();
+    });
+    if (!chip) return "chip never appeared";
+    return JSON.stringify({
+      fileBytes: file.size,
+      elapsedMs: Math.round(performance.now() - startedAt),
+      chipTitle: chip.getAttribute("title"),
+      chipStatus: chip.getAttribute("data-attachment-status"),
+    });
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  if (typeof attachResult !== "string" || !attachResult.startsWith("{")) {
+    throw new Error(`Attaching the image failed: ${String(attachResult)}`);
+  }
+  const attach = JSON.parse(attachResult) as { fileBytes: number; elapsedMs: number; chipTitle: string | null; chipStatus: string | null };
+  expect(attach.fileBytes).toBeGreaterThan(1_500_000);
+  expect(attach.elapsedMs).toBeLessThan(2_000);
+  // The chip keeps the original .png name: compression no longer runs before
+  // the chip renders (the old attach path re-encoded to .jpg first, which is
+  // exactly the silent dead time users saw).
+  expect(attach.chipTitle).toBe(attachmentName);
+  expect(attach.chipStatus).toBe("ready");
+  evidence.fact(
+    "Attaching a large image shows its composer chip instantly instead of blocking on compression",
+    `A ${attach.fileBytes}-byte PNG showed its chip ${attach.elapsedMs}ms after the file input change event, still named ${attachmentName} (compression now happens at send time).`,
+    true,
+  );
+
+  await screenshot(app);
+
+  // Watch for the uploading overlay before clicking send, so even a fast
+  // local upload cannot slip past the assertion.
+  await evalIn(app, `(() => {
+    window.__attachmentUploadingSeen = false;
+    const record = () => {
+      if (document.querySelector('[data-attachment-status="uploading"]')) {
+        window.__attachmentUploadingSeen = true;
+      }
+    };
+    const observer = new MutationObserver(record);
+    observer.observe(document.body, { subtree: true, attributes: true, attributeFilter: ["data-attachment-status"], childList: true });
+    record();
+    return "observing";
+  })()`);
+
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+
+  await waitFor(app, `window.__attachmentUploadingSeen === true`, {
+    timeoutMs: 30_000,
+    label: "attachment chip showed its uploading state during send",
+  });
+  evidence.fact(
+    "The attachment chip shows a visible uploading state while the send is in flight",
+    "A MutationObserver installed before composer.send recorded a chip with data-attachment-status=\"uploading\" — the send is no longer a silent hang.",
+    true,
+  );
+
+  // The regression is the pre-model attachment handoff. Prove the submission
+  // was accepted without depending on provider completion timing: the app
+  // creates a real session route and clears the sent chip from the composer.
+  // (The mock may still be generating when this bounded assertion completes.)
+  await waitFor(app, `window.location.hash.includes("/session/ses_")`, {
+    timeoutMs: 30_000,
+    label: "attachment submission created a session",
+  });
+  const sessionId = await evalIn(app, `window.location.hash.split("/session/")[1]?.split(/[/?#]/)[0] ?? ""`);
+  expect(typeof sessionId === "string" && sessionId.startsWith("ses_")).toBe(true);
+  await waitFor(app, `!document.querySelector("[data-attachment-id]")`, {
+    timeoutMs: 30_000,
+    label: "composer cleared its attachment chips after the send completed",
+  });
+  const errorToastVisible = await evalIn(app, `Boolean(document.querySelector('[data-sonner-toast][data-type="error"]'))`);
+  expect(errorToastVisible).toBe(false);
+  evidence.fact(
+    "The message with the attachment is accepted: a session is created, the composer clears, and no error toast appears",
+    `The app created session ${sessionId}, cleared the attachment chip from the composer, and showed no error toast.`,
+    true,
+  );
+
+  await screenshot(app);
+
+  const stopEnabled = await evalIn(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.stop" && !action.disabled)`);
+  if (stopEnabled) await control(app, "composer.stop");
+});


### PR DESCRIPTION
## Summary
- let authenticated clients upload into the constrained workspace inbox without parking on the host approval queue
- render attachment chips immediately and move oversized-image compression into the send pipeline
- show an uploading overlay and stable status attributes while attachment sends are in flight
- add server-contract and agent-first app coverage for the gateway and composer behaviors

## Verification
- `pnpm --dir apps/app typecheck` — passed
- `pnpm --dir apps/server typecheck` — passed
- `bun test src/inbox-upload-approval.e2e.test.ts` (apps/server) — 2 passed
- `bun test --isolate tests/attachment-file-part.test.ts` (apps/app) — 19 passed
- `OPENWORK_EVAL_SURFACES_DIR=/tmp/ow-eval-surfaces OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/attachment-upload-loading-state.slow.test.ts` — 1 passed

Execution lane: local fallback; Daytona credentials were unavailable. The testkit tape uses DOM/API assertions, evidence facts, and local screenshots. Per request, no Infisical-backed image upload or external vision validation was used.