### PR TITLE
fix(evals): name an expired Daytona preview URL at sign-in

### DIFF
--- a/evals/packages/behaviors/src/den.ts
+++ b/evals/packages/behaviors/src/den.ts
@@ -71,6 +71,30 @@ export async function denFetch(den: DenRef, path: string, init: RequestInit = {}
   return { response, body, text };
 }
 
+/**
+ * A Daytona preview URL carries a signed, expiring token in its hostname, and
+ * the proxy answers an expired one with its own 401 before the request ever
+ * reaches Den. That is indistinguishable from rejected credentials in the
+ * failure text, so a stale reused URL reads as "wrong password" and sends the
+ * reader hunting through Den auth. Name the real cause instead.
+ */
+export function expiredPreviewUrlHint(url: string, status: number, body: unknown): string {
+  if (status !== 401) return "";
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return "";
+  }
+  if (!/\.daytonaproxy\d*\.net$/i.test(host)) return "";
+  const code = typeof body === "object" && body !== null && "code" in body
+    ? String((body as { code?: unknown }).code ?? "")
+    : "";
+  if (code && code.toUpperCase() !== "UNAUTHORIZED") return "";
+  return " The Daytona preview URL looks expired (the proxy rejected the request before Den saw it)."
+    + " Re-provision the Den sandbox or re-mint its preview URLs, then update OPENWORK_EVAL_DEN_API_URL/_WEB_URL.";
+}
+
 export async function signIn(den: DenRef, credentials: { email: string; password: string }): Promise<DenSession> {
   const result = await denFetch(den, "/api/auth/sign-in/email", {
     method: "POST",
@@ -78,7 +102,10 @@ export async function signIn(den: DenRef, credentials: { email: string; password
   });
   const token = stringField(result.body, "token");
   if (!result.response.ok || !token) {
-    throw new Error(`Sign-in failed for ${credentials.email}: HTTP ${result.response.status} ${preview(result.body)}`);
+    const hint = expiredPreviewUrlHint(den.apiUrl, result.response.status, result.body);
+    throw new Error(
+      `Sign-in failed for ${credentials.email}: HTTP ${result.response.status} ${preview(result.body)}${hint}`,
+    );
   }
   return { ...den, token, email: credentials.email, password: credentials.password };
 }

--- a/evals/specs/den-signin-expired-preview-url.test.ts
+++ b/evals/specs/den-signin-expired-preview-url.test.ts
@@ -1,0 +1,72 @@
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { expect, test } from "vitest";
+import { expiredPreviewUrlHint, signIn } from "@openwork/behaviors";
+
+/**
+ * A Daytona preview hostname carries a signed, expiring token, so a reused URL
+ * eventually fails at the proxy with its own 401 — before Den ever sees the
+ * request. The failure text was indistinguishable from rejected credentials
+ * ("Sign-in failed for alex@acme.test: HTTP 401 ... Invalid or expired token"),
+ * which reads as a Den auth problem and sends the reader to the wrong layer.
+ * These claims pin the diagnosis to the layer that actually refused.
+ */
+
+const proxyBody = {
+  statusCode: 401,
+  message: "unauthorized: authentication failed: Invalid or expired token",
+  code: "UNAUTHORIZED",
+  path: "/api/auth/sign-in/email",
+  method: "POST",
+};
+
+async function startStub(status: number, body: unknown): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((_request, response) => {
+    response.writeHead(status, { "content-type": "application/json" });
+    response.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("stub server did not bind a port");
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  };
+}
+
+test("an expired Daytona preview URL is named as the cause, not the credentials", () => {
+  const hint = expiredPreviewUrlHint("https://8788-q1syj5cojnvni1pn.daytonaproxy01.net", 401, proxyBody);
+  expect(hint).toContain("preview URL looks expired");
+  expect(hint).toContain("OPENWORK_EVAL_DEN_API_URL");
+});
+
+test("a real Den credential rejection keeps its own diagnosis", () => {
+  // Same status from Den itself: no proxy host, so no preview-URL hint.
+  const denRejection = expiredPreviewUrlHint("https://den.example.com", 401, { code: "INVALID_CREDENTIALS" });
+  expect(denRejection).toBe("");
+  // A proxy host that answers something other than its expiry shape is Den's.
+  const otherProxyError = expiredPreviewUrlHint("https://8788-abc.daytonaproxy01.net", 401, { code: "INVALID_CREDENTIALS" });
+  expect(otherProxyError).toBe("");
+  // A non-401 never earns the hint.
+  const notUnauthorized = expiredPreviewUrlHint("https://8788-abc.daytonaproxy01.net", 500, proxyBody);
+  expect(notUnauthorized).toBe("");
+});
+
+test("signIn surfaces the failing status and body regardless of layer", async () => {
+  const stub = await startStub(401, proxyBody);
+  try {
+    const failure = await signIn(
+      { apiUrl: stub.url, webUrl: stub.url },
+      { email: "alex@acme.test", password: "OpenWorkDemo123!" },
+    ).then(() => null, (error: unknown) => (error instanceof Error ? error.message : String(error)));
+    expect(failure).toContain("Sign-in failed for alex@acme.test");
+    expect(failure).toContain("HTTP 401");
+    // A loopback stub is not a preview host, so the hint must stay off.
+    expect(failure).not.toContain("preview URL looks expired");
+  } finally {
+    await stub.close();
+  }
+});


### PR DESCRIPTION
## Problem

Daytona preview hostnames carry a signed, **expiring** token. When a reused preview URL expires, the Daytona proxy answers with its own 401 *before the request reaches Den*:

```json
{"statusCode":401,"message":"unauthorized: authentication failed: Invalid or expired token","code":"UNAUTHORIZED","path":"/api/auth/sign-in/email","method":"POST"}
```

`signIn` reported that as:

```
Sign-in failed for alex@acme.test: HTTP 401 {"message":"...Invalid or expired token","code":"UNAUTHORIZED"...}
```

which reads as *rejected credentials*. I hit this while running specs for #3634 and spent a full 10-minute cycle looking at Den auth and the seeded demo password before realizing the sandbox URL had simply aged out.

## Fix

Append the real diagnosis to the failure text when — and only when — the failing host is a `daytonaproxy*.net` host answering with the proxy's `UNAUTHORIZED` shape:

> The Daytona preview URL looks expired (the proxy rejected the request before Den saw it). Re-provision the Den sandbox or re-mint its preview URLs, then update `OPENWORK_EVAL_DEN_API_URL`/`_WEB_URL`.

A genuine Den credential rejection keeps its own message untouched.

## Tests

New PR-lane spec `evals/specs/den-signin-expired-preview-url.test.ts` — 3 passed:

```
pnpm evals:spec specs/den-signin-expired-preview-url.test.ts
Test Files  1 passed (1)
      Tests  3 passed (3)
```

Both halves are asserted: the expired-preview case earns the hint; a Den `INVALID_CREDENTIALS` at a non-proxy host, a proxy host returning a non-expiry code, and a non-401 status all keep the hint off. A third claim drives the real `signIn` against a loopback stub returning the proxy body and asserts the status/body still surface while the hint stays off for a non-preview host.

`pnpm evals:typecheck` clean (except the pre-existing `connectors-quick-add.slow.test.ts` error already on dev).

This is diagnostics only — no behavior change to provisioning or auth, so there is nothing runtime-observable to record a testkit tape for beyond the PR-lane spec above.

Related: #3634 (the run where this cost me a cycle).