### PR TITLE
fix(den-api): clamp config object projections to fit MySQL TEXT columns

### DIFF
--- a/ee/apps/den-api/src/routes/bootstrap/index.ts
+++ b/ee/apps/den-api/src/routes/bootstrap/index.ts
@@ -27,6 +27,7 @@ import { jsonValidator, publicRoute, authenticatedRoute } from "../../middleware
 import { DEFAULT_ORGANIZATION_LIMITS } from "../../organization-limits.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { seedDefaultOrganizationRoles, setSessionActiveOrganization } from "../../orgs.js"
+import { clampUtf8Bytes, PROJECTION_TEXT_MAX_BYTES } from "../org/plugin-system/projection-text.js"
 import type { AuthContextVariables } from "../../session.js"
 import {
   DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION,
@@ -270,7 +271,7 @@ export function registerBootstrapRoutes<T extends { Variables: AuthContextVariab
           sourceMode: "cloud",
           title: metadata.title,
           description: metadata.description,
-          searchText: [metadata.title, metadata.description, skillText].filter(Boolean).join("\n"),
+          searchText: clampUtf8Bytes([metadata.title, metadata.description, skillText].filter(Boolean).join("\n"), PROJECTION_TEXT_MAX_BYTES),
           currentFileName: null,
           currentFileExtension: null,
           currentRelativePath: null,

--- a/ee/apps/den-api/src/routes/org/plugin-system/projection-text.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/projection-text.ts
@@ -1,0 +1,40 @@
+/**
+ * config_object.title is varchar(255) and config_object.description /
+ * config_object.search_text are MySQL TEXT columns capped at 65,535 bytes.
+ * Vitess/PlanetScale runs in strict SQL mode, so an oversized derived
+ * projection fails the whole insert/update with errno 1406 ("Data too long
+ * for column") instead of truncating (Sentry DEN-API-Z / DEN-API-1K).
+ *
+ * Derived projections exist for listing and search only; the untruncated
+ * source of truth lives in config_object_version.raw_source_text
+ * (MEDIUMTEXT), so clamping here loses nothing.
+ */
+export const PROJECTION_TITLE_MAX_CHARS = 255
+export const PROJECTION_TEXT_MAX_BYTES = 60_000
+
+/** Truncate to at most maxBytes of UTF-8 without splitting a code point. */
+export function clampUtf8Bytes(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value
+  let bytes = 0
+  let end = 0
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, "utf8")
+    if (bytes + codePointBytes > maxBytes) break
+    bytes += codePointBytes
+    end += codePoint.length
+  }
+  return value.slice(0, end)
+}
+
+/** Truncate to at most maxCodePoints without splitting a surrogate pair. */
+export function clampCodePoints(value: string, maxCodePoints: number): string {
+  if (value.length <= maxCodePoints) return value
+  let count = 0
+  let end = 0
+  for (const codePoint of value) {
+    if (count === maxCodePoints) break
+    count += 1
+    end += codePoint.length
+  }
+  return value.slice(0, end)
+}

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -29,6 +29,7 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { hasSkillFrontmatterName, parseSkillMarkdown } from "@openwork-ee/utils"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
 import { isPluginArchOrgAdmin, PluginArchAuthorizationError, requirePluginArchResourceRole, resolvePluginArchGrantRole, resolvePluginArchResourceRole } from "./access.js"
+import { clampCodePoints, clampUtf8Bytes, PROJECTION_TEXT_MAX_BYTES, PROJECTION_TITLE_MAX_CHARS } from "./projection-text.js"
 import {
   buildGithubAppInstallUrl,
   createGithubInstallStateToken,
@@ -619,7 +620,7 @@ function deriveSkillProjection(value: ConfigObjectInput) {
 
   return {
     description,
-    searchText: [name, description, body].join("\n"),
+    searchText: clampUtf8Bytes([name, description, body].join("\n"), PROJECTION_TEXT_MAX_BYTES),
     title: name,
   }
 }
@@ -653,15 +654,18 @@ function deriveProjection(input: { objectType: ConfigObjectRow["objectType"]; va
       : null,
   ].find((value) => Boolean(normalizeOptionalString(value ?? undefined)))
 
-  const title = normalizeOptionalString(titleCandidate ?? undefined)
-    ?? `${input.objectType.charAt(0).toUpperCase()}${input.objectType.slice(1)} ${new Date().toISOString()}`
+  const title = clampCodePoints(
+    normalizeOptionalString(titleCandidate ?? undefined)
+      ?? `${input.objectType.charAt(0).toUpperCase()}${input.objectType.slice(1)} ${new Date().toISOString()}`,
+    PROJECTION_TITLE_MAX_CHARS,
+  )
 
   const description = normalizeOptionalString(descriptionCandidate ?? undefined)
-  const searchText = [title, description, rawSourceText].filter(Boolean).join("\n") || null
+  const searchText = [title, description, rawSourceText].filter(Boolean).join("\n")
 
   return {
-    description,
-    searchText,
+    description: description ? clampUtf8Bytes(description, PROJECTION_TEXT_MAX_BYTES) : null,
+    searchText: searchText ? clampUtf8Bytes(searchText, PROJECTION_TEXT_MAX_BYTES) : null,
     title,
   }
 }

--- a/ee/apps/den-api/test/config-object-projection-clamp.test.ts
+++ b/ee/apps/den-api/test/config-object-projection-clamp.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import {
+  clampCodePoints,
+  clampUtf8Bytes,
+  PROJECTION_TEXT_MAX_BYTES,
+  PROJECTION_TITLE_MAX_CHARS,
+} from "../src/routes/org/plugin-system/projection-text.js"
+
+const MYSQL_TEXT_MAX_BYTES = 65_535
+
+function utf8Bytes(value: string) {
+  return Buffer.byteLength(value, "utf8")
+}
+
+function roundTripsCleanly(value: string) {
+  return Buffer.from(value, "utf8").toString("utf8") === value
+}
+
+test("clampUtf8Bytes leaves values within budget untouched", () => {
+  expect(clampUtf8Bytes("short", 100)).toBe("short")
+  expect(clampUtf8Bytes("", 100)).toBe("")
+  const exact = "a".repeat(100)
+  expect(clampUtf8Bytes(exact, 100)).toBe(exact)
+})
+
+test("clampUtf8Bytes never splits a two-byte code point", () => {
+  // "é" is 2 bytes in UTF-8; a 5-byte budget fits two of them, not two and a half.
+  expect(clampUtf8Bytes("ééé", 5)).toBe("éé")
+  expect(utf8Bytes(clampUtf8Bytes("ééé", 5))).toBe(4)
+})
+
+test("clampUtf8Bytes never splits a surrogate pair", () => {
+  // "💚" is 4 UTF-8 bytes and one surrogate pair; a 6-byte budget fits one.
+  const clamped = clampUtf8Bytes("💚💚", 6)
+  expect(clamped).toBe("💚")
+  expect(roundTripsCleanly(clamped)).toBe(true)
+})
+
+test("clampUtf8Bytes keeps multibyte production payloads under the MySQL TEXT cap", () => {
+  const sentence = "Orchestre le développement complet d'apps mobiles — idée, validation, croissance, déploiement. "
+  const cjk = "大小阈值测试：这是用于探测载荷大小阈值的测试文本。"
+  let oversized = ""
+  while (utf8Bytes(oversized) <= MYSQL_TEXT_MAX_BYTES + 10_000) oversized += sentence + cjk
+  expect(utf8Bytes(oversized)).toBeGreaterThan(MYSQL_TEXT_MAX_BYTES)
+
+  const clamped = clampUtf8Bytes(oversized, PROJECTION_TEXT_MAX_BYTES)
+  expect(utf8Bytes(clamped)).toBeLessThanOrEqual(PROJECTION_TEXT_MAX_BYTES)
+  expect(utf8Bytes(clamped)).toBeGreaterThan(PROJECTION_TEXT_MAX_BYTES - 8)
+  expect(PROJECTION_TEXT_MAX_BYTES).toBeLessThanOrEqual(MYSQL_TEXT_MAX_BYTES)
+  expect(oversized.startsWith(clamped)).toBe(true)
+  expect(roundTripsCleanly(clamped)).toBe(true)
+})
+
+test("clampCodePoints counts code points, not UTF-16 units", () => {
+  expect(clampCodePoints("abc", 5)).toBe("abc")
+  const emojiTitle = "💚".repeat(PROJECTION_TITLE_MAX_CHARS + 45)
+  const clamped = clampCodePoints(emojiTitle, PROJECTION_TITLE_MAX_CHARS)
+  expect([...clamped].length).toBe(PROJECTION_TITLE_MAX_CHARS)
+  expect(roundTripsCleanly(clamped)).toBe(true)
+})

--- a/evals/specs/config-object-large-skill.slow.test.ts
+++ b/evals/specs/config-object-large-skill.slow.test.ts
@@ -70,6 +70,10 @@ test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) =
     "x-openwork-org-id": orgId,
   };
 
+  // Large multibyte bodies over the Daytona preview proxy need a wider, still
+  // bounded, per-request budget than the denFetch default.
+  const largeRequestSignal = () => AbortSignal.timeout(120_000);
+
   // 120 KB > 65,535-byte TEXT cap: this exact insert failed with errno 1406 (DEN-API-Z).
   const skillName = `grand-skill-multioctets-${unique}`;
   const skillV1 = buildSkillMarkdown(skillName, "Orchestrateur V1", 120_000);
@@ -77,6 +81,7 @@ test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) =
     method: "POST",
     headers: orgHeaders,
     body: JSON.stringify({ type: "skill", sourceMode: "cloud", input: { rawSourceText: skillV1 } }),
+    signal: largeRequestSignal(),
   });
   expect(created.response.status).toBe(201);
   const createdItem = itemOf(created.body);
@@ -94,6 +99,7 @@ test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) =
     method: "POST",
     headers: orgHeaders,
     body: JSON.stringify({ input: { rawSourceText: skillV2 }, reason: "spec: oversized multibyte update" }),
+    signal: largeRequestSignal(),
   });
   expect(versioned.response.status).toBe(201);
   evidence.fact(
@@ -104,6 +110,7 @@ test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) =
 
   const detail = await denFetch(admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}`, {
     headers: orgHeaders,
+    signal: largeRequestSignal(),
   });
   expect(detail.response.status).toBe(200);
   const item = itemOf(detail.body);

--- a/evals/specs/config-object-large-skill.slow.test.ts
+++ b/evals/specs/config-object-large-skill.slow.test.ts
@@ -1,0 +1,150 @@
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { expect } from "vitest";
+import { localMysqlIsRunning, needs, server, test } from "@openwork/testkit";
+
+// Reproduces Sentry DEN-API-Z (config object insert) and DEN-API-1K (version
+// update): a SKILL.md whose derived search_text projection exceeds the MySQL
+// TEXT column's 65,535-byte cap failed the whole write with errno 1406 on
+// strict-mode MySQL/Vitess and surfaced as HTTP 500.
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOverride = Boolean(process.env.OPENWORK_EVAL_MYSQL_URL?.trim());
+const mysqlOpen = !localPlacement || mysqlOverride || (await localMysqlIsRunning());
+const title = !appSpecsEnabled
+  ? "oversized multibyte skill projection skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !mysqlOpen
+    ? "oversized multibyte skill projection skipped — needs MySQL on 127.0.0.1:3306"
+    : "an oversized multibyte SKILL.md saves cleanly and only its derived search projection is clamped";
+
+const MYSQL_TEXT_MAX_BYTES = 65_535;
+const PROJECTION_TEXT_MAX_BYTES = 60_000;
+// Accented characters and em-dashes make byte length exceed character count,
+// matching the production payloads (French skill body, CJK threshold probe).
+const SENTENCE =
+  "Orchestre le développement complet d'apps mobiles — idée, étude de marché, validation, croissance, déploiement. 大小阈值测试。";
+
+function utf8Bytes(value: string) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function buildSkillMarkdown(name: string, headline: string, targetBytes: number) {
+  let markdown = `---\nname: ${name}\ndescription: Skill volumineux multi-octets qui prouve la limite de search_text.\n---\n\n# ${headline}\n\n`;
+  while (utf8Bytes(markdown) < targetBytes) markdown += SENTENCE;
+  return markdown.trimEnd();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function itemOf(body: unknown): Record<string, unknown> {
+  if (!isRecord(body) || !isRecord(body.item)) throw new Error(`Response had no item: ${JSON.stringify(body).slice(0, 300)}`);
+  return body.item;
+}
+
+async function activeOrganizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = orgs[0] && typeof orgs[0].id === "string" ? orgs[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Resolving the provisioned organization failed: HTTP ${result.response.status} ${result.text.slice(0, 300)}`);
+  }
+  return id;
+}
+
+test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const unique = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`;
+  await using den = await server({
+    place,
+    org: { name: `SearchText Overflow ${unique}` },
+  });
+  const admin = den.admin;
+  const orgId = await activeOrganizationId(admin);
+  const orgHeaders = {
+    authorization: `Bearer ${admin.token}`,
+    "x-openwork-org-id": orgId,
+  };
+
+  // 120 KB > 65,535-byte TEXT cap: this exact insert failed with errno 1406 (DEN-API-Z).
+  const skillName = `grand-skill-multioctets-${unique}`;
+  const skillV1 = buildSkillMarkdown(skillName, "Orchestrateur V1", 120_000);
+  const created = await denFetch(admin, "/v1/config-objects", {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({ type: "skill", sourceMode: "cloud", input: { rawSourceText: skillV1 } }),
+  });
+  expect(created.response.status).toBe(201);
+  const createdItem = itemOf(created.body);
+  const configObjectId = typeof createdItem.id === "string" ? createdItem.id : "";
+  expect(configObjectId).toMatch(/^cob_/);
+  evidence.fact(
+    "An oversized multibyte skill can be created",
+    `POST /v1/config-objects with a ${utf8Bytes(skillV1)}-byte SKILL.md returned HTTP ${created.response.status}; pre-fix this failed HTTP 500 with errno 1406 (DEN-API-Z).`,
+    created.response.status === 201,
+  );
+
+  // 200 KB update: this exact version create failed with errno 1406 (DEN-API-1K).
+  const skillV2 = buildSkillMarkdown(skillName, "Orchestrateur V2", 200_000);
+  const versioned = await denFetch(admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}/versions`, {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({ input: { rawSourceText: skillV2 }, reason: "spec: oversized multibyte update" }),
+  });
+  expect(versioned.response.status).toBe(201);
+  evidence.fact(
+    "An oversized multibyte version update saves",
+    `POST /v1/config-objects/:id/versions with a ${utf8Bytes(skillV2)}-byte SKILL.md returned HTTP ${versioned.response.status}; pre-fix this failed HTTP 500 with errno 1406 (DEN-API-1K).`,
+    versioned.response.status === 201,
+  );
+
+  const detail = await denFetch(admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}`, {
+    headers: orgHeaders,
+  });
+  expect(detail.response.status).toBe(200);
+  const item = itemOf(detail.body);
+  const searchText = typeof item.searchText === "string" ? item.searchText : "";
+  const searchTextBytes = utf8Bytes(searchText);
+  expect(searchText.startsWith(skillName)).toBe(true);
+  expect(searchTextBytes).toBeLessThanOrEqual(PROJECTION_TEXT_MAX_BYTES);
+  expect(searchTextBytes).toBeGreaterThan(PROJECTION_TEXT_MAX_BYTES - 8);
+  evidence.fact(
+    "Only the derived search projection is clamped",
+    `config_object.searchText holds ${searchTextBytes} UTF-8 bytes: within the ${PROJECTION_TEXT_MAX_BYTES}-byte projection budget, under the ${MYSQL_TEXT_MAX_BYTES}-byte MySQL TEXT cap, and cut on a code-point boundary.`,
+    searchTextBytes <= PROJECTION_TEXT_MAX_BYTES && searchTextBytes > PROJECTION_TEXT_MAX_BYTES - 8,
+  );
+
+  // Negative half: the immutable version keeps the full source; nothing the
+  // user wrote is truncated.
+  const latestVersion = isRecord(item.latestVersion) ? item.latestVersion : null;
+  const storedSource = latestVersion && typeof latestVersion.rawSourceText === "string" ? latestVersion.rawSourceText : "";
+  expect(storedSource).toBe(skillV2);
+  evidence.fact(
+    "The stored SKILL.md source is byte-identical",
+    `latestVersion.rawSourceText round-trips all ${utf8Bytes(skillV2)} bytes of the update; clamping never touches the source of truth.`,
+    storedSource === skillV2,
+  );
+
+  // Negative half: a small skill's projection is not altered by the clamp.
+  const smallName = `petit-skill-${unique}`;
+  const smallBody = "Corps compact avec accents — été, déjà, très.";
+  const smallSkill = `---\nname: ${smallName}\ndescription: Petit skill témoin.\n---\n\n${smallBody}`;
+  const smallCreated = await denFetch(admin, "/v1/config-objects", {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({ type: "skill", sourceMode: "cloud", input: { rawSourceText: smallSkill } }),
+  });
+  expect(smallCreated.response.status).toBe(201);
+  const smallItem = itemOf(smallCreated.body);
+  const smallSearchText = typeof smallItem.searchText === "string" ? smallItem.searchText : "";
+  expect(smallSearchText).toBe([smallName, "Petit skill témoin.", smallBody].join("\n"));
+  evidence.fact(
+    "Small skills keep their full projection",
+    "A compact skill's searchText remains the exact name/description/body join; the clamp only affects oversized values.",
+    smallSearchText === [smallName, "Petit skill témoin.", smallBody].join("\n"),
+  );
+});


### PR DESCRIPTION
## Problem

Production Sentry issues [DEN-API-1K](https://different-ai-inc.sentry.io/issues/DEN-API-1K) (`POST /v1/config-objects/:configObjectId/versions`) and [DEN-API-Z](https://different-ai-inc.sentry.io/issues/DEN-API-Z) (`POST /v1/config-objects`): saving a large SKILL.md makes the derived `search_text` projection exceed the 65,535-byte MySQL `TEXT` cap. Strict-mode MySQL/Vitess (PlanetScale) rejects the whole write with `Data too long for column 'search_text' (errno 1406, sqlstate 22001)` and the route surfaces HTTP 500. Render logs for the failing request (`req_01kzjrx744exs9vch9sbfeb4m8`) carry the unredacted driver cause confirming errno 1406.

Multibyte content makes this worse than it looks: French accents/em-dashes are 2–3 UTF-8 bytes and CJK is 3, so payloads far below 65,535 *characters* overflow the *byte* cap. Input validation allows `rawSourceText` up to 1 MiB, and the projection concatenated the entire body uncapped.

## Fix

- New `projection-text.ts`: `clampUtf8Bytes` (byte-aware, never splits a code point) and `clampCodePoints`; budgets `PROJECTION_TEXT_MAX_BYTES = 60_000`, `PROJECTION_TITLE_MAX_CHARS = 255`.
- Clamp derived `title`/`description`/`searchText` in `deriveSkillProjection` and `deriveProjection` (covers create, version update, plugin bundles, GitHub connector imports) and the inline bootstrap join.
- The immutable version's `raw_source_text` (MEDIUMTEXT) keeps the full source — only the derived search projection is truncated.

## Verification (agent-first)

Spec: `evals/specs/config-object-large-skill.slow.test.ts` — 5 claims: 120 KB multibyte create returns 201 (DEN-API-Z repro), 200 KB version update returns 201 (DEN-API-1K repro), `searchText` ≤ 60,000 bytes cut on a code-point boundary, `latestVersion.rawSourceText` byte-identical (no user data truncated), small skill projection unaltered.

| Run | Command | Result |
|---|---|---|
| RED control (fix stashed, dev tip `195f8e0ac`) | `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MYSQL_URL=mysql://root:password@127.0.0.1:3316 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/config-object-large-skill.slow.test.ts` | FAIL — `expected 500 to be 201` (reproduces production) |
| GREEN local (cold boot) | same command with fix | 1 passed / 0 failed / 0 skipped |
| GREEN cloud (Daytona sandbox, PR head `5aec1cf07`) | `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/config-object-searchtext-overflow OPENWORK_EVAL_APP_SPECS=1 infisical run --env dev --silent -- pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/config-object-large-skill.slow.test.ts` | 1 passed / 0 failed / 0 skipped, exit 0, 5/5 expectations |
| Unit | `bun test test/config-object-projection-clamp.test.ts test/plugin-system-create-bundle.test.ts` (ee/apps/den-api) | 11 pass / 0 fail |
| Typecheck | `tsc --noEmit -p ee/apps/den-api/tsconfig.json` | exit 0 |

Execution lane: Daytona (available and used for the final verdict); local lane used for the red/green control. Verdict: **Passed**. Evidence tape published below.

Fixes DEN-API-1K
Fixes DEN-API-Z