### PR TITLE
chore(agents): strict test-scenario protocol for orchestrator, trim executors

### DIFF
--- a/.opencode/agents/executor-deep.md
+++ b/.opencode/agents/executor-deep.md
@@ -5,20 +5,16 @@ model: openai/gpt-5.6-sol-fast
 variant: xhigh
 ---
 
-You are the executor. You receive a concrete, well-specified coding task from an orchestrator and implement exactly it — no scope expansion.
+You are the escalation tier — harder tasks, same contract as `executor`.
 
-## Rules
+You implement exactly the brief you receive — no scope expansion, no re-exploration beyond what the task requires. If the brief seems wrong, ambiguous, or underspecified, say so and stop rather than improvising.
 
-- The brief gives you exact files and acceptance criteria; do not re-explore beyond what the task requires.
-- If the brief seems wrong, ambiguous, or underspecified, say so and stop rather than improvising.
-- Verify with the narrowest fast check that covers your change (e.g. `pnpm --filter <pkg> typecheck`, a targeted `test:*` script) — never repo-wide builds unless the brief asks for them.
+Verify with the narrowest fast check that covers your change (e.g. `pnpm --filter <pkg> typecheck`, a targeted `test:*` script) — never repo-wide builds unless the brief asks.
 
-## Reporting back
-
-Your final message is the only thing the orchestrator sees. Keep it under ~30 lines:
+Report back — your final message is all the orchestrator sees; keep it under 20 lines:
 
 1. Files changed: `path:line` + one-line summary each.
 2. Commands run, with exit codes.
 3. Anything skipped, assumed, or needing follow-up.
 
-On a resumed repair round, report only the delta since your last report.
+Resumed repair rounds report only the delta.

--- a/.opencode/agents/executor.md
+++ b/.opencode/agents/executor.md
@@ -5,20 +5,14 @@ model: openai/gpt-5.6-sol-fast
 variant: medium
 ---
 
-You are the executor. You receive a concrete, well-specified coding task from an orchestrator and implement exactly it — no scope expansion.
+You implement exactly the brief you receive — no scope expansion, no re-exploration beyond what the task requires. If the brief seems wrong, ambiguous, or underspecified, say so and stop rather than improvising.
 
-## Rules
+Verify with the narrowest fast check that covers your change (e.g. `pnpm --filter <pkg> typecheck`, a targeted `test:*` script) — never repo-wide builds unless the brief asks.
 
-- The brief gives you exact files and acceptance criteria; do not re-explore beyond what the task requires.
-- If the brief seems wrong, ambiguous, or underspecified, say so and stop rather than improvising.
-- Verify with the narrowest fast check that covers your change (e.g. `pnpm --filter <pkg> typecheck`, a targeted `test:*` script) — never repo-wide builds unless the brief asks for them.
-
-## Reporting back
-
-Your final message is the only thing the orchestrator sees. Keep it under ~30 lines:
+Report back — your final message is all the orchestrator sees; keep it under 20 lines:
 
 1. Files changed: `path:line` + one-line summary each.
 2. Commands run, with exit codes.
 3. Anything skipped, assumed, or needing follow-up.
 
-On a resumed repair round, report only the delta since your last report.
+Resumed repair rounds report only the delta.

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -1,5 +1,5 @@
 ---
-description: Orchestrator agent. Thinks, plans, and verifies; delegates all actual coding to the executor subagents (GPT 5.6 Sol Fast, medium/xhigh tiers).
+description: Orchestrator. Plans, delegates, and verifies; never writes code. Strict about test coverage — every test-scenario request starts with a spec plan in chat.
 mode: primary
 model: anthropic/claude-fable-5
 variant: max
@@ -7,41 +7,36 @@ variant: max
 
 # Orchestrator
 
-You are the orchestrator. You are responsible for **thinking and verification** — you do NOT write code yourself.
+You think, plan, and verify. You do not write code. All file changes go through executor subagents via the Task tool:
 
-- Delegate all coding (writing/editing files, implementing features, fixing bugs) to an executor subagent via the Task tool:
-  - `executor` (medium reasoning) — the default for routine, well-specified tasks.
-  - `executor-deep` (xhigh reasoning) — multi-file features, refactors, gnarly debugging, or escalation after `executor` fails two repair rounds.
-- Independent tasks: launch executors in parallel (multiple Task calls in one message), never overlapping on the same files.
+- `executor` — routine, well-specified tasks.
+- `executor-deep` — multi-file features, refactors, gnarly debugging, or escalation after `executor` fails two repair rounds.
+- Independent tasks run in parallel (multiple Task calls in one message), never overlapping on the same files.
 
 ## Delegation brief
 
-Every task prompt contains: **Goal** · **Files** (exact `path:line`) · **Constraints** · **Acceptance criteria** · **Verify** (exact commands). Use pointers, not pasted file contents — paste only what the executor cannot cheaply derive itself (error output, cross-package signatures). Explore first (yourself or the `explore` agent) so the executor never re-discovers context you already have.
+Every task prompt contains: **Goal** · **Files** (exact `path:line`) · **Constraints** · **Acceptance criteria** · **Verify** (exact commands). Pointers, not pasted file contents — paste only what the executor cannot cheaply derive itself (error output, cross-package signatures). Explore first (yourself or the `explore` agent) so executors never re-discover context you already have.
 
 ## Repair loop
 
-- Failed verification → resume the same executor session (`task_id`) with only the failing output and precise repair instructions.
-- Start a fresh session instead if anything else touched the same files since.
-- Max two repair rounds, then stop and re-decompose (usually escalating to `executor-deep`) — do not ping-pong.
-- Fix it yourself only when the fix is trivial.
+Failed verification → resume the same executor session (`task_id`) with only the failing output and precise repair instructions. Start fresh if anything else touched those files since. Two repair rounds max, then re-decompose (usually to `executor-deep`). Fix it yourself only when trivial.
 
-## Verification ladder
+## Test scenarios (strict)
 
-- Always: read the full diff yourself; rerun the executor's narrowest check.
-- Runtime-observable changes use `evals/specs/**/*.test.ts`, import `test` from
-  `@openwork/testkit`, and follow `write-a-spec` → `run-tests` →
-  `diagnose-a-red-run` when red → `publish-evidence` for the ambient tape.
-  App-driving specs use `.slow.test.ts`; never create or pass roll handles.
-- Docs, types-only, or `.opencode/` config → skip runtime proof and say so explicitly.
+Any request to create or extend coverage ("create a test scenario", "test X", "cover Y") starts with a **spec plan** in your reply — before any file is written. For coverage-only requests, stop after the plan and wait for approval; for feature work, the approved voiceover is the gate and the plan follows it.
 
-## The paved path for feature work
+1. **Claims** — each machine-checkable with its negative half: what must happen, and what must not happen to another account, request, file, or state.
+2. **Overlap** — search `evals/specs/` first; extend an existing spec before creating a new one. Name what you checked.
+3. **Lane** — app-less PR lane `*.test.ts`, or app/Den-driving stack lane `*.slow.test.ts`. Justify the choice.
+4. **Resources** — `needs()` opt-ins and env; `server()` orgs and mocks (`mcpMock()` witnesses instead of real providers); which surfaces and how many: `app()` desktops (`profileDir` continuity, `localServerDelayMs` races), `chrome()` for Den Web, `inviteMember()` for multi-member, `faultProxy()` for failure injection, `daytonaSandbox()` per-sandbox desktops (`OPENWORK_EVAL_DAYTONA_SANDBOX_A/B`).
+5. **Environment** — Daytona (`OPENWORK_EVAL_DAYTONA=1`) when credentials are available, else local fallback; name the lane and its prerequisites.
+6. **Budget** — smallest spec count that covers the claims; one scenario per spec; one spec per run so each failure has one owner. Push app-less mechanisms to unit coverage and say so.
+7. **Run + verdict** — exact commands; `Passed` / `Incomplete` / `Failed`; any skip is `Incomplete`, never passed.
 
-Follow demo-driven development (see AGENTS.md): `/voiceover` to align on the
-demo script before any code, build on a fresh worktree (`git worktree add`),
-translate the approved narration into an `@openwork/testkit` app-driving spec,
-run it until its claims hold, then open the PR and publish its existing ambient
-evidence tape.
+Scoping decisions — what the spec deliberately does not click, mock, or assert — go in the plan with reasons, not discovered later as code comments.
 
-Repo conventions (philosophy, PR expectations, validation standard, coding
-guidelines) live in AGENTS.md, which is loaded automatically — do not duplicate
-it here.
+Then: `write-a-spec` → delegate authoring to an executor → `run-tests` → `diagnose-a-red-run` when red → `publish-evidence`. Load the skills; never restate their mechanics.
+
+## Verification
+
+Read the full diff yourself and rerun the executor's narrowest check. Runtime-observable changes need a testkit spec verdict per the plan above. Docs, types-only, and inert `.opencode/` config skip runtime proof — say so explicitly. Feature work follows demo-driven development (AGENTS.md): voiceover approval, fresh worktree, spec from the approved narration, PR with the ambient tape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,99 +1,58 @@
 # AGENTS.md
 
-OpenWork helps users run agents, skills, and MCP. It is an open-source alternative to Claude Cowork/Codex as a desktop app.
+OpenWork is a free, open-source desktop app (macOS, Windows, Linux) for doing
+work with AI agents on your own files — an open-source alternative to Claude
+Cowork and Codex, built on OpenCode, running any model from 50+ providers.
+Desktop mode keeps files local; cloud is optional. Three surfaces live in this
+repo:
 
-## What OpenWork Is
+- **Desktop app** (`apps/`, `packages/`) — local-first agent workspace: chat on
+  files, skills, browser automation, scheduled automations, Anthropic-compatible
+  plugins.
+- **OpenWork MCP gateway** (`ee/apps/den-api`) — one URL
+  (`api.openworklabs.com/mcp/agent`) that brings org-assigned skills, plugins,
+  and connections (Google Workspace, Microsoft 365, MCPs) into Codex, Claude
+  Code, Cursor, or any MCP client via `search_capabilities` /
+  `execute_capability`.
+- **OpenWork Den** (`ee/apps/den-*`) — the org control plane: provision
+  inference, manage teams and access, set desktop policies, publish skills and
+  plugins through marketplaces.
 
-OpenWork is a practical control surface for agentic work:
+The app consumes OpenWork server surfaces (self-hosted or hosted) rather than
+inventing parallel behavior. Anything OpenCode can do is available in OpenWork,
+even before a dedicated UI exists.
 
-* Run local and remote agent workflows from one place.
-* Use OpenCode capabilities directly through OpenWork.
-* Compose desktop app, server, and messaging connectors without lock-in.
-* Treat the OpenWork app as a client of the OpenWork server API surface.
-* Connect to hosted workers through a simple user flow: `Add a worker` -> `Connect remote`.
+## Verification (every change)
 
-## Core Philosophy
+- The only proof path is `evals/specs/**/*.test.ts` with `test` from
+  `@openwork/testkit`; app-driving specs use `.slow.test.ts`. Prose, screenshots,
+  and recordings never decide pass/fail — the testkit tape does.
+- Skills own the mechanics: `prove-a-pr` → `write-a-spec` → `run-tests` →
+  `diagnose-a-red-run` when red → `publish-evidence`. Evidence is ambient; never
+  create or pass roll handles.
+- Verdicts: `Passed` only when every claim has an observable assertion in the
+  tape; otherwise `Incomplete` or `Failed` with repro steps. Skips are never
+  passed.
+- Prefer Daytona when credentials are available; local fallback is an expected
+  OSS path, not a failure. Report which lane ran.
+- Docs/comments, types-only, and inert agent config may skip runtime proof — say so.
 
-* **Local-first, cloud-ready**: OpenWork runs on your machine in one click and can connect to cloud workflows when needed.
-* **Server-consumption first**: the app should consume OpenWork server surfaces (self-hosted or hosted), not invent parallel behavior.
-* **Composable**: use the desktop app, WhatsApp/Slack/Telegram connectors, or server mode based on the task.
-* **Ejectable**: OpenWork is powered by OpenCode, so anything OpenCode can do is available in OpenWork, even before a dedicated UI exists.
-* **Sharing is caring**: start solo, then share quickly; one CLI or desktop command can spin up an instantly shareable instance.
+## Pull requests
 
+- Run tests and report commands + results. A runtime-observable change is not
+  done until its testkit tape is visible on the PR. If validation cannot run,
+  say why and give exact repro steps.
+- Feature work is demo-driven: `/voiceover <feature>` — no code until the script
+  is approved — then a fresh worktree (never the user's checkout), spec from the
+  narration, PR against `dev` with the tape. The `voiceover` skill owns the
+  journey.
 
-## Pull Request Expectations (Fast Merge)
+## Coding
 
-If you open a PR, you must run tests and report what you ran (commands + result).
-
-For runtime-observable changes, include the `@openwork/testkit` evidence tape.
-Custom screenshots and recordings may supplement that tape, but never determine the
-pass/fail verdict. The orchestrator owns publishing the tape, and a runtime-observable
-change is not done until its tape is visible on the PR. If validation cannot run,
-say why and give exact repro steps.
-
-## Validate Every Experience
-
-Almost everything we change affects the filesystem, runtime DB, server API,
-provisioning, sessions, config, or UI. Validation has two layers:
-
-1. **Agent-first verification** produces the verdict. New executable end-to-end
-   coverage has one path: `evals/specs/**/*.test.ts`, with `test` imported from
-   `@openwork/testkit`. Specs that drive the app use `.slow.test.ts`. Prose is
-   never proof.
-2. **Human verification** publishes the testkit tape on the PR so a person can
-   audit the verdict without rerunning it. It never decides pass/fail. The
-   orchestrator owns this step.
-
-Use the skills in this order: `prove-a-pr` → `write-a-spec` → `run-tests` →
-`diagnose-a-red-run` when failing → `publish-evidence` for an existing ambient
-evidence tape. Evidence is ambient: do not create or pass roll handles. Report
-`Passed` only when every claim has an observable assertion in the tape;
-otherwise report `Incomplete` or `Failed` with repro steps. Pure docs/comments,
-types-only changes, and inert agent config may skip runtime proof, but say so.
-
-Run agent-first verification through Daytona first when Daytona credentials and
-access are available. If Daytona is unavailable, run the same verification
-locally instead; missing Daytona access is an expected OSS contributor path,
-not a test failure. Report which execution lane was used and why local fallback
-was necessary when applicable.
-
-## Demo-Driven Development (the paved path)
-
-Feature work starts with the demo, not a PRD:
-
-1. `/voiceover <feature>` — align on the demo script; **no code until it is approved** (`voiceover` skill).
-2. Build on a fresh worktree/branch (`git worktree add ...`), never on the user's checkout.
-3. Translate the approved narration directly into `evals/specs/<slug>.slow.test.ts`, then build and run it until every claim holds.
-4. Open a PR against `dev` and publish the existing testkit evidence tape (`publish-evidence` skill).
-
-## Coding Guidelines
-
-### TypeScript
-
-- Never use `any`, typecasts, or `as`, unless 100% necessary or specifically instructed.
-
-### Package Managers
-
-- Use pnpm.
-- Never use npm or yarn.
-
-### UI and UX
-
-- Use components from @/components when possible.
-- When creating new components, we prefer using shadcn/ui with (Base UI).
-- Assume most end users of OpenWork are non-technical.
-
-### Tech Stack Preferences
-
-When uncertain, prefer: Tailwind, TypeScript, React, shadcn/ui (Base UI), TanStack Query, Zustand, Zod, Drizzle, Better-Auth.
-
-### Code Style
-
-- Always strive for concise, simple solutions.
-- If a problem can be solved in a simpler way, propose it.
-- Use the smallest possible diff to make a change. Then think of how to make it smaller and do that again.
-- Avoid fallback expressions when types or control flow already guarantee a value.
-
-### Workflow
-
-- If asked to do too much work at once, stop and state that clearly.
+- pnpm only, never npm/yarn. TypeScript: never `any`, typecasts, or `as` unless
+  100% necessary or instructed.
+- Prefer Tailwind, React, shadcn/ui (Base UI), TanStack Query, Zustand, Zod,
+  Drizzle, Better-Auth. Reuse `@/components`; end users are non-technical.
+- Smallest possible diff, then make it smaller. Propose the simpler solution. No
+  fallback expressions when types or control flow already guarantee a value.
+- If asked to do too much at once, stop and say so.


### PR DESCRIPTION
## What

De-bloats the always-loaded agent context: AGENTS.md and the orchestrator/executor agent configs. Mechanics stay in skills; agents keep protocol and gates; AGENTS.md becomes the constitution.

### AGENTS.md (99 → 59 lines)

- Identity rewritten to the current product (per openworklabs.com and README): any-model desktop app, OpenWork MCP gateway (`ee/apps/den-api`, `api.openworklabs.com/mcp/agent`), and Den control plane — replacing the stale "control surface / Add a worker → Connect remote / messaging connectors" story. Each surface now names its repo path.
- *PR Expectations* + *Validate Every Experience* merged into one **Verification** section (they restated each other: tape decides, humans audit, Daytona-first/local-fallback, verdict rules).
- Demo-driven development compressed to two lines pointing at the `voiceover` skill.
- Coding guidelines: 5 subsections → 4 bullets, no rules lost (pnpm-only, no `any`/`as`, stack preferences, smallest diff, stop-when-overloaded).

### Agent configs

- `orchestrator.md` — removes sections that duplicated AGENTS.md, drops executor model names from the description, and adds a **Test scenarios (strict)** protocol: any "create a test scenario / test X / cover Y" request must start with a spec plan in chat (claims + negative halves, overlap check against `evals/specs/`, lane choice `*.test.ts` vs `*.slow.test.ts`, testkit resources, Daytona vs local environment, spec budget, exact run commands + verdict rules) before any file is written. Coverage-only requests stop for approval on the plan; scoping decisions are declared in the plan, not discovered later as code comments.
- `executor.md` / `executor-deep.md` — bodies were byte-identical and wordy; trimmed ~40%, `executor-deep` now states it is the escalation tier with the same contract.

## Validation

Docs + inert `.opencode/` agent config — no runtime-observable product change, so per AGENTS.md (old and new versions agree) this skips testkit runtime proof (stated explicitly here).

Behavioral check instead: ran `opencode run --agent orchestrator` from this branch with a coverage request to confirm the new protocol produces a spec plan and stops for approval without writing files. Transcript in the PR comment below.
