### PR TITLE
fix(automations): resolve chat proposal models into Den's provider namespace

### DIFF
--- a/apps/app/src/components/tools/openwork-automation-proposal.tsx
+++ b/apps/app/src/components/tools/openwork-automation-proposal.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, CalendarClock, Check } from "lucide-react"
 import type { DynamicToolUIPart } from "ai"
 import { useNavigate } from "react-router"
 import { toast } from "sonner"
+import { useQuery } from "@tanstack/react-query"
 
 import { automationProposalSchema, AUTOMATION_FREE_MODEL, type AutomationProposal } from "@openwork/types/automations"
 
@@ -13,6 +14,11 @@ import { Button } from "@/components/ui/button"
 import { Tool } from "@/components/ui/tool"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
 import { formatAutomationSchedule } from "@/react-app/domains/automations/automation-format"
+import {
+  automationModelOptions,
+  describeAutomationModel,
+  resolveProposalModel,
+} from "@/react-app/domains/automations/automation-model-options"
 import { automationsRoute } from "@/react-app/shell/workspace-routes"
 
 function parseOutputValue(output: unknown): unknown {
@@ -53,14 +59,27 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
   const [busy, setBusy] = useState(false)
 
   const proposal = part.state === "output-available" ? parseAutomationProposal(part.output) : null
-  if (!proposal) {
-    return <Tool toolPart={part} title="Proposed an Automation" />
-  }
-
   const settings = readDenSettings()
   const token = settings.authToken?.trim() ?? ""
   const organizationId = settings.activeOrgId?.trim() ?? ""
   const signedIn = denAuth.isSignedIn && Boolean(token) && Boolean(organizationId)
+  const providersQuery = useQuery({
+    queryKey: ["den", "automations", organizationId, "models"],
+    queryFn: () => createDenClient({ baseUrl: settings.baseUrl, token }).listOrgLlmProviders(organizationId),
+    enabled: signedIn && !created,
+  })
+  const providers = providersQuery.data ?? []
+  const resolved = providersQuery.isError || providersQuery.data === undefined || !proposal
+    ? null
+    : resolveProposalModel(proposal.model, providers)
+  const modelLabel = resolved
+    ? describeAutomationModel(resolved.model, automationModelOptions(providers))
+    : null
+
+  if (!proposal) {
+    return <Tool toolPart={part} title="Proposed an Automation" />
+  }
+
   const blocker = !signedIn
     ? "Sign in to OpenWork Cloud to create this Automation."
     : null
@@ -73,7 +92,7 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
         name: proposal.name,
         instructions: proposal.instructions,
         schedule: proposal.schedule,
-        model: proposal.model ?? {
+        model: resolved?.model ?? proposal.model ?? {
           providerId: AUTOMATION_FREE_MODEL.providerId,
           modelId: AUTOMATION_FREE_MODEL.modelId,
         },
@@ -92,6 +111,7 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
       className="not-prose w-full max-w-2xl overflow-hidden rounded-2xl border border-dls-border bg-dls-surface/95 shadow-sm"
       data-openwork-automation-proposal
       data-automation-created={created ?? undefined}
+      data-automation-model-resolution={resolved?.resolution}
     >
       <div className="flex items-start gap-3 border-b border-dls-border px-4 py-3">
         <div className={created
@@ -116,6 +136,7 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
         <div>
           <p className="truncate text-sm font-medium text-dls-primary" title={proposal.name}>{proposal.name}</p>
           <p className="text-xs text-dls-secondary">{formatAutomationSchedule(proposal.schedule)}</p>
+          {modelLabel ? <p className="text-xs text-dls-secondary">Runs with {modelLabel}</p> : null}
         </div>
         <p className="whitespace-pre-wrap text-sm text-dls-secondary">{proposal.instructions}</p>
       </div>
@@ -140,7 +161,7 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
             type="button"
             size="sm"
             className="shrink-0"
-            disabled={busy || blocker !== null}
+            disabled={busy || blocker !== null || (signedIn && providersQuery.isLoading)}
             data-create-automation
             onClick={() => void create()}
           >
@@ -153,6 +174,14 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
         <div className="flex items-center gap-2 border-t border-dls-border px-4 py-2 text-xs text-amber-11">
           <AlertTriangle className="size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">{blocker}</span>
+        </div>
+      ) : null}
+      {resolved?.resolution === "fallback" && !created ? (
+        <div className="flex items-center gap-2 border-t border-dls-border px-4 py-2 text-xs text-amber-11">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1">
+            The proposed model isn't available for Automations, so runs use the free starter model. You can change the model after creating.
+          </span>
         </div>
       ) : null}
     </div>

--- a/apps/app/src/react-app/domains/automations/automation-model-options.ts
+++ b/apps/app/src/react-app/domains/automations/automation-model-options.ts
@@ -16,6 +16,11 @@ export type AutomationModelOption = {
   accessKind: "free" | "openwork_managed" | "authorized_custom"
 }
 
+export type ResolvedProposalModel = {
+  model: AutomationModel
+  resolution: "exact" | "mapped" | "default" | "fallback"
+}
+
 const freeStarterModel: AutomationModelOption = {
   ...AUTOMATION_FREE_MODEL,
   accessKind: "free",
@@ -75,6 +80,39 @@ export function findAutomationModelOption(
 ) {
   return options.find((option) =>
     option.providerId === model.providerId && option.modelId === model.modelId) ?? null
+}
+
+export function resolveProposalModel(
+  proposed: AutomationModel | undefined,
+  providers: readonly DenOrgLlmProvider[],
+): ResolvedProposalModel {
+  const freeModel: AutomationModel = {
+    providerId: AUTOMATION_FREE_MODEL.providerId,
+    modelId: AUTOMATION_FREE_MODEL.modelId,
+    variant: null,
+  }
+  if (!proposed) return { model: freeModel, resolution: "default" }
+
+  if (findAutomationModelOption(automationModelOptions(providers), proposed)) {
+    return { model: proposed, resolution: "exact" }
+  }
+
+  const provider = providers.find((candidate) =>
+    candidate.source !== "openwork"
+    && candidate.providerId === proposed.providerId
+    && candidate.models.some((model) => model.id === proposed.modelId))
+  if (provider) {
+    return {
+      model: {
+        providerId: provider.id,
+        modelId: proposed.modelId,
+        variant: proposed.variant ?? null,
+      },
+      resolution: "mapped",
+    }
+  }
+
+  return { model: freeModel, resolution: "fallback" }
 }
 
 /**

--- a/apps/app/tests/automation-availability.test.ts
+++ b/apps/app/tests/automation-availability.test.ts
@@ -45,6 +45,8 @@ describe("Automations availability", () => {
     const proposal = read("src/components/tools/openwork-automation-proposal.tsx")
     expect(proposal).not.toContain("automationsEnabled")
     expect(proposal).toContain("Sign in to OpenWork Cloud")
+    expect(proposal).toContain("resolveProposalModel")
+    expect(proposal).toContain("data-automation-model-resolution")
   })
 
   test("the automations capability stays desktop-only", () => {

--- a/apps/app/tests/automation-model-options.test.ts
+++ b/apps/app/tests/automation-model-options.test.ts
@@ -4,6 +4,7 @@ import {
   automationModelOptions,
   automationPickerOptions,
   describeAutomationModel,
+  resolveProposalModel,
 } from "../src/react-app/domains/automations/automation-model-options"
 
 function provider(input: Partial<DenOrgLlmProvider> & Pick<DenOrgLlmProvider, "id" | "name" | "source">): DenOrgLlmProvider {
@@ -110,5 +111,75 @@ describe("Automation model options", () => {
     // still lists — just without reasoning levels.
     expect(free?.isFree).toBe(true)
     expect(free?.behaviorOptions).toEqual([])
+  })
+})
+
+describe("Automation proposal model resolution", () => {
+  const customProvider = provider({
+    id: "lpr_abc",
+    providerId: "deepseek",
+    source: "custom",
+    name: "DeepSeek",
+    models: [{ id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", config: {}, createdAt: null }],
+  })
+
+  test("defaults an omitted model to the free starter model", () => {
+    expect(resolveProposalModel(undefined, [])).toEqual({
+      model: { providerId: "opencode", modelId: "big-pickle", variant: null },
+      resolution: "default",
+    })
+  })
+
+  test("preserves exact custom, free, and managed model identities", () => {
+    const custom = { providerId: "lpr_abc", modelId: "deepseek-v4-flash", variant: "high" }
+    expect(resolveProposalModel(custom, [customProvider])).toEqual({ model: custom, resolution: "exact" })
+
+    const free = { providerId: "opencode", modelId: "big-pickle", variant: "low" }
+    expect(resolveProposalModel(free, [])).toEqual({ model: free, resolution: "exact" })
+
+    const managedProvider = provider({ id: "lpr_managed", source: "openwork", name: "OpenWork Models" })
+    const managedOption = automationModelOptions([managedProvider]).find((option) => option.accessKind === "openwork_managed")
+    expect(managedOption).toBeDefined()
+    if (!managedOption) throw new Error("Expected an enabled OpenWork managed model")
+    const managed = { providerId: managedOption.providerId, modelId: managedOption.modelId, variant: "high" }
+    expect(resolveProposalModel(managed, [managedProvider])).toEqual({ model: managed, resolution: "exact" })
+  })
+
+  test("maps an upstream provider key to the first matching concrete Den provider", () => {
+    const first = provider({ ...customProvider, id: "lpr_first" })
+    const second = provider({ ...customProvider, id: "lpr_second" })
+    expect(resolveProposalModel(
+      { providerId: "deepseek", modelId: "deepseek-v4-flash", variant: "high" },
+      [first, second],
+    )).toEqual({
+      model: { providerId: "lpr_first", modelId: "deepseek-v4-flash", variant: "high" },
+      resolution: "mapped",
+    })
+  })
+
+  test("does not map through OpenWork provider records", () => {
+    const managed = provider({
+      ...customProvider,
+      id: "lpr_managed",
+      source: "openwork",
+    })
+    expect(resolveProposalModel(
+      { providerId: "deepseek", modelId: "deepseek-v4-flash" },
+      [managed],
+    )).toEqual({
+      model: { providerId: "opencode", modelId: "big-pickle", variant: null },
+      resolution: "fallback",
+    })
+  })
+
+  test("falls back when the provider or model is unavailable", () => {
+    const fallback = {
+      model: { providerId: "opencode", modelId: "big-pickle", variant: null },
+      resolution: "fallback",
+    }
+    expect(resolveProposalModel({ providerId: "unknown", modelId: "missing", variant: "high" }, [customProvider]))
+      .toEqual(fallback)
+    expect(resolveProposalModel({ providerId: "deepseek", modelId: "missing", variant: "high" }, [customProvider]))
+      .toEqual(fallback)
   })
 })

--- a/evals/specs/automation-proposal-model-resolution.slow.test.ts
+++ b/evals/specs/automation-proposal-model-resolution.slow.test.ts
@@ -1,0 +1,320 @@
+import { expect } from "vitest";
+import { screenshot, validate } from "@openwork/fraimz";
+import {
+  denFetch,
+  evalIn,
+  go,
+  readAvailableModels,
+  selectModel,
+  sendComposerMessage,
+  visibleText,
+  waitFor,
+  waitForText,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { app, needs, server, test } from "@openwork/testkit";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MODEL_TURN_TIMEOUT_MS = 5 * 60_000;
+const PROVIDER_NAME = "DeepSeek Eval";
+const PROVIDER_KEY = "deepseek";
+const MODEL_ID = "deepseek-v4-flash";
+const FALLBACK_NOTICE = "The proposed model isn't available for Automations, so runs use the free starter model.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function activeOrganizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const activeId = isRecord(result.body) && typeof result.body.activeOrgId === "string"
+    ? result.body.activeOrgId
+    : "";
+  const active = organizations.find((organization) => organization.isActive === true) ?? organizations[0];
+  const orgId = activeId || (active && typeof active.id === "string" ? active.id : "");
+  if (!result.response.ok || !orgId) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return orgId;
+}
+
+async function selectOrganization(session: DenSession, orgId: string): Promise<void> {
+  const result = await denFetch(session, "/v1/me/active-organization", {
+    method: "POST",
+    headers: auth(session),
+    body: JSON.stringify({ organizationId: orgId }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!result.response.ok) {
+    throw new Error(`Selecting the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+}
+
+async function createProvider(admin: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: {
+      ...auth(admin),
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: ["EVAL_PROVIDER_API_KEY"],
+        models: [{ id: MODEL_ID, name: "DeepSeek V4 Flash" }],
+      },
+      allMembers: true,
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status).toBe(201);
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider)
+    ? result.body.llmProvider
+    : null;
+  const providerId = provider && typeof provider.id === "string" ? provider.id : "";
+  if (!providerId) throw new Error("The created LLM provider response did not include an id.");
+  expect(providerId).toMatch(/^lpr_/);
+  return providerId;
+}
+
+interface ProposalCardState {
+  createdId: string;
+  resolution: string;
+  text: string;
+}
+
+async function waitForProposalCard(
+  desktop: Surface,
+  name: string,
+  resolution: "mapped" | "fallback",
+  created: boolean,
+): Promise<ProposalCardState> {
+  await waitFor(desktop, `(() => {
+    const card = [...document.querySelectorAll('[data-openwork-automation-proposal]')]
+      .find((candidate) => (candidate.textContent ?? '').includes(${JSON.stringify(name)}));
+    if (!card || card.getAttribute('data-automation-model-resolution') !== ${JSON.stringify(resolution)}) return false;
+    const createdId = card.getAttribute('data-automation-created') ?? '';
+    return ${created ? "createdId.length > 0" : "createdId.length === 0"};
+  })()`, {
+    timeoutMs: created ? 120_000 : MODEL_TURN_TIMEOUT_MS,
+    label: `${resolution} Automation proposal card ${created ? "created" : "ready"}`,
+  });
+  const value = await evalIn(desktop, `(() => {
+    const card = [...document.querySelectorAll('[data-openwork-automation-proposal]')]
+      .find((candidate) => (candidate.textContent ?? '').includes(${JSON.stringify(name)}));
+    if (!card) return null;
+    card.scrollIntoView({ block: 'center' });
+    return {
+      createdId: card.getAttribute('data-automation-created') ?? '',
+      resolution: card.getAttribute('data-automation-model-resolution') ?? '',
+      text: card.innerText ?? '',
+    };
+  })()`);
+  if (!isRecord(value)) throw new Error(`Could not read the proposal card for ${name}.`);
+  return {
+    createdId: typeof value.createdId === "string" ? value.createdId : "",
+    resolution: typeof value.resolution === "string" ? value.resolution : "",
+    text: typeof value.text === "string" ? value.text : "",
+  };
+}
+
+async function clickCreateAutomation(desktop: Surface, name: string): Promise<void> {
+  await waitFor(desktop, `(() => {
+    const card = [...document.querySelectorAll('[data-openwork-automation-proposal]')]
+      .find((candidate) => (candidate.textContent ?? '').includes(${JSON.stringify(name)}));
+    const button = card?.querySelector('[data-create-automation]');
+    return button instanceof HTMLButtonElement && !button.disabled;
+  })()`, { timeoutMs: 60_000, label: `enabled create button for ${name}` });
+  const clicked = await evalIn(desktop, `(() => {
+    const card = [...document.querySelectorAll('[data-openwork-automation-proposal]')]
+      .find((candidate) => (candidate.textContent ?? '').includes(${JSON.stringify(name)}));
+    const button = card?.querySelector('[data-create-automation]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+interface StoredAutomationModel {
+  providerId: string;
+  modelId: string;
+}
+
+async function storedAutomationModel(
+  admin: DenSession,
+  orgId: string,
+  name: string,
+): Promise<StoredAutomationModel> {
+  const result = await denFetch(admin, "/v1/automations", {
+    headers: {
+      ...auth(admin),
+      "x-openwork-org-id": orgId,
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status).toBe(200);
+  const items = isRecord(result.body) && Array.isArray(result.body.items)
+    ? result.body.items.filter(isRecord)
+    : [];
+  const item = items.find((candidate) =>
+    isRecord(candidate.automation) && candidate.automation.name === name
+  );
+  const revision = item && isRecord(item.revision) ? item.revision : null;
+  const model = revision && isRecord(revision.model) ? revision.model : null;
+  if (!model || typeof model.providerId !== "string" || typeof model.modelId !== "string") {
+    throw new Error(`Automation ${name} was not returned with a stored model.`);
+  }
+  return { providerId: model.providerId, modelId: model.modelId };
+}
+
+async function recordProposalScreenshot(desktop: Surface, claims: string[]): Promise<void> {
+  const shot = await screenshot(desktop);
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const seen = await validate(shot, claims);
+      expect(seen.ok, seen.why).toBe(true);
+      return;
+    } catch (error) {
+      if (!(error instanceof TypeError) || attempt === 3) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+}
+
+test("chat Automation proposals map Den providers and disclose a safe fallback", async ({ evidence, place }) => {
+  needs({ model: "tool-capable", optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({ place });
+  const orgId = await activeOrganizationId(den.admin);
+  await selectOrganization(den.admin, orgId);
+  const providerRecordId = await createProvider(den.admin, orgId);
+  const stamp = Date.now();
+  const mappedName = `Feedback digest ${stamp}`;
+  const fallbackName = `Local model check ${stamp}`;
+
+  await using desktop = await app({ den, as: "admin", place });
+  await go(desktop, `/workspace/${desktop.workspaceId}/session`);
+  await waitFor(desktop, "Boolean(document.querySelector('[contenteditable=true]'))", {
+    timeoutMs: 120_000,
+    label: "session composer",
+  });
+  const evalModel = process.env.OPENWORK_EVAL_MODEL?.trim() ?? "";
+  const models = await readAvailableModels(desktop);
+  const evalModelOption = models.find((model) =>
+    model.selectable && (model.id === evalModel || model.id.endsWith(`/${evalModel}`))
+  );
+  expect(evalModelOption, `Could not select ${evalModel}; saw ${models.map((model) => model.id).join(", ")}`).toBeDefined();
+  if (!evalModelOption) throw new Error(`The eval model ${evalModel} is not selectable.`);
+  await selectModel(desktop, evalModelOption.id);
+  await evalIn(desktop, `(() => {
+    document.documentElement.dataset.automationProposalLegacyErrorSeen =
+      document.body.innerText.toLowerCase().includes('no longer available') ? 'true' : 'false';
+    const observer = new MutationObserver(() => {
+      if (document.body.innerText.toLowerCase().includes('no longer available')) {
+        document.documentElement.dataset.automationProposalLegacyErrorSeen = 'true';
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    return true;
+  })()`);
+
+  const mappedPrompt = `Use the openwork_execute tool exactly once with arguments: {"id":"automation.propose","args":{"name":${JSON.stringify(mappedName)},"instructions":"Summarize new OpenWork feedback and post one short digest.","schedule":{"kind":"weekly","timezone":"UTC","daysOfWeek":[1],"hour":9,"minute":0},"model":{"providerId":"deepseek","modelId":"deepseek-v4-flash"}}}. This is a tool-call test; do not ask questions, do not call any other tool, and reply only after the tool call.`;
+  expect(mappedPrompt).not.toContain(providerRecordId);
+  await sendComposerMessage(desktop, mappedPrompt);
+  const mappedCard = await waitForProposalCard(desktop, mappedName, "mapped", false);
+  expect(mappedCard.resolution).toBe("mapped");
+  expect(mappedCard.text).toContain(`Runs with ${PROVIDER_NAME}`);
+  expect(mappedCard.text).not.toContain(FALLBACK_NOTICE);
+  await recordProposalScreenshot(desktop, [
+    `A Suggested Automation named ${mappedName} is visible in the chat`,
+    `The proposal says it runs with ${PROVIDER_NAME} and does not show a free-starter-model fallback notice`,
+    "The proposal is waiting for the person to create it and no provider-unavailable error is visible",
+  ]);
+
+  await clickCreateAutomation(desktop, mappedName);
+  const mappedCreatedCard = await waitForProposalCard(desktop, mappedName, "mapped", true);
+  await waitForText(desktop, "Automation created and active", { timeoutMs: 120_000 });
+  const mappedPageText = await visibleText(desktop);
+  expect(mappedPageText).not.toMatch(/no longer available/i);
+  expect(mappedPageText).toContain("Automation created and active");
+  const mappedModel = await storedAutomationModel(den.admin, orgId, mappedName);
+  expect(mappedModel.providerId).toBe(providerRecordId);
+  expect(mappedModel.providerId).not.toBe(PROVIDER_KEY);
+  expect(mappedModel.modelId).toBe(MODEL_ID);
+  evidence.fact(
+    "The mapped proposal created with Den's canonical provider record",
+    `${mappedName} was created as ${mappedModel.providerId}/${mappedModel.modelId}, not ${PROVIDER_KEY}/${MODEL_ID}.`,
+    mappedCreatedCard.createdId.length > 0
+      && mappedModel.providerId === providerRecordId
+      && mappedModel.modelId === MODEL_ID,
+  );
+  await recordProposalScreenshot(desktop, [
+    `The ${mappedName} proposal visibly says Automation created and active`,
+    `The created Automation still says it runs with ${PROVIDER_NAME}`,
+    "No provider-unavailable error or failed creation message is visible",
+  ]);
+
+  const fallbackPrompt = `Use the openwork_execute tool exactly once with arguments: {"id":"automation.propose","args":{"name":${JSON.stringify(fallbackName)},"instructions":"Summarize new OpenWork feedback and post one short digest.","schedule":{"kind":"weekly","timezone":"UTC","daysOfWeek":[1],"hour":9,"minute":0},"model":{"providerId":"local-only-provider","modelId":"mystery-model"}}}. This is a tool-call test; do not ask questions, do not call any other tool, and reply only after the tool call.`;
+  expect(fallbackPrompt).not.toContain(providerRecordId);
+  await sendComposerMessage(desktop, fallbackPrompt);
+  const fallbackCard = await waitForProposalCard(desktop, fallbackName, "fallback", false);
+  expect(fallbackCard.resolution).toBe("fallback");
+  expect(fallbackCard.text).toContain("free starter model");
+  expect(fallbackCard.text).toContain("Runs with OpenCode Zen");
+  await recordProposalScreenshot(desktop, [
+    `A Suggested Automation named ${fallbackName} is visible in the chat`,
+    "An amber notice discloses that the unavailable proposed model will use the free starter model",
+    "The proposal says Runs with OpenCode Zen and no provider-unavailable failure is visible",
+  ]);
+
+  await clickCreateAutomation(desktop, fallbackName);
+  const fallbackCreatedCard = await waitForProposalCard(desktop, fallbackName, "fallback", true);
+  const fallbackPageText = await visibleText(desktop);
+  expect(fallbackPageText).not.toMatch(/no longer available/i);
+  expect(fallbackPageText).toContain("Automation created and active");
+  const fallbackModel = await storedAutomationModel(den.admin, orgId, fallbackName);
+  expect(fallbackModel).toEqual({ providerId: "opencode", modelId: "big-pickle" });
+  evidence.fact(
+    "The fallback was disclosed and created with the free starter model",
+    `${fallbackName} showed the fallback notice and was created as ${fallbackModel.providerId}/${fallbackModel.modelId}.`,
+    fallbackCard.text.includes("free starter model")
+      && fallbackCard.text.includes("Runs with OpenCode Zen")
+      && fallbackCreatedCard.createdId.length > 0
+      && fallbackModel.providerId === "opencode"
+      && fallbackModel.modelId === "big-pickle",
+  );
+  await recordProposalScreenshot(desktop, [
+    `The ${fallbackName} proposal visibly says Automation created and active`,
+    "The created Automation says it runs with OpenCode Zen · Big Pickle",
+    "No provider-unavailable error or failed creation message is visible",
+  ]);
+
+  const legacyErrorSeen = await evalIn(
+    desktop,
+    "document.documentElement.dataset.automationProposalLegacyErrorSeen === 'true'",
+  );
+  const finalPageText = await visibleText(desktop);
+  const legacyErrorAbsent = legacyErrorSeen === false && !/no longer available/i.test(finalPageText);
+  evidence.fact(
+    "The legacy provider-unavailable error never appeared",
+    "A DOM observer covered both proposal creations and the final page contains no 'no longer available' message.",
+    legacyErrorAbsent,
+  );
+  expect(legacyErrorAbsent).toBe(true);
+}, 20 * 60_000);


### PR DESCRIPTION
## Problem

User feedback (Tatenda, workspace "Notebook", desktop app): chat proposes a weekly Automation with model `deepseek/deepseek-v4-flash` — the same provider+model actively running the session — the proposal card renders, but **Create fails with "The selected model provider is no longer available."**

## Root cause

Namespace mismatch. The `automation.propose` result embeds the session model in the **local runtime provider namespace** (`deepseek`), but Den's create-time validation (`ee/apps/den-api/src/automations/authority.ts`) only accepts `opencode` (free starter), `openwork` (managed), or a concrete `lpr_*` provider record id. The proposal card forwarded `proposal.model` verbatim, so any locally-keyed provider failed `findProvider` and surfaced the misleading "no longer available" error. The Automations editor never hits this because it builds choices from `automationModelOptions(listOrgLlmProviders())`, which are already canonical.

## Fix (renderer-side; server untouched)

The card now resolves the embedded model into Den's namespace before creating (`resolveProposalModel` in `automation-model-options.ts`):

- **exact** — already an authorized option (`opencode`, `openwork` alias, `lpr_*`): submitted as-is.
- **mapped** — upstream provider key + model found in a usable org provider record: submitted as that record's `lpr_*` id (fixes the reported case when the org has the provider).
- **fallback** — unresolvable: the free starter model, with a visible amber disclosure on the card *before* creating ("The proposed model isn't available for Automations, so runs use the free starter model…"). No more dead-end error.

The card also shows a "Runs with {Provider · Model}" line once resolution is known, and exposes `data-automation-model-resolution` for tests.

## Validation

Commands + results (all on PR head eb0dd9467):

- `bun test --isolate tests/` (apps/app): targeted files `automation-model-options`, `automation-proposal-card`, `automation-availability` — **18 pass / 0 fail**. Full app suite: 666 pass / 3 fail — the 3 failures (`message-list-loading`, `extensions-sidebar-header`) are order-dependent flakes that fail identically on base `948aff229` (verified via stash run: 661 pass / same 3 fail).
- `pnpm typecheck` (apps/app) — clean.
- `pnpm exec tsc -p evals/tsconfig.json --noEmit` — only pre-existing error in untouched `connectors-quick-add.slow.test.ts`.
- **New spec** `evals/specs/automation-proposal-model-resolution.slow.test.ts` (`@openwork/testkit`, app-driving): seeds a Den org provider with upstream key `deepseek`, drives two real chat turns proposing Automations with local-namespace models, clicks Create on both cards, and asserts via the Den API that the stored revisions are canonical (`lpr_*`/`deepseek-v4-flash` and `opencode`/`big-pickle`), that the fallback is disclosed, and — via a DOM MutationObserver across the whole run — that the legacy "no longer available" error never appears.
  `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MODEL=big-pickle pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/automation-proposal-model-resolution.slow.test.ts` — **1 passed / 0 failed / 0 skipped**, cold-booted through `server()`, 7/7 frames, 15/15 expectations.

Execution lane: **local fallback** (Daytona credentials are available, but the Daytona provisioning path builds `origin/dev` and cannot exercise a pre-merge branch head; local run used the same isolated `server()` + Electron sandbox stack). Evidence tape for the exact PR head is published below.

Fixes the feedback from chitima.tatenda@gmail.com.