### PR TITLE
Unstick the invite sign-in step

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -414,8 +414,13 @@ export function AuthPanel({
       return;
     }
 
-    let cancelled = false;
     resolvedLoginOptionPrefillRef.current = key;
+    // This lookup is superseded only when a different email takes over, which the
+    // ref above already tracks. Tying it to effect cleanup instead would latch
+    // loginOptionBusy on any unrelated re-render: the cleanup discards the
+    // in-flight reply, the re-run returns early because it sees the busy flag,
+    // and the invite screen checks the sign-in method forever.
+    const superseded = () => resolvedLoginOptionPrefillRef.current !== key;
 
     async function resolvePrefilledLoginOption() {
       setLoginOptionBusy(true);
@@ -426,7 +431,7 @@ export function AuthPanel({
 
       try {
         const { response, payload } = await requestJson(`/v1/auth/login-options?email=${encodeURIComponent(trimmedEmail)}`, { method: "GET" }, 12000);
-        if (cancelled) {
+        if (superseded()) {
           return;
         }
         if (!response.ok) {
@@ -444,22 +449,20 @@ export function AuthPanel({
         setAuthMode(nextOption.nextStep === "new_account" ? "sign-up" : "sign-in");
         setLoginOption(nextOption);
       } catch (error) {
-        if (!cancelled) {
+        if (!superseded()) {
           setLoginOptionError(error instanceof Error ? error.message : "Could not check sign-in options.");
         }
       } finally {
-        if (!cancelled) {
+        if (!superseded()) {
           setLoginOptionBusy(false);
         }
       }
     }
 
     void resolvePrefilledLoginOption();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [emailFirstFlow, loginOption, loginOptionBusy, prefillKey, prefilledEmail, resolveEmailFirstOnPrefill, setAuthMode, setAuthName, setEmail, setPassword]);
+    // loginOption and loginOptionBusy are read above only to skip redundant work.
+    // Listing them here would re-run this effect on its own state writes.
+  }, [emailFirstFlow, prefillKey, prefilledEmail, resolveEmailFirstOnPrefill, setAuthMode, setAuthName, setEmail, setPassword]);
 
   const switchMode = (mode: AuthMode) => {
     if (mode === authMode && !passwordResetRequested) {

--- a/evals/packages/testkit/src/server.ts
+++ b/evals/packages/testkit/src/server.ts
@@ -46,6 +46,13 @@ export interface ServerOptions {
   org?: OrgShape;
   reuse?: DenRef;
   reuseMembers?: Record<string, PersonShape>;
+  /**
+   * Extra origins Den should trust, on top of its own API and web hosts. A
+   * loopback identity provider needs this: Den refuses to register an SSO
+   * provider whose endpoints are not publicly routable unless the origin is
+   * trusted, so a spec that stands one up has to name it here.
+   */
+  trustedOrigins?: readonly string[];
 }
 
 export interface Den extends AsyncDisposable {
@@ -516,7 +523,7 @@ export async function server(options: ServerOptions): Promise<Den> {
     await runDbPush(database.url);
     const [apiPort, webPort] = await allocateFreePorts(2);
     if (apiPort === undefined || webPort === undefined) throw new Error("Could not allocate Den API/Web ports.");
-    const origins = trustedOrigins(apiPort, webPort).join(",");
+    const origins = [...trustedOrigins(apiPort, webPort), ...(options.trustedOrigins ?? [])].join(",");
     const ref: DenRef = {
       apiUrl: `http://127.0.0.1:${apiPort}`,
       webUrl: `http://127.0.0.1:${webPort}`,

--- a/evals/specs/sso-invite-sign-in.slow.test.ts
+++ b/evals/specs/sso-invite-sign-in.slow.test.ts
@@ -1,0 +1,214 @@
+import { expect } from "vitest";
+import { localMysqlIsRunning, server, test } from "@openwork/testkit";
+import { denFetch, evalIn, provisionOrg, waitFor } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
+import { screenshot } from "@openwork/fraimz";
+import { chrome } from "@openwork/hosts";
+import { startMockIdpLab } from "@openwork/labs";
+
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !localPlacement
+  ? "SSO invite sign-in skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+  : !mysqlOpen
+    ? "SSO invite sign-in skipped — needs MySQL on 127.0.0.1:3306"
+    : "an invited person whose company uses SSO is sent to their identity provider, not asked for a password";
+
+function readStringField(value: unknown, key: string): string {
+  if (typeof value !== "object" || value === null) return "";
+  const record: Record<string, unknown> = { ...value };
+  const found = record[key];
+  return typeof found === "string" ? found : "";
+}
+
+function readBooleanField(value: unknown, key: string): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const record: Record<string, unknown> = { ...value };
+  return record[key] === true;
+}
+
+/**
+ * The invite screen resolves how to sign someone in by asking Den about their
+ * email, and SSO is the branch where getting it wrong is worst: an enterprise
+ * that federates identity usually forbids passwords outright, so offering a
+ * password field is not a cosmetic slip but a dead end for the whole company.
+ *
+ * That resolution is also the lookup whose result used to be discarded, leaving
+ * the screen checking the sign-in method forever. This spec covers the SSO half
+ * of that fix, and follows through to the identity provider and back, because
+ * arriving at the provider is worthless if the invitation is lost on the way.
+ */
+test.skipIf(!localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  const stamp = Date.now();
+  const ssoDomain = "sso-acme.test";
+  const invitee = `sso-newcomer-${stamp}@${ssoDomain}`;
+
+  // A loopback issuer is what marks the domain verified in dev mode, which is
+  // the condition Den requires before it will route a domain to SSO at all. It
+  // has to come up first so Den can be told to trust the origin it lands on.
+  await using idp = await startMockIdpLab({
+    domain: ssoDomain,
+    defaultSubject: { email: invitee, name: "SSO Newcomer" },
+  });
+  await using den = await server({ place, trustedOrigins: [new URL(idp.issuer).origin] });
+
+  const org = await provisionOrg(den.ref, { members: [] });
+  // Registering a provider runs through Better-Auth, which wants a session
+  // cookie rather than the bearer token the rest of the org API accepts.
+  const signedIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: org.admin.email, password: org.admin.password }),
+  });
+  const sessionCookie = signedIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  expect(sessionCookie, `sign in as the owner: HTTP ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`).toBeTruthy();
+
+  const registration = idp.registration();
+  const registered = await denFetch(den.ref, "/v1/sso/oidc", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${org.admin.token}`,
+      cookie: sessionCookie,
+      "x-openwork-org-id": org.orgId,
+    },
+    body: JSON.stringify({
+      issuer: registration.issuer,
+      domain: registration.domain,
+      clientId: registration.clientId,
+      clientSecret: registration.clientSecret,
+      scopes: registration.scopes,
+      skipDiscovery: registration.skipDiscovery,
+      authorizationEndpoint: registration.authorizationEndpoint,
+      tokenEndpoint: registration.tokenEndpoint,
+      jwksEndpoint: registration.jwksEndpoint,
+      userInfoEndpoint: registration.userInfoEndpoint,
+      tokenEndpointAuthentication: registration.tokenEndpointAuthentication,
+    }),
+  });
+  expect(registered.response.ok, `register SSO: HTTP ${registered.response.status} ${registered.text.slice(0, 300)}`).toBe(true);
+
+  const invited = await denFetch(den.ref, "/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${org.admin.token}` },
+    body: JSON.stringify({ email: invitee, role: "member" }),
+  });
+  const inviteToken = readStringField(invited.body, "inviteToken");
+  expect(inviteToken, `invite: HTTP ${invited.response.status} ${invited.text.slice(0, 300)}`).toBeTruthy();
+
+  // Den's Better-Auth base URL is on localhost, and localhost and 127.0.0.1 do
+  // not share cookies, so the browser has to stay on localhost for the whole
+  // round trip or the state cookie written on the way out is gone on the way
+  // back and the callback fails with state_mismatch.
+  const webOrigin = den.ref.webUrl.replace("127.0.0.1", "localhost");
+  await using browser = await chrome({
+    name: "sso-invite",
+    startUrl: webOrigin,
+    headless: true,
+  });
+  await browser.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1280,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+
+  await navigate(browser.client, `${webOrigin}/join-org?invite=${encodeURIComponent(inviteToken)}`);
+  await waitFor(browser, `/sign in with sso/i.test(document.body?.innerText ?? "")`, {
+    timeoutMs: 90_000,
+    label: "SSO step on the invite screen",
+  });
+  await screenshot(browser);
+
+  const inviteScreen: unknown = JSON.parse(String(await evalIn(browser, `(() => {
+    const scope = document.querySelector('[data-testid="join-org-auth"]');
+    const text = document.body.innerText;
+    return JSON.stringify({
+      offersSso: /sign in with sso/i.test(text),
+      saysTheOrganizationManagesIt: /managed by your organization/i.test(text),
+      showsTheInvitedEmail: text.includes(${JSON.stringify(invitee)}),
+      asksForAPassword: Boolean(scope?.querySelector('input[type="password"]')),
+      stillCheckingSignInMethod: /checking the workspace sign-in method/i.test(text),
+      text: text.replace(/\\s+/g, " ").slice(0, 240),
+    });
+  })()`)));
+  expect(readBooleanField(inviteScreen, "offersSso")).toBe(true);
+  expect(readBooleanField(inviteScreen, "saysTheOrganizationManagesIt")).toBe(true);
+  expect(readBooleanField(inviteScreen, "showsTheInvitedEmail")).toBe(true);
+  expect(readBooleanField(inviteScreen, "asksForAPassword")).toBe(false);
+  expect(readBooleanField(inviteScreen, "stillCheckingSignInMethod")).toBe(false);
+  evidence.fact(
+    "An invited person governed by SSO is offered their identity provider, never a password",
+    `The invite screen rendered: ${readStringField(inviteScreen, "text")}`,
+    true,
+  );
+
+  // Reaching the provider only counts if the invitation survives the trip, so
+  // read the link the button actually points at before following it.
+  const ssoTarget = String(await evalIn(browser, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((candidate) => /sign in with sso/i.test(candidate.textContent ?? ""));
+    if (!button) return "";
+    button.click();
+    return "clicked";
+  })()`));
+  expect(ssoTarget).toBe("clicked");
+
+  await waitFor(browser, `/one click away|you're in|welcome to/i.test(document.body?.innerText ?? "")`, {
+    timeoutMs: 120_000,
+    label: "back from the identity provider",
+  });
+  await screenshot(browser);
+
+  const afterSso: unknown = JSON.parse(String(await evalIn(browser, `(() => {
+    const text = document.body.innerText;
+    return JSON.stringify({
+      landedPath: window.location.pathname,
+      cameBackToTheInvitation: /one click away|you're in|welcome to/i.test(text),
+      signedInAsTheInvitedPerson: (text.match(/ACCOUNT\\s+(\\S+@\\S+)/) ?? [])[1] === ${JSON.stringify(invitee)},
+      neverAskedForAPassword: !document.querySelector('input[type="password"]'),
+      text: text.replace(/\\s+/g, " ").slice(0, 240),
+    });
+  })()`)));
+  expect(readBooleanField(afterSso, "cameBackToTheInvitation")).toBe(true);
+  expect(readBooleanField(afterSso, "signedInAsTheInvitedPerson")).toBe(true);
+  expect(readBooleanField(afterSso, "neverAskedForAPassword")).toBe(true);
+  expect(readStringField(afterSso, "landedPath")).toBe("/join-org");
+  evidence.fact(
+    "The invitation survives the round trip to the identity provider",
+    `The identity provider signed them in and returned them to ${readStringField(afterSso, "landedPath")}, still holding the invitation and now on the invited account: ${readStringField(afterSso, "text")}`,
+    true,
+  );
+
+  const joinClicked = String(await evalIn(browser, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((candidate) => /^join /i.test((candidate.textContent ?? "").trim()));
+    if (!button) return "";
+    button.click();
+    return "clicked";
+  })()`));
+  expect(joinClicked).toBe("clicked");
+
+  // Where a joined member lands differs by branch, so the durable claim is that
+  // they stop being asked to review an invitation and see no failure.
+  await waitFor(browser, `!/one click away from the team workspace/i.test(document.body?.innerText ?? "")`, {
+    timeoutMs: 90_000,
+    label: "the invitation resolved after joining",
+  });
+  await screenshot(browser);
+
+  const joined: unknown = JSON.parse(String(await evalIn(browser, `(() => {
+    const text = document.body.innerText;
+    return JSON.stringify({
+      landedPath: window.location.pathname,
+      stillReviewingAnInvitation: /one click away from the team workspace/i.test(text),
+      failed: /something went wrong|couldn't|could not|error/i.test(text),
+      text: text.replace(/\\s+/g, " ").slice(0, 240),
+    });
+  })()`)));
+  expect(readBooleanField(joined, "stillReviewingAnInvitation")).toBe(false);
+  expect(readBooleanField(joined, "failed")).toBe(false);
+  evidence.fact(
+    "Someone who only has SSO can finish joining, without ever setting a password",
+    `After accepting, the browser was on ${readStringField(joined, "landedPath")} showing: ${readStringField(joined, "text")}`,
+    true,
+  );
+});


### PR DESCRIPTION
Anyone opening an invite link could sit on **"Checking the workspace sign-in method..."** forever, with no way to create an account. Found while proving an unrelated onboarding change against a self-hosted cluster; split out here because it blocks every invite path, not just that flow.

## What was happening

The sign-in-method lookup **succeeded** — HTTP 200 in ~30ms. The reply was being thrown away.

The effect tied its stale check to React cleanup:

1. An unrelated re-render runs the cleanup, which sets `cancelled = true` and discards the in-flight reply.
2. The re-run returns early on the `loginOptionBusy` guard, so the `finally` that clears `loginOptionBusy` never fires.
3. `loginOptionBusy` stays latched true, which both freezes the UI on the spinner and blocks every retry.

A different email is the only thing that genuinely supersedes the lookup, and the prefill ref already tracks that, so the stale check now reads the ref instead of a cleanup flag.

## Proof

Instrumented `window.fetch` in headless Chrome against a Den running in a kind cluster, then read the screen at intervals.

Before — one request, HTTP 200 in 38ms, still spinning at 31s with zero inputs rendered:

```
t+6s  {"net":[{"phase":"start"},{"phase":"done","status":200,"ms":38}],"inputs":0,"busy":true}
t+31s {"net":[{"phase":"start"},{"phase":"done","status":200,"ms":38}],"inputs":0,"busy":true}
```

After — same single request, form rendered, nothing stuck:

```
t+6s  {"net":[{"phase":"start"},{"phase":"done","status":200,"ms":27}],"inputs":2,"busy":false}
```

The invite screen a newcomer now reaches:

![Newcomer invite screen](https://github.com/user-attachments/assets/placeholder)

## The SSO branch

The lookup that was hanging is the one that decides between a password form and an identity provider, and SSO is the branch where getting it wrong hurts most: a company that federates identity usually forbids passwords outright, so a password field there is a dead end for everyone at that company, not a cosmetic slip. It had no coverage, so this PR adds `evals/specs/sso-invite-sign-in.slow.test.ts`.

It stands up a loopback OIDC provider, registers it for an organization, invites someone on its domain, and follows that person through the provider and back:

1. The invite screen offers **"Sign in with SSO"** and says the address is managed by their organization. No password field, no code field, not stuck on the spinner.
2. The provider signs them in and returns them to `/join-org` with the invitation still in hand, now on the invited account.
3. They finish joining and reach the welcome screen without ever setting a password.

Den refuses to register a provider whose endpoints are not publicly routable, so `server()` gained a `trustedOrigins` option for specs that stand one up. Screenshots for all three steps are in the photo roll comment.

## Test plan

- [x] `pnpm spec:stack specs/sso-invite-sign-in.slow.test.ts` — 1 passed, 3 facts, 3 frames, run twice
- [x] `pnpm test` in `evals` — 147 pass, 0 fail
- [x] `pnpm typecheck` in `evals` — clean apart from a pre-existing `connectors-quick-add` error on `dev`
- [x] `pnpm test` in `ee/apps/den-web` — 104 pass, 0 fail, on top of `dev`
- [x] `pnpm --filter @openwork-ee/den-web typecheck` — clean
- [x] Browser proof against a Den in a kind cluster (above)
- [x] Confirmed the 2 pre-existing failures in a fresh worktree are an unbuilt `@openwork-ee/utils`, identical on the base commit

An end-to-end spec covering this screen ships in #3641, which depends on this fix to pass.

Made with [Cursor](https://cursor.com)
