### PR TITLE
fix(ci): confirm safe migrations from the toggle response, not `branch show`

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -136,11 +136,6 @@ jobs:
         if: steps.pending.outputs.pending == 'true' || github.event_name == 'workflow_dispatch'
         id: setup-pscale
         uses: planetscale/setup-pscale-action@v1
-        with:
-          # v0.311.0+ (2026-08-05) changed `branch show --format json` output and
-          # exit codes, breaking the safe-migrations state reads below. Pin to the
-          # last version verified by a green run of this workflow.
-          version: v0.310.0
 
       - name: Disable safe migrations (allow DDL for this run only)
         if: steps.pending.outputs.pending == 'true' || github.event_name == 'workflow_dispatch'
@@ -176,25 +171,18 @@ jobs:
             done
             return 1
           }
-          read_safe_migrations_state() {
-            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations // .branch.safe_migrations // empty"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
-          }
-          if ! state="$(read_safe_migrations_state)"; then
-            state=""
+          # Read the resulting state from the toggle's own response instead of a
+          # separate `pscale branch show`: `disable` is idempotent, and it saves a
+          # call that needs different API permissions and a different output shape.
+          if ! state="$(pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json)"; then
+            echo "::error::Could not disable safe migrations for $DATABASE_NAME/$PLANETSCALE_BRANCH."
+            exit 1
           fi
-          echo "safe_migrations before run: $state"
-          if [ "$state" = "true" ]; then
-            if ! pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"; then
-              echo "::error::Could not disable safe migrations for $DATABASE_NAME/$PLANETSCALE_BRANCH."
-              exit 1
-            fi
-            echo "Safe migrations disabled for the duration of this run."
-          elif [ "$state" = "false" ]; then
-            echo "Safe migrations already disabled; will re-enable at the end of this run."
-          else
-            echo "::warning::Could not read safe_migrations state for $DATABASE_NAME/$PLANETSCALE_BRANCH; attempting disable anyway (the DDL probes below are the real gate)."
-            pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" || true
+          if ! jq -e '.safe_migrations == false' >/dev/null <<<"$state"; then
+            echo "::error::PlanetScale did not confirm safe migrations were disabled. Response: $state"
+            exit 1
           fi
+          echo "Safe migrations disabled for the duration of this run."
 
           # The toggle propagates to the connection gateways asynchronously and
           # per edge node, so require several consecutive successful DDL probes
@@ -283,63 +271,25 @@ jobs:
         if: always() && steps.setup-pscale.conclusion == 'success'
         run: |
           set -euo pipefail
-          pscale_retry() {
-            local attempt err_file error_output output status
-            for attempt in $(seq 1 5); do
-              err_file="$(mktemp)"
-              if output="$("$@" 2>"$err_file")"; then
-                error_output="$(<"$err_file")"
-                rm -f "$err_file"
-                if [ -n "$error_output" ]; then
-                  printf '%s\n' "$error_output" >&2
-                fi
-                printf '%s\n' "$output"
-                return 0
-              else
-                status=$?
-                error_output="$(<"$err_file")"
-                rm -f "$err_file"
-                if [ -n "$output" ]; then
-                  printf '%s\n' "$output" >&2
-                fi
-                if [ -n "$error_output" ]; then
-                  printf '%s\n' "$error_output" >&2
-                fi
-                if [ "$attempt" -lt 5 ]; then
-                  echo "pscale command failed (attempt $attempt/5, exit $status); retrying in 10s..." >&2
-                  sleep 10
-                fi
-              fi
-            done
-            return 1
-          }
-          read_safe_migrations_state() {
-            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations // .branch.safe_migrations // empty"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
-          }
-
           confirmed="false"
           for attempt in $(seq 1 5); do
             echo "Enabling safe migrations (attempt $attempt/5)."
-            if output="$(pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" 2>&1)"; then
-              if [ -n "$output" ]; then
-                printf '%s\n' "$output"
+            # Same as the disable step: trust the toggle's own JSON response, and
+            # always echo it when it does not confirm, so a future API/CLI change
+            # shows up in the log instead of being swallowed.
+            if output="$(pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json 2>&1)"; then
+              if jq -e '.safe_migrations == true' >/dev/null <<<"$output"; then
+                confirmed="true"
+                echo "PlanetScale confirmed safe migrations are enabled."
+                break
               fi
+              echo "PlanetScale enable response did not confirm safe migrations: $output" >&2
             else
               status=$?
               if [ -n "$output" ]; then
                 printf '%s\n' "$output" >&2
               fi
-              echo "pscale enable failed (attempt $attempt/5, exit $status); checking branch state." >&2
-            fi
-
-            if state="$(read_safe_migrations_state)"; then
-              echo "safe_migrations after run: $state"
-              if [ "$state" = "true" ]; then
-                confirmed="true"
-                break
-              fi
-            else
-              echo "Could not verify safe_migrations state after enable attempt $attempt." >&2
+              echo "pscale enable failed (attempt $attempt/5, exit $status)." >&2
             fi
 
             if [ "$attempt" -lt 5 ]; then


### PR DESCRIPTION
cc @OmarMcAdam @src-opn @reachjalil

## What broke

[Run 31369155396](https://github.com/different-ai/openwork/actions/runs/31369155396) (Den DB Migrate, push of #3645) went red **after** applying the pending migrations successfully:

```
[✓] migrations applied successfully!
...
Enabling safe migrations (attempt 5/5).
Successfully enabled safe migrations for main
pscale command failed (attempt 1/5, exit 2); retrying in 10s...
...
Error: Safe migrations is NOT re-enabled on ***/main.
```

Production was never at risk: migrations applied (the following scheduled runs report `pending=false`) and safe migrations *was* re-enabled — `enable` reported success on all five attempts. Only the **read-back** failed.

## Root cause

The read-back was:

```sh
pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations // .branch.safe_migrations // empty"
```

Since ~v0.309 pscale emits errors as a **JSON envelope on stdout** (its own agent guide: exit `1` = `action_required`, exit `2` = `error`). Reproduced locally on v0.309.0 and v0.310.0:

```console
$ pscale branch show mydb main --org myorg --format json; echo "EXIT=$?"
{ "status": "action_required", "error": "...", "issues": [...] }
EXIT=1
```

When `branch show` errors, that envelope has no `.safe_migrations`, so `// empty` swallowed the entire message: **empty stdout, empty stderr, exit 2**. Hence five minutes of opaque `pscale command failed (attempt N/5, exit 2)` with zero diagnostic content.

## Why the previous fix didn't hold

#3606 pinned the CLI to `v0.310.0` as "the last version verified by a green run". It wasn't:

- Last green `branch show` read: **2026-08-05 09:40 UTC** ([run 30994259486](https://github.com/different-ai/openwork/actions/runs/30994259486), `safe_migrations before run: true`).
- `v0.310.0` was published **2026-08-05 16:38 UTC**. That green run was on **v0.309.0**.
- The #3606 merge run had nothing pending, so `Setup pscale CLI` through `Re-enable safe migrations` were all **skipped** — the pin was never exercised until yesterday.
- The same exit-2 signature reproduces on `v0.310.0`, `v0.311.0` and `latest`, so the pin was not the fix and the version is not the variable.

## The change

- Confirm state from the **toggle command's own `--format json` response** on both sides (`disable` → `.safe_migrations == false`, `enable` → `.safe_migrations == true`). `disable` is idempotent, so the pre-read it replaces was pure overhead; the consecutive DDL probes remain the real gate.
- **Echo raw pscale output whenever it fails to confirm**, so the next API/CLI change is diagnosable from the log instead of invisible.
- **Unpin the CLI** — the pin rested on a wrong attribution, and this approach went green end to end on `latest` in [run 31174511748](https://github.com/different-ai/openwork/actions/runs/31174511748) (`PlanetScale confirmed safe migrations are enabled.`).

Net −93/+31 lines; the duplicated `pscale_retry`/`read_safe_migrations_state` block in the re-enable step is gone.

## Verification

Workflow-only change, so there is no `@openwork/testkit` tape to publish — the only meaningful proof is a live run of this workflow. What I did run:

| Check | Result |
| --- | --- |
| `yaml.safe_load` of the workflow | parses |
| `bash -n` on all 8 `run:` blocks | all OK |
| Pin removal asserted (`steps[id=setup-pscale].with is None`) | OK |
| `pscale v0.309.0` / `v0.310.0` error envelope on stdout + exit codes | reproduced locally, confirms the root cause |
| `pscale ... --format json 2>/dev/null \| jq -e 'type'` | `"object"` — stdout is clean JSON, the update notice goes to stderr, so the new `jq -e` reads cannot be poisoned by it |
| `jq -e '.safe_migrations == true'` against an error envelope | exit 1 → falls into the retry branch and prints the raw response |

**Still needed before merge:** a `workflow_dispatch` of Den DB Migrate on this branch with `dry_run=true`. That exercises both toggle steps (disable → probes → re-enable) without applying DDL. I don't have permission to dispatch it; happy to hand it back, or one of you can fire it. Repro of the current failure is simply the last push run linked above.