### PR TITLE
feat(gmail): one drafts capability with declarative, host-fulfilled attachments (SEP-2356 shape)

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-file-inputs.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-file-inputs.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildFileInputExtensionCall,
+  OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL,
+  readFileInputDescriptor,
+  repairFileInputToolResult,
+} from "./openwork-extensions-preview-file-inputs.js";
+
+const descriptor = {
+  field: "attachments",
+  extensionId: "openwork-cloud-uploads",
+  action: "gmail_create_draft_with_attachments",
+  argsField: "paths",
+};
+
+function hostRequiredResult() {
+  return {
+    isError: true,
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        error: "file_input_requires_host",
+        message: "attachments lists workspace file paths whose bytes are uploaded by the OpenWork host.",
+        fileInput: descriptor,
+      }),
+    }],
+  };
+}
+
+function draftArgs() {
+  return {
+    name: "postCapabilitiesGoogleWorkspaceGmailDrafts",
+    body: {
+      to: "ben@openworklabs.com",
+      subject: "Sentry report",
+      body: "Attached.",
+      attachments: ["reports/sentry-unresolved-issues.md"],
+    },
+  };
+}
+
+describe("readFileInputDescriptor", () => {
+  test("reads the descriptor from a file_input_requires_host text payload", () => {
+    expect(readFileInputDescriptor(hostRequiredResult())).toEqual(descriptor);
+  });
+
+  test("ignores ordinary results and other errors", () => {
+    expect(readFileInputDescriptor({ content: [{ type: "text", text: JSON.stringify({ ok: true }) }] })).toBeNull();
+    expect(readFileInputDescriptor({ content: [{ type: "text", text: JSON.stringify({ error: "needs_connection" }) }] })).toBeNull();
+    expect(readFileInputDescriptor({ content: [{ type: "text", text: "not json" }] })).toBeNull();
+    expect(readFileInputDescriptor(null)).toBeNull();
+  });
+
+  test("rejects descriptors with missing fields", () => {
+    const result = hostRequiredResult();
+    result.content[0] = {
+      type: "text",
+      text: JSON.stringify({ error: "file_input_requires_host", fileInput: { field: "attachments" } }),
+    };
+    expect(readFileInputDescriptor(result)).toBeNull();
+  });
+});
+
+describe("buildFileInputExtensionCall", () => {
+  test("maps the capability body onto the extension action args", () => {
+    expect(buildFileInputExtensionCall(draftArgs(), descriptor)).toEqual({
+      extensionId: "openwork-cloud-uploads",
+      action: "gmail_create_draft_with_attachments",
+      args: {
+        to: "ben@openworklabs.com",
+        subject: "Sentry report",
+        body: "Attached.",
+        paths: ["reports/sentry-unresolved-issues.md"],
+      },
+    });
+  });
+
+  test("returns null without a non-empty string path array", () => {
+    expect(buildFileInputExtensionCall({ name: "x", body: { to: "a@b.c", attachments: [] } }, descriptor)).toBeNull();
+    expect(buildFileInputExtensionCall({ name: "x", body: { to: "a@b.c", attachments: [7] } }, descriptor)).toBeNull();
+    expect(buildFileInputExtensionCall({ name: "x", body: { to: "a@b.c" } }, descriptor)).toBeNull();
+    expect(buildFileInputExtensionCall({ name: "x" }, descriptor)).toBeNull();
+  });
+});
+
+describe("repairFileInputToolResult", () => {
+  test("re-runs the request through the local action and rewrites the result", async () => {
+    const result = hostRequiredResult();
+    const calls: unknown[] = [];
+    const repaired = await repairFileInputToolResult({
+      tool: OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL,
+      args: draftArgs(),
+      result,
+      callExtensionAction: async (call) => {
+        calls.push(call);
+        return { ok: true, draftId: "d1", draftUrl: "https://mail.google.com/#drafts?compose=d1" };
+      },
+    });
+    expect(repaired).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(result.isError).toBe(false);
+    const first = result.content[0];
+    if (!first) throw new Error("missing rewritten content");
+    expect(JSON.parse(first.text)).toEqual({
+      ok: true,
+      draftId: "d1",
+      draftUrl: "https://mail.google.com/#drafts?compose=d1",
+    });
+  });
+
+  test("surfaces upload failures as a structured error result", async () => {
+    const result = hostRequiredResult();
+    const repaired = await repairFileInputToolResult({
+      tool: OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL,
+      args: draftArgs(),
+      result,
+      callExtensionAction: async () => {
+        throw new Error("File was not found inside an authorized workspace root.");
+      },
+    });
+    expect(repaired).toBe(true);
+    expect(result.isError).toBe(true);
+    const first = result.content[0];
+    if (!first) throw new Error("missing rewritten content");
+    expect(JSON.parse(first.text)).toEqual({
+      error: "file_input_upload_failed",
+      message: "File was not found inside an authorized workspace root.",
+      fileInput: descriptor,
+    });
+  });
+
+  test("leaves other tools and other results untouched", async () => {
+    const untouched = hostRequiredResult();
+    const before = JSON.stringify(untouched);
+    expect(await repairFileInputToolResult({
+      tool: "some-other-tool",
+      args: draftArgs(),
+      result: untouched,
+      callExtensionAction: async () => ({ ok: true }),
+    })).toBe(false);
+    expect(JSON.stringify(untouched)).toBe(before);
+
+    const okResult = { content: [{ type: "text", text: JSON.stringify({ ok: true, draftId: "d2" }) }] };
+    expect(await repairFileInputToolResult({
+      tool: OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL,
+      args: draftArgs(),
+      result: okResult,
+      callExtensionAction: async () => ({ ok: true }),
+    })).toBe(false);
+  });
+
+  test("keeps the cloud error visible when args carry no usable paths", async () => {
+    const result = hostRequiredResult();
+    const before = JSON.stringify(result);
+    expect(await repairFileInputToolResult({
+      tool: OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL,
+      args: { name: "postCapabilitiesGoogleWorkspaceGmailDrafts", body: { to: "a@b.c", attachments: [] } },
+      result,
+      callExtensionAction: async () => ({ ok: true }),
+    })).toBe(false);
+    expect(JSON.stringify(result)).toBe(before);
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-file-inputs.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-file-inputs.ts
@@ -1,0 +1,120 @@
+/**
+ * Host-side fulfillment of declarative capability file inputs (SEP-2356 shape).
+ *
+ * Cloud capabilities never accept file bytes. A capability whose schema
+ * declares an `x-mcp-file` field (for example gmail-drafts `attachments`)
+ * accepts workspace file *paths* from the model and, when they reach the
+ * cloud route unfulfilled, answers `file_input_requires_host` with a
+ * descriptor naming the local extension action that owns the byte transport.
+ *
+ * This module is that fulfillment: a `tool.execute.after` hook spots the
+ * descriptor on `openwork-cloud_execute_capability` results, re-runs the
+ * request through the described local action (the authenticated multipart
+ * lane), and rewrites the tool result in place. The model sees one
+ * capability and one successful call; bytes never transit model context.
+ */
+
+export const OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL = "openwork-cloud_execute_capability";
+
+export type FileInputDescriptor = {
+  /** Capability body field that carried workspace file paths. */
+  field: string;
+  /** Local extension that owns the byte transport. */
+  extensionId: string;
+  /** Extension action to invoke. */
+  action: string;
+  /** Action argument that receives the workspace file paths. */
+  argsField: string;
+};
+
+export type FileInputExtensionCall = {
+  extensionId: string;
+  action: string;
+  args: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: Record<string, unknown>, key: string): string {
+  const field = value[key];
+  return typeof field === "string" ? field.trim() : "";
+}
+
+function readTextPayload(result: unknown): Record<string, unknown> | null {
+  if (!isRecord(result) || !Array.isArray(result.content)) return null;
+  for (const item of result.content) {
+    if (!isRecord(item) || item.type !== "text" || typeof item.text !== "string") continue;
+    try {
+      const parsed: unknown = JSON.parse(item.text);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Not JSON — keep scanning.
+    }
+  }
+  return null;
+}
+
+export function readFileInputDescriptor(result: unknown): FileInputDescriptor | null {
+  const payload = readTextPayload(result);
+  if (!payload || payload.error !== "file_input_requires_host") return null;
+  const fileInput = payload.fileInput;
+  if (!isRecord(fileInput)) return null;
+  const descriptor = {
+    field: readString(fileInput, "field"),
+    extensionId: readString(fileInput, "extensionId"),
+    action: readString(fileInput, "action"),
+    argsField: readString(fileInput, "argsField"),
+  };
+  if (!descriptor.field || !descriptor.extensionId || !descriptor.action || !descriptor.argsField) return null;
+  return descriptor;
+}
+
+export function buildFileInputExtensionCall(args: unknown, descriptor: FileInputDescriptor): FileInputExtensionCall | null {
+  if (!isRecord(args) || !isRecord(args.body)) return null;
+  const { [descriptor.field]: files, ...rest } = args.body;
+  if (!Array.isArray(files) || files.length === 0) return null;
+  if (!files.every((item) => typeof item === "string" && item.trim().length > 0)) return null;
+  return {
+    extensionId: descriptor.extensionId,
+    action: descriptor.action,
+    args: { ...rest, [descriptor.argsField]: files },
+  };
+}
+
+function replaceToolResultContent(result: unknown, payload: unknown, isError: boolean): void {
+  if (!isRecord(result)) return;
+  result.content = [{ type: "text", text: JSON.stringify(payload) }];
+  result.isError = isError;
+}
+
+/**
+ * Rewrites `result` in place when it is a `file_input_requires_host` answer
+ * from the cloud execute tool. Returns true when a repair was attempted.
+ * Anything unexpected leaves the result untouched so the model still sees
+ * the cloud route's own actionable error.
+ */
+export async function repairFileInputToolResult(input: {
+  tool: string;
+  args: unknown;
+  result: unknown;
+  callExtensionAction: (call: FileInputExtensionCall) => Promise<unknown>;
+}): Promise<boolean> {
+  if (input.tool !== OPENWORK_CLOUD_EXECUTE_CAPABILITY_TOOL) return false;
+  const descriptor = readFileInputDescriptor(input.result);
+  if (!descriptor) return false;
+  const call = buildFileInputExtensionCall(input.args, descriptor);
+  if (!call) return false;
+  try {
+    const payload = await input.callExtensionAction(call);
+    replaceToolResultContent(input.result, payload, false);
+  } catch (error) {
+    replaceToolResultContent(input.result, {
+      error: "file_input_upload_failed",
+      message: error instanceof Error ? error.message : String(error),
+      fileInput: descriptor,
+    }, true);
+  }
+  return true;
+}

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from "node:os";
 import { z } from "zod";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
+import { repairFileInputToolResult } from "./openwork-extensions-preview-file-inputs.js";
 import {
   combineInstructionSections,
   composeAgentInstructions,
@@ -923,6 +924,30 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
       createInstructionSection("browser", OPENWORK_BROWSER_INSTRUCTION),
     );
     output.system.push(...composeAgentInstructions(sections));
+  },
+  // Fulfills declarative capability file inputs (e.g. gmail-drafts attachments):
+  // when the cloud route answers file_input_requires_host, re-run the request
+  // through the named local extension action and rewrite the result in place.
+  "tool.execute.after": async (
+    input: { tool: string; sessionID: string; callID: string; args: unknown },
+    output: unknown,
+  ) => {
+    try {
+      await repairFileInputToolResult({
+        tool: input.tool,
+        args: input.args,
+        result: output,
+        callExtensionAction: (call) => postJson("/experimental/extensions/call", {
+          extensionId: call.extensionId,
+          action: call.action,
+          args: call.args,
+          context: contextPayload(factoryContext),
+        }),
+      });
+    } catch (error) {
+      // Never let repair failures break an unrelated tool result.
+      console.error("[openwork:file-inputs] repair failed", unknownErrorMessage(error));
+    }
   },
   tool: {
     openwork_context: {

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -81,6 +81,7 @@ const capabilityMatchOutputSchema = z.object({
   path: z.string(),
   score: z.number(),
   summary: z.string(),
+  description: z.string().optional(),
   pathParams: z.array(z.string()),
   queryParams: z.array(z.string()),
   hasBody: z.boolean(),

--- a/ee/apps/den-api/src/mcp/native-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/native-capabilities.ts
@@ -12,7 +12,7 @@ import {
 } from "./catalog.js"
 import { buildExternalConnectionStatus, type ExternalCapabilityMatch, type McpMemberIdentity } from "./external-capabilities.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
-import { compareCapabilityMatches, scoreText, tokenize, type CapabilityMatch } from "./search.js"
+import { compareCapabilityMatches, descriptionFor, scoreText, tokenize, type CapabilityMatch } from "./search.js"
 
 export const NATIVE_CAPABILITY_PREFIX = "native:"
 
@@ -53,7 +53,7 @@ function operationScore(connection: NativeProviderConnectionEntry, operation: Mc
     operationNameTokens(connection.name, operation.name),
     tokenize(`${connection.name} ${operationSummary(operation)}`),
     queryTokens,
-    tokenize(operation.path),
+    [...tokenize(operation.path), ...tokenize(descriptionFor(operation) ?? "")],
   )
 }
 
@@ -74,6 +74,7 @@ function capabilityMatch(
     path: operation.path,
     score,
     summary: `[${connection.name}] ${operationSummary(operation)}`,
+    ...(descriptionFor(operation) === undefined ? {} : { description: descriptionFor(operation) }),
     pathParams: pathParameterNamesFromTemplate(operation.path),
     queryParams: getParameters(operation.operation, "query")
       .flatMap((parameter) => typeof parameter.name === "string" ? [parameter.name] : []),

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -25,6 +25,8 @@ export type CapabilityMatch = {
   path: string
   score: number
   summary: string
+  /** Route-level description with agent guidance (for example redirects to companion actions), when it adds detail beyond the summary. */
+  description?: string
   /** Path parameter names this tool's `path` template requires, e.g. ["workerId"]. */
   pathParams: string[]
   /** Query parameter names this tool documents, if any. */
@@ -101,6 +103,17 @@ function summaryFor(operation: McpToolOperation): string {
   return operation.operation.summary ?? operation.operation.description ?? `${operation.method} ${operation.path}`
 }
 
+/**
+ * The route description often carries agent guidance the summary drops (for
+ * example the gmail-drafts capability redirecting attachment requests to the
+ * local `openwork-cloud-uploads` extension). On `/mcp/agent`, search matches
+ * are the only discovery surface, so that guidance must ride along.
+ */
+export function descriptionFor(operation: McpToolOperation): string | undefined {
+  const description = operation.operation.description
+  return description && description !== summaryFor(operation) ? description : undefined
+}
+
 function scoreOperation(operation: McpToolOperation, queryTokens: string[]): number {
   if (queryTokens.length === 0) {
     return 0
@@ -108,8 +121,8 @@ function scoreOperation(operation: McpToolOperation, queryTokens: string[]): num
 
   const nameTokens = tokenizeToolName(operation.name)
   const summaryTokens = tokenize(summaryFor(operation))
-  const pathTokens = tokenize(operation.path)
-  return scoreText(nameTokens, summaryTokens, queryTokens, pathTokens)
+  const extraTokens = [...tokenize(operation.path), ...tokenize(descriptionFor(operation) ?? "")]
+  return scoreText(nameTokens, summaryTokens, queryTokens, extraTokens)
 }
 
 export function searchCapabilities(
@@ -127,6 +140,7 @@ export function searchCapabilities(
       path: operation.path,
       score: scoreOperation(operation, queryTokens),
       summary: summaryFor(operation),
+      ...(descriptionFor(operation) === undefined ? {} : { description: descriptionFor(operation) }),
       pathParams: pathParameterNamesFromTemplate(operation.path),
       queryParams: getParameters(operation.operation, "query").map((parameter) => parameter.name as string),
       hasBody: hasJsonRequestBody(operation.operation),

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -58,6 +58,37 @@ const createDraftBodySchema = z.object({
   threadId: z.string().trim().min(1).max(512).optional().describe("Gmail thread id to reply on. Required for replies and forwards; get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
 }).strict()
 
+/**
+ * SEP-2356-style declarative file input. The model passes workspace file
+ * paths; it never passes bytes. A capable OpenWork host recognizes the
+ * file_input_requires_host error below and re-runs the draft through the
+ * authenticated multipart lane (/v1/direct-uploads/google-workspace/gmail-drafts),
+ * so attachment bytes stay outside model context end to end.
+ */
+const gmailDraftFileInput = {
+  field: "attachments",
+  extensionId: "openwork-cloud-uploads",
+  action: "gmail_create_draft_with_attachments",
+  argsField: "paths",
+}
+
+const createDraftCapabilityBodySchema = createDraftBodySchema.extend({
+  attachments: z.array(z.string().trim().min(1).max(2_000)).min(1).max(DIRECT_UPLOAD_MAX_FILES).optional()
+    .describe("Optional workspace file paths to attach (up to 10 files, 4 MiB total). Pass file paths exactly as they exist in the workspace — never file bytes or base64. The OpenWork host uploads the bytes outside model context.")
+    .meta({ "x-mcp-file": { maxSize: DIRECT_UPLOAD_MAX_BYTES, maxFiles: DIRECT_UPLOAD_MAX_FILES } }),
+})
+
+const fileInputRequiresHostSchema = z.object({
+  error: z.literal("file_input_requires_host"),
+  message: z.string(),
+  fileInput: z.object({
+    field: z.string(),
+    extensionId: z.string(),
+    action: z.string(),
+    argsField: z.string(),
+  }),
+}).meta({ ref: "GoogleWorkspaceFileInputRequiresHostError" })
+
 const createDraftResponseSchema = z.object({
   ok: z.literal(true),
   draftId: z.string(),
@@ -1295,20 +1326,29 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     "/v1/capabilities/google-workspace/gmail-drafts",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Create a Gmail draft or threaded reply draft without attachments",
-      description: "Creates a plain-text Gmail draft in the calling member own mailbox. For workspace attachments, use the openwork-cloud-uploads gmail_create_draft_with_attachments action so file bytes stay outside model context. Set threadId for replies and forwards. Always share the returned draftUrl.",
+      summary: "Create a Gmail draft or threaded reply draft, optionally attaching workspace files",
+      description: "Creates a plain-text Gmail draft in the calling member own mailbox. To attach workspace files, list their paths in attachments — pass paths only, never file bytes; the OpenWork host uploads the bytes outside model context. Set threadId for replies and forwards. Always share the returned draftUrl.",
       responses: {
         200: jsonResponse("Draft created.", createDraftResponseSchema),
         400: jsonResponse("The draft request was invalid.", z.union([invalidRequestSchema, missingThreadIdSchema])),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        422: jsonResponse("The attachments file input must be fulfilled by the OpenWork host; no draft was created.", fileInputRequiresHostSchema),
         502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
       },
     }),
     orgMemberRoute(),
-    jsonValidator(createDraftBodySchema),
+    jsonValidator(createDraftCapabilityBodySchema),
     async (c) => {
-      const result = await executeGmailDraft(c.req.valid("json"), c.get("organizationContext"), [])
+      const { attachments, ...draft } = c.req.valid("json")
+      if (attachments !== undefined) {
+        return c.json({
+          error: "file_input_requires_host",
+          message: "attachments lists workspace file paths whose bytes are uploaded by the OpenWork host, not through this capability. No draft was created. OpenWork desktop handles this automatically; if this error reaches you, the host cannot upload files here — create the draft without attachments or ask the user to update the OpenWork app.",
+          fileInput: gmailDraftFileInput,
+        }, 422)
+      }
+      const result = await executeGmailDraft(draft, c.get("organizationContext"), [])
       return c.json(result.body, result.status)
     },
   )

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -734,6 +734,30 @@ test("gmail plain draft supports cc without requiring a thread", async () => {
   })
 })
 
+test("gmail draft with attachment paths returns file_input_requires_host and creates nothing", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Quarterly plan",
+      body: "Draft body",
+      attachments: ["reports/quarterly-plan.pdf"],
+    },
+  })
+  expect(response.status).toBe(422)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "file input response")
+  expect(responseBody.error).toBe("file_input_requires_host")
+  expect(responseBody.fileInput).toEqual({
+    field: "attachments",
+    extensionId: "openwork-cloud-uploads",
+    action: "gmail_create_draft_with_attachments",
+    argsField: "paths",
+  })
+  expect(expectMessage(body)).toContain("No draft was created")
+})
+
 test("direct Gmail upload attaches exact workspace bytes without model-facing base64", async () => {
   const attachmentBytes = Buffer.from("%PDF-1.4\nworkspace invoice\n", "utf8")
   const form = new FormData()
@@ -1141,9 +1165,14 @@ test("Google Workspace capability tools are discoverable and keep readable names
   expect(gmailMatch?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
   expect(gmailMatch?.queryParams).toEqual(["q", "maxResults"])
   expect(searchCapabilities(catalog, "outlook mail messages", 20).find((match) => match.name === "getCapabilitiesMicrosoft365MailMessages")?.queryParams).toEqual(["search", "maxResults"])
-  const draftMatch = searchCapabilities(catalog, "gmail draft without attachments", 10)[0]
+  const draftMatch = searchCapabilities(catalog, "gmail draft with attachments", 10)[0]
   expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")
-  expect(draftMatch?.summary).toContain("without attachments")
+  expect(draftMatch?.summary).toContain("attaching workspace files")
+  expect(draftMatch?.description).toContain("never file bytes")
+  const draftBodySchema = expectRecord(draftMatch?.bodySchema, "draft body schema")
+  const draftProperties = expectRecord(draftBodySchema.properties, "draft body schema properties")
+  const attachmentsSchema = expectRecord(draftProperties.attachments, "attachments schema")
+  expect(attachmentsSchema["x-mcp-file"]).toEqual({ maxSize: 4 * 1024 * 1024, maxFiles: 10 })
   expect(searchCapabilities(catalog, "download gmail attachment bytes", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailAttachment")
 
   const expectedNames = [


### PR DESCRIPTION
## Problem

An agent asked to email a workspace file reported: *"The Gmail capability can't add attachments... no such capability exists on this connection."* Attachments were not gone — #3458 correctly moved bytes off model context — but the replacement lived on a **separate local extension action** that cloud `search_capabilities` can never return, and the one sentence pointing to it (the route description) was stripped from `/mcp/agent` search results. A capability split patched over with prose is not discoverable by construction.

## Standard practice

This is the exact problem the **MCP File Uploads Working Group** exists for. Its charter names the anti-pattern we had ("servers resort to prose instructions asking for base64 strings or local paths") and anchors on **SEP-2356: declarative file inputs** — file inputs are declared on the tool's input schema via an `x-mcp-file` descriptor (`accept`/`maxSize`), the **host** fulfills the file slot (the model passes paths/references, never bytes), and large files route through URL-mode elicitation (SEP-1036, Final). Prior art: OpenAI Apps SDK `openai/fileParams`.

## Design

One capability, intent-shaped schema; transport is plumbing.

1. **`gmail-drafts` declares the file input** (`ee/apps/den-api/src/routes/org/google-workspace.ts`): `attachments` — workspace file paths, annotated `x-mcp-file: { maxSize: 4 MiB, maxFiles: 10 }`. The schema rides along in every `search_capabilities` match (`bodySchema`), so discovery is data, not steering. Summary no longer says "without attachments".
2. **Cloud route never touches bytes**: if `attachments` reaches the JSON route, it creates nothing and answers `422 file_input_requires_host` with a machine-readable descriptor: `{ field, extensionId, action, argsField }`.
3. **Host fulfillment, generic** (`apps/server/src/opencode-plugins/openwork-extensions-preview-file-inputs.ts`): a `tool.execute.after` hook on `openwork-cloud_execute_capability` spots that error, re-runs the request through the descriptor's local action — the existing `openwork-cloud-uploads` authenticated multipart lane (authorized-roots + 4 MiB enforcement unchanged) — and rewrites the tool result in place. The model sees one capability and one successful call.
4. **Search results keep agent guidance** (`ee/apps/den-api/src/mcp/search.ts`, `native-capabilities.ts`, `agent.ts`): matches now carry the route `description` and score against it; `/mcp/agent` no longer drops text written specifically for agents.

Degradation is honest: hosts without the hook (old desktop, Cursor/Claude Code on `/mcp/agent`) get the 422 with explicit next steps. Drive upload and any future file-carrying capability reuse the same descriptor + hook with zero new code paths. When SEP-2356 ratifies, the schema surface is already conformant.

## Tests

Commands run locally (macOS, worktree off `origin/dev`):

- `apps/server`: `bun test src/opencode-plugins/openwork-extensions-preview-file-inputs.test.ts src/extensions/cloud-uploads.test.ts src/extensions-connect-gating.test.ts` — **18 pass / 0 fail** (3 consecutive runs); `bun test src/opencode-plugins/openwork-extensions-preview.test.ts src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts` — **32 pass / 0 fail**; `pnpm --filter openwork-server typecheck` — clean; `pnpm --filter openwork-server build` — bundles the new hook into `dist/opencode-plugins/openwork-extensions-preview.js`.
- `ee/apps/den-api`: `pnpm exec tsc -p tsconfig.json --noEmit` — clean; `bun test test/gmail-draft.test.ts test/mcp-catalog-parameter-refs.test.ts` — **18 pass / 0 fail**; direct check that `x-mcp-file` survives `hono-openapi` resolution and that `search_capabilities("gmail draft with attachments")` returns the capability with description + descriptor.
- **Not runnable locally** (needs seeded den DB; fails identically on clean `origin/dev`): `test/google-workspace-capabilities.test.ts` — extended with a `422 file_input_requires_host` route test (asserts `googleCallCount === 0`) and discoverability assertions for the new summary/description/`x-mcp-file`.

## Verification status

**Incomplete** — runtime-observable change; no `@openwork/testkit` tape yet. The end-to-end claim ("agent asks to email a file → one tool call → draft with attachment, bytes outside model context") needs an `evals/specs/*.slow.test.ts` against a Gmail witness plus the DB-backed den suite in CI/Daytona. Repro for the core loop without the app: run the den 422 test against a seeded den, then feed its response through `repairFileInputToolResult` (covered by the new unit tests).
