### PR TITLE
fix(desktop): mirror undici so the packaged embedded server boots

### DIFF
--- a/apps/desktop/electron/server-dependency-mirror.test.mjs
+++ b/apps/desktop/electron/server-dependency-mirror.test.mjs
@@ -1,0 +1,23 @@
+// Regression: server/dist/local-managed-mcp-url-guard.js failed to resolve undici in the packaged app (PR #3652).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const desktopPackage = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+const serverPackage = JSON.parse(
+  readFileSync(new URL("../../server/package.json", import.meta.url), "utf8"),
+);
+
+describe("server dependency mirror", () => {
+  it("mirrors every server runtime dependency in the desktop package", () => {
+    for (const [name, spec] of Object.entries(serverPackage.dependencies)) {
+      assert.equal(
+        desktopPackage.dependencies[name],
+        spec,
+        `Server runtime dependency "${name}" must be mirrored with the same version in apps/desktop/package.json because the packaged app imports server/dist from app.asar and electron-builder only packs node_modules declared by apps/desktop/package.json.`,
+      );
+    }
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-darwin.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/secure-vault-key.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-darwin.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/server-dependency-mirror.test.mjs electron/secure-vault-key.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -37,6 +37,7 @@
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.2.5",
     "node-pty": "npm:@lydell/node-pty@1.2.0-beta.12",
+    "undici": "6.28.0",
     "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       node-pty:
         specifier: npm:@lydell/node-pty@1.2.0-beta.12
         version: '@lydell/node-pty@1.2.0-beta.12'
+      undici:
+        specifier: 6.28.0
+        version: 6.28.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
## Symptom

Installed desktop app (dev tip) fails to boot the embedded server:

```
Cannot find package 'undici' imported from /Applications/OpenWork.app/Contents/Resources/app.asar/server/dist/local-managed-mcp-url-guard.js
```

The imports are static (`embedded.js → server.js → local-managed-mcp.js → local-managed-mcp-url-guard.js → "undici"`), so the entire embedded server fails to load in the packaged app — not just the managed OAuth gateway.

## Root cause

#3652 added `local-managed-mcp-url-guard.ts`, which imports the `undici` package (needed for `Agent({ connect: { lookup } })` — the DNS-rebinding-safe guarded fetch; neither Node's nor Bun's global fetch exposes that hook). It added `undici` to `apps/server/package.json`, and mirrored `@modelcontextprotocol/sdk` + `@openwork/enterprise-mcp-client` into `apps/desktop/package.json` — but missed `undici`.

The packaged app imports `server/dist` from inside `app.asar`, and electron-builder packs `node_modules` only from `apps/desktop/package.json` dependencies. Dev mode never sees this because the server resolves `undici` from the pnpm workspace, which is exactly why it slipped through.

## Fix

- `apps/desktop/package.json`: add `"undici": "6.28.0"` (identical pinned spec as `apps/server`).
- New guard test `apps/desktop/electron/server-dependency-mirror.test.mjs`: every runtime dependency of `apps/server/package.json` must appear in `apps/desktop/package.json` with the identical spec. The hand-mirroring convention already covered `better-sqlite3`, `drizzle-orm`, `jsonc-parser`, `minimatch`, `yaml`, `zod`, etc. — this pins it so the next server dep can't silently miss the asar.
- `pnpm-lock.yaml`: desktop importer entry only (undici@6.28.0 was already in the lockfile via apps/server).

## Validation

Commands run (in this branch's worktree):

1. Guard test **before** the dep fix (test written first) — **red on exactly `undici`**:
   ```
   AssertionError [ERR_ASSERTION]: Server runtime dependency "undici" must be mirrored...
   + undefined
   - '6.28.0'
   tests 1, pass 0, fail 1
   ```
2. `pnpm install` — exit 0.
3. `node --test electron/server-dependency-mirror.test.mjs` — pass (rerun independently by orchestrator).
4. `node -e "require('undici/package.json').version"` from `apps/desktop` → `6.28.0`; `apps/desktop/node_modules/undici` resolves, so electron-builder collects it.
5. `pnpm --filter @openwork/desktop test` — **187 tests, 186 pass, 1 platform skip, 0 fail** (run twice: executor + orchestrator).

## Why there is no testkit tape

The failure mode exists only inside the electron-builder-packed asar. `@openwork/testkit` specs run the server in dev-mode resolution (workspace `node_modules`), where `undici` always resolves — by construction, a dev-mode spec cannot observe this regression (that is exactly how it escaped #3652's e2e spec). The verdict here comes from the manifest guard test, red on the dev tip and green with the fix, plus the full desktop suite.

Packaged repro / final gate (release build):
```
pnpm --filter @openwork/desktop package:electron:dir
npx @electron/asar l dist-electron/mac-arm64/OpenWork.app/Contents/Resources/app.asar | grep node_modules/undici
```
Before this fix the packaged app throws `ERR_MODULE_NOT_FOUND` for `undici` at embedded-server import; after it, `node_modules/undici` ships in the asar.
