### PR TITLE
fix(app): summarize and clamp HTML error pages in chat errors

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -324,6 +324,20 @@ describe("describeOpencodeSessionError", () => {
     })).toBe("Service unavailable\nStatus: 503\nResponse: upstream overloaded");
   });
 
+  it("summarizes and bounds an HTML API response body", () => {
+    const responseBody = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`;
+    const described = describeOpencodeSessionError({
+      name: "APIError",
+      data: { message: "Proxy request failed", statusCode: 502, responseBody },
+    });
+
+    expect(described).toContain("Upstream returned an HTML error page (502 Bad Gateway)");
+    expect(described).toContain("[Error text truncated; original size:");
+    expect(described.toLowerCase()).not.toContain("<!doctype");
+    expect(described.toLowerCase()).not.toContain("<html");
+    expect(described.length).toBeLessThanOrEqual(500);
+  });
+
   it("uses named error defaults when opencode omits a message", () => {
     expect(describeOpencodeSessionError({
       name: "MessageOutputLengthError",

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/collapsible"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
 import { getCapabilityCallQuote, getCapabilityCallSentence, parseRecord } from "@/lib/capability-call"
+import { normalizeErrorText } from "@/lib/error-text"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
@@ -60,7 +61,11 @@ function failureInstruction(part: DynamicToolUIPart, reconnectName: string | nul
   }
 
   const firstLine = errorText?.split("\n")[0]?.trim()
-  if (firstLine && !firstLine.startsWith("{") && !firstLine.startsWith("[")) return firstLine
+  if (firstLine && !firstLine.startsWith("{") && !firstLine.startsWith("[") && !firstLine.startsWith("<")) return firstLine
+  if (firstLine?.startsWith("<") && errorText) {
+    const normalizedFirstLine = normalizeErrorText(errorText, { cap: 500 }).display.split("\n")[0]?.trim()
+    if (normalizedFirstLine && !normalizedFirstLine.startsWith("<")) return normalizedFirstLine
+  }
   return "The call failed. Full error is under Technical details."
 }
 

--- a/apps/app/src/components/tools/error-attribution.ts
+++ b/apps/app/src/components/tools/error-attribution.ts
@@ -22,6 +22,8 @@ const OPENWORK_CLOUD_CAPABILITY_TOOLS = new Set([
   "openwork-cloud_execute_capability",
 ])
 
+const MAX_PARSED_RESULT_LENGTH = 64 * 1_024
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -29,6 +31,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseResultRecord(result: unknown): Record<string, unknown> | null {
   if (isRecord(result)) return result
   if (typeof result !== "string") return null
+  if (result.length > MAX_PARSED_RESULT_LENGTH) return null
 
   const trimmed = result.trim()
   const jsonStart = trimmed.indexOf("{")
@@ -112,6 +115,7 @@ export function reconnectActionFromChatToolResult(
 }
 
 export function attributeChatToolError(errorText: string): ToolErrorAttribution | null {
+  if (errorText.length > MAX_PARSED_RESULT_LENGTH) return null
   const diagnostic = diagnosticFromError(errorText)
   const code = stringValue(diagnostic, "code")
   const category = stringValue(diagnostic, "category")

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -300,7 +300,7 @@ const Tool = ({
             )
           ) : null}
           {isError && toolPart.errorText ? (
-            <pre className="text-destructive whitespace-pre-wrap wrap-break-word">
+            <pre className="text-destructive max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word">
               {toolPart.errorText}
             </pre>
           ) : null}

--- a/apps/app/src/lib/error-text.ts
+++ b/apps/app/src/lib/error-text.ts
@@ -1,0 +1,180 @@
+export type NormalizeErrorTextOptions = {
+  cap?: number
+}
+
+export type NormalizedErrorText = {
+  display: string
+  truncated: boolean
+  originalLength: number
+}
+
+const DEFAULT_ERROR_TEXT_CAP = 4_096
+const MIN_ERROR_TEXT_CAP = 256
+const HTML_SCAN_LIMIT = 64 * 1_024
+
+const HTTP_STATUS_LABELS: Readonly<Record<string, string>> = {
+  "400": "Bad Request",
+  "401": "Unauthorized",
+  "403": "Forbidden",
+  "404": "Not Found",
+  "408": "Request Timeout",
+  "413": "Payload Too Large",
+  "429": "Too Many Requests",
+  "500": "Internal Server Error",
+  "501": "Not Implemented",
+  "502": "Bad Gateway",
+  "503": "Service Unavailable",
+  "504": "Gateway Timeout",
+  "520": "Web Server Returned an Unknown Error",
+  "522": "Connection Timed Out",
+  "524": "A Timeout Occurred",
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function formatCharacterCount(length: number): string {
+  return `${length.toLocaleString("en-US")} characters`
+}
+
+function formatHumanSize(length: number): string {
+  if (length >= 1_024 * 1_024) return `${(length / (1_024 * 1_024)).toFixed(1)} MB`
+  if (length >= 1_024) return `${(length / 1_024).toFixed(1)} KB`
+  return `${length} characters`
+}
+
+function truncationMarker(originalLength: number): string {
+  return `\n\n[Error text truncated; original size: ${formatCharacterCount(originalLength)}]`
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(?:amp|lt|gt|quot|apos|#39|#x27|#(\d+)|#x([\da-f]+));/gi, (entity, decimal: string | undefined, hex: string | undefined) => {
+    const named: Readonly<Record<string, string>> = {
+      "&amp;": "&",
+      "&lt;": "<",
+      "&gt;": ">",
+      "&quot;": '"',
+      "&apos;": "'",
+      "&#39;": "'",
+      "&#x27;": "'",
+    }
+    const replacement = named[entity.toLowerCase()]
+    if (replacement) return replacement
+    const codePoint = decimal ? Number.parseInt(decimal, 10) : Number.parseInt(hex ?? "", 16)
+    return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10_FFFF
+      ? String.fromCodePoint(codePoint)
+      : entity
+  })
+}
+
+function plainHtmlText(text: string): string {
+  return decodeHtmlEntities(text.replace(/<[^>]*>/g, " ")).replace(/\s+/g, " ").trim()
+}
+
+function htmlDocumentSummary(raw: string): string | null {
+  const head = raw.slice(0, HTML_SCAN_LIMIT)
+  const leading = head.trimStart()
+  const lower = leading.toLowerCase()
+  const tail = raw.slice(Math.max(0, raw.length - 2_048)).toLowerCase()
+  const doctypeIndex = lower.indexOf("<!doctype")
+  const htmlIndex = lower.indexOf("<html")
+  const hasDocumentStart = doctypeIndex >= 0 && doctypeIndex < 1_024
+    || htmlIndex >= 0 && htmlIndex < 1_024
+  const hasDocumentStructure = /<(?:head|body)\b/i.test(leading)
+    && /<\/(?:body|html)>/i.test(tail)
+  if (!hasDocumentStart && !hasDocumentStructure) return null
+
+  const titleMatch = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(head)
+  const title = titleMatch ? plainHtmlText(titleMatch[1] ?? "").slice(0, 160) : ""
+  const statusSource = `${title} ${plainHtmlText(head)}`
+  let status = ""
+  for (const [code, label] of Object.entries(HTTP_STATUS_LABELS)) {
+    if (new RegExp(`\\b${code}\\b`, "i").test(statusSource)) {
+      status = `${code} ${label}`
+      break
+    }
+  }
+
+  const detail = status
+    ? ` (${status})`
+    : title
+      ? ` (“${title}”)`
+      : ""
+  return `Upstream returned an HTML error page${detail} — ${formatHumanSize(raw.length)} hidden`
+}
+
+function jsonRecordRange(raw: string): { start: number; end: number } | null {
+  const scanEnd = Math.min(raw.length, HTML_SCAN_LIMIT)
+  const start = raw.indexOf("{", 0)
+  if (start < 0 || start >= scanEnd) return null
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = start; index < scanEnd; index += 1) {
+    const character = raw[index]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (character === "\\") escaped = true
+      else if (character === '"') inString = false
+      continue
+    }
+    if (character === '"') {
+      inString = true
+      continue
+    }
+    if (character === "{") depth += 1
+    if (character !== "}") continue
+    depth -= 1
+    if (depth !== 0) continue
+
+    const end = index + 1
+    try {
+      const parsed: unknown = JSON.parse(raw.slice(start, end))
+      return isRecord(parsed) ? { start, end } : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+function clampWithMarker(raw: string, cap: number, originalLength: number): string {
+  const marker = truncationMarker(originalLength)
+  const contentCap = cap - marker.length
+  const jsonRange = jsonRecordRange(raw)
+  if (jsonRange) {
+    const jsonLength = jsonRange.end - jsonRange.start
+    if (jsonLength <= contentCap) {
+      const prefixCap = contentCap - jsonLength
+      return `${raw.slice(0, Math.min(jsonRange.start, prefixCap))}${raw.slice(jsonRange.start, jsonRange.end)}${marker}`
+    }
+  }
+  return `${raw.slice(0, contentCap).trimEnd()}${marker}`
+}
+
+export function normalizeErrorText(raw: string, options?: NormalizeErrorTextOptions): NormalizedErrorText {
+  const requestedCap = options?.cap ?? DEFAULT_ERROR_TEXT_CAP
+  const cap = Number.isFinite(requestedCap)
+    ? Math.max(MIN_ERROR_TEXT_CAP, Math.floor(requestedCap))
+    : DEFAULT_ERROR_TEXT_CAP
+  const originalLength = raw.length
+  const htmlSummary = htmlDocumentSummary(raw)
+
+  if (htmlSummary) {
+    return {
+      display: clampWithMarker(htmlSummary, cap, originalLength),
+      truncated: true,
+      originalLength,
+    }
+  }
+  if (originalLength <= cap) {
+    return { display: raw, truncated: false, originalLength }
+  }
+  return {
+    display: clampWithMarker(raw, cap, originalLength),
+    truncated: true,
+    originalLength,
+  }
+}

--- a/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
@@ -2,6 +2,7 @@ import type { DynamicToolUIPart, TextUIPart } from "ai";
 import type { ToolPart } from "@opencode-ai/sdk/v2/client";
 
 import { safeStringify } from "@/app/utils";
+import { normalizeErrorText } from "@/lib/error-text";
 
 export const STRUCTURED_OUTPUT_TOOL = "StructuredOutput";
 
@@ -44,7 +45,7 @@ export function parseDynamicToolUIPart(part: ToolPart): DynamicToolUIPart | null
       toolCallId: part.callID,
       state: "output-error",
       input: part.state.input,
-      errorText: part.state.error,
+      errorText: normalizeErrorText(part.state.error).display,
       callProviderMetadata: { opencode: { partId: part.id } },
     };
   }

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -5,6 +5,7 @@ import type { FilePart, Part, ToolPart } from "@opencode-ai/sdk/v2/client";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
 import { safeStringify } from "../../../../app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
+import { normalizeErrorText } from "../../../../lib/error-text";
 import {
   parseDynamicToolUIPart,
   parseStructuredOutputUIPart,
@@ -67,10 +68,14 @@ function withSessionErrorHints(text: string) {
   return withOpenAiTokenRefreshHint(withAttachmentRecoveryHint(text));
 }
 
+function normalizeSessionError(text: string) {
+  return normalizeErrorText(withSessionErrorHints(text), { cap: 500 }).display;
+}
+
 export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  if (error instanceof Error) return withSessionErrorHints(error.message || fallback);
-  if (typeof error === "string") return withSessionErrorHints(error.trim() || fallback);
-  if (!error || typeof error !== "object") return fallback;
+  if (error instanceof Error) return normalizeSessionError(error.message || fallback);
+  if (typeof error === "string") return normalizeSessionError(error.trim() || fallback);
+  if (!error || typeof error !== "object") return normalizeSessionError(fallback);
 
   const data = recordValue(error, "data");
   const cause = recordValue(error, "cause");
@@ -89,11 +94,13 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);
   if (code) lines.push(`Code: ${code}`);
   if (retries !== null) lines.push(`Retries: ${retries}`);
-  if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
-  if (lines.some((line) => line !== fallback)) return withSessionErrorHints(lines.join("\n"));
+  if (responseBody && responseBody !== message) {
+    lines.push(`Response: ${normalizeErrorText(responseBody, { cap: 500 }).display}`);
+  }
+  if (lines.some((line) => line !== fallback)) return normalizeSessionError(lines.join("\n"));
 
   const serialized = safeStringify(error);
-  return serialized && serialized !== "{}" ? serialized : fallback;
+  return normalizeSessionError(serialized && serialized !== "{}" ? serialized : fallback);
 }
 
 function sessionErrorMessageId(turnKey: string) {

--- a/apps/app/tests/error-text.test.ts
+++ b/apps/app/tests/error-text.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+
+import { normalizeErrorText } from "../src/lib/error-text"
+
+describe("normalizeErrorText", () => {
+  test("summarizes and clamps a one-megabyte HTML error page", () => {
+    const raw = `  <!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`
+    const normalized = normalizeErrorText(raw)
+
+    expect(normalized.originalLength).toBe(raw.length)
+    expect(normalized.truncated).toBe(true)
+    expect(normalized.display).toContain("Upstream returned an HTML error page (502 Bad Gateway)")
+    expect(normalized.display).toContain("1.0 MB hidden")
+    expect(normalized.display).toContain(`[Error text truncated; original size: ${raw.length.toLocaleString("en-US")} characters]`)
+    expect(normalized.display.length).toBeLessThanOrEqual(4_096)
+    expect(normalized.display.toLowerCase()).not.toContain("<!doctype")
+  })
+
+  test("uses the HTML title when no HTTP status phrase is present", () => {
+    const normalized = normalizeErrorText("MCP error -32000: <html><head><title>Proxy temporarily unavailable</title></head><body>retry later</body></html>")
+
+    expect(normalized.display).toContain("Upstream returned an HTML error page (“Proxy temporarily unavailable”)")
+    expect(normalized.display).toContain("[Error text truncated; original size:")
+  })
+
+  test("preserves an embedded JSON diagnostic object intact while clamping", () => {
+    const diagnostic = JSON.stringify({
+      error: "connection_failed",
+      diagnostic: { code: "MCP_HTTP_504", httpStatus: 504 },
+    })
+    const raw = `MCP error: ${diagnostic}\n${"provider detail ".repeat(1_000)}`
+    const normalized = normalizeErrorText(raw, { cap: 512 })
+
+    expect(normalized.display).toContain(diagnostic)
+    expect(normalized.display).toContain("[Error text truncated; original size:")
+    expect(normalized.display.length).toBeLessThanOrEqual(512)
+  })
+
+  test("leaves a small plain error unchanged", () => {
+    expect(normalizeErrorText("The tool failed.")).toEqual({
+      display: "The tool failed.",
+      truncated: false,
+      originalLength: 16,
+    })
+  })
+
+  test("leaves JSON-only errors unchanged when they are under the cap", () => {
+    const raw = JSON.stringify({ diagnostic: { category: "provider_policy", providerStatus: 403 } })
+    expect(normalizeErrorText(raw)).toEqual({ display: raw, truncated: false, originalLength: raw.length })
+  })
+})

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -23,6 +23,7 @@ function writeToolPart(
   status: "pending" | "running" | "completed" | "error",
   input: Record<string, unknown>,
   overrides: Partial<Extract<Part, { type: "tool" }>> = {},
+  error = "failed",
 ): Extract<Part, { type: "tool" }> {
   const base = {
     id: "part-write",
@@ -55,7 +56,7 @@ function writeToolPart(
       state: {
         status: "error",
         input,
-        error: "failed",
+        error,
         time: { start: 1, end: 2 },
       },
     };
@@ -110,6 +111,17 @@ describe("tool part mapper", () => {
       input: { content: "hello", filePath: "src/a.ts" },
       output: "ok",
     });
+  });
+
+  test("summarizes and clamps huge HTML tool errors at ingestion", () => {
+    const htmlError = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`;
+    const parsed = parseDynamicToolUIPart(writeToolPart("error", {}, {}, htmlError));
+
+    expect(parsed?.state).toBe("output-error");
+    if (!parsed || parsed.state !== "output-error") throw new Error("Expected a parsed tool error");
+    expect(parsed.errorText).toContain("Upstream returned an HTML error page (502 Bad Gateway)");
+    expect(parsed.errorText.length).toBeLessThanOrEqual(4_096);
+    expect(parsed.errorText.toLowerCase()).not.toContain("<!doctype");
   });
 
   test("maps env var request tools for rich chat rendering", () => {

--- a/apps/app/tests/tool-error-attribution.test.ts
+++ b/apps/app/tests/tool-error-attribution.test.ts
@@ -4,6 +4,7 @@ import {
   attributeChatToolError,
   reconnectActionFromChatToolResult,
 } from "../src/components/tools/error-attribution"
+import { normalizeErrorText } from "../src/lib/error-text"
 
 function reconnectStatus(connectionId = "emc_knowledge", connectionName = "Knowledge Hub") {
   return {
@@ -95,6 +96,26 @@ describe("chat tool error attribution", () => {
 
   test("does not add attribution without useful evidence", () => {
     expect(attributeChatToolError("The tool failed.")).toBeNull()
+  })
+
+  test("bails out quickly on a pathological HTML page", () => {
+    const htmlError = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`
+    const started = performance.now()
+
+    expect(attributeChatToolError(htmlError)).toBeNull()
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+
+  test("keeps JSON-head attribution after surrounding error text is clamped", () => {
+    const diagnostic = JSON.stringify({
+      error: "connection_failed",
+      diagnostic: { code: "MCP_HTTP_504", httpStatus: 504 },
+    })
+    const unclamped = `MCP error: ${diagnostic} (tool execution failed)`
+    const clamped = normalizeErrorText(`${unclamped}\n${"provider detail ".repeat(1_000)}`, { cap: 512 }).display
+
+    expect(clamped).toContain(diagnostic)
+    expect(attributeChatToolError(clamped)).toEqual(attributeChatToolError(unclamped))
   })
 
   test("extracts a trusted reconnect action from a Cloud capability failure", () => {

--- a/evals/specs/clamp-html-errors.slow.test.ts
+++ b/evals/specs/clamp-html-errors.slow.test.ts
@@ -1,0 +1,539 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "clamp-html-errors-mock";
+const modelId = "clamp-html-errors-model";
+const mcpToolName = "explode_html";
+const closingReply = "The session recovered after the failed upstream call.";
+const htmlSummary = "Upstream returned an HTML error page (502 Bad Gateway)";
+const htmlError = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1>${"Z".repeat(1_024 * 1_024)}</body></html>`;
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "large HTML tool errors are summarized once without breaking the session"
+  : "large HTML tool errors skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+async function withTimeout<T>(task: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function rpcResponse(message: Record<string, unknown>): Record<string, unknown> {
+  const method = typeof message.method === "string" ? message.method : "";
+  if (method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "html-error-mcp", version: "1.0.0" },
+      },
+    };
+  }
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [{
+          name: mcpToolName,
+          title: "HTML upstream failure",
+          description: "Returns a deterministic upstream HTML error page.",
+          inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        }],
+      },
+    };
+  }
+  if (method === "tools/call") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { code: -32_000, message: htmlError },
+    };
+  }
+  return { jsonrpc: "2.0", id: message.id, result: {} };
+}
+
+function rpcDelayMs(message: Record<string, unknown>): number {
+  // Let the tool execution span a few seconds like a real upstream call, so
+  // its error part lands while the renderer's event stream is connected
+  // instead of inside the post-reload gap.
+  return message.method === "tools/call" ? 4_000 : 0;
+}
+
+function providerToolName(payload: Record<string, unknown>): string | null {
+  const tools = payload.tools;
+  if (!Array.isArray(tools)) return null;
+  for (const tool of tools) {
+    const fn = recordValue(tool, "function");
+    const name = recordValue(fn, "name");
+    if (typeof name === "string" && name.endsWith(mcpToolName)) return name;
+  }
+  return null;
+}
+
+function hasToolResult(payload: Record<string, unknown>): boolean {
+  const messages = payload.messages;
+  return Array.isArray(messages)
+    && messages.some((message) => recordValue(message, "role") === "tool");
+}
+
+function streamChunk(delta: Record<string, unknown>, finishReason: string | null = null): Record<string, unknown> {
+  return {
+    id: "chatcmpl-clamp-html-errors",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: modelId,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+function sendStream(response: ServerResponse, chunks: Record<string, unknown>[]): void {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  // Pace the stream like a real model. An instantly-finished turn can complete
+  // before the renderer's engine event stream (re)connects, leaving the UI
+  // permanently stale on this turn.
+  let delay = 400;
+  for (const chunk of chunks) {
+    setTimeout(() => response.write(`data: ${JSON.stringify(chunk)}\n\n`), delay);
+    delay += 400;
+  }
+  setTimeout(() => response.end("data: [DONE]\n\n"), delay);
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  let toolsListed = 0;
+  let toolCalls = 0;
+  let closingRounds = 0;
+  const mock = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        sendJson(response, 200, { object: "list", data: [{ id: modelId, object: "model" }] });
+        return;
+      }
+      if (url.pathname === "/mcp") {
+        if (request.method === "GET") {
+          sendJson(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        const raw = await readBody(request);
+        const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+        const messages = Array.isArray(parsed) ? parsed : [parsed];
+        const replies: Record<string, unknown>[] = [];
+        let delayMs = 0;
+        for (const candidate of messages) {
+          if (!isRecord(candidate)) continue;
+          if (candidate.method === "tools/list") toolsListed += 1;
+          if (candidate.method === "tools/call") toolCalls += 1;
+          delayMs = Math.max(delayMs, rpcDelayMs(candidate));
+          if (candidate.id !== undefined) replies.push(rpcResponse(candidate));
+        }
+        if (replies.length === 0) {
+          response.writeHead(202, { "access-control-allow-origin": "*" });
+          response.end();
+          return;
+        }
+        if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+        sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
+        return;
+      }
+      if (request.method === "POST" && (url.pathname === "/v1/chat/completions" || url.pathname === "/chat/completions")) {
+        const raw = await readBody(request);
+        const parsed: unknown = JSON.parse(raw);
+        if (!isRecord(parsed)) throw new Error("Mock provider received a non-object request.");
+        // The engine's session-title agent hits the same provider; keep it away
+        // from the tool-call script so counters stay deterministic. Utility
+        // requests carry no tools array; real agent turns always do.
+        const requestTools = parsed.tools;
+        if (!Array.isArray(requestTools) || requestTools.length === 0) {
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: "Session title" }),
+            streamChunk({}, "stop"),
+          ]);
+          return;
+        }
+        if (hasToolResult(parsed)) {
+          closingRounds += 1;
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: closingReply }),
+            streamChunk({}, "stop"),
+          ]);
+          return;
+        }
+        const toolName = providerToolName(parsed);
+        if (!toolName) {
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: "The deterministic MCP error tool was unavailable." }),
+            streamChunk({}, "stop"),
+          ]);
+          return;
+        }
+        sendStream(response, [
+          streamChunk({ role: "assistant" }),
+          streamChunk({
+            tool_calls: [{
+              index: 0,
+              id: "call_html_error",
+              type: "function",
+              function: { name: toolName, arguments: "{}" },
+            }],
+          }),
+          streamChunk({}, "tool_calls"),
+        ]);
+        return;
+      }
+      sendJson(response, 404, { error: { message: "not found" } });
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+  await withTimeout(new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  }), 10_000, "HTML error mock to listen");
+  onTestFinished(async () => {
+    await withTimeout(
+      new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve())),
+      10_000,
+      "HTML error mock to close",
+    );
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("HTML error mock did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  await using app = await desktop({
+    name: "clamp-html-errors",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+    // Provider keys in the runner env (e.g. via infisical) would make the
+    // engine register real providers and out-default the deterministic mock.
+    env: {
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      OPENWORK_API_KEY: "",
+      OPENWORK_INFERENCE_BASE_URL: "",
+    },
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-clamp-html-errors-${Date.now()}`,
+  });
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Clamp HTML errors mock",
+              options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-clamp-html-errors" },
+              models: {
+                [${JSON.stringify(modelId)}]: { name: "Clamp HTML errors model", tool_call: true },
+              },
+            },
+          },
+          mcp: {
+            "html-error": { type: "remote", url: ${JSON.stringify(`${baseUrl}/mcp`)}, enabled: true, oauth: false },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    // A slow dispose reports 504 opencode_reload_timeout while the reload
+    // keeps going; readiness is owned by the polling below.
+    if (reloaded !== "ok" && !reloaded.includes("opencode_reload_timeout")) return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  expect(configured).toBe("ok");
+  await expect.poll(() => toolsListed, { timeout: 30_000, interval: 100 }).toBeGreaterThan(0);
+
+  // Preferences hydrate at boot, so reload unconditionally: without this the
+  // engine's built-in free model stays the default and out-competes the mock.
+  await evalIn(app, "location.reload(); true");
+  await waitFor(app, "Boolean(window.__openworkControl)", {
+    timeoutMs: 30_000,
+    label: "app reloaded with the HTML error mock preferences",
+  });
+  // The engine restarts after /engine/reload; sending into that window races
+  // the swap and strands the run behind an "OpenCode unavailable" banner.
+  const engineReady = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const deadline = Date.now() + 60_000;
+    let last = "";
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/opencode/session", {
+          headers: { Authorization: "Bearer " + token },
+        });
+        if (response.ok) return "ready";
+        last = "HTTP " + response.status;
+      } catch (error) {
+        last = String(error);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    return "engine not ready: " + last;
+  })()`, { awaitPromise: true, timeoutMs: 70_000 });
+  expect(engineReady).toBe("ready");
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "new task action enabled",
+  });
+  await control(app, "session.create_task");
+  await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+    timeoutMs: 30_000,
+    label: "composer editor ready",
+  });
+  const prompt = "Call the HTML upstream failure tool once, then explain that the session recovered.";
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text: prompt });
+  await waitFor(app, `document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText === ${JSON.stringify(prompt)}`, {
+    timeoutMs: 10_000,
+    label: "task entered in composer",
+  });
+  // A click can land while the composer is still wiring up; retry until the
+  // send actually navigates into a session.
+  let sent = false;
+  for (let attempt = 0; attempt < 3 && !sent; attempt += 1) {
+    await clickButton(app, "Run task", { timeoutMs: 30_000 });
+    try {
+      await waitFor(app, `window.location.hash.includes("/session/ses_")`, {
+        timeoutMs: 10_000,
+        label: "task session created",
+      });
+      sent = true;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+
+  await waitFor(app, `(() => {
+    const transcript = [...document.querySelectorAll('[data-message-role]')]
+      .map((message) => message.textContent ?? "").join(" | ");
+    return transcript.includes(${JSON.stringify(closingReply)});
+  })()`, { timeoutMs: 120_000, label: "closing assistant reply" });
+  await waitFor(app, `(() => {
+    const failure = [...document.querySelectorAll('[data-capability-call]')]
+      .find((row) => (row.textContent ?? "").includes("failed"));
+    return Boolean(failure);
+  })()`, { timeoutMs: 60_000, label: "failed tool row rendered" });
+  expect(toolCalls).toBe(1);
+  expect(closingRounds).toBe(1);
+
+  const expandedFailure = await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    const trigger = row ? [...row.querySelectorAll("button")]
+      .find((button) => (button.getAttribute("aria-label") ?? "").includes("Show what to do next")) : null;
+    if (!(trigger instanceof HTMLElement)) return false;
+    trigger.click();
+    return true;
+  })()`);
+  expect(expandedFailure).toBe(true);
+  await waitFor(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    return (row?.innerText ?? "").includes(${JSON.stringify(htmlSummary)});
+  })()`, { timeoutMs: 10_000, label: "human HTML error summary visible" });
+
+  const transcriptClaim = await evalIn(app, `(() => {
+    const rows = [...document.querySelectorAll('[data-capability-call]')];
+    const failureVisible = rows.some((row) => (row.innerText ?? "").includes("failed"));
+    const transcript = [...document.querySelectorAll('[data-message-role]')]
+      .map((message) => message.innerText ?? "").join(" | ");
+    const lower = transcript.toLowerCase();
+    return failureVisible && transcript.includes(${JSON.stringify(htmlSummary)})
+      && !lower.includes("<!doctype") && !lower.includes("<html");
+  })()`);
+  expect(transcriptClaim).toBe(true);
+  evidence.fact(
+    "The failed tool row shows a human HTML-error summary instead of raw markup",
+    "The rendered transcript contained the 502 HTML-page summary and contained neither <!DOCTYPE nor <html.",
+    transcriptClaim === true,
+  );
+
+  const expandedTechnicalDetails = await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    const toggle = row ? [...row.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").trim().startsWith("Technical details")) : null;
+    if (!(toggle instanceof HTMLElement)) return false;
+    toggle.click();
+    return true;
+  })()`);
+  expect(expandedTechnicalDetails).toBe(true);
+  await waitFor(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    return [...(row?.querySelectorAll("pre") ?? [])]
+      .some((preview) => (preview.textContent ?? "").includes("[Error text truncated; original size:"));
+  })()`, { timeoutMs: 10_000, label: "bounded technical error preview visible" });
+
+  const detailsClaim = await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    const preview = [...(row?.querySelectorAll("pre") ?? [])]
+      .map((node) => node.textContent ?? "")
+      .find((text) => text.includes("[Error text truncated; original size:")) ?? "";
+    return preview.length > 0 && preview.length < 6000
+      && /\\[Error text truncated; original size: [\\d,]+ characters\\]/.test(preview)
+      && !preview.toLowerCase().includes("<!doctype")
+      && !preview.toLowerCase().includes("<html")
+      && !preview.includes("Z".repeat(1024));
+  })()`);
+  expect(detailsClaim).toBe(true);
+  evidence.fact(
+    "Expanded technical details keep the error preview bounded and name the hidden original size",
+    "The error preview was under 6,000 characters, included the original-size truncation marker, and omitted raw HTML and the megabyte filler.",
+    detailsClaim === true,
+  );
+
+  const usableClaim = await evalIn(app, `(() => {
+    const transcript = [...document.querySelectorAll('[data-message-role]')]
+      .map((message) => message.innerText ?? "").join(" | ");
+    const page = document.body.innerText.toLowerCase();
+    return transcript.includes(${JSON.stringify(closingReply)})
+      && !page.includes("tool step unavailable")
+      && !page.includes("failed to render");
+  })()`);
+  expect(usableClaim).toBe(true);
+  evidence.fact(
+    "The session remains usable after the oversized tool failure",
+    "The second-round closing assistant reply rendered and no tool error-boundary fallback or failed-to-render message appeared.",
+    usableClaim === true,
+  );
+
+  // Streaming rerenders can re-collapse the row after the DOM assertions, so
+  // put the expanded failure state back on screen before the visual take.
+  const reExpanded = await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    if (!(row instanceof HTMLElement)) return "missing row";
+    const failureToggle = [...row.querySelectorAll("button")]
+      .find((button) => (button.getAttribute("aria-label") ?? "").includes("failure details")
+        || (button.getAttribute("aria-label") ?? "").includes("Show what to do next"));
+    if (failureToggle instanceof HTMLElement && failureToggle.getAttribute("aria-expanded") !== "true") failureToggle.click();
+    return "ok";
+  })()`);
+  expect(reExpanded).toBe("ok");
+  await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    const details = row ? [...row.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").trim().startsWith("Technical details")) : null;
+    if (details instanceof HTMLElement && details.getAttribute("aria-expanded") !== "true") details.click();
+    row?.scrollIntoView({ block: "center" });
+    return true;
+  })()`);
+  await waitFor(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    return [...(row?.querySelectorAll("pre") ?? [])]
+      .some((preview) => (preview.textContent ?? "").includes("[Error text truncated; original size:"));
+  })()`, { timeoutMs: 10_000, label: "expanded failure state back on screen for the visual take" });
+  await evalIn(app, `(() => {
+    const row = [...document.querySelectorAll('[data-capability-call]')]
+      .find((candidate) => (candidate.textContent ?? "").includes("failed"));
+    const marker = [...(row?.querySelectorAll("pre") ?? [])]
+      .find((preview) => (preview.textContent ?? "").includes("[Error text truncated; original size:"));
+    marker?.scrollIntoView({ block: "center" });
+    return true;
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 750));
+  const shot = await screenshot(app);
+  const seen = await validate(shot, [
+    "A failed tool-call row is expanded with a human-readable 502 HTML error-page summary",
+    "Technical details are expanded and show a truncation marker rather than a full raw HTML page",
+    `The assistant closing message says: ${closingReply}`,
+    "No crash, failed-to-render fallback, or wall of raw HTML markup is visible",
+  ]);
+  expect(seen.ok, seen.why).toBe(true);
+});


### PR DESCRIPTION
## What

Tool-call errors and session-level errors rendered upstream bodies verbatim. A proxy/provider failing with a full HTML error page (sometimes megabytes) flooded the transcript with raw markup, and the client re-parsed the full blob on every render (error attribution, reconnect detection, JSON extraction).

## How

- **One shared normalizer** (`apps/app/src/lib/error-text.ts`): detects HTML documents and collapses them to a human summary (`Upstream returned an HTML error page (502 Bad Gateway) — 1.0 MB hidden`), caps everything at 4 KB with a truncation marker naming the original size, and preserves an embedded JSON diagnostic head intact so `attributeChatToolError` and openwork-cloud inline-reconnect detection behave identically on clamped text (unit-asserted equality).
- **Applied once at ingestion** (`parse-tool-parts.ts`) — both snapshot and live SSE transports funnel through it, so every render site downstream is bounded.
- **Session errors too** (`describeOpencodeSessionError`): `responseBody` and the final message clamp at 500 chars — covers the chat error message, the banner, and OS notifications.
- Hardening: early size-bail in error-attribution, capability failure line rejects `<`-leading raw markup, generic tool error `<pre>` gains `max-h-60`.
- Deliberate trade-off: the original blob is discarded at ingestion; copy actions yield the clamped text + size marker.

## Proof

- `evals/specs/clamp-html-errors.slow.test.ts` (stack lane) drives a real engine + local MCP mock whose tool fails with a **1 MB HTML 502 page**, via a scripted OpenAI-compatible provider that requests the tool call: (1) the transcript shows the human summary and contains no `<!DOCTYPE`/`<html` anywhere; (2) expanded technical details stay under 6 000 chars with the `[Error text truncated; original size: …]` marker and no megabyte filler; (3) the session stays usable — the follow-up assistant reply renders with no error-boundary fallback.
- Unit: `error-text.test.ts` (HTML summary, clamp, JSON-head preservation), `session-sync-tool-parts.test.ts` (1 MB ingestion fixture), `tool-error-attribution.test.ts` (pathological-input bail + clamped/unclamped attribution equality), `scripts/session-render-state.test.ts` (HTML responseBody bounded).
- Commands: `pnpm --filter @openwork/app typecheck` ✓ · targeted bun tests 31/31 + 28/28 ✓ · `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/clamp-html-errors.slow.test.ts` ✓ (local lane; Daytona not used for this run). Full `@openwork/app` bun suite shows 3 pre-existing `window.matchMedia` failures that reproduce identically on pristine `origin/dev`.

Testkit tape publishes to this PR after the head-SHA rerun.