### PR TITLE
fix(server): keep non-managed MCP delete and toggle off the credential vault

### DIFF
--- a/apps/server/src/local-managed-mcp-vault.test.ts
+++ b/apps/server/src/local-managed-mcp-vault.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { deleteLocalManagedMcp, setLocalManagedMcpEnabled } from "./local-managed-mcp.js";
+import type { ServerConfig } from "./types.js";
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: "ws_test", name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+describe("local managed MCP vault", () => {
+  test("returns false for non-managed connections when secure storage is unavailable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-local-managed-mcp-vault-"));
+    const previousEncryptionKey = process.env.OPENWORK_ENCRYPTION_KEY;
+    delete process.env.OPENWORK_ENCRYPTION_KEY;
+
+    try {
+      const config = serverConfig(root);
+      await expect(deleteLocalManagedMcp(config, "ws_test", "ordinary-mcp")).resolves.toBe(false);
+      await expect(setLocalManagedMcpEnabled(config, "ws_test", "ordinary-mcp", false)).resolves.toBe(false);
+    } finally {
+      if (previousEncryptionKey === undefined) delete process.env.OPENWORK_ENCRYPTION_KEY;
+      else process.env.OPENWORK_ENCRYPTION_KEY = previousEncryptionKey;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -724,6 +724,8 @@ export async function setLocalManagedMcpEnabled(
   name: string,
   enabled: boolean,
 ): Promise<boolean> {
+  const exists = await withVaultRead(config, (vault) => Boolean(vault.connections[connectionKey(workspaceId, name)]));
+  if (!exists) return false;
   const updated = await withVaultMutation(config, (vault) => {
     const connection = vault.connections[connectionKey(workspaceId, name)];
     if (!connection) return false;
@@ -752,6 +754,8 @@ export async function disconnectLocalManagedMcp(config: ServerConfig, workspaceI
 }
 
 export async function deleteLocalManagedMcp(config: ServerConfig, workspaceId: string, name: string): Promise<boolean> {
+  const exists = await withVaultRead(config, (vault) => Boolean(vault.connections[connectionKey(workspaceId, name)]));
+  if (!exists) return false;
   const removed = await withVaultMutation(config, (vault) => {
     const key = connectionKey(workspaceId, name);
     if (!vault.connections[key]) return false;


### PR DESCRIPTION
## Symptom

On any server without secure storage — the documented standalone case (no `OPENWORK_ENCRYPTION_KEY`, no desktop-provided vault key) — deleting or toggling **any** MCP fails:

```
503 managed_mcp_secure_storage_unavailable
"Secure storage for OpenWork-managed MCP credentials is unavailable. Start through OpenWork Desktop or set OPENWORK_ENCRYPTION_KEY."
```

This hits ordinary **non-managed** MCPs that have nothing to do with the OAuth gateway. It is also what turned `dev` red: `openwork-tests` fails at `175508512` while its parent `2db84f348` passed.

## Root cause

#3652 made two routes consult the managed-credential path first and unconditionally:

- `DELETE /workspace/:id/mcp/:name` → `deleteLocalManagedMcp(...)` before falling back to `removeMcp(...)`
- `POST /workspace/:id/mcp/:name/enabled` → `setLocalManagedMcpEnabled(...)` before falling back to `setMcpEnabled(...)`

In `local-managed-mcp.ts`, `withVaultMutation` does `readVault` → `mutate` → **`writeVault` unconditionally**, even when the mutator changed nothing and returned `false`. `writeVault` needs the key, so `resolveVaultKey` throws 503.

`readVault` is already keyless-safe (missing vault file → `ENOENT` → `emptyVault()`), so for a non-managed MCP the read succeeded, the mutator returned `false`, and then the pointless write threw.

`disconnectLocalManagedMcp` already had the correct guard — a keyless `withVaultRead` existence check with an early `false` return. The other two lacked it.

## Fix

Give `deleteLocalManagedMcp` and `setLocalManagedMcpEnabled` the same guard as `disconnectLocalManagedMcp`: a keyless existence check, returning `false` early when the connection is not managed, so the route falls through to the ordinary path and never reaches `writeVault`. 4 lines.

**A genuinely managed connection still surfaces 503 when the key is unavailable** — by construction: if the connection exists in the vault then the vault file exists, so `readVault` gets past `ENOENT` and calls `vaultKey`, which throws. The guard cannot mask a real credential-inaccessible error.

## Validation

`apps/server`, with `OPENWORK_ENCRYPTION_KEY` confirmed unset (`echo "[$OPENWORK_ENCRYPTION_KEY]"` → `[]`):

| command | before | after |
|---|---|---|
| `bun test src/mcp.engine-sync.e2e.test.ts` | 18 pass, **2 fail** | **20 pass, 0 fail** |
| `bun test src/local-managed-mcp` | — | 9 pass, 0 fail (3 files, incl. new) |
| `bun test` (full suite) | 641 pass, 8 skip, **2 fail** (CI) | **644 pass, 8 skip** |
| `pnpm --filter openwork-server typecheck` | — | clean |

The two tests fixed:
- `runtime MCP engine sync > pushes toggled enabled state to the engine`
- `runtime MCP engine sync > disconnects a removed MCP from the engine`

Diagnosis was confirmed by isolating the single variable on unmodified `origin/dev`:

```
bun test src/mcp.engine-sync.e2e.test.ts                              ->  18 pass, 2 fail
OPENWORK_ENCRYPTION_KEY=... bun test src/mcp.engine-sync.e2e.test.ts  ->  20 pass, 0 fail
```

New regression test `src/local-managed-mcp-vault.test.ts` asserts both functions return `false` (instead of throwing 503) for a non-managed name with no key available, and it deliberately does not set `OPENWORK_ENCRYPTION_KEY`.

**Local-only artifact:** my machine's bun 1.3.8 has no `node:sqlite`, so `src/workspace-kv-store.node.test.ts` fails locally (`1 fail / 1 error`) regardless of this diff — CI's bun resolves it, and dev's CI run shows only the 2 engine-sync failures. Unrelated to this change.

## Relationship to #3659

Both fix fallout from #3652 and touch disjoint files (this one `apps/server`, #3659 `apps/desktop`). No conflict; independently mergeable. #3659's red `openwork-tests` is caused by exactly the bug this PR fixes.
