### PR TITLE
feat(release): release:rollback stop-the-bleed script + post-publish rollback runbook

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,7 +69,59 @@ tag/dev divergence; the release waits on review latency.
 - **A tagged version turned out to be defective before publish**: leave the
   release as a draft or delete it (`gh release delete vX.Y.Z`), fix forward,
   and cut the next patch. If the bad version reached npm, deprecate it:
-  `npm deprecate openwork-server@X.Y.Z "<reason — use X.Y.Z+1>"`.
+  `npm deprecate openwork-server@X.Y.Z "<reason — use X.Y.Z+1>"`. If the
+  release was published, follow
+  [Rolling back a published release](#rolling-back-a-published-release).
+
+## Rolling back a published release
+
+Use this flow when a bad version is **published** and marked Latest.
+
+### 1. Stop the bleed
+
+Dry-run first, then execute:
+
+```bash
+pnpm release:rollback
+pnpm release:rollback --execute
+```
+
+By default, the script selects the current Latest release as bad and the
+newest lower published stable release as last good. It re-points Latest,
+demotes the bad release to prerelease, and prepends a warning to its notes.
+Use `--bad vX.Y.Z --to vX.Y.Z` to override selection. This protects only
+clients that have not updated yet.
+
+### 2. Reissue for updated clients
+
+Updaters refuse downgrades. Cut the next patch **from the last-good tag**, not
+from `dev`, which still contains the bad code:
+
+```bash
+git worktree add <tmp> <to-tag>
+cd <tmp>
+pnpm release:prepare  # must bump to a version higher than the bad release
+pnpm release:ship
+```
+
+Use the tag-first path (admins only). Review and merge the backfill PR per the
+existing flow. The org install door pin (`ee/apps/den-api` generated
+`PUBLISHED_DESKTOP_VERSIONS`) moves only with this reissue.
+
+### 3. Deprecate npm
+
+```bash
+npm deprecate openwork-server@<bad-version> "rolled back — use <next>"
+```
+
+| Client state | Recovery |
+| --- | --- |
+| Not yet updated | Fixed by step 1 |
+| Already updated | Fixed only by step 2 |
+
+Revert the offending PR on `dev` through the normal reviewed-PR flow (or the
+revert fast lane, when available). That cleanup is not in the critical path
+of user recovery.
 
 ## What blocks publishing (and what doesn't)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -83,8 +83,11 @@ Dry-run first, then execute:
 
 ```bash
 pnpm release:rollback
-pnpm release:rollback --execute
+pnpm release:rollback --bad vX.Y.Z --execute
 ```
+
+Always pin `--bad` when executing: after a successful rollback the *good*
+release is Latest, so a bare re-run would select it as bad.
 
 By default, the script selects the current Latest release as bad and the
 newest lower published stable release as last good. It re-points Latest,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "release:review": "node scripts/release/review.mjs",
     "release:prepare": "node scripts/release/prepare.mjs",
     "release:prepare:dry": "node scripts/release/prepare.mjs --dry-run",
+    "release:rollback": "node scripts/release/rollback.mjs",
     "release:ship": "node scripts/release/ship.mjs",
     "release:ship:watch": "node scripts/release/ship.mjs --watch"
   },

--- a/scripts/release/rollback.mjs
+++ b/scripts/release/rollback.mjs
@@ -286,7 +286,7 @@ export function runRollback(args, dependencies = {}) {
   if (options.execute) {
     console.log("\n  ✓ Stop-the-bleed rollback complete. Reissue is still required for already-updated clients.");
   } else {
-    console.log("\nDRY RUN — no changes made. Re-run with --execute.");
+    console.log(`\nDRY RUN — no changes made. Re-run with --bad ${badTag} --execute.`);
   }
 
   return { bad, target, plan, execute: options.execute };

--- a/scripts/release/rollback.mjs
+++ b/scripts/release/rollback.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO = "different-ai/openwork";
+const MAX_BUFFER = 128 * 1024 * 1024;
+
+const log = (message) => console.log(`  ${message}`);
+const heading = (message) => console.log(`\n▸ ${message}`);
+
+export function parseArgs(args) {
+  const options = {
+    bad: null,
+    to: null,
+    execute: false,
+    keepBadListed: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+    if (arg === "--keep-bad-listed") {
+      options.keepBadListed = true;
+      continue;
+    }
+    if (["--bad", "--to"].includes(arg)) {
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
+      options[arg.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function parseSemver(tag) {
+  const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+export function compareSemver(leftTag, rightTag) {
+  const left = parseSemver(leftTag);
+  const right = parseSemver(rightTag);
+  if (!left) throw new Error(`Release tag '${leftTag}' is not valid semver (expected vX.Y.Z).`);
+  if (!right) throw new Error(`Release tag '${rightTag}' is not valid semver (expected vX.Y.Z).`);
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function releaseTag(release) {
+  return release.tag_name;
+}
+
+function findRelease(releases, tag) {
+  return releases.find((release) => releaseTag(release) === tag) ?? null;
+}
+
+function validateBadRelease(releases, badTag) {
+  const bad = findRelease(releases, badTag);
+  if (!bad) throw new Error(`Bad release not found: ${badTag}.`);
+  if (bad.draft) throw new Error(`Bad release ${badTag} is a draft, not a published release.`);
+  if (!parseSemver(badTag)) {
+    throw new Error(`Bad release tag '${badTag}' is not valid semver (expected vX.Y.Z).`);
+  }
+  return bad;
+}
+
+export function selectRollbackTarget(releases, badTag) {
+  validateBadRelease(releases, badTag);
+  const candidates = releases.filter((release) => {
+    const tag = releaseTag(release);
+    return !release.draft
+      && !release.prerelease
+      && parseSemver(tag)
+      && compareSemver(tag, badTag) < 0;
+  });
+  candidates.sort((left, right) => compareSemver(releaseTag(right), releaseTag(left)));
+
+  if (!candidates[0]) {
+    throw new Error(`No published, non-prerelease release exists below ${badTag}.`);
+  }
+  return candidates[0];
+}
+
+export function resolveRollback(releases, badTag, requestedTargetTag = null) {
+  const bad = validateBadRelease(releases, badTag);
+  const targetTag = requestedTargetTag ?? releaseTag(selectRollbackTarget(releases, badTag));
+  const target = findRelease(releases, targetTag);
+
+  if (!target) throw new Error(`Target release not found: ${targetTag}.`);
+  if (badTag === targetTag) throw new Error(`Bad and target releases must differ (${badTag}).`);
+  if (target.draft) throw new Error(`Target release ${targetTag} is a draft, not a published release.`);
+  if (target.prerelease) throw new Error(`Target release ${targetTag} is a prerelease, not a stable published release.`);
+  if (!parseSemver(targetTag)) {
+    throw new Error(`Target release tag '${targetTag}' is not valid semver (expected vX.Y.Z).`);
+  }
+  if (compareSemver(targetTag, badTag) >= 0) {
+    throw new Error(`Target release ${targetTag} must be lower than bad release ${badTag}.`);
+  }
+
+  return { bad, target };
+}
+
+export function hasUpdaterManifest(release) {
+  return (release.assets ?? []).some(({ name }) => (
+    /^latest.*\.yml$/i.test(name) || name.toLowerCase() === "latest.json"
+  ));
+}
+
+export function rollbackBanner(targetTag, now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return `> ⚠️ Rolled back on ${date}. Do not install; use ${targetTag} instead.`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function hasRollbackBanner(body, targetTag) {
+  const target = escapeRegExp(targetTag);
+  return new RegExp(
+    `^> ⚠️ Rolled back on \\d{4}-\\d{2}-\\d{2}\\. Do not install; use ${target} instead\\.$`,
+    "m",
+  ).test(body ?? "");
+}
+
+export function buildRollbackBody(body, targetTag, now = new Date()) {
+  const existingBody = body ?? "";
+  if (hasRollbackBanner(existingBody, targetTag)) return existingBody;
+  const banner = rollbackBanner(targetTag, now);
+  return existingBody ? `${banner}\n\n${existingBody}` : banner;
+}
+
+export function buildRollbackPlan({
+  bad,
+  target,
+  latestTag,
+  keepBadListed = false,
+  now = new Date(),
+}) {
+  const badTag = releaseTag(bad);
+  const targetTag = releaseTag(target);
+  const nextBody = buildRollbackBody(bad.body, targetTag, now);
+
+  return [
+    {
+      name: `Re-point Latest from ${latestTag} to ${targetTag}`,
+      skip: latestTag === targetTag,
+      skipReason: `${targetTag} is already Latest`,
+      args: ["release", "edit", targetTag, "--repo", REPO, "--latest"],
+    },
+    {
+      name: `Demote ${badTag} to prerelease (assets and tag stay intact)`,
+      skip: keepBadListed || bad.prerelease,
+      skipReason: keepBadListed
+        ? "--keep-bad-listed was supplied"
+        : `${badTag} is already a prerelease`,
+      args: ["release", "edit", badTag, "--repo", REPO, "--prerelease"],
+    },
+    {
+      name: `Prepend the rollback banner to ${badTag} release notes`,
+      skip: nextBody === (bad.body ?? ""),
+      skipReason: "rollback banner is already present",
+      args: [
+        "api",
+        "--method",
+        "PATCH",
+        `repos/${REPO}/releases/${bad.id}`,
+        "-f",
+        `body=${nextBody}`,
+      ],
+    },
+  ];
+}
+
+function parseReleasePages(output) {
+  const parsed = JSON.parse(output);
+  if (!Array.isArray(parsed)) throw new Error("Expected a JSON array from gh api.");
+  if (parsed.every(Array.isArray)) return parsed.flat();
+  if (parsed.every((release) => !Array.isArray(release))) return parsed;
+  throw new Error("Expected gh api pagination output to contain release arrays.");
+}
+
+function defaultGh(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER,
+  }).trim();
+}
+
+function loadReleases(gh) {
+  return parseReleasePages(gh([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${REPO}/releases?per_page=100`,
+  ]));
+}
+
+function loadLatestRelease(gh) {
+  return JSON.parse(gh(["api", `repos/${REPO}/releases/latest`]));
+}
+
+function nextPatch(tag) {
+  const [major, minor, patch] = parseSemver(tag);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+function printGuidance(badTag, targetTag) {
+  const badVersion = badTag.slice(1);
+  const nextVersion = nextPatch(badTag);
+
+  heading("Next steps — reissue from last-good code (not automated)");
+  log("Updaters never downgrade. Reissue the last-good code at a version higher than the bad release:");
+  console.log("");
+  console.log(`    git worktree add <tmp> ${targetTag}`);
+  console.log("    cd <tmp>");
+  console.log(`    pnpm release:prepare   # bump to v${nextVersion} or higher`);
+  console.log("    pnpm release:ship");
+  console.log("");
+  log(`After npm publish: npm deprecate openwork-server@${badVersion} "rolled back — use ${nextVersion}"`);
+  log("The org install door pin (ee/apps/den-api generated PUBLISHED_DESKTOP_VERSIONS) moves only with the reissue.");
+  log("Review and merge the release backfill PR to dev per the normal policy.");
+}
+
+export function runRollback(args, dependencies = {}) {
+  const gh = dependencies.gh ?? defaultGh;
+  const now = dependencies.now ?? new Date();
+  const options = parseArgs(args);
+  const releases = loadReleases(gh);
+  const latest = loadLatestRelease(gh);
+  const badTag = options.bad ?? releaseTag(latest);
+  const { bad, target } = resolveRollback(releases, badTag, options.to);
+  const targetTag = releaseTag(target);
+  const plan = buildRollbackPlan({
+    bad,
+    target,
+    latestTag: releaseTag(latest),
+    keepBadListed: options.keepBadListed,
+    now,
+  });
+
+  console.log("Release rollback");
+  log(`Repository: ${REPO}`);
+  log(`Bad release: ${badTag}`);
+  log(`Last good: ${targetTag}`);
+  log(`Mode: ${options.execute ? "EXECUTE" : "DRY RUN"}`);
+
+  if (!hasUpdaterManifest(target)) {
+    console.error(`\n  ⚠ WARNING: ${targetTag} is missing updater manifests (latest*.yml or latest.json).`);
+    console.error("  ⚠ Re-pointing Latest may leave desktop auto-update downloads unavailable.");
+  }
+
+  heading("Stop-the-bleed plan");
+  for (let index = 0; index < plan.length; index += 1) {
+    const step = plan[index];
+    log(`${index + 1}. ${step.name}${step.skip ? ` — skip: ${step.skipReason}` : ""}`);
+  }
+
+  if (options.execute) {
+    heading("Executing rollback");
+    for (let index = 0; index < plan.length; index += 1) {
+      const step = plan[index];
+      if (step.skip) {
+        log(`${index + 1}. Skipped — ${step.skipReason}.`);
+        continue;
+      }
+      log(`${index + 1}. ${step.name}`);
+      gh(step.args);
+      log(`✓ Step ${index + 1} complete`);
+    }
+  }
+
+  printGuidance(badTag, targetTag);
+
+  if (options.execute) {
+    console.log("\n  ✓ Stop-the-bleed rollback complete. Reissue is still required for already-updated clients.");
+  } else {
+    console.log("\nDRY RUN — no changes made. Re-run with --execute.");
+  }
+
+  return { bad, target, plan, execute: options.execute };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    runRollback(process.argv.slice(2));
+  } catch (error) {
+    console.error(`  ✗ ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/release/rollback.test.mjs
+++ b/scripts/release/rollback.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildRollbackBody,
+  buildRollbackPlan,
+  resolveRollback,
+  runRollback,
+  selectRollbackTarget,
+} from "./rollback.mjs";
+
+const release = (id, tag, options = {}) => ({
+  id,
+  tag_name: tag,
+  draft: false,
+  prerelease: false,
+  body: `Notes for ${tag}`,
+  assets: [{ name: "latest-mac.yml" }],
+  ...options,
+});
+
+const releases = [
+  release(1, "v1.2.5"),
+  release(2, "v1.2.2"),
+  release(3, "v1.2.1"),
+  release(4, "v1.2.4", { draft: true }),
+  release(5, "v1.2.3", { prerelease: true }),
+  release(6, "alpha-macos-latest", { prerelease: true }),
+];
+
+function fakeGh(releaseList, latestTag) {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    if (args.includes("--paginate")) return JSON.stringify([releaseList]);
+    if (args.join(" ") === "api repos/different-ai/openwork/releases/latest") {
+      return JSON.stringify(releaseList.find((item) => item.tag_name === latestTag));
+    }
+    return "";
+  };
+  return { calls, gh };
+}
+
+test("selects the highest published stable semver below the bad release", () => {
+  assert.equal(selectRollbackTarget(releases, "v1.2.5").tag_name, "v1.2.2");
+});
+
+test("validates an explicit target", () => {
+  assert.equal(resolveRollback(releases, "v1.2.5", "v1.2.1").target.tag_name, "v1.2.1");
+});
+
+test("refuses targets that are not lower, stable, published releases", () => {
+  assert.throws(
+    () => resolveRollback(releases, "v1.2.5", "v1.2.5"),
+    /must differ/,
+  );
+  assert.throws(
+    () => resolveRollback(releases, "v1.2.5", "v1.2.4"),
+    /draft/,
+  );
+  assert.throws(
+    () => resolveRollback(releases, "v1.2.5", "v1.2.3"),
+    /prerelease/,
+  );
+  assert.throws(
+    () => resolveRollback(releases, "v1.2.5", "v9.9.9"),
+    /Target release not found/,
+  );
+  assert.throws(
+    () => resolveRollback(releases, "v1.2.2", "v1.2.5"),
+    /must be lower/,
+  );
+});
+
+test("dry-run builds the full plan without mutation", () => {
+  const fake = fakeGh(releases, "v1.2.5");
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    const result = runRollback([], {
+      gh: fake.gh,
+      now: new Date("2026-08-10T12:00:00Z"),
+    });
+    assert.equal(result.execute, false);
+    assert.equal(result.plan.length, 3);
+    assert.equal(fake.calls.length, 2);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("execute runs the three mutating plan steps in order", () => {
+  const fake = fakeGh(releases, "v1.2.5");
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    runRollback(["--execute"], {
+      gh: fake.gh,
+      now: new Date("2026-08-10T12:00:00Z"),
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(fake.calls.slice(2).map((args) => args.slice(0, 3)), [
+    ["release", "edit", "v1.2.2"],
+    ["release", "edit", "v1.2.5"],
+    ["api", "--method", "PATCH"],
+  ]);
+});
+
+test("idempotent plan skips completed steps", () => {
+  const body = "> ⚠️ Rolled back on 2026-08-10. Do not install; use v1.2.4 instead.\n\nOld notes";
+  const plan = buildRollbackPlan({
+    bad: release(1, "v1.2.5", { prerelease: true, body }),
+    target: release(2, "v1.2.4"),
+    latestTag: "v1.2.4",
+    now: new Date("2026-08-11T12:00:00Z"),
+  });
+  assert.deepEqual(plan.map((step) => step.skip), [true, true, true]);
+});
+
+test("keep-bad-listed skips only the demotion", () => {
+  const plan = buildRollbackPlan({
+    bad: release(1, "v1.2.5"),
+    target: release(2, "v1.2.4"),
+    latestTag: "v1.2.5",
+    keepBadListed: true,
+  });
+  assert.deepEqual(plan.map((step) => step.skip), [false, true, false]);
+});
+
+test("prepends a dated banner while preserving the existing body", () => {
+  assert.equal(
+    buildRollbackBody("Existing notes", "v1.2.4", new Date("2026-08-10T12:00:00Z")),
+    "> ⚠️ Rolled back on 2026-08-10. Do not install; use v1.2.4 instead.\n\nExisting notes",
+  );
+});


### PR DESCRIPTION
## Why

`dev` requires reviewed PRs (SOC 2 four-eyes) — which is right — but our only documented recovery for a bad release covered the *pre-publish* case. Once a bad version was published and marked Latest, rollback ran through merge → review → rebuild, the slowest possible incident path. Rollback of already-reviewed artifacts should not require a code change at all.

## What

- **`pnpm release:rollback`** (`scripts/release/rollback.mjs`): stop-the-bleed automation. Re-points Latest to the last good published release, demotes the bad release to prerelease (so `releases/latest` and updater endpoints can never resolve it — assets and tag stay intact), and prepends a rollback banner to its notes. **Dry-run by default**, `--execute` to act, `--bad`/`--to` overrides, idempotent re-runs, never deletes anything.
- **`docs/RELEASING.md`**: new "Rolling back a published release" runbook. Key nuance it encodes: updaters never downgrade, so re-pointing Latest only protects clients that haven't updated yet; already-updated clients need a **reissue of the last-good code from its tag** (not from `dev`, which still contains the bad commit) at a higher version. Includes the npm deprecate step and the den-api install-door pin caveat.

Part of a release-resilience set with the clean-revert fast lane and the emergency-change audit trail PRs.

## Verification

- `node --test scripts/release/rollback.test.mjs` — 8/8 pass (target selection, refusals, plan construction, idempotency skips, banner build; fake `gh`, no network).
- Live **read-only** dry run against the real repo: correctly selected bad=v0.18.18 (current Latest), good=v0.18.17, printed the 3-step plan + reissue guidance, made no mutations.
- `node scripts/release/rollback.mjs --bad v0.0.1` → clean failure, exit 1.
- `pnpm release:rollback` resolves from the root (package.json wiring).

No testkit tape: release tooling + docs, not app-runtime observable. Verified via unit tests and the live read-only dry run above; the `--execute` path issues the same `gh` commands the dry run prints.
