### PR TITLE
ci: clean-revert fast lane — machine-verified auto-approval for exact revert PRs

### DIFF
--- a/.github/workflows/revert-fastlane.yml
+++ b/.github/workflows/revert-fastlane.yml
@@ -12,7 +12,9 @@
 # change what executes here. actions/checkout is pinned to an immutable commit
 # (warden TBZ-HXQ) because this job holds a pull-request write token. The
 # same-repo guard below is mandatory under pull_request_target: the write token
-# must never run against fork-originated PRs.
+# must never run against fork-originated PRs. The approval is created through
+# the reviews API with commit_id bound to the verified head; if the head moves
+# before approval, it is withheld and the new push re-verifies.
 #
 # Scope is limited to single-commit, non-merge reverts whose tree is an exact inverse;
 # hand-adjusted reverts (revert conflicts or edits after `git revert`) are deliberately
@@ -90,9 +92,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REVERTED_SHA: ${{ steps.verify.outputs.reverted }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          body="Machine-verified that this PR's tree is the exact inverse of commit \`$REVERTED_SHA\`, which previously landed on protected \`dev\` via a reviewed PR. Auto-approval per the clean-revert fast-lane control; any further push re-runs verification."
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "$body"
+          set -euo pipefail
+          # Bind the approval to the verified head. If the head moved since
+          # verification, withhold — the synchronize event re-runs verification.
+          current="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [[ "$current" != "$HEAD_SHA" ]]; then
+            printf '## Revert Fast Lane\n\nHead moved after verification (%s -> %s); approval withheld. The new push re-runs verification.\n' "$HEAD_SHA" "$current" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          body="Machine-verified at \`$HEAD_SHA\`: this PR's tree is the exact inverse of commit \`$REVERTED_SHA\`, which previously landed on protected \`dev\` via a reviewed PR. Auto-approval per the clean-revert fast-lane control, bound to the verified commit; any further push re-runs verification."
+          gh api -X POST "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            -f commit_id="$HEAD_SHA" \
+            -f event=APPROVE \
+            -f body="$body" > /dev/null
           printf '## Revert Fast Lane\n\nPASS: %s\n' "$body" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record ineligible revert

--- a/.github/workflows/revert-fastlane.yml
+++ b/.github/workflows/revert-fastlane.yml
@@ -1,0 +1,86 @@
+# Repository prerequisite: enable Settings → Actions → General →
+# "Allow GitHub Actions to create and approve pull requests".
+# The bot approval satisfies the "someone other than the last pusher" rule because
+# this workflow's bot never pushes. For SOC 2 four-eyes, this automated control
+# inherits the original human review of the commit already landed on protected dev.
+# Scope is limited to single-commit, non-merge reverts whose tree is an exact inverse;
+# hand-adjusted reverts (revert conflicts or edits after `git revert`) are deliberately
+# rejected and take the normal human-review path.
+name: Revert Fast Lane
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: revert-fastlane-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify-and-approve:
+    if: startsWith(github.event.pull_request.title, 'Revert "') && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify exact clean revert
+        id: verify
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          reverted="$(node -e 'const match = (process.env.PR_BODY || "").match(/This reverts commit ([0-9a-f]{40})/i); process.stdout.write(match ? match[1] : "")')"
+          args=(--base "$BASE_SHA" --head "$HEAD_SHA")
+          if [[ -n "$reverted" ]]; then
+            args+=(--reverted "$reverted")
+          fi
+
+          output="$(node scripts/ci/verify-clean-revert.mjs "${args[@]}" 2>&1)"
+          status=$?
+          printf '%s\n' "$output"
+
+          verdict=""
+          verified_reverted=""
+          reason="verification failed"
+          while IFS= read -r line; do
+            case "$line" in
+              verdict=*) verdict="${line#verdict=}" ;;
+              reverted=*) verified_reverted="${line#reverted=}" ;;
+              FAIL\ *) reason="${line#FAIL }" ;;
+            esac
+          done <<< "$output"
+          if [[ $status -eq 0 && "$verdict" == "pass" ]]; then
+            echo "verdict=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "verdict=fail" >> "$GITHUB_OUTPUT"
+          fi
+          echo "reverted=$verified_reverted" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+      - name: Approve verified revert
+        if: steps.verify.outputs.verdict == 'pass'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVERTED_SHA: ${{ steps.verify.outputs.reverted }}
+        run: |
+          body="Machine-verified that this PR's tree is the exact inverse of commit \`$REVERTED_SHA\`, which previously landed on protected \`dev\` via a reviewed PR. Auto-approval per the clean-revert fast-lane control; any further push re-runs verification."
+          gh pr review "$PR_NUMBER" --approve --body "$body"
+          printf '## Revert Fast Lane\n\nPASS: %s\n' "$body" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record ineligible revert
+        if: steps.verify.outputs.verdict != 'pass'
+        env:
+          REASON: ${{ steps.verify.outputs.reason }}
+        run: |
+          printf '## Revert Fast Lane\n\nNot eligible for fast lane: %s. Needs normal human review.\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/revert-fastlane.yml
+++ b/.github/workflows/revert-fastlane.yml
@@ -15,6 +15,12 @@
 # must never run against fork-originated PRs. The approval is created through
 # the reviews API with commit_id bound to the verified head; if the head moves
 # before approval, it is withheld and the new push re-verifies.
+# GitHub offers no atomic compare-and-approve, so the residual read-then-approve
+# race is closed server-side by dev's ruleset (warden round 3):
+# dismiss_stale_reviews_on_push plus require_last_push_approval dismiss or ignore
+# any approval whose head moved afterward. Immediately before approving, the job
+# verifies both flags at runtime and withholds approval if either is disabled, so
+# the control cannot silently outlive its preconditions.
 #
 # Scope is limited to single-commit, non-merge reverts whose tree is an exact inverse;
 # hand-adjusted reverts (revert conflicts or edits after `git revert`) are deliberately
@@ -95,6 +101,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # This control's residual read-then-approve race is closed server-side by
+          # dev's ruleset. Refuse to approve if those guarantees are not confirmed.
+          rules="$(gh api "repos/$GITHUB_REPOSITORY/rules/branches/dev" --jq '[.[] | select(.type=="pull_request") | .parameters | (.dismiss_stale_reviews_on_push and .require_last_push_approval)] | any' 2>/dev/null || true)"
+          if [[ "$rules" != "true" ]]; then
+            printf '## Revert Fast Lane\n\nApproval withheld: could not confirm the dev ruleset still enforces dismiss_stale_reviews_on_push AND require_last_push_approval, which this control depends on to invalidate any approval whose head moves.\n' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           # Bind the approval to the verified head. If the head moved since
           # verification, withhold — the synchronize event re-runs verification.
           current="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"

--- a/.github/workflows/revert-fastlane.yml
+++ b/.github/workflows/revert-fastlane.yml
@@ -3,13 +3,24 @@
 # The bot approval satisfies the "someone other than the last pusher" rule because
 # this workflow's bot never pushes. For SOC 2 four-eyes, this automated control
 # inherits the original human review of the commit already landed on protected dev.
+#
+# Security model (warden SEP-C6H): this runs on pull_request_target, so the
+# workflow definition AND scripts/ci/verify-clean-revert.mjs execute from the
+# trusted base branch (dev) — never from the PR. PR commits are fetched as git
+# data only: the verifier re-applies `git revert` to them as patch content and
+# compares tree hashes. A PR that modifies this workflow or the verifier cannot
+# change what executes here. actions/checkout is pinned to an immutable commit
+# (warden TBZ-HXQ) because this job holds a pull-request write token. The
+# same-repo guard below is mandatory under pull_request_target: the write token
+# must never run against fork-originated PRs.
+#
 # Scope is limited to single-commit, non-merge reverts whose tree is an exact inverse;
 # hand-adjusted reverts (revert conflicts or edits after `git revert`) are deliberately
 # rejected and take the normal human-review path.
 name: Revert Fast Lane
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches: [dev]
 
@@ -26,10 +37,16 @@ jobs:
     if: startsWith(github.event.pull_request.title, 'Revert "') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Checkout trusted base (dev)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+
+      - name: Fetch PR commits as git data
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"
 
       - name: Verify exact clean revert
         id: verify
@@ -75,7 +92,7 @@ jobs:
           REVERTED_SHA: ${{ steps.verify.outputs.reverted }}
         run: |
           body="Machine-verified that this PR's tree is the exact inverse of commit \`$REVERTED_SHA\`, which previously landed on protected \`dev\` via a reviewed PR. Auto-approval per the clean-revert fast-lane control; any further push re-runs verification."
-          gh pr review "$PR_NUMBER" --approve --body "$body"
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "$body"
           printf '## Revert Fast Lane\n\nPASS: %s\n' "$body" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record ineligible revert

--- a/scripts/ci/verify-clean-revert.mjs
+++ b/scripts/ci/verify-clean-revert.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!["--base", "--head", "--reverted"].includes(arg)) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
+    options[arg.slice(2)] = value;
+    index += 1;
+  }
+  if (!options.base || !options.head) {
+    throw new Error("Usage: node scripts/ci/verify-clean-revert.mjs --base <sha> --head <sha> [--reverted <sha>]");
+  }
+  if (options.reverted && !SHA_PATTERN.test(options.reverted)) {
+    throw new Error("--reverted must be a full 40-character commit SHA.");
+  }
+  return options;
+}
+
+function command(run, args, cwd, allowFailure = false) {
+  const result = run("git", args, { cwd, encoding: "utf8" });
+  if (!allowFailure && result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args[0]} failed with exit code ${result.status ?? "unknown"}.`);
+  }
+  return result;
+}
+
+function parseRevertedSha(message) {
+  const matches = [...message.matchAll(/This reverts commit ([0-9a-f]{40})/gi)];
+  const shas = new Set(matches.map((match) => match[1].toLowerCase()));
+  if (shas.size === 0) throw new Error("head commit message has no 'This reverts commit <40-hex>' line");
+  if (shas.size > 1) throw new Error("head commit message names multiple distinct reverted commits; only single-commit reverts are supported");
+  return [...shas][0];
+}
+
+export function verifyCleanRevert(options, run = spawnSync) {
+  const cwd = process.cwd();
+  let reverted = options.reverted?.toLowerCase();
+  if (!reverted) {
+    const message = command(run, ["log", "-1", "--format=%B", options.head], cwd).stdout;
+    reverted = parseRevertedSha(message);
+  }
+
+  const parents = command(run, ["rev-list", "--parents", "-n", "1", reverted], cwd).stdout.trim().split(/\s+/);
+  if (parents.length > 2) throw new Error("reverted commit is a merge commit; only non-merge commits are supported");
+
+  const ancestor = command(run, ["merge-base", "--is-ancestor", reverted, options.base], cwd, true);
+  if (ancestor.status !== 0) throw new Error("reverted commit is not an ancestor of the PR base");
+
+  const tempRoot = mkdtempSync(resolve(tmpdir(), "verify-clean-revert-"));
+  const worktree = resolve(tempRoot, "worktree");
+  let added = false;
+  try {
+    command(run, ["worktree", "add", "--detach", worktree, options.base], cwd);
+    added = true;
+    const revert = command(run, ["revert", "--no-commit", "--no-edit", reverted], worktree, true);
+    if (revert.status !== 0) throw new Error("revert does not apply cleanly to PR base");
+
+    const expectedTree = command(run, ["write-tree"], worktree).stdout.trim();
+    const headTree = command(run, ["rev-parse", `${options.head}^{tree}`], cwd).stdout.trim();
+    if (expectedTree !== headTree) throw new Error("PR tree is not the exact inverse of the reverted commit");
+    return reverted;
+  } finally {
+    if (added) command(run, ["worktree", "remove", "--force", worktree], cwd, true);
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  let reverted = "";
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    reverted = options.reverted?.toLowerCase() ?? "";
+    reverted = verifyCleanRevert(options);
+    console.log(`PASS clean-revert of ${reverted}`);
+    console.log("verdict=pass");
+    console.log(`reverted=${reverted}`);
+  } catch (error) {
+    console.log(`FAIL ${error instanceof Error ? error.message : String(error)}`);
+    console.log("verdict=fail");
+    console.log(`reverted=${reverted}`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/ci/verify-clean-revert.test.mjs
+++ b/scripts/ci/verify-clean-revert.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, test } from "node:test";
+
+const script = resolve(import.meta.dirname, "verify-clean-revert.mjs");
+const tempDirs = [];
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function git(repo, ...args) {
+  const result = spawnSync("git", ["-c", "user.name=t", "-c", "user.email=t@t", ...args], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function fixture() {
+  const repo = mkdtempSync(resolve(tmpdir(), "clean-revert-test-"));
+  tempDirs.push(repo);
+  git(repo, "init", "-q");
+  writeFileSync(resolve(repo, "file.txt"), "A\n");
+  git(repo, "add", "file.txt");
+  git(repo, "commit", "-q", "-m", "A");
+  const a = git(repo, "rev-parse", "HEAD");
+  writeFileSync(resolve(repo, "file.txt"), "B\n");
+  git(repo, "commit", "-q", "-am", "B");
+  const b = git(repo, "rev-parse", "HEAD");
+  git(repo, "revert", "--no-edit", b);
+  const c = git(repo, "rev-parse", "HEAD");
+  return { repo, a, b, c };
+}
+
+function verify(repo, ...args) {
+  return spawnSync(process.execPath, [script, ...args], { cwd: repo, encoding: "utf8" });
+}
+
+test("passes an exact revert parsed from the head message", () => {
+  const { repo, b, c } = fixture();
+  const result = verify(repo, "--base", b, "--head", c);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, new RegExp(`PASS clean-revert of ${b}`));
+  assert.match(result.stdout, /verdict=pass/);
+});
+
+test("fails when the revert tree contains an extra edit", () => {
+  const { repo, b, c } = fixture();
+  writeFileSync(resolve(repo, "extra.txt"), "tampered\n");
+  git(repo, "add", "extra.txt");
+  git(repo, "commit", "-q", "-m", "extra edit");
+  const tampered = git(repo, "rev-parse", "HEAD");
+  const result = verify(repo, "--base", b, "--head", tampered, "--reverted", b);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL PR tree is not the exact inverse/);
+  assert.notEqual(c, tampered);
+});
+
+test("fails when source drift makes the revert conflict", () => {
+  const { repo, b } = fixture();
+  git(repo, "switch", "-q", "--detach", b);
+  writeFileSync(resolve(repo, "file.txt"), "unrelated edit to the same line\n");
+  git(repo, "commit", "-q", "-am", "source drift");
+  const driftedBase = git(repo, "rev-parse", "HEAD");
+  const result = verify(repo, "--base", driftedBase, "--head", driftedBase, "--reverted", b);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL revert does not apply cleanly to PR base/);
+});
+
+test("fails when the reverted commit is not an ancestor of base", () => {
+  const { repo, a, b, c } = fixture();
+  git(repo, "switch", "-q", "--detach", a);
+  writeFileSync(resolve(repo, "other.txt"), "other\n");
+  git(repo, "add", "other.txt");
+  git(repo, "commit", "-q", "-m", "divergent");
+  const divergent = git(repo, "rev-parse", "HEAD");
+  const result = verify(repo, "--base", b, "--head", c, "--reverted", divergent);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL reverted commit is not an ancestor of the PR base/);
+});
+
+test("fails when the head message does not identify a reverted commit", () => {
+  const { repo, a, b } = fixture();
+  const result = verify(repo, "--base", a, "--head", b);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL head commit message has no 'This reverts commit <40-hex>' line/);
+  assert.match(result.stdout, /verdict=fail/);
+});


### PR DESCRIPTION
## Why

`dev` requires one non-pusher approval (SOC 2 four-eyes). A **clean revert restores a previously-reviewed state**, so the second control can be a machine: verify the PR is the *exact* inverse of a commit that already landed on protected `dev`, then auto-approve. Incident reverts stop waiting on a human without weakening the control — the original review is inherited, and anything hand-adjusted drops to normal human review.

## What

- **`scripts/ci/verify-clean-revert.mjs`**: proves a PR is a clean revert. Parses `This reverts commit <sha>` (PR body or head commit message), requires the reverted commit to be a non-merge ancestor of the PR base (= it passed protected-branch review), re-applies `git revert` on the base in a throwaway worktree, and demands **tree-hash equality** with the PR head. Any extra change — even whitespace — fails it.
- **`.github/workflows/revert-fastlane.yml`**: runs on PRs into `dev` titled `Revert "…"` (same-repo only), approves via the Actions bot on PASS with the verified sha in the approval body. On FAIL it **never blocks** — writes "needs normal human review" to the summary and exits green. Every push re-runs verification.

Deliberate rejections (→ human review): hand-adjusted reverts (source drifted / conflicts), multi-commit or merge reverts.

**Admin follow-up required before this activates**: Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests". The bot approval satisfies "approval by someone other than the last pusher" because the bot never pushes.

Part of a release-resilience set with the rollback runbook and emergency-change audit trail PRs.

## Verification

- `node --test scripts/ci/verify-clean-revert.test.mjs` — 5/5 pass (synthetic repos: clean revert PASS; tampered tree FAIL; non-ancestor FAIL; missing marker FAIL; source-drift conflict FAIL).
- Real history: `6d37812d8` (revert of #3459) → **PASS**, verified inverse of `d720739…`. `736ed47ee` (revert of #3300) → **FAIL** correctly: that revert was hand-adjusted after source drift — exactly the class that must keep human review (true negative). Non-revert commit `4fb772cdd` → FAIL, exit 1.
- Workflow YAML parses clean; `checkout@v6` matches repo convention.

No testkit tape: CI workflow + verifier script, not app-runtime observable. The workflow itself is inert until it runs on GitHub; the verifier it delegates to is fully exercised above, including against real repo history.
