### PR TITLE
docs+ci: emergency-change policy + tag-first release audit trail

### DIFF
--- a/.github/workflows/expedited-release-audit.yml
+++ b/.github/workflows/expedited-release-audit.yml
@@ -22,7 +22,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        # Pinned to an immutable commit: this job holds an issues-write token.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/expedited-release-audit.yml
+++ b/.github/workflows/expedited-release-audit.yml
@@ -1,0 +1,94 @@
+name: Expedited Release Audit
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to audit
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch dev
+        run: git fetch origin dev
+
+      - name: Audit release path
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          TRIGGER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if git merge-base --is-ancestor "$(git rev-list -n1 "$TAG")" origin/dev; then
+            echo "PR-first release; tag commit is on dev; no action" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          existing_issue="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label emergency-change \
+            --state all \
+            --search "in:title \"Post-hoc review: $TAG\"" \
+            --limit 1 \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [[ -n "$existing_issue" ]]; then
+            echo "Post-hoc review issue already exists: $existing_issue" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh label create emergency-change \
+            --repo "$GITHUB_REPOSITORY" \
+            --color D93F0B \
+            --description "Expedited change requiring post-hoc review (SOC 2 evidence)" || true
+
+          backfill_pr="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --search "head:release/$TAG-dev-sync" \
+            --state all \
+            --limit 1 \
+            --json url \
+            --jq '.[0].url // ""' || true)"
+          backfill_link="${backfill_pr:-Not found yet}"
+          release_runs_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/release-macos-aarch64.yml?query=branch%3A$TAG"
+
+          body_file="$RUNNER_TEMP/post-hoc-review.md"
+          cat > "$body_file" <<EOF
+          This tag was released before its version-bump commit was reviewed into \`dev\`.
+
+          - [ ] Reason / incident link:
+          - [ ] Release App run: $release_runs_url
+          - [ ] Triggering audit run: $TRIGGER_RUN_URL
+          - [ ] Backfill PR merged: $backfill_link
+          - [ ] Reviewed by someone other than the release actor
+
+          Release actor: @$ACTOR
+
+          Only the reviewer closes this issue, per [the emergency-change policy]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/dev/docs/EMERGENCY-CHANGES.md).
+          EOF
+
+          issue_url="$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Post-hoc review: $TAG (tag-first release)" \
+            --label emergency-change \
+            --body-file "$body_file")"
+          gh issue edit "$issue_url" --add-assignee "$ACTOR" || true
+          echo "Post-hoc review issue: $issue_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/expedited-release-audit.yml
+++ b/.github/workflows/expedited-release-audit.yml
@@ -37,6 +37,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Release App triggers on v*, but only semver tags are releases.
+          # Stray tags (e.g. vffe6fee-dev) must not open audit issues.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "$TAG is not a semver release tag; skipping" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           if git merge-base --is-ancestor "$(git rev-list -n1 "$TAG")" origin/dev; then
             echo "PR-first release; tag commit is on dev; no action" >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/docs/EMERGENCY-CHANGES.md
+++ b/docs/EMERGENCY-CHANGES.md
@@ -1,0 +1,25 @@
+# Emergency changes
+
+## Why this exists
+
+The change management control is a reviewed pull request into `dev`.
+Incidents sometimes require a faster path.
+Every expedited path below has a compensating control and leaves evidence. No undocumented bypasses are permitted.
+
+## The expedited paths
+
+| Path | When | Compensating control | Evidence |
+| --- | --- | --- | --- |
+| Tag-first release (`pnpm release:prepare` + `pnpm release:ship` off a branch, admins only) | A release must go out now | The `v*` tag ruleset limits this path to admins. Only already-reviewed `dev` commits plus the version-bump commit ship. A backfill PR is reviewed afterward. | Auto-opened `Post-hoc review` issue from the expedited release audit workflow, plus the backfill PR |
+| Published-release rollback (`pnpm release:rollback`) | A bad version is live | The script is non-destructive: it re-points Latest and demotes the bad release, but never deletes it. It redeploys only previously reviewed artifacts. | GitHub audit log, release timeline, and a note in the post-hoc issue |
+| Clean-revert fast lane (auto-approved revert PRs) | A reviewed change must be undone immediately | A machine verifies that the PR tree is the exact inverse of a commit that already passed review. Approval inherits the original review. | Bot approval with the verified SHA on the PR |
+
+See [Releasing OpenWork](./RELEASING.md) for release mechanics.
+
+## Post-hoc review SLA
+
+Every `emergency-change` issue must receive sign-off from a human reviewer other than the actor within one business day. Link the incident or reason. Only that reviewer closes the issue.
+
+## Metrics & audit
+
+Quarterly, count `emergency-change` issues. Expect this path to remain rare (target: fewer than one per month), and require every issue to be closed with sign-off. This issue set is also the SOC 2 evidence set for the emergency-change control.


### PR DESCRIPTION
## Why

We already have an expedited release path (tag-first: `v*` tags are admin-bypassable, backfill PR follows). SOC 2 auditors accept expedited paths **only** with a written policy and per-use evidence of post-hoc review. Today neither exists — this PR adds both, and makes the evidence generate itself.

## What

- **`docs/EMERGENCY-CHANGES.md`**: the emergency-change policy. Each expedited path (tag-first release, published-release rollback, clean-revert fast lane) with its compensating control and evidence source; post-hoc review SLA (non-actor sign-off ≤ 1 business day, reviewer closes the issue); quarterly metric (target < 1/month). This doc + the `emergency-change` issue set is the audit evidence package.
- **`.github/workflows/expedited-release-audit.yml`**: on every `v*` push, detects which path was used and opens the audit trail automatically. Detector: `dev` is squash/rebase-only, so a tag-first tag commit is **never** an ancestor of `dev`, while PR-first tags a commit on `dev` — `git merge-base --is-ancestor` distinguishes them mechanically, forever. Tag-first → idempotently opens a `Post-hoc review: vX.Y.Z` issue (label `emergency-change`, assigns the actor, pre-links the Release App run and backfill PR). PR-first or non-semver `v*` tags → no-op with a summary line.

Part of a release-resilience set with the rollback runbook and clean-revert fast lane PRs.

## Verification

- Detector proven on real history: `v0.18.18` (`c3e1aa878`) → not an ancestor of `dev` → tag-first, issue would open. `origin/dev~1` → ancestor → no action. Stray tag `vffe6fee-dev` → skipped by the semver guard.
- Backfill-PR discovery proven live (read-only): `gh pr list --search "head:release/v0.18.16-dev-sync"` → finds merged #3564.
- Issue-search idempotency query runs clean against the live repo (no issues created).
- Workflow YAML parses clean; `checkout@v6` matches repo convention.

No testkit tape: policy doc + CI workflow, not app-runtime observable. The workflow is inert until a `v*` tag push; its two logic branches and both `gh` queries were exercised read-only against real repo state above.
