### PR TITLE
Capability parity: native providers in the codemode script tree, and no uncredentialed catalog leak

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -32,7 +32,8 @@ import {
 } from "./builtin-skills.js"
 import { executeNativeCapability, searchNativeCapabilities } from "./native-capabilities.js"
 import { externalToolContent, type AgentToolContentPart } from "./tool-content.js"
-import { buildCodemodeToolTree, codemodeScriptPath } from "./codemode-tools.js"
+import { buildCodemodeToolTree, codemodeScriptPath, isCredentialBoundNativeOperation } from "./codemode-tools.js"
+import { resolveCodemodeConnectionNamespaceContext } from "./codemode-namespaces.js"
 import { runCodemodeScript } from "./codemode-run.js"
 import { recordCodemodeScriptResult } from "../codemode-runs.js"
 
@@ -478,8 +479,15 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         const boundedLimit = limit ?? 5
         const sourceFilter = searchCapabilitySourceFilter(type)
         const marketplaceObjectTypes = type === "skills" ? skillMarketplaceObjectTypes : undefined
+        const namespaceContext = codemodeEnabled && memberIdentity && (sourceFilter.api || sourceFilter.mcp)
+          ? await resolveCodemodeConnectionNamespaceContext({
+            organizationId: principal.organizationId,
+            member: memberIdentity,
+            includeExternalMcp: externalMcpConnectionsEnabled,
+          })
+          : undefined
         const restMatches = sourceFilter.api
-          ? searchCapabilities(catalog, query, boundedLimit).map((match) => codemodeEnabled
+          ? searchCapabilities(catalog.filter((operation) => !isCredentialBoundNativeOperation(operation)), query, boundedLimit).map((match) => codemodeEnabled
             ? { ...match, scriptPath: codemodeScriptPath("den", match.name) }
             : match)
           : []
@@ -490,6 +498,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
             query,
             catalog,
             limit: boundedLimit,
+            includeScriptPaths: codemodeEnabled,
+            namespaceContext,
           })
           : []
         const adminMatches = sourceFilter.admin
@@ -511,6 +521,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
             redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
             limit: boundedLimit,
             includeScriptPaths: codemodeEnabled,
+            namespaceContext,
             reportCoverage: (coverage) => {
               externalCoverageHint = externalMcpSearchCoverageHint(coverage)
             },
@@ -621,8 +632,9 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
                   catalog,
                   principal,
                   organizationId: principal.organizationId,
-                  member: externalMcpConnectionsEnabled ? memberIdentity : null,
+                  member: memberIdentity,
                   redirectUriBase,
+                  externalMcpConnectionsEnabled,
                 }),
                 organizationId: principal.organizationId,
                 member: memberIdentity,
@@ -695,8 +707,9 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
               catalog,
               principal,
               organizationId: principal.organizationId,
-              member: externalMcpConnectionsEnabled ? memberIdentity : null,
+              member: memberIdentity,
               redirectUriBase,
+              externalMcpConnectionsEnabled,
             })
             const startedAt = new Date()
             const result = await runCodemodeScript({

--- a/ee/apps/den-api/src/mcp/codemode-namespaces.ts
+++ b/ee/apps/den-api/src/mcp/codemode-namespaces.ts
@@ -1,0 +1,134 @@
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import {
+  listUsableExternalMcpConnections,
+  type ExternalMcpConnectionRow,
+} from "../capability-sources/external-mcp-connections.js"
+import {
+  listNativeProviderUsableEntries,
+  type NativeProviderConnectionEntry,
+} from "../capability-sources/native-provider-connections.js"
+
+export type NamedConnection = { id: string; name: string }
+
+const RESERVED_CODEMODE_NAMESPACES = ["den", "$codemode", "__proto__", "constructor", "prototype"]
+const IDENTIFIER_PATTERN = /^[a-z_$][a-z0-9_$]*$/i
+
+export function codemodeScriptPath(namespace: string, toolName: string): string {
+  return IDENTIFIER_PATTERN.test(toolName)
+    ? `tools.${namespace}.${toolName}`
+    : `tools.${namespace}[${JSON.stringify(toolName)}]`
+}
+
+export function sanitizeNamespaceSegment(name: string): string {
+  const sanitized = name.toLowerCase().replace(/[^a-z0-9_]+/g, "_")
+  if (!sanitized) return "_"
+  return /^[a-z_]/.test(sanitized) ? sanitized : `_${sanitized}`
+}
+
+function allocateNamespaceMap(
+  connections: readonly NamedConnection[],
+  used: Set<string>,
+): Map<string, string> {
+  const namespaces = new Map<string, string>()
+  for (const connection of connections) {
+    const base = sanitizeNamespaceSegment(connection.name)
+    let namespace = base
+    let suffix = 2
+    while (used.has(namespace)) {
+      namespace = `${base}_${suffix}`
+      suffix += 1
+    }
+    used.add(namespace)
+    namespaces.set(connection.id, namespace)
+  }
+  return namespaces
+}
+
+export function buildExternalNamespaceMap(connections: readonly NamedConnection[]): Map<string, string> {
+  return allocateNamespaceMap(connections, new Set(RESERVED_CODEMODE_NAMESPACES))
+}
+
+export type CodemodeConnectionNamespaceMaps = {
+  native: Map<string, string>
+  externalMcp: Map<string, string>
+}
+
+export function buildCodemodeConnectionNamespaceMaps(input: {
+  native: readonly NamedConnection[]
+  externalMcp: readonly NamedConnection[]
+}): CodemodeConnectionNamespaceMaps {
+  const used = new Set(RESERVED_CODEMODE_NAMESPACES)
+  return {
+    native: allocateNamespaceMap(input.native, used),
+    externalMcp: allocateNamespaceMap(input.externalMcp, used),
+  }
+}
+
+export function isCodemodeEligibleConnection(
+  connection: Pick<ExternalMcpConnectionRow, "toolPolicy" | "oauthIssuerReviewRequiredAt">,
+): boolean {
+  return !connection.toolPolicy?.allDisabled && !connection.oauthIssuerReviewRequiredAt
+}
+
+export const CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT = 16
+
+export type CodemodeConnectionNamespaceContext = {
+  nativeProviderEntries: NativeProviderConnectionEntry[]
+  externalMcpConnections: ExternalMcpConnectionRow[]
+  codemodeNativeProviderEntries: NativeProviderConnectionEntry[]
+  codemodeExternalMcpConnections: ExternalMcpConnectionRow[]
+  namespaces: CodemodeConnectionNamespaceMaps
+}
+
+type CodemodeMemberIdentity = {
+  orgMembershipId: DenTypeId<"member">
+  teamIds: DenTypeId<"team">[]
+}
+
+export async function resolveCodemodeConnectionNamespaceContext(input: {
+  organizationId: string
+  member: CodemodeMemberIdentity | null
+  includeExternalMcp?: boolean
+}): Promise<CodemodeConnectionNamespaceContext> {
+  if (!input.member) {
+    return {
+      nativeProviderEntries: [],
+      externalMcpConnections: [],
+      codemodeNativeProviderEntries: [],
+      codemodeExternalMcpConnections: [],
+      namespaces: buildCodemodeConnectionNamespaceMaps({ native: [], externalMcp: [] }),
+    }
+  }
+
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const [nativeProviderEntries, externalMcpConnections] = await Promise.all([
+    listNativeProviderUsableEntries({
+      organizationId,
+      orgMembershipId: input.member.orgMembershipId,
+      teamIds: input.member.teamIds,
+    }),
+    input.includeExternalMcp === false
+      ? Promise.resolve([])
+      : listUsableExternalMcpConnections({
+        organizationId,
+        orgMembershipId: input.member.orgMembershipId,
+        teamIds: input.member.teamIds,
+      }),
+  ])
+  const codemodeNativeProviderEntries = nativeProviderEntries.filter((entry) => entry.connectedForMe === true)
+  const codemodeExternalMcpConnections = externalMcpConnections
+    .filter(isCodemodeEligibleConnection)
+    .slice(0, CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT)
+
+  return {
+    nativeProviderEntries,
+    externalMcpConnections,
+    codemodeNativeProviderEntries,
+    codemodeExternalMcpConnections,
+    namespaces: buildCodemodeConnectionNamespaceMaps({
+      native: codemodeNativeProviderEntries,
+      externalMcp: codemodeExternalMcpConnections,
+    }),
+  }
+}

--- a/ee/apps/den-api/src/mcp/codemode-tools.ts
+++ b/ee/apps/den-api/src/mcp/codemode-tools.ts
@@ -3,20 +3,39 @@ import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { Effect } from "effect"
 import type { Hono } from "hono"
 import { z } from "zod"
-import { listUsableExternalMcpConnections, type ExternalMcpConnectionRow } from "../capability-sources/external-mcp-connections.js"
+import type { ExternalMcpConnectionRow } from "../capability-sources/external-mcp-connections.js"
+import type { NativeProviderConnectionEntry } from "../capability-sources/native-provider-connections.js"
 import { listExternalMcpTools } from "../capability-sources/external-mcp-client-runtime.js"
 import { createExternalMcpLifecycleDeadline, EXTERNAL_MCP_TOOL_LIFECYCLE_TIMEOUT_MS } from "../capability-sources/external-mcp-client.js"
 import { isToolDisabled } from "../capability-sources/external-mcp-tool-policy.js"
+import { NATIVE_OAUTH_PROVIDERS } from "../capability-sources/provider-registry.js"
 import type { McpPrincipal } from "./auth.js"
 import type { McpToolOperation } from "./catalog.js"
+import {
+  codemodeScriptPath,
+  resolveCodemodeConnectionNamespaceContext,
+  type CodemodeConnectionNamespaceContext,
+} from "./codemode-namespaces.js"
 import {
   buildExternalCapabilityName,
   executeExternalCapability,
   EXTERNAL_MCP_SEARCH_CONCURRENCY,
-  EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT,
   type McpMemberIdentity,
 } from "./external-capabilities.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
+import {
+  buildNativeCapabilityName,
+  executeNativeCapability,
+  nativeOperations,
+} from "./native-capabilities.js"
+
+export {
+  buildCodemodeConnectionNamespaceMaps,
+  buildExternalNamespaceMap,
+  codemodeScriptPath,
+  isCodemodeEligibleConnection,
+  sanitizeNamespaceSegment,
+} from "./codemode-namespaces.js"
 
 export type CodemodeToolTree = Record<string, Record<string, Tool.Definition>>
 
@@ -32,9 +51,32 @@ export type BuiltCodemodeTools = {
   manifest: CodemodeManifestEntry[]
 }
 
-type NamedConnection = { id: string; name: string }
+export const CAPABILITY_SOURCE_KINDS = ["catalog", "native", "externalMcp", "marketplace", "builtinSkill", "admin"] as const
+export type CapabilitySourceKind = (typeof CAPABILITY_SOURCE_KINDS)[number]
 
-const IDENTIFIER_PATTERN = /^[a-z_$][a-z0-9_$]*$/i
+/** Interim parity primitive pending a full CapabilitySource registry. */
+export const CODEMODE_SOURCE_PARTICIPATION: Record<CapabilitySourceKind, "tree" | { excluded: string }> = {
+  catalog: "tree",
+  native: "tree",
+  externalMcp: "tree",
+  marketplace: {
+    excluded: "Marketplace capabilities return instructional content rather than data operations; marketplace script objects execute through their dedicated script rail.",
+  },
+  builtinSkill: {
+    excluded: "Built-in skills return instructional content rather than data operations.",
+  },
+  admin: {
+    excluded: "Admin capabilities are platform-admin gated and are not exposed to organization Code Mode scripts.",
+  },
+}
+
+function assertCodemodeSourceParticipation(): void {
+  for (const kind of CAPABILITY_SOURCE_KINDS) {
+    if (!CODEMODE_SOURCE_PARTICIPATION[kind]) {
+      throw new Error(`Code Mode participation is undecided for capability source: ${kind}`)
+    }
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -48,35 +90,6 @@ function denInputJsonSchema(operation: McpToolOperation): Tool.JsonSchema {
   const serialized = JSON.stringify(z.toJSONSchema(operation.inputSchema), (key, value: unknown) => key === "~standard" ? undefined : value)
   const schema: unknown = JSON.parse(serialized)
   return isCodemodeJsonSchema(schema) ? schema : {}
-}
-
-export function sanitizeNamespaceSegment(name: string): string {
-  const sanitized = name.toLowerCase().replace(/[^a-z0-9_]+/g, "_")
-  if (!sanitized) return "_"
-  return /^[a-z_]/.test(sanitized) ? sanitized : `_${sanitized}`
-}
-
-export function buildExternalNamespaceMap(connections: readonly NamedConnection[]): Map<string, string> {
-  const used = new Set(["den", "$codemode", "__proto__", "constructor", "prototype"])
-  const namespaces = new Map<string, string>()
-  for (const connection of connections) {
-    const base = sanitizeNamespaceSegment(connection.name)
-    let namespace = base
-    let suffix = 2
-    while (used.has(namespace)) {
-      namespace = `${base}_${suffix}`
-      suffix += 1
-    }
-    used.add(namespace)
-    namespaces.set(connection.id, namespace)
-  }
-  return namespaces
-}
-
-export function codemodeScriptPath(namespace: string, toolName: string): string {
-  return IDENTIFIER_PATTERN.test(toolName)
-    ? `tools.${namespace}.${toolName}`
-    : `tools.${namespace}[${JSON.stringify(toolName)}]`
 }
 
 export function restrictCodemodeToolTree(input: {
@@ -151,13 +164,22 @@ function toolResultError(value: unknown): string {
   return text || "Capability execution failed."
 }
 
+const NATIVE_CAPABILITY_PATH_PREFIXES = Object.keys(NATIVE_OAUTH_PROVIDERS)
+  .map((providerKey) => `/v1/capabilities/${providerKey}/`)
+
+/** Native provider routes are callable only through a credential-bound connection namespace. */
+export function isCredentialBoundNativeOperation(operation: Pick<McpToolOperation, "path">): boolean {
+  return NATIVE_CAPABILITY_PATH_PREFIXES.some((pathPrefix) => operation.path.startsWith(pathPrefix))
+}
+
 export function buildDenCatalogToolTree(input: {
   app: Hono
   env: unknown
   catalog: readonly McpToolOperation[]
   principal: McpPrincipal
 }): BuiltCodemodeTools {
-  const definitions = input.catalog.map((operation) => [operation.name, Tool.make({
+  const operations = input.catalog.filter((operation) => !isCredentialBoundNativeOperation(operation))
+  const definitions = operations.map((operation) => [operation.name, Tool.make({
     description: operation.operation.summary ?? operation.operation.description ?? operation.name,
     input: denInputJsonSchema(operation),
     run: (toolInput) => Effect.promise(() => invokeMcpOperation({
@@ -176,12 +198,85 @@ export function buildDenCatalogToolTree(input: {
   })] satisfies [string, Tool.Definition])
   return {
     tools: { den: Object.fromEntries(definitions) },
-    manifest: input.catalog.map((operation) => ({
+    manifest: operations.map((operation) => ({
       scriptPath: codemodeScriptPath("den", operation.name),
       capabilityName: operation.name,
       readOnly: operation.method === "GET",
       authority: "den" as const,
     })),
+  }
+}
+
+type NativeManifestConnection = Pick<NativeProviderConnectionEntry, "id" | "nativeProviderKey">
+
+export function buildNativeProviderManifest(input: {
+  connections: readonly NativeManifestConnection[]
+  catalog: readonly McpToolOperation[]
+  namespaces: ReadonlyMap<string, string>
+}): CodemodeManifestEntry[] {
+  return input.connections.flatMap((connection) => {
+    const namespace = input.namespaces.get(connection.id)
+    if (!namespace) return []
+    return nativeOperations(input.catalog, connection.nativeProviderKey).map((operation) => ({
+      scriptPath: codemodeScriptPath(namespace, operation.name),
+      capabilityName: buildNativeCapabilityName(connection.id, operation.name),
+      // Native providers are Den-implemented routes (invokeMcpOperation, just
+      // credential-bound to a connection), so they carry the same authority and
+      // read-only classification as the plain catalog. Without this, every
+      // native capability would be rejected by the unattended-run gate.
+      readOnly: operation.method === "GET",
+      authority: "den" as const,
+    }))
+  })
+}
+
+export async function buildNativeProviderToolTree(input: {
+  app: Hono
+  env: unknown
+  catalog: readonly McpToolOperation[]
+  principal: McpPrincipal
+  organizationId: string
+  member: McpMemberIdentity | null
+  namespaceContext?: CodemodeConnectionNamespaceContext
+}): Promise<BuiltCodemodeTools> {
+  if (!input.member) return { tools: {}, manifest: [] }
+  const memberIdentity = input.member
+  const namespaceContext = input.namespaceContext ?? await resolveCodemodeConnectionNamespaceContext({
+    organizationId: input.organizationId,
+    member: memberIdentity,
+  })
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const namespaceEntries = namespaceContext.codemodeNativeProviderEntries.flatMap((connection) => {
+    const namespace = namespaceContext.namespaces.native.get(connection.id)
+    if (!namespace) return []
+    const definitions = nativeOperations(input.catalog, connection.nativeProviderKey).map((operation) => [operation.name, Tool.make({
+      description: operation.operation.summary ?? operation.operation.description ?? operation.name,
+      input: denInputJsonSchema(operation),
+      run: (toolInput) => Effect.promise(() => executeNativeCapability({
+        app: input.app,
+        env: input.env,
+        name: buildNativeCapabilityName(connection.id, operation.name),
+        organizationId,
+        member: memberIdentity,
+        catalog: input.catalog,
+        principal: input.principal,
+        path: normalizeToolRecord(isRecord(toolInput) ? toolInput.path : undefined),
+        query: normalizeToolRecord(isRecord(toolInput) ? toolInput.query : undefined),
+        body: normalizeToolBody(isRecord(toolInput) ? toolInput.body : undefined),
+      })).pipe(Effect.flatMap((result) => !result || result.isError
+        ? Effect.fail(toolError(toolResultError(result)))
+        : Effect.succeed(toolResultValue(result)))),
+    })] satisfies [string, Tool.Definition])
+    return [[namespace, Object.fromEntries(definitions)] satisfies [string, Record<string, Tool.Definition>]]
+  })
+
+  return {
+    tools: Object.fromEntries(namespaceEntries),
+    manifest: buildNativeProviderManifest({
+      connections: namespaceContext.codemodeNativeProviderEntries,
+      catalog: input.catalog,
+      namespaces: namespaceContext.namespaces.native,
+    }),
   }
 }
 
@@ -214,26 +309,19 @@ function isListedExternalConnection(value: ListedExternalConnection | undefined)
   return value !== undefined
 }
 
-export function isCodemodeEligibleConnection(
-  connection: Pick<ExternalMcpConnectionRow, "toolPolicy" | "oauthIssuerReviewRequiredAt">,
-): boolean {
-  return !connection.toolPolicy?.allDisabled && !connection.oauthIssuerReviewRequiredAt
-}
-
 export async function buildExternalMcpToolTree(input: {
   organizationId: string
   member: McpMemberIdentity | null
   redirectUriBase: string
+  namespaceContext?: CodemodeConnectionNamespaceContext
 }): Promise<BuiltCodemodeTools> {
   if (!input.member) return { tools: {}, manifest: [] }
   const memberIdentity = input.member
-  const connections = (await listUsableExternalMcpConnections({
-    organizationId: normalizeDenTypeId("organization", input.organizationId),
-    orgMembershipId: memberIdentity.orgMembershipId,
-    teamIds: memberIdentity.teamIds,
-  }))
-    .filter(isCodemodeEligibleConnection)
-    .slice(0, EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT)
+  const namespaceContext = input.namespaceContext ?? await resolveCodemodeConnectionNamespaceContext({
+    organizationId: input.organizationId,
+    member: memberIdentity,
+  })
+  const connections = namespaceContext.codemodeExternalMcpConnections
   const deadline = createExternalMcpLifecycleDeadline(EXTERNAL_MCP_TOOL_LIFECYCLE_TIMEOUT_MS)
   const listed = (await mapConcurrent(connections, EXTERNAL_MCP_SEARCH_CONCURRENCY, async (connection) => {
     try {
@@ -252,7 +340,7 @@ export async function buildExternalMcpToolTree(input: {
       return undefined
     }
   })).filter(isListedExternalConnection)
-  const namespaces = buildExternalNamespaceMap(connections)
+  const namespaces = namespaceContext.namespaces.externalMcp
   const namespaceEntries = listed.flatMap(({ connection, tools }) => {
     const namespace = namespaces.get(connection.id)
     if (!namespace) return []
@@ -298,11 +386,21 @@ export async function buildCodemodeToolTree(input: {
   organizationId: string
   member: McpMemberIdentity | null
   redirectUriBase: string
+  externalMcpConnectionsEnabled?: boolean
 }): Promise<BuiltCodemodeTools> {
+  assertCodemodeSourceParticipation()
+  const namespaceContext = await resolveCodemodeConnectionNamespaceContext({
+    organizationId: input.organizationId,
+    member: input.member,
+    includeExternalMcp: input.externalMcpConnectionsEnabled !== false,
+  })
   const den = buildDenCatalogToolTree(input)
-  const external = await buildExternalMcpToolTree(input)
+  const [native, external] = await Promise.all([
+    buildNativeProviderToolTree({ ...input, namespaceContext }),
+    buildExternalMcpToolTree({ ...input, namespaceContext }),
+  ])
   return {
-    tools: { ...den.tools, ...external.tools },
-    manifest: [...den.manifest, ...external.manifest],
+    tools: { ...den.tools, ...native.tools, ...external.tools },
+    manifest: [...den.manifest, ...native.manifest, ...external.manifest],
   }
 }

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -41,7 +41,12 @@ import {
 } from "./external-mcp-tool-arguments.js"
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
-import { buildExternalNamespaceMap, codemodeScriptPath } from "./codemode-tools.js"
+import {
+  CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT,
+  codemodeScriptPath,
+  resolveCodemodeConnectionNamespaceContext,
+  type CodemodeConnectionNamespaceContext,
+} from "./codemode-namespaces.js"
 
 /**
  * Merges org-level External MCP Connections (capability-sources/) into the
@@ -62,7 +67,7 @@ import { buildExternalNamespaceMap, codemodeScriptPath } from "./codemode-tools.
  */
 
 const EXTERNAL_CAPABILITY_PREFIX = "mcp:"
-export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = 16
+export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT
 export const EXTERNAL_MCP_SEARCH_CONCURRENCY = 4
 export const EXTERNAL_MCP_SEARCH_MATCH_LIMIT = 20
 
@@ -786,6 +791,7 @@ export async function searchExternalCapabilities(input: {
   redirectUriBase: string
   limit?: number
   includeScriptPaths?: boolean
+  namespaceContext?: CodemodeConnectionNamespaceContext
   reportCoverage?: (coverage: ExternalMcpSearchCoverage) => void
 }): Promise<ExternalCapabilityMatch[]> {
   if (!input.member) return []
@@ -795,14 +801,18 @@ export async function searchExternalCapabilities(input: {
   if (!Number.isFinite(requestedLimit) || requestedLimit <= 0) return []
   const limit = Math.min(Math.max(1, Math.trunc(requestedLimit)), EXTERNAL_MCP_SEARCH_MATCH_LIMIT)
   const deadline = createExternalMcpLifecycleDeadline()
-  const connections = await listUsableExternalMcpConnections({
+  const namespaceContext = input.includeScriptPaths
+    ? input.namespaceContext ?? await resolveCodemodeConnectionNamespaceContext({
+      organizationId: input.organizationId,
+      member: input.member,
+    })
+    : input.namespaceContext
+  const connections = namespaceContext?.externalMcpConnections ?? await listUsableExternalMcpConnections({
     organizationId: normalizeDenTypeId("organization", input.organizationId),
     orgMembershipId: input.member.orgMembershipId,
     teamIds: input.member.teamIds,
   })
-  const scriptNamespaces = input.includeScriptPaths
-    ? buildExternalNamespaceMap(connections.filter((connection) => !connection.toolPolicy?.allDisabled))
-    : undefined
+  const scriptNamespaces = input.includeScriptPaths ? namespaceContext?.namespaces.externalMcp : undefined
   const selectedConnections = selectExternalMcpSearchConnections(connections, queryTokens)
   input.reportCoverage?.({
     eligibleConnections: connections.length,

--- a/ee/apps/den-api/src/mcp/native-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/native-capabilities.ts
@@ -13,6 +13,11 @@ import {
 import { buildExternalConnectionStatus, type ExternalCapabilityMatch, type McpMemberIdentity } from "./external-capabilities.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
 import { compareCapabilityMatches, scoreText, tokenize, type CapabilityMatch } from "./search.js"
+import {
+  codemodeScriptPath,
+  resolveCodemodeConnectionNamespaceContext,
+  type CodemodeConnectionNamespaceContext,
+} from "./codemode-namespaces.js"
 
 export const NATIVE_CAPABILITY_PREFIX = "native:"
 
@@ -57,7 +62,7 @@ function operationScore(connection: NativeProviderConnectionEntry, operation: Mc
   )
 }
 
-function nativeOperations(catalog: McpToolOperation[], nativeProviderKey: string): McpToolOperation[] {
+export function nativeOperations(catalog: readonly McpToolOperation[], nativeProviderKey: string): McpToolOperation[] {
   const pathPrefix = `/v1/capabilities/${nativeProviderKey}/`
   return catalog.filter((operation) => operation.path.startsWith(pathPrefix))
 }
@@ -66,6 +71,7 @@ function capabilityMatch(
   connection: NativeProviderConnectionEntry,
   operation: McpToolOperation,
   score: number,
+  scriptNamespace?: string,
 ): NativeCapabilityMatch {
   const bodySchema = getJsonRequestBodySchema(operation.operation)
   return {
@@ -80,6 +86,7 @@ function capabilityMatch(
     hasBody: hasJsonRequestBody(operation.operation),
     inputSchema: operation.inputSchema,
     ...(bodySchema === undefined ? {} : { bodySchema }),
+    ...(scriptNamespace ? { scriptPath: codemodeScriptPath(scriptNamespace, operation.name) } : {}),
   }
 }
 
@@ -113,11 +120,19 @@ export async function searchNativeCapabilities(input: {
   organizationId: DenTypeId<"organization">
   member: McpMemberIdentity | null
   query: string
-  catalog: McpToolOperation[]
+  catalog: readonly McpToolOperation[]
   limit: number
+  includeScriptPaths?: boolean
+  namespaceContext?: CodemodeConnectionNamespaceContext
 }): Promise<NativeCapabilityMatch[]> {
   if (!input.member) return []
-  const connections = await listNativeProviderUsableEntries({
+  const namespaceContext = input.includeScriptPaths
+    ? input.namespaceContext ?? await resolveCodemodeConnectionNamespaceContext({
+      organizationId: input.organizationId,
+      member: input.member,
+    })
+    : input.namespaceContext
+  const connections = namespaceContext?.nativeProviderEntries ?? await listNativeProviderUsableEntries({
     organizationId: input.organizationId,
     orgMembershipId: input.member.orgMembershipId,
     teamIds: input.member.teamIds,
@@ -133,7 +148,12 @@ export async function searchNativeCapabilities(input: {
     }
     for (const operation of operations) {
       const score = operationScore(connection, operation, queryTokens)
-      if (score > 0) matches.push(capabilityMatch(connection, operation, score))
+      if (score > 0) matches.push(capabilityMatch(
+        connection,
+        operation,
+        score,
+        input.includeScriptPaths ? namespaceContext?.namespaces.native.get(connection.id) : undefined,
+      ))
     }
   }
   const boundedLimit = Math.max(1, Math.min(20, Math.trunc(input.limit) || 5))
@@ -145,7 +165,7 @@ async function resolveNativeCapability(input: {
   member: McpMemberIdentity | null
   connectionId: string
   toolName: string
-  catalog: McpToolOperation[]
+  catalog: readonly McpToolOperation[]
 }): Promise<{ connection: NativeProviderConnectionEntry; operation: McpToolOperation } | null> {
   if (!input.member) return null
   const connections = await listNativeProviderUsableEntries({
@@ -171,7 +191,7 @@ export async function executeNativeCapability(input: {
   name: string
   organizationId: DenTypeId<"organization">
   member: McpMemberIdentity | null
-  catalog: McpToolOperation[]
+  catalog: readonly McpToolOperation[]
   principal: McpPrincipal
   path?: unknown
   query?: unknown

--- a/ee/apps/den-api/test/codemode-native-binding.test.ts
+++ b/ee/apps/den-api/test/codemode-native-binding.test.ts
@@ -1,0 +1,108 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { Effect } from "effect"
+import { Hono } from "hono"
+import type { NativeProviderConnectionEntry } from "../src/capability-sources/native-provider-connections.js"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function normalizeRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined
+  return Object.fromEntries(Object.entries(value))
+}
+
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+const connectionId = createDenTypeId("externalMcpConnection")
+const entry: NativeProviderConnectionEntry = {
+  id: connectionId,
+  name: "Google Workspace",
+  url: "https://workspace.google.com",
+  authType: "oauth",
+  credentialMode: "per_member",
+  connected: true,
+  connectedAt: null,
+  connectedForMe: true,
+  needsReconnect: false,
+  missingFeatures: [],
+  nativeProviderKey: "google-workspace",
+  requiredBy: [],
+  access: null,
+}
+let observedInvocation: unknown
+let codemodeTools: typeof import("../src/mcp/codemode-tools.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.module("../src/capability-sources/native-provider-connections.js", () => ({
+    listNativeProviderUsableEntries: () => Promise.resolve([entry]),
+  }))
+  mock.module("../src/mcp/invoke.js", () => ({
+    invokeMcpOperation: (input: unknown) => {
+      observedInvocation = input
+      return Promise.resolve({ content: [{ type: "text", text: "{\"bound\":true}" }] })
+    },
+    normalizeToolBody: (value: unknown) => value,
+    normalizeToolRecord: normalizeRecord,
+  }))
+  codemodeTools = await import("../src/mcp/codemode-tools.js")
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test("native Code Mode leaves bind invocation to the selected connection", async () => {
+  observedInvocation = undefined
+  const catalog = buildMcpCatalog({
+    paths: {
+      "/v1/capabilities/google-workspace/gmail/messages": {
+        get: {
+          operationId: "getV1CapabilitiesGoogleWorkspaceGmailMessages",
+          tags: ["Capability Sources"],
+        },
+      },
+    },
+  })
+  const namespaces = codemodeTools.buildCodemodeConnectionNamespaceMaps({
+    native: [entry],
+    externalMcp: [],
+  })
+  const built = await codemodeTools.buildNativeProviderToolTree({
+    app: new Hono(),
+    env: undefined,
+    catalog,
+    principal: {
+      userId: createDenTypeId("user"),
+      organizationId,
+      scopes: new Set(["mcp:read"]),
+      payload: {},
+    },
+    organizationId,
+    member: { orgMembershipId: memberId, teamIds: [] },
+    namespaceContext: {
+      nativeProviderEntries: [entry],
+      externalMcpConnections: [],
+      codemodeNativeProviderEntries: [entry],
+      codemodeExternalMcpConnections: [],
+      namespaces,
+    },
+  })
+  const namespace = namespaces.native.get(connectionId)
+  const leaf = namespace ? built.tools[namespace]?.getCapabilitiesGoogleWorkspaceGmailMessages : undefined
+  if (!leaf) throw new Error("Expected native Code Mode leaf")
+
+  await Effect.runPromise(leaf.run({ query: { maxResults: 1 } }))
+
+  expect(isRecord(observedInvocation) ? observedInvocation.nativeConnectionId : undefined).toBe(connectionId)
+})

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, expect, test } from "bun:test"
 import { Tool } from "@openwork/codemode"
 import { Effect } from "effect"
+import { Hono } from "hono"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -10,19 +12,32 @@ function seedRequiredEnv() {
 }
 
 let buildExternalNamespaceMap: typeof import("../src/mcp/codemode-tools.js")["buildExternalNamespaceMap"]
+let buildCodemodeConnectionNamespaceMaps: typeof import("../src/mcp/codemode-tools.js")["buildCodemodeConnectionNamespaceMaps"]
+let buildDenCatalogToolTree: typeof import("../src/mcp/codemode-tools.js")["buildDenCatalogToolTree"]
+let buildNativeProviderManifest: typeof import("../src/mcp/codemode-tools.js")["buildNativeProviderManifest"]
+let CAPABILITY_SOURCE_KINDS: typeof import("../src/mcp/codemode-tools.js")["CAPABILITY_SOURCE_KINDS"]
+let CODEMODE_SOURCE_PARTICIPATION: typeof import("../src/mcp/codemode-tools.js")["CODEMODE_SOURCE_PARTICIPATION"]
 let isCodemodeEligibleConnection: typeof import("../src/mcp/codemode-tools.js")["isCodemodeEligibleConnection"]
 let firstUnattendedUnsafeCapability: typeof import("../src/mcp/codemode-tools.js")["firstUnattendedUnsafeCapability"]
 let restrictCodemodeToolTree: typeof import("../src/mcp/codemode-tools.js")["restrictCodemodeToolTree"]
 let sanitizeNamespaceSegment: typeof import("../src/mcp/codemode-tools.js")["sanitizeNamespaceSegment"]
+let parseNativeCapabilityName: typeof import("../src/mcp/native-capabilities.js")["parseNativeCapabilityName"]
 
 beforeAll(async () => {
   seedRequiredEnv()
   const codemodeTools = await import("../src/mcp/codemode-tools.js")
+  const nativeCapabilities = await import("../src/mcp/native-capabilities.js")
   buildExternalNamespaceMap = codemodeTools.buildExternalNamespaceMap
+  buildCodemodeConnectionNamespaceMaps = codemodeTools.buildCodemodeConnectionNamespaceMaps
+  buildDenCatalogToolTree = codemodeTools.buildDenCatalogToolTree
+  buildNativeProviderManifest = codemodeTools.buildNativeProviderManifest
+  CAPABILITY_SOURCE_KINDS = codemodeTools.CAPABILITY_SOURCE_KINDS
+  CODEMODE_SOURCE_PARTICIPATION = codemodeTools.CODEMODE_SOURCE_PARTICIPATION
   isCodemodeEligibleConnection = codemodeTools.isCodemodeEligibleConnection
   firstUnattendedUnsafeCapability = codemodeTools.firstUnattendedUnsafeCapability
   restrictCodemodeToolTree = codemodeTools.restrictCodemodeToolTree
   sanitizeNamespaceSegment = codemodeTools.sanitizeNamespaceSegment
+  parseNativeCapabilityName = nativeCapabilities.parseNativeCapabilityName
 })
 
 test("sanitizes connection names into interpreter-safe namespaces", () => {
@@ -88,4 +103,100 @@ test("allows only first-party read-only Den capabilities in unattended Cloud run
   expect(firstUnattendedUnsafeCapability({ ...built, manifest: [{ ...required, readOnly: true, authority: "external" as const }] }, [required])).toEqual(required)
   expect(firstUnattendedUnsafeCapability({ ...built, manifest: [{ ...required, readOnly: false, authority: "den" as const }] }, [required])).toEqual(required)
   expect(firstUnattendedUnsafeCapability({ ...built, manifest: [] }, [required])).toEqual(required)
+})
+
+test("excludes credential-bound native routes from the Den namespace and manifest", () => {
+  const catalog = buildMcpCatalog({
+    paths: {
+      "/v1/workers": {
+        get: { operationId: "getV1Workers", tags: ["Workers"] },
+      },
+      "/v1/capabilities/google-workspace/gmail/messages": {
+        get: {
+          operationId: "getV1CapabilitiesGoogleWorkspaceGmailMessages",
+          tags: ["Capability Sources"],
+        },
+      },
+      "/v1/capabilities/microsoft-365/calendar/events": {
+        get: {
+          operationId: "getV1CapabilitiesMicrosoft365CalendarEvents",
+          tags: ["Capability Sources"],
+        },
+      },
+      "/v1/capabilities/telegram/status": {
+        get: {
+          operationId: "getV1CapabilitiesTelegramStatus",
+          tags: ["Capability Sources"],
+        },
+      },
+    },
+  })
+  const built = buildDenCatalogToolTree({
+    app: new Hono(),
+    env: undefined,
+    catalog,
+    principal: { userId: "user", organizationId: "organization", scopes: new Set(["mcp:read"]), payload: {} },
+  })
+
+  expect(built.tools.den?.getCapabilitiesGoogleWorkspaceGmailMessages).toBeUndefined()
+  expect(built.tools.den?.getCapabilitiesMicrosoft365CalendarEvents).toBeUndefined()
+  expect(built.tools.den?.getCapabilitiesTelegramStatus).toBeDefined()
+  expect(built.tools.den?.getWorkers).toBeDefined()
+  const manifestPaths = built.manifest.map((entry) => entry.scriptPath)
+  expect(manifestPaths).toContain("tools.den.getCapabilitiesTelegramStatus")
+  expect(manifestPaths).toContain("tools.den.getWorkers")
+  // Absence asserted by scriptPath, not by whole-object equality: extra manifest
+  // fields (readOnly/authority) would make an object comparison pass vacuously.
+  expect(manifestPaths).not.toContain("tools.den.getCapabilitiesGoogleWorkspaceGmailMessages")
+  expect(manifestPaths).not.toContain("tools.den.getCapabilitiesMicrosoft365CalendarEvents")
+})
+
+test("allocates native and external namespaces from one collision set", () => {
+  const namespaces = buildCodemodeConnectionNamespaceMaps({
+    native: [
+      { id: "native-den", name: "den" },
+      { id: "native-codemode", name: "$codemode" },
+      { id: "native-shared", name: "Shared" },
+    ],
+    externalMcp: [
+      { id: "external-shared", name: "Shared" },
+      { id: "external-constructor", name: "constructor" },
+    ],
+  })
+  const allocated = [...namespaces.native.values(), ...namespaces.externalMcp.values()]
+
+  expect(new Set(allocated).size).toBe(allocated.length)
+  expect(allocated).not.toContain("den")
+  expect(allocated).not.toContain("$codemode")
+  expect(allocated).not.toContain("constructor")
+  expect(namespaces.native.get("native-shared")).toBe("shared")
+  expect(namespaces.externalMcp.get("external-shared")).toBe("shared_2")
+})
+
+test("declares Code Mode participation for every capability source kind", () => {
+  expect(Object.keys(CODEMODE_SOURCE_PARTICIPATION).sort()).toEqual([...CAPABILITY_SOURCE_KINDS].sort())
+})
+
+test("native manifest capability names round-trip through the native parser", () => {
+  const catalog = buildMcpCatalog({
+    paths: {
+      "/v1/capabilities/google-workspace/gmail/messages": {
+        get: {
+          operationId: "getV1CapabilitiesGoogleWorkspaceGmailMessages",
+          tags: ["Capability Sources"],
+        },
+      },
+    },
+  })
+  const manifest = buildNativeProviderManifest({
+    connections: [{ id: "native-connection", nativeProviderKey: "google-workspace" }],
+    catalog,
+    namespaces: new Map([["native-connection", "google_workspace"]]),
+  })
+
+  expect(manifest).toHaveLength(1)
+  expect(parseNativeCapabilityName(manifest[0]?.capabilityName ?? "")).toEqual({
+    connectionId: "native-connection",
+    toolName: "getCapabilitiesGoogleWorkspaceGmailMessages",
+  })
 })

--- a/evals/specs/codemode-scripts.slow.test.ts
+++ b/evals/specs/codemode-scripts.slow.test.ts
@@ -1,7 +1,10 @@
-import { expect } from "vitest";
+import { expect, onTestFinished } from "vitest";
 import {
+  createNativeConnector,
   createOrgConnection,
+  deleteConnection,
   denFetch,
+  freshSession,
   evalIn,
   readComposerState,
   readSessionToolCalls,
@@ -318,6 +321,104 @@ test(title, { timeout: 1_500_000 }, async ({ evidence, place }) => {
   );
   expect(workersProbeText).toContain("builder-1");
 
+  const denNamesProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "execute_capability_script", {
+    code: `return Object.keys(tools.den).sort()`,
+  });
+  const denNamesText = toolText(denNamesProbe);
+  const denNamesValue: unknown = JSON.parse(denNamesText);
+  const denNames = Array.isArray(denNamesValue) ? denNamesValue.filter((name): name is string => typeof name === "string") : [];
+  const workersOperationName = workersPath.slice("tools.den.".length);
+  const leakedNativeNames = denNames.filter((name) => {
+    const normalized = name.toLowerCase();
+    return normalized.includes("googleworkspace") || normalized.includes("microsoft365");
+  });
+  evidence.fact(
+    "Credential-bound native provider operations are not reachable through the shared Den namespace, while ordinary Den capabilities remain available",
+    `tools.den names: ${JSON.stringify(denNames).slice(0, 500)}; native operation names: ${JSON.stringify(leakedNativeNames)}; expected workers operation: ${workersOperationName}`,
+    leakedNativeNames.length === 0 && denNames.length > 0 && denNames.includes(workersOperationName),
+  );
+  expect(leakedNativeNames).toEqual([]);
+  expect(denNames.length).toBeGreaterThan(0);
+  expect(denNames).toContain(workersOperationName);
+
+  const telegramProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "execute_capability_script", {
+    code: `return Object.keys(tools.den).filter((name) => name.toLowerCase().includes("telegram"))`,
+  });
+  const telegramText = toolText(telegramProbe);
+  const telegramValue: unknown = JSON.parse(telegramText);
+  const telegramNames = Array.isArray(telegramValue)
+    ? telegramValue.filter((name): name is string => typeof name === "string")
+    : [];
+  evidence.fact(
+    "Telegram capability operations remain reachable through the shared Den namespace",
+    `Telegram tools.den names: ${JSON.stringify(telegramNames)}`,
+    telegramNames.length > 0,
+  );
+  expect(telegramNames.length).toBeGreaterThan(0);
+
+  const unconnectedGoogle = await createNativeConnector(den.admin, {
+    providerKey: "google-workspace",
+    name: "Unconnected Google Rail Probe",
+    clientId: "unconnected-google-rail-client",
+    clientSecret: "unconnected-google-rail-secret",
+    access: { orgWide: true },
+  });
+  let unconnectedGoogleDeleted = false;
+  onTestFinished(async () => {
+    if (!unconnectedGoogleDeleted) {
+      try {
+        await deleteConnection(den.admin, unconnectedGoogle.id);
+      } catch {
+        // A local test Den may already be disposed when Vitest runs cleanup.
+      }
+    }
+  });
+  const unconnectedNamespace = "unconnected_google_rail_probe";
+  const unconnectedNamespacesProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "execute_capability_script", {
+    code: `return Object.keys(tools).sort()`,
+  });
+  const unconnectedNamespacesText = toolText(unconnectedNamespacesProbe);
+  const unconnectedNamespacesValue: unknown = JSON.parse(unconnectedNamespacesText);
+  const unconnectedNamespaces = Array.isArray(unconnectedNamespacesValue)
+    ? unconnectedNamespacesValue.filter((name): name is string => typeof name === "string")
+    : [];
+  // Closed-world: asserting one guessed namespace is absent would pass even if the
+  // sanitizer produced a different name, so pin the whole namespace set instead.
+  const expectedNamespaces = ["$codemode", "den", "drive_mock", "gmail_mock"];
+  evidence.fact(
+    "An unconnected native provider does not surface a callable script namespace",
+    `Object.keys(tools): ${JSON.stringify(unconnectedNamespaces)}; expected exactly: ${JSON.stringify(expectedNamespaces)}`,
+    JSON.stringify(unconnectedNamespaces) === JSON.stringify(expectedNamespaces),
+  );
+  expect(unconnectedNamespaces).toEqual(expectedNamespaces);
+  expect(unconnectedNamespaces).not.toContain(unconnectedNamespace);
+
+  const unconnectedSearchProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "search_capabilities", {
+    query: "Unconnected Google Rail Probe Gmail",
+    limit: 20,
+  });
+  const unconnectedSearchPayload = requireRecord(JSON.parse(toolText(unconnectedSearchProbe)), "unconnected Google search payload");
+  const unconnectedSearchMatches = Array.isArray(unconnectedSearchPayload.matches)
+    ? unconnectedSearchPayload.matches.filter(isRecord)
+    : [];
+  const unconnectedConnectionMatches = unconnectedSearchMatches.filter((match) =>
+    String(match.name ?? "").includes(unconnectedGoogle.id)
+    || (isRecord(match.connectionStatus) && match.connectionStatus.connectionName === unconnectedGoogle.name));
+  const unconnectedStatusOnly = unconnectedConnectionMatches.length > 0
+    && unconnectedConnectionMatches.every((match) =>
+      match.kind === "connection_status"
+      && match.status === "needs_connection"
+      && typeof match.scriptPath === "undefined");
+  evidence.fact(
+    "Capability search reports the unconnected Google provider as needing connection, never as a callable capability",
+    `Matching search rows: ${JSON.stringify(unconnectedConnectionMatches).slice(0, 500)}`,
+    unconnectedStatusOnly,
+  );
+  expect(unconnectedConnectionMatches.length).toBeGreaterThan(0);
+  expect(unconnectedStatusOnly).toBe(true);
+  await deleteConnection(den.admin, unconnectedGoogle.id);
+  unconnectedGoogleDeleted = true;
+
   // ---- Frames 2+3: one script step instead of a call per worker -------------
   await using desktopApp = await app({ den, as: "admin", place, ...(modelId ? { model: modelId } : {}) });
   await waitFor(desktopApp, `location.hash.includes('/session')`, { timeoutMs: 60_000, label: "session route" });
@@ -529,9 +630,13 @@ return { drive, gmail }`,
   expect(runsSeen.ok, runsSeen.why).toBe(true);
 
   // ---- Frame 7b: disabling a tool makes dependent saved scripts fail closed --
-  const mentionsPlugin = await denFetch(den.admin, "/v1/plugins", {
+  // Org-wide plugin creation is a step-up-protected admin write, and this spec runs
+  // long enough for the admin session's fresh-auth window to lapse. Re-authenticate
+  // first, the same way behaviors' connection helpers do on `reauth`.
+  const freshAdmin = await freshSession(den.admin);
+  const mentionsPlugin = await denFetch(freshAdmin, "/v1/plugins", {
     method: "POST",
-    headers: { authorization: `Bearer ${den.admin.token}` },
+    headers: { authorization: `Bearer ${freshAdmin.token}` },
     body: JSON.stringify({
       name: "offsite-mentions-report",
       description: "Echoes offsite mentions through the Drive Mock connection",


### PR DESCRIPTION
## What

The codemode script tree (shipped in #3645) only covered the Den REST catalog and external MCP connections. **Native providers — Google Workspace, Microsoft 365 — were missing**, so scripts could not use the most obvious capabilities an org has connected.

Worse than missing: those providers' REST operations *leaked* into `tools.den.*` via the shared catalog. They only function when `invokeMcpOperation` receives `nativeConnectionId` (which sets the internal connector header); the den namespace passes none. So the model saw callable tools that could not resolve credentials, and which bypassed `resolveNativeCapability`'s access/`connectedForMe` gating.

- `buildNativeProviderToolTree` exposes `tools.<connection>.<operation>` for connections the member has actually connected, dispatching through `executeNativeCapability` so calls stay credential-bound.
- `buildDenCatalogToolTree` and the `api`-source search now exclude credential-bound native operations — reachable only through their connection namespace.
- Namespace allocation moved to `codemode-namespaces.ts`, resolved **once per request and shared by search and the tree**, so a `scriptPath` from `search_capabilities` can never disagree with the tree, and cross-rail collisions are impossible.
- Native search matches carry `scriptPath`, like catalog and external ones.
- `CODEMODE_SOURCE_PARTICIPATION` is an exhaustive `Record<CapabilitySourceKind, "tree" | { excluded: reason }>` — every rail must declare participation or an explicit reason, so a new source cannot silently skip the tree.

### One scoping subtlety worth reviewing

The exclusion predicate derives its prefixes from `NATIVE_OAUTH_PROVIDERS`, **not** from the raw `/v1/capabilities/` path prefix. Telegram also lives under `/v1/capabilities/` and is *not* a native provider — a blanket prefix would have silently dropped working Telegram capabilities from both search and the tree. There's a regression test pinning both directions.

## Why

`search`, `execute`, and `execute_capability_script` should feel interchangeable: whatever search finds, execute should run and a script should call. Google Workspace being findable-and-executable but not scriptable broke that, and the leak made it worse by advertising a broken path. This restores the invariant for the native rail and adds the compiler-enforced primitive that stops the next rail from regressing it.

The full `CapabilitySource` registry (collapsing the six hand-wired search blocks, the prefix if/else in execute, and the tree builders onto one interface) is the follow-up PR; this one is deliberately scoped to correctness plus the interim guard.

## Verification

`evals/specs/codemode-scripts.slow.test.ts` — **20/20 facts, 0 failed** (local lane: real Den boot, real Electron, real Sonnet turn, MCP witnesses). Four new:

- Credential-bound native operations are **not** reachable through `tools.den.*` (with the negative half: the den namespace is still populated and still has the workers operation)
- Telegram capability operations **remain** reachable through `tools.den.*` — the over-exclusion guard
- An unconnected native provider surfaces **no** callable script namespace (closed-world assertion on the whole namespace set, so a mis-guessed name can't false-green)
- Search reports the unconnected provider as `kind: "connection_status"` / `needs_connection` with no `scriptPath`, never as a callable capability

Also: `bun test` across `codemode-tools`, `codemode-native-binding` (asserts `nativeConnectionId` actually reaches `invokeMcpOperation`), `agent-codemode-script`, `codemode-rollout`, `organization-capabilities`, `agent-mcp-routes`, `marketplace-codemode-*`, `marketplace-capabilities`, `codemode-runs` — all green. `tsc --noEmit` clean; `pnpm --filter @openwork-ee/den-api build` exit 0.

**Verification boundary, stated plainly:** connected-native *execution* is proven at unit level (credential binding) and by the tree/search parity assertions, not end-to-end against real Google OAuth. Driving a fully connected native provider needs the Google mock harness that `google-workspace-multi-account.slow.test.ts` uses (`DEN_GOOGLE_API_BASE_URL` + `DEN_GOOGLE_OAUTH_*` against a warm Den), which is out of scope here. Worth a follow-up if we want that path covered in CI.

Evidence tape published below.
