### PR TITLE
perf(den): batch connector sync target checks

### DIFF
--- a/ee/apps/den-api/src/workers/github-sync.ts
+++ b/ee/apps/den-api/src/workers/github-sync.ts
@@ -69,6 +69,22 @@ function changedRows(result: unknown): boolean {
   return false
 }
 
+async function connectorTargetIdsWithStatuses(
+  connectorTargetIds: string[],
+  statuses: Array<(typeof ConnectorSyncEventTable.$inferSelect)["status"]>,
+) {
+  if (connectorTargetIds.length === 0) return new Set<string>()
+  const rows = await db
+    .select({ connectorTargetId: ConnectorSyncEventTable.connectorTargetId })
+    .from(ConnectorSyncEventTable)
+    .where(and(
+      inArray(ConnectorSyncEventTable.connectorTargetId, connectorTargetIds),
+      inArray(ConnectorSyncEventTable.status, statuses),
+    ))
+    .groupBy(ConnectorSyncEventTable.connectorTargetId)
+  return new Set(rows.flatMap((row) => row.connectorTargetId ? [row.connectorTargetId] : []))
+}
+
 export function computeGithubSyncBackoffMs(
   attemptCount: number,
   baseMs = env.githubSync.retryBaseMs,
@@ -103,19 +119,12 @@ export async function processDueGithubSyncEvents(now = new Date()) {
     ))
     .orderBy(asc(ConnectorSyncEventTable.startedAt), asc(ConnectorSyncEventTable.id))
 
+  const eventTargetIds = [...new Set(events.flatMap((event) => event.connectorTargetId ? [event.connectorTargetId] : []))]
+  const runningTargetIds = await connectorTargetIdsWithStatuses(eventTargetIds, ["running"])
+
   let claimed = 0
   for (const event of events) {
-    if (event.connectorTargetId) {
-      const runningEvents = await db
-        .select({ id: ConnectorSyncEventTable.id })
-        .from(ConnectorSyncEventTable)
-        .where(and(
-          eq(ConnectorSyncEventTable.connectorTargetId, event.connectorTargetId),
-          eq(ConnectorSyncEventTable.status, "running"),
-        ))
-        .limit(1)
-      if (runningEvents[0]) continue
-    }
+    if (event.connectorTargetId && runningTargetIds.has(event.connectorTargetId)) continue
 
     const claimResult: unknown = await db
       .update(ConnectorSyncEventTable)
@@ -126,6 +135,7 @@ export async function processDueGithubSyncEvents(now = new Date()) {
       ))
     if (!changedRows(claimResult)) continue
     claimed += 1
+    if (event.connectorTargetId) runningTargetIds.add(event.connectorTargetId)
 
     try {
       await executeGithubConnectorSyncEvent({ connectorSyncEventId: event.id })
@@ -226,20 +236,11 @@ export async function reconcileGithubConnectorTargets() {
     ))
     .orderBy(asc(ConnectorTargetTable.createdAt), asc(ConnectorTargetTable.id))
 
-  const candidateTargets: typeof targets = []
-  for (const row of targets) {
-    const activeEvents = await db
-      .select({ id: ConnectorSyncEventTable.id })
-      .from(ConnectorSyncEventTable)
-      .where(and(
-        eq(ConnectorSyncEventTable.connectorTargetId, row.target.id),
-        inArray(ConnectorSyncEventTable.status, ["queued", "running"]),
-      ))
-      .limit(1)
-    if (activeEvents[0]) continue
-
-    candidateTargets.push(row)
-  }
+  const activeTargetIds = await connectorTargetIdsWithStatuses(
+    targets.map((row) => row.target.id),
+    ["queued", "running"],
+  )
+  const candidateTargets = targets.filter((row) => !activeTargetIds.has(row.target.id))
 
   const now = new Date()
   const selectedTargetIds = selectGithubReconcileCandidates({

--- a/ee/apps/den-api/test/github-sync-worker.test.ts
+++ b/ee/apps/den-api/test/github-sync-worker.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -89,4 +91,21 @@ test("GitHub reconcile selection excludes probes newer than the minimum age and 
       { createdAtMs: 30, targetId: "never-probed" },
     ],
   })).toEqual(["never-probed", "at-boundary"])
+})
+
+test("GitHub sync batches active-target lookups instead of querying once per event or target", () => {
+  const source = readFileSync(join(import.meta.dir, "../src/workers/github-sync.ts"), "utf8")
+  const dueEvents = source.slice(
+    source.indexOf("export async function processDueGithubSyncEvents"),
+    source.indexOf("function githubTargetConfig"),
+  )
+  const reconciliation = source.slice(
+    source.indexOf("export async function reconcileGithubConnectorTargets"),
+    source.indexOf("let workerTickRunning"),
+  )
+
+  expect(dueEvents).toContain("await connectorTargetIdsWithStatuses(eventTargetIds, [\"running\"])")
+  expect(dueEvents).not.toContain("const runningEvents = await db")
+  expect(reconciliation).toContain("targets.map((row) => row.target.id)")
+  expect(reconciliation).not.toContain("const activeEvents = await db")
 })


### PR DESCRIPTION
## Summary

- replace per-event `connector_sync_event` running-state queries with one target-bounded batch lookup per worker tick
- replace per-target queued/running reconciliation queries with one target-bounded batch lookup
- reuse the existing `(connector_target_id, status)` index and preserve the compare-and-set claim update

## Why

The worker selected a batch and then issued an additional `connector_sync_event` query for every event or target. The external-work batch limit did not cap those database reads, producing an N+1 query pattern on every worker tick.

The new lookups are constrained to target IDs already selected by the tick, so they avoid both the N+1 pattern and a broad status scan.

## Behavior

Per-target serialization remains intact. Once an event is claimed, its target is added to the in-memory running set, so another queued event for the same target waits for a later worker tick.

## Verification

- `bun test ee/apps/den-api/test/github-sync-worker.test.ts` — 5 passed, 18 expectations
- `git diff --check` — passed
- Den API `tsc --noEmit` currently stops on pre-existing `CreateAutomation` union errors in unchanged automation files on the exact `dev` base

