### PR TITLE
perf(automations): stop idle runner database heartbeats

### DIFF
--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -581,15 +581,6 @@ export class DenAutomationRepository implements AutomationRepository {
       ))
   }
 
-  async hasRecentDesktopRunner(input: { organizationId: string; ownerMemberId: string; seenAfter: number }) {
-    const rows = await db.select({ id: AutomationRunnerTable.id }).from(AutomationRunnerTable).where(and(
-      eq(AutomationRunnerTable.organization_id, normalizeOrganizationId(input.organizationId)),
-      eq(AutomationRunnerTable.owner_member_id, normalizeMemberId(input.ownerMemberId)),
-      gt(AutomationRunnerTable.last_seen_at, new Date(input.seenAfter)),
-    )).limit(1)
-    return rows.length > 0
-  }
-
   async discoverDesktopWork(input: { organizationId: string; ownerMemberId: string; now: number; limit: number }) {
     const rows = await db.select({ runId: AutomationRunTable.id, executionTarget: AutomationRunTable.execution_target })
       .from(AutomationRunTable)

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -12,7 +12,6 @@ import { isActiveAutomationOwner, resolveAutomationModelAccess } from "./authori
 import { automationRepository } from "./repository.js"
 
 const schedulerOwner = `den:${process.pid}:${randomUUID()}`
-const DESKTOP_RUNNER_ONLINE_WINDOW_MS = 45_000
 
 type OwnerScope = { organizationId: string; ownerMemberId: string }
 export type DesktopRunnerScope = OwnerScope & { runnerId: string }
@@ -138,14 +137,6 @@ export class AutomationService {
 
   touchDesktopRunner(scope: DesktopRunnerScope) {
     return automationRepository.touchDesktopRunner({ ...scope, now: Date.now() })
-  }
-
-  hasOnlineDesktopRunner(scope: OwnerScope) {
-    const now = Date.now()
-    return automationRepository.hasRecentDesktopRunner({
-      ...scope,
-      seenAfter: now - DESKTOP_RUNNER_ONLINE_WINDOW_MS,
-    })
   }
 
   async discoverDesktopRunnerWork(scope: DesktopRunnerScope) {

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -136,7 +136,10 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
           await stream.writeSSE({ id: payload.cursor, event: payload.type, data: JSON.stringify(payload) })
         }
         if (notifications.length === 0 && Date.now() - lastKeepaliveAt >= RUNNER_KEEPALIVE_INTERVAL_MS) {
-          await service.touchDesktopRunner(identity)
+          // The open SSE stream is the live presence signal. Persisting that
+          // signal every 15 seconds turns every idle runner into a perpetual
+          // database writer; durable runner metadata is refreshed when the
+          // runner registers or actually asks for work instead.
           await stream.writeSSE({ event: "keepalive", data: "{}" })
           lastKeepaliveAt = Date.now()
         }
@@ -335,12 +338,11 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     }),
     orgMemberRoute(), paramValidator(idParamsSchema),
     async (c) => {
-      const owner = scope(c)
-      if (!(await service.hasOnlineDesktopRunner(owner))) {
-        return c.json({ error: "runner_unavailable", message: "No desktop runner is online" }, 409)
-      }
       try {
-        const run = await service.runNow(owner, c.req.valid("param").id)
+        // Runner presence is advisory and must not require a database
+        // heartbeat. The durable claim deadline records an unclaimed desktop
+        // run as missed through the same path used by scheduled occurrences.
+        const run = await service.runNow(scope(c), c.req.valid("param").id)
         return run ? c.json({ run }, 202) : c.json({ error: "automation_not_found" }, 404)
       } catch (error) {
         const mapped = failure(error)

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -165,18 +165,25 @@ test("idle runner notification polling backs off without delaying keepalives", (
   assert.equal(nextRunnerNotificationPollDelay(delay, true), RUNNER_NOTIFICATION_POLL_MIN_MS)
 })
 
-test("manual runs use durable runner presence across Den API replicas", () => {
+test("idle runner keepalives do not persist liveness in the database", () => {
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
   const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
-  const runnerAuthSource = readFileSync(join(import.meta.dir, "../src/automations/runner-auth.ts"), "utf8")
+  const sse = routesSource.slice(
+    routesSource.indexOf("/v1/automation-runners/events\", async"),
+    routesSource.indexOf("/v1/automation-runner/work"),
+  )
+  const manualRun = routesSource.slice(
+    routesSource.indexOf("/v1/automations/:id/run"),
+    routesSource.indexOf("/v1/automations/:id/runs"),
+  )
 
-  assert.match(routesSource, /await service\.hasOnlineDesktopRunner\(owner\)/)
-  assert.doesNotMatch(routesSource, /automationRunnerAuth\.hasConnected/)
-  assert.doesNotMatch(runnerAuthSource, /connections = new Map/)
-  assert.match(serviceSource, /DESKTOP_RUNNER_ONLINE_WINDOW_MS = 45_000/)
-  assert.match(serviceSource, /automationRepository\.hasRecentDesktopRunner\(/)
-  assert.match(repositorySource, /gt\(AutomationRunnerTable\.last_seen_at, new Date\(input\.seenAfter\)\)/)
+  assert.match(sse, /stream\.writeSSE\(\{ event: "keepalive"/)
+  assert.doesNotMatch(sse, /touchDesktopRunner/)
+  assert.doesNotMatch(manualRun, /hasOnlineDesktopRunner/)
+  assert.match(serviceSource, /claimDeadlineMs: env\.automations\.runnerClaimDeadlineMs/)
+  assert.doesNotMatch(serviceSource, /hasRecentDesktopRunner/)
+  assert.doesNotMatch(repositorySource, /AutomationRunnerTable\.last_seen_at, new Date\(input\.seenAfter\)/)
 })
 
 test("every dispatch path revalidates the owner's model access", () => {


### PR DESCRIPTION
## Summary

- keep the desktop runner SSE keepalive without writing `automation_runner.last_seen_at` every 15 seconds
- refresh durable runner metadata only when the runner registers or requests work
- route manual desktop runs through the existing durable claim-deadline path instead of querying database-backed presence first

## Why

Idle desktop runners currently turn into perpetual database writers. Runner presence is transient state, while the run claim and lease protocol is already the durable correctness boundary. Removing the heartbeat write eliminates the steady update load without weakening run ownership, lease renewal, or missed-run receipts.

## Behavior change

When no desktop runner is connected, a manual run is now accepted and settles as `missed` through the configured claim deadline, matching scheduled desktop runs. It no longer returns an immediate `409 runner_unavailable` based on a recent database timestamp.

This leaves room for an advisory Redis-backed presence signal later without coupling correctness to cache availability.

## Verification

- `bun test ee/apps/den-api/test/automation-runner-protocol.test.ts` — 13 passed
- `git diff --check` — passed
- Den API `tsc --noEmit` currently stops on pre-existing `CreateAutomation` union errors present on the exact `dev` base; the same errors reproduce in an isolated branch that does not touch automation code

