### PR TITLE
fix(mcp): preserve ordinary MCP updates without a vault key

### DIFF
--- a/apps/server/src/local-managed-mcp.e2e.test.ts
+++ b/apps/server/src/local-managed-mcp.e2e.test.ts
@@ -8,6 +8,7 @@ import { join, resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
+import { deleteLocalManagedMcp, setLocalManagedMcpEnabled } from "./local-managed-mcp.js";
 import { runtimeStorageDir } from "./runtime-db.js";
 import { readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
@@ -135,6 +136,25 @@ async function connectGateway(runtimeConfig: Record<string, unknown>): Promise<C
 }
 
 describe("OpenWork-managed local MCP OAuth gateway", () => {
+  test("leaves ordinary MCP fallbacks usable when no managed vault exists", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-local-managed-mcp-fallback-"));
+    roots.push(workspaceRoot);
+    const config = createConfig({
+      port: await freePort(),
+      workspaceRoot,
+      engineBaseUrl: "http://127.0.0.1:1",
+      vaultKey: randomBytes(32),
+    });
+    config.configPath = join(workspaceRoot, "server.json");
+    config.localManagedMcpVaultKey = async () => {
+      throw new Error("vault key should not be requested");
+    };
+
+    expect(await setLocalManagedMcpEnabled(config, "ws_managed", "ordinary", false)).toBe(false);
+    expect(await deleteLocalManagedMcp(config, "ws_managed", "ordinary")).toBe(false);
+    expect(existsSync(join(runtimeStorageDir(config), "local-managed-mcp-vault.json"))).toBe(false);
+  });
+
   test("owns OAuth, exposes provider tools to OpenCode, refreshes, survives restart, and disconnects", async () => {
     const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
     const previousDevMode = process.env.OPENWORK_DEV_MODE;

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -219,7 +219,11 @@ async function writeVault(config: ServerConfig, vault: LocalManagedMcpVault): Pr
   await chmod(path, 0o600).catch(() => undefined);
 }
 
-async function withVaultMutation<T>(config: ServerConfig, mutate: (vault: LocalManagedMcpVault) => Promise<T> | T): Promise<T> {
+async function withVaultMutation<T>(
+  config: ServerConfig,
+  mutate: (vault: LocalManagedMcpVault) => Promise<T> | T,
+  shouldPersist: (result: T) => boolean = () => true,
+): Promise<T> {
   const path = vaultPath(config);
   const previous = vaultQueueByPath.get(path) ?? Promise.resolve();
   let resolveCurrent: (() => void) | undefined;
@@ -231,7 +235,7 @@ async function withVaultMutation<T>(config: ServerConfig, mutate: (vault: LocalM
   try {
     const vault = await readVault(config);
     const result = await mutate(vault);
-    await writeVault(config, vault);
+    if (shouldPersist(result)) await writeVault(config, vault);
     return result;
   } finally {
     resolveCurrent?.();
@@ -730,7 +734,7 @@ export async function setLocalManagedMcpEnabled(
     connection.enabled = enabled;
     connection.updatedAt = Date.now();
     return true;
-  });
+  }, (changed) => changed);
   if (updated) await writeManagedRuntimeEntry(config, workspaceId, name, enabled);
   return updated;
 }
@@ -757,7 +761,7 @@ export async function deleteLocalManagedMcp(config: ServerConfig, workspaceId: s
     if (!vault.connections[key]) return false;
     delete vault.connections[key];
     return true;
-  });
+  }, (changed) => changed);
   if (removed) await removeManagedRuntimeEntry(config, workspaceId, name);
   return removed;
 }


### PR DESCRIPTION
## Why

Merged #3652 made the generic MCP enable and delete routes probe the OpenWork-managed OAuth vault before falling through to the ordinary MCP implementation. The vault mutation helper persisted after every callback, including callbacks that returned `false` because no managed connection existed.

On server and CI configurations without a desktop vault key, that no-op attempted to create an empty encrypted vault and returned `managed_mcp_secure_storage_unavailable` (HTTP 503). This broke ordinary MCP toggle/delete operations and the server test matrix on both Linux and macOS.

## What changed

- Let managed-vault mutations decide whether their result requires persistence.
- Skip the encrypted vault write when enable/delete finds no managed connection.
- Preserve encrypted persistence for real managed connection changes.
- Preserve fail-closed behavior when an existing encrypted vault cannot be opened.
- Add a regression that uses a throwing key provider and verifies ordinary fallbacks return `false` without requesting the key or creating a vault file.

## Verification

- `pnpm -C apps/server test src/local-managed-mcp.e2e.test.ts src/mcp.engine-sync.e2e.test.ts`
  - 22 passed, 0 failed, 145 assertions
- `pnpm -C apps/server typecheck`
- `git diff --check`

The full local server suite reached 644 passed and 8 skipped before the existing Bun 1.3.4 resolver error in `workspace-kv-store.node.test.ts` (`node:sqlite` could not be resolved). The affected MCP suites pass in full.