### PR TITLE
fix(den-api): type batched connector-target ids as branded ids (unbreaks dev)

### DIFF
--- a/ee/apps/den-api/src/workers/github-sync.ts
+++ b/ee/apps/den-api/src/workers/github-sync.ts
@@ -70,7 +70,7 @@ function changedRows(result: unknown): boolean {
 }
 
 async function connectorTargetIdsWithStatuses(
-  connectorTargetIds: string[],
+  connectorTargetIds: Array<NonNullable<(typeof ConnectorSyncEventTable.$inferSelect)["connectorTargetId"]>>,
   statuses: Array<(typeof ConnectorSyncEventTable.$inferSelect)["status"]>,
 ) {
   if (connectorTargetIds.length === 0) return new Set<string>()


### PR DESCRIPTION
`origin/dev` is currently red: the den-api build fails, so **`Build openwork-den-api` fails on every open PR**. Reproduced in a clean worktree at `8eebd3f97` with no other changes:

```
$ pnpm --filter @openwork-ee/den-api build
src/workers/github-sync.ts(81,7): error TS2769: No overload matches this call.
  Overload 2 of 3, '(column: MySqlColumn<{ ... data: `ctg_${string}`; ... }>,
    values: SQLWrapper | readonly (`ctg_${string}` | Placeholder<...>)[]): SQL<...>',
    gave the following error.
    Argument of type 'string[]' is not assignable to parameter of type
    'SQLWrapper | readonly (`ctg_${string}` | Placeholder<string, any>)[]'
```

## Cause

#3674 ("perf(den): batch connector sync target checks") added the batch helper with `connectorTargetIds: string[]`, but `ConnectorSyncEventTable.connectorTargetId` is a branded `denTypeIdColumn("connectorTarget", …)` (`plugin-arch.ts:384`) whose data type is `` `ctg_${string}` ``, so `inArray` matched no overload. The sibling parameter one line below already used the right pattern:

```ts
statuses: Array<(typeof ConnectorSyncEventTable.$inferSelect)["status"]>,
```

## Fix

Derive `connectorTargetIds` from `$inferSelect` the same way (with `NonNullable`, since the event column is nullable). One line, types only, runtime unchanged. No casts.

Caller audit: every caller already holds branded ids — event ids come from `ConnectorSyncEventTable`, reconcile ids from `ConnectorTargetTable.id` — so nothing else needed changing.

## Verification

- `pnpm --filter @openwork-ee/den-api build` — **exit 0, zero TypeScript errors** (this is the exact CI failure)
- `pnpm exec bun test test/github-sync-worker.test.ts` — **exit 0, 5 passed**

Types-only change to a worker's parameter signature; no runtime behavior and no schema change, so no testkit spec applies.