### PR TITLE
One capability set, three verbs: collapse search/execute/script onto a source registry

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -30,7 +30,7 @@ import { registerMemoryRoutes } from "./routes/memory/index.js"
 import { registerAutomationRoutes } from "./routes/automations/index.js"
 import { configureCloudSavedScriptExecutor } from "./automations/service.js"
 import { getCatalog } from "./mcp/index.js"
-import { buildCodemodeToolTree } from "./mcp/codemode-tools.js"
+import { buildCapabilityToolTree, createCapabilityRegistryContext } from "./mcp/capability-registry.js"
 import { executeMarketplaceCapability } from "./mcp/marketplace-capabilities.js"
 import { resolveMcpMemberIdentity } from "./mcp/external-capabilities.js"
 import { DEN_MCP_REQUESTED_SCOPES } from "./mcp/scopes.js"
@@ -229,13 +229,27 @@ configureCloudSavedScriptExecutor(async ({ organizationId, ownerMemberId, automa
   const organizations = await db.select({ metadata: OrganizationTable.metadata }).from(OrganizationTable).where(
     eq(OrganizationTable.id, normalizedOrganizationId),
   ).limit(1)
-  if (!codemodeScriptsEnabled(organizations[0]?.metadata)) {
+  const organizationMetadata = organizations[0]?.metadata
+  const codemodeEnabled = codemodeScriptsEnabled(organizationMetadata)
+  if (!codemodeEnabled) {
     return { ok: false, message: "Code Mode scripts are disabled for this organization.", retryable: false }
   }
   const member = await resolveMcpMemberIdentity({ userId, organizationId })
   if (!member) return { ok: false, message: "The Automation owner is no longer active.", retryable: false }
   const catalog = await getCatalog(app as unknown as Hono, undefined)
   const principal = { userId, organizationId, scopes: new Set(DEN_MCP_REQUESTED_SCOPES), payload: {} }
+  const capabilityContext = createCapabilityRegistryContext({
+    app: app as unknown as Hono,
+    env: undefined,
+    catalog,
+    principal,
+    organizationId: normalizedOrganizationId,
+    member,
+    redirectUriBase: env.apiPublicUrl ?? "http://127.0.0.1",
+    codemodeEnabled,
+    organizationMetadata,
+    mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
+  })
   const result = await executeMarketplaceCapability({
     organizationId,
     member,
@@ -246,15 +260,7 @@ configureCloudSavedScriptExecutor(async ({ organizationId, ownerMemberId, automa
     body: action.input,
     codemodeEnabled: true,
     validateScriptOutput: true,
-    buildTools: () => buildCodemodeToolTree({
-      app: app as unknown as Hono,
-      env: undefined,
-      catalog,
-      principal,
-      organizationId,
-      member,
-      redirectUriBase: env.apiPublicUrl ?? "http://127.0.0.1",
-    }),
+    buildTools: () => buildCapabilityToolTree(capabilityContext),
   })
   if (!result.ok) return {
     ok: false,

--- a/ee/apps/den-api/src/mcp/admin-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/admin-capabilities.ts
@@ -37,9 +37,8 @@ export function parseAdminCapabilityName(name: string): string | null {
   return toolName.length > 0 ? toolName : null
 }
 
-export async function searchAdminCapabilities(query: string, limit = 5): Promise<CapabilityMatch[]> {
-  const queryTokens = tokenize(query)
-  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
+async function listAdminCapabilityMatches(query?: string): Promise<CapabilityMatch[]> {
+  const queryTokens = query === undefined ? undefined : tokenize(query)
   const { tools } = await withAdminClient((client) => client.listTools())
 
   return tools
@@ -49,12 +48,14 @@ export async function searchAdminCapabilities(query: string, limit = 5): Promise
         name: `${ADMIN_CAPABILITY_PREFIX}${tool.name}`,
         method: "MCP",
         path: "/mcp/admin",
-        score: scoreText(
-          tokenize(tool.name),
-          tokenize(tool.description ?? ""),
-          queryTokens,
-          ["admin", "platform"],
-        ),
+        score: queryTokens
+          ? scoreText(
+            tokenize(tool.name),
+            tokenize(tool.description ?? ""),
+            queryTokens,
+            ["admin", "platform"],
+          )
+          : 1,
         summary: `[OpenWork Admin] ${tool.description ?? tool.name}`,
         pathParams: [],
         queryParams: [],
@@ -62,8 +63,17 @@ export async function searchAdminCapabilities(query: string, limit = 5): Promise
         ...(hasBody ? { argumentsSchema: tool.inputSchema, invocation: ADMIN_ARGUMENT_INVOCATION } : {}),
       }
     })
-    .filter((match) => match.score > 0)
+    .filter((match) => queryTokens === undefined || match.score > 0)
     .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+}
+
+export async function listAvailableAdminCapabilities(platformAdmin: boolean): Promise<CapabilityMatch[]> {
+  return platformAdmin ? listAdminCapabilityMatches() : []
+}
+
+export async function searchAdminCapabilities(query: string, limit = 5): Promise<CapabilityMatch[]> {
+  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
+  return (await listAdminCapabilityMatches(query))
     .slice(0, boundedLimit)
 }
 

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -13,36 +13,40 @@ import { codemodeScriptsEnabled } from "../capability-sources/codemode-rollout.j
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
-import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
-import { compareCapabilityMatches, SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities, searchCapabilitySourceFilter, type CapabilityMatch } from "./search.js"
-import { executeExternalCapability, externalMcpSearchCoverageHint, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities, type ExternalCapabilityExecuteResult } from "./external-capabilities.js"
-import { executeMarketplaceCapability, listAccessibleMarketplaceSkillDescriptors, parseMarketplaceCapabilityName, searchMarketplaceCapabilities, type MarketplaceCapabilityExecuteResult, type MarketplaceCapabilityObjectType, type RemoteSkillDescriptor } from "./marketplace-capabilities.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, type CapabilityMatch } from "./search.js"
+import { resolveMcpMemberIdentity } from "./external-capabilities.js"
+import { executeMarketplaceCapability, listAccessibleMarketplaceSkillDescriptors, parseMarketplaceCapabilityName, type RemoteSkillDescriptor } from "./marketplace-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { automationService } from "../automations/service.js"
 import { AGENT_AUTOMATION_INDEX_LIMIT, registerAgentAutomationResources } from "./automation-index.js"
 import { env } from "../env.js"
 import { isPlatformAdminUserId } from "../middleware/admin.js"
-import { executeAvailableAdminCapability, parseAdminCapabilityName, searchAvailableAdminCapabilities } from "./admin-capabilities.js"
 import {
   executeBuiltinSkillCapability,
   listBuiltinSkillDescriptors,
-  searchBuiltinSkillCapabilities,
 } from "./builtin-skills.js"
-import { executeNativeCapability, searchNativeCapabilities } from "./native-capabilities.js"
-import { externalToolContent, type AgentToolContentPart } from "./tool-content.js"
-import { buildCodemodeToolTree, codemodeScriptPath, isCredentialBoundNativeOperation } from "./codemode-tools.js"
 import { resolveCodemodeConnectionNamespaceContext } from "./codemode-namespaces.js"
+import {
+  buildCapabilityToolTree,
+  executeCapability,
+  externalCapabilityErrorToolResult,
+  externalCapabilitySuccessToolResult,
+  searchCapabilityRegistry,
+  type CapabilityRegistryContext,
+  type ExecuteCapabilityToolResult,
+} from "./capability-registry.js"
 import { runCodemodeScript } from "./codemode-run.js"
 import { recordCodemodeScriptResult } from "../codemode-runs.js"
 
 export { externalToolContent } from "./tool-content.js"
+export { externalCapabilityErrorToolResult, externalCapabilitySuccessToolResult }
+export type { ExecuteCapabilityToolResult }
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
 export const EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME = "execute_capability_script"
 const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
-const skillMarketplaceObjectTypes: MarketplaceCapabilityObjectType[] = ["skill"]
 export const EXECUTE_CAPABILITY_TIMEOUT_MS = 180_000
 export const SEARCH_CAPABILITIES_ANNOTATIONS: ToolAnnotations = {
   readOnlyHint: true,
@@ -56,12 +60,6 @@ export const EXECUTE_CAPABILITY_ANNOTATIONS: ToolAnnotations = {
   idempotentHint: false,
   openWorldHint: true,
 }
-
-const externalMcpProviderErrorOutputSchema = z.object({
-  jsonRpcCode: z.number().int().optional(),
-  message: z.string().optional(),
-  data: z.string().optional(),
-})
 
 const connectionStatusOutputSchema = openworkCloudMcpConnectionActionSchema.extend({
   layer: z.enum(["mcp_connection", "downstream_provider"]),
@@ -99,28 +97,6 @@ const capabilityMatchOutputSchema = z.object({
 export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
   matches: z.array(capabilityMatchOutputSchema),
   hint: z.string().optional(),
-})
-
-const externalCapabilityErrorPayloadSchema = z.object({
-  error: z.string(),
-  message: z.string(),
-  referenceId: z.string().optional(),
-  retryable: z.boolean().optional(),
-  providerError: externalMcpProviderErrorOutputSchema.optional(),
-  connectionStatus: connectionStatusOutputSchema.optional(),
-  capability: z.string().optional(),
-  issues: z.array(z.object({
-    path: z.string(),
-    keyword: z.string(),
-    message: z.string(),
-  })).optional(),
-  schemaDigest: z.string().optional(),
-  sameArgumentsRetryable: z.literal(false).optional(),
-  retry: z.object({
-    action: z.enum(["correct_arguments", "search_capabilities"]),
-    searchRequired: z.boolean(),
-  }).optional(),
-  schemaGuidance: z.unknown().optional(),
 })
 
 export const AGENT_MCP_INSTRUCTIONS = [
@@ -178,46 +154,8 @@ function standardSkillMarkdown(skill: RemoteSkillDescriptor, source: string): st
 
 const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = `The capability call exceeded ${EXECUTE_CAPABILITY_TIMEOUT_MS / 1_000}s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.`
 
-export type ExecuteCapabilityToolResult = {
-  isError?: boolean
-  content: AgentToolContentPart[]
-}
-
 function textContent(text: string): { text: string; type: "text" }[] {
   return [{ type: "text", text }]
-}
-
-export function externalCapabilityErrorToolResult(
-  result: Exclude<ExternalCapabilityExecuteResult, { ok: true }>,
-): ExecuteCapabilityToolResult {
-  const payload = externalCapabilityErrorPayloadSchema.parse({
-    error: result.error,
-    message: result.message,
-    ...(result.referenceId === undefined ? {} : { referenceId: result.referenceId }),
-    ...(result.retryable === undefined ? {} : { retryable: result.retryable }),
-    ...(result.providerError ? { providerError: result.providerError } : {}),
-    ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
-    ...(result.capability ? { capability: result.capability } : {}),
-    ...(result.issues ? { issues: result.issues } : {}),
-    ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
-    ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
-    ...(result.retry ? { retry: result.retry } : {}),
-    ...(result.schemaGuidance ? { schemaGuidance: result.schemaGuidance } : {}),
-  })
-  return {
-    isError: true,
-    content: textContent(JSON.stringify(payload)),
-  }
-}
-
-function marketplaceCapabilityErrorToolResult(
-  result: Exclude<MarketplaceCapabilityExecuteResult, { ok: true }>,
-): ExecuteCapabilityToolResult {
-  const payload = Object.fromEntries(Object.entries(result).filter(([key]) => key !== "ok"))
-  return {
-    isError: true,
-    content: textContent(JSON.stringify(payload)),
-  }
 }
 
 export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string) {
@@ -229,26 +167,6 @@ export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T
   return {
     content: textContent(JSON.stringify(result, null, 2)),
     structuredContent: result,
-  }
-}
-
-function unknownCapabilityText(name: string): string {
-  return JSON.stringify({
-    error: "unknown_capability",
-    message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
-  })
-}
-
-export function externalCapabilitySuccessToolResult(
-  result: Extract<ExternalCapabilityExecuteResult, { ok: true }>,
-): ExecuteCapabilityToolResult {
-  const content = externalToolContent(result.result)
-  if (!result.schemaGuidance) return { content }
-  return {
-    content: [
-      ...content,
-      ...textContent(JSON.stringify({ schemaGuidance: result.schemaGuidance })),
-    ],
   }
 }
 
@@ -415,6 +333,28 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       gatingEnabled: env.mcpConnectionsGatingEnabled,
     })
     const codemodeEnabled = codemodeScriptsEnabled(organizationRows[0]?.metadata)
+    let namespaceContext: Promise<Awaited<ReturnType<typeof resolveCodemodeConnectionNamespaceContext>>> | undefined
+    const resolveNamespaceContext = () => {
+      namespaceContext ??= resolveCodemodeConnectionNamespaceContext({
+        organizationId: principal.organizationId,
+        member: memberIdentity,
+        includeExternalMcp: externalMcpConnectionsEnabled,
+      })
+      return namespaceContext
+    }
+    const capabilityContext: CapabilityRegistryContext = {
+      app: app as unknown as Hono,
+      env: c.env,
+      catalog,
+      principal,
+      organizationId,
+      member: memberIdentity,
+      redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
+      codemodeEnabled,
+      externalMcpConnectionsEnabled,
+      resolvePlatformAdmin,
+      resolveNamespaceContext,
+    }
     let remoteSkills: RemoteSkillDescriptor[] = []
     const method = await mcpRequestMethod(c.req.raw)
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
@@ -477,71 +417,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       },
       async ({ query, limit, type }) => {
         const boundedLimit = limit ?? 5
-        const sourceFilter = searchCapabilitySourceFilter(type)
-        const marketplaceObjectTypes = type === "skills" ? skillMarketplaceObjectTypes : undefined
-        const namespaceContext = codemodeEnabled && memberIdentity && (sourceFilter.api || sourceFilter.mcp)
-          ? await resolveCodemodeConnectionNamespaceContext({
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            includeExternalMcp: externalMcpConnectionsEnabled,
-          })
-          : undefined
-        const restMatches = sourceFilter.api
-          ? searchCapabilities(catalog.filter((operation) => !isCredentialBoundNativeOperation(operation)), query, boundedLimit).map((match) => codemodeEnabled
-            ? { ...match, scriptPath: codemodeScriptPath("den", match.name) }
-            : match)
-          : []
-        const nativeMatches = sourceFilter.api
-          ? await searchNativeCapabilities({
-            organizationId,
-            member: memberIdentity,
-            query,
-            catalog,
-            limit: boundedLimit,
-            includeScriptPaths: codemodeEnabled,
-            namespaceContext,
-          })
-          : []
-        const adminMatches = sourceFilter.admin
-          ? await searchAvailableAdminCapabilities(await resolvePlatformAdmin(), query, boundedLimit)
-          : []
-        const builtinSkillMatches = sourceFilter.skills
-          ? searchBuiltinSkillCapabilities(query, boundedLimit)
-          : []
-        // Merged in from each connected External MCP Connection's live
-        // tools/list (capability-sources/external-mcp-client.ts) — a
-        // Notion/Linear/Stripe/... connection an admin added in Den shows
-        // up here exactly like any native capability, ranked together.
-        let externalCoverageHint: string | undefined
-        const externalMatches = sourceFilter.mcp && externalMcpConnectionsEnabled
-          ? await searchExternalCapabilities({
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            query,
-            redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
-            limit: boundedLimit,
-            includeScriptPaths: codemodeEnabled,
-            namespaceContext,
-            reportCoverage: (coverage) => {
-              externalCoverageHint = externalMcpSearchCoverageHint(coverage)
-            },
-          })
-          : []
-        const marketplaceMatches = sourceFilter.marketplace && externalMcpConnectionsEnabled
-          ? await searchMarketplaceCapabilities({
-            codemodeEnabled,
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            objectTypes: marketplaceObjectTypes,
-            query,
-            limit: boundedLimit,
-            enabled: externalMcpConnectionsEnabled,
-          })
-          : []
-        const matches = [...restMatches, ...nativeMatches, ...adminMatches, ...builtinSkillMatches, ...externalMatches, ...marketplaceMatches]
-          .sort(compareCapabilityMatches)
-          .slice(0, boundedLimit)
-        return capabilitySearchToolResult(matches, externalCoverageHint)
+        const result = await searchCapabilityRegistry(capabilityContext, { query, limit: boundedLimit, type })
+        return capabilitySearchToolResult(result.matches, result.externalCoverageHint)
       },
     )
 
@@ -568,111 +445,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       async ({ name, schemaDigest, path, query, body }) => {
         return executeCapabilityWithBudget({
           capability: name,
-          invoke: async (): Promise<ExecuteCapabilityToolResult> => {
-            const adminResult = parseAdminCapabilityName(name)
-              ? await executeAvailableAdminCapability(await resolvePlatformAdmin(), name, body)
-              : null
-            if (adminResult) return adminResult
-
-            const builtinSkill = executeBuiltinSkillCapability(name)
-            if (builtinSkill) {
-              return { content: textContent(JSON.stringify(builtinSkill, null, 2)) }
-            }
-
-            const external = parseExternalCapabilityName(name)
-            if (external) {
-              if (!externalMcpConnectionsEnabled) {
-                return {
-                  isError: true,
-                  content: textContent(JSON.stringify({
-                    error: "unknown_capability",
-                    message: "No external MCP connection capabilities are available for this organization.",
-                  })),
-                }
-              }
-              const result = await executeExternalCapability({
-                organizationId: principal.organizationId,
-                member: memberIdentity,
-                connectionId: external.connectionId,
-                toolName: external.toolName,
-                args: normalizeToolBody(body),
-                schemaDigest,
-                redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
-              })
-              if (!result.ok) {
-                return externalCapabilityErrorToolResult(result)
-              }
-              // The SDK's callTool() can return either the standard {content:[...]}
-              // shape or a legacy-compatibility {toolResult} shape; normalize to
-              // what McpServer's own tool callback contract requires.
-              return externalCapabilitySuccessToolResult(result)
-            }
-
-            const nativeResult = await executeNativeCapability({
-              app: app as unknown as Hono,
-              env: c.env,
-              name,
-              organizationId,
-              member: memberIdentity,
-              catalog,
-              principal,
-              path,
-              query,
-              body,
-            })
-            if (nativeResult) return nativeResult
-
-            const marketplace = parseMarketplaceCapabilityName(name)
-            if (marketplace) {
-              const redirectUriBase = resolvePublicOrigin(c.req.raw, env.apiPublicUrl)
-              const result = await executeMarketplaceCapability({
-                buildTools: () => buildCodemodeToolTree({
-                  app: app as unknown as Hono,
-                  env: c.env,
-                  catalog,
-                  principal,
-                  organizationId: principal.organizationId,
-                  member: memberIdentity,
-                  redirectUriBase,
-                  externalMcpConnectionsEnabled,
-                }),
-                organizationId: principal.organizationId,
-                member: memberIdentity,
-                pluginId: marketplace.pluginId,
-                configObjectId: marketplace.configObjectId,
-                body,
-                codemodeEnabled,
-                enabled: externalMcpConnectionsEnabled,
-                redirectUriBase,
-              })
-              if (!result.ok) {
-                return result.error === "unknown_capability"
-                  ? { isError: true, content: textContent(unknownCapabilityText(name)) }
-                  : marketplaceCapabilityErrorToolResult(result)
-              }
-              return { content: textContent(JSON.stringify(result.result, null, 2)) }
-            }
-
-            const operation = catalog.find((candidate) => candidate.name === name)
-            if (!operation) {
-              return {
-                isError: true,
-                content: textContent(unknownCapabilityText(name)),
-              }
-            }
-
-            return invokeMcpOperation({
-              app: app as unknown as Hono,
-              env: c.env,
-              operation,
-              principal,
-              toolInput: {
-                path: normalizeToolRecord(path),
-                query: normalizeToolRecord(query),
-                body: normalizeToolBody(body),
-              },
-            })
-          },
+          invoke: () => executeCapability(capabilityContext, { name, schemaDigest, path, query, body }),
         })
       },
     )
@@ -700,17 +473,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         async ({ code, input }) => executeCapabilityWithBudget({
           capability: EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME,
           invoke: async (): Promise<ExecuteCapabilityToolResult> => {
-            const redirectUriBase = resolvePublicOrigin(c.req.raw, env.apiPublicUrl)
-            const { tools } = await buildCodemodeToolTree({
-              app: app as unknown as Hono,
-              env: c.env,
-              catalog,
-              principal,
-              organizationId: principal.organizationId,
-              member: memberIdentity,
-              redirectUriBase,
-              externalMcpConnectionsEnabled,
-            })
+            const { tools } = await buildCapabilityToolTree(capabilityContext)
             const startedAt = new Date()
             const result = await runCodemodeScript({
               code,

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -8,7 +8,6 @@ import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-
 import type { Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import { z } from "zod"
-import { memberFacingMcpConnectionsEnabled } from "../capability-sources/external-mcp-rollout.js"
 import { codemodeScriptsEnabled } from "../capability-sources/codemode-rollout.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
@@ -22,19 +21,17 @@ import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { automationService } from "../automations/service.js"
 import { AGENT_AUTOMATION_INDEX_LIMIT, registerAgentAutomationResources } from "./automation-index.js"
 import { env } from "../env.js"
-import { isPlatformAdminUserId } from "../middleware/admin.js"
 import {
   executeBuiltinSkillCapability,
   listBuiltinSkillDescriptors,
 } from "./builtin-skills.js"
-import { resolveCodemodeConnectionNamespaceContext } from "./codemode-namespaces.js"
 import {
   buildCapabilityToolTree,
+  createCapabilityRegistryContext,
   executeCapability,
   externalCapabilityErrorToolResult,
   externalCapabilitySuccessToolResult,
   searchCapabilityRegistry,
-  type CapabilityRegistryContext,
   type ExecuteCapabilityToolResult,
 } from "./capability-registry.js"
 import { runCodemodeScript } from "./codemode-run.js"
@@ -318,31 +315,14 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       userId: principal.userId,
       organizationId: principal.organizationId,
     })
-    let platformAdmin: Promise<boolean> | undefined
-    const resolvePlatformAdmin = () => {
-      platformAdmin ??= isPlatformAdminUserId(principal.userId)
-      return platformAdmin
-    }
     const organizationId = normalizeDenTypeId("organization", principal.organizationId)
     const organizationRows = await db
       .select({ metadata: OrganizationTable.metadata })
       .from(OrganizationTable)
       .where(eq(OrganizationTable.id, organizationId))
       .limit(1)
-    const externalMcpConnectionsEnabled = memberFacingMcpConnectionsEnabled(organizationRows[0]?.metadata, {
-      gatingEnabled: env.mcpConnectionsGatingEnabled,
-    })
     const codemodeEnabled = codemodeScriptsEnabled(organizationRows[0]?.metadata)
-    let namespaceContext: Promise<Awaited<ReturnType<typeof resolveCodemodeConnectionNamespaceContext>>> | undefined
-    const resolveNamespaceContext = () => {
-      namespaceContext ??= resolveCodemodeConnectionNamespaceContext({
-        organizationId: principal.organizationId,
-        member: memberIdentity,
-        includeExternalMcp: externalMcpConnectionsEnabled,
-      })
-      return namespaceContext
-    }
-    const capabilityContext: CapabilityRegistryContext = {
+    const capabilityContext = createCapabilityRegistryContext({
       app: app as unknown as Hono,
       env: c.env,
       catalog,
@@ -351,10 +331,10 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       member: memberIdentity,
       redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
       codemodeEnabled,
-      externalMcpConnectionsEnabled,
-      resolvePlatformAdmin,
-      resolveNamespaceContext,
-    }
+      organizationMetadata: organizationRows[0]?.metadata,
+      mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
+    })
+    const { externalMcpConnectionsEnabled } = capabilityContext
     let remoteSkills: RemoteSkillDescriptor[] = []
     const method = await mcpRequestMethod(c.req.raw)
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {

--- a/ee/apps/den-api/src/mcp/capability-registry.ts
+++ b/ee/apps/den-api/src/mcp/capability-registry.ts
@@ -1,0 +1,630 @@
+import { Tool, toolError } from "@openwork/codemode"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { Effect } from "effect"
+import type { Hono } from "hono"
+import { z } from "zod"
+import type { McpPrincipal } from "./auth.js"
+import type { McpToolOperation } from "./catalog.js"
+import {
+  executeAdminCapability,
+  listAvailableAdminCapabilities,
+  parseAdminCapabilityName,
+  searchAvailableAdminCapabilities,
+} from "./admin-capabilities.js"
+import {
+  executeBuiltinSkillCapability,
+  listBuiltinSkillDescriptors,
+  searchBuiltinSkillCapabilities,
+} from "./builtin-skills.js"
+import {
+  buildDenCatalogToolTree,
+  buildExternalMcpToolTree,
+  buildNativeProviderToolTree,
+  isCredentialBoundNativeOperation,
+  type BuiltCodemodeTools,
+} from "./codemode-tools.js"
+import {
+  codemodeScriptPath,
+  type CodemodeConnectionNamespaceContext,
+} from "./codemode-namespaces.js"
+import {
+  executeExternalCapability,
+  externalMcpSearchCoverageHint,
+  parseExternalCapabilityName,
+  searchExternalCapabilities,
+  type ExternalCapabilityExecuteResult,
+  type McpMemberIdentity,
+} from "./external-capabilities.js"
+import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
+import {
+  executeMarketplaceCapability,
+  listAccessibleMarketplaceCapabilityReferences,
+  parseMarketplaceCapabilityName,
+  searchMarketplaceCapabilities,
+  type MarketplaceCapabilityExecuteResult,
+  type MarketplaceCapabilityObjectType,
+} from "./marketplace-capabilities.js"
+import {
+  executeNativeCapability,
+  parseNativeCapabilityName,
+  searchNativeCapabilities,
+} from "./native-capabilities.js"
+import {
+  compareCapabilityMatches,
+  searchCapabilities,
+  searchCapabilitySourceFilter,
+  type CapabilityMatch,
+  type SearchCapabilityType,
+} from "./search.js"
+import type { AgentToolContentPart } from "./tool-content.js"
+import { externalToolContent } from "./tool-content.js"
+
+export const CAPABILITY_SOURCE_KINDS = ["catalog", "native", "externalMcp", "marketplace", "builtinSkill", "admin"] as const
+export type CapabilitySourceKind = (typeof CAPABILITY_SOURCE_KINDS)[number]
+
+export type ParsedCapability =
+  | { kind: "catalog"; name: string }
+  | { kind: "native"; name: string; connectionId: string; toolName: string }
+  | { kind: "externalMcp"; name: string; connectionId: string; toolName: string }
+  | { kind: "marketplace"; name: string; configObjectId: string; pluginId: string }
+  | { kind: "builtinSkill"; name: string }
+  | { kind: "admin"; name: string; toolName: string }
+
+export type ExecuteCapabilityToolResult = {
+  isError?: boolean
+  content: AgentToolContentPart[]
+}
+
+export type CapabilityExecuteInput = {
+  name: string
+  schemaDigest?: string
+  path?: unknown
+  query?: unknown
+  body?: unknown
+}
+
+export type CapabilityRegistryContext = {
+  app: Hono
+  env: unknown
+  catalog: readonly McpToolOperation[]
+  principal: McpPrincipal
+  organizationId: DenTypeId<"organization">
+  member: McpMemberIdentity | null
+  redirectUriBase: string
+  codemodeEnabled: boolean
+  externalMcpConnectionsEnabled: boolean
+  resolvePlatformAdmin: () => Promise<boolean>
+  resolveNamespaceContext: () => Promise<CodemodeConnectionNamespaceContext>
+}
+
+type CapabilitySearchContext = CapabilityRegistryContext & {
+  sourceFilter: ReturnType<typeof searchCapabilitySourceFilter>
+  marketplaceObjectTypes?: MarketplaceCapabilityObjectType[]
+  reportExternalCoverage: (hint: string | undefined) => void
+}
+
+export type CapabilityLeaf = {
+  namespace: string
+  toolName: string
+  scriptPath: string
+  capabilityName: string
+  definition: Tool.Definition
+}
+
+type CapabilitySourceExclusion = { excluded: string }
+
+export type CapabilitySource = {
+  kind: CapabilitySourceKind
+  parseName: (name: string) => ParsedCapability | null
+  search: (ctx: CapabilitySearchContext, query: string, limit: number) => Promise<CapabilityMatch[]>
+  enumerate: (ctx: CapabilityRegistryContext) => Promise<CapabilityLeaf[]> | CapabilitySourceExclusion
+  execute: (ctx: CapabilityRegistryContext, parsed: ParsedCapability, input: CapabilityExecuteInput) => Promise<ExecuteCapabilityToolResult>
+}
+
+function textContent(text: string): { text: string; type: "text" }[] {
+  return [{ type: "text", text }]
+}
+
+function unknownCapabilityText(name: string): string {
+  return JSON.stringify({
+    error: "unknown_capability",
+    message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+  })
+}
+
+function unknownCapabilityResult(name: string): ExecuteCapabilityToolResult {
+  return { isError: true, content: textContent(unknownCapabilityText(name)) }
+}
+
+const externalMcpProviderErrorOutputSchema = z.object({
+  jsonRpcCode: z.number().int().optional(),
+  message: z.string().optional(),
+  data: z.string().optional(),
+})
+
+const externalCapabilityErrorPayloadSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  referenceId: z.string().optional(),
+  retryable: z.boolean().optional(),
+  providerError: externalMcpProviderErrorOutputSchema.optional(),
+  connectionStatus: z.unknown().optional(),
+  capability: z.string().optional(),
+  issues: z.array(z.object({
+    path: z.string(),
+    keyword: z.string(),
+    message: z.string(),
+  })).optional(),
+  schemaDigest: z.string().optional(),
+  sameArgumentsRetryable: z.literal(false).optional(),
+  retry: z.object({
+    action: z.enum(["correct_arguments", "search_capabilities"]),
+    searchRequired: z.boolean(),
+  }).optional(),
+  schemaGuidance: z.unknown().optional(),
+})
+
+export function externalCapabilityErrorToolResult(
+  result: Exclude<ExternalCapabilityExecuteResult, { ok: true }>,
+): ExecuteCapabilityToolResult {
+  const payload = externalCapabilityErrorPayloadSchema.parse({
+    error: result.error,
+    message: result.message,
+    ...(result.referenceId === undefined ? {} : { referenceId: result.referenceId }),
+    ...(result.retryable === undefined ? {} : { retryable: result.retryable }),
+    ...(result.providerError ? { providerError: result.providerError } : {}),
+    ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
+    ...(result.capability ? { capability: result.capability } : {}),
+    ...(result.issues ? { issues: result.issues } : {}),
+    ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
+    ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
+    ...(result.retry ? { retry: result.retry } : {}),
+    ...(result.schemaGuidance ? { schemaGuidance: result.schemaGuidance } : {}),
+  })
+  return {
+    isError: true,
+    content: textContent(JSON.stringify(payload)),
+  }
+}
+
+export function externalCapabilitySuccessToolResult(
+  result: Extract<ExternalCapabilityExecuteResult, { ok: true }>,
+): ExecuteCapabilityToolResult {
+  const content = externalToolContent(result.result)
+  if (!result.schemaGuidance) return { content }
+  return {
+    content: [
+      ...content,
+      ...textContent(JSON.stringify({ schemaGuidance: result.schemaGuidance })),
+    ],
+  }
+}
+
+function marketplaceCapabilityErrorToolResult(
+  result: Exclude<MarketplaceCapabilityExecuteResult, { ok: true }>,
+): ExecuteCapabilityToolResult {
+  const payload = Object.fromEntries(Object.entries(result).filter(([key]) => key !== "ok"))
+  return {
+    isError: true,
+    content: textContent(JSON.stringify(payload)),
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isCodemodeJsonSchema(value: unknown): value is Tool.JsonSchema {
+  return isRecord(value)
+}
+
+function textParts(value: unknown): string[] {
+  if (!isRecord(value) || !Array.isArray(value.content)) return []
+  return value.content.flatMap((part) => isRecord(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : [])
+}
+
+function toolResultValue(value: unknown): unknown {
+  if (isRecord(value) && value.structuredContent !== undefined) return value.structuredContent
+  const text = textParts(value)
+  if (text.length === 0) return null
+  if (text.length > 1) return text.join("\n")
+  try {
+    return JSON.parse(text[0] ?? "")
+  } catch {
+    return text[0] ?? ""
+  }
+}
+
+function toolResultError(value: unknown): string {
+  const text = textParts(value).join("\n").trim()
+  return text || "Capability execution failed."
+}
+
+function leavesFromBuilt(built: BuiltCodemodeTools): CapabilityLeaf[] {
+  const definitions = new Map<string, { namespace: string; toolName: string; definition: Tool.Definition }>()
+  for (const [namespace, tools] of Object.entries(built.tools)) {
+    for (const [toolName, definition] of Object.entries(tools)) {
+      definitions.set(codemodeScriptPath(namespace, toolName), { namespace, toolName, definition })
+    }
+  }
+  return built.manifest.flatMap((entry) => {
+    const resolved = definitions.get(entry.scriptPath)
+    return resolved ? [{ ...resolved, ...entry }] : []
+  })
+}
+
+function contentLeaf(input: {
+  namespace: string
+  toolName: string
+  capabilityName: string
+  description: string
+  input?: Tool.JsonSchema
+  run: (args: unknown) => Promise<unknown>
+}): CapabilityLeaf {
+  return {
+    namespace: input.namespace,
+    toolName: input.toolName,
+    capabilityName: input.capabilityName,
+    scriptPath: codemodeScriptPath(input.namespace, input.toolName),
+    definition: Tool.make({
+      description: input.description,
+      input: input.input ?? { type: "object" },
+      run: (args) => Effect.promise(() => input.run(args)),
+    }),
+  }
+}
+
+async function executeMarketplaceSource(
+  ctx: CapabilityRegistryContext,
+  parsed: Extract<ParsedCapability, { kind: "marketplace" }>,
+  input: CapabilityExecuteInput,
+): Promise<MarketplaceCapabilityExecuteResult> {
+  return executeMarketplaceCapability({
+    buildTools: () => buildCapabilityToolTree(ctx),
+    organizationId: ctx.organizationId,
+    member: ctx.member,
+    pluginId: parsed.pluginId,
+    configObjectId: parsed.configObjectId,
+    body: input.body,
+    codemodeEnabled: ctx.codemodeEnabled,
+    enabled: ctx.externalMcpConnectionsEnabled,
+    redirectUriBase: ctx.redirectUriBase,
+  })
+}
+
+function parsedForKind<K extends CapabilitySourceKind>(parsed: ParsedCapability, kind: K): parsed is Extract<ParsedCapability, { kind: K }> {
+  return parsed.kind === kind
+}
+
+const catalogSource: CapabilitySource = {
+  kind: "catalog",
+  parseName: (name) => name.includes(":") ? null : { kind: "catalog", name },
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.api) return []
+    return searchCapabilities(
+      ctx.catalog.filter((operation) => !isCredentialBoundNativeOperation(operation)),
+      query,
+      limit,
+    ).map((match) => ctx.codemodeEnabled
+      ? { ...match, scriptPath: codemodeScriptPath("den", match.name) }
+      : match)
+  },
+  enumerate: (ctx) => Promise.resolve(leavesFromBuilt(buildDenCatalogToolTree(ctx))),
+  execute: async (ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "catalog")) return unknownCapabilityResult(input.name)
+    const operation = ctx.catalog.find((candidate) => (
+      candidate.name === parsed.name && !isCredentialBoundNativeOperation(candidate)
+    ))
+    if (!operation) return unknownCapabilityResult(input.name)
+    return invokeMcpOperation({
+      app: ctx.app,
+      env: ctx.env,
+      operation,
+      principal: ctx.principal,
+      toolInput: {
+        path: normalizeToolRecord(input.path),
+        query: normalizeToolRecord(input.query),
+        body: normalizeToolBody(input.body),
+      },
+    })
+  },
+}
+
+const nativeSource: CapabilitySource = {
+  kind: "native",
+  parseName: (name) => {
+    const parsed = parseNativeCapabilityName(name)
+    return parsed ? { kind: "native", name, ...parsed } : null
+  },
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.api) return []
+    return searchNativeCapabilities({
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      query,
+      catalog: ctx.catalog,
+      limit,
+      includeScriptPaths: ctx.codemodeEnabled,
+      namespaceContext: ctx.codemodeEnabled ? await ctx.resolveNamespaceContext() : undefined,
+    })
+  },
+  enumerate: async (ctx) => leavesFromBuilt(await buildNativeProviderToolTree({
+    ...ctx,
+    namespaceContext: await ctx.resolveNamespaceContext(),
+  })),
+  execute: async (ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "native")) return unknownCapabilityResult(input.name)
+    const result = await executeNativeCapability({
+      app: ctx.app,
+      env: ctx.env,
+      name: parsed.name,
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      catalog: ctx.catalog,
+      principal: ctx.principal,
+      path: input.path,
+      query: input.query,
+      body: input.body,
+    })
+    return result ?? unknownCapabilityResult(input.name)
+  },
+}
+
+const externalMcpSource: CapabilitySource = {
+  kind: "externalMcp",
+  parseName: (name) => {
+    const parsed = parseExternalCapabilityName(name)
+    return parsed ? { kind: "externalMcp", name, ...parsed } : null
+  },
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.mcp || !ctx.externalMcpConnectionsEnabled) return []
+    return searchExternalCapabilities({
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      query,
+      redirectUriBase: ctx.redirectUriBase,
+      limit,
+      includeScriptPaths: ctx.codemodeEnabled,
+      namespaceContext: ctx.codemodeEnabled ? await ctx.resolveNamespaceContext() : undefined,
+      reportCoverage: (coverage) => ctx.reportExternalCoverage(externalMcpSearchCoverageHint(coverage)),
+    })
+  },
+  enumerate: async (ctx) => {
+    if (!ctx.externalMcpConnectionsEnabled) return []
+    return leavesFromBuilt(await buildExternalMcpToolTree({
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      redirectUriBase: ctx.redirectUriBase,
+      namespaceContext: await ctx.resolveNamespaceContext(),
+    }))
+  },
+  execute: async (ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "externalMcp")) return unknownCapabilityResult(input.name)
+    if (!ctx.externalMcpConnectionsEnabled) {
+      return {
+        isError: true,
+        content: textContent(JSON.stringify({
+          error: "unknown_capability",
+          message: "No external MCP connection capabilities are available for this organization.",
+        })),
+      }
+    }
+    const result = await executeExternalCapability({
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      connectionId: parsed.connectionId,
+      toolName: parsed.toolName,
+      args: normalizeToolBody(input.body),
+      schemaDigest: input.schemaDigest,
+      redirectUriBase: ctx.redirectUriBase,
+    })
+    return result.ok
+      ? externalCapabilitySuccessToolResult(result)
+      : externalCapabilityErrorToolResult(result)
+  },
+}
+
+const marketplaceSource: CapabilitySource = {
+  kind: "marketplace",
+  parseName: (name) => {
+    const parsed = parseMarketplaceCapabilityName(name)
+    return parsed ? { kind: "marketplace", name, ...parsed } : null
+  },
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.marketplace || !ctx.externalMcpConnectionsEnabled) return []
+    const matches = await searchMarketplaceCapabilities({
+      codemodeEnabled: ctx.codemodeEnabled,
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      objectTypes: ctx.marketplaceObjectTypes,
+      query,
+      limit,
+      enabled: ctx.externalMcpConnectionsEnabled,
+    })
+    return matches.map((match) => ctx.codemodeEnabled && match.kind !== "script"
+      ? { ...match, scriptPath: codemodeScriptPath("marketplace", match.name) }
+      : match)
+  },
+  enumerate: async (ctx) => {
+    if (!ctx.externalMcpConnectionsEnabled) return []
+    const references = await listAccessibleMarketplaceCapabilityReferences({
+      organizationId: ctx.organizationId,
+      member: ctx.member,
+      enabled: ctx.externalMcpConnectionsEnabled,
+    })
+    const uniqueReferences = new Map(references
+      .filter((reference) => reference.objectType !== "script")
+      .map((reference) => [`${reference.pluginId}:${reference.configObjectId}`, reference]))
+    return [...uniqueReferences.values()].map((reference) => {
+      const capabilityName = `plugin:${reference.pluginId}:${reference.configObjectId}`
+      const parsed: Extract<ParsedCapability, { kind: "marketplace" }> = {
+        kind: "marketplace",
+        name: capabilityName,
+        pluginId: reference.pluginId,
+        configObjectId: reference.configObjectId,
+      }
+      return contentLeaf({
+        namespace: "marketplace",
+        toolName: capabilityName,
+        capabilityName,
+        description: `Retrieve marketplace capability ${capabilityName}`,
+        run: async (args) => {
+          const result = await executeMarketplaceSource(ctx, parsed, { name: capabilityName, body: args })
+          if (!result.ok) throw toolError(result.message)
+          const content = result.result.content ?? result.result.source ?? result.result.definition
+          return typeof content === "string" ? content : JSON.stringify(result.result)
+        },
+      })
+    })
+  },
+  execute: async (ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "marketplace")) return unknownCapabilityResult(input.name)
+    const result = await executeMarketplaceSource(ctx, parsed, input)
+    if (!result.ok) {
+      return result.error === "unknown_capability"
+        ? unknownCapabilityResult(input.name)
+        : marketplaceCapabilityErrorToolResult(result)
+    }
+    return { content: textContent(JSON.stringify(result.result, null, 2)) }
+  },
+}
+
+const builtinSkillSource: CapabilitySource = {
+  kind: "builtinSkill",
+  parseName: (name) => name.startsWith("skill:") && name.length > "skill:".length
+    ? { kind: "builtinSkill", name }
+    : null,
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.skills) return []
+    return searchBuiltinSkillCapabilities(query, limit).map((match) => ctx.codemodeEnabled
+      ? { ...match, scriptPath: codemodeScriptPath("skills", match.name) }
+      : match)
+  },
+  enumerate: (ctx) => Promise.resolve(listBuiltinSkillDescriptors().map((skill) => contentLeaf({
+    namespace: "skills",
+    toolName: skill.capability,
+    capabilityName: skill.capability,
+    description: skill.description,
+    run: async () => executeBuiltinSkillCapability(skill.capability)?.content ?? "",
+  }))),
+  execute: async (_ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "builtinSkill")) return unknownCapabilityResult(input.name)
+    const result = executeBuiltinSkillCapability(parsed.name)
+    return result
+      ? { content: textContent(JSON.stringify(result, null, 2)) }
+      : unknownCapabilityResult(input.name)
+  },
+}
+
+const adminSource: CapabilitySource = {
+  kind: "admin",
+  parseName: (name) => {
+    const toolName = parseAdminCapabilityName(name)
+    return toolName ? { kind: "admin", name, toolName } : null
+  },
+  search: async (ctx, query, limit) => {
+    if (!ctx.sourceFilter.admin) return []
+    const matches = await searchAvailableAdminCapabilities(await ctx.resolvePlatformAdmin(), query, limit)
+    return matches.map((match) => ctx.codemodeEnabled
+      ? { ...match, scriptPath: codemodeScriptPath("admin", parseAdminCapabilityName(match.name) ?? match.name) }
+      : match)
+  },
+  enumerate: async (ctx) => {
+    const matches = await listAvailableAdminCapabilities(await ctx.resolvePlatformAdmin())
+    return matches.flatMap((match) => {
+      const toolName = parseAdminCapabilityName(match.name)
+      if (!toolName) return []
+      const parsed: Extract<ParsedCapability, { kind: "admin" }> = { kind: "admin", name: match.name, toolName }
+      return [contentLeaf({
+        namespace: "admin",
+        toolName,
+        capabilityName: match.name,
+        description: match.summary,
+        input: isCodemodeJsonSchema(match.argumentsSchema) ? match.argumentsSchema : undefined,
+        run: async (args) => {
+          const result = await adminSource.execute(ctx, parsed, { name: match.name, body: args })
+          if (result.isError) throw toolError(toolResultError(result))
+          return toolResultValue(result)
+        },
+      })]
+    })
+  },
+  execute: async (ctx, parsed, input) => {
+    if (!parsedForKind(parsed, "admin") || !(await ctx.resolvePlatformAdmin())) {
+      return unknownCapabilityResult(input.name)
+    }
+    return (await executeAdminCapability(parsed.name, input.body)) ?? unknownCapabilityResult(input.name)
+  },
+}
+
+export const CAPABILITY_SOURCES: Record<CapabilitySourceKind, CapabilitySource> = {
+  catalog: catalogSource,
+  native: nativeSource,
+  externalMcp: externalMcpSource,
+  marketplace: marketplaceSource,
+  builtinSkill: builtinSkillSource,
+  admin: adminSource,
+}
+
+export function createCapabilityRegistry(sources: Record<CapabilitySourceKind, CapabilitySource>) {
+  return {
+    search: async (
+      ctx: CapabilityRegistryContext,
+      input: { query: string; limit: number; type?: SearchCapabilityType },
+    ): Promise<{ matches: CapabilityMatch[]; externalCoverageHint?: string }> => {
+      let externalCoverageHint: string | undefined
+      const sourceFilter = searchCapabilitySourceFilter(input.type)
+      const searchContext: CapabilitySearchContext = {
+        ...ctx,
+        sourceFilter,
+        ...(input.type === "skills" ? { marketplaceObjectTypes: ["skill"] } : {}),
+        reportExternalCoverage: (hint) => {
+          externalCoverageHint = hint
+        },
+      }
+      const sourceMatches = await Promise.all(CAPABILITY_SOURCE_KINDS.map((kind) => (
+        sources[kind].search(searchContext, input.query, input.limit)
+      )))
+      const matches = sourceMatches.flat()
+        .sort(compareCapabilityMatches)
+        .slice(0, input.limit)
+      return {
+        matches,
+        ...(externalCoverageHint ? { externalCoverageHint } : {}),
+      }
+    },
+    execute: async (
+      ctx: CapabilityRegistryContext,
+      input: CapabilityExecuteInput,
+    ): Promise<ExecuteCapabilityToolResult> => {
+      for (const kind of CAPABILITY_SOURCE_KINDS) {
+        const source = sources[kind]
+        const parsed = source.parseName(input.name)
+        if (parsed) return source.execute(ctx, parsed, input)
+      }
+      return unknownCapabilityResult(input.name)
+    },
+    buildToolTree: async (ctx: CapabilityRegistryContext): Promise<BuiltCodemodeTools> => {
+      const enumerated = await Promise.all(CAPABILITY_SOURCE_KINDS.map(async (kind) => {
+        const result = await sources[kind].enumerate(ctx)
+        return "excluded" in result ? [] : result
+      }))
+      const leaves = enumerated.flat()
+      const namespaceTools = new Map<string, Map<string, Tool.Definition>>()
+      for (const leaf of leaves) {
+        const tools = namespaceTools.get(leaf.namespace) ?? new Map<string, Tool.Definition>()
+        tools.set(leaf.toolName, leaf.definition)
+        namespaceTools.set(leaf.namespace, tools)
+      }
+      return {
+        tools: Object.fromEntries([...namespaceTools].map(([namespace, tools]) => [namespace, Object.fromEntries(tools)])),
+        manifest: leaves.map(({ capabilityName, scriptPath }) => ({ capabilityName, scriptPath })),
+      }
+    },
+  }
+}
+
+export const CAPABILITY_REGISTRY = createCapabilityRegistry(CAPABILITY_SOURCES)
+export const searchCapabilityRegistry = CAPABILITY_REGISTRY.search
+export const executeCapability = CAPABILITY_REGISTRY.execute
+export const buildCapabilityToolTree = CAPABILITY_REGISTRY.buildToolTree

--- a/ee/apps/den-api/src/mcp/capability-registry.ts
+++ b/ee/apps/den-api/src/mcp/capability-registry.ts
@@ -3,6 +3,8 @@ import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { Effect } from "effect"
 import type { Hono } from "hono"
 import { z } from "zod"
+import { memberFacingMcpConnectionsEnabled } from "../capability-sources/external-mcp-rollout.js"
+import { isPlatformAdminUserId } from "../middleware/admin.js"
 import type { McpPrincipal } from "./auth.js"
 import type { McpToolOperation } from "./catalog.js"
 import {
@@ -25,6 +27,7 @@ import {
 } from "./codemode-tools.js"
 import {
   codemodeScriptPath,
+  resolveCodemodeConnectionNamespaceContext,
   type CodemodeConnectionNamespaceContext,
 } from "./codemode-namespaces.js"
 import {
@@ -97,6 +100,52 @@ export type CapabilityRegistryContext = {
   resolveNamespaceContext: () => Promise<CodemodeConnectionNamespaceContext>
 }
 
+export type CapabilityRegistryContextInput = {
+  app: Hono
+  env: unknown
+  catalog: readonly McpToolOperation[]
+  principal: McpPrincipal
+  organizationId: DenTypeId<"organization">
+  member: McpMemberIdentity | null
+  redirectUriBase: string
+  codemodeEnabled: boolean
+  organizationMetadata: Parameters<typeof memberFacingMcpConnectionsEnabled>[0]
+  mcpConnectionsGatingEnabled: boolean
+}
+
+export function createCapabilityRegistryContext(input: CapabilityRegistryContextInput): CapabilityRegistryContext {
+  const externalMcpConnectionsEnabled = memberFacingMcpConnectionsEnabled(input.organizationMetadata, {
+    gatingEnabled: input.mcpConnectionsGatingEnabled,
+  })
+  let platformAdmin: Promise<boolean> | undefined
+  const resolvePlatformAdmin = () => {
+    platformAdmin ??= isPlatformAdminUserId(input.principal.userId)
+    return platformAdmin
+  }
+  let namespaceContext: Promise<CodemodeConnectionNamespaceContext> | undefined
+  const resolveNamespaceContext = () => {
+    namespaceContext ??= resolveCodemodeConnectionNamespaceContext({
+      organizationId: input.organizationId,
+      member: input.member,
+      includeExternalMcp: externalMcpConnectionsEnabled,
+    })
+    return namespaceContext
+  }
+  return {
+    app: input.app,
+    env: input.env,
+    catalog: input.catalog,
+    principal: input.principal,
+    organizationId: input.organizationId,
+    member: input.member,
+    redirectUriBase: input.redirectUriBase,
+    codemodeEnabled: input.codemodeEnabled,
+    externalMcpConnectionsEnabled,
+    resolvePlatformAdmin,
+    resolveNamespaceContext,
+  }
+}
+
 type CapabilitySearchContext = CapabilityRegistryContext & {
   sourceFilter: ReturnType<typeof searchCapabilitySourceFilter>
   marketplaceObjectTypes?: MarketplaceCapabilityObjectType[]
@@ -108,6 +157,8 @@ export type CapabilityLeaf = {
   toolName: string
   scriptPath: string
   capabilityName: string
+  readOnly?: boolean
+  authority?: "den" | "external"
   definition: Tool.Definition
 }
 
@@ -258,6 +309,8 @@ function contentLeaf(input: {
   toolName: string
   capabilityName: string
   description: string
+  readOnly: boolean
+  authority: "den" | "external"
   input?: Tool.JsonSchema
   run: (args: unknown) => Promise<unknown>
 }): CapabilityLeaf {
@@ -266,6 +319,8 @@ function contentLeaf(input: {
     toolName: input.toolName,
     capabilityName: input.capabilityName,
     scriptPath: codemodeScriptPath(input.namespace, input.toolName),
+    readOnly: input.readOnly,
+    authority: input.authority,
     definition: Tool.make({
       description: input.description,
       input: input.input ?? { type: "object" },
@@ -468,6 +523,8 @@ const marketplaceSource: CapabilitySource = {
         toolName: capabilityName,
         capabilityName,
         description: `Retrieve marketplace capability ${capabilityName}`,
+        readOnly: true,
+        authority: "den",
         run: async (args) => {
           const result = await executeMarketplaceSource(ctx, parsed, { name: capabilityName, body: args })
           if (!result.ok) throw toolError(result.message)
@@ -505,6 +562,8 @@ const builtinSkillSource: CapabilitySource = {
     toolName: skill.capability,
     capabilityName: skill.capability,
     description: skill.description,
+    readOnly: true,
+    authority: "den",
     run: async () => executeBuiltinSkillCapability(skill.capability)?.content ?? "",
   }))),
   execute: async (_ctx, parsed, input) => {
@@ -540,6 +599,8 @@ const adminSource: CapabilitySource = {
         toolName,
         capabilityName: match.name,
         description: match.summary,
+        readOnly: false,
+        authority: "den",
         input: isCodemodeJsonSchema(match.argumentsSchema) ? match.argumentsSchema : undefined,
         run: async (args) => {
           const result = await adminSource.execute(ctx, parsed, { name: match.name, body: args })
@@ -618,7 +679,12 @@ export function createCapabilityRegistry(sources: Record<CapabilitySourceKind, C
       }
       return {
         tools: Object.fromEntries([...namespaceTools].map(([namespace, tools]) => [namespace, Object.fromEntries(tools)])),
-        manifest: leaves.map(({ capabilityName, scriptPath }) => ({ capabilityName, scriptPath })),
+        manifest: leaves.map(({ capabilityName, scriptPath, readOnly, authority }) => ({
+          capabilityName,
+          scriptPath,
+          ...(readOnly === undefined ? {} : { readOnly }),
+          ...(authority === undefined ? {} : { authority }),
+        })),
       }
     },
   }

--- a/ee/apps/den-api/src/mcp/codemode-namespaces.ts
+++ b/ee/apps/den-api/src/mcp/codemode-namespaces.ts
@@ -11,7 +11,7 @@ import {
 
 export type NamedConnection = { id: string; name: string }
 
-const RESERVED_CODEMODE_NAMESPACES = ["den", "$codemode", "__proto__", "constructor", "prototype"]
+const RESERVED_CODEMODE_NAMESPACES = ["den", "skills", "marketplace", "admin", "$codemode", "__proto__", "constructor", "prototype"]
 const IDENTIFIER_PATTERN = /^[a-z_$][a-z0-9_$]*$/i
 
 export function codemodeScriptPath(namespace: string, toolName: string): string {

--- a/ee/apps/den-api/src/mcp/codemode-tools.ts
+++ b/ee/apps/den-api/src/mcp/codemode-tools.ts
@@ -51,33 +51,6 @@ export type BuiltCodemodeTools = {
   manifest: CodemodeManifestEntry[]
 }
 
-export const CAPABILITY_SOURCE_KINDS = ["catalog", "native", "externalMcp", "marketplace", "builtinSkill", "admin"] as const
-export type CapabilitySourceKind = (typeof CAPABILITY_SOURCE_KINDS)[number]
-
-/** Interim parity primitive pending a full CapabilitySource registry. */
-export const CODEMODE_SOURCE_PARTICIPATION: Record<CapabilitySourceKind, "tree" | { excluded: string }> = {
-  catalog: "tree",
-  native: "tree",
-  externalMcp: "tree",
-  marketplace: {
-    excluded: "Marketplace capabilities return instructional content rather than data operations; marketplace script objects execute through their dedicated script rail.",
-  },
-  builtinSkill: {
-    excluded: "Built-in skills return instructional content rather than data operations.",
-  },
-  admin: {
-    excluded: "Admin capabilities are platform-admin gated and are not exposed to organization Code Mode scripts.",
-  },
-}
-
-function assertCodemodeSourceParticipation(): void {
-  for (const kind of CAPABILITY_SOURCE_KINDS) {
-    if (!CODEMODE_SOURCE_PARTICIPATION[kind]) {
-      throw new Error(`Code Mode participation is undecided for capability source: ${kind}`)
-    }
-  }
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -375,32 +348,5 @@ export async function buildExternalMcpToolTree(input: {
           authority: "external" as const,
         }))
     }),
-  }
-}
-
-export async function buildCodemodeToolTree(input: {
-  app: Hono
-  env: unknown
-  catalog: readonly McpToolOperation[]
-  principal: McpPrincipal
-  organizationId: string
-  member: McpMemberIdentity | null
-  redirectUriBase: string
-  externalMcpConnectionsEnabled?: boolean
-}): Promise<BuiltCodemodeTools> {
-  assertCodemodeSourceParticipation()
-  const namespaceContext = await resolveCodemodeConnectionNamespaceContext({
-    organizationId: input.organizationId,
-    member: input.member,
-    includeExternalMcp: input.externalMcpConnectionsEnabled !== false,
-  })
-  const den = buildDenCatalogToolTree(input)
-  const [native, external] = await Promise.all([
-    buildNativeProviderToolTree({ ...input, namespaceContext }),
-    buildExternalMcpToolTree({ ...input, namespaceContext }),
-  ])
-  return {
-    tools: { ...den.tools, ...native.tools, ...external.tools },
-    manifest: [...den.manifest, ...native.manifest, ...external.manifest],
   }
 }

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -39,6 +39,8 @@ export type CapabilityMatch = {
   invocation?: { argumentsField: "body" }
   /** Exact confined-script path when Code Mode scripts are enabled. */
   scriptPath?: string
+  /** Callable capability or a source-specific advisory/content kind. */
+  kind?: string
 }
 
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {

--- a/ee/apps/den-api/src/routes/org/codemode-scripts.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-scripts.ts
@@ -23,7 +23,7 @@ import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema 
 import { listTeamsForMember } from "../../orgs.js"
 import { env } from "../../env.js"
 import { getCatalog } from "../../mcp/index.js"
-import { buildCodemodeToolTree } from "../../mcp/codemode-tools.js"
+import { buildCapabilityToolTree, createCapabilityRegistryContext } from "../../mcp/capability-registry.js"
 import {
   executeMarketplaceCapability,
   listAccessibleSavedCodemodeScripts,
@@ -119,7 +119,8 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
       scopes: new Set(DEN_MCP_REQUESTED_SCOPES),
       payload: {},
     }
-    const buildTools = () => buildCodemodeToolTree({
+    const codemodeEnabled = codemodeScriptsEnabled(context.organization.metadata)
+    const capabilityContext = createCapabilityRegistryContext({
       app: app as unknown as Hono,
       env: c.env,
       catalog,
@@ -127,9 +128,13 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
       organizationId: context.organization.id,
       member,
       redirectUriBase: env.apiPublicUrl ?? "http://127.0.0.1",
+      codemodeEnabled,
+      organizationMetadata: context.organization.metadata,
+      mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
     })
+    const buildTools = () => buildCapabilityToolTree(capabilityContext)
     const actorContext = { organizationContext: context, memberTeams: teams, session: c.get("session") }
-    return { context, member, actorContext, buildTools, codemodeEnabled: codemodeScriptsEnabled(context.organization.metadata) }
+    return { context, member, actorContext, buildTools, codemodeEnabled }
   }
 
   app.get(

--- a/ee/apps/den-api/test/capability-parity.test.ts
+++ b/ee/apps/den-api/test/capability-parity.test.ts
@@ -1,0 +1,212 @@
+import { beforeAll, expect, test } from "bun:test"
+
+import { Tool } from "@openwork/codemode"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { Effect } from "effect"
+import { Hono } from "hono"
+import type {
+  CapabilityLeaf,
+  CapabilityRegistryContext,
+  CapabilitySource,
+  CapabilitySourceKind,
+  ExecuteCapabilityToolResult,
+  ParsedCapability,
+} from "../src/mcp/capability-registry.js"
+import type { CapabilityMatch } from "../src/mcp/search.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_API_PUBLIC_URL = process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790"
+}
+
+let CAPABILITY_SOURCE_KINDS: typeof import("../src/mcp/capability-registry.js")["CAPABILITY_SOURCE_KINDS"]
+let createCapabilityRegistry: typeof import("../src/mcp/capability-registry.js")["createCapabilityRegistry"]
+let codemodeScriptPath: typeof import("../src/mcp/codemode-namespaces.js")["codemodeScriptPath"]
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const capabilityRegistry = await import("../src/mcp/capability-registry.js")
+  CAPABILITY_SOURCE_KINDS = capabilityRegistry.CAPABILITY_SOURCE_KINDS
+  createCapabilityRegistry = capabilityRegistry.createCapabilityRegistry
+  codemodeScriptPath = (await import("../src/mcp/codemode-namespaces.js")).codemodeScriptPath
+})
+
+const FIXTURES: Record<CapabilitySourceKind, { capabilityName: string; namespace: string; toolName: string }> = {
+  catalog: { capabilityName: "listFixtureWidgets", namespace: "den", toolName: "listFixtureWidgets" },
+  native: { capabilityName: "native:fixture:nativeAction", namespace: "native_fixture", toolName: "nativeAction" },
+  externalMcp: { capabilityName: "mcp:fixture:externalAction", namespace: "external_fixture", toolName: "externalAction" },
+  marketplace: { capabilityName: "plugin:fixture:content", namespace: "marketplace", toolName: "plugin:fixture:content" },
+  builtinSkill: { capabilityName: "skill:fixture", namespace: "skills", toolName: "skill:fixture" },
+  admin: { capabilityName: "admin:fixtureAction", namespace: "admin", toolName: "fixtureAction" },
+}
+
+function textResult(value: unknown): ExecuteCapabilityToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value) }] }
+}
+
+function unknownResult(name: string): ExecuteCapabilityToolResult {
+  return {
+    isError: true,
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        error: "unknown_capability",
+        message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+      }),
+    }],
+  }
+}
+
+function fixtureMatch(kind: CapabilitySourceKind): CapabilityMatch {
+  const fixture = FIXTURES[kind]
+  return {
+    name: fixture.capabilityName,
+    method: "FIXTURE",
+    path: `/fixture/${kind}`,
+    score: 10,
+    summary: `${kind} fixture capability`,
+    pathParams: [],
+    queryParams: [],
+    hasBody: false,
+    kind: "capability",
+    scriptPath: codemodeScriptPath(fixture.namespace, fixture.toolName),
+  }
+}
+
+function fixtureLeaf(kind: CapabilitySourceKind): CapabilityLeaf {
+  const fixture = FIXTURES[kind]
+  return {
+    namespace: fixture.namespace,
+    toolName: fixture.toolName,
+    capabilityName: fixture.capabilityName,
+    scriptPath: codemodeScriptPath(fixture.namespace, fixture.toolName),
+    definition: Tool.make({
+      description: `${kind} fixture capability`,
+      input: { type: "object" },
+      run: () => Effect.succeed({ source: kind }),
+    }),
+  }
+}
+
+function parsedCapability(kind: CapabilitySourceKind, name: string): ParsedCapability | null {
+  if (name !== FIXTURES[kind].capabilityName) return null
+  if (kind === "catalog") return { kind, name }
+  if (kind === "native") return { kind, name, connectionId: "fixture", toolName: "nativeAction" }
+  if (kind === "externalMcp") return { kind, name, connectionId: "fixture", toolName: "externalAction" }
+  if (kind === "marketplace") return { kind, name, pluginId: "fixture", configObjectId: "content" }
+  if (kind === "builtinSkill") return { kind, name }
+  return { kind, name, toolName: "fixtureAction" }
+}
+
+function fixtureSource(kind: CapabilitySourceKind): CapabilitySource {
+  const adminOnly = kind === "admin"
+  return {
+    kind,
+    parseName: (name) => parsedCapability(kind, name),
+    search: async (ctx) => adminOnly && !(await ctx.resolvePlatformAdmin()) ? [] : [fixtureMatch(kind)],
+    enumerate: async (ctx) => adminOnly && !(await ctx.resolvePlatformAdmin()) ? [] : [fixtureLeaf(kind)],
+    execute: async (ctx, _parsed, input) => adminOnly && !(await ctx.resolvePlatformAdmin())
+      ? unknownResult(input.name)
+      : textResult({ resolvedSource: kind }),
+  }
+}
+
+function fixtureSources(): Record<CapabilitySourceKind, CapabilitySource> {
+  return {
+    catalog: fixtureSource("catalog"),
+    native: fixtureSource("native"),
+    externalMcp: fixtureSource("externalMcp"),
+    marketplace: fixtureSource("marketplace"),
+    builtinSkill: fixtureSource("builtinSkill"),
+    admin: fixtureSource("admin"),
+  }
+}
+
+function fixtureContext(platformAdmin: boolean): CapabilityRegistryContext {
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  let platformAdminResolution: Promise<boolean> | undefined
+  return {
+    app: new Hono(),
+    env: undefined,
+    catalog: [],
+    principal: {
+      userId: createDenTypeId("user"),
+      organizationId,
+      scopes: new Set(["mcp:read", "mcp:write"]),
+      payload: {},
+    },
+    organizationId,
+    member: { orgMembershipId: memberId, teamIds: [] },
+    redirectUriBase: "http://127.0.0.1:8790",
+    codemodeEnabled: true,
+    externalMcpConnectionsEnabled: true,
+    resolvePlatformAdmin: () => {
+      platformAdminResolution ??= Promise.resolve(platformAdmin)
+      return platformAdminResolution
+    },
+    resolveNamespaceContext: () => Promise.resolve({
+      nativeProviderEntries: [],
+      externalMcpConnections: [],
+      codemodeNativeProviderEntries: [],
+      codemodeExternalMcpConnections: [],
+      namespaces: { native: new Map(), externalMcp: new Map() },
+    }),
+  }
+}
+
+function firstText(result: ExecuteCapabilityToolResult): string {
+  const part = result.content.find((candidate) => candidate.type === "text")
+  return part?.type === "text" ? part.text : ""
+}
+
+async function expectSearchExecuteTreeParity(platformAdmin: boolean) {
+  const registry = createCapabilityRegistry(fixtureSources())
+  const context = fixtureContext(platformAdmin)
+  const searched = await registry.search(context, { query: "fixture", limit: 20 })
+  const tree = await registry.buildToolTree(context)
+  const treePaths = new Set(Object.entries(tree.tools).flatMap(([namespace, tools]) => (
+    Object.keys(tools).map((toolName) => codemodeScriptPath(namespace, toolName))
+  )))
+  const callableMatches = searched.matches.filter((match) => match.kind === "capability")
+
+  for (const match of callableMatches) {
+    const executed = await registry.execute(context, { name: match.name })
+    expect(firstText(executed)).not.toContain("unknown_capability")
+    expect(match.scriptPath).toBeDefined()
+    expect(treePaths.has(match.scriptPath ?? "")).toBe(true)
+    expect(tree.manifest).toContainEqual({
+      capabilityName: match.name,
+      scriptPath: match.scriptPath,
+    })
+  }
+
+  return { callableMatches, context, registry, tree }
+}
+
+test("every member capability found by search resolves through execute and exists in the script tree", async () => {
+  const result = await expectSearchExecuteTreeParity(false)
+  expect(result.callableMatches.map((match) => match.name).sort()).toEqual(
+    CAPABILITY_SOURCE_KINDS
+      .filter((kind) => kind !== "admin")
+      .map((kind) => FIXTURES[kind].capabilityName)
+      .sort(),
+  )
+})
+
+test("a platform admin receives the same parity set plus admin capabilities", async () => {
+  const result = await expectSearchExecuteTreeParity(true)
+  expect(result.callableMatches.map((match) => match.name)).toContain(FIXTURES.admin.capabilityName)
+})
+
+test("a non-admin member has zero admin capabilities in search, execute, and the script tree", async () => {
+  const result = await expectSearchExecuteTreeParity(false)
+  expect(result.callableMatches.some((match) => match.name.startsWith("admin:"))).toBe(false)
+  expect(result.tree.manifest.some((entry) => entry.capabilityName.startsWith("admin:"))).toBe(false)
+
+  const executed = await result.registry.execute(result.context, { name: FIXTURES.admin.capabilityName })
+  expect(firstText(executed)).toContain("unknown_capability")
+})

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -15,8 +15,8 @@ let buildExternalNamespaceMap: typeof import("../src/mcp/codemode-tools.js")["bu
 let buildCodemodeConnectionNamespaceMaps: typeof import("../src/mcp/codemode-tools.js")["buildCodemodeConnectionNamespaceMaps"]
 let buildDenCatalogToolTree: typeof import("../src/mcp/codemode-tools.js")["buildDenCatalogToolTree"]
 let buildNativeProviderManifest: typeof import("../src/mcp/codemode-tools.js")["buildNativeProviderManifest"]
-let CAPABILITY_SOURCE_KINDS: typeof import("../src/mcp/codemode-tools.js")["CAPABILITY_SOURCE_KINDS"]
-let CODEMODE_SOURCE_PARTICIPATION: typeof import("../src/mcp/codemode-tools.js")["CODEMODE_SOURCE_PARTICIPATION"]
+let CAPABILITY_SOURCE_KINDS: typeof import("../src/mcp/capability-registry.js")["CAPABILITY_SOURCE_KINDS"]
+let CAPABILITY_SOURCES: typeof import("../src/mcp/capability-registry.js")["CAPABILITY_SOURCES"]
 let isCodemodeEligibleConnection: typeof import("../src/mcp/codemode-tools.js")["isCodemodeEligibleConnection"]
 let firstUnattendedUnsafeCapability: typeof import("../src/mcp/codemode-tools.js")["firstUnattendedUnsafeCapability"]
 let restrictCodemodeToolTree: typeof import("../src/mcp/codemode-tools.js")["restrictCodemodeToolTree"]
@@ -26,13 +26,14 @@ let parseNativeCapabilityName: typeof import("../src/mcp/native-capabilities.js"
 beforeAll(async () => {
   seedRequiredEnv()
   const codemodeTools = await import("../src/mcp/codemode-tools.js")
+  const capabilityRegistry = await import("../src/mcp/capability-registry.js")
   const nativeCapabilities = await import("../src/mcp/native-capabilities.js")
   buildExternalNamespaceMap = codemodeTools.buildExternalNamespaceMap
   buildCodemodeConnectionNamespaceMaps = codemodeTools.buildCodemodeConnectionNamespaceMaps
   buildDenCatalogToolTree = codemodeTools.buildDenCatalogToolTree
   buildNativeProviderManifest = codemodeTools.buildNativeProviderManifest
-  CAPABILITY_SOURCE_KINDS = codemodeTools.CAPABILITY_SOURCE_KINDS
-  CODEMODE_SOURCE_PARTICIPATION = codemodeTools.CODEMODE_SOURCE_PARTICIPATION
+  CAPABILITY_SOURCE_KINDS = capabilityRegistry.CAPABILITY_SOURCE_KINDS
+  CAPABILITY_SOURCES = capabilityRegistry.CAPABILITY_SOURCES
   isCodemodeEligibleConnection = codemodeTools.isCodemodeEligibleConnection
   firstUnattendedUnsafeCapability = codemodeTools.firstUnattendedUnsafeCapability
   restrictCodemodeToolTree = codemodeTools.restrictCodemodeToolTree
@@ -173,8 +174,14 @@ test("allocates native and external namespaces from one collision set", () => {
   expect(namespaces.externalMcp.get("external-shared")).toBe("shared_2")
 })
 
-test("declares Code Mode participation for every capability source kind", () => {
-  expect(Object.keys(CODEMODE_SOURCE_PARTICIPATION).sort()).toEqual([...CAPABILITY_SOURCE_KINDS].sort())
+test("registers every capability source kind with all three verbs", () => {
+  expect(Object.keys(CAPABILITY_SOURCES).sort()).toEqual([...CAPABILITY_SOURCE_KINDS].sort())
+  for (const kind of CAPABILITY_SOURCE_KINDS) {
+    expect(CAPABILITY_SOURCES[kind].kind).toBe(kind)
+    expect(typeof CAPABILITY_SOURCES[kind].search).toBe("function")
+    expect(typeof CAPABILITY_SOURCES[kind].execute).toBe("function")
+    expect(typeof CAPABILITY_SOURCES[kind].enumerate).toBe("function")
+  }
 })
 
 test("native manifest capability names round-trip through the native parser", () => {

--- a/ee/apps/den-api/test/marketplace-codemode-scripts.test.ts
+++ b/ee/apps/den-api/test/marketplace-codemode-scripts.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { Effect } from "effect"
+import { Hono } from "hono"
 import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
 
 function seedRequiredEnv() {
@@ -30,6 +31,7 @@ function seedRequiredEnv() {
 
 type Db = typeof import("../src/db.js").db
 type MarketplaceCapabilities = typeof import("../src/mcp/marketplace-capabilities.js")
+type CapabilityRegistry = typeof import("../src/mcp/capability-registry.js")
 type PluginStore = typeof import("../src/routes/org/plugin-system/store.js")
 type SavedScripts = typeof import("../src/codemode-scripts.js")
 type CodemodeRuns = typeof import("../src/codemode-runs.js")
@@ -43,6 +45,7 @@ type SeededScript = {
 
 let db: Db
 let marketplaceCapabilities: MarketplaceCapabilities
+let capabilityRegistry: CapabilityRegistry
 let pluginStore: PluginStore
 let savedScripts: SavedScripts
 let codemodeRuns: CodemodeRuns
@@ -61,6 +64,7 @@ beforeAll(async () => {
   marketplaceCapabilities = await import("../src/mcp/marketplace-capabilities.js")
   savedScripts = await import("../src/codemode-scripts.js")
   codemodeRuns = await import("../src/codemode-runs.js")
+  capabilityRegistry = await import("../src/mcp/capability-registry.js")
 })
 
 afterAll(() => {
@@ -347,6 +351,66 @@ describe("saved marketplace scripts", () => {
       missing: [{ capabilityName: "missingCapability", scriptPath: "tools.den.missingCapability" }],
     })
     expect(invocations).toBe(0)
+  })
+
+  test("keeps saved scripts and execute_capability_script out of the composable tree", async () => {
+    const seeded = await seedScript({
+      title: "Recursive Script",
+      code: "return 'must not run'",
+      payload: { language: "codemode-js", requiredCapabilities: [] },
+    })
+    const capabilityName = marketplaceCapabilities.buildMarketplaceCapabilityName(seeded.pluginId, seeded.configObjectId)
+    const requiredCapabilities = [
+      { capabilityName, scriptPath: `tools.marketplace[${JSON.stringify(capabilityName)}]` },
+      { capabilityName: "execute_capability_script", scriptPath: "tools.den.execute_capability_script" },
+    ]
+    await db.update(ConfigObjectVersionTable)
+      .set({ normalizedPayloadJson: { language: "codemode-js", requiredCapabilities } })
+      .where(eq(ConfigObjectVersionTable.configObjectId, seeded.configObjectId))
+
+    let platformAdmin: Promise<boolean> | undefined
+    const context: Parameters<CapabilityRegistry["buildCapabilityToolTree"]>[0] = {
+      app: new Hono(),
+      env: undefined,
+      catalog: [],
+      principal: {
+        userId: createDenTypeId("user"),
+        organizationId: seeded.organizationId,
+        scopes: new Set(["mcp:read", "mcp:write"]),
+        payload: {},
+      },
+      organizationId: seeded.organizationId,
+      member: seeded.member,
+      redirectUriBase: "http://127.0.0.1:8790",
+      codemodeEnabled: true,
+      externalMcpConnectionsEnabled: true,
+      resolvePlatformAdmin: () => {
+        platformAdmin ??= Promise.resolve(false)
+        return platformAdmin
+      },
+      resolveNamespaceContext: () => Promise.resolve({
+        nativeProviderEntries: [],
+        externalMcpConnections: [],
+        codemodeNativeProviderEntries: [],
+        codemodeExternalMcpConnections: [],
+        namespaces: { native: new Map(), externalMcp: new Map() },
+      }),
+    }
+    const built = await capabilityRegistry.buildCapabilityToolTree(context)
+    expect(built.manifest).not.toContainEqual(expect.objectContaining({ capabilityName }))
+    expect(built.manifest).not.toContainEqual(expect.objectContaining({ capabilityName: "execute_capability_script" }))
+
+    const result = await executeScript(seeded, {
+      buildTools: () => capabilityRegistry.buildCapabilityToolTree(context),
+    })
+    expect(result).toMatchObject({
+      ok: false,
+      error: "capability_unavailable",
+      providerCallAttempted: false,
+      missing: requiredCapabilities,
+    })
+    if (result.ok) throw new Error("Expected saved-script recursion to be blocked")
+    expect(result.message).toContain("is unavailable or disabled")
   })
 
   test("rejects input that does not match the saved inputSchema", async () => {

--- a/evals/specs/codemode-scripts.slow.test.ts
+++ b/evals/specs/codemode-scripts.slow.test.ts
@@ -384,7 +384,12 @@ test(title, { timeout: 1_500_000 }, async ({ evidence, place }) => {
     : [];
   // Closed-world: asserting one guessed namespace is absent would pass even if the
   // sanitizer produced a different name, so pin the whole namespace set instead.
-  const expectedNamespaces = ["$codemode", "den", "drive_mock", "gmail_mock"];
+  // The content rails (skills, marketplace, admin) are present because the capability
+  // set is one set for all three verbs — this admin is on the bootstrap allowlist, so
+  // admin capabilities are in their set; a non-admin member's set has none. No
+  // marketplace namespace yet: this org's only marketplace object is the saved script
+  // created later, and saved scripts are deliberately excluded (no script recursion).
+  const expectedNamespaces = ["$codemode", "admin", "den", "drive_mock", "gmail_mock", "skills"];
   evidence.fact(
     "An unconnected native provider does not surface a callable script namespace",
     `Object.keys(tools): ${JSON.stringify(unconnectedNamespaces)}; expected exactly: ${JSON.stringify(expectedNamespaces)}`,
@@ -392,6 +397,37 @@ test(title, { timeout: 1_500_000 }, async ({ evidence, place }) => {
   );
   expect(unconnectedNamespaces).toEqual(expectedNamespaces);
   expect(unconnectedNamespaces).not.toContain(unconnectedNamespace);
+
+  // Interchangeability: whatever search finds, execute runs AND a script can call.
+  // A built-in skill is the sharpest case — it used to be searchable and executable
+  // but deliberately absent from the script tree.
+  const skillSearch = await callAgentTool(den.ref.apiUrl, adminMcpToken, "search_capabilities", {
+    query: "skill",
+    type: "skills",
+    limit: 5,
+  });
+  const skillMatches = (() => {
+    const payload = requireRecord(JSON.parse(toolText(skillSearch)), "skill search payload");
+    return Array.isArray(payload.matches) ? payload.matches.filter(isRecord) : [];
+  })();
+  const skillWithPath = skillMatches.find((match) => typeof match.scriptPath === "string" && match.scriptPath.length > 0);
+  evidence.fact(
+    "A skill capability found by search carries a scriptPath, so the same set is reachable from a script",
+    `skills matches: ${JSON.stringify(skillMatches.map((m) => ({ name: m.name, scriptPath: m.scriptPath }))).slice(0, 400)}`,
+    Boolean(skillWithPath),
+  );
+  expect(skillWithPath).toBeTruthy();
+  const skillScriptPath = String((skillWithPath ?? {}).scriptPath ?? "");
+  const skillCallProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "execute_capability_script", {
+    code: `const result = await ${skillScriptPath}({})\nreturn typeof result === "string" ? result.slice(0, 120) : result`,
+  });
+  const skillCallText = toolText(skillCallProbe);
+  evidence.fact(
+    "That same skill capability is callable from inside a script at its advertised scriptPath",
+    `${skillScriptPath}({}) -> ${skillCallText.slice(0, 300)}`,
+    skillCallText.trim().length > 0 && !skillCallText.includes("script_failed"),
+  );
+  expect(skillCallText).not.toContain("script_failed");
 
   const unconnectedSearchProbe = await callAgentTool(den.ref.apiUrl, adminMcpToken, "search_capabilities", {
     query: "Unconnected Google Rail Probe Gmail",


### PR DESCRIPTION
> Stacked on #3670 (`feat/capability-parity`). Review/merge that first; this PR's base will retarget to `dev` automatically once it lands.

## The invariant

> There is **one capability set per member**. `search_capabilities` finds in it, `execute_capability` calls into it, `execute_capability_script` composes over it. Same set, three verbs, interchangeable.

Before this, each of the three verbs hand-enumerated the six rails independently — six search blocks, a prefix if/else execute chain, and separate tree builders. Nothing forced a new consumer to remember a rail, which is exactly how native providers were missed (fixed in #3670). This makes the set the only definition.

- `CapabilitySource` owns `parseName` / `search` / `enumerate` / `execute` for its rail.
- `CAPABILITY_SOURCES: Record<CapabilitySourceKind, CapabilitySource>` — a new kind **cannot compile** until it declares how it participates in all three verbs. This replaces the interim `CODEMODE_SOURCE_PARTICIPATION` record from #3670; the guarantee is now colocated with the source.
- **The set stays virtual.** search and the tree `enumerate`; execute resolves point-wise via `parseName`, so a single `execute_capability` never pays the external-MCP `tools/list` fan-out. Its existing bounds (16 connections / 4 concurrent / shared deadline) are untouched.
- `agent.ts`: **−277 / +40**.

## Intended behavior changes

These follow from the invariant rather than despite it — "excluded from scripts" was the wrong framing, since authorization defines the set and verbs don't filter:

1. **Built-in skills and marketplace content objects are now script-callable.** They were already searchable and executable; a script fetching a skill's content while doing data work is legitimate.
2. **Admin capabilities are script-callable for platform admins only** — gated by the same memoized `resolvePlatformAdmin()` the other verbs use, with a second check inside `execute`. A non-admin member's set contains zero admin capabilities in **all three** verbs.
3. **Saved marketplace `script` objects stay out of the tree** — no script-calls-script recursion in v1.

## Preserved (regression bar)

Org flags (`codemodeScripts`, `mcpConnections`) and their gating, `searchCapabilitySourceFilter` semantics, `executeCapabilityWithBudget`, every error payload shape (`unknown_capability`, `policy_blocked`, `capability_unavailable` + `providerCallAttempted: false`, `invalid_capability_arguments`, advisory `schemaGuidance`), the external coverage hint, shared namespace allocation, native credential binding via `executeNativeCapability`, and the `/mcp` full-catalog endpoint.

## Verification

**`capability-parity.test.ts` is the point of the PR.** For every search match that is a capability (advisory `connection_status` rows skipped): `execute_capability` must resolve it to a real source, **and** its `scriptPath` must exist in the script tree — across a fixture spanning catalog + native + externalMcp + marketplace + builtinSkill, plus an admin fixture, plus the negative half for a non-admin. The Google Workspace gap would have been a red test instead of a question from a user. It is self-contained (seeds its own env, passes standalone and in batch — an earlier version only passed when a sibling suite ran first, which I fixed).

- `evals/specs/codemode-scripts.slow.test.ts`: **22/22 facts, 0 failed**, including two new ones proving interchangeability end to end — a skill found by `search_capabilities` carries a `scriptPath`, and is callable at exactly that path from inside a script.
- den-api `bun test`: `capability-parity`, `codemode-tools`, `codemode-native-binding`, `agent-codemode-script`, `agent-mcp-routes`, `codemode-rollout`, `organization-capabilities` (30 pass), `marketplace-codemode-*` (6), `marketplace-capabilities` (19), `codemode-runs` (2) — all green.
- `tsc --noEmit` clean; `pnpm --filter @openwork-ee/den-api build` exit 0.

**Pre-existing failures, confirmed not mine** (reproduced on a clean `origin/dev` worktree, identical counts):
- `external-capabilities-search-divergence.test.ts` — 21 pass / **2 fail** ("Native provider connectors do not expose an MCP tool catalog"); the throwing code in `capability-sources/` is untouched dev code.
- `mcp-agent-config-policy.test.ts` — 14 pass / **2 fail**, identical on the parent branch.

Evidence tape published below.
