### PR TITLE
Allow trusted internal Redis without TLS

### DIFF
--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -2,6 +2,9 @@ PORT=8790
 CORS_ORIGINS=http://localhost:3005,http://127.0.0.1:3005
 DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den
 DATABASE_REDIS_URL=redis://127.0.0.1:6379
+# Set to 1 only for trusted private, non-public Redis endpoints that do not support TLS,
+# such as some Render internal Redis URLs. Prefer rediss:// when available.
+DATABASE_REDIS_ALLOW_INSECURE_INTERNAL=0
 DB_MODE=mysql
 DATABASE_HOST=
 DATABASE_USERNAME=

--- a/ee/apps/den-api/README.md
+++ b/ee/apps/den-api/README.md
@@ -89,6 +89,7 @@ Rules for adding cache helpers:
 - Add helpers under the exported `cache` namespace in `src/cache.ts`.
 - Keep each helper as a read-through function: check Redis, run the DB loader on miss, write Redis, then return the loaded value.
 - Redis is optional. Helpers must work when `DATABASE_REDIS_URL` is unset.
+- Non-local Redis should use `rediss://`. Set `DATABASE_REDIS_ALLOW_INSECURE_INTERNAL=1` only when the `redis://` endpoint is private, non-public, and restricted to a trusted internal network.
 - Use short TTLs unless invalidation is explicit and tested.
 - Auth sessions are DB-authoritative and cached for at most one hour. Any session delete or identity-changing update must invalidate `cache.auth.deleteSession(token)`.
 - Do not add new security-critical cache helpers without explicit invalidation and tests.

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -18,6 +18,7 @@ const EnvSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().min(1),
   DATABASE_REDIS_URL: z.string().optional(),
+  DATABASE_REDIS_ALLOW_INSECURE_INTERNAL: z.string().optional(),
   DEN_MCP_RESOURCE_URL: z.string().optional(),
   DEN_MCP_ADDITIONAL_RESOURCES: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
@@ -289,7 +290,12 @@ function isLocalRedisHost(hostname: string) {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1"
 }
 
-function normalizeRedisUrl(value: string | undefined) {
+function parseBooleanFlag(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on"
+}
+
+function normalizeRedisUrl(value: string | undefined, allowInsecureInternal: boolean) {
   const configured = optionalString(value)
   if (!configured) {
     return undefined
@@ -306,8 +312,8 @@ function normalizeRedisUrl(value: string | undefined) {
     throw new Error("DATABASE_REDIS_URL must use redis:// or rediss://.")
   }
 
-  if (url.protocol === "redis:" && !isLocalRedisHost(url.hostname)) {
-    throw new Error("DATABASE_REDIS_URL must use rediss:// for non-local Redis endpoints.")
+  if (url.protocol === "redis:" && !isLocalRedisHost(url.hostname) && !allowInsecureInternal) {
+    throw new Error("DATABASE_REDIS_URL must use rediss:// for non-local Redis endpoints unless DATABASE_REDIS_ALLOW_INSECURE_INTERNAL=1 is set for a trusted private network.")
   }
 
   return url.toString()
@@ -443,6 +449,7 @@ const orgMode = parseDenOrgMode(parsed.DEN_ORG_MODE)
 // (OPENWORK_DEV_MODE=1) is exempt automatically so evals against a local
 // stand-in server keep working.
 const allowPrivateMcpUrls = devMode || (parsed.DEN_ALLOW_PRIVATE_MCP_URLS ?? "0").trim() === "1"
+const allowInsecureInternalRedis = parseBooleanFlag(parsed.DATABASE_REDIS_ALLOW_INSECURE_INTERNAL)
 const requireEmailVerification = parsed.DEN_REQUIRE_EMAIL_VERIFICATION === undefined
   ? orgMode === "multi_org" && !devMode
   : parsed.DEN_REQUIRE_EMAIL_VERIFICATION.trim().toLowerCase() !== "false"
@@ -470,7 +477,13 @@ export const env = {
   planetscale: planetscaleCredentials,
   betterAuthSecret: parsed.BETTER_AUTH_SECRET,
   betterAuthUrl: normalizeOrigin(parsed.BETTER_AUTH_URL),
-  databaseRedisUrl: normalizeRedisUrl(parsed.DATABASE_REDIS_URL),
+  // SECURITY: `redis://` carries cached auth-session material in plaintext.
+  // Non-local redis:// is rejected by default. Hosted platforms such as Render
+  // may provide a private, non-public internal Redis URL without TLS; operators
+  // must explicitly opt in with DATABASE_REDIS_ALLOW_INSECURE_INTERNAL=1 after
+  // confirming the endpoint is only reachable inside a trusted private network.
+  databaseRedisUrl: normalizeRedisUrl(parsed.DATABASE_REDIS_URL, allowInsecureInternalRedis),
+  databaseRedisAllowInsecureInternal: allowInsecureInternalRedis,
   mcpResourceUrl: mcpResourceUrl
     ? normalizeOrigin(mcpResourceUrl)
     : devMode

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -152,14 +152,28 @@ The existing Secret must contain the keys listed under `secret.keys`, especially
 - `BETTER_AUTH_SECRET`
 - `DEN_DB_ENCRYPTION_KEY`
 
-Set optional `DATABASE_REDIS_URL` to enable Redis-backed Better Auth secondary storage and Den API query caching. Set `DAYTONA_API_KEY` when `config.provisioner.mode` is `daytona`. Set `POLAR_ACCESS_TOKEN` when Polar feature gating is enabled. Set `OPENROUTER_MANAGEMENT_API_KEY` when enabling OpenWork Models management.
+Set optional `DATABASE_REDIS_URL` to enable Den API Redis-backed session and query caching. Set `DAYTONA_API_KEY` when `config.provisioner.mode` is `daytona`. Set `POLAR_ACCESS_TOKEN` when Polar feature gating is enabled. Set `OPENROUTER_MANAGEMENT_API_KEY` when enabling OpenWork Models management.
 
-Redis cache example:
+Redis cache examples:
 
 ```yaml
 secret:
   values:
     databaseRedisUrl: "rediss://redis-master.openwork.svc.cluster.local:6379"
+```
+
+Prefer `rediss://`. For hosting platforms that only provide a private internal
+`redis://` URL, such as Render internal Redis, explicitly acknowledge the trust
+boundary with `redis.allowInsecureInternal=true`. Use this only when the Redis
+endpoint is non-public and reachable only from trusted services in the private
+network.
+
+```yaml
+redis:
+  allowInsecureInternal: true
+secret:
+  values:
+    databaseRedisUrl: "redis://red-...:6379"
 ```
 
 ## Custom CA certificates

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -9,6 +9,10 @@ data:
   NODE_ENV: "production"
   OPENWORK_DEV_MODE: {{ .Values.config.openworkDevMode | quote }}
   DEN_API_NODE_OPTIONS: {{ .Values.config.denApiNodeOptions | quote }}
+  # SECURITY: Enables non-local redis:// DATABASE_REDIS_URL values only for
+  # trusted private networks. Keep false for public or cross-network Redis;
+  # prefer rediss:// whenever the provider supports TLS.
+  DATABASE_REDIS_ALLOW_INSECURE_INTERNAL: {{ ternary "1" "0" .Values.redis.allowInsecureInternal | quote }}
   DB_MODE: {{ .Values.config.databaseMode | quote }}
   DEN_ORG_MODE: {{ .Values.config.tenancy.mode | quote }}
   DEN_SINGLE_ORG_NAME: {{ .Values.config.tenancy.singleOrgName | quote }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -134,6 +134,12 @@ customCa:
   existingConfigMap: ""
   key: ca.crt
 
+redis:
+  # Prefer rediss:// DATABASE_REDIS_URL values. Set this to true only for
+  # trusted private, non-public Redis endpoints that do not support TLS, such as
+  # some managed internal Redis URLs exposed by hosting platforms.
+  allowInsecureInternal: false
+
 secret:
   create: true
   existingSecret: ""


### PR DESCRIPTION
## Summary
- add explicit `DATABASE_REDIS_ALLOW_INSECURE_INTERNAL=1` opt-in for trusted private non-local `redis://` endpoints
- keep the default safety behavior: non-local `redis://` is rejected unless explicitly acknowledged; `rediss://` remains preferred
- expose Helm `redis.allowInsecureInternal` and document Render/internal Redis usage with security comments for reviewers

## Verification
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `bun test test/cache.test.ts test/bearer-session.test.ts`
- `helm template openwork-ee packaging/helm/openwork-ee`
- `helm template openwork-ee packaging/helm/openwork-ee --set redis.allowInsecureInternal=true --set secret.values.databaseRedisUrl=redis://render-internal:6379`
- `git diff --check`