### PR TITLE
fix(den-api): invalidate the org members cache when a membership is created

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -534,6 +534,7 @@ async function insertMemberIfMissing(input: {
     defaultRole: input.role,
   })
   if (invitedMember) {
+    await cache.org.deleteMembers(input.organizationId)
     return invitedMember
   }
 
@@ -553,6 +554,7 @@ async function insertMemberIfMissing(input: {
       role: input.role,
       joinedAt: new Date(),
     })
+    await cache.org.deleteMembers(input.organizationId)
   } catch {}
 
   const created = await db

--- a/ee/apps/den-api/test/invite-duplicate-members.test.ts
+++ b/ee/apps/den-api/test/invite-duplicate-members.test.ts
@@ -1,5 +1,5 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { afterAll, beforeAll, expect, test } from "bun:test"
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test"
 
 const singleOrgSlug = "invite-duplicates-test"
 const future = new Date(Date.now() + 1000 * 60 * 60)
@@ -52,6 +52,17 @@ let db: typeof import("../src/db.js").db | null = null
 let schema: typeof import("@openwork-ee/den-db/schema") | null = null
 let drizzle: typeof import("@openwork-ee/den-db/drizzle") | null = null
 let orgs: typeof import("../src/orgs.js") | null = null
+let restoreCacheDependencies: (() => void) | null = null
+const cacheDeleteCalls: string[] = []
+
+const redis = {
+  get: (_key: string) => Promise.resolve(null),
+  set: (_key: string, _value: string, _mode: "EX", _ttl: number) => Promise.resolve("OK"),
+  del: (key: string) => {
+    cacheDeleteCalls.push(key)
+    return Promise.resolve(1)
+  },
+}
 
 const userIds = [
   ownerUserId,
@@ -156,16 +167,18 @@ async function invitationStatus(invitationId: string) {
 
 beforeAll(async () => {
   seedRequiredEnv()
-  const [dbModule, schemaModule, drizzleModule, orgsModule] = await Promise.all([
+  const [dbModule, schemaModule, drizzleModule, orgsModule, cacheModule] = await Promise.all([
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
     import("@openwork-ee/den-db/drizzle"),
     import("../src/orgs.js"),
+    import("../src/cache.js"),
   ])
   db = dbModule.db
   schema = schemaModule
   drizzle = drizzleModule
   orgs = orgsModule
+  restoreCacheDependencies = cacheModule.setCacheDependenciesForTest({ redis })
 
   await cleanup()
 
@@ -194,11 +207,16 @@ beforeAll(async () => {
   ])
 })
 
+beforeEach(() => {
+  cacheDeleteCalls.length = 0
+})
+
 afterAll(async () => {
+  restoreCacheDependencies?.()
   await cleanup()
 })
 
-test("single-org bootstrap adopts a pending invitation instead of creating a duplicate member", async () => {
+test("single-org bootstrap adopts a pending invitation and invalidates the member cache", async () => {
   if (!orgs) {
     throw new Error("orgs module not initialized")
   }
@@ -233,9 +251,10 @@ test("single-org bootstrap adopts a pending invitation instead of creating a dup
   expect(relatedMembers[0]?.role).toBe("admin")
   expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
   await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+  expect(cacheDeleteCalls).toEqual([`cache:org:members:${organizationId}`])
 })
 
-test("single-org bootstrap without a pending invitation keeps the default member insert behavior", async () => {
+test("single-org bootstrap invalidates the member cache after a default member insert", async () => {
   if (!orgs) {
     throw new Error("orgs module not initialized")
   }
@@ -255,6 +274,7 @@ test("single-org bootstrap without a pending invitation keeps the default member
   expect(rows).toHaveLength(1)
   expect(rows[0]?.role).toBe("member")
   expect(rows[0]?.inviteId).toBeNull()
+  expect(cacheDeleteCalls).toEqual([`cache:org:members:${organizationId}`])
 })
 
 test("reconcilePendingInvitationsForUser merges a raw SSO JIT membership with its pending invitation", async () => {


### PR DESCRIPTION
## The bug

#3679 ("Add Den Redis session cache", merged ~3h ago) added a read-through Redis cache for org members with a **60-second TTL** (`cache.org.members`, `DEFAULT_CACHE_TTL_SECONDS = 60`). Five call sites invalidate it, but **the membership-creation path itself does not** — `insertMemberIfMissing` (`orgs.ts:513`) writes the row and returns without touching the cache.

**Effect:** a user who has just joined an organization stays invisible for up to a minute. Anything reading membership through that cache — role resolution, access checks, `GET /v1/org` — serves stale data in that window.

## How it was found

Building a fresh self-hosted onboarding spec (#3668). On a brand-new single-org deployment: the owner signs up, then a second user signs up and auto-joins the singleton org via `ensureSingletonOrganizationForUser` → `ensureBootstrapMembershipForOrganization` → `insertMemberIfMissing`. `GET /v1/org` then returned a `members` list containing **only the owner**. Reproduced twice, with Redis flushed in between (so it is a missing invalidation, not stale cross-run state).

## The fix

Invalidate after a successful insert and after adopting a pending invitation. An unchanged existing membership still skips invalidation, and a soft-removed membership returns `null` without touching the cache — both deliberate, since neither mutates membership state.

## Verification

- **Unit:** new coverage in `invite-duplicate-members.test.ts` (fake Redis) for both the insert and invitation-adoption paths. Confirmed it **fails without the fix** (0 pass / 1 fail) and **passes with it** (1 pass / 0 fail).
- `pnpm exec bun test test/cache.test.ts` — 6 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api build` — exit 0
- **End-to-end:** `evals/specs/self-host-onboarding.slow.test.ts` from #3668 — **fails twice** against a fresh single-org Den without this fix (second member never appears), and **passes in 22s** with the patch applied. That spec lands in #3668 and will cover this permanently.

Note: the full `bun test` suite in `ee/apps/den-api` has pre-existing local failures from shared mock/environment leakage and DB hook timeouts, unrelated to this change — CI is the authority there.