### PR TITLE
chore(release): v0.18.19

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.18",
+  "version": "0.18.19",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.18",
+  "version": "0.18.19",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.18",
+  "version": "0.18.19",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.19",
   "0.18.18",
   "0.18.17",
   "0.18.16",


### PR DESCRIPTION
Backfills the v0.18.19 version bump into dev (the release was cut from the tag). Needs one approval from someone other than the pusher.