### PR TITLE
Surface failed automatic session titles

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1056,6 +1056,8 @@ export default {
   "session.revert_failed": "Could not revert the conversation. Try again once the current run finishes.",
   "session.branch_failed": "Could not branch this conversation. Try again.",
   "session.default_title": "New session",
+  "session.title_generation_failed_body": "Your conversation is safe. Rename it from the task menu while we keep the generated placeholder.",
+  "session.title_generation_failed_title": "Automatic task title did not complete",
   "session.delete": "Delete",
   "session.delete_named_session_message": "This will permanently delete \"{title}\" and its messages.",
   "session.delete_session_generic": "This will permanently delete the selected session and its messages.",

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -4,7 +4,8 @@ import type { FilePart, Part, PermissionRequest, PermissionV2Request, QuestionRe
 import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
-import { createClient } from "@/app/lib/opencode";
+import { createClient, unwrap } from "@/app/lib/opencode";
+import { isGeneratedSessionTitle } from "@/app/lib/session-title";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
 import { createSessionErrorUIMessage, describeOpencodeSessionError, snapshotToUIMessages } from "./usechat-adapter";
@@ -19,6 +20,12 @@ import {
   useSessionActivityStore,
 } from "../status/session-activity-store";
 import { notifyDesktopEvent } from "../../../shell/desktop-notifications";
+import { notifyAlert } from "../../../shell/notifications";
+import { t } from "@/i18n";
+import {
+  createSessionTitleRecovery,
+  type SessionTitleRecovery,
+} from "./session-title-recovery";
 
 type SyncOptions = {
   workspaceId: string;
@@ -58,6 +65,7 @@ type SyncEntry = {
   // the user like the app "freezes after 2 words."
   deltaFlushBuffer: PendingDelta[];
   deltaFlushScheduled: boolean;
+  titleRecovery: SessionTitleRecovery | null;
 };
 
 const idleStatus: SessionStatus = { type: "idle" };
@@ -262,6 +270,7 @@ function disposeWorkspaceSync(key: string, entry: SyncEntry) {
   }
   for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
   entry.retainedSessionTimers.clear();
+  entry.titleRecovery?.dispose();
   entry.dispose();
   if (syncs.get(key) === entry) syncs.delete(key);
 }
@@ -665,6 +674,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.updated") {
     const update = getSessionUpdatedInfo(event);
     if (!update) return;
+    const title = typeof update.info.title === "string" ? update.info.title : "";
+    if (title && !isGeneratedSessionTitle(title)) entry.titleRecovery?.resolve(update.sessionId);
     if (!isTrackedSession(entry, update.sessionId)) return;
     // Keep the cached snapshot's revert cursor in sync with the server. The
     // renderer derives the visible transcript from this cursor, so a revert
@@ -685,6 +696,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.deleted") {
     const props = (event.properties ?? {}) as { sessionID?: string; info?: { id?: string } };
     const sessionId = props.sessionID ?? props.info?.id ?? "";
+    if (sessionId) entry.titleRecovery?.resolve(sessionId);
     if (sessionId) useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
     if (sessionId) {
       for (const listener of entry.sessionDeletedListeners) listener(sessionId);
@@ -988,6 +1000,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       });
       trackTaskCompleted(props.sessionID, Date.now() - runStartedAt);
       notifyDesktopEvent({ type: "task.completed", sessionId: props.sessionID });
+      entry.titleRecovery?.observe(props.sessionID);
     }
     useSessionActivityStore.getState().setRunStatus(workspaceId, props.sessionID, idleStatus);
     const tracked = isTrackedSession(entry, props.sessionID);
@@ -1199,7 +1212,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     return () => releaseWorkspaceSessionSync(input);
   }
 
-  syncs.set(key, {
+  const created: SyncEntry = {
     input,
     openworkToken: input.openworkToken,
     refs: 1,
@@ -1214,9 +1227,46 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
+    titleRecovery: null,
+  };
+  created.titleRecovery = createSessionTitleRecovery({
+    fetch: async (sessionId) => {
+      const client = createClient(input.baseUrl, undefined, { token: created.openworkToken, mode: "openwork" });
+      const [session, messages] = await Promise.all([
+        client.session.get({ sessionID: sessionId }).then(unwrap),
+        client.session.messages({ sessionID: sessionId, limit: 20 }).then(unwrap),
+      ]);
+      return {
+        title: session.title,
+        messages: messages.map((message) => ({
+          role: message.info.role,
+          synthetic: Reflect.get(message.info, "synthetic") === true,
+          error: Reflect.get(message.info, "error"),
+        })),
+      };
+    },
+    onResolved: (sessionId, title) => {
+      getReactQueryClient().setQueryData<OpenworkSessionSnapshot>(
+        snapshotKey(input.workspaceId, sessionId),
+        (current) => current
+          ? { ...current, session: { ...current.session, title } }
+          : current,
+      );
+      for (const listener of created.sessionUpdatedListeners) {
+        listener({ sessionId, info: { title } });
+      }
+    },
+    onFailure: (sessionId) => {
+      notifyAlert({
+        kind: "system",
+        severity: "warning",
+        title: t("session.title_generation_failed_title"),
+        body: t("session.title_generation_failed_body"),
+        dedupeKey: `session-title-generation:${input.workspaceId}:${sessionId}`,
+      });
+    },
   });
-
-  const created = syncs.get(key)!;
+  syncs.set(key, created);
   created.dispose = startSync(input, created);
 
   return () => releaseWorkspaceSessionSync(input);
@@ -1370,6 +1420,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
+    titleRecovery: null,
   });
   return () => {
     const entry = syncs.get(key);

--- a/apps/app/src/react-app/domains/session/sync/session-title-recovery.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-title-recovery.ts
@@ -1,0 +1,141 @@
+import { isGeneratedSessionTitle } from "@/app/lib/session-title";
+
+export const SESSION_TITLE_RECOVERY_DELAYS_MS = [1_000, 5_000, 25_000] as const;
+
+export type SessionTitleRecoveryMessage = {
+  role: string;
+  synthetic: boolean;
+  error: unknown;
+};
+
+export type SessionTitleRecoveryRead = {
+  title: string | null | undefined;
+  messages: SessionTitleRecoveryMessage[];
+};
+
+type SessionTitleRecoveryOptions = {
+  fetch: (sessionId: string) => Promise<SessionTitleRecoveryRead>;
+  onResolved: (sessionId: string, title: string) => void;
+  onFailure: (sessionId: string) => void;
+  delaysMs?: readonly number[];
+};
+
+export type SessionTitleRecovery = {
+  observe: (sessionId: string) => void;
+  resolve: (sessionId: string) => void;
+  dispose: () => void;
+};
+
+type PendingRecovery = {
+  attempt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+type RecoveryReadState = "pending" | "failed" | "not-applicable" | "resolved";
+
+export function classifySessionTitleRecoveryRead(read: SessionTitleRecoveryRead): RecoveryReadState {
+  if (!isGeneratedSessionTitle(read.title)) return "resolved";
+
+  const realUsers = read.messages.filter(
+    (message) => message.role === "user" && !message.synthetic,
+  );
+  if (realUsers.length > 1) return "not-applicable";
+
+  const latestUserIndex = read.messages.findLastIndex(
+    (message) => message.role === "user" && !message.synthetic,
+  );
+  const successfulAssistant = read.messages
+    .slice(latestUserIndex + 1)
+    .some((message) => message.role === "assistant" && message.error == null);
+
+  if (realUsers.length === 0 || !successfulAssistant) return "pending";
+  return "failed";
+}
+
+/**
+ * OpenCode generates the first title in a detached background task and does
+ * not expose a title-regeneration endpoint. Probe the session on a bounded
+ * schedule so a slow title still reaches the sidebar, then report a confirmed
+ * placeholder after a successful first turn instead of failing silently.
+ */
+export function createSessionTitleRecovery(options: SessionTitleRecoveryOptions): SessionTitleRecovery {
+  const delaysMs = options.delaysMs ?? SESSION_TITLE_RECOVERY_DELAYS_MS;
+  const pending = new Map<string, PendingRecovery>();
+  const warned = new Set<string>();
+  let disposed = false;
+
+  const finish = (sessionId: string) => {
+    const recovery = pending.get(sessionId);
+    if (recovery?.timer) clearTimeout(recovery.timer);
+    pending.delete(sessionId);
+  };
+
+  const schedule = (sessionId: string, recovery: PendingRecovery) => {
+    const delayMs = delaysMs[recovery.attempt];
+    if (delayMs === undefined) {
+      finish(sessionId);
+      return;
+    }
+    recovery.timer = setTimeout(() => {
+      recovery.timer = null;
+      void probe(sessionId, recovery);
+    }, delayMs);
+  };
+
+  const probe = async (sessionId: string, recovery: PendingRecovery) => {
+    if (disposed || pending.get(sessionId) !== recovery) return;
+
+    let read: SessionTitleRecoveryRead;
+    try {
+      read = await options.fetch(sessionId);
+    } catch {
+      recovery.attempt += 1;
+      schedule(sessionId, recovery);
+      return;
+    }
+    if (disposed || pending.get(sessionId) !== recovery) return;
+
+    const state = classifySessionTitleRecoveryRead(read);
+    if (state === "resolved") {
+      const title = read.title?.trim();
+      if (title) options.onResolved(sessionId, title);
+      finish(sessionId);
+      return;
+    }
+    if (state === "not-applicable") {
+      finish(sessionId);
+      return;
+    }
+
+    const finalAttempt = recovery.attempt + 1 >= delaysMs.length;
+    if (finalAttempt) {
+      if (state === "failed" && !warned.has(sessionId)) {
+        warned.add(sessionId);
+        options.onFailure(sessionId);
+      }
+      finish(sessionId);
+      return;
+    }
+
+    recovery.attempt += 1;
+    schedule(sessionId, recovery);
+  };
+
+  return {
+    observe: (sessionId) => {
+      const id = sessionId.trim();
+      if (!id || disposed || warned.has(id) || pending.has(id)) return;
+      const recovery: PendingRecovery = { attempt: 0, timer: null };
+      pending.set(id, recovery);
+      schedule(id, recovery);
+    },
+    resolve: finish,
+    dispose: () => {
+      disposed = true;
+      for (const recovery of pending.values()) {
+        if (recovery.timer) clearTimeout(recovery.timer);
+      }
+      pending.clear();
+    },
+  };
+}

--- a/apps/app/tests/session-title-recovery.test.ts
+++ b/apps/app/tests/session-title-recovery.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, jest, test } from "bun:test";
+
+import {
+  classifySessionTitleRecoveryRead,
+  createSessionTitleRecovery,
+  type SessionTitleRecoveryRead,
+} from "../src/react-app/domains/session/sync/session-title-recovery";
+
+const placeholder = "New session - 2026-08-11T10:00:00.000Z";
+
+function read(
+  title: string,
+  messages: SessionTitleRecoveryRead["messages"] = [],
+): SessionTitleRecoveryRead {
+  return { title, messages };
+}
+
+const user = { role: "user", synthetic: false, error: undefined };
+const assistant = { role: "assistant", synthetic: false, error: undefined };
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 5; index += 1) await Promise.resolve();
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("session title recovery", () => {
+  test("classifies only a successful first turn with a generated placeholder as failed", () => {
+    expect(classifySessionTitleRecoveryRead(read(placeholder, [user, assistant]))).toBe("failed");
+    expect(classifySessionTitleRecoveryRead(read("Useful title", [user, assistant]))).toBe("resolved");
+    expect(classifySessionTitleRecoveryRead(read(placeholder, [user, assistant, user, assistant]))).toBe("not-applicable");
+    expect(classifySessionTitleRecoveryRead(read(placeholder, [user, { ...assistant, error: { message: "denied" } }]))).toBe("pending");
+  });
+
+  test("refreshes until a slow generated title resolves", async () => {
+    jest.useFakeTimers();
+    const fetched = [
+      read(placeholder, [user, assistant]),
+      read("Investigate title access", [user, assistant]),
+    ];
+    const resolved: string[] = [];
+    let failures = 0;
+    const recovery = createSessionTitleRecovery({
+      delaysMs: [10, 20, 30],
+      fetch: async () => fetched.shift() ?? read("Investigate title access", [user, assistant]),
+      onResolved: (_sessionId, title) => resolved.push(title),
+      onFailure: () => { failures += 1; },
+    });
+
+    recovery.observe("session-a");
+    jest.advanceTimersByTime(10);
+    await flushMicrotasks();
+    jest.advanceTimersByTime(20);
+    await flushMicrotasks();
+
+    expect(resolved).toEqual(["Investigate title access"]);
+    expect(failures).toBe(0);
+    recovery.dispose();
+  });
+
+  test("warns once after the final confirmed placeholder", async () => {
+    jest.useFakeTimers();
+    let fetches = 0;
+    const failures: string[] = [];
+    const recovery = createSessionTitleRecovery({
+      delaysMs: [10, 20, 30],
+      fetch: async () => {
+        fetches += 1;
+        return read(placeholder, [user, assistant]);
+      },
+      onResolved: () => {},
+      onFailure: (sessionId) => failures.push(sessionId),
+    });
+
+    recovery.observe("session-a");
+    recovery.observe("session-a");
+    jest.advanceTimersByTime(10);
+    await flushMicrotasks();
+    jest.advanceTimersByTime(20);
+    await flushMicrotasks();
+    jest.advanceTimersByTime(30);
+    await flushMicrotasks();
+    recovery.observe("session-a");
+    jest.advanceTimersByTime(100);
+    await flushMicrotasks();
+
+    expect(fetches).toBe(3);
+    expect(failures).toEqual(["session-a"]);
+    recovery.dispose();
+  });
+
+  test("cancels pending probes when an update supplies a title", async () => {
+    jest.useFakeTimers();
+    let fetches = 0;
+    const recovery = createSessionTitleRecovery({
+      delaysMs: [10],
+      fetch: async () => {
+        fetches += 1;
+        return read(placeholder, [user, assistant]);
+      },
+      onResolved: () => {},
+      onFailure: () => {},
+    });
+
+    recovery.observe("session-a");
+    recovery.resolve("session-a");
+    jest.advanceTimersByTime(10);
+    await flushMicrotasks();
+
+    expect(fetches).toBe(0);
+    recovery.dispose();
+  });
+});

--- a/evals/specs/session-title-failure-warning.slow.test.ts
+++ b/evals/specs/session-title-failure-warning.slow.test.ts
@@ -1,0 +1,187 @@
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor, waitForText } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "session-title-failure-mock";
+const modelId = "session-title-main-model";
+const inaccessibleTitleModelId = "session-title-inaccessible-model";
+const reply = "the conversation completed safely";
+const warningTitle = "Automatic task title did not complete";
+const warningBody = "Your conversation is safe.";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "a failed background title model stays non-fatal and produces a persistent warning"
+  : "session title failure warning skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function newestSession(value: unknown): Record<string, unknown> {
+  if (!Array.isArray(value) || value.length === 0 || !isRecord(value[0])) {
+    throw new Error(`session.list_sessions did not return a newest session: ${JSON.stringify(value)}`);
+  }
+  return value[0];
+}
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { body += chunk; });
+      request.on("end", () => {
+        if (body.includes(`"model":"${inaccessibleTitleModelId}"`)) {
+          response.writeHead(403, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: { message: "model is not accessible to this user" } }));
+          return;
+        }
+        const chunks = [
+          { id: "chatcmpl-session-title-failure", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: "chatcmpl-session-title-failure", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: reply }, finish_reason: null }] },
+          { id: "chatcmpl-session-title-failure", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  const electronNodeDir = process.env.OPENWORK_EVAL_ELECTRON_NODEDIR?.trim();
+  await using app = await desktop({
+    name: "session-title-failure-warning",
+    env: electronNodeDir ? { npm_config_nodedir: electronNodeDir } : undefined,
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-session-title-failure-${Date.now()}`,
+  });
+
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          small_model: ${JSON.stringify(`${providerId}/${inaccessibleTitleModelId}`)},
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Session title failure mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-session-title-failure" },
+              models: {
+                [${JSON.stringify(modelId)}]: { name: "Session title main model" },
+              },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  await control(app, "session.create_task");
+  const created = newestSession(await control(app, "session.list_sessions"));
+  const sessionId = typeof created.sessionId === "string" ? created.sessionId : "";
+  expect(sessionId).not.toBe("");
+
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "session composer text action enabled",
+  });
+  await control(app, "composer.set_text", { text: `Reply with exactly: ${reply}` });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "session composer send action enabled",
+  });
+  await control(app, "composer.send");
+  await waitForText(app, reply, { timeoutMs: 60_000 });
+
+  await waitFor(app, `document.body.innerText.includes(${JSON.stringify(warningTitle)})`, {
+    timeoutMs: 50_000,
+    label: "non-fatal automatic title warning",
+  });
+  expect(await evalIn(app, `document.body.innerText.includes(${JSON.stringify(warningBody)})`)).toBe(true);
+  evidence.fact(
+    "A failed background title model does not discard or fail the completed conversation",
+    `The assistant reply '${reply}' remained visible when the title warning appeared for session ${sessionId}.`,
+    true,
+  );
+
+  await evalIn(app, `(() => {
+    const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+    const bell = [...(sidebar?.querySelectorAll("button") ?? [])]
+      .find((button) => (button.getAttribute("aria-label") ?? "").startsWith("Notifications"));
+    bell?.click();
+  })()`);
+  await waitFor(app, `document.body.innerText.includes(${JSON.stringify(warningTitle)})
+    && document.body.innerText.includes(${JSON.stringify(warningBody)})`, {
+    timeoutMs: 30_000,
+    label: "persistent automatic title warning in notification center",
+  });
+
+  const after = newestSession(await control(app, "session.list_sessions"));
+  expect(typeof after.title === "string" && after.title.startsWith("New session - ")).toBe(true);
+  evidence.fact(
+    "The unresolved generated placeholder is surfaced as one persistent, actionable warning",
+    `The notification center explains that the conversation is safe and can be renamed while session ${sessionId} still has its generated placeholder.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- retry session-title reads after a successful first turn so slow background titles still reach the sidebar
- show one persistent warning when OpenCode keeps its generated placeholder after the bounded recovery window
- keep title failures non-fatal and direct the user to manual rename

## Root cause

OpenCode generates the first session title in a detached background task. A configured title or `small_model` can be unavailable even when the model selected for the conversation is usable. That background failure does not emit a typed session error, so the conversation completes while the generated placeholder remains and OpenWork has nothing to surface.

This change probes the session after 1, 5, and 25 seconds. It stops as soon as a real title arrives, refreshes the local snapshot/sidebar when the title was merely late, and warns only when there is exactly one real user turn followed by a successful assistant turn. It does not mark the task failed or issue another model request.

OpenCode does not currently expose a title-regeneration endpoint, so actual model retry remains a follow-up. The warning explains that the conversation is safe and can be renamed from the task menu.

## Validation

- `pnpm --filter @openwork/app exec bun test tests/session-title-recovery.test.ts tests/session-sync-lifecycle.test.ts tests/session-sync-run-status.test.ts` — 19 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm evals:typecheck` — passed
- Added `session-title-failure-warning.slow.test.ts` for the real unavailable-title-model journey. Local tape execution was incomplete because the Electron harness hit header-download timeouts and a CDP timeout during engine reload before the corrected assertion could run.