### PR TITLE
Recover gracefully from interrupted OpenCode tasks

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -27,6 +27,10 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { openDesktopUrl, revealDesktopItemInDir } from "@/app/lib/desktop"
 import { isElectronRuntime } from "@/app/lib/runtime-env"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
+import {
+  sessionErrorPresentationFromUIMessage,
+  type OpencodeSessionErrorPresentation,
+} from "@/react-app/domains/session/sync/session-error"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
 import { EditTool } from "@/components/tools/edit"
@@ -742,7 +746,12 @@ type MessageComponentProps = {
 const MessageComponent = React.memo(
   ({ message, isLastMessage, isStreaming, isLastStep, hideReasoning }: MessageComponentProps) => {
     if (isSessionErrorMessage(message)) {
-      return <ErrorMessage error={getMessagesText([message]) || "Session failed"} />
+      return (
+        <ErrorMessage
+          error={getMessagesText([message]) || "Session failed"}
+          presentation={sessionErrorPresentationFromUIMessage(message)}
+        />
+      )
     }
 
     if (isEmptyMessage(message)) {
@@ -798,17 +807,79 @@ LoadingMessage.displayName = "LoadingMessage"
 
 interface ErrorMessageProps {
   error: string | null
+  presentation?: OpencodeSessionErrorPresentation | null
 }
 
-function ErrorMessage({ error }: ErrorMessageProps) {
+function ErrorMessage({ error, presentation }: ErrorMessageProps) {
+  const { setPrompt } = useMessageList()
+  const [detailsOpen, setDetailsOpen] = React.useState(false)
+  const title = presentation?.title ?? error ?? "Session failed"
+  const technicalDetails = presentation?.technicalDetails ?? error
+  const hasTechnicalDetails = Boolean(technicalDetails && technicalDetails.trim() !== title.trim())
+
+  const prepareRecovery = React.useCallback(() => {
+    if (!presentation?.recoveryPrompt) return
+    setPrompt(presentation.recoveryPrompt)
+  }, [presentation?.recoveryPrompt, setPrompt])
+
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
-      <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
-          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
-          <p className="whitespace-pre-wrap text-destructive">{error}</p>
+      <Collapsible
+        open={detailsOpen}
+        onOpenChange={setDetailsOpen}
+        className="group flex w-full flex-col items-start gap-0"
+        data-testid="session-error-message"
+        data-error-kind={presentation?.kind ?? "generic"}
+        role="alert"
+      >
+        <div className="text-foreground flex min-w-0 w-full flex-1 flex-col gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-3 py-2">
+          <div className="flex min-w-0 w-full items-start gap-2">
+            <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
+            <div className="min-w-0 flex-1">
+              <p className="whitespace-pre-wrap font-medium text-destructive">{title}</p>
+              {presentation?.description ? (
+                <p className="mt-0.5 text-xs leading-relaxed text-red-900/80">{presentation.description}</p>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {presentation?.recoveryPrompt ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 border-red-400/60 bg-background/70 px-2.5 text-xs text-red-950 hover:bg-red-100"
+                  onClick={prepareRecovery}
+                  data-testid="session-error-prepare-recovery"
+                >
+                  Prepare recovery
+                </Button>
+              ) : null}
+              {hasTechnicalDetails ? (
+                <CollapsibleTrigger
+                  className="inline-flex size-7 cursor-pointer items-center justify-center rounded-md text-red-900/70 transition-colors hover:bg-red-200/50 hover:text-red-950"
+                  aria-label={detailsOpen ? "Hide error details" : "Show error details"}
+                  data-testid="session-error-details-trigger"
+                >
+                  <ChevronRight
+                    aria-hidden="true"
+                    className={cn("size-4 transition-transform duration-150", detailsOpen && "rotate-90")}
+                  />
+                </CollapsibleTrigger>
+              ) : null}
+            </div>
+          </div>
+          {hasTechnicalDetails ? (
+            <CollapsibleContent className="h-(--collapsible-panel-height) w-full overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+              <div className="ml-6 border-t border-red-300/70 pt-2">
+                <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-red-900/70">Technical details</div>
+                <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/60 px-2.5 py-2 font-mono text-[11px] leading-relaxed text-red-950">
+                  {technicalDetails}
+                </pre>
+              </div>
+            </CollapsibleContent>
+          ) : null}
         </div>
-      </div>
+      </Collapsible>
     </Message>
   )
 }

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -1,0 +1,220 @@
+import type { UIMessage } from "ai";
+
+import { safeStringify } from "../../../../app/utils";
+import { normalizeErrorText } from "../../../../lib/error-text";
+
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "generic";
+
+export type OpencodeSessionErrorPresentation = {
+  kind: OpencodeSessionErrorKind;
+  title: string;
+  description: string | null;
+  technicalDetails: string;
+  recoveryPrompt: string | null;
+};
+
+const interruptedTaskRecoveryPrompt = [
+  "Continue the interrupted task from the current state.",
+  "First inspect the conversation and workspace to verify which actions already completed.",
+  "Preserve completed work, do not repeat side effects, and finish only what remains.",
+].join(" ");
+
+function recordValue(value: unknown, key: string) {
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function firstStringValue(records: unknown[], keys: string[]) {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = recordValue(record, key);
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  return null;
+}
+
+function firstNumberValue(records: unknown[], keys: string[]) {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = recordValue(record, key);
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+  }
+  return null;
+}
+
+function defaultErrorMessage(name: string | null, fallback: string) {
+  if (name === "ProviderAuthError") return "Provider authentication failed";
+  if (name === "MessageOutputLengthError") return "The model reached its output limit before finishing";
+  if (name === "StructuredOutputError") return "The model could not produce valid structured output";
+  if (name === "ContextOverflowError") return "The conversation is too large for the model context window";
+  if (name === "MessageAbortedError") return "The message was interrupted";
+  return fallback;
+}
+
+function sessionErrorKind(name: string | null, message: string | null, code: string | null): OpencodeSessionErrorKind {
+  const searchable = [name, message, code].filter(Boolean).join(" ");
+  if (
+    name === "MessageAbortedError" ||
+    code === "ABORT_ERR" ||
+    /\b(?:message\s+)?abort(?:ed)?\b/i.test(searchable)
+  ) {
+    return "aborted";
+  }
+  if (
+    name === "ProviderHeaderTimeoutError" ||
+    code === "UND_ERR_HEADERS_TIMEOUT" ||
+    /(?:response\s+)?headers?.{0,20}(?:timed?\s*out|timeout)/i.test(searchable)
+  ) {
+    return "provider-timeout";
+  }
+  return "generic";
+}
+
+function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
+  if (kind === "aborted") return "Task interrupted";
+  if (kind === "provider-timeout") return "Provider did not respond in time";
+  return fallback;
+}
+
+function errorDescription(kind: OpencodeSessionErrorKind) {
+  if (kind === "aborted") {
+    return "OpenCode stopped before the task finished. Output and files already produced are kept.";
+  }
+  if (kind === "provider-timeout") {
+    return "The provider connection timed out before a response began. Output and files already produced are kept.";
+  }
+  return null;
+}
+
+function errorRecoveryPrompt(kind: OpencodeSessionErrorKind) {
+  return kind === "aborted" || kind === "provider-timeout"
+    ? interruptedTaskRecoveryPrompt
+    : null;
+}
+
+function withAttachmentRecoveryHint(text: string) {
+  if (!text.includes("file part media type") || !text.includes("not supported")) return text;
+  return `${text}\nAn attached file in this conversation uses a format the model can't read. Revert the conversation to before the attachment was sent, or start a new session.`;
+}
+
+function withOpenAiTokenRefreshHint(text: string) {
+  if (!/Token refresh failed:\s*401/i.test(text)) return text;
+  return "OpenAI couldn’t renew the ChatGPT sign-in for this worker. Retry once. If it happens again, reconnect OpenAI under Connect providers → OpenAI → ChatGPT Pro/Plus.";
+}
+
+function normalizeSessionError(text: string) {
+  return normalizeErrorText(withOpenAiTokenRefreshHint(withAttachmentRecoveryHint(text)), { cap: 500 }).display;
+}
+
+function sessionErrorFields(error: unknown, fallback: string) {
+  if (error instanceof Error) {
+    return {
+      name: error.name || null,
+      message: error.message.trim() || fallback,
+      status: null,
+      provider: null,
+      code: null,
+      retries: null,
+      responseBody: null,
+    };
+  }
+  if (typeof error === "string") {
+    return {
+      name: null,
+      message: error.trim() || fallback,
+      status: null,
+      provider: null,
+      code: null,
+      retries: null,
+      responseBody: null,
+    };
+  }
+  if (!error || typeof error !== "object") {
+    return {
+      name: null,
+      message: fallback,
+      status: null,
+      provider: null,
+      code: null,
+      retries: null,
+      responseBody: null,
+    };
+  }
+
+  const data = recordValue(error, "data");
+  const cause = recordValue(error, "cause");
+  const causeData = recordValue(cause, "data");
+  const records = [error, data, cause, causeData].filter(Boolean);
+  return {
+    name: firstStringValue(records, ["name", "type"]),
+    message: firstStringValue(records, ["message", "detail", "reason", "error"]),
+    status: firstNumberValue(records, ["statusCode", "status"]),
+    provider: firstStringValue(records, ["providerID", "providerId", "provider"]),
+    code: firstStringValue(records, ["code", "errorCode"]),
+    retries: firstNumberValue(records, ["retries", "retryCount"]),
+    responseBody: firstStringValue(records, ["responseBody", "body", "response"]),
+  };
+}
+
+function technicalErrorDetails(error: unknown, fallback: string, fields: ReturnType<typeof sessionErrorFields>) {
+  const lines: string[] = [];
+  if (fields.name) lines.push(`Error type: ${fields.name}`);
+  if (fields.message) lines.push(`Message: ${fields.message}`);
+  if (fields.status !== null) lines.push(`Status: ${fields.status}`);
+  if (fields.provider) lines.push(`Provider: ${fields.provider}`);
+  if (fields.code) lines.push(`Code: ${fields.code}`);
+  if (fields.retries !== null) lines.push(`Retries: ${fields.retries}`);
+  if (fields.responseBody && fields.responseBody !== fields.message) {
+    lines.push(`Response: ${normalizeErrorText(fields.responseBody, { cap: 500 }).display}`);
+  }
+  if (lines.length > 0) {
+    return normalizeErrorText(lines.join("\n"), { cap: 1_500 }).display;
+  }
+
+  const serialized = safeStringify(error);
+  return normalizeErrorText(serialized && serialized !== "{}" ? serialized : fallback, { cap: 1_500 }).display;
+}
+
+export function presentOpencodeSessionError(error: unknown, fallback = "Session failed"): OpencodeSessionErrorPresentation {
+  const fields = sessionErrorFields(error, fallback);
+  const kind = sessionErrorKind(fields.name, fields.message, fields.code);
+  const fallbackTitle = normalizeSessionError(fields.message ?? defaultErrorMessage(fields.name, fallback));
+  return {
+    kind,
+    title: errorTitle(kind, fallbackTitle),
+    description: errorDescription(kind),
+    technicalDetails: technicalErrorDetails(error, fallback, fields),
+    recoveryPrompt: errorRecoveryPrompt(kind),
+  };
+}
+
+export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
+  const presentation = presentOpencodeSessionError(error, fallback);
+  return presentation.description
+    ? `${presentation.title}\n${presentation.description}`
+    : presentation.title;
+}
+
+export function sessionErrorPresentationFromUIMessage(message: UIMessage): OpencodeSessionErrorPresentation | null {
+  const part = message.parts.find((candidate) => candidate.type === "text");
+  if (!part || part.type !== "text") return null;
+  const metadata = part.providerMetadata?.opencode;
+  if (!metadata || typeof metadata !== "object") return null;
+  const sessionError = "sessionError" in metadata
+    ? (metadata as { sessionError?: unknown }).sessionError
+    : null;
+  if (!sessionError || typeof sessionError !== "object") return null;
+  const candidate = sessionError as Partial<OpencodeSessionErrorPresentation>;
+  if (
+    typeof candidate.kind !== "string" ||
+    typeof candidate.title !== "string" ||
+    !(typeof candidate.description === "string" || candidate.description === null) ||
+    typeof candidate.technicalDetails !== "string" ||
+    !(typeof candidate.recoveryPrompt === "string" || candidate.recoveryPrompt === null)
+  ) {
+    return null;
+  }
+  return candidate as OpencodeSessionErrorPresentation;
+}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -7,7 +7,14 @@ import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { createClient } from "@/app/lib/opencode";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
-import { createSessionErrorUIMessage, describeOpencodeSessionError, snapshotToUIMessages } from "./usechat-adapter";
+import {
+  createSessionErrorUIMessage,
+  snapshotToUIMessages,
+} from "./usechat-adapter";
+import {
+  describeOpencodeSessionError,
+  presentOpencodeSessionError,
+} from "./session-error";
 import {
   parseDynamicToolUIPart,
   parseStructuredOutputUIPart,
@@ -695,7 +702,9 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.error") {
     const sessionId = sessionIdFromProperties(event.properties);
     if (sessionId) {
-      const errorText = describeOpencodeSessionError(sessionErrorFromProperties(event.properties));
+      const sessionError = sessionErrorFromProperties(event.properties);
+      const errorPresentation = presentOpencodeSessionError(sessionError);
+      const errorText = describeOpencodeSessionError(sessionError);
       const runStartedAt = takeTaskRunStart(sessionId);
       if (runStartedAt !== null) {
         captureAnalyticsEvent("task_run_errored", {
@@ -716,7 +725,15 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
           // assistant message id) so a reload reconciles instead of
           // duplicating; the sessionId fallback only applies when the run
           // errored before any assistant message existed.
-          return upsertMessage(current, createSessionErrorUIMessage(turnKey, errorText));
+          return upsertMessage(current, createSessionErrorUIMessage(turnKey, errorPresentation));
+        });
+        // Reconcile against the server snapshot immediately after a failed
+        // turn. The SSE stream can end before its final part/attachment events
+        // reach the renderer; the snapshot is the durable source for partial
+        // output and files that completed before the interruption.
+        void queryClient.invalidateQueries({
+          queryKey: snapshotKey(workspaceId, sessionId),
+          exact: true,
         });
       }
     }

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -3,105 +3,16 @@ import type { UIMessage } from "ai";
 import type { FilePart, Part, ToolPart } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
-import { safeStringify } from "../../../../app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
-import { normalizeErrorText } from "../../../../lib/error-text";
 import {
   parseDynamicToolUIPart,
   parseStructuredOutputUIPart,
   STRUCTURED_OUTPUT_TOOL,
 } from "./parse-tool-parts";
-
-function recordValue(value: unknown, key: string) {
-  if (!value || typeof value !== "object") return undefined;
-  return (value as Record<string, unknown>)[key];
-}
-
-function firstStringValue(records: unknown[], keys: string[]) {
-  for (const record of records) {
-    for (const key of keys) {
-      const value = recordValue(record, key);
-      if (typeof value === "string" && value.trim()) return value.trim();
-    }
-  }
-  return null;
-}
-
-function firstNumberValue(records: unknown[], keys: string[]) {
-  for (const record of records) {
-    for (const key of keys) {
-      const value = recordValue(record, key);
-      if (typeof value === "number" && Number.isFinite(value)) return value;
-    }
-  }
-  return null;
-}
-
-function defaultErrorMessage(name: string | null, fallback: string) {
-  if (name === "ProviderAuthError") return "Provider authentication failed";
-  if (name === "MessageOutputLengthError") return "The model reached its output limit before finishing";
-  if (name === "StructuredOutputError") return "The model could not produce valid structured output";
-  if (name === "ContextOverflowError") return "The conversation is too large for the model context window";
-  if (name === "MessageAbortedError") return "The message was interrupted";
-  return fallback;
-}
-
-/**
- * Unsupported file parts live in server-side session history, so the same
- * provider error replays on every later prompt. Tell the user how to escape.
- */
-function withAttachmentRecoveryHint(text: string) {
-  if (!text.includes("file part media type") || !text.includes("not supported")) return text;
-  return `${text}\nAn attached file in this conversation uses a format the model can't read. Revert the conversation to before the attachment was sent, or start a new session.`;
-}
-
-/**
- * OpenCode Codex/ChatGPT OAuth refresh failures surface as a raw engine string.
- * Narrowly rewrite the 401 case so users reconnect OpenAI — not OpenWork Cloud.
- */
-function withOpenAiTokenRefreshHint(text: string) {
-  if (!/Token refresh failed:\s*401/i.test(text)) return text;
-  return "OpenAI couldn’t renew the ChatGPT sign-in for this worker. Retry once. If it happens again, reconnect OpenAI under Connect providers → OpenAI → ChatGPT Pro/Plus.";
-}
-
-function withSessionErrorHints(text: string) {
-  return withOpenAiTokenRefreshHint(withAttachmentRecoveryHint(text));
-}
-
-function normalizeSessionError(text: string) {
-  return normalizeErrorText(withSessionErrorHints(text), { cap: 500 }).display;
-}
-
-export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  if (error instanceof Error) return normalizeSessionError(error.message || fallback);
-  if (typeof error === "string") return normalizeSessionError(error.trim() || fallback);
-  if (!error || typeof error !== "object") return normalizeSessionError(fallback);
-
-  const data = recordValue(error, "data");
-  const cause = recordValue(error, "cause");
-  const causeData = recordValue(cause, "data");
-  const records = [error, data, cause, causeData].filter(Boolean);
-  const name = firstStringValue(records, ["name", "type"]);
-  const message = firstStringValue(records, ["message", "detail", "reason", "error"]);
-  const status = firstNumberValue(records, ["statusCode", "status"]);
-  const provider = firstStringValue(records, ["providerID", "providerId", "provider"]);
-  const code = firstStringValue(records, ["code", "errorCode"]);
-  const retries = firstNumberValue(records, ["retries", "retryCount"]);
-  const responseBody = firstStringValue(records, ["responseBody", "body", "response"]);
-
-  const lines = [message ?? defaultErrorMessage(name, fallback)];
-  if (status && !lines[0]?.includes(String(status))) lines.push(`Status: ${status}`);
-  if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);
-  if (code) lines.push(`Code: ${code}`);
-  if (retries !== null) lines.push(`Retries: ${retries}`);
-  if (responseBody && responseBody !== message) {
-    lines.push(`Response: ${normalizeErrorText(responseBody, { cap: 500 }).display}`);
-  }
-  if (lines.some((line) => line !== fallback)) return normalizeSessionError(lines.join("\n"));
-
-  const serialized = safeStringify(error);
-  return normalizeSessionError(serialized && serialized !== "{}" ? serialized : fallback);
-}
+import {
+  presentOpencodeSessionError,
+  type OpencodeSessionErrorPresentation,
+} from "./session-error";
 
 function sessionErrorMessageId(turnKey: string) {
   return `${SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX}${turnKey}`;
@@ -116,7 +27,11 @@ function sessionErrorMessageId(turnKey: string) {
  * message instead of duplicating — while a brand new error on a later turn
  * still produces its own message instead of overwriting the previous one.
  */
-export function createSessionErrorUIMessage(turnKey: string, text: string, options?: { created?: number }): UIMessage {
+export function createSessionErrorUIMessage(
+  turnKey: string,
+  presentation: OpencodeSessionErrorPresentation,
+  options?: { created?: number },
+): UIMessage {
   const id = sessionErrorMessageId(turnKey);
   const created = options?.created;
   return {
@@ -125,9 +40,9 @@ export function createSessionErrorUIMessage(turnKey: string, text: string, optio
     ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
     parts: [{
       type: "text",
-      text,
+      text: presentation.title,
       state: "done",
-      providerMetadata: { opencode: { partId: `${id}:text` } },
+      providerMetadata: { opencode: { partId: `${id}:text`, sessionError: presentation } },
     }],
   };
 }
@@ -264,7 +179,7 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
     const error = message.info.role === "assistant" && "error" in message.info ? message.info.error : undefined;
     if (!error) return [uiMessage];
 
-    const errorMessage = createSessionErrorUIMessage(message.info.id, describeOpencodeSessionError(error), { created });
+    const errorMessage = createSessionErrorUIMessage(message.info.id, presentOpencodeSessionError(error), { created });
     return uiMessage.parts.length > 0 ? [uiMessage, errorMessage] : [errorMessage];
   });
 }

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { UIMessage } from "ai"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { MessageList } from "../src/components/chat/message-list"
+import { MessageListProvider } from "../src/components/chat/message-list-provider"
+import { getReactQueryClient } from "../src/react-app/infra/query-client"
+import { createSessionErrorUIMessage } from "../src/react-app/domains/session/sync/usechat-adapter"
+import {
+  presentOpencodeSessionError,
+  sessionErrorPresentationFromUIMessage,
+} from "../src/react-app/domains/session/sync/session-error"
+import {
+  __applySessionSyncEventForTest,
+  __createWorkspaceSessionSyncForTest,
+  trackWorkspaceSessionSync,
+  transcriptKey,
+} from "../src/react-app/domains/session/sync/session-sync"
+
+afterEach(() => {
+  getReactQueryClient().clear()
+})
+
+describe("session error resilience", () => {
+  test("classifies an OpenCode abort and retains its diagnostic payload", () => {
+    const presentation = presentOpencodeSessionError({
+      name: "MessageAbortedError",
+      data: {
+        message: "Aborted",
+        providerID: "openai",
+        code: "ABORT_ERR",
+      },
+    })
+
+    expect(presentation.kind).toBe("aborted")
+    expect(presentation.title).toBe("Task interrupted")
+    expect(presentation.description).toContain("Output and files already produced are kept")
+    expect(presentation.technicalDetails).toContain("Error type: MessageAbortedError")
+    expect(presentation.technicalDetails).toContain("Provider: openai")
+    expect(presentation.technicalDetails).toContain("Code: ABORT_ERR")
+    expect(presentation.recoveryPrompt).toContain("do not repeat side effects")
+  })
+
+  test("distinguishes a provider header timeout from an engine abort", () => {
+    const presentation = presentOpencodeSessionError({
+      name: "ProviderHeaderTimeoutError",
+      data: {
+        message: "Provider response headers timed out after 10000ms",
+        providerID: "openai",
+        retries: 2,
+      },
+    })
+
+    expect(presentation.kind).toBe("provider-timeout")
+    expect(presentation.title).toBe("Provider did not respond in time")
+    expect(presentation.technicalDetails).toContain("Retries: 2")
+    expect(presentation.recoveryPrompt).not.toBeNull()
+  })
+
+  test("stores structured error data on the synthetic message for reload-safe rendering", () => {
+    const presentation = presentOpencodeSessionError({
+      name: "MessageAbortedError",
+      data: { message: "Aborted" },
+    })
+    const message = createSessionErrorUIMessage("assistant-turn", presentation)
+
+    expect(sessionErrorPresentationFromUIMessage(message)).toEqual(presentation)
+  })
+
+  test("keeps partial output and adds the recoverable error beside the failed turn", () => {
+    const syncInput = {
+      workspaceId: "workspace-1",
+      baseUrl: "http://127.0.0.1:1234",
+      openworkToken: "token",
+    }
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput)
+    const release = trackWorkspaceSessionSync(syncInput, "session-1")
+    const partialMessage: UIMessage = {
+      id: "assistant-turn",
+      role: "assistant",
+      parts: [{ type: "text", text: "I finished the first step.", state: "done" }],
+    }
+    getReactQueryClient().setQueryData(
+      transcriptKey("workspace-1", "session-1"),
+      [partialMessage],
+    )
+
+    try {
+      __applySessionSyncEventForTest(syncInput, {
+        type: "session.error",
+        properties: {
+          sessionID: "session-1",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      })
+
+      const transcript = getReactQueryClient().getQueryData<UIMessage[]>(
+        transcriptKey("workspace-1", "session-1"),
+      )
+      expect(transcript?.[0]).toEqual(partialMessage)
+      expect(transcript?.[1]?.id).toBe("session-error:assistant-turn")
+      const errorMessage = transcript?.[1]
+      if (!errorMessage) throw new Error("Expected the session error message")
+      expect(sessionErrorPresentationFromUIMessage(errorMessage)).toMatchObject({
+        kind: "aborted",
+        title: "Task interrupted",
+      })
+    } finally {
+      release()
+      cleanup()
+    }
+  })
+
+  test("renders an expandable abort row and a non-replaying recovery action", () => {
+    const message = createSessionErrorUIMessage(
+      "assistant-turn",
+      presentOpencodeSessionError({
+        name: "MessageAbortedError",
+        data: { message: "Aborted" },
+      }),
+    )
+    const html = renderToStaticMarkup(
+      <MessageListProvider
+        workspaceId="workspace-1"
+        sessionId="session-1"
+        showThinking={false}
+        developerMode={false}
+        displaySuggestions={false}
+        providerConnectedCount={1}
+        dispatchAction={() => undefined}
+        setPrompt={() => undefined}
+        onRevertToUserMessage={() => undefined}
+        onForkAtMessage={() => undefined}
+        onEditUserMessage={() => undefined}
+        onMcpReconnect={async () => "connected"}
+        onMcpReopenAuthorization={async () => undefined}
+        onMcpRetry={() => undefined}
+      >
+        <MessageList messages={[message]} status="ready" />
+      </MessageListProvider>,
+    )
+
+    expect(html).toContain("Task interrupted")
+    expect(html).toContain("Output and files already produced are kept")
+    expect(html).toContain("Prepare recovery")
+    expect(html).toContain('aria-label="Show error details"')
+    expect(html).toContain('data-testid="session-error-details-trigger"')
+  })
+})


### PR DESCRIPTION
## Summary

- classify OpenCode `MessageAbortedError` and provider header timeouts instead of collapsing both into an opaque error string
- reconcile the durable session snapshot as soon as a turn errors so partial output and completed file attachments survive a missed final stream event
- replace the plain `Aborted` row with an accessible expandable details control containing the error type, provider, status, code, retry count, and bounded response detail when available
- add a **Prepare recovery** action that drafts a continuation instructing the agent to verify completed work and avoid repeating side effects

## Why

An interrupted OpenCode turn can happen after some tools have already completed. Automatically replaying the original prompt is unsafe because external writes may have succeeded, while the current UI gives the user neither enough diagnostic detail nor a reliable recovery path.

This keeps completed work visible, identifies the error family, and lets the user review a safe continuation before sending it. It does not claim to resume the killed process or silently repeat tool calls.

## Verification

- Passed: `pnpm --dir apps/app exec bun test --isolate tests/session-error-resilience.test.tsx tests/session-sync-tool-parts.test.ts tests/session-sync-permissions.test.ts` — 28/28 tests, 53 assertions
- Passed: `pnpm --filter @openwork/app typecheck`
- Deferred: real-app acceptance/testkit tape to the verification pass