### PR TITLE
Pause Automations when their model becomes unavailable

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -2,6 +2,10 @@ import {
   normalizeDesktopConfig,
   type DesktopConfig as SharedDesktopConfig,
 } from "@openwork/types/den/desktop-policies";
+import {
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY,
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER,
+} from "@openwork/types/automations";
 import type {
   AutomationDetail,
   AutomationDesktopRunnerRegistration,
@@ -2193,6 +2197,7 @@ type DenRequestOptions = {
   body?: unknown;
   timeoutMs?: number;
   organizationId?: string | null;
+  automationModelAttentionCapable?: boolean;
 };
 
 async function fetchWithTimeout(fetchImpl: FetchLike, url: string, init: RequestInit, timeoutMs: number) {
@@ -2238,6 +2243,9 @@ async function requestJsonRaw<T>(
   const organizationId = options.organizationId?.trim() ?? "";
   if (organizationId) {
     headers[ORG_PROXY_HEADER] = organizationId;
+  }
+  if (options.automationModelAttentionCapable) {
+    headers[AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER] = AUTOMATION_MODEL_ATTENTION_CAPABILITY;
   }
   if (options.body !== undefined) {
     headers["Content-Type"] = "application/json";
@@ -2536,6 +2544,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         method: "GET",
         token,
         organizationId: orgId,
+        automationModelAttentionCapable: true,
       });
     },
 
@@ -2545,6 +2554,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         token,
         organizationId: orgId,
         body: registration,
+        automationModelAttentionCapable: true,
       });
     },
 
@@ -2554,6 +2564,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         token,
         organizationId: orgId,
         body: input,
+        automationModelAttentionCapable: true,
       });
     },
 
@@ -2561,7 +2572,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationDetail>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}`,
-        { method: "GET", token, organizationId: orgId },
+        { method: "GET", token, organizationId: orgId, automationModelAttentionCapable: true },
       );
     },
 
@@ -2573,7 +2584,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationDetail>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}`,
-        { method: "PATCH", token, organizationId: orgId, body: input },
+        { method: "PATCH", token, organizationId: orgId, body: input, automationModelAttentionCapable: true },
       );
     },
 
@@ -2581,7 +2592,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationDetail>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}/activate`,
-        { method: "POST", token, organizationId: orgId, body: {} },
+        { method: "POST", token, organizationId: orgId, body: {}, automationModelAttentionCapable: true },
       );
     },
 
@@ -2589,7 +2600,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationDetail>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}/deactivate`,
-        { method: "POST", token, organizationId: orgId, body: {} },
+        { method: "POST", token, organizationId: orgId, body: {}, automationModelAttentionCapable: true },
       );
     },
 
@@ -2597,7 +2608,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationDetail>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}`,
-        { method: "DELETE", token, organizationId: orgId },
+        { method: "DELETE", token, organizationId: orgId, automationModelAttentionCapable: true },
       );
     },
 
@@ -2605,7 +2616,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       const payload = await requestJson<{ run: AutomationRun }>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}/run`,
-        { method: "POST", token, organizationId: orgId, body: {} },
+        { method: "POST", token, organizationId: orgId, body: {}, automationModelAttentionCapable: true },
       );
       return payload.run;
     },
@@ -2622,7 +2633,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<{ items: AutomationRun[]; nextCursor: string | null }>(
         baseUrls,
         `/v1/automations/${encodeURIComponent(automationId)}/runs${query}`,
-        { method: "GET", token, organizationId: orgId },
+        { method: "GET", token, organizationId: orgId, automationModelAttentionCapable: true },
       );
     },
 
@@ -2630,7 +2641,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       return requestJson<AutomationRunReceipt>(
         baseUrls,
         `/v1/automation-runs/${encodeURIComponent(runId)}`,
-        { method: "GET", token, organizationId: orgId },
+        { method: "GET", token, organizationId: orgId, automationModelAttentionCapable: true },
       );
     },
 
@@ -2638,7 +2649,7 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       const payload = await requestJson<{ run: AutomationRun }>(
         baseUrls,
         `/v1/automation-runs/${encodeURIComponent(runId)}/cancel`,
-        { method: "POST", token, organizationId: orgId, body: {} },
+        { method: "POST", token, organizationId: orgId, body: {}, automationModelAttentionCapable: true },
       );
       return payload.run;
     },

--- a/apps/app/src/react-app/domains/automations/automation-editor.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-editor.tsx
@@ -64,6 +64,7 @@ export type AutomationEditorProps = {
   modelOptions: readonly AutomationModelOption[]
   providerCatalog?: AutomationProviderCatalog
   busy: boolean
+  openModelPickerOnMount?: boolean
   submitLabel: string
   onCancel: () => void
   onSave: (input: CreateAutomation) => Promise<void> | void
@@ -71,6 +72,7 @@ export type AutomationEditorProps = {
 
 export function AutomationEditor(props: AutomationEditorProps) {
   const [input, setInput] = useState<CreateAutomation>(() => props.initial ?? defaultInput(props.modelOptions))
+  const [pickerOpen, setPickerOpen] = useState(props.openModelPickerOnMount === true)
   const appliedInitialKey = useRef(props.initialKey)
 
   useEffect(() => {
@@ -83,7 +85,10 @@ export function AutomationEditor(props: AutomationEditorProps) {
     setInput(defaultInput(props.modelOptions))
   }, [props.initial, props.initialKey, props.modelOptions])
 
-  const [pickerOpen, setPickerOpen] = useState(false)
+  useEffect(() => {
+    if (props.openModelPickerOnMount) setPickerOpen(true)
+  }, [props.openModelPickerOnMount])
+
   const [modelQuery, setModelQuery] = useState("")
   const selectedModel = modelKey(input.model)
   const currentModelAvailable = props.modelOptions.some((option) => modelKey(option) === selectedModel)

--- a/apps/app/src/react-app/domains/automations/automation-events.ts
+++ b/apps/app/src/react-app/domains/automations/automation-events.ts
@@ -1,0 +1,5 @@
+export const automationsStateChangedEvent = "openwork:automations-state-changed"
+
+export function dispatchAutomationsStateChanged() {
+  window.dispatchEvent(new CustomEvent(automationsStateChangedEvent))
+}

--- a/apps/app/src/react-app/domains/automations/automation-model-options.ts
+++ b/apps/app/src/react-app/domains/automations/automation-model-options.ts
@@ -53,12 +53,18 @@ function authorizedProviderModels(provider: DenOrgLlmProvider): AutomationModelO
  * the submitted value normalized to the same IDs the server revalidates:
  * `opencode`, `openwork`, or the concrete `lpr_*` provider record.
  */
-export function automationModelOptions(providers: readonly DenOrgLlmProvider[]): AutomationModelOption[] {
+export function automationModelOptions(
+  providers: readonly DenOrgLlmProvider[],
+  options: { includeFreeStarter?: boolean } = {},
+): AutomationModelOption[] {
   const managed = providers.flatMap((provider) => provider.source === "openwork"
     ? openWorkManagedModels(provider)
     : authorizedProviderModels(provider))
 
-  return [freeStarterModel, ...managed].sort((left, right) => {
+  return [
+    ...(options.includeFreeStarter === false ? [] : [freeStarterModel]),
+    ...managed,
+  ].sort((left, right) => {
     const kindOrder = ["free", "openwork_managed", "authorized_custom"]
     return kindOrder.indexOf(left.accessKind) - kindOrder.indexOf(right.accessKind)
       || left.providerName.localeCompare(right.providerName)

--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect } from "react"
+import { AUTOMATION_MODEL_ATTENTION_CAPABILITY } from "@openwork/types/automations"
 
 import { createDenClient, readDenSettings } from "@/app/lib/den"
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events"
@@ -54,6 +55,7 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
           runnerId,
           protocolVersion: 1,
           supportedExecutionTargets: ["desktop"],
+          capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
           appVersion: String(build?.version ?? "unknown"),
           platform,
           concurrency: 1,

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   AlertCircle,
+  AlertTriangle,
   Archive,
   ArrowLeft,
   CalendarClock,
@@ -25,6 +26,7 @@ import type {
   AutomationState,
   CreateAutomation,
 } from "@openwork/types/automations"
+import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
 
 import { createDenClient, DenApiError, readDenSettings } from "@/app/lib/den"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -43,8 +45,10 @@ import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "@/components/ui/sonner"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider"
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal"
 import { AutomationEditor } from "./automation-editor"
+import { dispatchAutomationsStateChanged } from "./automation-events"
 import { automationExecutionThreadRoute, automationExecutionIdentity } from "./automation-cloud-thread"
 import { formatAutomationSchedule, formatAutomationTime } from "./automation-format"
 import type { AutomationProviderCatalog } from "./automation-model-options"
@@ -73,6 +77,9 @@ function runVariant(status: AutomationRun["status"]): "default" | "secondary" | 
 function runLabel(run: AutomationRun) {
   if (run.status === "skipped" && run.error?.code === "runner_unavailable") {
     return "Missed — desktop runner unavailable"
+  }
+  if (run.status === "skipped" && (run.error?.code === "model_access_lost" || run.error?.code === "provider_unavailable")) {
+    return "Skipped — model unavailable"
   }
   return run.status
 }
@@ -135,6 +142,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
   const [searchParams, setSearchParams] = useSearchParams()
   const [query, setQuery] = useState("")
   const [editing, setEditing] = useState(false)
+  const [repairingModel, setRepairingModel] = useState(false)
   const [busyAction, setBusyAction] = useState<string | null>(null)
   const [archiveOpen, setArchiveOpen] = useState(false)
 
@@ -151,6 +159,10 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
   const creating = searchParams.get("create") === "1"
   const ready = denAuth.isSignedIn && Boolean(client && organizationId)
   const queryRoot = ["den", "automations", organizationId]
+  const zenModelRestricted = useDesktopRestriction("allowZenModel")
+  const freeStarterInRuntime = props.providerCatalog === undefined || Boolean(
+    props.providerCatalog[AUTOMATION_FREE_MODEL.providerId]?.[AUTOMATION_FREE_MODEL.modelId],
+  )
 
   const listQuery = useQuery({
     queryKey: [...queryRoot, "list"],
@@ -184,7 +196,12 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     },
   })
 
-  const models = useMemo(() => automationModelOptions(providersQuery.data ?? []), [providersQuery.data])
+  const models = useMemo(
+    () => automationModelOptions(providersQuery.data ?? [], {
+      includeFreeStarter: !zenModelRestricted && freeStarterInRuntime,
+    }),
+    [freeStarterInRuntime, providersQuery.data, zenModelRestricted],
+  )
   const filteredItems = useMemo(() => {
     const normalized = query.trim().toLowerCase()
     const items = listQuery.data?.items.filter((item) => item.automation.state !== "archived") ?? []
@@ -200,9 +217,11 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     if (automationId) next.set("automation", automationId)
     setSearchParams(next)
     setEditing(false)
+    setRepairingModel(false)
   }
   const refresh = async () => {
     await queryClient.invalidateQueries({ queryKey: queryRoot })
+    dispatchAutomationsStateChanged()
   }
   const act = async (key: string, action: () => Promise<void>, success: string) => {
     setBusyAction(key)
@@ -305,6 +324,8 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     }
     const detail = detailQuery.data
     const task = detail.automation
+    const modelNeedsAttention = task.needsAttentionReason?.code === "model_access_lost"
+      || task.needsAttentionReason?.code === "provider_unavailable"
     const runs = runsQuery.data?.items ?? []
     const selectedReceipt = receiptQuery.data
     const threadMatches = !selectedThreadId || selectedReceipt?.run.executionThread?.id === selectedThreadId
@@ -320,16 +341,21 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             initial={inputFromDetail(detail)}
             initialKey={detail.revision.id}
             busy={busyAction === "update"}
+            openModelPickerOnMount={repairingModel}
             modelOptions={models}
             providerCatalog={props.providerCatalog}
             submitLabel="Save changes"
-            onCancel={() => setEditing(false)}
+            onCancel={() => {
+              setEditing(false)
+              setRepairingModel(false)
+            }}
             onSave={async (input) => {
               setBusyAction("update")
               try {
                 await client.updateAutomation(organizationId, task.id, input)
                 await refresh()
                 setEditing(false)
+                setRepairingModel(false)
                 toast.success("Automation updated")
               } catch (error) {
                 toast.error(describeError(error))
@@ -358,7 +384,10 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             </div>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button variant="outline" onClick={() => setEditing(true)}><Pencil />Edit</Button>
+            <Button variant="outline" onClick={() => {
+              setRepairingModel(false)
+              setEditing(true)
+            }}><Pencil />Edit</Button>
             {task.state === "active" ? (
               <Button
                 variant="outline"
@@ -369,7 +398,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
               >
                 <Square />Deactivate
               </Button>
-            ) : task.state !== "archived" ? (
+            ) : task.state === "inactive" ? (
               <Button
                 variant="outline"
                 disabled={busyAction !== null}
@@ -381,7 +410,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
               </Button>
             ) : null}
             <Button
-              disabled={busyAction !== null || task.state === "archived"}
+              disabled={busyAction !== null || task.state === "archived" || task.state === "needs_attention"}
               onClick={() => void act("run", async () => {
                 const run = await client.runAutomationNow(organizationId, task.id)
                 const next = new URLSearchParams({ automation: task.id, run: run.id })
@@ -397,10 +426,28 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
         </div>
 
         {task.needsAttentionReason ? (
-          <Alert variant="warning">
-            <AlertCircle />
-            <AlertTitle>Action required</AlertTitle>
-            <AlertDescription>{task.needsAttentionReason.message}</AlertDescription>
+          <Alert variant="warning" data-automation-model-attention={modelNeedsAttention || undefined}>
+            {modelNeedsAttention ? <AlertTriangle /> : <AlertCircle />}
+            <AlertTitle>{modelNeedsAttention ? "Model needs attention" : "Action required"}</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{task.needsAttentionReason.message}</p>
+              {modelNeedsAttention ? (
+                <>
+                  <p>This Automation is paused. Its instructions, schedule, and run history are unchanged.</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setRepairingModel(true)
+                      setEditing(true)
+                    }}
+                  >
+                    Select a supported model
+                  </Button>
+                </>
+              ) : null}
+            </AlertDescription>
           </Alert>
         ) : null}
 
@@ -423,7 +470,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
               </CardHeader>
               <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
                 <div className="min-w-0"><span className="text-muted-foreground">Model</span><p className="break-words">{describeAutomationModel(detail.revision.model, models)}</p></div>
-                <div className="min-w-0"><span className="text-muted-foreground">Next run</span><p className="break-words">{formatAutomationTime(task.nextDueAt)}</p></div>
+                <div className="min-w-0"><span className="text-muted-foreground">Next run</span><p className="break-words">{task.state === "needs_attention" ? "No future run scheduled" : formatAutomationTime(task.nextDueAt)}</p></div>
                 <div className="min-w-0"><span className="text-muted-foreground">Runtime limit</span><p className="break-words">{Math.round(detail.revision.maximumRuntimeMs / 60_000)} minutes</p></div>
                 <div className="min-w-0"><span className="text-muted-foreground">Integrations</span><p className="break-words">Your available OpenWork Connect tools</p></div>
               </CardContent>
@@ -582,12 +629,18 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             <button
               key={item.automation.id}
               type="button"
+              {...(item.automation.state === "needs_attention" ? { "data-automation-needs-attention": true } : {})}
               className="rounded-2xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/40"
               onClick={() => openAutomation(item.automation.id)}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <h3 className="truncate font-medium">{item.automation.name}</h3>
+                  <h3 className="flex items-center gap-2 truncate font-medium">
+                    {item.automation.state === "needs_attention" ? (
+                      <AlertTriangle className="size-4 shrink-0 text-warning" aria-label="Automation needs attention" />
+                    ) : null}
+                    <span className="truncate">{item.automation.name}</span>
+                  </h3>
                   <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{item.revision.instructions}</p>
                 </div>
                 <Badge variant={stateVariant(item.automation.state)}>{stateLabel(item.automation.state)}</Badge>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -147,6 +147,7 @@ export type SessionPageSidebarProps = {
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
   automationsActive?: boolean;
+  automationsNeedAttention?: boolean;
   onOpenAutomations?: () => void;
   /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
   onOpenSessionSearch?: () => void;
@@ -1047,6 +1048,7 @@ export function SessionPage(props: SessionPageProps) {
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
           onOpenSessionSearch={props.sidebar.onOpenSessionSearch}
           automationsActive={props.sidebar.automationsActive}
+          automationsNeedAttention={props.sidebar.automationsNeedAttention}
           onOpenAutomations={props.sidebar.onOpenAutomations}
           conversationHistory={{
             canGoBack: canGoBackInConversationHistory,

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import {
   AlertCircle,
+  AlertTriangle,
   Archive,
   ArchiveRestore,
   ArrowLeft,
@@ -847,6 +848,7 @@ export type AppSidebarProps = {
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
   automationsActive?: boolean;
+  automationsNeedAttention?: boolean;
   onOpenAutomations?: () => void;
   /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
   onOpenSessionSearch?: () => void;
@@ -1146,6 +1148,18 @@ export function AppSidebar(props: AppSidebarProps) {
                 active={props.automationsActive === true}
                 icon={Clock3}
                 label="Automations"
+                labelContent={(
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate">Automations</span>
+                    {props.automationsNeedAttention ? (
+                      <AlertTriangle
+                        data-automations-attention-indicator
+                        className="ml-auto size-3.5 shrink-0 text-warning"
+                        aria-label="An Automation needs attention"
+                      />
+                    ) : null}
+                  </span>
+                )}
                 onSelect={props.onOpenAutomations}
               />
             ) : null}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -93,6 +93,7 @@ import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
+import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
 import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
@@ -469,6 +470,7 @@ export function SessionRoute() {
   const automationsRouteActive = automationsEnabled && automationsRouteRequested;
   const denSettings = readDenSettings();
   const [automationsSupported, setAutomationsSupported] = useState(false);
+  const [automationsNeedAttention, setAutomationsNeedAttention] = useState(false);
   useEffect(() => {
     if (!automationsRouteRequested || automationsEnabled) return;
     navigate("/", { replace: true });
@@ -478,19 +480,31 @@ export function SessionRoute() {
     const organizationId = denSettings.activeOrgId?.trim();
     if (!automationsEnabled || !denAuth.isSignedIn || !authToken || !organizationId) {
       setAutomationsSupported(false);
+      setAutomationsNeedAttention(false);
       return;
     }
     let cancelled = false;
-    void createDenClient({ baseUrl: denSettings.baseUrl, token: authToken })
-      .listAutomations(organizationId, { limit: 1 })
-      .then(() => {
-        if (!cancelled) setAutomationsSupported(true);
-      })
-      .catch(() => {
-        if (!cancelled) setAutomationsSupported(false);
-      });
+    const client = createDenClient({ baseUrl: denSettings.baseUrl, token: authToken });
+    const refreshAutomationState = () => {
+      void client.listAutomations(organizationId, { limit: 100 })
+        .then((result) => {
+          if (cancelled) return;
+          setAutomationsSupported(true);
+          setAutomationsNeedAttention(result.items.some((item) => item.automation.state === "needs_attention"));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setAutomationsSupported(false);
+          setAutomationsNeedAttention(false);
+        });
+    };
+    refreshAutomationState();
+    const interval = window.setInterval(refreshAutomationState, 15_000);
+    window.addEventListener(automationsStateChangedEvent, refreshAutomationState);
     return () => {
       cancelled = true;
+      window.clearInterval(interval);
+      window.removeEventListener(automationsStateChangedEvent, refreshAutomationState);
     };
   }, [
     automationsEnabled,
@@ -2572,6 +2586,7 @@ export function SessionRoute() {
         sidebarHydratedFromCache: Object.values(sessionsByWorkspaceId).some((list) => list.length > 0),
         startupPhase: effectiveLoading ? "nativeInit" : "ready",
         automationsActive: automationsRouteActive,
+        automationsNeedAttention,
         onOpenAutomations: automationsNavigationAvailable
           ? () => {
               navigate(automationsRoute());

--- a/apps/app/tests/automation-model-options.test.ts
+++ b/apps/app/tests/automation-model-options.test.ts
@@ -30,6 +30,10 @@ describe("Automation model options", () => {
     }])
   })
 
+  test("removes the free starter model when desktop policy disables OpenCode Zen", () => {
+    expect(automationModelOptions([], { includeFreeStarter: false })).toEqual([])
+  })
+
   test("expands the member's managed OpenWork aliases even when Den stores no model rows", () => {
     const options = automationModelOptions([
       provider({ id: "lpr_member_openwork", source: "openwork", name: "OpenWork Models" }),

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -1,5 +1,31 @@
 const EMPTY_USAGE = { inputTokens: null, outputTokens: null, costMicros: null }
 
+function serializedError(value) {
+  if (value instanceof Error) return value.message
+  if (typeof value === "string") return value
+  try { return JSON.stringify(value) } catch { return String(value) }
+}
+
+export function classifyAutomationExecutionError(error) {
+  const raw = serializedError(error)
+  if (error?.code === "model_access_lost") {
+    return { code: "model_access_lost", message: raw }
+  }
+  if (/ProviderModelNotFoundError/i.test(raw) || /model\s+not\s+found\s*:/i.test(raw)) {
+    const identity = raw.match(/model\s+not\s+found\s*:\s*([^.,}\]"\n]+)/i)?.[1]?.trim()
+    return {
+      code: "model_access_lost",
+      message: identity
+        ? `The selected model ${identity} is no longer available. Choose a supported model to resume this Automation.`
+        : "The selected model is no longer available. Choose a supported model to resume this Automation.",
+    }
+  }
+  return {
+    code: "execution_failed",
+    message: raw || "Desktop Automation execution failed",
+  }
+}
+
 function sleep(ms, signal) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(resolve, ms)
@@ -105,6 +131,12 @@ export async function executeDesktopAutomation(assignment, options) {
       )
       const snapshot = response?.item
       const output = assistantResult(snapshot)
+      const snapshotError = classifyAutomationExecutionError(snapshot)
+      if (snapshotError.code === "model_access_lost") {
+        const error = new Error(snapshotError.message)
+        Object.defineProperty(error, "code", { value: snapshotError.code })
+        throw error
+      }
       if (snapshot?.status?.type === "idle" && output.resultSummary) {
         return { sessionId, workspaceId, ...output }
       }
@@ -190,6 +222,7 @@ export function createDesktopAutomationRunner(options) {
       result = { status: "succeeded", ...output, error: null }
     } catch (error) {
       const cancelled = controller.signal.aborted && String(controller.signal.reason).toLowerCase().includes("cancel")
+      const classified = classifyAutomationExecutionError(error)
       result = {
         status: cancelled ? "cancelled" : "failed",
         sessionId: null,
@@ -197,8 +230,10 @@ export function createDesktopAutomationRunner(options) {
         resultSummary: null,
         usage: EMPTY_USAGE,
         error: {
-          code: cancelled ? "cancelled" : "execution_failed",
-          message: error instanceof Error ? error.message : "Desktop Automation execution failed",
+          code: cancelled ? "cancelled" : classified.code,
+          message: cancelled
+            ? (error instanceof Error ? error.message : "Automation run cancelled")
+            : classified.message,
           retryable: false,
         },
       }

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -173,20 +173,29 @@ export function normalizeRunnerBaseUrl(value) {
  * key here: changing the audience also changes the token, so a renderer cannot
  * redirect an intact credential without failing this binding check.
  */
-export function runnerTokenAudience(token) {
+function runnerTokenBinding(token) {
   try {
     const [payload, signature, extra] = String(token).split(".")
     if (!payload || !signature || extra) return null
     const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
+    if (decoded?.v === 1) return { version: 1, audience: null }
     if (decoded?.v !== 2 || typeof decoded.a !== "string") return null
-    return normalizeRunnerBaseUrl(decoded.a)
+    const audience = normalizeRunnerBaseUrl(decoded.a)
+    return audience ? { version: 2, audience } : null
   } catch {
     return null
   }
 }
 
+export function runnerTokenAudience(token) {
+  return runnerTokenBinding(token)?.audience ?? null
+}
+
 export function createDesktopAutomationRunner(options) {
   const fetchImpl = options.fetchImpl ?? fetch
+  const legacyBaseUrls = new Set((options.legacyBaseUrls ?? [])
+    .map((value) => normalizeRunnerBaseUrl(value))
+    .filter(Boolean))
   let configuration = null
   let connectionController = null
   let generation = 0
@@ -351,8 +360,12 @@ export function createDesktopAutomationRunner(options) {
     configure(next) {
       const baseUrl = next ? normalizeRunnerBaseUrl(next.baseUrl) : null
       const token = next?.token ? String(next.token) : ""
-      const tokenAudience = token ? runnerTokenAudience(token) : null
-      const normalized = baseUrl && baseUrl === tokenAudience && token && next?.runnerId
+      const binding = token ? runnerTokenBinding(token) : null
+      const destinationAllowed = baseUrl && (
+        (binding?.version === 2 && binding.audience === baseUrl)
+        || (binding?.version === 1 && legacyBaseUrls.has(baseUrl))
+      )
+      const normalized = destinationAllowed && token && next?.runnerId
         ? { baseUrl, token, runnerId: String(next.runnerId) }
         : null
       if (configuration?.baseUrl === normalized?.baseUrl && configuration?.token === normalized?.token) {

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -167,6 +167,24 @@ export function normalizeRunnerBaseUrl(value) {
   return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "")
 }
 
+/**
+ * Runner credentials are opaque to the renderer but carry a server-signed
+ * audience in their payload. The main process does not need the Den signing
+ * key here: changing the audience also changes the token, so a renderer cannot
+ * redirect an intact credential without failing this binding check.
+ */
+export function runnerTokenAudience(token) {
+  try {
+    const [payload, signature, extra] = String(token).split(".")
+    if (!payload || !signature || extra) return null
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
+    if (decoded?.v !== 2 || typeof decoded.a !== "string") return null
+    return normalizeRunnerBaseUrl(decoded.a)
+  } catch {
+    return null
+  }
+}
+
 export function createDesktopAutomationRunner(options) {
   const fetchImpl = options.fetchImpl ?? fetch
   let configuration = null
@@ -332,8 +350,10 @@ export function createDesktopAutomationRunner(options) {
   return {
     configure(next) {
       const baseUrl = next ? normalizeRunnerBaseUrl(next.baseUrl) : null
-      const normalized = baseUrl && next?.token && next?.runnerId
-        ? { baseUrl, token: String(next.token), runnerId: String(next.runnerId) }
+      const token = next?.token ? String(next.token) : ""
+      const tokenAudience = token ? runnerTokenAudience(token) : null
+      const normalized = baseUrl && baseUrl === tokenAudience && token && next?.runnerId
+        ? { baseUrl, token, runnerId: String(next.runnerId) }
         : null
       if (configuration?.baseUrl === normalized?.baseUrl && configuration?.token === normalized?.token) {
         return { connected: Boolean(connectionController && !connectionController.signal.aborted) }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -6,7 +6,13 @@ import {
   createDesktopAutomationRunner,
   executeDesktopAutomation,
   normalizeRunnerBaseUrl,
+  runnerTokenAudience,
 } from "./automation-runner.mjs"
+
+function runnerTokenFor(audience) {
+  const payload = Buffer.from(JSON.stringify({ v: 2, a: audience })).toString("base64url")
+  return `${payload}.test-signature`
+}
 
 test("model-not-found failures become a repairable Automation error", () => {
   assert.deepEqual(classifyAutomationExecutionError({
@@ -18,7 +24,7 @@ test("model-not-found failures become a repairable Automation error", () => {
   })
 })
 
-test("runner base URLs are restricted to https or loopback http", () => {
+test("runner base URLs require a protected transport", () => {
   assert.equal(normalizeRunnerBaseUrl("https://den.example.com"), "https://den.example.com")
   assert.equal(normalizeRunnerBaseUrl("https://den.example.com/api/"), "https://den.example.com/api")
   assert.equal(normalizeRunnerBaseUrl("http://127.0.0.1:8788"), "http://127.0.0.1:8788")
@@ -31,6 +37,12 @@ test("runner base URLs are restricted to https or loopback http", () => {
   assert.equal(normalizeRunnerBaseUrl(undefined), null)
 })
 
+test("runner credentials retain their signed Den audience", () => {
+  assert.equal(runnerTokenAudience(runnerTokenFor("https://den.example.com/api/den")), "https://den.example.com/api/den")
+  assert.equal(runnerTokenAudience("not-a-runner-token"), null)
+  assert.equal(runnerTokenAudience(runnerTokenFor("http://attacker.example.com")), null)
+})
+
 test("a renderer-supplied non-https base URL never receives the runner token", async () => {
   const attempted = []
   const runner = createDesktopAutomationRunner({
@@ -40,7 +52,30 @@ test("a renderer-supplied non-https base URL never receives the runner token", a
       throw new Error("no network in test")
     },
   })
-  runner.configure({ baseUrl: "http://attacker.example.com", token: "runner-token", runnerId: "runner-1" })
+  runner.configure({
+    baseUrl: "http://attacker.example.com",
+    token: runnerTokenFor("http://attacker.example.com"),
+    runnerId: "runner-1",
+  })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  runner.stop()
+  assert.deepEqual(attempted, [])
+})
+
+test("a renderer cannot redirect a Den runner credential to another HTTPS origin", async () => {
+  const attempted = []
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      attempted.push(String(url))
+      throw new Error("no network in test")
+    },
+  })
+  runner.configure({
+    baseUrl: "https://attacker.example.com",
+    token: runnerTokenFor("https://den.example.com/api/den"),
+    runnerId: "runner-1",
+  })
   await new Promise((resolve) => setTimeout(resolve, 25))
   runner.stop()
   assert.deepEqual(attempted, [])

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -2,10 +2,21 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import {
+  classifyAutomationExecutionError,
   createDesktopAutomationRunner,
   executeDesktopAutomation,
   normalizeRunnerBaseUrl,
 } from "./automation-runner.mjs"
+
+test("model-not-found failures become a repairable Automation error", () => {
+  assert.deepEqual(classifyAutomationExecutionError({
+    name: "ProviderModelNotFoundError",
+    message: "Model not found: opencode/big-pickle",
+  }), {
+    code: "model_access_lost",
+    message: "The selected model opencode/big-pickle is no longer available. Choose a supported model to resume this Automation.",
+  })
+})
 
 test("runner base URLs are restricted to https or loopback http", () => {
   assert.equal(normalizeRunnerBaseUrl("https://den.example.com"), "https://den.example.com")
@@ -88,4 +99,51 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
     providerId: "opencode",
     modelId: "big-pickle",
   })
+})
+
+test("desktop Automation execution surfaces a missing pinned model", async () => {
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === "/workspaces") {
+      return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+      return Response.json({ item: { id: "session-1" }, started: true }, { status: 201 })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
+      return Response.json({ item: {
+        status: { type: "idle" },
+        messages: [{
+          info: {
+            role: "assistant",
+            error: {
+              name: "ProviderModelNotFoundError",
+              message: "Model not found: opencode/big-pickle",
+            },
+          },
+          parts: [],
+        }],
+      } })
+    }
+    throw new Error(`Unexpected request ${parsed.pathname}`)
+  }
+
+  await assert.rejects(
+    executeDesktopAutomation({
+      executionTarget: "desktop",
+      runId: "run-1",
+      automationId: "automation-1",
+      automationName: "Daily brief",
+      instructions: "Prepare the brief",
+      model: { providerId: "opencode", modelId: "big-pickle" },
+      timeoutMs: 30_000,
+      leaseExpiresAt: Date.now() + 60_000,
+      attempt: 1,
+    }, {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+      fetchImpl,
+      signal: new AbortController().signal,
+    }),
+    (error) => error?.code === "model_access_lost" && /Choose a supported model/.test(error.message),
+  )
 })

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -144,6 +144,8 @@ test("desktop Automation execution surfaces a missing pinned model", async () =>
       fetchImpl,
       signal: new AbortController().signal,
     }),
-    (error) => error?.code === "model_access_lost" && /Choose a supported model/.test(error.message),
+    (error) => error instanceof Error
+      && Reflect.get(error, "code") === "model_access_lost"
+      && /Choose a supported model/.test(error.message),
   )
 })

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -14,6 +14,11 @@ function runnerTokenFor(audience) {
   return `${payload}.test-signature`
 }
 
+function legacyRunnerToken() {
+  const payload = Buffer.from(JSON.stringify({ v: 1, o: "org", m: "member", r: "runner" })).toString("base64url")
+  return `${payload}.test-signature`
+}
+
 test("model-not-found failures become a repairable Automation error", () => {
   assert.deepEqual(classifyAutomationExecutionError({
     name: "ProviderModelNotFoundError",
@@ -74,6 +79,47 @@ test("a renderer cannot redirect a Den runner credential to another HTTPS origin
   runner.configure({
     baseUrl: "https://attacker.example.com",
     token: runnerTokenFor("https://den.example.com/api/den"),
+    runnerId: "runner-1",
+  })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  runner.stop()
+  assert.deepEqual(attempted, [])
+})
+
+test("a v1 runner credential works only with a main-process trusted Den endpoint", async () => {
+  const attempted = []
+  const runner = createDesktopAutomationRunner({
+    legacyBaseUrls: ["https://den.example.com/api/den"],
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      attempted.push(String(url))
+      throw new Error("no network in test")
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com/api/den",
+    token: legacyRunnerToken(),
+    runnerId: "runner-1",
+  })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  runner.stop()
+  assert.ok(attempted.length > 0)
+  assert.ok(attempted.every((url) => url.startsWith("https://den.example.com/api/den/")))
+})
+
+test("a v1 runner credential cannot use an untrusted HTTPS endpoint", async () => {
+  const attempted = []
+  const runner = createDesktopAutomationRunner({
+    legacyBaseUrls: ["https://den.example.com/api/den"],
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      attempted.push(String(url))
+      throw new Error("no network in test")
+    },
+  })
+  runner.configure({
+    baseUrl: "https://attacker.example.com",
+    token: legacyRunnerToken(),
     runnerId: "runner-1",
   })
   await new Promise((resolve) => setTimeout(resolve, 25))

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -55,7 +55,7 @@ import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostic
 import {
   createLinuxDesktopIntegration,
 } from "./linux-desktop-integration.mjs";
-import { createDesktopAutomationRunner } from "./automation-runner.mjs";
+import { createDesktopAutomationRunner, normalizeRunnerBaseUrl } from "./automation-runner.mjs";
 import {
   desktopActivationRequired,
   enterprisePreactivationCommandAllowed,
@@ -1193,7 +1193,19 @@ const runtimeManager = createRuntimeManager({
     loadSafeStorage: () => require("electron").safeStorage,
   }),
 });
+const initialRunnerBootstrap = workspaceStore.readDesktopBootstrapConfigSync();
+const legacyRunnerBaseUrls = [
+  initialRunnerBootstrap.apiBaseUrl,
+  initialRunnerBootstrap.baseUrl,
+  initialRunnerBootstrap.baseUrl
+    ? `${String(initialRunnerBootstrap.baseUrl).replace(/\/+$/, "")}/api/den`
+    : null,
+  `${DEFAULT_DEN_BASE_URL}/api/den`,
+].map((value) => normalizeRunnerBaseUrl(value)).filter(Boolean);
 const desktopAutomationRunner = createDesktopAutomationRunner({
+  // v1 credentials predate token audiences. Keep them usable during the Den
+  // rollout only for endpoints trusted before the renderer starts issuing IPC.
+  legacyBaseUrls: legacyRunnerBaseUrls,
   getLocalRuntime: async () => {
     const server = await runtimeManager.openworkServerInfo();
     return { baseUrl: server.baseUrl, token: server.clientToken ?? server.ownerToken };

--- a/ee/apps/den-api/src/automations/authority.ts
+++ b/ee/apps/den-api/src/automations/authority.ts
@@ -10,6 +10,7 @@ import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
 import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference"
 import { db } from "../db.js"
+import { calculateDesktopPolicyForOrgMember } from "../desktop-policies.js"
 
 type ProviderId = typeof LlmProviderTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
@@ -57,6 +58,7 @@ export type AutomationModelAuthorityStore = {
   findProvider(input: { organizationId: string; providerId: string }): Promise<AutomationAuthorityProvider | null>
   findModel(input: { providerRecordId: ProviderId; modelId: string }): Promise<AutomationAuthorityModel | null>
   canAccessProvider(input: { member: AutomationAuthorityMember; providerRecordId: ProviderId }): Promise<boolean>
+  allowsZenModel(input: { organizationId: string; ownerMemberId: string }): Promise<boolean>
 }
 
 const databaseAuthorityStore: AutomationModelAuthorityStore = {
@@ -115,6 +117,14 @@ const databaseAuthorityStore: AutomationModelAuthorityStore = {
     )).limit(1)
     return Boolean(grants[0])
   },
+
+  async allowsZenModel(input) {
+    const policy = await calculateDesktopPolicyForOrgMember({
+      organizationId: normalizeDenTypeId("organization", input.organizationId),
+      orgMemberId: normalizeDenTypeId("member", input.ownerMemberId),
+    })
+    return policy.allowZenModel
+  },
 }
 
 function enabledOpenWorkModel(modelId: string) {
@@ -152,6 +162,13 @@ export async function resolveAutomationModelAccessWithStore(
   if (input.providerId === AUTOMATION_FREE_MODEL.providerId) {
     if (input.modelId !== AUTOMATION_FREE_MODEL.modelId) {
       return { ok: false, code: "model_access_lost", message: "The selected free model is not available for Automations." }
+    }
+    if (!await store.allowsZenModel(input)) {
+      return {
+        ok: false,
+        code: "model_access_lost",
+        message: "The selected OpenCode Zen model is no longer available. Choose a supported model to resume this Automation.",
+      }
     }
     return {
       ok: true,

--- a/ee/apps/den-api/src/automations/model-attention-rollout.ts
+++ b/ee/apps/den-api/src/automations/model-attention-rollout.ts
@@ -1,0 +1,23 @@
+import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
+
+type ModelSelection = { providerId: string; modelId: string }
+type ModelAccessFailure = {
+  code: "owner_membership_lost" | "model_access_lost" | "provider_unavailable"
+}
+
+/**
+ * The legacy free model was accepted by already-published desktop clients.
+ * Den may turn its policy revocation into `needs_attention` only after the
+ * caller or runner advertises support for that state. Other authority losses
+ * remain fail-closed for every client generation.
+ */
+export function shouldApplyAutomationModelAccessFailure(input: {
+  model: ModelSelection
+  failure: ModelAccessFailure
+  modelAttentionCapable: boolean
+}): boolean {
+  if (input.modelAttentionCapable) return true
+  return input.failure.code !== "model_access_lost"
+    || input.model.providerId !== AUTOMATION_FREE_MODEL.providerId
+    || input.model.modelId !== AUTOMATION_FREE_MODEL.modelId
+}

--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -1048,13 +1048,23 @@ export class DenAutomationRepository implements AutomationRepository {
     return Boolean(rows[0]?.cancelledAt)
   }
 
-  async markNeedsAttention(input: { automationId: string; reason: NonNullable<Automation["needsAttentionReason"]>; now: number }): Promise<void> {
-    await db.update(AutomationTable).set({
+  async markNeedsAttention(input: {
+    automationId: string
+    expectedRevisionId: string
+    reason: NonNullable<Automation["needsAttentionReason"]>
+    now: number
+  }): Promise<boolean> {
+    const result = await db.update(AutomationTable).set({
       state: "needs_attention",
       next_due_at: null,
       needs_attention_reason: input.reason,
       updated_at: new Date(input.now),
-    }).where(eq(AutomationTable.id, normalizeAutomationId(input.automationId)))
+    }).where(and(
+      eq(AutomationTable.id, normalizeAutomationId(input.automationId)),
+      eq(AutomationTable.current_revision_id, normalizeRevisionId(input.expectedRevisionId)),
+      eq(AutomationTable.state, "active"),
+    ))
+    return automationUpdateChangedRows(result)
   }
 
   private async runById(runId: string): Promise<AutomationRun | null> {

--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -457,6 +457,73 @@ export class DenAutomationRepository implements AutomationRepository {
     })
   }
 
+  /** Records a manual attempt that policy refused without dispatching work. */
+  async recordSkippedManual(input: {
+    organizationId: string
+    ownerMemberId: string
+    automation: Automation
+    revision: AutomationRevision
+    nonce: string
+    code: AutomationError["code"]
+    message: string
+    now: number
+  }): Promise<AutomationRun> {
+    return db.transaction(async (tx) => {
+      const automationId = normalizeAutomationId(input.automation.id)
+      const revisionId = normalizeRevisionId(input.revision.id)
+      const locked = await tx.select().from(AutomationTable).where(and(
+        eq(AutomationTable.id, automationId),
+        eq(AutomationTable.organization_id, normalizeOrganizationId(input.organizationId)),
+        eq(AutomationTable.owner_member_id, normalizeMemberId(input.ownerMemberId)),
+      )).limit(1).for("update")
+      if (!locked[0] || locked[0].state === "archived") throw new Error("automation_not_found")
+      if (locked[0].current_revision_id !== revisionId) throw new Error("automation_revision_changed")
+
+      const identity = automationOccurrenceIdentity({
+        automationId: input.automation.id,
+        scheduledFor: null,
+        nonce: input.nonce,
+      })
+      const runId = createDenTypeId("automationRun")
+      await tx.insert(AutomationRunTable).values({
+        id: runId,
+        automation_id: automationId,
+        revision_id: revisionId,
+        trigger: "manual",
+        scheduled_for: null,
+        idempotency_key: identity.idempotencyKey,
+        status: "skipped",
+        execution_target: input.revision.executionTarget ?? "desktop",
+        claim_deadline_at: null,
+        lease_owner: null,
+        lease_expires_at: null,
+        heartbeat_at: null,
+        attempt_count: 0,
+        cloud_thread_id: createDenTypeId("automationThread"),
+        engine_kind: null,
+        engine_receipt: null,
+        engine_sequence: 0,
+        engine_admitted_at: null,
+        provider_id: input.revision.model.providerId,
+        model_id: input.revision.model.modelId,
+        model_variant: input.revision.model.variant ?? null,
+        finished_at: new Date(input.now),
+        error: { code: input.code, message: input.message, retryable: false },
+        result_summary: input.message,
+        usage: emptyUsage,
+        created_at: new Date(input.now),
+        updated_at: new Date(input.now),
+      })
+      await tx.update(AutomationTable).set({
+        latest_run_at: new Date(input.now),
+        updated_at: new Date(input.now),
+      }).where(eq(AutomationTable.id, automationId))
+      const rows = await tx.select().from(AutomationRunTable).where(eq(AutomationRunTable.id, runId)).limit(1)
+      if (!rows[0]) throw new Error("automation_run_not_durable")
+      return mapRun(rows[0])
+    })
+  }
+
   async claimCloud(input: { runId: string; leaseOwner: string; leaseMs: number; now: number }): Promise<DesktopClaim | null> {
     return db.transaction(async (tx) => {
       const rows = await tx.select({ run: AutomationRunTable, automation: AutomationTable })

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -1,4 +1,8 @@
 import { createHmac, timingSafeEqual } from "node:crypto"
+import {
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY,
+  type AutomationDesktopRunnerCapability,
+} from "@openwork/types/automations"
 import { env } from "../env.js"
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
@@ -8,6 +12,7 @@ export type AutomationRunnerIdentity = {
   organizationId: string
   ownerMemberId: string
   runnerId: string
+  capabilities: AutomationDesktopRunnerCapability[]
   audience: string | null
   expiresAt: number
 }
@@ -55,6 +60,7 @@ export class AutomationRunnerAuth {
       o: scope.organizationId,
       m: scope.ownerMemberId,
       r: scope.runnerId,
+      c: scope.capabilities,
       a: normalizedAudience,
       e: expiresAt,
     })).toString("base64url")
@@ -76,11 +82,19 @@ export class AutomationRunnerAuth {
       const audience = decoded.v === 2 && typeof decoded.a === "string"
         ? normalizeRunnerAudience(decoded.a)
         : null
+      const capabilities = decoded.c === undefined
+        ? []
+        : Array.isArray(decoded.c)
+            && decoded.c.length <= 1
+            && decoded.c.every((capability) => capability === AUTOMATION_MODEL_ATTENTION_CAPABILITY)
+          ? decoded.c as AutomationDesktopRunnerCapability[]
+          : null
       if (
         (decoded.v !== 1 && decoded.v !== 2)
         || typeof decoded.o !== "string"
         || typeof decoded.m !== "string"
         || typeof decoded.r !== "string"
+        || capabilities === null
         || (decoded.v === 2 && !audience)
         || typeof decoded.e !== "number"
         || !Number.isSafeInteger(decoded.e)
@@ -90,6 +104,7 @@ export class AutomationRunnerAuth {
         organizationId: decoded.o,
         ownerMemberId: decoded.m,
         runnerId: decoded.r,
+        capabilities,
         audience,
         expiresAt: decoded.e,
       }

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -2,12 +2,39 @@ import { createHmac, timingSafeEqual } from "node:crypto"
 import { env } from "../env.js"
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
+const TOKEN_ROUTE_SUFFIX = "/v1/automation-runners/token"
 
 export type AutomationRunnerIdentity = {
   organizationId: string
   ownerMemberId: string
   runnerId: string
+  audience: string | null
   expiresAt: number
+}
+
+function normalizeRunnerAudience(value: string): string | null {
+  try {
+    const parsed = new URL(value)
+    if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) return null
+    parsed.search = ""
+    parsed.hash = ""
+    return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "")
+  } catch {
+    return null
+  }
+}
+
+export function automationRunnerAudienceFromRequestUrl(requestUrl: string): string {
+  const parsed = new URL(requestUrl)
+  if (!["http:", "https:"].includes(parsed.protocol) || !parsed.pathname.endsWith(TOKEN_ROUTE_SUFFIX)) {
+    throw new Error("automation_runner_audience_invalid")
+  }
+  parsed.pathname = parsed.pathname.slice(0, -TOKEN_ROUTE_SUFFIX.length) || "/"
+  parsed.search = ""
+  parsed.hash = ""
+  const audience = normalizeRunnerAudience(parsed.toString())
+  if (!audience) throw new Error("automation_runner_audience_invalid")
+  return audience
 }
 
 export class AutomationRunnerAuth {
@@ -19,13 +46,16 @@ export class AutomationRunnerAuth {
       .digest("base64url")
   }
 
-  issue(scope: Omit<AutomationRunnerIdentity, "expiresAt">) {
+  issue(scope: Omit<AutomationRunnerIdentity, "audience" | "expiresAt">, audience: string) {
+    const normalizedAudience = normalizeRunnerAudience(audience)
+    if (!normalizedAudience) throw new Error("automation_runner_audience_invalid")
     const expiresAt = Date.now() + TOKEN_TTL_MS
     const payload = Buffer.from(JSON.stringify({
-      v: 1,
+      v: 2,
       o: scope.organizationId,
       m: scope.ownerMemberId,
       r: scope.runnerId,
+      a: normalizedAudience,
       e: expiresAt,
     })).toString("base64url")
     const token = `${payload}.${this.sign(payload)}`
@@ -43,11 +73,15 @@ export class AutomationRunnerAuth {
     if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null
     try {
       const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>
+      const audience = decoded.v === 2 && typeof decoded.a === "string"
+        ? normalizeRunnerAudience(decoded.a)
+        : null
       if (
-        decoded.v !== 1
+        (decoded.v !== 1 && decoded.v !== 2)
         || typeof decoded.o !== "string"
         || typeof decoded.m !== "string"
         || typeof decoded.r !== "string"
+        || (decoded.v === 2 && !audience)
         || typeof decoded.e !== "number"
         || !Number.isSafeInteger(decoded.e)
         || decoded.e <= Date.now()
@@ -56,6 +90,7 @@ export class AutomationRunnerAuth {
         organizationId: decoded.o,
         ownerMemberId: decoded.m,
         runnerId: decoded.r,
+        audience,
         expiresAt: decoded.e,
       }
     } catch {

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import type { AutomationClaimResult, AutomationListItem } from "@openwork/automations"
 import type {
   AutomationDesktopRunnerResult,
   AutomationDesktopRunnerRegistration,
@@ -39,11 +40,16 @@ export function configureCloudSavedScriptExecutor(executor: CloudSavedScriptExec
 
 export class AutomationService {
   async list(scope: OwnerScope, input: { cursor?: string; limit?: number }) {
-    return automationRepository.list({ ...scope, cursor: input.cursor, limit: input.limit ?? 50 })
+    const page = await automationRepository.list({ ...scope, cursor: input.cursor, limit: input.limit ?? 50 })
+    return {
+      ...page,
+      items: await Promise.all(page.items.map((item) => this.reconcileModelAttention(item))),
+    }
   }
 
   async get(scope: OwnerScope, automationId: string) {
-    return automationRepository.get({ ...scope, automationId })
+    const item = await automationRepository.get({ ...scope, automationId })
+    return item ? this.reconcileModelAttention(item) : null
   }
 
   async create(scope: OwnerScope, definition: CreateAutomationDefinition) {
@@ -98,6 +104,11 @@ export class AutomationService {
   async runNow(scope: OwnerScope, automationId: string): Promise<AutomationRun | null> {
     const current = await this.get(scope, automationId)
     if (!current || current.automation.state === "archived") return null
+    if (current.automation.state === "needs_attention" && current.automation.needsAttentionReason) {
+      const error = new Error(current.automation.needsAttentionReason.message)
+      error.name = current.automation.needsAttentionReason.code
+      throw error
+    }
     // The persisted model selection is only as good as the owner's current
     // access; a revoked grant must fail the manual run, not dispatch it.
     if (current.revision.action?.kind === "saved_script") {
@@ -158,19 +169,31 @@ export class AutomationService {
             ownerMemberId: item.automation.ownerMemberId,
             ...item.revision.model,
           })
-      const claim = await automationRepository.claim({
-        automation: item.automation,
-        revision: item.revision,
-        trigger: "scheduled",
-        scheduledFor,
-        leaseOwner: schedulerOwner,
-        leaseMs: env.automations.leaseMs,
-        claimDeadlineMs: env.automations.runnerClaimDeadlineMs,
-        now,
-      })
+      let claim: AutomationClaimResult
+      try {
+        claim = await automationRepository.claim({
+          automation: item.automation,
+          revision: item.revision,
+          trigger: "scheduled",
+          scheduledFor,
+          leaseOwner: schedulerOwner,
+          leaseMs: env.automations.leaseMs,
+          claimDeadlineMs: env.automations.runnerClaimDeadlineMs,
+          now,
+        })
+      } catch (error) {
+        if (error instanceof Error && error.message === "automation_not_active") continue
+        throw error
+      }
       if (claim.kind !== "claimed") continue
       if (!access.ok) {
         await automationRepository.skipRun({ runId: claim.run.id, code: access.code, message: access.message, now })
+        await automationRepository.markNeedsAttention({
+          automationId: item.automation.id,
+          expectedRevisionId: item.revision.id,
+          reason: { code: access.code, message: access.message, occurredAt: now },
+          now,
+        })
         continue
       }
       started.push(claim.run.id)
@@ -217,11 +240,18 @@ export class AutomationService {
       ...claimed.revision.model,
     })
     if (!access.ok) {
+      const now = Date.now()
       await automationRepository.skipRun({
         runId: claimed.run.id,
         code: access.code,
         message: access.message,
-        now: Date.now(),
+        now,
+      })
+      await automationRepository.markNeedsAttention({
+        automationId: claimed.automation.id,
+        expectedRevisionId: claimed.revision.id,
+        reason: { code: access.code, message: access.message, occurredAt: now },
+        now,
       })
       return null
     }
@@ -265,8 +295,9 @@ export class AutomationService {
     })
   }
 
-  completeDesktopRunner(scope: DesktopRunnerScope, runId: string, result: AutomationDesktopRunnerResult) {
-    return automationRepository.complete({
+  async completeDesktopRunner(scope: DesktopRunnerScope, runId: string, result: AutomationDesktopRunnerResult) {
+    const now = Date.now()
+    const completed = await automationRepository.complete({
       runId,
       leaseOwner: desktopLeaseOwner(scope),
       status: result.status,
@@ -274,8 +305,21 @@ export class AutomationService {
       usage: result.usage,
       error: result.error,
       attempt: result.attempt,
-      now: Date.now(),
+      now,
     })
+    if (result.error?.code === "model_access_lost" || result.error?.code === "provider_unavailable") {
+      await automationRepository.markNeedsAttention({
+        automationId: completed.automationId,
+        expectedRevisionId: completed.revisionId,
+        reason: {
+          code: result.error.code,
+          message: result.error.message,
+          occurredAt: now,
+        },
+        now,
+      })
+    }
+    return completed
   }
 
   runnerNotifications(scope: DesktopRunnerScope, after: number) {
@@ -289,6 +333,28 @@ export class AutomationService {
       error.name = result.code
       throw error
     }
+  }
+
+  private async reconcileModelAttention(item: AutomationListItem): Promise<AutomationListItem> {
+    if (item.automation.state !== "active" || item.revision.action?.kind === "saved_script") return item
+    const access = await resolveAutomationModelAccess({
+      organizationId: item.automation.organizationId,
+      ownerMemberId: item.automation.ownerMemberId,
+      ...item.revision.model,
+    })
+    if (access.ok) return item
+    const now = Date.now()
+    await automationRepository.markNeedsAttention({
+      automationId: item.automation.id,
+      expectedRevisionId: item.revision.id,
+      reason: { code: access.code, message: access.message, occurredAt: now },
+      now,
+    })
+    return await automationRepository.get({
+      organizationId: item.automation.organizationId,
+      ownerMemberId: item.automation.ownerMemberId,
+      automationId: item.automation.id,
+    }) ?? item
   }
 
   private async executeCloudRun(runId: string): Promise<void> {

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type { AutomationClaimResult, AutomationListItem } from "@openwork/automations"
+import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
 import type {
   AutomationDesktopRunnerResult,
   AutomationDesktopRunnerRegistration,
@@ -20,6 +21,19 @@ type OwnerScope = { organizationId: string; ownerMemberId: string }
 export type DesktopRunnerScope = OwnerScope & { runnerId: string }
 
 const desktopLeaseOwner = (scope: DesktopRunnerScope) => `desktop:${scope.ownerMemberId}:${scope.runnerId}`
+
+type ModelSelection = { providerId: string; modelId: string; variant?: string | null }
+
+function sameModel(left: ModelSelection, right: ModelSelection) {
+  return left.providerId === right.providerId
+    && left.modelId === right.modelId
+    && (left.variant ?? null) === (right.variant ?? null)
+}
+
+function isLegacyFreeModel(model: ModelSelection) {
+  return model.providerId === AUTOMATION_FREE_MODEL.providerId
+    && model.modelId === AUTOMATION_FREE_MODEL.modelId
+}
 
 export type CloudSavedScriptExecution =
   | { ok: true; value: unknown; canonicalResult: string; receiptId: string }
@@ -58,15 +72,16 @@ export class AutomationService {
         || (definition.action.kind === "agent" && definition.executionTarget !== "desktop")) {
         throw new Error("automation_action_target_mismatch")
       }
-      if (definition.action.kind === "agent") await this.requireModel(scope, definition.action.model)
+      if (definition.action.kind === "agent") await this.requireNewModel(scope, definition.action.model)
       else {
         if (!await isActiveAutomationOwner(scope)) throw new Error("automation_owner_inactive")
         await validateSavedScriptAutomationAction({ ...scope, action: definition.action })
       }
     } else {
-      await this.requireModel(scope, definition.model)
+      await this.requireNewModel(scope, definition.model)
     }
-    return automationRepository.create({ ...scope, definition, now: Date.now() })
+    const created = await automationRepository.create({ ...scope, definition, now: Date.now() })
+    return this.reconcileModelAttention(created)
   }
 
   async update(scope: OwnerScope, automationId: string, changes: UpdateAutomation) {
@@ -77,11 +92,16 @@ export class AutomationService {
     if ((nextAction?.kind === "saved_script" && nextTarget !== "cloud") || (nextAction?.kind !== "saved_script" && nextTarget !== "desktop")) {
       throw new Error("automation_action_target_mismatch")
     }
-    if (nextAction?.kind === "agent") await this.requireModel(scope, nextAction.model)
-    else if (nextAction?.kind === "saved_script") {
+    if (nextAction?.kind === "saved_script") {
       await validateSavedScriptAutomationAction({ ...scope, action: nextAction })
-    } else await this.requireModel(scope, changes.model ?? current.revision.model)
-    return automationRepository.update({ ...scope, automationId, changes, now: Date.now() })
+    } else if (nextAction?.kind === "agent") {
+      const requestedModel = changes.action?.kind === "agent"
+        ? changes.action.model
+        : changes.model ?? nextAction.model
+      if (!sameModel(requestedModel, current.revision.model)) await this.requireNewModel(scope, requestedModel)
+    }
+    const updated = await automationRepository.update({ ...scope, automationId, changes, now: Date.now() })
+    return this.reconcileModelAttention(updated)
   }
 
   async activate(scope: OwnerScope, automationId: string) {
@@ -89,8 +109,9 @@ export class AutomationService {
     if (!current) return null
     if (current.revision.action?.kind === "saved_script") {
       if (!await isActiveAutomationOwner(scope)) throw new Error("automation_owner_inactive")
-    } else await this.requireModel(scope, current.revision.model)
-    return automationRepository.setState({ ...scope, automationId, state: "active", now: Date.now() })
+    }
+    const activated = await automationRepository.setState({ ...scope, automationId, state: "active", now: Date.now() })
+    return activated ? this.reconcileModelAttention(activated) : null
   }
 
   deactivate(scope: OwnerScope, automationId: string) {
@@ -104,16 +125,31 @@ export class AutomationService {
   async runNow(scope: OwnerScope, automationId: string): Promise<AutomationRun | null> {
     const current = await this.get(scope, automationId)
     if (!current || current.automation.state === "archived") return null
-    if (current.automation.state === "needs_attention" && current.automation.needsAttentionReason) {
-      const error = new Error(current.automation.needsAttentionReason.message)
-      error.name = current.automation.needsAttentionReason.code
-      throw error
-    }
-    // The persisted model selection is only as good as the owner's current
-    // access; a revoked grant must fail the manual run, not dispatch it.
+    let blocked = current.automation.needsAttentionReason
     if (current.revision.action?.kind === "saved_script") {
       if (!await isActiveAutomationOwner(scope)) throw new Error("automation_owner_inactive")
-    } else await this.requireModel(scope, current.revision.model)
+    } else if (!blocked) {
+      const access = await resolveAutomationModelAccess({ ...scope, ...current.revision.model })
+      if (!access.ok) blocked = { code: access.code, message: access.message, occurredAt: Date.now() }
+    }
+    if (blocked) {
+      const now = Date.now()
+      await automationRepository.markNeedsAttention({
+        automationId: current.automation.id,
+        expectedRevisionId: current.revision.id,
+        reason: { ...blocked, occurredAt: now },
+        now,
+      })
+      return automationRepository.recordSkippedManual({
+        ...scope,
+        automation: current.automation,
+        revision: current.revision,
+        nonce: randomUUID(),
+        code: blocked.code,
+        message: blocked.message,
+        now,
+      })
+    }
     const claim = await automationRepository.claim({
       automation: { ...current.automation, state: "active" },
       revision: current.revision,
@@ -326,9 +362,15 @@ export class AutomationService {
     return automationRepository.listRunnerNotifications({ ...scope, after, limit: 100 })
   }
 
-  private async requireModel(scope: OwnerScope, model: { providerId: string; modelId: string }) {
+  /**
+   * New selections still require current authority. The exact legacy Zen
+   * selection is the rollout exception: published clients may continue to
+   * submit it, after which reconciliation returns the repairable attention
+   * state instead of a 409 they do not understand.
+   */
+  private async requireNewModel(scope: OwnerScope, model: ModelSelection) {
     const result = await resolveAutomationModelAccess({ ...scope, ...model })
-    if (!result.ok) {
+    if (!result.ok && !(result.code === "model_access_lost" && isLegacyFreeModel(model))) {
       const error = new Error(result.message)
       error.name = result.code
       throw error

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto"
 import type { AutomationClaimResult, AutomationListItem } from "@openwork/automations"
-import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
 import type {
+  AutomationDesktopRunnerCapability,
   AutomationDesktopRunnerResult,
   AutomationDesktopRunnerRegistration,
   AutomationRunEventType,
@@ -12,13 +12,21 @@ import type {
 } from "@openwork/types/automations"
 import { env } from "../env.js"
 import { isActiveAutomationOwner, resolveAutomationModelAccess } from "./authority.js"
+import { shouldApplyAutomationModelAccessFailure } from "./model-attention-rollout.js"
 import { automationRepository } from "./repository.js"
 import { validateSavedScriptAutomationAction } from "../codemode-scripts.js"
 
 const schedulerOwner = `den:${process.pid}:${randomUUID()}`
 
-type OwnerScope = { organizationId: string; ownerMemberId: string }
-export type DesktopRunnerScope = OwnerScope & { runnerId: string }
+type OwnerScope = {
+  organizationId: string
+  ownerMemberId: string
+  modelAttentionCapable?: boolean
+}
+export type DesktopRunnerScope = OwnerScope & {
+  runnerId: string
+  capabilities?: readonly AutomationDesktopRunnerCapability[]
+}
 
 const desktopLeaseOwner = (scope: DesktopRunnerScope) => `desktop:${scope.ownerMemberId}:${scope.runnerId}`
 
@@ -30,9 +38,9 @@ function sameModel(left: ModelSelection, right: ModelSelection) {
     && (left.variant ?? null) === (right.variant ?? null)
 }
 
-function isLegacyFreeModel(model: ModelSelection) {
-  return model.providerId === AUTOMATION_FREE_MODEL.providerId
-    && model.modelId === AUTOMATION_FREE_MODEL.modelId
+function supportsModelAttention(scope: OwnerScope | DesktopRunnerScope) {
+  return scope.modelAttentionCapable === true
+    || ("capabilities" in scope && scope.capabilities?.includes("model_attention_v1") === true)
 }
 
 export type CloudSavedScriptExecution =
@@ -57,13 +65,13 @@ export class AutomationService {
     const page = await automationRepository.list({ ...scope, cursor: input.cursor, limit: input.limit ?? 50 })
     return {
       ...page,
-      items: await Promise.all(page.items.map((item) => this.reconcileModelAttention(item))),
+      items: await Promise.all(page.items.map((item) => this.reconcileModelAttention(item, scope))),
     }
   }
 
   async get(scope: OwnerScope, automationId: string) {
     const item = await automationRepository.get({ ...scope, automationId })
-    return item ? this.reconcileModelAttention(item) : null
+    return item ? this.reconcileModelAttention(item, scope) : null
   }
 
   async create(scope: OwnerScope, definition: CreateAutomationDefinition) {
@@ -81,7 +89,7 @@ export class AutomationService {
       await this.requireNewModel(scope, definition.model)
     }
     const created = await automationRepository.create({ ...scope, definition, now: Date.now() })
-    return this.reconcileModelAttention(created)
+    return this.reconcileModelAttention(created, scope)
   }
 
   async update(scope: OwnerScope, automationId: string, changes: UpdateAutomation) {
@@ -101,7 +109,7 @@ export class AutomationService {
       if (!sameModel(requestedModel, current.revision.model)) await this.requireNewModel(scope, requestedModel)
     }
     const updated = await automationRepository.update({ ...scope, automationId, changes, now: Date.now() })
-    return this.reconcileModelAttention(updated)
+    return this.reconcileModelAttention(updated, scope)
   }
 
   async activate(scope: OwnerScope, automationId: string) {
@@ -111,7 +119,7 @@ export class AutomationService {
       if (!await isActiveAutomationOwner(scope)) throw new Error("automation_owner_inactive")
     }
     const activated = await automationRepository.setState({ ...scope, automationId, state: "active", now: Date.now() })
-    return activated ? this.reconcileModelAttention(activated) : null
+    return activated ? this.reconcileModelAttention(activated, scope) : null
   }
 
   deactivate(scope: OwnerScope, automationId: string) {
@@ -130,7 +138,11 @@ export class AutomationService {
       if (!await isActiveAutomationOwner(scope)) throw new Error("automation_owner_inactive")
     } else if (!blocked) {
       const access = await resolveAutomationModelAccess({ ...scope, ...current.revision.model })
-      if (!access.ok) blocked = { code: access.code, message: access.message, occurredAt: Date.now() }
+      if (!access.ok && shouldApplyAutomationModelAccessFailure({
+        model: current.revision.model,
+        failure: access,
+        modelAttentionCapable: supportsModelAttention(scope),
+      })) blocked = { code: access.code, message: access.message, occurredAt: Date.now() }
     }
     if (blocked) {
       const now = Date.now()
@@ -222,7 +234,13 @@ export class AutomationService {
         throw error
       }
       if (claim.kind !== "claimed") continue
-      if (!access.ok) {
+      if (!access.ok && shouldApplyAutomationModelAccessFailure({
+        model: item.revision.model,
+        failure: access,
+        // Scheduling must remain compatible until a capable desktop claims
+        // the work or a capable management client reconciles the Automation.
+        modelAttentionCapable: false,
+      })) {
         await automationRepository.skipRun({ runId: claim.run.id, code: access.code, message: access.message, now })
         await automationRepository.markNeedsAttention({
           automationId: item.automation.id,
@@ -241,7 +259,17 @@ export class AutomationService {
   async stop(): Promise<void> {}
 
   registerDesktopRunner(scope: OwnerScope, registration: AutomationDesktopRunnerRegistration) {
-    return automationRepository.registerDesktopRunner({ ...scope, ...registration, now: Date.now() })
+    return automationRepository.registerDesktopRunner({
+      organizationId: scope.organizationId,
+      ownerMemberId: scope.ownerMemberId,
+      runnerId: registration.runnerId,
+      protocolVersion: registration.protocolVersion,
+      supportedExecutionTargets: registration.supportedExecutionTargets,
+      appVersion: registration.appVersion,
+      platform: registration.platform,
+      concurrency: registration.concurrency,
+      now: Date.now(),
+    })
   }
 
   /** Runner tokens are revoked in effect the moment the owner leaves the org. */
@@ -275,7 +303,11 @@ export class AutomationService {
       ownerMemberId: scope.ownerMemberId,
       ...claimed.revision.model,
     })
-    if (!access.ok) {
+    if (!access.ok && shouldApplyAutomationModelAccessFailure({
+      model: claimed.revision.model,
+      failure: access,
+      modelAttentionCapable: supportsModelAttention(scope),
+    })) {
       const now = Date.now()
       await automationRepository.skipRun({
         runId: claimed.run.id,
@@ -363,28 +395,35 @@ export class AutomationService {
   }
 
   /**
-   * New selections still require current authority. The exact legacy Zen
-   * selection is the rollout exception: published clients may continue to
-   * submit it, after which reconciliation returns the repairable attention
-   * state instead of a 409 they do not understand.
+   * New capable clients require current authority. Published clients may
+   * continue submitting the exact legacy Zen selection until they advertise
+   * support for the repairable attention state.
    */
   private async requireNewModel(scope: OwnerScope, model: ModelSelection) {
     const result = await resolveAutomationModelAccess({ ...scope, ...model })
-    if (!result.ok && !(result.code === "model_access_lost" && isLegacyFreeModel(model))) {
+    if (!result.ok && shouldApplyAutomationModelAccessFailure({
+      model,
+      failure: result,
+      modelAttentionCapable: supportsModelAttention(scope),
+    })) {
       const error = new Error(result.message)
       error.name = result.code
       throw error
     }
   }
 
-  private async reconcileModelAttention(item: AutomationListItem): Promise<AutomationListItem> {
+  private async reconcileModelAttention(item: AutomationListItem, scope: OwnerScope): Promise<AutomationListItem> {
     if (item.automation.state !== "active" || item.revision.action?.kind === "saved_script") return item
     const access = await resolveAutomationModelAccess({
       organizationId: item.automation.organizationId,
       ownerMemberId: item.automation.ownerMemberId,
       ...item.revision.model,
     })
-    if (access.ok) return item
+    if (access.ok || !shouldApplyAutomationModelAccessFailure({
+      model: item.revision.model,
+      failure: access,
+      modelAttentionCapable: supportsModelAttention(scope),
+    })) return item
     const now = Date.now()
     await automationRepository.markNeedsAttention({
       automationId: item.automation.id,

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -3,6 +3,8 @@ import { describeRoute, type DescribeRouteOptions } from "hono-openapi"
 import { z } from "zod"
 import { streamSSE } from "hono/streaming"
 import {
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY,
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER,
   automationDesktopRunnerAssignmentSchema,
   automationDesktopRunnerRegistrationSchema,
   automationDesktopRunnerResultSchema,
@@ -54,9 +56,17 @@ const describeNonMcpRoute = (options: NonMcpDescribeRouteOptions) => describeRou
 
 type RouteVariables = Partial<OrganizationContextVariables>
 
-function scope(c: { get(name: "organizationContext"): OrganizationContextVariables["organizationContext"] }) {
+function scope(c: {
+  get(name: "organizationContext"): OrganizationContextVariables["organizationContext"]
+  req: { header(name: string): string | undefined }
+}) {
   const context = c.get("organizationContext")
-  return { organizationId: context.organization.id, ownerMemberId: context.currentMember.id }
+  return {
+    organizationId: context.organization.id,
+    ownerMemberId: context.currentMember.id,
+    modelAttentionCapable: c.req.header(AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER)
+      === AUTOMATION_MODEL_ATTENTION_CAPABILITY,
+  }
 }
 
 function failure(error: unknown): { status: 400 | 403 | 404 | 409; body: { error: string; message?: string } } | null {
@@ -111,7 +121,12 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
       const registration = c.req.valid("json")
       await service.registerDesktopRunner(scope(c), registration)
       return c.json(automationRunnerAuth.issue(
-        { ...scope(c), runnerId: registration.runnerId },
+        {
+          organizationId: scope(c).organizationId,
+          ownerMemberId: scope(c).ownerMemberId,
+          runnerId: registration.runnerId,
+          capabilities: registration.capabilities,
+        },
         automationRunnerAudienceFromRequestUrl(c.req.url),
       ))
     },

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -28,7 +28,7 @@ import {
 } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
-import { automationRunnerAuth } from "../../automations/runner-auth.js"
+import { automationRunnerAudienceFromRequestUrl, automationRunnerAuth } from "../../automations/runner-auth.js"
 import {
   RUNNER_KEEPALIVE_INTERVAL_MS,
   RUNNER_NOTIFICATION_POLL_MIN_MS,
@@ -110,7 +110,10 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     async (c) => {
       const registration = c.req.valid("json")
       await service.registerDesktopRunner(scope(c), registration)
-      return c.json(automationRunnerAuth.issue({ ...scope(c), runnerId: registration.runnerId }))
+      return c.json(automationRunnerAuth.issue(
+        { ...scope(c), runnerId: registration.runnerId },
+        automationRunnerAudienceFromRequestUrl(c.req.url),
+      ))
     },
   )
 

--- a/ee/apps/den-api/test/automation-model-attention-rollout.test.ts
+++ b/ee/apps/den-api/test/automation-model-attention-rollout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { shouldApplyAutomationModelAccessFailure } from "../src/automations/model-attention-rollout.js"
+
+const legacyFreeModel = { providerId: "opencode", modelId: "big-pickle" }
+
+describe("Automation model-attention rollout", () => {
+  test("keeps the legacy free model runnable for published clients", () => {
+    expect(shouldApplyAutomationModelAccessFailure({
+      model: legacyFreeModel,
+      failure: { code: "model_access_lost" },
+      modelAttentionCapable: false,
+    })).toBe(false)
+  })
+
+  test("applies the legacy free-model policy loss after capability advertisement", () => {
+    expect(shouldApplyAutomationModelAccessFailure({
+      model: legacyFreeModel,
+      failure: { code: "model_access_lost" },
+      modelAttentionCapable: true,
+    })).toBe(true)
+  })
+
+  test("keeps non-rollout authority losses fail-closed for every client", () => {
+    expect(shouldApplyAutomationModelAccessFailure({
+      model: legacyFreeModel,
+      failure: { code: "owner_membership_lost" },
+      modelAttentionCapable: false,
+    })).toBe(true)
+    expect(shouldApplyAutomationModelAccessFailure({
+      model: { providerId: "lpr_team", modelId: "removed-model" },
+      failure: { code: "model_access_lost" },
+      modelAttentionCapable: false,
+    })).toBe(true)
+  })
+})

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test"
+import { AUTOMATION_MODEL_ATTENTION_CAPABILITY } from "@openwork/types/automations"
+import { createHmac } from "node:crypto"
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -24,12 +26,14 @@ describe("Automation runner credentials", () => {
       organizationId: "org_test",
       ownerMemberId: "member_test",
       runnerId: "desktop-test",
+      capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
     }, "https://den.example.com/api/den")
 
     expect(verifier.authenticate(`Bearer ${issued.token}`)).toEqual({
       organizationId: "org_test",
       ownerMemberId: "member_test",
       runnerId: "desktop-test",
+      capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
       audience: "https://den.example.com/api/den",
       expiresAt: issued.expiresAt,
     })
@@ -43,5 +47,29 @@ describe("Automation runner credentials", () => {
     )).toBe("https://den.example.com/api/den")
     expect(() => automationRunnerAudienceFromRequestUrl("https://den.example.com/not-the-token-route"))
       .toThrow("automation_runner_audience_invalid")
+  })
+
+  test("keeps legacy v1 credentials capability-free", () => {
+    const secret = "runner-auth-test-secret".repeat(3)
+    const expiresAt = Date.now() + 60_000
+    const payload = Buffer.from(JSON.stringify({
+      v: 1,
+      o: "org_test",
+      m: "member_test",
+      r: "desktop-test",
+      e: expiresAt,
+    })).toString("base64url")
+    const signature = createHmac("sha256", secret)
+      .update(`openwork-automation-runner-v1.${payload}`)
+      .digest("base64url")
+
+    expect(new AutomationRunnerAuth(secret).authenticate(`Bearer ${payload}.${signature}`)).toEqual({
+      organizationId: "org_test",
+      ownerMemberId: "member_test",
+      runnerId: "desktop-test",
+      capabilities: [],
+      audience: null,
+      expiresAt,
+    })
   })
 })

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -8,10 +8,11 @@ function seedRequiredEnv() {
 }
 
 let AutomationRunnerAuth: typeof import("../src/automations/runner-auth.js")["AutomationRunnerAuth"]
+let automationRunnerAudienceFromRequestUrl: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequestUrl"]
 
 beforeAll(async () => {
   seedRequiredEnv()
-  ;({ AutomationRunnerAuth } = await import("../src/automations/runner-auth.js"))
+  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequestUrl } = await import("../src/automations/runner-auth.js"))
 })
 
 describe("Automation runner credentials", () => {
@@ -23,15 +24,24 @@ describe("Automation runner credentials", () => {
       organizationId: "org_test",
       ownerMemberId: "member_test",
       runnerId: "desktop-test",
-    })
+    }, "https://den.example.com/api/den")
 
     expect(verifier.authenticate(`Bearer ${issued.token}`)).toEqual({
       organizationId: "org_test",
       ownerMemberId: "member_test",
       runnerId: "desktop-test",
+      audience: "https://den.example.com/api/den",
       expiresAt: issued.expiresAt,
     })
     expect(new AutomationRunnerAuth(`${secret}x`).authenticate(`Bearer ${issued.token}`)).toBeNull()
     expect(verifier.authenticate(`Bearer ${issued.token}x`)).toBeNull()
+  })
+
+  test("binds a runner credential to the API base that minted it", () => {
+    expect(automationRunnerAudienceFromRequestUrl(
+      "https://den.example.com/api/den/v1/automation-runners/token?ignored=true",
+    )).toBe("https://den.example.com/api/den")
+    expect(() => automationRunnerAudienceFromRequestUrl("https://den.example.com/not-the-token-route"))
+      .toThrow("automation_runner_audience_invalid")
   })
 })

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import {
+  AUTOMATION_MODEL_ATTENTION_CAPABILITY,
   automationDesktopRunnerAssignmentSchema,
   automationDesktopRunnerRegistrationSchema,
   automationRunnerEventRequestSchema,
@@ -42,7 +43,15 @@ test("runner registration and assignment reject unsupported targets", () => {
     platform: "darwin",
     concurrency: 1,
   }
-  assert.equal(automationDesktopRunnerRegistrationSchema.safeParse(registration).success, true)
+  expectRegistrationCapabilities(registration, [])
+  expectRegistrationCapabilities({
+    ...registration,
+    capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+  }, [AUTOMATION_MODEL_ATTENTION_CAPABILITY])
+  assert.equal(automationDesktopRunnerRegistrationSchema.safeParse({
+    ...registration,
+    capabilities: ["unknown_capability"],
+  }).success, false)
   assert.equal(automationDesktopRunnerRegistrationSchema.safeParse({
     ...registration,
     supportedExecutionTargets: ["sandbox"],
@@ -59,6 +68,14 @@ test("runner registration and assignment reject unsupported targets", () => {
     attempt: 1,
   }).success, false)
 })
+
+function expectRegistrationCapabilities(
+  registration: Record<string, unknown>,
+  expected: string[],
+) {
+  const parsed = automationDesktopRunnerRegistrationSchema.parse(registration)
+  assert.deepEqual(parsed.capabilities, expected)
+}
 
 test("heartbeats and ordered events are bound to the claimed attempt", () => {
   assert.equal(automationRunnerHeartbeatResponseSchema.safeParse({
@@ -127,6 +144,8 @@ test("runner credential minting is never exposed as an MCP tool", () => {
   }), false, "the operation-id blocklist must override an explicit x-mcp opt-in")
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
   assert.match(routesSource, /operationId: "mintAutomationRunnerToken", "x-mcp": false/)
+  assert.match(routesSource, /capabilities: registration\.capabilities/)
+  assert.match(routesSource, /AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER/)
 })
 
 test("every runner endpoint re-checks that the token owner is still an active member", () => {
@@ -190,15 +209,18 @@ test("every dispatch path revalidates the owner's model access", () => {
   const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const tick = serviceSource.slice(serviceSource.indexOf("async tick"), serviceSource.indexOf("async stop"))
   assert.match(tick, /resolveAutomationModelAccess\(\{\s*organizationId: item\.automation\.organizationId/)
-  assert.match(tick, /if \(!access\.ok\) \{\s*await automationRepository\.skipRun\(/)
+  assert.match(tick, /shouldApplyAutomationModelAccessFailure\(\{[\s\S]*modelAttentionCapable: false/)
+  assert.match(tick, /await automationRepository\.skipRun\(/)
   const claim = serviceSource.slice(
     serviceSource.indexOf("async claimDesktopRunner"),
     serviceSource.indexOf("heartbeatDesktopRunner"),
   )
   assert.match(claim, /resolveAutomationModelAccess\(\{\s*organizationId: scope\.organizationId/)
-  assert.match(claim, /if \(!access\.ok\) \{[\s\S]*skipRun\([\s\S]*return null/)
+  assert.match(claim, /shouldApplyAutomationModelAccessFailure\(\{[\s\S]*supportsModelAttention\(scope\)/)
+  assert.match(claim, /skipRun\([\s\S]*return null/)
   const runNow = serviceSource.slice(serviceSource.indexOf("async runNow"), serviceSource.indexOf("listRuns"))
-  assert.match(runNow, /await this\.requireModel\(scope, current\.revision\.model\)/)
+  assert.match(runNow, /resolveAutomationModelAccess\(\{ \.\.\.scope, \.\.\.current\.revision\.model \}\)/)
+  assert.match(runNow, /shouldApplyAutomationModelAccessFailure\(\{[\s\S]*supportsModelAttention\(scope\)/)
 })
 
 test("runner protocol endpoints carry no operation id and stay out of the MCP catalog", () => {

--- a/ee/apps/den-api/test/automations-model-authority.test.ts
+++ b/ee/apps/den-api/test/automations-model-authority.test.ts
@@ -45,6 +45,7 @@ function authorityStore(overrides: Partial<AutomationModelAuthorityStore> = {}):
     async findProvider() { return customProvider },
     async findModel() { return customModel },
     async canAccessProvider() { return true },
+    async allowsZenModel() { return true },
     ...overrides,
   }
 }
@@ -83,6 +84,20 @@ describe("Automation normalized model authority", () => {
       providerId: "opencode",
       modelId: "not-a-free-model",
     }, store)).toMatchObject({ ok: false, code: "model_access_lost" })
+  })
+
+  test("rejects the legacy free starter model when desktop policy disables OpenCode Zen", async () => {
+    const result = await resolveAutomationModelAccessWithStore({
+      ...base,
+      providerId: "opencode",
+      modelId: "big-pickle",
+    }, authorityStore({ async allowsZenModel() { return false } }))
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "model_access_lost",
+      message: expect.stringContaining("Choose a supported model"),
+    })
   })
 
   test("resolves enabled OpenWork aliases through the owner's managed provider", async () => {

--- a/evals/specs/automation-model-needs-attention.slow.test.ts
+++ b/evals/specs/automation-model-needs-attention.slow.test.ts
@@ -1,0 +1,304 @@
+import { expect } from "vitest";
+import { screenshot, validate } from "@openwork/fraimz";
+import {
+  clickButton,
+  denFetch,
+  evalIn,
+  go,
+  visibleText,
+  waitFor,
+  waitForText,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { app, needs, server, test } from "@openwork/testkit";
+
+/**
+ * CORE JOURNEY: an active Automation keeps its instructions, cadence, and
+ * durable history when its pinned model disappears. Den records the first due
+ * occurrence as skipped, pauses future dispatches in `needs_attention`, and
+ * the app points the owner directly to a supported-model picker. Choosing a
+ * replacement creates a new immutable revision, clears the warning, and
+ * resumes from the next scheduled occurrence without replaying the skipped
+ * one.
+ */
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const SCHEDULE_TIMEOUT_MS = 120_000;
+const LEGACY_PROVIDER_NAME = "Legacy Automation Models";
+const LEGACY_MODEL_ID = "legacy-automation-model";
+const REPLACEMENT_PROVIDER_NAME = "Replacement Automation Models";
+const REPLACEMENT_MODEL_ID = "replacement-automation-model";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function activeOrganizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const activeId = isRecord(result.body) && typeof result.body.activeOrgId === "string"
+    ? result.body.activeOrgId
+    : "";
+  const active = organizations.find((organization) => organization.isActive === true) ?? organizations[0];
+  const orgId = activeId || (active && typeof active.id === "string" ? active.id : "");
+  if (!result.response.ok || !orgId) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return orgId;
+}
+
+async function createProvider(input: {
+  admin: DenSession;
+  orgId: string;
+  providerKey: string;
+  providerName: string;
+  modelId: string;
+  modelName: string;
+}): Promise<string> {
+  const result = await denFetch(input.admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(input.admin), "x-openwork-org-id": input.orgId },
+    body: JSON.stringify({
+      name: input.providerName,
+      source: "custom",
+      customConfig: {
+        id: input.providerKey,
+        name: input.providerName,
+        npm: "@ai-sdk/openai-compatible",
+        env: [`${input.providerKey.toUpperCase().replaceAll("-", "_")}_API_KEY`],
+        models: [{ id: input.modelId, name: input.modelName }],
+      },
+      apiKey: "sk-openwork-automation-transition-eval-only",
+      allMembers: true,
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider)
+    ? result.body.llmProvider
+    : null;
+  const providerId = provider && typeof provider.id === "string" ? provider.id : "";
+  if (result.response.status !== 201 || !providerId) {
+    throw new Error(`Creating ${input.providerName} failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return providerId;
+}
+
+async function createDueAutomation(input: {
+  admin: DenSession;
+  orgId: string;
+  providerId: string;
+  name: string;
+  instructions: string;
+}): Promise<string> {
+  const nextMinute = new Date(Date.now() + 90_000);
+  const result = await denFetch(input.admin, "/v1/automations", {
+    method: "POST",
+    headers: { ...auth(input.admin), "x-openwork-org-id": input.orgId },
+    body: JSON.stringify({
+      name: input.name,
+      instructions: input.instructions,
+      schedule: {
+        kind: "daily",
+        timezone: "UTC",
+        hour: nextMinute.getUTCHours(),
+        minute: nextMinute.getUTCMinutes(),
+      },
+      model: { providerId: input.providerId, modelId: LEGACY_MODEL_ID, variant: null },
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const automation = isRecord(result.body) && isRecord(result.body.automation)
+    ? result.body.automation
+    : null;
+  const automationId = automation && typeof automation.id === "string" ? automation.id : "";
+  if (result.response.status !== 201 || !automationId) {
+    throw new Error(`Creating the Automation failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return automationId;
+}
+
+async function deleteProvider(admin: DenSession, orgId: string, providerId: string): Promise<void> {
+  const result = await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "DELETE",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status).toBe(204);
+}
+
+async function skippedModelReceipt(admin: DenSession, orgId: string, automationId: string): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + SCHEDULE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const result = await denFetch(admin, `/v1/automations/${encodeURIComponent(automationId)}/runs`, {
+      headers: { ...auth(admin), "x-openwork-org-id": orgId },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const items = isRecord(result.body) && Array.isArray(result.body.items)
+      ? result.body.items.filter(isRecord)
+      : [];
+    const skipped = items.find((item) =>
+      item.status === "skipped"
+      && isRecord(item.error)
+      && (item.error.code === "provider_unavailable" || item.error.code === "model_access_lost")
+    );
+    if (skipped) return skipped;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error("The due occurrence was not recorded as skipped after its model disappeared.");
+}
+
+async function clickAutomationCard(surface: Surface, name: string): Promise<void> {
+  const clicked = await evalIn(surface, `(() => {
+    const card = [...document.querySelectorAll('button')]
+      .find((candidate) => (candidate.textContent ?? '').includes(${JSON.stringify(name)}));
+    if (!(card instanceof HTMLButtonElement)) return false;
+    card.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+test("an unavailable Automation model needs attention until the owner selects a supported replacement", async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS", "OPENWORK_EVAL_AUTOMATIONS_SPEC"] });
+
+  await using den = await server({ place });
+  const orgId = await activeOrganizationId(den.admin);
+  const stamp = Date.now();
+  const automationName = `CRM transition check ${stamp}`;
+  const instructions = `Keep the CRM transition marker ${stamp} in every summary.`;
+  const legacyProviderId = await createProvider({
+    admin: den.admin,
+    orgId,
+    providerKey: `legacy-automation-${stamp}`,
+    providerName: LEGACY_PROVIDER_NAME,
+    modelId: LEGACY_MODEL_ID,
+    modelName: "Legacy Automation Model",
+  });
+  await createProvider({
+    admin: den.admin,
+    orgId,
+    providerKey: `replacement-automation-${stamp}`,
+    providerName: REPLACEMENT_PROVIDER_NAME,
+    modelId: REPLACEMENT_MODEL_ID,
+    modelName: "Replacement Automation Model",
+  });
+  const automationId = await createDueAutomation({
+    admin: den.admin,
+    orgId,
+    providerId: legacyProviderId,
+    name: automationName,
+    instructions,
+  });
+
+  // The model disappears after the revision is durable but before dispatch.
+  await deleteProvider(den.admin, orgId, legacyProviderId);
+  const skippedReceipt = await skippedModelReceipt(den.admin, orgId, automationId);
+  expect(skippedReceipt.trigger).toBe("scheduled");
+  evidence.fact(
+    "The first unavailable-model occurrence is retained once",
+    "Den recorded one scheduled receipt as skipped before pausing the Automation.",
+    true,
+  );
+
+  await using desktop = await app({ den, as: "admin", place });
+  await go(desktop, `/workspace/${desktop.workspaceId}/automations`);
+  await waitForText(desktop, automationName, { timeoutMs: 60_000 });
+  await waitFor(desktop, `(() => {
+    const card = document.querySelector('[data-automation-needs-attention]');
+    return Boolean(card && (card.textContent ?? '').includes(${JSON.stringify(automationName)}));
+  })()`, { timeoutMs: 60_000, label: "Automation card warning" });
+  expect(await evalIn(desktop, "Boolean(document.querySelector('[data-automations-attention-indicator]'))")).toBe(true);
+  expect(await visibleText(desktop)).toContain("Needs attention");
+  evidence.fact(
+    "The Automations list calls out the broken model",
+    "The sidebar and affected card have warning icons, and the card reports Needs attention while healthy cards remain unchanged.",
+    true,
+  );
+
+  await clickAutomationCard(desktop, automationName);
+  await waitForText(desktop, "Model needs attention", { timeoutMs: 30_000 });
+  const pausedDetail = await visibleText(desktop);
+  expect(pausedDetail).toContain(instructions);
+  expect(pausedDetail).toContain(`${legacyProviderId}/${LEGACY_MODEL_ID}`);
+  expect(pausedDetail).toContain("No future run scheduled");
+  expect(pausedDetail).toContain("Skipped — model unavailable");
+  const runNowDisabled = await evalIn(desktop, `(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((candidate) => (candidate.textContent ?? '').trim() === 'Run now');
+    return button instanceof HTMLButtonElement && button.disabled;
+  })()`);
+  expect(runNowDisabled).toBe(true);
+  evidence.fact(
+    "The detail page preserves context and pauses execution",
+    "Instructions, schedule, old model identity, and skipped history remain visible; Run now and future scheduling are paused.",
+    true,
+  );
+
+  await clickButton(desktop, "Select a supported model");
+  await waitForText(desktop, "Current model is no longer available", { timeoutMs: 30_000 });
+  await waitFor(desktop, `(() => {
+    const dialog = document.querySelector('[role=dialog]');
+    return Boolean(dialog && (dialog.textContent ?? '').includes('Replacement Automation Model'));
+  })()`, { timeoutMs: 30_000, label: "supported replacement model picker" });
+  const pickerText = await evalIn(desktop, `document.querySelector('[role=dialog]')?.textContent ?? ''`);
+  expect(String(pickerText)).toContain("Replacement Automation Model");
+  expect(String(pickerText)).not.toContain("Legacy Automation Model");
+  const selectedReplacement = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role=dialog]');
+    const item = dialog && [...dialog.querySelectorAll('[cmdk-item], [role=option], button')]
+      .find((candidate) => (candidate.textContent ?? '').includes('Replacement Automation Model'));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(selectedReplacement).toBe(true);
+  await clickButton(desktop, "Save changes");
+
+  await waitForText(desktop, "Active", { timeoutMs: 60_000 });
+  await waitForText(desktop, "Revision 2", { timeoutMs: 30_000 });
+  const repairedDetail = await visibleText(desktop);
+  expect(repairedDetail).toContain(`${REPLACEMENT_PROVIDER_NAME} · Replacement Automation Model`);
+  expect(repairedDetail).not.toContain("Model needs attention");
+  expect(repairedDetail).not.toContain("No future run scheduled");
+  expect(repairedDetail).toContain("Skipped — model unavailable");
+  const finalRunNowDisabled = await evalIn(desktop, `(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((candidate) => (candidate.textContent ?? '').trim() === 'Run now');
+    return button instanceof HTMLButtonElement ? button.disabled : null;
+  })()`);
+  expect(finalRunNowDisabled).toBe(false);
+  await waitFor(desktop, "!document.querySelector('[data-automations-attention-indicator]')", {
+    timeoutMs: 30_000,
+    label: "sidebar warning clears after model replacement",
+  });
+
+  const runs = await denFetch(den.admin, `/v1/automations/${encodeURIComponent(automationId)}/runs`, {
+    headers: { ...auth(den.admin), "x-openwork-org-id": orgId },
+  });
+  const runItems = isRecord(runs.body) && Array.isArray(runs.body.items) ? runs.body.items : [];
+  expect(runItems).toHaveLength(1);
+  evidence.fact(
+    "Explicit replacement resumes without replay",
+    "Saving the supported model created revision 2, restored Active with a next run, retained the skipped receipt, and did not replay it.",
+    true,
+  );
+
+  const shot = await screenshot(desktop);
+  const seen = await validate(shot, [
+    "The repaired Automation is Active and shows revision 2",
+    "The replacement model is visible in Desktop execution",
+    "The earlier skipped run remains visible in Run history",
+    "No model-needs-attention warning or error stack is visible",
+  ]);
+  expect(seen.ok, seen.why).toBe(true);
+});

--- a/packages/types/src/automations.ts
+++ b/packages/types/src/automations.ts
@@ -176,10 +176,16 @@ export type AutomationExecutionThread = z.infer<typeof automationExecutionThread
 export const automationExecutionTargetSchema = z.enum(["desktop", "cloud"])
 export type AutomationExecutionTarget = z.infer<typeof automationExecutionTargetSchema>
 
+export const AUTOMATION_MODEL_ATTENTION_CAPABILITY = "model_attention_v1" as const
+export const AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER = "x-openwork-automation-model-attention" as const
+export const automationDesktopRunnerCapabilitySchema = z.literal(AUTOMATION_MODEL_ATTENTION_CAPABILITY)
+export type AutomationDesktopRunnerCapability = z.infer<typeof automationDesktopRunnerCapabilitySchema>
+
 export const automationDesktopRunnerRegistrationSchema = z.object({
   runnerId: idSchema.min(8),
   protocolVersion: z.literal(1),
   supportedExecutionTargets: z.array(z.literal("desktop")).length(1),
+  capabilities: z.array(automationDesktopRunnerCapabilitySchema).max(1).default([]),
   appVersion: z.string().trim().min(1).max(80),
   platform: z.enum(["darwin", "win32", "linux"]),
   concurrency: z.number().int().min(1).max(4),


### PR DESCRIPTION
## Summary

- classify desktop model-not-found failures and OpenCode Zen policy revocations as model access loss
- move affected Automations to Needs attention, pause future dispatches, and retain durable receipts and history
- add sidebar, list, and detail warnings with a supported-model reconfiguration path
- resume on an immutable replacement-model revision without replaying missed occurrences

## Checks

- `node --test apps/desktop/electron/automation-runner.test.mjs`
- `pnpm exec bun test apps/app/tests/automation-model-options.test.ts`
- `pnpm exec bun --conditions=development test ee/apps/den-api/test/automations-model-authority.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork-ee/den-api typecheck:automations`
- `pnpm evals:typecheck`

## Runtime acceptance

Added `evals/specs/automation-model-needs-attention.slow.test.ts` for the real Den scheduler and Electron recovery journey. The targeted spec registers successfully, but its runtime pass is deferred because the local Colima VM did not reach SSH readiness.