### PR TITLE
Add MCP Apps provider foundation for Dynamic Artifacts

### DIFF
--- a/docs/features/dynamic-artifact-mcp-apps/README.md
+++ b/docs/features/dynamic-artifact-mcp-apps/README.md
@@ -1,0 +1,90 @@
+# Dynamic Artifacts as MCP Apps
+
+OpenWork exposes saved Code Mode Script results as portable, standards-based
+MCP Apps. A supporting MCP host can render an artifact inline; every other MCP
+client still receives a useful Markdown result.
+
+## Product flow
+
+1. Code Mode produces data and a deterministic Markdown rendering.
+2. The result can be saved as an immutable Script snapshot with a receipt,
+   schema validation, result digest, and exact Script version.
+3. A person or an Automation may run the saved Script again. Automations only
+   refresh the data snapshot; they do not create or execute UI code.
+4. The read-only `render_dynamic_artifact` tool loads the latest successful
+   snapshot, or an exact receipt when requested.
+5. MCP Apps hosts resolve the linked `ui://` resource and inject the tool's
+   structured result. Other hosts show the Markdown fallback.
+
+This keeps execution, scheduling, data, and presentation separate:
+
+```text
+Code Mode Script ──run──> immutable snapshot ──read──> MCP tool result
+       ▲                        ▲                          ├─ Markdown fallback
+       │                        │                          └─ ui:// MCP App
+   explicit run           Automation refresh
+```
+
+The MCP App never runs a Script, mutates an artifact, or introduces another
+scheduler. It only presents an already-authorized snapshot.
+
+## MCP Apps conformance
+
+The agent MCP server implements the `io.modelcontextprotocol/ui` extension and
+the `2026-01-26` MCP Apps protocol:
+
+- server capability: `extensions.io.modelcontextprotocol/ui.mimeTypes`
+  contains `text/html;profile=mcp-app`;
+- tool metadata: `_meta.ui.resourceUri` points to
+  `ui://openwork/dynamic-artifact/view.html` (with the compatibility metadata
+  emitted by the official MCP Apps server helpers);
+- resource delivery: `resources/read` returns one self-contained HTML5 document
+  with MIME type `text/html;profile=mcp-app`;
+- view lifecycle: the document performs `ui/initialize`, sends
+  `ui/notifications/initialized`, receives tool input/result/cancellation and
+  host-context notifications, reports size changes, and acknowledges teardown;
+- data delivery: the tool returns versioned `structuredContent`, lightweight
+  lineage in result `_meta`, and a complete text fallback;
+- security: the resource declares an empty network/frame/base-URI CSP, loads no
+  external code, performs no network requests, and inserts artifact values with
+  DOM text APIs rather than HTML interpolation.
+
+The shared payload schema lives in `@openwork/types/dynamic-artifacts` so a host
+can validate the data contract independently of this presentation resource.
+
+## UI behavior
+
+The self-contained view is intentionally data-first and framework-neutral. It
+adapts the Preview tab to common result shapes:
+
+- arrays of records become a bounded table;
+- flat objects become metric cards;
+- nested or irregular values fall back to formatted JSON;
+- Data always exposes the full structured result, with a rendering-size guard;
+- Lineage shows the immutable receipt, Script/version IDs, source, digest,
+  renderer, and Automation run when present.
+
+The view follows host theme/style context, uses responsive HTML, and caps large
+tables and rendered JSON without changing the underlying tool result.
+
+## Authorization and failure behavior
+
+The renderer uses the same organization membership, team grants, and saved
+Script authorization path as the existing artifact APIs. It does not accept a
+plugin or result payload from the caller. The caller supplies only a saved
+Script ID, an optional exact receipt, and an optional freshness threshold.
+
+Only readable, successful, non-deleted snapshots can be rendered. Missing,
+failed, deleted, or unauthorized results fail closed with a non-sensitive text
+error. A stale snapshot remains renderable and is labeled stale; a failed
+refresh leaves the last successful artifact available with a needs-attention
+state.
+
+## Next interoperable slice
+
+The provider side is deliberately usable without an OpenWork-specific host.
+The next slice is a generic MCP Apps host in the desktop conversation surface:
+negotiate the UI extension with upstream MCP servers, preserve tool/resource
+metadata and structured results through the runtime, sandbox `ui://` resources,
+and bridge the standard JSON-RPC lifecycle. That host should consume the same
+standard contract rather than adding a custom React artifact format.

--- a/docs/features/dynamic-artifact-mcp-apps/README.md
+++ b/docs/features/dynamic-artifact-mcp-apps/README.md
@@ -36,7 +36,7 @@ the `2026-01-26` MCP Apps protocol:
 - server capability: `extensions.io.modelcontextprotocol/ui.mimeTypes`
   contains `text/html;profile=mcp-app`;
 - tool metadata: `_meta.ui.resourceUri` points to
-  `ui://openwork/dynamic-artifact/view.html` (with the compatibility metadata
+  `ui://openwork/dynamic-artifact/v1/view.html` (with the compatibility metadata
   emitted by the official MCP Apps server helpers);
 - resource delivery: `resources/read` returns one self-contained HTML5 document
   with MIME type `text/html;profile=mcp-app`;

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -34,6 +34,7 @@
     "@hono/otel": "1.1.2",
     "@hono/standard-validator": "^0.2.2",
     "@hono/swagger-ui": "^0.6.1",
+    "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.220.0",

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -21,6 +21,15 @@ import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { automationService } from "../automations/service.js"
 import { AGENT_AUTOMATION_INDEX_LIMIT, registerAgentAutomationResources } from "./automation-index.js"
 import { env } from "../env.js"
+import { getOrganizationContextForUser, listTeamsForMember } from "../orgs.js"
+import { getCodemodeScriptDetail, getCodemodeScriptSnapshot } from "../codemode-scripts.js"
+import { artifactFreshness } from "../saved-script-artifacts.js"
+import { PluginArchAuthorizationError } from "../routes/org/plugin-system/access.js"
+import {
+  DYNAMIC_ARTIFACT_APP_SCHEMA_VERSION,
+  dynamicArtifactAppServerCapabilities,
+  registerAgentDynamicArtifactApp,
+} from "./dynamic-artifact-app.js"
 import {
   executeBuiltinSkillCapability,
   listBuiltinSkillDescriptors,
@@ -97,7 +106,7 @@ export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
 })
 
 export const AGENT_MCP_INSTRUCTIONS = [
-  "This OpenWork Cloud connection always exposes search_capabilities and execute_capability; organizations with Code Mode scripts enabled also receive execute_capability_script.",
+  "This OpenWork Cloud connection always exposes search_capabilities and execute_capability; organizations with Code Mode scripts enabled also receive execute_capability_script and render_dynamic_artifact.",
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added.",
   "Allowlisted platform admins can also discover namespaced OpenWork Admin capabilities through this same connection; other members cannot discover or execute them.",
   "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities.",
@@ -216,6 +225,7 @@ export function createAgentMcpServer(): McpServer {
     name: "openwork-den-api-agent",
     version: "1.0.0",
   }, {
+    capabilities: dynamicArtifactAppServerCapabilities,
     instructions: AGENT_MCP_INSTRUCTIONS,
   })
 }
@@ -270,8 +280,8 @@ export function registerAgentSkillResources(input: {
 }
 
 /**
- * The minimal, harness-facing MCP surface: two core tools plus one gated
- * confined-script tool.
+ * The minimal, harness-facing MCP surface: two core tools plus gated Code Mode
+ * execution and standards-based Dynamic Artifact presentation.
  *
  * `/mcp` (index.ts) stays exactly as it is — every catalog operation
  * individually registered, ~129 tools today. That's unchanged and still
@@ -282,8 +292,10 @@ export function registerAgentSkillResources(input: {
  * desktop app's "OpenWork Cloud Control" connection, which is what an
  * OpenCode/Claude Code/Codex-style harness actually sees. It always registers
  * `search_capabilities` and `execute_capability`, and conditionally registers
- * `execute_capability_script` over the same authorized capability set. The
- * other ~127 operations are not individually callable on this endpoint.
+ * `execute_capability_script` plus `render_dynamic_artifact`. The renderer is
+ * a read-only MCP App over the same authorized saved-Script snapshots; it does
+ * not create a second execution or scheduling path. The other ~127 operations
+ * are not individually callable on this endpoint.
  */
 export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(app: Hono<T>) {
   app.get("/.well-known/oauth-protected-resource/mcp/agent", publicRoute, (c) =>
@@ -379,7 +391,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         title: "Search capabilities",
         description: [
           codemodeEnabled
-            ? "Search for a capability by keyword. This connection exposes this tool, execute_capability, and execute_capability_script —"
+            ? "Search for a capability by keyword. This connection also exposes execute_capability, execute_capability_script, and the read-only render_dynamic_artifact tool —"
             : "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
@@ -431,6 +443,112 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
     )
 
     if (codemodeEnabled) {
+      registerAgentDynamicArtifactApp({
+        server,
+        load: async ({ configObjectId, receiptId, maxAgeMs }) => {
+          if (!memberIdentity) {
+            return {
+              ok: false,
+              error: "saved_script_not_found",
+              message: "The saved Script is unavailable to this member.",
+            }
+          }
+          try {
+            const organizationContext = await getOrganizationContextForUser({
+              userId: normalizeDenTypeId("user", principal.userId),
+              organizationId,
+            })
+            if (!organizationContext) {
+              return {
+                ok: false,
+                error: "saved_script_not_found",
+                message: "The saved Script is unavailable to this member.",
+              }
+            }
+            const memberTeams = await listTeamsForMember({
+              organizationId,
+              memberId: memberIdentity.orgMembershipId,
+            })
+            const context = {
+              organizationContext,
+              memberTeams,
+              session: null,
+            }
+            const detail = await getCodemodeScriptDetail({
+              context,
+              configObjectId,
+              maxAgeMs,
+            })
+            const snapshot = receiptId
+              ? await getCodemodeScriptSnapshot({ context, configObjectId, receiptId })
+              : detail.latestSuccessfulSnapshot
+            if (!snapshot) {
+              return {
+                ok: false,
+                error: "saved_script_snapshot_not_found",
+                message: receiptId
+                  ? "That immutable artifact snapshot was not found."
+                  : "This saved Script does not have a successful artifact snapshot yet. Run it explicitly or through its Automation first.",
+              }
+            }
+            if (snapshot.status !== "succeeded" || snapshot.contentDeletedAt !== null
+              || snapshot.markdown === null
+              || snapshot.resultDigest === null || snapshot.rendererVersion !== "codemode-markdown-v1") {
+              return {
+                ok: false,
+                error: "saved_script_snapshot_unavailable",
+                message: "This artifact snapshot has no readable successful content.",
+              }
+            }
+            const freshness = receiptId
+              ? artifactFreshness({
+                  latestFinishedAt: new Date(snapshot.finishedAt),
+                  latestStatus: "succeeded",
+                  latestSuccessfulFinishedAt: new Date(snapshot.finishedAt),
+                  latestSuccessfulReceiptId: snapshot.receiptId,
+                  maxAgeMs: Math.min(30 * 24 * 60 * 60_000, Math.max(60_000, maxAgeMs ?? 24 * 60 * 60_000)),
+                })
+              : detail.freshness
+            return {
+              ok: true,
+              markdown: snapshot.markdown,
+              payload: {
+                schemaVersion: DYNAMIC_ARTIFACT_APP_SCHEMA_VERSION,
+                artifact: {
+                  title: detail.title,
+                  description: detail.description,
+                  pluginId: snapshot.pluginId,
+                  configObjectId: snapshot.configObjectId,
+                  configObjectVersionId: snapshot.configObjectVersionId,
+                  receiptId: snapshot.receiptId,
+                  automationRunId: snapshot.automationRunId,
+                  source: snapshot.source,
+                  generatedAt: snapshot.finishedAt,
+                  resultDigest: snapshot.resultDigest,
+                  rendererVersion: snapshot.rendererVersion,
+                  freshness,
+                },
+                data: snapshot.value,
+              },
+            }
+          } catch (error) {
+            if (error instanceof PluginArchAuthorizationError) {
+              return {
+                ok: false,
+                error: "saved_script_not_found",
+                message: "The saved Script is unavailable to this member.",
+              }
+            }
+            const message = error instanceof Error ? error.message : "saved_script_not_found"
+            return {
+              ok: false,
+              error: message.includes("not_found") ? "saved_script_not_found" : "saved_script_unavailable",
+              message: "The Dynamic Artifact could not be loaded.",
+            }
+          }
+        },
+      })
+
       server.registerTool(
         EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME,
         {

--- a/ee/apps/den-api/src/mcp/dynamic-artifact-app.ts
+++ b/ee/apps/den-api/src/mcp/dynamic-artifact-app.ts
@@ -1,0 +1,515 @@
+import {
+  EXTENSION_ID,
+  RESOURCE_MIME_TYPE,
+  registerAppResource,
+  registerAppTool,
+} from "@modelcontextprotocol/ext-apps/server"
+import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import {
+  dynamicArtifactAppPayloadSchema,
+  dynamicArtifactAppSchemaVersion,
+  type ArtifactFreshness,
+  type DynamicArtifactAppPayload,
+} from "@openwork/types/dynamic-artifacts"
+import { z } from "zod"
+
+export { dynamicArtifactAppPayloadSchema } from "@openwork/types/dynamic-artifacts"
+
+export const DYNAMIC_ARTIFACT_APP_RESOURCE_URI = "ui://openwork/dynamic-artifact/view.html"
+export const DYNAMIC_ARTIFACT_APP_TOOL_NAME = "render_dynamic_artifact"
+export const DYNAMIC_ARTIFACT_APP_SCHEMA_VERSION = dynamicArtifactAppSchemaVersion
+
+const idSchema = z.string().trim().min(1).max(160)
+
+export type DynamicArtifactAppLoadResult =
+  | { ok: true; payload: DynamicArtifactAppPayload; markdown: string }
+  | { ok: false; error: string; message: string }
+
+export const dynamicArtifactAppServerCapabilities = {
+  extensions: {
+    [EXTENSION_ID]: {
+      mimeTypes: [RESOURCE_MIME_TYPE],
+    },
+  },
+}
+
+const dynamicArtifactAppResourceMeta: { ui: McpUiResourceMeta } = {
+  ui: {
+    csp: {
+      connectDomains: [],
+      resourceDomains: [],
+      frameDomains: [],
+      baseUriDomains: [],
+    },
+    prefersBorder: true,
+  },
+}
+
+function formatFreshness(freshness: ArtifactFreshness): string {
+  switch (freshness.state) {
+    case "fresh":
+      return "fresh"
+    case "stale":
+      return `stale (${Math.round(freshness.ageMs / 60_000)} minutes old)`
+    case "needs_attention":
+      return `needs attention: ${freshness.reason}`
+    case "never_run":
+      return "never run"
+  }
+  return "unknown"
+}
+
+export function dynamicArtifactTextFallback(input: {
+  payload: DynamicArtifactAppPayload
+  markdown: string
+}): string {
+  const { artifact } = input.payload
+  return [
+    `# ${artifact.title}`,
+    artifact.description,
+    `Freshness: ${formatFreshness(artifact.freshness)}`,
+    `Generated: ${artifact.generatedAt}`,
+    `Source: ${artifact.source}`,
+    `Script version: ${artifact.configObjectVersionId}`,
+    `Receipt: ${artifact.receiptId}`,
+    "",
+    input.markdown,
+  ].filter((line): line is string => line !== null).join("\n")
+}
+
+export const DYNAMIC_ARTIFACT_APP_HTML = String.raw`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>OpenWork Dynamic Artifact</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --ow-bg: var(--color-background-primary, #ffffff);
+      --ow-bg-subtle: var(--color-background-secondary, #f5f5f4);
+      --ow-text: var(--color-text-primary, #1c1917);
+      --ow-muted: var(--color-text-secondary, #78716c);
+      --ow-border: var(--color-border-secondary, #e7e5e4);
+      --ow-accent: var(--color-text-info, #2563eb);
+      --ow-success: var(--color-text-success, #15803d);
+      --ow-warning: var(--color-text-warning, #b45309);
+      --ow-danger: var(--color-text-danger, #b91c1c);
+      font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+      background: transparent;
+      color: var(--ow-text);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-width: 0; background: transparent; }
+    button { font: inherit; }
+    .shell { display: grid; gap: 14px; padding: 18px; background: var(--ow-bg); }
+    .header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
+    .eyebrow { margin: 0 0 5px; color: var(--ow-muted); font-size: 11px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
+    h1 { margin: 0; font-size: var(--font-heading-sm-size, 20px); line-height: 1.2; letter-spacing: -.02em; }
+    .description { margin: 6px 0 0; max-width: 72ch; color: var(--ow-muted); font-size: var(--font-text-sm-size, 13px); line-height: 1.45; }
+    .badge { flex: none; border: 1px solid var(--ow-border); border-radius: 999px; padding: 5px 9px; color: var(--ow-muted); font-size: 11px; font-weight: 700; }
+    .badge[data-state="fresh"] { color: var(--ow-success); }
+    .badge[data-state="stale"] { color: var(--ow-warning); }
+    .badge[data-state="needs_attention"] { color: var(--ow-danger); }
+    .tabs { display: flex; gap: 4px; width: fit-content; padding: 3px; border: 1px solid var(--ow-border); border-radius: 10px; background: var(--ow-bg-subtle); }
+    .tab { border: 0; border-radius: 7px; padding: 6px 10px; background: transparent; color: var(--ow-muted); cursor: pointer; font-size: 12px; font-weight: 650; }
+    .tab[aria-selected="true"] { background: var(--ow-bg); color: var(--ow-text); box-shadow: 0 1px 2px rgb(0 0 0 / .08); }
+    .panel { min-width: 0; }
+    .status { display: grid; min-height: 150px; place-items: center; border: 1px dashed var(--ow-border); border-radius: 12px; color: var(--ow-muted); font-size: 13px; text-align: center; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 9px; }
+    .metric { min-width: 0; padding: 12px; border: 1px solid var(--ow-border); border-radius: 11px; background: var(--ow-bg-subtle); }
+    .metric dt { overflow: hidden; margin: 0 0 6px; color: var(--ow-muted); font-size: 11px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+    .metric dd { overflow-wrap: anywhere; margin: 0; font-size: 15px; font-weight: 700; line-height: 1.3; }
+    .table-wrap { max-width: 100%; overflow: auto; border: 1px solid var(--ow-border); border-radius: 11px; }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    th, td { max-width: 320px; padding: 9px 10px; border-bottom: 1px solid var(--ow-border); overflow: hidden; text-align: left; text-overflow: ellipsis; white-space: nowrap; }
+    th { position: sticky; top: 0; background: var(--ow-bg-subtle); color: var(--ow-muted); font-size: 11px; }
+    tbody tr:last-child td { border-bottom: 0; }
+    .more { margin: 9px 2px 0; color: var(--ow-muted); font-size: 11px; }
+    pre { max-height: 420px; overflow: auto; margin: 0; padding: 13px; border: 1px solid var(--ow-border); border-radius: 11px; background: var(--ow-bg-subtle); color: var(--ow-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
+    .lineage { display: grid; grid-template-columns: minmax(130px, .35fr) minmax(0, 1fr); margin: 0; border: 1px solid var(--ow-border); border-radius: 11px; overflow: hidden; }
+    .lineage dt, .lineage dd { min-width: 0; margin: 0; padding: 9px 11px; border-bottom: 1px solid var(--ow-border); font-size: 12px; }
+    .lineage dt { background: var(--ow-bg-subtle); color: var(--ow-muted); font-weight: 650; }
+    .lineage dd { overflow-wrap: anywhere; font-family: var(--font-mono, ui-monospace, monospace); }
+    .lineage dt:last-of-type, .lineage dd:last-of-type { border-bottom: 0; }
+    @media (max-width: 520px) {
+      .shell { padding: 14px; }
+      .header { display: grid; }
+      .badge { justify-self: start; }
+      .lineage { grid-template-columns: 1fr; }
+      .lineage dt { border-bottom: 0; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="header">
+      <div>
+        <p class="eyebrow">Dynamic Artifact</p>
+        <h1 id="title">Preparing artifact…</h1>
+        <p class="description" id="description"></p>
+      </div>
+      <span class="badge" id="freshness">Connecting</span>
+    </header>
+    <nav class="tabs" aria-label="Artifact views">
+      <button class="tab" type="button" data-tab="preview" aria-selected="true">Preview</button>
+      <button class="tab" type="button" data-tab="data" aria-selected="false">Data</button>
+      <button class="tab" type="button" data-tab="lineage" aria-selected="false">Lineage</button>
+    </nav>
+    <section class="panel" id="panel"><div class="status">Waiting for the artifact result…</div></section>
+  </main>
+  <script>
+    (function () {
+      'use strict';
+      var INIT_ID = 'openwork-dynamic-artifact:init';
+      var activeTab = 'preview';
+      var payload = null;
+      var panel = document.getElementById('panel');
+      var title = document.getElementById('title');
+      var description = document.getElementById('description');
+      var freshness = document.getElementById('freshness');
+
+      function isRecord(value) {
+        return value !== null && typeof value === 'object' && !Array.isArray(value);
+      }
+
+      function post(message) {
+        window.parent.postMessage(message, '*');
+      }
+
+      function clear(node) {
+        while (node.firstChild) node.removeChild(node.firstChild);
+      }
+
+      function text(value) {
+        if (value === null) return 'null';
+        if (value === undefined) return '';
+        if (typeof value === 'string') return value;
+        if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+        try { return JSON.stringify(value); } catch (_) { return '[unavailable]'; }
+      }
+
+      function scalar(value) {
+        return value === null || ['string', 'number', 'boolean'].indexOf(typeof value) !== -1;
+      }
+
+      function raw(value) {
+        var pre = document.createElement('pre');
+        var output;
+        try { output = JSON.stringify(value, null, 2); } catch (_) { output = '[Unable to serialize artifact data]'; }
+        if (output.length > 120000) output = output.slice(0, 120000) + '\n… output truncated in this view';
+        pre.textContent = output;
+        return pre;
+      }
+
+      function renderRecord(record) {
+        var keys = Object.keys(record).sort();
+        if (!keys.length || !keys.every(function (key) { return scalar(record[key]); })) return raw(record);
+        var list = document.createElement('dl');
+        list.className = 'metrics';
+        keys.slice(0, 20).forEach(function (key) {
+          var item = document.createElement('div');
+          item.className = 'metric';
+          var term = document.createElement('dt');
+          term.textContent = key;
+          var detail = document.createElement('dd');
+          detail.textContent = text(record[key]);
+          item.appendChild(term);
+          item.appendChild(detail);
+          list.appendChild(item);
+        });
+        return list;
+      }
+
+      function renderTable(rows) {
+        var columns = [];
+        rows.slice(0, 100).forEach(function (row) {
+          if (!isRecord(row)) return;
+          Object.keys(row).sort().forEach(function (key) {
+            if (columns.indexOf(key) === -1 && columns.length < 12) columns.push(key);
+          });
+        });
+        if (!columns.length) return raw(rows);
+        var wrap = document.createElement('div');
+        wrap.className = 'table-wrap';
+        var table = document.createElement('table');
+        var thead = document.createElement('thead');
+        var header = document.createElement('tr');
+        columns.forEach(function (column) {
+          var cell = document.createElement('th');
+          cell.scope = 'col';
+          cell.textContent = column;
+          header.appendChild(cell);
+        });
+        thead.appendChild(header);
+        table.appendChild(thead);
+        var tbody = document.createElement('tbody');
+        rows.slice(0, 100).forEach(function (row) {
+          var tr = document.createElement('tr');
+          columns.forEach(function (column) {
+            var td = document.createElement('td');
+            td.textContent = isRecord(row) ? text(row[column]) : text(row);
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        wrap.appendChild(table);
+        if (rows.length > 100) {
+          var more = document.createElement('p');
+          more.className = 'more';
+          more.textContent = '+ ' + (rows.length - 100) + ' more rows in Data';
+          var group = document.createElement('div');
+          group.appendChild(wrap);
+          group.appendChild(more);
+          return group;
+        }
+        return wrap;
+      }
+
+      function preview(value) {
+        if (Array.isArray(value)) return renderTable(value);
+        if (isRecord(value)) return renderRecord(value);
+        var list = document.createElement('dl');
+        list.className = 'metrics';
+        var item = document.createElement('div');
+        item.className = 'metric';
+        var term = document.createElement('dt');
+        term.textContent = 'Result';
+        var detail = document.createElement('dd');
+        detail.textContent = text(value);
+        item.appendChild(term);
+        item.appendChild(detail);
+        list.appendChild(item);
+        return list;
+      }
+
+      function lineage(artifact) {
+        var values = [
+          ['Generated', artifact.generatedAt],
+          ['Source', artifact.source],
+          ['Script', artifact.configObjectId],
+          ['Script version', artifact.configObjectVersionId],
+          ['Receipt', artifact.receiptId],
+          ['Automation run', artifact.automationRunId || '—'],
+          ['Result digest', artifact.resultDigest],
+          ['Renderer', artifact.rendererVersion]
+        ];
+        var list = document.createElement('dl');
+        list.className = 'lineage';
+        values.forEach(function (entry) {
+          var term = document.createElement('dt');
+          term.textContent = entry[0];
+          var detail = document.createElement('dd');
+          detail.textContent = entry[1];
+          list.appendChild(term);
+          list.appendChild(detail);
+        });
+        return list;
+      }
+
+      function freshnessLabel(value) {
+        if (!value || !value.state) return 'Unknown';
+        if (value.state === 'fresh') return 'Fresh';
+        if (value.state === 'stale') return 'Stale';
+        if (value.state === 'needs_attention') return 'Needs attention';
+        return 'Never run';
+      }
+
+      function render() {
+        if (!payload) return;
+        title.textContent = payload.artifact.title;
+        description.textContent = payload.artifact.description || '';
+        freshness.textContent = freshnessLabel(payload.artifact.freshness);
+        freshness.setAttribute('data-state', payload.artifact.freshness.state);
+        clear(panel);
+        if (activeTab === 'data') panel.appendChild(raw(payload.data));
+        else if (activeTab === 'lineage') panel.appendChild(lineage(payload.artifact));
+        else panel.appendChild(preview(payload.data));
+        window.requestAnimationFrame(function () {
+          post({
+            jsonrpc: '2.0',
+            method: 'ui/notifications/size-changed',
+            params: {
+              width: Math.ceil(document.documentElement.scrollWidth),
+              height: Math.ceil(document.documentElement.scrollHeight)
+            }
+          });
+        });
+      }
+
+      function showError(message) {
+        clear(panel);
+        var status = document.createElement('div');
+        status.className = 'status';
+        status.textContent = message;
+        panel.appendChild(status);
+        freshness.textContent = 'Unavailable';
+        freshness.setAttribute('data-state', 'needs_attention');
+      }
+
+      function applyHostContext(context) {
+        if (!context || !isRecord(context)) return;
+        if (context.theme === 'light' || context.theme === 'dark') {
+          document.documentElement.setAttribute('data-theme', context.theme);
+          document.documentElement.style.colorScheme = context.theme;
+        }
+        var variables = context.styles && context.styles.variables;
+        if (isRecord(variables)) {
+          Object.keys(variables).forEach(function (key) {
+            if (key.indexOf('--') === 0 && typeof variables[key] === 'string') {
+              document.documentElement.style.setProperty(key, variables[key]);
+            }
+          });
+        }
+      }
+
+      function onMessage(event) {
+        if (event.source !== window.parent) return;
+        var message = event.data;
+        if (!isRecord(message) || message.jsonrpc !== '2.0') return;
+        if (message.id === INIT_ID && isRecord(message.result)) {
+          applyHostContext(message.result.hostContext);
+          post({ jsonrpc: '2.0', method: 'ui/notifications/initialized' });
+          return;
+        }
+        if (message.method === 'ui/notifications/host-context-changed') {
+          applyHostContext(message.params);
+          return;
+        }
+        if (message.method === 'ui/notifications/tool-input') {
+          freshness.textContent = 'Loading';
+          return;
+        }
+        if (message.method === 'ui/notifications/tool-cancelled') {
+          showError(message.params && message.params.reason ? message.params.reason : 'Artifact rendering was cancelled.');
+          return;
+        }
+        if (message.method === 'ui/notifications/tool-result') {
+          if (message.params && message.params.isError) {
+            showError('The artifact could not be loaded. See the text result for details.');
+            return;
+          }
+          var structured = message.params && message.params.structuredContent;
+          if (!isRecord(structured) || structured.schemaVersion !== '1' || !isRecord(structured.artifact)) {
+            showError('This result does not match the Dynamic Artifact data contract.');
+            return;
+          }
+          payload = structured;
+          render();
+          return;
+        }
+        if (message.method === 'ui/resource-teardown' && message.id !== undefined) {
+          post({ jsonrpc: '2.0', id: message.id, result: {} });
+        }
+      }
+
+      Array.prototype.forEach.call(document.querySelectorAll('[data-tab]'), function (button) {
+        button.addEventListener('click', function () {
+          activeTab = button.getAttribute('data-tab') || 'preview';
+          Array.prototype.forEach.call(document.querySelectorAll('[data-tab]'), function (candidate) {
+            candidate.setAttribute('aria-selected', String(candidate === button));
+          });
+          render();
+        });
+      });
+
+      window.addEventListener('message', onMessage);
+      post({
+        jsonrpc: '2.0',
+        id: INIT_ID,
+        method: 'ui/initialize',
+        params: {
+          appInfo: { name: 'OpenWork Dynamic Artifact', version: '1.0.0' },
+          appCapabilities: {},
+          protocolVersion: '2026-01-26'
+        }
+      });
+    }());
+  </script>
+</body>
+</html>`
+
+export function registerAgentDynamicArtifactApp(input: {
+  server: McpServer
+  load: (request: {
+    configObjectId: string
+    receiptId?: string
+    maxAgeMs?: number
+  }) => Promise<DynamicArtifactAppLoadResult>
+}) {
+  registerAppResource(
+    input.server,
+    "OpenWork Dynamic Artifact",
+    DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+    {
+      description: "A data-first Preview, Data, and Lineage view for an immutable saved Script result.",
+      _meta: dynamicArtifactAppResourceMeta,
+    },
+    async () => ({
+      contents: [{
+        uri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+        mimeType: RESOURCE_MIME_TYPE,
+        text: DYNAMIC_ARTIFACT_APP_HTML,
+        _meta: dynamicArtifactAppResourceMeta,
+      }],
+    }),
+  )
+
+  registerAppTool(
+    input.server,
+    DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+    {
+      title: "Render Dynamic Artifact",
+      description: [
+        "Read an authorized immutable result from a saved Code Mode Script and present it as a Dynamic Artifact.",
+        "Use the latest successful snapshot by default, or pass receiptId to pin an exact snapshot.",
+        "This tool never runs or refreshes a Script; Automations and explicit Script runs own data refresh.",
+        "Clients without MCP Apps support receive the same artifact as Markdown text.",
+      ].join(" "),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inputSchema: z.object({
+        configObjectId: idSchema.describe("The saved Script configObjectId."),
+        receiptId: idSchema.optional().describe("Optional exact immutable artifact receipt. Defaults to the latest successful snapshot."),
+        maxAgeMs: z.number().int().min(60_000).max(30 * 24 * 60 * 60_000).optional().describe("Freshness threshold used for the rendered status. Defaults to 24 hours."),
+      }),
+      outputSchema: dynamicArtifactAppPayloadSchema,
+      _meta: {
+        ui: {
+          resourceUri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+          visibility: ["model", "app"],
+        },
+      },
+    },
+    async ({ configObjectId, receiptId, maxAgeMs }) => {
+      const loaded = await input.load({ configObjectId, receiptId, maxAgeMs })
+      if (!loaded.ok) {
+        return {
+          isError: true,
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ error: loaded.error, message: loaded.message }),
+          }],
+        }
+      }
+      return {
+        content: [{
+          type: "text" as const,
+          text: dynamicArtifactTextFallback(loaded),
+        }],
+        structuredContent: loaded.payload,
+        _meta: {
+          schemaVersion: loaded.payload.schemaVersion,
+          receiptId: loaded.payload.artifact.receiptId,
+          resultDigest: loaded.payload.artifact.resultDigest,
+        },
+      }
+    },
+  )
+}

--- a/ee/apps/den-api/src/mcp/dynamic-artifact-app.ts
+++ b/ee/apps/den-api/src/mcp/dynamic-artifact-app.ts
@@ -16,7 +16,7 @@ import { z } from "zod"
 
 export { dynamicArtifactAppPayloadSchema } from "@openwork/types/dynamic-artifacts"
 
-export const DYNAMIC_ARTIFACT_APP_RESOURCE_URI = "ui://openwork/dynamic-artifact/view.html"
+export const DYNAMIC_ARTIFACT_APP_RESOURCE_URI = "ui://openwork/dynamic-artifact/v1/view.html"
 export const DYNAMIC_ARTIFACT_APP_TOOL_NAME = "render_dynamic_artifact"
 export const DYNAMIC_ARTIFACT_APP_SCHEMA_VERSION = dynamicArtifactAppSchemaVersion
 

--- a/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
+++ b/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
@@ -33,16 +33,21 @@ const payload = dynamicArtifactAppPayloadSchema.parse({
   ],
 })
 
-async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+type LoadDynamicArtifact = Parameters<typeof registerAgentDynamicArtifactApp>[0]["load"]
+
+async function withClient<T>(
+  run: (client: Client) => Promise<T>,
+  load: LoadDynamicArtifact = async ({ receiptId }) => receiptId === "missing"
+    ? { ok: false, error: "saved_script_snapshot_not_found", message: "Snapshot not found." }
+    : { ok: true, payload, markdown: "| Stage | Value |\n| --- | --- |\n| Qualified | 12 |" },
+): Promise<T> {
   const server = new McpServer(
     { name: "dynamic-artifact-test", version: "1.0.0" },
     { capabilities: dynamicArtifactAppServerCapabilities },
   )
   registerAgentDynamicArtifactApp({
     server,
-    load: async ({ receiptId }) => receiptId === "missing"
-      ? { ok: false, error: "saved_script_snapshot_not_found", message: "Snapshot not found." }
-      : { ok: true, payload, markdown: "| Stage | Value |\n| --- | --- |\n| Qualified | 12 |" },
+    load,
   })
   const client = new Client(
     { name: "mcp-app-host-test", version: "1.0.0" },
@@ -122,7 +127,11 @@ test("serves a self-contained HTML5 app and a structured result with Markdown fa
     expect(DYNAMIC_ARTIFACT_APP_HTML).toContain("ui/notifications/size-changed")
     expect(DYNAMIC_ARTIFACT_APP_HTML).not.toContain("<script src=")
     expect(DYNAMIC_ARTIFACT_APP_HTML).not.toContain("fetch(")
-    const inlineScript = DYNAMIC_ARTIFACT_APP_HTML.match(/<script>([\s\S]+)<\/script>/)?.[1]
+    const scriptStart = DYNAMIC_ARTIFACT_APP_HTML.indexOf("<script>")
+    const scriptEnd = DYNAMIC_ARTIFACT_APP_HTML.lastIndexOf("</script>")
+    const inlineScript = scriptStart === -1 || scriptEnd <= scriptStart
+      ? undefined
+      : DYNAMIC_ARTIFACT_APP_HTML.slice(scriptStart + "<script>".length, scriptEnd)
     expect(inlineScript).toBeDefined()
     expect(() => Function(inlineScript ?? "")).not.toThrow()
 
@@ -141,6 +150,49 @@ test("serves a self-contained HTML5 app and a structured result with Markdown fa
       resultDigest: `sha256:${"a".repeat(64)}`,
     })
   })
+})
+
+test("forwards exact receipt and freshness selection without executing a Script", async () => {
+  const requests: Array<{ configObjectId: string; receiptId?: string; maxAgeMs?: number }> = []
+  await withClient(async (client) => {
+    const result = await client.callTool({
+      name: DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+      arguments: {
+        configObjectId: "configObject_pipeline",
+        receiptId: "codemodeRun_week_32",
+        maxAgeMs: 3_600_000,
+      },
+    })
+    expect(result.isError).not.toBe(true)
+  }, async (request) => {
+    requests.push(request)
+    return { ok: true, payload, markdown: "# Weekly pipeline" }
+  })
+  expect(requests).toEqual([{
+    configObjectId: "configObject_pipeline",
+    receiptId: "codemodeRun_week_32",
+    maxAgeMs: 3_600_000,
+  }])
+})
+
+test("preserves fail-closed authorization errors for non-UI clients", async () => {
+  await withClient(async (client) => {
+    const result = await client.callTool({
+      name: DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+      arguments: { configObjectId: "configObject_denied" },
+    })
+    expect(result.isError).toBe(true)
+    const first = result.content[0]
+    expect(first?.type === "text" ? JSON.parse(first.text) : null).toEqual({
+      error: "saved_script_not_found",
+      message: "The saved Script is unavailable to this member.",
+    })
+    expect(result.structuredContent).toBeUndefined()
+  }, async () => ({
+    ok: false,
+    error: "saved_script_not_found",
+    message: "The saved Script is unavailable to this member.",
+  }))
 })
 
 test("keeps missing snapshots useful to clients without a UI", async () => {

--- a/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
+++ b/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
@@ -1,0 +1,162 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { expect, test } from "bun:test"
+import {
+  DYNAMIC_ARTIFACT_APP_HTML,
+  DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+  DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+  dynamicArtifactAppPayloadSchema,
+  dynamicArtifactAppServerCapabilities,
+  registerAgentDynamicArtifactApp,
+} from "../src/mcp/dynamic-artifact-app.js"
+
+const payload = dynamicArtifactAppPayloadSchema.parse({
+  schemaVersion: "1",
+  artifact: {
+    title: "Weekly pipeline",
+    description: "Validated opportunities by stage.",
+    pluginId: "plugin_sales",
+    configObjectId: "configObject_pipeline",
+    configObjectVersionId: "configObjectVersion_4",
+    receiptId: "codemodeRun_week_32",
+    automationRunId: "automationRun_week_32",
+    source: "scheduled",
+    generatedAt: "2026-08-11T10:30:00.000Z",
+    resultDigest: `sha256:${"a".repeat(64)}`,
+    rendererVersion: "codemode-markdown-v1",
+    freshness: { state: "fresh", ageMs: 42_000 },
+  },
+  data: [
+    { stage: "Qualified", value: 12 },
+    { stage: "Proposal", value: 5 },
+  ],
+})
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const server = new McpServer(
+    { name: "dynamic-artifact-test", version: "1.0.0" },
+    { capabilities: dynamicArtifactAppServerCapabilities },
+  )
+  registerAgentDynamicArtifactApp({
+    server,
+    load: async ({ receiptId }) => receiptId === "missing"
+      ? { ok: false, error: "saved_script_snapshot_not_found", message: "Snapshot not found." }
+      : { ok: true, payload, markdown: "| Stage | Value |\n| --- | --- |\n| Qualified | 12 |" },
+  })
+  const client = new Client(
+    { name: "mcp-app-host-test", version: "1.0.0" },
+    {
+      capabilities: {
+        extensions: {
+          "io.modelcontextprotocol/ui": {
+            mimeTypes: ["text/html;profile=mcp-app"],
+          },
+        },
+      },
+    },
+  )
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  try {
+    return await run(client)
+  } finally {
+    await client.close()
+    await server.close()
+  }
+}
+
+test("negotiates MCP Apps and links the render tool to a ui:// resource", async () => {
+  await withClient(async (client) => {
+    expect(client.getServerCapabilities()?.extensions).toEqual({
+      "io.modelcontextprotocol/ui": {
+        mimeTypes: ["text/html;profile=mcp-app"],
+      },
+    })
+
+    const tools = await client.listTools()
+    const tool = tools.tools.find((candidate) => candidate.name === DYNAMIC_ARTIFACT_APP_TOOL_NAME)
+    expect(tool?._meta).toMatchObject({
+      ui: {
+        resourceUri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+        visibility: ["model", "app"],
+      },
+      "ui/resourceUri": DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+    })
+
+    const resources = await client.listResources()
+    const resource = resources.resources.find((candidate) => candidate.uri === DYNAMIC_ARTIFACT_APP_RESOURCE_URI)
+    expect(resource).toMatchObject({
+      uri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+      mimeType: "text/html;profile=mcp-app",
+      _meta: {
+        ui: {
+          csp: {
+            connectDomains: [],
+            resourceDomains: [],
+            frameDomains: [],
+            baseUriDomains: [],
+          },
+          prefersBorder: true,
+        },
+      },
+    })
+  })
+})
+
+test("serves a self-contained HTML5 app and a structured result with Markdown fallback", async () => {
+  await withClient(async (client) => {
+    const resource = await client.readResource({ uri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI })
+    expect(resource.contents).toHaveLength(1)
+    expect(resource.contents[0]).toMatchObject({
+      uri: DYNAMIC_ARTIFACT_APP_RESOURCE_URI,
+      mimeType: "text/html;profile=mcp-app",
+    })
+    const content = resource.contents[0]
+    expect(content && "text" in content ? content.text : "").toBe(DYNAMIC_ARTIFACT_APP_HTML)
+    expect(DYNAMIC_ARTIFACT_APP_HTML).toStartWith("<!doctype html>")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).toContain("method: 'ui/initialize'")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).toContain("ui/notifications/initialized")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).toContain("ui/notifications/tool-result")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).toContain("ui/notifications/size-changed")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).not.toContain("<script src=")
+    expect(DYNAMIC_ARTIFACT_APP_HTML).not.toContain("fetch(")
+    const inlineScript = DYNAMIC_ARTIFACT_APP_HTML.match(/<script>([\s\S]+)<\/script>/)?.[1]
+    expect(inlineScript).toBeDefined()
+    expect(() => Function(inlineScript ?? "")).not.toThrow()
+
+    const result = await client.callTool({
+      name: DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+      arguments: { configObjectId: "configObject_pipeline" },
+    })
+    expect(result.isError).not.toBe(true)
+    expect(dynamicArtifactAppPayloadSchema.parse(result.structuredContent)).toEqual(payload)
+    const first = result.content[0]
+    expect(first?.type === "text" ? first.text : "").toContain("# Weekly pipeline")
+    expect(first?.type === "text" ? first.text : "").toContain("| Qualified | 12 |")
+    expect(result._meta).toEqual({
+      schemaVersion: "1",
+      receiptId: "codemodeRun_week_32",
+      resultDigest: `sha256:${"a".repeat(64)}`,
+    })
+  })
+})
+
+test("keeps missing snapshots useful to clients without a UI", async () => {
+  await withClient(async (client) => {
+    const result = await client.callTool({
+      name: DYNAMIC_ARTIFACT_APP_TOOL_NAME,
+      arguments: {
+        configObjectId: "configObject_pipeline",
+        receiptId: "missing",
+      },
+    })
+    expect(result.isError).toBe(true)
+    const first = result.content[0]
+    expect(first?.type === "text" ? JSON.parse(first.text) : null).toEqual({
+      error: "saved_script_snapshot_not_found",
+      message: "Snapshot not found.",
+    })
+  })
+})

--- a/evals/specs/saved-script-automations.slow.test.ts
+++ b/evals/specs/saved-script-automations.slow.test.ts
@@ -341,16 +341,16 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   const renderTool = tools.find((candidate) => candidate.name === "render_dynamic_artifact");
   const renderToolMeta = isRecord(renderTool?._meta) ? renderTool._meta : {};
   const modernUi = isRecord(renderToolMeta.ui) ? renderToolMeta.ui : {};
-  expect(modernUi.resourceUri).toBe("ui://openwork/dynamic-artifact/view.html");
-  expect(renderToolMeta["ui/resourceUri"]).toBe("ui://openwork/dynamic-artifact/view.html");
+  expect(modernUi.resourceUri).toBe("ui://openwork/dynamic-artifact/v1/view.html");
+  expect(renderToolMeta["ui/resourceUri"]).toBe("ui://openwork/dynamic-artifact/v1/view.html");
 
   const resourceList = await agentRpc(den.ref.apiUrl, mcpToken, "resources/list", {});
   const resources = Array.isArray(resourceList.resources) ? resourceList.resources.filter(isRecord) : [];
-  const appResource = resources.find((candidate) => candidate.uri === "ui://openwork/dynamic-artifact/view.html");
+  const appResource = resources.find((candidate) => candidate.uri === "ui://openwork/dynamic-artifact/v1/view.html");
   expect(appResource?.mimeType).toBe("text/html;profile=mcp-app");
 
   const resourceRead = await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", {
-    uri: "ui://openwork/dynamic-artifact/view.html",
+    uri: "ui://openwork/dynamic-artifact/v1/view.html",
   });
   const resourceContents = Array.isArray(resourceRead.contents) ? resourceRead.contents.filter(isRecord) : [];
   expect(resourceContents[0]?.mimeType).toBe("text/html;profile=mcp-app");

--- a/evals/specs/saved-script-automations.slow.test.ts
+++ b/evals/specs/saved-script-automations.slow.test.ts
@@ -92,6 +92,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+let mcpRequestId = 0;
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value).slice(0, 500)}`);
+  return value;
+}
+
+async function agentRpc(
+  apiUrl: string,
+  token: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++mcpRequestId, method, params }),
+    signal: AbortSignal.timeout(180_000),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP ${method} failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`MCP ${method} returned no SSE data frame: ${raw.slice(0, 500)}`);
+  const message = requireRecord(JSON.parse(dataLine.slice(5)), "MCP response");
+  if (message.error) throw new Error(`MCP ${method} returned an error: ${JSON.stringify(message.error)}`);
+  return requireRecord(message.result, `MCP ${method} result`);
+}
+
 test("a Code Mode result becomes a cloud Automation and a durable artifact result", { timeout: 1_500_000 }, async ({ evidence, place }) => {
   needs(requirements);
   await using den = await server({
@@ -278,6 +310,72 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
     "No desktop execution thread, model requirement, or error banner is visible",
   ]);
   expect(seen.ok, seen.why).toBe(true);
+
+  const scriptsResponse = await denFetch(den.admin, "/v1/codemode-scripts", {
+    headers: { authorization: `Bearer ${den.admin.token}` },
+  });
+  expect(scriptsResponse.response.ok, scriptsResponse.text).toBe(true);
+  const scripts = isRecord(scriptsResponse.body) && Array.isArray(scriptsResponse.body.items)
+    ? scriptsResponse.body.items.filter(isRecord)
+    : [];
+  const savedScript = scripts.find((candidate) => candidate.title === scriptName);
+  const configObjectId = typeof savedScript?.configObjectId === "string" ? savedScript.configObjectId : "";
+  expect(configObjectId).not.toBe("");
+
+  const tokenResponse = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  expect(tokenResponse.response.ok, tokenResponse.text).toBe(true);
+  const mcpToken = isRecord(tokenResponse.body) && typeof tokenResponse.body.token === "string"
+    ? tokenResponse.body.token
+    : "";
+  expect(mcpToken).toMatch(/^ow_mcp_at_/);
+
+  const toolList = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {});
+  const tools = Array.isArray(toolList.tools) ? toolList.tools.filter(isRecord) : [];
+  const renderTool = tools.find((candidate) => candidate.name === "render_dynamic_artifact");
+  const renderToolMeta = isRecord(renderTool?._meta) ? renderTool._meta : {};
+  const modernUi = isRecord(renderToolMeta.ui) ? renderToolMeta.ui : {};
+  expect(modernUi.resourceUri).toBe("ui://openwork/dynamic-artifact/view.html");
+  expect(renderToolMeta["ui/resourceUri"]).toBe("ui://openwork/dynamic-artifact/view.html");
+
+  const resourceList = await agentRpc(den.ref.apiUrl, mcpToken, "resources/list", {});
+  const resources = Array.isArray(resourceList.resources) ? resourceList.resources.filter(isRecord) : [];
+  const appResource = resources.find((candidate) => candidate.uri === "ui://openwork/dynamic-artifact/view.html");
+  expect(appResource?.mimeType).toBe("text/html;profile=mcp-app");
+
+  const resourceRead = await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", {
+    uri: "ui://openwork/dynamic-artifact/view.html",
+  });
+  const resourceContents = Array.isArray(resourceRead.contents) ? resourceRead.contents.filter(isRecord) : [];
+  expect(resourceContents[0]?.mimeType).toBe("text/html;profile=mcp-app");
+  expect(String(resourceContents[0]?.text ?? "")).toContain("ui/initialize");
+  expect(String(resourceContents[0]?.text ?? "")).not.toContain("fetch(");
+
+  const rendered = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "render_dynamic_artifact",
+    arguments: { configObjectId },
+  });
+  expect(rendered.isError).not.toBe(true);
+  const structured = requireRecord(rendered.structuredContent, "Dynamic Artifact structuredContent");
+  const artifact = requireRecord(structured.artifact, "Dynamic Artifact lineage");
+  const fallback = Array.isArray(rendered.content) ? rendered.content.filter(isRecord) : [];
+  expect(structured.schemaVersion).toBe("1");
+  expect(artifact.configObjectId).toBe(configObjectId);
+  expect(artifact.source).toBe("scheduled");
+  expect(String(artifact.receiptId ?? "")).not.toBe("");
+  expect(JSON.stringify(structured.data)).toContain(scheduledMarker);
+  expect(String(fallback[0]?.text ?? "")).toContain(scheduledMarker);
+  evidence.fact(
+    "The latest Automation snapshot is portable as a standards-based MCP App",
+    "The agent endpoint links render_dynamic_artifact to a self-contained ui:// resource and returns the scheduled result as versioned structuredContent plus a Markdown fallback.",
+    true,
+  );
 
   const policyChangedAt = new Date().toISOString();
   const disabled = await denFetch(den.admin, `/v1/mcp-connections/${connection.id}/tool-policy`, {

--- a/packages/types/src/dynamic-artifacts.ts
+++ b/packages/types/src/dynamic-artifacts.ts
@@ -99,3 +99,30 @@ export const savedScriptTestResultSchema = z.object({
   finishedAt: z.string().datetime(),
 })
 export type SavedScriptTestResult = z.infer<typeof savedScriptTestResultSchema>
+
+/**
+ * Stable data contract injected into the Dynamic Artifact MCP App view.
+ *
+ * Keep this independent from the presentation resource so MCP hosts and other
+ * OpenWork surfaces can validate the same result without understanding the UI.
+ */
+export const dynamicArtifactAppSchemaVersion = "1" as const
+export const dynamicArtifactAppPayloadSchema = z.object({
+  schemaVersion: z.literal(dynamicArtifactAppSchemaVersion),
+  artifact: z.object({
+    title: z.string().trim().min(1).max(255),
+    description: z.string().nullable(),
+    pluginId: idSchema,
+    configObjectId: idSchema,
+    configObjectVersionId: idSchema,
+    receiptId: idSchema,
+    automationRunId: idSchema.nullable(),
+    source: z.enum(["manual", "scheduled"]),
+    generatedAt: z.string().datetime(),
+    resultDigest: digestSchema,
+    rendererVersion: z.literal("codemode-markdown-v1"),
+    freshness: artifactFreshnessSchema,
+  }),
+  data: z.unknown(),
+})
+export type DynamicArtifactAppPayload = z.infer<typeof dynamicArtifactAppPayloadSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       '@hono/swagger-ui':
         specifier: ^0.6.1
         version: 0.6.1(hono@4.12.34)
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.7.5
+        version: 1.7.5(@modelcontextprotocol/sdk@1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
@@ -2600,6 +2603,20 @@ packages:
 
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+
+  '@modelcontextprotocol/ext-apps@1.7.5':
+    resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -10445,6 +10462,15 @@ snapshots:
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@marijn/find-cluster-break@1.0.3': {}
+
+  '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.3.6
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@modelcontextprotocol/sdk@1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## Summary

- add the standards-based MCP Apps provider foundation for saved Code Mode Script snapshots
- expose a read-only `render_dynamic_artifact` tool with versioned structured content and complete Markdown fallback
- serve a self-contained Preview/Data/Lineage resource at `ui://openwork/dynamic-artifact/v1/view.html`
- keep execution boundaries explicit: manual runs and Automations refresh immutable data snapshots; the MCP App only reads and presents them

## Standards alignment

The agent MCP endpoint uses the official `@modelcontextprotocol/ext-apps` server helpers and advertises the `io.modelcontextprotocol/ui` extension:

- `text/html;profile=mcp-app` resource delivery through `resources/read`
- tool linkage through `_meta.ui.resourceUri` and its compatibility alias
- the 2026-01-26 initialize, initialized, tool-input/result, host-context, size-change, cancellation, and teardown lifecycle
- closed network, frame, resource, and base-URI permissions
- DOM text rendering with no caller-provided HTML, external scripts, or network requests

References: [MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview) and [2026-01-26 specification](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).

## Product and security behavior

The renderer reuses the existing organization membership, team grants, and saved-Script authorization path. A caller supplies only a Script ID, optional exact receipt, and optional freshness threshold. Missing, failed, deleted, unreadable, or unauthorized snapshots fail closed without exposing internal details.

Common result shapes render as bounded tables or metric cards; the Data and Lineage views retain the full structured result and immutable receipt/version/source/digest facts. Unsupported MCP Apps clients receive the same artifact as Markdown.

## Scope boundary

This PR is the provider half of the vertical. It does not add an MCP Apps host to the OpenWork desktop conversation surface. Until that follow-up lands, desktop users continue to receive the Markdown fallback. The host remains a separate implementation because it must preserve MCP metadata and structured results through the OpenCode boundary, resolve and validate resources, and enforce an opaque sandbox/bridge lifecycle generically for upstream MCP servers.

## Verification

Exact base/head at publication:

- base: `bf689dfbea3f5d87b866fe600b2ebc555dbfdb90`
- head: `149ece5c5`

Passed locally:

- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-dynamic-artifact-app.test.ts` — 5 passed, 27 assertions
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm evals:typecheck`
- prior unchanged provider proof: Den build, focused agent initialization, and frozen-lockfile validation

The opt-in saved-Script/Automation testkit journey is extended and typechecked but has not run in the required Den/model environment. No real iframe-host proof is claimed in this provider-only PR.