### PR TITLE
fix(den-api): add nosniff security header

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -82,6 +82,10 @@ app.use("*", async (c, next) => {
   await next()
   c.header("X-Request-Id", c.get("requestId"))
 })
+app.use("*", async (c, next) => {
+  await next()
+  c.header("X-Content-Type-Options", "nosniff")
+})
 app.use("*", createTelemetryErrorSanitizerMiddleware())
 app.use("*", async (c, next) => {
   await next()

--- a/ee/apps/den-api/test/security-headers.test.ts
+++ b/ee/apps/den-api/test/security-headers.test.ts
@@ -1,0 +1,40 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_API_PUBLIC_URL = process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://localhost:3005"
+}
+
+let app: typeof import("../src/app.js")["default"]
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  app = (await import("../src/app.js")).default
+})
+
+describe("security headers", () => {
+  test("JSON responses disable MIME sniffing", async () => {
+    const response = await app.request("/health")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+  })
+
+  test("middleware responses disable MIME sniffing", async () => {
+    const response = await app.request("/v1/auth/desktop-handoff/exchange", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://8787-rotating.daytonaproxy01.net",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type,authorization",
+      },
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+  })
+})


### PR DESCRIPTION
## Summary
- add global X-Content-Type-Options: nosniff header middleware for den-api responses
- add focused coverage for JSON responses and middleware-generated CORS preflight responses

## Tests
- bun --conditions=development test test/security-headers.test.ts
- pnpm --filter @openwork-ee/den-api build