### PR TITLE
fix(den-api): add HSTS security header

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -72,6 +72,7 @@ const openApiDocumentSchema = z.object({
 }).passthrough().meta({ ref: "OpenApiDocument" })
 
 const app = new Hono<{ Variables: AppVariables }>()
+const strictTransportSecurityHeader = "max-age=31536000; includeSubDomains"
 
 registerObservabilityMiddleware(app)
 app.use("*", requestId({
@@ -85,6 +86,7 @@ app.use("*", async (c, next) => {
 app.use("*", async (c, next) => {
   await next()
   c.header("X-Content-Type-Options", "nosniff")
+  c.header("Strict-Transport-Security", strictTransportSecurityHeader)
 })
 app.use("*", createTelemetryErrorSanitizerMiddleware())
 app.use("*", async (c, next) => {

--- a/ee/apps/den-api/test/security-headers.test.ts
+++ b/ee/apps/den-api/test/security-headers.test.ts
@@ -17,11 +17,14 @@ beforeAll(async () => {
 })
 
 describe("security headers", () => {
+  const hstsPolicy = "max-age=31536000; includeSubDomains"
+
   test("JSON responses disable MIME sniffing", async () => {
     const response = await app.request("/health")
 
     expect(response.status).toBe(200)
     expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+    expect(response.headers.get("strict-transport-security")).toBe(hstsPolicy)
   })
 
   test("middleware responses disable MIME sniffing", async () => {
@@ -36,5 +39,14 @@ describe("security headers", () => {
 
     expect(response.status).toBe(204)
     expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+    expect(response.headers.get("strict-transport-security")).toBe(hstsPolicy)
+  })
+
+  test("not-found responses include transport security", async () => {
+    const response = await app.request("/robots.txt")
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+    expect(response.headers.get("strict-transport-security")).toBe(hstsPolicy)
   })
 })


### PR DESCRIPTION
## Summary
- add a global `Strict-Transport-Security: max-age=31536000; includeSubDomains` header to the Den API
- cover JSON responses, CORS preflights, redirects, and 404s like `/robots.txt`
- extend the existing Den API security-header test coverage

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/security-headers.test.ts`
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`

## Astra
- Remediates vulnerability `7a96a269-5bd2-4e65-83bb-6d9ba39365b3` for `https://api.openworklabs.com`.