### PR TITLE
fix: harden managed OpenCode engine lifecycle tracking

### DIFF
--- a/apps/app/src/react-app/shell/engine-reload-escalation.ts
+++ b/apps/app/src/react-app/shell/engine-reload-escalation.ts
@@ -1,0 +1,90 @@
+// Shared escalation policy for engine reload failures.
+//
+// A full desktop engine restart (engineRestart) kills every live session, so
+// it is the last resort — only for server-reported states that a reload
+// cannot recover from, and only after re-verifying that an "unreachable"
+// engine is not a transient hiccup (mid-teardown, briefly overloaded, an
+// aborted loopback fetch). opencode_reload_timeout deliberately never lands
+// here: the server reports it while a dispose is still tearing down, and
+// restarting mid-teardown would kill the very sessions being drained.
+import { engineRestart } from "@/app/lib/desktop";
+import { OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
+import { isDesktopRuntime } from "@/app/lib/runtime-env";
+
+const UNREACHABLE_RETRY_DELAY_MS = 1500;
+
+export function canRestartDesktopForReloadError(error: unknown) {
+  return (
+    error instanceof OpenworkServerError &&
+    (error.code === "opencode_engine_unreachable" || error.code === "opencode_unconfigured")
+  );
+}
+
+function isEngineUnreachableError(error: unknown) {
+  return error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
+}
+
+/**
+ * Aborted or timed-out fetches are client→server transport blips (including
+ * AbortSignal-cancelable fetch cancellations), not proof the engine is gone.
+ * They must surface as errors, never as a restart.
+ */
+function isTransientTransportError(error: unknown) {
+  return (
+    typeof DOMException !== "undefined" &&
+    error instanceof DOMException &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type ReloadEngineFallbackResult = {
+  restartedEngine: boolean;
+};
+
+export type ReloadEngineFallbackOptions = {
+  retryDelayMs?: number;
+  /** Injectable for tests; defaults to the desktop engineRestart bridge. */
+  restartEngine?: () => Promise<unknown>;
+  /** Injectable for tests; defaults to isDesktopRuntime. */
+  isDesktop?: () => boolean;
+};
+
+/**
+ * Reload the workspace engine; escalate to a full desktop engine restart only
+ * when the reload keeps failing with a restartable server-reported code.
+ * `opencode_engine_unreachable` gets one delayed retry first — if the engine
+ * answers the second attempt, no session is disturbed.
+ */
+export async function reloadEngineWithDesktopFallback(
+  client: Pick<OpenworkServerClient, "reloadEngine">,
+  workspaceId: string,
+  options?: ReloadEngineFallbackOptions,
+): Promise<ReloadEngineFallbackResult> {
+  const restartEngine = options?.restartEngine ?? (() => engineRestart({}));
+  const isDesktop = options?.isDesktop ?? isDesktopRuntime;
+  try {
+    await client.reloadEngine(workspaceId);
+    return { restartedEngine: false };
+  } catch (error) {
+    if (isTransientTransportError(error)) throw error;
+    if (!canRestartDesktopForReloadError(error) || !isDesktop()) {
+      throw error;
+    }
+    if (isEngineUnreachableError(error)) {
+      await delay(options?.retryDelayMs ?? UNREACHABLE_RETRY_DELAY_MS);
+      try {
+        await client.reloadEngine(workspaceId);
+        return { restartedEngine: false };
+      } catch (retryError) {
+        if (isTransientTransportError(retryError)) throw retryError;
+        if (!canRestartDesktopForReloadError(retryError)) throw retryError;
+      }
+    }
+    await restartEngine();
+    return { restartedEngine: true };
+  }
+}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -14,7 +14,6 @@ import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
   readOpenworkServerSettings,
-  OpenworkServerError,
   type OpenworkCloudMcpHealth,
   type OpenworkCloudMcpProviderModelContext,
   type OpenworkServerCapabilities,
@@ -113,7 +112,6 @@ import {
   openworkServerInfo,
   openworkServerRestart,
   engineStart,
-  engineRestart,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
   workspaceForget,
@@ -159,6 +157,7 @@ import type { ModelRef } from "@/app/types";
 import { workspaceSwatchColor } from "@/react-app/domains/session/sidebar/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
+import { reloadEngineWithDesktopFallback } from "./engine-reload-escalation";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { notifyAlert } from "./notifications";
@@ -196,25 +195,13 @@ const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
   config: { read: true, write: true },
 };
 
-function canRestartDesktopForReloadError(error: unknown) {
-  return (
-    error instanceof OpenworkServerError &&
-    (error.code === "opencode_engine_unreachable" || error.code === "opencode_unconfigured")
-  );
-}
-
 async function reloadEngineOrRestartDesktop(
   client: Pick<OpenworkServerClient, "reloadEngine">,
   workspaceId: string,
   afterRestart?: () => Promise<void>,
 ): Promise<void> {
-  try {
-    await client.reloadEngine(workspaceId);
-  } catch (error) {
-    if (!canRestartDesktopForReloadError(error) || !isDesktopRuntime()) {
-      throw error;
-    }
-    await engineRestart({});
+  const { restartedEngine } = await reloadEngineWithDesktopFallback(client, workspaceId);
+  if (restartedEngine) {
     await afterRestart?.();
   }
 }

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -5,12 +5,13 @@
 // instead of `any`.
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { engineInfo, engineRestart } from "@/app/lib/desktop";
+import { engineInfo } from "@/app/lib/desktop";
 import type { EngineInfo } from "@/app/lib/desktop-types";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
-import { OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import { t } from "@/i18n";
+import { reloadEngineWithDesktopFallback } from "./engine-reload-escalation";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
@@ -18,13 +19,6 @@ import type { RouteWorkspace } from "./route-workspaces";
 import { toast } from "@/components/ui/sonner";
 
 const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
-
-function canRestartDesktopForReloadError(error: unknown) {
-  return (
-    error instanceof OpenworkServerError &&
-    (error.code === "opencode_engine_unreachable" || error.code === "opencode_unconfigured")
-  );
-}
 
 function taskCreateUnavailableToastId(workspaceId: string) {
   return `opencode-unavailable:${workspaceId}`;
@@ -67,16 +61,10 @@ export function useEngineReload(input: UseEngineReloadInput) {
       onError(t("app.error_connect_first"));
       return false;
     }
-    let restartedEngine = false;
-    try {
-      await endpoint.client.reloadEngine(endpoint.workspaceId);
-    } catch (error) {
-      if (!canRestartDesktopForReloadError(error) || !isDesktopRuntime()) {
-        throw error;
-      }
-      await engineRestart({});
-      restartedEngine = true;
-    }
+    const { restartedEngine } = await reloadEngineWithDesktopFallback(
+      endpoint.client,
+      endpoint.workspaceId,
+    );
     if (restartedEngine) {
       await refreshRouteState();
       await refreshProviderListQueries(getReactQueryClient()).catch(() => undefined);

--- a/apps/app/tests/engine-reload-escalation.test.ts
+++ b/apps/app/tests/engine-reload-escalation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenworkServerError } from "../src/app/lib/openwork-server";
+import { reloadEngineWithDesktopFallback } from "../src/react-app/shell/engine-reload-escalation";
+
+function unreachableError() {
+  return new OpenworkServerError(503, "opencode_engine_unreachable", "engine unreachable");
+}
+
+function unconfiguredError() {
+  return new OpenworkServerError(400, "opencode_unconfigured", "engine unconfigured");
+}
+
+type Harness = {
+  reloadCalls: number;
+  restartCalls: number;
+  client: { reloadEngine: (workspaceId: string) => Promise<void> };
+  options: {
+    retryDelayMs: number;
+    restartEngine: () => Promise<void>;
+    isDesktop: () => boolean;
+  };
+};
+
+function makeHarness(reloadResults: Array<Error | null>, isDesktop = true): Harness {
+  const harness: Harness = {
+    reloadCalls: 0,
+    restartCalls: 0,
+    client: {
+      reloadEngine: async () => {
+        const result = reloadResults[harness.reloadCalls];
+        harness.reloadCalls += 1;
+        if (result) throw result;
+      },
+    },
+    options: {
+      retryDelayMs: 1,
+      restartEngine: async () => {
+        harness.restartCalls += 1;
+      },
+      isDesktop: () => isDesktop,
+    },
+  };
+  return harness;
+}
+
+describe("reloadEngineWithDesktopFallback", () => {
+  test("a successful reload never restarts", async () => {
+    const harness = makeHarness([null]);
+    const result = await reloadEngineWithDesktopFallback(harness.client, "ws", harness.options);
+    expect(result.restartedEngine).toBe(false);
+    expect(harness.reloadCalls).toBe(1);
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("a transient unreachable engine recovers on the retry without a restart", async () => {
+    const harness = makeHarness([unreachableError(), null]);
+    const result = await reloadEngineWithDesktopFallback(harness.client, "ws", harness.options);
+    expect(result.restartedEngine).toBe(false);
+    expect(harness.reloadCalls).toBe(2);
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("a persistently unreachable engine escalates to a restart", async () => {
+    const harness = makeHarness([unreachableError(), unreachableError()]);
+    const result = await reloadEngineWithDesktopFallback(harness.client, "ws", harness.options);
+    expect(result.restartedEngine).toBe(true);
+    expect(harness.reloadCalls).toBe(2);
+    expect(harness.restartCalls).toBe(1);
+  });
+
+  test("an unconfigured engine restarts immediately — there is nothing to re-probe", async () => {
+    const harness = makeHarness([unconfiguredError()]);
+    const result = await reloadEngineWithDesktopFallback(harness.client, "ws", harness.options);
+    expect(result.restartedEngine).toBe(true);
+    expect(harness.reloadCalls).toBe(1);
+    expect(harness.restartCalls).toBe(1);
+  });
+
+  test("an aborted fetch is transport noise, never a restart", async () => {
+    const harness = makeHarness([new DOMException("aborted", "AbortError")]);
+    await expect(reloadEngineWithDesktopFallback(harness.client, "ws", harness.options)).rejects.toThrow("aborted");
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("an aborted retry surfaces instead of restarting", async () => {
+    const harness = makeHarness([unreachableError(), new DOMException("aborted", "AbortError")]);
+    await expect(reloadEngineWithDesktopFallback(harness.client, "ws", harness.options)).rejects.toThrow("aborted");
+    expect(harness.reloadCalls).toBe(2);
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("a non-restartable retry failure surfaces to the caller", async () => {
+    const retryFailure = new OpenworkServerError(502, "opencode_reload_failed", "dispose failed");
+    const harness = makeHarness([unreachableError(), retryFailure]);
+    await expect(reloadEngineWithDesktopFallback(harness.client, "ws", harness.options)).rejects.toBe(retryFailure);
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("non-desktop runtimes never restart", async () => {
+    const error = unreachableError();
+    const harness = makeHarness([error], false);
+    await expect(reloadEngineWithDesktopFallback(harness.client, "ws", harness.options)).rejects.toBe(error);
+    expect(harness.reloadCalls).toBe(1);
+    expect(harness.restartCalls).toBe(0);
+  });
+
+  test("reload timeouts surface instead of restarting mid-teardown", async () => {
+    const timeout = new OpenworkServerError(504, "opencode_reload_timeout", "dispose still tearing down");
+    const harness = makeHarness([timeout]);
+    await expect(reloadEngineWithDesktopFallback(harness.client, "ws", harness.options)).rejects.toBe(timeout);
+    expect(harness.restartCalls).toBe(0);
+  });
+});

--- a/apps/desktop/electron/nuke.mjs
+++ b/apps/desktop/electron/nuke.mjs
@@ -25,6 +25,7 @@ const OPENWORK_CONFIG_FILENAMES = [
   "runtime.sqlite-wal",
   "runtime.sqlite-shm",
   "runtime-opencode-config.json",
+  "engine-instances.json",
   "tokens.json",
   "env.json",
   "connect-state.json",

--- a/apps/desktop/electron/nuke.test.mjs
+++ b/apps/desktop/electron/nuke.test.mjs
@@ -124,6 +124,7 @@ test("buildNukeManifest includes default macOS state roots and preserves bootstr
   assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/runtime.sqlite-wal"));
   assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/runtime.sqlite-shm"));
   assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/runtime-opencode-config.json"));
+  assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/engine-instances.json"));
   assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/tokens.json"));
   assert.ok(manifest.deletePaths.includes("/Users/alice/.config/openwork/env.json"));
   assert.ok(manifest.deletePaths.includes("/Users/alice/.local/share/opencode"));

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -206,6 +206,32 @@ function snapshotOpenworkServerState(state) {
   };
 }
 
+/**
+ * A failed server start must not leave the state objects describing the
+ * runtime it already stopped: snapshotOpenworkServerState would report
+ * running:true with a dead baseUrl and assertOpenworkServerReady would pass
+ * against it. Keeps accumulated output for diagnostics and the project dir so
+ * a retry via engineRestart still knows its workspace. The engine state only
+ * resets when this start owned the engine (manageOpencode) — an external
+ * engine keeps running regardless of the server's fate.
+ */
+export function resetRuntimeStatesAfterFailedServerStart(openworkServerStateRef, engineStateRef, options = {}) {
+  const serverStdout = openworkServerStateRef.lastStdout;
+  const serverStderr = openworkServerStateRef.lastStderr;
+  Object.assign(openworkServerStateRef, createOpenworkServerState());
+  openworkServerStateRef.lastStdout = serverStdout;
+  openworkServerStateRef.lastStderr = serverStderr;
+  if (options.manageOpencode === true) {
+    const engineStdout = engineStateRef.lastStdout;
+    const engineStderr = engineStateRef.lastStderr;
+    const projectDir = engineStateRef.projectDir;
+    Object.assign(engineStateRef, createEngineState());
+    engineStateRef.lastStdout = engineStdout;
+    engineStateRef.lastStderr = engineStderr;
+    engineStateRef.projectDir = projectDir;
+  }
+}
+
 function assertOpenworkServerReady(snapshot) {
   if (!snapshot?.running) {
     throw new Error("OpenWork server did not stay running after startup.");
@@ -1550,6 +1576,17 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   let inProcessServer = null;
 
   async function startOpenworkServer(options) {
+    // The inner start stops any previous runtime before mutating state, so a
+    // throw below always happens with nothing left running.
+    try {
+      return await startOpenworkServerInner(options);
+    } catch (error) {
+      resetRuntimeStatesAfterFailedServerStart(openworkServerState, engineState, options);
+      throw error;
+    }
+  }
+
+  async function startOpenworkServerInner(options) {
     const evalDelayMs = resolveEvalLocalServerDelayMs();
     if (evalDelayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, evalDelayMs));

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -9,6 +9,7 @@ import {
   commandMatchesPackagedSidecar,
   embeddedServerImportUrl,
   prioritizeWorkspacePaths,
+  resetRuntimeStatesAfterFailedServerStart,
   resolveEvalLocalServerDelayMs,
   resolveOpenworkServerConfigPath,
   seedWorkspacePathsForEmbeddedServer,
@@ -180,5 +181,87 @@ describe("snapshotEngineState", () => {
     assert.equal(snapshot.running, true);
     assert.equal(snapshot.managedByServer, true);
     assert.equal(snapshot.pid, 12345);
+  });
+});
+
+describe("resetRuntimeStatesAfterFailedServerStart", () => {
+  function staleServerState() {
+    return {
+      child: null,
+      childExited: true,
+      inProcess: true,
+      remoteAccessEnabled: true,
+      host: "127.0.0.1",
+      port: 4141,
+      baseUrl: "http://127.0.0.1:4141",
+      connectUrl: null,
+      mdnsUrl: null,
+      lanUrl: null,
+      clientToken: "client-token",
+      ownerToken: "owner-token",
+      hostToken: "host-token",
+      managedOpencodeBinPath: "/usr/local/bin/opencode",
+      managedOpencodeBinSource: "known-location",
+      lastStdout: "server stdout",
+      lastStderr: "server stderr",
+      managedOpencodeExecution: { command: "opencode" },
+    };
+  }
+
+  function staleEngineState() {
+    return {
+      child: null,
+      childExited: false,
+      runtime: "direct",
+      projectDir: "/workspace/current",
+      hostname: "127.0.0.1",
+      port: 4097,
+      baseUrl: "http://127.0.0.1:4097",
+      opencodeUsername: "user",
+      opencodePassword: "pass",
+      opencodeBinPath: "/usr/local/bin/opencode",
+      opencodeBinSource: "known-location",
+      managedByServer: true,
+      managedPid: 12345,
+      managedIsAlive: () => true,
+      lastStdout: "engine stdout",
+      lastStderr: "engine stderr",
+      execution: { command: "opencode" },
+    };
+  }
+
+  it("clears a dead managed runtime so snapshots cannot report it running", () => {
+    const serverState = staleServerState();
+    const engineState = staleEngineState();
+
+    resetRuntimeStatesAfterFailedServerStart(serverState, engineState, { manageOpencode: true });
+
+    assert.equal(serverState.inProcess, false);
+    assert.equal(serverState.port, null);
+    assert.equal(serverState.baseUrl, null);
+    assert.equal(serverState.ownerToken, null);
+    // Diagnostics survive the reset.
+    assert.equal(serverState.lastStdout, "server stdout");
+    assert.equal(serverState.lastStderr, "server stderr");
+
+    assert.equal(engineState.baseUrl, null);
+    assert.equal(engineState.managedByServer, false);
+    assert.equal(engineState.managedPid, null);
+    assert.equal(snapshotEngineState(engineState).running, false);
+    // A retry via engineRestart still knows its workspace.
+    assert.equal(engineState.projectDir, "/workspace/current");
+    assert.equal(engineState.lastStderr, "engine stderr");
+  });
+
+  it("leaves an external engine untouched when the failed start did not manage it", () => {
+    const serverState = staleServerState();
+    const engineState = staleEngineState();
+    engineState.managedByServer = false;
+
+    resetRuntimeStatesAfterFailedServerStart(serverState, engineState, { manageOpencode: false });
+
+    assert.equal(serverState.inProcess, false);
+    assert.equal(engineState.baseUrl, "http://127.0.0.1:4097");
+    assert.equal(engineState.projectDir, "/workspace/current");
   });
 });

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -4,6 +4,12 @@ import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
+import {
+  buildEngineAuthProbeHeader,
+  registerEngineInstance,
+  removeEngineInstance,
+  reapOrphanEngineInstances,
+} from "./engine-registry.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import {
   clearTrustedOpencodeProcess,
@@ -34,17 +40,29 @@ if (args.version) {
 
 const config = await resolveServerConfig(args);
 const logger = createServerLogger(config);
-const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
 let managedOpencode: ManagedOpencodeServer | null = null;
 let managedOpencodeIdentity: string | null = null;
+let managedEngineRecordId: string | null = null;
 
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
 }
 
+// Bind the HTTP server before spawning the engine: serve-node may fall back
+// to an OS-assigned port on EADDRINUSE, and the engine's spawn-time env
+// (OPENWORK_SERVER_URL) must point at the port that actually bound, not the
+// requested one.
+const server = await startServer(config);
+config.port = server.port;
+const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`;
+const workerActivityHeartbeat = startWorkerActivityHeartbeat(config, logger);
+
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   const workspace = findManagedEngineWorkspace(config.workspaces);
   if (workspace) {
+    // Reap engines recorded by servers that died without cleanup. Best
+    // effort: a failed reap must never block startup.
+    await reapOrphanEngineInstances(config, { logger }).catch(() => undefined);
     // Server-managed config file: the engine re-reads it from disk on every
     // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
     // on every runtime-DB write — so disposes always pick up current state.
@@ -88,12 +106,24 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
       identity: managedOpencodeIdentity,
       isAlive: managedOpencode.isAlive,
     });
+    if (managedOpencode.pid) {
+      managedEngineRecordId = randomUUID();
+      await registerEngineInstance(config, {
+        id: managedEngineRecordId,
+        pid: managedOpencode.pid,
+        port: Number(new URL(managedOpencode.url).port) || 0,
+        url: managedOpencode.url,
+        startedAt: Date.now(),
+        role: "primary",
+        serverRunId: managedOpencodeIdentity,
+        ownerPid: process.pid,
+        authProbe: buildEngineAuthProbeHeader(managedOpencode.username, managedOpencode.password),
+        bin: process.env.OPENWORK_OPENCODE_BIN?.trim() || "opencode",
+      }).catch(() => undefined);
+    }
     logger.log("info", `Managed OpenCode listening on ${managedOpencode.url}`);
   }
 }
-
-const server = await startServer(config);
-const workerActivityHeartbeat = startWorkerActivityHeartbeat(config, logger);
 
 // The runtime config file above only covers workspaces[0]. Push every
 // workspace's runtime-DB MCPs into the engine so they aren't invisible
@@ -129,20 +159,28 @@ if (args.verbose) {
   logger.log("info", `Host token source: ${config.hostTokenSource}`);
 }
 
-const shutdown = () => {
+const shutdown = async () => {
   workerActivityHeartbeat?.stop();
   if (managedOpencodeIdentity) {
     clearTrustedOpencodeProcess(config, managedOpencodeIdentity);
   }
-  void managedOpencode?.close();
+  // Await the engine teardown (SIGTERM → 1s → SIGKILL, bounded ~1.5s): a
+  // synchronous process.exit here used to skip the escalation entirely and
+  // orphan the OpenCode child to init.
+  try {
+    await managedOpencode?.close();
+  } catch {
+    // Engine already exited.
+  }
+  if (managedEngineRecordId) {
+    await removeEngineInstance(config, managedEngineRecordId).catch(() => undefined);
+  }
   (server as { stop?: (closeActiveConnections?: boolean) => void }).stop?.(true);
 };
 
 process.once("SIGINT", () => {
-  shutdown();
-  process.exit(0);
+  void shutdown().finally(() => process.exit(0));
 });
 process.once("SIGTERM", () => {
-  shutdown();
-  process.exit(0);
+  void shutdown().finally(() => process.exit(0));
 });

--- a/apps/server/src/embedded-lifecycle.test.ts
+++ b/apps/server/src/embedded-lifecycle.test.ts
@@ -1,9 +1,11 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, spyOn, test } from "bun:test";
 
 import { startEmbeddedServer, type EmbeddedServerHandle, type EmbeddedServerOptions } from "./embedded.js";
+import { readEngineRegistry } from "./engine-registry.js";
 import * as managedOpencodeModule from "./managed-opencode.js";
 import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
@@ -51,6 +53,7 @@ async function writeFakeOpencodeBin(root: string): Promise<string> {
     "const logPath = process.env.OPENWORK_LIFECYCLE_LOG;",
     "const append = (line) => { if (logPath) appendFileSync(logPath, `${line}\\n`); };",
     "append(`vault-key:${process.env.OPENWORK_ENCRYPTION_KEY ? 'present' : 'absent'}`);",
+    "append(`server-url:${process.env.OPENWORK_SERVER_URL ?? ''}`);",
     "const server = Bun.serve({",
     "  hostname: '127.0.0.1',",
     "  port: requestedPort,",
@@ -191,6 +194,46 @@ async function logLines(path: string): Promise<string[]> {
 }
 
 describe("embedded server lifecycle", () => {
+  test.serial("spawns the engine against the actually bound server port and records it in the registry", async () => {
+    const fixture = await createFixture();
+    // Occupy a port so serve-node's EADDRINUSE fallback rebinds to an
+    // OS-assigned one: the engine env must follow the bound port, not the
+    // requested one.
+    const blocker = net.createServer();
+    const blockedPort = await new Promise<number>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(0, HOST, () => {
+        const address = blocker.address();
+        if (address && typeof address === "object") resolve(address.port);
+        else reject(new Error("Failed to bind blocker"));
+      });
+    });
+    try {
+      await mkdir(join(fixture.root, "bound-port-workspace"), { recursive: true });
+      const handle = await startEmbeddedServer({
+        ...managedOptions(fixture, "bound-port"),
+        port: blockedPort,
+      });
+      fixture.handles.push(handle);
+
+      expect(handle.port).not.toBe(blockedPort);
+      expect(handle.config.port).toBe(handle.port);
+      expect(await logLines(fixture.logPath)).toContain(`server-url:http://${HOST}:${handle.port}`);
+
+      const entries = await readEngineRegistry(handle.config);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.role).toBe("primary");
+      expect(entries[0]?.pid).toBe(handle.managedOpencode?.pid ?? -1);
+      expect(entries[0]?.ownerPid).toBe(process.pid);
+
+      await handle.stop();
+      expect(await readEngineRegistry(handle.config)).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      await fixture.restore();
+    }
+  });
+
   test.serial("does not expose the vault encryption key to managed OpenCode", async () => {
     const fixture = await createFixture();
     process.env.OPENWORK_ENCRYPTION_KEY = "server-only-vault-key";
@@ -324,32 +367,71 @@ describe("embedded server lifecycle", () => {
     }
   });
 
-  test.serial("startup failure after subscription registration unwinds acquired resources", async () => {
+  test.serial("HTTP startup failure aborts before any engine is spawned", async () => {
     const fixture = await createFixture();
     const startupError = new Error("forced HTTP startup failure");
-    let failedConfig: ServerConfig | null = null;
-    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async (config) => {
-      failedConfig = config;
+    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async () => {
       throw startupError;
     });
-    const clearTrustedSpy = spyOn(serverModule, "clearTrustedOpencodeProcess");
+    const managedSpy = spyOn(managedOpencodeModule, "createManagedOpencodeServer");
 
     try {
       const options = managedOptions(fixture, "startup-failure");
       await mkdir(options.opencodeCwd ?? "", { recursive: true });
       await expect(startEmbeddedServer(options)).rejects.toBe(startupError);
-      if (!failedConfig) throw new Error("Expected startup to reach the HTTP server");
+
+      // The HTTP server binds before the engine spawns, so a bind failure
+      // must leave no engine child (and nothing to SIGTERM).
+      expect(managedSpy).not.toHaveBeenCalled();
+      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(0);
+    } finally {
+      managedSpy.mockRestore();
+      startSpy.mockRestore();
+      await fixture.restore();
+    }
+  });
+
+  test.serial("engine spawn failure after HTTP start releases the server and subscription", async () => {
+    const fixture = await createFixture();
+    const spawnError = new Error("forced engine spawn failure");
+    let failedConfig: ServerConfig | null = null;
+    let httpStopCalls = 0;
+    const originalStartServer = serverModule.startServer;
+    const startSpy = spyOn(serverModule, "startServer").mockImplementation(async (config) => {
+      failedConfig = config;
+      const server = await originalStartServer(config);
+      return {
+        ...server,
+        async stop() {
+          httpStopCalls += 1;
+          await server.stop();
+        },
+      };
+    });
+    const managedSpy = spyOn(managedOpencodeModule, "createManagedOpencodeServer").mockImplementation(async () => {
+      throw spawnError;
+    });
+    const clearTrustedSpy = spyOn(serverModule, "clearTrustedOpencodeProcess");
+
+    try {
+      const options = managedOptions(fixture, "spawn-failure");
+      await mkdir(options.opencodeCwd ?? "", { recursive: true });
+      await expect(startEmbeddedServer(options)).rejects.toBe(spawnError);
+      if (!failedConfig) throw new Error("Expected startup to bind the HTTP server");
 
       const config = failedConfig;
       const id = workspaceId(config);
-      await mutateWorkspace(config, id, "after-startup-failure");
+      await mutateWorkspace(config, id, "after-spawn-failure");
       const barrier = await writeOpenworkRuntimeConfigFile(config, id);
 
       expect(barrier.changed).toBe(true);
-      expect(clearTrustedSpy).toHaveBeenCalledTimes(1);
-      expect((await logLines(fixture.logPath)).filter((line) => line === "SIGTERM")).toHaveLength(1);
+      expect(httpStopCalls).toBe(1);
+      // Nothing was registered, so nothing gets cleared.
+      expect(clearTrustedSpy).not.toHaveBeenCalled();
+      expect(await readEngineRegistry(config)).toEqual([]);
     } finally {
       clearTrustedSpy.mockRestore();
+      managedSpy.mockRestore();
       startSpy.mockRestore();
       await fixture.restore();
     }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -8,6 +8,12 @@
 import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
+import {
+  buildEngineAuthProbeHeader,
+  registerEngineInstance,
+  removeEngineInstance,
+  reapOrphanEngineInstances,
+} from "./engine-registry.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
 import {
   clearTrustedOpencodeProcess,
@@ -52,11 +58,11 @@ export type EmbeddedServerHandle = {
 export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {
   const config = await resolveServerConfig(options);
   config.localManagedMcpVaultKey = options.localManagedMcpVaultKey;
-  const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
 
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
   let managedOpencode: ManagedOpencodeServer | null = null;
   let managedOpencodeIdentity: string | null = null;
+  let managedEngineRecordId: string | null = null;
   let stopRuntimeConfigFileRefresh: (() => void) | null = null;
   let server: ServeResult | null = null;
   let stopPromise: Promise<void> | null = null;
@@ -82,6 +88,12 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       } catch (error) {
         errors.push(error);
       }
+    }
+
+    const engineRecordId = managedEngineRecordId;
+    managedEngineRecordId = null;
+    if (engineRecordId) {
+      await removeEngineInstance(config, engineRecordId).catch(() => undefined);
     }
 
     const httpServer = server;
@@ -135,9 +147,22 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     await ensureLocalWorkspaceFiles(config.workspaces);
   }
 
+  // Bind the HTTP server before spawning the engine: serve-node may fall back
+  // to an OS-assigned port on EADDRINUSE, and the engine's spawn-time env
+  // (OPENWORK_SERVER_URL) must point at the port that actually bound, not the
+  // requested one. Proxy requests that land in the short window before the
+  // engine is ready fail with opencode_unconfigured and clients retry; the
+  // desktop only learns the server URL after this function returns.
+  server = await duringStartup(() => startServer(config));
+  config.port = server.port;
+  const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`;
+
   if (!config.opencodeBaseUrl && options.manageOpencode) {
     const workspace = findManagedEngineWorkspace(config.workspaces);
     if (workspace) {
+      // Reap engines recorded by servers that died without cleanup. Best
+      // effort: a failed reap must never block startup.
+      await reapOrphanEngineInstances(config).catch(() => undefined);
       // Server-managed config file: the engine re-reads it from disk on every
       // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
       // on every runtime-DB write — so disposes always pick up current state.
@@ -150,8 +175,9 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
       const opencodeModelsUrl = await duringStartup(() => resolveOpencodeModelsUrl());
 
+      const opencodeBin = options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN;
       managedOpencode = await duringStartup(() => createManagedOpencodeServer({
-        bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
+        bin: opencodeBin,
         cwd,
         excludedPorts: [config.port],
         env: {
@@ -192,10 +218,23 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         identity: managedOpencodeIdentity,
         isAlive: managedOpencode.isAlive,
       });
+      if (managedOpencode.pid) {
+        managedEngineRecordId = randomUUID();
+        await registerEngineInstance(config, {
+          id: managedEngineRecordId,
+          pid: managedOpencode.pid,
+          port: Number(new URL(managedOpencode.url).port) || 0,
+          url: managedOpencode.url,
+          startedAt: Date.now(),
+          role: "primary",
+          serverRunId: managedOpencodeIdentity,
+          ownerPid: process.pid,
+          authProbe: buildEngineAuthProbeHeader(managedOpencode.username, managedOpencode.password),
+          bin: opencodeBin?.trim() || "opencode",
+        }).catch(() => undefined);
+      }
     }
   }
-
-  server = await duringStartup(() => startServer(config));
 
   // The runtime config file above only covers workspaces[0]. Push every
   // workspace's runtime-DB MCPs into the engine so they aren't invisible

--- a/apps/server/src/engine-registry.test.ts
+++ b/apps/server/src/engine-registry.test.ts
@@ -1,0 +1,364 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildEngineAuthProbeHeader,
+  engineRegistryFilePath,
+  readEngineRegistry,
+  reapOrphanEngineInstances,
+  registerEngineInstance,
+  removeEngineInstance,
+  updateEngineInstanceRole,
+  type EngineInstanceRecord,
+} from "./engine-registry.js";
+import type { ServerConfig } from "./types.js";
+
+type Fixture = {
+  root: string;
+  config: ServerConfig;
+  cleanups: Array<() => void | Promise<void>>;
+  restore: () => Promise<void>;
+};
+
+async function createFixture(): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-engine-registry-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const config = { configPath: join(root, "server.json") } as unknown as ServerConfig;
+  const cleanups: Array<() => void | Promise<void>> = [];
+  return {
+    root,
+    config,
+    cleanups,
+    async restore() {
+      for (const cleanup of cleanups.reverse()) {
+        try {
+          await cleanup();
+        } catch {
+          // Best-effort cleanup.
+        }
+      }
+      if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitForExit(pid: number, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !processAlive(pid);
+}
+
+/** Pid of a process that has already exited — a provably dead owner. */
+async function deadPid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+  const pid = child.pid;
+  if (!pid) throw new Error("Failed to spawn short-lived process");
+  await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  return pid;
+}
+
+type FakeEngine = {
+  pid: number;
+  port: number;
+  url: string;
+  scriptPath: string;
+  kill: () => void;
+};
+
+/**
+ * A long-lived process that answers /global/health only with the expected
+ * basic-auth header — the shape the reaper's identity probe relies on.
+ */
+async function spawnFakeEngine(fixture: Fixture, name: string, authHeader: string): Promise<FakeEngine> {
+  const scriptPath = join(fixture.root, `${name}.mjs`);
+  await writeFile(scriptPath, [
+    "const expected = process.env.FAKE_ENGINE_AUTH ?? \"\";",
+    "const server = Bun.serve({",
+    "  hostname: \"127.0.0.1\",",
+    "  port: 0,",
+    "  fetch(request) {",
+    "    const header = request.headers.get(\"authorization\") ?? \"\";",
+    "    if (expected && header !== expected) return new Response(\"unauthorized\", { status: 401 });",
+    "    return Response.json({ ok: true });",
+    "  },",
+    "});",
+    "console.log(`listening ${server.port}`);",
+    "process.on(\"SIGTERM\", () => process.exit(0));",
+    "setInterval(() => undefined, 1000);",
+  ].join("\n"));
+  const child = spawn(process.execPath, [scriptPath], {
+    env: { ...process.env, FAKE_ENGINE_AUTH: authHeader },
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const pid = child.pid;
+  if (!pid) throw new Error("Failed to spawn fake engine");
+  const kill = () => {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Already exited.
+    }
+  };
+  fixture.cleanups.push(kill);
+  const port = await new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Fake engine did not report a port")), 10_000);
+    let buffer = "";
+    child.stdout?.on("data", (chunk) => {
+      buffer += String(chunk);
+      const match = buffer.match(/listening (\d+)/);
+      if (match?.[1]) {
+        clearTimeout(timeout);
+        resolve(Number(match[1]));
+      }
+    });
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      reject(new Error("Fake engine exited before reporting a port"));
+    });
+  });
+  child.unref();
+  return { pid, port, url: `http://127.0.0.1:${port}`, scriptPath, kill };
+}
+
+/** A long-lived process with no HTTP listener — a hung engine or a stranger. */
+async function spawnIdleProcess(fixture: Fixture, name: string): Promise<{ pid: number; scriptPath: string; kill: () => void }> {
+  const scriptPath = join(fixture.root, `${name}.mjs`);
+  await writeFile(scriptPath, [
+    "process.on(\"SIGTERM\", () => process.exit(0));",
+    "setInterval(() => undefined, 1000);",
+  ].join("\n"));
+  const child = spawn(process.execPath, [scriptPath], { stdio: "ignore" });
+  const pid = child.pid;
+  if (!pid) throw new Error("Failed to spawn idle process");
+  const kill = () => {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Already exited.
+    }
+  };
+  fixture.cleanups.push(kill);
+  child.unref();
+  return { pid, scriptPath, kill };
+}
+
+function makeEntry(overrides: Partial<EngineInstanceRecord>): EngineInstanceRecord {
+  return {
+    id: overrides.id ?? `entry_${Math.random().toString(36).slice(2)}`,
+    pid: overrides.pid ?? 1,
+    port: overrides.port ?? 1024,
+    url: overrides.url ?? "http://127.0.0.1:1024",
+    startedAt: overrides.startedAt ?? Date.now(),
+    role: overrides.role ?? "primary",
+    serverRunId: overrides.serverRunId ?? "run",
+    ownerPid: overrides.ownerPid ?? process.pid,
+    authProbe: overrides.authProbe ?? "",
+    bin: overrides.bin ?? "opencode",
+  };
+}
+
+describe("engine registry", () => {
+  test("registers, updates, and removes entries", async () => {
+    const fixture = await createFixture();
+    try {
+      const first = makeEntry({ id: "first", pid: 111, role: "primary" });
+      const second = makeEntry({ id: "second", pid: 222, role: "starting" });
+      await registerEngineInstance(fixture.config, first);
+      await registerEngineInstance(fixture.config, second);
+      await updateEngineInstanceRole(fixture.config, "second", "draining");
+
+      const entries = await readEngineRegistry(fixture.config);
+      expect(entries).toHaveLength(2);
+      expect(entries.find((entry) => entry.id === "second")?.role).toBe("draining");
+
+      if (process.platform !== "win32") {
+        const mode = (await stat(engineRegistryFilePath(fixture.config))).mode & 0o777;
+        expect(mode).toBe(0o600);
+      }
+
+      await removeEngineInstance(fixture.config, "first");
+      expect((await readEngineRegistry(fixture.config)).map((entry) => entry.id)).toEqual(["second"]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("treats a corrupt registry file as empty and recovers on the next write", async () => {
+    const fixture = await createFixture();
+    try {
+      await registerEngineInstance(fixture.config, makeEntry({ id: "kept", pid: 333 }));
+      await writeFile(engineRegistryFilePath(fixture.config), "{not json");
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+      await registerEngineInstance(fixture.config, makeEntry({ id: "recovered", pid: 444 }));
+      expect((await readEngineRegistry(fixture.config)).map((entry) => entry.id)).toEqual(["recovered"]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("spares an engine whose owning server is still alive", async () => {
+    const fixture = await createFixture();
+    try {
+      const engine = await spawnFakeEngine(fixture, "owned-engine", buildEngineAuthProbeHeader("user", "pass"));
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "owned",
+        pid: engine.pid,
+        port: engine.port,
+        url: engine.url,
+        ownerPid: process.pid,
+        authProbe: buildEngineAuthProbeHeader("user", "pass"),
+        bin: engine.scriptPath,
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 100 });
+
+      expect(result.spared).toEqual([engine.pid]);
+      expect(result.killed).toEqual([]);
+      expect(processAlive(engine.pid)).toBe(true);
+      expect((await readEngineRegistry(fixture.config)).map((entry) => entry.id)).toEqual(["owned"]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("kills a provable orphan whose owner is gone", async () => {
+    const fixture = await createFixture();
+    try {
+      const authProbe = buildEngineAuthProbeHeader("orphan-user", "orphan-pass");
+      const engine = await spawnFakeEngine(fixture, "orphan-engine", authProbe);
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "orphan",
+        pid: engine.pid,
+        port: engine.port,
+        url: engine.url,
+        ownerPid: await deadPid(),
+        authProbe,
+        bin: engine.scriptPath,
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 200 });
+
+      expect(result.killed).toEqual([engine.pid]);
+      expect(await waitForExit(engine.pid)).toBe(true);
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("kills a hung orphan that matches the recorded binary but no longer answers", async () => {
+    const fixture = await createFixture();
+    try {
+      const hung = await spawnIdleProcess(fixture, "hung-engine");
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "hung",
+        pid: hung.pid,
+        // Nothing listens on this port, so the identity probe is unreachable;
+        // the command match against the recorded script is the kill evidence.
+        port: 1,
+        url: "http://127.0.0.1:1",
+        ownerPid: await deadPid(),
+        authProbe: buildEngineAuthProbeHeader("hung-user", "hung-pass"),
+        bin: hung.scriptPath,
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 200, probeTimeoutMs: 250 });
+
+      expect(result.killed).toEqual([hung.pid]);
+      expect(await waitForExit(hung.pid)).toBe(true);
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("never kills a process whose port answers with different credentials", async () => {
+    const fixture = await createFixture();
+    try {
+      const engine = await spawnFakeEngine(fixture, "stranger-engine", buildEngineAuthProbeHeader("real-user", "real-pass"));
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "stranger",
+        pid: engine.pid,
+        port: engine.port,
+        url: engine.url,
+        ownerPid: await deadPid(),
+        // Recorded credentials no longer match what the port expects, so the
+        // probe cannot prove the process is ours.
+        authProbe: buildEngineAuthProbeHeader("stale-user", "stale-pass"),
+        bin: engine.scriptPath,
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 100 });
+
+      expect(result.killed).toEqual([]);
+      expect(result.dropped).toEqual([engine.pid]);
+      expect(processAlive(engine.pid)).toBe(true);
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("drops entries whose pid was reused by an unrelated process", async () => {
+    const fixture = await createFixture();
+    try {
+      const bystander = await spawnIdleProcess(fixture, "unrelated-process");
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "reused",
+        pid: bystander.pid,
+        port: 1,
+        url: "http://127.0.0.1:1",
+        ownerPid: await deadPid(),
+        authProbe: buildEngineAuthProbeHeader("reused-user", "reused-pass"),
+        // The recorded binary shares nothing with the bystander's command line.
+        bin: "/opt/does-not-exist/managed-engine-bin",
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 100, probeTimeoutMs: 250 });
+
+      expect(result.killed).toEqual([]);
+      expect(result.dropped).toEqual([bystander.pid]);
+      expect(processAlive(bystander.pid)).toBe(true);
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
+  test("drops entries whose engine already exited without killing anything", async () => {
+    const fixture = await createFixture();
+    try {
+      await registerEngineInstance(fixture.config, makeEntry({
+        id: "gone",
+        pid: await deadPid(),
+        ownerPid: await deadPid(),
+      }));
+
+      const result = await reapOrphanEngineInstances(fixture.config, { killWaitMs: 100 });
+
+      expect(result.killed).toEqual([]);
+      expect(result.dropped).toHaveLength(1);
+      expect(await readEngineRegistry(fixture.config)).toEqual([]);
+    } finally {
+      await fixture.restore();
+    }
+  });
+});

--- a/apps/server/src/engine-registry.ts
+++ b/apps/server/src/engine-registry.ts
@@ -1,0 +1,339 @@
+/**
+ * Persisted registry of managed OpenCode engine processes.
+ *
+ * The engine URL/port live only in memory (ServerConfig), so an unclean
+ * OpenWork server exit orphans its engine child with no record to clean up.
+ * Packaged desktop builds have a `ps`-based sweep, but dev builds and Windows
+ * have nothing. This registry records every managed spawn on disk so the next
+ * server boot can reap provable orphans — and nothing else.
+ *
+ * Reaping errs toward NOT killing: a leaked orphan is recoverable on a later
+ * boot, killing a stranger's process is not. A recorded pid is only killed
+ * when its owning server is gone, the pid still looks like the engine we
+ * spawned (command match), and the recorded per-spawn credentials do not
+ * prove the port now belongs to someone else.
+ */
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import { runtimeStorageDir } from "./runtime-db.js";
+import { loopbackFetch } from "./server-fetch.js";
+import type { ServerConfig } from "./types.js";
+
+export type EngineInstanceRole = "starting" | "primary" | "draining";
+
+export type EngineInstanceRecord = {
+  /** Unique per spawn. */
+  id: string;
+  /** Engine child process id. */
+  pid: number;
+  /** Loopback port the engine reported at readiness. */
+  port: number;
+  /** Base URL parsed from the engine's readiness line. */
+  url: string;
+  startedAt: number;
+  role: EngineInstanceRole;
+  /** Unique per OpenWork server boot that spawned this engine. */
+  serverRunId: string;
+  /** Pid of the OpenWork server process that owns this engine. */
+  ownerPid: number;
+  /** `Basic <base64>` header for this spawn's random engine credentials. */
+  authProbe: string;
+  /** Binary the engine was spawned from. */
+  bin: string;
+};
+
+type EngineRegistryFile = {
+  version: 1;
+  entries: EngineInstanceRecord[];
+};
+
+export type EngineReapResult = {
+  killed: number[];
+  spared: number[];
+  dropped: number[];
+};
+
+type EngineRegistryLogger = {
+  log: (level: "info" | "warn" | "error", message: string, attributes?: Record<string, unknown>) => void;
+};
+
+export function engineRegistryFilePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), "engine-instances.json");
+}
+
+export function buildEngineAuthProbeHeader(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseEntry(value: unknown): EngineInstanceRecord | null {
+  if (!isRecord(value)) return null;
+  const pid = Number(value.pid);
+  const port = Number(value.port);
+  const ownerPid = Number(value.ownerPid);
+  if (typeof value.id !== "string" || !value.id.trim()) return null;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  if (!Number.isInteger(ownerPid) || ownerPid <= 0) return null;
+  if (typeof value.url !== "string" || !value.url.trim()) return null;
+  const role = value.role === "primary" || value.role === "draining" || value.role === "starting"
+    ? value.role
+    : "primary";
+  return {
+    id: value.id,
+    pid,
+    port,
+    url: value.url,
+    startedAt: Number(value.startedAt) || 0,
+    role,
+    serverRunId: typeof value.serverRunId === "string" ? value.serverRunId : "",
+    ownerPid,
+    authProbe: typeof value.authProbe === "string" ? value.authProbe : "",
+    bin: typeof value.bin === "string" ? value.bin : "",
+  };
+}
+
+async function readRegistryFile(path: string): Promise<EngineInstanceRecord[]> {
+  const content = await readFile(path, "utf8").catch(() => undefined);
+  if (!content) return [];
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!isRecord(parsed) || !Array.isArray(parsed.entries)) return [];
+    return parsed.entries
+      .map(parseEntry)
+      .filter((entry): entry is EngineInstanceRecord => entry !== null);
+  } catch {
+    // A corrupt registry must never block startup; treat it as empty and let
+    // the next write replace it.
+    return [];
+  }
+}
+
+// Serialize writes per path so concurrent register/remove calls can never
+// interleave a stale read-modify-write over a newer one.
+const registryWriteQueue = new Map<string, Promise<unknown>>();
+
+async function mutateRegistry(
+  config: ServerConfig,
+  mutate: (entries: EngineInstanceRecord[]) => EngineInstanceRecord[],
+): Promise<EngineInstanceRecord[]> {
+  const path = engineRegistryFilePath(config);
+  const job = async (): Promise<EngineInstanceRecord[]> => {
+    const entries = mutate(await readRegistryFile(path));
+    const payload: EngineRegistryFile = { version: 1, entries };
+    await mkdir(runtimeStorageDir(config), { recursive: true });
+    const tmp = `${path}.${randomUUID()}.tmp`;
+    // 0600: the auth probe header embeds this spawn's engine credentials.
+    await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    await rename(tmp, path).catch(async (error) => {
+      await rm(tmp, { force: true }).catch(() => undefined);
+      throw error;
+    });
+    return entries;
+  };
+  const previous = registryWriteQueue.get(path) ?? Promise.resolve();
+  const next = previous.then(job, job);
+  registryWriteQueue.set(path, next);
+  return await next;
+}
+
+export async function readEngineRegistry(config: ServerConfig): Promise<EngineInstanceRecord[]> {
+  return readRegistryFile(engineRegistryFilePath(config));
+}
+
+export async function registerEngineInstance(
+  config: ServerConfig,
+  record: EngineInstanceRecord,
+): Promise<void> {
+  await mutateRegistry(config, (entries) => [
+    ...entries.filter((entry) => entry.id !== record.id),
+    record,
+  ]);
+}
+
+export async function updateEngineInstanceRole(
+  config: ServerConfig,
+  id: string,
+  role: EngineInstanceRole,
+): Promise<void> {
+  await mutateRegistry(config, (entries) =>
+    entries.map((entry) => (entry.id === id ? { ...entry, role } : entry)),
+  );
+}
+
+export async function removeEngineInstance(config: ServerConfig, id: string): Promise<void> {
+  await mutateRegistry(config, (entries) => entries.filter((entry) => entry.id !== id));
+}
+
+function processAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists but belongs to another user.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Best-effort command line for a pid. Returns null when it cannot be read —
+ * callers must treat null as "unknown", never as "not the engine".
+ */
+function processCommand(pid: number): string | null {
+  try {
+    if (process.platform === "win32") {
+      const result = spawnSync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], { encoding: "utf8" });
+      if (result.status !== 0) return null;
+      const row = String(result.stdout ?? "").split(/\r?\n/).find((line) => line.includes(`"${pid}"`));
+      if (!row) return null;
+      const command = row.split('","')[0]?.replace(/^"/, "");
+      return command?.trim() || null;
+    }
+    const result = spawnSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" });
+    if (result.status !== 0) return null;
+    const command = String(result.stdout ?? "").trim();
+    return command || null;
+  } catch {
+    return null;
+  }
+}
+
+function commandMatchesEngine(command: string, bin: string): boolean {
+  const lower = command.toLowerCase();
+  if (/(^|[/\\ ])opencode[^/\\ ]*( |$)/.test(lower) && lower.includes("serve")) return true;
+  const binBase = basename(bin.trim()).toLowerCase();
+  return binBase.length > 0 && lower.includes(binBase);
+}
+
+type ProbeOutcome = "ours" | "stranger" | "unreachable";
+
+async function probeEngineIdentity(entry: EngineInstanceRecord, timeoutMs: number): Promise<ProbeOutcome> {
+  let target: string;
+  try {
+    target = new URL("/global/health", entry.url).toString();
+  } catch {
+    return "unreachable";
+  }
+  try {
+    const response = await loopbackFetch(target, {
+      headers: entry.authProbe ? { Authorization: entry.authProbe } : {},
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (response.ok) return "ours";
+    if (response.status === 401 || response.status === 403) return "stranger";
+    return "unreachable";
+  } catch {
+    return "unreachable";
+  }
+}
+
+function killEngineProcess(pid: number): void {
+  if (process.platform === "win32") {
+    // /T kills the tree so engine-spawned children (stdio MCPs, LSPs) go too.
+    spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], { encoding: "utf8" });
+    return;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return;
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Kill engine processes recorded by dead OpenWork servers, drop entries that
+ * can no longer be verified, and keep entries whose owning server is alive.
+ *
+ * Kill requires all of: the recorded owner process is gone, the recorded pid
+ * is alive AND its command still looks like the engine we spawned, and the
+ * identity probe did not prove the port belongs to a different process.
+ */
+export async function reapOrphanEngineInstances(
+  config: ServerConfig,
+  options?: { logger?: EngineRegistryLogger; probeTimeoutMs?: number; killWaitMs?: number },
+): Promise<EngineReapResult> {
+  const probeTimeoutMs = options?.probeTimeoutMs ?? 1000;
+  const killWaitMs = options?.killWaitMs ?? 1000;
+  const result: EngineReapResult = { killed: [], spared: [], dropped: [] };
+  const kept: EngineInstanceRecord[] = [];
+  const toKill: EngineInstanceRecord[] = [];
+
+  for (const entry of await readEngineRegistry(config)) {
+    if (entry.ownerPid === process.pid || processAlive(entry.ownerPid)) {
+      // A live OpenWork server (possibly the CLI next to the desktop) still
+      // owns this engine.
+      kept.push(entry);
+      result.spared.push(entry.pid);
+      continue;
+    }
+    if (!processAlive(entry.pid)) {
+      result.dropped.push(entry.pid);
+      continue;
+    }
+    const command = processCommand(entry.pid);
+    if (command !== null && !commandMatchesEngine(command, entry.bin)) {
+      // Pid was reused by an unrelated process.
+      result.dropped.push(entry.pid);
+      continue;
+    }
+    const probe = await probeEngineIdentity(entry, probeTimeoutMs);
+    if (probe === "stranger") {
+      // The port answers with different credentials, so we cannot prove the
+      // recorded pid is still ours. Drop the record rather than risk a kill.
+      result.dropped.push(entry.pid);
+      continue;
+    }
+    if (command === null && probe !== "ours") {
+      // No command evidence and no credential evidence: never kill blind.
+      result.dropped.push(entry.pid);
+      continue;
+    }
+    toKill.push(entry);
+  }
+
+  for (const entry of toKill) {
+    killEngineProcess(entry.pid);
+  }
+  if (toKill.length > 0 && process.platform !== "win32") {
+    await delay(killWaitMs);
+    for (const entry of toKill) {
+      if (processAlive(entry.pid)) {
+        try {
+          process.kill(entry.pid, "SIGKILL");
+        } catch {
+          // Exited between the check and the kill.
+        }
+      }
+    }
+  }
+  for (const entry of toKill) {
+    result.killed.push(entry.pid);
+    options?.logger?.log("info", `Reaped orphaned managed OpenCode engine (pid ${entry.pid}).`, {
+      "engine.pid": entry.pid,
+      "engine.port": entry.port,
+      "engine.owner_pid": entry.ownerPid,
+      "engine.role": entry.role,
+    });
+  }
+
+  await mutateRegistry(config, (entries) => {
+    const removed = new Set([...result.killed, ...result.dropped]);
+    const surviving = entries.filter((entry) => !removed.has(entry.pid));
+    // Preserve records added while the reap was scanning.
+    const known = new Set(kept.map((entry) => entry.id));
+    return [...kept, ...surviving.filter((entry) => !known.has(entry.id))];
+  }).catch(() => undefined);
+
+  return result;
+}

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -208,7 +208,11 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
       }
       reject(error);
     });
-    server.listen(port, hostname, () => {
+    // A standing "listening" listener, not the listen() callback: Node keeps
+    // the callback-registered once("listening") listener alive across the
+    // EADDRINUSE retry, but Bun does not — under Bun the fallback re-bind
+    // succeeded while this promise hung forever.
+    server.on("listening", () => {
       const addr = server.address();
       if (addr && typeof addr === "object") {
         boundPort = addr.port;
@@ -236,5 +240,6 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
         },
       });
     });
+    server.listen(port, hostname);
   });
 }


### PR DESCRIPTION
## Summary

Follow-ups to #3634's reload guard, targeting the remaining lifecycle-tracking gaps that surface as interrupted runs and leaked engine processes.

- **Persisted engine registry + boot reaper** (`apps/server/src/engine-registry.ts`): every managed engine spawn is recorded in `<runtime-storage>/engine-instances.json` (mode 0600 — it embeds the per-spawn probe credentials), and provably orphaned engines are reaped at the next boot. A kill requires all of: the recorded owning server process is gone, the pid still looks like the engine we spawned (command-line match), and the per-spawn credentials do not prove the port now belongs to someone else (401/403 → drop the record, never kill; no evidence → drop, never kill blind). This covers dev builds and Windows, which the packaged `ps`-based sidecar sweep does not; the sweep stays as a belt for pre-registry versions. The file is wired into the nuke manifest.
- **Engine env gets the actually bound server port**: the HTTP server now binds before the engine spawns, so `OPENWORK_SERVER_URL` and `excludedPorts` follow serve-node's EADDRINUSE fallback instead of the requested port, and `config.port` reflects the bound port. Requests in the short pre-engine window fail with `opencode_unconfigured` and retry; the desktop only learns the server URL after startup returns, and cloud provider sync only starts once a Den session registers, so nothing races the spawn.
- **serve-node's EADDRINUSE fallback hung under Bun**: Node re-fires the `listen()`-callback-registered `once("listening")` listener after an error + re-listen, Bun does not — the CLI (bun runtime) hung forever whenever the fallback engaged. A standing `"listening"` listener resolves under both runtimes.
- **A failed desktop server start no longer leaves stale state**: `startOpenworkServer` failures reset the runtime state objects so `snapshotOpenworkServerState` cannot report `running: true` with a dead `baseUrl` (previously `assertOpenworkServerReady` passed against exactly that); diagnostics output and the project dir survive so a retry via `engineRestart` still knows its workspace.
- **CLI shutdown awaits engine teardown**: `void managedOpencode.close()` followed by a synchronous `process.exit(0)` skipped the SIGTERM→SIGKILL escalation entirely and orphaned the engine child to init.
- **The desktop engine-restart escalation is gated** (`apps/app/src/react-app/shell/engine-reload-escalation.ts`, now shared by the session reload path and settings): `opencode_engine_unreachable` gets one delayed reload retry before escalating to a full `engineRestart` — a full restart kills every live session, so a transient loopback hiccup must not trigger it. Aborted and timed-out fetches surface as errors and never escalate, complementing #3634's `opencode_reload_timeout` exemption.

## Verification

- `apps/server`: `pnpm typecheck` clean; `bun test` — 654 pass. One pre-existing failure (`workspace-kv-store.node.test.ts`: `node:sqlite` unresolvable under local bun 1.3.4) reproduces identically on a clean `dev` checkout.
- `apps/app`: `pnpm typecheck` clean; `bun test --isolate tests/` — 698 pass, including 9 new escalation-policy tests. The 4 failures are full-suite-only flakes in unrelated files and fail identically on clean `dev`.
- `apps/desktop`: `node --test` suite — 188 pass, with new coverage for the failed-start state reset and the nuke manifest entry.
- New tests: `engine-registry.test.ts` reaper matrix (live owner spared; credentialed orphan killed; hung orphan killed via command match; wrong-credential port spared and record dropped; reused pid spared; dead pid dropped) and embedded-lifecycle additions (engine env matches the bound port after an EADDRINUSE fallback + registry add/remove across the lifecycle; an HTTP bind failure spawns no engine; an engine spawn failure releases the already-bound server and config subscription).