### PR TITLE
fix(app): preserve response text selection

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -423,7 +423,7 @@ type AssistantMessageProps = {
 }
 
 const AssistantMessage = React.memo(
-  ({ message, hideReasoning }: AssistantMessageProps) => {
+  ({ message, isStreaming, hideReasoning }: AssistantMessageProps) => {
     const { showThinking, highlightQuery } = useMessageList()
     const assistantRenderGroups = React.useMemo(
       () => {
@@ -447,6 +447,7 @@ const AssistantMessage = React.memo(
                   key={`text-${index}`}
                   className="text-foreground prose w-full min-w-0 flex-1 rounded-lg bg-transparent p-0"
                   markdown
+                  isStreaming={isStreaming}
                   highlightQuery={highlightQuery}
                 >
                   {group.text}

--- a/apps/app/src/components/chat/reasoning-block.tsx
+++ b/apps/app/src/components/chat/reasoning-block.tsx
@@ -39,6 +39,7 @@ export function ReasoningBlock({ text, isStreaming, className }: ReasoningBlockP
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
         <MessageContent
           markdown
+          isStreaming={isStreaming}
           className="text-muted-foreground prose mt-1 w-full min-w-0 rounded-lg bg-transparent p-0 text-sm"
         >
           {text}

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { motion } from "motion/react";
 
 import {
   Dialog,
@@ -20,6 +19,7 @@ import {
   syncMarkdownImagePreviews,
 } from "./markdown-primitive";
 import { LinkActionMenu } from "./link-action-menu";
+import { useSelectionStableValue } from "./selection-stability";
 
 export { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "./markdown-primitive";
 
@@ -88,7 +88,7 @@ type MarkdownBlockInnerProps = {
   streaming?: boolean;
   highlightQuery?: string;
 } & Omit<
-  React.ComponentProps<typeof motion.div>,
+  React.ComponentProps<"div">,
   "ref" | "className" | "children" | "dangerouslySetInnerHTML"
 >;
 
@@ -162,13 +162,13 @@ function MarkdownBlockInner({
     };
   }, [streaming, text]);
 
-  const html = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
+  const candidateHtml = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
+  const html = useSelectionStableValue(rootRef, candidateHtml);
+  const stableInnerHtml = useMemo(() => ({ __html: html }), [html]);
 
-  // Re-apply search highlights after EVERY render (no dependency array on
-  // purpose): motion.div re-sets dangerouslySetInnerHTML on unrelated
-  // re-renders (e.g. open-target context updates), silently wiping the
-  // <mark> nodes without `html`/`highlightQuery` changing. With no active
-  // query this is a single querySelector fast path.
+  // Keep the innerHTML prop referentially stable too: a fresh wrapper object
+  // can make an unrelated React render replace selected text nodes even when
+  // the HTML string itself is unchanged.
   useEffect(() => {
     const root = rootRef.current;
 
@@ -183,7 +183,7 @@ function MarkdownBlockInner({
 
       applyTextHighlights(root, highlightQuery ?? "");
     });
-  });
+  }, [highlightQuery, html]);
 
   useEffect(() => {
     const root = rootRef.current;
@@ -271,10 +271,10 @@ function MarkdownBlockInner({
 
   return (
     <>
-      <motion.div
+      <div
         ref={rootRef}
-        className={cn("markdown-content max-w-none text-foreground", className)}
-        dangerouslySetInnerHTML={{ __html: html }}
+        className={cn("markdown-content max-w-none select-text text-foreground", className)}
+        dangerouslySetInnerHTML={stableInnerHtml}
         {...props}
       />
       {linkMenu && onOpenTarget ? (

--- a/apps/app/src/components/markdown/selection-stability.ts
+++ b/apps/app/src/components/markdown/selection-stability.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState, type RefObject } from "react";
+
+type SelectionReader = Pick<Selection, "getRangeAt" | "isCollapsed" | "rangeCount">;
+
+export function selectionIntersectsElement(
+  root: Element,
+  selection: SelectionReader | null,
+) {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    try {
+      if (selection.getRangeAt(index).intersectsNode(root)) {
+        return true;
+      }
+    } catch {
+      // A range can become detached between selectionchange and this read.
+      // Ignore that stale range and inspect any remaining live ranges.
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Keep DOM-backed rich text unchanged while the user has a real selection in
+ * it. Replacing innerHTML remaps the browser Range to new text nodes, which can
+ * clear the highlight or make Cmd/Ctrl+C copy a different slice. The newest
+ * value is committed as soon as that selection moves away or collapses.
+ */
+export function useSelectionStableValue<T>(
+  rootRef: RefObject<Element | null>,
+  candidate: T,
+) {
+  const [committed, setCommitted] = useState(candidate);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const ownerDocument = root?.ownerDocument;
+
+    if (!root || !ownerDocument || !selectionIntersectsElement(root, ownerDocument.getSelection())) {
+      setCommitted((current) => Object.is(current, candidate) ? current : candidate);
+      return;
+    }
+
+    let listening = true;
+    const commitPending = () => {
+      const liveRoot = rootRef.current;
+      if (liveRoot && selectionIntersectsElement(liveRoot, ownerDocument.getSelection())) {
+        return;
+      }
+
+      setCommitted((current) => Object.is(current, candidate) ? current : candidate);
+      ownerDocument.removeEventListener("selectionchange", commitPending);
+      listening = false;
+    };
+
+    ownerDocument.addEventListener("selectionchange", commitPending);
+    return () => {
+      if (listening) ownerDocument.removeEventListener("selectionchange", commitPending);
+    };
+  }, [candidate, rootRef]);
+
+  return committed;
+}

--- a/apps/app/src/components/ui/message.tsx
+++ b/apps/app/src/components/ui/message.tsx
@@ -6,7 +6,6 @@ import {
 } from "@/components/ui/tooltip"
 import { MarkdownBlock } from "@/components/markdown/markdown"
 import { cn } from "@/lib/utils"
-import { motion } from "motion/react"
 
 const messageContentClassName =
   "rounded-lg p-2 text-foreground leading-relaxed bg-secondary prose wrap-break-word whitespace-normal"
@@ -53,7 +52,7 @@ export type MessageContentProps = {
   isStreaming?: boolean
   highlightQuery?: string
   className?: string
-} & React.ComponentProps<typeof motion.div>
+} & React.ComponentProps<"div">
 
 const MessageContent = ({
   children,
@@ -76,12 +75,12 @@ const MessageContent = ({
   }
 
   return (
-    <motion.div
+    <div
       className={cn(messageContentClassName, className)}
       {...props}
     >
       {children}
-    </motion.div>
+    </div>
   )
 }
 

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -7,6 +7,7 @@ import {
   renderHighlightedMarkdownHtml,
   renderMarkdownHtml,
 } from "@/components/markdown/markdown-primitive";
+import { useSelectionStableValue } from "@/components/markdown/selection-stability";
 
 function MarkdownBlockInner(props: {
   text: string;
@@ -36,7 +37,9 @@ function MarkdownBlockInner(props: {
     };
   }, [props.streaming, props.text]);
 
-  const html = !props.streaming && highlightedHtml?.text === props.text ? highlightedHtml.html : syncHtml;
+  const candidateHtml = !props.streaming && highlightedHtml?.text === props.text ? highlightedHtml.html : syncHtml;
+  const html = useSelectionStableValue(rootRef, candidateHtml);
+  const stableInnerHtml = useMemo(() => ({ __html: html }), [html]);
 
   useEffect(() => {
     const root = rootRef.current;
@@ -46,15 +49,15 @@ function MarkdownBlockInner(props: {
       if (!rootRef.current || rootRef.current !== root) return;
       applyTextHighlights(root, props.highlightQuery ?? "");
     });
-  });
+  }, [html, props.highlightQuery]);
 
   if (!html) return null;
 
   return (
     <div
       ref={rootRef}
-      className="markdown-content max-w-none text-foreground"
-      dangerouslySetInnerHTML={{ __html: html }}
+      className="markdown-content max-w-none select-text text-foreground"
+      dangerouslySetInnerHTML={stableInnerHtml}
     />
   );
 }

--- a/apps/app/tests/markdown-selection-stability.test.ts
+++ b/apps/app/tests/markdown-selection-stability.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { selectionIntersectsElement } from "../src/components/markdown/selection-stability";
+
+const root = {} as Element;
+
+function selection(input: {
+  collapsed?: boolean;
+  intersections: Array<boolean | Error>;
+}) {
+  return {
+    isCollapsed: input.collapsed ?? false,
+    rangeCount: input.intersections.length,
+    getRangeAt(index: number) {
+      const intersection = input.intersections[index];
+      return {
+        intersectsNode(node: Node) {
+          expect(node).toBe(root);
+          if (intersection instanceof Error) throw intersection;
+          return intersection;
+        },
+      } as Range;
+    },
+  } as Pick<Selection, "getRangeAt" | "isCollapsed" | "rangeCount">;
+}
+
+describe("markdown selection stability", () => {
+  test("recognizes a live range that intersects rendered markdown", () => {
+    expect(selectionIntersectsElement(root, selection({ intersections: [false, true] }))).toBe(true);
+  });
+
+  test("does not defer updates for a collapsed caret or an empty selection", () => {
+    expect(selectionIntersectsElement(root, selection({ collapsed: true, intersections: [true] }))).toBe(false);
+    expect(selectionIntersectsElement(root, null)).toBe(false);
+  });
+
+  test("ignores a detached stale range and continues checking live ranges", () => {
+    expect(selectionIntersectsElement(root, selection({ intersections: [new Error("detached"), true] }))).toBe(true);
+  });
+
+  test("keeps the innerHTML prop stable across unrelated completed-response renders", () => {
+    const sources = [
+      "../src/components/markdown/markdown.tsx",
+      "../src/react-app/domains/session/surface/markdown.tsx",
+    ].map((path) => readFileSync(join(import.meta.dir, path), "utf8"));
+
+    for (const source of sources) {
+      expect(source).toContain("const stableInnerHtml = useMemo(() => ({ __html: html }), [html]);");
+      expect(source).toContain("dangerouslySetInnerHTML={stableInnerHtml}");
+      expect(source).not.toContain("dangerouslySetInnerHTML={{ __html: html }}");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- keep rendered Markdown DOM unchanged while a non-collapsed browser selection intersects the response
- keep the `dangerouslySetInnerHTML` prop stable across unrelated completed-response rerenders
- apply the newest Markdown render after the selection moves away or collapses
- replace the unused motion-backed message-content wrapper with a stable selectable element
- forward live streaming state through assistant responses and reasoning so syntax highlighting waits for completion

## Why

Assistant responses are rendered with `dangerouslySetInnerHTML`. This is not limited to streaming: unrelated context updates can rerender an already-completed response, and delayed syntax highlighting can replace its HTML afterward. Replacing the underlying text nodes invalidates the browser Range, causing the highlight to disappear or Cmd/Ctrl+C to copy a different slice.

Keeping both the selected value and the inner-HTML prop stable preserves the original text nodes until the selection clears. User-message bubbles already explicitly allow text selection; this change closes the residual assistant-response and reasoning paths.

## Verification

- `bun test apps/app/tests/markdown-selection-stability.test.ts apps/app/tests/markdown-code-block.test.ts apps/app/tests/message-list-step-fold.test.tsx` — 14 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check upstream/dev...HEAD` — passed
- focused Chromium acceptance: a completed-response selection survived an unrelated React rerender with the same text node still connected; delayed highlighted HTML remained deferred while selected and committed after the selection cleared
