### PR TITLE
fix(den): strip internal response headers

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -44,6 +44,7 @@ import { registerWorkerRoutes } from "./routes/workers/index.js"
 import type { AuthContextVariables } from "./session.js"
 import { sessionMiddleware } from "./session.js"
 import { isOperationalErrorPath, normalizeOperationalErrorResponse, operationalErrorResponse } from "./operational-errors.js"
+import { sanitizePublicResponseHeaders } from "./public-response-headers.js"
 
 type AppVariables = RequestIdVariables & AuthContextVariables & Partial<UserOrganizationsContext> & Partial<OrganizationContextVariables> & Partial<MemberTeamsContext>
 
@@ -81,7 +82,7 @@ app.use("*", requestId({
 }))
 app.use("*", async (c, next) => {
   await next()
-  c.header("X-Request-Id", c.get("requestId"))
+  sanitizePublicResponseHeaders(c.res.headers)
 })
 app.use("*", async (c, next) => {
   await next()
@@ -128,7 +129,7 @@ if (env.corsOrigins.length > 0) {
         credentials: true,
         allowHeaders: ["Content-Type", "Authorization", "X-Api-Key", "X-Request-Id", "X-OpenWork-Legacy-Org-Id"],
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-        exposeHeaders: ["Content-Length", "X-Request-Id"],
+        exposeHeaders: ["Content-Length"],
         maxAge: 600,
     }),
   )

--- a/ee/apps/den-api/src/mcp/json-rpc-preflight.ts
+++ b/ee/apps/den-api/src/mcp/json-rpc-preflight.ts
@@ -23,7 +23,6 @@ function jsonRpcErrorResponse(code: -32700 | -32600, message: "Parse error" | "I
     status: 400,
     headers: {
       "content-type": "application/json",
-      "X-Request-Id": referenceId,
     },
   })
 }

--- a/ee/apps/den-api/src/operational-errors.ts
+++ b/ee/apps/den-api/src/operational-errors.ts
@@ -111,8 +111,7 @@ function normalizeRetryAfter(headers: Headers, status: number) {
   if (retryAfter) headers.set("Retry-After", retryAfter)
 }
 
-function normalizeOperationalHeaders(headers: Headers, path: string, status: number, requestId: string) {
-  headers.set("X-Request-Id", requestId)
+function normalizeOperationalHeaders(headers: Headers, path: string, status: number) {
   normalizeRetryAfter(headers, status)
   if (isOAuthOperationalPath(path)) {
     headers.set("Cache-Control", "no-store")
@@ -131,7 +130,7 @@ export async function normalizeOperationalErrorResponse(path: string, response: 
   }
 
   const headers = new Headers(response.headers)
-  normalizeOperationalHeaders(headers, path, response.status, requestId)
+  normalizeOperationalHeaders(headers, path, response.status)
   const jsonBody = await readOperationalJsonBody(path, response, headers)
   if (jsonBody === null) {
     return new Response(response.body, {
@@ -166,7 +165,6 @@ export function operationalErrorResponse(error: Error, c: Context, requestId: st
 
   const headers = new Headers({
     "content-type": "application/json",
-    "X-Request-Id": requestId,
   })
   if (isOAuthOperationalPath(path)) {
     headers.set("Cache-Control", "no-store")

--- a/ee/apps/den-api/src/public-response-headers.ts
+++ b/ee/apps/den-api/src/public-response-headers.ts
@@ -16,10 +16,12 @@ const INTERNAL_RESPONSE_HEADERS = new Set([
   "x-request-id",
   "x-vercel-id",
 ])
+const SAFE_X_RESPONSE_HEADERS = new Set(["x-content-type-options"])
 
 function isInternalResponseHeader(name: string) {
   const normalized = name.toLowerCase()
-  return INTERNAL_RESPONSE_HEADERS.has(normalized) || normalized.startsWith("x-")
+  return !SAFE_X_RESPONSE_HEADERS.has(normalized)
+    && (INTERNAL_RESPONSE_HEADERS.has(normalized) || normalized.startsWith("x-"))
 }
 
 function sanitizeExposeHeaders(headers: Headers) {

--- a/ee/apps/den-api/src/public-response-headers.ts
+++ b/ee/apps/den-api/src/public-response-headers.ts
@@ -1,0 +1,47 @@
+const INTERNAL_RESPONSE_HEADERS = new Set([
+  "alt-svc",
+  "cf-cache-status",
+  "cf-ray",
+  "rndr-id",
+  "server",
+  "via",
+  "x-amzn-trace-id",
+  "x-envoy-upstream-service-time",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-prefix",
+  "x-forwarded-proto",
+  "x-real-ip",
+  "x-render-origin-server",
+  "x-request-id",
+  "x-vercel-id",
+])
+
+function isInternalResponseHeader(name: string) {
+  const normalized = name.toLowerCase()
+  return INTERNAL_RESPONSE_HEADERS.has(normalized) || normalized.startsWith("x-")
+}
+
+function sanitizeExposeHeaders(headers: Headers) {
+  const exposedHeaders = headers.get("access-control-expose-headers")
+  if (!exposedHeaders) return
+
+  const safeHeaders = exposedHeaders
+    .split(",")
+    .map((header) => header.trim())
+    .filter((header) => header && !isInternalResponseHeader(header))
+  if (safeHeaders.length > 0) {
+    headers.set("access-control-expose-headers", safeHeaders.join(", "))
+  } else {
+    headers.delete("access-control-expose-headers")
+  }
+}
+
+export function sanitizePublicResponseHeaders(headers: Headers) {
+  const internalHeaders: string[] = []
+  headers.forEach((_value, name) => {
+    if (isInternalResponseHeader(name)) internalHeaders.push(name)
+  })
+  for (const name of internalHeaders) headers.delete(name)
+  sanitizeExposeHeaders(headers)
+}

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -193,7 +193,8 @@ test("GET /v1/mcp-connections/:connectionId/connect/start maps OAuth handshake f
   expect(body.diagnostic.highestPassed).toBe("configured")
   expect(body.diagnostic.actionOwner).toBe("network_admin")
   expect(typeof body.diagnostic.operatorAction).toBe("string")
-  expect(body.diagnostic.referenceId).toBe(response.headers.get("x-request-id"))
+  expect(typeof body.diagnostic.referenceId).toBe("string")
+  expect(response.headers.get("x-request-id")).toBeNull()
 })
 
 test("GET /v1/mcp-connections/:connectionId/connect/start still returns connection_not_found", async () => {
@@ -1128,11 +1129,12 @@ test("non-OAuth create validation returns the same structured network diagnostic
   }
   expect(body.error).toBe("connection_validation_failed")
   expect(body.diagnostic).toMatchObject({
-    referenceId: response.headers.get("x-request-id"),
     phase: "NETWORK_TCP",
     category: "network_failure",
     code: "MCP_ECONNREFUSED",
   })
+  expect(typeof body.diagnostic.referenceId).toBe("string")
+  expect(response.headers.get("x-request-id")).toBeNull()
 })
 
 test("connection configuration rejects credentials embedded in MCP URLs", async () => {

--- a/ee/apps/den-api/test/mcp-json-rpc-preflight.test.ts
+++ b/ee/apps/den-api/test/mcp-json-rpc-preflight.test.ts
@@ -12,7 +12,7 @@ function jsonRequest(body: string) {
 async function expectJsonRpcError(response: Response, code: -32700 | -32600, message: "Parse error" | "Invalid Request", referenceId: string) {
   expect(response.status).toBe(400)
   expect(response.headers.get("content-type")).toBe("application/json")
-  expect(response.headers.get("X-Request-Id")).toBe(referenceId)
+  expect(response.headers.get("X-Request-Id")).toBeNull()
   await expect(response.json()).resolves.toMatchObject({
     jsonrpc: "2.0",
     id: null,

--- a/ee/apps/den-api/test/operational-errors.test.ts
+++ b/ee/apps/den-api/test/operational-errors.test.ts
@@ -18,7 +18,7 @@ test("OAuth token errors include cache headers and a support reference", async (
 
   expect(response.headers.get("Cache-Control")).toBe("no-store")
   expect(response.headers.get("Pragma")).toBe("no-cache")
-  expect(response.headers.get("X-Request-Id")).toBe("req_oauth_token")
+  expect(response.headers.get("X-Request-Id")).toBeNull()
   const body: unknown = await response.json()
   expect(isRecord(body) && body.reference_id).toBe("req_oauth_token")
 })
@@ -52,7 +52,7 @@ test("OAuth text/plain JSON 429 errors are parsed and normalized", async () => {
   expect(response.headers.get("Cache-Control")).toBe("no-store")
   expect(response.headers.get("Pragma")).toBe("no-cache")
   expect(response.headers.get("Retry-After")).toBe("23")
-  expect(response.headers.get("X-Request-Id")).toBe("req_text_plain_rate_limit")
+  expect(response.headers.get("X-Request-Id")).toBeNull()
 
   const body: unknown = await response.json()
   expect(body).toMatchObject({
@@ -102,7 +102,7 @@ test("streaming non-JSON MCP errors keep their body and content type", async () 
   )
 
   expect(response.headers.get("content-type")).toBe("text/event-stream")
-  expect(response.headers.get("X-Request-Id")).toBe("req_mcp_stream")
+  expect(response.headers.get("X-Request-Id")).toBeNull()
   await expect(response.text()).resolves.toBe("data: retry\n\n")
 })
 
@@ -123,7 +123,7 @@ test("streaming non-JSON MCP errors are not parsed as JSON", async () => {
   expect(result).toBeInstanceOf(Response)
   if (result instanceof Response) {
     expect(result.headers.get("content-type")).toBe("text/event-stream")
-    expect(result.headers.get("X-Request-Id")).toBe("req_mcp_pending_stream")
+    expect(result.headers.get("X-Request-Id")).toBeNull()
   }
 })
 
@@ -144,7 +144,7 @@ test("streaming JSON-seq MCP errors are not buffered as finite JSON", async () =
   expect(result).toBeInstanceOf(Response)
   if (result instanceof Response) {
     expect(result.headers.get("content-type")).toBe("application/json-seq")
-    expect(result.headers.get("X-Request-Id")).toBe("req_mcp_json_seq")
+    expect(result.headers.get("X-Request-Id")).toBeNull()
   }
 })
 
@@ -165,7 +165,7 @@ test("streaming stream+json MCP errors are not buffered as finite JSON", async (
   expect(result).toBeInstanceOf(Response)
   if (result instanceof Response) {
     expect(result.headers.get("content-type")).toBe("application/stream+json")
-    expect(result.headers.get("X-Request-Id")).toBe("req_mcp_stream_json")
+    expect(result.headers.get("X-Request-Id")).toBeNull()
   }
 })
 
@@ -189,7 +189,7 @@ test("operational route error logging omits provider-controlled exception text",
     expect(response.status).toBe(500)
     expect(response.headers.get("Cache-Control")).toBe("no-store")
     expect(response.headers.get("Pragma")).toBe("no-cache")
-    expect(response.headers.get("X-Request-Id")).toBe("req_safe_log")
+    expect(response.headers.get("X-Request-Id")).toBeNull()
     const body: unknown = await response.json()
     expect(body).toMatchObject({
       error: "server_error",

--- a/ee/apps/den-api/test/public-response-headers.test.ts
+++ b/ee/apps/den-api/test/public-response-headers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizePublicResponseHeaders } from "../src/public-response-headers.js"
+
+describe("public response headers", () => {
+  test("strips internal and custom x-* headers from public responses", () => {
+    const headers = new Headers({
+      "access-control-expose-headers": "Content-Length, X-Request-Id, X-Origin-Host",
+      "content-type": "application/json",
+      "rndr-id": "render-request",
+      "server": "internal-origin",
+      "via": "internal-proxy",
+      "x-cache-key": "cache:key",
+      "x-origin-host": "den-api.internal",
+      "x-render-origin-server": "Render",
+      "x-request-id": "req_internal",
+    })
+
+    sanitizePublicResponseHeaders(headers)
+
+    expect(headers.get("access-control-expose-headers")).toBe("Content-Length")
+    expect(headers.get("content-type")).toBe("application/json")
+    for (const header of [
+      "rndr-id",
+      "server",
+      "via",
+      "x-cache-key",
+      "x-origin-host",
+      "x-render-origin-server",
+      "x-request-id",
+    ]) {
+      expect(headers.get(header)).toBeNull()
+    }
+  })
+})

--- a/ee/apps/den-api/test/public-response-headers.test.ts
+++ b/ee/apps/den-api/test/public-response-headers.test.ts
@@ -10,6 +10,7 @@ describe("public response headers", () => {
       "server": "internal-origin",
       "via": "internal-proxy",
       "x-cache-key": "cache:key",
+      "x-content-type-options": "nosniff",
       "x-origin-host": "den-api.internal",
       "x-render-origin-server": "Render",
       "x-request-id": "req_internal",
@@ -19,6 +20,7 @@ describe("public response headers", () => {
 
     expect(headers.get("access-control-expose-headers")).toBe("Content-Length")
     expect(headers.get("content-type")).toBe("application/json")
+    expect(headers.get("x-content-type-options")).toBe("nosniff")
     for (const header of [
       "rndr-id",
       "server",

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -58,6 +58,7 @@ describe("Den upstream proxy", () => {
               "server": "internal-origin",
               "via": "internal-proxy",
               "x-cache-key": "cache:key",
+              "x-content-type-options": "nosniff",
               "x-origin-host": "den-api.internal",
               "x-render-origin-server": "Render",
               "x-request-id": "req_internal",
@@ -257,6 +258,7 @@ describe("Den upstream proxy", () => {
     ]) {
       expect(response.headers.get(header)).toBeNull();
     }
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(response.headers.get("content-location")).toBe("https://app.example.com/api/den/v1/internal-headers/body");
     expect(response.headers.get("link")).toBe("<https://app.example.com/api/den/v1/internal-headers/next>; rel=\"next\"");
     expect(response.headers.get("location")).toBe("https://app.example.com/api/den/v1/internal-headers/redirect?next=1");

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -45,6 +45,27 @@ describe("Den upstream proxy", () => {
           return new Response("upstream unavailable", { status: 502 });
         }
 
+        if (url.pathname === "/v1/internal-headers") {
+          const upstreamOrigin = new URL(request.url).origin;
+          return new Response("sanitized", {
+            headers: {
+              "access-control-expose-headers": "Content-Length, X-Request-Id, X-Origin-Host",
+              "content-location": `${upstreamOrigin}/v1/internal-headers/body`,
+              "link": `<${upstreamOrigin}/v1/internal-headers/next>; rel="next"`,
+              "location": `${upstreamOrigin}/v1/internal-headers/redirect?next=1`,
+              "refresh": `0; url=${upstreamOrigin}/v1/internal-headers/login`,
+              "rndr-id": "render-request",
+              "server": "internal-origin",
+              "via": "internal-proxy",
+              "x-cache-key": "cache:key",
+              "x-origin-host": "den-api.internal",
+              "x-render-origin-server": "Render",
+              "x-request-id": "req_internal",
+              "x-upstream-result": "ok",
+            },
+          });
+        }
+
         return new Response("proxied", {
           status: 207,
           headers: {
@@ -195,7 +216,7 @@ describe("Den upstream proxy", () => {
       tracestate: null,
     });
     expect(response.status).toBe(207);
-    expect(response.headers.get("x-upstream-result")).toBe("ok");
+    expect(response.headers.get("x-upstream-result")).toBeNull();
     expect(response.headers.get("set-cookie")).toContain("sid=abc");
     expect(await response.text()).toBe("proxied");
     expect(logs).toHaveLength(1);
@@ -215,6 +236,32 @@ describe("Den upstream proxy", () => {
     expect(serializedLog).not.toContain("tok_test");
     expect(serializedLog).not.toContain("sess_test");
     expect(serializedLog).not.toContain(JSON.stringify({ ok: true }));
+  });
+
+  test("strips internal upstream response headers and rewrites upstream URLs", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/internal-headers");
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(response.headers.get("access-control-expose-headers")).toBe("Content-Length");
+    for (const header of [
+      "rndr-id",
+      "server",
+      "via",
+      "x-cache-key",
+      "x-origin-host",
+      "x-render-origin-server",
+      "x-request-id",
+      "x-upstream-result",
+    ]) {
+      expect(response.headers.get(header)).toBeNull();
+    }
+    expect(response.headers.get("content-location")).toBe("https://app.example.com/api/den/v1/internal-headers/body");
+    expect(response.headers.get("link")).toBe("<https://app.example.com/api/den/v1/internal-headers/next>; rel=\"next\"");
+    expect(response.headers.get("location")).toBe("https://app.example.com/api/den/v1/internal-headers/redirect?next=1");
+    expect(response.headers.get("refresh")).toBe("0; url=https://app.example.com/api/den/v1/internal-headers/login");
+    expect(await response.text()).toBe("sanitized");
   });
 
   test("drops content-encoding after upstream fetch decompresses the body", async () => {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -17,6 +17,25 @@ const HOP_BY_HOP_HEADERS = new Set([
 const REQUEST_ONLY_HEADERS = new Set(["host", "content-length"]);
 const RESPONSE_ONLY_HEADERS = new Set(["content-length", "content-encoding"]);
 const SPOOFABLE_FORWARDING_HEADERS = new Set(["forwarded", "x-forwarded-host", "x-forwarded-prefix", "x-forwarded-proto"]);
+const LOCATION_BASED_HEADERS = new Set(["content-location", "link", "location", "refresh"]);
+const INTERNAL_RESPONSE_HEADERS = new Set([
+  "alt-svc",
+  "cf-cache-status",
+  "cf-ray",
+  "rndr-id",
+  "server",
+  "via",
+  "x-amzn-trace-id",
+  "x-envoy-upstream-service-time",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-prefix",
+  "x-forwarded-proto",
+  "x-real-ip",
+  "x-render-origin-server",
+  "x-request-id",
+  "x-vercel-id",
+]);
 
 /**
  * OpenWork Cloud instances are served from Daytona preview origins that are
@@ -134,7 +153,33 @@ function shouldSkipRequestHeader(name: string): boolean {
 
 function shouldSkipResponseHeader(name: string): boolean {
   const normalized = name.toLowerCase();
-  return HOP_BY_HOP_HEADERS.has(normalized) || RESPONSE_ONLY_HEADERS.has(normalized) || normalized === "set-cookie";
+  return HOP_BY_HOP_HEADERS.has(normalized)
+    || RESPONSE_ONLY_HEADERS.has(normalized)
+    || INTERNAL_RESPONSE_HEADERS.has(normalized)
+    || normalized.startsWith("x-")
+    || normalized === "set-cookie";
+}
+
+function shouldSkipExposedResponseHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return HOP_BY_HOP_HEADERS.has(normalized)
+    || INTERNAL_RESPONSE_HEADERS.has(normalized)
+    || normalized.startsWith("x-");
+}
+
+function sanitizeExposeHeaders(headers: Headers): void {
+  const exposedHeaders = headers.get("access-control-expose-headers");
+  if (!exposedHeaders) return;
+
+  const safeHeaders = exposedHeaders
+    .split(",")
+    .map((header) => header.trim())
+    .filter((header) => header && !shouldSkipExposedResponseHeader(header));
+  if (safeHeaders.length > 0) {
+    headers.set("access-control-expose-headers", safeHeaders.join(", "));
+  } else {
+    headers.delete("access-control-expose-headers");
+  }
 }
 
 async function injectActiveTraceContext(headers: Headers): Promise<void> {
@@ -180,40 +225,77 @@ function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers
   }
 }
 
-function rewriteLocationHeader(location: string, request: NextRequest, apiBase: string): string {
-  let parsedLocation: URL;
+function publicProxyUrlForUpstreamUrl(value: string, request: NextRequest, apiBase: string, options: ProxyOptions): string {
+  let parsedValue: URL;
   try {
-    parsedLocation = new URL(location);
+    parsedValue = new URL(value);
   } catch {
-    return location;
+    return value;
   }
 
   let apiOrigin: string;
   try {
     apiOrigin = new URL(apiBase).origin;
   } catch {
-    return location;
+    return value;
   }
 
-  if (parsedLocation.origin !== apiOrigin || !parsedLocation.pathname.startsWith("/api/auth/")) {
-    return location;
+  if (parsedValue.origin !== apiOrigin) {
+    return value;
   }
 
   const requestOrigin = new URL(request.url).origin;
-  return `${requestOrigin}${parsedLocation.pathname}${parsedLocation.search}${parsedLocation.hash}`;
+  const routePrefix = options.routePrefix.startsWith("/") ? options.routePrefix : `/${options.routePrefix}`;
+  const upstreamPrefix = normalizePathPrefix(options.upstreamPathPrefix ?? "");
+  let publicPath: string;
+
+  if (upstreamPrefix) {
+    const normalizedUpstreamPrefix = `/${upstreamPrefix}`;
+    if (!parsedValue.pathname.startsWith(normalizedUpstreamPrefix)) return value;
+    const suffix = parsedValue.pathname.slice(normalizedUpstreamPrefix.length);
+    publicPath = `${routePrefix}${suffix.startsWith("/") ? suffix : `/${suffix}`}`;
+  } else {
+    publicPath = `${routePrefix}${parsedValue.pathname.startsWith("/") ? parsedValue.pathname : `/${parsedValue.pathname}`}`;
+  }
+
+  return `${requestOrigin}${publicPath}${parsedValue.search}${parsedValue.hash}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function rewriteEmbeddedUpstreamUrls(value: string, request: NextRequest, apiBase: string, options: ProxyOptions): string {
+  let apiOrigin: string;
+  try {
+    apiOrigin = new URL(apiBase).origin;
+  } catch {
+    return value;
+  }
+
+  const absoluteUpstreamUrl = new RegExp(`${escapeRegExp(apiOrigin)}[^\\s,;<>\"]*`, "g");
+  return value.replace(absoluteUpstreamUrl, (match) => publicProxyUrlForUpstreamUrl(match, request, apiBase, options));
+}
+
+function rewriteLocationBasedHeader(value: string, request: NextRequest, apiBase: string, options: ProxyOptions): string {
+  const rewrittenSingleUrl = publicProxyUrlForUpstreamUrl(value, request, apiBase, options);
+  return rewrittenSingleUrl === value
+    ? rewriteEmbeddedUpstreamUrls(value, request, apiBase, options)
+    : rewrittenSingleUrl;
 }
 
 function cloneResponseHeaders(request: NextRequest, upstream: Response, options: ProxyOptions, apiBase: string): Headers {
   const headers = new Headers();
   upstream.headers.forEach((value, name) => {
     if (shouldSkipResponseHeader(name)) return;
-    if (name.toLowerCase() === "location" && options.rewriteAuthLocationsToRequestOrigin) {
-      headers.append(name, rewriteLocationHeader(value, request, apiBase));
+    if (LOCATION_BASED_HEADERS.has(name.toLowerCase())) {
+      headers.append(name, rewriteLocationBasedHeader(value, request, apiBase, options));
       return;
     }
     headers.append(name, value);
   });
   copySetCookieHeaders(upstream.headers, headers);
+  sanitizeExposeHeaders(headers);
   return headers;
 }
 

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -36,6 +36,7 @@ const INTERNAL_RESPONSE_HEADERS = new Set([
   "x-request-id",
   "x-vercel-id",
 ]);
+const SAFE_X_RESPONSE_HEADERS = new Set(["x-content-type-options"]);
 
 /**
  * OpenWork Cloud instances are served from Daytona preview origins that are
@@ -156,7 +157,7 @@ function shouldSkipResponseHeader(name: string): boolean {
   return HOP_BY_HOP_HEADERS.has(normalized)
     || RESPONSE_ONLY_HEADERS.has(normalized)
     || INTERNAL_RESPONSE_HEADERS.has(normalized)
-    || normalized.startsWith("x-")
+    || (!SAFE_X_RESPONSE_HEADERS.has(normalized) && normalized.startsWith("x-"))
     || normalized === "set-cookie";
 }
 
@@ -164,7 +165,7 @@ function shouldSkipExposedResponseHeader(name: string): boolean {
   const normalized = name.toLowerCase();
   return HOP_BY_HOP_HEADERS.has(normalized)
     || INTERNAL_RESPONSE_HEADERS.has(normalized)
-    || normalized.startsWith("x-");
+    || (!SAFE_X_RESPONSE_HEADERS.has(normalized) && normalized.startsWith("x-"));
 }
 
 function sanitizeExposeHeaders(headers: Headers): void {


### PR DESCRIPTION
## Summary
- strip internal/platform/custom response headers from den-api public responses
- sanitize den-web's /api/den upstream response headers and CORS exposed headers
- rewrite location-based upstream URLs back through the public den-web proxy route

## Verification
- pnpm --filter @openwork-ee/den-web exec bun test app/api/_lib/upstream-proxy.test.mjs
- pnpm --filter @openwork-ee/den-api exec bun test test/public-response-headers.test.ts test/operational-errors.test.ts test/mcp-json-rpc-preflight.test.ts
- pnpm --filter @openwork-ee/den-web typecheck
