### PR TITLE
feat(desktop): add reliable version recovery

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -55,12 +55,29 @@ export type BrowserProxyState = {
   proxy: { rules: string; authenticated: boolean } | null;
 };
 
+export type RecoveryRelease = {
+  id: string;
+  version: string;
+  marking: "current" | "previous" | null;
+};
+
+export type RecoveryActionResult = {
+  ok: boolean;
+  action?: "install" | "installer" | "eval";
+  message?: string;
+  reason?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Electron bridge surface
 // ---------------------------------------------------------------------------
 
 declare global {
   interface Window {
+    __openworkRecoveryControl?: {
+      snapshot: () => Promise<unknown>;
+      select: (id: string) => Promise<unknown>;
+    };
     __OPENWORK_ELECTRON__?: {
       invokeDesktop?: <C extends DesktopCommandName>(
         command: C,
@@ -133,6 +150,16 @@ declare global {
         download?: () => Promise<{ ok: boolean; reason?: string }>;
         installAndRestart?: () => Promise<{ ok: boolean; reason?: string }>;
       };
+      recovery?: {
+        recordHealthy?: () => Promise<unknown>;
+        list?: (policy: {
+          versions: string[];
+          minimumVersion: string;
+          allowedVersions?: string[];
+        }) => Promise<{ ok: boolean; releases: RecoveryRelease[]; reason?: string }>;
+        restorePrevious?: () => Promise<RecoveryActionResult>;
+        use?: (id: string) => Promise<RecoveryActionResult>;
+      };
       browser?: {
         show?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
         hide?: () => Promise<void>;
@@ -177,6 +204,7 @@ declare global {
         initialDeepLinks?: string[];
         platform?: "darwin" | "linux" | "windows";
         version?: string;
+        evalFatalBootstrapFailure?: string | null;
       };
     };
   }

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -80,6 +80,8 @@ export function useDesktopRuntimeBoot() {
 
     void (async () => {
       try {
+        const evalFatalFailure = window.__OPENWORK_ELECTRON__?.meta?.evalFatalBootstrapFailure;
+        if (evalFatalFailure) throw new Error(evalFatalFailure);
         // On Electron specifically: if the previous Tauri install dropped
         // a migration snapshot, fold it into localStorage before any of
         // the boot code reads workspace preferences. Idempotent across
@@ -125,6 +127,7 @@ export function useDesktopRuntimeBoot() {
             return;
           }
           publishOpenworkServerInfo(serverInfo);
+          await window.__OPENWORK_ELECTRON__?.recovery?.recordHealthy?.().catch(() => undefined);
           markReady();
         };
 
@@ -185,6 +188,7 @@ export function useDesktopRuntimeBoot() {
             if (isOpenworkServerInfoLike(restarted)) serverInfo = restarted;
           }
           publishOpenworkServerInfo(serverInfo);
+          await window.__OPENWORK_ELECTRON__?.recovery?.recordHealthy?.().catch(() => undefined);
           markReady();
           return;
         }

--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -1,8 +1,23 @@
 /** @jsxImportSource react */
+import { useEffect, useState } from "react";
+import type { RecoveryActionResult, RecoveryRelease } from "@/app/lib/desktop";
+import type { DenAppVersionMetadata, DenDesktopConfig } from "@/app/lib/den";
+import { readFreshDenAppVersionMetadata } from "@/app/lib/version-gate";
+import { useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider";
 import { bootOverlayCanHide, useBootState, useBootOverlayVisible } from "./boot-state";
 import { OwDotTicker } from "./dot-ticker";
 
-const RELEASES_URL = "https://github.com/different-ai/openwork/releases";
+async function loadRecoveryPolicy(
+  refreshDesktopConfig: () => Promise<DenDesktopConfig>,
+): Promise<{ metadata: DenAppVersionMetadata; policy: DenDesktopConfig } | null> {
+  const timeout = new Promise<null>((resolve) => window.setTimeout(() => resolve(null), 10_000));
+  return Promise.race([
+    Promise.all([readFreshDenAppVersionMetadata(), refreshDesktopConfig()])
+      .then(([metadata, policy]) => ({ metadata, policy }))
+      .catch(() => null),
+    timeout,
+  ]);
+}
 
 /**
  * Quiet, opaque boot overlay. Solid surface fill so nothing bleeds through.
@@ -12,6 +27,64 @@ const RELEASES_URL = "https://github.com/different-ai/openwork/releases";
 export function LoadingOverlay() {
   const visible = useBootOverlayVisible();
   const { phase, routeReady, message, error } = useBootState();
+  const { config: desktopPolicy, refreshFresh: refreshDesktopPolicy } = useDesktopConfig();
+  const [releases, setReleases] = useState<RecoveryRelease[]>([]);
+  const [showPicker, setShowPicker] = useState(false);
+  const [actionState, setActionState] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!error) return;
+    let cancelled = false;
+    const bridge = window.__OPENWORK_ELECTRON__?.recovery;
+    if (!bridge?.list) return;
+    const cachedPolicy = {
+      versions: [],
+      minimumVersion: "0.0.0",
+      ...(Array.isArray(desktopPolicy.allowedDesktopVersions)
+        ? { allowedVersions: desktopPolicy.allowedDesktopVersions }
+        : {}),
+    };
+    void bridge.list(cachedPolicy)
+      .then((result) => {
+        if (!cancelled && result.ok) setReleases(result.releases);
+      })
+      .catch(() => undefined);
+    if (window.__openworkRecoveryControl) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    void loadRecoveryPolicy(refreshDesktopPolicy)
+      .then((fresh) => fresh ? bridge.list?.({
+        versions: fresh.metadata.publishedDesktopVersions,
+        minimumVersion: fresh.metadata.minAppVersion,
+        ...(Array.isArray(fresh.policy.allowedDesktopVersions)
+          ? { allowedVersions: fresh.policy.allowedDesktopVersions }
+          : {}),
+      }) : null)
+      .then((result) => {
+        if (!cancelled && result?.ok) setReleases(result.releases);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopPolicy, error, refreshDesktopPolicy]);
+
+  const runRecovery = async (action: (() => Promise<RecoveryActionResult>) | undefined) => {
+    if (!action) return;
+    setActionState("Preparing verified recovery…");
+    try {
+      const result = await action();
+      setActionState(result.ok
+        ? result.message ?? "Recovery is ready."
+        : result.reason ?? "Recovery could not be started. Please retry.");
+    } catch {
+      setActionState("Recovery could not be started. Please retry.");
+    }
+  };
+
+  const useRelease = window.__OPENWORK_ELECTRON__?.recovery?.use;
 
   if (!visible) return null;
 
@@ -27,26 +100,65 @@ export function LoadingOverlay() {
       role="status"
     >
       <div className="flex w-full max-w-[320px] flex-col items-center gap-4 px-6 text-center">
-        <OwDotTicker size="md" />
-        <div className="text-[12px] leading-5 text-dls-secondary">
-          {message || "Preparing workspace"}
-        </div>
         {error ? (
-          <div className="flex flex-col gap-2 text-[12px] leading-5 text-red-11">
-            <div>{error}</div>
-            <div className="text-dls-secondary">
-              Download the latest version manually here:{" "}
-              <a
-                href={RELEASES_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="text-dls-primary underline decoration-dls-primary/40 underline-offset-4"
-              >
-                {RELEASES_URL}
-              </a>
-            </div>
+          <div className="flex w-full flex-col gap-3 text-[12px] leading-5">
+            <div className="text-base font-medium text-dls-primary">OpenWork couldn't start</div>
+            <div className="text-dls-secondary">Return to a version that works on this computer.</div>
+            <button
+              type="button"
+              disabled={!releases.some((release) => release.marking === "previous")}
+              className="rounded-md bg-dls-accent px-3 py-2 font-medium text-dls-accent-foreground disabled:opacity-50"
+              onClick={() => void runRecovery(window.__OPENWORK_ELECTRON__?.recovery?.restorePrevious)}
+            >
+              Restore previous version
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-dls-border px-3 py-2 font-medium text-dls-primary"
+              onClick={() => setShowPicker((value) => !value)}
+            >
+              Pick another version
+            </button>
+            {showPicker ? (
+              <div className="flex flex-col gap-2">
+                {releases.map((release) => (
+                  <div key={release.id} className="flex items-center gap-2">
+                    {release.marking === "current" ? (
+                      <div className="flex-1 rounded-md border border-dls-border px-3 py-2 text-left text-dls-secondary">
+                        {release.version}
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="flex-1 rounded-md border border-dls-border px-3 py-2 text-left text-dls-primary"
+                        onClick={() => void runRecovery(
+                          useRelease
+                            ? () => useRelease(release.id)
+                            : undefined,
+                        )}
+                      >
+                        Use {release.version}
+                      </button>
+                    )}
+                    {release.marking ? <span className="text-dls-secondary">{release.marking}</span> : null}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {actionState ? <div className="text-dls-secondary">{actionState}</div> : null}
+            <details className="text-left text-dls-secondary">
+              <summary className="cursor-pointer">Technical details</summary>
+              <div className="mt-2 break-words">{error}</div>
+            </details>
           </div>
-        ) : null}
+        ) : (
+          <>
+            <OwDotTicker size="md" />
+            <div className="text-[12px] leading-5 text-dls-secondary">
+              {message || "Preparing workspace"}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1262,6 +1262,9 @@ function assertOpenworkServerReady(info) {
 }
 
 async function bootRuntimeForSelectedWorkspace() {
+  if (typeof process.env.OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE === "string") {
+    throw new Error(process.env.OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE);
+  }
   const list = await workspaceStore.readWorkspaceState();
   const selectedId = list.selectedId || list.activeId || list.workspaces[0]?.id || "";
   const workspace = selectedId
@@ -2528,6 +2531,11 @@ const { ensureAutoUpdater } = registerUpdaterIpc({
   manifestChannel: DESKTOP_DISTRIBUTION.flavor === "public"
     ? "latest"
     : DESKTOP_DISTRIBUTION.flavor,
+  electronNet,
+  shell,
+  distribution: DESKTOP_DISTRIBUTION.flavor,
+  platform: process.platform,
+  arch: process.arch,
 });
 
 if (!app.requestSingleInstanceLock()) {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -135,6 +135,20 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
       };
     },
   },
+  recovery: {
+    recordHealthy() {
+      return ipcRenderer.invoke("openwork:recovery:recordHealthy");
+    },
+    list(policy) {
+      return ipcRenderer.invoke("openwork:recovery:list", policy);
+    },
+    restorePrevious() {
+      return ipcRenderer.invoke("openwork:recovery:restorePrevious");
+    },
+    use(id) {
+      return ipcRenderer.invoke("openwork:recovery:use", id);
+    },
+  },
   browser: {
     show(bounds) { return ipcRenderer.invoke("openwork:browser:show", bounds); },
     hide() { return ipcRenderer.invoke("openwork:browser:hide"); },
@@ -193,8 +207,23 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     initialDeepLinks: [],
     platform: normalizePlatform(process.platform),
     version: process.versions.electron,
+    evalFatalBootstrapFailure: process.env.OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE ?? null,
   },
 });
+
+if (
+  process.env.OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE
+  && (process.env.OPENWORK_EVAL_RECOVERY_CANDIDATES || process.env.OPENWORK_EVAL_RECOVERY_RELEASES)
+) {
+  contextBridge.exposeInMainWorld("__openworkRecoveryControl", {
+    snapshot() {
+      return ipcRenderer.invoke("openwork:recovery:evalSnapshot");
+    },
+    select(id) {
+      return ipcRenderer.invoke("openwork:recovery:use", id);
+    },
+  });
+}
 
 ipcRenderer.on(NATIVE_DEEP_LINK_EVENT, (_event, urls) => {
   if (typeof window === "undefined") return;

--- a/apps/desktop/electron/recovery.mjs
+++ b/apps/desktop/electron/recovery.mjs
@@ -1,0 +1,286 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const RECOVERY_STATE_FILENAME = "app-recovery.v1.json";
+const RECOVERY_CACHE_DIRECTORY = "app-recovery-cache";
+const STABLE_VERSION = /^\d+\.\d+\.\d+$/;
+
+function stableVersion(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().replace(/^v/i, "");
+  return STABLE_VERSION.test(normalized) ? normalized : null;
+}
+
+function compareStableVersions(left, right) {
+  const a = stableVersion(left);
+  const b = stableVersion(right);
+  if (!a || !b) return null;
+  const leftParts = a.split(".").map(Number);
+  const rightParts = b.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] < rightParts[index] ? -1 : 1;
+  }
+  return 0;
+}
+
+function statePath(app) {
+  return path.join(app.getPath("userData"), RECOVERY_STATE_FILENAME);
+}
+
+export async function readRecoveryState(app, distribution) {
+  try {
+    const parsed = JSON.parse(await readFile(statePath(app), "utf8"));
+    if (parsed?.distribution !== distribution) return { currentVersion: null, previousVersion: null };
+    return {
+      currentVersion: stableVersion(parsed.currentVersion),
+      previousVersion: stableVersion(parsed.previousVersion),
+    };
+  } catch {
+    return { currentVersion: null, previousVersion: null };
+  }
+}
+
+export async function recordHealthyVersion(app, distribution, rawVersion) {
+  const version = stableVersion(rawVersion);
+  if (!version) throw new Error("Healthy app version must use the stable x.y.z format.");
+  const previous = await readRecoveryState(app, distribution);
+  const state = {
+    distribution,
+    currentVersion: version,
+    previousVersion: previous.currentVersion && previous.currentVersion !== version
+      ? previous.currentVersion
+      : previous.previousVersion,
+    writtenAt: new Date().toISOString(),
+  };
+  const outputPath = statePath(app);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.${process.pid}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await rename(temporaryPath, outputPath);
+  return state;
+}
+
+export function recoveryManifestName(platform, arch, distribution) {
+  const channel = distribution === "public" ? "latest" : distribution;
+  if (platform === "darwin") return `${channel}-mac.yml`;
+  if (platform === "win32") return `${channel}.yml`;
+  return `${channel}-linux${arch === "arm64" ? "-arm64" : ""}.yml`;
+}
+
+export function parseRecoveryManifest(raw) {
+  const files = [];
+  let current = null;
+  for (const line of String(raw ?? "").split(/\r?\n/)) {
+    const start = line.match(/^\s*-\s+url:\s*(.+?)\s*$/);
+    if (start) {
+      current = { url: start[1].trim().replace(/^['"]|['"]$/g, "") };
+      files.push(current);
+      continue;
+    }
+    const property = line.match(/^\s{4}([A-Za-z][A-Za-z0-9_-]*):\s*(.+?)\s*$/);
+    if (property && current) current[property[1]] = property[2].trim().replace(/^['"]|['"]$/g, "");
+  }
+  return files;
+}
+
+function installerExtension(platform) {
+  if (platform === "darwin") return ".dmg";
+  if (platform === "win32") return ".exe";
+  return ".AppImage";
+}
+
+function validRecoveryArtifactIdentity(artifact) {
+  const version = stableVersion(artifact?.version);
+  if (!version || artifact.version !== version) return false;
+  if (!["darwin", "win32", "linux"].includes(artifact.platform)) return false;
+  if (!["arm64", "x64"].includes(artifact.arch)) return false;
+  if (!["public", "cloud", "enterprise"].includes(artifact.distribution)) return false;
+  if (typeof artifact.url !== "string" || typeof artifact.sha512 !== "string" || !artifact.sha512.trim()) return false;
+  let url;
+  try {
+    url = new URL(artifact.url);
+  } catch {
+    return false;
+  }
+  const prefix = `/different-ai/openwork/releases/download/v${version}/`;
+  if (url.protocol !== "https:" || url.hostname !== "github.com" || !url.pathname.startsWith(prefix)) return false;
+  const assetArch = artifact.platform === "linux" && artifact.arch === "x64" ? "x86_64" : artifact.arch;
+  const platformSlug = artifact.platform === "darwin" ? "mac" : artifact.platform === "win32" ? "win" : "linux";
+  const fileName = path.basename(url.pathname);
+  const distributionSlug = artifact.distribution === "public" ? "" : `${artifact.distribution}-`;
+  return fileName === `openwork-${distributionSlug}${platformSlug}-${assetArch}-${version}${installerExtension(artifact.platform)}`;
+}
+
+export function selectRecoveryArtifact(files, { version, platform, arch, distribution }) {
+  const normalizedVersion = stableVersion(version);
+  if (!normalizedVersion || !["public", "cloud", "enterprise"].includes(distribution)) return null;
+  const assetArch = platform === "linux" && arch === "x64" ? "x86_64" : arch;
+  const extension = installerExtension(platform);
+  const matching = files.filter((file) =>
+    typeof file?.url === "string"
+    && file.url.includes(`-${assetArch}-`)
+    && file.url.endsWith(extension)
+    && typeof file.sha512 === "string"
+    && file.sha512.trim(),
+  );
+  const baseUrl = `https://github.com/different-ai/openwork/releases/download/v${normalizedVersion}/`;
+  for (const selected of matching) {
+    const url = new URL(selected.url, baseUrl);
+    if (url.origin !== "https://github.com" || !url.pathname.startsWith(`/different-ai/openwork/releases/download/v${normalizedVersion}/`)) {
+      continue;
+    }
+    const artifact = {
+      version: normalizedVersion,
+      platform,
+      arch,
+      distribution,
+      url: url.toString(),
+      sha512: selected.sha512.trim(),
+    };
+    return validRecoveryArtifactIdentity(artifact) ? artifact : null;
+  }
+  return null;
+}
+
+export async function compatibleRecoveryReleases({
+  versions,
+  currentVersion,
+  previousVersion,
+  minimumVersion,
+  allowedVersions,
+  resolveArtifact,
+  limit = 5,
+}) {
+  const current = stableVersion(currentVersion);
+  const previous = stableVersion(previousVersion);
+  const minimum = stableVersion(minimumVersion);
+  const allowed = Array.isArray(allowedVersions)
+    ? new Set(allowedVersions.flatMap((value) => stableVersion(value) ?? []))
+    : null;
+  const filtered = [...new Set(Array.isArray(versions) ? versions.flatMap((value) => stableVersion(value) ?? []) : [])]
+    .filter((version) => !minimum || compareStableVersions(version, minimum) >= 0)
+    .filter((version) => !allowed || allowed.has(version))
+    .sort((left, right) => compareStableVersions(right, left) ?? 0)
+    .slice(0, limit);
+  const releases = [];
+  for (const version of filtered) {
+    const artifact = await resolveArtifact(version);
+    if (!artifact) continue;
+    releases.push({
+      id: version,
+      version,
+      marking: version === current ? "current" : version === previous ? "previous" : null,
+      artifact,
+      cachedFilePath: artifact.cachedFilePath ?? null,
+    });
+  }
+  return releases;
+}
+
+export function recoveryVersionMarkers(installedVersion, persistedState) {
+  const currentVersion = stableVersion(installedVersion);
+  const persistedCurrent = stableVersion(persistedState?.currentVersion);
+  const persistedPrevious = stableVersion(persistedState?.previousVersion);
+  return {
+    currentVersion,
+    previousVersion: persistedCurrent && persistedCurrent !== currentVersion
+      ? persistedCurrent
+      : persistedPrevious,
+  };
+}
+
+export async function cacheVerifiedRecoveryArtifact({ app, artifact, fetchArtifact }) {
+  const response = await fetchArtifact(artifact.url);
+  if (!response.ok) throw new Error(`Recovery download failed with HTTP ${response.status}.`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const checksum = createHash("sha512").update(bytes).digest("base64");
+  if (checksum !== artifact.sha512) throw new Error("Recovery installer checksum did not match its signed manifest.");
+  const cacheDirectory = path.join(app.getPath("userData"), RECOVERY_CACHE_DIRECTORY);
+  const stagingDirectory = `${cacheDirectory}.staging`;
+  const backupDirectory = `${cacheDirectory}.backup`;
+  const fileName = path.basename(new URL(artifact.url).pathname);
+  await rm(stagingDirectory, { recursive: true, force: true });
+  await mkdir(stagingDirectory, { recursive: true });
+  await writeFile(path.join(stagingDirectory, fileName), bytes);
+  await writeFile(
+    path.join(stagingDirectory, "metadata.json"),
+    `${JSON.stringify({ ...artifact, checksum, fileName }, null, 2)}\n`,
+    "utf8",
+  );
+  await rm(backupDirectory, { recursive: true, force: true });
+  let previousMoved = false;
+  try {
+    await rename(cacheDirectory, backupDirectory);
+    previousMoved = true;
+  } catch {
+    // No prior cache is the normal first-run case.
+  }
+  try {
+    await rename(stagingDirectory, cacheDirectory);
+  } catch (error) {
+    if (previousMoved) await rename(backupDirectory, cacheDirectory).catch(() => undefined);
+    throw error;
+  }
+  await rm(backupDirectory, { recursive: true, force: true });
+  return path.join(cacheDirectory, fileName);
+}
+
+export async function verifyCachedRecoveryArtifact(filePath, artifact) {
+  try {
+    if (!validRecoveryArtifactIdentity(artifact)) return false;
+    const bytes = await readFile(filePath);
+    const metadata = JSON.parse(await readFile(path.join(path.dirname(filePath), "metadata.json"), "utf8"));
+    const checksum = createHash("sha512").update(bytes).digest("base64");
+    return metadata.version === artifact.version
+      && metadata.platform === artifact.platform
+      && metadata.arch === artifact.arch
+      && metadata.distribution === artifact.distribution
+      && metadata.url === artifact.url
+      && metadata.sha512 === artifact.sha512
+      && metadata.fileName === path.basename(filePath)
+      && metadata.fileName === path.basename(new URL(artifact.url).pathname)
+      && checksum === artifact.sha512;
+  } catch {
+    return false;
+  }
+}
+
+export async function readCachedRecoveryArtifact(app, expected) {
+  const directories = [
+    path.join(app.getPath("userData"), RECOVERY_CACHE_DIRECTORY),
+    path.join(app.getPath("userData"), `${RECOVERY_CACHE_DIRECTORY}.backup`),
+  ];
+  for (const directory of directories) {
+    try {
+      const metadata = JSON.parse(await readFile(path.join(directory, "metadata.json"), "utf8"));
+      const artifact = {
+        version: stableVersion(metadata.version),
+        platform: typeof metadata.platform === "string" ? metadata.platform : null,
+        arch: typeof metadata.arch === "string" ? metadata.arch : null,
+        distribution: typeof metadata.distribution === "string" ? metadata.distribution : null,
+        url: typeof metadata.url === "string" ? metadata.url : null,
+        sha512: typeof metadata.sha512 === "string" ? metadata.sha512 : null,
+      };
+      if (
+        !artifact.version
+        || !artifact.url
+        || !artifact.sha512
+        || artifact.platform !== expected.platform
+        || artifact.arch !== expected.arch
+        || artifact.distribution !== expected.distribution
+        || !validRecoveryArtifactIdentity(artifact)
+      ) continue;
+      const fileName = typeof metadata.fileName === "string" ? metadata.fileName : "";
+      if (!fileName || fileName !== path.basename(fileName)) continue;
+      const filePath = path.join(directory, fileName);
+      if (!(await verifyCachedRecoveryArtifact(filePath, artifact))) continue;
+      return { artifact, filePath };
+    } catch {
+      // Missing, incomplete, or tampered caches are ignored.
+    }
+  }
+  return null;
+}
+
+export { compareStableVersions, stableVersion };

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -3,6 +3,20 @@ import { readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  cacheVerifiedRecoveryArtifact,
+  compatibleRecoveryReleases,
+  compareStableVersions,
+  parseRecoveryManifest,
+  readCachedRecoveryArtifact,
+  readRecoveryState,
+  recordHealthyVersion,
+  recoveryManifestName,
+  recoveryVersionMarkers,
+  selectRecoveryArtifact,
+  stableVersion,
+  verifyCachedRecoveryArtifact,
+} from "./recovery.mjs";
 
 const ELECTRON_UPDATER_CHANNEL_FILENAME = "electron-updater-channel.v1.json";
 
@@ -148,7 +162,7 @@ function isVersionNewer(candidate, current) {
   return comparison === null ? candidate !== current : comparison > 0;
 }
 
-export function targetedStableUpdaterFeed(currentVersion, targetVersion) {
+export function targetedStableUpdaterFeed(currentVersion, targetVersion, allowOlder = false) {
   const normalizedTarget = normalizeStableTargetVersion(targetVersion);
   if (!normalizedTarget) {
     throw new Error("Target update version must use the stable x.y.z format.");
@@ -157,8 +171,10 @@ export function targetedStableUpdaterFeed(currentVersion, targetVersion) {
   if (comparison === null) {
     throw new Error("Installed version could not be validated for a targeted update.");
   }
-  if (comparison <= 0) {
-    throw new Error("Target update version must be newer than the installed version.");
+  if (comparison === 0 || (!allowOlder && comparison < 0)) {
+    throw new Error(allowOlder
+      ? "Recovery target version must differ from the installed version."
+      : "Target update version must be newer than the installed version.");
   }
   return `https://github.com/different-ai/openwork/releases/download/v${normalizedTarget}`;
 }
@@ -175,16 +191,23 @@ function updaterChannelState(app, channel, targetVersion = null, manifestChannel
   };
 }
 
-async function applyElectronUpdaterFeed(app, updater, targetVersion = null, manifestChannel = "latest") {
+async function applyElectronUpdaterFeed(app, updater, targetVersion = null, manifestChannel = "latest", allowOlder = false) {
   const channel = await readElectronUpdaterChannel(app, manifestChannel);
   if (targetVersion && channel !== "stable") {
     throw new Error("Version-specific update feeds are supported only on the stable channel.");
   }
-  const state = updaterChannelState(app, channel, targetVersion, manifestChannel);
+  const currentVersion = resolveAppVersion(app);
+  const state = targetVersion
+    ? {
+        channel,
+        feedUrl: targetedStableUpdaterFeed(currentVersion, targetVersion, allowOlder),
+        currentVersion,
+      }
+    : updaterChannelState(app, channel, null, manifestChannel);
   updater.allowPrerelease = state.channel === "alpha";
   // Moving from alpha back to stable can be a semver downgrade; still show
   // the latest stable so users can return to the stable channel deliberately.
-  updater.allowDowngrade = state.channel === "stable" && !targetVersion;
+  updater.allowDowngrade = state.channel === "stable" && (!targetVersion || allowOlder);
   // Select the manifest through the generic provider's own `channel` option
   // rather than AppUpdater#channel: that setter is a no-op unless the instance
   // was constructed with a channel, which would silently leave a custom
@@ -265,12 +288,20 @@ export function registerUpdaterIpc({
   loadAutoUpdater = () => import("electron-updater"),
   manifestChannel = "latest",
   shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN,
+  electronNet = null,
+  shell = null,
+  distribution = "public",
+  platform = process.platform,
+  arch = process.arch,
+  env = process.env,
 }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoaded = false;
   let checkedUpdateVersion = null;
   let checkedUpdateTargetVersion = null;
   let updateDownloaded = false;
+  let recoveryReleases = [];
+  const recoveryWitness = { installRequests: [], openedArtifactUrls: [], quitRequested: false };
 
   function sendToRenderer(channel, data) {
     try {
@@ -330,6 +361,215 @@ export function registerUpdaterIpc({
     }
     return autoUpdaterInstance;
   }
+
+  async function resolveRecoveryArtifact(version) {
+    if (!electronNet?.fetch) return null;
+    try {
+      const manifestUrl = `https://github.com/different-ai/openwork/releases/download/v${version}/${recoveryManifestName(platform, arch, distribution)}`;
+      const response = await electronNet.fetch(manifestUrl, { headers: { Accept: "text/yaml, text/plain, */*" } });
+      if (!response.ok) return null;
+      return selectRecoveryArtifact(parseRecoveryManifest(await response.text()), {
+        version,
+        platform,
+        arch,
+        distribution,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  async function cacheCurrentHealthyRelease() {
+    if (!electronNet?.fetch) return null;
+    const currentVersion = stableVersion(resolveAppVersion(app));
+    if (!currentVersion) return null;
+    const state = await readRecoveryState(app, distribution);
+    if (state.currentVersion !== currentVersion) return null;
+    const existing = await readCachedRecoveryArtifact(app, { platform, arch, distribution });
+    if (existing?.artifact.version === currentVersion) return existing;
+    const artifact = await resolveRecoveryArtifact(currentVersion);
+    if (!artifact) return null;
+    const filePath = await cacheVerifiedRecoveryArtifact({
+      app,
+      artifact,
+      fetchArtifact: (url) => electronNet.fetch(url),
+    });
+    return { artifact, filePath };
+  }
+
+  function evalRecoveryReleases() {
+    if (typeof env.OPENWORK_EVAL_RECOVERY_RELEASES === "string") {
+      try {
+        const target = String(env.OPENWORK_EVAL_RECOVERY_TARGET ?? "").split("-");
+        const targetPlatform = target[0];
+        const targetArch = target[1];
+        const targetDistribution = target.slice(2).join("-");
+        const raw = JSON.parse(env.OPENWORK_EVAL_RECOVERY_RELEASES);
+        const stable = Array.isArray(raw) ? raw.filter((release) =>
+          stableVersion(release?.version)
+          && release?.channel === "stable"
+          && release?.artifact?.platform === targetPlatform
+          && release?.artifact?.arch === targetArch
+          && release?.artifact?.distribution === targetDistribution
+          && typeof release?.artifact?.url === "string",
+        ) : [];
+        return stable.map((release, index) => ({
+          id: release.version,
+          version: release.version,
+          marking: index === 0 ? "current" : index === 1 ? "previous" : null,
+          artifact: release.artifact,
+          cachedFilePath: null,
+          eval: true,
+        }));
+      } catch {
+        return [];
+      }
+    }
+    if (typeof env.OPENWORK_EVAL_RECOVERY_CANDIDATES === "string") {
+      try {
+        const raw = JSON.parse(env.OPENWORK_EVAL_RECOVERY_CANDIDATES);
+        return Array.isArray(raw) ? raw.filter((candidate) =>
+          candidate?.verified === true
+          && stableVersion(candidate?.version)
+          && typeof candidate?.artifactUrl === "string",
+        ).map((candidate) => ({
+          id: candidate.version,
+          version: candidate.version,
+          marking: "previous",
+          artifact: { platform, arch, distribution, url: candidate.artifactUrl },
+          cachedFilePath: null,
+          eval: true,
+        })) : [];
+      } catch {
+        return [];
+      }
+    }
+    return null;
+  }
+
+  ipcMain.handle("openwork:recovery:recordHealthy", async () => {
+    return recordHealthyVersion(app, distribution, resolveAppVersion(app));
+  });
+
+  ipcMain.handle("openwork:recovery:list", async (_event, policy = {}) => {
+    const evalReleases = evalRecoveryReleases();
+    if (evalReleases) {
+      recoveryReleases = evalReleases;
+      return {
+        ok: true,
+        releases: recoveryReleases.map(({ id, version, marking }) => ({ id, version, marking })),
+      };
+    }
+    const state = await readRecoveryState(app, distribution);
+    const installedVersion = resolveAppVersion(app);
+    const markers = recoveryVersionMarkers(installedVersion, state);
+    const cached = await readCachedRecoveryArtifact(app, { platform, arch, distribution });
+    const catalogVersions = Array.isArray(policy?.versions) ? policy.versions : [];
+    const localOnly = catalogVersions.length === 0;
+    recoveryReleases = await compatibleRecoveryReleases({
+      versions: [
+        ...catalogVersions,
+        installedVersion,
+        ...(state.currentVersion ? [state.currentVersion] : []),
+        ...(state.previousVersion ? [state.previousVersion] : []),
+        ...(cached ? [cached.artifact.version] : []),
+      ],
+      currentVersion: markers.currentVersion,
+      previousVersion: markers.previousVersion,
+      minimumVersion: policy?.minimumVersion,
+      allowedVersions: policy?.allowedVersions,
+      resolveArtifact: async (version) =>
+        cached?.artifact.version === version
+          ? { ...cached.artifact, cachedFilePath: cached.filePath }
+          : localOnly ? null : resolveRecoveryArtifact(version),
+    });
+    return {
+      ok: true,
+      releases: recoveryReleases.map(({ id, version, marking }) => ({ id, version, marking })),
+    };
+  });
+
+  async function useRecoveryRelease(rawId) {
+    const id = stableVersion(rawId);
+    const release = id ? recoveryReleases.find((candidate) => candidate.id === id) : null;
+    if (!release) return { ok: false, reason: "That recovery version is no longer available. Retry the release list." };
+    if (release.eval) {
+      if (env.OPENWORK_EVAL_RECOVERY_CANDIDATES) {
+        recoveryWitness.installRequests.push({ version: release.version, artifactUrl: release.artifact.url });
+      } else {
+        recoveryWitness.openedArtifactUrls.push(release.artifact.url);
+      }
+      return { ok: true, action: "eval" };
+    }
+    if (compareStableVersions(release.version, resolveAppVersion(app)) === 0) {
+      return { ok: false, reason: "That version is already installed." };
+    }
+    if (release.cachedFilePath) {
+      if (!(await verifyCachedRecoveryArtifact(release.cachedFilePath, release.artifact))) {
+        return { ok: false, reason: "The cached recovery installer could not be verified. Retry while online." };
+      }
+      if (!shell?.openPath) return { ok: false, reason: "This package cannot open the recovery installer." };
+      const openError = await shell.openPath(release.cachedFilePath);
+      if (openError) return { ok: false, reason: openError };
+      return {
+        ok: true,
+        action: "installer",
+        message: "The verified installer is open. Follow the operating system steps to finish.",
+      };
+    }
+    const freshArtifact = await resolveRecoveryArtifact(release.version);
+    if (!freshArtifact || freshArtifact.url !== release.artifact.url || freshArtifact.sha512 !== release.artifact.sha512) {
+      return { ok: false, reason: "This installer could not be verified. Refresh the list and try again." };
+    }
+    const currentVersion = resolveAppVersion(app);
+    const updater = await ensureAutoUpdater();
+    if (updater && app.isPackaged) {
+      try {
+        await applyElectronUpdaterFeed(app, updater, release.version, manifestChannel, true);
+        const result = await updater.checkForUpdates();
+        if (compareVersions(result?.updateInfo?.version ?? "", release.version) !== 0) {
+          throw new Error("Recovery manifest resolved to a different version.");
+        }
+        if (compareStableVersions(release.version, currentVersion) === null) {
+          throw new Error("Installed version could not be validated.");
+        }
+        updater.autoInstallOnAppQuit = true;
+        await updater.downloadUpdate();
+        updater.quitAndInstall(false, true);
+        return { ok: true, action: "install" };
+      } catch (error) {
+        preventPendingUpdaterInstall(updater);
+        return { ok: false, reason: String(error?.message ?? error) };
+      }
+    }
+    if (!electronNet?.fetch || !shell?.openPath) return { ok: false, reason: "Automatic recovery is unavailable on this package." };
+    try {
+      const filePath = await cacheVerifiedRecoveryArtifact({
+        app,
+        artifact: freshArtifact,
+        fetchArtifact: (url) => electronNet.fetch(url),
+      });
+      if (!(await verifyCachedRecoveryArtifact(filePath, freshArtifact))) {
+        return { ok: false, reason: "The downloaded recovery installer could not be verified." };
+      }
+      const openError = await shell.openPath(filePath);
+      if (openError) return { ok: false, reason: openError };
+      return { ok: true, action: "installer", message: "The verified installer is open. Follow the operating system steps to finish." };
+    } catch (error) {
+      return { ok: false, reason: String(error?.message ?? error) };
+    }
+  }
+
+  ipcMain.handle("openwork:recovery:use", async (_event, id) => useRecoveryRelease(id));
+  ipcMain.handle("openwork:recovery:restorePrevious", async () => {
+    const previous = recoveryReleases.find((release) => release.marking === "previous");
+    return previous ? useRecoveryRelease(previous.id) : { ok: false, reason: "No verified previous version is available." };
+  });
+  ipcMain.handle("openwork:recovery:evalSnapshot", async () => ({
+    candidates: recoveryReleases,
+    releases: recoveryReleases,
+    ...recoveryWitness,
+  }));
 
   ipcMain.handle("openwork:updater:getChannel", async () => {
     const channel = await readElectronUpdaterChannel(app, manifestChannel);
@@ -436,6 +676,9 @@ export function registerUpdaterIpc({
       if (!checkedUpdateVersion) {
         return { ok: false, reason: "No update available." };
       }
+      await cacheCurrentHealthyRelease().catch((error) => {
+        console.warn("[updater] could not cache the current healthy installer", error);
+      });
       // Clear any stuck ShipIt state from a prior aborted install so this
       // download applies cleanly on quit.
       await cleanStaleUpdaterState(app, shipItDefaultsDomain);

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,7 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -11,6 +12,17 @@ import {
   staleUpdaterStatePaths,
   targetedStableUpdaterFeed,
 } from "./updater.mjs";
+import {
+  cacheVerifiedRecoveryArtifact,
+  compatibleRecoveryReleases,
+  parseRecoveryManifest,
+  readCachedRecoveryArtifact,
+  readRecoveryState,
+  recordHealthyVersion,
+  recoveryManifestName,
+  recoveryVersionMarkers,
+  selectRecoveryArtifact,
+} from "./recovery.mjs";
 
 const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
 
@@ -111,11 +123,363 @@ describe("targetedStableUpdaterFeed", () => {
     );
   });
 
+  it("allows only an explicit exact recovery downgrade", () => {
+    assert.equal(
+      targetedStableUpdaterFeed("0.17.23", "0.17.22", true),
+      "https://github.com/different-ai/openwork/releases/download/v0.17.22",
+    );
+    assert.throws(
+      () => targetedStableUpdaterFeed("0.17.23", "0.17.23", true),
+      /must differ/,
+    );
+  });
+
   it("fails closed when the installed version cannot be compared", () => {
     assert.throws(
       () => targetedStableUpdaterFeed("unknown", "0.17.23"),
       /could not be validated/,
     );
+  });
+});
+
+describe("recovery metadata and candidates", () => {
+  it("marks the installed version current and the last healthy version previous after a failed update boot", () => {
+    assert.deepEqual(recoveryVersionMarkers("2.0.0", {
+      currentVersion: "1.9.0",
+      previousVersion: "1.8.0",
+    }), {
+      currentVersion: "2.0.0",
+      previousVersion: "1.9.0",
+    });
+  });
+
+  it("keeps the prior healthy version previous after the installed version boots successfully", () => {
+    assert.deepEqual(recoveryVersionMarkers("2.0.0", {
+      currentVersion: "2.0.0",
+      previousVersion: "1.9.0",
+    }), {
+      currentVersion: "2.0.0",
+      previousVersion: "1.9.0",
+    });
+  });
+
+  it("atomically preserves the immediately prior healthy version", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-state-"));
+    const app = { getPath: () => userData };
+    try {
+      await recordHealthyVersion(app, "public", "1.2.3");
+      await recordHealthyVersion(app, "public", "1.2.4");
+      await recordHealthyVersion(app, "public", "1.2.4");
+      assert.deepEqual(await readRecoveryState(app, "public"), {
+        currentVersion: "1.2.4",
+        previousVersion: "1.2.3",
+      });
+      assert.match(await readFile(path.join(userData, "app-recovery.v1.json"), "utf8"), /"previousVersion": "1\.2\.3"/);
+      assert.deepEqual(await readRecoveryState(app, "cloud"), {
+        currentVersion: null,
+        previousVersion: null,
+      });
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("filters strict stable versions by minimum and fresh organization policy", async () => {
+    const releases = await compatibleRecoveryReleases({
+      versions: ["2.4.0", "2.3.1", "2.3.0-beta.1", "2.2.9", "https://invalid"],
+      currentVersion: "2.4.0",
+      previousVersion: "2.3.1",
+      minimumVersion: "2.3.0",
+      allowedVersions: ["2.4.0", "2.3.1"],
+      resolveArtifact: async (version) => ({ url: `verified:${version}` }),
+    });
+    assert.deepEqual(releases.map(({ version, marking }) => ({ version, marking })), [
+      { version: "2.4.0", marking: "current" },
+      { version: "2.3.1", marking: "previous" },
+    ]);
+  });
+
+  it("accepts only the exact platform, architecture, distribution release artifact", () => {
+    const files = [
+      { url: "openwork-mac-x64-1.2.3.dmg", sha512: "wrong-arch" },
+      { url: "https://tampered.invalid/openwork-mac-arm64-1.2.3.dmg", sha512: "tampered" },
+      { url: "openwork-mac-arm64-1.2.3.dmg", sha512: "verified" },
+    ];
+    assert.deepEqual(selectRecoveryArtifact(files, {
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+    }), {
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+      url: "https://github.com/different-ai/openwork/releases/download/v1.2.3/openwork-mac-arm64-1.2.3.dmg",
+      sha512: "verified",
+    });
+    assert.equal(selectRecoveryArtifact(files, {
+      version: "1.2.3-beta.1",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+    }), null);
+  });
+
+  it("accepts each artifact flavor only for its matching distribution", () => {
+    const artifacts = {
+      public: "openwork-mac-arm64-1.2.3.dmg",
+      cloud: "openwork-cloud-mac-arm64-1.2.3.dmg",
+      enterprise: "openwork-enterprise-mac-arm64-1.2.3.dmg",
+    };
+    for (const [distribution, fileName] of Object.entries(artifacts)) {
+      const files = [{ url: fileName, sha512: `${distribution}-checksum` }];
+      assert.equal(selectRecoveryArtifact(files, {
+        version: "1.2.3", platform: "darwin", arch: "arm64", distribution,
+      })?.url, `https://github.com/different-ai/openwork/releases/download/v1.2.3/${fileName}`);
+      for (const otherDistribution of Object.keys(artifacts).filter((flavor) => flavor !== distribution)) {
+        assert.equal(selectRecoveryArtifact(files, {
+          version: "1.2.3", platform: "darwin", arch: "arm64", distribution: otherDistribution,
+        }), null);
+      }
+    }
+  });
+
+  it("parses representative builder manifests and selects published installer extensions", () => {
+    const files = parseRecoveryManifest(`version: 1.2.3
+files:
+  - url: openwork-mac-arm64-1.2.3.dmg
+    sha512: mac-checksum
+    size: 100
+  - url: openwork-cloud-win-x64-1.2.3.exe
+    sha512: win-checksum
+  - url: openwork-enterprise-linux-x86_64-1.2.3.AppImage
+    sha512: linux-checksum
+path: openwork-mac-arm64-1.2.3.zip
+sha512: updater-zip-checksum
+releaseDate: '2026-08-11T00:00:00.000Z'
+`);
+    assert.equal(selectRecoveryArtifact(files, {
+      version: "1.2.3", platform: "darwin", arch: "arm64", distribution: "public",
+    })?.url.endsWith(".dmg"), true);
+    assert.equal(selectRecoveryArtifact(files, {
+      version: "1.2.3", platform: "win32", arch: "x64", distribution: "cloud",
+    })?.url.endsWith(".exe"), true);
+    assert.equal(selectRecoveryArtifact(files, {
+      version: "1.2.3", platform: "linux", arch: "x64", distribution: "enterprise",
+    })?.url.endsWith(".AppImage"), true);
+    assert.equal(recoveryManifestName("darwin", "arm64", "public"), "latest-mac.yml");
+    assert.equal(recoveryManifestName("win32", "x64", "cloud"), "cloud.yml");
+    assert.equal(recoveryManifestName("linux", "arm64", "enterprise"), "enterprise-linux-arm64.yml");
+  });
+
+  it("rejects a checksum mismatch without producing a cached installer", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-checksum-"));
+    try {
+      await assert.rejects(
+        cacheVerifiedRecoveryArtifact({
+          app: { getPath: () => userData },
+          artifact: { url: "https://github.com/different-ai/openwork/releases/download/v1.2.3/openwork.dmg", sha512: "invalid" },
+          fetchArtifact: async () => new Response("tampered"),
+        }),
+        /checksum did not match/,
+      );
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a valid rollback cache across network and checksum replacement failures", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-cache-preserve-"));
+    const app = { getPath: () => userData };
+    const bytes = Buffer.from("known-good");
+    const artifact = {
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+      url: "https://github.com/different-ai/openwork/releases/download/v1.2.3/openwork-mac-arm64-1.2.3.dmg",
+      sha512: createHash("sha512").update(bytes).digest("base64"),
+    };
+    try {
+      await cacheVerifiedRecoveryArtifact({
+        app,
+        artifact,
+        fetchArtifact: async () => new Response(bytes),
+      });
+      await assert.rejects(cacheVerifiedRecoveryArtifact({
+        app,
+        artifact: { ...artifact, version: "1.2.4", url: artifact.url.replace("1.2.3", "1.2.4") },
+        fetchArtifact: async () => { throw new Error("offline"); },
+      }), /offline/);
+      await assert.rejects(cacheVerifiedRecoveryArtifact({
+        app,
+        artifact: { ...artifact, version: "1.2.4", url: artifact.url.replace("1.2.3", "1.2.4") },
+        fetchArtifact: async () => new Response("tampered"),
+      }), /checksum did not match/);
+      assert.equal((await readCachedRecoveryArtifact(app, {
+        platform: "darwin", arch: "arm64", distribution: "public",
+      }))?.artifact.version, "1.2.3");
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects cached metadata with a modified URL or wrong installer filename", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-cache-identity-"));
+    const app = { getPath: () => userData };
+    const bytes = Buffer.from("known-good-identity");
+    const artifact = {
+      version: "0.18.18",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+      url: "https://github.com/different-ai/openwork/releases/download/v0.18.18/openwork-mac-arm64-0.18.18.dmg",
+      sha512: createHash("sha512").update(bytes).digest("base64"),
+    };
+    const expected = { platform: "darwin", arch: "arm64", distribution: "public" };
+    try {
+      await cacheVerifiedRecoveryArtifact({ app, artifact, fetchArtifact: async () => new Response(bytes) });
+      const metadataPath = path.join(userData, "app-recovery-cache", "metadata.json");
+      const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+      await writeFile(metadataPath, JSON.stringify({ ...metadata, url: "https://tampered.invalid/OpenWork.dmg" }), "utf8");
+      assert.equal(await readCachedRecoveryArtifact(app, expected), null);
+      await writeFile(metadataPath, JSON.stringify({ ...metadata, fileName: "OpenWork.dmg" }), "utf8");
+      assert.equal(await readCachedRecoveryArtifact(app, expected), null);
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers and opens a reverified cached healthy installer while offline", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-offline-"));
+    const quitCalls = [];
+    const app = {
+      isPackaged: true,
+      getVersion: () => "2.0.0",
+      getPath: () => userData,
+      quit: () => quitCalls.push("quit"),
+    };
+    const bytes = Buffer.from("offline-known-good");
+    const artifact = {
+      version: "1.9.0",
+      platform: "darwin",
+      arch: "arm64",
+      distribution: "public",
+      url: "https://github.com/different-ai/openwork/releases/download/v1.9.0/openwork-mac-arm64-1.9.0.dmg",
+      sha512: createHash("sha512").update(bytes).digest("base64"),
+    };
+    const handlers = new Map();
+    const opened = [];
+    const networkCalls = [];
+    let openError = "installer blocked";
+    try {
+      await recordHealthyVersion(app, "public", "1.9.0");
+      await cacheVerifiedRecoveryArtifact({ app, artifact, fetchArtifact: async () => new Response(bytes) });
+      isolatedUpdaterImportId += 1;
+      const isolated = await import(`./updater.mjs?offline-recovery=${isolatedUpdaterImportId}`);
+      isolated.registerUpdaterIpc({
+        app,
+        ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+        getMainWindow: () => null,
+        electronNet: { fetch: async () => { networkCalls.push("fetch"); throw new Error("offline"); } },
+        shell: { openPath: async (filePath) => { opened.push(filePath); return openError; } },
+        platform: "darwin",
+        arch: "arm64",
+        distribution: "public",
+      });
+      const listed = await handlers.get("openwork:recovery:list")(null, {
+        versions: [], minimumVersion: "0.0.0",
+      });
+      assert.deepEqual(listed.releases, [{ id: "1.9.0", version: "1.9.0", marking: "previous" }]);
+      assert.deepEqual(networkCalls, []);
+      assert.deepEqual(await handlers.get("openwork:recovery:use")(null, "1.9.0"), {
+        ok: false,
+        reason: "installer blocked",
+      });
+      assert.deepEqual(quitCalls, []);
+      openError = "";
+      assert.deepEqual(await handlers.get("openwork:recovery:use")(null, "1.9.0"), {
+        ok: true,
+        action: "installer",
+        message: "The verified installer is open. Follow the operating system steps to finish.",
+      });
+      assert.equal(opened.length, 2);
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a candidate whose fresh manifest changes without any destructive action", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-recovery-fresh-mismatch-"));
+    const handlers = new Map();
+    const destructiveCalls = [];
+    let candidateFetches = 0;
+    const manifest = (checksum) => `version: 1.9.0\nfiles:\n  - url: openwork-mac-arm64-1.9.0.dmg\n    sha512: ${checksum}\n`;
+    try {
+      isolatedUpdaterImportId += 1;
+      const isolated = await import(`./updater.mjs?fresh-mismatch=${isolatedUpdaterImportId}`);
+      isolated.registerUpdaterIpc({
+        app: {
+          isPackaged: true,
+          getVersion: () => "2.0.0",
+          getPath: () => userData,
+          quit: () => destructiveCalls.push("quit"),
+        },
+        ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+        getMainWindow: () => null,
+        electronNet: { fetch: async (url) => {
+          if (!url.includes("/v1.9.0/")) return new Response("missing", { status: 404 });
+          candidateFetches += 1;
+          return new Response(manifest(candidateFetches === 1 ? "first-checksum" : "changed-checksum"));
+        } },
+        shell: { openPath: async () => { destructiveCalls.push("open"); return ""; } },
+        platform: "darwin",
+        arch: "arm64",
+        distribution: "public",
+      });
+      const listed = await handlers.get("openwork:recovery:list")(null, {
+        versions: ["1.9.0"], minimumVersion: "0.0.0",
+      });
+      assert.deepEqual(listed.releases, [{ id: "1.9.0", version: "1.9.0", marking: null }]);
+      const result = await handlers.get("openwork:recovery:use")(null, "1.9.0");
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /could not be verified/);
+      assert.deepEqual(destructiveCalls, []);
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("does not download, install, or quit for an unverified renderer selection", async () => {
+    const handlers = new Map();
+    const destructiveCalls = [];
+    registerUpdaterIpc({
+      app: {
+        isPackaged: true,
+        getVersion: () => "1.2.3",
+        getPath: () => os.tmpdir(),
+        quit: () => destructiveCalls.push("quit"),
+      },
+      ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+      getMainWindow: () => null,
+      electronNet: { fetch: async () => {
+        destructiveCalls.push("download");
+        return new Response("unexpected");
+      } },
+      shell: { openPath: async () => {
+        destructiveCalls.push("open");
+        return "";
+      } },
+      env: {
+        OPENWORK_EVAL_RECOVERY_CANDIDATES: JSON.stringify([
+          { version: "1.2.2", verified: false, artifactUrl: "https://tampered.invalid/openwork.dmg" },
+        ]),
+      },
+    });
+    await handlers.get("openwork:recovery:list")(null, {});
+    assert.equal((await handlers.get("openwork:recovery:use")(null, "1.2.2")).ok, false);
+    assert.deepEqual(destructiveCalls, []);
   });
 });
 

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -393,8 +393,12 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     const sandbox = requireSandbox();
     const safeName = sanitizeName(name);
     const spawnStamp = timestamp();
-    const profileRoot = `/workspace/.openwork-daytona/profiles/${safeName}-${spawnStamp}`;
-    const profileDir = `${profileRoot}/electron-userdata`;
+    if (opts.profileDir !== undefined && !opts.profileDir.trim()) {
+      throw new Error("Electron profileDir must not be empty.");
+    }
+    const callerOwnedProfile = opts.profileDir !== undefined;
+    const profileRoot = opts.profileDir ?? `/workspace/.openwork-daytona/profiles/${safeName}-${spawnStamp}`;
+    const userDataDir = `${profileRoot}/electron-userdata`;
     const bootstrapPath = `${profileRoot}/bootstrap.json`;
     const port = await allocateSandboxPort(electronPorts, exec, sandbox);
     // Per-spawn log so the integrity check below can never read a previous
@@ -402,7 +406,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     const logPath = `/tmp/electron-${safeName}-${spawnStamp}.log`;
 
     try {
-      await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(profileDir)], `mkdir Daytona Electron profile ${profileDir}`, { timeoutMs: 30_000 });
+      await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");
@@ -418,7 +422,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
       appendExtraEnv(env, opts.env);
       env.set("DAYTONA_ELECTRON_LOG", logPath);
       env.set("OPENWORK_ELECTRON_REMOTE_DEBUG_PORT", String(port));
-      env.set("OPENWORK_ELECTRON_USERDATA", profileDir);
+      env.set("OPENWORK_ELECTRON_USERDATA", userDataDir);
       env.set("OPENWORK_WORKSPACE_DIR", "/workspace");
       env.set("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", "1");
       if (opts.bootstrap) env.set("OPENWORK_DESKTOP_BOOTSTRAP_PATH", bootstrapPath);
@@ -464,8 +468,8 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
         hostKind: "daytona",
         cdpUrl,
         sandboxId: sandbox,
-        profileDir,
-        meta: { cdpPort: String(port), log: logPath },
+        profileDir: profileRoot,
+        meta: { cdpPort: String(port), log: logPath, profileOwner: callerOwnedProfile ? "caller" : "host" },
       };
       spawnedSurfaces.add(handle);
       return handle;
@@ -564,7 +568,9 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     if (handle.kind === "electron" && port !== null) {
       const pattern = selfMatchSafePortPattern("electron", port);
-      const profilePattern = handle.profileDir ? electronProfilePattern(handle.profileDir) : "";
+      const profilePattern = handle.profileDir
+        ? electronProfilePattern(`${electronProfileRoot(handle.profileDir)}/electron-userdata`)
+        : "";
       const stopCommand = [
         profilePattern ? killGroupsForPatternCommand(profilePattern, "TERM") : "true",
         `pkill -f ${shellQuote(pattern)} || true`,
@@ -584,7 +590,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
         `verify Daytona Electron CDP stopped ${handle.name}`,
         { timeoutMs: 15_000 },
       );
-      if (handle.profileDir) {
+      if (handle.profileDir && handle.meta?.profileOwner !== "caller") {
         await checkedExec(
           exec,
           ["exec", sandbox, "--", `bash -lc ${shellQuote(`rm -rf ${shellQuote(electronProfileRoot(handle.profileDir))}`)}`],

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -4,7 +4,7 @@ export type { SurfaceHandle, SurfaceKind } from "@openwork/cdp";
 
 export interface ElectronSurfaceOptions {
   profile?: "fresh" | "shared";
-  /** Exact caller-owned profile root. Local hosts preserve it on disposal. */
+  /** Exact caller-owned profile root. Hosts preserve it on surface disposal. */
   profileDir?: string;
   bootstrap?: {
     baseUrl: string;

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -115,8 +115,10 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
 
   assert.equal(first.meta?.cdpPort, "9825");
   assert.equal(second.meta?.cdpPort, "9830");
-  assert.match(first.profileDir ?? "", /\/workspace\/\.openwork-daytona\/profiles\/owner-\d{17}\/electron-userdata$/);
-  assert.match(second.profileDir ?? "", /\/workspace\/\.openwork-daytona\/profiles\/member-\d{17}\/electron-userdata$/);
+  assert.match(first.profileDir ?? "", /\/workspace\/\.openwork-daytona\/profiles\/owner-\d{17}$/);
+  assert.match(second.profileDir ?? "", /\/workspace\/\.openwork-daytona\/profiles\/member-\d{17}$/);
+  assert.equal(first.meta?.profileOwner, "host");
+  assert.equal(second.meta?.profileOwner, "host");
   assert.deepEqual(polled, ["https://cdp-9825.example.test/json/list", "https://cdp-9830.example.test/json/list"]);
 
   const bootstrapCall = findCall(calls, "base64 -d");
@@ -145,6 +147,35 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert(secondStart.includes("OPENWORK_ELECTRON_USERDATA="));
   assert(secondStart.includes("/workspace/.openwork-daytona/profiles/member-"));
   assert(secondStart.includes("/electron-userdata"));
+});
+
+test("spawnElectron preserves a caller-owned Daytona profile while generated profiles are removed", async () => {
+  const { exec, calls } = createFakeExec((port) => `https://cdp-${port}.example.test`);
+  const host = createDaytonaHost({
+    sandboxId: "openwork-test-profile-owner",
+    log: () => undefined,
+    exec,
+    repoRoot: "/repo",
+    waitForCdp: successfulPolls(),
+  });
+  const suppliedProfile = "/tmp/reliable-recovery-profile";
+
+  const callerOwned = await host.spawnElectron("caller-owned", { profileDir: suppliedProfile });
+  const generated = await host.spawnElectron("generated");
+
+  assert.equal(callerOwned.profileDir, suppliedProfile);
+  assert.equal(callerOwned.meta?.profileOwner, "caller");
+  assert.equal(generated.meta?.profileOwner, "host");
+  const startCalls = calls.filter((call) => argsText(call).includes("/workspace/.devcontainer/start-daytona-electron.sh"));
+  assert(argsText(startCalls[0] ?? { args: [] }).includes(`${suppliedProfile}/electron-userdata`));
+
+  await host.disposeSurface(callerOwned);
+  await host.disposeSurface(generated);
+
+  const removalCalls = calls.filter((call) => argsText(call).includes("rm -rf"));
+  assert.equal(removalCalls.length, 1);
+  assert(argsText(removalCalls[0] ?? { args: [] }).includes(generated.profileDir ?? "missing-generated-profile"));
+  assert(!removalCalls.some((call) => argsText(call).includes(suppliedProfile)));
 });
 
 test("spawnElectron skips reserved Daytona CDP ports", async () => {
@@ -208,7 +239,7 @@ test("disposeSurface uses self-match-safe pkill patterns in separate execs", asy
     hostKind: "daytona",
     cdpUrl: "https://unused.example.test",
     sandboxId: "openwork-test-dispose",
-    profileDir: "/workspace/.openwork-daytona/profiles/desktop/electron-userdata",
+    profileDir: "/workspace/.openwork-daytona/profiles/desktop",
     meta: { cdpPort: "9825", log: "/tmp/electron-desktop.log" },
   };
   const chromeHandle: SurfaceHandle = {

--- a/evals/specs/compatible-release-picker.slow.test.ts
+++ b/evals/specs/compatible-release-picker.slow.test.ts
@@ -1,0 +1,98 @@
+import { expect } from "vitest";
+import { clickButton, evalIn, visibleText } from "@openwork/behaviors";
+import { screenshot } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { eventually, needs, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "recovery offers only recent stable releases with exact compatible artifacts"
+  : "compatible release picker skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+const currentArtifact = "https://releases.openwork.test/v2.4.0/OpenWork-darwin-arm64.dmg";
+const previousArtifact = "https://releases.openwork.test/v2.3.1/OpenWork-darwin-arm64.dmg";
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+  await using recoveryApp = await desktop({
+    name: "compatible-release-picker",
+    host: place.host(),
+    timeoutMs: 30_000,
+    env: {
+      OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE: "EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE",
+      OPENWORK_EVAL_RECOVERY_TARGET: "darwin-arm64-public",
+      OPENWORK_EVAL_RECOVERY_RELEASES: JSON.stringify([
+        { version: "2.4.0", channel: "stable", artifact: { platform: "darwin", arch: "arm64", distribution: "public", url: currentArtifact } },
+        { version: "2.3.1", channel: "stable", artifact: { platform: "darwin", arch: "arm64", distribution: "public", url: previousArtifact } },
+        { version: "2.3.0", channel: "stable", artifact: { platform: "linux", arch: "x64", distribution: "public", url: "https://incompatible.invalid/OpenWork.AppImage" } },
+        { version: "2.2.9", channel: "stable", artifact: { platform: "darwin", arch: "arm64", distribution: "enterprise", url: "https://wrong-flavor.invalid/OpenWork.dmg" } },
+        { version: "2.2.8-beta.1", channel: "prerelease", artifact: { platform: "darwin", arch: "arm64", distribution: "public", url: "https://prerelease.invalid/OpenWork.dmg" } },
+      ]),
+    },
+  });
+
+  const releaseObserverAvailable = await evalIn(
+    recoveryApp,
+    `typeof window.__openworkRecoveryControl?.snapshot === "function"
+      && typeof window.__openworkRecoveryControl?.select === "function"`,
+  );
+  expect(
+    releaseObserverAvailable,
+    "testkit cannot yet inject a release catalog or observe exact artifact selection",
+  ).toBe(true);
+
+  await clickButton(recoveryApp, "Pick another version", { timeoutMs: 5_000 });
+  const text = await visibleText(recoveryApp);
+  expect(text).toContain("2.4.0");
+  expect(text).toMatch(/2\.4\.0\s+current/i);
+  expect(text).not.toMatch(/Use 2\.4\.0/i);
+  expect(text).toMatch(/Use 2\.3\.1\s+previous/i);
+  expect(text).not.toContain("2.3.0");
+  expect(text).not.toContain("2.2.9");
+  expect(text).not.toContain("2.2.8-beta.1");
+  expect(await evalIn(
+    recoveryApp,
+    `[...document.querySelectorAll("button")].some((button) => (button.textContent ?? "").trim() === "Use 2.4.0")`,
+  )).toBe(false);
+
+  const offeredReleases = await evalIn(
+    recoveryApp,
+    `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.releases.map((release) => ({
+      version: release.version,
+      marking: release.marking,
+      platform: release.artifact.platform,
+      arch: release.artifact.arch,
+      distribution: release.artifact.distribution,
+      url: release.artifact.url,
+    })))`,
+    { awaitPromise: true },
+  );
+  expect(offeredReleases).toEqual([
+    { version: "2.4.0", marking: "current", platform: "darwin", arch: "arm64", distribution: "public", url: currentArtifact },
+    { version: "2.3.1", marking: "previous", platform: "darwin", arch: "arm64", distribution: "public", url: previousArtifact },
+  ]);
+
+  await evalIn(recoveryApp, `window.__openworkRecoveryControl.select("2.3.0")`, { awaitPromise: true });
+  await evalIn(recoveryApp, `window.__openworkRecoveryControl.select("9.9.9")`, { awaitPromise: true });
+  expect(await evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.openedArtifactUrls)`, { awaitPromise: true })).toEqual([]);
+
+  await clickButton(recoveryApp, "Use 2.3.1", { timeoutMs: 5_000 });
+  const openedArtifactUrls = await eventually(
+    () => evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.openedArtifactUrls)`, { awaitPromise: true }),
+    {
+      within: 5_000,
+      label: "exact compatible release artifact",
+      until: (urls) => Array.isArray(urls) && urls.length === 1,
+    },
+  );
+  expect(openedArtifactUrls).toEqual([previousArtifact]);
+  expect(openedArtifactUrls).not.toContain(currentArtifact);
+  expect(openedArtifactUrls).not.toContain("https://incompatible.invalid/OpenWork.AppImage");
+  expect(openedArtifactUrls).not.toContain("https://wrong-flavor.invalid/OpenWork.dmg");
+  expect(openedArtifactUrls).not.toContain("https://prerelease.invalid/OpenWork.dmg");
+  await screenshot(recoveryApp);
+  evidence.fact(
+    "The picker opened only the exact compatible previous stable artifact",
+    "Current and previous were marked, incompatible and prerelease targets were absent, and arbitrary selection opened nothing.",
+    true,
+  );
+});

--- a/evals/specs/compatible-release-picker.slow.test.ts
+++ b/evals/specs/compatible-release-picker.slow.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "vitest";
 import { clickButton, evalIn, visibleText } from "@openwork/behaviors";
-import { screenshot } from "@openwork/fraimz";
 import { desktop } from "@openwork/hosts";
 import { eventually, needs, test } from "@openwork/testkit";
 
@@ -89,7 +88,6 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence, place }) => {
   expect(openedArtifactUrls).not.toContain("https://incompatible.invalid/OpenWork.AppImage");
   expect(openedArtifactUrls).not.toContain("https://wrong-flavor.invalid/OpenWork.dmg");
   expect(openedArtifactUrls).not.toContain("https://prerelease.invalid/OpenWork.dmg");
-  await screenshot(recoveryApp);
   evidence.fact(
     "The picker opened only the exact compatible previous stable artifact",
     "Current and previous were marked, incompatible and prerelease targets were absent, and arbitrary selection opened nothing.",

--- a/evals/specs/reliable-app-recovery.slow.test.ts
+++ b/evals/specs/reliable-app-recovery.slow.test.ts
@@ -1,7 +1,6 @@
 import { rm } from "node:fs/promises";
 import { expect } from "vitest";
 import { clickButton, evalIn, visibleText } from "@openwork/behaviors";
-import { screenshot } from "@openwork/fraimz";
 import {
   checkedExec,
   daytonaSandbox,
@@ -111,7 +110,6 @@ test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
     );
     expect(installRequests).toEqual([{ version: "1.8.2", artifactUrl: verifiedArtifact }]);
     expect(await evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.quitRequested)`, { awaitPromise: true })).toBe(false);
-    await screenshot(recoveryApp);
     evidence.fact(
       "Fatal bootstrap recovery selected one verified previous release without losing the profile",
       "The recovery observer recorded exactly one verified install request, no invalid request, and no quit intent.",

--- a/evals/specs/reliable-app-recovery.slow.test.ts
+++ b/evals/specs/reliable-app-recovery.slow.test.ts
@@ -1,0 +1,140 @@
+import { rm } from "node:fs/promises";
+import { expect } from "vitest";
+import { clickButton, evalIn, visibleText } from "@openwork/behaviors";
+import { screenshot } from "@openwork/fraimz";
+import {
+  checkedExec,
+  daytonaSandbox,
+  defaultDaytonaExec,
+  deleteSandboxes,
+  desktop,
+  localHost,
+  provisionDesktopSandbox,
+} from "@openwork/hosts";
+import { eventually, needs, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const title = appSpecsEnabled
+  ? "a fatal desktop bootstrap failure offers one-click verified recovery without losing the profile"
+  : "reliable app recovery skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+const profileMarker = "reliable-recovery-profile-marker";
+const fatalFailure = "EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE: dlopen(/private/tmp/runtime.node): invalid code signature";
+const verifiedArtifact = "https://releases.openwork.test/v1.8.2/OpenWork-darwin-arm64.dmg";
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+  const profileDir = `/tmp/openwork-reliable-recovery-${process.pid}-${Date.now()}`;
+  const provisioned = daytonaEnabled
+    ? await provisionDesktopSandbox({
+        ref: process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev",
+        name: "reliable-app-recovery",
+        reuse: process.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim(),
+        log: (line) => console.error(`[openwork/testkit] ${line}`),
+      })
+    : null;
+  const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
+
+  try {
+    {
+      await using seededApp = await desktop({ name: "recovery-profile-seed", host, profileDir });
+      const seededWorkspaceNames = await evalIn(
+        seededApp,
+        `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
+          folderPath: ${JSON.stringify(`${profileDir}/continuity-workspace`)},
+          name: ${JSON.stringify(profileMarker)}
+        }).then((state) => state.workspaces.map((workspace) => workspace.displayName))`,
+        { awaitPromise: true },
+      );
+      expect(seededWorkspaceNames).toContain(profileMarker);
+    }
+
+    await using recoveryApp = await desktop({
+      name: "fatal-bootstrap-recovery",
+      host,
+      profileDir,
+      timeoutMs: 30_000,
+      env: {
+        OPENWORK_EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE: fatalFailure,
+        OPENWORK_EVAL_RECOVERY_CANDIDATES: JSON.stringify([
+          { version: "1.8.2", verified: true, artifactUrl: verifiedArtifact },
+          { version: "1.8.1", verified: false, artifactUrl: "https://tampered.invalid/OpenWork.dmg" },
+        ]),
+      },
+    });
+
+    const recoveryObserverAvailable = await evalIn(
+      recoveryApp,
+      `typeof window.__openworkRecoveryControl?.snapshot === "function"
+        && typeof window.__openworkRecoveryControl?.select === "function"`,
+    );
+    expect(
+      recoveryObserverAvailable,
+      "testkit cannot yet inject or observe the approved fatal-bootstrap recovery journey",
+    ).toBe(true);
+
+    const text = await visibleText(recoveryApp);
+    expect(text).toMatch(/OpenWork (couldn't|could not) start/i);
+    expect(text).toContain("Restore previous version");
+    expect(text).not.toContain(fatalFailure);
+    expect(text).not.toMatch(/GitHub|open an issue|download.*manually/i);
+    const recoveredWorkspaceNames = await evalIn(
+      recoveryApp,
+      `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceBootstrap")
+        .then((state) => state.workspaces.map((workspace) => workspace.displayName))`,
+      { awaitPromise: true },
+    );
+    expect(recoveredWorkspaceNames).toContain(profileMarker);
+
+    const offeredVersions = await eventually(
+      () => evalIn(
+        recoveryApp,
+        `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.candidates.map((candidate) => candidate.version))`,
+        { awaitPromise: true },
+      ),
+      { within: 5_000, label: "verified recovery candidates", until: (versions) => Array.isArray(versions) && versions.length === 1 },
+    );
+    expect(offeredVersions).toEqual(["1.8.2"]);
+
+    await evalIn(recoveryApp, `window.__openworkRecoveryControl.select("1.8.1")`, { awaitPromise: true });
+    expect(await evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.installRequests)`, { awaitPromise: true })).toEqual([]);
+    expect(await evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.quitRequested)`, { awaitPromise: true })).toBe(false);
+
+    await clickButton(recoveryApp, "Restore previous version", { timeoutMs: 5_000 });
+    const installRequests = await eventually(
+      () => evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.installRequests)`, { awaitPromise: true }),
+      {
+        within: 5_000,
+        label: "verified previous recovery install intent",
+        until: (requests) => Array.isArray(requests) && requests.length === 1,
+      },
+    );
+    expect(installRequests).toEqual([{ version: "1.8.2", artifactUrl: verifiedArtifact }]);
+    expect(await evalIn(recoveryApp, `window.__openworkRecoveryControl.snapshot().then((snapshot) => snapshot.quitRequested)`, { awaitPromise: true })).toBe(false);
+    await screenshot(recoveryApp);
+    evidence.fact(
+      "Fatal bootstrap recovery selected one verified previous release without losing the profile",
+      "The recovery observer recorded exactly one verified install request, no invalid request, and no quit intent.",
+      true,
+    );
+  } finally {
+    try {
+      await host[Symbol.asyncDispose]();
+    } finally {
+      if (provisioned) {
+        try {
+          await checkedExec(
+            defaultDaytonaExec,
+            ["exec", provisioned.sandbox, "--", "rm", "-rf", profileDir],
+            `remove caller-owned recovery profile ${profileDir}`,
+            { timeoutMs: 30_000 },
+          );
+        } finally {
+          if (provisioned.created) await deleteSandboxes([provisioned.sandbox]);
+        }
+      } else {
+        await rm(profileDir, { recursive: true, force: true });
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace fatal startup errors with a simple recovery screen
- track and verify the last known-good desktop release, including an offline installer cache
- add a compatible stable-release picker with strict platform, architecture, checksum, and distribution validation
- preserve caller-owned Daytona profiles so recovery continuity can be tested across relaunches

## Verification
- `node --test electron/updater.test.mjs` — 25 passed, 1 platform skip
- `node --test packages/hosts/test/daytona-host.test.ts` — 8 passed
- `pnpm typecheck` — passed
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm exec tsc -p evals/tsconfig.json` — passed
- Daytona `reliable-app-recovery.slow.test.ts` — 1 passed, 0 skipped
- Daytona `compatible-release-picker.slow.test.ts` — 1 passed, 0 skipped

## Verdict
**Passed** on PR head `e171c9a794d6ac62348b7ceb3b5f535e9c3032ca`. Testkit evidence is published in the sticky PR comment.