### PR TITLE
fix(server): stop runtime-store reads from creating the runtime DB

### DIFF
--- a/apps/server/src/workspace-kv-store.test.ts
+++ b/apps/server/src/workspace-kv-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -121,6 +122,21 @@ describe("workspace kv store", () => {
       sqlite.close();
     }
     expect(await store.get(config, WORKSPACE_ID)).toEqual({});
+  });
+
+  test("reads leave a never-written runtime DB uncreated", async () => {
+    const { config, dbPath } = await tempWorkspace();
+    const store = recordStore("workspace_kv_read_never_creates");
+
+    expect(await store.get(config, WORKSPACE_ID)).toBeUndefined();
+    expect(await store.has(config, WORKSPACE_ID)).toBe(false);
+    expect(await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).toEqual({});
+    expect(existsSync(dbPath)).toBe(false);
+
+    await store.set(config, WORKSPACE_ID, { enabled: true });
+
+    expect(existsSync(dbPath)).toBe(true);
+    expect(await store.get(config, WORKSPACE_ID)).toEqual({ enabled: true });
   });
 
   test("returns each migrated store's documented defaults for missing and malformed rows", async () => {

--- a/apps/server/src/workspace-kv-store.ts
+++ b/apps/server/src/workspace-kv-store.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { existsSync } from "node:fs";
 import { openRuntimeSqliteDatabase, runtimeDbPath, type RuntimeSqliteDatabase } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
 
@@ -199,12 +200,30 @@ async function workspaceKvDb(path: string, config: WorkspaceKvTableConfig): Prom
   return db;
 }
 
+/**
+ * Reads must never materialize the runtime DB. A fresh install reads stores
+ * before anything is written (startup provider-auth sync is one), and opening
+ * with create:true would grow the state directory and an empty SQLite file
+ * just to learn there is nothing stored. A missing file reads like an empty
+ * one. An already-open connection still wins: a write in flight has the file
+ * on the way even when it is not on disk yet.
+ */
+async function readableWorkspaceKvDb(
+  path: string,
+  config: WorkspaceKvTableConfig,
+): Promise<WorkspaceKvDb | undefined> {
+  const opened = tableDbByPath.get(path)?.get(config.tableName);
+  if (opened) return opened;
+  if (!dbByPath.has(path) && !existsSync(path)) return undefined;
+  return workspaceKvDb(path, config);
+}
+
 export function createWorkspaceKvStore<T>(options: WorkspaceKvStoreOptions<T>) {
   const config = tableConfig(options);
 
   async function getRow(serverConfig: ServerConfig, workspaceId: string): Promise<WorkspaceKvRow<T> | undefined> {
-    const db = await workspaceKvDb(runtimeDbPath(serverConfig), config);
-    const row = db.get(workspaceId);
+    const db = await readableWorkspaceKvDb(runtimeDbPath(serverConfig), config);
+    const row = db?.get(workspaceId);
     return row ? { ...row, value: options.parse(row.valueJson) } : undefined;
   }
 
@@ -225,8 +244,8 @@ export function createWorkspaceKvStore<T>(options: WorkspaceKvStoreOptions<T>) {
       return (await getRow(serverConfig, workspaceId))?.value;
     },
     has: async (serverConfig: ServerConfig, workspaceId: string): Promise<boolean> => {
-      const db = await workspaceKvDb(runtimeDbPath(serverConfig), config);
-      return Boolean(db.get(workspaceId));
+      const db = await readableWorkspaceKvDb(runtimeDbPath(serverConfig), config);
+      return Boolean(db?.get(workspaceId));
     },
     set: async (serverConfig: ServerConfig, workspaceId: string, value: T, updatedAt = Date.now()): Promise<void> => {
       await setSerialized(serverConfig, workspaceId, options.serialize(value), updatedAt);


### PR DESCRIPTION
## The flake

`apps/server/src/agent-context-diagnostics.test.ts` → *"returns a no-store collaborator report on fresh state without creating or changing configuration"* fails intermittently on ubuntu CI (e.g. run 31493347524, first attempt) with `state/` + `state/runtime.sqlite` appearing between the two `snapshotTree` calls. A rerun of the identical commit passed, so it is a race, not a deterministic failure.

## What actually causes it

Not the diagnostics POST. `startServer` fires the startup provider-auth sync as fire-and-forget:

```ts
// apps/server/src/server.ts
void syncManagedProviderAuth({ config, env, logger: … }).catch(() => undefined);
```

That task reads the global runtime config, and the read opened the runtime DB with `create: true` (`workspace-kv-store` → `openRuntimeSqliteDatabase` → `ensureDir` + `new Database(path, { create: true })`). On a fresh install the server therefore grew `state/` and an empty `state/runtime.sqlite` at an unpredictable point *after* `start()` resolved, purely to learn it had nothing stored.

The test snapshots the fixture root right after `startOpenwork`, POSTs diagnostics, then re-snapshots. When that startup write lands between the two snapshots, the diff is exactly `state/` + `state/runtime.sqlite`, and the test reads it as the POST having created configuration.

I instrumented `openRuntimeSqliteDatabase` and `workspaceKvDb` and confirmed the whole test opens the runtime DB exactly once, from `syncManagedProviderAuth` ← `startServer`. I also instrumented `reloadOpencodeEngineAfterInternalBootstrap` (the suspected culprit): it never fires in this test, and `reloadOpencodeEngine` would in any case throw at its `loopbackFetch` before reaching any runtime-DB write, so it is left untouched.

## The fix

Reads treat a missing DB file as an empty one instead of materializing it. An already-open connection still wins, so a write in flight is never mistaken for absence. Writes are unchanged and still create on demand.

No assertion was loosened — the diagnostics test is untouched. The invariant is locked by a new deterministic unit test rather than by timing.

## Verification (bun 1.3.14; system bun 1.3.4 cannot load these files — `node:sqlite`)

**Race reproduced and closed.** Injecting a delay into `openRuntimeSqliteDatabase` moves the startup write past the baseline snapshot, which is what a loaded CI runner does:

| injected delay | before | after |
|---|---|---|
| 1 / 2 / 3 / 5 / 8 / 12 ms | ❌ fail — `state`, `state/runtime.sqlite` added | ✅ pass, 0 DB opens |
| 20 ms | ✅ pass (write lands after both snapshots) | ✅ pass, 0 DB opens |

Reproduced failure output at 5 ms, matching CI exactly:

```
2035 |     expect(await snapshotTree(fixture.root)).toEqual(before);
error: expect(received).toEqual(expected)
+   "state": "directory:16877:…",
+   "state/runtime.sqlite": "file:33188:12288:…",
```

After the change the test opens the runtime DB **zero** times at every delay.

**Loop.** `bun test src/agent-context-diagnostics.test.ts` ×25 → 65 pass / 0 fail every run.

**Suite.** `pnpm --filter openwork-server test` (what CI runs) → **655 pass, 8 skip, 0 fail**, stable across 3 runs. `pnpm --filter openwork-server typecheck` clean.

Not run: the evals spec lane (needs an engine; this change removes a startup side effect and adds no product surface) and `workspace-kv-store.node.test.ts`, which is inert under `bun test` and fails to resolve its `.js` imports under plain `node --test` on `dev` too — pre-existing, unrelated. The `existsSync` guard sits ahead of the bun/node split, so both drivers take the same path.