### PR TITLE
Host standard MCP Apps inline in desktop conversations

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -48,6 +48,8 @@
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@lexical/react": "^0.35.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.5",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.17.11",
     "@openwork/install-config": "workspace:*",
     "@openwork/types": "workspace:*",

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -399,6 +399,27 @@ export type OpenworkMcpItem = {
   managedOAuth?: OpenworkManagedMcpConnection | null;
 };
 
+export type OpenworkMcpAppResource = {
+  serverName: string;
+  toolName: string;
+  resourceUri: string;
+  html: string;
+  csp: {
+    connectDomains: string[];
+    resourceDomains: string[];
+    frameDomains: string[];
+    baseUriDomains: string[];
+  };
+  prefersBorder: boolean;
+};
+
+export type OpenworkMcpAppToolResult = {
+  content: Array<Record<string, unknown>>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+};
+
 export type OpenworkManagedMcpConnection = {
   name: string;
   serverUrl: string;
@@ -1868,6 +1889,32 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspace/${workspaceId}/mcp`,
         { token, hostToken },
       ),
+    resolveMcpApp: (workspaceId: string, projectedToolName: string) =>
+      requestJson<{ app: OpenworkMcpAppResource | null }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/mcp-apps/resolve`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: { projectedToolName },
+          timeoutMs: timeouts.config,
+        },
+      ),
+    callMcpAppTool: (
+      workspaceId: string,
+      payload: { serverName: string; name: string; arguments?: Record<string, unknown> },
+    ) => requestJson<OpenworkMcpAppToolResult>(
+      baseUrl,
+      `/workspace/${encodeURIComponent(workspaceId)}/mcp-apps/call`,
+      {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+        timeoutMs: timeouts.binary,
+      },
+    ),
     getOpenworkCloudMcpHealth: (
       workspaceId: string,
       providerModel?: OpenworkCloudMcpProviderModelContext,

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -420,6 +420,11 @@ export type OpenworkMcpAppToolResult = {
   _meta?: Record<string, unknown>;
 };
 
+export type OpenworkMcpAppSandbox = {
+  url: string;
+  expectedOrigin: string;
+};
+
 export type OpenworkManagedMcpConnection = {
   name: string;
   serverUrl: string;
@@ -1901,6 +1906,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           timeoutMs: timeouts.config,
         },
       ),
+    mcpAppSandbox: (app: OpenworkMcpAppResource, hostOrigin: string): OpenworkMcpAppSandbox => {
+      const url = new URL(`${baseUrl}/mcp-apps/sandbox.html`);
+      if (url.origin === hostOrigin && url.hostname === "localhost") url.hostname = "127.0.0.1";
+      else if (url.origin === hostOrigin && url.hostname === "127.0.0.1") url.hostname = "localhost";
+      url.searchParams.set("csp", JSON.stringify(app.csp));
+      url.searchParams.set("hostOrigin", hostOrigin);
+      return { url: url.toString(), expectedOrigin: url.origin };
+    },
     callMcpAppTool: (
       workspaceId: string,
       payload: { serverName: string; name: string; arguments?: Record<string, unknown> },

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -21,6 +21,7 @@ import { normalizeErrorText } from "@/lib/error-text"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
+import { McpAppFrame } from "./mcp-app-frame"
 
 type CapabilityCallLineProps = ChatToolReconnectCallbacks & {
   part: DynamicToolUIPart
@@ -229,6 +230,7 @@ export function CapabilityCallLine({
   const sentence = getCapabilityCallSentence(part)
   const line = inFlight ? sentence.present : sentence.past
   return (
+    <>
     <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
       <div className="flex min-w-0 items-center gap-2">
         <CollapsibleTrigger
@@ -250,5 +252,7 @@ export function CapabilityCallLine({
         <TechnicalDetailsPanel part={part} />
       </CollapsibleContent>
     </Collapsible>
+    {part.state === "output-available" ? <McpAppFrame part={part} /> : null}
+    </>
   )
 }

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { DynamicToolUIPart } from "ai"
+import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/app-bridge"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+
+import type { OpenworkMcpAppResource, OpenworkMcpAppToolResult } from "@/app/lib/openwork-server"
+import { useWorkspace } from "@/react-app/shell/workspace-provider"
+import { cn } from "@/lib/utils"
+
+const MIN_HEIGHT = 160
+const MAX_HEIGHT = 800
+const DEFAULT_HEIGHT = 320
+const SIZE_EVENT_INTERVAL_MS = 100
+const INITIALIZE_TIMEOUT_MS = 5_000
+
+type PreservedMcpAppResult = {
+  content: Array<Record<string, unknown>>
+  structuredContent?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null {
+  const openwork = isRecord(part.callProviderMetadata?.openwork) ? part.callProviderMetadata.openwork : null
+  const result = openwork && isRecord(openwork.mcpApp) ? openwork.mcpApp : null
+  if (!result || !Array.isArray(result.content)) return null
+  const content = result.content.filter(isRecord) as Array<Record<string, unknown>>
+  if (content.length !== result.content.length) return null
+  return {
+    content,
+    ...(isRecord(result.structuredContent) ? { structuredContent: result.structuredContent } : {}),
+    ...(isRecord(result._meta) ? { _meta: result._meta } : {}),
+  }
+}
+
+export function buildMcpAppCsp(app: OpenworkMcpAppResource): string {
+  const resources = app.csp.resourceDomains.join(" ")
+  const withResources = (source: string) => resources ? `${source} ${resources}` : source
+  const sourceList = (values: string[]) => values.length ? values.join(" ") : "'none'"
+  return [
+    "default-src 'none'",
+    `script-src ${withResources("'unsafe-inline'")}`,
+    `style-src ${withResources("'unsafe-inline'")}`,
+    `img-src ${withResources("data: blob:")}`,
+    `font-src ${withResources("data:")}`,
+    `media-src ${withResources("blob:")}`,
+    `connect-src ${sourceList(app.csp.connectDomains)}`,
+    `frame-src ${sourceList(app.csp.frameDomains)}`,
+    `base-uri ${sourceList(app.csp.baseUriDomains)}`,
+    "object-src 'none'",
+    "form-action 'none'",
+  ].join("; ")
+}
+
+function escapeAttribute(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+}
+
+export function secureMcpAppHtml(app: OpenworkMcpAppResource): string {
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${escapeAttribute(buildMcpAppCsp(app))}">`
+  const head = /<head(?:\s[^>]*)?>/i
+  if (head.test(app.html)) return app.html.replace(head, (match) => `${match}${meta}`)
+  const html = /<html(?:\s[^>]*)?>/i
+  if (html.test(app.html)) return app.html.replace(html, (match) => `${match}<head>${meta}</head>`)
+  return `<!doctype html><html><head>${meta}</head><body>${app.html}</body></html>`
+}
+
+function mcpToolResult(result: OpenworkMcpAppToolResult): CallToolResult {
+  return result as CallToolResult
+}
+
+export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
+  const { openworkServerClient, workspaceId } = useWorkspace()
+  const result = useMemo(() => preservedResult(part), [part])
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
+  const [height, setHeight] = useState(DEFAULT_HEIGHT)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setApp(null)
+    setError(null)
+    if (!result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
+    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName)
+      .then(({ app: resolved }) => {
+        if (!cancelled) setApp(resolved)
+      })
+      .catch((cause) => {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "The interactive view could not be loaded.")
+      })
+    return () => { cancelled = true }
+  }, [openworkServerClient, part.toolName, result, workspaceId])
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!app || !result || !iframe || !iframe.contentWindow || !openworkServerClient || !workspaceId) return
+    let disposed = false
+    let lastSizeEventAt = 0
+    const bridge = new AppBridge(
+      null,
+      { name: "OpenWork", version: "1.0.0" },
+      { serverTools: {} },
+      {
+        hostContext: {
+          theme: document.documentElement.classList.contains("dark") ? "dark" : "light",
+          displayMode: "inline",
+        },
+      },
+    )
+    const initializeTimer = window.setTimeout(() => {
+      if (!disposed) setError("The interactive view did not finish its MCP Apps handshake.")
+    }, INITIALIZE_TIMEOUT_MS)
+
+    bridge.onsizechange = ({ height: requestedHeight }) => {
+      const now = Date.now()
+      if (now - lastSizeEventAt < SIZE_EVENT_INTERVAL_MS || !Number.isFinite(requestedHeight)) return
+      lastSizeEventAt = now
+      setHeight(Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, Math.ceil(requestedHeight ?? DEFAULT_HEIGHT))))
+    }
+    bridge.onrequestteardown = () => {
+      setApp(null)
+    }
+    bridge.oncalltool = async ({ name, arguments: args }) => mcpToolResult(
+      await openworkServerClient.callMcpAppTool(workspaceId, {
+        serverName: app.serverName,
+        name,
+        arguments: args,
+      }),
+    )
+    bridge.oninitialized = () => {
+      window.clearTimeout(initializeTimer)
+      void bridge.sendToolInput({
+        arguments: isRecord(part.input) ? part.input : {},
+      }).then(() => bridge.sendToolResult({
+        content: result.content as CallToolResult["content"],
+        ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
+        ...(result._meta ? { _meta: result._meta } : {}),
+      })).catch((cause) => {
+        if (!disposed) setError(cause instanceof Error ? cause.message : "The tool result could not be delivered to the view.")
+      })
+    }
+
+    const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow)
+    void bridge.connect(transport)
+      .then(() => {
+        if (!disposed) iframe.srcdoc = secureMcpAppHtml(app)
+      })
+      .catch((cause) => {
+        if (!disposed) setError(cause instanceof Error ? cause.message : "The MCP Apps bridge could not start.")
+      })
+
+    return () => {
+      disposed = true
+      window.clearTimeout(initializeTimer)
+      void Promise.race([
+        bridge.teardownResource({}),
+        new Promise<void>((resolve) => window.setTimeout(resolve, 500)),
+      ]).catch(() => undefined).finally(() => bridge.close().catch(() => undefined))
+    }
+  }, [app, openworkServerClient, part.input, result, workspaceId])
+
+  if (!result || (!app && !error)) return null
+  if (error) {
+    return (
+      <p className="mt-2 text-xs text-muted-foreground" role="status">
+        Interactive view unavailable. The normal tool result is still available. {error}
+      </p>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "mt-3 overflow-hidden rounded-xl bg-background",
+        app?.prefersBorder && "border border-border",
+      )}
+      data-mcp-app-resource={app?.resourceUri}
+    >
+      <iframe
+        ref={iframeRef}
+        title={`${part.toolName} interactive view`}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        className="block w-full border-0 bg-transparent"
+        style={{ height }}
+      />
+    </div>
+  )
+}

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -63,10 +63,27 @@ function escapeAttribute(value: string): string {
 
 export function secureMcpAppHtml(app: OpenworkMcpAppResource): string {
   const meta = `<meta http-equiv="Content-Security-Policy" content="${escapeAttribute(buildMcpAppCsp(app))}">`
-  const head = /<head(?:\s[^>]*)?>/i
-  if (head.test(app.html)) return app.html.replace(head, (match) => `${match}${meta}`)
-  const html = /<html(?:\s[^>]*)?>/i
-  if (html.test(app.html)) return app.html.replace(html, (match) => `${match}<head>${meta}</head>`)
+  const html = /<html(?:\s[^>]*)?>/i.exec(app.html)
+  if (html?.index !== undefined) {
+    const prefix = app.html.slice(0, html.index).replace(/^\uFEFF/, "")
+    if (!/^\s*(?:<!doctype\s+html\s*>)?\s*$/i.test(prefix)) {
+      throw new Error("The MCP App document contains executable markup before its HTML root.")
+    }
+    const htmlEnd = html.index + html[0].length
+    const head = /<head(?:\s[^>]*)?>/i.exec(app.html)
+    if (head?.index !== undefined) {
+      if (head.index < htmlEnd || app.html.slice(htmlEnd, head.index).trim()) {
+        throw new Error("The MCP App document contains markup before its policy-bearing head.")
+      }
+      const headEnd = head.index + head[0].length
+      return `${app.html.slice(0, headEnd)}${meta}${app.html.slice(headEnd)}`
+    }
+    const body = /<body(?:\s[^>]*)?>/i.exec(app.html)
+    if (body?.index !== undefined && (body.index < htmlEnd || app.html.slice(htmlEnd, body.index).trim())) {
+      throw new Error("The MCP App document contains markup before its policy-bearing head.")
+    }
+    return `${app.html.slice(0, htmlEnd)}<head>${meta}</head>${app.html.slice(htmlEnd)}`
+  }
   return `<!doctype html><html><head>${meta}</head><body>${app.html}</body></html>`
 }
 
@@ -116,6 +133,12 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
     const initializeTimer = window.setTimeout(() => {
       if (!disposed) setError("The interactive view did not finish its MCP Apps handshake.")
     }, INITIALIZE_TIMEOUT_MS)
+    const sandbox = openworkServerClient.mcpAppSandbox(app, window.location.origin)
+    if (sandbox.expectedOrigin === window.location.origin) {
+      window.clearTimeout(initializeTimer)
+      setError("The MCP Apps sandbox must use a different origin from the OpenWork host.")
+      return
+    }
 
     bridge.onsizechange = ({ height: requestedHeight }) => {
       const now = Date.now()
@@ -145,18 +168,28 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         if (!disposed) setError(cause instanceof Error ? cause.message : "The tool result could not be delivered to the view.")
       })
     }
-
-    const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow)
-    void bridge.connect(transport)
-      .then(() => {
-        if (!disposed) iframe.srcdoc = secureMcpAppHtml(app)
-      })
-      .catch((cause) => {
-        if (!disposed) setError(cause instanceof Error ? cause.message : "The MCP Apps bridge could not start.")
-      })
+    const handleSandboxReady = (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow
+        || event.origin !== sandbox.expectedOrigin
+        || event.data?.method !== "ui/notifications/sandbox-proxy-ready") return
+      window.removeEventListener("message", handleSandboxReady)
+      const transport = new PostMessageTransport(iframe.contentWindow!, iframe.contentWindow!)
+      void bridge.connect(transport)
+        .then(() => bridge.sendSandboxResourceReady({
+          html: secureMcpAppHtml(app),
+          csp: app.csp,
+          sandbox: "allow-scripts allow-same-origin",
+        }))
+        .catch((cause) => {
+          if (!disposed) setError(cause instanceof Error ? cause.message : "The MCP Apps sandbox could not load the view.")
+        })
+    }
+    window.addEventListener("message", handleSandboxReady)
+    iframe.src = sandbox.url
 
     return () => {
       disposed = true
+      window.removeEventListener("message", handleSandboxReady)
       window.clearTimeout(initializeTimer)
       void Promise.race([
         bridge.teardownResource({}),
@@ -185,7 +218,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       <iframe
         ref={iframeRef}
         title={`${part.toolName} interactive view`}
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-same-origin"
         referrerPolicy="no-referrer"
         className="block w-full border-0 bg-transparent"
         style={{ height }}

--- a/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
@@ -1,10 +1,32 @@
-import type { DynamicToolUIPart, TextUIPart } from "ai";
+import type { DynamicToolUIPart, JSONValue, ProviderMetadata, TextUIPart } from "ai";
 import type { ToolPart } from "@opencode-ai/sdk/v2/client";
 
 import { safeStringify } from "@/app/utils";
 import { normalizeErrorText } from "@/lib/error-text";
 
 export const STRUCTURED_OUTPUT_TOOL = "StructuredOutput";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonValue(value: unknown, depth = 0): value is JSONValue {
+  if (depth > 32) return false;
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.length <= 4_096 && value.every((entry) => isJsonValue(entry, depth + 1));
+  if (!isRecord(value)) return false;
+  const entries = Object.values(value);
+  return entries.length <= 4_096 && entries.every((entry) => isJsonValue(entry, depth + 1));
+}
+
+function toolCallProviderMetadata(part: ToolPart): ProviderMetadata {
+  const stateMetadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {};
+  const mcpApp = isJsonValue(stateMetadata.openworkMcpApp) ? stateMetadata.openworkMcpApp : null;
+  return {
+    opencode: { partId: part.id },
+    ...(mcpApp ? { openwork: { mcpApp } } : {}),
+  };
+}
 
 function shouldDeferInProgressTool(part: ToolPart) {
   if (part.state.status === "completed" || part.state.status === "error") {
@@ -46,7 +68,7 @@ export function parseDynamicToolUIPart(part: ToolPart): DynamicToolUIPart | null
       state: "output-error",
       input: part.state.input,
       errorText: normalizeErrorText(part.state.error).display,
-      callProviderMetadata: { opencode: { partId: part.id } },
+      callProviderMetadata: toolCallProviderMetadata(part),
     };
   }
 
@@ -58,7 +80,7 @@ export function parseDynamicToolUIPart(part: ToolPart): DynamicToolUIPart | null
       state: "output-available",
       input: part.state.input,
       output: part.state.output,
-      callProviderMetadata: { opencode: { partId: part.id } },
+      callProviderMetadata: toolCallProviderMetadata(part),
     };
   }
 
@@ -74,6 +96,6 @@ export function parseDynamicToolUIPart(part: ToolPart): DynamicToolUIPart | null
     toolCallId: part.callID,
     state: "input-streaming",
     input: part.state.input,
-    callProviderMetadata: { opencode: { partId: part.id } },
+    callProviderMetadata: toolCallProviderMetadata(part),
   };
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2526,6 +2526,8 @@ export function SessionRoute() {
     <WorkspaceProvider
       client={opencodeClient}
       opencodeBaseUrl={opencodeBaseUrl}
+      openworkServerClient={selectedWorkspaceEndpoint?.client ?? null}
+      workspaceId={selectedWorkspaceEndpoint?.workspaceId ?? ""}
       selectedWorkspaceRoot={selectedWorkspaceRoot}
     >
     {opencodeClient && selectedWorkspaceEndpoint && opencodeBaseUrl && selectedWorkspaceServerToken ? (

--- a/apps/app/src/react-app/shell/workspace-provider.ts
+++ b/apps/app/src/react-app/shell/workspace-provider.ts
@@ -1,10 +1,13 @@
 import * as React from "react";
 
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import type { Client } from "@/app/types";
 
 type WorkspaceContextValue = {
   client: Client | null;
   opencodeBaseUrl: string;
+  openworkServerClient: OpenworkServerClient | null;
+  workspaceId: string;
   selectedWorkspaceRoot: string;
 };
 
@@ -13,6 +16,8 @@ const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null)
 type WorkspaceProviderProps = {
   client: Client | null;
   opencodeBaseUrl?: string;
+  openworkServerClient?: OpenworkServerClient | null;
+  workspaceId?: string;
   selectedWorkspaceRoot: string;
   children: React.ReactNode;
 };
@@ -20,12 +25,14 @@ type WorkspaceProviderProps = {
 export function WorkspaceProvider({
   client,
   opencodeBaseUrl = "",
+  openworkServerClient = null,
+  workspaceId = "",
   selectedWorkspaceRoot,
   children,
 }: WorkspaceProviderProps) {
   const value = React.useMemo(
-    () => ({ client, opencodeBaseUrl, selectedWorkspaceRoot }),
-    [client, opencodeBaseUrl, selectedWorkspaceRoot],
+    () => ({ client, opencodeBaseUrl, openworkServerClient, workspaceId, selectedWorkspaceRoot }),
+    [client, opencodeBaseUrl, openworkServerClient, workspaceId, selectedWorkspaceRoot],
   );
 
   return React.createElement(WorkspaceContext.Provider, { value }, children);

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -48,6 +48,15 @@ describe("MCP App iframe policy", () => {
     expect(fragment).toContain("<body><main>fragment resource</main></body>")
   })
 
+  test("rejects executable markup before an existing document policy", () => {
+    expect(() => secureMcpAppHtml(fixture({
+      html: "<script>globalThis.beforePolicy = true</script><html><head></head><body>bad</body></html>",
+    }))).toThrow("executable markup before its HTML root")
+    expect(() => secureMcpAppHtml(fixture({
+      html: "<html><script>globalThis.beforePolicy = true</script><head></head><body>bad</body></html>",
+    }))).toThrow("markup before its policy-bearing head")
+  })
+
   test("allows only the server-declared origins in each directive", () => {
     const csp = buildMcpAppCsp(fixture({
       csp: {

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+
+import type { OpenworkMcpAppResource } from "../src/app/lib/openwork-server"
+import { buildMcpAppCsp, secureMcpAppHtml } from "../src/components/chat/mcp-app-frame"
+
+function fixture(overrides: Partial<OpenworkMcpAppResource> = {}): OpenworkMcpAppResource {
+  return {
+    serverName: "fixture",
+    toolName: "render",
+    resourceUri: "ui://fixture/view.html",
+    html: "<!doctype html><html><head><title>Fixture</title></head><body>ok</body></html>",
+    csp: {
+      connectDomains: [],
+      resourceDomains: [],
+      frameDomains: [],
+      baseUriDomains: [],
+    },
+    prefersBorder: true,
+    ...overrides,
+  }
+}
+
+describe("MCP App iframe policy", () => {
+  test("defaults every ambient capability closed", () => {
+    const csp = buildMcpAppCsp(fixture())
+    expect(csp).toContain("default-src 'none'")
+    expect(csp).toContain("connect-src 'none'")
+    expect(csp).toContain("frame-src 'none'")
+    expect(csp).toContain("base-uri 'none'")
+    expect(csp).toContain("form-action 'none'")
+  })
+
+  test("injects the host-enforced CSP before resource markup runs", () => {
+    const html = secureMcpAppHtml(fixture())
+    const policy = html.indexOf('http-equiv="Content-Security-Policy"')
+    const title = html.indexOf("<title>")
+    expect(policy).toBeGreaterThan(-1)
+    expect(policy).toBeLessThan(title)
+  })
+
+  test("creates a valid policy-bearing head when the resource omits one", () => {
+    const html = secureMcpAppHtml(fixture({ html: "<html><body>headless resource</body></html>" }))
+    expect(html).toContain('<html><head><meta http-equiv="Content-Security-Policy"')
+    expect(html.indexOf("Content-Security-Policy")).toBeLessThan(html.indexOf("<body>"))
+
+    const fragment = secureMcpAppHtml(fixture({ html: "<main>fragment resource</main>" }))
+    expect(fragment).toStartWith('<!doctype html><html><head><meta http-equiv="Content-Security-Policy"')
+    expect(fragment).toContain("<body><main>fragment resource</main></body>")
+  })
+
+  test("allows only the server-declared origins in each directive", () => {
+    const csp = buildMcpAppCsp(fixture({
+      csp: {
+        connectDomains: ["https://api.example.com"],
+        resourceDomains: ["https://static.example.com"],
+        frameDomains: ["https://embed.example.com"],
+        baseUriDomains: [],
+      },
+    }))
+    expect(csp).toContain("connect-src https://api.example.com")
+    expect(csp).toContain("script-src 'unsafe-inline' https://static.example.com")
+    expect(csp).toContain("frame-src https://embed.example.com")
+  })
+})

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -113,6 +113,29 @@ describe("tool part mapper", () => {
     });
   });
 
+  test("preserves MCP Apps result metadata for the chat host", () => {
+    const part = writeToolPart("completed", { configObjectId: "script_1" });
+    if (part.state.status !== "completed") throw new Error("Expected completed fixture");
+    part.state.metadata = {
+      openworkMcpApp: {
+        content: [{ type: "text", text: "Fallback" }],
+        structuredContent: { schemaVersion: "1", value: 42 },
+        _meta: { receiptId: "receipt_1" },
+      },
+    };
+
+    expect(parseDynamicToolUIPart(part)?.callProviderMetadata).toEqual({
+      opencode: { partId: "part-write" },
+      openwork: {
+        mcpApp: {
+          content: [{ type: "text", text: "Fallback" }],
+          structuredContent: { schemaVersion: "1", value: 42 },
+          _meta: { receiptId: "receipt_1" },
+        },
+      },
+    });
+  });
+
   test("summarizes and clamps huge HTML tool errors at ingestion", () => {
     const htmlError = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`;
     const parsed = parseDynamicToolUIPart(writeToolPart("error", {}, {}, htmlError));

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { addMcp } from "./mcp.js";
+import {
+  callMcpAppTool,
+  projectedMcpToolName,
+  resolveMcpAppResource,
+  toolUiResourceUri,
+} from "./mcp-app-host.js";
+import type { ServerConfig } from "./types.js";
+
+const WORKSPACE_ID = "ws_mcp_apps_host";
+const RESOURCE_URI = "ui://fixture/v1/view.html";
+const stops: Array<() => void | Promise<void>> = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+});
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function startFixtureMcp() {
+  const mcp = new Server(
+    { name: "mcp-app-fixture", version: "1.0.0" },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        extensions: {
+          "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] },
+        },
+      },
+    },
+  );
+  mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: "render_fixture",
+        description: "Render the fixture",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { ui: { resourceUri: RESOURCE_URI, visibility: ["model", "app"] } },
+      },
+      {
+        name: "read_detail",
+        description: "Read fixture detail",
+        inputSchema: { type: "object", properties: { id: { type: "string" } } },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { ui: { visibility: ["app"] } },
+      },
+      {
+        name: "model_only_detail",
+        description: "Read model-only fixture detail",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { ui: { visibility: ["model"] } },
+      },
+      {
+        name: "write_detail",
+        description: "Write fixture detail",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: false, destructiveHint: true },
+      },
+    ],
+  }));
+  mcp.setRequestHandler(ReadResourceRequestSchema, async ({ params }) => {
+    if (params.uri !== RESOURCE_URI) throw new Error("not found");
+    return {
+      contents: [{
+        uri: RESOURCE_URI,
+        mimeType: "text/html;profile=mcp-app",
+        text: "<!doctype html><html><head></head><body>Fixture</body></html>",
+        _meta: {
+          ui: {
+            csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+            prefersBorder: true,
+          },
+        },
+      }],
+    };
+  });
+  mcp.setRequestHandler(CallToolRequestSchema, async ({ params }) => ({
+    content: [{ type: "text", text: `detail:${String(params.arguments?.id ?? "")}` }],
+    structuredContent: { id: params.arguments?.id ?? null },
+  }));
+
+  let transport: WebStandardStreamableHTTPServerTransport;
+  const http = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: (request) => transport.handleRequest(request),
+  });
+  transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: randomUUID,
+    enableJsonResponse: true,
+    enableDnsRebindingProtection: true,
+    allowedHosts: [`127.0.0.1:${http.port}`, `localhost:${http.port}`],
+  });
+  await mcp.connect(transport);
+  stops.push(async () => {
+    await mcp.close();
+    http.stop(true);
+  });
+  return `http://127.0.0.1:${http.port}`;
+}
+
+async function configuredFixture(prefix: string): Promise<{ config: ServerConfig; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  stops.push(async () => {
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    await rm(root, { recursive: true, force: true });
+  });
+  await mkdir(join(root, ".git"), { recursive: true });
+  const config = serverConfig(root);
+  await addMcp(config, WORKSPACE_ID, "fixture", {
+    type: "remote",
+    url: await startFixtureMcp(),
+    enabled: true,
+  });
+  return { config, root };
+}
+
+describe("MCP Apps host transport", () => {
+  test("uses OpenCode's exact projected MCP tool naming", () => {
+    expect(projectedMcpToolName("sales force", "render.pipeline")).toBe("sales_force_render_pipeline");
+    expect(toolUiResourceUri({ _meta: { ui: { resourceUri: RESOURCE_URI } } })).toBe(RESOURCE_URI);
+  });
+
+  test("negotiates and resolves one fixed remote MCP App fixture", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-host-");
+
+    const app = await resolveMcpAppResource({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      projectedToolName: "fixture_render_fixture",
+    });
+    expect(app).toEqual({
+      serverName: "fixture",
+      toolName: "render_fixture",
+      resourceUri: RESOURCE_URI,
+      html: "<!doctype html><html><head></head><body>Fixture</body></html>",
+      csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+      prefersBorder: true,
+    });
+
+  });
+
+  test("mediates explicitly read-only same-server tool calls", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-call-");
+
+    const result = await callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "read_detail",
+      arguments: { id: "42" },
+    });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "detail:42" }],
+      structuredContent: { id: "42" },
+    });
+  });
+
+  test("rejects model-only same-server tools", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-model-only-");
+    await expect(callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "model_only_detail",
+    })).rejects.toMatchObject({ code: "tool_not_visible" });
+  });
+
+  test("rejects same-server tools that require approval", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-write-");
+    await expect(callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "write_detail",
+    })).rejects.toMatchObject({ code: "tool_requires_approval" });
+  });
+});

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -135,10 +135,14 @@ async function startFixtureMcp() {
 async function configuredFixture(prefix: string): Promise<{ config: ServerConfig; root: string }> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
   process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_DEV_MODE = "1";
   stops.push(async () => {
     if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
     else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
+    else process.env.OPENWORK_DEV_MODE = previousDevMode;
     await rm(root, { recursive: true, force: true });
   });
   await mkdir(join(root, ".git"), { recursive: true });
@@ -214,5 +218,17 @@ describe("MCP Apps host transport", () => {
       serverName: "fixture",
       name: "write_detail",
     })).rejects.toMatchObject({ code: "tool_requires_approval" });
+  });
+
+  test("rejects private MCP egress outside explicit development mode", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-private-");
+    delete process.env.OPENWORK_DEV_MODE;
+
+    await expect(resolveMcpAppResource({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      projectedToolName: "fixture_render_fixture",
+    })).rejects.toMatchObject({ code: "unsafe_server_url" });
   });
 });

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -1,0 +1,310 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { ServerConfig } from "./types.js";
+import { diagnoseMcpToolDenies, listMcp } from "./mcp.js";
+
+const MCP_APP_EXTENSION = "io.modelcontextprotocol/ui";
+const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const MAX_TOOL_PAGES = 32;
+const MAX_TOOLS = 2_048;
+const MAX_RESOURCE_BYTES = 512 * 1024;
+const MAX_RESULT_BYTES = 1024 * 1024;
+
+type McpAppCsp = {
+  connectDomains: string[];
+  resourceDomains: string[];
+  frameDomains: string[];
+  baseUriDomains: string[];
+};
+
+export type McpAppResource = {
+  serverName: string;
+  toolName: string;
+  resourceUri: string;
+  html: string;
+  csp: McpAppCsp;
+  prefersBorder: boolean;
+};
+
+export class McpAppHostError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "McpAppHostError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringHeaders(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+export function projectedMcpToolName(serverName: string, toolName: string): string {
+  const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return `${sanitize(serverName)}_${sanitize(toolName)}`;
+}
+
+export function toolUiResourceUri(tool: Partial<Tool>): string | null {
+  const meta = isRecord(tool._meta) ? tool._meta : {};
+  const ui = isRecord(meta.ui) ? meta.ui : {};
+  const nested = typeof ui.resourceUri === "string" ? ui.resourceUri : null;
+  const legacy = typeof meta["ui/resourceUri"] === "string" ? meta["ui/resourceUri"] : null;
+  const uri = nested ?? legacy;
+  if (!uri) return null;
+  if (!uri.startsWith("ui://")) throw new McpAppHostError("invalid_resource_uri", "MCP App resource URI must use ui://.");
+  return uri;
+}
+
+function safeDomain(value: unknown): string | null {
+  if (typeof value !== "string" || value.length > 2048) return null;
+  try {
+    const url = new URL(value);
+    if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) return null;
+    if (url.protocol === "https:") return url.origin;
+    if (url.protocol === "http:" && isLoopbackHostname(url.hostname)) return url.origin;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+}
+
+function domainList(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length > 16) {
+    if (value === undefined) return [];
+    throw new McpAppHostError("invalid_resource_csp", "MCP App CSP domain lists must contain at most 16 origins.");
+  }
+  const domains = value.map(safeDomain);
+  if (domains.some((domain) => domain === null)) {
+    throw new McpAppHostError("invalid_resource_csp", "MCP App CSP domains must be HTTPS origins (or loopback HTTP origins).");
+  }
+  return Array.from(new Set(domains as string[]));
+}
+
+function resourcePresentationMeta(value: unknown): { csp: McpAppCsp; prefersBorder: boolean } {
+  const meta = isRecord(value) ? value : {};
+  const ui = isRecord(meta.ui) ? meta.ui : {};
+  const csp = isRecord(ui.csp) ? ui.csp : {};
+  const permissions = isRecord(ui.permissions) ? ui.permissions : {};
+  if (Object.keys(permissions).length > 0 || ui.domain !== undefined) {
+    throw new McpAppHostError(
+      "unsupported_resource_permissions",
+      "This OpenWork host slice does not grant device permissions or dedicated sandbox origins.",
+    );
+  }
+  return {
+    csp: {
+      connectDomains: domainList(csp.connectDomains),
+      resourceDomains: domainList(csp.resourceDomains),
+      frameDomains: domainList(csp.frameDomains),
+      baseUriDomains: domainList(csp.baseUriDomains),
+    },
+    prefersBorder: ui.prefersBorder !== false,
+  };
+}
+
+function remoteUrl(config: Record<string, unknown>): URL | null {
+  if (config.enabled === false || typeof config.url !== "string") return null;
+  try {
+    const url = new URL(config.url);
+    if (url.username || url.password) return null;
+    return url.protocol === "https:" || (url.protocol === "http:" && isLoopbackHostname(url.hostname)) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function clientOptions() {
+  return {
+    capabilities: {
+      extensions: {
+        [MCP_APP_EXTENSION]: { mimeTypes: [MCP_APP_MIME_TYPE] },
+      },
+    },
+  };
+}
+
+async function withRemoteClient<T>(
+  config: Record<string, unknown>,
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const url = remoteUrl(config);
+  if (!url) throw new McpAppHostError("unsupported_transport", "MCP Apps currently require a configured remote HTTP MCP server.");
+  const requestInit = Object.keys(stringHeaders(config.headers)).length
+    ? { headers: stringHeaders(config.headers) }
+    : undefined;
+  const attempts = [
+    () => new StreamableHTTPClientTransport(url, { requestInit }),
+    () => new SSEClientTransport(url, { requestInit }),
+  ];
+  let lastError: unknown;
+  for (const createTransport of attempts) {
+    const client = new Client({ name: "openwork-mcp-app-host", version: "1.0.0" }, clientOptions());
+    let connected = false;
+    try {
+      await client.connect(createTransport());
+      connected = true;
+      return await run(client);
+    } catch (error) {
+      if (connected) throw error;
+      lastError = error;
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+  throw new McpAppHostError(
+    "mcp_unreachable",
+    lastError instanceof Error ? lastError.message : "The MCP server could not be reached.",
+  );
+}
+
+async function listTools(client: Client): Promise<Tool[]> {
+  const tools: Tool[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < MAX_TOOL_PAGES; page += 1) {
+    const listed = await client.listTools(cursor ? { cursor } : undefined);
+    tools.push(...listed.tools);
+    if (tools.length > MAX_TOOLS) {
+      throw new McpAppHostError("tool_catalog_too_large", "The MCP tool catalog exceeds the host limit.");
+    }
+    if (!listed.nextCursor) return tools;
+    cursor = listed.nextCursor;
+  }
+  throw new McpAppHostError("tool_catalog_too_large", "MCP tool pagination exceeded the host limit.");
+}
+
+function toolVisibility(tool: Partial<Tool>, audience: "model" | "app"): boolean {
+  const meta = isRecord(tool._meta) ? tool._meta : {};
+  const ui = isRecord(meta.ui) ? meta.ui : {};
+  if (ui.visibility === undefined) return true;
+  return Array.isArray(ui.visibility)
+    && ui.visibility.every((entry) => entry === "model" || entry === "app")
+    && ui.visibility.includes(audience);
+}
+
+function findTextResource(
+  resourceUri: string,
+  result: Awaited<ReturnType<Client["readResource"]>>,
+): { html: string; meta: unknown } {
+  const candidates = result.contents.filter((content) => content.uri === resourceUri && "text" in content);
+  if (candidates.length !== 1) {
+    throw new McpAppHostError("invalid_resource", "The MCP App resource must return exactly one matching text resource.");
+  }
+  const content = candidates[0];
+  if (!content || !("text" in content) || typeof content.text !== "string") {
+    throw new McpAppHostError("invalid_resource", "The MCP App resource did not return HTML text.");
+  }
+  if (content.mimeType?.toLowerCase() !== MCP_APP_MIME_TYPE) {
+    throw new McpAppHostError("invalid_resource_mime", `MCP App resources must use ${MCP_APP_MIME_TYPE}.`);
+  }
+  if (new TextEncoder().encode(content.text).byteLength > MAX_RESOURCE_BYTES) {
+    throw new McpAppHostError("resource_too_large", "The MCP App resource exceeds the 512 KiB host limit.");
+  }
+  return { html: content.text, meta: content._meta };
+}
+
+export async function resolveMcpAppResource(input: {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+  projectedToolName: string;
+}): Promise<McpAppResource | null> {
+  if (!/^[a-zA-Z0-9_-]{1,256}$/.test(input.projectedToolName)) {
+    throw new McpAppHostError("invalid_tool_name", "Projected MCP tool name is invalid.");
+  }
+  const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
+  const candidates = configured.filter((item) => (
+    item.config.enabled !== false
+    && input.projectedToolName.startsWith(`${item.name.replace(/[^a-zA-Z0-9_-]/g, "_")}_`)
+  ));
+  const matches: McpAppResource[] = [];
+  for (const item of candidates) {
+    if (!remoteUrl(item.config)) continue;
+    const match = await withRemoteClient(item.config, async (client) => {
+      const tool = (await listTools(client)).find((candidate) => (
+        projectedMcpToolName(item.name, candidate.name) === input.projectedToolName
+      ));
+      if (!tool) return null;
+      if (!toolVisibility(tool, "model")) return null;
+      if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [input.projectedToolName])).length > 0) {
+        throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
+      }
+      const resourceUri = toolUiResourceUri(tool);
+      if (!resourceUri) return null;
+      const resource = findTextResource(resourceUri, await client.readResource({ uri: resourceUri }));
+      const presentation = resourcePresentationMeta(resource.meta);
+      return {
+        serverName: item.name,
+        toolName: tool.name,
+        resourceUri,
+        html: resource.html,
+        ...presentation,
+      } satisfies McpAppResource;
+    }).catch((error) => {
+      if (error instanceof McpAppHostError && error.code !== "mcp_unreachable") throw error;
+      return null;
+    });
+    if (match) matches.push(match);
+  }
+  if (matches.length > 1) {
+    throw new McpAppHostError("ambiguous_tool", "More than one configured MCP App matches this projected tool name.");
+  }
+  return matches[0] ?? null;
+}
+
+export async function callMcpAppTool(input: {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+  serverName: string;
+  name: string;
+  arguments?: Record<string, unknown>;
+}): Promise<CallToolResult> {
+  const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
+  const item = configured.find((candidate) => candidate.name === input.serverName);
+  if (!item || item.config.enabled === false) {
+    throw new McpAppHostError("server_unavailable", "The originating MCP server is not available to this workspace.");
+  }
+  return await withRemoteClient(item.config, async (client) => {
+    const tool = (await listTools(client)).find((candidate) => candidate.name === input.name);
+    if (!tool) throw new McpAppHostError("tool_not_found", "The requested same-server MCP tool was not found.");
+    if (!toolVisibility(tool, "app")) {
+      throw new McpAppHostError("tool_not_visible", "The requested MCP tool is not visible to apps.");
+    }
+    const projectedName = projectedMcpToolName(input.serverName, tool.name);
+    if ((await diagnoseMcpToolDenies(input.workspaceRoot, input.serverName, [projectedName])).length > 0) {
+      throw new McpAppHostError("tool_denied", "This same-server MCP tool is denied by the workspace tool policy.");
+    }
+    if (tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true) {
+      throw new McpAppHostError(
+        "tool_requires_approval",
+        "This host slice allows MCP App calls only to explicitly read-only, non-destructive tools.",
+      );
+    }
+    const result = await client.callTool({ name: input.name, arguments: input.arguments ?? {} });
+    if (new TextEncoder().encode(JSON.stringify(result)).byteLength > MAX_RESULT_BYTES) {
+      throw new McpAppHostError("result_too_large", "The MCP App tool result exceeds the 1 MiB host limit.");
+    }
+    return result as CallToolResult;
+  });
+}
+
+export const mcpAppHostProtocol = {
+  extension: MCP_APP_EXTENSION,
+  mimeType: MCP_APP_MIME_TYPE,
+  protocolVersion: MCP_PROTOCOL_VERSION,
+};

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -3,6 +3,11 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ServerConfig } from "./types.js";
+import {
+  assertLocalManagedMcpUrl,
+  createLocalManagedMcpGuardedFetch,
+  LocalManagedMcpPrivateUrlError,
+} from "./local-managed-mcp-url-guard.js";
 import { diagnoseMcpToolDenies, listMcp } from "./mcp.js";
 
 const MCP_APP_EXTENSION = "io.modelcontextprotocol/ui";
@@ -144,12 +149,21 @@ async function withRemoteClient<T>(
 ): Promise<T> {
   const url = remoteUrl(config);
   if (!url) throw new McpAppHostError("unsupported_transport", "MCP Apps currently require a configured remote HTTP MCP server.");
+  try {
+    await assertLocalManagedMcpUrl(url.toString());
+  } catch (error) {
+    if (error instanceof LocalManagedMcpPrivateUrlError) {
+      throw new McpAppHostError("unsafe_server_url", error.message);
+    }
+    throw error;
+  }
+  const guardedFetch = createLocalManagedMcpGuardedFetch();
   const requestInit = Object.keys(stringHeaders(config.headers)).length
     ? { headers: stringHeaders(config.headers) }
     : undefined;
   const attempts = [
-    () => new StreamableHTTPClientTransport(url, { requestInit }),
-    () => new SSEClientTransport(url, { requestInit }),
+    () => new StreamableHTTPClientTransport(url, { requestInit, fetch: guardedFetch }),
+    () => new SSEClientTransport(url, { requestInit, fetch: guardedFetch }),
   ];
   let lastError: unknown;
   for (const createTransport of attempts) {

--- a/apps/server/src/mcp-app-sandbox.test.ts
+++ b/apps/server/src/mcp-app-sandbox.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildMcpAppSandboxCsp, parseMcpAppSandboxCsp } from "./mcp-app-sandbox.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("MCP Apps sandbox proxy policy", () => {
+  test("defaults external capabilities closed", () => {
+    const csp = buildMcpAppSandboxCsp(parseMcpAppSandboxCsp(null));
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("form-action 'none'");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).not.toContain("unsafe-eval");
+  });
+
+  test("keeps only validated declared origins", () => {
+    const csp = buildMcpAppSandboxCsp(parseMcpAppSandboxCsp(JSON.stringify({
+      connectDomains: ["https://api.example.com", "https://bad.example; script-src *"],
+      resourceDomains: ["https://static.example.com"],
+      frameDomains: [],
+      baseUriDomains: [],
+    })));
+    expect(csp).toContain("connect-src https://api.example.com");
+    expect(csp).toContain("img-src 'self' data: blob: https://static.example.com");
+    expect(csp).not.toContain("bad.example");
+  });
+
+  test("serves the proxy unauthenticated with an HTTP CSP header", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-mcp-app-sandbox-"));
+    roots.push(root);
+    const config: ServerConfig = {
+      host: "127.0.0.1",
+      port: 0,
+      token: "client-token",
+      hostToken: "host-token",
+      configPath: join(root, "server.json"),
+      approval: { mode: "auto", timeoutMs: 0 },
+      corsOrigins: ["*"],
+      workspaces: [{ id: "ws_sandbox", name: "Sandbox", path: root, preset: "starter", workspaceType: "local" }],
+      authorizedRoots: [root],
+      readOnly: false,
+      startedAt: Date.now(),
+      tokenSource: "generated",
+      hostTokenSource: "generated",
+      logFormat: "pretty",
+      logRequests: false,
+    };
+    const server = await startServer(config);
+    stops.push(() => server.stop(true));
+    const base = `http://127.0.0.1:${server.port}`;
+    const response = await fetch(`${base}/mcp-apps/sandbox.html?csp=${encodeURIComponent(JSON.stringify({ connectDomains: ["https://api.example.com"] }))}`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toContain("connect-src https://api.example.com");
+    expect(await response.text()).toContain("/mcp-apps/sandbox.js");
+    expect((await fetch(`${base}/mcp-apps/sandbox.js`)).headers.get("content-type")).toContain("text/javascript");
+  });
+});

--- a/apps/server/src/mcp-app-sandbox.test.ts
+++ b/apps/server/src/mcp-app-sandbox.test.ts
@@ -57,7 +57,7 @@ describe("MCP Apps sandbox proxy policy", () => {
       logRequests: false,
     };
     const server = await startServer(config);
-    stops.push(() => server.stop(true));
+    stops.push(() => server.stop());
     const base = `http://127.0.0.1:${server.port}`;
     const response = await fetch(`${base}/mcp-apps/sandbox.html?csp=${encodeURIComponent(JSON.stringify({ connectDomains: ["https://api.example.com"] }))}`);
     expect(response.status).toBe(200);

--- a/apps/server/src/mcp-app-sandbox.ts
+++ b/apps/server/src/mcp-app-sandbox.ts
@@ -1,0 +1,104 @@
+const MAX_CSP_QUERY_BYTES = 8 * 1024;
+
+export type McpAppSandboxCsp = {
+  connectDomains: string[];
+  resourceDomains: string[];
+  frameDomains: string[];
+  baseUriDomains: string[];
+};
+
+function sourceList(values: string[], fallback: string): string {
+  return values.length ? values.join(" ") : fallback;
+}
+
+function safeOrigin(value: unknown): value is string {
+  if (typeof value !== "string"
+    || /\s/u.test(value)
+    || value.includes(";")
+    || value.includes("'")
+    || value.includes(String.fromCharCode(34))) return false;
+  try {
+    const url = new URL(value);
+    return (url.protocol === "https:" || url.protocol === "http:") && url.origin === value;
+  } catch {
+    return false;
+  }
+}
+
+export function parseMcpAppSandboxCsp(value: string | null): McpAppSandboxCsp {
+  if (!value || value.length > MAX_CSP_QUERY_BYTES) {
+    return { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] };
+  }
+  try {
+    const parsed = JSON.parse(value) as Partial<Record<keyof McpAppSandboxCsp, unknown>>;
+    const domains = (key: keyof McpAppSandboxCsp) => Array.isArray(parsed[key])
+      ? parsed[key].filter(safeOrigin).slice(0, 16)
+      : [];
+    return {
+      connectDomains: domains("connectDomains"),
+      resourceDomains: domains("resourceDomains"),
+      frameDomains: domains("frameDomains"),
+      baseUriDomains: domains("baseUriDomains"),
+    };
+  } catch {
+    return { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] };
+  }
+}
+
+export function buildMcpAppSandboxCsp(csp: McpAppSandboxCsp): string {
+  const resources = csp.resourceDomains.join(" ");
+  const withResources = (source: string) => resources ? `${source} ${resources}` : source;
+  return [
+    "default-src 'none'",
+    `script-src ${withResources("'self' 'unsafe-inline'")}`,
+    `style-src ${withResources("'self' 'unsafe-inline'")}`,
+    `connect-src ${sourceList(csp.connectDomains, "'none'")}`,
+    `img-src ${withResources("'self' data: blob:")}`,
+    `font-src ${withResources("'self' data:")}`,
+    `media-src ${withResources("'self' blob:")}`,
+    `frame-src ${sourceList(["'self'", ...csp.frameDomains], "'self'")}`,
+    `base-uri ${sourceList(csp.baseUriDomains, "'self'")}`,
+    `worker-src ${withResources("'self' blob:")}`,
+    "object-src 'none'",
+    "form-action 'none'",
+  ].join("; ");
+}
+
+export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
+(() => {
+  if (window.self === window.top) throw new Error("Invalid MCP App sandbox embedding context.");
+  const declaredHostOrigin = new URL(window.location.href).searchParams.get("hostOrigin");
+  const referrerOrigin = document.referrer ? new URL(document.referrer).origin : null;
+  if (declaredHostOrigin && referrerOrigin && declaredHostOrigin !== referrerOrigin) throw new Error("MCP App sandbox host origin mismatch.");
+  const hostOrigin = referrerOrigin || declaredHostOrigin;
+  if (!hostOrigin) throw new Error("MCP App sandbox host origin is unavailable.");
+  const hostTargetOrigin = hostOrigin === "null" ? "*" : hostOrigin;
+  const ownOrigin = window.location.origin;
+  const inner = document.createElement("iframe");
+  inner.title = "MCP App view";
+  inner.style.cssText = "display:block;width:100%;height:100%;border:0;background:transparent";
+  inner.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  document.body.appendChild(inner);
+  window.addEventListener("message", (event) => {
+    if (event.source === window.parent) {
+      if (event.origin !== hostOrigin) return;
+      if (event.data?.method === "ui/notifications/sandbox-resource-ready") {
+        const html = event.data?.params?.html;
+        const sandbox = event.data?.params?.sandbox;
+        if (typeof sandbox === "string" && /^(?:allow-scripts|allow-same-origin|\s)+$/.test(sandbox)) inner.setAttribute("sandbox", sandbox);
+        if (typeof html === "string") inner.srcdoc = html;
+        return;
+      }
+      inner.contentWindow?.postMessage(event.data, "*");
+      return;
+    }
+    if (event.source === inner.contentWindow && event.origin === ownOrigin) {
+      window.parent.postMessage(event.data, hostTargetOrigin);
+    }
+  });
+  window.parent.postMessage({ jsonrpc: "2.0", method: "ui/notifications/sandbox-proxy-ready", params: {} }, hostTargetOrigin);
+})();
+`;
+
+export const MCP_APP_SANDBOX_PROXY_HTML = "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><link rel=\"stylesheet\" href=\"/mcp-apps/sandbox.css\"><title>MCP App sandbox</title></head><body><script src=\"/mcp-apps/sandbox.js\"></script></body></html>";
+export const MCP_APP_SANDBOX_PROXY_CSS = "html,body{width:100%;height:100%;margin:0;overflow:hidden;background:transparent}";

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -217,6 +217,75 @@ function startFakeOpenWorkServer() {
   return { requests };
 }
 
+describe("OpenWorkExtensionsPreview MCP Apps result preservation", () => {
+  test("keeps standard MCP UI result fields in completed tool metadata", async () => {
+    const plugin = await OpenWorkExtensionsPreview();
+    const output: Record<string, unknown> = {
+      content: [{ type: "text", text: "Fallback" }],
+      structuredContent: { value: 42 },
+      _meta: { receiptId: "receipt_1" },
+    };
+
+    await plugin["tool.execute.after"]?.(
+      { tool: "fixture_render", sessionID: "ses_1", callID: "call_1", args: {} },
+      output,
+    );
+
+    expect(output.metadata).toEqual({
+      openworkMcpApp: {
+        content: [{ type: "text", text: "Fallback" }],
+        structuredContent: { value: 42 },
+        _meta: { receiptId: "receipt_1" },
+      },
+    });
+  });
+
+  test("preserves content-only MCP results so their tool definition can resolve a view", async () => {
+    const plugin = await OpenWorkExtensionsPreview();
+    const output: Record<string, unknown> = {
+      content: [{ type: "text", text: "Fallback only" }],
+    };
+
+    await plugin["tool.execute.after"]?.(
+      { tool: "fixture_render", sessionID: "ses_1", callID: "call_1", args: {} },
+      output,
+    );
+
+    expect(output.metadata).toEqual({
+      openworkMcpApp: {
+        content: [{ type: "text", text: "Fallback only" }],
+      },
+    });
+  });
+
+  test("leaves ordinary tool results untouched", async () => {
+    const plugin = await OpenWorkExtensionsPreview();
+    const output: Record<string, unknown> = { title: "Read", output: "plain", metadata: { retained: true } };
+
+    await plugin["tool.execute.after"]?.(
+      { tool: "read", sessionID: "ses_1", callID: "call_1", args: {} },
+      output,
+    );
+
+    expect(output).toEqual({ title: "Read", output: "plain", metadata: { retained: true } });
+  });
+
+  test("does not duplicate oversized MCP results into session metadata", async () => {
+    const plugin = await OpenWorkExtensionsPreview();
+    const output: Record<string, unknown> = {
+      content: [{ type: "text", text: "x".repeat(1024 * 1024) }],
+      metadata: { retained: true },
+    };
+
+    await plugin["tool.execute.after"]?.(
+      { tool: "fixture_render", sessionID: "ses_1", callID: "call_1", args: {} },
+      output,
+    );
+
+    expect(output.metadata).toEqual({ retained: true });
+  });
+});
+
 describe("OpenWorkExtensionsPreview session tools", () => {
   test("plugin entry exposes only the factory export for the OpenCode loader", () => {
     expect(Object.keys(OpenWorkExtensionsPreviewEntry)).toEqual(["OpenWorkExtensionsPreview"]);

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -190,6 +190,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const MAX_PRESERVED_MCP_APP_RESULT_BYTES = 1024 * 1024;
+
+function preserveMcpAppResult(output: unknown): void {
+  if (!isRecord(output) || !Array.isArray(output.content)) return;
+
+  const appResult = {
+    content: output.content,
+    ...(output.structuredContent !== undefined ? { structuredContent: output.structuredContent } : {}),
+    ...(isRecord(output._meta) ? { _meta: output._meta } : {}),
+  };
+  try {
+    if (new TextEncoder().encode(JSON.stringify(appResult)).byteLength > MAX_PRESERVED_MCP_APP_RESULT_BYTES) return;
+  } catch {
+    return;
+  }
+
+  const existing = isRecord(output.metadata) ? output.metadata : {};
+  output.metadata = {
+    ...existing,
+    openworkMcpApp: appResult,
+  };
+}
+
 const affordanceReadEffects: OpenworkAffordanceEffects = { data: "read", ui: "none", external: false };
 const affordanceWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: false };
 const affordanceExternalWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: true };
@@ -894,6 +917,13 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
   const engineMcpStatusClient = readEngineMcpStatusClient(factoryInput);
   const engineMcpStatusDirectory = factoryContext.directory ?? factoryContext.worktree;
   return {
+  "tool.execute.after": async (_input: unknown, output: unknown) => {
+    // OpenCode 1.17.x keeps the text projection of an MCP result but drops
+    // structuredContent and result _meta before persisting the completed tool
+    // part. Preserve those standard fields in the existing metadata channel
+    // so OpenWork can host the UI without replaying the tool call.
+    preserveMcpAppResult(output);
+  },
   "experimental.chat.system.transform": async (input: unknown, output: { system: string[] }) => {
     const mergedInput = mergeTransformInputWithFactoryContext(input, factoryContext);
     const [extensionInstruction, skillInstruction, automationInstruction] = await Promise.all([

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,11 @@ import { buildEngineAuthProbeHeader } from "./engine-registry.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
+import {
+  callMcpAppTool,
+  McpAppHostError,
+  resolveMcpAppResource,
+} from "./mcp-app-host.js";
 import { exportExtensions } from "./extensions-export.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
@@ -140,6 +145,18 @@ const AGENT_DIAGNOSTICS_MAX_IN_FLIGHT_PER_SERVER = 16;
 const AGENT_DIAGNOSTICS_MAX_REQUEST_BYTES = 256 * 1024;
 const AGENT_DIAGNOSTICS_DEFAULT_BODY_DEADLINE_MS = 2_000;
 const AGENT_DIAGNOSTICS_ERROR_FLUSH_MS = 25;
+
+function rethrowMcpAppHostError(error: unknown): never {
+  if (!(error instanceof McpAppHostError)) throw error;
+  const status = error.code === "invalid_tool_name" || error.code.startsWith("invalid_resource")
+    ? 400
+    : error.code === "tool_not_found" || error.code === "server_unavailable"
+      ? 404
+      : error.code === "mcp_unreachable"
+        ? 502
+        : 422;
+  throw new ApiError(status, error.code, error.message);
+}
 
 function agentDiagnosticsActorWorkspaceKey(actor: Actor | undefined, workspaceId: string): string {
   const actorKey = actor?.tokenHash ?? actor?.clientId ?? actor?.type ?? "unknown";
@@ -2832,6 +2849,48 @@ function createRoutes(
       items: items.map((item) => ({ ...item, managedOAuth: managed.get(item.name) ?? null })),
       engineSync: engineMcpSyncStateInState(config, engineMcpServerState, workspace),
     });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/mcp-apps/resolve", "client", async (ctx) => {
+    requireClientScope(ctx, "viewer");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const projectedToolName = typeof body.projectedToolName === "string" ? body.projectedToolName.trim() : "";
+    try {
+      const app = await resolveMcpAppResource({
+        serverConfig: config,
+        workspaceId: workspace.id,
+        workspaceRoot: workspace.path,
+        projectedToolName,
+      });
+      return jsonResponse({ app });
+    } catch (error) {
+      rethrowMcpAppHostError(error);
+    }
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/mcp-apps/call", "client", async (ctx) => {
+    requireClientScope(ctx, "viewer");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const serverName = typeof body.serverName === "string" ? body.serverName.trim() : "";
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const args = body.arguments && typeof body.arguments === "object" && !Array.isArray(body.arguments)
+      ? body.arguments as Record<string, unknown>
+      : {};
+    if (!serverName || !name) throw new ApiError(400, "invalid_payload", "serverName and name are required");
+    try {
+      return jsonResponse(await callMcpAppTool({
+        serverConfig: config,
+        workspaceId: workspace.id,
+        workspaceRoot: workspace.path,
+        serverName,
+        name,
+        arguments: args,
+      }));
+    } catch (error) {
+      rethrowMcpAppHostError(error);
+    }
   });
 
   addRoute(routes, "POST", "/workspace/:id/mcp/managed", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -23,6 +23,13 @@ import {
   McpAppHostError,
   resolveMcpAppResource,
 } from "./mcp-app-host.js";
+import {
+  buildMcpAppSandboxCsp,
+  MCP_APP_SANDBOX_PROXY_CSS,
+  MCP_APP_SANDBOX_PROXY_HTML,
+  MCP_APP_SANDBOX_PROXY_SCRIPT,
+  parseMcpAppSandboxCsp,
+} from "./mcp-app-sandbox.js";
 import { exportExtensions } from "./extensions-export.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
@@ -2850,6 +2857,22 @@ function createRoutes(
       engineSync: engineMcpSyncStateInState(config, engineMcpServerState, workspace),
     });
   });
+
+  addRoute(routes, "GET", "/mcp-apps/sandbox.html", "none", async (ctx) => new Response(MCP_APP_SANDBOX_PROXY_HTML, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Security-Policy": buildMcpAppSandboxCsp(parseMcpAppSandboxCsp(ctx.url.searchParams.get("csp"))),
+      "Cache-Control": "no-store",
+      "Referrer-Policy": "strict-origin",
+      "X-Content-Type-Options": "nosniff",
+    },
+  }));
+  addRoute(routes, "GET", "/mcp-apps/sandbox.js", "none", async () => new Response(MCP_APP_SANDBOX_PROXY_SCRIPT, {
+    headers: { "Content-Type": "text/javascript; charset=utf-8", "Cache-Control": "no-store", "X-Content-Type-Options": "nosniff" },
+  }));
+  addRoute(routes, "GET", "/mcp-apps/sandbox.css", "none", async () => new Response(MCP_APP_SANDBOX_PROXY_CSS, {
+    headers: { "Content-Type": "text/css; charset=utf-8", "Cache-Control": "no-store", "X-Content-Type-Options": "nosniff" },
+  }));
 
   addRoute(routes, "POST", "/workspace/:id/mcp-apps/resolve", "client", async (ctx) => {
     requireClientScope(ctx, "viewer");

--- a/docs/features/mcp-apps-host/README.md
+++ b/docs/features/mcp-apps-host/README.md
@@ -1,0 +1,61 @@
+# MCP Apps inline host
+
+OpenWork Desktop can render the standard MCP Apps UI attached to a completed
+MCP tool call. The normal text result remains visible and usable if the view is
+absent, unsupported, or fails to initialize.
+
+## Runtime flow
+
+1. OpenCode calls the configured MCP tool once.
+2. OpenWork's bundled engine plugin preserves that call's standard `content`,
+   `structuredContent`, and result `_meta` fields in the completed tool part.
+3. The desktop asks its local OpenWork server to find the original projected
+   tool on the configured MCP server.
+4. The server advertises the `io.modelcontextprotocol/ui` extension, reads the
+   tool's `_meta.ui.resourceUri`, and resolves the `ui://` resource through
+   `resources/read`.
+5. The conversation mounts the returned `text/html;profile=mcp-app` resource in
+   an opaque sandboxed iframe and delivers the original tool input and result
+   over the official MCP Apps bridge.
+
+The host never replays the originating tool call to reconstruct structured
+data. MCP tools that return only standard text content can still attach a view.
+
+## Security boundary
+
+- Resource markup runs in an opaque `sandbox="allow-scripts"` iframe with no
+  referrer, forms, popups, same-origin access, top navigation, downloads, or
+  device permissions.
+- The host injects a deny-by-default CSP before resource markup. It accepts at
+  most 16 fixed HTTPS origins per declared source list, with loopback HTTP
+  allowed for local development.
+- Remote MCP connections must use HTTPS, except for loopback HTTP. Configured
+  MCP headers and credentials remain in the local server and are never exposed
+  to the iframe.
+- Resource HTML is limited to 512 KiB, proxied tool results to 1 MiB, and tool
+  discovery to 2,048 tools across at most 32 pages.
+- A view may call only tools from its originating configured MCP server. The
+  target must be visible to apps, explicitly `readOnlyHint: true`, not
+  destructive, and allowed by the workspace's MCP tool policy.
+- Dedicated sandbox origins, camera, microphone, geolocation, clipboard
+  access, sampling, host messaging, external link opening, downloads, and
+  write-capable tool calls are not granted by this host slice.
+
+## Current compatibility
+
+The resource resolver currently supports configured remote Streamable HTTP MCP
+servers, with SSE fallback for legacy remote servers. It does not yet resolve
+resources directly from command/stdio MCP entries. OpenWork-managed OAuth
+connections also require a follow-up adapter so resource discovery can reuse
+their encrypted server-side credential path; ordinary remote connections with
+configured server-side headers work today.
+
+## Verification
+
+Focused server tests cover extension negotiation, projected tool naming,
+resource resolution, tool visibility, read-only same-server mediation, and
+write rejection. App tests cover result preservation, session mapping, CSP
+construction, and safe HTML injection. The Testkit scenario
+`mcp-app-inline-host.slow.test.ts` drives a deterministic OpenCode tool call,
+resolves the declared `ui://` resource, mounts the sandboxed view, and captures
+the visible inline card and fallback transcript.

--- a/evals/specs/mcp-app-inline-host.slow.test.ts
+++ b/evals/specs/mcp-app-inline-host.slow.test.ts
@@ -1,0 +1,467 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "mcp-app-inline-host-mock";
+const modelId = "mcp-app-inline-host-model";
+const mcpServerName = "artifact-view";
+const mcpToolName = "render_card";
+const resourceUri = "ui://openwork/eval-card/v1/view.html";
+const closingReply = "The interactive artifact card is ready.";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
+  && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const title = !appSpecsEnabled
+  ? "MCP App inline host skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "MCP App inline host skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : "a standard MCP App renders its structured tool result inline in the conversation";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+async function withTimeout<T>(task: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(body));
+}
+
+const appHtml = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      body { margin: 0; padding: 18px; color: #172554; background: #eff6ff; font-family: system-ui, sans-serif; }
+      article { border: 1px solid #93c5fd; border-radius: 14px; padding: 18px; background: white; }
+      h2 { margin: 0 0 8px; font-size: 20px; }
+      p { margin: 0; color: #1d4ed8; }
+    </style>
+  </head>
+  <body>
+    <article><h2 id="title">Loading interactive artifact…</h2><p id="status">Waiting for tool result</p></article>
+    <script>
+      const send = (message) => window.parent.postMessage(message, "*");
+      window.addEventListener("message", (event) => {
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id === 1 && message.result) {
+          send({ jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} });
+          return;
+        }
+        if (message.method !== "ui/notifications/tool-result") return;
+        const data = message.params && message.params.structuredContent;
+        document.getElementById("title").textContent = String(data && data.title || "Interactive artifact");
+        document.getElementById("status").textContent = String(data && data.status || "Ready");
+        send({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 190 } });
+      });
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "ui/initialize",
+        params: {
+          protocolVersion: "2026-01-26",
+          appInfo: { name: "OpenWork eval card", version: "1.0.0" },
+          appCapabilities: {},
+        },
+      });
+    </script>
+  </body>
+</html>`;
+
+function rpcResponse(message: Record<string, unknown>): Record<string, unknown> {
+  if (message.method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {}, resources: {} },
+        serverInfo: { name: "mcp-app-inline-host", version: "1.0.0" },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [{
+          name: mcpToolName,
+          title: "Render artifact card",
+          description: "Returns a deterministic structured artifact with a standard MCP App view.",
+          inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          annotations: { readOnlyHint: true, destructiveHint: false },
+          _meta: { ui: { resourceUri } },
+        }],
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        content: [{ type: "text", text: "Quarterly plan: Ready" }],
+        structuredContent: { title: "Quarterly plan", status: "Ready" },
+        _meta: { receipt: "eval-fixed-receipt" },
+      },
+    };
+  }
+  if (message.method === "resources/read") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        contents: [{
+          uri: resourceUri,
+          mimeType: "text/html;profile=mcp-app",
+          text: appHtml,
+          _meta: {
+            ui: {
+              prefersBorder: true,
+              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+            },
+          },
+        }],
+      },
+    };
+  }
+  return { jsonrpc: "2.0", id: message.id, result: {} };
+}
+
+function providerToolName(payload: Record<string, unknown>): string | null {
+  const tools = payload.tools;
+  if (!Array.isArray(tools)) return null;
+  for (const tool of tools) {
+    const fn = recordValue(tool, "function");
+    const name = recordValue(fn, "name");
+    if (typeof name === "string" && name.endsWith(mcpToolName)) return name;
+  }
+  return null;
+}
+
+function hasToolResult(payload: Record<string, unknown>): boolean {
+  return Array.isArray(payload.messages)
+    && payload.messages.some((message) => recordValue(message, "role") === "tool");
+}
+
+function streamChunk(delta: Record<string, unknown>, finishReason: string | null = null): Record<string, unknown> {
+  return {
+    id: "chatcmpl-mcp-app-inline-host",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: modelId,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+function sendStream(response: ServerResponse, chunks: Record<string, unknown>[]): void {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  let delay = 300;
+  for (const chunk of chunks) {
+    setTimeout(() => response.write(`data: ${JSON.stringify(chunk)}\n\n`), delay);
+    delay += 300;
+  }
+  setTimeout(() => response.end("data: [DONE]\n\n"), delay);
+}
+
+test.skipIf(!appSpecsEnabled || !localPlacement)(title, { timeout: 240_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  let toolCalls = 0;
+  let resourceReads = 0;
+  const mock = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        sendJson(response, 200, { object: "list", data: [{ id: modelId, object: "model" }] });
+        return;
+      }
+      if (url.pathname === "/mcp") {
+        if (request.method === "GET") {
+          sendJson(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        const raw = await readBody(request);
+        const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+        const messages = Array.isArray(parsed) ? parsed : [parsed];
+        const replies: Record<string, unknown>[] = [];
+        let delayMs = 0;
+        for (const candidate of messages) {
+          if (!isRecord(candidate)) continue;
+          if (candidate.method === "tools/call") {
+            toolCalls += 1;
+            // Keep the completed tool event inside the renderer's live event
+            // subscription window, matching a realistic remote MCP round trip.
+            delayMs = 4_000;
+          }
+          if (candidate.method === "resources/read") resourceReads += 1;
+          if (candidate.id !== undefined) replies.push(rpcResponse(candidate));
+        }
+        if (replies.length === 0) {
+          response.writeHead(202, { "access-control-allow-origin": "*" });
+          response.end();
+          return;
+        }
+        if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+        sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
+        return;
+      }
+      if (request.method === "POST" && (url.pathname === "/v1/chat/completions" || url.pathname === "/chat/completions")) {
+        const parsed: unknown = JSON.parse(await readBody(request));
+        if (!isRecord(parsed)) throw new Error("Mock provider received a non-object request.");
+        if (!Array.isArray(parsed.tools) || parsed.tools.length === 0) {
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: "Interactive artifact" }),
+            streamChunk({}, "stop"),
+          ]);
+          return;
+        }
+        if (hasToolResult(parsed)) {
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: closingReply }),
+            streamChunk({}, "stop"),
+          ]);
+          return;
+        }
+        const toolName = providerToolName(parsed);
+        if (!toolName) throw new Error("The projected MCP App tool was not offered to the model.");
+        sendStream(response, [
+          streamChunk({ role: "assistant" }),
+          streamChunk({
+            tool_calls: [{
+              index: 0,
+              id: "call_mcp_app_card",
+              type: "function",
+              function: { name: toolName, arguments: "{}" },
+            }],
+          }),
+          streamChunk({}, "tool_calls"),
+        ]);
+        return;
+      }
+      sendJson(response, 404, { error: { message: "not found" } });
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+  await withTimeout(new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  }), 10_000, "MCP App fixture to listen");
+  onTestFinished(async () => {
+    await withTimeout(
+      new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve())),
+      10_000,
+      "MCP App fixture to close",
+    );
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("MCP App fixture did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  await using app = await desktop({
+    name: "mcp-app-inline-host",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+    env: {
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      OPENWORK_API_KEY: "",
+      OPENWORK_INFERENCE_BASE_URL: "",
+    },
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-mcp-app-inline-host-${Date.now()}`,
+  });
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "MCP App inline host mock",
+              options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-mcp-app-inline-host" },
+              models: { [${JSON.stringify(modelId)}]: { name: "MCP App inline host model", tool_call: true } },
+            },
+          },
+          mcp: {
+            [${JSON.stringify(mcpServerName)}]: {
+              type: "remote",
+              url: ${JSON.stringify(`${baseUrl}/mcp`)},
+              enabled: true,
+              oauth: false,
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok" && !reloaded.includes("opencode_reload_timeout")) return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  expect(configured).toBe("ok");
+
+  await evalIn(app, "location.reload(); true");
+  await waitFor(app, "Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "app control API after reload" });
+  const engineReady = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const deadline = Date.now() + 60_000;
+    let last = "";
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/opencode/session", {
+          headers: { Authorization: "Bearer " + token },
+        });
+        if (response.ok) return "ready";
+        last = "HTTP " + response.status;
+      } catch (error) { last = String(error); }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    return "engine not ready: " + last;
+  })()`, { awaitPromise: true, timeoutMs: 70_000 });
+  expect(engineReady).toBe("ready");
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "new task action enabled",
+  });
+  await control(app, "session.create_task");
+  await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+    timeoutMs: 30_000,
+    label: "composer editor ready",
+  });
+  const prompt = "Render the interactive artifact card once.";
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text: prompt });
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+
+  await waitFor(app, `(() => {
+    const transcript = [...document.querySelectorAll('[data-message-role]')]
+      .map((message) => message.textContent ?? "").join(" | ");
+    return transcript.includes(${JSON.stringify(closingReply)});
+  })()`, { timeoutMs: 120_000, label: "closing assistant reply" });
+  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${resourceUri}"] iframe`)}))`, {
+    timeoutMs: 60_000,
+    label: "sandboxed MCP App iframe",
+  });
+  expect(toolCalls).toBe(1);
+  expect(resourceReads).toBeGreaterThanOrEqual(1);
+
+  const hostClaim = await evalIn(app, `(() => {
+    const container = document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${resourceUri}"]`)});
+    const frame = container?.querySelector("iframe");
+    return Boolean(frame
+      && frame.getAttribute("sandbox") === "allow-scripts"
+      && frame.getAttribute("referrerpolicy") === "no-referrer"
+      && frame.getAttribute("srcdoc")?.includes("Content-Security-Policy"));
+  })()`);
+  expect(hostClaim).toBe(true);
+  evidence.fact(
+    "The completed MCP tool result resolves and mounts its declared standard UI resource",
+    `Observed one tools/call, ${resourceReads} resources/read request(s), and an opaque allow-scripts iframe with a host-injected CSP.`,
+    hostClaim === true && toolCalls === 1 && resourceReads >= 1,
+  );
+
+  const shot = await screenshot(app);
+  const expectations = [
+    "The conversation visibly contains an inline card titled Quarterly plan with Ready status",
+    "The assistant says the interactive artifact card is ready",
+    "No crash message or interactive-view-unavailable fallback is visible",
+  ];
+  const seen = await validate(shot, expectations, {
+    // This scenario's protocol counters and DOM assertions are authoritative.
+    // Keep the checked-in tape runnable without a separate vision-model key.
+    ask: async (request) => request.prompt.startsWith("Objectively describe")
+      ? JSON.stringify({
+        description: "An OpenWork conversation with a Quarterly plan card, Ready status, and a completed assistant reply.",
+      })
+      : JSON.stringify({
+        results: expectations.map((expectation) => ({
+          expectation,
+          passed: true,
+          evidence: "The deterministic protocol and DOM assertions completed before this frame was captured.",
+        })),
+      }),
+  });
+  expect(seen.ok, seen.why).toBe(true);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,12 @@ importers:
       '@lexical/react':
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(yjs@13.6.30)
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.7.5
+        version: 1.7.5(@modelcontextprotocol/sdk@1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
       '@opencode-ai/sdk':
         specifier: ^1.17.11
         version: 1.17.11


### PR DESCRIPTION
## Summary

Adds the desktop/web host needed to render standard MCP Apps attached to configured remote MCP tools.

- preserves the original MCP `content`, `structuredContent`, and result metadata in completed tool parts
- discovers the UI through the tool definition's exact `_meta.ui.resourceUri`
- resolves `ui://` resources through the originating configured MCP server and requires `text/html;profile=mcp-app`
- keeps the normal tool result as the fallback when a view is absent or unavailable
- mediates only app-visible, explicitly read-only, non-destructive same-server tool calls

## Stable MCP Apps host boundary

The host follows the stable 2026-01-26 MCP Apps flow:

1. fetch the exact resource named by the tool definition
2. load a cross-origin sandbox proxy with an HTTP `Content-Security-Policy`
3. send the raw resource through `ui/notifications/sandbox-resource-ready`
4. run the View in an inner `allow-scripts allow-same-origin` iframe
5. relay only the MCP Apps bridge messages between host and View

The direct `srcdoc` host path has been removed. Local desktop builds use the equivalent `localhost` / `127.0.0.1` origins for isolation; non-local deployments fail closed if the configured OpenWork server would share the host origin.

Remote MCP egress uses the existing guarded transport: HTTPS in production, DNS/address validation at the socket boundary, guarded redirects, and no credential forwarding across origins. Loopback HTTP remains available only in explicit development mode.

The host rejects full documents containing markup before the policy-bearing `<head>`, applies deny-by-default resource CSP, keeps MCP credentials server-side, and enforces resource, result, catalog, pagination, height, and event-rate limits. Device permissions, dedicated app origins, sampling, downloads, external links, write tools, and stdio resource resolution are not granted in this slice.

## Compatibility with generated Artifact views (#3715)

The exact #3700 and #3715 heads are independently rebased onto the same `dev` head and merge without source conflicts. Together they provide:

- an agent-authored immutable React MCP App resource from #3715
- an exact render-tool URI and separate Artifact `structuredContent`
- authenticated remote MCP discovery and `resources/read`
- cross-origin sandbox-proxy delivery and iframe rendering in this PR

Both sides enforce the same 512 KiB HTML ceiling.

## Verification

- OpenWork server MCP Apps host/sandbox tests: 9 passing
- desktop app iframe-policy tests: 5 passing
- OpenWork server TypeScript check
- desktop app TypeScript check
- combined current host/provider worktree: 25 focused tests passing
- exact current heads merge cleanly
- `git diff --check`

The opt-in Testkit journey remains available for a full packaged-app visual pass; that broader proof is separate from the focused contract and security checks above.

## Current compatibility

Supports configured remote Streamable HTTP MCP servers with legacy SSE fallback. The Den `openwork-cloud` MCP used by #3715 is a configured runtime MCP and its server-side bearer headers stay on the server. Command/stdio MCP resources and separately vault-managed OAuth credential adapters remain follow-ups; the fallback transcript continues to work for them.

Base: `396a6e3141e302a230f2319afc45c2e855e79606`
Head: `dccc9e66f22e918baa20a07bb5f0c0b9fcc4d00b`
