### PR TITLE
Keep session header actions right-aligned

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1154,12 +1154,10 @@ export function SessionPage(props: SessionPageProps) {
                 />
                 <TooltipContent>{sidePanelOpen ? "Close side panel" : "Open side panel"}</TooltipContent>
               </Tooltip>
-              {shellConfig.cloudSignin ? (
+              {showCloudSignIn ? (
                 <Button
                   variant="secondary"
                   size="sm"
-                  className={showCloudSignIn ? undefined : "invisible"}
-                  disabled={!showCloudSignIn}
                   onClick={openCloudSignIn}
                   title={t("den.signin_title")}
                   aria-label={t("den.signin_title")}

--- a/apps/app/tests/session-header-actions.test.ts
+++ b/apps/app/tests/session-header-actions.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "bun:test";
+
+const sessionPagePath = fileURLToPath(
+  new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),
+);
+
+test("hidden Cloud sign-in does not reserve header space", () => {
+  const source = readFileSync(sessionPagePath, "utf8");
+
+  expect(source).toContain("{showCloudSignIn ? (");
+  expect(source).not.toContain('className={showCloudSignIn ? undefined : "invisible"}');
+  expect(source).not.toContain("disabled={!showCloudSignIn}");
+});


### PR DESCRIPTION
## Summary

- render the Cloud sign-in action only when it should be visible
- keep Find and side-panel actions anchored to the right edge after sign-in
- add a focused regression test for the hidden-control layout case

## Why

The signed-in and auth-checking states used `visibility: hidden` for the Cloud sign-in button. That removed the button visually but kept its width in the header flex row, shifting the neighboring icon actions left.

## Verification

- `bun test apps/app/tests/session-header-actions.test.ts` — 1 passed, 0 failed
- `tsc -p apps/app/tsconfig.json --noEmit` — passed
- App-driving testkit tape — deferred for this narrow conditional-render fix

Base: `29ed19edd7a19fb2ce2cad8cbf5b49f5d5a39a66`

Head: `6801a92d99e7d4f475a57aa6119f5974cbb77451`