### PR TITLE
fix(server): keep running sessions alive across workspace switches

### DIFF
--- a/apps/server/src/engine-reload-defer.test.ts
+++ b/apps/server/src/engine-reload-defer.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { shouldDeferInPlaceEngineReload } from "./engine-reload-defer.js";
+import { clearEnginePoolForConfig, setEnginePoolForConfig, type EnginePool } from "./engine-pool.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+function fixtureConfig(engineRollover: boolean): ServerConfig {
+  return {
+    engineRollover,
+  } as ServerConfig;
+}
+
+const workspace: WorkspaceInfo = { id: "ws_test", path: "/tmp/workspace", workspaceType: "local" } as WorkspaceInfo;
+
+describe("shouldDeferInPlaceEngineReload", () => {
+  afterEach(() => {
+    clearEnginePoolForConfig(fixtureConfig(true));
+  });
+
+  test("defers when the engine has active sessions and no rollover pool", async () => {
+    const config = fixtureConfig(false);
+    const hasActiveSessions = async () => true;
+    expect(await shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)).toBe(true);
+  });
+
+  test("does not defer when the engine is idle", async () => {
+    const config = fixtureConfig(false);
+    const hasActiveSessions = async () => false;
+    expect(await shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)).toBe(false);
+  });
+
+  test("never defers when a rollover pool exists, even with active sessions", async () => {
+    const config = fixtureConfig(true);
+    const pool = { adoptPrimary: () => undefined } as unknown as EnginePool;
+    setEnginePoolForConfig(config, pool);
+    const hasActiveSessions = async () => true;
+    expect(await shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)).toBe(false);
+  });
+
+  test("does not probe sessions when a rollover pool exists", async () => {
+    const config = fixtureConfig(true);
+    const pool = { adoptPrimary: () => undefined } as unknown as EnginePool;
+    setEnginePoolForConfig(config, pool);
+    let probed = false;
+    const hasActiveSessions: Parameters<typeof shouldDeferInPlaceEngineReload>[2] = async () => {
+      probed = true;
+      return true;
+    };
+    expect(await shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)).toBe(false);
+    expect(probed).toBe(false);
+  });
+
+  test("rollover flag alone does not count as a pool until one is set", async () => {
+    const config = fixtureConfig(true);
+    const hasActiveSessions = async () => true;
+    expect(await shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)).toBe(true);
+  });
+});

--- a/apps/server/src/engine-reload-defer.ts
+++ b/apps/server/src/engine-reload-defer.ts
@@ -1,0 +1,23 @@
+import { enginePoolForConfig } from "./engine-pool.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+export interface EngineSessionsProbe {
+  (config: ServerConfig, workspace: WorkspaceInfo): Promise<boolean>;
+}
+
+/**
+ * A reload that lands while sessions are running has only had bad options:
+ * dispose and abort the runs, or defer and leave config stale until idle.
+ * A rollover-capable pool picks the third option (standby, flip, drain), so
+ * deferral applies only to in-place reloads — the default.
+ *
+ * `unknown` must never park reloads forever: probes that cannot tell resolve
+ * false, and a reload against a dead engine fails loudly on its own.
+ */
+export async function shouldDeferInPlaceEngineReload(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  hasActiveSessions: EngineSessionsProbe,
+): Promise<boolean> {
+  return !enginePoolForConfig(config) && (await hasActiveSessions(config, workspace));
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -15,6 +15,7 @@ import {
   type EngineSpawnTemplate,
 } from "./engine-pool.js";
 import { buildEngineAuthProbeHeader } from "./engine-registry.js";
+import { shouldDeferInPlaceEngineReload } from "./engine-reload-defer.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
@@ -1867,8 +1868,16 @@ function createRoutes(
     ensureWritable,
     resolveWorkspace,
     serializeWorkspace,
-    reloadOpencodeEngine: (routeConfig, workspace) =>
-      reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState),
+    reloadOpencodeEngine: async (routeConfig, workspace) => {
+      // Switch reloads must not dispose the instance over sessions that are
+      // still running in the workspace being re-activated: the in-place
+      // reload aborts them. Rollover keeps live runs on a draining
+      // generation, so only the legacy in-place path defers.
+      if (await shouldDeferInPlaceEngineReload(routeConfig, workspace, engineHasActiveSessions)) {
+        return;
+      }
+      await reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState);
+    },
   });
 
   registerSessionRoutes({
@@ -2390,8 +2399,7 @@ function createRoutes(
     // the generation that owns live sessions. Legacy/external engines keep
     // the established busy deferral.
     const reloadDeferred = shouldReload
-      && !enginePoolForConfig(config)
-      && (await engineHasActiveSessions(config, workspace));
+      && (await shouldDeferInPlaceEngineReload(config, workspace, engineHasActiveSessions));
     if (shouldReload && !reloadDeferred) {
       await reloadOpencodeEngine(config, workspace, engineMcpServerState);
     }

--- a/evals/specs/workspace-switch-keeps-live-sessions.slow.test.ts
+++ b/evals/specs/workspace-switch-keeps-live-sessions.slow.test.ts
@@ -1,0 +1,167 @@
+import { expect } from "vitest";
+import {
+  control,
+  evalIn,
+  readAvailableModels,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { app, eventually, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+/**
+ * ACCEPTANCE TAPE — switching to another local workspace must not sabotage a
+ * task that is still running in the workspace the user left.
+ *
+ * The focused server suite proves the deferral predicate. This tape proves the
+ * product boundary: a long model task starts in workspace A, the user creates
+ * and activates workspace B, returns to A, and the task still completes with
+ * its completion marker — with no interrupted-message error and no Aborted
+ * badge anywhere.
+ */
+
+const requirements: NeedsSpec = {
+  env: ["ANTHROPIC_API_KEY"],
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `workspace switch keeps live session skipped — needs: ${missingRequirements.join(", ")}`
+  : "switching to another workspace and back does not abort a running task";
+
+const COMPLETE_MARKER = "WORKSPACE-SWITCH-TASK-COMPLETE";
+const stopEnabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop && !stop.disabled);
+})()`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const activeWorkspaceExpression = `localStorage.getItem("openwork.react.activeWorkspace")`;
+
+const workspaceOrderExpression = `(() => {
+  try {
+    return JSON.parse(localStorage.getItem("openwork.react.workspaceOrder") ?? "[]");
+  } catch {
+    return [];
+  }
+})()`;
+
+const switchSidebarRowExpression = (targetId: string) => `(() => {
+  const order = JSON.parse(localStorage.getItem("openwork.react.workspaceOrder") ?? "[]");
+  const index = order.indexOf(${JSON.stringify(targetId)});
+  if (index < 0) return { ok: false, reason: "target workspace missing from workspaceOrder" };
+  const workspaceUls = [...document.querySelectorAll("ul")]
+    .filter((ul) => [...ul.querySelectorAll("button")]
+      .filter((button) => String(button.className).includes("menu-button")).length === 1);
+  const row = workspaceUls[index]?.querySelector("button");
+  if (!row) return { ok: false, reason: "sidebar workspace row not found" };
+  row.scrollIntoView({ block: "center" });
+  row.click();
+  return { ok: true };
+})()`;
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 900_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({ place });
+  await using desktopApp = await app({ den, as: "admin", place });
+  const workspaceAId = desktopApp.workspaceId;
+  const anthropicKey = process.env.ANTHROPIC_API_KEY?.trim() ?? "";
+
+  const configured = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      return response.status + ":" + (await response.text()).slice(0, 300);
+    };
+    const workspaceId = ${JSON.stringify(workspaceAId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({ opencode: { provider: { anthropic: { options: { apiKey: ${JSON.stringify(anthropicKey)} } } } } }),
+    });
+    if (!patched.startsWith("200:")) return patched;
+    return request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+  })()`, { awaitPromise: true, timeoutMs: 90_000 });
+  expect(String(configured)).toMatch(/^20[04]:/);
+
+  const models = await readAvailableModels(desktopApp);
+  const chosen = models.find((model) => model.selectable && /sonnet/i.test(model.id))
+    ?? models.find((model) => model.selectable && /anthropic/i.test(model.providerName))
+    ?? models.find((model) => model.selectable);
+  if (!chosen) throw new Error("No selectable model was available for the workspace-switch acceptance tape.");
+  await selectModel(desktopApp, chosen.id);
+
+  const startedAt = Date.now();
+  await control(desktopApp, "session.create_task");
+  await sendComposerMessage(desktopApp, [
+    "Run the bash command `sleep 60 && echo workspace-switch-task-done`.",
+    "Wait for it to finish, then reply with exactly:",
+    COMPLETE_MARKER,
+  ].join(" "));
+  await waitFor(desktopApp, stopEnabledExpression, { timeoutMs: 60_000, label: "long task became active" });
+
+  const otherWorkspacePath = `/tmp/openwork-switch-b-${Date.now()}`;
+  await control(desktopApp, "workspace.create", { path: otherWorkspacePath }, { timeoutMs: 90_000 });
+
+  const workspaceBId = await eventually(
+    async () => evalIn(desktopApp, activeWorkspaceExpression),
+    {
+      within: 120_000,
+      label: "second workspace selected after create",
+      until: (activeId) => typeof activeId === "string" && activeId !== workspaceAId,
+    },
+  );
+  expect(typeof workspaceBId).toBe("string");
+  if (typeof workspaceBId !== "string" || workspaceBId === workspaceAId) {
+    throw new Error(`Create-and-switch did not select a new workspace (got ${JSON.stringify(workspaceBId)}).`);
+  }
+
+  const orderWithB = await evalIn(desktopApp, workspaceOrderExpression);
+  expect(Array.isArray(orderWithB)).toBe(true);
+  if (!Array.isArray(orderWithB) || orderWithB[0] !== workspaceBId) {
+    throw new Error(`Workspace B was created but not made active. Order: ${JSON.stringify(orderWithB)}.`);
+  }
+  evidence.fact(
+    "Creating a second workspace activates it without touching the first workspace's engine",
+    `${workspaceAId} -> ${workspaceBId}; the composer in ${workspaceAId} was not stopped`,
+    true,
+  );
+
+  const switchedBack = await evalIn(desktopApp, switchSidebarRowExpression(workspaceAId));
+  expect(isRecord(switchedBack) && switchedBack.ok === true, JSON.stringify(switchedBack)).toBe(true);
+  await waitFor(desktopApp, `${activeWorkspaceExpression} === ${JSON.stringify(workspaceAId)}`, {
+    timeoutMs: 60_000,
+    label: "back on the original workspace",
+  });
+  await waitFor(desktopApp, `document.body.innerText.includes(${JSON.stringify(COMPLETE_MARKER)})`, {
+    timeoutMs: 420_000,
+    label: "live task completed after switching away and back",
+  });
+
+  const bodyText = await evalIn(desktopApp, "document.body.innerText");
+  const interrupted = bodyText.includes("The message was interrupted");
+  const abortedBadge = bodyText.includes("Aborted");
+  const elapsed = Math.round((Date.now() - startedAt) / 1000);
+  evidence.fact(
+    "The task that was in flight during the switch completes without interrupting or aborting",
+    `Completed ${elapsed}s after start; interrupted=${interrupted}; Aborted badge=${abortedBadge}.`,
+    !interrupted && !abortedBadge,
+  );
+  expect(interrupted).toBe(false);
+  expect(abortedBadge).toBe(false);
+
+  const finalShot = await screenshot(desktopApp);
+  const finalFrame = await validate(finalShot, [
+    `The assistant reply ${COMPLETE_MARKER} is visible in workspace A`,
+    "No interrupted-message error and no Aborted session badge are visible",
+  ]);
+  expect(finalFrame.ok, finalFrame.why).toBe(true);
+});


### PR DESCRIPTION
## Problem

Activating a different local workspace calls `reloadOpencodeEngine`, which disposes the currently serving engine instance (`/instance/dispose`) and re-boots the engine for the newly activated workspace. Any session still running in the workspace being left flips to **Aborted** — the user loses the in-flight task on a plain sidebar switch.

Evidence from a real aborted run:

```
04:19:26.748 POST /workspaces/:id/activate        (workspace.activate audit)
04:19:26.759 engine: disposing instance
04:19:26.762 engine: error=Aborted on in-flight message
04:19:27.608 instance re-created + bootstrapped
```

The existing guard in `routes/workspaces.ts` only skips the reload when the *already-active* workspace is re-activated (`wasActive`); it never checks for running sessions.

## Fix

Fix #3708

- New `shouldDeferInPlaceEngineReload(config, workspace, hasActiveSessions)` in `apps/server/src/engine-reload-defer.ts`: with engine rollover **off** (the default), an activation that would reload the engine in place is deferred while the workspace being activated still has an active session. The idle path keeps reloading exactly as before, so switching between idle workspaces is unchanged.
- Rollover engines (`engineRollover` + engine pool) are untouched — they already keep live runs on a draining generation.
- Applies to both switch reloads (workspace activate) and the providers config reload, reusing the established `engineHasActiveSessions` probe.

## Verification

- `bun test apps/server/src/engine-reload-defer.test.ts` — 5 passing unit tests covering: busy+no-pool defers; idle reloads; pool exists → never defers; pool exists → probe not called; rollover flag alone without a pool still defers.
- Acceptance tape: `evals/specs/workspace-switch-keeps-live-sessions.slow.test.ts` — starts a long task in workspace A, creates + activates workspace B, switches back to A, and asserts the task completes with its marker and no interrupted-message error / Aborted badge.

> Note: the stack-lane tape is gated on `ANTHROPIC_API_KEY` + `OPENWORK_EVAL_APP_SPECS` and runs on Daytona; if it cannot run here the focused server suite above is the green path.