### PR TITLE
fix(app): show assigned models before workspace creation

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/react-app/domains/cloud/openwork-models-promo";
 import { getConnectedProviderItems, useProviderListQuery } from "@/react-app/infra/provider-list-query";
 import { filterEntitledModelOptions } from "@/react-app/domains/connections/provider-auth/provider-policy";
+import { mergeModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 import {
   Command,
   CommandCollection,
@@ -62,7 +63,7 @@ function getProviderDisplayName(providerId: string) {
     .join(" ");
 }
 
-function useModelOptions(open: boolean) {
+function useModelOptions(open: boolean, fallbackOptions: readonly ModelOption[]) {
   const { client, opencodeBaseUrl, selectedWorkspaceRoot } = useWorkspace();
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
@@ -111,11 +112,11 @@ function useModelOptions(open: boolean) {
         })),
       );
 
-    return filterEntitledModelOptions(options, {
+    return filterEntitledModelOptions(mergeModelOptions(options, fallbackOptions), {
       restrictToCloud,
       checkRestriction: checkDesktopRestriction,
     });
-  }, [checkDesktopRestriction, data]);
+  }, [checkDesktopRestriction, data, fallbackOptions]);
 }
 
 type ModelSelectModelItem = {
@@ -196,6 +197,8 @@ interface ModelSelectProps {
   sessionId?: string;
   /** Den/import includes OpenWork Models — never show Subscribe while true. */
   openWorkModelsEntitled?: boolean;
+  /** Member-scoped models available before a workspace OpenCode client exists. */
+  fallbackOptions?: readonly ModelOption[];
 }
 
 export function ModelSelect({
@@ -207,11 +210,12 @@ export function ModelSelect({
   disabled = false,
   sessionId,
   openWorkModelsEntitled = false,
+  fallbackOptions = [],
 }: ModelSelectProps) {
   const [search, setSearch] = React.useState("");
   const [promoHidden, setPromoHidden] = React.useState(isOpenWorkModelsPromoHidden);
   const searchInputRef = React.useRef<HTMLInputElement>(null);
-  const modelOptions = useModelOptions(open);
+  const modelOptions = useModelOptions(open, fallbackOptions);
   const denAuth = useDenAuth();
   const navigate = useNavigate();
   const platform = usePlatform();

--- a/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
@@ -1,0 +1,45 @@
+import type { DenOrgLlmProvider } from "@/app/lib/den";
+import type { ModelOption } from "@/app/types";
+import { getCloudManagedProviderId } from "./cloud-provider-config";
+
+export function assignedModelOptions(
+  providers: readonly DenOrgLlmProvider[],
+): ModelOption[] {
+  return providers.flatMap((provider) => {
+    const providerID = getCloudManagedProviderId(provider);
+    if (!providerID) return [];
+
+    return provider.models.flatMap((model) => {
+      const modelID = model.id.trim();
+      if (!modelID) return [];
+
+      const option: ModelOption = {
+        providerID,
+        modelID,
+        title: model.name.trim() || modelID,
+        description: provider.name.trim() || provider.providerId.trim() || providerID,
+        behaviorTitle: "Reasoning",
+        behaviorLabel: "Default",
+        behaviorDescription: "",
+        behaviorValue: null,
+        isFree: false,
+        source: "cloud",
+      };
+      return [option];
+    });
+  });
+}
+
+export function mergeModelOptions(
+  primary: readonly ModelOption[],
+  fallback: readonly ModelOption[],
+): ModelOption[] {
+  const merged = new Map<string, ModelOption>();
+  for (const option of fallback) {
+    merged.set(`${option.providerID}:${option.modelID}`, option);
+  }
+  for (const option of primary) {
+    merged.set(`${option.providerID}:${option.modelID}`, option);
+  }
+  return [...merged.values()];
+}

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -4,7 +4,7 @@ import type { Agent } from "@opencode-ai/sdk/v2/client";
 
 import { createDenClient, readDenSettings } from "@/app/lib/den";
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
+import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelOption, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { t } from "@/i18n";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
 import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
@@ -31,6 +31,7 @@ export type NewTaskComposerContext = {
   client: OpenworkServerClient;
   workspaceId: string | null;
   selectedModel: ModelRef;
+  modelOptions?: readonly ModelOption[];
   modelUnavailable?: boolean;
   modelUnavailableMessage?: string | null;
   organizationModelsEmpty?: boolean;
@@ -250,6 +251,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       statusLabel=""
       modelPickerOpen={context?.modelPickerOpen ?? false}
       selectedModel={context?.selectedModel ?? FALLBACK_MODEL}
+      modelOptions={context?.modelOptions}
       openWorkModelsEntitled={context?.openWorkModelsEntitled}
       onRefreshOrganizationModels={context?.onRefreshOrganizationModels}
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -8,6 +8,7 @@ import type { Client, ModelOption } from "@/app/types";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
 import { filterEntitledModelOptions } from "@/react-app/domains/connections/provider-auth/provider-policy";
+import { mergeModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 import {
   getConnectedProviderItems,
   useProviderListQuery,
@@ -25,10 +26,12 @@ export type UseModelPickerInput = {
   onOpen?: () => void;
   /** Optional: surface option-load failures (settings shows a toast; the session route stays silent). */
   onLoadError?: (error: unknown) => void;
+  /** Member-scoped models available before a workspace OpenCode client exists. */
+  fallbackOptions?: readonly ModelOption[];
 };
 
 export function useModelPicker(input: UseModelPickerInput) {
-  const { client, baseUrl, workspaceRoot, onOpen, onLoadError } = input;
+  const { client, baseUrl, workspaceRoot, onOpen, onLoadError, fallbackOptions = [] } = input;
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
   const [open, setOpenState] = useState(false);
@@ -130,8 +133,8 @@ export function useModelPicker(input: UseModelPickerInput) {
         });
       }
     }
-    return next;
-  }, [providerListQuery.data, recentProviderIds]);
+    return mergeModelOptions(next, fallbackOptions);
+  }, [fallbackOptions, providerListQuery.data, recentProviderIds]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -12,7 +12,7 @@ import {
   type McpDirectoryInfo,
 } from "@/app/constants";
 import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/import-state";
-import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
+import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelOption, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
@@ -71,6 +71,7 @@ type ComposerProps = {
   statusLabel: string;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
+  modelOptions?: readonly ModelOption[];
   /** When set, the full model picker opened from here targets this session. */
   sessionId?: string;
   openWorkModelsEntitled?: boolean;
@@ -1686,6 +1687,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                   disabled={props.steering}
                   sessionId={props.sessionId}
                   openWorkModelsEntitled={props.openWorkModelsEntitled}
+                  fallbackOptions={props.modelOptions}
                 />
                 {props.modelUnavailable ? props.onRefreshOrganizationModels ? (
                   <button

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -122,6 +122,7 @@ import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
 import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
+import { assignedModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 import {
   filterEntitledModelOptions,
   resolveEntitledOrgDefaultModel,
@@ -853,6 +854,10 @@ export function SessionRoute() {
     setProviderConnectedIds,
     setDisabledProviderIds,
   });
+  const organizationAssignedModelOptions = useMemo(
+    () => assignedModelOptions(sessionProviderAuthSnapshot.cloudOrgProviders),
+    [sessionProviderAuthSnapshot.cloudOrgProviders],
+  );
   useEffect(() => {
     if (!denAuth.isSignedIn) {
       setActiveOrganizationRole(null);
@@ -926,15 +931,24 @@ export function SessionRoute() {
     return new URL("/dashboard/custom-llm-providers", readDenSettings().baseUrl).toString();
   }, [activeOrganizationRole, denSessionVersion]);
   const restrictToCloudProviders = checkDesktopRestriction({ restriction: "allowCustomProviders" });
-  const entitledModelOptions = useMemo(() =>
-    filterEntitledModelOptions(
-      providerListModelEntitlementOptions(cloudProviderList ?? providerListQuery.data),
+  const entitledModelOptions = useMemo(() => {
+    const runtimeOptions = providerListModelEntitlementOptions(
+      cloudProviderList ?? providerListQuery.data,
+    );
+    return filterEntitledModelOptions(
+      runtimeOptions.length > 0 ? runtimeOptions : organizationAssignedModelOptions,
       {
         restrictToCloud: restrictToCloudProviders,
         checkRestriction: checkDesktopRestriction,
       },
-    ),
-  [checkDesktopRestriction, cloudProviderList, providerListQuery.data, restrictToCloudProviders]);
+    );
+  }, [
+    checkDesktopRestriction,
+    cloudProviderList,
+    organizationAssignedModelOptions,
+    providerListQuery.data,
+    restrictToCloudProviders,
+  ]);
   const organizationModelsEmpty = isOrganizationModelsEmpty({
     workspaceReady: Boolean(selectedWorkspaceId && opencodeClient),
     loading,
@@ -947,6 +961,7 @@ export function SessionRoute() {
     baseUrl: opencodeBaseUrl,
     workspaceRoot: selectedWorkspaceRoot,
     onOpen: handleModelPickerOpen,
+    fallbackOptions: organizationAssignedModelOptions,
   });
   // Which session the open model picker targets. Selecting a model while a
   // session is targeted remembers it for that conversation only; null means
@@ -967,16 +982,26 @@ export function SessionRoute() {
   const selectedModelProviderList = selectedModelUsesCloudProvider
     ? cloudProviderList
     : providerListQuery.data;
-  const entitledOrgDefaultModel = useMemo(() =>
-    resolveEntitledOrgDefaultModel(
-      providerListModelEntitlementOptions(cloudProviderList ?? providerListQuery.data),
+  const entitledOrgDefaultModel = useMemo(() => {
+    const runtimeOptions = providerListModelEntitlementOptions(
+      cloudProviderList ?? providerListQuery.data,
+    );
+    return resolveEntitledOrgDefaultModel(
+      runtimeOptions.length > 0 ? runtimeOptions : organizationAssignedModelOptions,
       {
         currentDefault: local.prefs.defaultModel,
         restrictToCloud: restrictToCloudProviders,
         checkRestriction: checkDesktopRestriction,
       },
-    ),
-  [checkDesktopRestriction, cloudProviderList, local.prefs.defaultModel, providerListQuery.data, restrictToCloudProviders]);
+    );
+  }, [
+    checkDesktopRestriction,
+    cloudProviderList,
+    local.prefs.defaultModel,
+    organizationAssignedModelOptions,
+    providerListQuery.data,
+    restrictToCloudProviders,
+  ]);
   useEffect(() => {
     if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel);
   }, [entitledOrgDefaultModel]);
@@ -1511,6 +1536,7 @@ export function SessionRoute() {
       client,
       workspaceId: selectedWorkspaceId || null,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
+      modelOptions: organizationAssignedModelOptions,
       modelUnavailable: selectedModelUnavailable,
       modelUnavailableMessage,
       organizationModelsEmpty,
@@ -1577,6 +1603,7 @@ export function SessionRoute() {
     modelVariantValue,
     opencodeClient,
     openWorkModelsEntitled,
+    organizationAssignedModelOptions,
     organizationModelsEmpty,
     refreshCloudProviderSync,
     refreshOrganizationModelAccess,

--- a/apps/app/tests/assigned-model-options.test.ts
+++ b/apps/app/tests/assigned-model-options.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import type { DenOrgLlmProvider } from "../src/app/lib/den";
+import type { ModelOption } from "../src/app/types";
+import {
+  assignedModelOptions,
+  mergeModelOptions,
+} from "../src/react-app/domains/connections/provider-auth/assigned-model-options";
+
+function provider(
+  input: Pick<DenOrgLlmProvider, "id" | "source" | "providerId" | "name" | "hasApiKey" | "models">,
+): DenOrgLlmProvider {
+  return {
+    ...input,
+    providerConfig: {},
+    createdAt: null,
+    updatedAt: null,
+  };
+}
+
+function option(providerID: string, modelID: string, title: string): ModelOption {
+  return {
+    providerID,
+    modelID,
+    title,
+    behaviorTitle: "Reasoning",
+    behaviorLabel: "Default",
+    behaviorDescription: "",
+    behaviorValue: null,
+    isFree: false,
+  };
+}
+
+describe("assigned model options", () => {
+  test("exposes member-assigned provider models before a workspace exists", () => {
+    const result = assignedModelOptions([
+      provider({
+        id: "lpr_anthropic_team",
+        source: "custom",
+        providerId: "anthropic",
+        name: "Team Anthropic",
+        hasApiKey: true,
+        models: [{ id: "claude-sonnet", name: "Claude Sonnet", config: {}, createdAt: null }],
+      }),
+      provider({
+        id: "lpr_openwork_subscription",
+        source: "openwork",
+        providerId: "openwork",
+        name: "OpenWork Models",
+        hasApiKey: false,
+        models: [{ id: "gpt-5", name: "GPT-5", config: {}, createdAt: null }],
+      }),
+    ]);
+
+    expect(result).toMatchObject([
+      {
+        providerID: "lpr_anthropic_team",
+        modelID: "claude-sonnet",
+        title: "Claude Sonnet",
+        description: "Team Anthropic",
+        source: "cloud",
+      },
+      {
+        providerID: "openwork",
+        modelID: "gpt-5",
+        title: "GPT-5",
+        description: "OpenWork Models",
+        source: "cloud",
+      },
+    ]);
+  });
+
+  test("keeps local API-key models and lets the live workspace catalog replace fallbacks", () => {
+    const fallback = option("lpr_anthropic_team", "claude-sonnet", "Assigned Sonnet");
+    const live = option("lpr_anthropic_team", "claude-sonnet", "Live Sonnet");
+    const local = option("openai", "gpt-5", "GPT-5");
+
+    expect(mergeModelOptions([live, local], [fallback])).toEqual([live, local]);
+  });
+});

--- a/evals/specs/cloud-provider-before-workspace.slow.test.ts
+++ b/evals/specs/cloud-provider-before-workspace.slow.test.ts
@@ -165,6 +165,28 @@ test("managed models survive sign-in before the first workspace exists", async (
   );
   expect(initialSucceeded).toBe(true);
 
+  const preWorkspaceModels = await eventually(
+    () => readAvailableModels(desktopApp),
+    {
+      within: 30_000,
+      intervalMs: 1_000,
+      label: "assigned model in the picker before workspace creation",
+      until: (candidates) => candidates.some(
+        (candidate) => candidate.id === MODEL_ID && candidate.selectable,
+      ),
+    },
+  );
+  const preWorkspaceModel = preWorkspaceModels.find(
+    (candidate) => candidate.id === MODEL_ID && candidate.selectable,
+  );
+  evidence.fact(
+    "Assigned models are visible before the first workspace exists",
+    `Selectable model: ${JSON.stringify(preWorkspaceModel)}`,
+    preWorkspaceModel?.id === MODEL_ID && preWorkspaceModel.selectable,
+  );
+  expect(preWorkspaceModel?.id).toBe(MODEL_ID);
+  expect(preWorkspaceModel?.selectable).toBe(true);
+
   // The first workspace is created through the product itself: organization
   // onboarding plus the app's workspace.create action, the same journey a
   // person takes right after this sign-in.


### PR DESCRIPTION
## Summary

Users who sign in before creating their first workspace now see the models assigned to them by their organization in both the compact composer picker and the full model picker.

## What changed

- Derive picker-ready model options from the member-scoped organization provider catalog, which is available without a workspace.
- Use those assignments as a fallback while the workspace-scoped OpenCode catalog is unavailable.
- Let the live workspace catalog replace matching fallback entries after workspace creation while preserving locally connected/API-key models.
- Select an entitled organization default from the same pre-workspace catalog.
- Extend the existing first-workspace acceptance journey to assert that an assigned model is selectable before workspace creation.

## Verification

Passed:

- `pnpm --dir apps/app exec bun test --isolate tests/assigned-model-options.test.ts` — 2 passed, 0 failed
- `pnpm --filter @openwork/app typecheck`
- `pnpm evals:typecheck`
- `git diff --check`

Deferred to the verification pass:

- `evals/specs/cloud-provider-before-workspace.slow.test.ts` real-app/Daytona journey

Base: `8362dddae39017eb8b8bb36133ff2cc82ce1b69c`
Head: `b03ef3ba4e8f364cf72c2ddf4fa8f77e7ea56cb5`