### PR TITLE
fix(app): hydrate assigned models before workspace creation

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -57,6 +57,7 @@ export type ProviderAuthOpenworkServer = {
   };
 };
 import {
+  denSettingsChangedEvent,
   denSessionUpdatedEvent,
   type DenSessionUpdatedDetail,
 } from "../../../../app/lib/den-session-events";
@@ -2229,6 +2230,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             cloudProviderServerSync: null,
             lastSyncError: {},
           }));
+          void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
           void pushDenSession().then(() => runCloudProviderSync("sign_in"));
         } else {
           if (serverHandlesProviderSync()) {
@@ -2286,13 +2288,29 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         denSessionUpdatedEvent,
         handleDenSessionUpdate as EventListener,
       );
+      const handleDenSettingsChange = () => {
+        void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
+      };
+      window.addEventListener(
+        denSettingsChangedEvent,
+        handleDenSettingsChange,
+      );
       denSessionCleanup = () => {
         window.removeEventListener(
           denSessionUpdatedEvent,
           handleDenSessionUpdate as EventListener,
         );
+        window.removeEventListener(
+          denSettingsChangedEvent,
+          handleDenSettingsChange,
+        );
       };
     }
+    // The member's assigned model catalog is organization-scoped, not
+    // workspace-scoped. Hydrate it independently so the model picker works on
+    // first launch before a workspace exists (workspace sync still handles
+    // credential materialization once a workspace is selected).
+    void refreshCloudOrgProviders().catch(() => undefined);
     void refreshImportedCloudProviders().then((imported) => {
       // Startup cleanup: if no auth token, remove any cloud providers that
       // were left behind. Handles orphans from a previous sign-out that

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -28,7 +28,7 @@ import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/
  * hero creates.
  */
 export type NewTaskComposerContext = {
-  client: OpenworkServerClient;
+  client: OpenworkServerClient | null;
   workspaceId: string | null;
   selectedModel: ModelRef;
   modelOptions?: readonly ModelOption[];
@@ -89,16 +89,17 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const skillsConnectPushRef = useRef(0);
   const mcpConnectPushRef = useRef(0);
   const context = props.context;
+  const workspaceClient = context?.client ?? null;
   const workspaceId = context?.workspaceId ?? null;
 
-  const listSkills = context && workspaceId
+  const listSkills = workspaceClient && workspaceId
     ? async (): Promise<SkillCard[]> => {
         const pushId = ++skillsConnectPushRef.current;
         // Paint cached Connect inventory instantly; the fresh fan-out lands live.
         const scope = readCloudInventoryScope();
         const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
         const connectPromise = loadSessionConnectCapabilities();
-        const response = await context.client.listSkills(workspaceId, { includeGlobal: true });
+        const response = await workspaceClient.listSkills(workspaceId, { includeGlobal: true });
         const localSkills = (response.items ?? []).map((skill) => ({
           name: skill.name,
           path: skill.path,
@@ -117,13 +118,13 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       }
     : undefined;
 
-  const listMcp = context && workspaceId
+  const listMcp = workspaceClient && workspaceId
     ? async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
         const pushId = ++mcpConnectPushRef.current;
         const scope = readCloudInventoryScope();
         const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
         const connectPromise = loadSessionConnectCapabilities();
-        const response = await context.client.listMcp(workspaceId);
+        const response = await workspaceClient.listMcp(workspaceId);
         const localServers = (response.items ?? []).map((entry) => ({
           name: entry.name,
           config: entry.config as McpServerEntry["config"],

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1531,7 +1531,6 @@ export function SessionRoute() {
   // created. Model and agent choices land in the same route-level state the
   // session composer reads, so they carry into the created session.
   const newTaskComposerContext = useMemo<NewTaskComposerContext | null>(() => {
-    if (!client) return null;
     return {
       client,
       workspaceId: selectedWorkspaceId || null,
@@ -1545,6 +1544,7 @@ export function SessionRoute() {
       onModelPickerOpenChange: (open: boolean) => {
         modelPicker.setCompactOpen(open);
         if (open) {
+          void sessionProviderAuthStore.refreshCloudOrgProviders({ force: true }).catch(() => undefined);
           void refreshCloudProviderSync("model_picker_open");
         }
       },
@@ -1612,6 +1612,7 @@ export function SessionRoute() {
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
+    sessionProviderAuthStore,
     setSelectedAgent,
   ]);
 

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -278,6 +278,41 @@ describe("session-route cloud provider sync wiring", () => {
     else process.env.VITE_OPENWORK_DEPLOYMENT = originalDeployment;
   });
 
+  test("startup hydrates assigned organization models without a workspace endpoint", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests);
+    const store = createSessionRouteStore({
+      endpoint: null,
+      hostToken: "",
+    });
+    const assignedModelsLoaded = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("assigned models did not load")), 1_000);
+      const unsubscribe = store.subscribe(() => {
+        if (store.getSnapshot().cloudOrgProviders.length === 0) return;
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve();
+      });
+    });
+
+    store.start();
+    await assignedModelsLoaded;
+
+    expect(store.getSnapshot().cloudOrgProviders).toMatchObject([
+      {
+        id: "lpr_test",
+        models: [{ id: "gpt-test", name: "GPT Test" }],
+      },
+    ]);
+    expect(
+      requests.filter((request) => request.url === "https://den.example/api/den/v1/llm-providers"),
+    ).toHaveLength(1);
+    expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(0);
+    store.dispose();
+  });
+
   test("a local endpoint with a host token pushes the Den session and syncs server-side after sign-in", async () => {
     const storage = installWindow();
     installCloudSession(storage);


### PR DESCRIPTION
## Problem

After #3714, the model picker could render organization-assigned models, but the assignment catalog was still populated only as a side effect of workspace provider synchronization. On a fresh account with no workspace, the picker therefore showed only the starter/OpenWork catalog. Creating a workspace caused the assigned model to appear.

The empty-state composer also discarded its model context whenever no workspace server client existed, which kept the organization fallback options from reaching the picker in exactly this state.

## Change

- load the organization-scoped assignment catalog when the provider-auth store starts
- refresh assignments after Den sign-in and active-organization setting changes
- retain model-picker context when there is no workspace client, while keeping workspace-only skills and MCP calls gated on that client
- refresh the organization catalog when the empty-state model picker opens
- add a regression test proving startup loads assigned models without a workspace endpoint

## Checks

- `pnpm typecheck` (apps/app)
- `bun test --isolate tests/assigned-model-options.test.ts tests/session-provider-auth-server-sync.test.ts` (6 passed)
- `git diff --check origin/dev...HEAD`