### PR TITLE
Fix stuck OpenWork Models sync status

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -197,6 +197,8 @@ interface ModelSelectProps {
   sessionId?: string;
   /** Den/import includes OpenWork Models — never show Subscribe while true. */
   openWorkModelsEntitled?: boolean;
+  /** The server is waiting to reload this workspace with OpenWork Models. */
+  openWorkModelsSyncing?: boolean;
   /** Member-scoped models available before a workspace OpenCode client exists. */
   fallbackOptions?: readonly ModelOption[];
 }
@@ -210,6 +212,7 @@ export function ModelSelect({
   disabled = false,
   sessionId,
   openWorkModelsEntitled = false,
+  openWorkModelsSyncing = false,
   fallbackOptions = [],
 }: ModelSelectProps) {
   const [search, setSearch] = React.useState("");
@@ -261,7 +264,6 @@ export function ModelSelect({
     () => hasOpenWorkModelsProvider(modelOptions.map((option) => option.providerID)),
     [modelOptions],
   );
-  const showOpenWorkModelsSyncing = openWorkModelsEntitled && !openWorkModelsAvailable;
   const showOpenWorkModelsPromo = React.useMemo(
     () =>
       openWorkModelsPromoEligible &&
@@ -369,7 +371,7 @@ export function ModelSelect({
             />
           </CommandHeader>
           <CommandEmpty>No models found.</CommandEmpty>
-          {showOpenWorkModelsSyncing ? (
+          {openWorkModelsSyncing ? (
             <div className="mx-1 mb-1 flex items-center gap-2 rounded-md border border-amber-6/60 bg-amber-2/40 px-2 py-1.5">
               <ProviderIcon
                 providerId={OPENWORK_MODELS_PROVIDER_ID}
@@ -382,7 +384,7 @@ export function ModelSelect({
                   {OPENWORK_MODELS_PROVIDER_NAME}
                 </span>
                 <span className="block truncate text-[11px] text-muted-foreground">
-                  Included — syncing into this workspace…
+                  Included — pending workspace reload…
                 </span>
               </span>
             </div>

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -11,6 +11,7 @@ import {
   isOpenWorkModelsPromoEligible,
   isOpenWorkModelsPromoEligibleForDenBaseUrl,
   shouldShowOpenWorkModelsPromo,
+  shouldShowOpenWorkModelsSyncing,
   wasOpenWorkModelsStartupPromoShown,
 } from "./openwork-models-promo";
 
@@ -46,5 +47,28 @@ describe("hasOpenWorkModelsAvailable", () => {
         providers: [{ id: "openwork", models: { "gpt-5": {} } }],
       }),
     ).toBe(true);
+  });
+});
+
+describe("shouldShowOpenWorkModelsSyncing", () => {
+  test("only reports a real pending workspace reload", () => {
+    expect(shouldShowOpenWorkModelsSyncing({
+      entitled: true,
+      available: false,
+      workspaceReady: false,
+      reloadPending: true,
+    })).toBe(false);
+    expect(shouldShowOpenWorkModelsSyncing({
+      entitled: true,
+      available: false,
+      workspaceReady: true,
+      reloadPending: false,
+    })).toBe(false);
+    expect(shouldShowOpenWorkModelsSyncing({
+      entitled: true,
+      available: false,
+      workspaceReady: true,
+      reloadPending: true,
+    })).toBe(true);
   });
 });

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -83,6 +83,15 @@ export function hasOpenWorkModelsAvailable(input: {
   return Object.keys(openwork?.models ?? {}).length > 0;
 }
 
+export function shouldShowOpenWorkModelsSyncing(input: {
+  entitled: boolean;
+  available: boolean;
+  workspaceReady: boolean;
+  reloadPending: boolean;
+}) {
+  return input.entitled && !input.available && input.workspaceReady && input.reloadPending;
+}
+
 export function getOpenWorkModelsActionUrl(
   isSignedIn: boolean,
   authMode: "sign-in" | "sign-up" = "sign-in",

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -40,6 +40,7 @@ export type NewTaskComposerContext = {
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
   openWorkModelsEntitled?: boolean;
+  openWorkModelsSyncing?: boolean;
   modelVariantLabel: string;
   modelVariant: string | null;
   modelBehaviorOptions?: { value: string | null; label: string }[];
@@ -254,6 +255,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       selectedModel={context?.selectedModel ?? FALLBACK_MODEL}
       modelOptions={context?.modelOptions}
       openWorkModelsEntitled={context?.openWorkModelsEntitled}
+      openWorkModelsSyncing={context?.openWorkModelsSyncing}
       onRefreshOrganizationModels={context?.onRefreshOrganizationModels}
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
       onModelChange={context?.onModelChange ?? noop}

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -63,7 +63,8 @@ export type ModelPickerModalProps = {
   onClose: (options?: { restorePromptFocus?: boolean }) => void;
   /** Den entitlement present; used to avoid a false Subscribe CTA while models sync. */
   openWorkModelsEntitled?: boolean;
-  onRefreshOpenWorkModels?: () => void | Promise<void>;
+  /** The server is waiting to reload this workspace with OpenWork Models. */
+  openWorkModelsSyncing?: boolean;
   onRefreshOrganizationModels?: () => void | Promise<void>;
   restrictToCloud?: boolean;
 };
@@ -258,7 +259,6 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     () => hasOpenWorkModelsProvider(props.options.map((option) => option.providerID)),
     [props.options],
   );
-  const showOpenWorkModelsSyncing = Boolean(props.openWorkModelsEntitled) && !openWorkModelsAvailable;
   const showOpenWorkModelsPromo = useMemo(
     () =>
       openWorkModelsPromoEligible &&
@@ -345,7 +345,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             />
           </div>
 
-          {showOpenWorkModelsSyncing ? (
+          {props.openWorkModelsSyncing ? (
             <div className="mb-3 flex shrink-0 items-center overflow-hidden rounded-2xl border border-amber-6/60 bg-amber-2/40">
               <div className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5">
                 <ProviderIcon providerId={OPENWORK_MODELS_PROVIDER_ID} providerName={OPENWORK_MODELS_PROVIDER_NAME} size={18} className="shrink-0 text-amber-11" />
@@ -354,18 +354,9 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                     <span>{OPENWORK_MODELS_PROVIDER_NAME}</span>
                   </div>
                   <div className="truncate text-[11px] text-dls-secondary">
-                    Included on your plan — finish syncing to choose a model.
+                    Included on your plan — pending workspace reload.
                   </div>
                 </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="shrink-0"
-                  onClick={() => void props.onRefreshOpenWorkModels?.()}
-                >
-                  <RefreshCw className="mr-1 size-3" />
-                  Refresh
-                </Button>
               </div>
             </div>
           ) : null}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -75,6 +75,7 @@ type ComposerProps = {
   /** When set, the full model picker opened from here targets this session. */
   sessionId?: string;
   openWorkModelsEntitled?: boolean;
+  openWorkModelsSyncing?: boolean;
   onRefreshOrganizationModels?: () => void | Promise<void>;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
@@ -1687,6 +1688,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                   disabled={props.steering}
                   sessionId={props.sessionId}
                   openWorkModelsEntitled={props.openWorkModelsEntitled}
+                  openWorkModelsSyncing={props.openWorkModelsSyncing}
                   fallbackOptions={props.modelOptions}
                 />
                 {props.modelUnavailable ? props.onRefreshOrganizationModels ? (

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -313,6 +313,8 @@ export type SessionSurfaceProps = {
   providerCatalog?: ProviderCatalog;
   /** Den/import includes OpenWork Models for this org member (not just local sync). */
   openWorkModelsEntitled?: boolean;
+  /** The server is waiting to reload this workspace with OpenWork Models. */
+  openWorkModelsSyncing?: boolean;
   onRefreshOrganizationModels?: () => void | Promise<void>;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
@@ -2135,6 +2137,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         modelPickerOpen={modelPickerOpen}
         selectedModel={sessionModel.selectedModel}
         openWorkModelsEntitled={props.openWorkModelsEntitled}
+        openWorkModelsSyncing={props.openWorkModelsSyncing}
         onRefreshOrganizationModels={props.onRefreshOrganizationModels}
         onModelPickerOpenChange={handleModelPickerOpenChange}
         onModelChange={handleModelChange}

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
-import { ArrowRight, CheckCircle2, KeyRound, RefreshCw, X } from "lucide-react";
+import { ArrowRight, CheckCircle2, KeyRound, X } from "lucide-react";
 
 import { t } from "@/i18n";
 import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
@@ -50,7 +50,6 @@ export type AiSettingsViewProps = {
   /** Den entitlement is present but local engine has no selectable openwork models yet. */
   showOpenWorkModelsSyncing?: boolean;
   onSubscribeOpenWorkModels?: () => void | Promise<void>;
-  onRefreshOpenWorkModels?: () => void | Promise<void>;
   onDismissOpenWorkModels?: () => void | Promise<void>;
   cloudProvidersView?: ReactNode;
 };
@@ -246,22 +245,14 @@ export function AiSettingsView(props: AiSettingsViewProps) {
                 <div className="flex items-center gap-2">
                   <span className="truncate text-sm font-medium text-dls-text">OpenWork Models</span>
                   <span className="shrink-0 rounded-full border border-amber-6 bg-amber-3 px-2 py-0.5 text-[10px] font-medium text-amber-11">
-                    Included — finish syncing
+                    Included — syncing
                   </span>
                 </div>
                 <div className="truncate text-xs text-muted-foreground">
-                  Your plan includes OpenWork Models, but they are not ready in this workspace yet.
+                  OpenWork Models will become available automatically when the pending workspace reload completes.
                 </div>
               </div>
             </div>
-            <Button
-              variant="outline"
-              onClick={() => void props.onRefreshOpenWorkModels?.()}
-              disabled={props.busy || props.providerAuthBusy}
-            >
-              <RefreshCw className="mr-1.5 size-3.5" />
-              Refresh models
-            </Button>
           </LayoutSectionItem>
         ) : null}
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -146,6 +146,10 @@ import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-works
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import {
+  hasOpenWorkModelsAvailable,
+  shouldShowOpenWorkModelsSyncing,
+} from "@/react-app/domains/cloud/openwork-models-promo";
+import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
   testRemoteWorkspaceConnection,
@@ -921,9 +925,6 @@ export function SessionRoute() {
     if (!cloudProviderSyncReady || !cloudProviderList) return;
     clearCloudMcpSubmissionFailure();
   }, [clearCloudMcpSubmissionFailure, cloudProviderList, cloudProviderSyncReady]);
-  const refreshOpenWorkModels = useCallback(async () => {
-    await refreshOrganizationModelAccess();
-  }, [refreshOrganizationModelAccess]);
   const organizationModelsSettingsUrl = useMemo(() => {
     if (!isDenOrgAdminRole(activeOrganizationRole)) {
       return undefined;
@@ -949,6 +950,16 @@ export function SessionRoute() {
     providerListQuery.data,
     restrictToCloudProviders,
   ]);
+  const openWorkModelsAvailable = hasOpenWorkModelsAvailable({
+    providerConnectedIds,
+    providers,
+  });
+  const openWorkModelsSyncing = shouldShowOpenWorkModelsSyncing({
+    entitled: openWorkModelsEntitled,
+    available: openWorkModelsAvailable,
+    workspaceReady: Boolean(selectedWorkspaceId && opencodeClient),
+    reloadPending: sessionProviderAuthSnapshot.cloudProviderServerSync?.reloadPending === true,
+  });
   const organizationModelsEmpty = isOrganizationModelsEmpty({
     workspaceReady: Boolean(selectedWorkspaceId && opencodeClient),
     loading,
@@ -1251,6 +1262,7 @@ export function SessionRoute() {
       organizationModelsEmpty,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       openWorkModelsEntitled,
+      openWorkModelsSyncing,
       onRefreshOrganizationModels: refreshOrganizationModelAccess,
       onModelPickerOpenChange: (open: boolean) => {
         modelPicker.setCompactOpen(open);
@@ -1496,6 +1508,7 @@ export function SessionRoute() {
     navigate,
     providerCatalog,
     openWorkModelsEntitled,
+    openWorkModelsSyncing,
     refreshCloudProviderSync,
     refreshOrganizationModelAccess,
     opencodeBaseUrl,
@@ -1559,6 +1572,7 @@ export function SessionRoute() {
         modelPicker.setCompactOpen(false);
       },
       openWorkModelsEntitled,
+      openWorkModelsSyncing,
       modelVariantLabel,
       modelVariant: modelVariantValue,
       modelBehaviorOptions,
@@ -1603,6 +1617,7 @@ export function SessionRoute() {
     modelVariantValue,
     opencodeClient,
     openWorkModelsEntitled,
+    openWorkModelsSyncing,
     organizationAssignedModelOptions,
     organizationModelsEmpty,
     refreshCloudProviderSync,
@@ -2992,7 +3007,7 @@ export function SessionRoute() {
       }}
       onClose={() => { modelPicker.setOpen(false); modelPicker.setRecentProviderIds(new Set()); }}
       openWorkModelsEntitled={openWorkModelsEntitled}
-      onRefreshOpenWorkModels={refreshOpenWorkModels}
+      openWorkModelsSyncing={openWorkModelsSyncing}
       onRefreshOrganizationModels={refreshOrganizationModelAccess}
       restrictToCloud={restrictToCloudProviders}
     />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -133,6 +133,7 @@ import {
   useOpenWorkModelsPromoEligibility,
   isOpenWorkModelsPromoHidden,
   openWorkModelsPromoChangedEvent,
+  shouldShowOpenWorkModelsSyncing,
 } from "@/react-app/domains/cloud/openwork-models-promo";
 import {
   isDesktopRuntime,
@@ -864,7 +865,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     providerConnectedIds,
     providers,
   });
-  const showOpenWorkModelsSyncing = openWorkModelsEntitled && !openWorkModelsAvailable;
+  const showOpenWorkModelsSyncing = shouldShowOpenWorkModelsSyncing({
+    entitled: openWorkModelsEntitled,
+    available: openWorkModelsAvailable,
+    workspaceReady: Boolean(selectedWorkspaceId && activeClient),
+    reloadPending: providerAuthSnapshot.cloudProviderServerSync?.reloadPending === true,
+  });
   const showOpenWorkModelsSubscribe =
     openWorkModelsPromoEligible &&
     !openWorkModelsEntitled &&
@@ -897,11 +903,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       platform.openLink(getDenInferenceUrl(cloudSession.baseUrl));
     }, 0);
   }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
-
-  const refreshOpenWorkModels = useCallback(async () => {
-    await providerAuthStore.runCloudProviderSync("settings_cloud_opened");
-    await providerAuthStore.refreshProviders();
-  }, [providerAuthStore]);
 
   const handleOpenProviderAuth = useCallback(() => {
     if (providerAuthStore.isProviderAddRestricted()) {
@@ -2217,7 +2218,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             showOpenWorkModelsConnect={showOpenWorkModelsConnect}
             showOpenWorkModelsSyncing={showOpenWorkModelsSyncing}
             onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
-            onRefreshOpenWorkModels={refreshOpenWorkModels}
             onDismissOpenWorkModels={dismissOpenWorkModelsPromo}
             cloudProvidersView={
               <CloudProvidersView


### PR DESCRIPTION
## Summary

- show the OpenWork Models syncing state only while the server reports a pending workspace reload
- suppress workspace-sync messaging when no workspace is connected
- remove redundant model refresh controls because provider synchronization and pending reload retries are automatic

## Root cause

The UI inferred an active sync whenever the account was entitled to OpenWork Models but the current provider catalog did not contain them. That condition can also occur without a workspace or after synchronization has settled, leaving the interface in a permanent amber state. The refresh controls repeated the automatic provider sync without representing progress or resolving the underlying pending reload.

## User impact

Users still see their assigned models before creating a workspace, but they no longer see a false or permanently stuck workspace-sync prompt. A genuine pending reload remains visible and explains that completion is automatic.

## Validation

- `pnpm typecheck` in `apps/app`
- `bun test --isolate src/react-app/domains/cloud/openwork-models-promo.test.ts` (4 passing)
- `git diff --check`
