### PR TITLE
Clear cloud providers on logout

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -26,6 +26,7 @@ export { normalizeDesktopConfig };
 
 import { isDesktopDeployment, isWebDeployment } from "./openwork-deployment";
 import {
+  dispatchDenSessionUpdated,
   dispatchDenSettingsChanged,
 } from "./den-session-events";
 import {
@@ -1194,6 +1195,10 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
 
   dispatchDenSettingsChanged({
     settings: readDenSettings(),
+  });
+  dispatchDenSessionUpdated({
+    status: "signed_out",
+    baseUrl: readDenSettings().baseUrl,
   });
 }
 

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -23,7 +23,6 @@ import { clearDesktopBootstrapConfig } from "@/app/lib/desktop";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import {
   denSessionUpdatedEvent,
-  dispatchDenSessionUpdated,
   type DenSessionUpdatedDetail,
 } from "@/app/lib/den-session-events";
 import { t } from "@/i18n";
@@ -189,7 +188,6 @@ export function useDenSession({
   const clearSignedInState = React.useCallback(
     (
       message?: string | null,
-      eventDetail?: Pick<DenSessionUpdatedDetail, "baseUrl">,
       options?: { includeBaseUrls?: boolean },
     ) => {
       const includeBaseUrls = options?.includeBaseUrls ?? !developerMode;
@@ -226,8 +224,6 @@ export function useDenSession({
           }
         }
       } catch {}
-      // Notify provider auth store so it can clean up cloud-imported providers
-      dispatchDenSessionUpdated({ status: "signed_out", ...eventDetail });
       });
     },
     [clearSessionState, developerMode, onBeforeSignedOut, setAuthToken, setBaseUrl],
@@ -283,9 +279,7 @@ export function useDenSession({
 
       setBaseUrl(persisted.baseUrl);
       setBaseUrlDraft(persisted.baseUrl);
-      await clearSignedInState(t("den.status_base_url_updated"), {
-        baseUrl: persisted.baseUrl,
-      }, { includeBaseUrls: false });
+      await clearSignedInState(t("den.status_base_url_updated"), { includeBaseUrls: false });
     } catch (error) {
       setBaseUrlError(error instanceof Error ? error.message : t("den.error_base_url"));
     } finally {
@@ -306,9 +300,7 @@ export function useDenSession({
       setBaseUrlError(null);
       setBaseUrl(persisted.baseUrl);
       setBaseUrlDraft(persisted.baseUrl);
-      await clearSignedInState(t("den.status_base_url_updated"), {
-        baseUrl: persisted.baseUrl,
-      }, { includeBaseUrls: false });
+      await clearSignedInState(t("den.status_base_url_updated"), { includeBaseUrls: false });
     } catch (error) {
       setBaseUrlError(error instanceof Error ? error.message : t("den.error_base_url"));
     } finally {
@@ -340,9 +332,7 @@ export function useDenSession({
       );
       setBaseUrl(resolved.baseUrl);
       setBaseUrlDraft(resolved.baseUrl);
-      await clearSignedInState(t("den.status_server_config_cleared"), {
-        baseUrl: resolved.baseUrl,
-      }, { includeBaseUrls: false });
+      await clearSignedInState(t("den.status_server_config_cleared"), { includeBaseUrls: false });
     } catch (error) {
       setBaseUrlError(error instanceof Error ? error.message : t("den.error_base_url"));
     } finally {

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -34,10 +34,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, clearDenSession, DEFAULT_DEN_BASE_URL, readDenSettings } from "../../app/lib/den";
-import {
-  denSettingsChangedEvent,
-  dispatchDenSessionUpdated,
-} from "../../app/lib/den-session-events";
+import { denSettingsChangedEvent } from "../../app/lib/den-session-events";
 import { writeActiveWorkspaceId, writeLastSessionFor, writeWorkspaceProjectDimension } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -193,7 +190,6 @@ export function WelcomeRoute() {
         return false;
       }
       clearDenSession({ includeBaseUrls: false });
-      dispatchDenSessionUpdated({ status: "signed_out", baseUrl: persisted.baseUrl });
       setOrganizationServerUrl(persisted.baseUrl);
       return true;
     } catch (error) {

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { clearDenSession } from "../src/app/lib/den";
 import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
 import { createClient } from "../src/app/lib/opencode";
 import type { ResolvedWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
@@ -64,12 +65,22 @@ function memoryStorage(): Storage {
 
 function installWindow(): Storage {
   const localStorage = memoryStorage();
+  const listeners = new Map<string, Set<EventListener>>();
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
-      addEventListener: () => undefined,
-      removeEventListener: () => undefined,
-      dispatchEvent: () => true,
+      addEventListener: (type: string, listener: EventListener) => {
+        const registered = listeners.get(type) ?? new Set<EventListener>();
+        registered.add(listener);
+        listeners.set(type, registered);
+      },
+      removeEventListener: (type: string, listener: EventListener) => {
+        listeners.get(type)?.delete(listener);
+      },
+      dispatchEvent: (event: Event) => {
+        for (const listener of listeners.get(event.type) ?? []) listener(event);
+        return true;
+      },
       localStorage,
       location: { origin: "https://self-hosted.example" },
       __OPENWORK_GATEWAY__: undefined,
@@ -310,6 +321,34 @@ describe("session-route cloud provider sync wiring", () => {
       requests.filter((request) => request.url === "https://den.example/api/den/v1/llm-providers"),
     ).toHaveLength(1);
     expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(0);
+    store.dispose();
+  });
+
+  test("clearing the Den session clears assigned organization models", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests);
+    const store = createSessionRouteStore({
+      endpoint: null,
+      hostToken: "",
+    });
+    const assignedModelsLoaded = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("assigned models did not load")), 1_000);
+      const unsubscribe = store.subscribe(() => {
+        if (store.getSnapshot().cloudOrgProviders.length === 0) return;
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve();
+      });
+    });
+
+    store.start();
+    await assignedModelsLoaded;
+    clearDenSession();
+
+    expect(store.getSnapshot().cloudOrgProviders).toEqual([]);
+    expect(store.getSnapshot().importedCloudProviders).toEqual({});
     store.dispose();
   });
 


### PR DESCRIPTION
## Summary

- emit the signed-out session event from the shared Den session-clear boundary
- clear assigned organization models and imported cloud providers for every logout surface
- remove duplicate event dispatches from settings and welcome flows

## Root cause

Provider cleanup listens for the Den `signed_out` session event. Settings logout emitted that event explicitly, but sidebar logout, cloud-workspace logout, forced sign-out, and revoked-session cleanup only called `clearDenSession()`. Those paths removed the token while leaving provider state visible until a later refresh or restart.

## User impact

Logging out now immediately invalidates account-scoped provider and model state regardless of where logout was initiated. Local and user-configured providers remain unaffected by the existing cloud-provider cleanup policy.

## Verification

- `bun test --isolate tests/session-provider-auth-server-sync.test.ts` (5 passing)
- `pnpm typecheck` in `apps/app`
- `git diff --check`

Base: `300f1528a1030cda4dc3967cce5caf72f65f1a8a`

Candidate: `ab783c792`
