### PR TITLE
ci: pin Azure signing actions

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -696,14 +696,14 @@ jobs:
           }
 
       - name: Azure login with GitHub OIDC
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign all Windows installers
-        uses: azure/artifact-signing-action@v2
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         with:
           endpoint: ${{ env.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
           signing-account-name: ${{ env.AZURE_ARTIFACT_SIGNING_ACCOUNT }}


### PR DESCRIPTION
## Summary

- Pin `azure/login` to the immutable commit currently backing v3.0.1.
- Pin `azure/artifact-signing-action` to the immutable commit currently backing v2.
- Address the Warden PR #3719 finding about mutable Azure action tags in the privileged Windows signing job.

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-macos-aarch64.yml'); puts 'workflow yaml parsed'"`
- `rg -n "azure/(login|artifact-signing-action)@" .github/workflows/release-macos-aarch64.yml`

## Notes

- Full Actions execution still needs the live release workflow because this only changes third-party action refs.
