### PR TITLE
feat(release): one-button Release Cut workflow

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,171 @@
+# Release Cut — one-button release, no local toolchain required.
+#
+# Does remotely what `pnpm release:prepare` + `pnpm release:ship` do locally:
+#   1. bump versions on current dev HEAD (scripts/release/prepare.mjs --ci)
+#   2. push the vX.Y.Z tag
+#   3. open the dev backfill PR (dev is PR-only, even for admins)
+#   4. dispatch the Release App workflow for the tag
+#
+# Step 4 exists because a tag pushed with the workflow's GITHUB_TOKEN does not
+# fire `on: push: tags` (GitHub suppresses recursive triggers). Dispatching by
+# API is exempt from that rule, so the chain works with the default token.
+# If RELEASE_CUT_TOKEN (a PAT/App token with v* tag-ruleset bypass) is
+# configured, the tag push itself triggers Release App and the dispatch is
+# skipped to avoid a double run.
+#
+# One-time repo config: the v* tag ruleset must allow this workflow's actor to
+# create tags — either add the GitHub Actions app as a bypass actor, or store
+# an admin bot token as the RELEASE_CUT_TOKEN secret.
+
+name: Release Cut
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      dry_run:
+        description: "Rehearse the cut without pushing anything"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: release-cut
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    name: Cut ${{ inputs.bump }} release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_CUT_TOKEN: ${{ secrets.RELEASE_CUT_TOKEN }}
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          # The tag/branch pushes below use the bot token when configured so
+          # the tag push itself can trigger Release App.
+          token: ${{ secrets.RELEASE_CUT_TOKEN || github.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # Must match the root packageManager pin; prepare.mjs refuses to run
+          # on a mismatch (a mismatched pnpm silently rewrites pnpm-lock.yaml).
+          version: 11.4.0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "OpenWork Release Bot"
+          git config user.email "release-bot@users.noreply.github.com"
+
+      - name: Prepare release (bump + review + commit + tag)
+        env:
+          BUMP: ${{ inputs.bump }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=("$BUMP" --ci)
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          node scripts/release/prepare.mjs "${args[@]}"
+
+      - name: Resolve tag
+        id: tag
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "Dry run — nothing was committed or tagged." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          tag="$(git describe --tags --exact-match HEAD)"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "HEAD tag '$tag' does not look like a release tag (expected vX.Y.Z)" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        if: steps.tag.outputs.tag != ''
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git push origin "$RELEASE_TAG"
+          echo "Pushed $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open dev backfill PR
+        if: steps.tag.outputs.tag != ''
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          sync_branch="release/${RELEASE_TAG}-dev-sync"
+          git push -f origin "HEAD:refs/heads/${sync_branch}"
+
+          pr_url="$(gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base dev \
+            --head "$sync_branch" \
+            --title "chore(release): ${RELEASE_TAG}" \
+            --body "Backfills the ${RELEASE_TAG} version bump into dev (the release was cut from the tag by the Release Cut workflow). Needs one approval from someone other than the pusher." \
+            2>/dev/null || true)"
+
+          if [ -n "$pr_url" ]; then
+            echo "Backfill PR: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Backfill PR could not be opened automatically (may already exist): https://github.com/$GITHUB_REPOSITORY/compare/dev...${sync_branch}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Dispatch Release App
+        # A tag pushed with the default GITHUB_TOKEN does not trigger
+        # `on: push: tags`, so dispatch explicitly. Skipped when the tag was
+        # pushed with RELEASE_CUT_TOKEN — that push already triggered the run.
+        if: steps.tag.outputs.tag != '' && env.RELEASE_CUT_TOKEN == ''
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run release-macos-aarch64.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG" \
+            -f "tag=$RELEASE_TAG"
+          echo "Dispatched Release App for $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary
+        if: steps.tag.outputs.tag != ''
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          {
+            echo "### Release Cut: $RELEASE_TAG"
+            echo
+            echo "- Workflow runs: https://github.com/$GITHUB_REPOSITORY/actions/workflows/release-macos-aarch64.yml"
+            echo "- Release: https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+            echo "- The release is done when 'Publish GitHub Release' flips the draft public."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -9,25 +9,28 @@ Arguments: `$ARGUMENTS`
 - If set to `minor` or `major`, use that bump type.
 
 Load and follow `.opencode/skills/release/SKILL.md`; `docs/RELEASING.md` is the
-full runbook. Use the tag-first path unless the user explicitly requests
-PR-first.
+full runbook. Use the Release Cut workflow path unless the user explicitly
+requests PR-first or the workflow is unavailable.
 
-1. Fetch `origin/dev`. Work only from a clean checkout based on its current
-   tip. If the user's checkout is dirty or `dev` is already checked out, create
-   an isolated release worktree and leave the original checkout untouched.
-2. Run `pnpm release:prepare:dry -- <bump>`, then
-   `pnpm release:prepare -- <bump>`. In an isolated branch worktree, pass
-   `--ci` only after independently confirming the branch is based on current
-   `origin/dev` and the worktree is clean.
-3. Run `pnpm release:ship`. A rejected direct push to protected `dev` is
-   expected: `release:ship` must push a `release/vX.Y.Z-dev-sync` branch and
-   open the backfill PR. Never bypass or force-push `dev`.
-4. Watch the matching `Release App` run through completion. The release is not
+1. Dispatch the cut and find its run:
+
+   ```bash
+   gh workflow run release-cut.yml --repo different-ai/openwork -f bump=<bump>
+   gh run list --repo different-ai/openwork --workflow "Release Cut" --limit 1
+   ```
+
+   Watch it through completion; its summary reports the tag, the backfill PR,
+   and the dispatched `Release App` run. If the cut fails on the tag push, the
+   `v*` tag ruleset does not allow the Actions actor — report that the
+   one-time bypass setup (or a `RELEASE_CUT_TOKEN` secret) is required and
+   fall back to the local tag-first path from the release skill only if the
+   user is an admin and asks for it.
+2. Watch the matching `Release App` run through completion. The release is not
    done until `Publish GitHub Release` succeeds and the release is public.
-5. Get the version backfill PR approved and merged. If the workflow opens an
+3. Get the version backfill PR approved and merged. If the workflow opens an
    AUR packaging PR, report its URL, wait for it to merge, then rerun Release
    App with the same tag as described by the release skill.
-6. Verify the public release assets resolve, `npm view openwork-server version`
+4. Verify the public release assets resolve, `npm view openwork-server version`
    matches the tag, and the latest relevant Daytona snapshot run is green.
 
 Diagnose unexpected failures instead of treating Node runtime deprecation

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -12,12 +12,23 @@ A release is **done when the run is green and the GitHub release is published**
 
 ## Choose a path
 
-- **PR-first (default)**: land the bump on `dev` through a reviewed PR, then
-  tag the merge commit. No tag/dev divergence; release waits on review.
-- **Tag-first (expedited, admins only)**: `pnpm release:prepare` on a branch
-  off `dev`, push the tag (the `v*` tag ruleset grants admins bypass), and
-  backfill the bump into `dev` through a PR afterwards. Releases immediately;
-  `dev` catches up through review. Use when a release must go out now.
+- **Release Cut workflow (default)**: dispatch the `Release Cut` GitHub
+  Actions workflow (`.github/workflows/release-cut.yml`). It bumps versions on
+  current `dev` HEAD, pushes the tag, opens the dev backfill PR, and starts
+  Release App — no local toolchain involved:
+
+  ```bash
+  gh workflow run release-cut.yml --repo different-ai/openwork -f bump=patch
+  # rehearse without pushing anything:
+  gh workflow run release-cut.yml --repo different-ai/openwork -f bump=patch -f dry_run=true
+  ```
+
+- **Local tag-first (fallback, admins only)**: `pnpm release:prepare` on a
+  branch off `dev`, then `pnpm release:ship` (the `v*` tag ruleset grants
+  admins bypass). Use when Actions is down or the cut workflow itself is
+  broken.
+- **PR-first**: land the bump on `dev` through a reviewed PR, then tag the
+  merge commit. No tag/dev divergence; release waits on review.
 
 Either way, **never push `dev` directly, force-push it, or bypass its branch
 rules** — `dev` requires: at least one approval; approval of the latest push
@@ -31,6 +42,10 @@ Toolchain: pnpm must match the root `packageManager` pin —
 ---
 
 ## Bump
+
+Release Cut path: nothing to do locally — the workflow runs
+`scripts/release/prepare.mjs --ci` on the runner (bump + lockfile + strict
+review + commit + tag). Watch its run, then skip to "Watch" below.
 
 PR-first path:
 
@@ -59,6 +74,11 @@ instead of double-bumping.
 
 ## Tag and ship
 
+Release Cut path — the workflow pushes the tag, opens the
+`release/vX.Y.Z-dev-sync` backfill PR, and dispatches Release App. Your only
+follow-up is getting the backfill PR approved (by someone other than the
+pusher) and merged.
+
 PR-first — tag the merge commit on dev:
 
 ```bash
@@ -67,8 +87,8 @@ git tag vX.Y.Z origin/dev
 git push origin vX.Y.Z
 ```
 
-Tag-first — `pnpm release:ship` pushes the tag, then syncs `dev`: direct push
-if allowed, otherwise it pushes `release/vX.Y.Z-dev-sync` and opens the
+Local tag-first — `pnpm release:ship` pushes the tag, then syncs `dev`: direct
+push if allowed, otherwise it pushes `release/vX.Y.Z-dev-sync` and opens the
 backfill PR. Get it approved by someone other than the pusher and merged.
 
 ---

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,30 @@
 # Releasing OpenWork
 
-The release flow is three root scripts wrapping `scripts/release/*.mjs`. A
-release is **done when the `Release App` run is green and `Publish GitHub
+A release is **done when the `Release App` run is green and `Publish GitHub
 Release` has flipped the release public** — not when the tag is pushed.
+
+## One-button path (default): Release Cut workflow
+
+```bash
+gh workflow run release-cut.yml --repo different-ai/openwork -f bump=patch
+# rehearse without pushing anything:
+gh workflow run release-cut.yml --repo different-ai/openwork -f bump=patch -f dry_run=true
+```
+
+`.github/workflows/release-cut.yml` runs `scripts/release/prepare.mjs --ci` on
+current `dev` HEAD (bump + lockfile + strict review + commit + tag), pushes
+the tag, opens the `release/vX.Y.Z-dev-sync` backfill PR, and dispatches
+`Release App` for the tag. No local toolchain is involved; the only human
+follow-up is merging the backfill PR.
+
+One-time setup: the `v*` tag ruleset must allow the workflow to create tags —
+add the GitHub Actions app as a bypass actor, or store an admin bot token as
+the `RELEASE_CUT_TOKEN` repo secret (with the secret set, the tag push itself
+triggers `Release App` and the explicit dispatch is skipped).
+
+## Local path (fallback)
+
+The local flow is three root scripts wrapping `scripts/release/*.mjs`:
 
 ```bash
 pnpm release:review          # sanity: versions aligned, opencode pin present


### PR DESCRIPTION
## What

Makes cutting a release a single GitHub Actions dispatch — no local pnpm/git/toolchain:

```bash
gh workflow run release-cut.yml -f bump=patch          # cut
gh workflow run release-cut.yml -f bump=patch -f dry_run=true  # rehearse
```

`Release Cut` (`.github/workflows/release-cut.yml`) does remotely what `release:prepare` + `release:ship` do locally:

1. runs `scripts/release/prepare.mjs --ci` on current `dev` HEAD (bump + lockfile + strict review + commit + tag) — no logic duplicated, same script as the local flow
2. pushes the `vX.Y.Z` tag
3. opens the `release/vX.Y.Z-dev-sync` backfill PR (dev is PR-only)
4. dispatches Release App for the tag — needed because a tag pushed with `GITHUB_TOKEN` doesn't fire `on: push: tags`; `workflow_dispatch` via API is exempt

Safe with the existing pipeline: `resolve-release` always creates the release as a draft regardless of trigger, and only `publish-release` flips it public.

Also updates `.opencode/skills/release/SKILL.md`, `.opencode/commands/release.md`, and `docs/RELEASING.md` to make this the default path. The local tag-first flow stays documented as the admin fallback.

## One-time setup required before first use

The `v*` tag ruleset must allow the workflow to create tags. Either:
- add the GitHub Actions app as a bypass actor on the `v*` tag ruleset, **or**
- store an admin bot PAT as the `RELEASE_CUT_TOKEN` repo secret (then the tag push itself triggers Release App and the explicit dispatch is skipped, avoiding a double run)

## Verification

`workflow_dispatch` workflows are only invocable once the file exists on the default branch, so a live run cannot be attached to this PR. Validation done here: YAML parses; `prepare.mjs --ci` inputs verified against the script (node-stdlib-only bump/review scripts, pnpm pin matched by the setup step). Post-merge proof plan:

1. `gh workflow run release-cut.yml -f bump=patch -f dry_run=true` — expect a green run, no tag/commit/PR created
2. next real release goes through the workflow; expect tag, backfill PR, and a normal Release App run

No runtime app behavior changes; docs + workflow + agent config only.