### PR TITLE
Clear stale provider models after logout

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -33,7 +33,11 @@ import {
 } from "@/react-app/domains/cloud/openwork-models-promo";
 import { getConnectedProviderItems, useProviderListQuery } from "@/react-app/infra/provider-list-query";
 import { filterEntitledModelOptions } from "@/react-app/domains/connections/provider-auth/provider-policy";
-import { mergeModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
+import {
+  filterCloudManagedModelOptions,
+  mergeModelOptions,
+} from "@/react-app/domains/connections/provider-auth/assigned-model-options";
+import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
 import {
   Command,
   CommandCollection,
@@ -63,7 +67,11 @@ function getProviderDisplayName(providerId: string) {
     .join(" ");
 }
 
-function useModelOptions(open: boolean, fallbackOptions: readonly ModelOption[]) {
+function useModelOptions(
+  open: boolean,
+  fallbackOptions: readonly ModelOption[],
+  cloudProvidersEnabled: boolean,
+) {
   const { client, opencodeBaseUrl, selectedWorkspaceRoot } = useWorkspace();
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
@@ -112,11 +120,14 @@ function useModelOptions(open: boolean, fallbackOptions: readonly ModelOption[])
         })),
       );
 
-    return filterEntitledModelOptions(mergeModelOptions(options, fallbackOptions), {
+    return filterEntitledModelOptions(filterCloudManagedModelOptions(
+      mergeModelOptions(options, fallbackOptions),
+      cloudProvidersEnabled,
+    ), {
       restrictToCloud,
       checkRestriction: checkDesktopRestriction,
     });
-  }, [checkDesktopRestriction, data, fallbackOptions]);
+  }, [checkDesktopRestriction, cloudProvidersEnabled, data, fallbackOptions]);
 }
 
 type ModelSelectModelItem = {
@@ -218,8 +229,8 @@ export function ModelSelect({
   const [search, setSearch] = React.useState("");
   const [promoHidden, setPromoHidden] = React.useState(isOpenWorkModelsPromoHidden);
   const searchInputRef = React.useRef<HTMLInputElement>(null);
-  const modelOptions = useModelOptions(open, fallbackOptions);
   const denAuth = useDenAuth();
+  const modelOptions = useModelOptions(open, fallbackOptions, denAuth.isSignedIn);
   const navigate = useNavigate();
   const platform = usePlatform();
   const openWorkModelsPromoEligible = useOpenWorkModelsPromoEligibility();
@@ -350,7 +361,9 @@ export function ModelSelect({
           }
         >
           <span className="max-w-48 truncate">
-            {hideValue ? "Select model" : (selectedOption?.title ?? value.modelID ?? "Select model")}
+            {hideValue || (!denAuth.isSignedIn && isCloudManagedProviderKey(value.providerID))
+              ? "Select model"
+              : (selectedOption?.title ?? value.modelID ?? "Select model")}
           </span>
           <ChevronDown className="h-3 w-3" />
         </TooltipTrigger>

--- a/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
@@ -1,6 +1,15 @@
 import type { DenOrgLlmProvider } from "@/app/lib/den";
 import type { ModelOption } from "@/app/types";
-import { getCloudManagedProviderId } from "./cloud-provider-config";
+import { getCloudManagedProviderId, isCloudManagedProviderKey } from "./cloud-provider-config";
+
+export function filterCloudManagedModelOptions<T extends Pick<ModelOption, "providerID">>(
+  options: readonly T[],
+  cloudProvidersEnabled: boolean,
+): T[] {
+  return cloudProvidersEnabled
+    ? [...options]
+    : options.filter((option) => !isCloudManagedProviderKey(option.providerID));
+}
 
 export function assignedModelOptions(
   providers: readonly DenOrgLlmProvider[],

--- a/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts
@@ -8,6 +8,7 @@ declare const expect: (value: unknown) => {
 import { readFileSync } from "node:fs";
 
 import {
+  isManagedModelAvailabilityPending,
   isOrganizationModelsEmpty,
   refreshOrganizationModels,
   shouldAutoOpenUnavailableModelPicker,
@@ -39,6 +40,42 @@ describe("managed model sync ordering", () => {
       workspaceId: "workspace-1",
       activeOrgId: "org-1",
       cloudProviderSyncReady: true,
+    })).toBe(false);
+  });
+
+  test("keeps a selected cloud model loading through provider sync and workspace reload", () => {
+    expect(isManagedModelAvailabilityPending({
+      signedIn: true,
+      selectedModelUsesCloudProvider: true,
+      cloudProviderSyncReady: false,
+      openWorkModelsSyncing: false,
+    })).toBe(true);
+    expect(isManagedModelAvailabilityPending({
+      signedIn: true,
+      selectedModelUsesCloudProvider: true,
+      cloudProviderSyncReady: true,
+      openWorkModelsSyncing: true,
+    })).toBe(true);
+    expect(isManagedModelAvailabilityPending({
+      signedIn: true,
+      selectedModelUsesCloudProvider: true,
+      cloudProviderSyncReady: true,
+      openWorkModelsSyncing: false,
+    })).toBe(false);
+  });
+
+  test("does not hide a genuinely unavailable local or signed-out model behind loading", () => {
+    expect(isManagedModelAvailabilityPending({
+      signedIn: true,
+      selectedModelUsesCloudProvider: false,
+      cloudProviderSyncReady: false,
+      openWorkModelsSyncing: true,
+    })).toBe(false);
+    expect(isManagedModelAvailabilityPending({
+      signedIn: false,
+      selectedModelUsesCloudProvider: true,
+      cloudProviderSyncReady: false,
+      openWorkModelsSyncing: true,
     })).toBe(false);
   });
 });

--- a/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.ts
@@ -16,6 +16,24 @@ export function isOrganizationModelsEmpty(input: OrganizationModelsEmptyInput) {
   );
 }
 
+export type ManagedModelAvailabilityPendingInput = {
+  signedIn: boolean;
+  selectedModelUsesCloudProvider: boolean;
+  cloudProviderSyncReady: boolean;
+  openWorkModelsSyncing: boolean;
+};
+
+/** A cloud model can temporarily disappear while its provider is being reconciled. */
+export function isManagedModelAvailabilityPending(
+  input: ManagedModelAvailabilityPendingInput,
+) {
+  return (
+    input.signedIn &&
+    input.selectedModelUsesCloudProvider &&
+    (!input.cloudProviderSyncReady || input.openWorkModelsSyncing)
+  );
+}
+
 export type UnavailableModelPickerAutoOpenInput = {
   selectedModelUnavailableKey: string | null;
   signedIn: boolean;

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -94,6 +94,7 @@ import {
   readStoredDefaultModel,
   writeStoredDefaultModel,
 } from "../../../kernel/model-config";
+import { DEFAULT_MODEL } from "../../../../app/constants";
 
 type ProviderReturnFocusTarget = "none" | "composer";
 type CloudProviderSyncReason =
@@ -2252,10 +2253,25 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
           void pushDenSession().then(() => runCloudProviderSync("sign_in"));
         } else {
+          const logoutProviderIds = detail?.status === "signed_out"
+            ? [...new Set(options.providerConnectedIds())].filter(
+              (providerId) => providerId.trim().toLowerCase() !== DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
+            )
+            : [];
           // Account-scoped catalog state must disappear synchronously. Config
           // and credential cleanup continues below without leaving stale
           // models visible while those best-effort operations finish.
           clearProviderListQueries(getReactQueryClient());
+          for (const providerId of logoutProviderIds) {
+            removeProviderFromState(providerId);
+          }
+          if (
+            logoutProviderIds.some(
+              (providerId) => providerId === readStoredDefaultModel().providerID,
+            )
+          ) {
+            writeStoredDefaultModel(DEFAULT_MODEL);
+          }
           mutateState((current) => ({
             ...current,
             cloudOrgProviders: [],
@@ -2275,6 +2291,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           // Best-effort cleanup: remove each cloud provider from opencode.jsonc
           // BEFORE clearing state so removeCloudProviderInternal can find the records
           void (async () => {
+            for (const providerId of logoutProviderIds) {
+              try {
+                await removeProviderAuthCredentials(providerId);
+              } catch {
+                // Providers backed exclusively by the environment have no
+                // stored credential to remove. Their environment remains
+                // operator-owned and is not mutated by account logout.
+              }
+            }
             for (const cloudId of importedIds) {
               try {
                 await removeCloudProviderInternal(cloudId, { silent: true });

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1828,6 +1828,19 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     );
   };
 
+  const publishSettingsCloudProviderSyncError = (
+    reason: CloudProviderSyncReason,
+    message: string,
+  ) => {
+    if (reason !== "settings_cloud_opened") return;
+    // A sync that loses its session while logout is clearing account state is
+    // cancellation, not a user-actionable provider failure.
+    setStateField(
+      "providerAuthError",
+      hasCloudProviderSyncPrerequisites() ? message : null,
+    );
+  };
+
   const preselectEntitledOrgDefaultModel = (
     providerList: ProviderListResponse | null | undefined,
   ) => {
@@ -2000,6 +2013,12 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   }
 
   async function runCloudProviderSync(reason: CloudProviderSyncReason) {
+    if (!hasCloudProviderSyncPrerequisites()) {
+      if (reason === "settings_cloud_opened") {
+        setStateField("providerAuthError", null);
+      }
+      return;
+    }
     if (getOpenworkGatewayOrigin()) {
       if (!loggedGatewayCloudProviderSyncSkip) {
         loggedGatewayCloudProviderSyncSkip = true;
@@ -2030,9 +2049,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             reason,
             new Error(result.message ?? "Cloud provider sync failed."),
           );
-          if (reason === "settings_cloud_opened") {
-            setStateField("providerAuthError", message);
-          }
+          publishSettingsCloudProviderSyncError(reason, message);
           return;
         }
         // The server may already be synchronized while this route still holds
@@ -2043,9 +2060,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         return { outcome: "handled_server_side" };
       } catch (error) {
         const message = logCloudProviderSyncError(reason, error);
-        if (reason === "settings_cloud_opened") {
-          setStateField("providerAuthError", message);
-        }
+        publishSettingsCloudProviderSyncError(reason, message);
         return;
       }
     }
@@ -2060,9 +2075,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       )
       .catch((error) => {
         const message = logCloudProviderSyncError(reason, error);
-        if (reason === "settings_cloud_opened") {
-          setStateField("providerAuthError", message);
-        }
+        publishSettingsCloudProviderSyncError(reason, message);
       });
 
     cloudProviderSyncTail = request;
@@ -2247,6 +2260,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             ...current,
             cloudOrgProviders: [],
             providerAuthMethods: {},
+            providerAuthError: null,
             cloudProviderServerSync: null,
             lastSyncError: {},
           }));
@@ -2276,6 +2290,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             ...current,
             cloudOrgProviders: [],
             providerAuthMethods: {},
+            providerAuthError: null,
             cloudProviderServerSync: null,
             lastSyncError: {},
           }));
@@ -2339,6 +2354,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
               ...current,
               cloudOrgProviders: [],
               providerAuthMethods: {},
+              providerAuthError: null,
               importedCloudProviders: {},
               cloudProviderServerSync: null,
               lastSyncError: {},

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -36,6 +36,7 @@ import {
 } from "../../../../app/utils/providers";
 import { getReactQueryClient } from "../../../infra/query-client";
 import {
+  clearProviderListQueries,
   ensureProviderListQuery,
   getConnectedProviderItems,
 } from "../../../infra/provider-list-query";
@@ -2254,6 +2255,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           // Account-scoped catalog state must disappear synchronously. Config
           // and credential cleanup continues below without leaving stale
           // models visible while those best-effort operations finish.
+          clearProviderListQueries(getReactQueryClient());
           mutateState((current) => ({
             ...current,
             cloudOrgProviders: [],

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -285,6 +285,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   let cloudOrgProvidersLoadKey = "";
   let cloudOrgProvidersInFlightKey = "";
   let cloudOrgProvidersInFlight: Promise<DenOrgLlmProvider[]> | null = null;
+  let cloudOrgProvidersGeneration = 0;
   let cloudProviderSyncTail: Promise<void> = Promise.resolve();
   let cloudProviderSyncContextKey = "";
   let lastDenSessionPushKey = "";
@@ -1017,6 +1018,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     if (!token || !orgId) {
+      cloudOrgProvidersGeneration += 1;
       setStateField("cloudOrgProviders", []);
       cloudOrgProvidersLoadKey = loadKey;
       return [];
@@ -1026,20 +1028,35 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       baseUrl: settings.baseUrl,
       token,
     });
+    const generation = ++cloudOrgProvidersGeneration;
     const request = client
       .listOrgLlmProviders(orgId)
       .then((providers) => {
+        if (
+          generation !== cloudOrgProvidersGeneration ||
+          getCloudOrgProvidersKey() !== loadKey
+        ) {
+          return state.cloudOrgProviders;
+        }
         setStateField("cloudOrgProviders", providers);
         cloudOrgProvidersLoadKey = loadKey;
         return providers;
       })
       .catch((error) => {
-        setStateField("cloudOrgProviders", []);
-        cloudOrgProvidersLoadKey = "";
+        if (
+          generation === cloudOrgProvidersGeneration &&
+          getCloudOrgProvidersKey() === loadKey
+        ) {
+          setStateField("cloudOrgProviders", []);
+          cloudOrgProvidersLoadKey = "";
+        }
         throw error;
       })
       .finally(() => {
-        if (cloudOrgProvidersInFlightKey === loadKey) {
+        if (
+          generation === cloudOrgProvidersGeneration &&
+          cloudOrgProvidersInFlightKey === loadKey
+        ) {
           cloudOrgProvidersInFlight = null;
           cloudOrgProvidersInFlightKey = "";
         }
@@ -2217,6 +2234,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     lastWorkspaceKey = currentWorkspaceKey();
     if (typeof window !== "undefined") {
       const handleDenSessionUpdate = (event: Event) => {
+        cloudOrgProvidersGeneration += 1;
         cloudOrgProvidersLoadKey = "";
         cloudOrgProvidersInFlightKey = "";
         cloudOrgProvidersInFlight = null;
@@ -2233,6 +2251,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
           void pushDenSession().then(() => runCloudProviderSync("sign_in"));
         } else {
+          // Account-scoped catalog state must disappear synchronously. Config
+          // and credential cleanup continues below without leaving stale
+          // models visible while those best-effort operations finish.
+          mutateState((current) => ({
+            ...current,
+            cloudOrgProviders: [],
+            providerAuthMethods: {},
+            cloudProviderServerSync: null,
+            lastSyncError: {},
+          }));
           if (serverHandlesProviderSync()) {
             lastDenSessionPushKey = "";
             void options.openworkServer.getSnapshot().openworkServerClient?.deleteDenSession().catch(() => undefined);

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -2281,7 +2281,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           }));
           if (serverHandlesProviderSync()) {
             lastDenSessionPushKey = "";
-            void options.openworkServer.getSnapshot().openworkServerClient?.deleteDenSession().catch(() => undefined);
+            void (async () => {
+              await options.openworkServer.getSnapshot().openworkServerClient?.deleteDenSession().catch(() => undefined);
+              // The server removes cloud-owned environment entries from disk,
+              // but a running OpenCode child retains its spawn environment.
+              // Explicit desktop sign-out must replace that process so an
+              // account-scoped provider cannot remain connected in the UI.
+              if (detail?.status === "signed_out" && isDesktopRuntime()) {
+                await engineRestart({}).catch(() => undefined);
+              }
+            })();
           }
           // Sign-out or error: remove all cloud-imported providers from the workspace
           // Capture the full import records BEFORE clearing state

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.test.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.test.ts
@@ -4,7 +4,7 @@ declare const expect: (value: unknown) => {
   toEqual: (expected: unknown) => void;
 };
 
-import { filterCloudManagedModelOptions } from "./use-model-picker";
+import { filterCloudManagedModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 
 describe("filterCloudManagedModelOptions", () => {
   const options = [

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.test.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.test.ts
@@ -1,0 +1,25 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toEqual: (expected: unknown) => void;
+};
+
+import { filterCloudManagedModelOptions } from "./use-model-picker";
+
+describe("filterCloudManagedModelOptions", () => {
+  const options = [
+    { providerID: "openwork", modelID: "cloud-model" },
+    { providerID: "lpr_team", modelID: "managed-model" },
+    { providerID: "anthropic", modelID: "local-model" },
+  ];
+
+  test("hides cached cloud providers after logout", () => {
+    expect(filterCloudManagedModelOptions(options, false)).toEqual([
+      { providerID: "anthropic", modelID: "local-model" },
+    ]);
+  });
+
+  test("retains cloud providers while signed in", () => {
+    expect(filterCloudManagedModelOptions(options, true)).toEqual(options);
+  });
+});

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -28,10 +28,29 @@ export type UseModelPickerInput = {
   onLoadError?: (error: unknown) => void;
   /** Member-scoped models available before a workspace OpenCode client exists. */
   fallbackOptions?: readonly ModelOption[];
+  /** Account-scoped providers are hidden immediately after cloud sign-out. */
+  cloudProvidersEnabled?: boolean;
 };
 
+export function filterCloudManagedModelOptions<T extends Pick<ModelOption, "providerID">>(
+  options: readonly T[],
+  cloudProvidersEnabled: boolean,
+) {
+  return cloudProvidersEnabled
+    ? [...options]
+    : options.filter((option) => !isCloudManagedProviderKey(option.providerID));
+}
+
 export function useModelPicker(input: UseModelPickerInput) {
-  const { client, baseUrl, workspaceRoot, onOpen, onLoadError, fallbackOptions = [] } = input;
+  const {
+    client,
+    baseUrl,
+    workspaceRoot,
+    onOpen,
+    onLoadError,
+    fallbackOptions = [],
+    cloudProvidersEnabled = true,
+  } = input;
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
   const [open, setOpenState] = useState(false);
@@ -133,8 +152,11 @@ export function useModelPicker(input: UseModelPickerInput) {
         });
       }
     }
-    return mergeModelOptions(next, fallbackOptions);
-  }, [fallbackOptions, providerListQuery.data, recentProviderIds]);
+    return filterCloudManagedModelOptions(
+      mergeModelOptions(next, fallbackOptions),
+      cloudProvidersEnabled,
+    );
+  }, [cloudProvidersEnabled, fallbackOptions, providerListQuery.data, recentProviderIds]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -8,7 +8,10 @@ import type { Client, ModelOption } from "@/app/types";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
 import { filterEntitledModelOptions } from "@/react-app/domains/connections/provider-auth/provider-policy";
-import { mergeModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
+import {
+  filterCloudManagedModelOptions,
+  mergeModelOptions,
+} from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 import {
   getConnectedProviderItems,
   useProviderListQuery,
@@ -31,15 +34,6 @@ export type UseModelPickerInput = {
   /** Account-scoped providers are hidden immediately after cloud sign-out. */
   cloudProvidersEnabled?: boolean;
 };
-
-export function filterCloudManagedModelOptions<T extends Pick<ModelOption, "providerID">>(
-  options: readonly T[],
-  cloudProvidersEnabled: boolean,
-) {
-  return cloudProvidersEnabled
-    ? [...options]
-    : options.filter((option) => !isCloudManagedProviderKey(option.providerID));
-}
 
 export function useModelPicker(input: UseModelPickerInput) {
   const {

--- a/apps/app/src/react-app/infra/provider-list-query.test.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.test.ts
@@ -1,0 +1,38 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+};
+
+import { QueryClient } from "@tanstack/react-query";
+
+import {
+  clearProviderListQueries,
+  providerListQueryKey,
+} from "./provider-list-query";
+
+describe("clearProviderListQueries", () => {
+  test("removes every workspace provider cache without touching unrelated queries", () => {
+    const queryClient = new QueryClient();
+    const firstProviderKey = providerListQueryKey({
+      baseUrl: "http://127.0.0.1:4096",
+      directory: "/workspace/one",
+    });
+    const secondProviderKey = providerListQueryKey({
+      baseUrl: "http://127.0.0.1:4097",
+      directory: "/workspace/two",
+    });
+    const unrelatedKey = ["workspaces"] as const;
+    const unrelatedValue = ["workspace"];
+
+    queryClient.setQueryData(firstProviderKey, { all: ["openwork"] });
+    queryClient.setQueryData(secondProviderKey, { all: ["lpr_team"] });
+    queryClient.setQueryData(unrelatedKey, unrelatedValue);
+
+    clearProviderListQueries(queryClient);
+
+    expect(queryClient.getQueryData(firstProviderKey)).toBe(undefined);
+    expect(queryClient.getQueryData(secondProviderKey)).toBe(undefined);
+    expect(queryClient.getQueryData(unrelatedKey)).toBe(unrelatedValue);
+  });
+});

--- a/apps/app/src/react-app/infra/provider-list-query.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.ts
@@ -40,6 +40,13 @@ export async function refreshProviderListQueries(queryClient: QueryClient) {
   await queryClient.refetchQueries({ queryKey: PROVIDER_LIST_QUERY_ROOT, type: "active" });
 }
 
+/** Drop account-sensitive provider snapshots when the Den session ends. */
+export function clearProviderListQueries(queryClient: QueryClient) {
+  queryClient.removeQueries({ queryKey: PROVIDER_LIST_QUERY_ROOT });
+  connectedProviderSnapshots.clear();
+  connectedProviderSnapshotChanges.clear();
+}
+
 export async function fetchProviderList(input: {
   client: Client;
   baseUrl?: string | null;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -973,6 +973,7 @@ export function SessionRoute() {
     workspaceRoot: selectedWorkspaceRoot,
     onOpen: handleModelPickerOpen,
     fallbackOptions: organizationAssignedModelOptions,
+    cloudProvidersEnabled: denAuth.isSignedIn,
   });
   // Which session the open model picker targets. Selecting a model while a
   // session is targeted remembers it for that conversation only; null means
@@ -1111,18 +1112,17 @@ export function SessionRoute() {
 
     const applyProviderState = (value: ProviderListResponse) => {
       if (cancelled) return;
-      // When not signed in, filter out cloud-managed providers (lpr_*)
-      // so stale entries from a previous session don't appear.
+      // When not signed in, filter out every cloud-managed provider key so
+      // stale org imports and the hosted `openwork` catalog do not reappear.
       const hasCloudAuth = !!readDenSettings().authToken?.trim();
-      const isCloudProvider = (id: string) => /^lpr_/i.test(id);
       const all = hasCloudAuth
         ? ((value.all ?? []) as ProviderListItem[])
         : ((value.all ?? []) as ProviderListItem[]).filter(
-            (p) => !isCloudProvider(p.id ?? ""),
+            (provider) => !isCloudManagedProviderKey(provider.id ?? ""),
           );
       const connected = hasCloudAuth
         ? (value.connected ?? [])
-        : (value.connected ?? []).filter((id) => !isCloudProvider(id));
+        : (value.connected ?? []).filter((id) => !isCloudManagedProviderKey(id));
       setProviders(all);
       setProviderConnectedIds(connected);
       // New-provider detection is handled globally by the provider auth

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -129,6 +129,7 @@ import {
   type ModelEntitlementOption,
 } from "@/react-app/domains/connections/provider-auth/provider-policy";
 import {
+  isManagedModelAvailabilityPending,
   isOrganizationModelsEmpty,
   shouldAutoOpenUnavailableModelPicker,
 } from "@/react-app/domains/connections/provider-auth/managed-models-recovery";
@@ -1017,10 +1018,17 @@ export function SessionRoute() {
   useEffect(() => {
     if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel);
   }, [entitledOrgDefaultModel]);
+  const selectedModelAvailabilityPending = isManagedModelAvailabilityPending({
+    signedIn: denAuth.isSignedIn,
+    selectedModelUsesCloudProvider,
+    cloudProviderSyncReady,
+    openWorkModelsSyncing,
+  });
   const selectedModelUnavailable = Boolean(
     selectedWorkspaceId &&
       opencodeClient &&
       !loading &&
+      !selectedModelAvailabilityPending &&
       local.prefs.defaultModel &&
       (!selectedModelUsesCloudProvider || cloudProviderSyncReady) &&
       (
@@ -1071,9 +1079,18 @@ export function SessionRoute() {
     modelPicker.setOpen(true);
   }, [cloudProviderSyncReady, denAuth.isSignedIn, entitledOrgDefaultModel, modelPicker.setCompactOpen, modelPicker.setOpen, modelPicker.setQuery, modelPicker.setRecentProviderIds, organizationModelsEmpty, selectedModelUnavailableKey]);
 
-  const hasUsableModel = Boolean(local.prefs.defaultModel && !selectedModelUnavailable);
+  const hasUsableModel = Boolean(
+    local.prefs.defaultModel &&
+      !selectedModelUnavailable &&
+      !selectedModelAvailabilityPending,
+  );
   const canCreateTask = Boolean(
-    opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
+    opencodeClient &&
+      selectedWorkspaceId &&
+      !loading &&
+      !selectedWorkspaceError &&
+      !selectedModelUnavailable &&
+      !selectedModelAvailabilityPending,
   );
 
   const {
@@ -1098,6 +1115,7 @@ export function SessionRoute() {
   const showPreparingStatus =
     !organizationModelsEmpty &&
     (effectiveLoading ||
+      selectedModelAvailabilityPending ||
       (!canCreateTask && !routeError && !selectedWorkspaceError));
 
   useEffect(() => {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1016,6 +1016,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     workspaceRoot: selectedWorkspaceRoot,
     onOpen: handleModelPickerOpen,
     onLoadError: handleModelPickerLoadError,
+    cloudProvidersEnabled: cloudSession.isSignedIn,
   });
   const currentCloudMcpModel = useMemo<OpenworkCloudMcpProviderModelContext | null>(() => {
     const provider = local.prefs.defaultModel?.providerID.trim() ?? "";

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -185,6 +185,7 @@ function installProviderSyncFetch(
     statusProviders?: Array<Record<string, unknown>>;
     statusReloadPending?: boolean;
     statusSkipped?: Array<Record<string, unknown>>;
+    onRun?: () => void;
   } = {},
 ) {
   let runIndex = 0;
@@ -212,6 +213,7 @@ function installProviderSyncFetch(
         return new Response(null, { status: 204 });
       }
       if (url.origin === "https://server.example" && url.pathname === "/cloud-provider-sync/run" && method === "POST") {
+        options.onRun?.();
         const statuses = options.runStatuses ?? [{ status: "noop" }];
         const result = statuses[Math.min(runIndex, statuses.length - 1)];
         runIndex += 1;
@@ -411,6 +413,31 @@ describe("cloud provider sync in server-capability mode", () => {
 
     expect(await store.runCloudProviderSync("settings_cloud_opened")).toBeUndefined();
     expect(store.getSnapshot().providerAuthError).toContain("Provider import failed");
+  });
+
+  test("does not show a sync failure when logout removes the session in flight", async () => {
+    const storage = installWindow({ origin: "https://self-hosted.example" });
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, {
+      runStatuses: [{ status: "failed", message: "Cloud provider sync failed." }],
+      onRun: () => storage.clear(),
+    });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toBeUndefined();
+    expect(store.getSnapshot().providerAuthError).toBeNull();
+  });
+
+  test("does not start settings sync while signed out", async () => {
+    installWindow({ origin: "https://self-hosted.example" });
+    const requests: RecordedRequest[] = [];
+    installProviderSyncFetch(requests, { runStatuses: [{ status: "no_session" }] });
+    const { store } = createProviderAuthTestStore({ read: true, write: true, providerSync: true });
+
+    expect(await store.runCloudProviderSync("settings_cloud_opened")).toBeUndefined();
+    expect(requests).toEqual([]);
+    expect(store.getSnapshot().providerAuthError).toBeNull();
   });
 
   test("pushes the resolved Den API session and retries once when missing", async () => {

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -229,6 +229,7 @@ function makeEndpoint(options: { origin: string; isRemote: boolean }): ResolvedW
 function createSessionRouteStore(options: {
   endpoint: ResolvedWorkspaceEndpoint | null;
   hostToken: string;
+  connectedProviderIds?: string[];
 }) {
   const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test", {
     token: "engine-token",
@@ -243,7 +244,7 @@ function createSessionRouteStore(options: {
   } satisfies WorkspaceDisplay;
   let providers: ProviderListItem[] = [];
   let providerDefaults: Record<string, string> = {};
-  let providerConnectedIds: string[] = [];
+  let providerConnectedIds: string[] = options.connectedProviderIds ?? [];
   let disabledProviders: string[] = [];
 
   return createProviderAuthStore({
@@ -352,6 +353,36 @@ describe("session-route cloud provider sync wiring", () => {
 
     expect(store.getSnapshot().cloudOrgProviders).toEqual([]);
     expect(store.getSnapshot().importedCloudProviders).toEqual({});
+    store.dispose();
+  });
+
+  test("logout removes connected provider credentials and resets their saved default", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    storage.setItem("openwork.defaultModel", "anthropic/claude-fable-5");
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests);
+    const store = createSessionRouteStore({
+      endpoint: null,
+      hostToken: "",
+      connectedProviderIds: ["opencode", "anthropic"],
+    });
+
+    store.start();
+    clearDenSession();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (requests.some((request) =>
+        request.method === "DELETE" && new URL(request.url).pathname === "/auth/anthropic"
+      )) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(
+      requests.filter((request) =>
+        request.method === "DELETE" && new URL(request.url).pathname === "/auth/anthropic"
+      ),
+    ).toHaveLength(1);
+    expect(storage.getItem("openwork.defaultModel")).not.toBe("anthropic/claude-fable-5");
     store.dispose();
   });
 

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -147,7 +147,10 @@ function cloudProviderPayload() {
 
 function installFetchMock(
   requests: RecordedRequest[],
-  options: { runStatuses?: Array<{ status: "applied" | "noop" | "failed" | "no_session"; message?: string }> } = {},
+  options: {
+    runStatuses?: Array<{ status: "applied" | "noop" | "failed" | "no_session"; message?: string }>;
+    providerResponse?: Promise<Response>;
+  } = {},
 ) {
   let runIndex = 0;
   Object.defineProperty(globalThis, "fetch", {
@@ -163,7 +166,7 @@ function installFetchMock(
       });
 
       if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers") {
-        return jsonResponse({ llmProviders: [cloudProviderPayload()] });
+        return options.providerResponse ?? jsonResponse({ llmProviders: [cloudProviderPayload()] });
       }
       if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers/lpr_test/connect") {
         return jsonResponse({ llmProvider: cloudProviderPayload() });
@@ -346,6 +349,38 @@ describe("session-route cloud provider sync wiring", () => {
     store.start();
     await assignedModelsLoaded;
     clearDenSession();
+
+    expect(store.getSnapshot().cloudOrgProviders).toEqual([]);
+    expect(store.getSnapshot().importedCloudProviders).toEqual({});
+    store.dispose();
+  });
+
+  test("an organization provider request started before logout cannot restore stale models", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    let resolveProviderResponse: (response: Response) => void = () => undefined;
+    const providerResponse = new Promise<Response>((resolve) => {
+      resolveProviderResponse = resolve;
+    });
+    installFetchMock(requests, { providerResponse });
+    const store = createSessionRouteStore({
+      endpoint: null,
+      hostToken: "",
+    });
+
+    store.start();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers")) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(
+      requests.filter((request) => request.url === "https://den.example/api/den/v1/llm-providers"),
+    ).toHaveLength(1);
+    clearDenSession();
+    resolveProviderResponse(jsonResponse({ llmProviders: [cloudProviderPayload()] }));
+    await providerResponse;
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(store.getSnapshot().cloudOrgProviders).toEqual([]);
     expect(store.getSnapshot().importedCloudProviders).toEqual({});

--- a/apps/desktop/electron/runtime-user-env.test.mjs
+++ b/apps/desktop/electron/runtime-user-env.test.mjs
@@ -1,7 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { reconcileInjectedUserEnv } from "./runtime.mjs";
+import path from "node:path";
+
+import { reconcileInjectedUserEnv, resolveUserEnvFilePath } from "./runtime.mjs";
+
+test("resolves the user env store from the effective desktop profile", () => {
+  assert.equal(
+    resolveUserEnvFilePath({
+      HOME: "/Users/example",
+      XDG_CONFIG_HOME: "/tmp/openwork-dev-profile/config",
+    }),
+    path.join("/tmp/openwork-dev-profile/config", "openwork", "env.json"),
+  );
+});
 
 test("removes a user env key from the long-lived desktop process after deletion", () => {
   const inheritedEnv = { PATH: "/usr/bin" };

--- a/apps/desktop/electron/runtime-user-env.test.mjs
+++ b/apps/desktop/electron/runtime-user-env.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { reconcileInjectedUserEnv } from "./runtime.mjs";
+
+test("removes a user env key from the long-lived desktop process after deletion", () => {
+  const inheritedEnv = { PATH: "/usr/bin" };
+  const processEnv = {
+    ...inheritedEnv,
+    ANTHROPIC_API_KEY: "previously-injected",
+  };
+
+  const nextKeys = reconcileInjectedUserEnv({
+    processEnv,
+    inheritedEnv,
+    userEnv: {},
+    previouslyInjectedKeys: new Set(["ANTHROPIC_API_KEY"]),
+  });
+
+  assert.equal(processEnv.ANTHROPIC_API_KEY, undefined);
+  assert.deepEqual([...nextKeys], []);
+});
+
+test("restores an inherited value when a user env override is removed", () => {
+  const inheritedEnv = {
+    PATH: "/usr/bin",
+    ANTHROPIC_API_KEY: "inherited",
+  };
+  const processEnv = {
+    ...inheritedEnv,
+    ANTHROPIC_API_KEY: "user-store-value",
+  };
+
+  reconcileInjectedUserEnv({
+    processEnv,
+    inheritedEnv,
+    userEnv: {},
+    previouslyInjectedKeys: new Set(["ANTHROPIC_API_KEY"]),
+  });
+
+  assert.equal(processEnv.ANTHROPIC_API_KEY, "inherited");
+});
+
+test("refreshes an injected user env key when its stored value changes", () => {
+  const inheritedEnv = { PATH: "/usr/bin" };
+  const processEnv = {
+    ...inheritedEnv,
+    ANTHROPIC_API_KEY: "old-value",
+  };
+
+  reconcileInjectedUserEnv({
+    processEnv,
+    inheritedEnv,
+    userEnv: { ANTHROPIC_API_KEY: "new-value" },
+    previouslyInjectedKeys: new Set(["ANTHROPIC_API_KEY"]),
+  });
+
+  assert.equal(processEnv.ANTHROPIC_API_KEY, "new-value");
+});

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -488,8 +488,8 @@ async function fetchJson(url, options = {}, timeoutMs = 3000) {
   }
 }
 
-function resolveUserEnvFilePath() {
-  return openworkEnvStorePath();
+export function resolveUserEnvFilePath(env = process.env) {
+  return openworkEnvStorePath({ env });
 }
 
 const USER_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -497,9 +497,9 @@ const USER_ENV_RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"];
 
 // Synchronous, best-effort; absent or malformed returns {}. Reserved prefixes
 // are stripped so a tampered file can never shadow OPENWORK_* / OPENCODE_*.
-function loadUserEnvFile() {
+function loadUserEnvFile(env = process.env) {
   try {
-    const raw = readFileSync(resolveUserEnvFilePath(), "utf8");
+    const raw = readFileSync(resolveUserEnvFilePath(env), "utf8");
     const parsed = JSON.parse(raw);
     if (!parsed || !Array.isArray(parsed.variables)) return {};
     const out = {};
@@ -1307,7 +1307,18 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // User env is layered first so process.env + any caller overrides always
     // win. See apps/server/src/env-file.ts — all loaders must agree on path +
     // reserved-keys policy.
-    const userEnv = loadUserEnvFile();
+    const devPaths = process.env.OPENWORK_DEV_MODE === "1"
+      ? await ensureDevModePaths()
+      : null;
+    const userEnvPathEnv = devPaths
+      ? {
+          ...process.env,
+          HOME: devPaths.homeDir,
+          USERPROFILE: devPaths.homeDir,
+          XDG_CONFIG_HOME: devPaths.xdgConfigHome,
+        }
+      : process.env;
+    const userEnv = loadUserEnvFile(userEnvPathEnv);
     injectedUserEnvKeys = reconcileInjectedUserEnv({
       processEnv: process.env,
       inheritedEnv: inheritedProcessEnv,
@@ -1332,8 +1343,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     if (pathEnv) {
       env[pathKey] = pathEnv;
     }
-    if (process.env.OPENWORK_DEV_MODE === "1") {
-      const devPaths = await ensureDevModePaths();
+    if (devPaths) {
       env.OPENWORK_DEV_MODE = "1";
       env.HOME = devPaths.homeDir;
       env.USERPROFILE = devPaths.homeDir;

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -83,6 +83,33 @@ export function resolveEvalLocalServerDelayMs(env = process.env) {
   return Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
 }
 
+export function reconcileInjectedUserEnv({
+  processEnv,
+  inheritedEnv,
+  userEnv,
+  previouslyInjectedKeys = new Set(),
+}) {
+  for (const key of previouslyInjectedKeys) {
+    if (Object.prototype.hasOwnProperty.call(userEnv, key)) continue;
+    if (Object.prototype.hasOwnProperty.call(inheritedEnv, key)) {
+      processEnv[key] = inheritedEnv[key];
+    } else {
+      delete processEnv[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(userEnv)) {
+    if (Object.prototype.hasOwnProperty.call(inheritedEnv, key)) continue;
+    processEnv[key] = value;
+  }
+
+  return new Set(
+    Object.keys(userEnv).filter(
+      (key) => !Object.prototype.hasOwnProperty.call(inheritedEnv, key),
+    ),
+  );
+}
+
 export function commandMatchesPackagedSidecar(command, sidecarDirs = []) {
   const value = String(command ?? "");
   if (!sidecarDirs.some((dir) => String(dir ?? "").trim() && value.includes(dir))) {
@@ -1099,6 +1126,8 @@ export function mergeSystemCaChildEnv(baseEnv = {}, caEnv = {}, extra = {}) {
 }
 
 export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths, localManagedMcpVaultKey }) {
+  const inheritedProcessEnv = { ...process.env };
+  let injectedUserEnvKeys = new Set();
   const engineState = createEngineState();
   const openworkServerState = createOpenworkServerState();
 
@@ -1278,8 +1307,15 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // User env is layered first so process.env + any caller overrides always
     // win. See apps/server/src/env-file.ts — all loaders must agree on path +
     // reserved-keys policy.
+    const userEnv = loadUserEnvFile();
+    injectedUserEnvKeys = reconcileInjectedUserEnv({
+      processEnv: process.env,
+      inheritedEnv: inheritedProcessEnv,
+      userEnv,
+      previouslyInjectedKeys: injectedUserEnvKeys,
+    });
     const baseEnv = {
-      ...loadUserEnvFile(),
+      ...userEnv,
       ...process.env,
       BUN_CONFIG_DNS_RESULT_ORDER: "verbatim",
     };


### PR DESCRIPTION
## Summary

- clear the account-scoped provider catalog and runtime provider-query cache synchronously on logout
- remove stored credentials for connected non-starter providers and clear their live state
- remove cloud-synced provider environment keys from the long-lived desktop process and replace the managed OpenCode process on explicit sign-out
- prevent provider requests started before logout from restoring stale models afterward
- hide cached `openwork` and `lpr_*` options from both compact and full model pickers while signed out
- reset a saved default model when logout removes its provider
- treat cloud-model synchronization and pending workspace reload as loading instead of reporting the selected model unavailable
- suppress logout-cancelled provider synchronization failures and clear stale Settings errors

## Root cause

Provider information had four independent lifetimes: workspace config and credentials, organization assignment state, a five-minute React Query runtime provider cache, and the environment inherited by the managed OpenCode child. The shared logout event added in #3720 did not clear every one of those layers. In particular, the server correctly deleted a cloud-synced `ANTHROPIC_API_KEY` from its environment store, but Electron had already copied the value into its long-lived `process.env`; an engine reload therefore inherited the deleted key and reported Anthropic as connected again.

This change removes credentials and live state for every connected provider except the built-in free starter, clears every provider-list query and its change snapshots at the logout boundary, rejects stale organization-provider responses, and applies a signed-out cloud-provider filter in both picker implementations. Explicit desktop sign-out now waits for server-side cloud cleanup, reconciles the app-managed environment with the current store, and replaces the managed engine so removed keys cannot survive in the child process. Independently inherited operator environment variables remain untouched.

Desktop dev profiles now also resolve their provider environment store from the effective isolated `HOME`/`XDG_CONFIG_HOME` before spawning OpenCode. Previously the desktop read the real home-level OpenWork environment first, while logout and nuke cleaned the isolated dev profile; that split allowed a home-level Anthropic key to reconnect Fable after a full profile reset.

## User impact

Once logout completes, account-scoped models and cloud-synced API-key providers disappear from the model pickers and Connected provider section. They cannot return from an old request, cached runtime result, or stale process environment. The built-in free starter remains available. Temporary provider reconciliation shows a loading state, and signed-out Settings returns to its connection state without a false sync-failure banner.

## Verification

- `bun test --isolate tests/session-provider-auth-server-sync.test.ts src/react-app/domains/session/modals/use-model-picker.test.ts src/react-app/infra/provider-list-query.test.ts` (10 passing)
- `node --test apps/desktop/electron/runtime-user-env.test.mjs` (3 passing)
- `node --test apps/desktop/electron/runtime-ca.test.mjs` (14 passing)
- `pnpm --filter @openwork/app typecheck`
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/windows-artifact-signing.test.ts` (2 passing)
- `bun test --isolate src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts tests/cloud-provider-sync-gateway.test.ts` (20 passing)
- `git diff --check`
- local Electron desktop rebuilt and launched from this branch

Base: `f81e4ce008d758488ff97fad33f7ae6f29859bce`

Candidate: `96039ea74a16c68adf7e7408ba6527abbc3d8290`