### PR TITLE
fix(app): keep desktop session and route state through local server restarts

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -443,14 +443,36 @@ export class DenApiError extends Error {
 }
 
 /**
- * True only for 401s that actually came from the Den API (its JSON error
- * envelope parsed into a code). A bare/foreign 401 from a corporate proxy,
- * captive portal, or LB while the control plane is unreachable must be
- * treated as "unavailable", not as a revoked session — otherwise a VPN blip
- * signs the user out and destroys the stored token.
+ * Codes the Den API uses when the session itself is invalid, expired, or
+ * revoked. Only these may destroy the stored token; every other 401 code is
+ * treated as the control plane being temporarily unreachable.
+ */
+const DEN_SESSION_TERMINATION_CODES = new Set([
+  "unauthorized",
+  "invalid_session",
+  "session_expired",
+  "session_revoked",
+  "session_not_found",
+  "invalid_token",
+  "token_expired",
+  "token_revoked",
+]);
+
+/**
+ * True only for 401s whose Den error code explicitly names an invalid,
+ * expired, or revoked session. A bare/foreign 401 from a corporate proxy or
+ * captive portal — and structured 401s minted by deployment infrastructure in
+ * front of the control plane (`base_url_not_present`, misrouted proxies,
+ * platform placeholders) — must be treated as "unavailable", not as a revoked
+ * session. Otherwise a VPN blip or a mid-deploy edge response signs the user
+ * out and destroys the stored token.
  */
 export function isDenSessionRevokedError(error: unknown): boolean {
-  return error instanceof DenApiError && error.status === 401 && error.code !== "request_failed";
+  return (
+    error instanceof DenApiError &&
+    error.status === 401 &&
+    DEN_SESSION_TERMINATION_CODES.has(error.code)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -88,6 +88,21 @@ export function hasRetainedDenSession(status: DenAuthStatus): boolean {
   return status === "signed_in" || status === "unavailable";
 }
 
+/**
+ * True while a retained session has not produced a confirmed user yet: the
+ * initial check is still running, or it failed with a transient error
+ * ("unavailable") before the first success — e.g. the control plane or a
+ * local proxy is unreachable during an app update or server restart. Account
+ * UI must show a restoring state in this window, never "Sign in".
+ */
+export function isDenSessionRestoring(input: {
+  status: DenAuthStatus;
+  hasUser: boolean;
+}): boolean {
+  if (input.status === "checking") return true;
+  return hasRetainedDenSession(input.status) && !input.hasUser;
+}
+
 export function shouldRetryDenAuthOnSignal(input: {
   status: DenAuthStatus;
   online: boolean;

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -22,7 +22,7 @@ import {
 import { cn } from "@/lib/utils";
 import { t } from "@/i18n";
 import { usePlatform } from "../../../kernel/platform";
-import { useDenAuth } from "../../cloud/den-auth-provider";
+import { isDenSessionRestoring, useDenAuth } from "../../cloud/den-auth-provider";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useShellConfig } from "../../../shell/shell-config";
 import type { OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -257,8 +257,14 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
 
   const user = denAuth.user;
   const signedIn = denAuth.isSignedIn && user !== null;
-  // A retained session still restores in the background; never flash "Sign in".
-  const restoringSession = denAuth.status === "checking";
+  // A retained session still restores in the background; never flash "Sign
+  // in". This covers both the initial check and a retained session whose
+  // first check failed transiently (local server restart, control-plane
+  // blip) and is being retried.
+  const restoringSession = isDenSessionRestoring({
+    status: denAuth.status,
+    hasUser: user !== null,
+  });
   const accountLabel = signedIn
     ? user.name?.trim() || user.email
     : restoringSession ? "OpenWork Cloud" : "Sign in";

--- a/apps/app/src/react-app/shell/desktop-local-openwork.ts
+++ b/apps/app/src/react-app/shell/desktop-local-openwork.ts
@@ -8,6 +8,7 @@ import {
 import { readOpenworkServerSettings, writeOpenworkServerSettings } from "../../app/lib/openwork-server";
 import { safeStringify } from "../../app/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
+import type { BootPhaseId } from "./boot-state";
 
 type LocalWorkspaceLike = {
   id: string;
@@ -29,6 +30,80 @@ function emitOpenworkSettingsChanged() {
   } catch {
     // ignore browser event dispatch failures
   }
+}
+
+/** Matches the boot sequence's definition of a usable local server: running,
+ * with a base URL and at least one token the route can authenticate with. */
+export function isReadyLocalOpenworkServerInfo(
+  info: OpenworkServerInfo | null | undefined,
+): info is OpenworkServerInfo {
+  return Boolean(
+    info?.running === true &&
+      info.baseUrl?.trim() &&
+      (info.ownerToken?.trim() || info.clientToken?.trim()),
+  );
+}
+
+export const LOCAL_OPENWORK_READINESS_MAX_ATTEMPTS = 20;
+export const LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS = 500;
+
+/**
+ * Poll the local server bridge until it reports a ready server. A restart
+ * (app update, remote-access toggle, slow cold start) briefly answers with
+ * `running: false` or without a base URL/tokens; that window is a readiness
+ * gap, not a failure. Bounded: returns the last observed info (ready or not)
+ * after `maxAttempts` polls so callers decide how to report exhaustion.
+ */
+export async function waitForReadyLocalOpenworkServerInfo(options?: {
+  fetchInfo?: () => Promise<OpenworkServerInfo | null>;
+  maxAttempts?: number;
+  wait?: (delayMs: number) => Promise<void>;
+}): Promise<OpenworkServerInfo | null> {
+  const fetchInfo =
+    options?.fetchInfo ?? (() => openworkServerInfo() as Promise<OpenworkServerInfo | null>);
+  const maxAttempts = Math.max(1, options?.maxAttempts ?? LOCAL_OPENWORK_READINESS_MAX_ATTEMPTS);
+  const wait =
+    options?.wait ??
+    ((delayMs: number) => new Promise<void>((resolve) => window.setTimeout(resolve, delayMs)));
+
+  let lastInfo: OpenworkServerInfo | null = null;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (attempt > 0) await wait(LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS);
+    lastInfo = await fetchInfo().catch(() => null);
+    if (isReadyLocalOpenworkServerInfo(lastInfo)) return lastInfo;
+  }
+  return lastInfo;
+}
+
+export type DesktopLocalReconnectInput = {
+  desktopRuntime: boolean;
+  bootPhase: BootPhaseId;
+  bootRouteReady: boolean;
+  routeLoading: boolean;
+  hasClient: boolean;
+  connectionPending: boolean;
+  workspaceType: string | null | undefined;
+};
+
+/**
+ * Gate for the session route's local reconnect effect. Reconnect must not
+ * start while desktop runtime bootstrap is still in flight — the boot
+ * sequence owns starting the server, and probing `openworkServerInfo`
+ * mid-bootstrap is what surfaced "did not report a base URL" errors during
+ * app updates. It runs only once boot completed (`ready`), definitively
+ * failed (`error`), or is idle after the route already became interactive
+ * (dev HMR remounts the boot provider without re-running boot).
+ */
+export function shouldAttemptDesktopLocalReconnect(input: DesktopLocalReconnectInput): boolean {
+  if (!input.desktopRuntime) return false;
+  const bootSettled =
+    input.bootPhase === "ready" ||
+    input.bootPhase === "error" ||
+    (input.bootPhase === "idle" && input.bootRouteReady);
+  if (!bootSettled) return false;
+  if (input.routeLoading) return false;
+  if (input.hasClient && !input.connectionPending) return false;
+  return input.workspaceType === "local";
 }
 
 function describeError(error: unknown) {
@@ -74,9 +149,12 @@ export async function ensureDesktopLocalOpenworkConnection(
       });
     }
 
-    const info = await openworkServerInfo() as OpenworkServerInfo | null;
-    if (!info?.baseUrl) {
-      throw new Error("OpenWork server did not report a base URL after activation.");
+    // The server publishes its base URL and tokens asynchronously after a
+    // (re)start, so gate on observed readiness with bounded retries instead
+    // of failing on the first empty answer.
+    const info = await waitForReadyLocalOpenworkServerInfo();
+    if (!isReadyLocalOpenworkServerInfo(info) || !info.baseUrl) {
+      throw new Error("OpenWork server did not become ready after activation.");
     }
 
     writeOpenworkServerSettings({

--- a/apps/app/src/react-app/shell/openwork-connection.ts
+++ b/apps/app/src/react-app/shell/openwork-connection.ts
@@ -26,6 +26,31 @@ function hasUsableConnection(url: string, token: string) {
 }
 
 /**
+ * Stored settings for a desktop-managed local server are snapshots of
+ * ephemeral state: the server mints a fresh loopback port and tokens on every
+ * (re)start. When the live desktop runtime definitively reports that the
+ * server is not ready, any stored loopback connection is from a previous
+ * server lifetime — resolving it would point the route at a dead port and
+ * make a restart look like a broken connection instead of a transient gap.
+ * Stored non-loopback URLs (remote/manual servers) stay usable as fallbacks,
+ * and a failing desktop bridge (no definitive answer) keeps today's fallback
+ * behavior.
+ */
+export function isStaleStoredDesktopConnection(input: {
+  desktopRuntime: boolean;
+  desktopServerReportedNotReady: boolean;
+  storedBaseUrl: string;
+  runtimeReportedBaseUrl: string;
+}): boolean {
+  if (!input.desktopRuntime || !input.desktopServerReportedNotReady) return false;
+  if (!input.storedBaseUrl) return false;
+  return (
+    isLoopbackOpenworkServerUrl(input.storedBaseUrl) ||
+    input.storedBaseUrl === input.runtimeReportedBaseUrl
+  );
+}
+
+/**
  * Resolve the OpenWork server connection for routes that consume the server API.
  *
  * Local desktop-hosted servers expose ephemeral loopback ports and freshly
@@ -46,6 +71,7 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
   }
 
   let staleDesktopRuntimeBaseUrl = "";
+  let desktopServerReportedNotReady = false;
 
   if (isDesktopRuntime()) {
     try {
@@ -63,6 +89,9 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
           source: "desktop-runtime",
         };
       }
+      // Definitive live answer: the local server is booting/restarting and
+      // has not republished a usable connection yet.
+      desktopServerReportedNotReady = true;
       staleDesktopRuntimeBaseUrl = normalizedBaseUrl;
     } catch {
       // Fall through to stored settings for remote/manual connections.
@@ -80,11 +109,12 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
     normalizedBaseUrl && isLoopbackOpenworkServerUrl(normalizedBaseUrl)
       ? settings.hostToken?.trim() ?? ""
       : "";
-  const storedConnectionIsStaleDesktopRuntime = Boolean(
-    isDesktopRuntime() &&
-      staleDesktopRuntimeBaseUrl &&
-      normalizedBaseUrl === staleDesktopRuntimeBaseUrl,
-  );
+  const storedConnectionIsStaleDesktopRuntime = isStaleStoredDesktopConnection({
+    desktopRuntime: isDesktopRuntime(),
+    desktopServerReportedNotReady,
+    storedBaseUrl: normalizedBaseUrl,
+    runtimeReportedBaseUrl: staleDesktopRuntimeBaseUrl,
+  });
   const source =
     !storedConnectionIsStaleDesktopRuntime && hasUsableConnection(normalizedBaseUrl, resolvedToken)
       ? "stored-settings"

--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -1,0 +1,88 @@
+// Concurrency and degraded-state policy for the session route's
+// refreshRouteState. Extracted as pure helpers so the desktop restart
+// recovery contract is unit-testable without rendering the route.
+
+export type RouteRefreshAttempt = {
+  readonly generation: number;
+  /**
+   * False once a newer refresh began. Stale attempts must stop writing
+   * route state: their remaining awaits resolve against a connection that
+   * newer attempts already replaced.
+   */
+  isCurrent(): boolean;
+  /**
+   * Release the in-flight slot if this attempt still owns it. A superseded
+   * attempt no longer owns the slot, so its completion cannot re-open the
+   * route for a duplicate refresh while the newer attempt is still running.
+   */
+  finish(): boolean;
+};
+
+export type RouteRefreshLifecycle = {
+  /**
+   * Start a refresh attempt. Returns null while another attempt is in
+   * flight unless `supersede` is set, which cancels the in-flight attempt
+   * (its `isCurrent()` turns false) instead of forcibly resetting a shared
+   * latch and letting two writers race.
+   */
+  begin(options?: { supersede?: boolean }): RouteRefreshAttempt | null;
+  isInFlight(): boolean;
+};
+
+export function createRouteRefreshLifecycle(): RouteRefreshLifecycle {
+  let latestGeneration = 0;
+  let inFlightGeneration = 0;
+
+  return {
+    begin(options) {
+      if (inFlightGeneration !== 0 && !options?.supersede) return null;
+      const generation = ++latestGeneration;
+      inFlightGeneration = generation;
+      return {
+        generation,
+        isCurrent: () => latestGeneration === generation,
+        finish: () => {
+          if (inFlightGeneration !== generation) return false;
+          inFlightGeneration = 0;
+          return true;
+        },
+      };
+    },
+    isInFlight: () => inFlightGeneration !== 0,
+  };
+}
+
+export type RouteConnectionGapPlan = {
+  /**
+   * Keep the last usable client, base URL, token, workspaces, sessions, and
+   * host info instead of clearing them.
+   */
+  retainExistingState: boolean;
+  /**
+   * Whether this refresh may report route readiness to the boot overlay.
+   * A transient desktop gap must not: the overlay stays up until a refresh
+   * that actually established a connection (or recovery definitively fails).
+   */
+  markRouteReady: boolean;
+};
+
+/**
+ * Decide what a refresh does when it resolves no usable OpenWork server
+ * URL/token.
+ *
+ * On desktop the local server owns that URL and mints fresh tokens on every
+ * (re)start, so an empty resolution during boot, an app update, or a server
+ * restart is a transient gap: boot or the local reconnect path will publish
+ * new connection info and trigger another refresh. Clearing route state here
+ * is what used to drop the active session list and flash disconnected UI
+ * mid-restart.
+ *
+ * On web there is no local process to wait for — an empty resolution is a
+ * real disconnected state and the route should reflect it immediately.
+ */
+export function planRouteConnectionGap(input: { desktopRuntime: boolean }): RouteConnectionGapPlan {
+  if (input.desktopRuntime) {
+    return { retainExistingState: true, markRouteReady: false };
+  }
+  return { retainExistingState: false, markRouteReady: true };
+}

--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -54,8 +54,11 @@ export function createRouteRefreshLifecycle(): RouteRefreshLifecycle {
 
 export type RouteConnectionGapPlan = {
   /**
-   * Keep the last usable client, base URL, token, workspaces, sessions, and
-   * host info instead of clearing them.
+   * Keep the workspaces, session lists, selection, and host info as display
+   * state instead of clearing them. The live client and endpoint resolver
+   * are quarantined either way: during a gap the previous loopback port is
+   * no longer owned by our server, so no request may carry the previous
+   * bearer token there.
    */
   retainExistingState: boolean;
   /**
@@ -73,9 +76,10 @@ export type RouteConnectionGapPlan = {
  * On desktop the local server owns that URL and mints fresh tokens on every
  * (re)start, so an empty resolution during boot, an app update, or a server
  * restart is a transient gap: boot or the local reconnect path will publish
- * new connection info and trigger another refresh. Clearing route state here
- * is what used to drop the active session list and flash disconnected UI
- * mid-restart.
+ * new connection info and trigger another refresh. Clearing the *display*
+ * state here is what used to drop the active session list and flash
+ * disconnected UI mid-restart; the *connection* is still torn down for the
+ * duration of the gap.
  *
  * On web there is no local process to wait for — an empty resolution is a
  * real disconnected state and the route should reflect it immediately.

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -559,7 +559,6 @@ export function SessionRoute() {
     setLegacySelectedWorkspaceId,
     retryingWorkspaceIds,
     setRetryingWorkspaceIds,
-    refreshInFlightRef,
     startupRetryTimerRef,
     selectedWorkspaceId,
     selectedWorkspace,
@@ -597,9 +596,8 @@ export function SessionRoute() {
       nextStatus: cloudWorkspace.viewModel.variant,
       gatewayMode: cloudWorkspace.gatewayMode && cloudWorkspace.visible,
     })) return;
-    refreshInFlightRef.current = false;
-    void refreshRouteState();
-  }, [cloudWorkspace.gatewayMode, cloudWorkspace.viewModel.variant, cloudWorkspace.visible, refreshInFlightRef, refreshRouteState]);
+    void refreshRouteState({ supersede: true });
+  }, [cloudWorkspace.gatewayMode, cloudWorkspace.viewModel.variant, cloudWorkspace.visible, refreshRouteState]);
   const cloudMcpProviderModel = useMemo(() => local.prefs.defaultModel
     ? {
         provider: local.prefs.defaultModel.providerID,
@@ -1839,8 +1837,7 @@ export function SessionRoute() {
         if (startupRetryTimerRef.current === null) {
           startupRetryTimerRef.current = window.setTimeout(() => {
             startupRetryTimerRef.current = null;
-            refreshInFlightRef.current = false;
-            void refreshRouteState();
+            void refreshRouteState({ supersede: true });
           }, 1_000);
         }
       }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -158,7 +158,10 @@ import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picke
 import type { ModelRef } from "@/app/types";
 import { workspaceSwatchColor } from "@/react-app/domains/session/sidebar/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
-import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
+import {
+  ensureDesktopLocalOpenworkConnection,
+  shouldAttemptDesktopLocalReconnect,
+} from "./desktop-local-openwork";
 import { reloadEngineWithDesktopFallback } from "./engine-reload-escalation";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
@@ -1282,7 +1285,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     writeStoredBoolean(SETTINGS_UPDATE_AUTO_DOWNLOAD_KEY, updateAutoDownload);
   }, [updateAutoDownload]);
 
-  const { markRouteReady: markBootRouteReady } = useBootState();
+  const {
+    markRouteReady: markBootRouteReady,
+    phase: bootPhase,
+    routeReady: bootRouteReady,
+  } = useBootState();
   const refreshRouteState = useMemo(() => async () => {
     if (refreshInFlightRef.current) return;
     refreshInFlightRef.current = true;
@@ -1606,13 +1613,25 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   );
 
   useEffect(() => {
-    if (!isDesktopRuntime()) return;
-    if (loading) return;
     if (openworkClient) {
       reconnectAttemptedWorkspaceIdRef.current = "";
+    }
+    // Same gate as the session route: reconnect must not probe the local
+    // server while desktop runtime bootstrap is still starting it.
+    if (
+      !shouldAttemptDesktopLocalReconnect({
+        desktopRuntime: isDesktopRuntime(),
+        bootPhase,
+        bootRouteReady,
+        routeLoading: loading,
+        hasClient: Boolean(openworkClient),
+        connectionPending: false,
+        workspaceType: selectedWorkspace?.workspaceType ?? null,
+      })
+    ) {
       return;
     }
-    if (!selectedWorkspace || selectedWorkspace.workspaceType !== "local") return;
+    if (!selectedWorkspace) return;
     const workspaceId = selectedWorkspace.id?.trim() ?? "";
     if (!workspaceId || reconnectAttemptedWorkspaceIdRef.current === workspaceId) return;
     reconnectAttemptedWorkspaceIdRef.current = workspaceId;
@@ -1631,7 +1650,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         dedupeKey: "server-reconnect",
       });
     });
-  }, [loading, openworkClient, selectedWorkspace, workspaces]);
+  }, [bootPhase, bootRouteReady, loading, openworkClient, selectedWorkspace, workspaces]);
 
   useEffect(() => {
     void refreshRouteState();

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -442,12 +442,19 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         if (gapPlan.retainExistingState) {
           // Transient desktop gap: the local server is booting or restarting
           // (app update, remote-access toggle, slow cold start) and has not
-          // republished its ephemeral base URL/tokens yet. Keep the last
-          // usable client, connection, sessions, and host info; boot or the
-          // reconnect effect publishes fresh info and supersedes this
-          // refresh. Only seed workspaces when the route has none so a fresh
-          // renderer still shows the sidebar under the boot overlay.
+          // republished its ephemeral base URL/tokens yet. Retain the
+          // workspaces, session lists, and host info as display state, but
+          // quarantine the live connection: the previous loopback port is no
+          // longer owned by our server, and a request there would hand the
+          // stale bearer token to whatever process binds the freed port.
+          // Boot or the reconnect effect publishes fresh info and supersedes
+          // this refresh. Only seed workspaces when the route has none so a
+          // fresh renderer still shows the sidebar under the boot overlay.
           setConnectionPending(true);
+          updateLocalServer({ baseUrl: "", token: "" });
+          setClient(null);
+          setBaseUrl("");
+          setToken("");
           if (workspacesRef.current.length === 0 && desktopWorkspaces.length > 0) {
             const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
             setWorkspaces(orderedDesktopWorkspaces);

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -40,8 +40,12 @@ import {
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { useBootState } from "./boot-state";
-import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
+import {
+  ensureDesktopLocalOpenworkConnection,
+  shouldAttemptDesktopLocalReconnect,
+} from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
+import { createRouteRefreshLifecycle, planRouteConnectionGap } from "./route-refresh-control";
 import {
   classifyRouteSessionReadError,
   describeRouteError,
@@ -143,7 +147,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     navigateToWorkspaceSession(workspaceId, sessionId, options);
   }, [extensionsRouteActive, extensionsRoutePath, location.pathname, navigate, navigateToWorkspaceSession, workspaceRoute]);
 
-  const { markRouteReady: markBootRouteReady } = useBootState();
+  const {
+    markRouteReady: markBootRouteReady,
+    phase: bootPhase,
+    routeReady: bootRouteReady,
+  } = useBootState();
   const [loading, setLoading] = useState(true);
   const [client, setClient] = useState<OpenworkServerClient | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
@@ -154,6 +162,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [routeError, setRouteError] = useState<string | null>(null);
+  // True while the desktop local server has not (re)published a usable base
+  // URL/token — a restart or boot gap. The route retains its last usable
+  // connection state during this window instead of clearing it.
+  const [connectionPending, setConnectionPending] = useState(false);
   const [modernRouteSessionResolution, setModernRouteSessionResolution] = useState<ModernRouteSessionResolution | null>(null);
   const [routeRefreshVersion, setRouteRefreshVersion] = useState(0);
   const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState<string>(() => readActiveWorkspaceId() ?? "");
@@ -187,7 +199,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       workspaceServerClientResolverRef.current(workspace),
     [],
   );
-  const refreshInFlightRef = useRef(false);
+  const refreshLifecycleRef = useRef(createRouteRefreshLifecycle());
   const workspacesRef = useRef<RouteWorkspace[]>([]);
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
@@ -386,13 +398,16 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     [endpointForWorkspace, mergeFetchedSessionsWithPending],
   );
 
-  const refreshRouteState = useCallback(async () => {
+  const refreshRouteState = useCallback(async (options?: { supersede?: boolean }) => {
     // Dedupe: if a refresh is already running, skip this call. Fast workspace
     // switches used to fire 5-6 overlapping refreshRouteState() calls which
     // each fetched workspaces + sessions for every workspace. That workload
     // multiplied quickly on the event loop and caused the UI to freeze.
-    if (refreshInFlightRef.current) return;
-    refreshInFlightRef.current = true;
+    // Callers reacting to changed connection info pass `supersede` instead of
+    // resetting the in-flight guard: the running attempt goes stale (its
+    // remaining writes are discarded) rather than racing the new one.
+    const attempt = refreshLifecycleRef.current.begin(options);
+    if (!attempt) return;
     setLoading(true);
     setRouteError(null);
     let desktopList: WorkspaceList | null = null;
@@ -414,13 +429,35 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           desktopWorkspaces = workspacesRef.current;
         }
       }
+      if (!attempt.isCurrent()) return;
 
       const { normalizedBaseUrl, resolvedToken, resolvedHostToken, hostInfo } = await withRouteRefreshTimeout(
         resolveOpenworkConnection(),
         "OpenWork server connection",
       );
-      onHostInfo(hostInfo);
+      if (!attempt.isCurrent()) return;
       if (!normalizedBaseUrl || !resolvedToken) {
+        const gapPlan = planRouteConnectionGap({ desktopRuntime: isDesktopRuntime() });
+        routeReadyAfterRefresh = gapPlan.markRouteReady;
+        if (gapPlan.retainExistingState) {
+          // Transient desktop gap: the local server is booting or restarting
+          // (app update, remote-access toggle, slow cold start) and has not
+          // republished its ephemeral base URL/tokens yet. Keep the last
+          // usable client, connection, sessions, and host info; boot or the
+          // reconnect effect publishes fresh info and supersedes this
+          // refresh. Only seed workspaces when the route has none so a fresh
+          // renderer still shows the sidebar under the boot overlay.
+          setConnectionPending(true);
+          if (workspacesRef.current.length === 0 && desktopWorkspaces.length > 0) {
+            const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
+            setWorkspaces(orderedDesktopWorkspaces);
+            setLegacySelectedWorkspaceId(
+              (current) => current || resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "",
+            );
+          }
+          return;
+        }
+        onHostInfo(hostInfo);
         // Keep the workspace endpoint resolver in lockstep with the disconnected state.
         // Otherwise a previously-cached baseUrl/token would still resolve a
         // (now invalid) endpoint for any callback that consults the resolver ref.
@@ -436,6 +473,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "");
         return;
       }
+      onHostInfo(hostInfo);
 
       // Update the local-server resolver synchronously, BEFORE we kick off any
       // workspace-scoped requests below. `endpointForWorkspace` reads from
@@ -459,6 +497,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         orderIds: workspaceOrderIdsRef.current,
         retryDelaysMs: [250, 750, 1_500],
       });
+      if (!attempt.isCurrent()) return;
       if (!workspaceListState.usable || workspaceListState.error) {
         const message = workspaceListState.error
           ? describeRouteError(workspaceListState.error)
@@ -504,6 +543,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
 
       updateLocalServer({ baseUrl: normalizedBaseUrl, token: resolvedToken });
 
+      setConnectionPending(false);
       setClient(openworkClient);
       setBaseUrl(normalizedBaseUrl);
       setToken(resolvedToken);
@@ -561,6 +601,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         void loadWorkspaceSessionsInBackground(orderedWorkspaces);
       }
     } catch (error) {
+      if (!attempt.isCurrent()) return;
       const message = describeRouteError(error);
       console.error("[session-route] refreshRouteState failed", error);
       recordInspectorEvent("route.refresh.error", {
@@ -577,14 +618,19 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         );
       }
     } finally {
-      setLoading(false);
-      refreshInFlightRef.current = false;
-      setRouteRefreshVersion((current) => current + 1);
-      // Tell the boot overlay the first route data load has completed so
-      // the overlay dismisses after BOTH the desktop boot and the workspace
-      // list/sessions are ready.
-      if (routeReadyAfterRefresh) {
-        markBootRouteReady();
+      attempt.finish();
+      // A superseded attempt changes nothing here: the newer attempt owns
+      // loading, the refresh version, and boot-overlay readiness.
+      if (attempt.isCurrent()) {
+        setLoading(false);
+        setRouteRefreshVersion((current) => current + 1);
+        // Tell the boot overlay the first route data load has completed so
+        // the overlay dismisses after BOTH the desktop boot and the workspace
+        // list/sessions are ready. A transient desktop connection gap does
+        // not count: the overlay must outlast the restart recovery.
+        if (routeReadyAfterRefresh) {
+          markBootRouteReady();
+        }
       }
     }
   }, [loadWorkspaceSessionsInBackground, markBootRouteReady, routeWorkspaceId, updateLocalServer, workspaceInferenceSessionId]);
@@ -684,11 +730,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
 
     const handleSettingsChange = () => {
       onServerSettingsChanged();
-      // Self-heal: if the previous refresh got stuck mid-flight (e.g. macOS
-      // backgrounded the webview and never let a fetch resolve), clear the
-      // guard so a re-entry after resume actually goes through.
-      refreshInFlightRef.current = false;
-      void refreshRouteState();
+      // Fresh connection info was published (boot, restart, or reconnect).
+      // Supersede any in-flight refresh — including one stuck mid-flight
+      // (e.g. macOS backgrounded the webview and never let a fetch resolve) —
+      // so its stale resolution cannot overwrite the new connection state.
+      void refreshRouteState({ supersede: true });
     };
     window.addEventListener("openwork-server-settings-changed", handleSettingsChange);
 
@@ -697,8 +743,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     const handleVisibility = () => {
       if (typeof document === "undefined") return;
       if (document.visibilityState !== "visible") return;
-      refreshInFlightRef.current = false;
-      void refreshRouteState();
+      void refreshRouteState({ supersede: true });
     };
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", handleVisibility);
@@ -728,6 +773,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       baseUrl,
       tokenPresent: token.length > 0,
       connected: Boolean(client),
+      connectionPending,
       routeError,
       selectedSessionId,
       selectedWorkspaceId,
@@ -756,6 +802,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   }, [
     baseUrl,
     client,
+    connectionPending,
     errorsByWorkspaceId,
     loading,
     retryingWorkspaceIds,
@@ -820,13 +867,23 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   // can be reintroduced later as a one-shot triggered from a button or from
   // the onboarding flow, not from the route effect loop.
   useEffect(() => {
-    if (!isDesktopRuntime()) return;
-    if (loading) return;
-    if (client) {
+    if (client && !connectionPending) {
       reconnectAttemptedWorkspaceIdRef.current = "";
+    }
+    if (
+      !shouldAttemptDesktopLocalReconnect({
+        desktopRuntime: isDesktopRuntime(),
+        bootPhase,
+        bootRouteReady,
+        routeLoading: loading,
+        hasClient: Boolean(client),
+        connectionPending,
+        workspaceType: selectedWorkspace?.workspaceType ?? null,
+      })
+    ) {
       return;
     }
-    if (!selectedWorkspace || selectedWorkspace.workspaceType !== "local") return;
+    if (!selectedWorkspace) return;
     const workspaceId = selectedWorkspace.id?.trim() ?? "";
     if (!workspaceId || reconnectAttemptedWorkspaceIdRef.current === workspaceId) return;
     reconnectAttemptedWorkspaceIdRef.current = workspaceId;
@@ -838,8 +895,12 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     }).catch((error) => {
       const message = error instanceof Error ? error.message : describeRouteError(error);
       setRouteError(message);
+      // Recovery definitively failed. Release the boot overlay so the
+      // retained route (with this error surfaced) is visible instead of the
+      // overlay wedging forever.
+      markBootRouteReady();
     });
-  }, [client, loading, selectedWorkspace, workspaces]);
+  }, [bootPhase, bootRouteReady, client, connectionPending, loading, markBootRouteReady, selectedWorkspace, workspaces]);
 
   const selectedWorkspaceRoot = selectedWorkspace?.path?.trim() || "";
   // Single source of truth for the selected workspace's server URL/token/id.
@@ -1077,7 +1138,6 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     setLegacySelectedWorkspaceId,
     retryingWorkspaceIds,
     setRetryingWorkspaceIds,
-    refreshInFlightRef,
     startupRetryTimerRef,
     selectedWorkspaceId,
     selectedWorkspace,

--- a/apps/app/tests/den-auth-provider.test.ts
+++ b/apps/app/tests/den-auth-provider.test.ts
@@ -4,6 +4,7 @@ import { DenApiError } from "../src/app/lib/den";
 import {
   DEN_AUTH_SIGNAL_RETRY_COOLDOWN_MS,
   hasRetainedDenSession,
+  isDenSessionRestoring,
   resolveDenActiveOrganizationWithRetry,
   resolveDenAuthFailureStatus,
   shouldRetryDenAuthOnSignal,
@@ -41,6 +42,25 @@ describe("retained Den sessions", () => {
     expect(hasRetainedDenSession("unavailable")).toBe(true);
     expect(hasRetainedDenSession("checking")).toBe(false);
     expect(hasRetainedDenSession("signed_out")).toBe(false);
+  });
+});
+
+describe("isDenSessionRestoring", () => {
+  test("a retained account without a confirmed user is restoring, never signed out", () => {
+    // Initial check in flight.
+    expect(isDenSessionRestoring({ status: "checking", hasUser: false })).toBe(true);
+    // First check failed transiently (local restart, control-plane blip)
+    // before any user was confirmed: the account UI must keep showing the
+    // restoring state instead of flashing "Sign in".
+    expect(isDenSessionRestoring({ status: "unavailable", hasUser: false })).toBe(true);
+  });
+
+  test("settled sessions are not restoring", () => {
+    expect(isDenSessionRestoring({ status: "signed_in", hasUser: true })).toBe(false);
+    // A previously confirmed user stays rendered as the account during an
+    // availability blip.
+    expect(isDenSessionRestoring({ status: "unavailable", hasUser: true })).toBe(false);
+    expect(isDenSessionRestoring({ status: "signed_out", hasUser: false })).toBe(false);
   });
 });
 

--- a/apps/app/tests/den-session-offline-resilience.test.ts
+++ b/apps/app/tests/den-session-offline-resilience.test.ts
@@ -271,8 +271,17 @@ describe("ensureDenActiveOrganization", () => {
 });
 
 describe("isDenSessionRevokedError", () => {
-  test("only treats Den-shaped 401s as revoked sessions", () => {
+  test("treats only explicit invalid/expired/revoked session codes as revoked", () => {
     expect(isDenSessionRevokedError(new DenApiError(401, "unauthorized", "Unauthorized"))).toBe(
+      true,
+    );
+    expect(
+      isDenSessionRevokedError(new DenApiError(401, "session_expired", "Session expired")),
+    ).toBe(true);
+    expect(
+      isDenSessionRevokedError(new DenApiError(401, "session_revoked", "Session revoked")),
+    ).toBe(true);
+    expect(isDenSessionRevokedError(new DenApiError(401, "invalid_token", "Invalid token"))).toBe(
       true,
     );
     expect(isDenSessionRevokedError(new DenApiError(401, "request_failed", "Proxy 401"))).toBe(
@@ -282,6 +291,25 @@ describe("isDenSessionRevokedError", () => {
       false,
     );
     expect(isDenSessionRevokedError(new Error("Request timed out."))).toBe(false);
+  });
+
+  test("keeps the session for structured 401s minted by infrastructure", () => {
+    // Deployment platforms, proxies, and misrouted edges answer with their
+    // own JSON 401 envelopes while the control plane is unreachable. None of
+    // them prove the stored session is invalid.
+    expect(
+      isDenSessionRevokedError(
+        new DenApiError(401, "base_url_not_present", "Base URL not present"),
+      ),
+    ).toBe(false);
+    expect(
+      isDenSessionRevokedError(
+        new DenApiError(401, "deployment_not_found", "Deployment not found"),
+      ),
+    ).toBe(false);
+    expect(
+      isDenSessionRevokedError(new DenApiError(401, "proxy_authentication", "Proxy auth")),
+    ).toBe(false);
   });
 });
 
@@ -293,6 +321,63 @@ describe("resolveDenAuthFailureStatus", () => {
     expect(resolveDenAuthFailureStatus(new DenApiError(401, "unauthorized", "Unauthorized"))).toBe(
       "signed_out",
     );
+    expect(
+      resolveDenAuthFailureStatus(new DenApiError(401, "session_expired", "Session expired")),
+    ).toBe("signed_out");
     expect(resolveDenAuthFailureStatus(new Error("Request timed out."))).toBe("unavailable");
+  });
+
+  test("reports transient structured 401s as unavailable, retaining the session", () => {
+    expect(
+      resolveDenAuthFailureStatus(
+        new DenApiError(401, "base_url_not_present", "Base URL not present"),
+      ),
+    ).toBe("unavailable");
+    expect(
+      resolveDenAuthFailureStatus(new DenApiError(401, "deployment_not_found", "Deployment not found")),
+    ).toBe("unavailable");
+  });
+});
+
+describe("explicit sign-out", () => {
+  test("clears the stored session and notifies listeners with signed_out", () => {
+    const dispatched: Event[] = [];
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: (event: Event) => {
+          dispatched.push(event);
+          return true;
+        },
+      },
+    });
+
+    writeDenSettings(
+      {
+        baseUrl: "https://den.test",
+        authToken: "tok_stored",
+        activeOrgId: "org_stored",
+        activeOrgSlug: "stored-org",
+        activeOrgName: "Stored Org",
+      },
+      { persistBootstrap: false },
+    );
+    dispatched.length = 0;
+
+    clearDenSession();
+
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBeNull();
+
+    // The provider store listens for this signed_out notification to remove
+    // organization and imported Cloud providers; explicit logout must keep
+    // emitting it.
+    const sessionUpdated = dispatched.find(
+      (event) => event.type === "openwork-den-session-updated",
+    ) as CustomEvent<{ status?: string }> | undefined;
+    expect(sessionUpdated?.detail.status).toBe("signed_out");
   });
 });

--- a/apps/app/tests/desktop-local-openwork.test.ts
+++ b/apps/app/tests/desktop-local-openwork.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+
+import type { OpenworkServerInfo } from "../src/app/lib/desktop";
+import {
+  isReadyLocalOpenworkServerInfo,
+  LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS,
+  shouldAttemptDesktopLocalReconnect,
+  waitForReadyLocalOpenworkServerInfo,
+  type DesktopLocalReconnectInput,
+} from "../src/react-app/shell/desktop-local-openwork";
+
+function serverInfo(overrides: Partial<OpenworkServerInfo> = {}): OpenworkServerInfo {
+  return {
+    running: false,
+    engineRollover: false,
+    remoteAccessEnabled: false,
+    host: null,
+    port: null,
+    baseUrl: null,
+    connectUrl: null,
+    mdnsUrl: null,
+    lanUrl: null,
+    clientToken: null,
+    ownerToken: null,
+    hostToken: null,
+    managedOpencodeBinPath: null,
+    managedOpencodeBinSource: null,
+    pid: null,
+    lastStdout: null,
+    lastStderr: null,
+    managedOpencodeExecution: null,
+    ...overrides,
+  };
+}
+
+const readyInfo = () =>
+  serverInfo({ running: true, baseUrl: "http://127.0.0.1:4187", ownerToken: "tok_owner" });
+
+describe("isReadyLocalOpenworkServerInfo", () => {
+  test("requires running, a base URL, and at least one token", () => {
+    expect(isReadyLocalOpenworkServerInfo(readyInfo())).toBe(true);
+    expect(
+      isReadyLocalOpenworkServerInfo(
+        serverInfo({ running: true, baseUrl: "http://127.0.0.1:4187", clientToken: "tok_client" }),
+      ),
+    ).toBe(true);
+    expect(
+      isReadyLocalOpenworkServerInfo(
+        serverInfo({ running: false, baseUrl: "http://127.0.0.1:4187", ownerToken: "tok_owner" }),
+      ),
+    ).toBe(false);
+    expect(
+      isReadyLocalOpenworkServerInfo(serverInfo({ running: true, ownerToken: "tok_owner" })),
+    ).toBe(false);
+    expect(
+      isReadyLocalOpenworkServerInfo(serverInfo({ running: true, baseUrl: "http://127.0.0.1:4187" })),
+    ).toBe(false);
+    expect(isReadyLocalOpenworkServerInfo(null)).toBe(false);
+  });
+});
+
+describe("waitForReadyLocalOpenworkServerInfo", () => {
+  test("keeps polling through a restart gap until the server is ready", async () => {
+    const responses: Array<OpenworkServerInfo | null> = [
+      serverInfo({ running: false }),
+      serverInfo({ running: true, baseUrl: "http://127.0.0.1:4187" }),
+      readyInfo(),
+    ];
+    let calls = 0;
+    const waits: number[] = [];
+
+    const result = await waitForReadyLocalOpenworkServerInfo({
+      fetchInfo: async () => responses[Math.min(calls++, responses.length - 1)] ?? null,
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+    });
+
+    expect(calls).toBe(3);
+    expect(waits).toEqual([
+      LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS,
+      LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS,
+    ]);
+    expect(isReadyLocalOpenworkServerInfo(result)).toBe(true);
+  });
+
+  test("tolerates bridge errors while polling", async () => {
+    let calls = 0;
+    const result = await waitForReadyLocalOpenworkServerInfo({
+      fetchInfo: async () => {
+        calls += 1;
+        if (calls < 3) throw new Error("bridge not ready");
+        return readyInfo();
+      },
+      wait: async () => {},
+    });
+
+    expect(calls).toBe(3);
+    expect(isReadyLocalOpenworkServerInfo(result)).toBe(true);
+  });
+
+  test("is bounded: reports the last unready observation after max attempts", async () => {
+    let calls = 0;
+    const result = await waitForReadyLocalOpenworkServerInfo({
+      fetchInfo: async () => {
+        calls += 1;
+        return serverInfo({ running: false });
+      },
+      maxAttempts: 4,
+      wait: async () => {},
+    });
+
+    expect(calls).toBe(4);
+    expect(isReadyLocalOpenworkServerInfo(result)).toBe(false);
+    expect(result?.running).toBe(false);
+  });
+});
+
+describe("shouldAttemptDesktopLocalReconnect", () => {
+  const disconnectedLocal: DesktopLocalReconnectInput = {
+    desktopRuntime: true,
+    bootPhase: "ready",
+    bootRouteReady: true,
+    routeLoading: false,
+    hasClient: false,
+    connectionPending: false,
+    workspaceType: "local",
+  };
+
+  test("never runs before desktop runtime bootstrap settles", () => {
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, bootPhase: "bootstrapping-workspaces" }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, bootPhase: "starting-engine" }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, bootPhase: "activating-workspace" }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({
+        ...disconnectedLocal,
+        bootPhase: "idle",
+        bootRouteReady: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("runs once boot completed, definitively failed, or is idle after route readiness", () => {
+    expect(shouldAttemptDesktopLocalReconnect(disconnectedLocal)).toBe(true);
+    expect(shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, bootPhase: "error" })).toBe(true);
+    expect(
+      shouldAttemptDesktopLocalReconnect({
+        ...disconnectedLocal,
+        bootPhase: "idle",
+        bootRouteReady: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("runs for a retained connection whose republished info is still pending", () => {
+    expect(
+      shouldAttemptDesktopLocalReconnect({
+        ...disconnectedLocal,
+        hasClient: true,
+        connectionPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("stays quiet for healthy, loading, non-desktop, and non-local cases", () => {
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, hasClient: true }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, routeLoading: true }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, desktopRuntime: false }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, workspaceType: "remote" }),
+    ).toBe(false);
+    expect(
+      shouldAttemptDesktopLocalReconnect({ ...disconnectedLocal, workspaceType: null }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -14,7 +14,10 @@ import {
 } from "../src/app/lib/openwork-server";
 import { createOpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
 import { buildOpenworkHealthHeaders } from "../src/react-app/kernel/server-provider";
-import { resolveOpenworkConnection } from "../src/react-app/shell/openwork-connection";
+import {
+  isStaleStoredDesktopConnection,
+  resolveOpenworkConnection,
+} from "../src/react-app/shell/openwork-connection";
 
 const originalWindow = globalThis.window;
 const originalFetch = globalThis.fetch;
@@ -78,8 +81,14 @@ function installWindow(options: {
     ownerToken: string;
     hostToken?: string;
   };
+  /** Raw openworkServerInfo response for non-ready/restarting server states. */
+  electronServerInfoRaw?: Record<string, unknown>;
+  /** Simulate a desktop bridge whose openworkServerInfo call fails outright. */
+  electronServerInfoError?: boolean;
 }) {
   const localStorage = memoryStorage();
+  const electronBridgeInstalled =
+    options.electronInfo || options.electronServerInfoRaw || options.electronServerInfoError;
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
@@ -88,11 +97,17 @@ function installWindow(options: {
       location: { origin: options.origin },
       __OPENWORK_GATEWAY__: options.gateway ? { version: 1 } : undefined,
       __OPENWORK_BOOTSTRAP__: options.bootstrapToken ? { token: options.bootstrapToken } : undefined,
-      __OPENWORK_ELECTRON__: options.electronInfo
+      __OPENWORK_ELECTRON__: electronBridgeInstalled
         ? {
             invokeDesktop: async (command: string) => {
               if (command !== "openworkServerInfo") {
                 throw new Error(`Unexpected desktop command: ${command}`);
+              }
+              if (options.electronServerInfoError) {
+                throw new Error("desktop bridge unavailable");
+              }
+              if (options.electronServerInfoRaw) {
+                return options.electronServerInfoRaw;
               }
               return {
                 running: true,
@@ -379,5 +394,111 @@ describe("non-gateway connection modes", () => {
     expect(connection.resolvedToken).toBe("owner-token");
     expect(connection.resolvedHostToken).toBe("host-token");
     expect(connection.source).toBe("desktop-runtime");
+  });
+
+  test("a restarting desktop server invalidates stored loopback settings instead of resolving a dead port", async () => {
+    // App update / slow restart: the live runtime answers definitively, but
+    // the server has not republished its base URL and tokens yet. The stored
+    // loopback settings are from the previous server lifetime.
+    const storage = installWindow({
+      origin: "https://instance.example.com",
+      electronServerInfoRaw: { running: false, baseUrl: null, ownerToken: null, clientToken: null },
+    });
+    storage.setItem("openwork.server.urlOverride", "http://127.0.0.1:4100");
+    storage.setItem("openwork.server.token", "tok_previous_lifetime");
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection.source).toBe("empty");
+    expect(connection.normalizedBaseUrl).toBe("");
+    expect(connection.resolvedToken).toBe("");
+  });
+
+  test("a restarting desktop server keeps stored remote/manual servers as the fallback", async () => {
+    const storage = installWindow({
+      origin: "https://instance.example.com",
+      electronServerInfoRaw: { running: false, baseUrl: null, ownerToken: null, clientToken: null },
+    });
+    storage.setItem("openwork.server.urlOverride", "https://manual.example.com");
+    storage.setItem("openwork.server.token", "manual-token");
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection.source).toBe("stored-settings");
+    expect(connection.normalizedBaseUrl).toBe("https://manual.example.com");
+    expect(connection.resolvedToken).toBe("manual-token");
+  });
+
+  test("a failing desktop bridge still falls back to stored settings", async () => {
+    // No definitive live answer: keep the pre-existing fallback so broken
+    // bridges do not strand configured connections.
+    const storage = installWindow({
+      origin: "https://instance.example.com",
+      electronServerInfoError: true,
+    });
+    storage.setItem("openwork.server.urlOverride", "http://127.0.0.1:4100");
+    storage.setItem("openwork.server.token", "tok_stored");
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection.source).toBe("stored-settings");
+    expect(connection.normalizedBaseUrl).toBe("http://127.0.0.1:4100");
+    expect(connection.resolvedToken).toBe("tok_stored");
+  });
+});
+
+describe("isStaleStoredDesktopConnection", () => {
+  test("marks stored loopback connections stale only on a definitive not-ready answer", () => {
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: true,
+        desktopServerReportedNotReady: true,
+        storedBaseUrl: "http://127.0.0.1:4100",
+        runtimeReportedBaseUrl: "",
+      }),
+    ).toBe(true);
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: true,
+        desktopServerReportedNotReady: false,
+        storedBaseUrl: "http://127.0.0.1:4100",
+        runtimeReportedBaseUrl: "",
+      }),
+    ).toBe(false);
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: false,
+        desktopServerReportedNotReady: true,
+        storedBaseUrl: "http://127.0.0.1:4100",
+        runtimeReportedBaseUrl: "",
+      }),
+    ).toBe(false);
+  });
+
+  test("keeps remote URLs unless they match the runtime-reported base URL", () => {
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: true,
+        desktopServerReportedNotReady: true,
+        storedBaseUrl: "https://manual.example.com",
+        runtimeReportedBaseUrl: "",
+      }),
+    ).toBe(false);
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: true,
+        desktopServerReportedNotReady: true,
+        storedBaseUrl: "https://manual.example.com",
+        runtimeReportedBaseUrl: "https://manual.example.com",
+      }),
+    ).toBe(true);
+    expect(
+      isStaleStoredDesktopConnection({
+        desktopRuntime: true,
+        desktopServerReportedNotReady: true,
+        storedBaseUrl: "",
+        runtimeReportedBaseUrl: "",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createRouteRefreshLifecycle,
+  planRouteConnectionGap,
+} from "../src/react-app/shell/route-refresh-control";
+
+describe("createRouteRefreshLifecycle", () => {
+  test("dedupes refreshes while one is in flight", () => {
+    const lifecycle = createRouteRefreshLifecycle();
+
+    const first = lifecycle.begin();
+    expect(first).not.toBeNull();
+    expect(lifecycle.begin()).toBeNull();
+
+    expect(first?.finish()).toBe(true);
+    expect(lifecycle.isInFlight()).toBe(false);
+    expect(lifecycle.begin()).not.toBeNull();
+  });
+
+  test("supersede cancels the in-flight attempt instead of racing it", () => {
+    const lifecycle = createRouteRefreshLifecycle();
+
+    const stale = lifecycle.begin();
+    const fresh = lifecycle.begin({ supersede: true });
+
+    expect(stale?.isCurrent()).toBe(false);
+    expect(fresh?.isCurrent()).toBe(true);
+
+    // The superseded attempt no longer owns the in-flight slot, so its
+    // completion cannot re-open the route mid-refresh.
+    expect(stale?.finish()).toBe(false);
+    expect(lifecycle.isInFlight()).toBe(true);
+    expect(fresh?.finish()).toBe(true);
+    expect(lifecycle.isInFlight()).toBe(false);
+  });
+});
+
+describe("planRouteConnectionGap", () => {
+  test("desktop gaps retain route state and hold the boot overlay", () => {
+    expect(planRouteConnectionGap({ desktopRuntime: true })).toEqual({
+      retainExistingState: true,
+      markRouteReady: false,
+    });
+  });
+
+  test("web treats a missing connection as a real disconnected state", () => {
+    expect(planRouteConnectionGap({ desktopRuntime: false })).toEqual({
+      retainExistingState: false,
+      markRouteReady: true,
+    });
+  });
+});
+
+// Mirrors refreshRouteState's control flow: begin → resolve connection →
+// staleness check → gap plan or apply → finish, with route readiness reported
+// only by the attempt that still owns the refresh.
+type SimulatedRouteState = {
+  baseUrl: string;
+  token: string;
+  sessions: string[];
+  routeReady: boolean;
+};
+
+function createSimulatedRoute(initial: SimulatedRouteState) {
+  const lifecycle = createRouteRefreshLifecycle();
+  const state = { ...initial, sessions: [...initial.sessions] };
+
+  const refresh = async (
+    resolveConnection: () => Promise<{ baseUrl: string; token: string } | null>,
+    options?: { supersede?: boolean },
+  ) => {
+    const attempt = lifecycle.begin(options);
+    if (!attempt) return;
+    let routeReadyAfterRefresh = true;
+    try {
+      const resolution = await resolveConnection();
+      if (!attempt.isCurrent()) return;
+      if (!resolution) {
+        const gapPlan = planRouteConnectionGap({ desktopRuntime: true });
+        routeReadyAfterRefresh = gapPlan.markRouteReady;
+        if (!gapPlan.retainExistingState) {
+          state.baseUrl = "";
+          state.token = "";
+          state.sessions = [];
+        }
+        return;
+      }
+      state.baseUrl = resolution.baseUrl;
+      state.token = resolution.token;
+    } finally {
+      attempt.finish();
+      if (attempt.isCurrent() && routeReadyAfterRefresh) {
+        state.routeReady = true;
+      }
+    }
+  };
+
+  return { state, refresh };
+}
+
+describe("desktop restart refresh sequence", () => {
+  test("an empty first resolution retains state and a later one recovers", async () => {
+    const route = createSimulatedRoute({
+      baseUrl: "http://127.0.0.1:4100",
+      token: "tok_before_restart",
+      sessions: ["task-1", "task-2"],
+      routeReady: false,
+    });
+
+    // Local server is restarting: the first resolution has no base URL/token.
+    await route.refresh(async () => null);
+
+    expect(route.state.baseUrl).toBe("http://127.0.0.1:4100");
+    expect(route.state.token).toBe("tok_before_restart");
+    expect(route.state.sessions).toEqual(["task-1", "task-2"]);
+    // The boot overlay must not be released by the gap refresh.
+    expect(route.state.routeReady).toBe(false);
+
+    // The restarted server published fresh connection info.
+    await route.refresh(async () => ({ baseUrl: "http://127.0.0.1:4187", token: "tok_after_restart" }));
+
+    expect(route.state.baseUrl).toBe("http://127.0.0.1:4187");
+    expect(route.state.token).toBe("tok_after_restart");
+    expect(route.state.sessions).toEqual(["task-1", "task-2"]);
+    expect(route.state.routeReady).toBe(true);
+  });
+
+  test("a stale slow refresh cannot overwrite the recovered connection", async () => {
+    const route = createSimulatedRoute({
+      baseUrl: "",
+      token: "",
+      sessions: ["task-1"],
+      routeReady: false,
+    });
+
+    let releaseStaleResolution: (value: null) => void = () => {};
+    const staleResolution = new Promise<null>((resolve) => {
+      releaseStaleResolution = resolve;
+    });
+
+    // A refresh starts against the restarting server and hangs on resolution.
+    const staleRun = route.refresh(() => staleResolution);
+    // The republished server settings supersede it with a fresh refresh.
+    await route.refresh(
+      async () => ({ baseUrl: "http://127.0.0.1:4187", token: "tok_recovered" }),
+      { supersede: true },
+    );
+
+    expect(route.state.baseUrl).toBe("http://127.0.0.1:4187");
+    expect(route.state.routeReady).toBe(true);
+
+    // The stale attempt finally resolves empty — after the recovery. Its
+    // completion must change nothing.
+    releaseStaleResolution(null);
+    await staleRun;
+
+    expect(route.state.baseUrl).toBe("http://127.0.0.1:4187");
+    expect(route.state.token).toBe("tok_recovered");
+    expect(route.state.sessions).toEqual(["task-1"]);
+    expect(route.state.routeReady).toBe(true);
+  });
+});

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -54,7 +54,9 @@ describe("planRouteConnectionGap", () => {
 
 // Mirrors refreshRouteState's control flow: begin → resolve connection →
 // staleness check → gap plan or apply → finish, with route readiness reported
-// only by the attempt that still owns the refresh.
+// only by the attempt that still owns the refresh. On a desktop gap the
+// connection is quarantined (no request may carry the previous bearer token
+// to the freed loopback port) while session display state is retained.
 type SimulatedRouteState = {
   baseUrl: string;
   token: string;
@@ -79,9 +81,10 @@ function createSimulatedRoute(initial: SimulatedRouteState) {
       if (!resolution) {
         const gapPlan = planRouteConnectionGap({ desktopRuntime: true });
         routeReadyAfterRefresh = gapPlan.markRouteReady;
+        // The live connection is quarantined in every gap.
+        state.baseUrl = "";
+        state.token = "";
         if (!gapPlan.retainExistingState) {
-          state.baseUrl = "";
-          state.token = "";
           state.sessions = [];
         }
         return;
@@ -100,7 +103,7 @@ function createSimulatedRoute(initial: SimulatedRouteState) {
 }
 
 describe("desktop restart refresh sequence", () => {
-  test("an empty first resolution retains state and a later one recovers", async () => {
+  test("an empty resolution quarantines the connection, retains sessions, and a later one recovers", async () => {
     const route = createSimulatedRoute({
       baseUrl: "http://127.0.0.1:4100",
       token: "tok_before_restart",
@@ -111,8 +114,11 @@ describe("desktop restart refresh sequence", () => {
     // Local server is restarting: the first resolution has no base URL/token.
     await route.refresh(async () => null);
 
-    expect(route.state.baseUrl).toBe("http://127.0.0.1:4100");
-    expect(route.state.token).toBe("tok_before_restart");
+    // No live endpoint or bearer token survives the gap — the freed loopback
+    // port must never receive the previous credentials…
+    expect(route.state.baseUrl).toBe("");
+    expect(route.state.token).toBe("");
+    // …while the session display state is retained for the user.
     expect(route.state.sessions).toEqual(["task-1", "task-2"]);
     // The boot overlay must not be released by the gap refresh.
     expect(route.state.routeReady).toBe(false);


### PR DESCRIPTION
## Problem

During an application update or a slow local restart, the renderer becomes active before the restarted local OpenWork server has republished its ephemeral base URL and tokens. Several layers treated that temporary gap as a final disconnected state:

- `refreshRouteState` resolved an empty connection and cleared the active client, base URL, token, session lists, and host info, so the sidebar and provider-facing status dropped to disconnected mid-restart.
- The local reconnect effect could call `openworkServerInfo` before desktop runtime bootstrap finished and surface "OpenWork server did not report a base URL after activation."
- The boot overlay could dismiss while recovery was still running: the route reported readiness even for a refresh that resolved no connection, and several callers force-reset the refresh in-flight latch, so a stale slow refresh could complete last and overwrite newer recovered state.
- Den authentication classified any structured 401 as a revoked session. A 401 minted by infrastructure in front of the control plane (`base_url_not_present`, deployment placeholders, proxies) cleared the stored token, so a retained account briefly rendered "Sign in".

## Change

- `apps/app/src/react-app/shell/route-refresh-control.ts` (new): generation-based refresh lifecycle (`begin` / `supersede` / owner-checked `finish`) plus the connection-gap policy. Desktop gaps retain display state and hold the boot overlay; web still treats an empty resolution as a real disconnect.
- `apps/app/src/react-app/shell/use-workspace-route-state.ts`: callers reacting to changed connection info (settings-changed, visibility, cloud-ready transition, startup retry) now supersede the in-flight refresh instead of force-resetting a shared latch; superseded attempts write nothing. A desktop connection gap retains the workspaces, session lists, selection, and host info as **display state** while **quarantining the live connection** — the client, base URL, token, and endpoint resolver are cleared exactly like a disconnect, so no request can carry the previous bearer token to the freed loopback port while the server is down (the port could be re-bound by another local process during the restart window). It seeds workspaces only when the route has none and does not release the boot overlay; the existing not-ready presentation renders the gap as "Preparing workspace". The reconnect effect is gated on boot settledness and also engages while republication is pending; a definitive reconnect failure surfaces the error and releases the overlay so it cannot wedge.
- `apps/app/src/react-app/shell/desktop-local-openwork.ts`: the reconnect path polls `openworkServerInfo` with bounded retries (20 × 500 ms) against the same readiness definition the boot sequence uses (running + base URL + a token) instead of failing on the first empty answer. Exports the shared reconnect gate.
- `apps/app/src/react-app/shell/settings-route.tsx`: the settings route's background reconnect uses the same boot-settled gate.
- `apps/app/src/react-app/shell/openwork-connection.ts`: stored **loopback** server settings are treated as stale whenever the live desktop runtime definitively reports the server not ready. Previously a restarting server (definitive `running: false` answer with no republished URL) fell back to the stored loopback URL/token from the previous server lifetime, so the route built a client against a dead port and flashed a degraded workspace-list error instead of entering the transient-gap path. Stored non-loopback (remote/manual) URLs keep their fallback role, and a failing desktop bridge (no definitive answer) keeps the pre-existing fallback behavior.
- `apps/app/src/app/lib/den.ts`: `isDenSessionRevokedError` now requires an explicit invalid/expired/revoked session code. den-api's canonical invalid-session response is `{ error: "unauthorized" }`; the allowlist accepts that plus explicit session/token termination spellings. `request_failed` and infrastructure-shaped 401s such as `base_url_not_present` report "unavailable" and retain the session.
- `apps/app/src/react-app/domains/cloud/den-auth-provider.tsx`, `apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx`: the account UI shows "Restoring your session" while a retained session has no confirmed user yet (initial check, or a transient first failure being retried), and never flashes "Sign in" in that window.

## Behavior invariants

- Explicit logout is unchanged: it still clears the stored session and dispatches `signed_out`, which is what removes organization/imported Cloud providers.
- Remote workspaces are unaffected; the web/gateway resolution path still clears on genuine disconnects.
- No fixed sleeps as primary synchronization: recovery is driven by the settings-changed event published by boot/reconnect, and readiness polling is bounded and gated on observed server state.

## Verification

- `cd apps/app && bun test tests/route-refresh-control.test.ts tests/desktop-local-openwork.test.ts tests/den-session-offline-resilience.test.ts tests/den-auth-provider.test.ts tests/boot-state.test.ts tests/gateway-runtime.test.ts tests/settings-route.test.ts tests/den-sign-in-intent.test.ts tests/den-handoff.test.ts tests/den-signin-routing.test.ts` — 82 pass (re-run after each rebase, including over the merged #3734 sign-in changes). Covers: sessions retained while the connection is quarantined through an empty resolution (no base URL/token survives the gap) with a later resolution recovering; a stale refresh completion unable to overwrite the recovered connection; reconnect gated on runtime-bootstrap settledness; bounded readiness polling (including bridge errors and exhaustion); the boot overlay held for desktop gaps; a restarting server invalidating stored loopback settings while remote/manual fallbacks and bridge-failure fallbacks stay intact; restoring-instead-of-"Sign in" for retained accounts; transient structured 401 retention vs. explicit revocation; explicit sign-out still notifying provider cleanup.
- `cd apps/app && pnpm typecheck` — clean.
- `cd apps/app && bun test --isolate tests/` — 758 pass, 6 fail; the same 6 failures reproduce identically on the merge-base commit in the same environment (extensions-sidebar-header, connect-capability-inventory, cloud-workspace-overlay, message-list-loading ×2, session-provider-auth-server-sync; `window.matchMedia` is unavailable in this local bun environment), so they are pre-existing and unrelated.

## Review follow-up

The diff-security-review finding ("retained client can send bearer tokens to a hijacked old loopback endpoint") is addressed: a desktop gap no longer keeps the previous client or endpoint resolver alive. Retention is now limited to display state, and every outbound path (background session loads, workspace-scoped calls, endpoint resolution) sees a cleared connection until the restarted server publishes fresh info. The companion location in `den.ts` differs in kind: the retained Den session token is only ever sent to the configured control-plane origin (a stable HTTPS URL, not an ephemeral loopback port), so retaining it on transient 401s does not create the freed-port window; the loopback vector was exclusively the route client, which is now quarantined.
- No testkit tape for this one: the race lives in renderer state transitions during a desktop update/restart and is not reachable from a spec without an instrumented slow-restart harness; the regression coverage is at the extracted policy seams instead. Manual repro without the fix: open a workspace in the desktop app, restart the embedded server (toggle remote access, or relaunch right after an update), and observe the session list clear, "Sign in" flash in the account footer, and occasionally "OpenWork server did not report a base URL after activation". With the fix the route retains its state and re-attaches when the server republishes its connection info.
