### PR TITLE
fix(evals): match SHA-pinned Azure signing action in windows spec

### DIFF
--- a/evals/specs/windows-artifact-signing.test.ts
+++ b/evals/specs/windows-artifact-signing.test.ts
@@ -22,7 +22,7 @@ const installers = [
 test("one Azure OIDC job signs and publishes every Windows installer", async ({ evidence }) => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  expect(workflow.match(/uses: azure\/artifact-signing-action@v2/g)).toHaveLength(1);
+  expect(workflow.match(/uses: azure\/artifact-signing-action@[0-9a-f]{40} # v2/g)).toHaveLength(1);
   expect(workflow).toContain("sign-and-publish-windows:");
   expect(workflow).toContain("runs-on: windows-2022");
   expect(workflow).toContain("environment: windows-signing");


### PR DESCRIPTION
## Problem

`OpenWork Tests` (the `pnpm --dir evals run spec` PR lane) is red on `dev`. Both runners (macos-14 and ubuntu) fail on the same single assertion:

```
FAIL |pr| specs/windows-artifact-signing.test.ts > one Azure OIDC job signs and publishes every Windows installer
AssertionError: Target cannot be null or undefined.
 ❯ specs/windows-artifact-signing.test.ts:25:70
```

## Root cause

- **#3719** ("ci: sign Windows releases with Azure") added the signing job with `uses: azure/artifact-signing-action@v2`, matching the spec.
- **#3721** ("ci: pin Azure signing actions") pinned the action to an immutable commit SHA — correct security hardening:
  ```yaml
  uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
  ```
- The spec still asserted the mutable tag `uses: azure/artifact-signing-action@v2`, so `String.match` returned `null` and `expect(null).toHaveLength(1)` threw.

The SHA pin is the correct production state and stays untouched. The **spec assertion** was outdated.

## Fix

One-line change to the regex so it matches the pinned-SHA + `# v2` form, still requiring exactly one occurrence:

```diff
-  expect(workflow.match(/uses: azure\/artifact-signing-action@v2/g)).toHaveLength(1);
+  expect(workflow.match(/uses: azure\/artifact-signing-action@[0-9a-f]{40} # v2/g)).toHaveLength(1);
```

No workflow or source changes; test-assertion only.

## Verification

`pnpm --dir evals run spec` (exact CI command) locally on this branch:

```
 ✓ |pr| specs/windows-artifact-signing.test.ts (2 tests) 161ms
 ...
 Test Files  5 passed | 2 skipped (7)
      Tests  10 passed | 2 skipped (12)
```

The 2 skips (`skill-grant-access`, `kube-egress-allowlist`) are pre-existing conditional skips, unchanged.