### PR TITLE
Add invitees to teams from member invite

### DIFF
--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,5 +1,5 @@
-import { and, desc, eq, isNull } from "@openwork-ee/den-db/drizzle"
-import { AuthUserTable, InvitationTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema"
+import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { AuthUserTable, InvitationTable, MemberTable, OrganizationTable, TeamMemberTable, TeamTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -20,6 +20,7 @@ import { buildInvitationLink, createInvitationId, createInvitationToken, ensureI
 const inviteMemberSchema = z.object({
   email: z.string().email(),
   role: z.string().trim().min(1).max(64),
+  teamIds: z.array(denTypeIdSchema("team")).optional().default([]),
 })
 const logger = appLogger.child({ component: "invitations" })
 
@@ -61,8 +62,13 @@ const invitationNotPendingSchema = z.object({
 }).meta({ ref: "InvitationNotPendingError" })
 
 type InvitationId = typeof InvitationTable.$inferSelect.id
+type TeamId = typeof TeamTable.$inferSelect.id
 
 const orgInvitationParamsSchema = idParamSchema("invitationId", "invitation")
+
+function parseTeamIds(teamIds: string[]) {
+  return [...new Set(teamIds.map((value) => normalizeDenTypeId("team", value)))]
+}
 
 export function validateInvitationRefreshRole(input: {
   existingRole: string
@@ -95,7 +101,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         401: jsonResponse("The caller must be signed in to invite organization members.", unauthorizedSchema),
         402: jsonResponse("A seat subscription is required before inviting more members.", invitePaymentRequiredSchema),
         403: jsonResponse("Only workspace owners and admins can create invitations. Admins can only invite members.", forbiddenSchema),
-        404: jsonResponse("The organization could not be found.", notFoundSchema),
+        404: jsonResponse("The organization or a referenced team could not be found.", notFoundSchema),
         409: jsonResponse("The email address is outside this workspace's allowed domains.", inviteEmailDomainNotAllowedSchema),
         502: jsonResponse("The invitation was saved but the email provider rejected or failed to deliver it. Retry by submitting the same email again.", invitationEmailFailedSchema),
       },
@@ -141,6 +147,13 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       return c.json({ error: assignableRole.error, message: assignableRole.message }, 403)
     }
     const assignedRole = assignableRole.role
+
+    let teamIds: TeamId[]
+    try {
+      teamIds = parseTeamIds(input.teamIds)
+    } catch {
+      return c.json({ error: "team_not_found" }, 404)
+    }
 
     const invitationWrite = await db.transaction(async (tx) => {
       await tx
@@ -198,6 +211,18 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         : createInvitationToken()
       let createdOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
       let invitationOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
+
+      if (teamIds.length > 0) {
+        const organizationTeams = await tx
+          .select({ id: TeamTable.id })
+          .from(TeamTable)
+          .where(and(eq(TeamTable.organizationId, payload.organization.id), inArray(TeamTable.id, teamIds)))
+          .for("update")
+        const organizationTeamIds = new Set(organizationTeams.map((team) => team.id))
+        if (!teamIds.every((teamId) => organizationTeamIds.has(teamId))) {
+          return { status: "team_not_found" as const }
+        }
+      }
 
       if (existingInvitation) {
         await tx
@@ -258,6 +283,27 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         invitationOrgMemberId = memberId
       }
 
+      if (invitationOrgMemberId && teamIds.length > 0) {
+        const teamMemberOrgMemberId = invitationOrgMemberId
+        const existingTeamMembers = await tx
+          .select({ teamId: TeamMemberTable.teamId })
+          .from(TeamMemberTable)
+          .where(and(eq(TeamMemberTable.orgMembershipId, teamMemberOrgMemberId), inArray(TeamMemberTable.teamId, teamIds)))
+        const existingTeamIds = new Set(existingTeamMembers.map((teamMember) => teamMember.teamId))
+        const nextTeamMemberRows = teamIds
+          .filter((teamId) => !existingTeamIds.has(teamId))
+          .map((teamId) => ({
+            id: createDenTypeId("teamMember"),
+            teamId,
+            orgMembershipId: teamMemberOrgMemberId,
+            createdAt: now,
+          }))
+
+        if (nextTeamMemberRows.length > 0) {
+          await tx.insert(TeamMemberTable).values(nextTeamMemberRows)
+        }
+      }
+
       return {
         status: "saved" as const,
         createdOrgMemberId,
@@ -292,6 +338,9 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         freeSeatCount: seatEligibility.freeSeatCount,
         message: `This workspace includes ${seatEligibility.freeSeatCount} free members. Start seat billing before inviting another member.`,
       }, 402)
+    }
+    if (invitationWrite.status === "team_not_found") {
+      return c.json({ error: "team_not_found" }, 404)
     }
 
     const {

--- a/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
+++ b/ee/apps/den-api/test/invitation-lifecycle-hardening.test.ts
@@ -32,6 +32,8 @@ const ownerSessionId = createDenTypeId("session")
 const racingSessionId = createDenTypeId("session")
 const invitationId = createDenTypeId("invitation")
 const teamId = createDenTypeId("team")
+const inviteTeamId = createDenTypeId("team")
+const inviteSecondTeamId = createDenTypeId("team")
 const teamMemberId = createDenTypeId("teamMember")
 const ownerSessionToken = `invitation-lifecycle-owner-${ownerSessionId}`
 const racingSessionToken = `invitation-lifecycle-racing-${racingSessionId}`
@@ -136,6 +138,18 @@ beforeAll(async () => {
     organizationId,
     name: "Invitation Lifecycle Team",
   })
+  await db.insert(schema.TeamTable).values([
+    {
+      id: inviteTeamId,
+      organizationId,
+      name: "Invite Team",
+    },
+    {
+      id: inviteSecondTeamId,
+      organizationId,
+      name: "Invite Second Team",
+    },
+  ])
   await db.insert(schema.TeamMemberTable).values({
     id: teamMemberId,
     teamId,
@@ -165,11 +179,11 @@ afterAll(async () => {
   }
 
   await db.delete(schema.AuditEventTable).where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
-  await db.delete(schema.TeamMemberTable).where(drizzle.eq(schema.TeamMemberTable.teamId, teamId))
+  await db.delete(schema.TeamMemberTable).where(drizzle.inArray(schema.TeamMemberTable.teamId, [teamId, inviteTeamId, inviteSecondTeamId]))
   await db.delete(schema.AuthSessionTable).where(drizzle.inArray(schema.AuthSessionTable.id, [ownerSessionId, racingSessionId]))
   await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
   await db.delete(schema.InvitationTable).where(drizzle.eq(schema.InvitationTable.organizationId, organizationId))
-  await db.delete(schema.TeamTable).where(drizzle.eq(schema.TeamTable.id, teamId))
+  await db.delete(schema.TeamTable).where(drizzle.inArray(schema.TeamTable.id, [teamId, inviteTeamId, inviteSecondTeamId]))
   await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
   await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
   await db.delete(schema.AuthUserTable).where(
@@ -267,6 +281,46 @@ test("concurrent invite requests converge on one pending invitation and one usab
       drizzle.isNull(schema.MemberTable.removedAt),
     ))
   expect(pendingMembers).toHaveLength(1)
+})
+
+test("creating an invite can add its pending member to selected teams", async () => {
+  const teamInviteEmail = `team-invite-${organizationId}@test.local`
+  const response = await app.fetch(new Request(`${API_ORIGIN}/v1/invitations`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: ownerCookie,
+      origin: API_ORIGIN,
+    },
+    body: JSON.stringify({
+      email: teamInviteEmail,
+      role: "member",
+      teamIds: [inviteTeamId, inviteSecondTeamId],
+    }),
+  }))
+  const payload: unknown = await response.json()
+
+  expect(response.status).toBe(201)
+  expect(isRecord(payload)).toBe(true)
+  if (!isRecord(payload) || typeof payload.invitationId !== "string") {
+    throw new Error("Invitation response did not include an invitation id")
+  }
+
+  const pendingMembers = await db
+    .select({ id: schema.MemberTable.id })
+    .from(schema.MemberTable)
+    .where(drizzle.and(
+      drizzle.eq(schema.MemberTable.organizationId, organizationId),
+      drizzle.eq(schema.MemberTable.inviteId, payload.invitationId),
+      drizzle.isNull(schema.MemberTable.removedAt),
+    ))
+  expect(pendingMembers).toHaveLength(1)
+
+  const teamMembers = await db
+    .select({ teamId: schema.TeamMemberTable.teamId })
+    .from(schema.TeamMemberTable)
+    .where(drizzle.eq(schema.TeamMemberTable.orgMembershipId, pendingMembers[0]?.id ?? ownerMemberId))
+  expect(teamMembers.map((teamMember) => teamMember.teamId).sort()).toEqual([inviteSecondTeamId, inviteTeamId].sort())
 })
 
 test("an accepted invitation cannot be canceled by stale admin state", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -153,6 +153,8 @@ export function ManageMembersScreen() {
   const [showInviteForm, setShowInviteForm] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("member");
+  const [inviteAddToTeams, setInviteAddToTeams] = useState(false);
+  const [inviteTeamIds, setInviteTeamIds] = useState<string[]>([]);
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null);
   const [openMemberMenuId, setOpenMemberMenuId] = useState<string | null>(null);
   const [memberRoleDraft, setMemberRoleDraft] = useState("member");
@@ -232,6 +234,8 @@ export function ManageMembersScreen() {
   function resetInviteForm() {
     setInviteEmail("");
     setInviteRole(access.canManageRoles ? assignableRoles[0]?.role ?? "member" : "member");
+    setInviteAddToTeams(false);
+    setInviteTeamIds([]);
     setShowInviteForm(false);
   }
 
@@ -357,6 +361,14 @@ export function ManageMembersScreen() {
     );
   }, [access.canManageRoles, assignableRoles]);
 
+  useEffect(() => {
+    const availableTeamIds = new Set((orgContext?.teams ?? []).map((team) => team.id));
+    setInviteTeamIds((current) => current.filter((teamId) => availableTeamIds.has(teamId)));
+    if (availableTeamIds.size === 0) {
+      setInviteAddToTeams(false);
+    }
+  }, [orgContext?.teams]);
+
   if (orgBusy && !orgContext) {
     return (
       <div className="mx-auto max-w-[1200px] px-6 py-8 md:px-8">
@@ -377,6 +389,12 @@ export function ManageMembersScreen() {
     );
   }
 
+  const inviteTeamSummary = inviteTeamIds.length === 0
+    ? "Select teams"
+    : inviteTeamIds.length === 1
+      ? orgContext.teams.find((team) => team.id === inviteTeamIds[0])?.name ?? "1 team selected"
+      : `${inviteTeamIds.length} teams selected`;
+
   const inviteForm =
     showInviteForm && access.canInviteMembers ? (
       <DenCard className="mb-6">
@@ -386,7 +404,11 @@ export function ManageMembersScreen() {
             event.preventDefault();
             setPageError(null);
             try {
-              await inviteMember({ email: inviteEmail, role: access.canManageRoles ? inviteRole : "member" });
+              await inviteMember({
+                email: inviteEmail,
+                role: access.canManageRoles ? inviteRole : "member",
+                teamIds: inviteAddToTeams ? inviteTeamIds : [],
+              });
               resetInviteForm();
             } catch (error) {
               const paymentRequiredError = getOrgPaymentRequiredError(error);
@@ -442,6 +464,55 @@ export function ManageMembersScreen() {
               Send invite
             </DenButton>
           </div>
+          {orgContext.teams.length > 0 ? (
+            <div className="grid gap-3 lg:col-span-full">
+              <label className="inline-flex w-fit items-center gap-2 text-[14px] font-medium text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={inviteAddToTeams}
+                  onChange={(event) => {
+                    setInviteAddToTeams(event.target.checked);
+                    if (!event.target.checked) {
+                      setInviteTeamIds([]);
+                    }
+                  }}
+                  className="h-4 w-4 rounded border-gray-300 text-gray-900"
+                />
+                <span>Add this person to a team</span>
+              </label>
+              {inviteAddToTeams ? (
+                <details className="relative max-w-[420px]">
+                  <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2 text-[14px] text-gray-700 shadow-sm marker:hidden">
+                    <span>{inviteTeamSummary}</span>
+                    <span className="text-[12px] text-gray-400">Choose</span>
+                  </summary>
+                  <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl shadow-gray-900/10">
+                    {orgContext.teams.map((team) => {
+                      const checked = inviteTeamIds.includes(team.id);
+                      return (
+                        <label
+                          key={team.id}
+                          className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-4 py-3 text-[14px] text-gray-700 last:border-b-0 hover:bg-gray-50"
+                        >
+                          <input
+                            type="checkbox"
+                            value={team.id}
+                            checked={checked}
+                            onChange={(event) => {
+                              setInviteTeamIds((current) => event.target.checked
+                                ? [...current, team.id]
+                                : current.filter((teamId) => teamId !== team.id));
+                            }}
+                          />
+                          <span className="min-w-0 flex-1 truncate">{team.name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </details>
+              ) : null}
+            </div>
+          ) : null}
         </form>
       </DenCard>
     ) : null;

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -44,7 +44,7 @@ type OrgDashboardContextValue = {
   updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null; requireSso?: boolean; brandAppName?: string | null; brandLogoUrl?: string | null; brandIconUrl?: string | null; brandAccentColor?: string | null }) => Promise<void>;
   deleteOrganization: () => Promise<void>;
   switchOrganization: (slug: string) => void;
-  inviteMember: (input: { email: string; role: string }) => Promise<void>;
+  inviteMember: (input: { email: string; role: string; teamIds?: string[] }) => Promise<void>;
   startSeatCheckout: () => Promise<void>;
   cancelInvitation: (invitationId: string) => Promise<void>;
   updateMemberRole: (memberId: string, role: string) => Promise<void>;
@@ -597,7 +597,7 @@ export function OrgDashboardProvider({
     });
   }
 
-  async function inviteMember(input: { email: string; role: string }) {
+  async function inviteMember(input: { email: string; role: string; teamIds?: string[] }) {
     const access = getCurrentAccess();
     if (!access.canInviteMembers) {
       throw new Error("Only workspace admins can invite members.");
@@ -611,7 +611,7 @@ export function OrgDashboardProvider({
         "/v1/invitations",
         {
           method: "POST",
-          body: JSON.stringify({ email: input.email, role: invitationRole }),
+          body: JSON.stringify({ email: input.email, role: invitationRole, teamIds: input.teamIds ?? [] }),
         },
         12000,
       );


### PR DESCRIPTION
## Summary
- add an optional `teamIds` array to organization invitations and validate team IDs
- create team membership rows for the pending invite member after invite/member creation
- add the members-page "Add this person to a team" checkbox and team multi-select UI

## Verification
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false`
- `pnpm --filter @openwork-ee/den-api build`
- `git diff --check`

## Notes
- `pnpm --filter @openwork-ee/den-api exec bun test test/invitation-lifecycle-hardening.test.ts` was attempted, but the local MySQL/Docker daemon was unavailable (ECONNREFUSED 127.0.0.1:3306 / missing Docker socket).