### PR TITLE
fix(cloud): let desktop-initiated sign-ins choose the organization

### DIFF
--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -6,6 +6,13 @@ import {
   type DenDesktopHandoffExchange,
 } from "./den";
 import { dispatchDenSessionUpdated } from "./den-session-events";
+import {
+  clearDesktopSignInIntent,
+  clearOrgSelectionPending,
+  hasActiveDesktopSignInIntent,
+  markOrgSelectionPending,
+  resolveHandoffOrgPlan,
+} from "./den-sign-in-intent";
 
 type DenClient = ReturnType<typeof createDenClient>;
 export const DEN_HANDOFF_AUTO_CONTINUE_KEY = "openwork.den.handoffAutoContinueAt";
@@ -23,6 +30,14 @@ export type ExchangeHandoffOptions = {
   client?: DenClient;
   /** Optional active org to select on sign-in (bootstrap prepares this). */
   activeOrg?: HandoffActiveOrg | null;
+  /**
+   * How this sign-in started. Desktop-initiated flows (in-app sign-in
+   * buttons, pasted one-time codes) defer the organization choice to the org
+   * onboarding step instead of adopting the exchange-reported org. When
+   * omitted, the short-lived desktop sign-in intent marker decides;
+   * automation surfaces pass `false` to keep committing directly.
+   */
+  desktopInitiated?: boolean;
   /** Message used when the exchange fails without a specific Error message. */
   fallbackErrorMessage?: string;
 };
@@ -58,19 +73,45 @@ export async function exchangeHandoffAndSignIn(
         window.sessionStorage.setItem(DEN_HANDOFF_AUTO_CONTINUE_KEY, String(Date.now()));
       } catch {}
     }
-    // Prefer the caller-provided org (install-link bootstrap), then the org the
-    // server resolved for this session. When neither is known, keep whatever is
-    // already stored: overwriting with null strands fresh profiles without an
-    // organization, which disables Connect and skips org onboarding.
-    const activeOrg = options.activeOrg ?? exchange.organization ?? null;
-    const storedSettings = readDenSettings();
-    writeDenSettings({
-      baseUrl: options.baseUrl,
-      authToken: exchange.token,
-      activeOrgId: activeOrg ? activeOrg.id : storedSettings.activeOrgId,
-      activeOrgSlug: activeOrg ? activeOrg.slug ?? null : storedSettings.activeOrgSlug,
-      activeOrgName: activeOrg ? activeOrg.name ?? null : storedSettings.activeOrgName,
+    const desktopInitiated = options.desktopInitiated ?? hasActiveDesktopSignInIntent();
+    clearDesktopSignInIntent();
+    const plan = resolveHandoffOrgPlan({
+      explicitActiveOrg: options.activeOrg ?? null,
+      exchangeOrganization: exchange.organization ?? null,
+      desktopInitiated,
     });
+    const storedSettings = readDenSettings();
+    if (plan.kind === "await-user-selection") {
+      // Desktop-initiated sign-in: hold the org choice for the onboarding
+      // step. The exchange-reported org is only the chooser's default;
+      // single-org accounts still auto-select there without a visible stop.
+      markOrgSelectionPending(plan.suggestion);
+      writeDenSettings(
+        {
+          baseUrl: options.baseUrl,
+          authToken: exchange.token,
+          activeOrgId: null,
+          activeOrgSlug: null,
+          activeOrgName: null,
+        },
+        { intentionalActiveOrgClear: true },
+      );
+    } else {
+      // Prefer the caller-provided org (install-link bootstrap), then the org
+      // the server resolved for this session. When neither is known, keep
+      // whatever is already stored: overwriting with null strands fresh
+      // profiles without an organization, which disables Connect and skips
+      // org onboarding.
+      clearOrgSelectionPending();
+      const activeOrg = plan.organization;
+      writeDenSettings({
+        baseUrl: options.baseUrl,
+        authToken: exchange.token,
+        activeOrgId: activeOrg ? activeOrg.id : storedSettings.activeOrgId,
+        activeOrgSlug: activeOrg ? activeOrg.slug ?? null : storedSettings.activeOrgSlug,
+        activeOrgName: activeOrg ? activeOrg.name ?? null : storedSettings.activeOrgName,
+      });
+    }
     if (exchange.organization) {
       seedDenDesktopConfigConnectPolicy({
         organizationId: exchange.organization.id,

--- a/apps/app/src/app/lib/den-sign-in-intent.ts
+++ b/apps/app/src/app/lib/den-sign-in-intent.ts
@@ -1,0 +1,148 @@
+// Desktop sign-in intent and pending organization selection.
+//
+// The desktop handoff exchange always reports an organization: den-api
+// hydrates the browser session's active organization server-side whenever it
+// is empty, so the payload cannot distinguish "the user chose this org
+// remotely" from "the server defaulted one". The reliable discriminator is
+// who initiated the sign-in:
+//
+// - Remotely-initiated handoffs (install/invite links, enterprise bootstrap,
+//   "Open in desktop" from the Cloud dashboard) carry the org the user is
+//   actually working in — connect straight through.
+// - Desktop-initiated sign-ins (an in-app "Sign in" button opening the
+//   browser, or a pasted one-time code) must not silently adopt the
+//   server-resolved org when the account has several; the org chooser decides,
+//   with the exchange-reported org only pre-highlighted.
+//
+// This module owns the short-lived "the desktop started this sign-in" marker
+// and the "organization selection pending" state the routing and auth layers
+// consult between token exchange and the user's explicit choice.
+
+const DESKTOP_SIGN_IN_STARTED_AT_KEY = "openwork.den.desktopSignInStartedAt";
+const ORG_SELECTION_PENDING_KEY = "openwork.den.orgSelectionPendingAt";
+const ORG_SELECTION_SUGGESTION_KEY = "openwork.den.orgSelectionSuggestion";
+
+/** Comfortably outlives the 5-minute handoff grant plus the browser round
+ * trip, without leaving a stale marker that reclassifies a much later,
+ * unrelated remote handoff. */
+export const DESKTOP_SIGN_IN_INTENT_TTL_MS = 15 * 60 * 1000;
+
+export type SignInOrgRef = {
+  id: string;
+  slug?: string | null;
+  name?: string | null;
+};
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Record that the desktop app itself started a sign-in flow. */
+export function markDesktopSignInInitiated(now: number = Date.now()) {
+  storage()?.setItem(DESKTOP_SIGN_IN_STARTED_AT_KEY, String(now));
+}
+
+export function clearDesktopSignInIntent() {
+  storage()?.removeItem(DESKTOP_SIGN_IN_STARTED_AT_KEY);
+}
+
+export function hasActiveDesktopSignInIntent(now: number = Date.now()): boolean {
+  return isDesktopSignInIntentActive(storage()?.getItem(DESKTOP_SIGN_IN_STARTED_AT_KEY) ?? null, now);
+}
+
+/** Pure form of the marker check for tests and reuse. */
+export function isDesktopSignInIntentActive(startedAtRaw: string | null, now: number): boolean {
+  if (!startedAtRaw) return false;
+  const startedAt = Number.parseInt(startedAtRaw, 10);
+  if (!Number.isFinite(startedAt)) return false;
+  if (now < startedAt) return true;
+  return now - startedAt <= DESKTOP_SIGN_IN_INTENT_TTL_MS;
+}
+
+export function markOrgSelectionPending(suggestion: SignInOrgRef | null, now: number = Date.now()) {
+  const store = storage();
+  if (!store) return;
+  store.setItem(ORG_SELECTION_PENDING_KEY, String(now));
+  if (suggestion?.id?.trim()) {
+    store.setItem(
+      ORG_SELECTION_SUGGESTION_KEY,
+      JSON.stringify({
+        id: suggestion.id,
+        slug: suggestion.slug ?? null,
+        name: suggestion.name ?? null,
+      }),
+    );
+  } else {
+    store.removeItem(ORG_SELECTION_SUGGESTION_KEY);
+  }
+}
+
+export function clearOrgSelectionPending() {
+  const store = storage();
+  if (!store) return;
+  store.removeItem(ORG_SELECTION_PENDING_KEY);
+  store.removeItem(ORG_SELECTION_SUGGESTION_KEY);
+}
+
+export type OrgSelectionPendingState = {
+  pending: boolean;
+  suggestion: SignInOrgRef | null;
+};
+
+export function readOrgSelectionPending(): OrgSelectionPendingState {
+  const store = storage();
+  if (!store?.getItem(ORG_SELECTION_PENDING_KEY)) {
+    return { pending: false, suggestion: null };
+  }
+  let suggestion: SignInOrgRef | null = null;
+  const raw = store.getItem(ORG_SELECTION_SUGGESTION_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<SignInOrgRef> | null;
+      if (parsed && typeof parsed.id === "string" && parsed.id.trim()) {
+        suggestion = {
+          id: parsed.id,
+          slug: typeof parsed.slug === "string" ? parsed.slug : null,
+          name: typeof parsed.name === "string" ? parsed.name : null,
+        };
+      }
+    } catch {
+      suggestion = null;
+    }
+  }
+  return { pending: true, suggestion };
+}
+
+export type HandoffOrgPlan =
+  | { kind: "commit"; organization: SignInOrgRef | null }
+  | { kind: "await-user-selection"; suggestion: SignInOrgRef | null };
+
+/**
+ * Decide what a successful handoff exchange does with the organization.
+ *
+ * - An explicitly scoped org (install/invite link, enterprise bootstrap) is
+ *   always committed — the link itself is the remote selection.
+ * - A desktop-initiated sign-in commits nothing: the exchange-reported org
+ *   becomes a chooser suggestion and the org onboarding step decides
+ *   (auto-selecting silently only for single-org accounts).
+ * - A remotely-initiated handoff commits the exchange-reported org — it is
+ *   the organization the user's Cloud session is actually working in.
+ */
+export function resolveHandoffOrgPlan(input: {
+  explicitActiveOrg: SignInOrgRef | null;
+  exchangeOrganization: SignInOrgRef | null;
+  desktopInitiated: boolean;
+}): HandoffOrgPlan {
+  if (input.explicitActiveOrg?.id?.trim()) {
+    return { kind: "commit", organization: input.explicitActiveOrg };
+  }
+  if (input.desktopInitiated) {
+    return { kind: "await-user-selection", suggestion: input.exchangeOrganization };
+  }
+  return { kind: "commit", organization: input.exchangeOrganization };
+}

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -38,6 +38,7 @@ import {
   type DesktopBootstrapConfig as ShellDesktopBootstrapConfig,
 } from "./desktop";
 import { getOpenworkGatewayOrigin } from "./gateway-runtime";
+import { clearDesktopSignInIntent, clearOrgSelectionPending } from "./den-sign-in-intent";
 import { isDesktopRuntime } from "./runtime-env";
 import type { ReloadReason } from "../types";
 import type {
@@ -1192,6 +1193,10 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_SLUG);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);
   window.localStorage.removeItem(CLOUD_MCP_SYNC_MARKER_STORAGE_KEY);
+  // Sign-out resets any in-flight sign-in intent and pending org choice so a
+  // later handoff starts from a clean slate.
+  clearDesktopSignInIntent();
+  clearOrgSelectionPending();
 
   dispatchDenSettingsChanged({
     settings: readDenSettings(),

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -25,6 +25,7 @@ import {
   type DenUser,
 } from "../../../app/lib/den";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
+import { readOrgSelectionPending } from "../../../app/lib/den-sign-in-intent";
 import { readDesktopDistributionInfo } from "../../../app/lib/desktop";
 import {
   denSessionUpdatedEvent,
@@ -213,12 +214,17 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
 
       if (currentRun !== refreshTokenRef.current) return;
 
-      await resolveDenActiveOrganizationWithRetry(() =>
-        ensureDenActiveOrganization({
-          forceServerSync:
-            !settings.activeOrgId?.trim() || !settings.activeOrgSlug?.trim(),
-        })
-      );
+      // While a desktop-initiated sign-in is waiting for the user's explicit
+      // organization choice, do not auto-resolve a default — that would
+      // silently commit an org the chooser is still asking about.
+      if (!readOrgSelectionPending().pending) {
+        await resolveDenActiveOrganizationWithRetry(() =>
+          ensureDenActiveOrganization({
+            forceServerSync:
+              !settings.activeOrgId?.trim() || !settings.activeOrgSlug?.trim(),
+          })
+        );
+      }
 
       if (currentRun !== refreshTokenRef.current) return;
 
@@ -292,9 +298,11 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     );
     // A signed-in session without an organization is a stranded first
     // sign-in (e.g. org discovery was rate limited during a handoff). Keep
-    // repairing in the background until an organization resolves.
+    // repairing in the background until an organization resolves — unless the
+    // missing org is deliberate because the chooser is waiting for the user.
     const repairMissingOrganization = () => {
       if (statusRef.current !== "signed_in") return;
+      if (readOrgSelectionPending().pending) return;
       const settings = readDenSettings();
       if (!settings.authToken?.trim() || settings.activeOrgId?.trim()) return;
       void resolveDenActiveOrganizationWithRetry(() =>

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -12,6 +12,7 @@ import {
   readDenSettings,
   resolveDenBaseUrls,
 } from "../../../app/lib/den";
+import { markDesktopSignInInitiated } from "../../../app/lib/den-sign-in-intent";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
 import {
   denSessionUpdatedEvent,
@@ -111,6 +112,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
   const openBrowserAuth = useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
+      markDesktopSignInInitiated();
       setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
@@ -140,6 +142,8 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl: nextBaseUrl,
         client,
+        // Pasted one-time codes are desktop-initiated sign-ins.
+        desktopInitiated: true,
         fallbackErrorMessage: t("den.error_no_token"),
       });
       if (!result.ok) {

--- a/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
@@ -153,6 +153,8 @@ export function JoinOrganizationDialog({
     const result = await exchangeHandoffAndSignIn(parsed.grant, {
       baseUrl,
       client: createDenClient({ baseUrl }),
+      // Pasted one-time codes are desktop-initiated sign-ins.
+      desktopInitiated: true,
       fallbackErrorMessage: t("den.error_no_token"),
     });
 

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -38,6 +38,7 @@ import {
   exchangeHandoffAndSignIn,
 } from "@/app/lib/den-handoff";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { clearOrgSelectionPending, readOrgSelectionPending } from "@/app/lib/den-sign-in-intent";
 import { usePlatform } from "../../kernel/platform";
 import { useBootState } from "../../shell/boot-state";
 import { resolveModelDisplayName, resolveProviderDisplayName } from "@/app/utils";
@@ -239,6 +240,8 @@ function PreparedWorkspacePage({ prepared }: { prepared: PreparedBootstrapSummar
       const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl: settings.baseUrl,
         client: createDenClient({ baseUrl: settings.baseUrl }),
+        // A pasted one-time code is a desktop-initiated sign-in.
+        desktopInitiated: true,
       });
       if (!result.ok) setSignInError(result.error);
     } finally {
@@ -401,6 +404,9 @@ export function OrgOnboardingPage() {
   );
   const [autoSelectFailedOrgId, setAutoSelectFailedOrgId] = useState<string | null>(null);
   const autoSelectingOrgIdRef = useRef<string | null>(null);
+  // A desktop-initiated sign-in parks the exchange-reported org here instead
+  // of committing it; the chooser pre-highlights it as its default.
+  const [suggestedOrgId] = useState(() => readOrgSelectionPending().suggestion?.id ?? "");
 
   useEffect(() => {
     window.dispatchEvent(new CustomEvent(orgOnboardingVisibilityEvent, { detail: { visible: true } }));
@@ -440,7 +446,7 @@ export function OrgOnboardingPage() {
   const orgs = data?.orgs ?? [];
   const postListStep = resolveOrgOnboardingPostListStep({
     orgs,
-    activeOrgId: orgId,
+    activeOrgId: orgId || suggestedOrgId,
     hasSelectedOrganization,
     autoContinueResources,
     autoSelectFailedOrgId,
@@ -459,6 +465,7 @@ export function OrgOnboardingPage() {
       .setActiveOrganization({ organizationId: autoSelectOrg.id })
       .then(() => {
         if (cancelled) return;
+        clearOrgSelectionPending();
         writeDenSettings({
           ...settings,
           authToken: authToken || null,
@@ -1127,6 +1134,7 @@ function OrganizationSelectionPage({
       return nextOrg;
     },
     onSuccess: (nextOrg) => {
+      clearOrgSelectionPending();
       writeDenSettings({
         ...settings,
         authToken: authToken || null,

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -8,6 +8,7 @@ import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-ico
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
+import { markDesktopSignInInitiated } from "../../../../app/lib/den-sign-in-intent";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
@@ -350,6 +351,7 @@ export function SessionPage(props: SessionPageProps) {
   const showCloudSignIn = shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking";
   const openCloudSignIn = useCallback(() => {
     const baseUrl = readDenBootstrapConfig().baseUrl;
+    markDesktopSignInInitiated();
     // Label stays "Sign in"; opens the sign-up tab so new users aren't defaulted into sign-in.
     platform.openLink(buildDenAuthUrl(baseUrl, "sign-up"));
   }, [platform]);

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -33,6 +33,7 @@ import {
   readDenBootstrapConfig,
   readDenSettings,
 } from "../../../../app/lib/den";
+import { markDesktopSignInInitiated } from "../../../../app/lib/den-sign-in-intent";
 import {
   openWorkConnectAttentionTitle,
   resolveOpenWorkConnectStatus,
@@ -285,6 +286,7 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
   const showStatus = shellConfig.statusBar && (runtimeStatus !== null || connectStatus !== null);
 
   const openSignIn = () => {
+    markDesktopSignInInitiated();
     platform.openLink(buildDenAuthUrl(readDenBootstrapConfig().baseUrl, "sign-up"));
   };
 
@@ -420,7 +422,10 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
           <DropdownMenuItem
             onClick={() => {
               hideOpenWorkModelsPromo();
-              if (!denAuth.isSignedIn) navigate("/settings/cloud-account");
+              if (!denAuth.isSignedIn) {
+                navigate("/settings/cloud-account");
+                markDesktopSignInInitiated();
+              }
               platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
             }}
           >

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -19,6 +19,7 @@ import {
   type DenSettings,
   type DenOrgSummary,
 } from "@/app/lib/den";
+import { markDesktopSignInInitiated } from "@/app/lib/den-sign-in-intent";
 import { clearDesktopBootstrapConfig } from "@/app/lib/desktop";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import {
@@ -240,6 +241,7 @@ export function useDenSession({
   const openBrowserAuth = React.useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
+      markDesktopSignInInitiated();
       setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
@@ -499,6 +501,8 @@ export function useDenSession({
       const result = await exchangeHandoffAndSignIn(parsed.grant, {
         baseUrl: nextBaseUrl,
         client: exchangeClient,
+        // Pasted one-time codes are desktop-initiated sign-ins.
+        desktopInitiated: true,
         fallbackErrorMessage: t("den.error_no_token"),
       });
       if (!result.ok) {

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -44,6 +44,7 @@ import { SessionRoute } from "./session-route";
 import { SettingsRoute } from "./settings-route";
 import { ShellConfigProvider } from "./shell-config";
 import { WelcomeRoute } from "./welcome-route";
+import { readOrgSelectionPending } from "../../app/lib/den-sign-in-intent";
 import { signedInRoute } from "./den-signin-routing";
 
 
@@ -103,11 +104,25 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       if (!denAuth.isSignedIn && !onSignin) {
         navigate("/signin", { replace: true });
       } else if (denAuth.isSignedIn && onSignin) {
-        navigate(signedInRoute(readDenSettings().activeOrgId), { replace: true });
+        navigate(
+          signedInRoute(readDenSettings().activeOrgId, {
+            orgSelectionPending: readOrgSelectionPending().pending,
+          }),
+          { replace: true },
+        );
       }
     } else if (onSignin) {
       navigate("/session", { replace: true });
     } else if (!denAuth.isSignedIn && hasPreparedBootstrap && !onOnboarding) {
+      navigate("/onboarding", { replace: true });
+    } else if (
+      denAuth.isSignedIn &&
+      !onOnboarding &&
+      readOrgSelectionPending().pending
+    ) {
+      // A desktop-initiated sign-in is still waiting for the user's explicit
+      // organization choice (including after an app relaunch mid-flow); the
+      // onboarding step owns resolving it.
       navigate("/onboarding", { replace: true });
     }
 
@@ -135,7 +150,11 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       const check = () => {
         attempts++;
         const settings = readDenSettings();
-        if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
+        if (settings.authToken?.trim() && readOrgSelectionPending().pending) {
+          // Desktop-initiated sign-in: the org chooser decides — do not race
+          // it to /session while the choice is deliberately open.
+          navigate("/onboarding", { replace: true });
+        } else if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
           navigate("/session", { replace: true });
         } else if (attempts < 10) {
           // Session persistence should already be done, but retry briefly in
@@ -213,6 +232,9 @@ function DenAuthControlActions() {
       const result = await exchangeHandoffAndSignIn(grant.trim(), {
         baseUrl: targetBaseUrl,
         client,
+        // Automation surface: commit the exchange-reported org directly; a
+        // UI chooser would strand a headless driver.
+        desktopInitiated: false,
         fallbackErrorMessage: "No token returned",
       });
       if (!result.ok) return { ok: false, error: result.error };

--- a/apps/app/src/react-app/shell/den-signin-routing.ts
+++ b/apps/app/src/react-app/shell/den-signin-routing.ts
@@ -1,3 +1,14 @@
-export function signedInRoute(activeOrgId: string | null | undefined): "/session" | "/onboarding" {
+/**
+ * Where a signed-in user lands. `/onboarding` owns organization resolution:
+ * it runs when no active organization is committed yet, and also while a
+ * desktop-initiated sign-in is deliberately holding the choice open for the
+ * user (`orgSelectionPending`) — even if a background layer has already
+ * written some default organization id.
+ */
+export function signedInRoute(
+  activeOrgId: string | null | undefined,
+  options?: { orgSelectionPending?: boolean },
+): "/session" | "/onboarding" {
+  if (options?.orgSelectionPending) return "/onboarding";
   return activeOrgId?.trim() ? "/session" : "/onboarding";
 }

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -34,6 +34,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, clearDenSession, DEFAULT_DEN_BASE_URL, readDenSettings } from "../../app/lib/den";
+import { markDesktopSignInInitiated } from "../../app/lib/den-sign-in-intent";
 import { denSettingsChangedEvent } from "../../app/lib/den-session-events";
 import { writeActiveWorkspaceId, writeLastSessionFor, writeWorkspaceProjectDimension } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
@@ -387,6 +388,7 @@ export function WelcomeRoute() {
   const handleTeamSignIn = useCallback(() => {
     markOnboardingComplete();
     const settings = readDenSettings();
+    markDesktopSignInInitiated();
     platform.openLink(buildDenAuthUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL, "sign-in"));
   }, [markOnboardingComplete, platform]);
 

--- a/apps/app/tests/den-handoff.test.ts
+++ b/apps/app/tests/den-handoff.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { exchangeHandoffAndSignIn } from "../src/app/lib/den-handoff";
+import {
+  hasActiveDesktopSignInIntent,
+  markDesktopSignInInitiated,
+  markOrgSelectionPending,
+  readOrgSelectionPending,
+} from "../src/app/lib/den-sign-in-intent";
 
 const originalWindow = globalThis.window;
 const originalFetch = globalThis.fetch;
@@ -120,5 +126,86 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(result.exchange.connectEnabled).toBeNull();
     expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_stored"))
       .toBeNull();
+  });
+
+  test("a desktop-initiated sign-in defers the org choice to the chooser", async () => {
+    stubWindow();
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_default", slug: "default-org", name: "Default Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", {
+      baseUrl: "https://den.test",
+      desktopInitiated: true,
+    });
+
+    expect(result.ok).toBe(true);
+    // Token persists, but no organization is committed…
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_handoff");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBeNull();
+    // …and the chooser sees the pending state with the exchange org suggested.
+    expect(readOrgSelectionPending()).toEqual({
+      pending: true,
+      suggestion: { id: "org_default", slug: "default-org", name: "Default Org" },
+    });
+  });
+
+  test("the desktop sign-in intent marker classifies an unlabeled handoff", async () => {
+    stubWindow();
+    markDesktopSignInInitiated();
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_default", slug: "default-org", name: "Default Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBeNull();
+    expect(readOrgSelectionPending().pending).toBe(true);
+    // The marker is consumed: a later remote handoff is not reclassified.
+    expect(hasActiveDesktopSignInIntent()).toBe(false);
+  });
+
+  test("an explicitly scoped org connects straight through even when desktop-initiated", async () => {
+    stubWindow();
+    markDesktopSignInInitiated();
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_exchange", slug: "exchange-org", name: "Exchange Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", {
+      baseUrl: "https://den.test",
+      activeOrg: { id: "org_invite", slug: "invite-org", name: "Invite Org" },
+      desktopInitiated: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_invite");
+    expect(readOrgSelectionPending().pending).toBe(false);
+  });
+
+  test("a remote handoff clears stale pending state and commits its organization", async () => {
+    stubWindow();
+    markOrgSelectionPending({ id: "org_stale", slug: null, name: null });
+    stubExchangeResponse({
+      token: "tok_handoff",
+      user: exchangeUser,
+      organization: { id: "org_remote", slug: "remote-org", name: "Remote Org" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_test", {
+      baseUrl: "https://den.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_remote");
+    expect(readOrgSelectionPending()).toEqual({ pending: false, suggestion: null });
   });
 });

--- a/apps/app/tests/den-sign-in-intent.test.ts
+++ b/apps/app/tests/den-sign-in-intent.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  DESKTOP_SIGN_IN_INTENT_TTL_MS,
+  clearOrgSelectionPending,
+  hasActiveDesktopSignInIntent,
+  isDesktopSignInIntentActive,
+  markDesktopSignInInitiated,
+  markOrgSelectionPending,
+  readOrgSelectionPending,
+  resolveHandoffOrgPlan,
+} from "../src/app/lib/den-sign-in-intent";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function stubWindow() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: memoryStorage(),
+      dispatchEvent: () => true,
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("desktop sign-in intent marker", () => {
+  test("is active within the TTL and expires after it", () => {
+    stubWindow();
+    markDesktopSignInInitiated(1_000);
+
+    expect(hasActiveDesktopSignInIntent(1_000)).toBe(true);
+    expect(hasActiveDesktopSignInIntent(1_000 + DESKTOP_SIGN_IN_INTENT_TTL_MS)).toBe(true);
+    expect(hasActiveDesktopSignInIntent(1_000 + DESKTOP_SIGN_IN_INTENT_TTL_MS + 1)).toBe(false);
+  });
+
+  test("is inactive without a marker or with a malformed one", () => {
+    expect(isDesktopSignInIntentActive(null, 1_000)).toBe(false);
+    expect(isDesktopSignInIntentActive("not-a-number", 1_000)).toBe(false);
+  });
+});
+
+describe("pending organization selection state", () => {
+  test("round-trips the suggestion and clears completely", () => {
+    stubWindow();
+    markOrgSelectionPending({ id: "org_a", slug: "org-a", name: "Org A" });
+
+    expect(readOrgSelectionPending()).toEqual({
+      pending: true,
+      suggestion: { id: "org_a", slug: "org-a", name: "Org A" },
+    });
+
+    clearOrgSelectionPending();
+    expect(readOrgSelectionPending()).toEqual({ pending: false, suggestion: null });
+  });
+
+  test("stays pending without a usable suggestion", () => {
+    stubWindow();
+    markOrgSelectionPending(null);
+
+    expect(readOrgSelectionPending()).toEqual({ pending: true, suggestion: null });
+  });
+});
+
+describe("resolveHandoffOrgPlan", () => {
+  const exchangeOrg = { id: "org_session", slug: "session-org", name: "Session Org" };
+
+  test("an explicitly scoped org (install/invite/bootstrap) always commits", () => {
+    expect(
+      resolveHandoffOrgPlan({
+        explicitActiveOrg: { id: "org_invite", slug: "invite-org", name: "Invite Org" },
+        exchangeOrganization: exchangeOrg,
+        desktopInitiated: true,
+      }),
+    ).toEqual({
+      kind: "commit",
+      organization: { id: "org_invite", slug: "invite-org", name: "Invite Org" },
+    });
+  });
+
+  test("a desktop-initiated sign-in defers to the chooser with the exchange org as suggestion", () => {
+    expect(
+      resolveHandoffOrgPlan({
+        explicitActiveOrg: null,
+        exchangeOrganization: exchangeOrg,
+        desktopInitiated: true,
+      }),
+    ).toEqual({ kind: "await-user-selection", suggestion: exchangeOrg });
+    expect(
+      resolveHandoffOrgPlan({
+        explicitActiveOrg: null,
+        exchangeOrganization: null,
+        desktopInitiated: true,
+      }),
+    ).toEqual({ kind: "await-user-selection", suggestion: null });
+  });
+
+  test("a remotely-initiated handoff commits the session's organization", () => {
+    expect(
+      resolveHandoffOrgPlan({
+        explicitActiveOrg: null,
+        exchangeOrganization: exchangeOrg,
+        desktopInitiated: false,
+      }),
+    ).toEqual({ kind: "commit", organization: exchangeOrg });
+  });
+
+  test("an explicit org with a blank id does not count as a remote selection", () => {
+    expect(
+      resolveHandoffOrgPlan({
+        explicitActiveOrg: { id: "  ", slug: null, name: null },
+        exchangeOrganization: exchangeOrg,
+        desktopInitiated: true,
+      }),
+    ).toEqual({ kind: "await-user-selection", suggestion: exchangeOrg });
+  });
+});

--- a/apps/app/tests/den-signin-routing.test.ts
+++ b/apps/app/tests/den-signin-routing.test.ts
@@ -12,4 +12,11 @@ describe("signed-in routing", () => {
     expect(signedInRoute(null)).toBe("/onboarding");
     expect(signedInRoute("  ")).toBe("/onboarding");
   });
+
+  test("routes to onboarding while an org selection is deliberately pending", () => {
+    expect(signedInRoute(null, { orgSelectionPending: true })).toBe("/onboarding");
+    // Pending wins even if a background layer already wrote a default org id.
+    expect(signedInRoute("org-default", { orgSelectionPending: true })).toBe("/onboarding");
+    expect(signedInRoute("org-default", { orgSelectionPending: false })).toBe("/session");
+  });
 });


### PR DESCRIPTION
## Problem

Signing in from the desktop app auto-selects an organization within a moment of the browser round-trip finishing, instead of letting the user choose. Multi-organization accounts never see the existing choose-org onboarding step.

Four layers combine to cause it:

1. den-api hydrates the browser session's active organization server-side whenever it is empty (`hydrateSessionActiveOrganization`), so the desktop handoff exchange **always** reports an `organization` — the payload cannot distinguish "the user chose this org remotely" from "the server defaulted one".
2. `exchangeHandoffAndSignIn` pins that organization into settings immediately.
3. Even without it, `ensureDenActiveOrganization` falls back to the first listed org (immediately on sign-in and again from a 30-second repair loop).
4. `signedInRoute()` and the app-root post-sign-in poller route any org-bearing session straight to `/session`, so `/onboarding`'s `choose-org` step never renders.

## Change

The reliable discriminator is who initiated the sign-in, which the desktop knows:

- **Remotely-initiated handoffs keep connecting straight through.** Install/invite links and enterprise bootstrap carry an explicitly scoped org; a handoff the desktop did not initiate (e.g. "Open in desktop" from the Cloud dashboard) carries the organization the user's Cloud session is actually working in.
- **Desktop-initiated sign-ins defer the choice to the chooser.** Every in-app sign-in button records a short-lived intent marker (`apps/app/src/app/lib/den-sign-in-intent.ts`, 15-minute TTL in localStorage so it survives the browser round-trip and an app relaunch); pasted one-time codes are desktop-initiated by construction. On exchange, the token persists but no organization is committed: the exchange-reported org is stored as the chooser's pre-highlighted default and an `orgSelectionPending` state routes sign-in through `/onboarding`. The existing choose-org step commits only on explicit confirmation; single-organization accounts still auto-select silently there.
- **While the choice is pending, the auto-select layers stand down:** the org auto-resolution fallback and repair loop skip, the post-sign-in poller and `signedInRoute()` go to `/onboarding` (including after an app relaunch mid-flow), and the cloud provider sync pipeline already waits for a committed org (`hasCloudProviderSyncPrerequisites` requires `activeOrgId`), so org-scoped syncing runs once against the org the user actually picked.
- **Committing or leaving clears the state:** both chooser confirmation and single-org auto-select clear it before writing settings; sign-out (`clearDenSession`) clears the marker and pending state; the automation grant-exchange control action passes `desktopInitiated: false` so headless drivers keep committing directly.

Known tradeoff: a remote handoff arriving within the 15-minute window after an abandoned desktop-initiated attempt shows the chooser once, pre-highlighted with that handoff's org — one extra confirmation click, never a wrong silent commit.

## Verification

- `cd apps/app && bun test tests/den-sign-in-intent.test.ts tests/den-handoff.test.ts tests/den-signin-routing.test.ts tests/den-auth-provider.test.ts tests/den-session-offline-resilience.test.ts` — 35 pass. Covers the plan matrix (explicit org always commits; desktop-initiated defers with suggestion; remote commits; blank explicit ids don't count), marker TTL/consumption, handoff persistence for both policies (token kept, org withheld, pending + suggestion stored; remote handoffs clear stale pending state), and pending-aware routing.
- `cd apps/app && pnpm typecheck` — clean.
- `cd apps/app && bun test --isolate tests/` — 733 pass, 6 fail; the same 6 failures reproduce with the change stashed on the merge-base commit in the same environment (`window.matchMedia`/ordering-dependent files: extensions-sidebar-header, connect-capability-inventory, cloud-workspace-overlay, message-list-loading ×2, session-provider-auth-server-sync), so they are pre-existing and unrelated.
- Manual repro of the defect on dev: sign in from the desktop with a multi-org account → the app lands in `/session` with an org silently selected. With this change: the chooser renders with the previous org pre-highlighted; dashboard-initiated "Open in desktop" still connects directly.
