### PR TITLE
Clear cloud provider credentials after restart

### DIFF
--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -301,6 +301,12 @@ describe("cloud provider sync gateway", () => {
         marketplaces: { mkp_keep: { name: "Keep" } },
       },
     }));
+    // Simulate an upgrade/restart after an older process persisted the cloud
+    // credential. The next sync sees the same value, performs no upsert, and
+    // must still reclaim ownership so logout removes it.
+    await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).upsertMany([
+      { key: "TEST_PROVIDER_API_KEY", value: "sk-test-provider" },
+    ]);
 
     const server = await startServer(config);
     stops.push(() => server.stop());

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -757,9 +757,14 @@ export class CloudProviderSync {
     const envUpserts = prepared.envEntries.filter((entry) => storedEnv.get(entry.key) !== entry.value);
     if (envUpserts.length > 0) {
       await this.env.upsertMany(envUpserts);
-      for (const entry of envUpserts) this.ownedEnvKeys.add(entry.key);
     }
     const desiredEnvKeys = new Set(prepared.envEntries.map((entry) => entry.key));
+    // Ownership follows the active cloud materialization, not whether this
+    // process happened to write the value. After an app/server restart the
+    // persisted credential can already equal Den's value, so envUpserts is
+    // empty. Reclaim every desired key or the next logout will leave that
+    // cloud credential behind permanently.
+    for (const key of desiredEnvKeys) this.ownedEnvKeys.add(key);
     const envDeletes = [...this.ownedEnvKeys].filter((key) => !desiredEnvKeys.has(key));
     for (const key of envDeletes) {
       await this.env.delete(key);


### PR DESCRIPTION
## Summary

- reclaim every environment key in the active cloud-provider materialization, even when its persisted value already matches
- ensure logout removes cloud credentials left by an older process or app restart
- add an end-to-end regression for the matching-value restart/upgrade path

## Root cause

Cloud provider environment ownership was recorded only for keys written by the current server process. After a restart, an existing matching credential required no upsert, so it was never added to the ownership set and logout left it in env.json. OpenCode then rediscovered the provider as a local API-key connection.

## Verification

- pnpm --filter openwork-server test -- cloud-provider-sync.e2e.test.ts
- pnpm --filter openwork-server typecheck
- git diff --check origin/dev...HEAD
