### PR TITLE
chore(release): v0.18.22

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.21",
+  "version": "0.18.22",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.21",
+  "version": "0.18.22",
   "desktopName": "com.differentai.openwork",
   "description": "OpenWork desktop shell",
   "author": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.21",
+  "version": "0.18.22",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.22",
   "0.18.21",
   "0.18.20",
   "0.18.19",


### PR DESCRIPTION
## Summary

- bump the app, desktop, and openwork-server versions to 0.18.22
- publish 0.18.22 as the newest supported desktop version for the Den install route
- prepare a new release from dev containing the Windows Azure-signing repair and cloud-provider logout cleanup

## Why

The v0.18.21 GitHub release published without Windows installer assets. The Windows signing configuration repair has since landed on dev, so a new patch release is required to produce and publish the Windows builds. This release also includes the follow-up that removes matching cloud-managed provider credentials after a restart and logout.

## Verification

- pnpm release:review
- git diff --check origin/dev...HEAD
- versions aligned at 0.18.22 across app, desktop, and openwork-server
- branch based on dev@de02b0d2f2397a32fd4c5ea94762b03400aad366
