### PR TITLE
fix(den-api): rank capability results by relevance

### DIFF
--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -46,7 +46,8 @@ export type CapabilityMatch = {
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {
   const statusPriority = Number("kind" in b && b.kind === "connection_status")
     - Number("kind" in a && a.kind === "connection_status")
-  return statusPriority || (b.score - a.score) || a.name.localeCompare(b.name)
+  // Relevance leads globally; an actionable status only wins an equal-score tie.
+  return (b.score - a.score) || statusPriority || a.name.localeCompare(b.name)
 }
 
 export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -455,7 +455,7 @@ test("capability discovery is marked read-only while generic execution remains g
   })
 })
 
-test("connection status ranks above unrelated callable tools without distorting relevance scores", () => {
+test("connection status only outranks equally relevant callable tools", () => {
   type ConnectionStatusMatch = CapabilityMatch & { kind: "connection_status" }
   const callableMatch: CapabilityMatch = {
     name: "slack_search_emojis",
@@ -482,6 +482,12 @@ test("connection status ranks above unrelated callable tools without distorting 
 
   matches.sort(compareCapabilityMatches)
 
+  expect(matches[0]?.name).toBe("slack_search_emojis")
+  expect(matches[0]?.score).toBe(20)
+
+  statusMatch.score = callableMatch.score
+  matches.sort(compareCapabilityMatches)
+
   expect(matches[0]?.kind).toBe("connection_status")
-  expect(matches[0]?.score).toBe(7)
+  expect(matches[0]?.score).toBe(20)
 })

--- a/evals/specs/capability-search-status-ranking.test.ts
+++ b/evals/specs/capability-search-status-ranking.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  compareCapabilityMatches,
+  type CapabilityMatch,
+} from "../../ee/apps/den-api/src/mcp/search.js";
+
+function match(input: Pick<CapabilityMatch, "name" | "score"> & Partial<CapabilityMatch>): CapabilityMatch {
+  return {
+    method: "GET",
+    path: "/v1/example",
+    summary: input.name,
+    pathParams: [],
+    queryParams: [],
+    hasBody: false,
+    ...input,
+  };
+}
+
+test("capability search ranks stronger task matches above unrelated connection prompts", async ({ evidence }) => {
+  const invitation = match({
+    name: "postInvitations",
+    method: "POST",
+    path: "/v1/invitations",
+    score: 5,
+    summary: "Create organization invitation",
+    hasBody: true,
+    bodySchema: { type: "object", required: ["email", "role"] },
+  });
+  const microsoftConnection = match({
+    name: "native:microsoft-365:*",
+    method: "NATIVE",
+    path: "https://www.microsoft.com/microsoft-365",
+    score: 3,
+    summary: "Microsoft 365 needs connection",
+    kind: "connection_status",
+  });
+
+  const ranked = [microsoftConnection, invitation].sort(compareCapabilityMatches);
+
+  expect(ranked.map((candidate) => candidate.name)).toEqual([
+    "postInvitations",
+    "native:microsoft-365:*",
+  ]);
+  expect(ranked[0]).toBe(invitation);
+  expect(ranked[0]?.bodySchema).toEqual({ type: "object", required: ["email", "role"] });
+  evidence.fact(
+    "Task relevance leads capability search ordering",
+    "The score-5 organization invitation capability and its request schema remain intact above the score-3 Microsoft 365 connection prompt.",
+    true,
+  );
+});
+
+test("an actionable connection prompt wins an equal-relevance tie", async ({ evidence }) => {
+  const callable = match({ name: "getTeams", score: 5, summary: "List teams" });
+  const connection = match({
+    name: "native:microsoft-365:*",
+    method: "NATIVE",
+    path: "https://www.microsoft.com/microsoft-365",
+    score: 5,
+    summary: "Microsoft 365 needs connection",
+    kind: "connection_status",
+  });
+
+  const ranked = [callable, connection].sort(compareCapabilityMatches);
+
+  expect(ranked[0]?.kind).toBe("connection_status");
+  evidence.fact(
+    "Connection recovery stays actionable when relevance ties",
+    "At the same lexical score, the connection-status row remains ahead of an ordinary callable capability.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- rank capability-search matches by lexical relevance score before considering connection state
- preserve actionable `connection_status` rows as the tie-breaker when scores are equal
- prove the observed cross-source shape: a score-5 organization invitation ranks above a score-3 Microsoft 365 connection prompt, with its request schema unchanged

## Why

The global comparator gave every connection-status row absolute priority. That allowed a lower-scoring provider prompt to precede stronger task matches even though search had already computed their relative relevance.

This change makes the existing score authoritative while keeping recovery actions prominent when they are equally relevant.

## Scope and prior work

This keeps the useful narrow principles from the closed #2966 experiment: apply one deterministic global ordering rule across sources and preserve each result's execution metadata. It does not revive that branch's larger stemming, synonym, rarity, or adjacency ranker.

It is complementary to #3428, which improves how REST create routes receive scores. External MCP caching from #2967 and agent prompt behavior from #2977 remain separate concerns.

## Verification

- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-agent-timeouts.test.ts -t 'connection status only outranks equally relevant callable tools'` — 1 passed, 14 filtered, 0 failed
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/capability-search-status-ranking.test.ts` — 2 passed, 0 failed; exact-head testkit evidence published
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p tsconfig.json` — passed
- `git diff --check upstream/dev...HEAD` — passed
- an earlier full-file attempt reached 14 passing tests and one database-dependent failure because MySQL was unavailable at `127.0.0.1:3306`; the changed comparator test passes independently

Rebased without conflicts onto current `dev`.

Base: `e6bc9685e02e8dcdfe6d0b02ccc07ba4063e6afd`
Head: `3413c4e8831dccb35c1ea359725dd035c726c0d3`