### PR TITLE
fix(server): stabilize local MCP OAuth start

### DIFF
--- a/apps/server/src/local-managed-mcp-url-guard.ts
+++ b/apps/server/src/local-managed-mcp-url-guard.ts
@@ -191,7 +191,15 @@ export async function assertLocalManagedMcpUrl(rawUrl: string): Promise<void> {
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const guardedDispatcher = new Agent({
-  connect: { lookup: createLocalManagedMcpPublicLookup() },
+  connect: {
+    lookup: createLocalManagedMcpPublicLookup(),
+    // Node's 250 ms family-attempt default is too aggressive for otherwise
+    // healthy dual-stack MCP providers on some macOS networks. Keep fallback
+    // enabled, but give the first family enough time to establish TLS before
+    // trying the validated alternative address.
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 1_000,
+  },
 });
 
 function redirectedRequestInit(init: RequestInit | undefined, status: number, from: URL, to: URL): RequestInit {

--- a/apps/server/src/local-managed-mcp.e2e.test.ts
+++ b/apps/server/src/local-managed-mcp.e2e.test.ts
@@ -155,6 +155,55 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
     expect(existsSync(join(runtimeStorageDir(config), "local-managed-mcp-vault.json"))).toBe(false);
   });
 
+  test("rolls back a new managed connection when the initial OAuth handshake fails", async () => {
+    const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+    const previousDevMode = process.env.OPENWORK_DEV_MODE;
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-local-managed-mcp-rollback-"));
+    roots.push(workspaceRoot);
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    process.env.OPENWORK_DEV_MODE = "1";
+
+    try {
+      const engine = startMockOpencode();
+      const unavailableProviderPort = await freePort();
+      const config = createConfig({
+        port: await freePort(),
+        workspaceRoot,
+        engineBaseUrl: `http://127.0.0.1:${engine.server.port}`,
+        vaultKey: randomBytes(32),
+      });
+      const server = await startServer(config);
+      stops.push(() => server.stop());
+      const openworkBaseUrl = `http://127.0.0.1:${server.port}`;
+
+      const created = await fetch(`${openworkBaseUrl}/workspace/ws_managed/mcp/managed`, {
+        method: "POST",
+        headers: clientHeaders(config.token),
+        body: JSON.stringify({
+          name: "unreachable-oauth",
+          url: `http://127.0.0.1:${unavailableProviderPort}/mcp`,
+          oauth: { applicationType: "native", requestedScopes: ["mcp:read"] },
+        }),
+      });
+      expect(created.status).toBe(502);
+      expect(await created.json()).toMatchObject({
+        code: "managed_mcp_connection_failed",
+      });
+
+      const status = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/unreachable-oauth/managed`,
+        { headers: clientHeaders(config.token) },
+      );
+      expect(status.status).toBe(404);
+      expect(await readRuntimeMcpConfig(config, "ws_managed", "unreachable-oauth")).toBeNull();
+    } finally {
+      if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+      if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
+      else process.env.OPENWORK_DEV_MODE = previousDevMode;
+    }
+  });
+
   test("owns OAuth, exposes provider tools to OpenCode, refreshes, survives restart, and disconnects", async () => {
     const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
     const previousDevMode = process.env.OPENWORK_DEV_MODE;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2872,7 +2872,22 @@ function createRoutes(
         ...(typeof oauth.clientSecret === "string" && oauth.clientSecret.trim() ? { clientSecret: oauth.clientSecret.trim() } : {}),
       },
     });
-    const result = await startLocalManagedMcpAuthorization(config, workspace.id, name);
+    const result = await (async () => {
+      try {
+        return await startLocalManagedMcpAuthorization(config, workspace.id, name);
+      } catch (error) {
+        // Creation writes the encrypted connection and runtime facade before
+        // OAuth discovery starts. If that first handshake fails, roll both back
+        // so the failed Add request cannot leave a ghost connection behind.
+        await deleteLocalManagedMcp(config, workspace.id, name).catch(() => undefined);
+        if (error instanceof ApiError) throw error;
+        throw new ApiError(
+          502,
+          "managed_mcp_connection_failed",
+          "OpenWork could not start sign-in with this MCP server. Check the server URL, OAuth settings, and network connection, then try again.",
+        );
+      }
+    })();
     await syncRuntimeMcpToOpencodeEngine(config, workspace, [name], undefined, engineMcpServerState).catch(() => undefined);
     await recordAudit(workspace.path, {
       id: shortId(),


### PR DESCRIPTION
## Summary

- give the guarded MCP transport enough time to fall back between validated IPv4 and IPv6 addresses on dual-stack networks
- roll back a newly created managed MCP vault/runtime entry when its initial OAuth handshake fails
- return a structured, actionable 502 instead of leaving a ghost `Sign in needed` connection after a failed Add request

## Problem

The managed BigQuery flow could intermittently fail during the initial MCP initialize request before an OAuth authorization URL existed. The connection had already been persisted at that point, so the failed request returned a generic server error while a partial connection remained visible after reload. Retrying Sign in repeated the same pre-browser handshake.

## Verification

- `bun --conditions=development test src/local-managed-mcp-url-guard.test.ts src/local-managed-mcp.e2e.test.ts` — 10 passed
- `pnpm typecheck` in `apps/server` — passed
