### PR TITLE
fix(desktop): package MCP validation dependencies

### DIFF
--- a/apps/desktop/electron/server-dependency-mirror.test.mjs
+++ b/apps/desktop/electron/server-dependency-mirror.test.mjs
@@ -9,6 +9,9 @@ const desktopPackage = JSON.parse(
 const serverPackage = JSON.parse(
   readFileSync(new URL("../../server/package.json", import.meta.url), "utf8"),
 );
+const mcpSdkPackage = JSON.parse(
+  readFileSync(new URL("../node_modules/@modelcontextprotocol/sdk/package.json", import.meta.url), "utf8"),
+);
 
 describe("server dependency mirror", () => {
   it("mirrors every server runtime dependency in the desktop package", () => {
@@ -17,6 +20,16 @@ describe("server dependency mirror", () => {
         desktopPackage.dependencies[name],
         spec,
         `Server runtime dependency "${name}" must be mirrored with the same version in apps/desktop/package.json because the packaged app imports server/dist from app.asar and electron-builder only packs node_modules declared by apps/desktop/package.json.`,
+      );
+    }
+  });
+
+  it("declares MCP validation dependencies that electron-builder must pack", () => {
+    for (const name of ["ajv", "ajv-formats"]) {
+      assert.equal(
+        desktopPackage.dependencies[name],
+        mcpSdkPackage.dependencies[name],
+        `MCP SDK runtime dependency "${name}" must be declared directly in apps/desktop/package.json so it is available from app.asar.`,
       );
     }
   });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,8 @@
     "@openwork/enterprise-mcp-client": "workspace:*",
     "@openwork/paths": "workspace:*",
     "@opencode-ai/sdk": "^1.17.11",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "better-sqlite3": "^13.0.2",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,12 @@ importers:
       '@openwork/paths':
         specifier: workspace:*
         version: link:../../packages/paths
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       better-sqlite3:
         specifier: ^13.0.2
         version: 13.0.2


### PR DESCRIPTION
## Summary

- declare `ajv` and `ajv-formats` as Desktop runtime dependencies
- keep their declared ranges aligned with the MCP SDK
- add a regression check for the packaged `app.asar` dependency boundary

## Root cause

The MCP Apps host activates the MCP SDK AJV validation provider in the packaged local server. Electron Builder packages the Desktop dependency graph from `apps/desktop/package.json`; the validation packages were only transitive, so the installed app could not resolve `ajv` and failed to reconnect its local workspace.

## User impact

Packaged Desktop builds can start the local server and reconnect workspaces after the MCP Apps host changes.

## Verification

- `node --test apps/desktop/electron/server-dependency-mirror.test.mjs` — 2 passed
- direct ESM import of `@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js` from the Desktop dependency tree — passed

The full Electron packaging build was left to CI because registry requests were timing out locally.