### PR TITLE
fix(desktop): include MCP validation runtime in packaged app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .turbo/
 node_modules/
 apps/desktop/dist-electron/
+apps/desktop/.electron-runtime/
 apps/desktop/dist-electron-demo-a/
 apps/desktop/dist-electron-demo-b/
 packages/*/node_modules/

--- a/apps/desktop/electron-builder.base.yml
+++ b/apps/desktop/electron-builder.base.yml
@@ -7,6 +7,8 @@ files:
   - server/**/*
   - "!server/dist/opencode-plugins/**"
   - package.json
+  - from: .electron-runtime/node_modules
+    to: node_modules
 extraResources:
   - from: ../app/dist
     to: app-dist

--- a/apps/desktop/electron/electron-builder-config.test.mjs
+++ b/apps/desktop/electron/electron-builder-config.test.mjs
@@ -19,6 +19,10 @@ describe("Electron distribution configs", () => {
     const config = await readConfig("electron-builder.base.yml");
     assert.equal(packageMetadata.desktopName, "com.differentai.openwork");
     assert.equal(config.npmRebuild, false);
+    assert.deepEqual(config.files.at(-1), {
+      from: ".electron-runtime/node_modules",
+      to: "node_modules",
+    });
     assert.equal(config.linux.syncDesktopName, true);
     assert.equal(config.linux.icon, "resources/icons/linux");
     assert.deepEqual(config.linux.extraResources[0], {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -44,6 +44,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electron/asar": "^3.4.1",
     "@electron/rebuild": "^4.2.0",
     "@openwork/types": "workspace:*",
     "electron": "^43.2.0",

--- a/apps/desktop/scripts/electron-after-pack.cjs
+++ b/apps/desktop/scripts/electron-after-pack.cjs
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const asar = require("@electron/asar");
 
 const computerUseHelperAppName = "OpenWork Computer Use.app";
 
@@ -44,6 +45,28 @@ function resolveMacAppPath(context) {
   return fallback ? path.join(context.appOutDir, fallback) : null;
 }
 
+function resolveAppAsarPath(context) {
+  if (context.electronPlatformName === "darwin") {
+    const appPath = resolveMacAppPath(context);
+    return appPath ? path.join(appPath, "Contents", "Resources", "app.asar") : null;
+  }
+  return path.join(context.appOutDir, "resources", "app.asar");
+}
+
+function verifyRuntimeDependencies(context) {
+  const appAsarPath = resolveAppAsarPath(context);
+  if (!appAsarPath || !fs.existsSync(appAsarPath)) {
+    throw new Error(`Missing packaged app.asar at ${appAsarPath || context.appOutDir}`);
+  }
+  const packagedFiles = new Set(asar.listPackage(appAsarPath));
+  for (const packageName of ["ajv", "ajv-formats", "fast-deep-equal", "fast-uri", "json-schema-traverse", "require-from-string"]) {
+    const packageJsonPath = `/node_modules/${packageName}/package.json`;
+    if (!packagedFiles.has(packageJsonPath)) {
+      throw new Error(`Missing MCP validation runtime dependency from app.asar: ${packageName}`);
+    }
+  }
+}
+
 function signComputerUseHelper(context) {
   const appPath = resolveMacAppPath(context);
   if (!appPath) return;
@@ -84,6 +107,7 @@ function copyExecutableTargetToAlias(sidecarsDir, targetName, aliasName) {
 }
 
 async function afterPack(context) {
+  verifyRuntimeDependencies(context);
   const triple = targetTriple(context.electronPlatformName, context.arch);
   if (!triple) return;
 

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -10,6 +10,7 @@ const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
 const electronHelperDir = resolve(desktopRoot, "resources", "helpers");
 const electronRoot = resolve(desktopRoot, "electron");
 const packagedServerRoot = resolve(desktopRoot, "server");
+const packagedRuntimeRoot = resolve(desktopRoot, ".electron-runtime", "node_modules");
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const nodeCmd = process.execPath;
@@ -32,6 +33,7 @@ function run(command, args, cwd, env) {
 
 run(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], desktopRoot);
 run(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], desktopRoot);
+run(nodeCmd, [resolve(__dirname, "prepare-runtime-node-modules.mjs"), "--outdir", packagedRuntimeRoot], desktopRoot);
 // Build the server TS → JS so Electron can import it in-process
 run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
 // OPENWORK_ELECTRON_BUILD tells Vite to emit relative asset paths so

--- a/apps/desktop/scripts/prepare-runtime-node-modules.mjs
+++ b/apps/desktop/scripts/prepare-runtime-node-modules.mjs
@@ -1,0 +1,55 @@
+import { cpSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const dirnameHere = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = resolve(dirnameHere, "..");
+const requiredRoots = ["ajv", "ajv-formats"];
+
+function packageRoot(name, fromPackageJson) {
+  const requireFromPackage = createRequire(pathToFileURL(fromPackageJson));
+  let current = dirname(requireFromPackage.resolve(name));
+  while (current !== dirname(current)) {
+    try {
+      const packageJson = JSON.parse(readFileSync(join(current, "package.json"), "utf8"));
+      if (packageJson.name === name) return { root: current, packageJson };
+    } catch {
+      // Keep walking from the resolved entry to its package root.
+    }
+    current = dirname(current);
+  }
+  throw new Error(`Could not resolve runtime package root for ${name}.`);
+}
+
+export function stageRuntimeNodeModules(outdir) {
+  const output = resolve(outdir);
+  const desktopPackageJson = resolve(desktopRoot, "package.json");
+  const pending = requiredRoots.map((name) => ({ name, fromPackageJson: desktopPackageJson }));
+  const staged = new Set();
+  rmSync(output, { recursive: true, force: true });
+  mkdirSync(output, { recursive: true });
+
+  while (pending.length > 0) {
+    const item = pending.shift();
+    if (!item || staged.has(item.name)) continue;
+    const resolvedPackage = packageRoot(item.name, item.fromPackageJson);
+    const destination = resolve(output, item.name);
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(resolvedPackage.root, destination, { recursive: true, dereference: true });
+    staged.add(item.name);
+    const dependencies = resolvedPackage.packageJson.dependencies ?? {};
+    for (const dependencyName of Object.keys(dependencies)) {
+      pending.push({ name: dependencyName, fromPackageJson: resolve(resolvedPackage.root, "package.json") });
+    }
+  }
+
+  return [...staged].sort();
+}
+
+const outdirIndex = process.argv.indexOf("--outdir");
+if (outdirIndex !== -1) {
+  const outdir = process.argv[outdirIndex + 1];
+  if (!outdir) throw new Error("--outdir requires a path.");
+  process.stdout.write(`${JSON.stringify({ staged: stageRuntimeNodeModules(outdir) })}\n`);
+}

--- a/evals/specs/desktop-packaged-mcp-validation.test.ts
+++ b/evals/specs/desktop-packaged-mcp-validation.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "vitest";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("the packaged Desktop runtime can load MCP JSON Schema validation", async () => {
+  const root = mkdtempSync(join(tmpdir(), "openwork-mcp-validation-"));
+  try {
+    const nodeModules = join(root, "node_modules");
+    const prepare = spawnSync(process.execPath, [
+      resolve(repoRoot, "apps/desktop/scripts/prepare-runtime-node-modules.mjs"),
+      "--outdir",
+      nodeModules,
+    ], { encoding: "utf8" });
+    expect(prepare.status, prepare.stderr).toBe(0);
+
+    const requireFromDesktop = createRequire(pathToFileURL(resolve(repoRoot, "apps/desktop/package.json")));
+    const providerSource = requireFromDesktop.resolve("@modelcontextprotocol/sdk/validation/ajv");
+    const providerDestination = join(nodeModules, "@modelcontextprotocol", "sdk", "validation", "ajv-provider.js");
+    mkdirSync(dirname(providerDestination), { recursive: true });
+    cpSync(providerSource, providerDestination);
+    if (existsSync(`${providerSource}.map`)) cpSync(`${providerSource}.map`, `${providerDestination}.map`);
+    writeFileSync(join(nodeModules, "@modelcontextprotocol", "sdk", "package.json"), JSON.stringify({ type: "module" }));
+
+    const provider = await import(`${pathToFileURL(providerDestination).href}?test=${Date.now()}`);
+    const validator = new provider.AjvJsonSchemaValidator().getValidator({
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+      additionalProperties: false,
+    });
+    expect(validator({ title: "Artifact" })).toMatchObject({ valid: true });
+    expect(validator({ title: 42 })).toMatchObject({ valid: false });
+
+    for (const packageName of ["ajv", "ajv-formats", "fast-deep-equal", "fast-uri", "json-schema-traverse", "require-from-string"]) {
+      const staged = JSON.parse(readFileSync(join(nodeModules, packageName, "package.json"), "utf8"));
+      expect(staged.name).toBe(packageName);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@electron/asar':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@electron/rebuild':
         specifier: ^4.2.0
         version: 4.2.0


### PR DESCRIPTION
## Problem

The packaged Desktop app includes the MCP SDK but omits its AJV validation runtime from `app.asar`. This leaves the latest alpha unable to start even after declaring AJV as a direct Desktop dependency.

## Fix

- Stage the AJV production dependency closure into a dedicated Electron runtime directory before packaging.
- Copy that closure into `app.asar/node_modules` through the shared electron-builder config.
- Fail `afterPack` unless AJV and every required transitive package are physically present in the completed archive.
- Add a focused runtime test that loads the MCP SDK AJV provider from a package-shaped temporary tree and validates accepted and rejected data.

## Checks

- `pnpm --dir evals exec vitest run specs/desktop-packaged-mcp-validation.test.ts --config vitest.config.ts --project pr`
- `node --test apps/desktop/electron/electron-builder-config.test.mjs apps/desktop/electron/server-dependency-mirror.test.mjs`
- Node syntax checks for all changed packaging scripts
- Constructed a temporary `app.asar` from the staged dependency closure and passed the actual `afterPack` archive verification
- `git diff --check`