### PR TITLE
fix(desktop): package the complete MCP SDK runtime

### DIFF
--- a/apps/desktop/scripts/electron-after-pack.cjs
+++ b/apps/desktop/scripts/electron-after-pack.cjs
@@ -59,10 +59,33 @@ function verifyRuntimeDependencies(context) {
     throw new Error(`Missing packaged app.asar at ${appAsarPath || context.appOutDir}`);
   }
   const packagedFiles = new Set(asar.listPackage(appAsarPath));
-  for (const packageName of ["ajv", "ajv-formats", "fast-deep-equal", "fast-uri", "json-schema-traverse", "require-from-string"]) {
-    const packageJsonPath = `/node_modules/${packageName}/package.json`;
+  const stagedNodeModules = path.resolve(__dirname, "..", ".electron-runtime", "node_modules");
+  const packageJsonPaths = [];
+  function visitNodeModules(nodeModulesPath, archivePrefix) {
+    for (const entry of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith("@")) {
+        visitNodeModules(path.join(nodeModulesPath, entry.name), `${archivePrefix}/${entry.name}`);
+        continue;
+      }
+      const packagePath = path.join(nodeModulesPath, entry.name);
+      if (!fs.existsSync(path.join(packagePath, "package.json"))) continue;
+      const packageJsonPath = `${archivePrefix}/${entry.name}/package.json`;
+      packageJsonPaths.push(packageJsonPath);
+      const nestedNodeModules = path.join(packagePath, "node_modules");
+      if (fs.existsSync(nestedNodeModules)) {
+        visitNodeModules(nestedNodeModules, `${archivePrefix}/${entry.name}/node_modules`);
+      }
+    }
+  }
+  if (!fs.existsSync(stagedNodeModules)) {
+    throw new Error(`Missing staged MCP runtime at ${stagedNodeModules}`);
+  }
+  visitNodeModules(stagedNodeModules, "/node_modules");
+  if (packageJsonPaths.length === 0) throw new Error("The staged MCP runtime is empty.");
+  for (const packageJsonPath of packageJsonPaths) {
     if (!packagedFiles.has(packageJsonPath)) {
-      throw new Error(`Missing MCP validation runtime dependency from app.asar: ${packageName}`);
+      throw new Error(`Missing staged MCP runtime package from app.asar: ${packageJsonPath}`);
     }
   }
 }

--- a/apps/desktop/scripts/prepare-runtime-node-modules.mjs
+++ b/apps/desktop/scripts/prepare-runtime-node-modules.mjs
@@ -1,15 +1,30 @@
 import { cpSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const dirnameHere = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(dirnameHere, "..");
-const requiredRoots = ["ajv", "ajv-formats"];
+const requiredRoots = [{
+  name: "@modelcontextprotocol/sdk",
+  resolveTarget: "@modelcontextprotocol/sdk/validation/ajv",
+}];
 
-function packageRoot(name, fromPackageJson) {
+function packageRoot(name, fromPackageJson, resolveTarget = name) {
   const requireFromPackage = createRequire(pathToFileURL(fromPackageJson));
-  let current = dirname(requireFromPackage.resolve(name));
+  let current;
+  try {
+    current = dirname(requireFromPackage.resolve(resolveTarget));
+  } catch (error) {
+    const linkedPackageRoot = resolve(dirname(dirname(fromPackageJson)), name);
+    try {
+      const linkedPackageJson = JSON.parse(readFileSync(join(linkedPackageRoot, "package.json"), "utf8"));
+      if (linkedPackageJson.name === name) return { root: linkedPackageRoot, packageJson: linkedPackageJson };
+    } catch {
+      // Preserve the original module-resolution error below.
+    }
+    throw error;
+  }
   while (current !== dirname(current)) {
     try {
       const packageJson = JSON.parse(readFileSync(join(current, "package.json"), "utf8"));
@@ -25,26 +40,46 @@ function packageRoot(name, fromPackageJson) {
 export function stageRuntimeNodeModules(outdir) {
   const output = resolve(outdir);
   const desktopPackageJson = resolve(desktopRoot, "package.json");
-  const pending = requiredRoots.map((name) => ({ name, fromPackageJson: desktopPackageJson }));
-  const staged = new Set();
+  const staged = [];
+  const rootPackages = new Map();
+  const placements = new Set();
   rmSync(output, { recursive: true, force: true });
   mkdirSync(output, { recursive: true });
 
-  while (pending.length > 0) {
-    const item = pending.shift();
-    if (!item || staged.has(item.name)) continue;
-    const resolvedPackage = packageRoot(item.name, item.fromPackageJson);
-    const destination = resolve(output, item.name);
+  function stagePackage({ name, fromPackageJson, resolveTarget }, parentDestination, forceRoot = false) {
+    const resolvedPackage = packageRoot(name, fromPackageJson, resolveTarget);
+    const rootPackage = rootPackages.get(name);
+    if (!rootPackage) rootPackages.set(name, resolvedPackage.root);
+    if (!forceRoot && rootPackage === resolvedPackage.root) return;
+    const nodeModulesRoot = forceRoot || !rootPackage
+      ? output
+      : resolve(parentDestination, "node_modules");
+    const destination = resolve(nodeModulesRoot, name);
+    const placementKey = `${destination}\0${resolvedPackage.root}`;
+    if (placements.has(placementKey)) return;
+    placements.add(placementKey);
     mkdirSync(dirname(destination), { recursive: true });
-    cpSync(resolvedPackage.root, destination, { recursive: true, dereference: true });
-    staged.add(item.name);
+    cpSync(resolvedPackage.root, destination, {
+      recursive: true,
+      dereference: true,
+      filter: (source) => source === resolvedPackage.root
+        || !relative(resolvedPackage.root, source).split(sep).includes("node_modules"),
+    });
+    staged.push(destination.slice(output.length + 1));
     const dependencies = resolvedPackage.packageJson.dependencies ?? {};
     for (const dependencyName of Object.keys(dependencies)) {
-      pending.push({ name: dependencyName, fromPackageJson: resolve(resolvedPackage.root, "package.json") });
+      stagePackage(
+        { name: dependencyName, fromPackageJson: resolve(resolvedPackage.root, "package.json") },
+        destination,
+      );
     }
   }
 
-  return [...staged].sort();
+  for (const item of requiredRoots) {
+    stagePackage({ ...item, fromPackageJson: desktopPackageJson }, output, true);
+  }
+
+  return staged.sort();
 }
 
 const outdirIndex = process.argv.indexOf("--outdir");

--- a/evals/specs/desktop-packaged-mcp-validation.test.ts
+++ b/evals/specs/desktop-packaged-mcp-validation.test.ts
@@ -1,15 +1,14 @@
 import { expect } from "vitest";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
 import { test } from "@openwork/testkit";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
-test("the packaged Desktop runtime can load MCP JSON Schema validation", async () => {
+test("the packaged Desktop runtime can load MCP validation and SSE transport", async () => {
   const root = mkdtempSync(join(tmpdir(), "openwork-mcp-validation-"));
   try {
     const nodeModules = join(root, "node_modules");
@@ -20,15 +19,8 @@ test("the packaged Desktop runtime can load MCP JSON Schema validation", async (
     ], { encoding: "utf8" });
     expect(prepare.status, prepare.stderr).toBe(0);
 
-    const requireFromDesktop = createRequire(pathToFileURL(resolve(repoRoot, "apps/desktop/package.json")));
-    const providerSource = requireFromDesktop.resolve("@modelcontextprotocol/sdk/validation/ajv");
-    const providerDestination = join(nodeModules, "@modelcontextprotocol", "sdk", "validation", "ajv-provider.js");
-    mkdirSync(dirname(providerDestination), { recursive: true });
-    cpSync(providerSource, providerDestination);
-    if (existsSync(`${providerSource}.map`)) cpSync(`${providerSource}.map`, `${providerDestination}.map`);
-    writeFileSync(join(nodeModules, "@modelcontextprotocol", "sdk", "package.json"), JSON.stringify({ type: "module" }));
-
-    const provider = await import(`${pathToFileURL(providerDestination).href}?test=${Date.now()}`);
+    const sdkRoot = join(nodeModules, "@modelcontextprotocol", "sdk");
+    const provider = await import(`${pathToFileURL(join(sdkRoot, "dist", "esm", "validation", "ajv-provider.js")).href}?test=${Date.now()}`);
     const validator = new provider.AjvJsonSchemaValidator().getValidator({
       type: "object",
       properties: { title: { type: "string" } },
@@ -38,10 +30,11 @@ test("the packaged Desktop runtime can load MCP JSON Schema validation", async (
     expect(validator({ title: "Artifact" })).toMatchObject({ valid: true });
     expect(validator({ title: 42 })).toMatchObject({ valid: false });
 
-    for (const packageName of ["ajv", "ajv-formats", "fast-deep-equal", "fast-uri", "json-schema-traverse", "require-from-string"]) {
-      const staged = JSON.parse(readFileSync(join(nodeModules, packageName, "package.json"), "utf8"));
-      expect(staged.name).toBe(packageName);
-    }
+    const sse = await import(`${pathToFileURL(join(sdkRoot, "dist", "esm", "client", "sse.js")).href}?test=${Date.now()}`);
+    expect(sse.SSEClientTransport).toBeTypeOf("function");
+
+    expect(JSON.parse(readFileSync(join(nodeModules, "ajv", "package.json"), "utf8")).name).toBe("ajv");
+    expect(JSON.parse(readFileSync(join(nodeModules, "eventsource", "package.json"), "utf8")).name).toBe("eventsource");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

Desktop alpha `0.18.24-alpha.2297` includes the AJV subtree added by #3743, but still fails during startup because the packaged MCP SDK imports `eventsource`, which is absent from `app.asar`. The previous fix enumerated one SDK dependency subtree rather than packaging the SDK's complete production runtime.

## Fix

- Stage `@modelcontextprotocol/sdk` and recursively discover its complete production dependency closure from installed package metadata.
- Build a conventional deduplicated `node_modules` layout, retaining nested packages only when dependency versions genuinely conflict.
- Verify every staged package path against the completed `app.asar` during `afterPack`; packaging now fails if any part of the staged MCP runtime is omitted.
- Extend the focused regression test to import and exercise both the AJV validator and the SDK SSE client transport from the staged package tree.

## Verification

- Targeted Vitest runtime spec passes, including `SSEClientTransport` import and AJV valid/invalid inputs.
- Electron builder config and server dependency mirror tests: 6 passed.
- Packaging scripts pass Node syntax checks.
- A temporary `app.asar` containing the staged closure passes the actual `afterPack` archive verification.
- The staged closure contains 94 package instances (93 unique package names), with nested copies only for two version conflicts.
- `git diff --check` passes.