### PR TITLE
Fix managed provider auth reload ordering

### DIFF
--- a/apps/server/src/cloud-provider-sync-reload-guard.test.ts
+++ b/apps/server/src/cloud-provider-sync-reload-guard.test.ts
@@ -308,7 +308,8 @@ describe("engine reload guard", () => {
     const server = await startServer(config);
     stops.push(() => server.stop());
     const base = `http://127.0.0.1:${server.port}`;
-    const den = startFakeDen({ providers: [stableDenProvider()] });
+    const provider = stableDenProvider();
+    const den = startFakeDen({ providers: [provider] });
 
     const put = await fetch(`${base}/den-session`, {
       method: "PUT",
@@ -327,6 +328,9 @@ describe("engine reload guard", () => {
     }));
     const settledDisposes = engine.disposeCount();
     expect(settledDisposes).toBeGreaterThan(0);
+    expect(engine.requests.indexOf("PUT /auth/lpr_steady")).toBeLessThan(
+      engine.requests.indexOf("POST /instance/dispose"),
+    );
 
     // Every later pass sees byte-identical Den state. A pass that still reports
     // "applied" here is the runaway-dispose bug: on the 5-minute interval it
@@ -344,6 +348,22 @@ describe("engine reload guard", () => {
     // The credential push is fingerprint-guarded, so it must not re-deliver
     // on every pass either.
     expect(engine.requests.filter((entry) => entry === "PUT /auth/lpr_steady")).toHaveLength(1);
+
+    // A credential rotation leaves the provider config byte-identical, but
+    // the cached SDK client must still be replaced after the new auth lands.
+    provider.apiKey = "sk-steady-provider-rotated";
+    const beforeRotationDisposes = engine.disposeCount();
+    const rotated = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "credential_rotated" }),
+    }));
+    expect(rotated.status).toBe("applied");
+    expect(engine.requests.filter((entry) => entry === "PUT /auth/lpr_steady")).toHaveLength(2);
+    expect(engine.disposeCount()).toBe(beforeRotationDisposes + 1);
+    expect(engine.requests.lastIndexOf("PUT /auth/lpr_steady")).toBeLessThan(
+      engine.requests.lastIndexOf("POST /instance/dispose"),
+    );
   });
 
   test("a deferred reload lands by itself once the engine idles, even with no Den session", async () => {

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -354,6 +354,9 @@ describe("cloud provider sync gateway", () => {
     }]);
     // The idle engine accepted the reload, so no reload is still owed.
     expect(firstStatus.reloadPending).toBe(false);
+    expect(engineRequests.indexOf("PUT /auth/lpr_test")).toBeLessThan(
+      engineRequests.indexOf("POST /instance/dispose"),
+    );
 
     expect(denRequests.every((request) => request.authorization === "Bearer den-token")).toBe(true);
     expect(denRequests.every((request) => request.orgId === "org_test")).toBe(true);

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -476,6 +476,9 @@ describe("cloud provider sync gateway", () => {
     }]);
     // The idle engine accepted the reload, so no reload is still owed.
     expect(firstStatus.reloadPending).toBe(false);
+    expect(engineRequests.indexOf("PUT /auth/lpr_test")).toBeLessThan(
+      engineRequests.indexOf("POST /instance/dispose"),
+    );
 
     expect(denRequests.every((request) => request.authorization === "Bearer den-token")).toBe(true);
     expect(denRequests.every((request) => request.orgId === "org_test")).toBe(true);

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -776,8 +776,20 @@ export class CloudProviderSync {
     const runtimeFileChanged = engineWorkspace
       ? (await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id)).changed
       : false;
-    // Credentials reach a live engine through PUT /auth/{providerID} below, so
-    // a key rotation never needs a reload. Provider *config* (models, npm,
+    // Deliver credentials before disposing the current provider instances.
+    // OpenCode constructs and caches SDK clients from config + auth together;
+    // reloading first can cache a client without the just-synced credential,
+    // even though PUT /auth/{providerID} later reports success. Credential
+    // rotation therefore needs the same instance refresh as provider config.
+    const authResult = await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    const authChanged = authResult.delivered.length > 0 || authResult.removed.length > 0;
+
+    // Provider *config* (models, npm,
     // options.baseURL) has no live path: the engine reads it from
     // OPENCODE_CONFIG when it builds an instance, and the only write endpoint
     // that accepts it, PATCH /config, performs the same instance dispose as
@@ -788,7 +800,8 @@ export class CloudProviderSync {
     this.reloadPending = this.reloadPending
       || providerStateChanged
       || workspaceCleanup.runtimeChanged
-      || runtimeFileChanged;
+      || runtimeFileChanged
+      || authChanged;
     let reloadError: unknown;
     let reloadDeferred = false;
     if (engineWorkspace && this.reloadPending) {
@@ -808,13 +821,6 @@ export class CloudProviderSync {
         }
       }
     }
-    await syncManagedProviderAuth({
-      config: this.config,
-      env: this.env,
-      fetchImpl: this.fetchImpl,
-      logger: this.logger,
-    });
-
     this.managedProviderIds = new Set(Object.keys(desiredProviders));
     const detail: CloudProviderSyncRunDetail = {
       fingerprintChanged: this.fingerprint !== prepared.fingerprint,
@@ -907,6 +913,15 @@ export class CloudProviderSync {
       const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
       this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
     }
+    const authResult = await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    this.reloadPending = this.reloadPending
+      || authResult.delivered.length > 0
+      || authResult.removed.length > 0;
     let reloadError: unknown;
     if (this.reloadPending && (await this.reloadDeferredByActivity())) {
       this.scheduleReloadRetry();
@@ -920,12 +935,6 @@ export class CloudProviderSync {
         this.scheduleReloadRetry();
       }
     }
-    await syncManagedProviderAuth({
-      config: this.config,
-      env: this.env,
-      fetchImpl: this.fetchImpl,
-      logger: this.logger,
-    });
     if (reloadError) throw reloadError;
   }
 }

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -886,8 +886,20 @@ export class CloudProviderSync {
     const runtimeFileChanged = engineWorkspace
       ? (await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id)).changed
       : false;
-    // Credentials reach a live engine through PUT /auth/{providerID} below, so
-    // a key rotation never needs a reload. Provider *config* (models, npm,
+    // Deliver credentials before disposing the current provider instances.
+    // OpenCode constructs and caches SDK clients from config + auth together;
+    // reloading first can cache a client without the just-synced credential,
+    // even though PUT /auth/{providerID} later reports success. Credential
+    // rotation therefore needs the same instance refresh as provider config.
+    const authResult = await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    const authChanged = authResult.delivered.length > 0 || authResult.removed.length > 0;
+
+    // Provider *config* (models, npm,
     // options.baseURL) has no live path: the engine reads it from
     // OPENCODE_CONFIG when it builds an instance, and the only write endpoint
     // that accepts it, PATCH /config, performs the same instance dispose as
@@ -898,7 +910,8 @@ export class CloudProviderSync {
     this.reloadPending = this.reloadPending
       || providerStateChanged
       || workspaceCleanup.runtimeChanged
-      || runtimeFileChanged;
+      || runtimeFileChanged
+      || authChanged;
     let reloadError: unknown;
     let reloadDeferred = false;
     if (engineWorkspace && this.reloadPending) {
@@ -918,13 +931,6 @@ export class CloudProviderSync {
         }
       }
     }
-    await syncManagedProviderAuth({
-      config: this.config,
-      env: this.env,
-      fetchImpl: this.fetchImpl,
-      logger: this.logger,
-    });
-
     this.managedProviderIds = new Set(Object.keys(desiredProviders));
     const detail: CloudProviderSyncRunDetail = {
       fingerprintChanged: this.fingerprint !== prepared.fingerprint,
@@ -1017,6 +1023,15 @@ export class CloudProviderSync {
       const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
       this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
     }
+    const authResult = await syncManagedProviderAuth({
+      config: this.config,
+      env: this.env,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+    });
+    this.reloadPending = this.reloadPending
+      || authResult.delivered.length > 0
+      || authResult.removed.length > 0;
     let reloadError: unknown;
     if (this.reloadPending && (await this.reloadDeferredByActivity())) {
       this.scheduleReloadRetry();
@@ -1030,12 +1045,6 @@ export class CloudProviderSync {
         this.scheduleReloadRetry();
       }
     }
-    await syncManagedProviderAuth({
-      config: this.config,
-      env: this.env,
-      fetchImpl: this.fetchImpl,
-      logger: this.logger,
-    });
     if (reloadError) throw reloadError;
   }
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1109,10 +1109,18 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
 
   // Deliver server-managed provider credentials to the engine on startup. The
   // engine process receives a fixed env allowlist, so credentials materialized
-  // into the env store only reach it through the engine's auth API. Fire and
-  // forget: a credential problem must never stop the server from serving.
+  // into the env store only reach it through the engine's auth API. A delivered
+  // credential also invalidates any SDK client the engine cached before auth
+  // arrived; the sync coordinator lands that reload without interrupting a
+  // live session.
   resetManagedProviderAuthCache();
-  void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) }).catch(() => undefined);
+  void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) })
+    .then((result) => {
+      if (result.delivered.length > 0 || result.removed.length > 0) {
+        cloudProviderSync.markReloadPending();
+      }
+    })
+    .catch(() => undefined);
 
   return {
     ...server,
@@ -2409,7 +2417,18 @@ function createRoutes(
     }));
 
     const fileResult = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-    const shouldReload = result.changed || fileResult.changed;
+    // Auth must land before the reload so the replacement provider instance is
+    // constructed with its credential. This also refreshes SDK clients after
+    // a key rotation even when provider config itself did not change.
+    const authResult = await syncManagedProviderAuth({
+      config,
+      env,
+      logger: toManagedProviderAuthLogger(logger),
+    });
+    const shouldReload = result.changed
+      || fileResult.changed
+      || authResult.delivered.length > 0
+      || authResult.removed.length > 0;
     // A rollover-capable pool can apply this immediately without disposing
     // the generation that owns live sessions. Legacy/external engines keep
     // the established busy deferral.
@@ -2422,14 +2441,6 @@ function createRoutes(
     if (reloadDeferred) {
       cloudProviderSync.markReloadPending();
     }
-    // The provider entry only names its credential env vars; the engine needs
-    // the value itself via its auth API.
-    await syncManagedProviderAuth({
-      config,
-      env,
-      logger: toManagedProviderAuthLogger(logger),
-    }).catch(() => undefined);
-
     return jsonResponse({
       ok: true,
       changed: result.changed,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1265,10 +1265,18 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
 
   // Deliver server-managed provider credentials to the engine on startup. The
   // engine process receives a fixed env allowlist, so credentials materialized
-  // into the env store only reach it through the engine's auth API. Fire and
-  // forget: a credential problem must never stop the server from serving.
+  // into the env store only reach it through the engine's auth API. A delivered
+  // credential also invalidates any SDK client the engine cached before auth
+  // arrived; the sync coordinator lands that reload without interrupting a
+  // live session.
   resetManagedProviderAuthCache();
-  void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) }).catch(() => undefined);
+  void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) })
+    .then((result) => {
+      if (result.delivered.length > 0 || result.removed.length > 0) {
+        cloudProviderSync.markReloadPending();
+      }
+    })
+    .catch(() => undefined);
 
   return {
     ...server,
@@ -2661,7 +2669,18 @@ function createRoutes(
     }));
 
     const fileResult = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-    const shouldReload = result.changed || fileResult.changed;
+    // Auth must land before the reload so the replacement provider instance is
+    // constructed with its credential. This also refreshes SDK clients after
+    // a key rotation even when provider config itself did not change.
+    const authResult = await syncManagedProviderAuth({
+      config,
+      env,
+      logger: toManagedProviderAuthLogger(logger),
+    });
+    const shouldReload = result.changed
+      || fileResult.changed
+      || authResult.delivered.length > 0
+      || authResult.removed.length > 0;
     // A rollover-capable pool can apply this immediately without disposing
     // the generation that owns live sessions. Legacy/external engines keep
     // the established busy deferral.
@@ -2673,14 +2692,6 @@ function createRoutes(
     if (reloadDeferred) {
       cloudProviderSync.markReloadPending();
     }
-    // The provider entry only names its credential env vars; the engine needs
-    // the value itself via its auth API.
-    await syncManagedProviderAuth({
-      config,
-      env,
-      logger: toManagedProviderAuthLogger(logger),
-    }).catch(() => undefined);
-
     return jsonResponse({
       ok: true,
       changed: result.changed,

--- a/evals/specs/managed-provider-auth-order.test.ts
+++ b/evals/specs/managed-provider-auth-order.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { CloudProviderSync } from "../../apps/server/src/cloud-provider-sync.js";
+import { EnvService } from "../../apps/server/src/env-file.js";
+import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+const PROVIDER_ID = "lpr_auth_order";
+const MODEL_ID = "auth-order-model";
+
+test("managed provider credentials land before SDK clients are refreshed", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-provider-auth-order-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  resetManagedProviderAuthCache();
+
+  const events: string[] = [];
+  const provider: Record<string, unknown> = {
+    id: PROVIDER_ID,
+    providerId: "anthropic",
+    name: "Managed Anthropic",
+    source: "custom",
+    updatedAt: "2026-08-12T00:00:00.000Z",
+    providerConfig: {
+      env: ["MANAGED_ANTHROPIC_API_KEY"],
+      npm: "@ai-sdk/anthropic",
+    },
+    apiKey: "sk-managed-first",
+    apiKeys: null,
+    models: [{ id: MODEL_ID, name: "Managed Anthropic Model", config: {} }],
+  };
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_auth_order",
+      name: "Auth order",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: "http://engine.example.test",
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === "den.example.test" && url.pathname === "/v1/llm-providers") {
+      return Response.json({ llmProviders: [provider] });
+    }
+    if (url.hostname === "den.example.test" && url.pathname === `/v1/llm-providers/${PROVIDER_ID}/connect`) {
+      return Response.json({ llmProvider: provider });
+    }
+    if (url.hostname === "engine.example.test" && url.pathname === `/auth/${PROVIDER_ID}`) {
+      events.push(`${init?.method ?? "GET"} auth`);
+      return Response.json(true);
+    }
+    return Response.json({ error: "not_found" }, { status: 404 });
+  };
+  const sync = new CloudProviderSync({
+    config,
+    env: new EnvService({ path: join(root, "env.json") }),
+    fetchImpl,
+    reloadEngine: async () => {
+      events.push("reload");
+    },
+    intervalMs: 3_600_000,
+  });
+
+  try {
+    sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "den-token",
+      orgId: "org-auth-order",
+    });
+    await sync.run("initial_materialization");
+
+    expect(events).toEqual(["PUT auth", "reload"]);
+    evidence.fact(
+      "A managed credential is delivered before the provider SDK client is refreshed",
+      `Observed engine event order: ${events.join(" -> ")}`,
+      events[0] === "PUT auth" && events[1] === "reload",
+    );
+
+    await sync.run("unchanged_snapshot");
+    expect(events).toEqual(["PUT auth", "reload"]);
+    evidence.fact(
+      "An unchanged provider snapshot does not churn the engine",
+      `The stable pass left the event log unchanged at ${events.length} events.`,
+      events.length === 2,
+    );
+
+    provider.apiKey = "sk-managed-rotated";
+    await sync.run("credential_rotation");
+    expect(events).toEqual(["PUT auth", "reload", "PUT auth", "reload"]);
+    evidence.fact(
+      "A rotated credential lands before exactly one replacement SDK client is created",
+      `Observed rotation event order: ${events.slice(2).join(" -> ")}`,
+      events[2] === "PUT auth" && events[3] === "reload" && events.length === 4,
+    );
+  } finally {
+    sync.stop();
+    resetManagedProviderAuthCache();
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/managed-provider-auth-order.test.ts
+++ b/evals/specs/managed-provider-auth-order.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { CloudProviderSync } from "../../apps/server/src/cloud-provider-sync.js";
+import { EnvService } from "../../apps/server/src/env-file.js";
+import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+const PROVIDER_ID = "lpr_auth_order";
+const MODEL_ID = "auth-order-model";
+
+test("managed provider credentials land before SDK clients are refreshed", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-provider-auth-order-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  resetManagedProviderAuthCache();
+
+  const events: string[] = [];
+  const provider: Record<string, unknown> = {
+    id: PROVIDER_ID,
+    providerId: "anthropic",
+    name: "Managed Anthropic",
+    source: "custom",
+    updatedAt: "2026-08-12T00:00:00.000Z",
+    providerConfig: {
+      env: ["MANAGED_ANTHROPIC_API_KEY"],
+      npm: "@ai-sdk/anthropic",
+    },
+    apiKey: "sk-managed-first",
+    apiKeys: null,
+    models: [{ id: MODEL_ID, name: "Managed Anthropic Model", config: {} }],
+  };
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_auth_order",
+      name: "Auth order",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: "http://engine.example.test",
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === "den.example.test" && url.pathname === "/v1/llm-providers") {
+      return Response.json({ llmProviders: [provider] });
+    }
+    if (url.hostname === "den.example.test" && url.pathname === `/v1/llm-providers/${PROVIDER_ID}/connect`) {
+      return Response.json({ llmProvider: provider });
+    }
+    if (url.hostname === "engine.example.test" && url.pathname === `/auth/${PROVIDER_ID}`) {
+      events.push(`${init?.method ?? "GET"} auth`);
+      return Response.json(true);
+    }
+    return Response.json({ error: "not_found" }, { status: 404 });
+  };
+  const sync = new CloudProviderSync({
+    config,
+    env: new EnvService({ path: join(root, "env.json") }),
+    fetchImpl,
+    reloadEngine: async () => {
+      events.push("reload");
+    },
+    intervalMs: 3_600_000,
+  });
+
+  try {
+    sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "den-token",
+      orgId: "org-auth-order",
+    });
+    await sync.run("initial_materialization");
+
+    expect(events).toEqual(["PUT auth", "reload"]);
+    evidence.recordAssertionEvidence(
+      "A managed credential is delivered before the provider SDK client is refreshed",
+      `Observed engine event order: ${events.join(" -> ")}`,
+      events[0] === "PUT auth" && events[1] === "reload",
+    );
+
+    await sync.run("unchanged_snapshot");
+    expect(events).toEqual(["PUT auth", "reload"]);
+    evidence.recordAssertionEvidence(
+      "An unchanged provider snapshot does not churn the engine",
+      `The stable pass left the event log unchanged at ${events.length} events.`,
+      events.length === 2,
+    );
+
+    provider.apiKey = "sk-managed-rotated";
+    await sync.run("credential_rotation");
+    expect(events).toEqual(["PUT auth", "reload", "PUT auth", "reload"]);
+    evidence.recordAssertionEvidence(
+      "A rotated credential lands before exactly one replacement SDK client is created",
+      `Observed rotation event order: ${events.slice(2).join(" -> ")}`,
+      events[2] === "PUT auth" && events[3] === "reload" && events.length === 4,
+    );
+  } finally {
+    sync.stop();
+    resetManagedProviderAuthCache();
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- deliver managed provider credentials before refreshing OpenCode provider instances
- refresh cached SDK clients when a managed credential is added or rotated
- preserve the existing busy-session reload guard and stable-snapshot no-op behavior

## Root cause

Cloud provider sync reloaded OpenCode before writing the provider credential through its auth API. OpenCode could therefore construct and cache an Anthropic SDK client without an API key. The later auth write made the provider appear connected, but the cached client still failed requests with `Anthropic API key is missing`.

## Verification

- `pnpm exec bun --conditions=development test src/managed-provider-auth.test.ts src/cloud-provider-sync-reload-guard.test.ts src/cloud-provider-sync.e2e.test.ts src/runtime-config-global-providers.test.ts` — 19 passed, 0 failed
- `pnpm typecheck` in `apps/server` — passed
- `pnpm evals:spec specs/managed-provider-auth-order.test.ts` — 1 passed, 0 failed; 3/3 testkit evidence claims passed

The testkit spec proves that initial and rotated credentials reach the auth API before provider instances reload, while unchanged snapshots do not churn the engine.
