### PR TITLE
Fix Automation runner registration through Den proxy

### DIFF
--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -4,9 +4,11 @@ import {
   type AutomationDesktopRunnerCapability,
 } from "@openwork/types/automations"
 import { env } from "../env.js"
+import { firstForwardedValue, trustedForwardedOrigin } from "../request-url.js"
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
 const TOKEN_ROUTE_SUFFIX = "/v1/automation-runners/token"
+const DEN_WEB_PROXY_PREFIX = "/api/den"
 
 export type AutomationRunnerIdentity = {
   organizationId: string
@@ -40,6 +42,25 @@ export function automationRunnerAudienceFromRequestUrl(requestUrl: string): stri
   const audience = normalizeRunnerAudience(parsed.toString())
   if (!audience) throw new Error("automation_runner_audience_invalid")
   return audience
+}
+
+/**
+ * Bind proxied runner credentials to the public Den route the desktop will
+ * actually use. The Den Web proxy strips caller-supplied forwarding headers
+ * and writes its own, while trustedForwardedOrigin limits the destination to
+ * configured first-party origins. Direct API requests keep their request URL.
+ */
+export function automationRunnerAudienceFromRequest(
+  request: Request,
+  options: { trustedOrigins: readonly string[] },
+): string {
+  const forwardedPrefix = firstForwardedValue(request.headers.get("x-forwarded-prefix"))
+    ?.replace(/\/+$/, "")
+  if (forwardedPrefix === DEN_WEB_PROXY_PREFIX) {
+    const forwarded = trustedForwardedOrigin(request, { trustedOrigins: options.trustedOrigins })
+    if (forwarded) return `${forwarded.origin}${DEN_WEB_PROXY_PREFIX}`
+  }
+  return automationRunnerAudienceFromRequestUrl(request.url)
 }
 
 export class AutomationRunnerAuth {

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -31,7 +31,8 @@ import {
 } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
-import { automationRunnerAudienceFromRequestUrl, automationRunnerAuth } from "../../automations/runner-auth.js"
+import { automationRunnerAudienceFromRequest, automationRunnerAuth } from "../../automations/runner-auth.js"
+import { env } from "../../env.js"
 import {
   RUNNER_KEEPALIVE_INTERVAL_MS,
   RUNNER_NOTIFICATION_POLL_MIN_MS,
@@ -131,7 +132,9 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
           runnerId: registration.runnerId,
           capabilities: registration.capabilities,
         },
-        automationRunnerAudienceFromRequestUrl(c.req.url),
+        automationRunnerAudienceFromRequest(c.req.raw, {
+          trustedOrigins: env.publicUrlTrustedOrigins,
+        }),
       ))
     },
   )

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -10,11 +10,12 @@ function seedRequiredEnv() {
 }
 
 let AutomationRunnerAuth: typeof import("../src/automations/runner-auth.js")["AutomationRunnerAuth"]
+let automationRunnerAudienceFromRequest: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequest"]
 let automationRunnerAudienceFromRequestUrl: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequestUrl"]
 
 beforeAll(async () => {
   seedRequiredEnv()
-  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequestUrl } = await import("../src/automations/runner-auth.js"))
+  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequest, automationRunnerAudienceFromRequestUrl } = await import("../src/automations/runner-auth.js"))
 })
 
 describe("Automation runner credentials", () => {
@@ -47,6 +48,34 @@ describe("Automation runner credentials", () => {
     )).toBe("https://den.example.com/api/den")
     expect(() => automationRunnerAudienceFromRequestUrl("https://den.example.com/not-the-token-route"))
       .toThrow("automation_runner_audience_invalid")
+  })
+
+  test("binds a Den Web proxied credential to its trusted public route", () => {
+    const request = new Request("http://api.openworklabs.com/v1/automation-runners/token", {
+      headers: {
+        "x-forwarded-host": "app.openworklabs.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-prefix": "/api/den",
+      },
+    })
+
+    expect(automationRunnerAudienceFromRequest(request, {
+      trustedOrigins: ["https://app.openworklabs.com"],
+    })).toBe("https://app.openworklabs.com/api/den")
+  })
+
+  test("ignores an untrusted forwarded runner destination", () => {
+    const request = new Request("https://api.openworklabs.com/v1/automation-runners/token", {
+      headers: {
+        "x-forwarded-host": "attacker.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-prefix": "/api/den",
+      },
+    })
+
+    expect(automationRunnerAudienceFromRequest(request, {
+      trustedOrigins: ["https://app.openworklabs.com"],
+    })).toBe("https://api.openworklabs.com")
   })
 
   test("keeps legacy v1 credentials capability-free", () => {


### PR DESCRIPTION
## Summary

Restore Desktop Automation runner registration when Den API requests are routed through the public Den Web proxy.

## What changed

- Derive the v2 runner-token audience from the trusted forwarded origin and the known `/api/den` proxy prefix.
- Keep direct API requests bound to their own request URL.
- Ignore forwarded destinations that are not in Den's configured trusted-origin set.
- Add regression coverage for both the trusted proxy route and an untrusted forwarded host.

## Why

The token route previously signed its internal upstream request URL. In the hosted proxy path this produced an audience such as `http://api.openworklabs.com`, while Desktop connected to `https://app.openworklabs.com/api/den`. Electron correctly rejected the audience mismatch, leaving manual and scheduled runs unclaimed until they became `runner_unavailable`.

## Verification

- `bun test ee/apps/den-api/test/automation-runner-auth.test.ts ee/apps/den-api/test/automation-runner-protocol.test.ts` — 22 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api typecheck:automations` — passed
- `git diff --check origin/dev...HEAD` — passed

Base: `030652638f97f7099ca5015eb005d08aae9cf1e4`

Head: `d751747fb04a31d43ef1b7fc16bb6d28db1cf2d5`
