### PR TITLE
fix(artifacts): isolate generated view handshake

### DIFF
--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -13,7 +13,8 @@ const MIN_HEIGHT = 160
 const MAX_HEIGHT = 800
 const DEFAULT_HEIGHT = 320
 const SIZE_EVENT_INTERVAL_MS = 100
-const INITIALIZE_TIMEOUT_MS = 5_000
+const SANDBOX_READY_TIMEOUT_MS = 5_000
+const INITIALIZE_TIMEOUT_MS = 10_000
 
 type PreservedMcpAppResult = {
   content: Array<Record<string, unknown>>
@@ -130,12 +131,14 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         },
       },
     )
-    const initializeTimer = window.setTimeout(() => {
-      if (!disposed) setError("The interactive view did not finish its MCP Apps handshake.")
-    }, INITIALIZE_TIMEOUT_MS)
+    let initializeTimer: number | undefined
+    let initialized = false
+    const sandboxReadyTimer = window.setTimeout(() => {
+      if (!disposed) setError("The interactive view sandbox did not finish loading.")
+    }, SANDBOX_READY_TIMEOUT_MS)
     const sandbox = openworkServerClient.mcpAppSandbox(app, window.location.origin)
     if (sandbox.expectedOrigin === window.location.origin) {
-      window.clearTimeout(initializeTimer)
+      window.clearTimeout(sandboxReadyTimer)
       setError("The MCP Apps sandbox must use a different origin from the OpenWork host.")
       return
     }
@@ -157,7 +160,8 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       }),
     )
     bridge.oninitialized = () => {
-      window.clearTimeout(initializeTimer)
+      initialized = true
+      if (initializeTimer !== undefined) window.clearTimeout(initializeTimer)
       void bridge.sendToolInput({
         arguments: isRecord(part.input) ? part.input : {},
       }).then(() => bridge.sendToolResult({
@@ -173,6 +177,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         || event.origin !== sandbox.expectedOrigin
         || event.data?.method !== "ui/notifications/sandbox-proxy-ready") return
       window.removeEventListener("message", handleSandboxReady)
+      window.clearTimeout(sandboxReadyTimer)
       const transport = new PostMessageTransport(iframe.contentWindow!, iframe.contentWindow!)
       void bridge.connect(transport)
         .then(() => bridge.sendSandboxResourceReady({
@@ -180,6 +185,13 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
           csp: app.csp,
           sandbox: "allow-scripts allow-same-origin",
         }))
+        .then(() => {
+          if (!initialized) {
+            initializeTimer = window.setTimeout(() => {
+              if (!disposed) setError("The interactive view did not finish its MCP Apps handshake.")
+            }, INITIALIZE_TIMEOUT_MS)
+          }
+        })
         .catch((cause) => {
           if (!disposed) setError(cause instanceof Error ? cause.message : "The MCP Apps sandbox could not load the view.")
         })
@@ -190,7 +202,8 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
     return () => {
       disposed = true
       window.removeEventListener("message", handleSandboxReady)
-      window.clearTimeout(initializeTimer)
+      window.clearTimeout(sandboxReadyTimer)
+      if (initializeTimer !== undefined) window.clearTimeout(initializeTimer)
       void Promise.race([
         bridge.teardownResource({}),
         new Promise<void>((resolve) => window.setTimeout(resolve, 500)),

--- a/ee/apps/den-api/src/generated-artifact-view-builder.ts
+++ b/ee/apps/den-api/src/generated-artifact-view-builder.ts
@@ -18,7 +18,7 @@ const reactPackageRoot = require.resolve("react/package.json").replace(/\/packag
 const reactDomPackageRoot = require.resolve("react-dom/package.json").replace(/\/package\.json$/u, "")
 
 export const GENERATED_ARTIFACT_VIEW_COMPILER = "openwork-react-view"
-export const GENERATED_ARTIFACT_VIEW_COMPILER_VERSION = "1"
+export const GENERATED_ARTIFACT_VIEW_COMPILER_VERSION = "2"
 export const GENERATED_ARTIFACT_VIEW_CSP: GeneratedArtifactViewCsp = {
   connectDomains: [],
   resourceDomains: [],
@@ -168,21 +168,48 @@ async function buildClientBundle(reactSource: string, previewData: unknown, prev
   const entry = `
     import React from "react";
     import { createRoot } from "react-dom/client";
-    import ArtifactView from "artifact:view";
+    const ArtifactView = React.lazy(() => import("artifact:view"));
     const mount = document.getElementById("openwork-artifact-view-root");
     let payload = { data: ${safeJson(previewData)}, artifact: ${safeJson(previewArtifact)} };
-    const root = createRoot(mount);
-    root.render(React.createElement(ArtifactView, payload));
     const post = (message) => window.parent.postMessage(message, "*");
-    const apply = (next) => { payload = next; root.render(React.createElement(ArtifactView, next)); requestAnimationFrame(() => post({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { width: Math.ceil(document.documentElement.scrollWidth), height: Math.ceil(document.documentElement.scrollHeight) } })); };
+    const renderFailure = () => React.createElement("p", { role: "alert", style: { margin: "16px", fontFamily: "system-ui, sans-serif" } }, "This Artifact view could not render. The normal tool result is still available.");
+    class ArtifactViewErrorBoundary extends React.Component {
+      constructor(props) { super(props); this.state = { failed: false }; }
+      static getDerivedStateFromError() { return { failed: true }; }
+      render() { return this.state.failed ? renderFailure() : this.props.children; }
+    }
+    let root = null;
+    let renderRevision = 0;
+    let resizeFrame = 0;
+    const reportSize = () => {
+      cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(() => post({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { width: Math.ceil(document.documentElement.scrollWidth), height: Math.ceil(document.documentElement.scrollHeight) } }));
+    };
+    let resizeObserver = null;
+    const apply = (next) => {
+      payload = next;
+      if (!root) { mount.textContent = "This Artifact view could not render. The normal tool result is still available."; return; }
+      renderRevision += 1;
+      root.render(React.createElement(ArtifactViewErrorBoundary, { key: renderRevision }, React.createElement(React.Suspense, { fallback: null }, React.createElement(ArtifactView, next))));
+      reportSize();
+    };
     window.addEventListener("message", (event) => {
       if (event.source !== window.parent || !event.data || event.data.jsonrpc !== "2.0") return;
       const message = event.data;
       if (message.id === "openwork-generated-artifact:init" && message.result) { post({ jsonrpc: "2.0", method: "ui/notifications/initialized" }); return; }
       if (message.method === "ui/notifications/tool-result" && message.params && !message.params.isError && message.params.structuredContent) apply(message.params.structuredContent);
-      if (message.method === "ui/resource-teardown" && message.id !== undefined) post({ jsonrpc: "2.0", id: message.id, result: {} });
+      if (message.method === "ui/resource-teardown" && message.id !== undefined) { resizeObserver?.disconnect(); cancelAnimationFrame(resizeFrame); post({ jsonrpc: "2.0", id: message.id, result: {} }); }
     });
     post({ jsonrpc: "2.0", id: "openwork-generated-artifact:init", method: "ui/initialize", params: { appInfo: { name: "OpenWork Generated Artifact", version: "1.0.0" }, appCapabilities: {}, protocolVersion: "2026-01-26" } });
+    try {
+      if (typeof ResizeObserver === "function") {
+        resizeObserver = new ResizeObserver(reportSize);
+        resizeObserver.observe(document.documentElement);
+        resizeObserver.observe(document.body);
+      }
+      root = createRoot(mount);
+      apply(payload);
+    } catch { mount.textContent = "This Artifact view could not render. The normal tool result is still available."; }
   `
   const result = await build({
     stdin: { contents: entry, loader: "tsx", resolveDir: process.cwd(), sourcefile: "generated-artifact-entry.tsx" },

--- a/ee/apps/den-api/test/generated-artifact-view-builder.test.ts
+++ b/ee/apps/den-api/test/generated-artifact-view-builder.test.ts
@@ -38,6 +38,7 @@ test("server-builds React source into a deterministic self-contained MCP App", a
   expect(first.html).not.toContain("script-src 'unsafe-inline'")
   expect(first.html).toContain("form-action 'none'")
   expect(first.html).toContain("object-src 'none'")
+  expect(first.compilerVersion).toBe("2")
   const javascript = first.html.match(/<script>([\s\S]*)<\/script>/iu)?.[1]
   expect(javascript).toBeDefined()
   const scriptDigest = createHash("sha256").update(javascript ?? "").digest("base64")
@@ -50,6 +51,24 @@ test("server-builds React source into a deterministic self-contained MCP App", a
     frameDomains: [],
     baseUriDomains: [],
   })
+})
+
+test("defers authored module evaluation until after the MCP Apps bootstrap", async () => {
+  const result = await buildGeneratedArtifactView({
+    title: "Runtime failure",
+    description: null,
+    outputSchema: schema,
+    reactSource: `
+      throw new Error("authored module failed")
+      export default function ArtifactView() { return <p>unreachable</p> }
+    `,
+  })
+  expect(result.ok).toBe(true)
+  if (!result.ok) return
+  expect(result.compilerVersion).toBe("2")
+  expect(result.html).toContain("ui/initialize")
+  expect(result.html).toContain("This Artifact view could not render. The normal tool result is still available.")
+  expect(result.html).toContain("Promise.resolve().then")
 })
 
 test("rejects authored and dynamically selected unsafe HTML elements", async () => {


### PR DESCRIPTION
## Summary

- bootstrap the MCP Apps protocol before evaluating agent-authored React modules
- load generated views lazily and contain render failures inside the iframe with an accessible fallback
- separate sandbox readiness from app initialization timeouts in the chat host
- record the corrected generated-view runtime as compiler version 2

## Root cause

Generated Artifact bundles statically imported the authored view and began rendering before installing the MCP Apps message listener or sending `ui/initialize`. A top-level authored module error could therefore prevent the handshake entirely, leaving chat on the normal tool result with a misleading timeout. The host also shared one five-second timer across sandbox loading and app initialization.

## Immutable view behavior

Existing saved view revisions remain byte-for-byte unchanged. New view revisions built after this change use compiler version 2; saving a new revision is required to rebuild an existing authored view with the corrected runtime.

## Verification

- `bun test test/generated-artifact-view-builder.test.ts`
- `bun test test/mcp-generated-artifact-views.test.ts`
- `bun test tests/mcp-app-frame.test.ts`
- `pnpm typecheck` in `apps/app`
- manual cross-origin sandbox exercise confirmed `ui/initialize` / `ui/notifications/initialized` and the in-frame fallback for a top-level authored module exception
- `git diff --check`