### PR TITLE
fix(artifacts): complete stable MCP Apps interoperability

### DIFF
--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -21,6 +21,7 @@ import type { ServerConfig } from "./types.js";
 
 const WORKSPACE_ID = "ws_mcp_apps_host";
 const RESOURCE_URI = "ui://fixture/v1/view.html";
+const RESOURCE_HTML = "<!doctype html><html><head></head><body>Fixture</body></html>";
 const stops: Array<() => void | Promise<void>> = [];
 
 afterEach(async () => {
@@ -47,7 +48,7 @@ function serverConfig(root: string): ServerConfig {
   };
 }
 
-async function startFixtureMcp() {
+async function startFixtureMcp(resourceContent: { text?: string; blob?: string } = { text: RESOURCE_HTML }) {
   const mcp = new Server(
     { name: "mcp-app-fixture", version: "1.0.0" },
     {
@@ -97,7 +98,7 @@ async function startFixtureMcp() {
       contents: [{
         uri: RESOURCE_URI,
         mimeType: "text/html;profile=mcp-app",
-        text: "<!doctype html><html><head></head><body>Fixture</body></html>",
+        ...resourceContent,
         _meta: {
           ui: {
             csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
@@ -132,7 +133,10 @@ async function startFixtureMcp() {
   return `http://127.0.0.1:${http.port}`;
 }
 
-async function configuredFixture(prefix: string): Promise<{ config: ServerConfig; root: string }> {
+async function configuredFixture(
+  prefix: string,
+  resourceContent?: { text?: string; blob?: string },
+): Promise<{ config: ServerConfig; root: string }> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
   const previousDevMode = process.env.OPENWORK_DEV_MODE;
@@ -149,7 +153,7 @@ async function configuredFixture(prefix: string): Promise<{ config: ServerConfig
   const config = serverConfig(root);
   await addMcp(config, WORKSPACE_ID, "fixture", {
     type: "remote",
-    url: await startFixtureMcp(),
+    url: await startFixtureMcp(resourceContent),
     enabled: true,
   });
   return { config, root };
@@ -174,11 +178,37 @@ describe("MCP Apps host transport", () => {
       serverName: "fixture",
       toolName: "render_fixture",
       resourceUri: RESOURCE_URI,
-      html: "<!doctype html><html><head></head><body>Fixture</body></html>",
+      html: RESOURCE_HTML,
       csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
       prefersBorder: true,
     });
 
+  });
+
+  test("decodes a stable-spec blob-backed HTML resource", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-host-blob-", {
+      blob: Buffer.from(RESOURCE_HTML, "utf8").toString("base64"),
+    });
+
+    const app = await resolveMcpAppResource({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      projectedToolName: "fixture_render_fixture",
+    });
+    expect(app?.html).toBe(RESOURCE_HTML);
+  });
+
+  test("rejects non-UTF-8 blob-backed HTML", async () => {
+    const invalidUtf8 = await configuredFixture("openwork-mcp-app-host-bad-utf8-", {
+      blob: Buffer.from([0xff]).toString("base64"),
+    });
+    await expect(resolveMcpAppResource({
+      serverConfig: invalidUtf8.config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: invalidUtf8.root,
+      projectedToolName: "fixture_render_fixture",
+    })).rejects.toMatchObject({ code: "invalid_resource" });
   });
 
   test("mediates explicitly read-only same-server tool calls", async () => {

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -210,25 +210,50 @@ function toolVisibility(tool: Partial<Tool>, audience: "model" | "app"): boolean
     && ui.visibility.includes(audience);
 }
 
-function findTextResource(
+function strictBase64Bytes(value: string): Uint8Array {
+  if (value.length > Math.ceil(MAX_RESOURCE_BYTES / 3) * 4) {
+    throw new McpAppHostError("resource_too_large", "The MCP App resource exceeds the 512 KiB host limit.");
+  }
+  if (value.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw new McpAppHostError("invalid_resource", "The MCP App resource blob is not valid base64.");
+  }
+  return Buffer.from(value, "base64");
+}
+
+function decodeResourceHtml(content: { text?: string; blob?: string }): { html: string; bytes: number } {
+  if (typeof content.text === "string" && content.blob === undefined) {
+    const bytes = new TextEncoder().encode(content.text).byteLength;
+    return { html: content.text, bytes };
+  }
+  if (typeof content.blob === "string" && content.text === undefined) {
+    const bytes = strictBase64Bytes(content.blob);
+    try {
+      return { html: new TextDecoder("utf-8", { fatal: true }).decode(bytes), bytes: bytes.byteLength };
+    } catch {
+      throw new McpAppHostError("invalid_resource", "The MCP App resource blob is not valid UTF-8 HTML.");
+    }
+  }
+  throw new McpAppHostError("invalid_resource", "The MCP App resource must contain exactly one of text or blob HTML.");
+}
+
+function findHtmlResource(
   resourceUri: string,
   result: Awaited<ReturnType<Client["readResource"]>>,
 ): { html: string; meta: unknown } {
-  const candidates = result.contents.filter((content) => content.uri === resourceUri && "text" in content);
+  const candidates = result.contents.filter((content) => content.uri === resourceUri);
   if (candidates.length !== 1) {
-    throw new McpAppHostError("invalid_resource", "The MCP App resource must return exactly one matching text resource.");
+    throw new McpAppHostError("invalid_resource", "The MCP App resource must return exactly one matching HTML resource.");
   }
   const content = candidates[0];
-  if (!content || !("text" in content) || typeof content.text !== "string") {
-    throw new McpAppHostError("invalid_resource", "The MCP App resource did not return HTML text.");
-  }
+  if (!content) throw new McpAppHostError("invalid_resource", "The MCP App resource did not return HTML content.");
   if (content.mimeType?.toLowerCase() !== MCP_APP_MIME_TYPE) {
     throw new McpAppHostError("invalid_resource_mime", `MCP App resources must use ${MCP_APP_MIME_TYPE}.`);
   }
-  if (new TextEncoder().encode(content.text).byteLength > MAX_RESOURCE_BYTES) {
+  const decoded = decodeResourceHtml(content);
+  if (decoded.bytes > MAX_RESOURCE_BYTES) {
     throw new McpAppHostError("resource_too_large", "The MCP App resource exceeds the 512 KiB host limit.");
   }
-  return { html: content.text, meta: content._meta };
+  return { html: decoded.html, meta: content._meta };
 }
 
 export async function resolveMcpAppResource(input: {
@@ -259,7 +284,7 @@ export async function resolveMcpAppResource(input: {
       }
       const resourceUri = toolUiResourceUri(tool);
       if (!resourceUri) return null;
-      const resource = findTextResource(resourceUri, await client.readResource({ uri: resourceUri }));
+      const resource = findHtmlResource(resourceUri, await client.readResource({ uri: resourceUri }));
       const presentation = resourcePresentationMeta(resource.meta);
       return {
         serverName: item.name,

--- a/ee/apps/den-api/src/generated-artifact-view-builder.ts
+++ b/ee/apps/den-api/src/generated-artifact-view-builder.ts
@@ -180,12 +180,31 @@ async function buildClientBundle(reactSource: string, previewData: unknown, prev
     }
     let root = null;
     let renderRevision = 0;
-    let resizeFrame = 0;
-    const reportSize = () => {
-      cancelAnimationFrame(resizeFrame);
-      resizeFrame = requestAnimationFrame(() => post({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { width: Math.ceil(document.documentElement.scrollWidth), height: Math.ceil(document.documentElement.scrollHeight) } }));
-    };
     let resizeObserver = null;
+    let sizeFrame;
+    let initialized = false;
+    const reportSize = () => {
+      if (!initialized || sizeFrame !== undefined) return;
+      sizeFrame = requestAnimationFrame(() => {
+        sizeFrame = undefined;
+        const documentElement = document.documentElement;
+        const previousHeight = documentElement.style.height;
+        documentElement.style.height = "max-content";
+        const height = Math.ceil(documentElement.getBoundingClientRect().height);
+        documentElement.style.height = previousHeight;
+        post({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { width: Math.ceil(window.innerWidth), height } });
+      });
+    };
+    const startAutoResize = () => {
+      initialized = true;
+      if (resizeObserver) return;
+      if (typeof ResizeObserver === "function") {
+        resizeObserver = new ResizeObserver(reportSize);
+        resizeObserver.observe(document.documentElement);
+        resizeObserver.observe(document.body);
+      }
+      reportSize();
+    };
     const apply = (next) => {
       payload = next;
       if (!root) { mount.textContent = "This Artifact view could not render. The normal tool result is still available."; return; }
@@ -196,17 +215,12 @@ async function buildClientBundle(reactSource: string, previewData: unknown, prev
     window.addEventListener("message", (event) => {
       if (event.source !== window.parent || !event.data || event.data.jsonrpc !== "2.0") return;
       const message = event.data;
-      if (message.id === "openwork-generated-artifact:init" && message.result) { post({ jsonrpc: "2.0", method: "ui/notifications/initialized" }); return; }
+      if (message.id === "openwork-generated-artifact:init" && message.result) { post({ jsonrpc: "2.0", method: "ui/notifications/initialized" }); startAutoResize(); return; }
       if (message.method === "ui/notifications/tool-result" && message.params && !message.params.isError && message.params.structuredContent) apply(message.params.structuredContent);
-      if (message.method === "ui/resource-teardown" && message.id !== undefined) { resizeObserver?.disconnect(); cancelAnimationFrame(resizeFrame); post({ jsonrpc: "2.0", id: message.id, result: {} }); }
+      if (message.method === "ui/resource-teardown" && message.id !== undefined) { initialized = false; resizeObserver?.disconnect(); if (sizeFrame !== undefined) cancelAnimationFrame(sizeFrame); post({ jsonrpc: "2.0", id: message.id, result: {} }); }
     });
     post({ jsonrpc: "2.0", id: "openwork-generated-artifact:init", method: "ui/initialize", params: { appInfo: { name: "OpenWork Generated Artifact", version: "1.0.0" }, appCapabilities: {}, protocolVersion: "2026-01-26" } });
     try {
-      if (typeof ResizeObserver === "function") {
-        resizeObserver = new ResizeObserver(reportSize);
-        resizeObserver.observe(document.documentElement);
-        resizeObserver.observe(document.body);
-      }
       root = createRoot(mount);
       apply(payload);
     } catch { mount.textContent = "This Artifact view could not render. The normal tool result is still available."; }

--- a/ee/apps/den-api/test/generated-artifact-view-builder.test.ts
+++ b/ee/apps/den-api/test/generated-artifact-view-builder.test.ts
@@ -32,6 +32,8 @@ test("server-builds React source into a deterministic self-contained MCP App", a
   expect(first.html).toStartWith("<!doctype html>")
   expect(first.html).toContain('<div id="openwork-artifact-view-root"></div>')
   expect(first.html).toContain("ui/initialize")
+  expect(first.html).toContain("ResizeObserver")
+  expect(first.html).toContain("ui/notifications/size-changed")
   expect(first.html).toContain("ui/notifications/tool-result")
   expect(first.html).not.toContain("<script src=")
   expect(first.html).toContain("script-src 'sha256-")

--- a/evals/specs/generated-artifact-views.slow.test.ts
+++ b/evals/specs/generated-artifact-views.slow.test.ts
@@ -10,6 +10,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${String(JSON.stringify(value)).slice(0, 500)}`)
+  return value
+}
+
+let requestId = 0
+
+async function agentRpc(apiUrl: string, token: string, method: string, params: Record<string, unknown>) {
+  const currentRequestId = ++requestId
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: currentRequestId, method, params }),
+    signal: AbortSignal.timeout(180_000),
+  })
+  const raw = await response.text()
+  if (!response.ok) throw new Error(`MCP ${method} failed: HTTP ${response.status} ${raw.slice(0, 500)}`)
+  const payload = raw.split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => JSON.parse(line.slice(5)) as unknown)
+    .find((candidate) => isRecord(candidate) && candidate.id === currentRequestId)
+  if (!payload) throw new Error(`MCP ${method} returned no matching SSE response: ${raw.slice(0, 500)}`)
+  const message = requireRecord(payload, `${method} response`)
+  if (message.error) throw new Error(`MCP ${method} returned an error: ${JSON.stringify(message.error)}`)
+  return requireRecord(message.result, `${method} result`)
+}
+
+function toolResourceUri(result: Record<string, unknown>, name: string): string | null {
+  const tools = Array.isArray(result.tools) ? result.tools.filter(isRecord) : []
+  const tool = tools.find((candidate) => candidate.name === name)
+  const meta = isRecord(tool?._meta) ? tool._meta : {}
+  return isRecord(meta.ui) && typeof meta.ui.resourceUri === "string" ? meta.ui.resourceUri : null
+}
+
+function resourceContent(result: Record<string, unknown>): Record<string, unknown> {
+  const contents = Array.isArray(result.contents) ? result.contents.filter(isRecord) : []
+  return requireRecord(contents[0], "resource content")
+}
+
 test("the agent MCP exposes the custom Artifact view authoring lifecycle", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs(requirements)
   await using den = await server({
@@ -29,10 +72,22 @@ test("the agent MCP exposes the custom Artifact view authoring lifecycle", { tim
   })
   expect(enabled.response.ok, enabled.text).toBe(true)
 
-  const initialized = await denFetch(den.admin, "/mcp/agent", {
+  const tokenResponse = await denFetch(den.admin, "/v1/mcp/token", {
     method: "POST",
     headers: {
       authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  })
+  const mcpToken = isRecord(tokenResponse.body) ? String(tokenResponse.body.token ?? "") : ""
+  expect(tokenResponse.response.ok, tokenResponse.text).toBe(true)
+  expect(mcpToken).toMatch(/^ow_mcp_at_/)
+
+  const initialized = await denFetch(den.admin, "/mcp/agent", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
       accept: "application/json, text/event-stream",
       "content-type": "application/json",
     },
@@ -49,9 +104,132 @@ test("the agent MCP exposes the custom Artifact view authoring lifecycle", { tim
   })
   expect(initialized.response.ok, initialized.text).toBe(true)
   expect(initialized.text).toContain("io.modelcontextprotocol/ui")
+
+  const code = 'return { title: "Quarterly plan", status: "Ready" }'
+  const executed = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "execute_capability_script",
+    arguments: { code },
+  })
+  expect(executed.isError, JSON.stringify(executed)).not.toBe(true)
+
+  const savedScript = await denFetch(den.admin, "/v1/codemode-scripts", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({
+      name: "Quarterly plan source",
+      description: "Deterministic source for generated Artifact view verification.",
+      code,
+      currentInput: {},
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      outputSchema: {
+        type: "object",
+        properties: { title: { type: "string" }, status: { type: "string" } },
+        required: ["title", "status"],
+        additionalProperties: false,
+      },
+    }),
+  })
+  expect(savedScript.response.status, savedScript.text).toBe(201)
+  const saved = requireRecord(savedScript.body, "saved Script")
+  const configObjectId = String(saved.configObjectId ?? "")
+  expect(configObjectId).toMatch(/^cob_/)
+
+  const scriptRun = await denFetch(den.admin, `/v1/codemode-scripts/${configObjectId}/run`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({
+      pluginId: saved.pluginId,
+      configObjectVersionId: saved.configObjectVersionId,
+      input: {},
+    }),
+  })
+  expect(scriptRun.response.ok, scriptRun.text).toBe(true)
+
+  const firstSave = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "save_artifact_view",
+    arguments: {
+      configObjectId,
+      title: "Quarterly plan",
+      description: "Agent-authored custom Artifact view.",
+      reactSource: "export default function QuarterlyPlan({ data }) { return <article><h1>{data.title}</h1><p>{data.status}</p></article> }",
+      cssSource: "article{padding:20px;border:2px solid #2563eb;border-radius:16px}",
+    },
+  })
+  expect(firstSave.isError, JSON.stringify(firstSave)).not.toBe(true)
+  const firstView = requireRecord(requireRecord(firstSave.structuredContent, "first save result").view, "first view")
+  const artifactViewId = String(firstView.id ?? "")
+  const firstRevisionId = String(firstView.activeRevisionId ?? "")
+  const firstRevision = Array.isArray(firstView.revisions) ? firstView.revisions.filter(isRecord)[0] : undefined
+  const firstUri = String(firstRevision?.resourceUri ?? "")
+  expect(firstUri).toBe(`ui://openwork/artifacts/${artifactViewId}/views/${firstRevisionId}/index.html`)
+
+  const firstRead = resourceContent(await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", { uri: firstUri }))
+  const firstHtml = String(firstRead.text ?? "")
+  expect(firstRead.mimeType).toBe("text/html;profile=mcp-app")
+  expect(firstHtml).toContain("ui/initialize")
+  expect(firstHtml).toContain("2026-01-26")
+  expect(firstHtml).toContain("ResizeObserver")
+  expect(firstHtml).not.toContain('"Ready"')
+
+  const renderName = `render_artifact_${artifactViewId}`
+  let tools = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {})
+  expect(toolResourceUri(tools, renderName)).toBe(firstUri)
+  const rendered = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", { name: renderName, arguments: {} })
+  expect(rendered.isError, JSON.stringify(rendered)).not.toBe(true)
+  expect(requireRecord(rendered.structuredContent, "render result").data).toEqual({ title: "Quarterly plan", status: "Ready" })
+
+  const secondSave = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "save_artifact_view",
+    arguments: {
+      artifactViewId,
+      configObjectId,
+      title: "Quarterly plan",
+      description: "Second immutable custom revision.",
+      reactSource: "export default function QuarterlyPlanV2({ data }) { return <section><h1>{data.title}</h1><strong>{data.status}</strong></section> }",
+      cssSource: "section{padding:24px;border:3px solid #16a34a;border-radius:18px}",
+    },
+  })
+  const secondView = requireRecord(requireRecord(secondSave.structuredContent, "second save result").view, "second view")
+  const revisions = Array.isArray(secondView.revisions) ? secondView.revisions.filter(isRecord) : []
+  const secondRevision = revisions.find((revision) => revision.id !== firstRevisionId)
+  const secondRevisionId = String(secondRevision?.id ?? "")
+  const secondUri = String(secondRevision?.resourceUri ?? "")
+  expect(secondUri).toBe(`ui://openwork/artifacts/${artifactViewId}/views/${secondRevisionId}/index.html`)
+  expect(secondUri).not.toBe(firstUri)
+
+  const secondHtml = String(resourceContent(await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", { uri: secondUri })).text ?? "")
+  expect(secondHtml).not.toBe(firstHtml)
+  expect(String(resourceContent(await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", { uri: firstUri })).text ?? "")).toBe(firstHtml)
+  tools = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {})
+  expect(toolResourceUri(tools, renderName)).toBe(firstUri)
+  expect(toolResourceUri(tools, `preview_artifact_${artifactViewId}`)).toBe(secondUri)
+
+  await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "activate_artifact_view_revision",
+    arguments: { artifactViewId, revisionId: secondRevisionId },
+  })
+  tools = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {})
+  expect(toolResourceUri(tools, renderName)).toBe(secondUri)
+
+  await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "activate_artifact_view_revision",
+    arguments: { artifactViewId, revisionId: firstRevisionId },
+  })
+  tools = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {})
+  expect(toolResourceUri(tools, renderName)).toBe(firstUri)
+
+  await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "retire_artifact_view",
+    arguments: { artifactViewId },
+  })
+  tools = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {})
+  expect(toolResourceUri(tools, renderName)).toBeNull()
+  expect(String(resourceContent(await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", { uri: firstUri })).text ?? "")).toBe(firstHtml)
+  expect(String(resourceContent(await agentRpc(den.ref.apiUrl, mcpToken, "resources/read", { uri: secondUri })).text ?? "")).toBe(secondHtml)
+
   evidence.fact(
     "Custom Artifact view provider is available only on the Code Mode agent MCP",
-    "The initialized provider negotiates the stable MCP Apps extension; focused unit tapes cover immutable URI registration, resource bytes, structured data separation, and list-changed notifications.",
+    "The live provider built two custom React revisions, preserved both immutable resources, injected Script data through structuredContent, activated the second revision, rolled back to the first, and retired the render tool without deleting either resource.",
     true,
   )
 })

--- a/evals/specs/mcp-app-inline-host.slow.test.ts
+++ b/evals/specs/mcp-app-inline-host.slow.test.ts
@@ -4,12 +4,13 @@ import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from 
 import { screenshot, validate } from "@openwork/fraimz";
 import { desktop } from "@openwork/hosts";
 import { needs, test } from "@openwork/testkit";
+import { buildGeneratedArtifactViewInWorker } from "../../ee/apps/den-api/src/generated-artifact-view-builder.js";
 
 const providerId = "mcp-app-inline-host-mock";
 const modelId = "mcp-app-inline-host-model";
 const mcpServerName = "artifact-view";
 const mcpToolName = "render_card";
-const resourceUri = "ui://openwork/eval-card/v1/view.html";
+const resourceUri = "ui://openwork/artifacts/arv_eval_card/views/avr_eval_card/index.html";
 const closingReply = "The interactive artifact card is ready.";
 const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
 const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
@@ -63,47 +64,21 @@ function sendJson(response: ServerResponse, status: number, body: unknown): void
   response.end(JSON.stringify(body));
 }
 
-const appHtml = `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <style>
-      body { margin: 0; padding: 18px; color: #172554; background: #eff6ff; font-family: system-ui, sans-serif; }
-      article { border: 1px solid #93c5fd; border-radius: 14px; padding: 18px; background: white; }
-      h2 { margin: 0 0 8px; font-size: 20px; }
-      p { margin: 0; color: #1d4ed8; }
-    </style>
-  </head>
-  <body>
-    <article><h2 id="title">Loading interactive artifact…</h2><p id="status">Waiting for tool result</p></article>
-    <script>
-      const send = (message) => window.parent.postMessage(message, "*");
-      window.addEventListener("message", (event) => {
-        const message = event.data;
-        if (!message || message.jsonrpc !== "2.0") return;
-        if (message.id === 1 && message.result) {
-          send({ jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} });
-          return;
-        }
-        if (message.method !== "ui/notifications/tool-result") return;
-        const data = message.params && message.params.structuredContent;
-        document.getElementById("title").textContent = String(data && data.title || "Interactive artifact");
-        document.getElementById("status").textContent = String(data && data.status || "Ready");
-        send({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 190 } });
-      });
-      send({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "ui/initialize",
-        params: {
-          protocolVersion: "2026-01-26",
-          appInfo: { name: "OpenWork eval card", version: "1.0.0" },
-          appCapabilities: {},
-        },
-      });
-    </script>
-  </body>
-</html>`;
+const builtApp = await buildGeneratedArtifactViewInWorker({
+  reactSource: `export default function GeneratedArtifact({ data }) {
+    return <article><h2>{data.title}</h2><p>{data.status}</p></article>
+  }`,
+  cssSource: "body{margin:0;padding:18px;color:#172554;background:#eff6ff;font-family:system-ui,sans-serif}article{border:1px solid #93c5fd;border-radius:14px;padding:18px;background:white}h2{margin:0 0 8px;font-size:20px}p{margin:0;color:#1d4ed8}",
+  outputSchema: {
+    type: "object",
+    properties: { title: { type: "string" }, status: { type: "string" } },
+    required: ["title", "status"],
+  },
+  title: "Quarterly plan",
+  description: "Generated Artifact host acceptance fixture.",
+});
+if (!builtApp.ok) throw new Error(`Generated Artifact build failed: ${JSON.stringify(builtApp.diagnostics)}`);
+const appHtml = builtApp.html;
 
 function rpcResponse(message: Record<string, unknown>): Record<string, unknown> {
   if (message.method === "initialize") {
@@ -139,7 +114,11 @@ function rpcResponse(message: Record<string, unknown>): Record<string, unknown> 
       id: message.id,
       result: {
         content: [{ type: "text", text: "Quarterly plan: Ready" }],
-        structuredContent: { title: "Quarterly plan", status: "Ready" },
+        structuredContent: {
+          schemaVersion: "1",
+          artifact: { title: "Quarterly plan", description: "Generated Artifact host acceptance fixture." },
+          data: { title: "Quarterly plan", status: "Ready" },
+        },
         _meta: { receipt: "eval-fixed-receipt" },
       },
     };
@@ -152,7 +131,7 @@ function rpcResponse(message: Record<string, unknown>): Record<string, unknown> 
         contents: [{
           uri: resourceUri,
           mimeType: "text/html;profile=mcp-app",
-          text: appHtml,
+          blob: Buffer.from(appHtml, "utf8").toString("base64"),
           _meta: {
             ui: {
               prefersBorder: true,
@@ -430,15 +409,18 @@ test.skipIf(!appSpecsEnabled || !localPlacement)(title, { timeout: 240_000 }, as
   const hostClaim = await evalIn(app, `(() => {
     const container = document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${resourceUri}"]`)});
     const frame = container?.querySelector("iframe");
-    return Boolean(frame
-      && frame.getAttribute("sandbox") === "allow-scripts"
+    if (!(frame instanceof HTMLIFrameElement) || !frame.src) return false;
+    const sandbox = new Set((frame.getAttribute("sandbox") || "").split(/\\s+/).filter(Boolean));
+    return sandbox.has("allow-scripts")
+      && sandbox.has("allow-same-origin")
       && frame.getAttribute("referrerpolicy") === "no-referrer"
-      && frame.getAttribute("srcdoc")?.includes("Content-Security-Policy"));
+      && new URL(frame.src).origin !== window.location.origin
+      && !frame.hasAttribute("srcdoc");
   })()`);
   expect(hostClaim).toBe(true);
   evidence.fact(
     "The completed MCP tool result resolves and mounts its declared standard UI resource",
-    `Observed one tools/call, ${resourceReads} resources/read request(s), and an opaque allow-scripts iframe with a host-injected CSP.`,
+    `Observed one tools/call, ${resourceReads} blob-backed resources/read request(s), and a different-origin sandbox proxy with the stable sandbox flags.`,
     hostClaim === true && toolCalls === 1 && resourceReads >= 1,
   );
 


### PR DESCRIPTION
## Summary

- Accept stable MCP Apps HTML resources in either text or base64 blob form, with strict 512 KiB, base64, and UTF-8 validation.
- Make generated Artifact bundles complete initialization before continuously reporting iframe size changes with ResizeObserver, including teardown cleanup.
- Replace partial acceptance coverage with real server and desktop journeys covering React bundle build, immutable resource revisions, structured data injection, activation, rollback, retirement, blob reads, and sandbox proxy rendering.

## Why

MCP Apps resources/read permits resource contents through either text or blob. The desktop host accepted only text, generated bundles only reported size after data updates, and the checked-in acceptance paths did not exercise an actual generated React bundle through the combined provider and host flow.

The conflict resolution with #3748 retains deferred authored-module evaluation and the render-failure boundary, while starting continuous resize observation only after the MCP Apps handshake completes.

## Verification

- Host and sandbox focused tests: 11 passed
- Generated Artifact provider focused tests: 17 passed
- Client frame focused tests: 5 passed
- Server typecheck: passed
- Desktop app typecheck: passed
- Den production build: passed
- Live Den generated Artifact lifecycle: 1 passed
- Desktop generated-bundle blob and cross-origin sandbox journey: 1 passed
- Refreshed PR checks: 23 passed, 0 failed, 0 pending

The full evals typecheck remains blocked by the pre-existing unrelated TS18048 failure in evals/specs/windows-artifact-signing.test.ts:61 on dev.