### PR TITLE
fix(dev): run headless server from source

### DIFF
--- a/evals/specs/headless-web-source-server.test.ts
+++ b/evals/specs/headless-web-source-server.test.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { buildHeadlessServerLaunch } from "../../scripts/dev-headless-web-lib";
+
+test("headless web development launches the server from current source", ({ evidence }) => {
+  const launch = buildHeadlessServerLaunch("/repo/openwork", ["--port", "8787"]);
+
+  expect(launch).toEqual({
+    command: "bun",
+    args: [
+      "--conditions=development",
+      path.join("/repo/openwork", "apps/server/src/cli.ts"),
+      "--port",
+      "8787",
+    ],
+  });
+  expect(launch.args.join(" ")).not.toContain("apps/server/dist");
+  expect(launch.args.join(" ")).not.toContain("openwork-server");
+
+  evidence.fact(
+    "Local headless development is source-first",
+    "The launch command executes apps/server/src/cli.ts and never references compiled server output, so a stale dist binary cannot affect a restarted development stack.",
+    true,
+  );
+});

--- a/scripts/dev-headless-web-lib.ts
+++ b/scripts/dev-headless-web-lib.ts
@@ -55,8 +55,23 @@ export function isHeadlessStackCommand(command: string): boolean {
   return (
     command.includes("dev-headless-web") ||
     command.includes("openwork-server") ||
+    command.includes("apps/server/src/cli.ts") ||
     command.includes("vite")
   );
+}
+
+export function buildHeadlessServerLaunch(
+  cwd: string,
+  serverArgs: string[],
+): { command: string; args: string[] } {
+  return {
+    command: "bun",
+    args: [
+      "--conditions=development",
+      path.join(cwd, "apps/server/src/cli.ts"),
+      ...serverArgs,
+    ],
+  };
 }
 
 export function resolveHeadlessServerConfigPath(

--- a/scripts/dev-headless-web.test.ts
+++ b/scripts/dev-headless-web.test.ts
@@ -5,6 +5,7 @@ import {
   buildDetachedRespawnArgs,
   buildHeadlessCorsOrigins,
   buildHeadlessRuntimeManifest,
+  buildHeadlessServerLaunch,
   buildOpenworkServerArgs,
   isHeadlessStackCommand,
   mergeHeadlessServerConfig,
@@ -114,6 +115,18 @@ describe("dev-headless-web helpers", () => {
     expect(args).not.toContain("--host-token");
   });
 
+  test("server launch always uses current source instead of compiled output", () => {
+    expect(buildHeadlessServerLaunch("/repo/openwork", ["--port", "8787"])).toEqual({
+      command: "bun",
+      args: [
+        "--conditions=development",
+        path.join("/repo/openwork", "apps/server/src/cli.ts"),
+        "--port",
+        "8787",
+      ],
+    });
+  });
+
   test("CORS is pinned to the web app origins, never wildcarded", () => {
     const corsOrigins = buildHeadlessCorsOrigins({
       webUrl: "http://127.0.0.1:5178",
@@ -211,6 +224,9 @@ describe("dev-headless-web helpers", () => {
     expect(isHeadlessStackCommand("bun scripts/dev-headless-web.ts")).toBe(true);
     expect(
       isHeadlessStackCommand("/repo/apps/server/dist/bin/openwork-server --config tmp/headless-server.json"),
+    ).toBe(true);
+    expect(
+      isHeadlessStackCommand("bun --conditions=development /repo/apps/server/src/cli.ts --config tmp/headless-server.json"),
     ).toBe(true);
     expect(isHeadlessStackCommand("node vite --host 127.0.0.1 --port 5178")).toBe(true);
     expect(isHeadlessStackCommand("/usr/bin/some-unrelated-daemon")).toBe(false);

--- a/scripts/dev-headless-web.ts
+++ b/scripts/dev-headless-web.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { openSync } from "node:fs";
-import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -10,6 +10,7 @@ import {
   normalizeDenTarget,
   buildHeadlessCorsOrigins,
   buildHeadlessRuntimeManifest,
+  buildHeadlessServerLaunch,
   buildOpenworkServerArgs,
   isHeadlessStackCommand,
   mergeHeadlessServerConfig,
@@ -84,36 +85,10 @@ const replaceRequested =
   process.argv.includes("--replace") ||
   readBool(process.env.OPENWORK_DEV_HEADLESS_WEB_REPLACE);
 
-const autoBuildEnabled =
-  process.env.OPENWORK_DEV_HEADLESS_WEB_AUTOBUILD == null
-    ? true
-    : readBool(process.env.OPENWORK_DEV_HEADLESS_WEB_AUTOBUILD);
-
 const denProxyEnabled =
   process.env.OPENWORK_DEV_HEADLESS_WEB_DEN_PROXY == null
     ? true
     : readBool(process.env.OPENWORK_DEV_HEADLESS_WEB_DEN_PROXY);
-
-const runCommand = (command: string, args: string[]) =>
-  new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env: process.env,
-      stdio: silent ? "ignore" : "inherit",
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(
-        new Error(
-          `${command} ${args.join(" ")} exited with code ${code ?? "unknown"}`,
-        ),
-      );
-    });
-  });
 
 // Detached: each child leads its own process group, so signals aimed at the
 // launcher (e.g. a terminal session getting reaped) cannot take the stack down.
@@ -314,61 +289,12 @@ const { token: openworkToken, hostToken: openworkHostToken } =
     previous: rotateTokensRequested ? null : existingManifest,
     generate: randomUUID,
   });
-const openworkServerBin = path.join(
-  cwd,
-  "apps/server/dist/bin/openwork-server",
-);
-const openworkPluginDir = path.join(
-  cwd,
-  "apps/server/dist/opencode-plugins",
-);
 const serverConfigPath = resolveHeadlessServerConfigPath(
   cwd,
   process.env.OPENWORK_DEV_HEADLESS_WEB_CONFIG,
 );
 const webLogPath = path.join(tmpDir, "dev-web.log");
 const headlessLogPath = path.join(tmpDir, "dev-headless.log");
-
-const ensureOpenworkServer = async () => {
-  try {
-    await access(openworkServerBin);
-    await access(openworkPluginDir);
-  } catch {
-    if (!autoBuildEnabled) {
-      logLine(
-        `[dev:headless-web] Missing OpenWork server build output at ${openworkServerBin}`,
-      );
-      logLine(
-        "[dev:headless-web] Auto-build disabled (OPENWORK_DEV_HEADLESS_WEB_AUTOBUILD=0)",
-      );
-      logLine(
-        "[dev:headless-web] Run: pnpm --filter openwork-server build && pnpm --filter openwork-server build:bin",
-      );
-      logLine(
-        "[dev:headless-web] Or unset/enable OPENWORK_DEV_HEADLESS_WEB_AUTOBUILD to auto-build.",
-      );
-      process.exit(1);
-    }
-
-    logLine(
-      `[dev:headless-web] Missing OpenWork server build output at ${openworkServerBin}`,
-    );
-    logLine(
-      "[dev:headless-web] Auto-building: pnpm --filter openwork-server build && pnpm --filter openwork-server build:bin",
-    );
-    try {
-      await runCommand("pnpm", ["--filter", "openwork-server", "build"]);
-      await runCommand("pnpm", ["--filter", "openwork-server", "build:bin"]);
-      await access(openworkServerBin);
-      await access(openworkPluginDir);
-    } catch (error) {
-      logLine(
-        `[dev:headless-web] Auto-build failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      process.exit(1);
-    }
-  }
-};
 
 // Merge (never rewrite) the isolated config: the server persists registered
 // workspaces and expanded authorizedRoots into it at runtime.
@@ -431,10 +357,7 @@ const headlessEnv = {
   OPENWORK_SERVER_CONFIG: serverConfigPath,
   OPENWORK_MANAGE_OPENCODE: "1",
   OPENWORK_OPENCODE_BIN: process.env.OPENWORK_OPENCODE_BIN ?? "opencode",
-  OPENWORK_EXTENSIONS_PLUGIN_DIR: openworkPluginDir,
 };
-
-await ensureOpenworkServer();
 
 const children: ChildProcess[] = [];
 
@@ -456,14 +379,18 @@ const webProcess = spawnLogged(
 );
 children.push(webProcess);
 
-const headlessProcess = spawnLogged(
-  openworkServerBin,
+const headlessServerLaunch = buildHeadlessServerLaunch(
+  cwd,
   buildOpenworkServerArgs({
     host,
     port: openworkPort,
     configPath: serverConfigPath,
     corsOrigins: buildHeadlessCorsOrigins({ webUrl, webPort }),
   }),
+);
+const headlessProcess = spawnLogged(
+  headlessServerLaunch.command,
+  headlessServerLaunch.args,
   headlessLogPath,
   headlessEnv,
 );


### PR DESCRIPTION
## Summary
- run the local headless OpenWork server directly from TypeScript source
- remove stale compiled-binary and plugin build reuse from the development launcher
- keep stale-process cleanup compatible with source-based server commands

## Verification
- `bun test scripts/dev-headless-web.test.ts` (13 passed)
- `pnpm --filter openwork-server typecheck`
- `pnpm evals:spec specs/headless-web-source-server.test.ts` (1 passed, local PR lane)
- launched `pnpm dev:headless-web --detach` with no `apps/server/dist` output; health reported server 0.18.23 and OpenCode exposed `openwork_docs_search` and `openwork_query`
