### PR TITLE
fix(artifacts): expose MCP App handshake diagnostics

### DIFF
--- a/apps/app/src/components/chat/mcp-app-diagnostics.ts
+++ b/apps/app/src/components/chat/mcp-app-diagnostics.ts
@@ -1,0 +1,48 @@
+export type McpAppDiagnosticStage =
+  | "resource-resolution"
+  | "sandbox-proxy"
+  | "resource-delivery"
+  | "app-initialization"
+  | "tool-result-delivery"
+
+export type McpAppDiagnostic = {
+  code: string
+  causeCode?: string
+  stage: McpAppDiagnosticStage
+  message: string
+  toolName: string
+  resourceUri?: string
+  sandboxOrigin?: string
+  elapsedMs: number
+  checkpoints: string[]
+  sandboxDocument?: {
+    readyState: string | null
+    hasHtmlRoot: boolean | null
+    scriptCount: number | null
+  }
+}
+
+export function safeMcpAppDiagnosticMessage(cause: unknown, fallback: string): string {
+  const raw = cause instanceof Error ? cause.message : typeof cause === "string" ? cause : fallback
+  return raw
+    .replace(/Bearer\s+[^\s]+/giu, "Bearer [redacted]")
+    .replace(/([?&](?:token|access_token|authorization)=)[^&#\s]+/giu, "$1[redacted]")
+    .replace(/[\r\n\t]+/gu, " ")
+    .slice(0, 500)
+}
+
+export function formatMcpAppDiagnostic(diagnostic: McpAppDiagnostic): string {
+  const document = diagnostic.sandboxDocument
+  return [
+    `Code: ${diagnostic.code}`,
+    diagnostic.causeCode ? `Cause code: ${diagnostic.causeCode}` : null,
+    `Stage: ${diagnostic.stage}`,
+    `Message: ${diagnostic.message}`,
+    `Tool: ${diagnostic.toolName}`,
+    diagnostic.resourceUri ? `Resource: ${diagnostic.resourceUri}` : null,
+    diagnostic.sandboxOrigin ? `Sandbox origin: ${diagnostic.sandboxOrigin}` : null,
+    `Elapsed: ${diagnostic.elapsedMs} ms`,
+    document ? `Document: readyState=${document.readyState ?? "unknown"}, htmlRoot=${document.hasHtmlRoot ?? "unknown"}, scripts=${document.scriptCount ?? "unknown"}` : null,
+    `Checkpoints: ${diagnostic.checkpoints.length ? diagnostic.checkpoints.join(" -> ") : "none"}`,
+  ].filter((line): line is string => line !== null).join("\n")
+}

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -5,9 +5,15 @@ import type { DynamicToolUIPart } from "ai"
 import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 
-import type { OpenworkMcpAppResource, OpenworkMcpAppToolResult } from "@/app/lib/openwork-server"
+import { OpenworkServerError, type OpenworkMcpAppResource, type OpenworkMcpAppToolResult } from "@/app/lib/openwork-server"
 import { useWorkspace } from "@/react-app/shell/workspace-provider"
 import { cn } from "@/lib/utils"
+import {
+  formatMcpAppDiagnostic,
+  safeMcpAppDiagnosticMessage,
+  type McpAppDiagnostic,
+  type McpAppDiagnosticStage,
+} from "./mcp-app-diagnostics"
 
 const MIN_HEIGHT = 160
 const MAX_HEIGHT = 800
@@ -98,19 +104,48 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
   const [height, setHeight] = useState(DEFAULT_HEIGHT)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<McpAppDiagnostic | null>(null)
+  const [detailsCopied, setDetailsCopied] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     setApp(null)
     setError(null)
+    setDetailsCopied(false)
     if (!result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
+    const startedAt = performance.now()
     void openworkServerClient.resolveMcpApp(workspaceId, part.toolName)
       .then(({ app: resolved }) => {
-        if (!cancelled) setApp(resolved)
+        if (cancelled) return
+        if (resolved) {
+          setApp(resolved)
+          return
+        }
+        const diagnostic: McpAppDiagnostic = {
+          code: "MCP_APP_RESOURCE_NOT_FOUND",
+          stage: "resource-resolution",
+          message: "The completed tool result referenced an interactive view, but the current tool definition did not resolve to an MCP App resource.",
+          toolName: part.toolName,
+          elapsedMs: Math.round(performance.now() - startedAt),
+          checkpoints: ["resolve-started", "resolve-empty"],
+        }
+        console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
+        setError(diagnostic)
       })
       .catch((cause) => {
-        if (!cancelled) setError(cause instanceof Error ? cause.message : "The interactive view could not be loaded.")
+        if (!cancelled) {
+          const diagnostic: McpAppDiagnostic = {
+            code: "MCP_APP_RESOURCE_RESOLUTION_FAILED",
+            ...(cause instanceof OpenworkServerError ? { causeCode: cause.code } : {}),
+            stage: "resource-resolution",
+            message: safeMcpAppDiagnosticMessage(cause, "The interactive view resource could not be resolved."),
+            toolName: part.toolName,
+            elapsedMs: Math.round(performance.now() - startedAt),
+            checkpoints: ["resolve-started"],
+          }
+          console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
+          setError(diagnostic)
+        }
       })
     return () => { cancelled = true }
   }, [openworkServerClient, part.toolName, result, workspaceId])
@@ -120,6 +155,44 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
     if (!app || !result || !iframe || !iframe.contentWindow || !openworkServerClient || !workspaceId) return
     let disposed = false
     let lastSizeEventAt = 0
+    const startedAt = performance.now()
+    const checkpoints: string[] = []
+    let sandboxDocument: McpAppDiagnostic["sandboxDocument"]
+    const checkpoint = (name: string) => checkpoints.push(`${name}+${Math.round(performance.now() - startedAt)}ms`)
+    const fail = (
+      code: string,
+      stage: McpAppDiagnosticStage,
+      cause: unknown,
+      fallback: string,
+      sandboxOrigin?: string,
+    ) => {
+      if (disposed) return
+      const diagnostic: McpAppDiagnostic = {
+        code,
+        stage,
+        message: safeMcpAppDiagnosticMessage(cause, fallback),
+        toolName: part.toolName,
+        resourceUri: app.resourceUri,
+        ...(sandboxOrigin ? { sandboxOrigin } : {}),
+        elapsedMs: Math.round(performance.now() - startedAt),
+        checkpoints: [...checkpoints],
+        ...(sandboxDocument ? { sandboxDocument } : {}),
+      }
+      console.error(`[OpenWork MCP App] ${code}`, diagnostic)
+      setError(diagnostic)
+    }
+    checkpoint("resource-resolved")
+    const sandbox = openworkServerClient.mcpAppSandbox(app, window.location.origin)
+    if (sandbox.expectedOrigin === window.location.origin) {
+      fail(
+        "MCP_APP_SANDBOX_ORIGIN_INVALID",
+        "sandbox-proxy",
+        null,
+        "The sandbox resolved to the same origin as the OpenWork host.",
+        sandbox.expectedOrigin,
+      )
+      return
+    }
     const bridge = new AppBridge(
       null,
       { name: "OpenWork", version: "1.0.0" },
@@ -133,15 +206,16 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
     )
     let initializeTimer: number | undefined
     let initialized = false
+    let proxyReady = false
     const sandboxReadyTimer = window.setTimeout(() => {
-      if (!disposed) setError("The interactive view sandbox did not finish loading.")
+      fail(
+        "MCP_APP_SANDBOX_PROXY_TIMEOUT",
+        "sandbox-proxy",
+        null,
+        "The sandbox proxy did not report that it was ready within 5 seconds.",
+        sandbox.expectedOrigin,
+      )
     }, SANDBOX_READY_TIMEOUT_MS)
-    const sandbox = openworkServerClient.mcpAppSandbox(app, window.location.origin)
-    if (sandbox.expectedOrigin === window.location.origin) {
-      window.clearTimeout(sandboxReadyTimer)
-      setError("The MCP Apps sandbox must use a different origin from the OpenWork host.")
-      return
-    }
 
     bridge.onsizechange = ({ height: requestedHeight }) => {
       const now = Date.now()
@@ -161,6 +235,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
     )
     bridge.oninitialized = () => {
       initialized = true
+      checkpoint("app-initialized")
       if (initializeTimer !== undefined) window.clearTimeout(initializeTimer)
       void bridge.sendToolInput({
         arguments: isRecord(part.input) ? part.input : {},
@@ -169,39 +244,97 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
         ...(result._meta ? { _meta: result._meta } : {}),
       })).catch((cause) => {
-        if (!disposed) setError(cause instanceof Error ? cause.message : "The tool result could not be delivered to the view.")
+        fail(
+          "MCP_APP_TOOL_RESULT_DELIVERY_FAILED",
+          "tool-result-delivery",
+          cause,
+          "The tool result could not be delivered to the initialized view.",
+          sandbox.expectedOrigin,
+        )
       })
     }
-    const handleSandboxReady = (event: MessageEvent) => {
+    const handleSandboxMessage = (event: MessageEvent) => {
       if (event.source !== iframe.contentWindow
         || event.origin !== sandbox.expectedOrigin
-        || event.data?.method !== "ui/notifications/sandbox-proxy-ready") return
-      window.removeEventListener("message", handleSandboxReady)
+        || !isRecord(event.data)) return
+      if (event.data.method === "ui/notifications/sandbox-resource-loaded") {
+        event.stopImmediatePropagation()
+        const params = isRecord(event.data.params) ? event.data.params : {}
+        sandboxDocument = {
+          readyState: typeof params.readyState === "string" ? params.readyState : null,
+          hasHtmlRoot: typeof params.hasHtmlRoot === "boolean" ? params.hasHtmlRoot : null,
+          scriptCount: typeof params.scriptCount === "number" ? params.scriptCount : null,
+        }
+        checkpoint("resource-document-loaded")
+        return
+      }
+      if (event.data.method === "ui/notifications/sandbox-resource-accepted") {
+        event.stopImmediatePropagation()
+        checkpoint("resource-accepted")
+        return
+      }
+      if (event.data.method === "ui/notifications/sandbox-diagnostic") {
+        event.stopImmediatePropagation()
+        const params = isRecord(event.data.params) ? event.data.params : {}
+        fail(
+          typeof params.code === "string" ? params.code : "MCP_APP_SANDBOX_RESOURCE_FAILED",
+          "resource-delivery",
+          typeof params.message === "string" ? params.message : null,
+          "The sandbox could not load the MCP App resource.",
+          sandbox.expectedOrigin,
+        )
+        return
+      }
+      if (event.data.method !== "ui/notifications/sandbox-proxy-ready") return
+      event.stopImmediatePropagation()
+      if (proxyReady) return
+      proxyReady = true
+      checkpoint("sandbox-proxy-ready")
       window.clearTimeout(sandboxReadyTimer)
       const transport = new PostMessageTransport(iframe.contentWindow!, iframe.contentWindow!)
       void bridge.connect(transport)
-        .then(() => bridge.sendSandboxResourceReady({
-          html: secureMcpAppHtml(app),
-          csp: app.csp,
-          sandbox: "allow-scripts allow-same-origin",
-        }))
         .then(() => {
+          checkpoint("bridge-connected")
+          return bridge.sendSandboxResourceReady({
+            html: secureMcpAppHtml(app),
+            csp: app.csp,
+            sandbox: "allow-scripts allow-same-origin",
+          })
+        })
+        .then(() => {
+          checkpoint("resource-sent")
           if (!initialized) {
             initializeTimer = window.setTimeout(() => {
-              if (!disposed) setError("The interactive view did not finish its MCP Apps handshake.")
+              const message = sandboxDocument
+                ? "The HTML document loaded, but the MCP App did not send ui/notifications/initialized within 10 seconds."
+                : "The resource was sent to the sandbox, but its document did not report loading or complete MCP Apps initialization within 10 seconds."
+              fail(
+                "MCP_APP_INITIALIZE_TIMEOUT",
+                "app-initialization",
+                null,
+                message,
+                sandbox.expectedOrigin,
+              )
             }, INITIALIZE_TIMEOUT_MS)
           }
         })
         .catch((cause) => {
-          if (!disposed) setError(cause instanceof Error ? cause.message : "The MCP Apps sandbox could not load the view.")
+          fail(
+            "MCP_APP_RESOURCE_DELIVERY_FAILED",
+            "resource-delivery",
+            cause,
+            "The host could not deliver the MCP App HTML to the sandbox.",
+            sandbox.expectedOrigin,
+          )
         })
     }
-    window.addEventListener("message", handleSandboxReady)
+    window.addEventListener("message", handleSandboxMessage)
+    checkpoint("sandbox-navigation-started")
     iframe.src = sandbox.url
 
     return () => {
       disposed = true
-      window.removeEventListener("message", handleSandboxReady)
+      window.removeEventListener("message", handleSandboxMessage)
       window.clearTimeout(sandboxReadyTimer)
       if (initializeTimer !== undefined) window.clearTimeout(initializeTimer)
       void Promise.race([
@@ -213,10 +346,28 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
 
   if (!result || (!app && !error)) return null
   if (error) {
+    const details = formatMcpAppDiagnostic(error)
     return (
-      <p className="mt-2 text-xs text-muted-foreground" role="status">
-        Interactive view unavailable. The normal tool result is still available. {error}
-      </p>
+      <div className="mt-2 text-xs text-muted-foreground" role="status">
+        <p>Interactive view unavailable. The normal tool result is still available. {error.message}</p>
+        <details className="mt-1">
+          <summary className="cursor-pointer select-none">Technical details ({error.code})</summary>
+          <p className="mt-1">Copy these details when reporting the rendering problem.</p>
+          <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-2 font-mono text-[11px] text-foreground">{details}</pre>
+          <button
+            type="button"
+            className="mt-1 underline underline-offset-2"
+            onClick={() => {
+              if (!navigator.clipboard) return
+              void navigator.clipboard.writeText(details)
+                .then(() => setDetailsCopied(true))
+                .catch(() => setDetailsCopied(false))
+            }}
+          >
+            {detailsCopied ? "Copied" : "Copy details"}
+          </button>
+        </details>
+      </div>
     )
   }
 

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import type { OpenworkMcpAppResource } from "../src/app/lib/openwork-server"
+import { formatMcpAppDiagnostic, safeMcpAppDiagnosticMessage } from "../src/components/chat/mcp-app-diagnostics"
 import { buildMcpAppCsp, secureMcpAppHtml } from "../src/components/chat/mcp-app-frame"
 
 function fixture(overrides: Partial<OpenworkMcpAppResource> = {}): OpenworkMcpAppResource {
@@ -21,6 +22,34 @@ function fixture(overrides: Partial<OpenworkMcpAppResource> = {}): OpenworkMcpAp
 }
 
 describe("MCP App iframe policy", () => {
+  test("formats safe, copyable handshake diagnostics", () => {
+    const details = formatMcpAppDiagnostic({
+      code: "MCP_APP_INITIALIZE_TIMEOUT",
+      causeCode: "mcp_unreachable",
+      stage: "app-initialization",
+      message: "The HTML document loaded, but initialization did not complete.",
+      toolName: "artifact_render_card",
+      resourceUri: "ui://openwork/artifacts/arv_1/views/avr_2/index.html",
+      sandboxOrigin: "http://127.0.0.1:4321",
+      elapsedMs: 10_025,
+      checkpoints: ["resource-resolved+0ms", "resource-document-loaded+24ms"],
+      sandboxDocument: { readyState: "complete", hasHtmlRoot: true, scriptCount: 1 },
+    })
+    expect(details).toContain("Code: MCP_APP_INITIALIZE_TIMEOUT")
+    expect(details).toContain("Cause code: mcp_unreachable")
+    expect(details).toContain("Stage: app-initialization")
+    expect(details).toContain("Resource: ui://openwork/artifacts/arv_1/views/avr_2/index.html")
+    expect(details).toContain("Document: readyState=complete, htmlRoot=true, scripts=1")
+    expect(details).toContain("resource-document-loaded+24ms")
+  })
+
+  test("redacts credentials from diagnostic messages", () => {
+    expect(safeMcpAppDiagnosticMessage(
+      new Error("request failed: Bearer secret-value https://example.com?access_token=also-secret"),
+      "fallback",
+    )).toBe("request failed: Bearer [redacted] https://example.com?access_token=[redacted]")
+  })
+
   test("defaults every ambient capability closed", () => {
     const csp = buildMcpAppCsp(fixture())
     expect(csp).toContain("default-src 'none'")

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -211,6 +211,18 @@ describe("MCP Apps host transport", () => {
     })).rejects.toMatchObject({ code: "invalid_resource" });
   });
 
+  test("preserves an unreachable provider error for host diagnostics", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-host-unreachable-");
+    await stops.pop()?.();
+
+    await expect(resolveMcpAppResource({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      projectedToolName: "fixture_render_fixture",
+    })).rejects.toMatchObject({ code: "mcp_unreachable" });
+  });
+
   test("mediates explicitly read-only same-server tool calls", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-call-");
 

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -271,6 +271,7 @@ export async function resolveMcpAppResource(input: {
     && input.projectedToolName.startsWith(`${item.name.replace(/[^a-zA-Z0-9_-]/g, "_")}_`)
   ));
   const matches: McpAppResource[] = [];
+  const resolutionErrors: McpAppHostError[] = [];
   for (const item of candidates) {
     if (!remoteUrl(item.config)) continue;
     const match = await withRemoteClient(item.config, async (client) => {
@@ -295,6 +296,9 @@ export async function resolveMcpAppResource(input: {
       } satisfies McpAppResource;
     }).catch((error) => {
       if (error instanceof McpAppHostError && error.code !== "mcp_unreachable") throw error;
+      resolutionErrors.push(error instanceof McpAppHostError
+        ? error
+        : new McpAppHostError("mcp_app_resolution_failed", "The MCP App resource could not be resolved."));
       return null;
     });
     if (match) matches.push(match);
@@ -302,6 +306,7 @@ export async function resolveMcpAppResource(input: {
   if (matches.length > 1) {
     throw new McpAppHostError("ambiguous_tool", "More than one configured MCP App matches this projected tool name.");
   }
+  if (matches.length === 0 && resolutionErrors[0]) throw resolutionErrors[0];
   return matches[0] ?? null;
 }
 

--- a/apps/server/src/mcp-app-sandbox.test.ts
+++ b/apps/server/src/mcp-app-sandbox.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildMcpAppSandboxCsp, parseMcpAppSandboxCsp } from "./mcp-app-sandbox.js";
+import { buildMcpAppSandboxCsp, MCP_APP_SANDBOX_PROXY_SCRIPT, parseMcpAppSandboxCsp } from "./mcp-app-sandbox.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
@@ -15,6 +15,13 @@ afterEach(async () => {
 });
 
 describe("MCP Apps sandbox proxy policy", () => {
+  test("reports resource acceptance, document load, and safe sandbox failures", () => {
+    expect(MCP_APP_SANDBOX_PROXY_SCRIPT).toContain("ui/notifications/sandbox-resource-accepted");
+    expect(MCP_APP_SANDBOX_PROXY_SCRIPT).toContain("ui/notifications/sandbox-resource-loaded");
+    expect(MCP_APP_SANDBOX_PROXY_SCRIPT).toContain("ui/notifications/sandbox-diagnostic");
+    expect(MCP_APP_SANDBOX_PROXY_SCRIPT).not.toContain("params.html");
+  });
+
   test("defaults external capabilities closed", () => {
     const csp = buildMcpAppSandboxCsp(parseMcpAppSandboxCsp(null));
     expect(csp).toContain("connect-src 'none'");

--- a/apps/server/src/mcp-app-sandbox.ts
+++ b/apps/server/src/mcp-app-sandbox.ts
@@ -74,10 +74,27 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
   if (!hostOrigin) throw new Error("MCP App sandbox host origin is unavailable.");
   const hostTargetOrigin = hostOrigin === "null" ? "*" : hostOrigin;
   const ownOrigin = window.location.origin;
+  const notifyHost = (method, params = {}) => window.parent.postMessage({ jsonrpc: "2.0", method, params }, hostTargetOrigin);
   const inner = document.createElement("iframe");
   inner.title = "MCP App view";
   inner.style.cssText = "display:block;width:100%;height:100%;border:0;background:transparent";
   inner.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  let resourceAssigned = false;
+  inner.addEventListener("load", () => {
+    if (!resourceAssigned) return;
+    let readyState = null;
+    let hasHtmlRoot = null;
+    let scriptCount = null;
+    try {
+      readyState = inner.contentDocument?.readyState || null;
+      hasHtmlRoot = Boolean(inner.contentDocument?.documentElement);
+      scriptCount = inner.contentDocument?.scripts.length ?? null;
+    } catch {}
+    notifyHost("ui/notifications/sandbox-resource-loaded", { readyState, hasHtmlRoot, scriptCount });
+  });
+  inner.addEventListener("error", () => {
+    if (resourceAssigned) notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_DOCUMENT_ERROR", message: "The sandbox iframe reported a document load error." });
+  });
   document.body.appendChild(inner);
   window.addEventListener("message", (event) => {
     if (event.source === window.parent) {
@@ -86,7 +103,17 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
         const html = event.data?.params?.html;
         const sandbox = event.data?.params?.sandbox;
         if (typeof sandbox === "string" && /^(?:allow-scripts|allow-same-origin|\s)+$/.test(sandbox)) inner.setAttribute("sandbox", sandbox);
-        if (typeof html === "string") inner.srcdoc = html;
+        if (typeof html !== "string") {
+          notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_RESOURCE_INVALID", message: "The sandbox received an invalid HTML resource payload." });
+          return;
+        }
+        try {
+          resourceAssigned = true;
+          inner.srcdoc = html;
+          notifyHost("ui/notifications/sandbox-resource-accepted");
+        } catch {
+          notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_RESOURCE_ASSIGNMENT_FAILED", message: "The sandbox could not assign the HTML resource to its isolated document." });
+        }
         return;
       }
       inner.contentWindow?.postMessage(event.data, "*");
@@ -96,7 +123,7 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
       window.parent.postMessage(event.data, hostTargetOrigin);
     }
   });
-  window.parent.postMessage({ jsonrpc: "2.0", method: "ui/notifications/sandbox-proxy-ready", params: {} }, hostTargetOrigin);
+  notifyHost("ui/notifications/sandbox-proxy-ready");
 })();
 `;
 


### PR DESCRIPTION
## Summary

- keep the normal artifact result visible when an interactive MCP App fails
- show a stable failure code, lifecycle stage, elapsed checkpoints, and copyable technical details
- distinguish resource resolution, sandbox startup, HTML delivery and load, app initialization, and tool-result delivery failures
- preserve upstream provider errors such as mcp_unreachable instead of silently treating them as no UI resource
- report safe sandbox document state without including HTML, headers, credentials, or structured artifact data

## Why

Artifact views currently reduce handshake failures to a generic timeout and can disappear entirely when resource resolution returns no match. This makes user reports difficult to diagnose and obscures whether the provider, sandbox, document load, MCP Apps initialization, or render-data delivery failed.

## Verification

- bun test tests/mcp-app-frame.test.ts (7 passed)
- bun --conditions=development test src/mcp-app-sandbox.test.ts src/mcp-app-host.test.ts (13 passed)
- pnpm typecheck in apps/app
- pnpm typecheck in apps/server
- OPENWORK_EVAL_APP_SPECS=1 MCP App inline-host stack journey (1 passed)