### PR TITLE
fix(server): preserve live sessions across workspace switches

### DIFF
--- a/apps/server/src/engine-directory-fence.ts
+++ b/apps/server/src/engine-directory-fence.ts
@@ -1,0 +1,44 @@
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+type Queue = Map<string, Promise<void>>;
+
+const queuesByConfig = new WeakMap<ServerConfig, Queue>();
+
+function directoryKey(workspace: WorkspaceInfo): string {
+  const directory = workspace.directory?.trim() || workspace.path.trim();
+  return process.platform === "win32"
+    ? directory.replace(/^\\\\\?\\/, "").replace(/^\/\/\?\//, "").toLowerCase()
+    : directory;
+}
+
+/**
+ * Serialize target-directory instance disposal with prompt admission routed
+ * through OpenWork. Different directories intentionally use different queues.
+ */
+export async function withEngineDirectoryFence<T>(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let queue = queuesByConfig.get(config);
+  if (!queue) {
+    queue = new Map();
+    queuesByConfig.set(config, queue);
+  }
+
+  const key = directoryKey(workspace);
+  const previous = queue.get(key) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  queue.set(key, current);
+
+  await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (queue.get(key) === current) queue.delete(key);
+  }
+}

--- a/apps/server/src/engine-reload-defer.test.ts
+++ b/apps/server/src/engine-reload-defer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldDeferInPlaceEngineReload } from "./engine-reload-defer.js";
+import { clearEnginePoolForConfig, setEnginePoolForConfig, type EnginePool } from "./engine-pool.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+const first: WorkspaceInfo = {
+  id: "ws_first",
+  name: "First",
+  path: "/tmp/first",
+  preset: "starter",
+  workspaceType: "local",
+  baseUrl: "http://127.0.0.1:4096",
+};
+const second: WorkspaceInfo = {
+  ...first,
+  id: "ws_second",
+  name: "Second",
+  path: "/tmp/second",
+  baseUrl: "http://127.0.0.1:4096/",
+};
+function fixtureConfig(engineRollover = false): ServerConfig {
+  return {
+    engineRollover,
+    workspaces: [first, second],
+  } as ServerConfig;
+}
+
+describe("shouldDeferInPlaceEngineReload", () => {
+  test("defers when the target directory has a live session", async () => {
+    const config = fixtureConfig();
+    const probed: string[] = [];
+    const hasActiveSessions = async (_config: ServerConfig, workspace: WorkspaceInfo) => {
+      probed.push(workspace.id);
+      return workspace.id === second.id;
+    };
+
+    expect(await shouldDeferInPlaceEngineReload(config, second, hasActiveSessions)).toBe(true);
+    expect(probed).toEqual([second.id]);
+  });
+
+  test("does not let another directory block an idle target reload", async () => {
+    const config = fixtureConfig();
+    const probed: string[] = [];
+    const hasActiveSessions = async (_config: ServerConfig, workspace: WorkspaceInfo) => {
+      probed.push(workspace.id);
+      return workspace.id === first.id;
+    };
+
+    expect(await shouldDeferInPlaceEngineReload(config, second, hasActiveSessions)).toBe(false);
+    expect(probed).toEqual([second.id]);
+  });
+
+  test("does not probe or defer when a rollover pool exists", async () => {
+    const config = fixtureConfig(true);
+    setEnginePoolForConfig(config, { adoptPrimary: () => undefined } as unknown as EnginePool);
+    let probed = false;
+    try {
+      expect(await shouldDeferInPlaceEngineReload(config, second, async () => {
+        probed = true;
+        return true;
+      })).toBe(false);
+      expect(probed).toBe(false);
+    } finally {
+      clearEnginePoolForConfig(config);
+    }
+  });
+});

--- a/apps/server/src/engine-reload-defer.ts
+++ b/apps/server/src/engine-reload-defer.ts
@@ -1,0 +1,22 @@
+import { enginePoolForConfig } from "./engine-pool.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+export interface EngineSessionsProbe {
+  (config: ServerConfig, workspace: WorkspaceInfo): Promise<boolean>;
+}
+
+/**
+ * OpenCode's instance cache and `/instance/dispose?directory=...` are scoped
+ * to one directory. Only the target directory can be interrupted by this
+ * reload; sessions in other workspaces on the same server are independent.
+ * A rollover pool does not need to defer because it leaves live sessions on
+ * the draining generation.
+ */
+export async function shouldDeferInPlaceEngineReload(
+  config: ServerConfig,
+  target: WorkspaceInfo,
+  hasActiveSessions: EngineSessionsProbe,
+): Promise<boolean> {
+  if (enginePoolForConfig(config)) return false;
+  return hasActiveSessions(config, target);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -14,6 +14,8 @@ import {
   type EngineEventProxyLease,
   type EngineSpawnTemplate,
 } from "./engine-pool.js";
+import { withEngineDirectoryFence } from "./engine-directory-fence.js";
+import { shouldDeferInPlaceEngineReload } from "./engine-reload-defer.js";
 import { buildEngineAuthProbeHeader } from "./engine-registry.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
@@ -882,6 +884,10 @@ function isSessionCommandProxyRequest(method: string, proxyPath: string) {
   return method === "POST" && /^\/session\/[^/]+\/command$/.test(normalizeOpencodeProxyPath(proxyPath));
 }
 
+function isPromptAsyncProxyRequest(method: string, proxyPath: string) {
+  return method === "POST" && /^\/session\/[^/]+\/prompt_async$/.test(normalizeOpencodeProxyPath(proxyPath));
+}
+
 export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
@@ -1270,22 +1276,29 @@ export async function proxyOpencodeRequest(input: {
     });
     return jsonResponse({ ok: true, accepted: true });
   }
-  const response = await loopbackFetch(targetUrl, {
-    method,
-    headers,
-    body,
-  });
+  const forward = async () => {
+    const response = await loopbackFetch(targetUrl, {
+      method,
+      headers,
+      body,
+    });
 
-  if (response.status === 404 && route?.fallback) {
-    const fallbackHeaders = headersForEngineConnection(headers, route.fallback);
-    const fallbackResponse = await loopbackFetch(
-      buildOpencodeProxyUrl(route.fallback.baseUrl, proxyPath, input.url.search),
-      { method, headers: fallbackHeaders, body },
-    );
-    return sanitizeProxyResponse(fallbackResponse);
+    if (response.status === 404 && route?.fallback) {
+      const fallbackHeaders = headersForEngineConnection(headers, route.fallback);
+      const fallbackResponse = await loopbackFetch(
+        buildOpencodeProxyUrl(route.fallback.baseUrl, proxyPath, input.url.search),
+        { method, headers: fallbackHeaders, body },
+      );
+      return sanitizeProxyResponse(fallbackResponse);
+    }
+
+    return sanitizeProxyResponse(response);
+  };
+
+  if (workspace && workspace.workspaceType !== "remote" && !pool && isPromptAsyncProxyRequest(method, proxyPath)) {
+    return withEngineDirectoryFence(input.config, workspace, forward);
   }
-
-  return sanitizeProxyResponse(response);
+  return forward();
 }
 
 function isEngineEventPath(proxyPath: string): boolean {
@@ -1891,8 +1904,14 @@ function createRoutes(
     ensureWritable,
     resolveWorkspace,
     serializeWorkspace,
-    reloadOpencodeEngine: (routeConfig, workspace) =>
-      reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState),
+    reloadOpencodeEngine: async (routeConfig, workspace) => {
+      await withEngineDirectoryFence(routeConfig, workspace, async () => {
+        if (await shouldDeferInPlaceEngineReload(routeConfig, workspace, engineHasActiveSessions)) {
+          return;
+        }
+        await reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState);
+      });
+    },
   });
 
   registerSessionRoutes({
@@ -2414,8 +2433,7 @@ function createRoutes(
     // the generation that owns live sessions. Legacy/external engines keep
     // the established busy deferral.
     const reloadDeferred = shouldReload
-      && !enginePoolForConfig(config)
-      && (await engineHasActiveSessions(config, workspace));
+      && (await shouldDeferInPlaceEngineReload(config, workspace, engineHasActiveSessions));
     if (shouldReload && !reloadDeferred) {
       await reloadOpencodeEngine(config, workspace, engineMcpServerState);
     }

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -34,6 +34,10 @@ function hostAuth(token: string) {
   return { "X-OpenWork-Host-Token": token };
 }
 
+function clientAuth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
 function workspaceIdsFromConfig(value: unknown): string[] {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
   if (!("workspaces" in value) || !Array.isArray(value.workspaces)) return [];
@@ -68,15 +72,40 @@ async function readPersistedConfig(configPath: string): Promise<unknown> {
 }
 
 function startMockOpencode() {
-  const requests: Array<{ method: string; pathname: string; search: string }> = [];
+  const requests: Array<{ method: string; pathname: string; search: string; directory: string | null }> = [];
+  const busyDirectories = new Set<string>();
+  const abortedDirectories = new Set<string>();
+  const heldStatus = new Map<string, Promise<void>>();
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
       const url = new URL(request.url);
-      requests.push({ method: request.method, pathname: url.pathname, search: url.search });
+      const directory = request.headers.get("x-opencode-directory");
+      requests.push({ method: request.method, pathname: url.pathname, search: url.search, directory });
+
+      if (url.pathname === "/session/status") {
+        const hold = directory ? heldStatus.get(directory) : undefined;
+        if (hold) {
+          heldStatus.delete(directory!);
+          return hold.then(() => Response.json({}));
+        }
+        return Response.json(
+          directory && busyDirectories.has(directory)
+            ? { ses_busy: { type: "busy" } }
+            : {},
+        );
+      }
+
+      if (url.pathname.endsWith("/prompt_async") && request.method === "POST") {
+        if (directory) busyDirectories.add(directory);
+        return new Response(null, { status: 204 });
+      }
 
       if (url.pathname === "/instance/dispose") {
+        const target = url.searchParams.get("directory");
+        if (target && busyDirectories.has(target)) abortedDirectories.add(target);
+        if (target) busyDirectories.delete(target);
         return Response.json({ disposed: true });
       }
 
@@ -84,7 +113,36 @@ function startMockOpencode() {
     },
   }) as Served;
   stops.push(() => server.stop(true));
-  return { server, requests };
+  return {
+    server,
+    requests,
+    busyDirectories,
+    abortedDirectories,
+    setBusy(directory: string, busy: boolean) {
+      if (busy) busyDirectories.add(directory);
+      else busyDirectories.delete(directory);
+    },
+    holdNextStatus(directory: string) {
+      let release: () => void = () => {};
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      heldStatus.set(directory, released);
+      return {
+        reached: new Promise<void>((resolve) => {
+          const poll = () => {
+            if (requests.some((entry) => entry.pathname === "/session/status" && entry.directory === directory)) {
+              resolve();
+              return;
+            }
+            setTimeout(poll, 1);
+          };
+          poll();
+        }),
+        release,
+      };
+    },
+  };
 }
 
 function startMockRemoteOpenwork() {
@@ -140,10 +198,11 @@ async function startOpenworkServerWithWorkspaces(input: {
     hostTokenSource: "cli",
     logFormat: "pretty",
     logRequests: false,
+    engineRollover: false,
   };
   const server = await startServer(config) as Served;
   stops.push(() => server.stop(true));
-  return { server, hostToken: config.hostToken };
+  return { server, token: config.token, hostToken: config.hostToken };
 }
 
 describe("workspace activation", () => {
@@ -206,6 +265,147 @@ describe("workspace activation", () => {
 
     expect(sameWorkspaceResponse.status).toBe(200);
     expect(disposeCount()).toBe(1);
+  });
+
+  test("does not dispose the target directory after its prompt was admitted before activation completes", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      {
+        id: "ws_1",
+        name: "One",
+        path: firstRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: opencodeBaseUrl,
+      },
+      {
+        id: "ws_2",
+        name: "Two",
+        path: secondRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: opencodeBaseUrl,
+      },
+    ];
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath: join(firstRoot, "server.json"),
+      workspaces,
+      authorizedRoots: [firstRoot, secondRoot],
+    });
+    mock.setBusy(firstRoot, true);
+
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const promptResponse = await fetch(`${base}/workspace/ws_2/opencode/session/ses_b/prompt_async`, {
+      method: "POST",
+      headers: clientAuth(openwork.token),
+      body: JSON.stringify({ parts: [{ type: "text", text: "Keep running" }] }),
+    });
+    expect(promptResponse.status).toBe(204);
+
+    const response = await fetch(`${base}/workspaces/ws_2/activate`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).activeId).toBe("ws_2");
+    expect(mock.requests.some(
+      (request) => request.pathname === "/session/status" && request.directory === secondRoot,
+    )).toBe(true);
+    expect(mock.requests.some(
+      (request) => request.pathname === "/session/status" && request.directory === firstRoot,
+    )).toBe(false);
+    expect(mock.requests.some((request) => request.pathname === "/instance/dispose")).toBe(false);
+    expect(mock.busyDirectories.has(firstRoot)).toBe(true);
+    expect(mock.busyDirectories.has(secondRoot)).toBe(true);
+    expect(mock.abortedDirectories.size).toBe(0);
+  });
+
+  test("does not let a busy task in another directory block an idle target reload", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+    ];
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath: join(firstRoot, "server.json"),
+      workspaces,
+      authorizedRoots: [firstRoot, secondRoot],
+    });
+    mock.setBusy(firstRoot, true);
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspaces/ws_2/activate`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mock.requests.some(
+      (request) => request.pathname === "/session/status" && request.directory === firstRoot,
+    )).toBe(false);
+    const dispose = mock.requests.find((request) => request.pathname === "/instance/dispose");
+    expect(dispose?.search).toContain(`directory=${encodeURIComponent(secondRoot)}`);
+    expect(mock.busyDirectories.has(firstRoot)).toBe(true);
+    expect(mock.abortedDirectories.size).toBe(0);
+  });
+
+  test("serializes target prompt admission against the idle-check-to-dispose window", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+    ];
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath: join(firstRoot, "server.json"),
+      workspaces,
+      authorizedRoots: [firstRoot, secondRoot],
+    });
+    const heldStatus = mock.holdNextStatus(secondRoot);
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+
+    const activation = fetch(`${base}/workspaces/ws_2/activate`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+    await heldStatus.reached;
+
+    const otherDirectoryPrompt = await fetch(`${base}/workspace/ws_1/opencode/session/ses_a/prompt_async`, {
+      method: "POST",
+      headers: clientAuth(openwork.token),
+      body: JSON.stringify({ parts: [{ type: "text", text: "Continue independently" }] }),
+    });
+    expect(otherDirectoryPrompt.status).toBe(204);
+
+    const prompt = fetch(`${base}/workspace/ws_2/opencode/session/ses_b/prompt_async`, {
+      method: "POST",
+      headers: clientAuth(openwork.token),
+      body: JSON.stringify({ parts: [{ type: "text", text: "Start after activation" }] }),
+    });
+    await Bun.sleep(10);
+    expect(mock.requests.some(
+      (request) => request.pathname.endsWith("/prompt_async") && request.directory === secondRoot,
+    )).toBe(false);
+
+    heldStatus.release();
+    expect((await activation).status).toBe(200);
+    expect((await prompt).status).toBe(204);
+
+    const relevant = mock.requests.filter((request) =>
+      request.directory === secondRoot || request.search.includes(encodeURIComponent(secondRoot))
+    ).map((request) => request.pathname);
+    expect(relevant).toEqual(["/session/status", "/instance/dispose", "/session/ses_b/prompt_async"]);
+    expect(mock.busyDirectories.has(firstRoot)).toBe(true);
+    expect(mock.busyDirectories.has(secondRoot)).toBe(true);
+    expect(mock.abortedDirectories.size).toBe(0);
   });
 
   test("persists activation order only when requested", async () => {


### PR DESCRIPTION
## Summary

Prevent workspace activation from disposing the target OpenCode directory after that directory has already admitted a prompt.

OpenCode v1.17.11 keeps independent instance state per directory. Activating workspace B calls `/instance/dispose?directory=B`; it does not dispose workspace A. The guard is therefore target-directory scoped rather than server-wide.

Closes #3708. Supersedes the narrower proposal in #3707.

## Root cause

The renderer can select B and send `prompt_async` while its fire-and-forget `activateWorkspace(B)` request is still running. If activation disposes B after the prompt is accepted, OpenCode interrupts that new B task with `MessageAbortedError`.

A status check by itself leaves a second race: B can appear idle, then accept a prompt before activation sends the dispose.

## What changed

- Probe only the target directory before an in-place activation reload.
- Defer B's dispose when B already has an active parent, child, or parallel session.
- Serialize target-directory activation reloads with OpenWork-proxied `prompt_async` admission:
  - a prompt accepted first makes the later activation observe B as busy;
  - an activation that owns the fence first completes its idle reload before a new B prompt reaches OpenCode.
- Keep fences directory-scoped, so activity in A neither blocks B nor gets interrupted by B's disposal.
- Preserve idle target-directory reload behavior.
- Leave rollover engines unchanged; their draining generation already preserves live work.
- Apply the same target-directory busy predicate to provider-config reload deferral.

## Verification

- `bun --conditions=development test apps/server/src/engine-reload-defer.test.ts apps/server/src/workspace-activate.e2e.test.ts` — 12 passing tests, 75 assertions.
- `pnpm --filter openwork-server typecheck` — passing.
- `git diff --check upstream/dev...HEAD` — passing.

The deterministic regressions prove:

1. B prompt admitted before B activation completes → activation probes B and does not dispose it.
2. B activation paused after an idle probe → a new B prompt is fenced until B's dispose completes, then is admitted.
3. A prompt remains independently admissible during B's fence.
4. A busy task does not block an idle B reload and is not interrupted.
5. Default `engineRollover: false` and idle reload behavior remain covered.

## Residual boundary

The admission fence covers prompts routed through OpenWork's workspace-mounted proxy, which is the desktop path involved in this incident. A client that bypasses OpenWork and sends directly to the underlying OpenCode port is outside the fence and can still race an OpenWork-triggered dispose. Fully closing that cross-process case requires an atomic busy-aware reload primitive inside OpenCode itself.

Real-app acceptance and the broader repository matrix remain delegated to PR verification. PR #3726 is unrelated renderer/reconnection resilience and is not relied upon here.