### PR TITLE
fix(automations): bind runner credentials to the Den Web proxy origin

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -368,6 +368,13 @@ export function createDesktopAutomationRunner(options) {
       const normalized = destinationAllowed && token && next?.runnerId
         ? { baseUrl, token, runnerId: String(next.runnerId) }
         : null
+      if (next && !normalized) {
+        // Without this the desktop stays quiet while every scheduled run is
+        // recorded as missed, which reads as a scheduler fault rather than a
+        // credential bound to a different Den route than this desktop uses.
+        options.log?.(`rejected runner credential for ${baseUrl ?? "an unusable base URL"}`
+          + `: token audience ${binding?.audience ?? (binding ? "v1 (untrusted here)" : "unreadable")}`)
+      }
       if (configuration?.baseUrl === normalized?.baseUrl && configuration?.token === normalized?.token) {
         return { connected: Boolean(connectionController && !connectionController.signal.aborted) }
       }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -146,8 +146,10 @@ test("a runner credential bound elsewhere reports why this desktop stays disconn
   await new Promise((resolve) => setTimeout(resolve, 25))
   runner.stop()
   assert.deepEqual(attempted, [])
-  assert.ok(logged.some((entry) =>
-    entry.includes("https://den.example.com/api/den") && entry.includes("https://api.example.com")))
+  assert.deepEqual(logged, [
+    "rejected runner credential for https://den.example.com/api/den"
+      + ": token audience https://api.example.com",
+  ])
 })
 
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -127,6 +127,29 @@ test("a v1 runner credential cannot use an untrusted HTTPS endpoint", async () =
   assert.deepEqual(attempted, [])
 })
 
+test("a runner credential bound elsewhere reports why this desktop stays disconnected", async () => {
+  const logged = []
+  const attempted = []
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      attempted.push(String(url))
+      throw new Error("no network in test")
+    },
+    log: (state) => logged.push(state),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com/api/den",
+    token: runnerTokenFor("https://api.example.com"),
+    runnerId: "runner-1",
+  })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  runner.stop()
+  assert.deepEqual(attempted, [])
+  assert.ok(logged.some((entry) =>
+    entry.includes("https://den.example.com/api/den") && entry.includes("https://api.example.com")))
+})
+
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {
   const requests = []
   let snapshots = 0

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -4,7 +4,7 @@ import {
   type AutomationDesktopRunnerCapability,
 } from "@openwork/types/automations"
 import { env } from "../env.js"
-import { firstForwardedValue, trustedForwardedOrigin } from "../request-url.js"
+import { firstForwardedValue, publicRequestUrl, trustedForwardedOrigin } from "../request-url.js"
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
 const TOKEN_ROUTE_SUFFIX = "/v1/automation-runners/token"
@@ -48,7 +48,10 @@ export function automationRunnerAudienceFromRequestUrl(requestUrl: string): stri
  * Bind proxied runner credentials to the public Den route the desktop will
  * actually use. The Den Web proxy strips caller-supplied forwarding headers
  * and writes its own, while trustedForwardedOrigin limits the destination to
- * configured first-party origins. Direct API requests keep their request URL.
+ * configured first-party origins. Direct API requests keep their request URL,
+ * resolved through the public scheme because hosted deployments terminate TLS
+ * ahead of this process: desktops reject a plaintext runner destination, so an
+ * http audience would silently disconnect every runner behind such a proxy.
  */
 export function automationRunnerAudienceFromRequest(
   request: Request,
@@ -60,7 +63,9 @@ export function automationRunnerAudienceFromRequest(
     const forwarded = trustedForwardedOrigin(request, { trustedOrigins: options.trustedOrigins })
     if (forwarded) return `${forwarded.origin}${DEN_WEB_PROXY_PREFIX}`
   }
-  return automationRunnerAudienceFromRequestUrl(request.url)
+  return automationRunnerAudienceFromRequestUrl(
+    publicRequestUrl(request, { trustedOrigins: options.trustedOrigins }).toString(),
+  )
 }
 
 export class AutomationRunnerAuth {

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -441,6 +441,15 @@ const publicUrlTrustedOrigins = Array.from(new Set([
   ...corsOrigins,
   ...betterAuthTrustedOrigins,
 ])).filter((origin) => origin !== "*")
+// Den Web serves this API under /api/den on the better-auth origin, so a
+// request forwarded from that origin is first-party by construction. Hosted
+// deployments proxy browser and desktop calls server-side and never need that
+// origin in CORS_ORIGINS, so deriving public routes from the CORS allowlist
+// alone silently drops the one origin clients actually call.
+const publicProxyTrustedOrigins = Array.from(new Set([
+  normalizeOrigin(parsed.BETTER_AUTH_URL),
+  ...publicUrlTrustedOrigins,
+]))
 const orgMode = parseDenOrgMode(parsed.DEN_ORG_MODE)
 // SSRF guard for External MCP Connection URLs: on hosted (multi-tenant)
 // deployments, Den must not fetch private/reserved addresses on behalf of
@@ -574,6 +583,7 @@ export const env = {
     renderGitCommit: parsed.RENDER_GIT_COMMIT,
   }),
   publicUrlTrustedOrigins,
+  publicProxyTrustedOrigins,
   installerArtifactsDir: optionalString(parsed.OPENWORK_INSTALLER_ARTIFACTS_DIR),
   // Standard desktop release assets: the release tag to download from,
   // defaulting to the pinned app release this den-api build shipped with.

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -133,7 +133,7 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
           capabilities: registration.capabilities,
         },
         automationRunnerAudienceFromRequest(c.req.raw, {
-          trustedOrigins: env.publicUrlTrustedOrigins,
+          trustedOrigins: env.publicProxyTrustedOrigins,
         }),
       ))
     },

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -53,10 +53,7 @@ const organizationRequiredSchema = z.object({
 
 type McpRouteVariables = AuthContextVariables & Partial<OrganizationContextVariables>
 
-const firstPartyMcpTokenTrustedOrigins = Array.from(new Set([
-  env.betterAuthUrl,
-  ...env.publicUrlTrustedOrigins,
-]))
+const firstPartyMcpTokenTrustedOrigins = env.publicProxyTrustedOrigins
 
 export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables }>(app: Hono<T>) {
   app.post(

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -64,6 +64,37 @@ describe("Automation runner credentials", () => {
     })).toBe("https://app.openworklabs.com/api/den")
   })
 
+  test("trusts the Den Web proxy origin this API is actually served from", async () => {
+    const { env } = await import("../src/env.js")
+    const denWeb = new URL(env.betterAuthUrl)
+    const request = new Request("http://api.internal/v1/automation-runners/token", {
+      headers: {
+        "x-forwarded-host": denWeb.host,
+        "x-forwarded-proto": denWeb.protocol.replace(/:$/, ""),
+        "x-forwarded-prefix": "/api/den",
+      },
+    })
+
+    expect(automationRunnerAudienceFromRequest(request, {
+      trustedOrigins: env.publicProxyTrustedOrigins,
+    })).toBe(`${denWeb.origin}/api/den`)
+    // Hosted deployments proxy every call server-side, so the Den Web origin
+    // has no reason to appear in CORS_ORIGINS. Binding off that list alone
+    // sends desktops to the internal API, where their credential is refused
+    // and every desktop occurrence is recorded as missed.
+    expect(automationRunnerAudienceFromRequest(request, { trustedOrigins: [] }))
+      .toBe(`${denWeb.protocol}//api.internal`)
+  })
+
+  test("keeps a directly reached runner destination on its public scheme", () => {
+    const request = new Request("http://api.den.test/v1/automation-runners/token", {
+      headers: { "x-forwarded-proto": "https" },
+    })
+
+    expect(automationRunnerAudienceFromRequest(request, { trustedOrigins: [] }))
+      .toBe("https://api.den.test")
+  })
+
   test("ignores an untrusted forwarded runner destination", () => {
     const request = new Request("https://api.openworklabs.com/v1/automation-runners/token", {
       headers: {


### PR DESCRIPTION
## Problem

Every desktop Automation occurrence is recorded as `Missed — desktop runner unavailable`, including manual **Run now** runs started from a desktop that is open, signed in, and idle. Nothing fails loudly: the Automation stays Active, the desktop logs nothing, and the run expires at its claim deadline.

## Root cause

A runner credential carries the Den route it may be used against (`v2` audience, #3688). The desktop refuses to open its event stream when that audience is not the base URL it was configured with — `apps/desktop/electron/automation-runner.mjs`, `configure()`.

den-api derived the audience from `env.publicUrlTrustedOrigins`, which is `CORS_ORIGINS` plus `DEN_BETTER_AUTH_TRUSTED_ORIGINS`. Hosted deployments proxy browser and desktop traffic through Den Web server-side, so the Den Web origin has no reason to appear in the CORS allowlist. `trustedForwardedOrigin` therefore rejected the forwarded origin and #3746's proxy branch never ran, binding credentials to the internal API origin while desktops call the API under `/api/den` on the Den Web origin.

Observable on the current hosted deployment, same request path and same session:

| Route | Derived public route |
| --- | --- |
| `POST /api/den/v1/mcp/token` | `https://app.openworklabs.com/api/den/mcp` |
| `POST /api/den/v1/automation-runners/token` | `http://api.openworklabs.com` |

The MCP token route already trusted the better-auth origin the API is served from; the runner route did not. Every desktop runner has been silently disconnected since v2 audiences shipped, so no run is ever claimed.

Two smaller faults kept it invisible:

- The direct (unproxied) audience came from the raw request URL, which is plaintext wherever TLS terminates ahead of the process — note the `http://` above. `normalizeRunnerBaseUrl` rejects a plaintext destination, so deployments reached directly could not connect either.
- The desktop discarded a credential bound elsewhere without logging anything, so the scheduler looked at fault.

## Change

- Add `env.publicProxyTrustedOrigins` (the better-auth origin plus `publicUrlTrustedOrigins`) and use it for both public-route derivations, so the runner audience and the first-party MCP resource cannot diverge again. The MCP route's behaviour is unchanged — it built the same list locally.
- Resolve the direct-request fallback through `publicRequestUrl`, so a proxy that terminates TLS yields an `https` audience.
- Log the rejected destination and the audience actually carried when the desktop discards a runner configuration.

## Verification

- `bun test test/automation-runner-auth.test.ts test/automation-runner-protocol.test.ts test/mcp-resource.test.ts` — 33 pass, including new regressions for the proxied and direct audiences.
- `node --test apps/desktop/electron/automation-runner.test.mjs` — 10 pass, including the rejection log.
- `bun test --isolate tests/automation-availability.test.ts` (`apps/app`) — 5 pass.
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.automations-test.json --noEmit` in `ee/apps/den-api` — clean.
- `test/mcp-resource-url.test.ts` fails identically on `dev` without a local MySQL; not affected by this change.

The new den-api regressions fail on `dev`: the same forwarded request bound off `publicUrlTrustedOrigins` resolves to the internal API origin instead of the proxy route.

## Rollout

Desktop runners recover on their own once den-api ships this — the renderer refreshes its credential every 5 minutes. No desktop release is required; the desktop-side change is logging only.

Deployments that need automations working before this ships can add the Den Web origin to `CORS_ORIGINS`, which puts it into `publicUrlTrustedOrigins` and makes the existing code derive the correct audience.