### PR TITLE
Keep the workspace New task plus clickable over long names

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1481,7 +1481,7 @@ function WorkspaceHeader({
         )}
       </SidebarGlyphSlot>
       <div
-        className="min-w-0 flex-1 cursor-grab touch-none transition-[padding] duration-75 active:cursor-grabbing group-hover/workspace-header:pr-14 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-14 group-has-data-popup-open/workspace-header:pr-10 group-hover/workspace-header:group-has-data-popup-open/workspace-header:pr-14 pr-2"
+        className="min-w-0 flex-1 cursor-grab touch-none active:cursor-grabbing pr-8 group-hover/workspace-header:pr-20 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-20 group-has-data-popup-open/workspace-header:pr-20"
         onPointerDown={onTitlePointerDown}
       >
         <span className="block ow-fade-truncate">{label}</span>
@@ -1605,16 +1605,19 @@ function WorkspaceSidebarGroup({
                 isLoading={isConnecting}
                 onTitlePointerDown={onWorkspaceTitlePointerDown}
               />
-              <div data-workspace-actions className="group/workspace-actions absolute right-8 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+              <div
+                data-workspace-actions
+                className="group/workspace-actions absolute right-8 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 opacity-0 pointer-events-none transition-opacity group-hover/workspace-header:opacity-100 group-hover/workspace-header:pointer-events-auto group-focus-within/workspace-actions:opacity-100 group-focus-within/workspace-actions:pointer-events-auto group-has-data-popup-open/workspace-header:opacity-100 group-has-data-popup-open/workspace-header:pointer-events-auto"
+              >
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="size-5 text-muted-foreground opacity-0 group-hover/workspace-header:opacity-100 group-focus-within/workspace-actions:opacity-100"
+                  data-workspace-new-task
+                  className="size-5 text-muted-foreground"
                   onClick={(e) => {
                     e.stopPropagation();
                     ctx.onCreateTaskInWorkspace(workspace.id);
                   }}
-                  disabled={ctx.newTaskDisabled}
                   aria-label={t("session.new_task")}
                   title={t("session.new_task")}
                 >
@@ -1624,13 +1627,13 @@ function WorkspaceSidebarGroup({
                   workspace={workspace}
                   isConnectionActionBusy={isConnectionActionBusy}
                   canRecover={canRecover}
-                  className="size-5 text-muted-foreground opacity-0 group-hover/workspace-header:opacity-100 group-focus-within/workspace-actions:opacity-100 data-popup-open:opacity-100"
+                  className="size-5 text-muted-foreground"
                 />
               </div>
               <Button
                 variant="ghost"
                 size="icon"
-                className="absolute right-2 top-1/2 size-5 -translate-y-1/2 text-muted-foreground flex items-center justify-center group/expand-collapse-button"
+                className="absolute right-2 top-1/2 z-10 size-5 -translate-y-1/2 text-muted-foreground flex items-center justify-center group/expand-collapse-button"
                 aria-label={isExpanded ? t("sidebar.collapse") : t("sidebar.expand")}
                 aria-expanded={isExpanded}
                 onClick={(e) => {

--- a/evals/specs/workspace-new-task-hit-target.slow.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.slow.test.ts
@@ -1,0 +1,107 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "the per-workspace New task plus stays clickable over a long truncated workspace name"
+  : "workspace new-task hit target skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sessionCount(value: unknown): number {
+  if (!Array.isArray(value)) throw new Error(`session.list_sessions did not return a list: ${JSON.stringify(value)}`);
+  return value.length;
+}
+
+function pointFromEval(value: unknown, label: string): { x: number; y: number } {
+  if (typeof value !== "string" || !value) throw new Error(`${label} did not return coordinates.`);
+  const parsed: unknown = JSON.parse(value);
+  if (!isRecord(parsed) || typeof parsed.x !== "number" || typeof parsed.y !== "number") {
+    throw new Error(`${label} returned invalid coordinates: ${value}`);
+  }
+  return { x: parsed.x, y: parsed.y };
+}
+
+const plusSelector = '[data-workspace-new-task]';
+const plusPointExpression = `(() => {
+  const plus = document.querySelector(${JSON.stringify(plusSelector)});
+  if (!(plus instanceof HTMLElement)) return "";
+  plus.scrollIntoView({ block: "center" });
+  const rect = plus.getBoundingClientRect();
+  return JSON.stringify({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+})()`;
+
+const plusHitExpression = `(() => {
+  const plus = document.querySelector(${JSON.stringify(plusSelector)});
+  if (!(plus instanceof HTMLElement)) {
+    return { hitPlus: false, hitTitle: false, tag: "" };
+  }
+  const rect = plus.getBoundingClientRect();
+  const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+  const header = plus.closest("[data-workspace-actions]")?.parentElement;
+  const title = header?.querySelector(".ow-fade-truncate");
+  return {
+    hitPlus: plus.contains(node),
+    hitTitle: Boolean(title && node instanceof Node && title.contains(node)),
+    tag: node instanceof Element ? node.tagName.toLowerCase() : "",
+  };
+})()`;
+
+test.skipIf(!appSpecsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using app = await desktop({ name: "workspace-new-task-hit-target" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-kitchen-vercel-env-hit-target-${Date.now()}`,
+  });
+
+  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(plusSelector)}))`, {
+    timeoutMs: 60_000,
+    label: "per-workspace New task plus",
+  });
+
+  const point = pointFromEval(await evalIn(app, plusPointExpression), "workspace New task plus");
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await waitFor(app, `${plusHitExpression}.hitPlus === true`, {
+    timeoutMs: 10_000,
+    label: "New task plus is the topmost hit target",
+  });
+
+  const hit = await evalIn(app, plusHitExpression);
+  if (!isRecord(hit) || hit.hitPlus !== true || hit.hitTitle !== false) {
+    throw new Error(`New task plus was not the topmost hit target: ${JSON.stringify(hit)}`);
+  }
+  evidence.fact(
+    "Hovering a long workspace name still leaves the New task plus as the click target",
+    `elementFromPoint at the plus center hit the plus button and not the truncated title (node=${String(hit.tag)}).`,
+    true,
+  );
+
+  const expandedBefore = await evalIn(
+    app,
+    `document.querySelector(${JSON.stringify(plusSelector)})?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`,
+  );
+  const before = sessionCount(await control(app, "session.list_sessions"));
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
+  await waitFor(app, `window.location.hash.includes("/session/ses_")`, {
+    timeoutMs: 60_000,
+    label: "session created from the workspace New task plus",
+  });
+  const after = sessionCount(await control(app, "session.list_sessions"));
+  expect(after).toBeGreaterThan(before);
+  const expandedAfter = await evalIn(
+    app,
+    `document.querySelector(${JSON.stringify(plusSelector)})?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`,
+  );
+  expect(expandedAfter).toBe(expandedBefore);
+  evidence.fact(
+    "Clicking the per-workspace New task plus creates a session instead of collapsing the workspace",
+    `Sessions went from ${before} to ${after}, and the workspace expand state stayed ${JSON.stringify(expandedAfter)}.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- The per-workspace New task plus is an overlay on a full-width title that is also a drag handle. On long truncated names, clicks at the plus often hit the title instead, so the row selects or starts a drag instead of creating a task.
- Raise the action overlay above the title, keep pointer events off until hover or keyboard focus, and reserve enough title padding to cover plus, overflow menu, and chevron.
- Stop gating that plus on the selected workspace's global New task disabled state. Creating a task in another workspace uses that workspace's own client; a loading or model-unavailable selected workspace should not swallow clicks on other rows.

## What changed

- Workspace action overlay: `z-10`, `pointer-events-none` until hover, focus-within, or an open menu, matching the existing session-row hover actions.
- Title padding: `pr-8` at rest for the always-visible chevron, `pr-20` on hover/focus without the 75ms padding race.
- Per-workspace plus is no longer `disabled={newTaskDisabled}`. The top-level sidebar New task row is unchanged.
- Added `data-workspace-new-task` and `evals/specs/workspace-new-task-hit-target.slow.test.ts`. The spec hovers a long workspace name, asserts `elementFromPoint` at the plus center is the plus rather than the title, then clicks it and expects a new session without collapsing the workspace.

## Why

A visible plus that does not receive the click is worse than a hidden control. Session-row hover actions already used stacking and pointer-event gating; the workspace row did not.

## Verification

- `pnpm --filter @openwork/app typecheck` — passed on the pre-rebase candidate.
- `git diff --check` — passed.
- Exact-head Electron spec: `pnpm evals workspace-new-task-hit-target` — **Incomplete**. Local spawn died before CDP (`electron-rebuild` / registry timeout). No feature assertion ran. Lane: local.

Repro for the missing tape:

```bash
OPENWORK_EVAL_APP_SPECS=1 pnpm evals workspace-new-task-hit-target
```

## Exact candidate

- Base: `fa246ee110be9beb4f63c16b58640fb8a1741285`
- Head: `ba79b8c3ee62a826e6eecf04b083102c91204d48`


Made with [Cursor](https://cursor.com)