### PR TITLE
fix(app): show one wait indicator on gateway boot

### DIFF
--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -249,7 +249,7 @@ function BootStageRow(props: { stage: CloudWorkspaceBootStage; reduceMotion: boo
               />
             </svg>
           ) : stage.state === "active" ? (
-            <OwDotTicker size="md" />
+            <span className="size-2.5 rounded-full bg-dls-accent" />
           ) : (
             <span className="size-2.5 rounded-full border-[1.5px] border-[rgb(var(--dls-secondary-rgb)/0.45)]" />
           )}

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -159,6 +159,18 @@ export function cloudWorkspaceStatusHasReadyContent(variant: CloudWorkspacePillV
   return variant === "ready" || variant === "stale";
 }
 
+/**
+ * Gateway boot is owned by the workspace takeover. Showing the generic overlay
+ * at the same time stacks two wait indicators on first load.
+ */
+export function shouldSuppressBootOverlayForGateway(input: {
+  gatewayMode: boolean;
+  signedIn: boolean;
+  variant: CloudWorkspacePillVariant;
+}): boolean {
+  return input.gatewayMode && input.signedIn && !cloudWorkspaceStatusHasReadyContent(input.variant);
+}
+
 export function shouldShowCloudWorkspaceStatusPill(input: {
   variant: CloudWorkspacePillVariant;
   hasInstance: boolean;

--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -5,6 +5,8 @@ import type { DenAppVersionMetadata, DenDesktopConfig } from "@/app/lib/den";
 import { readFreshDenAppVersionMetadata } from "@/app/lib/version-gate";
 import { useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider";
 import { bootOverlayCanHide, useBootState, useBootOverlayVisible } from "./boot-state";
+import { useCloudWorkspaceStatus } from "./cloud-workspace-overlay";
+import { shouldSuppressBootOverlayForGateway } from "./cloud-workspace-status";
 import { OwDotTicker } from "./dot-ticker";
 
 async function loadRecoveryPolicy(
@@ -27,6 +29,12 @@ async function loadRecoveryPolicy(
 export function LoadingOverlay() {
   const visible = useBootOverlayVisible();
   const { phase, routeReady, message, error } = useBootState();
+  const cloudWorkspace = useCloudWorkspaceStatus();
+  const suppressForGateway = shouldSuppressBootOverlayForGateway({
+    gatewayMode: cloudWorkspace.gatewayMode,
+    signedIn: cloudWorkspace.visible,
+    variant: cloudWorkspace.viewModel.variant,
+  });
   const { config: desktopPolicy, refreshFresh: refreshDesktopPolicy } = useDesktopConfig();
   const [releases, setReleases] = useState<RecoveryRelease[]>([]);
   const [showPicker, setShowPicker] = useState(false);
@@ -86,7 +94,7 @@ export function LoadingOverlay() {
 
   const useRelease = window.__OPENWORK_ELECTRON__?.recovery?.use;
 
-  if (!visible) return null;
+  if (!visible || (suppressForGateway && !error)) return null;
 
   const fading = bootOverlayCanHide(phase, routeReady);
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1560,7 +1560,7 @@ export function SessionRoute() {
     !cloudWorkspace.gatewayMode ||
     !cloudWorkspace.visible ||
     cloudWorkspaceStatusHasReadyContent(cloudWorkspace.viewModel.variant);
-  const cloudWorkspaceMainContentTakeover = !bootOverlayVisible && cloudWorkspaceMainContentDecision === "takeover" ? (
+  const cloudWorkspaceMainContentTakeover = cloudWorkspaceMainContentDecision === "takeover" ? (
     <CloudWorkspaceBootTakeover decision={cloudWorkspaceMainContentDecision} />
   ) : null;
   const gatedRouteNotFoundMessage = cloudWorkspaceReadyForRouteErrors ? routeNotFoundMessage : null;

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -20,6 +20,7 @@ import {
   mapCloudWorkspaceState,
   shouldShowCloudWorkspaceStatusPill,
   shouldRefetchCloudWorkspaceOnReadyTransition,
+  shouldSuppressBootOverlayForGateway,
 } from "../src/react-app/shell/cloud-workspace-status";
 import type { CloudWorkspaceMainContentDecision, CloudWorkspacePillVariant } from "../src/react-app/shell/cloud-workspace-status";
 import { BootStateProvider } from "../src/react-app/shell/boot-state";
@@ -299,6 +300,35 @@ describe("cloud workspace boot takeover", () => {
     // The old bar was hardcoded to two thirds and pulsed there forever.
     expect(html).not.toContain("w-2/3");
     expect(html).not.toContain("animate-pulse");
+  });
+
+  test("keeps a single wait indicator on the takeover card", () => {
+    const html = renderTakeover("provisioning");
+    // One 3x3 ticker lives in the header; checkpoints use a static dot.
+    expect(html.split("ow-dot-ticker").length - 1).toBe(9);
+  });
+
+  test("does not stack the generic boot overlay on top of the gateway takeover", () => {
+    expect(shouldSuppressBootOverlayForGateway({
+      gatewayMode: true,
+      signedIn: true,
+      variant: "provisioning",
+    })).toBe(true);
+    expect(shouldSuppressBootOverlayForGateway({
+      gatewayMode: true,
+      signedIn: true,
+      variant: "waking",
+    })).toBe(true);
+    expect(shouldSuppressBootOverlayForGateway({
+      gatewayMode: true,
+      signedIn: true,
+      variant: "ready",
+    })).toBe(false);
+    expect(shouldSuppressBootOverlayForGateway({
+      gatewayMode: false,
+      signedIn: true,
+      variant: "waking",
+    })).toBe(false);
   });
 
   test("keeps the wait calm until the promised minute is at risk", () => {


### PR DESCRIPTION
## Summary
- Gateway boot was stacking the generic overlay spinner on top of the workspace takeover, and the takeover also spun in the header and the active checkpoint.
- Hide the overlay while the sandbox is still starting, show the takeover immediately, and keep a single ticker on that card.

## Test plan
- [ ] `pnpm --filter @openwork/app exec bun test tests/cloud-workspace-overlay.test.tsx`
- [ ] Open OpenWork Web / gateway while the workspace is provisioning or waking
- [ ] Confirm one wait indicator until the workspace is ready
- [ ] Confirm desktop boot overlay is unchanged


Made with [Cursor](https://cursor.com)