### PR TITLE
feat(desktop,server): persist service logs to disk with rotation

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1734,6 +1734,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       opencodeCwd: managedOpencodeWorkdir(),
       localManagedMcpVaultKey,
       engineRollover: options.engineRollover === true,
+      logFile: path.join(userDataDir, "logs", "openwork-server.log"),
     });
     inProcessServer = handle;
     openworkServerState.managedOpencodeExecution = handle.managedOpencodeExecution ?? null;

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -22,6 +22,7 @@ export interface CliArgs {
   verbose?: boolean;
   logFormat?: LogFormat;
   logRequests?: boolean;
+  logFile?: string;
   engineRollover?: boolean;
   version?: boolean;
   help?: boolean;
@@ -43,6 +44,7 @@ interface FileConfig {
   opencodePassword?: string;
   logFormat?: LogFormat;
   logRequests?: boolean;
+  logFile?: string;
   engineRollover?: boolean;
 }
 
@@ -96,6 +98,11 @@ export function parseCliArgs(argv: string[]): CliArgs {
     }
     if (value === "--no-log-requests") {
       args.logRequests = false;
+      continue;
+    }
+    if (value === "--log-file") {
+      args.logFile = argv[index + 1];
+      index += 1;
       continue;
     }
     if (value === "--config") {
@@ -306,6 +313,8 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
   const envLogRequests = parseBoolean(process.env.OPENWORK_LOG_REQUESTS);
   const logRequests = cli.logRequests ?? envLogRequests ?? fileConfig.logRequests ?? DEFAULT_LOG_REQUESTS;
 
+  const logFile = cli.logFile ?? fileConfig.logFile;
+
   const envEngineRollover = parseBoolean(process.env.OPENWORK_ENGINE_ROLLOVER);
   const engineRollover = cli.engineRollover ?? envEngineRollover ?? fileConfig.engineRollover ?? false;
 
@@ -337,6 +346,6 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
     hostTokenSource,
     logFormat,
     logRequests,
-    engineRollover,
+    logFile,
   };
 }

--- a/apps/server/src/embedded-lifecycle.test.ts
+++ b/apps/server/src/embedded-lifecycle.test.ts
@@ -268,6 +268,49 @@ describe("embedded server lifecycle", () => {
     }
   });
 
+  test.serial("persists server and managed engine output to log files when logFile is set", async () => {
+    const fixture = await createFixture();
+    try {
+      const serverLogPath = join(fixture.root, "logs", "openwork-server.log");
+      const engineLogPath = join(fixture.root, "logs", "opencode-engine.log");
+      const handle = await startEmbeddedServer({
+        ...managedOptions(fixture, "log-file"),
+        logFile: serverLogPath,
+      });
+      fixture.handles.push(handle);
+
+      const health = await fetch(`${handle.url}/health`);
+      expect(health.status).toBe(200);
+
+      // Server log: the request logger writes each handled request. The file
+      // sink flushes on a timer, so poll until the buffered lines land.
+      const enginePort = new URL(handle.config.opencodeBaseUrl ?? "").port;
+      const waitForLine = async (path: string, predicate: (line: string) => boolean): Promise<string[]> => {
+        const deadline = Date.now() + 3000;
+        let lines: string[] = [];
+        while (Date.now() < deadline) {
+          lines = await logLines(path);
+          if (lines.some(predicate)) return lines;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        return lines;
+      };
+
+      await waitForLine(serverLogPath, (line) => line.includes("GET /health 200"));
+      await waitForLine(engineLogPath, (line) =>
+        line.includes(`opencode server listening on http://${HOST}:${enginePort}`)
+      );
+
+      await handle.stop();
+      expect((await logLines(serverLogPath)).some((line) => line.includes("GET /health 200"))).toBe(true);
+      expect((await logLines(engineLogPath)).some((line) =>
+        line.includes(`opencode server listening on http://${HOST}:${enginePort}`)
+      )).toBe(true);
+    } finally {
+      await fixture.restore();
+    }
+  });
+
   test.serial("a stopped server no longer writes generated runtime configuration", async () => {
     const fixture = await createFixture();
     try {

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -7,7 +7,9 @@
  */
 import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { resolveServerConfig, type CliArgs } from "./config.js";
+import { createServiceLogWriter } from "./service-log.js";
 import {
   buildEngineAuthProbeHeader,
   registerEngineInstance,
@@ -68,6 +70,10 @@ export type EmbeddedServerHandle = {
 export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {
   const config = await resolveServerConfig(options);
   config.localManagedMcpVaultKey = options.localManagedMcpVaultKey;
+
+  // Single rotating file sink for the server itself; the managed engine's
+  // output goes to a sibling file so the two services never interleave.
+  const engineLogSink = config.logFile ? createServiceLogWriter(join(dirname(config.logFile), "opencode-engine.log")) : null;
 
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
   let managedOpencode: ManagedOpencodeServer | null = null;
@@ -140,6 +146,8 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         errors.push(error);
       }
     }
+
+    engineLogSink?.close();
 
     if (errors.length === 1) throw errors[0];
     if (errors.length > 1) {
@@ -229,6 +237,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         cwd,
         excludedPorts: [config.port],
         env: engineEnv,
+        ...(engineLogSink ? { outputSink: (chunk: string) => engineLogSink.write(chunk) } : {}),
       }));
 
       config.opencodeBaseUrl = managedOpencode.url;
@@ -292,6 +301,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       fingerprint: await computeEngineConfigFingerprint(engineSpawnTemplate),
       registryId: managedEngineRecordId,
       trustedIdentity: managedOpencodeIdentity,
+      ...(engineLogSink ? { outputSink: (chunk: string) => engineLogSink.write(chunk) } : {}),
     });
   }
 

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -265,6 +265,7 @@ export class EnginePool {
   private readonly config: ServerConfig;
   private readonly template: EngineSpawnTemplate;
   private readonly hooks: EnginePoolHooks;
+  private readonly outputSink: ((chunk: string) => void) | null;
   private generations: Generation[] = [];
   private inFlight: Promise<RolloverOutcome> | null = null;
   private pendingRollover: { reason: RolloverReason; workspace: WorkspaceInfo; manual: boolean } | null = null;
@@ -275,10 +276,16 @@ export class EnginePool {
   private readonly activeSessionsByGeneration = new Map<string, Set<string>>();
   private readonly eventProxyControllers = new Set<AbortController>();
 
-  constructor(input: { config: ServerConfig; template: EngineSpawnTemplate; hooks: EnginePoolHooks }) {
+  constructor(input: {
+    config: ServerConfig;
+    template: EngineSpawnTemplate;
+    hooks: EnginePoolHooks;
+    outputSink?: (chunk: string) => void;
+  }) {
     this.config = input.config;
     this.template = input.template;
     this.hooks = input.hooks;
+    this.outputSink = input.outputSink ?? null;
   }
 
   /**
@@ -516,6 +523,7 @@ export class EnginePool {
           ...this.template.env,
           OPENCODE_CONFIG: this.template.runtimeConfigPath,
         },
+        ...(this.outputSink ? { outputSink: this.outputSink } : {}),
       });
     } catch (error) {
       this.hooks.logger?.log("error", "Engine rollover standby failed to start; the live engine is untouched.", {

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -64,6 +64,8 @@ export async function createManagedOpencodeServer(options: {
   excludedPorts?: number[];
   timeoutMs?: number;
   env?: Record<string, string | undefined>;
+  /** Receives every stdout/stderr chunk so callers can persist engine output. */
+  outputSink?: (chunk: string) => void;
 }): Promise<ManagedOpencodeServer> {
   const hostname = options.hostname ?? "127.0.0.1";
   const port = options.port ?? await findFreePort(hostname, options.excludedPorts);
@@ -137,7 +139,9 @@ export async function createManagedOpencodeServer(options: {
         reject(error);
       };
       child.stdout?.on("data", (chunk) => {
-        output += chunk.toString();
+        const text = chunk.toString();
+        options.outputSink?.(text);
+        output += text;
         for (const line of output.split("\n")) {
           if (!line.startsWith("opencode server listening")) continue;
           const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
@@ -146,7 +150,9 @@ export async function createManagedOpencodeServer(options: {
         }
       });
       child.stderr?.on("data", (chunk) => {
-        output += chunk.toString();
+        const text = chunk.toString();
+        options.outputSink?.(text);
+        output += text;
       });
       child.once("error", fail);
       child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -48,6 +48,7 @@ import { sanitizeCommandName, validateMcpName, validateUserMcpName } from "./val
 import { TokenService } from "./tokens.js";
 import { resetManagedProviderAuthCache, syncManagedProviderAuth } from "./managed-provider-auth.js";
 import { EnvService } from "./env-file.js";
+import { createServiceLogWriter } from "./service-log.js";
 import {
   normalizeResourceSnapshot,
   readDesktopCloudSyncState,
@@ -768,6 +769,7 @@ export function createServerLogger(config: ServerConfig): ServerLogger {
     "run.id": runId,
     "process.pid": process.pid,
   };
+  const fileSink = config.logFile ? createServiceLogWriter(config.logFile) : null;
 
   const emit = (level: LogLevel, message: string, attributes?: LogAttributes) => {
     const merged = { ...baseAttributes, ...(attributes ?? {}) };
@@ -780,11 +782,22 @@ export function createServerLogger(config: ServerConfig): ServerLogger {
         attributes: merged,
         resource,
       };
-      process.stdout.write(`${JSON.stringify(record)}\n`);
+      const line = `${JSON.stringify(record)}\n`;
+      process.stdout.write(line);
+      fileSink?.write(line);
       return;
     }
-    process.stdout.write(`${message}\n`);
+    const line = `${message}\n`;
+    process.stdout.write(line);
+    fileSink?.write(line);
   };
+
+  // Flush buffered file output on exit so the last lines before a shutdown
+  // or crash actually land on disk.
+  const flushOnExit = (): void => {
+    fileSink?.flush();
+  };
+  process.once("exit", flushOnExit);
 
   return { log: emit };
 }
@@ -4512,11 +4525,13 @@ export function createEnginePoolForConfig(input: {
   fingerprint: string;
   registryId: string | null;
   trustedIdentity: string | null;
+  outputSink?: (chunk: string) => void;
 }): EnginePool {
   const { config } = input;
   const pool = new EnginePool({
     config,
     template: input.template,
+    outputSink: input.outputSink,
     hooks: {
       reloadInPlace: (poolConfig, workspace) => reloadOpencodeEngineInPlace(poolConfig, workspace),
       engineBusy: (poolConfig, workspace) => engineHasActiveSessions(poolConfig, workspace),

--- a/apps/server/src/service-log.test.ts
+++ b/apps/server/src/service-log.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createServiceLogWriter } from "./service-log.js";
+
+const ROOTS: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "openwork-service-log-"));
+  ROOTS.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (ROOTS.length > 0) {
+    const root = ROOTS.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("createServiceLogWriter", () => {
+  test("creates the parent directory and appends lines to the file", () => {
+    const root = tempRoot();
+    const filePath = join(root, "logs", "openwork-server.log");
+    const writer = createServiceLogWriter(filePath);
+
+    writer.write("hello\n");
+    writer.write("world\n");
+    writer.flush();
+    writer.close();
+
+    expect(readFileSync(filePath, "utf8")).toBe("hello\nworld\n");
+  });
+
+  test("rotates to <path>.1 once the size cap is exceeded", () => {
+    const root = tempRoot();
+    const filePath = join(root, "openwork-server.log");
+    const writer = createServiceLogWriter(filePath, 32);
+
+    writer.write("a".repeat(24) + "\n");
+    writer.flush();
+    writer.write("b".repeat(24) + "\n");
+    writer.flush();
+    writer.close();
+
+    const rotated = `${filePath}.1`;
+    expect(existsSync(rotated)).toBe(true);
+    expect(readFileSync(rotated, "utf8")).toBe("a".repeat(24) + "\n");
+    expect(readFileSync(filePath, "utf8")).toBe("b".repeat(24) + "\n");
+  });
+
+  test("keeps appending to the current file after rotation", () => {
+    const root = tempRoot();
+    const filePath = join(root, "openwork-server.log");
+    const writer = createServiceLogWriter(filePath, 60);
+
+    writer.write("a".repeat(20) + "\n");
+    writer.flush();
+    writer.write("b".repeat(20) + "\n");
+    writer.flush();
+    writer.write("c".repeat(20) + "\n");
+    writer.flush();
+    writer.write("d".repeat(20) + "\n");
+    writer.flush();
+    writer.close();
+
+    expect(readFileSync(`${filePath}.1`, "utf8")).toBe(
+      "a".repeat(20) + "\n" + "b".repeat(20) + "\n",
+    );
+    expect(readFileSync(filePath, "utf8")).toBe(
+      "c".repeat(20) + "\n" + "d".repeat(20) + "\n",
+    );
+  });
+
+  test("never throws when the target path is unwritable", () => {
+    const writer = createServiceLogWriter("/nonexistent-parent-dir/logs/server.log");
+    expect(() => {
+      writer.write("line\n");
+      writer.flush();
+      writer.close();
+    }).not.toThrow();
+  });
+
+  test("flush with no buffered data is a no-op and leaves no file behind", () => {
+    const root = tempRoot();
+    const filePath = join(root, "logs", "openwork-server.log");
+    const writer = createServiceLogWriter(filePath);
+
+    writer.flush();
+    writer.close();
+
+    expect(existsSync(filePath)).toBe(false);
+    expect(readdirSync(root)).toEqual([]);
+  });
+});

--- a/apps/server/src/service-log.ts
+++ b/apps/server/src/service-log.ts
@@ -1,0 +1,60 @@
+import { existsSync, mkdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+const FLUSH_INTERVAL_MS = 1000;
+const FLUSH_THRESHOLD_BYTES = 16 * 1024;
+
+export type ServiceLogWriter = {
+  write: (chunk: string) => void;
+  flush: () => void;
+  close: () => void;
+};
+
+/**
+ * Bounded, best-effort file sink for service logs. Buffers writes and flushes
+ * them to disk on a timer so hot request logs never block the server. Rotates
+ * the file to `<path>.1` once it exceeds `maxBytes`, keeping at most two files.
+ *
+ * Logging must never throw or crash the server: every failure is swallowed.
+ */
+export function createServiceLogWriter(filePath: string, maxBytes = DEFAULT_MAX_BYTES): ServiceLogWriter {
+  let buffer = "";
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const flushSync = (): void => {
+    if (!buffer) return;
+    const chunk = buffer;
+    buffer = "";
+    try {
+      mkdirSync(dirname(filePath), { recursive: true });
+      if (existsSync(filePath) && statSync(filePath).size + chunk.length > maxBytes) {
+        renameSync(filePath, `${filePath}.1`);
+      }
+      writeFileSync(filePath, chunk, { flag: "a" });
+    } catch {
+      // Logging is best-effort; never propagate write failures.
+    }
+  };
+
+  const write = (chunk: string): void => {
+    buffer += chunk;
+    if (timer === null) {
+      timer = setInterval(flushSync, FLUSH_INTERVAL_MS);
+      timer.unref?.();
+    }
+    if (buffer.length >= FLUSH_THRESHOLD_BYTES) {
+      flushSync();
+    }
+  };
+
+  const close = (): void => {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+    flushSync();
+  };
+
+  return { write, flush: flushSync, close };
+}

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -103,6 +103,8 @@ export interface ServerConfig {
   hostTokenSource: "cli" | "env" | "file" | "generated";
   logFormat: LogFormat;
   logRequests: boolean;
+  /** When set, server log lines are also appended to this file (rotating). */
+  logFile?: string;
   /**
    * Roll the managed engine over instead of disposing it when a reload is
    * needed while sessions are live: a standby engine takes new work and the


### PR DESCRIPTION
Closes #3780

## Problem

Service logs (OpenWork server, managed OpenCode engine, developer stream) live only in in-memory buffers in the Electron main process (8 KB tail via `appendOutput` in `runtime.mjs`). The managed engine's stdout/stderr is dropped right after the "listening" line is parsed, and the in-process server writes to `process.stdout` which is not observable from an AppImage. On crash, quit, or restart, every log line is gone — the Debug report's "copy/export logs" cannot help after the fact.

## Change

- **`apps/server/src/service-log.ts`** (new): bounded, best-effort `ServiceLogWriter` — buffers writes, flushes on a 1 s timer + 16 KB threshold, rotates to `<file>.1` at 1 MB (2 files kept), never throws.
- **`ServerConfig.logFile`** plumbed through `config.ts` (`--log-file`, file config) and `createServerLogger` (`server.ts`): every server log line (JSON or pretty) is also written to the file; buffered output is flushed on `process.exit`.
- **Managed engine output**: `createManagedOpencodeServer` gains `outputSink` — every stdout/stderr chunk is teed through it after the URL is parsed (previously dropped). `embedded.ts` wires one rotating writer per server to `logs/opencode-engine.log` (sibling of the server log), shared with engine-rollover standby spawns via `EnginePool`.
- **Desktop** (`apps/desktop/electron/runtime.mjs`): passes `userData/logs/openwork-server.log` into `startEmbeddedServer`.

Result on Linux: `~/.config/com.differentai.openwork/logs/openwork-server.log` + `opencode-engine.log`, surviving crashes and restarts.

## Verification

- `apps/server`: `bun test` → **705 pass / 0 fail** (includes new `service-log.test.ts` rotation suite + an embedded-lifecycle e2e asserting both files get written, incl. engine stdout tee).
- `apps/server`: `tsc --noEmit` clean.
- `apps/desktop`: `pnpm test` → **207 pass / 0 fail**.

No testkit `.slow.test.ts` tape yet (needs a Daytona Electron run); happy to add one if you want the desktop-side flow proven there too.