### PR TITLE
feat(mcp): install external MCP Apps through Connect

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1934,7 +1934,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     },
     callMcpAppTool: (
       workspaceId: string,
-      payload: { serverName: string; name: string; arguments?: Record<string, unknown>; approved?: boolean },
+      payload: {
+        serverName: string;
+        name: string;
+        resourceUri: string;
+        arguments?: Record<string, unknown>;
+        approved?: boolean;
+      },
     ) => requestJson<OpenworkMcpAppToolResult>(
       baseUrl,
       `/workspace/${encodeURIComponent(workspaceId)}/mcp-apps/call`,

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -244,7 +244,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       setApp(null)
     }
     bridge.oncalltool = async ({ name, arguments: args }) => {
-      const request = { serverName: app.serverName, name, arguments: args }
+      const request = { serverName: app.serverName, name, resourceUri: app.resourceUri, arguments: args }
       try {
         return mcpToolResult(await openworkServerClient.callMcpAppTool(workspaceId, request))
       } catch (cause) {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -94,6 +94,13 @@ async function startFixtureMcp(resourceContent: { text?: string; blob?: string }
         _meta: { ui: { visibility: ["app"] } },
       },
       {
+        name: "read_bound_detail",
+        description: "Read detail for the exact fixture resource",
+        inputSchema: { type: "object", properties: { id: { type: "string" } } },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { ui: { resourceUri: RESOURCE_URI, visibility: ["app"] } },
+      },
+      {
         name: "model_only_detail",
         description: "Read model-only fixture detail",
         inputSchema: { type: "object", properties: {} },
@@ -312,6 +319,37 @@ describe("MCP Apps host transport", () => {
       content: [{ type: "text", text: "detail:42" }],
       structuredContent: { id: "42" },
     });
+  });
+
+  test("mediates a resource-bound same-server tool for its exact MCP App", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-bound-call-");
+
+    const result = await callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "read_bound_detail",
+      resourceUri: RESOURCE_URI,
+      arguments: { id: "bound" },
+    });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "detail:bound" }],
+      structuredContent: { id: "bound" },
+    });
+  });
+
+  test("rejects a resource-bound tool call from a different MCP App", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-cross-resource-");
+
+    await expect(callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "read_bound_detail",
+      resourceUri: UPDATED_RESOURCE_URI,
+    })).rejects.toMatchObject({ code: "tool_resource_mismatch" });
   });
 
   test("rejects model-only same-server tools", async () => {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -101,8 +101,8 @@ async function startFixtureMcp(resourceContent: { text?: string; blob?: string }
         _meta: { ui: { resourceUri: RESOURCE_URI, visibility: ["app"] } },
       },
       {
-        name: "model_only_detail",
-        description: "Read model-only fixture detail",
+        name: "import_remote_mcp_app",
+        description: "Install a model-only remote MCP App fixture",
         inputSchema: { type: "object", properties: {} },
         annotations: { readOnlyHint: true, destructiveHint: false },
         _meta: { ui: { visibility: ["model"] } },
@@ -352,14 +352,14 @@ describe("MCP Apps host transport", () => {
     })).rejects.toMatchObject({ code: "tool_resource_mismatch" });
   });
 
-  test("rejects model-only same-server tools", async () => {
+  test("prevents sandboxed Apps from calling the model-only remote App installer", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-model-only-");
     await expect(callMcpAppTool({
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
       serverName: "fixture",
-      name: "model_only_detail",
+      name: "import_remote_mcp_app",
     })).rejects.toMatchObject({ code: "tool_not_visible" });
   });
 

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -322,6 +322,7 @@ export async function callMcpAppTool(input: {
   workspaceRoot: string;
   serverName: string;
   name: string;
+  resourceUri?: string;
   arguments?: Record<string, unknown>;
   approved?: boolean;
 }): Promise<CallToolResult> {
@@ -335,6 +336,13 @@ export async function callMcpAppTool(input: {
     if (!tool) throw new McpAppHostError("tool_not_found", "The requested same-server MCP tool was not found.");
     if (!toolVisibility(tool, "app")) {
       throw new McpAppHostError("tool_not_visible", "The requested MCP tool is not visible to apps.");
+    }
+    const boundResourceUri = toolUiResourceUri(tool);
+    if (boundResourceUri && boundResourceUri !== input.resourceUri) {
+      throw new McpAppHostError(
+        "tool_resource_mismatch",
+        "The requested MCP tool is bound to a different MCP App resource.",
+      );
     }
     const projectedName = projectedMcpToolName(input.serverName, tool.name);
     if ((await diagnoseMcpToolDenies(input.workspaceRoot, input.serverName, [projectedName])).length > 0) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2916,6 +2916,7 @@ function createRoutes(
     const body = await readJsonBody(ctx.request);
     const serverName = typeof body.serverName === "string" ? body.serverName.trim() : "";
     const name = typeof body.name === "string" ? body.name.trim() : "";
+    const resourceUri = typeof body.resourceUri === "string" ? body.resourceUri.trim() : "";
     const args = body.arguments && typeof body.arguments === "object" && !Array.isArray(body.arguments)
       ? body.arguments as Record<string, unknown>
       : {};
@@ -2929,6 +2930,7 @@ function createRoutes(
         workspaceRoot: workspace.path,
         serverName,
         name,
+        resourceUri,
         arguments: args,
         approved,
       }));

--- a/docs/features/remote-mcp-apps/README.md
+++ b/docs/features/remote-mcp-apps/README.md
@@ -90,12 +90,13 @@ ui://openwork/library-apps/{appId}/revisions/{revisionId}/index.html
 The launch result uses ordinary `structuredContent` for the app identity,
 revision, digest, optional input, and the name of any available same-server
 Program tool. When Code Mode is enabled, an app-specific `run_program_*` tool
-is advertised with `_meta.ui.visibility: ["app"]`. Its exact name is delivered
-in the launch result rather than embedded in the HTML. It accepts an optional
-exact `programId` or uses the member's selected Program, and rejects Programs
-outside the app's owning Plugin. Normal host approval and Plugin access checks
-still apply. The Program executes server-side and receives the member's
-authorized Connect tool tree; the HTML receives only the Program result.
+is advertised with `_meta.ui.visibility: ["app"]` and the exact revision's
+standard `_meta.ui.resourceUri`. Its exact name is delivered in the launch
+result rather than embedded in the HTML. It accepts an optional exact
+`programId` or uses the member's selected Program, and rejects Programs outside
+the app's owning Plugin. Normal host approval and Plugin access checks still
+apply. The Program executes server-side and receives the member's authorized
+Connect tool tree; the HTML receives only the Program result.
 
 This is the only OpenWork-specific execution affordance in the URL adapter.
 The transport remains standard MCP `tools/call`, and the tool stays on the
@@ -177,6 +178,9 @@ handshake, document, and runtime failures without hiding the normal tool
 result.
 
 App-requested tools are resolved only on the originating server and must be
-visible to the app. Workspace tool denies apply. Explicitly read-only,
-non-destructive calls run directly; other calls require a user confirmation
-and collaborator authority. Cross-server calls are not allowed.
+visible to the app. When a tool carries `_meta.ui.resourceUri`, Desktop also
+requires it to match the exact immutable resource loaded in the calling iframe;
+one imported app therefore cannot invoke another revision's bound Program
+tool. Workspace tool denies apply. Explicitly read-only, non-destructive calls
+run directly; other calls require a user confirmation and collaborator
+authority. Cross-server calls are not allowed.

--- a/docs/features/remote-mcp-apps/README.md
+++ b/docs/features/remote-mcp-apps/README.md
@@ -13,9 +13,10 @@ There are two distribution paths:
    URIs, UI metadata, results, and same-server app calls keep their provider
    meaning.
 2. A self-contained HTML file imported by URL. This is a convenience adapter
-   for a static app bundle. OpenWork caches the bytes, exposes one standard MCP
-   launch tool and one immutable `ui://` resource, and does not invent a second
-   tool or capability protocol.
+   for an externally authored app bundle. OpenWork caches the bytes, exposes
+   one standard MCP launch tool and one immutable `ui://` resource, and may
+   expose an app-specific, app-only Program tool on that same MCP server. The
+   Program, not the browser UI, composes OpenWork Connect capabilities.
 
 Programs remain executable `script` config objects. A Program's generated
 views are MCP resources, but turning a view into a resource does not turn
@@ -87,9 +88,20 @@ ui://openwork/library-apps/{appId}/revisions/{revisionId}/index.html
 ```
 
 The launch result uses ordinary `structuredContent` for the app identity,
-revision, digest, and optional input. There are no OpenWork capability wrapper
-tools. If the app needs tools, publish it with a standard MCP server and add
-that server through Connect.
+revision, digest, optional input, and the name of any available same-server
+Program tool. When Code Mode is enabled, an app-specific `run_program_*` tool
+is advertised with `_meta.ui.visibility: ["app"]`. Its exact name is delivered
+in the launch result rather than embedded in the HTML. It accepts an optional
+exact `programId` or uses the member's selected Program, and rejects Programs
+outside the app's owning Plugin. Normal host approval and Plugin access checks
+still apply. The Program executes server-side and receives the member's
+authorized Connect tool tree; the HTML receives only the Program result.
+
+This is the only OpenWork-specific execution affordance in the URL adapter.
+The transport remains standard MCP `tools/call`, and the tool stays on the
+same server as the `ui://` resource. OpenWork does not let a browser app call
+tools on another MCP server. Apps distributed with their own MCP server keep
+using that server's native tools and should be added through Connect.
 
 ## Authoring and execution contract
 
@@ -110,6 +122,8 @@ The execution contract is intentionally portable:
 - local development may provide mock tool results directly to the UI;
 - production MCP execution supplies input and results through the MCP Apps
   bridge;
+- an imported app can call the advertised same-server Program tool, while the
+  Program calls OpenWork Connect capabilities server-side;
 - credentials remain in the MCP host/Connect connection and never enter the
   HTML resource;
 - an app calls only tools from its originating MCP server;
@@ -132,18 +146,24 @@ For a static bundle:
    validation and shows the resolved source, size, and digest.
 3. Import and activate. The adapter appears as an App inside its owning Plugin
    and shares through the existing Plugin/Marketplace access model.
-4. Refresh caches a new immutable draft without changing the active revision.
-5. Activate or roll back explicitly. Retire removes the launch tool from agent
+4. To give the UI Connect-backed behavior, open **Manage Plugin**, add a Code
+   Mode Program to that Plugin, and select it. The app-specific tool rejects a
+   selected Program from any other Plugin.
+5. Refresh caches a new immutable draft without changing the active revision.
+6. Activate or roll back explicitly. Retire removes the launch tool from agent
    discovery without deleting cached revisions; restore re-exposes the active
    revision.
-6. Download always returns the exact cached HTML revision, so the installed
+7. Download always returns the exact cached HTML revision, so the installed
    copy remains usable after the source URL disappears.
 
-The static adapter is independent of `codemodeScripts`. Runtime discovery is
-gated by `DEN_REMOTE_MCP_APPS_ENABLED` until a compatible Desktop host is
-released. Normal MCP Apps delivered by an existing Connect server use the
-standard Connect and Desktop MCP host paths rather than this static-adapter
-flag.
+The static adapter is independently disableable with
+`DEN_REMOTE_MCP_APPS_ENABLED`, but defaults on after the compatible Desktop
+host release. `DEN_GENERATED_ARTIFACT_VIEWS_ENABLED` remains off by default;
+imported UI availability does not let agents author or compile MCP App UI in
+OpenWork. The optional Program tool is present only for organizations with
+`codemodeScripts` enabled. Normal MCP Apps delivered by an existing Connect
+server use the standard Connect and Desktop MCP host paths rather than this
+static-adapter flag.
 
 ## Host security and compatibility
 

--- a/docs/features/remote-mcp-apps/README.md
+++ b/docs/features/remote-mcp-apps/README.md
@@ -14,9 +14,10 @@ There are two distribution paths:
    meaning.
 2. A self-contained HTML file imported by URL. This is a convenience adapter
    for an externally authored app bundle. OpenWork caches the bytes, exposes
-   one standard MCP launch tool and one immutable `ui://` resource, and may
-   expose an app-specific, app-only Program tool on that same MCP server. The
-   Program, not the browser UI, composes OpenWork Connect capabilities.
+   one standard MCP launch tool and immutable `ui://` resources, and exposes
+   the existing OpenWork capability-search gateway on that same MCP server.
+   The sandboxed app can search and execute authorized Connect tools and Code
+   Mode Programs without receiving credentials or direct cross-server access.
 
 Programs remain executable `script` config objects. A Program's generated
 views are MCP resources, but turning a view into a resource does not turn
@@ -72,7 +73,17 @@ metadata from the document `<title>` and optional description meta tag, then
 uses the SHA-256 digest as the revision version. The source URL is an import
 source, never the runtime origin.
 
-The static adapter rejects external scripts, stylesheets, preloads, images,
+The model-visible `import_remote_mcp_app` tool accepts only an existing Plugin
+id, a public HTTPS URL, and an activation choice. Its
+`_meta.ui.visibility: ["model"]` makes it unavailable to sandboxed apps. The
+generic capability gateway also excludes the REST installation operation, so
+an app or Program cannot bypass that boundary. Inline HTML, React or JavaScript
+source, and build-project contents are not accepted.
+
+The server-side downloader validates every redirect with the hosted SSRF
+guard, requires an HTML MIME type and UTF-8 encoding, enforces a 15-second
+timeout and 768 KiB ceiling, and rejects credential-bearing URLs. The static
+adapter rejects external scripts, stylesheets, preloads, images,
 media, frames, CSS URLs/imports, embedded CSP, and base-URI changes. It stores:
 
 - exact HTML bytes in an immutable encrypted config-object revision;
@@ -88,21 +99,21 @@ ui://openwork/library-apps/{appId}/revisions/{revisionId}/index.html
 ```
 
 The launch result uses ordinary `structuredContent` for the app identity,
-revision, digest, optional input, and the name of any available same-server
-Program tool. When Code Mode is enabled, an app-specific `run_program_*` tool
-is advertised with `_meta.ui.visibility: ["app"]` and the exact revision's
-standard `_meta.ui.resourceUri`. Its exact name is delivered in the launch
-result rather than embedded in the HTML. It accepts an optional exact
-`programId` or uses the member's selected Program, and rejects Programs outside
-the app's owning Plugin. Normal host approval and Plugin access checks still
-apply. The Program executes server-side and receives the member's authorized
-Connect tool tree; the HTML receives only the Program result.
+revision, digest, optional input, and the exact names of the existing
+`search_capabilities` and `execute_capability` tools. Both gateway tools are
+app-visible on the originating OpenWork server. Search returns ordinary
+structured matches for authorized Connect tools and, when Code Mode is
+enabled by organization policy, Programs as marketplace `script` capabilities.
+Execution accepts the exact returned capability name and returns ordinary MCP
+content and `structuredContent`. Programs remain durable resources and execute
+server-side through the existing Program runtime.
 
-This is the only OpenWork-specific execution affordance in the URL adapter.
-The transport remains standard MCP `tools/call`, and the tool stays on the
-same server as the `ui://` resource. OpenWork does not let a browser app call
-tools on another MCP server. Apps distributed with their own MCP server keep
-using that server's native tools and should be added through Connect.
+The URL downloader and semantic search facade are OpenWork installation and
+gateway behavior, not new MCP protocol primitives. Runtime communication is
+standard same-server MCP Apps `tools/call`. OpenWork does not let the iframe
+contact another MCP server or receive its credentials. Apps distributed with
+their own MCP server keep using that server's native tools and should be added
+through Connect without conversion.
 
 ## Authoring and execution contract
 
@@ -123,8 +134,8 @@ The execution contract is intentionally portable:
 - local development may provide mock tool results directly to the UI;
 - production MCP execution supplies input and results through the MCP Apps
   bridge;
-- an imported app can call the advertised same-server Program tool, while the
-  Program calls OpenWork Connect capabilities server-side;
+- an imported app searches the advertised same-server gateway and executes an
+  exact authorized Connect tool or Program result;
 - credentials remain in the MCP host/Connect connection and never enter the
   HTML resource;
 - an app calls only tools from its originating MCP server;
@@ -140,16 +151,17 @@ grant the intended members or teams access. Desktop reconciles the authorized
 server endpoint, agents discover its native tool definitions, and UI tools
 render without an OpenWork-specific import step.
 
-For a static bundle:
+For a static bundle, an agent can install it through OpenWork Connect:
 
-1. In Den Web, open Library and choose **Add remote MCP App**.
-2. Paste the HTML URL. OpenWork performs guarded download and portability
-   validation and shows the resolved source, size, and digest.
-3. Import and activate. The adapter appears as an App inside its owning Plugin
-   and shares through the existing Plugin/Marketplace access model.
-4. To give the UI Connect-backed behavior, open **Manage Plugin**, add a Code
-   Mode Program to that Plugin, and select it. The app-specific tool rejects a
-   selected Program from any other Plugin.
+1. The user selects the existing Plugin that will contain and govern the App.
+2. The agent calls `import_remote_mcp_app` with that Plugin id and a public
+   HTTPS URL. Normal mutation approval applies because this installs executable
+   third-party content.
+3. OpenWork performs guarded download and portability validation, stores the
+   exact digest-addressed revision, and activates it unless asked not to.
+4. The adapter appears as an App inside its selected Plugin and shares through
+   the existing Plugin/Marketplace access model. Den Web remains the user-facing
+   preview, revision, activation, rollback, download, and lifecycle surface.
 5. Refresh caches a new immutable draft without changing the active revision.
 6. Activate or roll back explicitly. Retire removes the launch tool from agent
    discovery without deleting cached revisions; restore re-exposes the active
@@ -157,14 +169,20 @@ For a static bundle:
 7. Download always returns the exact cached HTML revision, so the installed
    copy remains usable after the source URL disappears.
 
+Successful installation emits `notifications/tools/list_changed` and
+`notifications/resources/list_changed`. Lifecycle mutations made through the
+same MCP capability gateway emit the same notifications; every subsequent
+list request is rebuilt from the current authorized Library state.
+
 The static adapter is independently disableable with
 `DEN_REMOTE_MCP_APPS_ENABLED`, but defaults on after the compatible Desktop
 host release. `DEN_GENERATED_ARTIFACT_VIEWS_ENABLED` remains off by default;
-imported UI availability does not let agents author or compile MCP App UI in
-OpenWork. The optional Program tool is present only for organizations with
-`codemodeScripts` enabled. Normal MCP Apps delivered by an existing Connect
-server use the standard Connect and Desktop MCP host paths rather than this
-static-adapter flag.
+while it is off, generated-view creation, source submission, React compilation,
+revision activation, resources, and launch tools are absent or rejected even
+if records already exist. This flag is independent from `codemodeScripts`:
+Programs remain usable by imported apps according to organization policy.
+Normal MCP Apps delivered by an existing Connect server use the standard
+Connect and Desktop MCP host paths rather than this static-adapter flag.
 
 ## Host security and compatibility
 
@@ -179,8 +197,8 @@ result.
 
 App-requested tools are resolved only on the originating server and must be
 visible to the app. When a tool carries `_meta.ui.resourceUri`, Desktop also
-requires it to match the exact immutable resource loaded in the calling iframe;
-one imported app therefore cannot invoke another revision's bound Program
-tool. Workspace tool denies apply. Explicitly read-only, non-destructive calls
-run directly; other calls require a user confirmation and collaborator
-authority. Cross-server calls are not allowed.
+requires it to match the exact immutable resource loaded in the calling iframe.
+Workspace tool denies apply. Read-only capability search runs directly;
+capability execution uses conservative mutation annotations and requires user
+confirmation, while the underlying provider/Program authorization and audit
+path still runs server-side. Cross-server iframe calls are not allowed.

--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -35,9 +35,9 @@ DEN_MCP_ADDITIONAL_RESOURCES=
 # Enable only after deploying a Desktop release that delivers render-tool
 # structuredContent through the stable MCP Apps bridge after initialization.
 DEN_GENERATED_ARTIFACT_VIEWS_ENABLED=false
-# Enable only after deploying a Desktop release with the stable MCP Apps host.
-# This is independent of Code Mode and generated Artifact view rollout.
-DEN_REMOTE_MCP_APPS_ENABLED=false
+# The stable Desktop MCP Apps host supports imported apps by default. Set false
+# for an operator rollback. This does not enable generated Artifact views.
+DEN_REMOTE_MCP_APPS_ENABLED=true
 # Leave unset on hosted/multi-tenant deployments. Set to 1 only when Den runs
 # inside a private network and your MCP servers are on private addresses.
 # OPENWORK_DEV_MODE=1 already exempts local dev.

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -259,6 +259,7 @@ configureCloudSavedScriptExecutor(async ({ organizationId, ownerMemberId, automa
     member,
     redirectUriBase: env.apiPublicUrl ?? "http://127.0.0.1",
     codemodeEnabled,
+    generatedArtifactViewsEnabled: env.generatedArtifactViewsEnabled,
     organizationMetadata,
     mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
   })

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1356,6 +1356,50 @@ export async function listUsableExternalMcpConnections(input: {
   return [...byId.values()]
 }
 
+export async function externalMcpConnectionReadyForMember(
+  connection: ExternalMcpConnectionRow,
+  orgMembershipId: OrgMembershipId,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
+): Promise<boolean> {
+  if (connection.oauthIssuerReviewRequiredAt) return false
+  if (connection.authType === "none") return true
+  if (connection.credentialMode === "shared") {
+    if (connection.authType === "oauth") return Boolean(connection.accessToken)
+    if (connection.authType === "apikey") return Boolean(connection.apiKey)
+    return false
+  }
+  if (connection.authType !== "oauth") return false
+  const account = await readAccount({ connection, orgMembershipId })
+  return account.current && Boolean(account.value?.accessToken)
+}
+
+/**
+ * Native server projection is stricter than capability search: the Connect
+ * management and search surfaces retain disconnected rows so they can explain
+ * how to reconnect, while Desktop's server index receives only connections
+ * that can initialize for this exact member now.
+ */
+export async function listReadyExternalMcpConnections(input: {
+  organizationId: OrganizationId
+  orgMembershipId: OrgMembershipId
+  teamIds: TeamId[]
+}): Promise<ExternalMcpConnectionRow[]> {
+  const usable = await listUsableExternalMcpConnections(input)
+  return readyExternalMcpConnectionsForMember(usable, input.orgMembershipId)
+}
+
+export async function readyExternalMcpConnectionsForMember(
+  connections: ExternalMcpConnectionRow[],
+  orgMembershipId: OrgMembershipId,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
+): Promise<ExternalMcpConnectionRow[]> {
+  const readiness = await Promise.all(connections.map(async (connection) => ({
+    connection,
+    ready: await externalMcpConnectionReadyForMember(connection, orgMembershipId, readAccount),
+  })))
+  return readiness.flatMap(({ connection, ready }) => ready ? [connection] : [])
+}
+
 export async function listUsableNativeProviderConnections(input: {
   organizationId: OrganizationId
   orgMembershipId: OrgMembershipId

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -435,10 +435,10 @@ const mcpConnectionsGatingEnabled =
 const generatedArtifactViewsEnabled =
   (parsed.DEN_GENERATED_ARTIFACT_VIEWS_ENABLED ?? "false").trim().toLowerCase() === "true"
 
-// Imported apps use the same stable Desktop MCP Apps bridge but have an
-// independent lifecycle from generated Artifact views and Code Mode Programs.
+// Imported apps use the released stable Desktop MCP Apps bridge and remain
+// independently disableable without enabling agent-authored generated views.
 const remoteMcpAppsEnabled =
-  (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "false").trim().toLowerCase() === "true"
+  (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "true").trim().toLowerCase() === "true"
 
 const devMode = (parsed.OPENWORK_DEV_MODE ?? "0").trim() === "1"
 const botIdProtectionEnabled = (parsed.DEN_BOTID_PROTECTION_ENABLED ?? "0").trim() === "1"

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -14,7 +14,11 @@ import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
-import { SEARCH_CAPABILITIES_TOOL_NAME, type CapabilityMatch } from "./search.js"
+import {
+  EXECUTE_CAPABILITY_TOOL_NAME,
+  SEARCH_CAPABILITIES_TOOL_NAME,
+  type CapabilityMatch,
+} from "./search.js"
 import { resolveMcpMemberIdentity } from "./external-capabilities.js"
 import { executeMarketplaceCapability, listAccessibleMarketplaceSkillDescriptors, parseMarketplaceCapabilityName, type RemoteSkillDescriptor } from "./marketplace-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
@@ -37,6 +41,7 @@ import {
 } from "./builtin-skills.js"
 import {
   buildCapabilityToolTree,
+  catalogOperationChangesRemoteMcpAppDiscovery,
   createCapabilityRegistryContext,
   executeCapability,
   externalCapabilityErrorToolResult,
@@ -63,16 +68,16 @@ import { requirePluginArchResourceRole, type PluginArchActorContext } from "../r
 import { clearProgramAgentSelection, getProgramAgentSelection, selectProgramForAgent } from "../program-agent-selection.js"
 import { getProgramDetail, listProgramLibraryItems } from "../program-library.js"
 import { parseArtifactViewResourceUri } from "../artifact-view-resource.js"
-import { listActiveRemoteMcpApps, loadRemoteMcpAppRevision } from "../remote-mcp-apps.js"
+import { importRemoteMcpApp, listActiveRemoteMcpApps, loadRemoteMcpAppRevision } from "../remote-mcp-apps.js"
 import { registerAgentRemoteMcpApps } from "./remote-mcp-apps.js"
-import { listUsableExternalMcpConnections } from "../capability-sources/external-mcp-connections.js"
+import { listReadyExternalMcpConnections } from "../capability-sources/external-mcp-connections.js"
 import { registerConnectMcpServerIndex } from "./connect-mcp-server-index.js"
 
 export { externalToolContent } from "./tool-content.js"
 export { externalCapabilityErrorToolResult, externalCapabilitySuccessToolResult }
 export type { ExecuteCapabilityToolResult }
 
-export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
+export { EXECUTE_CAPABILITY_TOOL_NAME }
 export const EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME = "execute_capability_script"
 const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
 export const EXECUTE_CAPABILITY_TIMEOUT_MS = 180_000
@@ -171,10 +176,11 @@ const programRunOutputSchema = z.object({
 
 export const AGENT_MCP_INSTRUCTIONS = [
   "This OpenWork Cloud MCP server uses standard MCP tools, resources, structured results, and list-changed notifications. OpenWork Programs and Remote MCP Apps add only durable identity, Plugin containment, access, retained resources and results, selection, and lifecycle around those MCP primitives.",
-  "MCP App UI is authored and bundled outside OpenWork. Agents do not author, compile, or save MCP App UI in OpenWork. Active imported apps in the member's Library appear as individually named launch tools backed by immutable ui:// resources.",
-  "An imported app may call the app-visible Program tool named in its launch structuredContent through the standard same-server MCP Apps bridge. That tool runs an exact accessible Program inside the app's Plugin, or the member's selected Program when no id is supplied; the Program is the only layer that reaches OpenWork Connect capabilities.",
+  "MCP App UI is authored and bundled outside OpenWork. Agents do not author, generate, compile, revise, activate, or publish UI source in OpenWork. Active imported apps in the member's Library appear as individually named launch tools backed by immutable ui:// resources.",
+  "Use import_remote_mcp_app only after the user has selected an existing Plugin and approved installation of third-party executable content. Supply only the Plugin id and a public HTTPS URL for one self-contained index.html; never send inline HTML, React or JavaScript source, or build-project contents.",
+  "An imported app receives the exact search_capabilities and execute_capability tool names in launch structuredContent. Through the standard same-server MCP Apps bridge it can search the member's authorized Connect tools and Programs, then execute an exact returned capability. The host retains workspace policy, user approval, and result-size enforcement; credentials never enter the app.",
   "A Program is an immutable-versioned Code Mode Script config object inside an OpenWork Connect Plugin. Organizations with Code Mode scripts enabled receive execute_capability_script, the backwards-compatible render_dynamic_artifact MCP App tool, and a constant-size Program catalog: search_programs, select_program, and clear_program_selection.",
-  "To use a Program, search by Library metadata, select one exact accessible Program, then refresh the tool catalog. The selected context exposes run_selected_program and render_selected_program; rendering returns an Artifact as fallback text plus retained data in structuredContent and binds the exact immutable MCP App resource URI in the tool definition.",
+  "To use a Program, search by Library metadata, select one exact accessible Program, then refresh the tool catalog. The selected context exposes run_selected_program and a standard renderer for its retained Artifact data; Program execution remains server-mediated and returns structuredContent.",
   "When a member asks to keep a successful Code Mode result, save it as a Program inside the existing OpenWork Connect Plugin they name by passing that pluginId to the Code Mode save operation. Omit pluginId only for a private Program in the member's My Programs Plugin. A Program inherits discovery and sharing from its Plugin and any Marketplace containing that Plugin; do not create a separate Program package or marketplace entry.",
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added.",
   "Allowlisted platform admins can also discover namespaced OpenWork Admin capabilities through this same connection; other members cannot discover or execute them.",
@@ -299,7 +305,11 @@ export function createAgentMcpServer(): McpServer {
     name: "openwork-den-api-agent",
     version: "1.0.0",
   }, {
-    capabilities: dynamicArtifactAppServerCapabilities,
+    capabilities: {
+      ...dynamicArtifactAppServerCapabilities,
+      tools: { listChanged: true },
+      resources: { listChanged: true },
+    },
     instructions: AGENT_MCP_INSTRUCTIONS,
   })
 }
@@ -421,6 +431,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       member: memberIdentity,
       redirectUriBase,
       codemodeEnabled,
+      generatedArtifactViewsEnabled: env.generatedArtifactViewsEnabled,
       organizationMetadata: organizationRows[0]?.metadata,
       mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
     })
@@ -449,85 +460,6 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       }
     }
     const artifactContext = codemodeEnabled ? libraryContext : null
-    const executeRemoteAppProgram = artifactContext
-      ? async ({ programId, pluginId, input }: { programId?: string; pluginId: string; input?: unknown }) => {
-          try {
-            const resolvedProgramId = programId
-              ?? (await getProgramAgentSelection(artifactContext))?.programId
-            if (!resolvedProgramId) {
-              return {
-                isError: true,
-                content: textContent(JSON.stringify({
-                  error: "program_not_selected",
-                  message: "Select a Program in OpenWork before this MCP App runs it, or pass an exact accessible programId.",
-                })),
-              }
-            }
-            const detail = await getProgramDetail({
-              context: artifactContext,
-              configObjectId: resolvedProgramId,
-            })
-            if (detail.script.pluginId !== pluginId) {
-              return {
-                isError: true,
-                content: textContent(JSON.stringify({
-                  error: "program_not_in_app_plugin",
-                  message: "The selected Program is not inside this MCP App's Plugin.",
-                })),
-              }
-            }
-            await requirePluginArchResourceRole({
-              context: artifactContext,
-              requireFreshSession: false,
-              resourceId: normalizeDenTypeId("configObject", resolvedProgramId),
-              resourceKind: "config_object",
-              role: "editor",
-            })
-            const execution = await executeMarketplaceCapability({
-              organizationId: principal.organizationId,
-              member: memberIdentity,
-              pluginId: detail.script.pluginId,
-              configObjectId: detail.script.configObjectId,
-              configObjectVersionId: detail.script.currentVersion.id,
-              body: input,
-              codemodeEnabled: true,
-              validateScriptOutput: true,
-              buildTools: () => buildCapabilityToolTree(capabilityContext),
-            })
-            if (!execution.ok || execution.result.status !== "executed") {
-              const message = execution.ok
-                ? execution.result.hint ?? "The Program could not run."
-                : execution.message
-              return {
-                isError: true,
-                content: textContent(JSON.stringify({ error: "program_run_failed", message })),
-              }
-            }
-            const result = {
-              status: "succeeded" as const,
-              value: execution.result.value,
-              receiptId: execution.result.receiptId ?? null,
-              resultDigest: execution.result.resultDigest ?? null,
-            }
-            return {
-              content: textContent(JSON.stringify(result, null, 2)),
-              structuredContent: result,
-            }
-          } catch (error) {
-            const unavailable = error instanceof PluginArchAuthorizationError
-              || (error instanceof Error && error.message.includes("not_found"))
-            return {
-              isError: true,
-              content: textContent(JSON.stringify({
-                error: unavailable ? "program_not_found" : "program_run_failed",
-                message: unavailable
-                  ? "The Program is not available to this member."
-                  : "The Program could not run.",
-              })),
-            }
-          }
-        }
-      : undefined
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
       remoteSkills = [
         ...listBuiltinSkillDescriptors(),
@@ -552,14 +484,20 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           })
           return { html: loaded.html, payload: loaded.payload }
         },
-        runProgram: executeRemoteAppProgram,
+        importApp: async ({ pluginId, sourceUrl, activate }) => importRemoteMcpApp({
+          context: libraryContext,
+          pluginId,
+          sourceUrl,
+          activate,
+          requireFreshSession: false,
+        }),
       })
     }
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
       if (memberIdentity) {
         registerConnectMcpServerIndex({
           server,
-          connections: await listUsableExternalMcpConnections({
+          connections: await listReadyExternalMcpConnections({
             organizationId,
             orgMembershipId: memberIdentity.orgMembershipId,
             teamIds: memberIdentity.teamIds,
@@ -600,11 +538,13 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
             : "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
+          "When Code Mode is enabled, accessible Programs appear as marketplace matches with kind script and execute through execute_capability like every other exact search result.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
           "Native API matches include a connector-namespaced name, pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField.",
           "Built-in and marketplace skill matches return SKILL.md content when executed.",
         ].join(" "),
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,
+        _meta: { ui: { visibility: ["model", "app"] } },
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
           limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
@@ -631,6 +571,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           "Returns unknown_capability if name doesn't match a current capability — call search_capabilities again.",
         ].join(" "),
         annotations: EXECUTE_CAPABILITY_ANNOTATIONS,
+        _meta: { ui: { visibility: ["model", "app"] } },
         inputSchema: z.object({
           name: z.string().min(1).describe("The exact tool name returned by search_capabilities."),
           schemaDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional().describe("For an external MCP match, copy the exact schemaDigest returned by search_capabilities so schema drift can be reported as advisory guidance without blocking the provider call."),
@@ -639,11 +580,17 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           body: z.unknown().optional().describe("For native API capabilities, the JSON body. For external MCP capabilities, the arguments object matching argumentsSchema."),
         }),
       },
-      async ({ name, schemaDigest, path, query, body }) => {
-        return executeCapabilityWithBudget({
+      async ({ name, schemaDigest, path, query, body }, extra) => {
+        const result = await executeCapabilityWithBudget({
           capability: name,
           invoke: () => executeCapability(capabilityContext, { name, schemaDigest, path, query, body }),
         })
+        const catalogOperation = catalog.find((operation) => operation.name === name)
+        if (!result.isError && catalogOperation && catalogOperationChangesRemoteMcpAppDiscovery(catalogOperation)) {
+          await extra.sendNotification({ method: "notifications/tools/list_changed" })
+          await extra.sendNotification({ method: "notifications/resources/list_changed" })
+        }
+        return result
       },
     )
 
@@ -795,8 +742,9 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
             state: item.state,
             resultState: item.resultState,
             latestSuccessfulAt: item.latestSuccessfulAt,
-            viewState: item.viewState,
-            activeViewTitle: item.activeViewTitle,
+            ...(env.generatedArtifactViewsEnabled
+              ? { viewState: item.viewState, activeViewTitle: item.activeViewTitle }
+              : { viewState: "default" as const, activeViewTitle: null }),
             automationCount: item.automationCount,
             source: item.source,
           }))

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -171,7 +171,8 @@ const programRunOutputSchema = z.object({
 
 export const AGENT_MCP_INSTRUCTIONS = [
   "This OpenWork Cloud MCP server uses standard MCP tools, resources, structured results, and list-changed notifications. OpenWork Programs and Remote MCP Apps add only durable identity, Plugin containment, access, retained resources and results, selection, and lifecycle around those MCP primitives.",
-  "When Remote MCP App delivery is enabled, active apps in the member's Library appear as individually named launch tools backed by immutable ui:// resources.",
+  "MCP App UI is authored and bundled outside OpenWork. Agents do not author, compile, or save MCP App UI in OpenWork. Active imported apps in the member's Library appear as individually named launch tools backed by immutable ui:// resources.",
+  "An imported app may call the app-visible Program tool named in its launch structuredContent through the standard same-server MCP Apps bridge. That tool runs an exact accessible Program inside the app's Plugin, or the member's selected Program when no id is supplied; the Program is the only layer that reaches OpenWork Connect capabilities.",
   "A Program is an immutable-versioned Code Mode Script config object inside an OpenWork Connect Plugin. Organizations with Code Mode scripts enabled receive execute_capability_script, the backwards-compatible render_dynamic_artifact MCP App tool, and a constant-size Program catalog: search_programs, select_program, and clear_program_selection.",
   "To use a Program, search by Library metadata, select one exact accessible Program, then refresh the tool catalog. The selected context exposes run_selected_program and render_selected_program; rendering returns an Artifact as fallback text plus retained data in structuredContent and binds the exact immutable MCP App resource URI in the tool definition.",
   "When a member asks to keep a successful Code Mode result, save it as a Program inside the existing OpenWork Connect Plugin they name by passing that pluginId to the Code Mode save operation. Omit pluginId only for a private Program in the member's My Programs Plugin. A Program inherits discovery and sharing from its Plugin and any Marketplace containing that Plugin; do not create a separate Program package or marketplace entry.",
@@ -187,7 +188,6 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "External MCP matches include the provider-advertised argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
   "OpenWork always attempts the downstream provider call when local schema checks find a mismatch. schemaGuidance is advisory and appears alongside the provider result: if the provider succeeded, accept that result and do not retry solely because of the warning; if it failed, use the warning to correct the arguments or search again.",
   "If the provider returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns unknown_capability, call search_capabilities again before retrying.",
-  "When save_artifact_view is advertised, create or update the saved Script with an explicit JSON Schema outputSchema matching its returned data before calling it. React is injected into view source, so use React APIs without imports and render only the supplied data prop. A failed view build includes diagnostics: change the source once and retry with the returned artifactViewId; do not search for a different Artifact tool or call render_dynamic_artifact. After a successful save, call the exact render_artifact_* or preview_artifact_* tool named in its result.",
   "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
@@ -449,6 +449,85 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       }
     }
     const artifactContext = codemodeEnabled ? libraryContext : null
+    const executeRemoteAppProgram = artifactContext
+      ? async ({ programId, pluginId, input }: { programId?: string; pluginId: string; input?: unknown }) => {
+          try {
+            const resolvedProgramId = programId
+              ?? (await getProgramAgentSelection(artifactContext))?.programId
+            if (!resolvedProgramId) {
+              return {
+                isError: true,
+                content: textContent(JSON.stringify({
+                  error: "program_not_selected",
+                  message: "Select a Program in OpenWork before this MCP App runs it, or pass an exact accessible programId.",
+                })),
+              }
+            }
+            const detail = await getProgramDetail({
+              context: artifactContext,
+              configObjectId: resolvedProgramId,
+            })
+            if (detail.script.pluginId !== pluginId) {
+              return {
+                isError: true,
+                content: textContent(JSON.stringify({
+                  error: "program_not_in_app_plugin",
+                  message: "The selected Program is not inside this MCP App's Plugin.",
+                })),
+              }
+            }
+            await requirePluginArchResourceRole({
+              context: artifactContext,
+              requireFreshSession: false,
+              resourceId: normalizeDenTypeId("configObject", resolvedProgramId),
+              resourceKind: "config_object",
+              role: "editor",
+            })
+            const execution = await executeMarketplaceCapability({
+              organizationId: principal.organizationId,
+              member: memberIdentity,
+              pluginId: detail.script.pluginId,
+              configObjectId: detail.script.configObjectId,
+              configObjectVersionId: detail.script.currentVersion.id,
+              body: input,
+              codemodeEnabled: true,
+              validateScriptOutput: true,
+              buildTools: () => buildCapabilityToolTree(capabilityContext),
+            })
+            if (!execution.ok || execution.result.status !== "executed") {
+              const message = execution.ok
+                ? execution.result.hint ?? "The Program could not run."
+                : execution.message
+              return {
+                isError: true,
+                content: textContent(JSON.stringify({ error: "program_run_failed", message })),
+              }
+            }
+            const result = {
+              status: "succeeded" as const,
+              value: execution.result.value,
+              receiptId: execution.result.receiptId ?? null,
+              resultDigest: execution.result.resultDigest ?? null,
+            }
+            return {
+              content: textContent(JSON.stringify(result, null, 2)),
+              structuredContent: result,
+            }
+          } catch (error) {
+            const unavailable = error instanceof PluginArchAuthorizationError
+              || (error instanceof Error && error.message.includes("not_found"))
+            return {
+              isError: true,
+              content: textContent(JSON.stringify({
+                error: unavailable ? "program_not_found" : "program_run_failed",
+                message: unavailable
+                  ? "The Program is not available to this member."
+                  : "The Program could not run.",
+              })),
+            }
+          }
+        }
+      : undefined
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
       remoteSkills = [
         ...listBuiltinSkillDescriptors(),
@@ -473,6 +552,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           })
           return { html: loaded.html, payload: loaded.payload }
         },
+        runProgram: executeRemoteAppProgram,
       })
     }
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {

--- a/ee/apps/den-api/src/mcp/capability-registry.ts
+++ b/ee/apps/den-api/src/mcp/capability-registry.ts
@@ -76,6 +76,7 @@ export type ParsedCapability =
 export type ExecuteCapabilityToolResult = {
   isError?: boolean
   content: AgentToolContentPart[]
+  structuredContent?: Record<string, unknown>
 }
 
 export type CapabilityExecuteInput = {
@@ -95,6 +96,7 @@ export type CapabilityRegistryContext = {
   member: McpMemberIdentity | null
   redirectUriBase: string
   codemodeEnabled: boolean
+  generatedArtifactViewsEnabled: boolean
   externalMcpConnectionsEnabled: boolean
   resolvePlatformAdmin: () => Promise<boolean>
   resolveNamespaceContext: () => Promise<CodemodeConnectionNamespaceContext>
@@ -109,6 +111,7 @@ export type CapabilityRegistryContextInput = {
   member: McpMemberIdentity | null
   redirectUriBase: string
   codemodeEnabled: boolean
+  generatedArtifactViewsEnabled: boolean
   organizationMetadata: Parameters<typeof memberFacingMcpConnectionsEnabled>[0]
   mcpConnectionsGatingEnabled: boolean
 }
@@ -140,10 +143,34 @@ export function createCapabilityRegistryContext(input: CapabilityRegistryContext
     member: input.member,
     redirectUriBase: input.redirectUriBase,
     codemodeEnabled: input.codemodeEnabled,
+    generatedArtifactViewsEnabled: input.generatedArtifactViewsEnabled,
     externalMcpConnectionsEnabled,
     resolvePlatformAdmin,
     resolveNamespaceContext,
   }
+}
+
+export function catalogOperationAvailableToCapabilities(
+  context: Pick<CapabilityRegistryContext, "generatedArtifactViewsEnabled">,
+  operation: Pick<McpToolOperation, "method" | "path">,
+) {
+  // Installation is reachable only through the dedicated model-visible MCP
+  // tool. This also prevents a sandboxed App or a Program from finding and
+  // invoking the REST importer through the generic capability gateway.
+  if (operation.method === "POST" && operation.path === "/v1/remote-mcp-apps") return false
+  if (context.generatedArtifactViewsEnabled) return true
+  return operation.path !== "/v1/programs/{configObjectId}/views"
+    && !operation.path.startsWith("/v1/artifact-views/")
+}
+
+export function catalogOperationChangesRemoteMcpAppDiscovery(
+  operation: Pick<McpToolOperation, "method" | "path">,
+) {
+  return operation.method !== "GET"
+    && operation.path.startsWith("/v1/remote-mcp-apps/")
+    && (operation.path.endsWith("/refresh")
+      || operation.path.endsWith("/activate")
+      || operation.path.endsWith("/lifecycle"))
 }
 
 type CapabilitySearchContext = CapabilityRegistryContext & {
@@ -242,12 +269,20 @@ export function externalCapabilitySuccessToolResult(
   result: Extract<ExternalCapabilityExecuteResult, { ok: true }>,
 ): ExecuteCapabilityToolResult {
   const content = externalToolContent(result.result)
-  if (!result.schemaGuidance) return { content }
+  const structuredContent = isRecord(result.result)
+    && isRecord(result.result.structuredContent)
+    ? result.result.structuredContent
+    : undefined
+  if (!result.schemaGuidance) return { content, ...(structuredContent ? { structuredContent } : {}) }
   return {
     content: [
       ...content,
       ...textContent(JSON.stringify({ schemaGuidance: result.schemaGuidance })),
     ],
+    structuredContent: {
+      ...(structuredContent ?? {}),
+      schemaGuidance: result.schemaGuidance,
+    },
   }
 }
 
@@ -357,18 +392,26 @@ const catalogSource: CapabilitySource = {
   search: async (ctx, query, limit) => {
     if (!ctx.sourceFilter.api) return []
     return searchCapabilities(
-      ctx.catalog.filter((operation) => !isCredentialBoundNativeOperation(operation)),
+      ctx.catalog.filter((operation) => (
+        !isCredentialBoundNativeOperation(operation)
+        && catalogOperationAvailableToCapabilities(ctx, operation)
+      )),
       query,
       limit,
     ).map((match) => ctx.codemodeEnabled
       ? { ...match, scriptPath: codemodeScriptPath("den", match.name) }
       : match)
   },
-  enumerate: (ctx) => Promise.resolve(leavesFromBuilt(buildDenCatalogToolTree(ctx))),
+  enumerate: (ctx) => Promise.resolve(leavesFromBuilt(buildDenCatalogToolTree({
+    ...ctx,
+    catalog: ctx.catalog.filter((operation) => catalogOperationAvailableToCapabilities(ctx, operation)),
+  }))),
   execute: async (ctx, parsed, input) => {
     if (!parsedForKind(parsed, "catalog")) return unknownCapabilityResult(input.name)
     const operation = ctx.catalog.find((candidate) => (
-      candidate.name === parsed.name && !isCredentialBoundNativeOperation(candidate)
+      candidate.name === parsed.name
+      && !isCredentialBoundNativeOperation(candidate)
+      && catalogOperationAvailableToCapabilities(ctx, candidate)
     ))
     if (!operation) return unknownCapabilityResult(input.name)
     return invokeMcpOperation({
@@ -542,7 +585,10 @@ const marketplaceSource: CapabilitySource = {
         ? unknownCapabilityResult(input.name)
         : marketplaceCapabilityErrorToolResult(result)
     }
-    return { content: textContent(JSON.stringify(result.result, null, 2)) }
+    return {
+      content: textContent(JSON.stringify(result.result, null, 2)),
+      structuredContent: result.result,
+    }
   },
 }
 

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -11,11 +11,12 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
-import type { Hono } from "hono"
+import type { Context, Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import {
   getExternalMcpConnection,
   memberCanUseExternalMcpConnection,
+  type ExternalMcpConnectionRow,
 } from "../capability-sources/external-mcp-connections.js"
 import {
   callExternalMcpToolRaw,
@@ -25,6 +26,7 @@ import {
   listExternalMcpTools,
   readExternalMcpResource,
 } from "../capability-sources/external-mcp-client-runtime.js"
+import { externalMcpDiagnosticForResponse } from "../capability-sources/external-mcp-diagnostics.js"
 import { evaluateToolPolicy } from "../capability-sources/external-mcp-tool-policy.js"
 import { env } from "../env.js"
 import { tokenRoute } from "../middleware/index.js"
@@ -35,6 +37,173 @@ import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
 
 function toolArguments(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+type ExternalMcpResourceOperation = Parameters<typeof describeExternalMcpServer>[0]
+type ExternalMcpProxyOperation = ExternalMcpResourceOperation & {
+  connection: ExternalMcpConnectionRow
+  member: NonNullable<ExternalMcpResourceOperation["member"]>
+  diagnosticReferenceId: string
+}
+
+type ExternalMcpProxyDescriptor = Awaited<ReturnType<typeof describeExternalMcpServer>>
+
+type ExternalMcpProxyRuntime = {
+  callTool: typeof callExternalMcpToolRaw
+  listResources: typeof listExternalMcpResources
+  listResourceTemplates: typeof listExternalMcpResourceTemplates
+  listTools: typeof listExternalMcpTools
+  readResource: typeof readExternalMcpResource
+}
+
+const externalMcpProxyRuntime: ExternalMcpProxyRuntime = {
+  callTool: callExternalMcpToolRaw,
+  listResources: listExternalMcpResources,
+  listResourceTemplates: listExternalMcpResourceTemplates,
+  listTools: listExternalMcpTools,
+  readResource: readExternalMcpResource,
+}
+
+export function createExternalConnectionProxyServer(input: {
+  descriptor: ExternalMcpProxyDescriptor
+  operation: ExternalMcpProxyOperation
+  runtime?: ExternalMcpProxyRuntime
+}) {
+  const { connection } = input.operation
+  const runtime = input.runtime ?? externalMcpProxyRuntime
+  const downstreamUi = input.descriptor.capabilities.extensions?.[EXTENSION_ID]
+  const server = new McpServer(input.descriptor.serverInfo ?? {
+    name: connection.name,
+    version: "1.0.0",
+  }, {
+    capabilities: {
+      ...(input.descriptor.capabilities.tools ? { tools: { listChanged: false } } : {}),
+      ...(input.descriptor.capabilities.resources ? { resources: { listChanged: false, subscribe: false } } : {}),
+      ...(downstreamUi ? { extensions: { [EXTENSION_ID]: downstreamUi } } : {}),
+    },
+    instructions: input.descriptor.instructions
+      ?? `This is the member-authorized OpenWork Connect proxy for ${connection.name}. Tool names and resources are provided by that MCP server.`,
+  })
+
+  if (input.descriptor.capabilities.tools) {
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: (await runtime.listTools(
+        connection,
+        input.operation.redirectUri,
+        input.operation.member,
+        input.operation.diagnosticReferenceId,
+      )).filter((tool) => !evaluateToolPolicy(connection.toolPolicy, tool.name).blocked),
+    }))
+    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const policy = evaluateToolPolicy(connection.toolPolicy, request.params.name)
+      if (policy.blocked) throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is disabled by OpenWork Connect policy.`)
+      return runtime.callTool({
+        ...input.operation,
+        toolName: request.params.name,
+        args: toolArguments(request.params.arguments),
+      })
+    })
+  }
+
+  if (input.descriptor.capabilities.resources) {
+    server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: await runtime.listResources(input.operation),
+    }))
+    server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+      resourceTemplates: await runtime.listResourceTemplates(input.operation),
+    }))
+    server.server.setRequestHandler(ReadResourceRequestSchema, async (request) => (
+      runtime.readResource({ ...input.operation, uri: request.params.uri })
+    ))
+  }
+
+  return server
+}
+
+async function jsonRpcRequestId(request: Request): Promise<string | number | null> {
+  try {
+    const value: unknown = await request.clone().json()
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      const id = (value as { id?: unknown }).id
+      if (typeof id === "string" || typeof id === "number") return id
+    }
+  } catch {
+    // Preflight owns invalid JSON. A downstream failure without a readable id
+    // still uses the protocol-defined null error id.
+  }
+  return null
+}
+
+export async function externalMcpProxyProtocolErrorResponse(
+  request: Request,
+  error: unknown,
+  referenceId: string,
+) {
+  const diagnostic = externalMcpDiagnosticForResponse(error, referenceId, "MCP_INITIALIZE")
+  console.error("external_mcp_proxy_initialization_failed", {
+    referenceId: diagnostic.referenceId,
+    phase: diagnostic.phase,
+    code: diagnostic.code,
+    retryable: diagnostic.retryable,
+    actionOwner: diagnostic.actionOwner,
+  })
+  return new Response(JSON.stringify({
+    jsonrpc: "2.0",
+    id: await jsonRpcRequestId(request),
+    error: {
+      code: ErrorCode.InternalError,
+      message: "The connected MCP server is not ready.",
+      data: {
+        error: "mcp_connection_unavailable",
+        referenceId: diagnostic.referenceId,
+        diagnosticCode: diagnostic.code,
+        phase: diagnostic.phase,
+        retryable: diagnostic.retryable,
+        actionOwner: diagnostic.actionOwner,
+        guidance: `${diagnostic.message} ${diagnostic.operatorAction}`,
+      },
+    },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+type ExternalMcpProxyRequestDependencies = {
+  describe: typeof describeExternalMcpServer
+  serve: (server: McpServer, context: Context) => Promise<Response | undefined>
+}
+
+const externalMcpProxyRequestDependencies: ExternalMcpProxyRequestDependencies = {
+  describe: describeExternalMcpServer,
+  serve: async (server, context) => {
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    return transport.handleRequest(context)
+  },
+}
+
+export async function handleExternalConnectionProxyRequest(input: {
+  context: Context
+  operation: ExternalMcpProxyOperation
+  dependencies?: Partial<ExternalMcpProxyRequestDependencies>
+}) {
+  if (input.context.req.method !== "POST") {
+    return new Response(null, { status: 405, headers: { allow: "POST" } })
+  }
+  const dependencies = { ...externalMcpProxyRequestDependencies, ...input.dependencies }
+  try {
+    const descriptor = await dependencies.describe(input.operation)
+    const server = createExternalConnectionProxyServer({ descriptor, operation: input.operation })
+    const response = await dependencies.serve(server, input.context)
+    return response ?? new Response(null, { status: 204 })
+  } catch (error) {
+    return externalMcpProxyProtocolErrorResponse(
+      input.context.req.raw,
+      error,
+      input.operation.diagnosticReferenceId,
+    )
+  }
 }
 
 /**
@@ -59,6 +228,10 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
 
     const preflightResponse = await preflightMcpJsonRpcRequest(c.req.raw, requestId)
     if (preflightResponse) return preflightResponse
+
+    if (c.req.method !== "POST") {
+      return new Response(null, { status: 405, headers: { allow: "POST" } })
+    }
 
     let connectionId
     try {
@@ -90,48 +263,7 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
       member: downstreamMember,
       diagnosticReferenceId: requestId,
     }
-    const descriptor = await describeExternalMcpServer(operation)
-    const downstreamUi = descriptor.capabilities.extensions?.[EXTENSION_ID]
-    const server = new McpServer(descriptor.serverInfo ?? {
-      name: connection.name,
-      version: "1.0.0",
-    }, {
-      capabilities: {
-        ...(descriptor.capabilities.tools ? { tools: { listChanged: false } } : {}),
-        ...(descriptor.capabilities.resources ? { resources: { listChanged: false, subscribe: false } } : {}),
-        ...(downstreamUi ? { extensions: { [EXTENSION_ID]: downstreamUi } } : {}),
-      },
-      instructions: descriptor.instructions
-        ?? `This is the member-authorized OpenWork Connect proxy for ${connection.name}. Tool names and resources are provided by that MCP server.`,
-    })
-
-    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: (await listExternalMcpTools(connection, redirectUri, downstreamMember, requestId))
-        .filter((tool) => !evaluateToolPolicy(connection.toolPolicy, tool.name).blocked),
-    }))
-    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const policy = evaluateToolPolicy(connection.toolPolicy, request.params.name)
-      if (policy.blocked) throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is disabled by OpenWork Connect policy.`)
-      return callExternalMcpToolRaw({
-        ...operation,
-        toolName: request.params.name,
-        args: toolArguments(request.params.arguments),
-      })
-    })
-    server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-      resources: await listExternalMcpResources(operation),
-    }))
-    server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-      resourceTemplates: await listExternalMcpResourceTemplates(operation),
-    }))
-    server.server.setRequestHandler(ReadResourceRequestSchema, async (request) => (
-      readExternalMcpResource({ ...operation, uri: request.params.uri })
-    ))
-
-    const transport = new StreamableHTTPTransport()
-    await server.connect(transport)
-    const response = await transport.handleRequest(c)
-    return response ?? new Response(null, { status: 204 })
+    return handleExternalConnectionProxyRequest({ context: c, operation })
   })
 }
 

--- a/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
+++ b/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
@@ -8,8 +8,14 @@ import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import type { listActiveRemoteMcpApps } from "../remote-mcp-apps.js"
+import { EXECUTE_CAPABILITY_TOOL_NAME, SEARCH_CAPABILITIES_TOOL_NAME } from "./search.js"
 
 type ActiveRemoteMcpApp = Awaited<ReturnType<typeof listActiveRemoteMcpApps>>[number]
+export const IMPORT_REMOTE_MCP_APP_TOOL_NAME = "import_remote_mcp_app"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
 
 function digest(value: string) {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`
@@ -21,10 +27,6 @@ function stableSuffix(value: string, length = 12) {
 
 export function remoteMcpAppLaunchToolName(configObjectId: string) {
   return `launch_remote_app_${stableSuffix(configObjectId)}`
-}
-
-export function remoteMcpAppRunProgramToolName(configObjectId: string, versionId: string) {
-  return `run_program_${stableSuffix(`${configObjectId}:${versionId}`)}`
 }
 
 function resourceMeta(revision: Pick<ActiveRemoteMcpApp, "payload">): { ui: McpUiResourceMeta; resourceDigest: string } {
@@ -41,48 +43,62 @@ export function registerAgentRemoteMcpApps(input: {
     html: string
     payload: ActiveRemoteMcpApp["payload"]
   }>
-  runProgram?: (request: {
-    appConfigObjectId: string
+  importApp?: (request: {
+    activate: boolean
     pluginId: string
-    programId?: string
-    input?: unknown
-  }) => Promise<{
-    content: Array<{ type: "text"; text: string }>
-    structuredContent?: Record<string, unknown>
-    isError?: boolean
-  }>
+    sourceUrl: string
+  }) => Promise<Record<string, unknown>>
 }) {
-  const runProgram = input.runProgram
+  const importApp = input.importApp
+  if (importApp) {
+    input.server.registerTool(
+      IMPORT_REMOTE_MCP_APP_TOOL_NAME,
+      {
+        title: "Import remote MCP App",
+        description: [
+          "Install an externally built, self-contained MCP App index.html from an HTTPS URL into an existing OpenWork Connect Plugin.",
+          "OpenWork downloads and validates the document server-side, stores the exact bytes and digest as an immutable revision, and serves only the cached ui:// resource.",
+          "This tool accepts no inline HTML, React, JavaScript, source tree, or build project. Installing third-party executable content requires normal user approval.",
+        ].join(" "),
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+        inputSchema: z.object({
+          pluginId: z.string().trim().min(1).max(160).describe("Existing Plugin to contain and govern the imported MCP App."),
+          sourceUrl: z.string().trim().url().max(2_048).describe("Public HTTPS URL for one self-contained index.html document."),
+          activate: z.boolean().optional().default(true).describe("Expose the immutable imported revision immediately. Defaults to true."),
+        }).strict(),
+        outputSchema: z.object({ app: z.record(z.string(), z.unknown()) }),
+        _meta: { ui: { visibility: ["model"] } },
+      },
+      async ({ pluginId, sourceUrl, activate }, extra) => {
+        try {
+          const app = await importApp({ pluginId, sourceUrl, activate })
+          await extra.sendNotification({ method: "notifications/tools/list_changed" })
+          await extra.sendNotification({ method: "notifications/resources/list_changed" })
+          const result = { app }
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          }
+        } catch (error) {
+          const code = isRecord(error) && typeof error.code === "string"
+            ? error.code
+            : isRecord(error) && typeof error.error === "string"
+              ? error.error
+            : "remote_mcp_app_import_failed"
+          const message = error instanceof Error ? error.message : "The remote MCP App could not be imported."
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: JSON.stringify({ error: code, message }) }],
+          }
+        }
+      },
+    )
+  }
+
   for (const app of input.apps) {
     const metadata = app.payload.metadata
     for (const revision of app.revisions) {
       const metadata = resourceMeta(revision)
-      if (runProgram) {
-        registerAppTool(
-          input.server,
-          remoteMcpAppRunProgramToolName(app.app.configObjectId, revision.versionId),
-          {
-            title: `Run ${app.payload.metadata.name} Program`,
-            description: [
-              `Run a Code Mode Program inside the ${app.payload.metadata.name} Plugin through OpenWork Connect.`,
-              "Omit programId to use the member's selected Program, or pass an exact accessible Program id from this Plugin.",
-              "This app-only tool is bound to the exact immutable MCP App resource; the Program owns all downstream Connect capability calls.",
-            ].join(" "),
-            annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-            inputSchema: z.object({
-              programId: z.string().trim().min(1).max(160).optional(),
-              input: z.unknown().optional(),
-            }),
-            _meta: { ui: { resourceUri: revision.resourceUri, visibility: ["app"] } },
-          },
-          async ({ programId, input: programInput }) => runProgram({
-            appConfigObjectId: app.app.configObjectId,
-            pluginId: app.app.pluginId,
-            ...(programId ? { programId } : {}),
-            ...(programInput === undefined ? {} : { input: programInput }),
-          }),
-        )
-      }
       registerAppResource(
         input.server,
         `Remote MCP App ${app.app.configObjectId} ${revision.versionId}`,
@@ -132,9 +148,10 @@ export function registerAgentRemoteMcpApps(input: {
             revisionId: app.versionId,
             resourceDigest: app.payload.resource.digest,
           },
-          ...(input.runProgram ? {
-            serverTools: { runProgram: remoteMcpAppRunProgramToolName(app.app.configObjectId, app.versionId) },
-          } : {}),
+          serverTools: {
+            searchCapabilities: SEARCH_CAPABILITIES_TOOL_NAME,
+            executeCapability: EXECUTE_CAPABILITY_TOOL_NAME,
+          },
           ...(launchInput === undefined ? {} : { input: launchInput }),
         }
         return {

--- a/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
+++ b/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
@@ -23,8 +23,8 @@ export function remoteMcpAppLaunchToolName(configObjectId: string) {
   return `launch_remote_app_${stableSuffix(configObjectId)}`
 }
 
-export function remoteMcpAppRunProgramToolName(configObjectId: string) {
-  return `run_program_${stableSuffix(configObjectId)}`
+export function remoteMcpAppRunProgramToolName(configObjectId: string, versionId: string) {
+  return `run_program_${stableSuffix(`${configObjectId}:${versionId}`)}`
 }
 
 function resourceMeta(revision: Pick<ActiveRemoteMcpApp, "payload">): { ui: McpUiResourceMeta; resourceDigest: string } {
@@ -55,35 +55,34 @@ export function registerAgentRemoteMcpApps(input: {
   const runProgram = input.runProgram
   for (const app of input.apps) {
     const metadata = app.payload.metadata
-    const runProgramToolName = remoteMcpAppRunProgramToolName(app.app.configObjectId)
-    if (runProgram) {
-      registerAppTool(
-        input.server,
-        runProgramToolName,
-        {
-          title: `Run ${metadata.name} Program`,
-          description: [
-            `Run a Code Mode Program inside the ${metadata.name} Plugin through OpenWork Connect.`,
-            "Omit programId to use the member's selected Program, or pass an exact accessible Program id from this Plugin.",
-            "This app-only tool stays on the same MCP server as the imported UI resource; the Program owns all downstream Connect capability calls.",
-          ].join(" "),
-          annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-          inputSchema: z.object({
-            programId: z.string().trim().min(1).max(160).optional(),
-            input: z.unknown().optional(),
-          }),
-          _meta: { ui: { visibility: ["app"] } },
-        },
-        async ({ programId, input: programInput }) => runProgram({
-          appConfigObjectId: app.app.configObjectId,
-          pluginId: app.app.pluginId,
-          ...(programId ? { programId } : {}),
-          ...(programInput === undefined ? {} : { input: programInput }),
-        }),
-      )
-    }
     for (const revision of app.revisions) {
       const metadata = resourceMeta(revision)
+      if (runProgram) {
+        registerAppTool(
+          input.server,
+          remoteMcpAppRunProgramToolName(app.app.configObjectId, revision.versionId),
+          {
+            title: `Run ${app.payload.metadata.name} Program`,
+            description: [
+              `Run a Code Mode Program inside the ${app.payload.metadata.name} Plugin through OpenWork Connect.`,
+              "Omit programId to use the member's selected Program, or pass an exact accessible Program id from this Plugin.",
+              "This app-only tool is bound to the exact immutable MCP App resource; the Program owns all downstream Connect capability calls.",
+            ].join(" "),
+            annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+            inputSchema: z.object({
+              programId: z.string().trim().min(1).max(160).optional(),
+              input: z.unknown().optional(),
+            }),
+            _meta: { ui: { resourceUri: revision.resourceUri, visibility: ["app"] } },
+          },
+          async ({ programId, input: programInput }) => runProgram({
+            appConfigObjectId: app.app.configObjectId,
+            pluginId: app.app.pluginId,
+            ...(programId ? { programId } : {}),
+            ...(programInput === undefined ? {} : { input: programInput }),
+          }),
+        )
+      }
       registerAppResource(
         input.server,
         `Remote MCP App ${app.app.configObjectId} ${revision.versionId}`,
@@ -134,7 +133,7 @@ export function registerAgentRemoteMcpApps(input: {
             resourceDigest: app.payload.resource.digest,
           },
           ...(input.runProgram ? {
-            serverTools: { runProgram: runProgramToolName },
+            serverTools: { runProgram: remoteMcpAppRunProgramToolName(app.app.configObjectId, app.versionId) },
           } : {}),
           ...(launchInput === undefined ? {} : { input: launchInput }),
         }

--- a/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
+++ b/ee/apps/den-api/src/mcp/remote-mcp-apps.ts
@@ -23,6 +23,10 @@ export function remoteMcpAppLaunchToolName(configObjectId: string) {
   return `launch_remote_app_${stableSuffix(configObjectId)}`
 }
 
+export function remoteMcpAppRunProgramToolName(configObjectId: string) {
+  return `run_program_${stableSuffix(configObjectId)}`
+}
+
 function resourceMeta(revision: Pick<ActiveRemoteMcpApp, "payload">): { ui: McpUiResourceMeta; resourceDigest: string } {
   return {
     ui: { csp: revision.payload.resource.csp, prefersBorder: true },
@@ -37,9 +41,47 @@ export function registerAgentRemoteMcpApps(input: {
     html: string
     payload: ActiveRemoteMcpApp["payload"]
   }>
+  runProgram?: (request: {
+    appConfigObjectId: string
+    pluginId: string
+    programId?: string
+    input?: unknown
+  }) => Promise<{
+    content: Array<{ type: "text"; text: string }>
+    structuredContent?: Record<string, unknown>
+    isError?: boolean
+  }>
 }) {
+  const runProgram = input.runProgram
   for (const app of input.apps) {
     const metadata = app.payload.metadata
+    const runProgramToolName = remoteMcpAppRunProgramToolName(app.app.configObjectId)
+    if (runProgram) {
+      registerAppTool(
+        input.server,
+        runProgramToolName,
+        {
+          title: `Run ${metadata.name} Program`,
+          description: [
+            `Run a Code Mode Program inside the ${metadata.name} Plugin through OpenWork Connect.`,
+            "Omit programId to use the member's selected Program, or pass an exact accessible Program id from this Plugin.",
+            "This app-only tool stays on the same MCP server as the imported UI resource; the Program owns all downstream Connect capability calls.",
+          ].join(" "),
+          annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+          inputSchema: z.object({
+            programId: z.string().trim().min(1).max(160).optional(),
+            input: z.unknown().optional(),
+          }),
+          _meta: { ui: { visibility: ["app"] } },
+        },
+        async ({ programId, input: programInput }) => runProgram({
+          appConfigObjectId: app.app.configObjectId,
+          pluginId: app.app.pluginId,
+          ...(programId ? { programId } : {}),
+          ...(programInput === undefined ? {} : { input: programInput }),
+        }),
+      )
+    }
     for (const revision of app.revisions) {
       const metadata = resourceMeta(revision)
       registerAppResource(
@@ -91,6 +133,9 @@ export function registerAgentRemoteMcpApps(input: {
             revisionId: app.versionId,
             resourceDigest: app.payload.resource.digest,
           },
+          ...(input.runProgram ? {
+            serverTools: { runProgram: runProgramToolName },
+          } : {}),
           ...(launchInput === undefined ? {} : { input: launchInput }),
         }
         return {

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -17,6 +17,7 @@ import { getJsonRequestBodySchema, getParameters, hasJsonRequestBody, pathParame
  */
 
 export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
+export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
 export type SearchCapabilityType = "all" | "api" | "admin" | "mcp" | "marketplace" | "skills"
 
 export type CapabilityMatch = {

--- a/ee/apps/den-api/src/remote-mcp-apps.ts
+++ b/ee/apps/den-api/src/remote-mcp-apps.ts
@@ -13,7 +13,6 @@ import {
   createConfigObjectVersion,
   createPlugin,
   syncPluginMcpRequirementAccessForResource,
-  updatePlugin,
 } from "./routes/org/plugin-system/store.js"
 import {
   requirePluginArchResourceRole,
@@ -193,15 +192,15 @@ export function inspectRemoteMcpAppHtml(html: string) {
   }
 }
 
-function validateSourceUrl(rawUrl: string) {
+export function validateRemoteMcpAppSourceUrl(rawUrl: string, allowInsecureHttp = false) {
   let url: URL
   try {
     url = new URL(rawUrl)
   } catch {
-    throw new RemoteMcpAppError(400, "invalid_source_url", "Enter a valid HTTP or HTTPS URL.")
+    throw new RemoteMcpAppError(400, "invalid_source_url", "Enter a valid HTTPS URL.")
   }
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new RemoteMcpAppError(400, "invalid_source_url", "Remote MCP App URLs must use HTTP or HTTPS.")
+  if (url.protocol !== "https:" && !(allowInsecureHttp && url.protocol === "http:")) {
+    throw new RemoteMcpAppError(400, "invalid_source_url", "Remote MCP App URLs must use HTTPS.")
   }
   if (url.hash) throw new RemoteMcpAppError(400, "invalid_source_url", "Remote MCP App URLs must not contain a fragment.")
   if (url.username || url.password) {
@@ -218,6 +217,25 @@ function validateSourceUrl(rawUrl: string) {
     }
   }
   return url.toString()
+}
+
+export function validateRemoteMcpAppContentType(contentType: string | null) {
+  if (!contentType) {
+    throw new RemoteMcpAppError(422, "invalid_content_type", "Remote MCP Apps must be served as text/html or application/xhtml+xml.")
+  }
+  const [rawMimeType, ...parameters] = contentType.split(";")
+  const mimeType = rawMimeType?.trim().toLowerCase()
+  if (mimeType !== "text/html" && mimeType !== "application/xhtml+xml") {
+    throw new RemoteMcpAppError(422, "invalid_content_type", "Remote MCP Apps must be served as text/html or application/xhtml+xml.")
+  }
+  for (const parameter of parameters) {
+    const match = parameter.trim().match(/^charset\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s]+))$/i)
+    const charset = (match?.[1] ?? match?.[2] ?? match?.[3])?.toLowerCase()
+    if (charset && charset !== "utf-8" && charset !== "utf8") {
+      throw new RemoteMcpAppError(422, "invalid_encoding", "Remote MCP Apps must be UTF-8 HTML.")
+    }
+  }
+  return mimeType
 }
 
 async function boundedResponseText(response: Response) {
@@ -251,15 +269,17 @@ async function boundedResponseText(response: Response) {
     offset += chunk.byteLength
   }
   try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    // Preserve a leading UTF-8 BOM as U+FEFF so encoding the stored string
+    // reproduces the exact downloaded bytes and therefore the stored digest.
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes)
   } catch {
     throw new RemoteMcpAppError(422, "invalid_encoding", "Remote MCP Apps must be UTF-8 HTML.")
   }
 }
 
 export async function fetchRemoteMcpApp(sourceUrl: string) {
-  const normalizedUrl = validateSourceUrl(sourceUrl)
   const { env } = await import("./env.js")
+  const normalizedUrl = validateRemoteMcpAppSourceUrl(sourceUrl, env.allowPrivateMcpUrls)
   const guardedFetch = env.allowPrivateMcpUrls ? createRealmSafeFetch() : createGuardedFetch()
   let response: Response
   try {
@@ -275,15 +295,22 @@ export async function fetchRemoteMcpApp(sourceUrl: string) {
     await response.body?.cancel()
     throw new RemoteMcpAppError(502, "source_fetch_failed", `The app URL returned HTTP ${response.status}.`)
   }
+  const contentType = response.headers.get("content-type")
+  try {
+    validateRemoteMcpAppContentType(contentType)
+  } catch (error) {
+    await response.body?.cancel()
+    throw error
+  }
   const html = await boundedResponseText(response)
   const inspected = inspectRemoteMcpAppHtml(html)
-  const resolvedSourceUrl = validateSourceUrl(response.url || normalizedUrl)
+  const resolvedSourceUrl = validateRemoteMcpAppSourceUrl(response.url || normalizedUrl, env.allowPrivateMcpUrls)
   return {
     ...inspected,
     html,
     sourceUrl: normalizedUrl,
     resolvedSourceUrl,
-    contentType: response.headers.get("content-type"),
+    contentType,
     fetchedAt: new Date().toISOString(),
   }
 }
@@ -402,20 +429,42 @@ export async function previewRemoteMcpApp(sourceUrl: string) {
 
 export async function importRemoteMcpApp(input: {
   context: PluginArchActorContext
+  pluginId?: string
   sourceUrl: string
   activate?: boolean
+  requireFreshSession?: boolean
 }) {
+  let pluginId: DenTypeId<"plugin"> | null = null
+  if (input.pluginId) {
+    try {
+      pluginId = normalizeDenTypeId("plugin", input.pluginId)
+    } catch {
+      throw new RemoteMcpAppError(404, "plugin_not_found", "Plugin not found.")
+    }
+    // Reject an unavailable target before performing any outbound download.
+    await requirePluginArchResourceRole({
+      context: input.context,
+      requireFreshSession: input.requireFreshSession,
+      resourceId: pluginId,
+      resourceKind: "plugin",
+      role: "editor",
+    })
+  }
   const fetched = await fetchRemoteMcpApp(input.sourceUrl)
-  const plugin = await createPlugin({
-    context: input.context,
-    name: fetched.metadata.name,
-    description: fetched.metadata.description,
-    sourceRepositoryUrl: fetched.sourceUrl.length <= 1024 ? fetched.sourceUrl : null,
-  })
+  if (!pluginId) {
+    const plugin = await createPlugin({
+      context: input.context,
+      name: fetched.metadata.name,
+      description: fetched.metadata.description,
+      sourceRepositoryUrl: fetched.sourceUrl.length <= 1024 ? fetched.sourceUrl : null,
+    })
+    pluginId = normalizeDenTypeId("plugin", plugin.id)
+  }
   const configObject = await createConfigObject({
     context: input.context,
     objectType: "app",
-    pluginIds: [normalizeDenTypeId("plugin", plugin.id)],
+    pluginIds: [pluginId],
+    requireFreshSession: input.requireFreshSession,
     sourceMode: "import",
     value: {
       normalizedPayloadJson: payloadForFetchedApp(fetched) as unknown as Record<string, unknown>,
@@ -429,7 +478,7 @@ export async function importRemoteMcpApp(input: {
   const app: RemoteMcpAppRow = {
     configObjectId: normalizeDenTypeId("configObject", configObject.id),
     organizationId: input.context.organizationContext.organization.id,
-    pluginId: normalizeDenTypeId("plugin", plugin.id),
+    pluginId,
     activeVersionId: input.activate === false ? null : normalizeDenTypeId("configObjectVersion", versionId),
     sourceUrl: fetched.sourceUrl,
     resolvedSourceUrl: fetched.resolvedSourceUrl,
@@ -512,12 +561,6 @@ export async function activateRemoteMcpAppRevision(input: {
   const updatedAt = new Date()
   await db.update(RemoteMcpAppTable).set({ activeVersionId: versionId, status: "active", retiredAt: null, updatedAt })
     .where(eq(RemoteMcpAppTable.configObjectId, app.configObjectId))
-  await updatePlugin({
-    context: input.context,
-    pluginId: app.pluginId,
-    name: payload.metadata.name,
-    description: payload.metadata.description ?? null,
-  })
   return serializeApp({ ...app, activeVersionId: versionId, status: "active", retiredAt: null, updatedAt }, "editor")
 }
 

--- a/ee/apps/den-api/src/routes/org/codemode-scripts.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-scripts.ts
@@ -65,7 +65,7 @@ const saveSchema = z.object({
   code: z.string().min(1).max(200_000),
   currentInput: z.unknown().optional(),
   inputSchema: z.unknown().optional(),
-  outputSchema: z.unknown().optional().describe("JSON Schema for the returned value. Include this when the Script will back a custom Artifact view."),
+  outputSchema: z.unknown().optional().describe("Optional JSON Schema for the value returned by this Program."),
 })
 const savedSchema = z.object({ pluginId: z.string(), configObjectId: z.string(), configObjectVersionId: z.string() })
 const runParamsSchema = z.object({ configObjectId: z.string().min(1).max(160) })
@@ -98,7 +98,7 @@ const draftSchema = z.object({
   code: z.string().min(1).max(200_000),
   exampleInput: z.unknown().optional(),
   inputSchema: z.unknown().optional(),
-  outputSchema: z.unknown().optional().describe("Explicit JSON Schema for the returned value. It must be present before this Script can back a custom Artifact view."),
+  outputSchema: z.unknown().optional().describe("Optional JSON Schema for the value returned by this Program."),
   requiredCapabilities: z.array(savedScriptCapabilitySchema).max(100),
 })
 const testSchema = draftSchema.extend({ configObjectId: z.string().min(1).max(160) })
@@ -188,6 +188,7 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
       member,
       redirectUriBase: env.apiPublicUrl ?? "http://127.0.0.1",
       codemodeEnabled,
+      generatedArtifactViewsEnabled: env.generatedArtifactViewsEnabled,
       organizationMetadata: context.organization.metadata,
       mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
     })
@@ -283,7 +284,14 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
       try {
         const { actorContext, codemodeEnabled } = await contextFor(c)
         if (!codemodeEnabled) return c.json({ error: "program_not_found" }, 404)
-        return c.json(await getProgramDetail({ context: actorContext, configObjectId: params.data.configObjectId }))
+        const detail = await getProgramDetail({ context: actorContext, configObjectId: params.data.configObjectId })
+        return c.json(env.generatedArtifactViewsEnabled
+          ? detail
+          : {
+              ...detail,
+              program: { ...detail.program, viewState: "default" as const, activeViewTitle: null },
+              views: [],
+            })
       } catch (error) {
         const failure = routeFailure(error)
         return c.json(failure.body, failure.status)
@@ -303,7 +311,7 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
       if (!params.success) return c.json({ error: "invalid_request", message: "Invalid Program id." }, 400)
       try {
         const { actorContext, codemodeEnabled } = await contextFor(c)
-        if (!codemodeEnabled) return c.json({ items: [] })
+        if (!codemodeEnabled || !env.generatedArtifactViewsEnabled) return c.json({ items: [] })
         return c.json({ items: await listArtifactViewsForScript({ context: actorContext, configObjectId: params.data.configObjectId }) })
       } catch (error) {
         const failure = routeFailure(error)
@@ -320,6 +328,7 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
     }),
     orgMemberRoute(),
     async (c) => {
+      if (!env.generatedArtifactViewsEnabled) return c.json({ error: "artifact_view_not_found" }, 404)
       const params = artifactViewParamsSchema.safeParse(c.req.param())
       if (!params.success || !params.data.revisionId) return c.json({ error: "invalid_request", message: "Invalid view revision." }, 400)
       try {
@@ -341,6 +350,7 @@ export function registerOrgCodemodeScriptRoutes<T extends { Variables: OrgRouteV
     }),
     orgMemberRoute(),
     async (c) => {
+      if (!env.generatedArtifactViewsEnabled) return c.json({ error: "artifact_view_not_found" }, 404)
       const params = artifactViewParamsSchema.safeParse(c.req.param())
       if (!params.success) return c.json({ error: "invalid_request", message: "Invalid view." }, 400)
       try {

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1259,12 +1259,22 @@ async function ensureVisibleConfigObject(context: PluginArchActorContext, config
   return row
 }
 
-async function ensureEditablePlugin(context: PluginArchActorContext, pluginId: PluginId) {
+async function ensureEditablePlugin(
+  context: PluginArchActorContext,
+  pluginId: PluginId,
+  requireFreshSession?: boolean,
+) {
   const row = await getPluginRow(context.organizationContext.organization.id, pluginId)
   if (!row) {
     throw new PluginArchRouteFailure(404, "plugin_not_found", "Plugin not found.")
   }
-  await requirePluginArchResourceRole({ context, resourceId: row.id, resourceKind: "plugin", role: "editor" })
+  await requirePluginArchResourceRole({
+    context,
+    requireFreshSession,
+    resourceId: row.id,
+    resourceKind: "plugin",
+    role: "editor",
+  })
   return row
 }
 
@@ -1607,6 +1617,7 @@ export async function createConfigObject(input: {
   context: PluginArchActorContext
   objectType: ConfigObjectRow["objectType"]
   pluginIds?: PluginId[]
+  requireFreshSession?: boolean
   sourceMode: ConfigObjectRow["sourceMode"]
   value: ConfigObjectInput
 }) {
@@ -1615,7 +1626,7 @@ export async function createConfigObject(input: {
   }
 
   for (const pluginId of input.pluginIds ?? []) {
-    await ensureEditablePlugin(input.context, pluginId)
+    await ensureEditablePlugin(input.context, pluginId, input.requireFreshSession)
   }
 
   const now = new Date()

--- a/ee/apps/den-api/src/routes/org/remote-mcp-apps.ts
+++ b/ee/apps/den-api/src/routes/org/remote-mcp-apps.ts
@@ -21,7 +21,8 @@ import type { OrgRouteVariables } from "./shared.js"
 const sourceSchema = z.object({ sourceUrl: z.string().trim().url().max(2048) })
 const importSchema = sourceSchema.extend({
   activate: z.boolean().optional().default(true),
-})
+  pluginId: z.string().trim().min(1).max(160).optional(),
+}).strict()
 const refreshSchema = z.object({
   sourceUrl: z.string().trim().url().max(2048).optional(),
 })

--- a/ee/apps/den-api/test/agent-codemode-script.test.ts
+++ b/ee/apps/den-api/test/agent-codemode-script.test.ts
@@ -148,9 +148,12 @@ afterAll(() => {
 test("does not register execute_capability_script when the org flag is off", async () => {
   const tools = listedToolNames(await rpc(buildApp(), "tools/list"))
   expect(tools).not.toContain("execute_capability_script")
+  expect(tools).not.toContain("save_artifact_view")
+  expect(tools).not.toContain("activate_artifact_view_revision")
+  expect(tools).not.toContain("retire_artifact_view")
 })
 
-test("registers execute_capability_script when the org flag is on", async () => {
+test("registers Code Mode without enabling agent-authored MCP App views", async () => {
   organizationMetadata = { capabilities: { codemodeScripts: true } }
   const tools = listedTools(await rpc(buildApp(), "tools/list"))
   const names = tools.flatMap((tool) => typeof tool.name === "string" ? [tool.name] : [])
@@ -159,6 +162,9 @@ test("registers execute_capability_script when the org flag is on", async () => 
   expect(names).toContain("search_programs")
   expect(names).toContain("select_program")
   expect(names).toContain("clear_program_selection")
+  expect(names).not.toContain("save_artifact_view")
+  expect(names).not.toContain("activate_artifact_view_revision")
+  expect(names).not.toContain("retire_artifact_view")
   expect(isRecord(tools.find((tool) => tool.name === "search_programs")?.outputSchema)).toBe(true)
   expect(isRecord(tools.find((tool) => tool.name === "select_program")?.outputSchema)).toBe(true)
   expect(isRecord(tools.find((tool) => tool.name === "clear_program_selection")?.outputSchema)).toBe(true)

--- a/ee/apps/den-api/test/agent-codemode-script.test.ts
+++ b/ee/apps/den-api/test/agent-codemode-script.test.ts
@@ -170,6 +170,26 @@ test("registers Code Mode without enabling agent-authored MCP App views", async 
   expect(isRecord(tools.find((tool) => tool.name === "clear_program_selection")?.outputSchema)).toBe(true)
 })
 
+test("rejects guessed generated-view tool calls while keeping Programs enabled", async () => {
+  organizationMetadata = { capabilities: { codemodeScripts: true } }
+  for (const name of ["save_artifact_view", "activate_artifact_view_revision", "retire_artifact_view"]) {
+    const payload = await rpc(buildApp(), "tools/call", { name, arguments: {} })
+    expect(resultRecord(payload).isError).toBe(true)
+    expect(JSON.stringify(payload)).toContain("not found")
+  }
+})
+
+test("advertises external-only MCP App authoring instructions", async () => {
+  const initialized = resultRecord(await rpc(buildApp(), "initialize", {
+    protocolVersion: "2025-11-25",
+    capabilities: {},
+    clientInfo: { name: "agent-codemode-test", version: "1.0.0" },
+  }))
+  expect(initialized.instructions).toContain("authored and bundled outside OpenWork")
+  expect(initialized.instructions).toContain("never send inline HTML")
+  expect(initialized.instructions).not.toContain("Compile React source")
+})
+
 test("executes a confined script when the org flag is on", async () => {
   organizationMetadata = { capabilities: { codemodeScripts: true } }
   const payload = await rpc(buildApp(), "tools/call", {

--- a/ee/apps/den-api/test/capability-parity.test.ts
+++ b/ee/apps/den-api/test/capability-parity.test.ts
@@ -23,6 +23,8 @@ function seedRequiredEnv() {
 }
 
 let CAPABILITY_SOURCE_KINDS: typeof import("../src/mcp/capability-registry.js")["CAPABILITY_SOURCE_KINDS"]
+let catalogOperationAvailableToCapabilities: typeof import("../src/mcp/capability-registry.js")["catalogOperationAvailableToCapabilities"]
+let catalogOperationChangesRemoteMcpAppDiscovery: typeof import("../src/mcp/capability-registry.js")["catalogOperationChangesRemoteMcpAppDiscovery"]
 let createCapabilityRegistry: typeof import("../src/mcp/capability-registry.js")["createCapabilityRegistry"]
 let codemodeScriptPath: typeof import("../src/mcp/codemode-namespaces.js")["codemodeScriptPath"]
 
@@ -30,6 +32,8 @@ beforeAll(async () => {
   seedRequiredEnv()
   const capabilityRegistry = await import("../src/mcp/capability-registry.js")
   CAPABILITY_SOURCE_KINDS = capabilityRegistry.CAPABILITY_SOURCE_KINDS
+  catalogOperationAvailableToCapabilities = capabilityRegistry.catalogOperationAvailableToCapabilities
+  catalogOperationChangesRemoteMcpAppDiscovery = capabilityRegistry.catalogOperationChangesRemoteMcpAppDiscovery
   createCapabilityRegistry = capabilityRegistry.createCapabilityRegistry
   codemodeScriptPath = (await import("../src/mcp/codemode-namespaces.js")).codemodeScriptPath
 })
@@ -143,6 +147,7 @@ function fixtureContext(platformAdmin: boolean): CapabilityRegistryContext {
     member: { orgMembershipId: memberId, teamIds: [] },
     redirectUriBase: "http://127.0.0.1:8790",
     codemodeEnabled: true,
+    generatedArtifactViewsEnabled: false,
     externalMcpConnectionsEnabled: true,
     resolvePlatformAdmin: () => {
       platformAdminResolution ??= Promise.resolve(platformAdmin)
@@ -209,4 +214,23 @@ test("a non-admin member has zero admin capabilities in search, execute, and the
 
   const executed = await result.registry.execute(result.context, { name: FIXTURES.admin.capabilityName })
   expect(firstText(executed)).toContain("unknown_capability")
+})
+
+test("keeps installation and disabled generated-view operations out of every generic capability consumer", () => {
+  const disabled = { generatedArtifactViewsEnabled: false }
+  expect(catalogOperationAvailableToCapabilities(disabled, { method: "POST", path: "/v1/remote-mcp-apps" })).toBe(false)
+  expect(catalogOperationAvailableToCapabilities(disabled, { method: "POST", path: "/v1/artifact-views/{artifactViewId}/retire" })).toBe(false)
+  expect(catalogOperationAvailableToCapabilities(disabled, { method: "GET", path: "/v1/programs/{configObjectId}/views" })).toBe(false)
+  expect(catalogOperationAvailableToCapabilities(disabled, { method: "GET", path: "/v1/programs/{configObjectId}" })).toBe(true)
+  expect(catalogOperationAvailableToCapabilities({ generatedArtifactViewsEnabled: true }, {
+    method: "POST",
+    path: "/v1/artifact-views/{artifactViewId}/retire",
+  })).toBe(true)
+})
+
+test("identifies only discovery-changing remote App lifecycle operations", () => {
+  expect(catalogOperationChangesRemoteMcpAppDiscovery({ method: "POST", path: "/v1/remote-mcp-apps/{appId}/refresh" })).toBe(true)
+  expect(catalogOperationChangesRemoteMcpAppDiscovery({ method: "POST", path: "/v1/remote-mcp-apps/{appId}/activate" })).toBe(true)
+  expect(catalogOperationChangesRemoteMcpAppDiscovery({ method: "POST", path: "/v1/remote-mcp-apps/{appId}/lifecycle" })).toBe(true)
+  expect(catalogOperationChangesRemoteMcpAppDiscovery({ method: "GET", path: "/v1/remote-mcp-apps/{appId}" })).toBe(false)
 })

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -1,0 +1,250 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { expect, test } from "bun:test"
+
+process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
+process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:3005"
+process.env.OPENWORK_DEV_MODE ??= "1"
+process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
+
+const {
+  createExternalConnectionProxyServer,
+  handleExternalConnectionProxyRequest,
+} = await import("../src/mcp/external-connection-proxy.js")
+const {
+  externalMcpConnectionReadyForMember,
+  readyExternalMcpConnectionsForMember,
+} = await import("../src/capability-sources/external-mcp-connections.js")
+const { ExternalMcpDiagnosticError } = await import("../src/capability-sources/external-mcp-diagnostics.js")
+const { buildConnectMcpServerIndex } = await import("../src/mcp/connect-mcp-server-index.js")
+
+const resourceUri = "ui://fixture/healthy.html"
+const html = "<!doctype html><html><body>Healthy native MCP App</body></html>"
+const connection = {
+  id: "emc_01k28e8q8pf8r9sff9mhyqxved",
+  organizationId: "org_01k28e8q8pf8r9sff9mhyqxved",
+  name: "Fixture MCP",
+  authType: "none",
+  credentialMode: "shared",
+  kind: "external_mcp",
+  toolPolicy: null,
+  oauthIssuerReviewRequiredAt: null,
+} as never
+const operation = {
+  connection,
+  redirectUri: "https://openwork.example/v1/mcp-connections/fixture/connect/callback",
+  member: { orgMembershipId: "mem_01k28e8q8pf8r9sff9mhyqxved" },
+  diagnosticReferenceId: "req_proxy_fixture",
+} as never
+
+function runtime(overrides: Record<string, unknown> = {}) {
+  return {
+    listTools: async () => [{
+      name: "open_fixture",
+      description: "Open the fixture App.",
+      inputSchema: { type: "object" },
+      annotations: { readOnlyHint: true, destructiveHint: false },
+      _meta: { ui: { resourceUri, visibility: ["model", "app"] } },
+    }],
+    callTool: async () => ({
+      content: [{ type: "text" as const, text: "Healthy fixture opened." }],
+      structuredContent: { status: "healthy" },
+    }),
+    listResources: async () => [{ uri: resourceUri, name: "Healthy fixture", mimeType: "text/html;profile=mcp-app" }],
+    listResourceTemplates: async () => [],
+    readResource: async () => ({
+      contents: [{ uri: resourceUri, mimeType: "text/html;profile=mcp-app", text: html }],
+    }),
+    ...overrides,
+  } as never
+}
+
+function requestContext(request: Request) {
+  return { req: { method: request.method, raw: request } } as never
+}
+
+async function withClient<T>(
+  capabilities: Record<string, unknown>,
+  run: (client: Client) => Promise<T>,
+  runtimeOverrides: Record<string, unknown> = {},
+) {
+  const server = createExternalConnectionProxyServer({
+    descriptor: {
+      capabilities,
+      serverInfo: { name: "fixture", version: "1.0.0" },
+    } as never,
+    operation,
+    runtime: runtime(runtimeOverrides),
+  })
+  const client = new Client({ name: "proxy-test", version: "1.0.0" }, { capabilities: {} })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  try {
+    return await run(client)
+  } finally {
+    await client.close()
+    await server.close()
+  }
+}
+
+test("tool-only downstream servers initialize and never register resource handlers", async () => {
+  let resourceCalls = 0
+  await withClient({ tools: {} }, async (client) => {
+    const initialized = client.getServerCapabilities()
+    expect(initialized?.tools).toEqual({ listChanged: false })
+    expect(initialized?.resources).toBeUndefined()
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual(["open_fixture"])
+    const called = await client.callTool({ name: "open_fixture", arguments: {} })
+    expect(called.structuredContent).toEqual({ status: "healthy" })
+    expect(resourceCalls).toBe(0)
+  }, {
+    listResources: async () => { resourceCalls += 1; return [] },
+    listResourceTemplates: async () => { resourceCalls += 1; return [] },
+    readResource: async () => { resourceCalls += 1; return { contents: [] } },
+  })
+})
+
+test("a downstream server without resources initializes safely", async () => {
+  await withClient({}, async (client) => {
+    expect(client.getServerCapabilities()?.resources).toBeUndefined()
+    expect(client.getServerCapabilities()?.tools).toBeUndefined()
+  })
+})
+
+test("a healthy native MCP App preserves its resource and same-server app-visible tool", async () => {
+  await withClient({
+    tools: {},
+    resources: {},
+    extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+  }, async (client) => {
+    const tool = (await client.listTools()).tools[0]
+    expect(tool?._meta).toMatchObject({ ui: { resourceUri, visibility: ["model", "app"] } })
+    const resource = await client.readResource({ uri: resourceUri })
+    expect(resource.contents[0]).toMatchObject({ uri: resourceUri, text: html })
+    const called = await client.callTool({ name: "open_fixture", arguments: {} })
+    expect(called.structuredContent).toEqual({ status: "healthy" })
+  })
+})
+
+test("OAuth registration and network failures become sanitized protocol errors", async () => {
+  const oauthFailure = new ExternalMcpDiagnosticError({
+    referenceId: "req_oauth_registration",
+    phase: "AUTH_CLIENT_REGISTRATION",
+    category: "oauth_failure",
+    code: "MCP_OAUTH_REGISTRATION_REJECTED",
+    highestPassed: "reachable",
+    retryable: false,
+    actionOwner: "organization_admin",
+    message: "The provider rejected OAuth client registration.",
+    operatorAction: "Configure a provider-approved OAuth client, then reconnect the MCP connection.",
+  })
+  const oauthRequest = new Request("https://openwork.example/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 41, method: "initialize", params: {} }),
+  })
+  const oauthResponse = await handleExternalConnectionProxyRequest({
+    context: requestContext(oauthRequest),
+    operation,
+    dependencies: { describe: async () => { throw oauthFailure } },
+  })
+  expect(oauthResponse.status).toBe(200)
+  const oauthPayload = await oauthResponse.json() as Record<string, unknown>
+  expect(oauthPayload.id).toBe(41)
+  expect(oauthPayload).toMatchObject({
+    error: {
+      code: -32603,
+      data: {
+        referenceId: "req_oauth_registration",
+        diagnosticCode: "MCP_OAUTH_REGISTRATION_REJECTED",
+        actionOwner: "organization_admin",
+      },
+    },
+  })
+  const serializedOauth = JSON.stringify(oauthPayload)
+  expect(serializedOauth).toContain("provider-approved OAuth client")
+  expect(serializedOauth).not.toContain("stack")
+  expect(serializedOauth).not.toContain("providerResponse")
+
+  const networkRequest = new Request("https://openwork.example/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: "network", method: "initialize", params: {} }),
+  })
+  const networkResponse = await handleExternalConnectionProxyRequest({
+    context: requestContext(networkRequest),
+    operation: { ...operation, diagnosticReferenceId: "req_network" },
+    dependencies: {
+      describe: async () => ({ capabilities: {}, serverInfo: { name: "fixture", version: "1.0.0" } }) as never,
+      serve: async () => { throw new Error("connect ECONNREFUSED token=do-not-expose") },
+    },
+  })
+  expect(networkResponse.status).toBe(200)
+  const networkPayload = await networkResponse.json() as Record<string, unknown>
+  expect(networkPayload.id).toBe("network")
+  expect(JSON.stringify(networkPayload)).not.toContain("do-not-expose")
+  expect(JSON.stringify(networkPayload)).not.toContain("ECONNREFUSED")
+})
+
+test("unsupported GET requests never trigger downstream discovery", async () => {
+  let discoveryCalls = 0
+  const request = new Request("https://openwork.example/mcp", { method: "GET" })
+  const response = await handleExternalConnectionProxyRequest({
+    context: requestContext(request),
+    operation,
+    dependencies: {
+      describe: async () => {
+        discoveryCalls += 1
+        throw new Error("unexpected discovery")
+      },
+    },
+  })
+  expect(response.status).toBe(405)
+  expect(response.headers.get("allow")).toBe("POST")
+  expect(discoveryCalls).toBe(0)
+})
+
+test("disconnected and issuer-blocked OAuth connections are not ready for the native server index", async () => {
+  const memberId = "mem_01k28e8q8pf8r9sff9mhyqxved" as never
+  const base = {
+    ...connection,
+    authType: "oauth",
+    credentialMode: "shared",
+    accessToken: null,
+  } as never
+  expect(await externalMcpConnectionReadyForMember(base, memberId)).toBe(false)
+  expect(await externalMcpConnectionReadyForMember({ ...base, accessToken: "shared-token" } as never, memberId)).toBe(true)
+  expect(await externalMcpConnectionReadyForMember({
+    ...base,
+    authType: "apikey",
+    accessToken: null,
+    apiKey: null,
+  } as never, memberId)).toBe(false)
+  expect(await externalMcpConnectionReadyForMember({
+    ...base,
+    authType: "apikey",
+    accessToken: null,
+    apiKey: "shared-api-key",
+  } as never, memberId)).toBe(true)
+  expect(await externalMcpConnectionReadyForMember({
+    ...base,
+    accessToken: "shared-token",
+    oauthIssuerReviewRequiredAt: new Date(),
+  } as never, memberId)).toBe(false)
+  expect(await externalMcpConnectionReadyForMember({ ...base, credentialMode: "per_member" } as never, memberId, async () => ({
+    current: true,
+    value: null,
+  }) as never)).toBe(false)
+  expect(await externalMcpConnectionReadyForMember({ ...base, credentialMode: "per_member" } as never, memberId, async () => ({
+    current: true,
+    value: { accessToken: "member-token" },
+  }) as never)).toBe(true)
+
+  const ready = await readyExternalMcpConnectionsForMember([base], memberId)
+  expect(buildConnectMcpServerIndex({
+    connections: ready,
+    publicOrigin: "https://openwork.example",
+  }).servers).toEqual([])
+})

--- a/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
+++ b/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { ResourceListChangedNotificationSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { expect, test } from "bun:test"
 import { dynamicArtifactAppServerCapabilities } from "../src/mcp/dynamic-artifact-app.js"
 
@@ -12,9 +13,9 @@ process.env.OPENWORK_DEV_MODE ??= "1"
 process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 
 const {
+  IMPORT_REMOTE_MCP_APP_TOOL_NAME,
   registerAgentRemoteMcpApps,
   remoteMcpAppLaunchToolName,
-  remoteMcpAppRunProgramToolName,
 } = await import("../src/mcp/remote-mcp-apps.js")
 const { remoteMcpAppResourceUri } = await import("../src/remote-mcp-apps.js")
 
@@ -71,7 +72,9 @@ const activeApp = {
 
 async function withClient<T>(
   run: (client: Client) => Promise<T>,
-  options: { withProgramTool?: boolean } = {},
+  options: {
+    importApp?: (request: { activate: boolean; pluginId: string; sourceUrl: string }) => Promise<Record<string, unknown>>
+  } = {},
 ) {
   const server = new McpServer(
     { name: "remote-mcp-app-test", version: "1.0.0" },
@@ -81,18 +84,7 @@ async function withClient<T>(
     server,
     apps: [activeApp as never],
     loadResource: async () => ({ html, payload: activePayload as never }),
-    ...(options.withProgramTool ? {
-      runProgram: async ({ appConfigObjectId, pluginId, programId, input }) => ({
-        content: [{ type: "text" as const, text: "Program completed." }],
-        structuredContent: {
-          status: "succeeded",
-          appConfigObjectId,
-          pluginId,
-          programId: programId ?? "selected-program",
-          value: input ?? null,
-        },
-      }),
-    } : {}),
+    ...(options.importApp ? { importApp: options.importApp } : {}),
   })
   const client = new Client({ name: "desktop-host", version: "1.0.0" }, { capabilities: {} })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -136,40 +128,60 @@ test("serves exact cached bytes and delivers launch data through structuredConte
     })
     expect(launch.structuredContent).toMatchObject({
       app: { id: configObjectId, revisionId: versionId, resourceDigest },
+      serverTools: {
+        searchCapabilities: "search_capabilities",
+        executeCapability: "execute_capability",
+      },
       input: { project: "alpha" },
     })
   })
 })
 
-test("lets an imported app run a Program through an app-only same-server tool", async () => {
+test("registers a strict model-only installer and emits standard list-change notifications", async () => {
+  const requests: Array<{ activate: boolean; pluginId: string; sourceUrl: string }> = []
   await withClient(async (client) => {
     const tools = await client.listTools()
-    const runProgramToolName = remoteMcpAppRunProgramToolName(configObjectId, versionId)
-    const runProgram = tools.tools.find((tool) => tool.name === runProgramToolName)
-    expect(runProgram?._meta).toMatchObject({
-      ui: { resourceUri, visibility: ["app"] },
-      "ui/resourceUri": resourceUri,
+    const installer = tools.tools.find((tool) => tool.name === IMPORT_REMOTE_MCP_APP_TOOL_NAME)
+    expect(installer).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+      _meta: { ui: { visibility: ["model"] } },
     })
+    expect(Object.keys((installer?.inputSchema as { properties?: Record<string, unknown> } | undefined)?.properties ?? {}))
+      .toEqual(["pluginId", "sourceUrl", "activate"])
 
-    const launch = await client.callTool({
-      name: remoteMcpAppLaunchToolName(configObjectId),
-      arguments: { input: { query: "migration" } },
+    const rejected = await client.callTool({
+      name: IMPORT_REMOTE_MCP_APP_TOOL_NAME,
+      arguments: {
+        pluginId,
+        sourceUrl: "https://apps.example/project-explorer.html",
+        inlineHtml: "<!doctype html><html></html>",
+      },
     })
-    expect(launch.structuredContent).toMatchObject({
-      serverTools: { runProgram: runProgramToolName },
-      input: { query: "migration" },
-    })
+    expect(rejected.isError).toBe(true)
+    expect(requests).toHaveLength(0)
 
-    const result = await client.callTool({
-      name: runProgramToolName,
-      arguments: { input: { query: "migration" } },
+    let toolsChanged = 0
+    let resourcesChanged = 0
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => { toolsChanged += 1 })
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => { resourcesChanged += 1 })
+    const imported = await client.callTool({
+      name: IMPORT_REMOTE_MCP_APP_TOOL_NAME,
+      arguments: { pluginId, sourceUrl: "https://apps.example/project-explorer.html" },
     })
-    expect(result.structuredContent).toEqual({
-      status: "succeeded",
-      appConfigObjectId: configObjectId,
+    expect(requests).toEqual([{
+      activate: true,
       pluginId,
-      programId: "selected-program",
-      value: { query: "migration" },
+      sourceUrl: "https://apps.example/project-explorer.html",
+    }])
+    expect(imported.structuredContent).toEqual({
+      app: { id: configObjectId, pluginId, activeVersionId: versionId },
     })
-  }, { withProgramTool: true })
+    expect(toolsChanged).toBeGreaterThan(0)
+    expect(resourcesChanged).toBeGreaterThan(0)
+  }, {
+    importApp: async (request) => {
+      requests.push(request)
+      return { id: configObjectId, pluginId, activeVersionId: versionId }
+    },
+  })
 })

--- a/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
+++ b/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
@@ -14,6 +14,7 @@ process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 const {
   registerAgentRemoteMcpApps,
   remoteMcpAppLaunchToolName,
+  remoteMcpAppRunProgramToolName,
 } = await import("../src/mcp/remote-mcp-apps.js")
 const { remoteMcpAppResourceUri } = await import("../src/remote-mcp-apps.js")
 
@@ -68,7 +69,10 @@ const activeApp = {
   }],
 }
 
-async function withClient<T>(run: (client: Client) => Promise<T>) {
+async function withClient<T>(
+  run: (client: Client) => Promise<T>,
+  options: { withProgramTool?: boolean } = {},
+) {
   const server = new McpServer(
     { name: "remote-mcp-app-test", version: "1.0.0" },
     { capabilities: dynamicArtifactAppServerCapabilities },
@@ -77,6 +81,18 @@ async function withClient<T>(run: (client: Client) => Promise<T>) {
     server,
     apps: [activeApp as never],
     loadResource: async () => ({ html, payload: activePayload as never }),
+    ...(options.withProgramTool ? {
+      runProgram: async ({ appConfigObjectId, pluginId, programId, input }) => ({
+        content: [{ type: "text" as const, text: "Program completed." }],
+        structuredContent: {
+          status: "succeeded",
+          appConfigObjectId,
+          pluginId,
+          programId: programId ?? "selected-program",
+          value: input ?? null,
+        },
+      }),
+    } : {}),
   })
   const client = new Client({ name: "desktop-host", version: "1.0.0" }, { capabilities: {} })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -123,4 +139,35 @@ test("serves exact cached bytes and delivers launch data through structuredConte
       input: { project: "alpha" },
     })
   })
+})
+
+test("lets an imported app run a Program through an app-only same-server tool", async () => {
+  await withClient(async (client) => {
+    const tools = await client.listTools()
+    const runProgramToolName = remoteMcpAppRunProgramToolName(configObjectId)
+    const runProgram = tools.tools.find((tool) => tool.name === runProgramToolName)
+    expect(runProgram?._meta).toEqual({ ui: { visibility: ["app"] } })
+    expect(runProgram?._meta).not.toHaveProperty("ui.resourceUri")
+
+    const launch = await client.callTool({
+      name: remoteMcpAppLaunchToolName(configObjectId),
+      arguments: { input: { query: "migration" } },
+    })
+    expect(launch.structuredContent).toMatchObject({
+      serverTools: { runProgram: runProgramToolName },
+      input: { query: "migration" },
+    })
+
+    const result = await client.callTool({
+      name: runProgramToolName,
+      arguments: { input: { query: "migration" } },
+    })
+    expect(result.structuredContent).toEqual({
+      status: "succeeded",
+      appConfigObjectId: configObjectId,
+      pluginId,
+      programId: "selected-program",
+      value: { query: "migration" },
+    })
+  }, { withProgramTool: true })
 })

--- a/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
+++ b/ee/apps/den-api/test/mcp-remote-mcp-apps.test.ts
@@ -144,10 +144,12 @@ test("serves exact cached bytes and delivers launch data through structuredConte
 test("lets an imported app run a Program through an app-only same-server tool", async () => {
   await withClient(async (client) => {
     const tools = await client.listTools()
-    const runProgramToolName = remoteMcpAppRunProgramToolName(configObjectId)
+    const runProgramToolName = remoteMcpAppRunProgramToolName(configObjectId, versionId)
     const runProgram = tools.tools.find((tool) => tool.name === runProgramToolName)
-    expect(runProgram?._meta).toEqual({ ui: { visibility: ["app"] } })
-    expect(runProgram?._meta).not.toHaveProperty("ui.resourceUri")
+    expect(runProgram?._meta).toMatchObject({
+      ui: { resourceUri, visibility: ["app"] },
+      "ui/resourceUri": resourceUri,
+    })
 
     const launch = await client.callTool({
       name: remoteMcpAppLaunchToolName(configObjectId),

--- a/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
+++ b/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
@@ -28,13 +28,13 @@ function probeRemoteMcpApps(value?: string) {
   })
 }
 
-test("Remote MCP Apps stay undiscoverable until a compatible Desktop rollout is enabled", () => {
+test("Remote MCP Apps default on after the compatible Desktop rollout and remain disableable", () => {
   const unset = probeRemoteMcpApps()
   const disabled = probeRemoteMcpApps("false")
   const enabled = probeRemoteMcpApps("true")
 
   expect(unset.status).toBe(0)
-  expect(unset.stdout.trim()).toBe("false")
+  expect(unset.stdout.trim()).toBe("true")
   expect(disabled.status).toBe(0)
   expect(disabled.stdout.trim()).toBe("false")
   expect(enabled.status).toBe(0)

--- a/ee/apps/den-api/test/remote-mcp-apps.test.ts
+++ b/ee/apps/den-api/test/remote-mcp-apps.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { createHash } from "node:crypto"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
 process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
@@ -6,7 +7,12 @@ process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:3005"
 process.env.OPENWORK_DEV_MODE ??= "1"
 process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 
-const { inspectRemoteMcpAppHtml, REMOTE_MCP_APP_MAX_BYTES } = await import("../src/remote-mcp-apps.js")
+const {
+  inspectRemoteMcpAppHtml,
+  REMOTE_MCP_APP_MAX_BYTES,
+  validateRemoteMcpAppContentType,
+  validateRemoteMcpAppSourceUrl,
+} = await import("../src/remote-mcp-apps.js")
 
 function appHtml(extra = "") {
   return `<!doctype html><html><head><title>Project Explorer</title><meta name="description" content="Browse connected projects."><style>body{font:14px sans-serif}</style></head><body><main id="app"></main>${extra}<script>document.querySelector('#app').textContent='Ready'</script></body></html>`
@@ -63,4 +69,28 @@ test("rejects runtime resource dependencies instead of caching a partially porta
 
 test("uses the desktop MCP App host's exact resource byte ceiling", () => {
   expect(REMOTE_MCP_APP_MAX_BYTES).toBe(768 * 1024)
+})
+
+test("requires a credential-free HTTPS source outside explicit private development mode", () => {
+  expect(validateRemoteMcpAppSourceUrl("https://apps.example/app/index.html")).toBe("https://apps.example/app/index.html")
+  expect(() => validateRemoteMcpAppSourceUrl("http://apps.example/app/index.html")).toThrow("must use HTTPS")
+  expect(() => validateRemoteMcpAppSourceUrl("file:///tmp/index.html")).toThrow("must use HTTPS")
+  expect(() => validateRemoteMcpAppSourceUrl("https://token@apps.example/index.html")).toThrow("embedded credentials")
+  expect(() => validateRemoteMcpAppSourceUrl("https://apps.example/index.html?access_token=secret")).toThrow("must not contain credentials")
+  expect(validateRemoteMcpAppSourceUrl("http://127.0.0.1:8787/index.html", true)).toBe("http://127.0.0.1:8787/index.html")
+})
+
+test("accepts only UTF-8 HTML MIME types", () => {
+  expect(validateRemoteMcpAppContentType("text/html; charset=UTF-8")).toBe("text/html")
+  expect(validateRemoteMcpAppContentType("application/xhtml+xml; charset=\"utf-8\"")).toBe("application/xhtml+xml")
+  expect(() => validateRemoteMcpAppContentType(null)).toThrow("must be served as text/html")
+  expect(() => validateRemoteMcpAppContentType("text/plain")).toThrow("must be served as text/html")
+  expect(() => validateRemoteMcpAppContentType("text/html; charset=iso-8859-1")).toThrow("must be UTF-8")
+})
+
+test("digests the exact stored UTF-8 document including a leading BOM", () => {
+  const html = `\uFEFF${appHtml()}`
+  const inspected = inspectRemoteMcpAppHtml(html)
+  expect(inspected.byteSize).toBe(Buffer.byteLength(html, "utf8"))
+  expect(inspected.digest).toBe(`sha256:${createHash("sha256").update(html).digest("hex")}`)
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-detail-screen.tsx
@@ -127,7 +127,7 @@ export function RemoteMcpAppDetailScreen({ appId }: { appId: string }) {
       <section className="mb-6 rounded-2xl border border-gray-200 bg-white p-5">
         <h2 className="text-[14px] font-semibold text-gray-900">Standard MCP runtime</h2>
         <p className="mt-1 text-[12px] leading-5 text-gray-500">
-          OpenWork exposes this immutable HTML as a standard MCP App resource from the OpenWork Cloud server. It may call its app-visible Program tool on that same server; a selected Code Mode Program inside this Plugin can compose OpenWork Connect capabilities without sending credentials into the UI. Apps distributed with their own MCP server keep that server&apos;s native tools, resources, UI metadata, and same-server calls through Connect.
+          OpenWork exposes this immutable HTML as a standard MCP App resource from the OpenWork Cloud server. It can use app-visible capability search on that same server to call authorized Connect tools and Code Mode Programs without receiving credentials. Apps distributed with their own MCP server keep that server&apos;s native tools, resources, UI metadata, and same-server calls through Connect.
         </p>
       </section>
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-detail-screen.tsx
@@ -87,7 +87,7 @@ export function RemoteMcpAppDetailScreen({ appId }: { appId: string }) {
           <div className="flex items-center gap-2">
             <DenChip tone={app.status === "active" ? "success" : "warning"}>{app.status === "active" ? "Ready" : "Retired"}</DenChip>
             <DenChip tone="neutral">v{metadata.version}</DenChip>
-            {canManage ? <Link href={getPluginRoute(orgSlug, app.pluginId)} className={buttonVariants({ variant: "secondary", size: "xs" })}>Manage sharing</Link> : null}
+            {canManage ? <Link href={getPluginRoute(orgSlug, app.pluginId)} className={buttonVariants({ variant: "secondary", size: "xs" })}>Manage Plugin</Link> : null}
           </div>
         )}
         className="mb-8"
@@ -127,7 +127,7 @@ export function RemoteMcpAppDetailScreen({ appId }: { appId: string }) {
       <section className="mb-6 rounded-2xl border border-gray-200 bg-white p-5">
         <h2 className="text-[14px] font-semibold text-gray-900">Standard MCP runtime</h2>
         <p className="mt-1 text-[12px] leading-5 text-gray-500">
-          This installed copy is a static adapter: OpenWork exposes its immutable HTML as a standard MCP App resource from the OpenWork Cloud server. Apps distributed with their own MCP server keep that server's native tools, resources, UI metadata, and same-server calls through OpenWork Connect.
+          OpenWork exposes this immutable HTML as a standard MCP App resource from the OpenWork Cloud server. It may call its app-visible Program tool on that same server; a selected Code Mode Program inside this Plugin can compose OpenWork Connect capabilities without sending credentials into the UI. Apps distributed with their own MCP server keep that server&apos;s native tools, resources, UI metadata, and same-server calls through Connect.
         </p>
       </section>
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-import.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-import.tsx
@@ -127,7 +127,7 @@ export function RemoteMcpAppImport({
                 </dl>
               </div>
 
-              <DenNotice tone="info" message="OpenWork will expose this cached HTML through an ordinary MCP tool and immutable ui:// resource. The app can call its app-visible Program tool on that same OpenWork MCP server; a selected Code Mode Program inside this Plugin can then use OpenWork Connect capabilities. Apps with their own MCP server keep that server's native tools and same-server calls through Connect." />
+              <DenNotice tone="info" message="OpenWork will expose this cached HTML through an ordinary MCP tool and immutable ui:// resource. The app can use app-visible capability search on that same OpenWork MCP server to call authorized Connect tools and Code Mode Programs. Apps with their own MCP server keep that server's native tools and same-server calls through Connect." />
               {importApp.error ? <DenNotice tone="error" message={importApp.error.message} /> : null}
               <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 pt-5">
                 <DenButton variant="ghost" icon={ArrowLeft} onClick={() => preview.reset()}>Use another URL</DenButton>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-import.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/remote-mcp-app-import.tsx
@@ -127,7 +127,7 @@ export function RemoteMcpAppImport({
                 </dl>
               </div>
 
-              <DenNotice tone="info" message="OpenWork will expose this cached HTML through an ordinary MCP tool and immutable ui:// resource. Apps that need tools should be distributed with a standard MCP server; OpenWork Connect will preserve that server's native tools, resources, and same-server calls." />
+              <DenNotice tone="info" message="OpenWork will expose this cached HTML through an ordinary MCP tool and immutable ui:// resource. The app can call its app-visible Program tool on that same OpenWork MCP server; a selected Code Mode Program inside this Plugin can then use OpenWork Connect capabilities. Apps with their own MCP server keep that server's native tools and same-server calls through Connect." />
               {importApp.error ? <DenNotice tone="error" message={importApp.error.message} /> : null}
               <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 pt-5">
                 <DenButton variant="ghost" icon={ArrowLeft} onClick={() => preview.reset()}>Use another URL</DenButton>

--- a/evals/specs/remote-mcp-apps.slow.test.ts
+++ b/evals/specs/remote-mcp-apps.slow.test.ts
@@ -758,6 +758,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   );
   const runProgramToolName = String(runProgramTool.name);
   expect(requireRecord(requireRecord(runProgramTool._meta, "Program tool metadata").ui, "Program tool UI metadata")).toEqual({
+    resourceUri: firstResourceUri,
     visibility: ["app"],
   });
   const rejectedCrossPluginRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {

--- a/evals/specs/remote-mcp-apps.slow.test.ts
+++ b/evals/specs/remote-mcp-apps.slow.test.ts
@@ -17,10 +17,11 @@ const title = !appSpecsEnabled
     ? "Remote MCP Apps skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
     : !mysqlOpen
       ? "Remote MCP Apps skipped — needs MySQL on 127.0.0.1:3306"
-      : "standard MCP Apps run through Connect and URL imports remain immutable standard resources";
+      : "externally authored MCP Apps run through Connect or Plugin Programs as immutable standard resources";
 const providerId = "remote-mcp-apps-provider";
 const modelId = "remote-mcp-apps-model";
 const desktopClosingReply = "Project Atlas is open through its standard MCP server.";
+const installedClosingReply = "Installed Project Atlas is open with its selected OpenWork Program.";
 const connectedResourceUri = "ui://project-atlas/view.html";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -32,7 +33,11 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value;
 }
 
-async function waitForMountedProjectAtlas(app: Awaited<ReturnType<typeof desktop>>, timeoutMs = 60_000): Promise<boolean> {
+async function waitForMountedProjectAtlas(
+  app: Awaited<ReturnType<typeof desktop>>,
+  expected: string[] = ["Project Atlas", "Connected through OpenWork Connect"],
+  timeoutMs = 60_000,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const targets = await listTargets(app.handle.cdpUrl);
@@ -44,7 +49,7 @@ async function waitForMountedProjectAtlas(app: Awaited<ReturnType<typeof desktop
       try {
         const mounted = await evaluate(client, `(() => {
           const text = document.querySelector("iframe")?.contentDocument?.body?.innerText ?? "";
-          return text.includes("Project Atlas") && text.includes("Connected through OpenWork Connect");
+          return ${JSON.stringify(expected)}.every((value) => text.includes(value));
         })()`);
         if (mounted === true) return true;
       } finally {
@@ -115,17 +120,18 @@ function sendStream(response: ServerResponse, chunks: Record<string, unknown>[])
   setTimeout(() => response.end("data: [DONE]\n\n"), delay);
 }
 
-function projectedLaunchTool(payload: Record<string, unknown>) {
+function projectedLaunchTool(payload: Record<string, unknown>, preferInstalled: boolean) {
   if (!Array.isArray(payload.tools)) return null;
   let staticAdapterTool: string | null = null;
+  let connectedTool: string | null = null;
   for (const tool of payload.tools) {
     if (!isRecord(tool) || !isRecord(tool.function)) continue;
     const name = tool.function.name;
     if (typeof name !== "string") continue;
-    if (name.includes("open_project_atlas")) return name;
+    if (name.includes("open_project_atlas")) connectedTool = name;
     if (name.includes("launch_remote_app_")) staticAdapterTool = name;
   }
-  return staticAdapterTool;
+  return preferInstalled ? staticAdapterTool : connectedTool ?? staticAdapterTool;
 }
 
 function hasToolResult(payload: Record<string, unknown>) {
@@ -146,11 +152,95 @@ const builtPortableApp = await buildGeneratedArtifactViewInWorker({
 if (!builtPortableApp.ok) throw new Error(`Portable app build failed: ${JSON.stringify(builtPortableApp.diagnostics)}`);
 const portableAppDocument = builtPortableApp.html.replace(/<meta http-equiv="Content-Security-Policy"[^>]*>/i, "");
 
-function appHtml(version: string): string {
+function connectedAppHtml(version: string): string {
   return portableAppDocument.replace(
     "</body>",
     `<!-- Portable revision ${version} --></body>`,
   );
+}
+
+function programAppHtml(version: string): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="description" content="Run a selected OpenWork Program through the standard MCP Apps bridge.">
+    <title>Project Atlas</title>
+    <style>
+      body{margin:0;padding:18px;color:#172033;background:#f5f7fb;font-family:system-ui,sans-serif}
+      main{padding:22px;border:1px solid #dbe4f0;border-radius:16px;background:white}
+      .eyebrow{color:#2563eb;font-size:11px;font-weight:700;letter-spacing:.12em}
+      h1{margin:8px 0;font-size:24px}pre{white-space:pre-wrap;word-break:break-word;font-size:12px}
+    </style>
+  </head>
+  <body>
+    <main><p class="eyebrow">REMOTE MCP APP</p><h1>Project Atlas</h1><p id="status">Waiting for OpenWork…</p><pre id="result"></pre></main>
+    <script>
+      (() => {
+        const INIT_ID = "project-atlas-init";
+        let requestId = 0;
+        const pending = new Map();
+        const status = document.querySelector("#status");
+        const result = document.querySelector("#result");
+        const post = (message) => window.parent.postMessage(message, "*");
+        const runProgram = (name, input) => {
+          const id = "project-atlas-program-" + (++requestId);
+          pending.set(id, true);
+          status.textContent = "Running selected Program through OpenWork Connect…";
+          post({
+            jsonrpc: "2.0",
+            id,
+            method: "tools/call",
+            params: { name, arguments: { input: input || {} } },
+          });
+        };
+        window.addEventListener("message", (event) => {
+          if (event.source !== window.parent || !event.data || event.data.jsonrpc !== "2.0") return;
+          const message = event.data;
+          if (message.id === INIT_ID && message.result) {
+            post({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+            return;
+          }
+          if (message.method === "ui/notifications/tool-result") {
+            const structured = message.params && message.params.structuredContent;
+            const toolName = structured && structured.serverTools && structured.serverTools.runProgram;
+            if (typeof toolName !== "string") {
+              status.textContent = "No Program tool is available.";
+              return;
+            }
+            runProgram(toolName, structured.input);
+            return;
+          }
+          if (message.method === "ui/resource-teardown" && message.id !== undefined) {
+            post({ jsonrpc: "2.0", id: message.id, result: {} });
+            return;
+          }
+          if (pending.has(message.id)) {
+            pending.delete(message.id);
+            if (message.error || (message.result && message.result.isError)) {
+              status.textContent = "Program failed.";
+              result.textContent = JSON.stringify(message.error || message.result, null, 2);
+              return;
+            }
+            status.textContent = "Connected through an OpenWork Program.";
+            result.textContent = JSON.stringify(message.result && message.result.structuredContent, null, 2);
+          }
+        });
+        post({
+          jsonrpc: "2.0",
+          id: INIT_ID,
+          method: "ui/initialize",
+          params: {
+            appInfo: { name: "Project Atlas", version: ${JSON.stringify(version)} },
+            appCapabilities: {},
+            protocolVersion: "2026-01-26",
+          },
+        });
+      })();
+    </script>
+    <!-- Portable revision ${version} -->
+  </body>
+</html>`;
 }
 
 function standardMcpAppRpc(message: Record<string, unknown>): Record<string, unknown> {
@@ -234,7 +324,7 @@ function standardMcpAppRpc(message: Record<string, unknown>): Record<string, unk
         contents: [{
           uri: connectedResourceUri,
           mimeType: "text/html;profile=mcp-app",
-          text: appHtml("Connect 1.0.0"),
+          text: connectedAppHtml("Connect 1.0.0"),
           _meta: {
             ui: {
               csp: { connectDomains: [], resourceDomains: [] },
@@ -333,7 +423,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
           sendJson(response, 404, { error: "source_removed" });
           return;
         }
-        const html = appHtml(publishedVersion);
+        const html = programAppHtml(publishedVersion);
         response.writeHead(200, {
           "cache-control": "no-store",
           "content-length": String(Buffer.byteLength(html, "utf8")),
@@ -348,15 +438,20 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
       }
       if (request.method === "POST" && (url.pathname === "/v1/chat/completions" || url.pathname === "/chat/completions")) {
         const payload = requireRecord(JSON.parse(await readBody(request)), "chat completion request");
+        const installedRequest = JSON.stringify(payload.messages ?? []).includes("installed Project Atlas");
         if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
           sendStream(response, [streamChunk({ role: "assistant" }), streamChunk({ content: "Project Atlas" }), streamChunk({}, "stop")]);
           return;
         }
         if (hasToolResult(payload)) {
-          sendStream(response, [streamChunk({ role: "assistant" }), streamChunk({ content: desktopClosingReply }), streamChunk({}, "stop")]);
+          sendStream(response, [
+            streamChunk({ role: "assistant" }),
+            streamChunk({ content: installedRequest ? installedClosingReply : desktopClosingReply }),
+            streamChunk({}, "stop"),
+          ]);
           return;
         }
-        const toolName = projectedLaunchTool(payload);
+        const toolName = projectedLaunchTool(payload, installedRequest);
         if (!toolName) throw new Error("The Remote MCP App launch tool was not projected to the model.");
         sendStream(response, [
           streamChunk({ role: "assistant" }),
@@ -365,7 +460,10 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
               index: 0,
               id: "call_project_atlas",
               type: "function",
-              function: { name: toolName, arguments: "{}" },
+              function: {
+                name: toolName,
+                arguments: installedRequest ? JSON.stringify({ input: { query: "migration" } }) : "{}",
+              },
             }],
           }),
           streamChunk({}, "tool_calls"),
@@ -462,6 +560,12 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     : [];
   const organizationId = String(orgs[0]?.id ?? "");
   expect(organizationId).not.toBe("");
+  const enabled = await denFetch(den.admin, `/v1/admin/organizations/${organizationId}/capabilities`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({ capabilities: { codemodeScripts: true } }),
+  });
+  expect(enabled.response.ok, enabled.text).toBe(true);
 
   const connection = await createOrgConnection(den.admin, {
     name: "Atlas read-only projects",
@@ -572,7 +676,103 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   });
   expect(initialized.protocolVersion).toBeTruthy();
 
+  const programCode = "return { projects: await tools.atlas_read_only_projects.search_projects({ query: input.query }) }";
+  const programInput = { query: "migration" };
+  const programDraft = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "execute_capability_script",
+    arguments: { code: programCode, input: programInput },
+  });
+  expect(programDraft.isError, JSON.stringify(programDraft)).not.toBe(true);
+  expect(JSON.stringify(programDraft.content)).toContain("Atlas migration");
+  expect(standardMcpCalls).toBe(1);
+
+  const unrelatedProgramResult = await denFetch(den.admin, "/v1/codemode-scripts", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+    body: JSON.stringify({
+      name: "Unrelated Project Atlas program",
+      description: "Proves an imported app cannot run a Program from another Plugin.",
+      code: programCode,
+      currentInput: programInput,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+        properties: { projects: {} },
+        required: ["projects"],
+        additionalProperties: false,
+      },
+    }),
+  });
+  expect(unrelatedProgramResult.response.status, unrelatedProgramResult.text).toBe(201);
+  const unrelatedProgramId = String(requireRecord(unrelatedProgramResult.body, "unrelated Program").configObjectId ?? "");
+  expect(unrelatedProgramId).toMatch(/^cob_/);
+
+  const savedProgramResult = await denFetch(den.admin, "/v1/codemode-scripts", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+    body: JSON.stringify({
+      pluginId: detail.pluginId,
+      name: "Project Atlas Connect program",
+      description: "Loads Project Atlas data through the connected standard MCP server.",
+      code: programCode,
+      currentInput: programInput,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+        properties: { projects: {} },
+        required: ["projects"],
+        additionalProperties: false,
+      },
+    }),
+  });
+  expect(savedProgramResult.response.status, savedProgramResult.text).toBe(201);
+  const savedProgram = requireRecord(savedProgramResult.body, "saved Program");
+  const programId = String(savedProgram.configObjectId ?? "");
+  expect(programId).toMatch(/^cob_/);
+  await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "select_program",
+    arguments: { programId: unrelatedProgramId },
+  });
+
   const listed = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {});
+  expect(toolsFrom(listed).some((tool) => tool.name === "save_artifact_view")).toBe(false);
+  const runProgramTool = requireRecord(
+    toolsFrom(listed).find((tool) => typeof tool.name === "string" && tool.name.startsWith("run_program_")),
+    "app-only Program tool",
+  );
+  const runProgramToolName = String(runProgramTool.name);
+  expect(requireRecord(requireRecord(runProgramTool._meta, "Program tool metadata").ui, "Program tool UI metadata")).toEqual({
+    visibility: ["app"],
+  });
+  const rejectedCrossPluginRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: runProgramToolName,
+    arguments: { input: programInput },
+  });
+  expect(rejectedCrossPluginRun.isError).toBe(true);
+  expect(JSON.stringify(rejectedCrossPluginRun.content)).toContain("program_not_in_app_plugin");
+  expect(standardMcpCalls).toBe(1);
+
+  const selectedProgram = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "select_program",
+    arguments: { programId },
+  });
+  expect(requireRecord(requireRecord(selectedProgram.structuredContent, "selected Program").selection, "selection").programId).toBe(programId);
   const launchTool = toolsFrom(listed).find((tool) => tool.title === "Open Project Atlas");
   expect(launchTool).toBeTruthy();
   const launchMeta = requireRecord(requireRecord(launchTool?._meta, "launch metadata").ui, "launch UI metadata");
@@ -586,6 +786,15 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const launchStructured = requireRecord(launched.structuredContent, "launch structured content");
   expect(JSON.stringify(launchStructured)).not.toContain(connection.id);
   expect(requireRecord(launchStructured.app, "launch app").id).toBe(appId);
+  expect(requireRecord(launchStructured.serverTools, "launch server tools").runProgram).toBe(runProgramToolName);
+
+  const programRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: runProgramToolName,
+    arguments: { input: programInput },
+  });
+  expect(programRun.isError, JSON.stringify(programRun)).not.toBe(true);
+  expect(JSON.stringify(requireRecord(programRun.structuredContent, "Program run result").value)).toContain("Atlas migration");
+  expect(standardMcpCalls).toBe(2);
 
   const resources = await agentRpc(den.ref.apiUrl, mcpToken, "resources/list", {});
   expect(Array.isArray(resources.resources) && resources.resources.some((resource) => isRecord(resource) && resource.uri === firstResourceUri)).toBe(true);
@@ -634,7 +843,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     name: "search_projects",
     arguments: { query: "migration" },
   }, connectedEndpoint);
-  expect(standardMcpCalls).toBe(1);
+  expect(standardMcpCalls).toBe(3);
   expect(JSON.stringify(proxied.content)).toContain("Atlas project result for migration");
   expect(JSON.stringify(proxied.structuredContent)).toContain("Atlas migration");
   expect(requireRecord(proxied._meta, "proxied metadata").source).toBe("project-atlas-standard-mcp");
@@ -680,6 +889,12 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
             },
           },
           mcp: {
+            "openwork-cloud-apps": {
+              type: "remote",
+              url: ${JSON.stringify(`${fixtureUrl}/agent-mcp`)},
+              enabled: true,
+              oauth: false,
+            },
             "project-atlas-connect": {
               type: "remote",
               url: ${JSON.stringify(`${fixtureUrl}/connected-mcp`)},
@@ -795,12 +1010,12 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     timeoutMs: 60_000,
     label: "connected standard MCP App sandboxed iframe",
   });
-  const mountedProjectAtlas = await waitForMountedProjectAtlas(desktopApp, 15_000);
+  const mountedProjectAtlas = await waitForMountedProjectAtlas(desktopApp, undefined, 15_000);
   const desktopTranscript = await evalIn(desktopApp, "document.body?.innerText ?? ''");
   expect(mountedProjectAtlas, `${desktopTranscript}\nPersisted tool: ${persistedProjectAtlasTool}`).toBe(true);
   expect(desktopTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(desktopTranscript).not.toContain("Interactive view unavailable");
-  expect(standardMcpCalls).toBe(2);
+  expect(standardMcpCalls).toBe(4);
   const desktopShot = await screenshot(desktopApp);
   const desktopExpectations = [
     "The conversation visibly contains the connected Project Atlas MCP App",
@@ -814,6 +1029,61 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
       : JSON.stringify({ results: desktopExpectations.map((expectation) => ({ expectation, passed: true, evidence: "The deterministic desktop DOM and MCP protocol assertions completed before capture." })) }),
   });
   expect(desktopSeen.ok, desktopSeen.why).toBe(true);
+
+  await control(desktopApp, "session.create_task");
+  await waitFor(desktopApp, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+    timeoutMs: 30_000,
+    label: "installed app composer ready",
+  });
+  const installedComposerFocused = await evalIn(desktopApp, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    window.__remoteMcpApprovalCount = 0;
+    window.confirm = () => {
+      window.__remoteMcpApprovalCount += 1;
+      return true;
+    };
+    editor.focus();
+    return true;
+  })()`);
+  expect(installedComposerFocused).toBe(true);
+  await desktopApp.client.send("Input.insertText", {
+    text: "Open installed Project Atlas and load the migration projects through its selected Program once.",
+  });
+  await clickButton(desktopApp, "Run task", { timeoutMs: 30_000 });
+  await waitFor(desktopApp, `document.body.innerText.includes(${JSON.stringify(installedClosingReply)})`, {
+    timeoutMs: 120_000,
+    label: "installed Remote MCP App desktop response",
+  });
+  await waitFor(desktopApp, `Boolean(document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${firstResourceUri}"] iframe`)}))`, {
+    timeoutMs: 60_000,
+    label: "installed Remote MCP App sandboxed iframe",
+  });
+  const mountedProgramApp = await waitForMountedProjectAtlas(
+    desktopApp,
+    ["Project Atlas", "Connected through an OpenWork Program", "Atlas migration"],
+    30_000,
+  );
+  const approvalCount = await evalIn(desktopApp, "window.__remoteMcpApprovalCount ?? 0");
+  const installedTranscript = await evalIn(desktopApp, "document.body?.innerText ?? ''");
+  expect(mountedProgramApp, String(installedTranscript)).toBe(true);
+  expect(approvalCount).toBe(1);
+  expect(installedTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
+  expect(installedTranscript).not.toContain("Interactive view unavailable");
+  expect(standardMcpCalls).toBe(5);
+  const installedShot = await screenshot(desktopApp);
+  const installedExpectations = [
+    "The conversation visibly contains the installed Project Atlas MCP App",
+    "The app reports that it connected through an OpenWork Program",
+    "The Program-backed result contains Atlas migration",
+    "No interactive-view-unavailable or crash message is visible",
+  ];
+  const installedSeen = await validate(installedShot, installedExpectations, {
+    ask: async (request) => request.prompt.startsWith("Objectively describe")
+      ? JSON.stringify({ description: "An installed Project Atlas MCP App calling a selected OpenWork Program, with Atlas migration data returned through OpenWork Connect." })
+      : JSON.stringify({ results: installedExpectations.map((expectation) => ({ expectation, passed: true, evidence: "The deterministic Desktop, MCP Apps bridge, approval, Program, and downstream Connect assertions completed before capture." })) }),
+  });
+  expect(installedSeen.ok, installedSeen.why).toBe(true);
 
   publishedVersion = "2.0.0";
   const refreshedResult = await denFetch(den.admin, `/v1/remote-mcp-apps/${encodeURIComponent(appId)}/refresh`, {
@@ -907,8 +1177,8 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(toolsFrom(restoredTools).some((tool) => tool.name === launchToolName)).toBe(true);
 
   evidence.fact(
-    "Standard Connect MCP Apps and URL-imported static resources work without a custom execution protocol",
-    `Preserved native Project Atlas server identity, tools, exact UI metadata, resources, structuredContent, and _meta through connection ${connection.id}; completed the MCP Apps handshake and mounted the bundled UI; imported ${appId}; served two immutable ui:// revisions after the source returned 404; and removed/restored ${launchToolName} through the Library lifecycle.`,
-    standardMcpCalls === 2 && mountedProjectAtlas,
+    "Externally authored MCP Apps use standard same-server tools while Programs compose OpenWork Connect",
+    `Preserved native Project Atlas server identity, tools, exact UI metadata, resources, structuredContent, and _meta through connection ${connection.id}; completed both MCP Apps handshakes; imported ${appId}; called app-visible run_program on the originating OpenWork server; returned Atlas migration from the selected Program's downstream Connect call; served two immutable ui:// revisions after the source returned 404; and removed/restored ${launchToolName} through the Library lifecycle.`,
+    standardMcpCalls === 5 && mountedProjectAtlas && mountedProgramApp && approvalCount === 1,
   );
 });

--- a/evals/specs/remote-mcp-apps.slow.test.ts
+++ b/evals/specs/remote-mcp-apps.slow.test.ts
@@ -1,6 +1,7 @@
+import { createHash } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { expect, onTestFinished } from "vitest";
-import { clickButton, control, createAndSelectWorkspace, createOrgConnection, denFetch, evalIn, fill, waitFor } from "@openwork/behaviors";
+import { clickButton, control, createAndSelectWorkspace, createOrgConnection, denFetch, evalIn, waitFor } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
 import { screenshot, validate } from "@openwork/fraimz";
 import { chrome, desktop } from "@openwork/hosts";
@@ -17,11 +18,11 @@ const title = !appSpecsEnabled
     ? "Remote MCP Apps skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
     : !mysqlOpen
       ? "Remote MCP Apps skipped — needs MySQL on 127.0.0.1:3306"
-      : "externally authored MCP Apps run through Connect or Plugin Programs as immutable standard resources";
+      : "agents install external MCP Apps while Apps use standard same-server capability search";
 const providerId = "remote-mcp-apps-provider";
 const modelId = "remote-mcp-apps-model";
 const desktopClosingReply = "Project Atlas is open through its standard MCP server.";
-const installedClosingReply = "Installed Project Atlas is open with its selected OpenWork Program.";
+const installedClosingReply = "Installed Project Atlas is open with Connect and Program results.";
 const connectedResourceUri = "ui://project-atlas/view.html";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -164,7 +165,7 @@ function programAppHtml(version: string): string {
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="description" content="Run a selected OpenWork Program through the standard MCP Apps bridge.">
+    <meta name="description" content="Search and execute authorized OpenWork Connect tools and Programs through the standard MCP Apps bridge.">
     <title>Project Atlas</title>
     <style>
       body{margin:0;padding:18px;color:#172033;background:#f5f7fb;font-family:system-ui,sans-serif}
@@ -180,19 +181,26 @@ function programAppHtml(version: string): string {
         const INIT_ID = "project-atlas-init";
         let requestId = 0;
         const pending = new Map();
+        let serverTools = null;
+        let connectResult = null;
         const status = document.querySelector("#status");
         const result = document.querySelector("#result");
         const post = (message) => window.parent.postMessage(message, "*");
-        const runProgram = (name, input) => {
-          const id = "project-atlas-program-" + (++requestId);
-          pending.set(id, true);
-          status.textContent = "Running selected Program through OpenWork Connect…";
+        const call = (kind, name, args) => {
+          const id = "project-atlas-" + kind + "-" + (++requestId);
+          pending.set(id, kind);
           post({
             jsonrpc: "2.0",
             id,
             method: "tools/call",
-            params: { name, arguments: { input: input || {} } },
+            params: { name, arguments: args || {} },
           });
+        };
+        const structured = (message) => message && message.result && message.result.structuredContent;
+        const firstMatch = (message, kind) => {
+          const value = structured(message);
+          const matches = value && Array.isArray(value.matches) ? value.matches : [];
+          return matches.find((entry) => entry && (kind ? entry.kind === kind : true)) || matches[0];
         };
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent || !event.data || event.data.jsonrpc !== "2.0") return;
@@ -202,13 +210,14 @@ function programAppHtml(version: string): string {
             return;
           }
           if (message.method === "ui/notifications/tool-result") {
-            const structured = message.params && message.params.structuredContent;
-            const toolName = structured && structured.serverTools && structured.serverTools.runProgram;
-            if (typeof toolName !== "string") {
-              status.textContent = "No Program tool is available.";
+            const launch = message.params && message.params.structuredContent;
+            serverTools = launch && launch.serverTools;
+            if (!serverTools || typeof serverTools.searchCapabilities !== "string" || typeof serverTools.executeCapability !== "string") {
+              status.textContent = "Capability gateway unavailable.";
               return;
             }
-            runProgram(toolName, structured.input);
+            status.textContent = "Confirming the installer is unavailable to Apps…";
+            call("installer", "import_remote_mcp_app", {});
             return;
           }
           if (message.method === "ui/resource-teardown" && message.id !== undefined) {
@@ -216,14 +225,51 @@ function programAppHtml(version: string): string {
             return;
           }
           if (pending.has(message.id)) {
+            const kind = pending.get(message.id);
             pending.delete(message.id);
-            if (message.error || (message.result && message.result.isError)) {
-              status.textContent = "Program failed.";
+            const failed = message.error || (message.result && message.result.isError);
+            if (kind === "installer") {
+              if (!failed) {
+                status.textContent = "Unsafe installer access.";
+                return;
+              }
+              status.textContent = "Installer blocked; searching authorized Connect tools…";
+              call("search-connect", serverTools.searchCapabilities, { query: "Atlas read-only projects", type: "mcp", limit: 5 });
+              return;
+            }
+            if (failed) {
+              status.textContent = "Capability call failed.";
               result.textContent = JSON.stringify(message.error || message.result, null, 2);
               return;
             }
-            status.textContent = "Connected through an OpenWork Program.";
-            result.textContent = JSON.stringify(message.result && message.result.structuredContent, null, 2);
+            if (kind === "search-connect") {
+              const match = firstMatch(message);
+              if (!match || typeof match.name !== "string") throw new Error("Connect capability missing");
+              status.textContent = "Executing the authorized Connect tool…";
+              call("execute-connect", serverTools.executeCapability, {
+                name: match.name,
+                schemaDigest: match.schemaDigest,
+                body: { query: "migration" },
+              });
+              return;
+            }
+            if (kind === "execute-connect") {
+              connectResult = structured(message);
+              status.textContent = "Searching authorized Programs…";
+              call("search-program", serverTools.searchCapabilities, { query: "Project Atlas Connect program", type: "marketplace", limit: 5 });
+              return;
+            }
+            if (kind === "search-program") {
+              const match = firstMatch(message, "script");
+              if (!match || typeof match.name !== "string") throw new Error("Program capability missing");
+              status.textContent = "Executing the authorized Program…";
+              call("execute-program", serverTools.executeCapability, { name: match.name, body: { query: "migration" } });
+              return;
+            }
+            if (kind === "execute-program") {
+              status.textContent = "Connected through OpenWork capability search.";
+              result.textContent = JSON.stringify({ installer: "blocked", connect: connectResult, program: structured(message) }, null, 2);
+            }
           }
         });
         post({
@@ -575,82 +621,17 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     access: { orgWide: true },
   });
 
-  await using browser = await chrome({ name: "remote-mcp-apps", startUrl: den.ref.webUrl, headless: true });
-  await navigate(browser.client, den.ref.webUrl);
-  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
-    timeoutMs: 60_000,
-    label: "Den Web origin",
-  });
-  const tokenStored = await evalIn(browser, `(() => {
-    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
-    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
-  })()`);
-  expect(tokenStored).toBe(true);
-  await navigate(browser.client, `${den.ref.webUrl}/dashboard/library`);
-  await waitFor(browser, "document.body.innerText.includes('Add remote MCP App')", {
-    timeoutMs: 60_000,
-    label: "Remote MCP App Library action",
-  });
-  const modalOpened = await evalIn(browser, `(async () => {
-    const deadline = Date.now() + 30000;
-    while (Date.now() < deadline) {
-      const existing = document.querySelector("[data-remote-app-import]");
-      if (existing) return true;
-      const button = [...document.querySelectorAll("button")]
-        .find((entry) => entry.textContent?.trim() === "Add remote MCP App");
-      if (button instanceof HTMLButtonElement) button.click();
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    }
-    return false;
-  })()`, { awaitPromise: true, timeoutMs: 35_000 });
-  expect(modalOpened).toBe(true);
-  await fill(browser, "[data-testid=remote-app-source-url]", sourceUrl);
-  await clickButton(browser, "Download and review");
-  await waitFor(browser, `document.body.innerText.includes("Project Atlas")
-    && document.body.innerText.includes("Validated")
-    && document.body.innerText.includes("ordinary MCP tool")`, {
-    timeoutMs: 30_000,
-    label: "validated Remote MCP App import review",
-  });
-
-  const reviewShot = await screenshot(browser);
-  const reviewExpectations = [
-    "A Remote MCP App review shows Project Atlas as validated",
-    "The review explains that the cached HTML becomes an ordinary immutable MCP App resource",
-    "An Import and activate action is visible",
-  ];
-  const reviewed = await validate(reviewShot, reviewExpectations, {
-    ask: async (request) => request.prompt.startsWith("Objectively describe")
-      ? JSON.stringify({ description: "The Den Web Remote MCP App review for a validated, cached Project Atlas HTML resource." })
-      : JSON.stringify({ results: reviewExpectations.map((expectation) => ({ expectation, passed: true, evidence: "The deterministic DOM assertions completed before capture." })) }),
-  });
-  expect(reviewed.ok, reviewed.why).toBe(true);
-
-  await clickButton(browser, "Import and activate");
-  await waitFor(browser, `location.pathname.includes("/dashboard/apps/")
-    && document.body.innerText.includes("Installed copy")
-    && document.body.innerText.includes("Immutable revisions")
-    && document.body.innerText.includes("ui://openwork/library-apps/")`, {
-    timeoutMs: 60_000,
-    label: "active Remote MCP App detail",
-  });
-  const appId = await evalIn(browser, `document.querySelector("[data-remote-app-detail]")?.getAttribute("data-remote-app-detail") ?? ""`);
-  expect(typeof appId === "string" && appId.startsWith("cob_")).toBe(true);
-  if (typeof appId !== "string") throw new Error("Imported app id was unavailable.");
-
-  const detailResult = await denFetch(den.admin, `/v1/remote-mcp-apps/${encodeURIComponent(appId)}`, {
+  const pluginResult = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
     headers: {
       authorization: `Bearer ${den.admin.token}`,
       "x-openwork-org-id": organizationId,
     },
+    body: JSON.stringify({ name: "Project Atlas Plugin", components: [] }),
   });
-  expect(detailResult.response.ok, detailResult.text).toBe(true);
-  const detail = requireRecord(requireRecord(detailResult.body, "app detail response").item, "app detail");
-  const firstRevision = requireRecord(detail.activeRevision, "active revision");
-  const firstRevisionId = String(firstRevision.id);
-  const firstResourceUri = String(firstRevision.resourceUri);
-  const firstDigest = String(requireRecord(firstRevision.resource, "active revision resource").digest);
-  expect(firstResourceUri).toBe(`ui://openwork/library-apps/${appId}/revisions/${firstRevisionId}/index.html`);
+  expect(pluginResult.response.status, pluginResult.text).toBe(201);
+  const pluginId = String(requireRecord(requireRecord(pluginResult.body, "Plugin response").item, "Plugin").id ?? "");
+  expect(pluginId).toMatch(/^plg_/);
 
   const tokenResult = await denFetch(den.admin, "/v1/mcp/token", {
     method: "POST",
@@ -675,6 +656,75 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     clientInfo: { name: "remote-mcp-app-eval", version: "1.0.0" },
   });
   expect(initialized.protocolVersion).toBeTruthy();
+  expect(String(initialized.instructions ?? "")).toContain("authored and bundled outside OpenWork");
+  const initializedCapabilities = requireRecord(initialized.capabilities, "agent capabilities");
+  expect(requireRecord(initializedCapabilities.tools, "agent tool capabilities").listChanged).toBe(true);
+  expect(requireRecord(initializedCapabilities.resources, "agent resource capabilities").listChanged).toBe(true);
+
+  const beforeImport = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {});
+  const importTool = requireRecord(toolsFrom(beforeImport).find((tool) => tool.name === "import_remote_mcp_app"), "remote App import tool");
+  expect(requireRecord(requireRecord(importTool._meta, "import metadata").ui, "import UI metadata").visibility).toEqual(["model"]);
+  for (const generatedTool of ["save_artifact_view", "activate_artifact_view_revision", "retire_artifact_view"]) {
+    expect(toolsFrom(beforeImport).some((tool) => tool.name === generatedTool)).toBe(false);
+    const rejected = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", { name: generatedTool, arguments: {} });
+    expect(rejected.isError).toBe(true);
+  }
+  const inlineRejected = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "import_remote_mcp_app",
+    arguments: { pluginId, sourceUrl, inlineHtml: programAppHtml("inline") },
+  });
+  expect(inlineRejected.isError).toBe(true);
+  const unsafeRejected = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "import_remote_mcp_app",
+    arguments: { pluginId, sourceUrl: "file:///etc/passwd" },
+  });
+  expect(unsafeRejected.isError).toBe(true);
+
+  const imported = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "import_remote_mcp_app",
+    arguments: { pluginId, sourceUrl, activate: true },
+  });
+  expect(imported.isError, JSON.stringify(imported)).not.toBe(true);
+  const importedApp = requireRecord(requireRecord(imported.structuredContent, "import structured content").app, "imported App");
+  const appId = String(importedApp.id ?? "");
+  expect(appId).toMatch(/^cob_/);
+  expect(importedApp.pluginId).toBe(pluginId);
+
+  const detailResult = await denFetch(den.admin, `/v1/remote-mcp-apps/${encodeURIComponent(appId)}`, {
+    headers: {
+      authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+  });
+  expect(detailResult.response.ok, detailResult.text).toBe(true);
+  const detail = requireRecord(requireRecord(detailResult.body, "app detail response").item, "app detail");
+  const firstRevision = requireRecord(detail.activeRevision, "active revision");
+  const firstRevisionId = String(firstRevision.id);
+  const firstResourceUri = String(firstRevision.resourceUri);
+  const firstDigest = String(requireRecord(firstRevision.resource, "active revision resource").digest);
+  const firstHtml = programAppHtml("1.0.0");
+  expect(firstResourceUri).toBe(`ui://openwork/library-apps/${appId}/revisions/${firstRevisionId}/index.html`);
+  expect(firstDigest).toBe(`sha256:${createHash("sha256").update(firstHtml).digest("hex")}`);
+  expect(detail.pluginId).toBe(pluginId);
+
+  await using browser = await chrome({ name: "remote-mcp-apps", startUrl: den.ref.webUrl, headless: true });
+  await navigate(browser.client, den.ref.webUrl);
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin",
+  });
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+  await navigate(browser.client, `${den.ref.webUrl}/dashboard/apps/${encodeURIComponent(appId)}`);
+  await waitFor(browser, `document.body.innerText.includes("Installed copy")
+    && document.body.innerText.includes("Immutable revisions")
+    && document.body.innerText.includes(${JSON.stringify(firstResourceUri)})`, {
+    timeoutMs: 60_000,
+    label: "agent-imported Remote MCP App detail",
+  });
 
   const programCode = "return { projects: await tools.atlas_read_only_projects.search_projects({ query: input.query }) }";
   const programInput = { query: "migration" };
@@ -686,35 +736,6 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(JSON.stringify(programDraft.content)).toContain("Atlas migration");
   expect(standardMcpCalls).toBe(1);
 
-  const unrelatedProgramResult = await denFetch(den.admin, "/v1/codemode-scripts", {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${den.admin.token}`,
-      "x-openwork-org-id": organizationId,
-    },
-    body: JSON.stringify({
-      name: "Unrelated Project Atlas program",
-      description: "Proves an imported app cannot run a Program from another Plugin.",
-      code: programCode,
-      currentInput: programInput,
-      inputSchema: {
-        type: "object",
-        properties: { query: { type: "string" } },
-        required: ["query"],
-        additionalProperties: false,
-      },
-      outputSchema: {
-        type: "object",
-        properties: { projects: {} },
-        required: ["projects"],
-        additionalProperties: false,
-      },
-    }),
-  });
-  expect(unrelatedProgramResult.response.status, unrelatedProgramResult.text).toBe(201);
-  const unrelatedProgramId = String(requireRecord(unrelatedProgramResult.body, "unrelated Program").configObjectId ?? "");
-  expect(unrelatedProgramId).toMatch(/^cob_/);
-
   const savedProgramResult = await denFetch(den.admin, "/v1/codemode-scripts", {
     method: "POST",
     headers: {
@@ -722,7 +743,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
       "x-openwork-org-id": organizationId,
     },
     body: JSON.stringify({
-      pluginId: detail.pluginId,
+      pluginId,
       name: "Project Atlas Connect program",
       description: "Loads Project Atlas data through the connected standard MCP server.",
       code: programCode,
@@ -745,35 +766,10 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const savedProgram = requireRecord(savedProgramResult.body, "saved Program");
   const programId = String(savedProgram.configObjectId ?? "");
   expect(programId).toMatch(/^cob_/);
-  await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
-    name: "select_program",
-    arguments: { programId: unrelatedProgramId },
-  });
 
   const listed = await agentRpc(den.ref.apiUrl, mcpToken, "tools/list", {});
   expect(toolsFrom(listed).some((tool) => tool.name === "save_artifact_view")).toBe(false);
-  const runProgramTool = requireRecord(
-    toolsFrom(listed).find((tool) => typeof tool.name === "string" && tool.name.startsWith("run_program_")),
-    "app-only Program tool",
-  );
-  const runProgramToolName = String(runProgramTool.name);
-  expect(requireRecord(requireRecord(runProgramTool._meta, "Program tool metadata").ui, "Program tool UI metadata")).toEqual({
-    resourceUri: firstResourceUri,
-    visibility: ["app"],
-  });
-  const rejectedCrossPluginRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
-    name: runProgramToolName,
-    arguments: { input: programInput },
-  });
-  expect(rejectedCrossPluginRun.isError).toBe(true);
-  expect(JSON.stringify(rejectedCrossPluginRun.content)).toContain("program_not_in_app_plugin");
-  expect(standardMcpCalls).toBe(1);
-
-  const selectedProgram = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
-    name: "select_program",
-    arguments: { programId },
-  });
-  expect(requireRecord(requireRecord(selectedProgram.structuredContent, "selected Program").selection, "selection").programId).toBe(programId);
+  expect(toolsFrom(listed).some((tool) => typeof tool.name === "string" && tool.name.startsWith("run_program_"))).toBe(false);
   const launchTool = toolsFrom(listed).find((tool) => tool.title === "Open Project Atlas");
   expect(launchTool).toBeTruthy();
   const launchMeta = requireRecord(requireRecord(launchTool?._meta, "launch metadata").ui, "launch UI metadata");
@@ -787,15 +783,42 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const launchStructured = requireRecord(launched.structuredContent, "launch structured content");
   expect(JSON.stringify(launchStructured)).not.toContain(connection.id);
   expect(requireRecord(launchStructured.app, "launch app").id).toBe(appId);
-  expect(requireRecord(launchStructured.serverTools, "launch server tools").runProgram).toBe(runProgramToolName);
+  expect(requireRecord(launchStructured.serverTools, "launch server tools")).toEqual({
+    searchCapabilities: "search_capabilities",
+    executeCapability: "execute_capability",
+  });
 
+  const programSearch = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "search_capabilities",
+    arguments: { query: "Project Atlas Connect program", type: "marketplace", limit: 5 },
+  });
+  const programMatches = Array.isArray(requireRecord(programSearch.structuredContent, "Program search").matches)
+    ? (requireRecord(programSearch.structuredContent, "Program search").matches as unknown[]).filter(isRecord)
+    : [];
+  const programMatch = requireRecord(programMatches.find((match) => match.kind === "script"), "Program capability match");
   const programRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
-    name: runProgramToolName,
-    arguments: { input: programInput },
+    name: "execute_capability",
+    arguments: { name: programMatch.name, body: programInput },
   });
   expect(programRun.isError, JSON.stringify(programRun)).not.toBe(true);
-  expect(JSON.stringify(requireRecord(programRun.structuredContent, "Program run result").value)).toContain("Atlas migration");
+  expect(JSON.stringify(programRun.structuredContent)).toContain("Atlas migration");
   expect(standardMcpCalls).toBe(2);
+
+  const connectSearch = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "search_capabilities",
+    arguments: { query: "Atlas read-only projects", type: "mcp", limit: 5 },
+  });
+  const connectMatches = Array.isArray(requireRecord(connectSearch.structuredContent, "Connect search").matches)
+    ? (requireRecord(connectSearch.structuredContent, "Connect search").matches as unknown[]).filter(isRecord)
+    : [];
+  const connectMatch = requireRecord(connectMatches.find((match) => String(match.name ?? "").includes("search_projects")), "Connect capability match");
+  const connectRun = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "execute_capability",
+    arguments: { name: connectMatch.name, schemaDigest: connectMatch.schemaDigest, body: programInput },
+  });
+  expect(connectRun.isError, JSON.stringify(connectRun)).not.toBe(true);
+  expect(JSON.stringify(connectRun.structuredContent)).toContain("Atlas migration");
+  expect(standardMcpCalls).toBe(3);
 
   const resources = await agentRpc(den.ref.apiUrl, mcpToken, "resources/list", {});
   expect(Array.isArray(resources.resources) && resources.resources.some((resource) => isRecord(resource) && resource.uri === firstResourceUri)).toBe(true);
@@ -844,7 +867,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     name: "search_projects",
     arguments: { query: "migration" },
   }, connectedEndpoint);
-  expect(standardMcpCalls).toBe(3);
+  expect(standardMcpCalls).toBe(4);
   expect(JSON.stringify(proxied.content)).toContain("Atlas project result for migration");
   expect(JSON.stringify(proxied.structuredContent)).toContain("Atlas migration");
   expect(requireRecord(proxied._meta, "proxied metadata").source).toBe("project-atlas-standard-mcp");
@@ -1016,7 +1039,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(mountedProjectAtlas, `${desktopTranscript}\nPersisted tool: ${persistedProjectAtlasTool}`).toBe(true);
   expect(desktopTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(desktopTranscript).not.toContain("Interactive view unavailable");
-  expect(standardMcpCalls).toBe(4);
+  expect(standardMcpCalls).toBe(5);
   const desktopShot = await screenshot(desktopApp);
   const desktopExpectations = [
     "The conversation visibly contains the connected Project Atlas MCP App",
@@ -1049,7 +1072,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   })()`);
   expect(installedComposerFocused).toBe(true);
   await desktopApp.client.send("Input.insertText", {
-    text: "Open installed Project Atlas and load the migration projects through its selected Program once.",
+    text: "Open installed Project Atlas and let it search and execute the authorized Connect tool and Program once.",
   });
   await clickButton(desktopApp, "Run task", { timeoutMs: 30_000 });
   await waitFor(desktopApp, `document.body.innerText.includes(${JSON.stringify(installedClosingReply)})`, {
@@ -1062,26 +1085,27 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   });
   const mountedProgramApp = await waitForMountedProjectAtlas(
     desktopApp,
-    ["Project Atlas", "Connected through an OpenWork Program", "Atlas migration"],
+    ["Project Atlas", "Connected through OpenWork capability search", "Atlas migration", "blocked"],
     30_000,
   );
   const approvalCount = await evalIn(desktopApp, "window.__remoteMcpApprovalCount ?? 0");
   const installedTranscript = await evalIn(desktopApp, "document.body?.innerText ?? ''");
   expect(mountedProgramApp, String(installedTranscript)).toBe(true);
-  expect(approvalCount).toBe(1);
+  expect(approvalCount).toBe(2);
   expect(installedTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(installedTranscript).not.toContain("Interactive view unavailable");
-  expect(standardMcpCalls).toBe(5);
+  expect(standardMcpCalls).toBe(7);
   const installedShot = await screenshot(desktopApp);
   const installedExpectations = [
     "The conversation visibly contains the installed Project Atlas MCP App",
-    "The app reports that it connected through an OpenWork Program",
-    "The Program-backed result contains Atlas migration",
+    "The app reports that it connected through OpenWork capability search",
+    "The Connect tool and Program results contain Atlas migration",
+    "The app-visible attempt to invoke the model-only installer was blocked",
     "No interactive-view-unavailable or crash message is visible",
   ];
   const installedSeen = await validate(installedShot, installedExpectations, {
     ask: async (request) => request.prompt.startsWith("Objectively describe")
-      ? JSON.stringify({ description: "An installed Project Atlas MCP App calling a selected OpenWork Program, with Atlas migration data returned through OpenWork Connect." })
+      ? JSON.stringify({ description: "An installed Project Atlas MCP App using same-server capability search to call an authorized Connect tool and Program, with the model-only installer blocked." })
       : JSON.stringify({ results: installedExpectations.map((expectation) => ({ expectation, passed: true, evidence: "The deterministic Desktop, MCP Apps bridge, approval, Program, and downstream Connect assertions completed before capture." })) }),
   });
   expect(installedSeen.ok, installedSeen.why).toBe(true);
@@ -1138,7 +1162,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     "content-disposition": expect.stringContaining("project-atlas.html"),
     etag: `"${firstDigest}"`,
   });
-  expect(await download.text()).toContain("Portable revision 1.0.0");
+  expect(await download.text()).toBe(firstHtml);
 
   await navigate(browser.client, `${den.ref.webUrl}/dashboard/apps/${encodeURIComponent(appId)}`);
   await waitFor(browser, `document.body.innerText.includes("Project Atlas")
@@ -1179,7 +1203,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
 
   evidence.fact(
     "Externally authored MCP Apps use standard same-server tools while Programs compose OpenWork Connect",
-    `Preserved native Project Atlas server identity, tools, exact UI metadata, resources, structuredContent, and _meta through connection ${connection.id}; completed both MCP Apps handshakes; imported ${appId}; called app-visible run_program on the originating OpenWork server; returned Atlas migration from the selected Program's downstream Connect call; served two immutable ui:// revisions after the source returned 404; and removed/restored ${launchToolName} through the Library lifecycle.`,
-    standardMcpCalls === 5 && mountedProjectAtlas && mountedProgramApp && approvalCount === 1,
+    `Preserved native Project Atlas server identity, tools, exact UI metadata, resources, structuredContent, and _meta through connection ${connection.id}; completed both MCP Apps handshakes; imported ${appId} through the model-only installer; blocked installer access from the App; searched and executed an authorized Connect tool and durable Program through ordinary same-server tools/call; returned Atlas migration; served two immutable ui:// revisions after the source returned 404; and removed/restored ${launchToolName} through the Library lifecycle.`,
+    standardMcpCalls === 7 && mountedProjectAtlas && mountedProgramApp && approvalCount === 2,
   );
 });

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -41,8 +41,9 @@ config:
     installLinksGatingEnabled: "false"
     # Enable only after compatible Desktop MCP Apps hosts are deployed.
     generatedArtifactViewsEnabled: "false"
-    # Independent rollout for imported, cached Remote MCP Apps.
-    remoteMcpAppsEnabled: "false"
+    # Imported, cached standard MCP Apps are on by default after the compatible
+    # Desktop host rollout. Set false for an operator rollback.
+    remoteMcpAppsEnabled: "true"
     connectLinkMode: exchange
     connectLinkKeyId: ""
     openworkAppConnectUrl: ""


### PR DESCRIPTION
## Summary

- Preserves native standard MCP Apps from connected MCP servers without conversion: OpenWork proxies their advertised tools, `ui://` resources, UI metadata, results, and app-visible same-server calls.
- Adds a model-visible, app-invisible `import_remote_mcp_app` tool for installing an externally built self-contained `index.html` from a public HTTPS URL into an existing Plugin after normal user approval.
- Downloads the document server-side with guarded redirects, SSRF protection, MIME and UTF-8 validation, a 15-second timeout, and a 768 KiB limit. OpenWork stores the exact bytes, digest, diagnostics, CSP, and immutable revision, then serves only the versioned cached `ui://` resource.
- Gives imported Apps the existing app-visible `search_capabilities` and `execute_capability` tools on their originating OpenWork MCP server. Apps can search and execute authorized Connect tools and Code Mode Programs through ordinary `tools/call` and `structuredContent`; credentials and direct cross-server iframe access remain prohibited.
- Keeps agent-generated UI authoring default-off behind `DEN_GENERATED_ARTIFACT_VIEWS_ENABLED`. Generated source submission, compilation, revision, activation, resource, and launch tools are absent or rejected while disabled. This flag remains independent from organization `codemodeScripts` policy.
- Keeps Remote MCP Apps enabled by default behind the independent `DEN_REMOTE_MCP_APPS_ENABLED` operator rollback.

## Production regression fixes

- **DEN-API-1X:** the external MCP proxy registers `tools/list` and `tools/call` only when the downstream server advertises `tools`, and resource list/template/read handlers only when it advertises `resources`. Tool-only and resource-less servers now initialize safely.
- **DEN-API-1W / DEN-API-1Y:** OAuth registration, discovery, network, and downstream initialization failures return sanitized JSON-RPC errors with a diagnostic reference and safe reconnect/configuration guidance instead of escaping as Hono 500s. Credentials, provider bodies, and stack traces are never returned. Provider-rejected OAuth registration is contained and attributed; OpenWork does not claim to repair it.
- The native Connect server index now includes only connections ready for the requesting member: shared OAuth/API-key credentials must exist, per-member OAuth requires that member's credential, and issuer-review-blocked connections remain excluded. Disconnected rows remain available through existing Connect management and capability-status flows.
- Unsupported/stateless GET requests return before downstream discovery.

## Standards and security boundary

URL download and semantic capability search are OpenWork installation/gateway behavior, not new MCP protocol primitives. Runtime UI delivery and communication use the stable MCP Apps resource and same-server `tools/call` contracts. React or Vite may be used outside OpenWork to author and bundle the self-contained HTML; OpenWork does not accept React/JavaScript source or build projects through the agent tool, and this is not React SSR.

Installation cannot be invoked from a sandboxed App or through the generic capability registry. Underlying Plugin access, member authorization, provider tool policy, conservative write/destructive confirmation, audit paths, iframe isolation, CSP, byte limits, teardown, and error containment remain enforced.

## Release matrix

- Standard MCP Apps from connected MCP servers: enabled.
- Agent-imported HTTPS MCP Apps: enabled with approval.
- Connect capability search and Code Mode Programs: enabled according to existing organization policy.
- Agent-generated OpenWork UI and server-side React authoring: disabled by default.

## Non-goals

- No external MCP architecture redesign.
- No live external iframes, direct cross-server iframe calls, custom runtime messaging, or inline source authoring.
- No generated Artifact view rollout or coupling to `codemodeScripts`.
- No database migration.

## Verification

- Focused Den API MCP, diagnostics, OAuth, policy, capability, Program, rollout, and Remote MCP App suites: 154 passed, 0 failed.
- Desktop server MCP App host suite: 15 passed, 0 failed, including model-only installer denial, exact-resource binding, approval, and healthy native MCP App calls.
- TypeScript checks passed for Den API, Desktop, Desktop server, and Den Web.
- Exact-head `@openwork/testkit` spec passed with no skips on `943e6889d52c057d009119019ff5bd006afcc01d`: `pnpm evals remote-mcp-apps`.
- The tape proves agent discovery/import, strict input rejection, immutable digest-addressed caching, source-loss resilience, generated-authoring denial, native MCP App preservation, same-server Connect and Program execution, Desktop approval/handshake, refresh, activation, rollback, retirement, restore, and discovery updates.

Public authoring example: https://github.com/reachjalil/openwork-remote-mcp-app-example

Installable bundle: https://reachjalil.github.io/openwork-remote-mcp-app-example/index.html
