### PR TITLE
feat(den-web): confirm the app is running as its own install step

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { detectPlatform, DownloadPlatformGrid, type DetectedPlatform, type DownloadPlatformGroup, type DownloadPlatformOption } from "@openwork/ui/react";
-import { ChevronDown, Download, ShieldCheck } from "lucide-react";
+import { Check, ChevronDown, Download, ShieldCheck } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { requestJson } from "../_lib/den-flow";
@@ -35,6 +35,16 @@ type InstallConfig = {
 
 const RETURN_TO_OPENWORK_URL = "openwork://open";
 const INSTALL_PLATFORMS: InstallPlatform[] = ["mac-arm64", "mac-x64", "win-x64", "linux-x64", "linux-arm64"];
+const TOTAL_GUIDE_STEPS = 4;
+
+type GuideStep = 1 | 2 | 3 | 4;
+
+function parseGuideStep(value: string | null): GuideStep {
+  if (value === "4") return 4;
+  if (value === "3") return 3;
+  if (value === "2") return 2;
+  return 1;
+}
 
 type InstallerOs = "macos" | "windows" | "linux";
 
@@ -200,7 +210,7 @@ type StepState = "complete" | "active" | "pending";
 
 const STEP_SHELL: Record<StepState, string> = {
   complete: "border-[#e7eaef] bg-[#fafbfc]",
-  active: "border-[#c8d6f5] bg-[#f8faff]",
+  active: "border-[#b9cafa] bg-[#f8faff] shadow-[0_12px_30px_rgba(62,99,221,0.08)]",
   pending: "border-[#e1e4e8] bg-[#f7f8fa]",
 };
 
@@ -292,10 +302,9 @@ export function InstallScreen() {
   const [downloadPlatform, setDownloadPlatform] = useState<InstallPlatform | null>(null);
   const [detected, setDetected] = useState<DetectedPlatform | null>(null);
   const [currentLink, setCurrentLink] = useState("");
-  const requestedStep = searchParams.get("step");
-  const initialStep = requestedStep === "3" ? 3 : requestedStep === "2" ? 2 : 1;
-  const [guideStep, setGuideStep] = useState<1 | 2 | 3>(initialStep);
-  const [expandedStep, setExpandedStep] = useState<1 | 2 | 3>(initialStep);
+  const initialStep = parseGuideStep(searchParams.get("step"));
+  const [guideStep, setGuideStep] = useState<GuideStep>(initialStep);
+  const [expandedStep, setExpandedStep] = useState<GuideStep>(initialStep);
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [desktopGrant, setDesktopGrant] = useState<string | null>(null);
@@ -408,7 +417,7 @@ export function InstallScreen() {
     }
   }
 
-  function advanceGuide(nextStep: 2 | 3) {
+  function advanceGuide(nextStep: 2 | 3 | 4) {
     setGuideStep(nextStep);
     setExpandedStep(nextStep);
     const url = new URL(window.location.href);
@@ -456,7 +465,7 @@ export function InstallScreen() {
       rememberDesktopHandoffGrant(grant);
       setDesktopGrant(grant);
       setConnectLink(nextConnectLink);
-      advanceGuide(3);
+      advanceGuide(4);
       window.location.assign(nextConnectLink);
     } catch (connectFailure) {
       setConnectError(connectFailure instanceof Error ? connectFailure.message : "Could not open OpenWork. Try again.");
@@ -522,7 +531,7 @@ export function InstallScreen() {
 
   if (busy) {
     return (
-      <OnboardingShell state="install-loading" width="wide">
+      <OnboardingShell state="install-loading" width="wide" background="surface">
         <section className="grid gap-4 rounded-[1.75rem] border border-slate-200/80 bg-white p-6 md:p-8" data-testid="install-page">
           <p className="den-eyebrow">OpenWork Desktop</p>
           <h1 className="den-title-lg">Loading your install link.</h1>
@@ -534,7 +543,7 @@ export function InstallScreen() {
 
   if (!config) {
     return (
-      <OnboardingShell state="install-error" width="wide">
+      <OnboardingShell state="install-error" width="wide" background="surface">
         <section className="grid gap-6 rounded-[1.75rem] border border-slate-200/80 bg-white p-6 md:p-8" data-testid="install-page">
           <div className="grid gap-2">
             <p className="den-eyebrow">OpenWork Desktop</p>
@@ -548,7 +557,7 @@ export function InstallScreen() {
 
   if (config.distribution === "cloud") {
     return (
-      <OnboardingShell state="install" width="full">
+      <OnboardingShell state="install" width="full" background="surface">
         <section data-testid="install-page">
           <div className="grid gap-6 rounded-[1.75rem] border border-[#e7eaef] bg-[#fcfcfd] p-5 text-center sm:p-6 md:p-8" data-testid="install-card">
             <div className="grid justify-items-center gap-3">
@@ -587,10 +596,14 @@ export function InstallScreen() {
   const guidance = openGuidance(installerOsFor(downloadPlatform, detected), installerFile);
 
   return (
-    <OnboardingShell state="install" width="full">
+    <OnboardingShell state="install" width="full" background="surface">
       <section data-testid="install-page">
-        <div className="grid gap-6 rounded-[1.75rem] border border-[#e7eaef] bg-[#fcfcfd] p-5 text-center sm:p-6 md:p-8" data-testid="install-card">
+        <div className="grid gap-6 rounded-[1.75rem] border border-[#e1e5eb] bg-white p-5 text-center shadow-[0_18px_55px_rgba(16,24,40,0.06)] sm:p-6 md:p-8" data-testid="install-card">
           <div className="grid justify-items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border border-[#d3e0fb] bg-[#f4f7ff] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#3e63dd]">
+              <span className="size-1.5 rounded-full bg-[#3e63dd]" aria-hidden="true" />
+              Step {guideStep} of {TOTAL_GUIDE_STEPS}
+            </div>
             <h1 className="m-0 grid max-w-[22ch] gap-1 text-[2rem] font-semibold leading-[1.04] tracking-[-0.05em] text-slate-950 sm:text-[2.4rem]">
               <span>Download OpenWork Enterprise</span>
               <span className="flex min-w-0 flex-wrap items-center justify-center gap-x-[0.18em] gap-y-1">
@@ -601,7 +614,7 @@ export function InstallScreen() {
                 />
               </span>
             </h1>
-            <p className="den-copy">Complete one step at a time. Select any step to expand or review.</p>
+            <p className="den-copy max-w-xl">Complete one step at a time. We&apos;ll guide you from download to activation.</p>
           </div>
 
         {isMobile ? (
@@ -660,18 +673,15 @@ export function InstallScreen() {
             <InstallStep
               index={2}
               state={guideStep === 2 ? "active" : guideStep > 2 ? "complete" : "pending"}
-              title="Continue on your computer"
+              title="Install and open OpenWork Enterprise"
               description={guideStep < 2
-                ? "Only continue once OpenWork Enterprise is installed and open on this computer."
-                : "Open the downloaded app. It will wait at the pixel-dither activation screen."}
+                ? "Only continue once the download finished on this computer."
+                : "Run the installer, then launch the app."}
               expanded={expandedStep === 2 && guideStep >= 2}
               onExpand={() => setExpandedStep(2)}
               testId="install-guide-step-open"
             >
-                  <div className="grid content-start gap-3 rounded-[14px] border border-[#e1e4e8] bg-white p-[18px]">
-                      <p className="m-0 text-xs font-semibold uppercase tracking-[0.04em] text-[#667085]">Next, on your computer</p>
-                      <p className="m-0 text-base font-semibold text-[#101828]">Open the file you just downloaded</p>
-
+                  <div className="grid content-start gap-3">
                       {installerFile ? (
                         <div className="flex items-center gap-2.5 rounded-[10px] border border-[#e1e4e8] bg-[#fafbfc] px-3 py-2.5" data-testid="install-file-chip">
                           <span className="grid size-[30px] shrink-0 place-items-center rounded-lg border border-[#e1e4e8] bg-white" aria-hidden="true">
@@ -696,43 +706,60 @@ export function InstallScreen() {
                       </ol>
 
                       {guidance.trust ? (
-                        <div className="flex items-start gap-2.5" data-testid="install-os-trust-note">
-                          <ShieldCheck className="mt-px size-[15px] shrink-0 text-[#8a6420]" aria-hidden="true" />
-                          <span className="grid gap-0.5">
-                            <span className="text-[13px] font-semibold leading-[17px] text-[#7a5714]">{guidance.trust.title}</span>
-                            <span className="text-[13px] leading-[17px] text-[#7a5714]">{guidance.trust.body}</span>
-                          </span>
-                        </div>
+                        <p className="m-0 flex items-start gap-2 text-[13px] leading-[17px] text-[#7a5714]" data-testid="install-os-trust-note">
+                          <ShieldCheck className="mt-px size-[15px] shrink-0" aria-hidden="true" />
+                          {guidance.trust.body}
+                        </p>
                       ) : null}
 
-                      <div className="flex items-start gap-2.5 rounded-[10px] border border-[#d3e0fb] bg-[#eef4ff] px-3 py-2.5" data-testid="install-handoff-note">
-                        <span className="mt-0.5 grid size-3.5 shrink-0 place-items-center rounded-full bg-[#3e63dd]/20" aria-hidden="true">
-                          <span className="size-1.5 rounded-full bg-[#3e63dd]" />
-                        </span>
-                        <span className="grid gap-0.5">
-                          <span className="text-[13px] font-semibold leading-[17px] text-[#1f3d8f]">Activation happens from this Den page</span>
-                          <span className="text-[13px] leading-[17px] text-[#3a4e80]">OpenWork Enterprise stays locked until this signed-in portal sends it a one-time activation link.</span>
-                        </span>
-                      </div>
+                      <button
+                        type="button"
+                        className="grid min-h-10 w-fit place-items-center rounded-[9px] bg-[#101828] px-4 text-[13px] font-semibold text-white transition-colors hover:bg-black"
+                        data-testid="install-app-ready"
+                        onClick={() => advanceGuide(3)}
+                      >
+                        The app is installed and open
+                      </button>
+                  </div>
+            </InstallStep>
 
-                      <div className="flex items-center gap-2.5 py-1">
-                        <span className="h-px grow bg-[#e1e4e8]" />
-                        <span className="text-xs text-[#7a808a]">THEN</span>
-                        <span className="h-px grow bg-[#e1e4e8]" />
-                      </div>
+            <InstallStep
+              index={3}
+              state={guideStep === 3 ? "active" : guideStep > 3 ? "complete" : "pending"}
+              title="Confirm the app is running, then activate"
+              description={guideStep < 3
+                ? "Activation only works while OpenWork Enterprise is open on this computer."
+                : "Check both lines below, then send the one-time activation link from this page."}
+              expanded={expandedStep === 3 && guideStep >= 3}
+              onExpand={() => setExpandedStep(3)}
+              testId="install-guide-step-confirm-running"
+            >
+                  <div className="grid content-start gap-3">
+                      <ul className="m-0 grid list-none gap-2 p-0" data-testid="install-running-checklist">
+                        {[
+                          `${config.appName} is installed and open on this computer.`,
+                          "It is waiting on its activation screen.",
+                        ].map((item) => (
+                          <li key={item} className="flex items-start gap-2.5">
+                            <Check className="mt-0.5 size-4 shrink-0 text-[#30a46c]" aria-hidden="true" />
+                            <span className="text-[13px] leading-5 text-[#344054]">{item}</span>
+                          </li>
+                        ))}
+                      </ul>
 
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="m-0 text-[13px] leading-[17px] text-[#344054]">When the enterprise app is open at its activation screen:</p>
-                        <button
-                          type="button"
-                          className="grid h-9 shrink-0 place-items-center rounded-[9px] bg-[#101828] px-4 text-[13px] font-semibold text-white transition-colors hover:bg-black disabled:opacity-60"
-                          data-testid="install-connect-open"
-                          disabled={connecting}
-                          onClick={() => void beginConnect()}
-                        >
-                          {connecting ? "Preparing…" : "Activate OpenWork Enterprise"}
-                        </button>
-                      </div>
+                      <p className="m-0 text-[13px] leading-[17px] text-[#60646c]" data-testid="install-handoff-note">
+                        {config.appName} stays locked until this signed-in page sends it a one-time activation link.
+                      </p>
+
+                      <button
+                        type="button"
+                        className="grid min-h-10 w-fit place-items-center rounded-[9px] bg-[#101828] px-4 text-[13px] font-semibold text-white transition-colors hover:bg-black disabled:opacity-60"
+                        data-testid="install-connect-open"
+                        disabled={connecting}
+                        onClick={() => void beginConnect()}
+                      >
+                        {connecting ? "Preparing…" : "Activate OpenWork Enterprise"}
+                      </button>
 
                       <details className="grid gap-2 border-t border-[#e1e4e8] pt-3 [&[open]_svg]:rotate-180">
                         <summary className="flex cursor-pointer list-none items-center gap-1.5 text-xs font-semibold text-[#344054] [&::-webkit-details-marker]:hidden">
@@ -756,12 +783,12 @@ export function InstallScreen() {
             </InstallStep>
 
             <InstallStep
-              index={3}
-              state={guideStep === 3 ? "active" : "pending"}
+              index={4}
+              state={guideStep === 4 ? "active" : "pending"}
               title="Confirm activation"
               description="Keep this page open while OpenWork Enterprise consumes the one-time link and signs you in."
-              expanded={expandedStep === 3 && guideStep === 3}
-              onExpand={() => setExpandedStep(3)}
+              expanded={expandedStep === 4 && guideStep === 4}
+              onExpand={() => setExpandedStep(4)}
               testId="install-guide-step-signin"
             >
                   <div className="grid gap-3" aria-live="polite">
@@ -789,7 +816,7 @@ export function InstallScreen() {
                         </span>
                       </div>
                     ) : handoffStatus.status === "unknown" ? (
-                      <p className="m-0 text-sm text-amber-700">This one-time link expired. Return to step 2 and create a fresh activation link.</p>
+                      <p className="m-0 text-sm text-amber-700">This one-time link expired. Return to step 3 and create a fresh activation link.</p>
                     ) : null}
 
                     {handoffStatus.status === "consumed" ? (

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -11,6 +11,7 @@ import {
   rememberDesktopHandoffGrant,
 } from "../_lib/desktop-handoff";
 import { getInstallConfigErrorMessage } from "../_lib/install-errors";
+import { CONFIRM_RUNNING_STEP, parseGuideStep, TOTAL_GUIDE_STEPS, type GuideStep } from "../_lib/install-guide";
 import { buildInstallDownloadHref, type InstallPlatform, installerFileName } from "../_lib/install-download";
 import { isMobileUserAgent } from "../_lib/platform";
 import { useDesktopHandoffStatus } from "../_lib/use-desktop-handoff-status";
@@ -35,16 +36,7 @@ type InstallConfig = {
 
 const RETURN_TO_OPENWORK_URL = "openwork://open";
 const INSTALL_PLATFORMS: InstallPlatform[] = ["mac-arm64", "mac-x64", "win-x64", "linux-x64", "linux-arm64"];
-const TOTAL_GUIDE_STEPS = 4;
 
-type GuideStep = 1 | 2 | 3 | 4;
-
-function parseGuideStep(value: string | null): GuideStep {
-  if (value === "4") return 4;
-  if (value === "3") return 3;
-  if (value === "2") return 2;
-  return 1;
-}
 
 type InstallerOs = "macos" | "windows" | "linux";
 
@@ -716,7 +708,7 @@ export function InstallScreen() {
                         type="button"
                         className="grid min-h-10 w-fit place-items-center rounded-[9px] bg-[#101828] px-4 text-[13px] font-semibold text-white transition-colors hover:bg-black"
                         data-testid="install-app-ready"
-                        onClick={() => advanceGuide(3)}
+                        onClick={() => advanceGuide(CONFIRM_RUNNING_STEP)}
                       >
                         The app is installed and open
                       </button>

--- a/ee/apps/den-web/app/(den)/_components/onboarding-shell.tsx
+++ b/ee/apps/den-web/app/(den)/_components/onboarding-shell.tsx
@@ -2,17 +2,110 @@
 
 import { DitheredOnboardingShell } from "@openwork/ui/react";
 import type { DitheredOnboardingShellProps } from "@openwork/ui/react";
-import type { ReactNode } from "react";
+import { Dithering } from "@paper-design/shaders-react";
+import { useSyncExternalStore, type ReactNode } from "react";
+import { useWebGlSupported } from "../_lib/use-webgl-supported";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+const SURFACE_WIDTHS = {
+  compact: "max-w-md",
+  wide: "max-w-3xl",
+  full: "max-w-5xl",
+} as const;
+
+function subscribeToReducedMotion(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getReducedMotionSnapshot() {
+  return typeof window === "undefined"
+    ? true
+    : window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+/**
+ * Same dither field as the signed-in organization picker, so activation flows
+ * that continue a Den session keep that surface instead of the lighter blue
+ * pre-sign-in onboarding wash.
+ */
+function SurfaceShell({
+  children,
+  state,
+  width,
+}: {
+  children: ReactNode;
+  state: string;
+  width: keyof typeof SURFACE_WIDTHS;
+}) {
+  const reducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    () => true,
+  );
+  const webGlSupported = useWebGlSupported();
+  const shaderSpeed = reducedMotion ? 0 : 0.01;
+
+  return (
+    <div
+      className="relative isolate min-h-dvh overflow-y-auto bg-[var(--dls-surface)] px-4 py-8 text-[var(--dls-text-primary)] sm:py-12"
+      data-testid="join-org-root"
+      data-state={state}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-0 overflow-hidden opacity-[0.1]"
+        data-motion={shaderSpeed === 0 ? "reduced" : "ambient"}
+        data-shader-speed={shaderSpeed}
+        data-testid="join-org-background"
+      >
+        {webGlSupported ? (
+          <Dithering
+            speed={shaderSpeed}
+            shape="warp"
+            type="2x2"
+            size={20.3}
+            scale={1.19}
+            frame={264559.21}
+            colorBack="#00000000"
+            colorFront="#000000"
+            style={{ width: "100%", height: "100%" }}
+          />
+        ) : null}
+      </div>
+
+      <main
+        className={`relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full ${SURFACE_WIDTHS[width]} flex-col justify-center sm:min-h-[calc(100dvh-6rem)]`}
+        data-testid="join-org-foreground"
+      >
+        {children}
+      </main>
+    </div>
+  );
+}
 
 export function OnboardingShell({
   children,
   state,
   width = "compact",
+  background = "onboarding",
 }: {
   children: ReactNode;
   state: string;
   width?: DitheredOnboardingShellProps["width"];
+  background?: "onboarding" | "surface";
 }) {
+  if (background === "surface") {
+    return (
+      <SurfaceShell state={state} width={width}>
+        {children}
+      </SurfaceShell>
+    );
+  }
+
   return (
     <DitheredOnboardingShell state={state} width={width}>
       {children}

--- a/ee/apps/den-web/app/(den)/_lib/install-guide.ts
+++ b/ee/apps/den-web/app/(den)/_lib/install-guide.ts
@@ -1,0 +1,13 @@
+export const TOTAL_GUIDE_STEPS = 4;
+
+export type GuideStep = 1 | 2 | 3 | 4;
+
+/** Step 3 confirms the app is installed and running before activation is offered. */
+export const CONFIRM_RUNNING_STEP = 3;
+
+export function parseGuideStep(value: string | null): GuideStep {
+  if (value === "4") return 4;
+  if (value === "3") return 3;
+  if (value === "2") return 2;
+  return 1;
+}

--- a/evals/specs/install-confirm-app-running.test.ts
+++ b/evals/specs/install-confirm-app-running.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  CONFIRM_RUNNING_STEP,
+  parseGuideStep,
+  TOTAL_GUIDE_STEPS,
+} from "../../ee/apps/den-web/app/(den)/_lib/install-guide";
+
+const installScreenPath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/(den)/_components/install-screen.tsx", import.meta.url),
+);
+const denShellPath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/(den)/_components/onboarding-shell.tsx", import.meta.url),
+);
+const sharedShellPath = fileURLToPath(
+  new URL("../../packages/ui/src/react/dithered-onboarding-shell.tsx", import.meta.url),
+);
+
+function stepBody(source: string, testId: string) {
+  const start = source.indexOf(`testId="${testId}"`);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf("</InstallStep>", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+test("the enterprise install guide confirms the app is running in its own step", async ({ evidence }) => {
+  const source = readFileSync(installScreenPath, "utf8");
+  const confirmStep = stepBody(source, "install-guide-step-confirm-running");
+  const openStep = stepBody(source, "install-guide-step-open");
+
+  expect(TOTAL_GUIDE_STEPS).toBe(4);
+  expect(CONFIRM_RUNNING_STEP).toBe(3);
+  expect(parseGuideStep("2")).toBe(2);
+  expect(parseGuideStep("3")).toBe(3);
+  expect(parseGuideStep("4")).toBe(4);
+  expect(parseGuideStep(null)).toBe(1);
+  expect(parseGuideStep("nonsense")).toBe(1);
+
+  // Activation is reachable only from the confirm-running step, never from installing.
+  expect(confirmStep).toContain('data-testid="install-connect-open"');
+  expect(confirmStep).toContain('data-testid="install-running-checklist"');
+  expect(confirmStep).toContain("is installed and open on this computer.");
+  expect(confirmStep).toContain("It is waiting on its activation screen.");
+  expect(openStep).not.toContain('data-testid="install-connect-open"');
+  expect(openStep).toContain('data-testid="install-app-ready"');
+  expect(openStep).toContain("advanceGuide(CONFIRM_RUNNING_STEP)");
+
+  // The install step stays light: no nested card, no heading repeating its own title.
+  expect(openStep).not.toContain("Next, on your computer");
+  expect(openStep).not.toContain("Open the file you just downloaded");
+  expect(openStep).not.toContain("bg-white p-4 shadow-");
+  expect(source).toContain("Step {guideStep} of {TOTAL_GUIDE_STEPS}");
+  expect(source).toContain('index={4}');
+  expect(source).toContain('testId="install-guide-step-signin"');
+
+  evidence.fact(
+    "Confirming the app runs is its own install step",
+    "parseGuideStep accepts steps 1-4, the activate action lives only in step 3 next to the running checklist, and step 2 only installs/opens the app and hands off with install-app-ready.",
+    true,
+  );
+});
+
+test("the install guide renders on the organization-picker dither surface", async ({ evidence }) => {
+  const installSource = readFileSync(installScreenPath, "utf8");
+  const denShell = readFileSync(denShellPath, "utf8");
+  const sharedShell = readFileSync(sharedShellPath, "utf8");
+  const shellUsages = installSource.match(/<OnboardingShell\b[^>]*>/g) ?? [];
+
+  expect(shellUsages.length).toBeGreaterThanOrEqual(4);
+  for (const usage of shellUsages) {
+    expect(usage).toContain('background="surface"');
+  }
+
+  // The surface variant mirrors the signed-in organization picker field.
+  expect(denShell).toContain('colorFront="#000000"');
+  expect(denShell).toContain('colorBack="#00000000"');
+  expect(denShell).toContain('type="2x2"');
+  expect(denShell).toContain("size={20.3}");
+  expect(denShell).toContain("scale={1.19}");
+  expect(denShell).toContain("bg-[var(--dls-surface)]");
+  expect(denShell).toContain("const shaderSpeed = reducedMotion ? 0 : 0.01;");
+  expect(denShell).toContain("useWebGlSupported");
+
+  // The pre-sign-in onboarding wash is untouched for every other flow.
+  expect(sharedShell).toContain('colorFront="#8FB7E8"');
+  expect(sharedShell).toContain("bg-[#f8fbff]");
+  expect(sharedShell).toContain("const shaderSpeed = reducedMotion ? 0 : 0.012;");
+  expect((sharedShell.match(/<Dithering\b/g) ?? []).length).toBe(1);
+  expect(denShell).toContain("<DitheredOnboardingShell");
+
+  evidence.fact(
+    "The install guide uses the organization-picker shader, not the onboarding wash",
+    "Every install OnboardingShell passes background=surface, the den shell renders the 2x2 #000000 dither over --dls-surface behind a WebGL guard, and the shared onboarding shell keeps its single #8FB7E8 layer.",
+    true,
+  );
+});


### PR DESCRIPTION
## What changed

The enterprise install guide asked one step to do too much: install the app, confirm it was running, and activate it.

- **Split into 4 steps.** Step 2 installs and opens the app; new step 3 confirms it is running and owns the Activate action; step 4 confirms activation. `install-connect-open` no longer appears while the user is still installing.
- **Cut the density.** Removed the nested white card inside each step, the eyebrow + heading that repeated the step's own title, and collapsed the OS trust and handoff callout boxes into single lines.
- **Added step context.** A `Step N of 4` badge in the header.
- **Organization-picker background.** The install guide now renders on the same dither field as the signed-in org picker (2x2, `size 20.3`, `#000000` over `--dls-surface`, speed `0.01`, behind the existing WebGL guard) through a new `background="surface"` variant on the den-web `OnboardingShell`. The shared `DitheredOnboardingShell` keeps its single `#8FB7E8` sky layer, so join-org and other pre-sign-in flows are unchanged.

## Verification

| Command | Result |
| --- | --- |
| `pnpm evals:spec specs/install-confirm-app-running.test.ts` | **2 passed**, 0 failed, 0 skipped (lane: local — no Daytona credentials in this environment) |
| `pnpm --dir ee/apps/den-web test` | **113 passed**, 0 failed |
| `pnpm --dir ee/apps/den-web typecheck` | no new errors (pre-existing `.next/types` skill-hub module errors only, present on `dev`) |

The spec `evals/specs/install-confirm-app-running.test.ts` holds two witnessed facts:

1. `parseGuideStep` accepts steps 1–4, the activate action exists only inside the confirm-running step next to the running checklist, and the install step only installs/opens and hands off via `install-app-ready`.
2. Every install `OnboardingShell` passes `background="surface"`, the den shell renders the org-picker dither, and the shared onboarding shell keeps its single sky-palette layer.

Driven against the real page at `/install?token=…` over CDP:

- `step=2` → `download:complete, open:active, confirm-running:pending, signin:pending`, badge `STEP 2 OF 4`
- `step=3` → `download:complete, open:complete, confirm-running:active, signin:pending`, badge `STEP 3 OF 4`, activate button present inside step 3, root surface `rgb(255,255,255)` with the shader canvas mounted at `opacity 0.1`

## Note for reviewers

Two frozen legacy flows (`evals/flows/org-download-handoff.flow.mjs`, `evals/flows/keyless-den-connect.flow.mjs`) assume `install-connect-open` is reachable at `step=2`; it now lives in step 3. `ci-no-new-eval-flows.yml` allows only deletions under `evals/flows/**`, so they were left untouched — those assertions are not run by CI.
