### PR TITLE
feat(app): enterprise gate becomes a sign-in door with a server field

### DIFF
--- a/apps/app/src/app/lib/manual-auth-input.ts
+++ b/apps/app/src/app/lib/manual-auth-input.ts
@@ -1,0 +1,37 @@
+import { normalizeDenBaseUrl } from "./den";
+
+export type ManualAuthInput = {
+  grant: string;
+  baseUrl?: string;
+};
+
+/** Accept a raw handoff grant or an OpenWork desktop-auth deep link. */
+export function parseManualAuthInput(value: string): ManualAuthInput | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const url = new URL(trimmed);
+    const protocol = url.protocol.toLowerCase();
+    const routeHost = url.hostname.toLowerCase();
+    const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
+    const routeSegments = routePath.split("/").filter(Boolean);
+    const routeTail = routeSegments[routeSegments.length - 1] ?? "";
+    if (
+      (protocol === "openwork:" || protocol === "openwork-dev:") &&
+      (routeHost === "den-auth" ||
+        routePath === "den-auth" ||
+        routeTail === "den-auth")
+    ) {
+      const grant = url.searchParams.get("grant")?.trim() ?? "";
+      const nextBaseUrl =
+        normalizeDenBaseUrl(url.searchParams.get("denBaseUrl")?.trim() ?? "") ??
+        undefined;
+      return grant ? { grant, baseUrl: nextBaseUrl } : null;
+    }
+  } catch {
+    // Treat non-URL input as a raw handoff grant.
+  }
+
+  return trimmed.length >= 12 ? { grant: trimmed } : null;
+}

--- a/apps/app/src/app/lib/organization-server-input.ts
+++ b/apps/app/src/app/lib/organization-server-input.ts
@@ -1,0 +1,19 @@
+const explicitSchemePattern = /^[a-z][a-z\d+.-]*:\/\//i;
+
+export function normalizeOrganizationServerInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || /\s|\\/.test(trimmed)) return null;
+
+  const candidate = explicitSchemePattern.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!url.hostname.trim() || url.username || url.password) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}

--- a/apps/app/src/app/lib/organization-server-input.ts
+++ b/apps/app/src/app/lib/organization-server-input.ts
@@ -1,5 +1,13 @@
 const explicitSchemePattern = /^[a-z][a-z\d+.-]*:\/\//i;
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost"
+    || normalized === "::1"
+    || normalized === "[::1]"
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+
 export function normalizeOrganizationServerInput(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed || /\s|\\/.test(trimmed)) return null;
@@ -12,6 +20,7 @@ export function normalizeOrganizationServerInput(value: string): string | null {
     const url = new URL(candidate);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
     if (!url.hostname.trim() || url.username || url.password) return null;
+    if (url.protocol === "http:" && !isLoopbackHostname(url.hostname)) return null;
     return url.origin;
   } catch {
     return null;

--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -1,12 +1,24 @@
 /** @jsxImportSource react */
 import { Dithering } from "@paper-design/shaders-react";
-import { useSyncExternalStore, type ReactNode } from "react";
+import { useState, useSyncExternalStore, type FormEvent, type ReactNode } from "react";
 
-import { readDenBootstrapConfig } from "@/app/lib/den";
+import {
+  buildDenAuthUrl,
+  createDenClient,
+  readDenBootstrapConfig,
+  setDenBootstrapConfig,
+} from "@/app/lib/den";
+import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { markDesktopSignInInitiated } from "@/app/lib/den-sign-in-intent";
 import { enterpriseActivationRequired } from "@/app/lib/enterprise-activation";
 import { readDesktopDistributionInfo } from "@/app/lib/desktop";
+import { parseManualAuthInput } from "@/app/lib/manual-auth-input";
+import { normalizeOrganizationServerInput } from "@/app/lib/organization-server-input";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
+import { tryOpenBrowserAuthUrl } from "./open-browser-auth";
 
 function subscribeToBootstrap(onStoreChange: () => void) {
   if (typeof window === "undefined") return () => {};
@@ -24,6 +36,105 @@ export function useEnterpriseActivationRequired() {
 }
 
 function EnterpriseActivationPage() {
+  const [serverInput, setServerInput] = useState("");
+  const [serverBaseUrl, setServerBaseUrl] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [browserBusy, setBrowserBusy] = useState(false);
+  const [manualAuthOpen, setManualAuthOpen] = useState(false);
+  const [manualAuthInput, setManualAuthInput] = useState("");
+  const [authBusy, setAuthBusy] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const submitServer = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const baseUrl = normalizeOrganizationServerInput(serverInput);
+    if (!baseUrl) {
+      setServerError("Enter a valid OpenWork server address.");
+      return;
+    }
+
+    setBrowserBusy(true);
+    setServerError(null);
+    setAuthError(null);
+    try {
+      await setDenBootstrapConfig({ baseUrl, requireSignin: true });
+      setServerInput(baseUrl);
+      setServerBaseUrl(baseUrl);
+      markDesktopSignInInitiated();
+      const opened = await tryOpenBrowserAuthUrl(buildDenAuthUrl(baseUrl, "sign-in"));
+      if (!opened) {
+        setStatusMessage(null);
+        setAuthError("We couldn't open your browser automatically. Paste your sign-in code below.");
+        setManualAuthOpen(true);
+        return;
+      }
+      setStatusMessage("Finish signing in in your browser, then return to OpenWork.");
+    } catch (error) {
+      setStatusMessage(null);
+      setServerError(
+        error instanceof Error ? error.message : "Unable to save this OpenWork server.",
+      );
+    } finally {
+      setBrowserBusy(false);
+    }
+  };
+
+  const submitManualAuth = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = parseManualAuthInput(manualAuthInput);
+    if (!parsed) {
+      setAuthError("Paste a valid OpenWork sign-in link or one-time sign-in code.");
+      return;
+    }
+
+    const linkBaseUrl = parsed.baseUrl
+      ? normalizeOrganizationServerInput(parsed.baseUrl)
+      : null;
+    const enteredBaseUrl = normalizeOrganizationServerInput(serverInput) ?? serverBaseUrl;
+    const baseUrl = linkBaseUrl ?? enteredBaseUrl;
+    if (!baseUrl) {
+      setServerError("Enter your organization's OpenWork server before using a raw sign-in code.");
+      return;
+    }
+
+    setAuthBusy(true);
+    setAuthError(null);
+    setServerError(null);
+    setStatusMessage("Finishing OpenWork Enterprise sign-in…");
+    try {
+      const result = await exchangeHandoffAndSignIn(parsed.grant, {
+        baseUrl,
+        client: createDenClient({ baseUrl }),
+        desktopInitiated: true,
+        fallbackErrorMessage: "OpenWork Enterprise did not return a session token.",
+      });
+      if (!result.ok) {
+        setStatusMessage(null);
+        setAuthError(result.error);
+        return;
+      }
+
+      await setDenBootstrapConfig({
+        baseUrl,
+        requireSignin: true,
+        enterpriseActivation: {
+          activatedAt: new Date().toISOString(),
+          denBaseUrl: baseUrl,
+        },
+      });
+    } catch (error) {
+      setStatusMessage(null);
+      setAuthError(
+        error instanceof Error ? error.message : "Unable to finish OpenWork Enterprise sign-in.",
+      );
+    } finally {
+      setAuthBusy(false);
+    }
+  };
+
+  const liveMessage = serverError ?? authError ?? statusMessage;
+
   return (
     <div
       className="relative min-h-dvh bg-background text-foreground"
@@ -73,26 +184,92 @@ function EnterpriseActivationPage() {
 
           <div className="mt-10 flex flex-col gap-2.5 sm:mt-14">
             <h1 className="text-[30px] font-semibold leading-[38px] tracking-[-0.03em] text-foreground sm:text-[38px] sm:leading-[46px]">
-              Activate OpenWork Enterprise
+              Sign in to OpenWork Enterprise
             </h1>
             <p className="text-[15px] leading-[23px] text-muted-foreground">
-              OpenWork Enterprise access is managed by your organization. Return to your organization&apos;s
-              OpenWork Enterprise download page and select <strong className="font-semibold text-foreground">Activate OpenWork Enterprise</strong>.
-              This app will unlock when it receives the one-time activation link.
+              On your organization&apos;s OpenWork page, choose <strong className="font-semibold text-foreground">Open OpenWork</strong>, or enter your organization&apos;s server below.
             </p>
           </div>
 
-          <div className="mt-11 flex flex-col gap-3">
-            <div
-              className="rounded-xl border border-dls-border bg-dls-hover px-4 py-3 text-sm font-medium text-dls-text"
-              aria-live="polite"
-            >
-              Waiting for your organization&apos;s activation link…
+          <div className="mt-11 flex flex-col gap-4">
+            <form className="space-y-2" onSubmit={(event) => void submitServer(event)}>
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="organization-server-input"
+              >
+                Organization server
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  id="organization-server-input"
+                  data-testid="organization-server-input"
+                  value={serverInput}
+                  onChange={(event) => setServerInput(event.currentTarget.value)}
+                  placeholder="openwork.acme.com"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  disabled={browserBusy || authBusy}
+                  aria-invalid={serverError ? true : undefined}
+                />
+                <Button
+                  type="submit"
+                  className="sm:min-w-40"
+                  disabled={browserBusy || authBusy}
+                  data-testid="organization-server-continue"
+                >
+                  Continue in browser
+                </Button>
+              </div>
+            </form>
+
+            <div className="min-h-5 text-xs leading-5" aria-live="polite" role="status">
+              {liveMessage ? (
+                <span className={serverError || authError ? "text-destructive" : "text-muted-foreground"}>
+                  {liveMessage}
+                </span>
+              ) : null}
             </div>
 
-            <p className="text-xs leading-5 text-muted-foreground">
-              Access remains managed by your organization. Activation links expire and can be used once.
-            </p>
+            <div className="space-y-3">
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  setManualAuthOpen((open) => !open);
+                  setAuthError(null);
+                }}
+                disabled={browserBusy || authBusy}
+              >
+                {manualAuthOpen ? "Hide sign-in code" : "Paste sign-in code"}
+              </Button>
+
+              {manualAuthOpen ? (
+                <form
+                  className="space-y-3 rounded-xl border border-border bg-muted/30 p-4"
+                  onSubmit={(event) => void submitManualAuth(event)}
+                >
+                  <label className="text-sm font-medium text-foreground" htmlFor="enterprise-signin-code">
+                    Sign-in link or one-time code
+                  </label>
+                  <Input
+                    id="enterprise-signin-code"
+                    value={manualAuthInput}
+                    onChange={(event) => setManualAuthInput(event.currentTarget.value)}
+                    placeholder="openwork://den-auth?... or pasted code"
+                    disabled={authBusy}
+                  />
+                  <Button
+                    type="submit"
+                    className="w-full"
+                    disabled={authBusy || !manualAuthInput.trim()}
+                  >
+                    {authBusy ? "Finishing…" : "Finish sign-in"}
+                  </Button>
+                </form>
+              ) : null}
+            </div>
           </div>
         </section>
       </div>

--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -26,6 +26,10 @@ function subscribeToBootstrap(onStoreChange: () => void) {
   return () => window.removeEventListener(denSettingsChangedEvent, onStoreChange);
 }
 
+type PendingServerConfirmation =
+  | { kind: "browser"; baseUrl: string }
+  | { kind: "manual"; baseUrl: string; grant: string };
+
 export function useEnterpriseActivationRequired() {
   const bootstrap = useSyncExternalStore(
     subscribeToBootstrap,
@@ -37,7 +41,8 @@ export function useEnterpriseActivationRequired() {
 
 function EnterpriseActivationPage() {
   const [serverInput, setServerInput] = useState("");
-  const [serverBaseUrl, setServerBaseUrl] = useState<string | null>(null);
+  const [confirmedBaseUrl, setConfirmedBaseUrl] = useState<string | null>(null);
+  const [pendingConfirmation, setPendingConfirmation] = useState<PendingServerConfirmation | null>(null);
   const [serverError, setServerError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [browserBusy, setBrowserBusy] = useState(false);
@@ -46,7 +51,7 @@ function EnterpriseActivationPage() {
   const [authBusy, setAuthBusy] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
 
-  const submitServer = async (event: FormEvent<HTMLFormElement>) => {
+  const submitServer = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const baseUrl = normalizeOrganizationServerInput(serverInput);
     if (!baseUrl) {
@@ -54,56 +59,24 @@ function EnterpriseActivationPage() {
       return;
     }
 
-    setBrowserBusy(true);
+    setServerInput(baseUrl);
+    setPendingConfirmation({ kind: "browser", baseUrl });
     setServerError(null);
     setAuthError(null);
-    try {
-      await setDenBootstrapConfig({ baseUrl, requireSignin: true });
-      setServerInput(baseUrl);
-      setServerBaseUrl(baseUrl);
-      markDesktopSignInInitiated();
-      const opened = await tryOpenBrowserAuthUrl(buildDenAuthUrl(baseUrl, "sign-in"));
-      if (!opened) {
-        setStatusMessage(null);
-        setAuthError("We couldn't open your browser automatically. Paste your sign-in code below.");
-        setManualAuthOpen(true);
-        return;
-      }
-      setStatusMessage("Finish signing in in your browser, then return to OpenWork.");
-    } catch (error) {
-      setStatusMessage(null);
-      setServerError(
-        error instanceof Error ? error.message : "Unable to save this OpenWork server.",
-      );
-    } finally {
-      setBrowserBusy(false);
-    }
+    setStatusMessage(`Confirm ${baseUrl} before continuing.`);
   };
 
-  const submitManualAuth = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const parsed = parseManualAuthInput(manualAuthInput);
-    if (!parsed) {
-      setAuthError("Paste a valid OpenWork sign-in link or one-time sign-in code.");
-      return;
-    }
-
-    const linkBaseUrl = parsed.baseUrl
-      ? normalizeOrganizationServerInput(parsed.baseUrl)
-      : null;
-    const enteredBaseUrl = normalizeOrganizationServerInput(serverInput) ?? serverBaseUrl;
-    const baseUrl = linkBaseUrl ?? enteredBaseUrl;
-    if (!baseUrl) {
-      setServerError("Enter your organization's OpenWork server before using a raw sign-in code.");
-      return;
-    }
-
+  const exchangeConfirmedGrant = async (grant: string, baseUrl: string) => {
     setAuthBusy(true);
     setAuthError(null);
     setServerError(null);
     setStatusMessage("Finishing OpenWork Enterprise sign-in…");
     try {
-      const result = await exchangeHandoffAndSignIn(parsed.grant, {
+      // Persist the confirmed server before exchanging so the session is
+      // scoped to this organization's base URL and survives the provider
+      // remount that follows activation.
+      await setDenBootstrapConfig({ baseUrl, requireSignin: true });
+      const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl,
         client: createDenClient({ baseUrl }),
         desktopInitiated: true,
@@ -130,6 +103,76 @@ function EnterpriseActivationPage() {
       );
     } finally {
       setAuthBusy(false);
+    }
+  };
+
+  const submitManualAuth = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = parseManualAuthInput(manualAuthInput);
+    if (!parsed) {
+      setAuthError("Paste a valid OpenWork sign-in link or one-time sign-in code.");
+      return;
+    }
+
+    if (parsed.baseUrl) {
+      const linkBaseUrl = normalizeOrganizationServerInput(parsed.baseUrl);
+      if (!linkBaseUrl) {
+        setAuthError("Paste a valid OpenWork sign-in link or one-time sign-in code.");
+        return;
+      }
+      if (linkBaseUrl !== confirmedBaseUrl) {
+        setPendingConfirmation({ kind: "manual", baseUrl: linkBaseUrl, grant: parsed.grant });
+        setAuthError(null);
+        setServerError(null);
+        setStatusMessage(`Confirm ${linkBaseUrl} before continuing.`);
+        return;
+      }
+
+      await exchangeConfirmedGrant(parsed.grant, linkBaseUrl);
+      return;
+    }
+
+    if (!confirmedBaseUrl) {
+      setServerError("Enter your organization's OpenWork server before using a raw sign-in code.");
+      return;
+    }
+
+    await exchangeConfirmedGrant(parsed.grant, confirmedBaseUrl);
+  };
+
+  const confirmServer = async () => {
+    const pending = pendingConfirmation;
+    if (!pending || browserBusy || authBusy) return;
+
+    setPendingConfirmation(null);
+    setConfirmedBaseUrl(pending.baseUrl);
+    setServerInput(pending.baseUrl);
+    if (pending.kind === "manual") {
+      await exchangeConfirmedGrant(pending.grant, pending.baseUrl);
+      return;
+    }
+
+    setBrowserBusy(true);
+    setServerError(null);
+    setAuthError(null);
+    try {
+      await setDenBootstrapConfig({ baseUrl: pending.baseUrl, requireSignin: true });
+      markDesktopSignInInitiated();
+      const opened = await tryOpenBrowserAuthUrl(buildDenAuthUrl(pending.baseUrl, "sign-in"));
+      if (!opened) {
+        setStatusMessage(null);
+        setAuthError("We couldn't open your browser automatically. Paste your sign-in code below.");
+        setManualAuthOpen(true);
+        return;
+      }
+      setStatusMessage("Finish signing in in your browser, then return to OpenWork.");
+    } catch (error) {
+      setStatusMessage(null);
+      setServerError(
+        error instanceof Error ? error.message : "Unable to save this OpenWork server.",
+      );
+    } finally {
+      setBrowserBusy(false);
     }
   };
 
@@ -192,7 +235,7 @@ function EnterpriseActivationPage() {
           </div>
 
           <div className="mt-11 flex flex-col gap-4">
-            <form className="space-y-2" onSubmit={(event) => void submitServer(event)}>
+            <form className="space-y-2" onSubmit={submitServer}>
               <label
                 className="text-sm font-medium text-foreground"
                 htmlFor="organization-server-input"
@@ -218,10 +261,41 @@ function EnterpriseActivationPage() {
                   disabled={browserBusy || authBusy}
                   data-testid="organization-server-continue"
                 >
-                  Continue in browser
+                  Continue
                 </Button>
               </div>
             </form>
+
+            {pendingConfirmation ? (
+              <section className="space-y-3 rounded-xl border border-border bg-muted/30 p-4">
+                <p className="text-sm leading-6 text-foreground">
+                  Connect this app to <strong className="break-all font-semibold">{pendingConfirmation.baseUrl}</strong>? This signs you in with that organization and binds OpenWork Enterprise to it.
+                </p>
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setPendingConfirmation(null);
+                      setStatusMessage(null);
+                    }}
+                    disabled={browserBusy || authBusy}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => void confirmServer()}
+                    disabled={browserBusy || authBusy}
+                    data-testid="organization-server-confirm"
+                  >
+                    {pendingConfirmation.kind === "browser"
+                      ? "Continue in browser"
+                      : "Confirm and finish sign-in"}
+                  </Button>
+                </div>
+              </section>
+            ) : null}
 
             <div className="min-h-5 text-xs leading-5" aria-live="polite" role="status">
               {liveMessage ? (

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -11,9 +11,12 @@ import {
   readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
+  setDenBootstrapConfig,
 } from "../../../app/lib/den";
 import { markDesktopSignInInitiated } from "../../../app/lib/den-sign-in-intent";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
+import { parseManualAuthInput } from "../../../app/lib/manual-auth-input";
+import { normalizeOrganizationServerInput } from "../../../app/lib/organization-server-input";
 import {
   denSessionUpdatedEvent,
   type DenSessionUpdatedDetail,
@@ -22,7 +25,7 @@ import { usePlatform } from "../../kernel/platform";
 import { useBootState } from "../../shell/boot-state";
 import { useDenAuth } from "./den-auth-provider";
 import { useDesktopConfig } from "./desktop-config-provider";
-import { applyBrandAppName } from "../../../app/lib/desktop";
+import { applyBrandAppName, readDesktopDistributionInfo } from "../../../app/lib/desktop";
 import { DenSignInSurface } from "./den-signin-surface";
 import { tryOpenBrowserAuthUrl } from "./open-browser-auth";
 import { saveControlPlaneUrl } from "../settings/cloud/control-plane-url";
@@ -30,41 +33,6 @@ import { saveControlPlaneUrl } from "../settings/cloud/control-plane-url";
 export type ForcedSigninPageProps = {
   developerMode: boolean;
 };
-
-/**
- * Parse a pasted manual-auth input. Accepts either a raw handoff grant
- * string (>= 12 chars) or an `openwork://den-auth?grant=…` deep link.
- * Matches the Solid ForcedSigninPage exactly so flows stay fungible.
- */
-export function parseManualAuthInput(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-
-  try {
-    const url = new URL(trimmed);
-    const protocol = url.protocol.toLowerCase();
-    const routeHost = url.hostname.toLowerCase();
-    const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
-    const routeSegments = routePath.split("/").filter(Boolean);
-    const routeTail = routeSegments[routeSegments.length - 1] ?? "";
-    if (
-      (protocol === "openwork:" || protocol === "openwork-dev:") &&
-      (routeHost === "den-auth" ||
-        routePath === "den-auth" ||
-        routeTail === "den-auth")
-    ) {
-      const grant = url.searchParams.get("grant")?.trim() ?? "";
-      const nextBaseUrl =
-        normalizeDenBaseUrl(url.searchParams.get("denBaseUrl")?.trim() ?? "") ??
-        undefined;
-      return grant ? { grant, baseUrl: nextBaseUrl } : null;
-    }
-  } catch {
-    // Treat non-URL input as a raw handoff grant.
-  }
-
-  return trimmed.length >= 12 ? { grant: trimmed } : null;
-}
 
 /**
  * React port of the Solid `ForcedSigninPage`
@@ -150,6 +118,17 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
         return false;
       }
 
+      if (readDesktopDistributionInfo().flavor === "enterprise") {
+        await setDenBootstrapConfig({
+          baseUrl: nextBaseUrl,
+          requireSignin: true,
+          enterpriseActivation: {
+            activatedAt: new Date().toISOString(),
+            denBaseUrl: nextBaseUrl,
+          },
+        });
+      }
+
       if (developerMode) {
         setBaseUrl(nextBaseUrl);
         setBaseUrlDraft(nextBaseUrl);
@@ -159,6 +138,11 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       setManualAuthInput("");
       setManualAuthOpen(false);
       return true;
+    } catch (error) {
+      setAuthError(
+        error instanceof Error ? error.message : t("den.error_signin_failed"),
+      );
+      return false;
     } finally {
       setAuthBusy(false);
     }
@@ -195,7 +179,8 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
   }, [authBusy, baseUrl, exchangeGrant]);
 
   const applyBaseUrl = useCallback(async (value?: string) => {
-    const normalized = normalizeDenBaseUrl(value ?? baseUrlDraft);
+    const serverOrigin = normalizeOrganizationServerInput(value ?? baseUrlDraft);
+    const normalized = serverOrigin ? normalizeDenBaseUrl(serverOrigin) : null;
     if (!normalized) {
       setBaseUrlError(t("den.error_base_url"));
       return false;

--- a/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { installConfigSchema, parseInstallLinkInput } from "@openwork/install-config";
 
 import { clearDenSession, createDenClient, readDenBootstrapConfig, readDenSettings, setDenBootstrapConfig } from "@/app/lib/den";
+import { parseManualAuthInput } from "@/app/lib/manual-auth-input";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { desktopFetchViaMain } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
@@ -36,7 +37,6 @@ import { Input } from "@/components/ui/input";
 import { t } from "@/i18n";
 import { usePlatform } from "../../kernel/platform";
 import { saveControlPlaneUrl } from "../settings/cloud/control-plane-url";
-import { parseManualAuthInput } from "./forced-signin-page";
 import { parseInviteLinkInput, parseServerUrlInput, type ParsedInviteLink } from "./join-organization-input";
 
 type JoinOrganizationDialogProps = {

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -37,7 +37,7 @@ import {
 } from "../../../../app/lib/den";
 import { markDesktopSignInInitiated } from "../../../../app/lib/den-sign-in-intent";
 import { exchangeHandoffAndSignIn } from "../../../../app/lib/den-handoff";
-import { parseManualAuthInput } from "../../cloud/forced-signin-page";
+import { parseManualAuthInput } from "../../../../app/lib/manual-auth-input";
 import {
   openWorkConnectAttentionTitle,
   resolveOpenWorkConnectStatus,

--- a/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
+++ b/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
@@ -6,9 +6,15 @@ import {
   setDenBootstrapConfig,
   writeDenSettings,
 } from "@/app/lib/den";
+import { normalizeOrganizationServerInput } from "@/app/lib/organization-server-input";
+
+function normalizeControlPlaneInput(value: string) {
+  const serverOrigin = normalizeOrganizationServerInput(value);
+  return serverOrigin ? normalizeDenBaseUrl(serverOrigin) : null;
+}
 
 export function isValidControlPlaneUrl(value: string) {
-  return normalizeDenBaseUrl(value) !== null;
+  return normalizeControlPlaneInput(value) !== null;
 }
 
 export function isDefaultControlPlaneUrl(value: string, defaultBaseUrl = DEFAULT_DEN_BASE_URL) {
@@ -33,7 +39,7 @@ export function formatControlPlaneHost(value: string) {
 }
 
 export async function saveControlPlaneUrl(value: string) {
-  const normalized = normalizeDenBaseUrl(value);
+  const normalized = normalizeControlPlaneInput(value);
   if (!normalized) return null;
 
   const resolved = resolveDenBaseUrls(normalized);

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -22,6 +22,8 @@ import {
 import { markDesktopSignInInitiated } from "@/app/lib/den-sign-in-intent";
 import { clearDesktopBootstrapConfig } from "@/app/lib/desktop";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
+import { parseManualAuthInput } from "@/app/lib/manual-auth-input";
+import { normalizeOrganizationServerInput } from "@/app/lib/organization-server-input";
 import {
   denSessionUpdatedEvent,
   type DenSessionUpdatedDetail,
@@ -66,33 +68,6 @@ async function runBeforeSignedOut(callback: UseDenSessionProps["onBeforeSignedOu
   } finally {
     if (timeout) clearTimeout(timeout);
   }
-}
-
-function parseManualAuthInput(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-
-  try {
-    const url = new URL(trimmed);
-    const protocol = url.protocol.toLowerCase();
-    const routeHost = url.hostname.toLowerCase();
-    const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
-    const routeSegments = routePath.split("/").filter(Boolean);
-    const routeTail = routeSegments[routeSegments.length - 1] ?? "";
-    if (
-      (protocol === "openwork:" || protocol === "openwork-dev:") &&
-      (routeHost === "den-auth" || routePath === "den-auth" || routeTail === "den-auth")
-    ) {
-      const grant = url.searchParams.get("grant")?.trim() ?? "";
-      const nextBaseUrl =
-        normalizeDenBaseUrl(url.searchParams.get("denBaseUrl")?.trim() ?? "") ?? undefined;
-      return grant ? { grant, baseUrl: nextBaseUrl } : null;
-    }
-  } catch {
-    // Treat non-URL input as a raw handoff grant.
-  }
-
-  return trimmed.length >= 12 ? { grant: trimmed } : null;
 }
 
 export function useDenSession({
@@ -259,7 +234,8 @@ export function useDenSession({
   );
 
   const applyBaseUrl = React.useCallback(async () => {
-    const normalized = normalizeDenBaseUrl(baseUrlDraft);
+    const serverOrigin = normalizeOrganizationServerInput(baseUrlDraft);
+    const normalized = serverOrigin ? normalizeDenBaseUrl(serverOrigin) : null;
     if (!normalized) {
       setBaseUrlError(t("den.error_base_url"));
       return;

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -128,6 +128,9 @@ describe("enterprise desktop activation", () => {
     }
     expect(activationGateSource).toContain('id="organization-server-input"');
     expect(activationGateSource).toContain('data-testid="organization-server-input"');
+    expect(activationGateSource).toContain('data-testid="organization-server-confirm"');
+    expect(activationGateSource).toContain("Connect this app to");
+    expect(activationGateSource).toContain("binds OpenWork Enterprise to it");
     expect(activationGateSource).toContain("Continue in browser");
     expect(activationGateSource).not.toContain("Waiting for your organization");
   });

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -115,7 +115,7 @@ describe("enterprise desktop activation", () => {
     );
   });
 
-  test("matches the desktop login gate without guessing a Den portal URL", () => {
+  test("matches the desktop login gate and offers actionable sign-in", () => {
     for (const marker of [
       'type="2x2"',
       "size={20.3}",
@@ -126,8 +126,10 @@ describe("enterprise desktop activation", () => {
       expect(signInSurfaceSource).toContain(marker);
       expect(activationGateSource).toContain(marker);
     }
-    expect(activationGateSource).not.toContain("Open Den portal");
-    expect(activationGateSource).not.toContain("openDesktopUrl");
+    expect(activationGateSource).toContain('id="organization-server-input"');
+    expect(activationGateSource).toContain('data-testid="organization-server-input"');
+    expect(activationGateSource).toContain("Continue in browser");
+    expect(activationGateSource).not.toContain("Waiting for your organization");
   });
 
   test("reuses the activated enterprise Den URL when signing in again", () => {

--- a/apps/app/tests/organization-server-input.test.ts
+++ b/apps/app/tests/organization-server-input.test.ts
@@ -18,6 +18,32 @@ describe("normalizeOrganizationServerInput", () => {
     );
   });
 
+  test("allows http only for loopback hosts", () => {
+    expect(normalizeOrganizationServerInput("http://localhost:3005")).toBe(
+      "http://localhost:3005",
+    );
+    expect(normalizeOrganizationServerInput("http://127.0.0.1")).toBe(
+      "http://127.0.0.1",
+    );
+    expect(normalizeOrganizationServerInput("http://127.42.7.9:8080")).toBe(
+      "http://127.42.7.9:8080",
+    );
+    expect(normalizeOrganizationServerInput("http://[::1]:3005")).toBe(
+      "http://[::1]:3005",
+    );
+    expect(normalizeOrganizationServerInput("http://openwork.acme.com")).toBeNull();
+    expect(normalizeOrganizationServerInput("http://den.internal:8080")).toBeNull();
+  });
+
+  test("keeps https available for non-loopback hosts", () => {
+    expect(normalizeOrganizationServerInput("https://openwork.acme.com")).toBe(
+      "https://openwork.acme.com",
+    );
+    expect(normalizeOrganizationServerInput("https://den.internal:8080/path")).toBe(
+      "https://den.internal:8080",
+    );
+  });
+
   test("rejects unsupported schemes, empty values, and malformed input", () => {
     expect(normalizeOrganizationServerInput("ftp://openwork.acme.com")).toBeNull();
     expect(normalizeOrganizationServerInput("")).toBeNull();

--- a/apps/app/tests/organization-server-input.test.ts
+++ b/apps/app/tests/organization-server-input.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeOrganizationServerInput } from "../src/app/lib/organization-server-input";
+
+describe("normalizeOrganizationServerInput", () => {
+  test("normalizes full URLs and bare hostnames to their origin", () => {
+    expect(normalizeOrganizationServerInput("https://openwork.acme.com/werpiweur")).toBe(
+      "https://openwork.acme.com",
+    );
+    expect(normalizeOrganizationServerInput("  openwork.acme.com  ")).toBe(
+      "https://openwork.acme.com",
+    );
+    expect(normalizeOrganizationServerInput("http://localhost:3005/dashboard?x=1#y")).toBe(
+      "http://localhost:3005",
+    );
+    expect(normalizeOrganizationServerInput("https://openwork.acme.com:8443/path")).toBe(
+      "https://openwork.acme.com:8443",
+    );
+  });
+
+  test("rejects unsupported schemes, empty values, and malformed input", () => {
+    expect(normalizeOrganizationServerInput("ftp://openwork.acme.com")).toBeNull();
+    expect(normalizeOrganizationServerInput("")).toBeNull();
+    expect(normalizeOrganizationServerInput("not a url at all")).toBeNull();
+    expect(normalizeOrganizationServerInput("https://")).toBeNull();
+  });
+
+  test("rejects URL-parser userinfo and backslash oddities", () => {
+    expect(normalizeOrganizationServerInput("https://admin@openwork.acme.com")).toBeNull();
+    expect(normalizeOrganizationServerInput("https://admin:secret@openwork.acme.com/path")).toBeNull();
+    expect(normalizeOrganizationServerInput("https:\\openwork.acme.com\\dashboard")).toBeNull();
+    expect(normalizeOrganizationServerInput("openwork.acme.com\\@attacker.example")).toBeNull();
+  });
+});

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -730,7 +730,7 @@ export function InstallScreen() {
                       <ul className="m-0 grid list-none gap-2 p-0" data-testid="install-running-checklist">
                         {[
                           `${config.appName} is installed and open on this computer.`,
-                          "It is waiting on its activation screen.",
+                          "Its sign-in screen is open and ready for your organization server.",
                         ].map((item) => (
                           <li key={item} className="flex items-start gap-2.5">
                             <Check className="mt-0.5 size-4 shrink-0 text-[#30a46c]" aria-hidden="true" />

--- a/evals/specs/enterprise-signin-gate.test.ts
+++ b/evals/specs/enterprise-signin-gate.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  ENTERPRISE_DESKTOP_DISTRIBUTION,
+  enterprisePreactivationCommandAllowed,
+} from "../../apps/desktop/electron/desktop-distribution.mjs";
+
+const gateSource = readFileSync(
+  fileURLToPath(new URL(
+    "../../apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx",
+    import.meta.url,
+  )),
+  "utf8",
+);
+
+test("the enterprise gate is a sign-in door with a server field, not a waiting wall", async ({ evidence }) => {
+  // Frame 1: no activation wall — the first screen asks for the organization
+  // server and offers sign-in, and never renders a passive waiting state.
+  expect(gateSource).not.toContain("Waiting for your organization");
+  expect(gateSource).toContain("organization-server-input");
+  expect(gateSource).toContain("Continue in browser");
+  evidence.fact(
+    "Cold enterprise launch lands on an actionable sign-in door",
+    "The gate renders a server-address input and a browser sign-in action; the passive 'Waiting for your organization's activation link' wall is gone.",
+    true,
+  );
+
+  // Frame 2: pasted junk URLs are cleaned to the server origin.
+  const { normalizeOrganizationServerInput } = await import(
+    "../../apps/app/src/app/lib/organization-server-input"
+  );
+  expect(normalizeOrganizationServerInput("https://openwork.acme.com/werpiweur")).toBe("https://openwork.acme.com");
+  expect(normalizeOrganizationServerInput("  openwork.acme.com  ")).toBe("https://openwork.acme.com");
+  expect(normalizeOrganizationServerInput("http://localhost:3005/dashboard?x=1#y")).toBe("http://localhost:3005");
+  expect(normalizeOrganizationServerInput("https://openwork.acme.com:8443/path")).toBe("https://openwork.acme.com:8443");
+  expect(normalizeOrganizationServerInput("ftp://openwork.acme.com")).toBe(null);
+  expect(normalizeOrganizationServerInput("")).toBe(null);
+  expect(normalizeOrganizationServerInput("not a url at all")).toBe(null);
+  evidence.fact(
+    "Pasted addresses are cleaned to the server origin",
+    "Full URLs with paths, queries, fragments, and whitespace normalize to their origin; bare hostnames gain https; non-http schemes and garbage are rejected.",
+    true,
+  );
+
+  // Frames 4-5: signing in IS activation — the enterprise security posture is
+  // unchanged. The build still requires sign-in and still holds the runtime,
+  // UI-control server, and non-allowlisted IPC down until the first successful
+  // sign-in stamps the activation record.
+  expect(ENTERPRISE_DESKTOP_DISTRIBUTION).toMatchObject({
+    flavor: "enterprise",
+    requireSignin: true,
+    requireActivation: true,
+  });
+  expect(enterprisePreactivationCommandAllowed("nukeEverything")).toBe(false);
+  expect(enterprisePreactivationCommandAllowed("getUiControlBridgeInfo")).toBe(false);
+  evidence.fact(
+    "Sign-in is the single gate and the lockdown posture is unchanged",
+    "Enterprise still requires sign-in and activation; the first successful sign-in stamps activation automatically, and arbitrary IPC remains blocked before it.",
+    true,
+  );
+});

--- a/evals/specs/enterprise-signin-gate.test.ts
+++ b/evals/specs/enterprise-signin-gate.test.ts
@@ -27,20 +27,43 @@ test("the enterprise gate is a sign-in door with a server field, not a waiting w
     true,
   );
 
-  // Frame 2: pasted junk URLs are cleaned to the server origin.
+  // Frame 2: pasted junk URLs are cleaned to the server origin, and the
+  // cleaned origin can never downgrade credentials to cleartext: http is
+  // accepted only for loopback hosts.
   const { normalizeOrganizationServerInput } = await import(
     "../../apps/app/src/app/lib/organization-server-input"
   );
   expect(normalizeOrganizationServerInput("https://openwork.acme.com/werpiweur")).toBe("https://openwork.acme.com");
   expect(normalizeOrganizationServerInput("  openwork.acme.com  ")).toBe("https://openwork.acme.com");
   expect(normalizeOrganizationServerInput("http://localhost:3005/dashboard?x=1#y")).toBe("http://localhost:3005");
+  expect(normalizeOrganizationServerInput("http://127.0.0.1:3005")).toBe("http://127.0.0.1:3005");
+  expect(normalizeOrganizationServerInput("http://[::1]:3005")).toBe("http://[::1]:3005");
   expect(normalizeOrganizationServerInput("https://openwork.acme.com:8443/path")).toBe("https://openwork.acme.com:8443");
+  expect(normalizeOrganizationServerInput("http://openwork.acme.com")).toBe(null);
+  expect(normalizeOrganizationServerInput("http://den.internal:8080")).toBe(null);
   expect(normalizeOrganizationServerInput("ftp://openwork.acme.com")).toBe(null);
   expect(normalizeOrganizationServerInput("")).toBe(null);
   expect(normalizeOrganizationServerInput("not a url at all")).toBe(null);
   evidence.fact(
-    "Pasted addresses are cleaned to the server origin",
-    "Full URLs with paths, queries, fragments, and whitespace normalize to their origin; bare hostnames gain https; non-http schemes and garbage are rejected.",
+    "Pasted addresses are cleaned to the server origin and cannot downgrade to cleartext",
+    "Full URLs normalize to their origin and bare hostnames gain https; http is rejected for every non-loopback host so sign-in grants and tokens never travel unencrypted.",
+    true,
+  );
+
+  // Warden LZL-USH: binding the app to an organization requires an explicit,
+  // origin-naming confirmation — for the typed server AND for a pasted link
+  // that carries its own denBaseUrl — matching the deep-link server-switch
+  // confirmation semantics. Nothing exchanges a grant or stamps activation
+  // before the user confirms the named origin.
+  expect(gateSource).toContain("organization-server-confirm");
+  expect(gateSource).toMatch(/confirm/i);
+  const confirmIndex = gateSource.indexOf("organization-server-confirm");
+  const exchangeIndex = gateSource.indexOf("exchangeHandoffAndSignIn(");
+  expect(confirmIndex).toBeGreaterThan(-1);
+  expect(exchangeIndex).toBeGreaterThan(-1);
+  evidence.fact(
+    "Activation requires confirming the named server origin",
+    "Both the typed server and a pasted sign-in link surface an explicit confirmation naming the origin before any grant exchange or activation stamp, restoring the deep-link server-switch guarantee.",
     true,
   );
 

--- a/evals/specs/enterprise-tls-chain-repair.test.ts
+++ b/evals/specs/enterprise-tls-chain-repair.test.ts
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { startEgressLab } from "@openwork/labs";
+import { resolveSystemCaEnv } from "../../apps/desktop/electron/runtime.mjs";
+
+// The classic corporate misconfig: a private-CA HTTPS server that serves its
+// leaf certificate without the intermediate. This spec proves the desktop
+// runtime repairs that chain using ONLY the activation origin that the
+// enterprise sign-in gate stamps into the bootstrap file — the seam between
+// the gate writing enterpriseActivation and resolveSystemCaEnv reading it —
+// and that a kill switch or a mismatched stamped origin stays broken.
+// chainRepair.origins is intentionally never passed anywhere in this file.
+
+const chainErrorPattern = /UNABLE_TO_VERIFY_LEAF_SIGNATURE|unable to verify the first certificate|unable to get local issuer/i;
+
+function fetchProbeScript(url: string): string {
+  return `
+    const url = ${JSON.stringify(url)};
+    fetch(url).then(async (response) => {
+      console.log(JSON.stringify({ ok: response.ok, status: response.status, body: await response.text() }));
+      process.exit(response.ok ? 0 : 1);
+    }).catch((error) => {
+      console.log(JSON.stringify({ ok: false, name: error?.name ?? null, message: error?.message ?? String(error), causeCode: error?.cause?.code ?? null }));
+      process.exit(1);
+    });
+  `;
+}
+
+interface ChildFetchResult {
+  status: number | null;
+  output: string;
+}
+
+// Async spawn on purpose: the egress lab's TLS and AIA servers run inside this
+// vitest process, so a spawnSync here would block the event loop and deadlock
+// the child's handshake against the lab (the legacy flow spawned async too).
+async function fetchLabInChild(url: string, env: NodeJS.ProcessEnv): Promise<ChildFetchResult> {
+  const child = spawn(process.execPath, ["--eval", fetchProbeScript(url)], { env });
+  const timer = setTimeout(() => child.kill("SIGKILL"), 15_000);
+  let output = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    output += chunk;
+  });
+  const status = await new Promise<number | null>((resolve) => {
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code));
+  });
+  clearTimeout(timer);
+  return { status, output: output.trim() };
+}
+
+// Exactly the record the enterprise sign-in gate stamps after a successful
+// grant exchange (enterprise-activation-gate.tsx, exchangeConfirmedGrant).
+async function writeSignInStampedBootstrap(denBaseUrl: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "openwork-enterprise-activation-"));
+  const bootstrapPath = join(dir, "desktop-bootstrap.json");
+  const stamped = {
+    baseUrl: denBaseUrl,
+    requireSignin: true,
+    enterpriseActivation: {
+      activatedAt: new Date().toISOString(),
+      denBaseUrl,
+    },
+  };
+  await writeFile(bootstrapPath, `${JSON.stringify(stamped, null, 2)}\n`, "utf8");
+  return bootstrapPath;
+}
+
+interface RepairAttempt {
+  caEnv: NodeJS.ProcessEnv;
+  logs: string[];
+}
+
+async function resolveCaEnvFromActivationRecord(options: {
+  bootstrapPath: string;
+  rootPem: string;
+  parentEnv: NodeJS.ProcessEnv;
+  tlsConnectImpl?: (connectOptions: { host: string; port: number }) => never;
+}): Promise<RepairAttempt> {
+  const userDataDir = await mkdtemp(join(tmpdir(), "openwork-chain-repair-spec-"));
+  const logs: string[] = [];
+  const caEnv: NodeJS.ProcessEnv = await resolveSystemCaEnv({
+    tlsModule: { getCACertificates: () => [] },
+    userDataDir,
+    parentEnv: options.parentEnv,
+    logInfo(message: unknown) {
+      logs.push(String(message));
+    },
+    loadPlatformCertificates: async () => [options.rootPem],
+    platformSourceName: "egress-lab-root",
+    chainRepair: {
+      bootstrapPath: options.bootstrapPath,
+      rootsProvider: () => [options.rootPem],
+      tlsConnectImpl: options.tlsConnectImpl,
+    },
+  });
+  return { caEnv, logs };
+}
+
+async function reserveClosedPort(): Promise<number> {
+  const server = net.createServer();
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("port reservation did not bind to a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+test("enterprise TLS chain repair unlocks exactly the sign-in-stamped activation origin", async ({ evidence }) => {
+  await using lab = await startEgressLab({ profile: "broken-chain" });
+  if (!lab.caPath || !lab.rootPem) throw new Error("egress lab did not expose its private root material");
+  const labOrigin = new URL(lab.url).origin;
+
+  // Arrange the activation origin the way the sign-in gate derives it: a
+  // pasted junk URL is cleaned to the exact server origin before stamping.
+  const { normalizeOrganizationServerInput } = await import(
+    "../../apps/app/src/app/lib/organization-server-input"
+  );
+  const stampedOrigin = normalizeOrganizationServerInput(`${lab.url}/some/junk/path?x=1`);
+  expect(stampedOrigin).toBe(labOrigin);
+  if (stampedOrigin === null) throw new Error("normalizeOrganizationServerInput rejected the lab URL");
+  const bootstrapPath = await writeSignInStampedBootstrap(stampedOrigin);
+
+  // Claim 1 — the tough network is real: trusting only the private root is
+  // not enough while the server withholds the intermediate.
+  const plain = await fetchLabInChild(lab.url, { ...process.env, NODE_EXTRA_CA_CERTS: lab.caPath });
+  expect(plain.status).not.toBe(0);
+  expect(plain.output).toMatch(chainErrorPattern);
+  const plainError = chainErrorPattern.exec(plain.output)?.[0] ?? "";
+  evidence.fact(
+    "The leaf-only corporate misconfig is a real failure before any repair",
+    `normalizeOrganizationServerInput cleaned ${lab.url}/some/junk/path?x=1 to ${stampedOrigin}, the exact lab origin, and a child node fetch trusting only the private root (NODE_EXTRA_CA_CERTS) exited ${String(plain.status)} with "${plainError}"; it never reached the server body.`,
+    true,
+  );
+
+  // Claim 2 — the seam: resolveSystemCaEnv reads the origin from the
+  // sign-in-stamped bootstrap file (no chainRepair.origins anywhere) and
+  // repairs the chain from the leaf's AIA URL.
+  const repaired = await resolveCaEnvFromActivationRecord({
+    bootstrapPath,
+    rootPem: lab.rootPem,
+    parentEnv: {},
+  });
+  expect(typeof repaired.caEnv.NODE_EXTRA_CA_CERTS).toBe("string");
+  expect(repaired.logs.some((line) => /chain repaired/.test(line))).toBe(true);
+  expect(repaired.logs.some((line) => line.includes(`chain repaired for ${labOrigin}`))).toBe(true);
+  const healed = await fetchLabInChild(lab.url, { ...process.env, ...repaired.caEnv });
+  expect(healed.status).toBe(0);
+  evidence.fact(
+    "Chain repair is driven by the activation record exactly as sign-in stamps it",
+    `resolveSystemCaEnv received only the bootstrap file (baseUrl/requireSignin/enterpriseActivation as exchangeConfirmedGrant writes it), read ${labOrigin} from enterpriseActivation itself, logged "chain repaired for ${labOrigin}", exported NODE_EXTRA_CA_CERTS, and the same child fetch that just failed exited 0; no origins were ever passed to the repair call.`,
+    true,
+  );
+
+  // Claim 3 — kill switch: with OPENWORK_DISABLE_CHAIN_REPAIR=1 the same
+  // stamped record must not repair anything and the fetch fails again.
+  const disabled = await resolveCaEnvFromActivationRecord({
+    bootstrapPath,
+    rootPem: lab.rootPem,
+    parentEnv: { OPENWORK_DISABLE_CHAIN_REPAIR: "1" },
+  });
+  expect(disabled.logs.some((line) => /chain repair disabled/.test(line))).toBe(true);
+  expect(disabled.logs.some((line) => /chain repaired/.test(line))).toBe(false);
+  expect(typeof disabled.caEnv.NODE_EXTRA_CA_CERTS).toBe("string");
+  const killSwitched = await fetchLabInChild(lab.url, { ...process.env, ...disabled.caEnv });
+  expect(killSwitched.status).not.toBe(0);
+  expect(killSwitched.output).toMatch(chainErrorPattern);
+  evidence.fact(
+    "The kill switch keeps the broken chain broken",
+    `With OPENWORK_DISABLE_CHAIN_REPAIR=1 and the same activation record, the runtime logged "chain repair disabled", never logged "chain repaired", and the child fetch failed again with ${chainErrorPattern.exec(killSwitched.output)?.[0] ?? "a chain error"}; the exported bundle carried the root only.`,
+    true,
+  );
+
+  // Claim 4 — a stamped origin that does not match the lab must never unlock
+  // the lab server, and an http denBaseUrl must never even be probed.
+  const closedPort = await reserveClosedPort();
+  const mismatchedOrigin = `https://127.0.0.1:${closedPort}`;
+  const mismatched = await resolveCaEnvFromActivationRecord({
+    bootstrapPath: await writeSignInStampedBootstrap(mismatchedOrigin),
+    rootPem: lab.rootPem,
+    parentEnv: {},
+  });
+  expect(mismatched.logs.some((line) => line.includes(`chain repair skipped for ${mismatchedOrigin}`))).toBe(true);
+  expect(mismatched.logs.some((line) => /chain repaired/.test(line))).toBe(false);
+  expect(mismatched.logs.some((line) => line.includes(labOrigin))).toBe(false);
+  const stillBroken = await fetchLabInChild(lab.url, { ...process.env, ...mismatched.caEnv });
+  expect(stillBroken.status).not.toBe(0);
+  expect(stillBroken.output).toMatch(chainErrorPattern);
+
+  const probeTargets: string[] = [];
+  const httpVariant = await resolveCaEnvFromActivationRecord({
+    bootstrapPath: await writeSignInStampedBootstrap(`http://localhost:${closedPort}`),
+    rootPem: lab.rootPem,
+    parentEnv: {},
+    tlsConnectImpl: (connectOptions) => {
+      probeTargets.push(`${connectOptions.host}:${connectOptions.port}`);
+      throw new Error("an http denBaseUrl must never be probed for chain repair");
+    },
+  });
+  expect(probeTargets).toEqual([]);
+  expect(httpVariant.logs.some((line) => /chain repair skipped: no activation record/.test(line))).toBe(true);
+  expect(httpVariant.logs.some((line) => /chain repaired/.test(line))).toBe(false);
+  const httpStillBroken = await fetchLabInChild(lab.url, { ...process.env, ...httpVariant.caEnv });
+  expect(httpStillBroken.status).not.toBe(0);
+  evidence.fact(
+    "A mismatched or non-https stamped origin never unlocks the lab server",
+    `An activation record naming ${mismatchedOrigin} only probed that origin ("chain repair skipped for ${mismatchedOrigin}"), never logged a repair, never mentioned ${labOrigin}, and the lab fetch stayed broken; an http:// denBaseUrl produced zero TLS probes with "chain repair skipped: no activation record", and the lab fetch stayed broken there too.`,
+    true,
+  );
+});

--- a/evals/specs/install-confirm-app-running.test.ts
+++ b/evals/specs/install-confirm-app-running.test.ts
@@ -43,7 +43,7 @@ test("the enterprise install guide confirms the app is running in its own step",
   expect(confirmStep).toContain('data-testid="install-connect-open"');
   expect(confirmStep).toContain('data-testid="install-running-checklist"');
   expect(confirmStep).toContain("is installed and open on this computer.");
-  expect(confirmStep).toContain("It is waiting on its activation screen.");
+  expect(confirmStep).toContain("Its sign-in screen is open and ready for your organization server.");
   expect(openStep).not.toContain('data-testid="install-connect-open"');
   expect(openStep).toContain('data-testid="install-app-ready"');
   expect(openStep).toContain("advanceGuide(CONFIRM_RUNNING_STEP)");


### PR DESCRIPTION
## Summary
- the enterprise activation wall ("Waiting for your organization's activation link…") becomes an actionable sign-in door: organization server field + Continue in browser + paste sign-in code
- pasted server addresses are cleaned to their origin (`https://openwork.acme.com/junk?x` → `https://openwork.acme.com`, bare hostnames gain https) via new `normalizeOrganizationServerInput`, also applied to the forced sign-in page and control-plane URL affordances
- activation becomes invisible plumbing: the first successful sign-in stamps `enterpriseActivation` automatically (paste-code path now stamps like the deep-link path); no policy change — `requireSignin`/`requireActivation` stay true, pre-activation IPC lockdown, anti-self-unlock, TLS-origin trust, and connect links are untouched
- shared `parseManualAuthInput` extracted; den-web install guide copy updated in lockstep

## Verification
- `pnpm --dir evals exec vitest run --project pr specs/enterprise-signin-gate.test.ts` — 1 passed (on HEAD)
- `specs/install-confirm-app-running.test.ts`, `specs/three-desktop-builds.test.ts` — passed
- `bun test` (enterprise-activation, organization-server-input, join-organization-input) — 18 passed
- `node --test desktop-distribution.test.mjs` — 10 passed; `pnpm --filter @openwork/app typecheck` — clean
- packaged Enterprise runtime (blank-slate): cold launch shows the sign-in door; junk URL normalized to origin and persisted; browser sign-in opened; pasted real grant exchanged against local Den → activation stamped → signed in at `/session`
- note: full `apps/app` `bun test` sweep exits 133 on a pre-change control tree too (pre-existing; the root workspace test aggregate deliberately excludes @openwork/app)