### PR TITLE
Fix packaged MCP App sandbox origin

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -425,6 +425,10 @@ export type OpenworkMcpAppSandbox = {
   expectedOrigin: string;
 };
 
+export function normalizeMcpAppHostOrigin(hostOrigin: string): string {
+  return hostOrigin === "file://" ? "null" : hostOrigin;
+}
+
 export type OpenworkManagedMcpConnection = {
   name: string;
   serverUrl: string;
@@ -1925,11 +1929,12 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         },
       ),
     mcpAppSandbox: (app: OpenworkMcpAppResource, hostOrigin: string): OpenworkMcpAppSandbox => {
+      const messageOrigin = normalizeMcpAppHostOrigin(hostOrigin);
       const url = new URL(`${baseUrl}/mcp-apps/sandbox.html`);
       if (url.origin === hostOrigin && url.hostname === "localhost") url.hostname = "127.0.0.1";
       else if (url.origin === hostOrigin && url.hostname === "127.0.0.1") url.hostname = "localhost";
       url.searchParams.set("csp", JSON.stringify(app.csp));
-      url.searchParams.set("hostOrigin", hostOrigin);
+      url.searchParams.set("hostOrigin", messageOrigin);
       return { url: url.toString(), expectedOrigin: url.origin };
     },
     callMcpAppTool: (

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 
-import { OpenworkServerError, type OpenworkMcpAppResource } from "../src/app/lib/openwork-server"
+import {
+  createOpenworkServerClient,
+  normalizeMcpAppHostOrigin,
+  OpenworkServerError,
+  type OpenworkMcpAppResource,
+} from "../src/app/lib/openwork-server"
 import { formatMcpAppDiagnostic, safeMcpAppDiagnosticMessage } from "../src/components/chat/mcp-app-diagnostics"
 import {
   buildMcpAppCsp,
@@ -26,6 +31,16 @@ function fixture(overrides: Partial<OpenworkMcpAppResource> = {}): OpenworkMcpAp
 }
 
 describe("MCP App iframe policy", () => {
+  test("uses the opaque message origin for packaged file hosts", () => {
+    expect(normalizeMcpAppHostOrigin("file://")).toBe("null")
+    expect(normalizeMcpAppHostOrigin("null")).toBe("null")
+    expect(normalizeMcpAppHostOrigin("https://desktop.example")).toBe("https://desktop.example")
+
+    const client = createOpenworkServerClient({ baseUrl: "http://localhost:61856" })
+    const sandbox = client.mcpAppSandbox(fixture(), "file://")
+    expect(new URL(sandbox.url).searchParams.get("hostOrigin")).toBe("null")
+  })
+
   test("keeps ordinary tools silent while surfacing advertised resource failures", () => {
     expect(isActionableMcpAppResolutionError(new OpenworkServerError(503, "mcp_unreachable", "offline"))).toBe(false)
     expect(isActionableMcpAppResolutionError(new OpenworkServerError(404, "resource_read_failed", "missing"))).toBe(true)

--- a/evals/specs/mcp-app-inline-host.slow.test.ts
+++ b/evals/specs/mcp-app-inline-host.slow.test.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { expect, onTestFinished } from "vitest";
 import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
 import { screenshot, validate } from "@openwork/fraimz";
 import { desktop } from "@openwork/hosts";
 import { needs, test } from "@openwork/testkit";
@@ -21,6 +22,97 @@ const title = !appSpecsEnabled
   : !localPlacement
     ? "MCP App inline host skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
     : "a generated Artifact saves normally, then initializes and renders structuredContent inline";
+
+async function createWorkspaceForRenderer(
+  app: Awaited<ReturnType<typeof desktop>>,
+  path: string,
+): Promise<{ workspaceId: string; route: string }> {
+  const packaged = await evalIn(app, "location.protocol === 'file:'");
+  if (packaged !== true) return createAndSelectWorkspace(app, { path });
+
+  const created = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const hostToken = localStorage.getItem("openwork.server.hostToken");
+    const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!port || !hostToken || !invokeDesktop) return {
+      error: "packaged host prerequisites unavailable",
+      missing: [!port ? "port" : null, !hostToken ? "hostToken" : null, !invokeDesktop ? "invokeDesktop" : null].filter(Boolean),
+    };
+    const response = await fetch("http://127.0.0.1:" + port + "/workspaces/local", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-OpenWork-Host-Token": hostToken },
+      body: JSON.stringify({ folderPath: ${JSON.stringify(path)}, preset: "starter" }),
+    });
+    const payload = await response.json();
+    if (!response.ok || typeof payload?.activeId !== "string") {
+      return { error: "workspace creation failed: " + response.status + " " + JSON.stringify(payload) };
+    }
+    const workspaceId = payload.activeId;
+    await invokeDesktop("workspaceSetSelected", workspaceId);
+    await invokeDesktop("workspaceSetRuntimeActive", workspaceId);
+    localStorage.setItem("openwork.react.activeWorkspace", workspaceId);
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({ ...preferences, hasCompletedOnboarding: true }));
+    return { workspaceId };
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  if (!isRecord(created) || typeof created.workspaceId !== "string") {
+    throw new Error(`Could not prepare the packaged workspace: ${JSON.stringify(created)}`);
+  }
+  await evalIn(app, `(() => {
+    location.hash = "/workspace/" + encodeURIComponent(${JSON.stringify(created.workspaceId)}) + "/session";
+    location.reload();
+    return true;
+  })()`);
+  await waitFor(app, `location.protocol === "file:"
+    && location.hash.includes(${JSON.stringify(`/workspace/${created.workspaceId}/session`)})
+    && Boolean(window.__openworkControl)`, {
+    timeoutMs: 120_000,
+    label: "packaged workspace task route",
+  });
+  const engineStarted = await evalIn(app, `(async () => {
+    const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!invokeDesktop) return "invokeDesktop unavailable";
+    await invokeDesktop("engineStart", ${JSON.stringify(path)}, {
+      runtime: "direct",
+      workspacePaths: [${JSON.stringify(path)}],
+      openworkRemoteAccess: false,
+    });
+    const serverInfo = await invokeDesktop("openworkServerInfo");
+    if (serverInfo?.baseUrl) {
+      const serverUrl = new URL(serverInfo.baseUrl);
+      localStorage.setItem("openwork.server.url", serverInfo.baseUrl);
+      localStorage.setItem("openwork.server.port", serverUrl.port);
+      if (serverInfo.clientToken) localStorage.setItem("openwork.server.token", serverInfo.clientToken);
+      if (serverInfo.hostToken) localStorage.setItem("openwork.server.hostToken", serverInfo.hostToken);
+    }
+    return "started";
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  if (engineStarted !== "started") throw new Error(String(engineStarted));
+  const engineReady = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const deadline = Date.now() + 120_000;
+    let last = "";
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(
+          "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(created.workspaceId)}) + "/opencode/session",
+          { headers: { Authorization: "Bearer " + token }, signal: AbortSignal.timeout(2_000) },
+        );
+        if (response.ok) return "ready";
+        last = "HTTP " + response.status;
+      } catch (error) { last = String(error); }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    return "engine not ready: " + last;
+  })()`, { awaitPromise: true, timeoutMs: 130_000 });
+  if (engineReady !== "ready") throw new Error(String(engineReady));
+  return { workspaceId: created.workspaceId, route: String(await evalIn(app, "location.hash")) };
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -57,6 +149,22 @@ async function waitForMountedArtifact(app: Awaited<ReturnType<typeof desktop>>, 
       includeDOMRects: false,
     });
     if (snapshotContainsMountedArtifact(snapshot)) return true;
+    const targets = await listTargets(app.handle.cdpUrl);
+    const sandbox = targets.find((target) => target.type === "iframe"
+      && target.url.includes("/mcp-apps/sandbox.html")
+      && target.webSocketDebuggerUrl);
+    if (sandbox) {
+      const client = await connect(debuggerUrlFor(app.handle.cdpUrl, sandbox));
+      try {
+        const mounted = await evaluate(client, `(() => {
+          const text = document.querySelector("iframe")?.contentDocument?.body?.innerText ?? "";
+          return text.includes("Quarterly plan") && text.includes("Ready");
+        })()`);
+        if (mounted === true) return true;
+      } finally {
+        client.close();
+      }
+    }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   return false;
@@ -360,9 +468,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement)(title, { timeout: 240_000 }, as
       OPENWORK_INFERENCE_BASE_URL: "",
     },
   });
-  const workspace = await createAndSelectWorkspace(app, {
-    path: `/tmp/openwork-mcp-app-inline-host-${Date.now()}`,
-  });
+  const workspace = await createWorkspaceForRenderer(app, `/tmp/openwork-mcp-app-inline-host-${Date.now()}`);
   const configured = await evalIn(app, `(async () => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
@@ -485,8 +591,8 @@ test.skipIf(!appSpecsEnabled || !localPlacement)(title, { timeout: 240_000 }, as
   })()`);
   expect(hostClaim).toBe(true);
   const mountedReact = await waitForMountedArtifact(app);
-  expect(mountedReact).toBe(true);
   const transcript = await evalIn(app, `document.body?.innerText ?? ""`);
+  expect(mountedReact, transcript).toBe(true);
   expect(transcript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(transcript).not.toContain("MCP_APP_RESOURCE_ACCEPT_TIMEOUT");
   expect(transcript).not.toContain("MCP_APP_RESOURCE_NOT_FOUND");


### PR DESCRIPTION
## Summary

- normalize packaged Desktop's `file://` renderer to the web platform's opaque `null` postMessage origin before constructing the MCP App sandbox URL
- preserve existing HTTP/HTTPS origin isolation and CSP behavior
- extend the MCP App host acceptance spec so it can exercise a packaged Electron binary and observe out-of-process sandbox iframes

## Root cause

Packaged Desktop loads the renderer from `file://`. Chromium represents messages from that opaque origin as `null`, while OpenWork declared `file://` to the sandbox proxy. The proxy therefore rejected the host's resource-delivery message before assigning the MCP App HTML, producing `MCP_APP_RESOURCE_ACCEPT_TIMEOUT` after two attempts.

## User impact

Standard MCP Apps launched through their native Connect MCP server now receive their `ui://` resource and render in packaged Desktop. This does not change MCP discovery, tool execution, resource contents, CSP, or the same-server app/tool boundary.

## Verification

- `pnpm --filter @openwork/app exec bun test tests/mcp-app-frame.test.ts` — 9 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — passed
- `OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_ELECTRON_BINARY='<exact-head packaged OpenWork binary>' pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/mcp-app-inline-host.slow.test.ts` — 1 passed, 0 failed, 0 skipped
- exact-head testkit tape: 2/2 frames passed, 4/4 expectations passed, no pending judgments
- GitHub Actions on the identical tested commit: Linux and macOS OpenWork test suites passed

The packaged journey asserts the sandbox policy, initializes the MCP App, delivers structured content, visibly mounts the React-authored bundle, and excludes `MCP_APP_RESOURCE_ACCEPT_TIMEOUT`, `MCP_APP_INITIALIZE_TIMEOUT`, and the interactive-view fallback.

Supersedes the fork-based publication in #3790; the implementation commit is unchanged.