### PR TITLE
chore(den-web): remove hero title badges from dashboard pages

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
@@ -9,7 +9,7 @@ import { useWebGlSupported } from "../../_lib/use-webgl-supported";
  *
  * A consistent page shell for all org dashboard pages.
  * Provides:
- *  - A compact gradient hero card (badge + title)
+ *  - A compact gradient hero card with the page title
  *  - A description line below the card
  *  - A children slot for page-specific content
  *
@@ -25,10 +25,6 @@ export type DashboardPageTemplateProps = {
     className?: string;
     strokeWidth?: number;
   }>;
-  /** Short label rendered as a frosted pill badge beside the title. Omit to hide. */
-  badgeLabel?: string;
-  /** Optional content rendered beside the badge inside the gradient band. */
-  badgeCompanion?: ReactNode;
   /** Page heading rendered large inside the card */
   title: string;
   /** One-liner rendered in gray below the card, above children */
@@ -46,8 +42,6 @@ export type DashboardPageTemplateProps = {
 };
 
 export function DashboardPageTemplate({
-  badgeLabel,
-  badgeCompanion,
   title,
   description,
   colors,
@@ -86,12 +80,6 @@ export function DashboardPageTemplate({
 
         <div className="relative z-10 flex min-w-0 items-center gap-2">
           <h1 className="truncate text-[24px] font-semibold leading-[30px] tracking-[-0.02em] text-white">{title}</h1>
-          {badgeLabel ? (
-            <span className="shrink-0 rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
-              {badgeLabel}
-            </span>
-          ) : null}
-          {badgeCompanion}
         </div>
       </div>
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
@@ -291,7 +291,6 @@ export function ApiKeysScreen() {
         return (
             <DashboardPageTemplate
                 icon={KeyRound}
-                badgeLabel="Admin"
                 title="API Keys"
                 description="Create named, rate-limited API keys for your own org membership and revoke any key in the workspace when needed."
                 colors={["#E6FFFA", "#0F766E", "#14B8A6", "#99F6E4"]}
@@ -306,7 +305,6 @@ export function ApiKeysScreen() {
     return (
         <DashboardPageTemplate
             icon={KeyRound}
-            badgeLabel="Admin"
             title="API Keys"
             description="Manage your OpenWork API keys."
             colors={["#E6FFFA", "#0F766E", "#14B8A6", "#99F6E4"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/background-agents-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/background-agents-screen.tsx
@@ -381,7 +381,6 @@ export function BackgroundAgentsScreen() {
   return (
     <DashboardPageTemplate
       icon={Bot}
-      badgeLabel="Alpha"
       title="Background Tasks"
       description="Run selected workflows in the background without asking each teammate to run them locally. Coming soon."
       colors={["#E9FFE0", "#3E9A1D", "#B3F750", "#51F0A3"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/github-integration-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/github-integration-screen.tsx
@@ -80,7 +80,6 @@ export function GithubIntegrationScreen() {
   return (
     <DashboardPageTemplate
       icon={Github}
-      badgeLabel="GitHub"
       title="Connect GitHub"
       description="Choose a connected account from the Integrations page to continue."
       colors={["#E2E8F0", "#0F172A", "#111827", "#94A3B8"]}
@@ -116,7 +115,6 @@ function GithubInstallCompletionRedirect({ installationId, state }: { installati
   return (
     <DashboardPageTemplate
       icon={Github}
-      badgeLabel="GitHub"
       title="Finishing GitHub connection"
       description="OpenWork is finalizing the GitHub App installation for this organization."
       colors={["#E2E8F0", "#0F172A", "#111827", "#94A3B8"]}
@@ -192,7 +190,6 @@ function ConfigurationLoadingState() {
   return (
     <DashboardPageTemplate
       icon={Puzzle}
-      badgeLabel="Repository"
       title="Loading…"
       description="OpenWork is loading this repository's connector configuration."
       colors={["#DBEAFE", "#0F172A", "#1D4ED8", "#BFDBFE"]}
@@ -274,7 +271,6 @@ function GithubConnectorInstanceManagePhase({
   return (
     <DashboardPageTemplate
       icon={Puzzle}
-      badgeLabel="Repository"
       title={repoName}
       description="Manage which plugins OpenWork imports from this repository."
       colors={["#DBEAFE", "#0F172A", "#1D4ED8", "#BFDBFE"]}
@@ -682,7 +678,6 @@ function GithubConnectedAccountSelectionPhase({ connectorAccountId }: { connecto
   return (
     <DashboardPageTemplate
       icon={Github}
-      badgeLabel="GitHub"
       title="Add a repository"
       description={ownerLogin
         ? `Pick one of the repositories the @${ownerLogin} installation can already read.`
@@ -1007,7 +1002,6 @@ function GithubDiscoveryPhase({ connectorInstanceId, onBack }: { connectorInstan
   return (
     <DashboardPageTemplate
       icon={Sparkles}
-      badgeLabel="Discovery"
       title={repoName ?? "Discover repository"}
       description="Pick which plugins OpenWork should import from this repository."
       colors={["#DBEAFE", "#0F172A", "#1D4ED8", "#BFDBFE"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
@@ -56,7 +56,6 @@ export function IntegrationsScreen() {
   return (
     <DashboardPageTemplate
       icon={Cable}
-      badgeLabel="Alpha"
       title="Sources"
       description="Connect to GitHub or Bitbucket. Once an account is linked, plugins and skills from those repositories show up on the Plugins page."
       colors={["#E0F2FE", "#0C4A6E", "#0284C7", "#7DD3FC"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
@@ -489,12 +489,6 @@ export function LibraryScreen() {
   return (
     <DashboardPageTemplate
       icon={LibraryBig}
-      badgeLabel="Member library"
-      badgeCompanion={(
-        <DenChip tone="success">
-          {stateCounts.ready} ready to use
-        </DenChip>
-      )}
       title="My Library"
       description="Everything you can use in chat — yours, shared with you, from your teams, and org-wide."
       descriptionPlacement="hero"

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
@@ -285,7 +285,6 @@ export function LlmProvidersScreen() {
   return (
     <DashboardPageTemplate
       icon={KeyRound}
-      badgeLabel="New"
       title="Bring your Own Keys"
       description="Connect Anthropic, OpenAI, Azure or any models.dev provider with your own credentials, choose the exact models each one exposes, and grant access to the right people and teams."
       colors={["#F3FFF9", "#0F766E", "#34D399", "#7DD3FC"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
@@ -51,7 +51,6 @@ export function MarketplacesScreen() {
   return (
     <DashboardPageTemplate
       icon={Store}
-      badgeLabel="Preview"
       title="Marketplaces"
       description="Marketplaces contain plugins. OpenWork Marketplace is built in, and assigned marketplaces show up inside the desktop app after sign-in."
       colors={["#FEF3C7", "#92400E", "#F59E0B", "#FDE68A"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -639,7 +639,6 @@ export function McpConnectionsScreen() {
     <DashboardPageTemplate
       icon={Plug}
       title="Connectors"
-      badgeLabel="Beta"
       description="Connectors is where you can add MCP servers that your whole team can use."
       colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
     >

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
@@ -158,7 +158,6 @@ export function PluginsScreen() {
   return (
     <DashboardPageTemplate
       icon={Puzzle}
-      badgeLabel="Preview"
       title="Plugin Directory"
       description="Discover and manage plugins — bundles of skills, hooks, MCP servers, agents, and commands that extend your workers."
       colors={["#EDE9FE", "#4C1D95", "#7C3AED", "#C4B5FD"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
@@ -322,7 +322,6 @@ export function ScimScreen() {
     return (
       <DashboardPageTemplate
         icon={Shield}
-        badgeLabel="Admin"
         title="SCIM"
         description="Provision organization members from your identity provider with an org-scoped SCIM connector."
         colors={["#ECFEFF", "#155E75", "#06B6D4", "#A5F3FC"]}
@@ -337,7 +336,6 @@ export function ScimScreen() {
   return (
     <DashboardPageTemplate
       icon={Shield}
-      badgeLabel="Admin"
       title="SCIM"
       description="Create one SCIM connector per workspace, then give your identity provider the base URL and bearer token shown here."
       colors={["#ECFEFF", "#155E75", "#06B6D4", "#A5F3FC"]}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -307,7 +307,7 @@ export function SsoScreen() {
 
   if (!orgContext) {
     return (
-      <DashboardPageTemplate icon={Shield} badgeLabel="Admin" title="SSO" description="Set up enterprise single sign-on for this workspace." colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}>
+      <DashboardPageTemplate icon={Shield} title="SSO" description="Set up enterprise single sign-on for this workspace." colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}>
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">Loading organization details...</div>
       </DashboardPageTemplate>
     );
@@ -316,7 +316,7 @@ export function SsoScreen() {
   const ssoFormDisabled = formReadOnly || saving || !orgContext.entitlements.sso;
 
   return (
-    <DashboardPageTemplate icon={Shield} badgeLabel="Admin" title="SSO" description="Configure one enterprise SSO connection per workspace and share the generated sign-in URL with your team." colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}>
+    <DashboardPageTemplate icon={Shield} title="SSO" description="Configure one enterprise SSO connection per workspace and share the generated sign-in URL with your team." colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}>
       {!access.canViewSettings ? (
         <div className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-[14px] text-amber-900">Only workspace admins can view SSO.</div>
       ) : (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/tool-tester/tool-tester-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/tool-tester/tool-tester-screen.tsx
@@ -403,7 +403,6 @@ export function ToolTesterScreen() {
     <DashboardPageTemplate
       icon={Wrench}
       title="Tool Tester"
-      badgeLabel="Beta"
       colors={["#CFFAFE", "#155E75", "#0E7490", "#67E8F9"]}
       description="Run any tool your connections expose, inspect the request on the wire, and control which tools your organization can use. Runs execute with your credential and are never written to OpenWork logs."
     >

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -81,7 +81,6 @@ export function YourConnectionsScreen() {
     <DashboardPageTemplate
       icon={Plug}
       title="Your Connections"
-      badgeLabel="Beta"
       description="Tools your organization has made available to you. Connect your own account where needed; workspace admins can test tools directly, and your AI coworker uses them with your permissions."
       colors={["#DBEAFE", "#1E3A8A", "#2563EB", "#93C5FD"]}
     >

--- a/ee/apps/den-web/app/(den)/dashboard/web/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/web/page.tsx
@@ -75,7 +75,6 @@ export default function WebPage() {
   return (
     <DashboardPageTemplate
       icon={Globe}
-      badgeLabel="Alpha"
       title="OpenWork Web"
       description="Open OpenWork in your browser."
       colors={["#EFF6FF", "#0F172A", "#2563EB", "#BAE6FD"]}

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -25,19 +25,18 @@ describe("connector and marketplace polish", () => {
     expect(shell).toContain('badge: "Alpha"');
   });
 
-  test("uses the shared page maturity badge to label Sources alpha", () => {
+  test("keeps the Sources page title free of maturity badges", () => {
     const screen = readDashboardComponent("integrations-screen.tsx");
 
     expect(screen).toContain('title="Sources"');
-    expect(screen).toContain('badgeLabel="Alpha"');
-    expect(screen).not.toContain('badgeLabel="Preview"');
+    expect(screen).not.toContain("badgeLabel");
   });
 
   test("uses the smart connector bar and the approved connector copy", () => {
     const screen = readDashboardComponent("mcp-connections-screen.tsx");
 
     expect(screen).toContain('title="Connectors"');
-    expect(screen).toContain('badgeLabel="Beta"');
+    expect(screen).not.toContain("badgeLabel");
     expect(screen).toContain('description="Connectors is where you can add MCP servers that your whole team can use."');
     expect(screen).toContain('data-testid="connector-smart-bar"');
     expect(screen).not.toMatch(/>\s*Add MCP\s*</);


### PR DESCRIPTION
## What

Removes all badges from the dashboard page hero cards in Den Web, keeping only the page title. This covers the "Member library" pill and the "N ready to use" chip on My Library, plus every maturity/context badge ("Alpha", "Beta", "New", "Preview", "Admin", "GitHub", "Repository", "Discovery") across the other dashboard screens.

- `DashboardPageTemplate` no longer accepts or renders `badgeLabel` / `badgeCompanion`
- All 15 screen usages removed (library, connectors, sources, plugins, marketplaces, LLM providers, background agents, tool tester, SSO, SCIM, API keys, GitHub integration, your connections, web, my library)
- Updated `tests/connector-marketplace-polish.test.ts` to assert the titles render without badges

Sidebar nav badges (e.g. "MCPs" next to Connectors) are untouched — this is scoped to the page hero.

## Verification

UI-copy-only removal (deleting an optional decorative prop and its usages); no runtime behavior changes, so no `.slow` tape was recorded.

- `pnpm exec tsc --noEmit` in `ee/apps/den-web`: no errors outside pre-existing stale `.next/types` cache entries referencing skill-hubs pages absent from `dev`
- `pnpm exec bun test` in `ee/apps/den-web`: 262 pass / 4 fail — the identical 4 failures reproduce on clean `dev` (billing refresh, MCP OAuth row contract, workspace favicon) and are unrelated
- `tests/connector-marketplace-polish.test.ts` (the file this PR touches): 5/5 pass