### PR TITLE
Enforce Den password policy

### DIFF
--- a/ee/apps/den-api/src/auth-protection.ts
+++ b/ee/apps/den-api/src/auth-protection.ts
@@ -13,6 +13,7 @@ export const EMAIL_PASSWORD_SIGN_UP_PATH = "/api/auth/sign-up/email"
 export const CHANGE_PASSWORD_PATH = "/api/auth/change-password"
 export const RESET_PASSWORD_PATH = "/api/auth/reset-password"
 export const MIN_PASSWORD_LENGTH = 8
+export const MAX_PASSWORD_LENGTH = 32
 export const MIN_PASSWORD_STRENGTH_SCORE = 3
 export const LOGIN_LOCKOUT_FAILURE_THRESHOLD = 5
 export const LOGIN_LOCKOUT_FAILURE_WINDOW_MS = 60 * 60 * 1000
@@ -34,6 +35,11 @@ type LockoutStatus = {
 }
 
 type PwnedPasswordsFetch = (input: string, init?: RequestInit) => Promise<Response>
+
+type PasswordPolicyViolation = {
+  error: string
+  message: string
+}
 
 const passwordStrengthEstimator = new ZxcvbnFactory({
   translations: englishPasswordTranslations,
@@ -241,6 +247,52 @@ function getPasswordStrengthMessage(feedback: { warning: string | null; suggesti
   return feedback.warning?.trim() || feedback.suggestions.find((suggestion) => suggestion.trim().length > 0)?.trim() || "Password is too weak."
 }
 
+function getPasswordPolicyViolation(password: string): PasswordPolicyViolation | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return {
+      error: "password_too_short",
+      message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+    }
+  }
+
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return {
+      error: "password_too_long",
+      message: `Password must be at most ${MAX_PASSWORD_LENGTH} characters.`,
+    }
+  }
+
+  if (!/[A-Z]/u.test(password)) {
+    return {
+      error: "password_missing_uppercase",
+      message: "Password must include at least one uppercase letter.",
+    }
+  }
+
+  if (!/[a-z]/u.test(password)) {
+    return {
+      error: "password_missing_lowercase",
+      message: "Password must include at least one lowercase letter.",
+    }
+  }
+
+  if (!/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/u.test(password)) {
+    return {
+      error: "password_missing_special_character",
+      message: "Password must include at least one special character.",
+    }
+  }
+
+  if (!/[0-9]/u.test(password)) {
+    return {
+      error: "password_missing_digit",
+      message: "Password must include at least one digit.",
+    }
+  }
+
+  return null
+}
+
 export async function isPasswordCompromised(password: string, fetchPasswordRange: PwnedPasswordsFetch = fetch) {
   const hash = hashPasswordForRangeLookup(password)
   const prefix = hash.slice(0, 5)
@@ -299,16 +351,14 @@ export async function getBreachedPasswordResponse(
   })
 }
 
-export async function getShortPasswordResponse(request: Request) {
+export async function getPasswordPolicyResponse(request: Request) {
   const password = await readPasswordForBreachCheck(request)
-  if (password === null || password.length >= MIN_PASSWORD_LENGTH) {
+  if (password === null) {
     return null
   }
 
-  return jsonError(400, {
-    error: "password_too_short",
-    message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
-  })
+  const violation = getPasswordPolicyViolation(password)
+  return violation ? jsonError(400, violation) : null
 }
 
 export async function getWeakPasswordResponse(request: Request) {

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -13,7 +13,7 @@ import {
   EMAIL_PASSWORD_SIGN_UP_PATH,
   getBreachedPasswordResponse,
   getEmailPasswordLockoutResponse,
-  getShortPasswordResponse,
+  getPasswordPolicyResponse,
   getWeakPasswordResponse,
   readEmailSignInAttempt,
   recordEmailSignInResult,
@@ -606,9 +606,9 @@ async function handleAuthRequest(c: Context) {
     return singleOrgAuthGuardResponse
   }
 
-  const shortPasswordResponse = await getShortPasswordResponse(authRequest)
-  if (shortPasswordResponse) {
-    return shortPasswordResponse
+  const passwordPolicyResponse = await getPasswordPolicyResponse(authRequest)
+  if (passwordPolicyResponse) {
+    return passwordPolicyResponse
   }
 
   const weakPasswordResponse = await getWeakPasswordResponse(authRequest)
@@ -750,7 +750,7 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
       responses: {
         200: emptyResponse("Better Auth handled the request successfully."),
         302: emptyResponse("Better Auth redirected the user to continue the auth flow."),
-        400: emptyResponse("Better Auth rejected the request as invalid. Password creation, password change, or reset is also rejected when the proposed password is too short or is known to be compromised."),
+        400: emptyResponse("Better Auth rejected the request as invalid. Password creation, password change, or reset is also rejected when the proposed password fails Den password policy or is known to be compromised."),
         401: emptyResponse("Better Auth rejected the request because authentication failed."),
         429: jsonResponse("Email/password sign-in is temporarily locked after too many failed attempts. The response includes a Retry-After header.", authLoginLockedSchema),
         503: jsonResponse("Password breach screening is temporarily unavailable, so password creation or reset should be retried later.", authPasswordScreeningUnavailableSchema),

--- a/ee/apps/den-api/test/auth-protection.test.ts
+++ b/ee/apps/den-api/test/auth-protection.test.ts
@@ -122,39 +122,110 @@ test("breached password response blocks compromised passwords and fails closed o
   })
 })
 
-test("short password response rejects passwords below the minimum length on creation routes", async () => {
+test("password policy response rejects passwords that miss mandatory requirements on creation routes", async () => {
   const tooShort = new Request("http://den.local/api/auth/sign-up/email", {
-    body: JSON.stringify({ email: "user@example.com", password: "short" }),
+    body: JSON.stringify({ email: "user@example.com", password: "Aa1!" }),
     headers: { "content-type": "application/json" },
     method: "POST",
   })
-  const rejected = await authProtection.getShortPasswordResponse(tooShort)
+  const rejected = await authProtection.getPasswordPolicyResponse(tooShort)
   expect(rejected?.status).toBe(400)
   await expect(rejected?.json()).resolves.toEqual({
     error: "password_too_short",
     message: `Password must be at least ${authProtection.MIN_PASSWORD_LENGTH} characters.`,
   })
 
-  const atBoundary = new Request("http://den.local/api/auth/sign-up/email", {
-    body: JSON.stringify({ email: "user@example.com", password: "a".repeat(authProtection.MIN_PASSWORD_LENGTH) }),
+  const tooLong = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: `Aa1!${"x".repeat(authProtection.MAX_PASSWORD_LENGTH - 3)}` }),
     headers: { "content-type": "application/json" },
     method: "POST",
   })
-  await expect(authProtection.getShortPasswordResponse(atBoundary)).resolves.toBeNull()
+  const overLimit = await authProtection.getPasswordPolicyResponse(tooLong)
+  expect(overLimit?.status).toBe(400)
+  await expect(overLimit?.json()).resolves.toEqual({
+    error: "password_too_long",
+    message: `Password must be at most ${authProtection.MAX_PASSWORD_LENGTH} characters.`,
+  })
 
-  const longEnough = new Request("http://den.local/api/auth/sign-up/email", {
-    body: JSON.stringify({ email: "user@example.com", password: "longenough" }),
+  const missingUppercase = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "lowercase1!" }),
     headers: { "content-type": "application/json" },
     method: "POST",
   })
-  await expect(authProtection.getShortPasswordResponse(longEnough)).resolves.toBeNull()
+  const noUppercase = await authProtection.getPasswordPolicyResponse(missingUppercase)
+  expect(noUppercase?.status).toBe(400)
+  await expect(noUppercase?.json()).resolves.toEqual({
+    error: "password_missing_uppercase",
+    message: "Password must include at least one uppercase letter.",
+  })
+
+  const missingLowercase = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "UPPERCASE1!" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  const noLowercase = await authProtection.getPasswordPolicyResponse(missingLowercase)
+  expect(noLowercase?.status).toBe(400)
+  await expect(noLowercase?.json()).resolves.toEqual({
+    error: "password_missing_lowercase",
+    message: "Password must include at least one lowercase letter.",
+  })
+
+  const missingSpecialCharacter = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "Password1" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  const noSpecialCharacter = await authProtection.getPasswordPolicyResponse(missingSpecialCharacter)
+  expect(noSpecialCharacter?.status).toBe(400)
+  await expect(noSpecialCharacter?.json()).resolves.toEqual({
+    error: "password_missing_special_character",
+    message: "Password must include at least one special character.",
+  })
+
+  const missingDigit = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "Password!" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  const noDigit = await authProtection.getPasswordPolicyResponse(missingDigit)
+  expect(noDigit?.status).toBe(400)
+  await expect(noDigit?.json()).resolves.toEqual({
+    error: "password_missing_digit",
+    message: "Password must include at least one digit.",
+  })
+
+  const validSignup = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "ValidPass1!" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  await expect(authProtection.getPasswordPolicyResponse(validSignup)).resolves.toBeNull()
+
+  const validChange = new Request("http://den.local/api/auth/change-password", {
+    body: JSON.stringify({ newPassword: "ChangedPass1!" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  await expect(authProtection.getPasswordPolicyResponse(validChange)).resolves.toBeNull()
+
+  const invalidChange = new Request("http://den.local/api/auth/change-password", {
+    body: JSON.stringify({ newPassword: "ChangedPass!" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  const rejectedChange = await authProtection.getPasswordPolicyResponse(invalidChange)
+  expect(rejectedChange?.status).toBe(400)
+  await expect(rejectedChange?.json()).resolves.toMatchObject({
+    error: "password_missing_digit",
+  })
 
   const signIn = new Request("http://den.local/api/auth/sign-in/email", {
     body: JSON.stringify({ email: "user@example.com", password: "x" }),
     headers: { "content-type": "application/json" },
     method: "POST",
   })
-  await expect(authProtection.getShortPasswordResponse(signIn)).resolves.toBeNull()
+  await expect(authProtection.getPasswordPolicyResponse(signIn)).resolves.toBeNull()
 })
 
 test("weak password response rejects low-strength signup passwords with feedback", async () => {


### PR DESCRIPTION
## Summary
- Add a Den password policy check for password creation routes: 8-32 chars, uppercase, lowercase, special character, and digit
- Apply the policy before zxcvbn and breach screening in the Better Auth proxy
- Cover signup, password change, invalid password change, and sign-in no-op behavior in auth-protection tests

## Verification
- pnpm --filter @openwork-ee/den-db build
- bun test test/auth-protection.test.ts
- pnpm --filter @openwork-ee/den-api build