### PR TITLE
Add the Den foundation for a private MCP App host

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -16,6 +16,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
 import {
+  compareCapabilityMatches,
   EXECUTE_CAPABILITY_TOOL_NAME,
   SEARCH_CAPABILITIES_TOOL_NAME,
   type CapabilityMatch,
@@ -122,6 +123,7 @@ const capabilityMatchOutputSchema = z.object({
   schemaDigest: z.string().optional(),
   invocation: z.object({ argumentsField: z.literal("body") }).optional(),
   kind: z.string().optional(),
+  mcpApp: z.object({ resourceUri: z.string() }).optional(),
   status: z.string().optional(),
   hint: z.string().optional(),
   connectionStatus: connectionStatusOutputSchema.optional(),
@@ -180,6 +182,7 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "MCP App UI is authored and bundled outside OpenWork. Agents do not author, generate, compile, revise, activate, or publish UI source in OpenWork. Active imported apps in the member's Library appear as individually named launch tools backed by immutable ui:// resources.",
   "Use import_remote_mcp_app only after the user has selected an existing Plugin and approved installation of third-party executable content. Supply only the Plugin id and a public HTTPS URL for one self-contained index.html; never send inline HTML, React or JavaScript source, or build-project contents.",
   "An imported app receives the exact search_capabilities and execute_capability tool names in launch structuredContent. Through the standard same-server MCP Apps bridge it can search the member's authorized Connect tools and Programs, then execute an exact returned capability. The host retains workspace policy, user approval, and result-size enforcement; credentials never enter the app.",
+  "Standard MCP Apps supplied by connected MCP servers are discovered through search_capabilities. A match with kind mcp_app must be executed through execute_capability like any other exact match; compatible OpenWork hosts preserve the current _meta.ui.resourceUri and render it without a generated direct-tool name.",
   "A Program is an immutable-versioned Code Mode Script config object inside an OpenWork Connect Plugin. Organizations with Code Mode scripts enabled receive execute_capability_script, the backwards-compatible render_dynamic_artifact MCP App tool, and a constant-size Program catalog: search_programs, select_program, and clear_program_selection.",
   "To use a Program, search by Library metadata, select one exact accessible Program, then refresh the tool catalog. The selected context exposes run_selected_program and a standard renderer for its retained Artifact data; Program execution remains server-mediated and returns structuredContent.",
   "When a member asks to keep a successful Code Mode result, save it as a Program inside the existing OpenWork Connect Plugin they name by passing that pluginId to the Code Mode save operation. Omit pluginId only for a private Program in the member's My Programs Plugin. A Program inherits discovery and sharing from its Plugin and any Marketplace containing that Plugin; do not create a separate Program package or marketplace entry.",
@@ -193,6 +196,7 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "Do not invent OAuth-client, credential, or local-extension setup. Organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect. When a returned connection or marketplace readiness state requires administrator setup or member sign-in, relay that exact action.",
   "A successful search_capabilities call proves this OpenWork Cloud MCP connection is authorized. Never tell the user to reconnect OpenWork Cloud because a downstream connector failed.",
   "External MCP matches include the provider-advertised argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
+  "Do not import, convert, or browse for a standalone HTML URL when a connected capability already appears with kind mcp_app. Execute that exact match and let the host resolve its originating ui:// resource.",
   "OpenWork always attempts the downstream provider call when local schema checks find a mismatch. schemaGuidance is advisory and appears alongside the provider result: if the provider succeeded, accept that result and do not retry solely because of the warning; if it failed, use the warning to correct the arguments or search again.",
   "If the provider returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns unknown_capability, call search_capabilities again before retrying.",
   "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
@@ -439,6 +443,10 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       generatedArtifactViewsEnabled: env.generatedArtifactViewsEnabled,
       organizationMetadata,
       mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
+      // This metadata is an opaque binding on an already authorized bounded
+      // search/execute result. Resolving the provider tool or resource still
+      // requires the separately scoped App-host credential below.
+      mcpAppsEnabled: remoteAppsEnabled,
     })
     const { externalMcpConnectionsEnabled } = capabilityContext
     let remoteSkills: RemoteSkillDescriptor[] = []
@@ -548,7 +556,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
           "When Code Mode is enabled, accessible Programs appear as marketplace matches with kind script and execute through execute_capability like every other exact search result.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
-          "Native API matches include a connector-namespaced name, pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField.",
+          "Native API matches include a connector-namespaced name, pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField. A match with kind mcp_app is a standard MCP App launch capability from a connected MCP server; execute it normally and the OpenWork host will render its advertised ui:// resource.",
           "Built-in and marketplace skill matches return SKILL.md content when executed.",
         ].join(" "),
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,
@@ -563,7 +571,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       async ({ query, limit, type }) => {
         const boundedLimit = limit ?? 5
         const result = await searchCapabilityRegistry(capabilityContext, { query, limit: boundedLimit, type })
-        return capabilitySearchToolResult(result.matches, result.externalCoverageHint)
+        const matches = result.matches.sort(compareCapabilityMatches).slice(0, boundedLimit)
+        return capabilitySearchToolResult(matches, result.externalCoverageHint)
       },
     )
 
@@ -575,6 +584,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           "Call a capability found via search_capabilities, by its exact name.",
           "Pass path/query/body only as described by that match's pathParams/queryParams/hasBody.",
           "For external MCP capabilities, provider-advertised schema mismatches are returned as advisory schemaGuidance alongside the provider result; they do not block the downstream call.",
+          "When the exact capability is a standard MCP App launch tool, this call preserves its originating tool and ui:// binding so compatible OpenWork hosts render it without requiring a generated direct-tool name.",
           "For skill capabilities listed in the remote skill catalog, this returns their authorized SKILL.md content.",
           "Returns unknown_capability if name doesn't match a current capability — call search_capabilities again.",
         ].join(" "),
@@ -591,7 +601,9 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       async ({ name, schemaDigest, path, query, body }, extra) => {
         const result = await executeCapabilityWithBudget({
           capability: name,
-          invoke: () => executeCapability(capabilityContext, { name, schemaDigest, path, query, body }),
+          invoke: async (): Promise<ExecuteCapabilityToolResult> => (
+            executeCapability(capabilityContext, { name, schemaDigest, path, query, body })
+          ),
         })
         const catalogOperation = catalog.find((operation) => operation.name === name)
         if (!result.isError && catalogOperation && catalogOperationChangesRemoteMcpAppDiscovery(catalogOperation)) {

--- a/ee/apps/den-api/src/mcp/capability-registry.ts
+++ b/ee/apps/den-api/src/mcp/capability-registry.ts
@@ -54,8 +54,10 @@ import {
 } from "./native-capabilities.js"
 import {
   compareCapabilityMatches,
+  EXECUTE_CAPABILITY_TOOL_NAME,
   searchCapabilities,
   searchCapabilitySourceFilter,
+  SEARCH_CAPABILITIES_TOOL_NAME,
   type CapabilityMatch,
   type SearchCapabilityType,
 } from "./search.js"
@@ -77,6 +79,7 @@ export type ExecuteCapabilityToolResult = {
   isError?: boolean
   content: AgentToolContentPart[]
   structuredContent?: Record<string, unknown>
+  _meta?: Record<string, unknown>
 }
 
 export type CapabilityExecuteInput = {
@@ -98,6 +101,7 @@ export type CapabilityRegistryContext = {
   codemodeEnabled: boolean
   generatedArtifactViewsEnabled: boolean
   externalMcpConnectionsEnabled: boolean
+  mcpAppsEnabled: boolean
   resolvePlatformAdmin: () => Promise<boolean>
   resolveNamespaceContext: () => Promise<CodemodeConnectionNamespaceContext>
 }
@@ -114,6 +118,7 @@ export type CapabilityRegistryContextInput = {
   generatedArtifactViewsEnabled: boolean
   organizationMetadata: Parameters<typeof memberFacingMcpConnectionsEnabled>[0]
   mcpConnectionsGatingEnabled: boolean
+  mcpAppsEnabled?: boolean
 }
 
 export function createCapabilityRegistryContext(input: CapabilityRegistryContextInput): CapabilityRegistryContext {
@@ -145,6 +150,7 @@ export function createCapabilityRegistryContext(input: CapabilityRegistryContext
     codemodeEnabled: input.codemodeEnabled,
     generatedArtifactViewsEnabled: input.generatedArtifactViewsEnabled,
     externalMcpConnectionsEnabled,
+    mcpAppsEnabled: input.mcpAppsEnabled === true,
     resolvePlatformAdmin,
     resolveNamespaceContext,
   }
@@ -269,11 +275,33 @@ export function externalCapabilitySuccessToolResult(
   result: Extract<ExternalCapabilityExecuteResult, { ok: true }>,
 ): ExecuteCapabilityToolResult {
   const content = externalToolContent(result.result)
-  const structuredContent = isRecord(result.result)
+  const providerStructuredContent = isRecord(result.result)
     && isRecord(result.result.structuredContent)
     ? result.result.structuredContent
     : undefined
-  if (!result.schemaGuidance) return { content, ...(structuredContent ? { structuredContent } : {}) }
+  const structuredContent = result.mcpApp
+    ? {
+        ...(providerStructuredContent ?? {}),
+        serverTools: {
+          searchCapabilities: SEARCH_CAPABILITIES_TOOL_NAME,
+          executeCapability: EXECUTE_CAPABILITY_TOOL_NAME,
+        },
+      }
+    : providerStructuredContent
+  const providerMeta = isRecord(result.result) && isRecord(result.result._meta)
+    ? result.result._meta
+    : {}
+  const meta = {
+    ...providerMeta,
+    ...(result.mcpApp ? { "openwork/mcpApp": result.mcpApp } : {}),
+  }
+  if (!result.schemaGuidance) {
+    return {
+      content,
+      ...(structuredContent ? { structuredContent } : {}),
+      ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+    }
+  }
   return {
     content: [
       ...content,
@@ -283,6 +311,7 @@ export function externalCapabilitySuccessToolResult(
       ...(structuredContent ?? {}),
       schemaGuidance: result.schemaGuidance,
     },
+    ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
   }
 }
 
@@ -484,6 +513,7 @@ const externalMcpSource: CapabilitySource = {
       limit,
       includeScriptPaths: ctx.codemodeEnabled,
       namespaceContext: ctx.codemodeEnabled ? await ctx.resolveNamespaceContext() : undefined,
+      mcpAppsEnabled: ctx.mcpAppsEnabled,
       reportCoverage: (coverage) => ctx.reportExternalCoverage(externalMcpSearchCoverageHint(coverage)),
     })
   },
@@ -515,6 +545,7 @@ const externalMcpSource: CapabilitySource = {
       args: normalizeToolBody(input.body),
       schemaDigest: input.schemaDigest,
       redirectUriBase: ctx.redirectUriBase,
+      mcpAppsEnabled: ctx.mcpAppsEnabled,
     })
     return result.ok
       ? externalCapabilitySuccessToolResult(result)

--- a/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
+++ b/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
@@ -3,6 +3,15 @@ import type { ExternalMcpConnectionRow } from "../capability-sources/external-mc
 
 export const CONNECT_MCP_SERVER_INDEX_URI = "openwork://connect/mcp-servers/index.json"
 export const CONNECT_MCP_SERVER_INDEX_SCHEMA_VERSION = "openwork.connect/mcp-servers/1"
+export const CONNECT_MCP_APP_HOST_CAPABILITY_HEADER = "x-openwork-mcp-client-capabilities"
+export const CONNECT_MCP_APP_HOST_CAPABILITY = "mcp-app-host-v1"
+
+export function supportsConnectMcpAppHost(value: string | undefined): boolean {
+  return value
+    ?.split(",")
+    .map((capability) => capability.trim())
+    .includes(CONNECT_MCP_APP_HOST_CAPABILITY) ?? false
+}
 
 export type ConnectMcpServerIndexEntry = {
   connectionId: string

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -180,11 +180,18 @@ export type ExternalCapabilityMatch = CapabilityMatch & {
   /** Tells the generic execute facade where MCP arguments must be supplied. */
   invocation?: { argumentsField: "body" }
   /** Distinguishes a connection-health result from a callable capability. */
-  kind?: "connection_status"
+  kind?: "connection_status" | "mcp_app"
   /** Set for connection-level status rows: the tool exists but needs a human/admin fix before real tools can be listed. */
   status?: "needs_connection" | "error"
   hint?: string
   connectionStatus?: ExternalConnectionStatus
+}
+
+export type ExternalMcpAppLaunch = {
+  connectionId: string
+  toolName: string
+  resourceUri: string
+  arguments: Record<string, unknown>
 }
 
 export type ExternalConnectionStatus = {
@@ -225,6 +232,17 @@ const PROVIDER_ADMIN_ACTION_PATTERN = /\b(?:app (?:is )?not installed|admin(?:is
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function externalMcpAppResourceUri(tool: { _meta?: unknown }): string | null {
+  const meta = isRecord(tool._meta) ? tool._meta : {}
+  const ui = isRecord(meta.ui) ? meta.ui : {}
+  const resourceUri = typeof ui.resourceUri === "string"
+    ? ui.resourceUri
+    : typeof meta["ui/resourceUri"] === "string"
+      ? meta["ui/resourceUri"]
+      : null
+  return resourceUri?.startsWith("ui://") ? resourceUri : null
 }
 
 function cappedErrorMessage(message: string): string {
@@ -643,6 +661,7 @@ async function probeExternalMcpConnection(input: {
   limit: number
   deadline: ExternalMcpLifecycleDeadline
   scriptNamespace?: string
+  mcpAppsEnabled: boolean
 }): Promise<ExternalCapabilityMatch[]> {
   const matches: ExternalCapabilityMatch[] = []
   const add = (match: ExternalCapabilityMatch) => {
@@ -783,6 +802,7 @@ async function probeExternalMcpConnection(input: {
     const summaryTokens = tokenize(summary)
     const score = scoreText(nameTokens, summaryTokens, input.queryTokens)
     if (score <= 0) continue
+    const resourceUri = input.mcpAppsEnabled ? externalMcpAppResourceUri(tool) : null
     add({
       name: buildExternalCapabilityName(connection.id, tool.name),
       method: "MCP",
@@ -795,6 +815,7 @@ async function probeExternalMcpConnection(input: {
       argumentsSchema: tool.inputSchema,
       schemaDigest: externalMcpToolSchemaDigest(tool.inputSchema),
       invocation: { argumentsField: "body" },
+      ...(resourceUri ? { kind: "mcp_app" as const, mcpApp: { resourceUri } } : {}),
       ...(input.scriptNamespace ? { scriptPath: codemodeScriptPath(input.scriptNamespace, tool.name) } : {}),
     })
   }
@@ -816,6 +837,7 @@ export async function searchExternalCapabilities(input: {
   includeScriptPaths?: boolean
   namespaceContext?: CodemodeConnectionNamespaceContext
   reportCoverage?: (coverage: ExternalMcpSearchCoverage) => void
+  mcpAppsEnabled?: boolean
 }): Promise<ExternalCapabilityMatch[]> {
   if (!input.member) return []
   const queryTokens = tokenize(input.query)
@@ -854,6 +876,7 @@ export async function searchExternalCapabilities(input: {
       limit,
       deadline: sharedDeadline,
       scriptNamespace: scriptNamespaces?.get(connection.id),
+      mcpAppsEnabled: input.mcpAppsEnabled === true,
     }),
   })
 }
@@ -890,6 +913,7 @@ export type ExternalCapabilityExecuteResult =
       ok: true
       result: Awaited<ReturnType<typeof callExternalMcpTool>>
       schemaGuidance?: ExternalMcpSchemaGuidance
+      mcpApp?: ExternalMcpAppLaunch
     }
   | {
       ok: false
@@ -1007,6 +1031,7 @@ export async function executeExternalCapability(input: {
   requireReadOnly?: boolean
   /** Fail closed when the live input schema no longer matches schemaDigest. */
   requireSchemaMatch?: boolean
+  mcpAppsEnabled?: boolean
 }): Promise<ExternalCapabilityExecuteResult> {
   if (!input.member) {
     return { ok: false, error: "forbidden", message: "No active org membership for this token." }
@@ -1195,10 +1220,21 @@ export async function executeExternalCapability(input: {
 
     schemaGuidance = advisorySchemaGuidance(schemaWarnings)
     const result = await providerCall
+    const resourceUri = input.mcpAppsEnabled === true ? externalMcpAppResourceUri(tool) : null
     return {
       ok: true,
       result,
       ...(schemaGuidance ? { schemaGuidance } : {}),
+      ...(resourceUri
+        ? {
+            mcpApp: {
+              connectionId: connection.id,
+              toolName: tool.name,
+              resourceUri,
+              arguments: forwardedArguments,
+            },
+          }
+        : {}),
     }
   } catch (error) {
     const message = upstreamErrorMessage(error)

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -36,11 +36,18 @@ import { tokenRoute } from "../middleware/index.js"
 import { remoteMcpAppsEnabled } from "../capability-sources/remote-mcp-apps-rollout.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
-import { resolveMcpMemberIdentity } from "./external-capabilities.js"
+import { externalMcpAppResourceUri, resolveMcpMemberIdentity } from "./external-capabilities.js"
+import { externalMcpToolSchemaDigest } from "./external-mcp-tool-arguments.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { EXECUTE_CAPABILITY_TOOL_NAME, scoreText, SEARCH_CAPABILITIES_TOOL_NAME, tokenize } from "./search.js"
+import { DEN_MCP_APP_HOST_SCOPE } from "./scopes.js"
 
 function toolArguments(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 type ExternalMcpResourceOperation = Parameters<typeof describeExternalMcpServer>[0]
@@ -51,6 +58,7 @@ type ExternalMcpProxyOperation = ExternalMcpResourceOperation & {
 }
 
 type ExternalMcpProxyDescriptor = Awaited<ReturnType<typeof describeExternalMcpServer>>
+type ExternalMcpProxyTool = Awaited<ReturnType<typeof listExternalMcpTools>>[number]
 
 type ExternalMcpProxyRuntime = {
   callTool: typeof callExternalMcpToolRaw
@@ -66,6 +74,70 @@ const externalMcpProxyRuntime: ExternalMcpProxyRuntime = {
   listResourceTemplates: listExternalMcpResourceTemplates,
   listTools: listExternalMcpTools,
   readResource: readExternalMcpResource,
+}
+
+const PROXY_GATEWAY_TOOL_NAMES = new Set([SEARCH_CAPABILITIES_TOOL_NAME, EXECUTE_CAPABILITY_TOOL_NAME])
+
+const appGatewayTools: ExternalMcpProxyTool[] = [
+  {
+    name: SEARCH_CAPABILITIES_TOOL_NAME,
+    title: "Search capabilities",
+    description: "Search the ordinary tools on this connected MCP server without exposing its full catalog to the client.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 1 },
+        limit: { type: "integer", minimum: 1, maximum: 20 },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _meta: { ui: { visibility: ["app"] } },
+  },
+  {
+    name: EXECUTE_CAPABILITY_TOOL_NAME,
+    title: "Execute capability",
+    description: "Execute an exact tool returned by search_capabilities on this connected MCP server.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", minLength: 1 },
+        body: { type: "object" },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    _meta: { ui: { visibility: ["app"] } },
+  },
+]
+
+function toolVisibleToApp(tool: ExternalMcpProxyTool): boolean {
+  const meta = isRecord(tool._meta) ? tool._meta : {}
+  const ui = isRecord(meta.ui) ? meta.ui : {}
+  if (ui.visibility === undefined) return true
+  return Array.isArray(ui.visibility)
+    && ui.visibility.every((entry) => entry === "model" || entry === "app")
+    && ui.visibility.includes("app")
+}
+
+function appOnlyProxyTool(tool: ExternalMcpProxyTool): ExternalMcpProxyTool | null {
+  const resourceUri = externalMcpAppResourceUri(tool)
+  if (!resourceUri || !toolVisibleToApp(tool)) return null
+  const meta = isRecord(tool._meta) ? tool._meta : {}
+  const ui = isRecord(meta.ui) ? meta.ui : {}
+  return {
+    ...tool,
+    _meta: {
+      ...meta,
+      ui: {
+        ...ui,
+        resourceUri,
+        visibility: ["app"],
+      },
+    },
+  }
 }
 
 export function createDisabledExternalConnectionProxyServer() {
@@ -97,10 +169,32 @@ export function createExternalConnectionProxyServer(input: {
   descriptor: ExternalMcpProxyDescriptor
   operation: ExternalMcpProxyOperation
   runtime?: ExternalMcpProxyRuntime
+  appHostClient?: boolean
 }) {
   const { connection } = input.operation
   const runtime = input.runtime ?? externalMcpProxyRuntime
   const downstreamUi = input.descriptor.capabilities.extensions?.[EXTENSION_ID]
+  const listProviderTools = async () => {
+    if (!input.descriptor.capabilities.tools) return []
+    return (await runtime.listTools(
+      connection,
+      input.operation.redirectUri,
+      input.operation.member,
+      input.operation.diagnosticReferenceId,
+    )).filter((tool) => (
+      !PROXY_GATEWAY_TOOL_NAMES.has(tool.name)
+      && !evaluateToolPolicy(connection.toolPolicy, tool.name).blocked
+    ))
+  }
+  const listAppTools = async () => (
+    await listProviderTools()
+  ).flatMap((tool) => {
+    const appTool = appOnlyProxyTool(tool)
+    return appTool ? [appTool] : []
+  })
+  const appResourceUris = async () => new Set(
+    (await listAppTools()).map((tool) => externalMcpAppResourceUri(tool)).filter((uri) => uri !== null),
+  )
   const server = new McpServer(input.descriptor.serverInfo ?? {
     name: connection.name,
     version: "1.0.0",
@@ -110,40 +204,103 @@ export function createExternalConnectionProxyServer(input: {
       ...(input.descriptor.capabilities.resources ? { resources: { listChanged: false, subscribe: false } } : {}),
       ...(downstreamUi ? { extensions: { [EXTENSION_ID]: downstreamUi } } : {}),
     },
-    instructions: input.descriptor.instructions
-      ?? `This is the member-authorized OpenWork Connect proxy for ${connection.name}. Tool names and resources are provided by that MCP server.`,
+    instructions: input.appHostClient
+      ? `This member-authorized OpenWork Connect endpoint exposes only app-visible MCP App tools and their bound resources for ${connection.name}. Ordinary provider capabilities remain available exclusively through search_capabilities and execute_capability.`
+      : input.descriptor.instructions
+        ?? `This is the member-authorized OpenWork Connect proxy for ${connection.name}. Tool names and resources are provided by that MCP server.`,
   })
 
   if (input.descriptor.capabilities.tools) {
     server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: (await runtime.listTools(
-        connection,
-        input.operation.redirectUri,
-        input.operation.member,
-        input.operation.diagnosticReferenceId,
-      )).filter((tool) => !evaluateToolPolicy(connection.toolPolicy, tool.name).blocked),
+      tools: input.appHostClient ? [...appGatewayTools, ...await listAppTools()] : await listProviderTools(),
     }))
     server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const policy = evaluateToolPolicy(connection.toolPolicy, request.params.name)
-      if (policy.blocked) throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is disabled by OpenWork Connect policy.`)
+      if (!input.appHostClient) {
+        const policy = evaluateToolPolicy(connection.toolPolicy, request.params.name)
+        if (policy.blocked) {
+          throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is disabled by OpenWork Connect policy.`)
+        }
+        return runtime.callTool({
+          ...input.operation,
+          toolName: request.params.name,
+          args: toolArguments(request.params.arguments),
+        })
+      }
+      const args = toolArguments(request.params.arguments)
+      if (request.params.name === SEARCH_CAPABILITIES_TOOL_NAME) {
+        const query = typeof args.query === "string" ? args.query.trim() : ""
+        if (!query) throw new McpError(ErrorCode.InvalidParams, "search_capabilities requires a non-empty query.")
+        const requestedLimit = typeof args.limit === "number" && Number.isInteger(args.limit) ? args.limit : 5
+        const limit = Math.max(1, Math.min(20, requestedLimit))
+        const queryTokens = tokenize(query)
+        const matches = (await listProviderTools()).flatMap((tool) => {
+          const summary = tool.description ?? tool.title ?? tool.name
+          const score = scoreText(tokenize(tool.name), tokenize(summary), queryTokens)
+          if (score <= 0) return []
+          const resourceUri = externalMcpAppResourceUri(tool)
+          return [{
+            name: tool.name,
+            method: "MCP",
+            path: connection.name,
+            score,
+            summary,
+            pathParams: [],
+            queryParams: [],
+            hasBody: true,
+            argumentsSchema: tool.inputSchema,
+            schemaDigest: externalMcpToolSchemaDigest(tool.inputSchema),
+            invocation: { argumentsField: "body" },
+            ...(resourceUri ? { kind: "mcp_app", mcpApp: { resourceUri } } : {}),
+          }]
+        }).sort((left, right) => (right.score - left.score) || left.name.localeCompare(right.name)).slice(0, limit)
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ matches }) }],
+          structuredContent: { matches },
+        }
+      }
+      if (request.params.name === EXECUTE_CAPABILITY_TOOL_NAME) {
+        const toolName = typeof args.name === "string" ? args.name.trim() : ""
+        const tool = (await listProviderTools()).find((candidate) => candidate.name === toolName)
+        if (!tool) throw new McpError(ErrorCode.InvalidRequest, "The capability is unavailable. Call search_capabilities again.")
+        return runtime.callTool({
+          ...input.operation,
+          toolName,
+          args: toolArguments(args.body),
+        })
+      }
+      const allowed = (await listAppTools()).some((tool) => tool.name === request.params.name)
+      if (!allowed) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Tool ${request.params.name} is not available on the MCP Apps endpoint. Use search_capabilities and execute_capability.`,
+        )
+      }
       return runtime.callTool({
         ...input.operation,
         toolName: request.params.name,
-        args: toolArguments(request.params.arguments),
+        args,
       })
     })
   }
 
   if (input.descriptor.capabilities.resources) {
-    server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-      resources: await runtime.listResources(input.operation),
-    }))
+    server.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      if (!input.appHostClient) return { resources: await runtime.listResources(input.operation) }
+      const allowedUris = await appResourceUris()
+      return { resources: (await runtime.listResources(input.operation)).filter((resource) => allowedUris.has(resource.uri)) }
+    })
     server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-      resourceTemplates: await runtime.listResourceTemplates(input.operation),
+      resourceTemplates: input.appHostClient ? [] : await runtime.listResourceTemplates(input.operation),
     }))
-    server.server.setRequestHandler(ReadResourceRequestSchema, async (request) => (
-      runtime.readResource({ ...input.operation, uri: request.params.uri })
-    ))
+    server.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      if (!input.appHostClient) {
+        return runtime.readResource({ ...input.operation, uri: request.params.uri })
+      }
+      if (!(await appResourceUris()).has(request.params.uri)) {
+        throw new McpError(ErrorCode.InvalidRequest, "The resource is not bound to an available MCP App tool.")
+      }
+      return runtime.readResource({ ...input.operation, uri: request.params.uri })
+    })
   }
 
   return server
@@ -215,6 +372,7 @@ const externalMcpProxyRequestDependencies: ExternalMcpProxyRequestDependencies =
 export async function handleExternalConnectionProxyRequest(input: {
   context: Context
   operation: ExternalMcpProxyOperation
+  appHostClient?: boolean
   dependencies?: Partial<ExternalMcpProxyRequestDependencies>
 }) {
   if (input.context.req.method !== "POST") {
@@ -223,7 +381,11 @@ export async function handleExternalConnectionProxyRequest(input: {
   const dependencies = { ...externalMcpProxyRequestDependencies, ...input.dependencies }
   try {
     const descriptor = await dependencies.describe(input.operation)
-    const server = createExternalConnectionProxyServer({ descriptor, operation: input.operation })
+    const server = createExternalConnectionProxyServer({
+      descriptor,
+      operation: input.operation,
+      appHostClient: input.appHostClient === true,
+    })
     const response = await dependencies.serve(server, input.context)
     return response ?? new Response(null, { status: 204 })
   } catch (error) {
@@ -236,14 +398,9 @@ export async function handleExternalConnectionProxyRequest(input: {
 }
 
 /**
- * Exposes one member-authorized Connect connection as one ordinary MCP
- * server. Names, schemas, resource URIs, UI metadata, results, and provider
- * errors stay on their native MCP protocol fields instead of being projected
- * through OpenWork-specific wrapper tools.
- *
- * Keeping a connection on its own endpoint also preserves the MCP Apps
- * same-server execution boundary and prevents collisions between two servers
- * that legitimately advertise the same tool name.
+ * Preserves the published member-authorized proxy while adding a separately
+ * scoped private App-host view. The legacy surface is removed only after a
+ * compatible Desktop release is broadly available.
  */
 export function registerExternalConnectionProxyRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(
   app: Hono<T>,
@@ -314,7 +471,11 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
       member: downstreamMember,
       diagnosticReferenceId: requestId,
     }
-    return handleExternalConnectionProxyRequest({ context: c, operation })
+    return handleExternalConnectionProxyRequest({
+      context: c,
+      operation,
+      appHostClient: principal.scopes.has(DEN_MCP_APP_HOST_SCOPE),
+    })
   })
 }
 

--- a/ee/apps/den-api/src/mcp/scopes.ts
+++ b/ee/apps/den-api/src/mcp/scopes.ts
@@ -1,6 +1,8 @@
 export const DEN_MCP_READ_SCOPE = "mcp:read"
 export const DEN_MCP_WRITE_SCOPE = "mcp:write"
 export const DEN_MCP_OFFLINE_SCOPE = "offline_access"
+/** First-party Desktop-only scope. Never advertise or grant this through public OAuth. */
+export const DEN_MCP_APP_HOST_SCOPE = "mcp:app-host"
 
 export type DenMcpTokenScope = typeof DEN_MCP_READ_SCOPE | typeof DEN_MCP_WRITE_SCOPE
 

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -42,6 +42,8 @@ export type CapabilityMatch = {
   scriptPath?: string
   /** Callable capability or a source-specific advisory/content kind. */
   kind?: string
+  /** Standard MCP App binding advertised by the matched provider tool. */
+  mcpApp?: { resourceUri: string }
 }
 
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -9,7 +9,7 @@ import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { hashOpaqueMcpSecret } from "../../mcp/auth.js"
 import { deriveFirstPartyMcpTokenResourceFromRequest } from "../../mcp/resource.js"
-import { resolveMcpTokenScopes } from "../../mcp/scopes.js"
+import { DEN_MCP_APP_HOST_SCOPE, resolveMcpTokenScopes } from "../../mcp/scopes.js"
 import { DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS } from "../../mcp/token-lifetime.js"
 import {
   jsonValidator,
@@ -40,7 +40,9 @@ const mintMcpTokenSchema = z.object({
 
 const mcpTokenResponseSchema = z.object({
   token: z.string(),
+  appHostToken: z.string(),
   expiresAt: z.string().datetime(),
+  appHostExpiresAt: z.string().datetime(),
   organizationId: z.string(),
   scopes: z.array(z.string()),
   resource: z.string(),
@@ -90,6 +92,7 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
 
       const scopes = resolveMcpTokenScopes(input.scopes)
       const secret = crypto.randomBytes(32).toString("base64url")
+      const appHostSecret = crypto.randomBytes(32).toString("base64url")
       const expiresAt = new Date(Date.now() + DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS)
 
       let sessionId = null
@@ -99,20 +102,33 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
         sessionId = null
       }
 
-      await db.insert(OAuthAccessTokenTable).values({
-        id: createDenTypeId("oauthAccessToken"),
-        token: hashOpaqueMcpSecret(secret),
+      const tokenOwner = {
         clientId: DEN_MCP_FIRST_PARTY_CLIENT_ID,
         sessionId,
         userId: normalizeDenTypeId("user", user.id),
         referenceId: normalizeDenTypeId("organization", orgId),
         expiresAt,
-        scopes: JSON.stringify(scopes),
-      })
+      }
+      await db.insert(OAuthAccessTokenTable).values([
+        {
+          id: createDenTypeId("oauthAccessToken"),
+          token: hashOpaqueMcpSecret(secret),
+          ...tokenOwner,
+          scopes: JSON.stringify(scopes),
+        },
+        {
+          id: createDenTypeId("oauthAccessToken"),
+          token: hashOpaqueMcpSecret(appHostSecret),
+          ...tokenOwner,
+          scopes: JSON.stringify(["mcp:read", "mcp:write", DEN_MCP_APP_HOST_SCOPE]),
+        },
+      ])
 
       return c.json({
         token: `${DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX}${secret}`,
+        appHostToken: `${DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX}${appHostSecret}`,
         expiresAt: expiresAt.toISOString(),
+        appHostExpiresAt: expiresAt.toISOString(),
         organizationId: normalizeDenTypeId("organization", orgId),
         scopes,
         resource: deriveFirstPartyMcpTokenResourceFromRequest(c.req.raw, {

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -29,6 +29,7 @@ const redirectUriBase = "http://127.0.0.1:8790"
 type FakeTool = {
   name: string
   description: string
+  _meta?: Record<string, unknown>
 }
 
 type FakeMcpServer = {
@@ -63,6 +64,7 @@ let listUsableExternalMcpConnections: typeof import("../src/capability-sources/e
 let saveExternalMcpTokens: typeof import("../src/capability-sources/external-mcp-connections.js").saveExternalMcpTokens
 let searchExternalCapabilities: typeof import("../src/mcp/external-capabilities.js").searchExternalCapabilities
 let executeExternalCapability: typeof import("../src/mcp/external-capabilities.js").executeExternalCapability
+let externalCapabilitySuccessToolResult: typeof import("../src/mcp/capability-registry.js").externalCapabilitySuccessToolResult
 let slackServer: FakeMcpServer | undefined
 let authedSlackServer: FakeMcpServer | undefined
 let notionServer: FakeMcpServer | undefined
@@ -70,6 +72,7 @@ let refreshErrorServer: FakeMcpServer | undefined
 let providerErrorServer: FakeMcpServer | undefined
 let needleServer: FakeMcpServer | undefined
 let mutableSchemaServer: MutableSchemaMcpServer | undefined
+let mcpAppServer: FakeMcpServer | undefined
 
 const slackTools: FakeTool[] = [
   { name: "slack-send-message", description: "Send a message to a Slack channel or DM." },
@@ -135,6 +138,7 @@ function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: st
         {
           description: tool.description,
           inputSchema: z.object({ text: z.string().optional() }),
+          ...(tool._meta ? { _meta: tool._meta } : {}),
         },
         async ({ text }) => ({ content: textContent(text ?? `${tool.name} ok`) }),
       )
@@ -389,6 +393,7 @@ function standaloneConnection(
     name: "Standalone Slack",
     url,
     authType,
+    kind: "external_mcp",
     credentialMode: "shared",
     apiKey,
     accessToken,
@@ -449,13 +454,14 @@ async function expectConnectionListed(seed: SeededOrganization, connectionId: De
   expect(connections.map((connection) => connection.id)).toContain(connectionId)
 }
 
-function search(seed: SeededOrganization, query: string) {
+function search(seed: SeededOrganization, query: string, mcpAppsEnabled = false) {
   return searchExternalCapabilities({
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     query,
     redirectUriBase,
     limit: 10,
+    mcpAppsEnabled,
   })
 }
 
@@ -472,12 +478,13 @@ beforeAll(async () => {
   }).db
   mock.module("../src/db.js", () => ({ db: realDb }))
 
-  const [dbMod, schemaMod, clientMod, connectionsMod, capabilitiesMod, envMod] = await Promise.all([
+  const [dbMod, schemaMod, clientMod, connectionsMod, capabilitiesMod, registryMod, envMod] = await Promise.all([
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
     import("../src/capability-sources/external-mcp-client.js"),
     import("../src/capability-sources/external-mcp-connections.js"),
     import("../src/mcp/external-capabilities.js"),
+    import("../src/mcp/capability-registry.js"),
     import("../src/env.js"),
   ])
   // Another co-run test file's static src import may have parsed env.ts before
@@ -494,6 +501,7 @@ beforeAll(async () => {
   saveExternalMcpTokens = connectionsMod.saveExternalMcpTokens
   searchExternalCapabilities = capabilitiesMod.searchExternalCapabilities
   executeExternalCapability = capabilitiesMod.executeExternalCapability
+  externalCapabilitySuccessToolResult = registryMod.externalCapabilitySuccessToolResult
   slackServer = startFakeMcpServer("fake-slack", slackTools)
   authedSlackServer = startFakeMcpServer("fake-authed-slack", slackTools, "valid-key")
   notionServer = startFakeMcpServer("fake-notion", notionTools)
@@ -504,6 +512,11 @@ beforeAll(async () => {
     description: "The only catalog entry matching the coverage test keyword.",
   }])
   mutableSchemaServer = startMutableSchemaMcpServer()
+  mcpAppServer = startFakeMcpServer("fake-mcp-app", [{
+    name: "open_project_atlas",
+    description: "Open the Project Atlas MCP App.",
+    _meta: { ui: { resourceUri: "ui://atlas/1.0.0/index.html" } },
+  }])
 })
 
 afterAll(() => {
@@ -514,7 +527,80 @@ afterAll(() => {
   providerErrorServer?.stop()
   needleServer?.stop()
   mutableSchemaServer?.stop()
+  mcpAppServer?.stop()
   mock.restore()
+})
+
+test("the rollout flag controls MCP App launch metadata without removing regular search and execute", async () => {
+  if (!mcpAppServer) throw new Error("MCP App server missing")
+  const seed = await seedOrganization("mcp-app-gateway")
+  const connection = await createGrantedConnection(seed, {
+    name: "Project Atlas",
+    url: mcpAppServer.url,
+    authType: "none",
+    credentialMode: "shared",
+  })
+
+  const disabledMatches = await search(seed, "Project Atlas")
+  const disabledMatch = disabledMatches.find((candidate) => candidate.name.endsWith(":open_project_atlas"))
+  expect(disabledMatch).toBeTruthy()
+  expect(disabledMatch?.kind).toBeUndefined()
+  expect(disabledMatch?.mcpApp).toBeUndefined()
+
+  const disabledExecution = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "open_project_atlas",
+    args: { text: "migration" },
+    redirectUriBase,
+  })
+  expect(disabledExecution.ok).toBe(true)
+  if (!disabledExecution.ok) throw new Error(disabledExecution.message)
+  expect(disabledExecution.mcpApp).toBeUndefined()
+  expect(externalCapabilitySuccessToolResult(disabledExecution)._meta).toBeUndefined()
+
+  const matches = await search(seed, "Project Atlas", true)
+  const match = matches.find((candidate) => candidate.name.endsWith(":open_project_atlas"))
+  expect(match).toMatchObject({
+    kind: "mcp_app",
+    mcpApp: { resourceUri: "ui://atlas/1.0.0/index.html" },
+  })
+
+  const executed = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "open_project_atlas",
+    args: { text: "migration" },
+    redirectUriBase,
+    mcpAppsEnabled: true,
+  })
+  expect(executed).toMatchObject({
+    ok: true,
+    mcpApp: {
+      connectionId: connection.id,
+      toolName: "open_project_atlas",
+      resourceUri: "ui://atlas/1.0.0/index.html",
+      arguments: { text: "migration" },
+    },
+  })
+  if (!executed.ok) throw new Error(executed.message)
+  const launchResult = externalCapabilitySuccessToolResult(executed)
+  expect(launchResult.structuredContent).toMatchObject({
+    serverTools: {
+      searchCapabilities: "search_capabilities",
+      executeCapability: "execute_capability",
+    },
+  })
+  expect(launchResult._meta).toMatchObject({
+    "openwork/mcpApp": {
+      connectionId: connection.id,
+      toolName: "open_project_atlas",
+      resourceUri: "ui://atlas/1.0.0/index.html",
+      arguments: { text: "migration" },
+    },
+  })
 })
 
 test("fake MCP server helper lists tools with the external MCP client", async () => {

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -69,6 +69,7 @@ async function withClient<T>(
   capabilities: Record<string, unknown>,
   run: (client: Client) => Promise<T>,
   runtimeOverrides: Record<string, unknown> = {},
+  appHostClient = true,
 ) {
   const server = createExternalConnectionProxyServer({
     descriptor: {
@@ -77,6 +78,7 @@ async function withClient<T>(
     } as never,
     operation,
     runtime: runtime(runtimeOverrides),
+    appHostClient,
   })
   const client = new Client({ name: "proxy-test", version: "1.0.0" }, { capabilities: {} })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -90,13 +92,72 @@ async function withClient<T>(
   }
 }
 
+test("published MCP clients keep their existing per-provider surface during the additive phase", async () => {
+  await withClient({ tools: {}, resources: {} }, async (client) => {
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual(["open_fixture"])
+    expect((await client.listResources()).resources.map((resource) => resource.uri)).toEqual([resourceUri])
+    expect((await client.listResourceTemplates()).resourceTemplates).toEqual([])
+    expect((await client.callTool({ name: "open_fixture", arguments: {} })).structuredContent)
+      .toEqual({ status: "healthy" })
+    expect((await client.readResource({ uri: resourceUri })).contents[0]).toMatchObject({ uri: resourceUri, text: html })
+  }, {}, false)
+})
+
+test("the private App-host view is additive and separately bounded", async () => {
+  await withClient({ tools: {}, resources: {} }, async (client) => {
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual([
+      "search_capabilities",
+      "execute_capability",
+      "open_fixture",
+    ])
+    expect((await client.listResources()).resources.map((resource) => resource.uri)).toEqual([resourceUri])
+    expect((await client.listResourceTemplates()).resourceTemplates).toEqual([])
+  })
+})
+
+test("a forged App-host audience header cannot unlock the private gateway", async () => {
+  let toolNames: string[] = []
+  const request = new Request("https://openwork.example/mcp/agent/connections/fixture", {
+    method: "POST",
+    headers: { "x-openwork-mcp-client-audience": "app-host" },
+  })
+  await handleExternalConnectionProxyRequest({
+    context: requestContext(request),
+    operation,
+    dependencies: {
+      describe: async () => ({
+        capabilities: { tools: {}, resources: {} },
+        serverInfo: { name: "fixture", version: "1.0.0" },
+      }) as never,
+      serve: async (server) => {
+        const client = new Client({ name: "forged-audience-test", version: "1.0.0" }, { capabilities: {} })
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+        await server.connect(serverTransport)
+        await client.connect(clientTransport)
+        try {
+          toolNames = (await client.listTools()).tools.map((tool) => tool.name)
+        } finally {
+          await client.close()
+          await server.close()
+        }
+        return new Response(null, { status: 204 })
+      },
+    },
+  })
+  expect(toolNames).toEqual(["open_fixture"])
+})
+
 test("tool-only downstream servers initialize and never register resource handlers", async () => {
   let resourceCalls = 0
   await withClient({ tools: {} }, async (client) => {
     const initialized = client.getServerCapabilities()
     expect(initialized?.tools).toEqual({ listChanged: false })
     expect(initialized?.resources).toBeUndefined()
-    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual(["open_fixture"])
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual([
+      "search_capabilities",
+      "execute_capability",
+      "open_fixture",
+    ])
     const called = await client.callTool({ name: "open_fixture", arguments: {} })
     expect(called.structuredContent).toEqual({ status: "healthy" })
     expect(resourceCalls).toBe(0)
@@ -120,12 +181,101 @@ test("a healthy native MCP App preserves its resource and same-server app-visibl
     resources: {},
     extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
   }, async (client) => {
-    const tool = (await client.listTools()).tools[0]
-    expect(tool?._meta).toMatchObject({ ui: { resourceUri, visibility: ["model", "app"] } })
+    const tool = (await client.listTools()).tools.find((candidate) => candidate.name === "open_fixture")
+    expect(tool?._meta).toMatchObject({ ui: { resourceUri, visibility: ["app"] } })
     const resource = await client.readResource({ uri: resourceUri })
     expect(resource.contents[0]).toMatchObject({ uri: resourceUri, text: html })
     const called = await client.callTool({ name: "open_fixture", arguments: {} })
     expect(called.structuredContent).toEqual({ status: "healthy" })
+  })
+})
+
+test("a regular MCP with an App keeps every model-visible tool behind search and execute", async () => {
+  let downstreamCalls = 0
+  let downstreamReads = 0
+  const privateResourceUri = "data://fixture/private.json"
+  const modelOnlyResourceUri = "ui://fixture/model-only.html"
+  await withClient({ tools: {}, resources: {} }, async (client) => {
+    const tools = (await client.listTools()).tools
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "search_capabilities",
+      "execute_capability",
+      "open_fixture",
+    ])
+    for (const tool of tools) expect(tool._meta).toMatchObject({ ui: { visibility: ["app"] } })
+    expect(tools.find((tool) => tool.name === "open_fixture")?._meta).toMatchObject({
+      ui: { resourceUri, visibility: ["app"] },
+    })
+
+    const resources = (await client.listResources()).resources
+    expect(resources.map((resource) => resource.uri)).toEqual([resourceUri])
+    expect((await client.listResourceTemplates()).resourceTemplates).toEqual([])
+
+    await expect(client.callTool({ name: "search_fixture", arguments: { query: "private" } })).rejects.toThrow(
+      "Use search_capabilities and execute_capability",
+    )
+    await expect(client.callTool({ name: "model_only_fixture", arguments: {} })).rejects.toThrow(
+      "Use search_capabilities and execute_capability",
+    )
+    await expect(client.readResource({ uri: privateResourceUri })).rejects.toThrow(
+      "not bound to an available MCP App tool",
+    )
+    await expect(client.readResource({ uri: modelOnlyResourceUri })).rejects.toThrow(
+      "not bound to an available MCP App tool",
+    )
+    expect(downstreamCalls).toBe(0)
+    expect(downstreamReads).toBe(0)
+
+    const searched = await client.callTool({
+      name: "search_capabilities",
+      arguments: { query: "private fixture records", limit: 5 },
+    })
+    const matches = (searched.structuredContent as { matches: Array<Record<string, unknown>> }).matches
+    expect(matches).toContainEqual(expect.objectContaining({
+      name: "search_fixture",
+      invocation: { argumentsField: "body" },
+    }))
+    const executed = await client.callTool({
+      name: "execute_capability",
+      arguments: { name: "search_fixture", body: { query: "private" } },
+    })
+    expect(executed.structuredContent).toEqual({ status: "healthy" })
+    expect(downstreamCalls).toBe(1)
+
+    const opened = await client.callTool({ name: "open_fixture", arguments: {} })
+    expect(opened.structuredContent).toEqual({ status: "healthy" })
+    expect(downstreamCalls).toBe(2)
+  }, {
+    listTools: async () => [
+      ...(await runtime().listTools()),
+      {
+        name: "search_fixture",
+        description: "Search private fixture records.",
+        inputSchema: { type: "object" },
+      },
+      {
+        name: "model_only_fixture",
+        description: "A model-only UI tool that must not be projected into the App host.",
+        inputSchema: { type: "object" },
+        _meta: { ui: { resourceUri: modelOnlyResourceUri, visibility: ["model"] } },
+      },
+    ],
+    callTool: async () => {
+      downstreamCalls += 1
+      return {
+        content: [{ type: "text" as const, text: "Healthy fixture opened." }],
+        structuredContent: { status: "healthy" },
+      }
+    },
+    listResources: async () => [
+      { uri: resourceUri, name: "Healthy fixture", mimeType: "text/html;profile=mcp-app" },
+      { uri: modelOnlyResourceUri, name: "Model-only fixture", mimeType: "text/html;profile=mcp-app" },
+      { uri: privateResourceUri, name: "Private fixture", mimeType: "application/json" },
+    ],
+    readResource: async () => {
+      downstreamReads += 1
+      return { contents: [] }
+    },
   })
 })
 

--- a/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
+++ b/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
@@ -32,16 +32,20 @@ function probeRemoteMcpApps(value?: string) {
   `, value)
 }
 
-function probeNativeMcpAppIndex(value: string | undefined, organizationEnabled: boolean) {
+function probeNativeMcpAppIndex(
+  value: string | undefined,
+  organizationEnabled: boolean,
+  clientCapabilities?: string,
+) {
   return probe(`
     const { env } = await import("./src/env.ts")
     const { remoteMcpAppsEnabled } = await import("./src/capability-sources/remote-mcp-apps-rollout.ts")
-    const { buildConnectMcpServerIndex } = await import("./src/mcp/connect-mcp-server-index.ts")
+    const { buildConnectMcpServerIndex, supportsConnectMcpAppHost } = await import("./src/mcp/connect-mcp-server-index.ts")
     const index = buildConnectMcpServerIndex({
       enabled: remoteMcpAppsEnabled(
         { capabilities: { remoteMcpApps: ${JSON.stringify(organizationEnabled)} } },
         { deploymentEnabled: env.remoteMcpAppsEnabled },
-      ),
+      ) && supportsConnectMcpAppHost(${JSON.stringify(clientCapabilities)}),
       connections: [{ id: "emc_fixture", name: "Fixture MCP" }],
       publicOrigin: "https://openwork.example",
     })
@@ -62,11 +66,12 @@ test("Remote MCP Apps deployment gate defaults off and requires an explicit true
   expect(enabled.stdout.trim()).toBe("true")
 })
 
-test("native provider publication requires both deployment and organization opt-ins", () => {
-  const absentDeployment = probeNativeMcpAppIndex(undefined, true)
-  const disabledDeployment = probeNativeMcpAppIndex("false", true)
-  const disabledOrganization = probeNativeMcpAppIndex("true", false)
-  const enabled = probeNativeMcpAppIndex("true", true)
+test("native provider publication requires both rollout gates and explicit client support", () => {
+  const absentDeployment = probeNativeMcpAppIndex(undefined, true, "mcp-app-host-v1")
+  const disabledDeployment = probeNativeMcpAppIndex("false", true, "mcp-app-host-v1")
+  const disabledOrganization = probeNativeMcpAppIndex("true", false, "mcp-app-host-v1")
+  const legacyClient = probeNativeMcpAppIndex("true", true)
+  const enabled = probeNativeMcpAppIndex("true", true, "future-v2, mcp-app-host-v1")
 
   expect(absentDeployment.status).toBe(0)
   expect(absentDeployment.stdout.trim()).toBe("[]")
@@ -74,6 +79,8 @@ test("native provider publication requires both deployment and organization opt-
   expect(disabledDeployment.stdout.trim()).toBe("[]")
   expect(disabledOrganization.status).toBe(0)
   expect(disabledOrganization.stdout.trim()).toBe("[]")
+  expect(legacyClient.status).toBe(0)
+  expect(legacyClient.stdout.trim()).toBe("[]")
   expect(enabled.status).toBe(0)
   expect(enabled.stdout.trim()).toBe('["Fixture MCP"]')
 })

--- a/evals/specs/remote-mcp-apps.slow.test.ts
+++ b/evals/specs/remote-mcp-apps.slow.test.ts
@@ -422,6 +422,7 @@ async function agentRpc(
   method: string,
   params: Record<string, unknown>,
   endpoint = "/mcp/agent",
+  extraHeaders: Record<string, string> = {},
 ) {
   const id = ++agentRequestId;
   const response = await fetch(`${apiUrl}${endpoint}`, {
@@ -430,6 +431,7 @@ async function agentRpc(
       authorization: `Bearer ${token}`,
       accept: "application/json, text/event-stream",
       "content-type": "application/json",
+      ...extraHeaders,
     },
     body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
     signal: AbortSignal.timeout(90_000),
@@ -609,7 +611,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const enabled = await denFetch(den.admin, `/v1/admin/organizations/${organizationId}/capabilities`, {
     method: "PUT",
     headers: { authorization: `Bearer ${den.admin.token}` },
-    body: JSON.stringify({ capabilities: { codemodeScripts: true } }),
+    body: JSON.stringify({ capabilities: { codemodeScripts: true, remoteMcpApps: true } }),
   });
   expect(enabled.response.ok, enabled.text).toBe(true);
 
@@ -642,7 +644,12 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
   });
   expect(tokenResult.response.ok, tokenResult.text).toBe(true);
-  const mcpToken = String(requireRecord(tokenResult.body, "MCP token response").token ?? "");
+  const mcpTokenBody = requireRecord(tokenResult.body, "MCP token response");
+  const mcpToken = String(mcpTokenBody.token ?? "");
+  const appHostMcpToken = String(mcpTokenBody.appHostToken ?? "");
+  expect(appHostMcpToken).toMatch(/^ow_mcp_/);
+  expect(appHostMcpToken).not.toBe(mcpToken);
+  expect(mcpTokenBody.appHostExpiresAt).toBe(mcpTokenBody.expiresAt);
   const connectedEndpoint = `/mcp/agent/connections/${encodeURIComponent(connection.id)}`;
   agentMcpUpstream = {
     token: mcpToken,
@@ -872,6 +879,73 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(JSON.stringify(proxied.structuredContent)).toContain("Atlas migration");
   expect(requireRecord(proxied._meta, "proxied metadata").source).toBe("project-atlas-standard-mcp");
 
+  const privateHostHeaders = { "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" };
+  const privateToolsResult = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "tools/list",
+    {},
+    connectedEndpoint,
+    privateHostHeaders,
+  );
+  const privateTools = toolsFrom(privateToolsResult);
+  expect(privateTools.map((tool) => tool.name).sort()).toEqual([
+    "execute_capability",
+    "open_project_atlas",
+    "search_capabilities",
+  ]);
+  const privateResources = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "resources/list",
+    {},
+    connectedEndpoint,
+    privateHostHeaders,
+  );
+  expect(privateResources.resources).toEqual([]);
+  const privateRead = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "resources/read",
+    { uri: connectedResourceUri },
+    connectedEndpoint,
+    privateHostHeaders,
+  );
+  expect(String(contentsFrom(privateRead)[0]?.text ?? "")).toContain("Portable revision Connect 1.0.0");
+  const privateSearch = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "tools/call",
+    { name: "search_capabilities", arguments: { query: "search projects", limit: 5 } },
+    connectedEndpoint,
+    privateHostHeaders,
+  );
+  const privateMatches = Array.isArray(requireRecord(privateSearch.structuredContent, "private search").matches)
+    ? (requireRecord(privateSearch.structuredContent, "private search").matches as unknown[]).filter(isRecord)
+    : [];
+  const privateMatch = requireRecord(
+    privateMatches.find((match) => match.name === "search_projects"),
+    "private same-server capability",
+  );
+  const privateRun = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "tools/call",
+    {
+      name: "execute_capability",
+      arguments: {
+        name: privateMatch.name,
+        schemaDigest: privateMatch.schemaDigest,
+        body: { query: "migration" },
+      },
+    },
+    connectedEndpoint,
+    privateHostHeaders,
+  );
+  expect(privateRun.isError, JSON.stringify(privateRun)).not.toBe(true);
+  expect(JSON.stringify(privateRun.structuredContent)).toContain("Atlas migration");
+  expect(standardMcpCalls).toBe(5);
+
   await using desktopApp = await desktop({
     name: "remote-mcp-apps",
     mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
@@ -1039,7 +1113,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(mountedProjectAtlas, `${desktopTranscript}\nPersisted tool: ${persistedProjectAtlasTool}`).toBe(true);
   expect(desktopTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(desktopTranscript).not.toContain("Interactive view unavailable");
-  expect(standardMcpCalls).toBe(5);
+  expect(standardMcpCalls).toBe(6);
   const desktopShot = await screenshot(desktopApp);
   const desktopExpectations = [
     "The conversation visibly contains the connected Project Atlas MCP App",
@@ -1094,7 +1168,7 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(approvalCount).toBe(2);
   expect(installedTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(installedTranscript).not.toContain("Interactive view unavailable");
-  expect(standardMcpCalls).toBe(7);
+  expect(standardMcpCalls).toBe(8);
   const installedShot = await screenshot(desktopApp);
   const installedExpectations = [
     "The conversation visibly contains the installed Project Atlas MCP App",
@@ -1204,6 +1278,6 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   evidence.fact(
     "Externally authored MCP Apps use standard same-server tools while Programs compose OpenWork Connect",
     `Preserved native Project Atlas server identity, tools, exact UI metadata, resources, structuredContent, and _meta through connection ${connection.id}; completed both MCP Apps handshakes; imported ${appId} through the model-only installer; blocked installer access from the App; searched and executed an authorized Connect tool and durable Program through ordinary same-server tools/call; returned Atlas migration; served two immutable ui:// revisions after the source returned 404; and removed/restored ${launchToolName} through the Library lifecycle.`,
-    standardMcpCalls === 7 && mountedProjectAtlas && mountedProgramApp && approvalCount === 2,
+    standardMcpCalls === 8 && mountedProjectAtlas && mountedProgramApp && approvalCount === 2,
   );
 });


### PR DESCRIPTION
## Summary

This is **Phase 1 of 3** for moving native MCP Apps out of the model-facing runtime. It adds the Den-side protocol foundation required by a future Desktop release while preserving every surface used by already-published Desktop clients.

- mints a separate short-lived `mcp:app-host` credential alongside the existing central MCP token;
- classifies native MCP Apps from regular connected MCP servers in bounded `search_capabilities` results;
- adds an App-host-private provider descriptor resource;
- gives the scoped provider endpoint only App-visible launch tools, exact bound `ui://` resources, and same-server `search_capabilities` / `execute_capability`;
- preserves member authorization, provider tool policy, schema validation, result limits, approvals, and same-server isolation.

## Rollout compatibility

This phase is intentionally additive. It does **not** switch Desktop to the private host and it does **not** retire any published Den contract.

Existing clients still receive:

- the current provider index;
- the current per-provider tools and resource behavior;
- the current native MCP App projection;
- the current standalone URL-App importer, resources, routes, and UI.

That overlap is required by the Desktop ↔ Den rollout policy. A new Den can ship before a new Desktop without breaking the published client. The later removal work is deliberately excluded from this PR.

Both native MCP Apps gates remain default-off. When the feature is disabled, the new private catalog and native App metadata remain closed while ordinary central Connect search and execution continue to work.

## Stack

1. **This PR — Den additive foundation:** introduce the private protocol while keeping legacy behavior.
2. **Desktop adoption:** move native Apps into Desktop's private host, keep OpenCode on central `openwork-cloud`, and create zero `openwork-connect-*` runtime entries.
3. **Den retirement:** only after the Desktop adoption is released, remove legacy provider projection and defer standalone URL-imported Apps.

The dependent phases are #3861 (Desktop adoption) and #3862 (legacy/URL-App retirement). Each must be rebased onto `dev` and receive fresh exact-head proof and Warden review as its prerequisite lands. #3862 must not ship before the #3861 Desktop release.

## Verification

Passed on exact head `a7d44c61114f611690c8b2841b6e5e1e8b060b8b`, rebased directly on `different-ai/openwork:dev` at `9f4425725960a5f7cd7c8d965de1e79fc633ea92`:

- Den API TypeScript check;
- `git diff --check`;
- required `@openwork/testkit` `remote-mcp-apps` stack tape: **1 passed, 0 failed, 0 skipped**.

The tape proves the new scoped token and private bounded host work while the published Desktop journey, native Apps from regular MCP servers, direct legacy provider surface, and standalone URL-installed Apps remain compatible in this rollout phase.
