### PR TITLE
fix(den-gateway): allow pruned image patches

### DIFF
--- a/packaging/docker/Dockerfile.den-gateway
+++ b/packaging/docker/Dockerfile.den-gateway
@@ -16,6 +16,12 @@ ENV DEN_GATEWAY_WEB_ROOT=/opt/openwork/web
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY patches /app/patches
+
+# This image installs only the gateway runtime workspace. Some root patches apply
+# to packages that are intentionally not copied here, and pnpm rejects those as
+# unused unless this pruned install opts out of that check.
+RUN node -e "const fs = require('node:fs'); fs.appendFileSync('/app/pnpm-workspace.yaml', '\nallowUnusedPatches: true\n')"
+
 COPY packages/types/package.json /app/packages/types/package.json
 COPY packages/ui/package.json /app/packages/ui/package.json
 COPY packages/install-config/package.json /app/packages/install-config/package.json


### PR DESCRIPTION
## Summary
- allow unused patches only inside the pruned den-gateway Docker install
- keep the root workspace patch validation unchanged for normal installs
- fixes pnpm 11 rejecting the gateway image because the Better Auth drizzle adapter patch is unused in that smaller workspace slice

## Verification
- docker build -f packaging/docker/Dockerfile.den-gateway .

## Notes
- No testkit tape: this is a Dockerfile-only deployment build fix, validated by the image build reaching completion.