### PR TITLE
feat(ci): prune old Daytona dev snapshots after each publish

### DIFF
--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -235,3 +235,32 @@ jobs:
             echo
             echo "Triggered a den-api deploy so the new pin takes effect."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Per-push dev snapshots accumulate forever. Keep the pinned snapshot plus
+      # the 5 newest and skip snapshots referenced by active sandboxes. Old
+      # stopped/archived sandboxes do not block pruning because they keep their own disks.
+      # This also runs nightly as a pruning backstop when the snapshot already exists.
+      - name: Prune old dev snapshots
+        if: steps.channel.outputs.enabled == 'true' && steps.resolve.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_URL: ${{ vars.DAYTONA_API_URL }}
+          DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+        run: |
+          set -euo pipefail
+
+          result="$(node scripts/prune-daytona-dev-snapshots.mjs \
+            ${DAYTONA_API_URL:+--api-url "$DAYTONA_API_URL"} \
+            --name-base "${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}" \
+            --keep "$DAYTONA_SNAPSHOT_NAME" \
+            --keep-count 5)"
+          echo "$result"
+          {
+            echo "### Daytona dev snapshot prune"
+            echo
+            echo '```'
+            echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/prune-daytona-dev-snapshots.mjs
+++ b/scripts/prune-daytona-dev-snapshots.mjs
@@ -164,20 +164,44 @@ async function readSnapshots({ apiUrl, apiKey, fetchImpl }) {
 
 async function readSandboxes({ apiUrl, apiKey, fetchImpl }) {
   const sandboxes = []
-  for (let page = 1; ; page += 1) {
+  let nextCursor = ""
+  for (let page = 1; page <= 100; page += 1) {
+    const pagination = nextCursor
+      ? `&cursor=${encodeURIComponent(nextCursor)}`
+      : page > 1
+        ? `&page=${page}`
+        : ""
     const response = await fetchImpl(
-      `${apiUrl}/sandbox?limit=${PAGE_LIMIT}&page=${page}`,
+      `${apiUrl}/sandbox?limit=${PAGE_LIMIT}${pagination}`,
       { method: "GET", headers: authorizationHeaders(apiKey) },
     )
     const parsed = await responseJson(response, "sandboxes")
-    if (!Array.isArray(parsed)) {
-      throw new Error("Daytona API sandbox response was not an array.")
+    if (Array.isArray(parsed)) {
+      sandboxes.push(...parsed)
+      if (parsed.length < PAGE_LIMIT) {
+        return sandboxes
+      }
+      continue
     }
-    sandboxes.push(...parsed)
-    if (parsed.length < PAGE_LIMIT) {
+
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray(parsed.items)
+    ) {
+      throw new Error("Daytona API sandbox response did not contain a sandbox list.")
+    }
+    sandboxes.push(...parsed.items)
+    nextCursor =
+      typeof parsed.nextCursor === "string" && parsed.nextCursor.length > 0
+        ? parsed.nextCursor
+        : ""
+    if (!nextCursor) {
       return sandboxes
     }
   }
+
+  throw new Error("Daytona API sandbox pagination exceeded 100 pages.")
 }
 
 export async function pruneDaytonaDevSnapshots({

--- a/scripts/prune-daytona-dev-snapshots.mjs
+++ b/scripts/prune-daytona-dev-snapshots.mjs
@@ -1,0 +1,342 @@
+import process from "node:process"
+import { pathToFileURL } from "node:url"
+
+const DEFAULT_API_URL = "https://app.daytona.io/api"
+const PAGE_LIMIT = 200
+const SETTLED_SNAPSHOT_STATES = new Set([
+  "active",
+  "inactive",
+  "error",
+  "build_failed",
+])
+const INACTIVE_SANDBOX_STATES = new Set([
+  "stopped",
+  "archived",
+  "destroyed",
+  "error",
+])
+
+function requiredValue(value, message) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(message)
+  }
+
+  return value.trim()
+}
+
+function validateSnapshotName(snapshotName) {
+  const value = requiredValue(
+    snapshotName,
+    "Missing snapshot name. Pass --keep <name>.",
+  )
+
+  if (value !== snapshotName || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    throw new Error(
+      `Invalid snapshot name ${JSON.stringify(snapshotName)}. Use only letters, numbers, dots, underscores, and hyphens, with no whitespace.`,
+    )
+  }
+
+  return value
+}
+
+function validateKeepCount(keepCount) {
+  if (!Number.isSafeInteger(keepCount) || keepCount < 0) {
+    throw new Error("--keep-count must be an integer greater than or equal to 0.")
+  }
+
+  return keepCount
+}
+
+function authorizationHeaders(apiKey) {
+  const key = requiredValue(
+    apiKey,
+    "Missing Daytona API key. Set DAYTONA_API_KEY before running this command.",
+  )
+  return {
+    Accept: "application/json",
+    Authorization: `Bearer ${key}`,
+  }
+}
+
+async function responseBody(response) {
+  const body = await response.text()
+  if (!response.ok) {
+    const statusText = response.statusText ? ` ${response.statusText}` : ""
+    throw new Error(
+      `Daytona API request failed with HTTP ${response.status}${statusText}: ${body}`,
+    )
+  }
+
+  return body
+}
+
+async function responseJson(response, description) {
+  const body = await responseBody(response)
+
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new Error(`Daytona API returned invalid JSON for ${description}: ${body}`)
+  }
+}
+
+function normalizedState(value) {
+  return typeof value === "string" ? value.toLowerCase() : ""
+}
+
+function compareNewest(left, right) {
+  const created = right.createdAt.localeCompare(left.createdAt)
+  return created || left.name.localeCompare(right.name)
+}
+
+function compareOldest(left, right) {
+  const created = left.createdAt.localeCompare(right.createdAt)
+  return created || left.name.localeCompare(right.name)
+}
+
+export function selectDevSnapshotPrunes({
+  snapshots,
+  sandboxes,
+  nameBase,
+  keepNames,
+  keepCount,
+}) {
+  const prefix = `${nameBase}-dev-`
+  const scoped = snapshots.filter((snapshot) => snapshot.name.startsWith(prefix))
+  const recentNames = new Set(
+    [...scoped].sort(compareNewest).slice(0, keepCount).map((snapshot) => snapshot.name),
+  )
+  const explicitNames = new Set(keepNames)
+  const activeReferences = new Set(
+    sandboxes
+      .filter((sandbox) => !INACTIVE_SANDBOX_STATES.has(normalizedState(sandbox.state)))
+      .map((sandbox) => sandbox.snapshot)
+      .filter((snapshotName) => typeof snapshotName === "string"),
+  )
+  const prune = []
+  const keep = []
+
+  for (const snapshot of [...scoped].sort(compareOldest)) {
+    let reason
+    if (explicitNames.has(snapshot.name)) {
+      reason = "explicit"
+    } else if (recentNames.has(snapshot.name)) {
+      reason = "recent"
+    } else if (!SETTLED_SNAPSHOT_STATES.has(normalizedState(snapshot.state))) {
+      reason = "in-flight"
+    } else if (activeReferences.has(snapshot.name)) {
+      reason = "active-ref"
+    }
+
+    if (reason) {
+      keep.push({ ...snapshot, reason })
+    } else {
+      prune.push(snapshot)
+    }
+  }
+
+  return { prune, keep }
+}
+
+async function readSnapshots({ apiUrl, apiKey, fetchImpl }) {
+  const snapshots = []
+  for (let page = 1; ; page += 1) {
+    const response = await fetchImpl(
+      `${apiUrl}/snapshots?limit=${PAGE_LIMIT}&page=${page}`,
+      { method: "GET", headers: authorizationHeaders(apiKey) },
+    )
+    const parsed = await responseJson(response, "snapshots")
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      !Array.isArray(parsed.items) ||
+      typeof parsed.total !== "number"
+    ) {
+      throw new Error("Daytona API snapshots response did not contain items and total.")
+    }
+    snapshots.push(...parsed.items)
+    if (snapshots.length >= parsed.total || parsed.items.length < PAGE_LIMIT) {
+      return snapshots
+    }
+  }
+}
+
+async function readSandboxes({ apiUrl, apiKey, fetchImpl }) {
+  const sandboxes = []
+  for (let page = 1; ; page += 1) {
+    const response = await fetchImpl(
+      `${apiUrl}/sandbox?limit=${PAGE_LIMIT}&page=${page}`,
+      { method: "GET", headers: authorizationHeaders(apiKey) },
+    )
+    const parsed = await responseJson(response, "sandboxes")
+    if (!Array.isArray(parsed)) {
+      throw new Error("Daytona API sandbox response was not an array.")
+    }
+    sandboxes.push(...parsed)
+    if (parsed.length < PAGE_LIMIT) {
+      return sandboxes
+    }
+  }
+}
+
+export async function pruneDaytonaDevSnapshots({
+  apiUrl = DEFAULT_API_URL,
+  nameBase = "openwork",
+  keepNames,
+  keepCount = 5,
+  dryRun = false,
+  apiKey,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+}) {
+  const baseUrl = requiredValue(apiUrl, "Missing Daytona API URL.").replace(/\/+$/, "")
+  const base = requiredValue(nameBase, "Missing snapshot name base.")
+  const protectedNames = keepNames.map(validateSnapshotName)
+  const recentCount = validateKeepCount(keepCount)
+  authorizationHeaders(apiKey)
+
+  const snapshots = await readSnapshots({ apiUrl: baseUrl, apiKey, fetchImpl })
+  const sandboxes = await readSandboxes({ apiUrl: baseUrl, apiKey, fetchImpl })
+  const selection = selectDevSnapshotPrunes({
+    snapshots,
+    sandboxes,
+    nameBase: base,
+    keepNames: protectedNames,
+    keepCount: recentCount,
+  })
+  const failures = []
+  let prunedCount = 0
+
+  for (const snapshot of selection.keep) {
+    log(`${dryRun ? "dry-run: " : ""}keep: ${snapshot.name} (${snapshot.reason})`)
+  }
+
+  for (const snapshot of selection.prune) {
+    if (dryRun) {
+      log(`dry-run: pruned: ${snapshot.name} (${snapshot.id})`)
+      prunedCount += 1
+      continue
+    }
+
+    try {
+      const response = await fetchImpl(
+        `${baseUrl}/snapshots/${encodeURIComponent(snapshot.id)}`,
+        { method: "DELETE", headers: authorizationHeaders(apiKey) },
+      )
+      await responseBody(response)
+      log(`pruned: ${snapshot.name} (${snapshot.id})`)
+      prunedCount += 1
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      failures.push({ snapshot, message })
+      log(`failed: ${snapshot.name} (${snapshot.id}): ${message}`)
+    }
+  }
+
+  const outOfScope = snapshots.length - selection.prune.length - selection.keep.length
+  const summary = `summary: pruned=${prunedCount} kept=${selection.keep.length} out-of-scope=${outOfScope} failed=${failures.length}`
+  log(summary)
+  const result = { ...selection, failures, summary }
+
+  if (failures.length > 0) {
+    const error = new Error(`${failures.length} Daytona snapshot deletion(s) failed.`)
+    error.result = result
+    throw error
+  }
+
+  return result
+}
+
+function optionValue(args, index, option) {
+  const value = args[index + 1]
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}.`)
+  }
+  return value
+}
+
+export const USAGE = `Prune old per-push Daytona dev snapshots.
+
+Usage:
+  node scripts/prune-daytona-dev-snapshots.mjs [--api-url <url>] [--name-base <base>] --keep <name> [--keep <name> ...] [--keep-count <n>] [--dry-run]
+
+Options:
+  --api-url <url>       Daytona API base URL (default: https://app.daytona.io/api).
+  --name-base <base>    Snapshot name base (default: openwork).
+  --keep <name>         Snapshot name to protect; may be repeated.
+  --keep-count <n>      Protect the newest n dev snapshots (default: 5).
+  --dry-run             Fetch and report without deleting snapshots.
+  -h, --help            Show this help.
+
+Environment:
+  DAYTONA_API_KEY       Required (except with --help).`
+
+export function parseArgs(args) {
+  const options = {
+    apiUrl: DEFAULT_API_URL,
+    nameBase: "openwork",
+    keepNames: [],
+    keepCount: 5,
+    dryRun: false,
+    help: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === "--api-url") {
+      options.apiUrl = optionValue(args, index, argument)
+      index += 1
+    } else if (argument === "--name-base") {
+      options.nameBase = optionValue(args, index, argument)
+      index += 1
+    } else if (argument === "--keep") {
+      options.keepNames.push(validateSnapshotName(optionValue(args, index, argument)))
+      index += 1
+    } else if (argument === "--keep-count") {
+      const value = optionValue(args, index, argument)
+      if (!/^\d+$/.test(value)) {
+        throw new Error("--keep-count must be an integer greater than or equal to 0.")
+      }
+      options.keepCount = validateKeepCount(Number(value))
+      index += 1
+    } else if (argument === "--dry-run") {
+      options.dryRun = true
+    } else if (argument === "--help" || argument === "-h") {
+      options.help = true
+    } else {
+      throw new Error(`Unknown argument: ${argument}`)
+    }
+  }
+
+  if (options.help) {
+    return options
+  }
+  if (options.keepNames.length === 0) {
+    throw new Error("Missing snapshot name. Pass --keep <name>.")
+  }
+
+  return options
+}
+
+export async function main(args, environment = process.env) {
+  const options = parseArgs(args)
+  if (options.help) {
+    console.log(USAGE)
+    return { status: "help" }
+  }
+
+  return pruneDaytonaDevSnapshots({
+    ...options,
+    apiKey: environment.DAYTONA_API_KEY,
+  })
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+  main(process.argv.slice(2)).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Error: ${message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/prune-daytona-dev-snapshots.test.mjs
+++ b/scripts/prune-daytona-dev-snapshots.test.mjs
@@ -144,22 +144,31 @@ test("pagination protects newest snapshots and reads all sandbox pages", async (
   const calls = []
   const fetchImpl = async (url, options) => {
     calls.push({ url, options })
-    const page = Number(new URL(url).searchParams.get("page"))
     if (url.includes("/snapshots?")) {
+      const page = Number(new URL(url).searchParams.get("page"))
       return jsonResponse({
         items: page === 1 ? firstPage : [newest],
         total: 201,
       })
     }
     if (url.includes("/sandbox?")) {
+      const cursor = new URL(url).searchParams.get("cursor")
       return jsonResponse(
-        page === 1
-          ? Array.from({ length: 200 }, (_, index) => ({
-              id: `sandbox-${index}`,
-              state: "stopped",
-              snapshot: null,
-            }))
-          : [{ id: "active", state: "started", snapshot: firstPage[0].name }],
+        cursor
+          ? {
+              items: [
+                { id: "active", state: "started", snapshot: firstPage[0].name },
+              ],
+              nextCursor: null,
+            }
+          : {
+              items: Array.from({ length: 200 }, (_, index) => ({
+                id: `sandbox-${index}`,
+                state: "stopped",
+                snapshot: null,
+              })),
+              nextCursor: "cursor-2",
+            },
       )
     }
     return jsonResponse({})
@@ -179,7 +188,10 @@ test("pagination protects newest snapshots and reads all sandbox pages", async (
   assert.equal(calls.some((call) => call.url.includes("/snapshots/newest")), false)
   assert.equal(calls.some((call) => call.url.includes("/snapshots/old-0")), false)
   assert.equal(calls.some((call) => call.url.endsWith("/snapshots/old-1")), true)
-  assert.equal(calls.filter((call) => call.url.includes("/sandbox?")).length, 2)
+  const sandboxCalls = calls.filter((call) => call.url.includes("/sandbox?"))
+  assert.equal(sandboxCalls.length, 2)
+  assert.equal(sandboxCalls[1].url.includes("cursor=cursor-2"), true)
+  assert.equal(sandboxCalls[1].url.includes("page="), false)
 })
 
 test("a failed DELETE does not prevent later deletes and rejects with the result", async () => {

--- a/scripts/prune-daytona-dev-snapshots.test.mjs
+++ b/scripts/prune-daytona-dev-snapshots.test.mjs
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  pruneDaytonaDevSnapshots,
+  selectDevSnapshotPrunes,
+} from "./prune-daytona-dev-snapshots.mjs"
+
+const apiKey = "test-daytona-api-key"
+const apiUrl = "https://app.daytona.io/api"
+
+function jsonResponse(value, init) {
+  return new Response(JSON.stringify(value), init)
+}
+
+function snapshot(id, name, createdAt, state = "inactive") {
+  return { id, name, state, createdAt }
+}
+
+function inventoryFetch(snapshots, sandboxes = []) {
+  const calls = []
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options })
+    if (url.includes("/snapshots?")) {
+      return jsonResponse({ items: snapshots, total: snapshots.length })
+    }
+    if (url.includes("/sandbox?")) {
+      return jsonResponse(sandboxes)
+    }
+    return jsonResponse({})
+  }
+  return { calls, fetchImpl }
+}
+
+test("selection prunes only unprotected dev snapshots", () => {
+  const snapshots = [
+    snapshot("old", "openwork-dev-old", "2026-01-01T00:00:00Z"),
+    snapshot("stopped", "openwork-dev-stopped", "2026-01-02T00:00:00Z"),
+    snapshot("explicit", "openwork-dev-explicit", "2026-01-03T00:00:00Z"),
+    snapshot("pulling", "openwork-dev-pulling", "2026-01-04T00:00:00Z", "pulling"),
+    snapshot("active", "openwork-dev-active-ref", "2026-01-05T00:00:00Z"),
+    snapshot("recent-1", "openwork-dev-recent-1", "2026-01-06T00:00:00Z"),
+    snapshot("recent-2", "openwork-dev-recent-2", "2026-01-07T00:00:00Z"),
+    snapshot("release", "openwork-0.18.23", "2026-01-08T00:00:00Z"),
+    snapshot("base", "daytonaio/sandbox:0.8.0", "2026-01-09T00:00:00Z"),
+    snapshot("windows", "windows-small", "2026-01-10T00:00:00Z"),
+  ]
+  const sandboxes = [
+    { id: "started", state: "started", snapshot: "openwork-dev-active-ref" },
+    { id: "stopped", state: "stopped", snapshot: "openwork-dev-stopped" },
+    { id: "archived", state: "archived", snapshot: "openwork-dev-stopped" },
+  ]
+
+  const result = selectDevSnapshotPrunes({
+    snapshots,
+    sandboxes,
+    nameBase: "openwork",
+    keepNames: ["openwork-dev-explicit"],
+    keepCount: 2,
+  })
+
+  assert.deepEqual(result.prune.map((item) => item.name), [
+    "openwork-dev-old",
+    "openwork-dev-stopped",
+  ])
+  assert.deepEqual(result.keep.map((item) => [item.name, item.reason]), [
+    ["openwork-dev-explicit", "explicit"],
+    ["openwork-dev-pulling", "in-flight"],
+    ["openwork-dev-active-ref", "active-ref"],
+    ["openwork-dev-recent-1", "recent"],
+    ["openwork-dev-recent-2", "recent"],
+  ])
+  assert.equal(result.prune.some((item) => !item.name.startsWith("openwork-dev-")), false)
+})
+
+test("exactly keepCount in-scope snapshots prunes nothing", () => {
+  const snapshots = [
+    snapshot("one", "openwork-dev-one", "2026-01-01T00:00:00Z"),
+    snapshot("two", "openwork-dev-two", "2026-01-02T00:00:00Z"),
+  ]
+  const result = selectDevSnapshotPrunes({
+    snapshots,
+    sandboxes: [],
+    nameBase: "openwork",
+    keepNames: [],
+    keepCount: 2,
+  })
+
+  assert.deepEqual(result.prune, [])
+})
+
+test("dry-run fetches inventory but sends no DELETE requests", async () => {
+  const snapshots = [
+    snapshot("old", "openwork-dev-old", "2026-01-01T00:00:00Z"),
+    snapshot("new", "openwork-dev-new", "2026-01-02T00:00:00Z"),
+  ]
+  const { calls, fetchImpl } = inventoryFetch(snapshots)
+
+  const result = await pruneDaytonaDevSnapshots({
+    apiKey,
+    keepNames: ["openwork-dev-new"],
+    keepCount: 1,
+    dryRun: true,
+    fetchImpl,
+    log: () => {},
+  })
+
+  assert.deepEqual(result.prune.map((item) => item.id), ["old"])
+  assert.equal(calls.filter((call) => call.options.method === "DELETE").length, 0)
+  assert.equal(calls.filter((call) => call.options.method === "GET").length, 2)
+})
+
+test("real run deletes every selected id and no kept ids", async () => {
+  const snapshots = [
+    snapshot("old-1", "openwork-dev-old-1", "2026-01-01T00:00:00Z"),
+    snapshot("old-2", "openwork-dev-old-2", "2026-01-02T00:00:00Z"),
+    snapshot("new", "openwork-dev-new", "2026-01-03T00:00:00Z"),
+  ]
+  const { calls, fetchImpl } = inventoryFetch(snapshots)
+
+  await pruneDaytonaDevSnapshots({
+    apiKey,
+    keepNames: ["openwork-dev-new"],
+    keepCount: 1,
+    fetchImpl,
+    log: () => {},
+  })
+
+  assert.deepEqual(
+    calls.filter((call) => call.options.method === "DELETE").map((call) => call.url),
+    [`${apiUrl}/snapshots/old-1`, `${apiUrl}/snapshots/old-2`],
+  )
+})
+
+test("pagination protects newest snapshots and reads all sandbox pages", async () => {
+  const firstPage = Array.from({ length: 200 }, (_, index) =>
+    snapshot(
+      `old-${index}`,
+      `openwork-dev-old-${String(index).padStart(3, "0")}`,
+      `2025-01-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+    ),
+  )
+  const newest = snapshot("newest", "openwork-dev-newest", "2026-01-01T00:00:00Z")
+  const calls = []
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options })
+    const page = Number(new URL(url).searchParams.get("page"))
+    if (url.includes("/snapshots?")) {
+      return jsonResponse({
+        items: page === 1 ? firstPage : [newest],
+        total: 201,
+      })
+    }
+    if (url.includes("/sandbox?")) {
+      return jsonResponse(
+        page === 1
+          ? Array.from({ length: 200 }, (_, index) => ({
+              id: `sandbox-${index}`,
+              state: "stopped",
+              snapshot: null,
+            }))
+          : [{ id: "active", state: "started", snapshot: firstPage[0].name }],
+      )
+    }
+    return jsonResponse({})
+  }
+
+  const result = await pruneDaytonaDevSnapshots({
+    apiKey,
+    keepNames: [newest.name],
+    keepCount: 1,
+    fetchImpl,
+    log: () => {},
+  })
+
+  assert.equal(result.keep.some((item) => item.id === "newest"), true)
+  assert.equal(result.keep.some((item) => item.id === "old-0"), true)
+  assert.equal(result.prune.length, 199)
+  assert.equal(calls.some((call) => call.url.includes("/snapshots/newest")), false)
+  assert.equal(calls.some((call) => call.url.includes("/snapshots/old-0")), false)
+  assert.equal(calls.some((call) => call.url.endsWith("/snapshots/old-1")), true)
+  assert.equal(calls.filter((call) => call.url.includes("/sandbox?")).length, 2)
+})
+
+test("a failed DELETE does not prevent later deletes and rejects with the result", async () => {
+  const snapshots = [
+    snapshot("old-1", "openwork-dev-old-1", "2026-01-01T00:00:00Z"),
+    snapshot("old-2", "openwork-dev-old-2", "2026-01-02T00:00:00Z"),
+    snapshot("new", "openwork-dev-new", "2026-01-03T00:00:00Z"),
+  ]
+  const calls = []
+  const messages = []
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options })
+    if (url.includes("/snapshots?")) {
+      return jsonResponse({ items: snapshots, total: snapshots.length })
+    }
+    if (url.includes("/sandbox?")) {
+      return jsonResponse([])
+    }
+    if (url.endsWith("/old-1")) {
+      return new Response("upstream exploded", { status: 500 })
+    }
+    return jsonResponse({})
+  }
+
+  await assert.rejects(
+    pruneDaytonaDevSnapshots({
+      apiKey,
+      keepNames: ["openwork-dev-new"],
+      keepCount: 1,
+      fetchImpl,
+      log: (message) => messages.push(message),
+    }),
+    (error) => {
+      assert.equal(error.result.failures.length, 1)
+      assert.equal(
+        error.result.summary,
+        "summary: pruned=1 kept=1 out-of-scope=0 failed=1",
+      )
+      return true
+    },
+  )
+  assert.deepEqual(
+    calls.filter((call) => call.options.method === "DELETE").map((call) => call.url),
+    [`${apiUrl}/snapshots/old-1`, `${apiUrl}/snapshots/old-2`],
+  )
+  assert.equal(messages.at(-1), "summary: pruned=1 kept=1 out-of-scope=0 failed=1")
+})


### PR DESCRIPTION
## Why
Every push to `dev` publishes a Daytona snapshot (`openwork-dev-<sha>`) and nothing ever deleted them — 18 live snapshots and counting, one per merge. (50 older ones had already been deleted by hand, which also proved deletion is safe while stopped/archived sandboxes still reference a snapshot: sandboxes keep their own disks.)

## What
- `scripts/prune-daytona-dev-snapshots.mjs` — mirrors the `update-daytona-snapshot-pin.mjs` conventions (pure exported selection fn, injectable fetch/log, argv parsing, USAGE, main-guard). Scope is strictly `<base>-dev-*`; releases and base images are structurally out of scope.
  - Protects: explicit `--keep` names (the just-pinned snapshot), the `--keep-count 5` newest, in-flight states (pulling/building/…), and snapshots referenced by any sandbox in an active state.
  - Deletes the rest oldest-first; a failed DELETE continues the batch and exits non-zero.
  - Paginates `/snapshots` (page/total) and `/sandbox` (cursor) with a hard page cap.
- `.github/workflows/dev-daytona-snapshot.yml` — final step runs the pruner after pin+redeploy on pushes, the nightly backstop, and dispatch, reporting into the step summary.

## Verification
- `node --test scripts/prune-daytona-dev-snapshots.test.mjs` → 6 pass / 0 fail (selection incl. negative halves, dry-run issues zero DELETEs, exact DELETE targeting, cross-page keep-count protection with real cursor shape, delete-failure exits non-zero).
- `node --test scripts/update-daytona-snapshot-pin.test.mjs` → 13 pass (sibling untouched).
- Live read-only dry-run against the prod Daytona org (keep=`openwork-dev-2633397`, keep-count 5):
```
summary: pruned=13 kept=5 out-of-scope=41 failed=0
```
  Keeps = pin + 4 newest; prunes exactly the 13 stale dev snapshots; all 41 release/base images untouched. The first unit-test iteration assumed `/sandbox` returned a bare array — the live dry-run caught the real `{items, nextCursor}` cursor shape, fixed in the second commit.
- Workflow YAML is inert config: validated by the live dry-run above and observable on the next dev merge / nightly run. `actionlint` flags only the pre-existing Blacksmith runner-label warning, reproduced identically on clean `origin/dev`.

## Not in scope (tracked follow-ups)
- den-api deletion of superseded per-worker sandboxes after successful recycle (~30 accumulated for one worker).
- Release snapshot (`openwork-X.Y.Z`) retention policy — left manual for rollback value.