### PR TITLE
ci(daytona): redeploy den-api only when the snapshot pin moves

### DIFF
--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -200,13 +200,20 @@ jobs:
             echo
             echo "$result"
           } >> "$GITHUB_STEP_SUMMARY"
+          changed=false
+          case "$result" in
+            updated:*) changed=true ;;
+          esac
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Redeploy den-api so the new pin takes effect
         # Render does not redeploy services when an env group value changes, so
         # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
         # Without this the pin moves but `latestVersion` stays stale and no
         # sandbox ever recycles - observed for real on v0.18.11.
-        if: steps.channel.outputs.enabled == 'true' && steps.pin.outcome == 'success'
+        # Gated on the pin actually moving, so unchanged re-runs and the
+        # nightly backstop no longer redeploy production for a no-op.
+        if: steps.channel.outputs.enabled == 'true' && steps.pin.outcome == 'success' && steps.pin.outputs.changed == 'true'
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -200,13 +200,20 @@ jobs:
             echo
             echo "$result"
           } >> "$GITHUB_STEP_SUMMARY"
+          changed=false
+          case "$result" in
+            updated:*) changed=true ;;
+          esac
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Redeploy den-api so the new pin takes effect
         # Render does not redeploy services when an env group value changes, so
         # den-api keeps serving the previous DAYTONA_SNAPSHOT until it redeploys.
         # Without this the pin moves but `latestVersion` stays stale and no
         # sandbox ever recycles - observed for real on v0.18.11.
-        if: steps.pin.outcome == 'success' && vars.DAYTONA_PIN_CHANNEL != 'dev'
+        # Gated on the pin actually moving, so unchanged re-runs and the
+        # nightly backstop no longer redeploy production for a no-op.
+        if: steps.pin.outcome == 'success' && steps.pin.outputs.changed == 'true' && vars.DAYTONA_PIN_CHANNEL != 'dev'
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}


### PR DESCRIPTION
## Summary
- Gate the `Redeploy den-api so the new pin takes effect` step on the Daytona snapshot pin **actually moving**, instead of on the pin step merely succeeding.
- The pin step now emits a `changed` output derived from the script's existing, test-locked `updated:` / `unchanged:` message contract.

## Why
Both snapshot workflows redeployed production den-api whenever the pin step *succeeded* (`steps.pin.outcome == 'success'`), which is true in three cases that need no redeploy:

1. **Pin unchanged** — `update-daytona-snapshot-pin.mjs` returns `{status: "unchanged"}` and exits 0 without writing (`scripts/update-daytona-snapshot-pin.mjs:126-130`). The nightly `cron: "0 3 * * *"` backstop hits this every night no commits land on `dev`.
2. **Manual re-runs** of an already-pinned commit.
3. **Env group not configured** — the step prints a notice and `exit 0` (still `success`), so production was redeployed despite no pin being written at all.

The redeploy itself remains necessary and is unchanged in spirit: `DAYTONA_SNAPSHOT` is parsed once at module load into a frozen object (`ee/apps/den-api/src/env.ts:212` → `:437` → `:629`), so an env-group write is a no-op until the process restarts. This PR only stops the *no-op* redeploys.

## Issue
- N/A (found while diagnosing the Render 403 that froze the pin at `openwork-dev-fa246ee` for ~2 days)

## Scope
- `.github/workflows/dev-daytona-snapshot.yml` — emit `changed`, gate redeploy on it.
- `.github/workflows/release-daytona-snapshot.yml` — same.

## Out of scope
- `scripts/update-daytona-snapshot-pin.mjs` and its test are **byte-identical to `dev`** — no script change was needed.
- Resolving the snapshot dynamically from `daytona.snapshot.list()` instead of a pinned env var. Feasible (~100-150 lines) but trades an auditable, rollback-able pin for "whatever Daytona sorted newest", and would require rewriting the drift detector, which reads the pin back to infer the channel.
- The pre-existing double-deploy per `dev` merge (`api` has `autoDeploy=yes` on `dev`, so Render deploys once on the commit with the stale pin, then this workflow deploys again once the snapshot is built).

## Testing
### Ran
- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows
- `node --test scripts/update-daytona-snapshot-pin.test.mjs`
- `actionlint` on both workflows, compared against the `origin/dev` baseline
- Gating harness replaying both real message forms through the exact `case` statement added

### Result
- pass: YAML parses (`YAML_OK`)
- pass: `13 pass / 0 fail` — the `updated:` / `unchanged:` message strings this gate depends on are exact-asserted at `scripts/update-daytona-snapshot-pin.test.mjs:39` and `:72`
- pass: gating harness → `changed=true` for `updated: ...`, `changed=false` for `unchanged: ...`
- pass: `actionlint` reports the **same 3 findings on this branch as on `origin/dev`** (`dev-...:34`, `release-...:43`, `release-...:58`) — all pre-existing (`blacksmith` runner label, one SC2129 style note at line 58). **Zero new findings**, none on the changed lines (203-216).

## CI status
- pass: workflow YAML + pin script tests
- code-related failures: none
- external/env/auth blockers: none

## Manual verification
1. `git diff origin/dev -- scripts/` → empty, confirming the script contract is untouched.
2. Inspect both redeploy conditions → each now includes `steps.pin.outputs.changed == 'true'`.
3. Next `dev` push: pin moves → `Update production snapshot pin` prints `updated: ...` → redeploy step **runs**.
4. Next nightly cron with no new commits: pin prints `unchanged: ...` → redeploy step shows as **skipped** in the run.

## Evidence
`N/A (CI-config-only)` — this changes GitHub Actions step gating, not app or Den runtime behaviour, so no `evals/specs` testkit tape applies. The behavioural contract this gate rides on is covered by the existing node test above.

## Risk
Low, and fail-safe in the conservative direction. If `changed` were ever unset or misparsed, the redeploy is **skipped**, not spuriously fired — the failure mode is a stale pin visible the same day in the `Daytona Snapshot Drift` check, not an unwanted production deploy. The early `exit 0` path deliberately leaves `changed` unset, which now correctly means "do not redeploy".

## Rollback
Revert this commit; the redeploy returns to firing on every successful pin step.
