### PR TITLE
ci(daytona): move the dev snapshot pin to the nightly run and protect the live pin in pruning

### DIFF
--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -1,5 +1,7 @@
 # web.openworklabs.com engine channel:
-# Per-push snapshot from dev HEAD, named <base>-dev-<short-sha>, with a nightly backstop.
+# Per-push snapshot builds from dev HEAD stay; the production pin moves only on
+# the nightly backstop, manual dispatch, or releases after the 2026-08-15
+# merge-burst update treadmill recycled every running cloud workspace 3 times.
 # DAYTONA_PIN_CHANNEL resolves pin ping-pong: release pinning defers to the dev channel.
 # Set DAYTONA_PIN_CHANNEL=release to stop this pipeline; the next release re-pins.
 # Sandboxes roll forward via the existing stopped+stale recycle.
@@ -168,7 +170,7 @@ jobs:
 
       - name: Update production snapshot pin
         id: pin
-        if: steps.channel.outputs.enabled == 'true'
+        if: steps.channel.outputs.enabled == 'true' && github.event_name != 'push'
         shell: bash
         env:
           DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
@@ -213,7 +215,7 @@ jobs:
         # sandbox ever recycles - observed for real on v0.18.11.
         # Gated on the pin actually moving, so unchanged re-runs and the
         # nightly backstop no longer redeploy production for a no-op.
-        if: steps.channel.outputs.enabled == 'true' && steps.pin.outcome == 'success' && steps.pin.outputs.changed == 'true'
+        if: steps.channel.outputs.enabled == 'true' && github.event_name != 'push' && steps.pin.outcome == 'success' && steps.pin.outputs.changed == 'true'
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
@@ -253,15 +255,34 @@ jobs:
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_API_URL: ${{ vars.DAYTONA_API_URL }}
+          DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
           DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
           DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
         run: |
           set -euo pipefail
+
+          if [ -z "${DAYTONA_CLOUD_ENV_GROUP_ID:-}" ] || [ -z "${RENDER_API_KEY:-}" ]; then
+            echo "::notice::prune skipped: current pin unknown"
+            echo "prune skipped: current pin unknown" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if ! current_pin="$(node .snapshot-pin-automation/scripts/update-daytona-snapshot-pin.mjs --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" --read)"; then
+            echo "::notice::prune skipped: current pin unknown"
+            echo "prune skipped: current pin unknown" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -z "$current_pin" ]; then
+            echo "::notice::prune skipped: current pin unknown"
+            echo "prune skipped: current pin unknown" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
           result="$(node scripts/prune-daytona-dev-snapshots.mjs \
             ${DAYTONA_API_URL:+--api-url "$DAYTONA_API_URL"} \
             --name-base "${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}" \
             --keep "$DAYTONA_SNAPSHOT_NAME" \
+            --keep "$current_pin" \
             --keep-count 5)"
           echo "$result"
           {


### PR DESCRIPTION
## Why
2026-08-15: three dev merges in 5 minutes moved the production `DAYTONA_SNAPSHOT` pin three times; every running cloud workspace auto-recycled 3× back-to-back (multi-minute outage each — the 'update treadmill', verified from workflow runs + den-api request logs + the worker_instance ledger). Owner decision: per-push snapshot **builds** stay, but the production **pin** moves only on the nightly run, manual dispatch, or releases.

## What
- `Update production snapshot pin` + `Redeploy den-api`: additionally gated on `github.event_name != 'push'` (schedule/dispatch only). #3803's changed-pin gate preserved.
- `Prune old dev snapshots`: now that the live pin can be older than the 5 newest builds, the pruner must never delete it — the step reads the current pin (`update-daytona-snapshot-pin.mjs --read`) and passes it as a second `--keep`. Fail-safe: if the pin cannot be determined (missing env group id / RENDER_API_KEY / read failure), pruning is skipped with a step-summary notice rather than running blind.
- Header comment updated with the rationale.

## Verification
Workflow YAML is inert config: PyYAML parse clean; `actionlint` shows only the pre-existing Blacksmith runner-label warning (reproduced on clean dev). Behavior observable on the next push (no pin move) and tonight's 03:00 run (single pin move + prune keeping the live pin). The pruner's keep semantics (explicit `--keep` always protected) are already unit-covered in `scripts/prune-daytona-dev-snapshots.test.mjs`.

⚠️ Touches `.github/workflows/` → warden won't self-approve; needs a human review.