### PR TITLE
fix(den-gateway): pool upstream connections and retry connect-phase failures

### DIFF
--- a/ee/apps/den-gateway/package.json
+++ b/ee/apps/den-gateway/package.json
@@ -14,6 +14,7 @@
     "@openwork-ee/utils": "workspace:*",
     "dotenv": "^16.4.5",
     "hono": "4.12.34",
+    "undici": "7.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/ee/apps/den-gateway/src/app.ts
+++ b/ee/apps/den-gateway/src/app.ts
@@ -5,6 +5,7 @@ import { extname, resolve, sep } from "node:path"
 import { createJsonStdoutLogger, type JsonObject, type JsonStdoutLogger } from "@openwork-ee/utils/observability"
 import { Hono } from "hono"
 import { env } from "./env.js"
+import { createInstanceFetch, fetchWithConnectRetry, type FetchLike } from "./instance-fetch.js"
 
 type InstanceStatus = "provisioning" | "waking" | "ready" | "failed"
 type NonReadyStatus = "provisioning" | "waking" | "failed"
@@ -34,6 +35,7 @@ export type GatewayAppOptions = {
   resolveTtlMs?: number
   now?: () => number
   fetchImpl?: typeof fetch
+  instanceFetch?: FetchLike
   logger?: JsonStdoutLogger
   logRequests?: boolean
 }
@@ -46,6 +48,7 @@ type GatewayConfig = {
   resolveTtlMs: number
   now: () => number
   fetchImpl: typeof fetch
+  instanceFetch: FetchLike
   logger: JsonStdoutLogger
   logRequests: boolean
 }
@@ -87,6 +90,14 @@ const alwaysProxyPathPrefixes = [
 const workspacePathPrefix = "/workspace/"
 const defaultLogger = createJsonStdoutLogger({ serviceName: "den-gateway" })
 
+function createLazyInstanceFetch(connectTimeoutMs: number): FetchLike {
+  let instanceFetch: FetchLike | undefined
+  return (url, init) => {
+    instanceFetch ??= createInstanceFetch({ connectTimeoutMs })
+    return instanceFetch(url, init)
+  }
+}
+
 class GatewayHttpError extends Error {
   status: number
   code: string
@@ -112,6 +123,7 @@ function createConfig(options: GatewayAppOptions): GatewayConfig {
     resolveTtlMs: options.resolveTtlMs ?? env.resolveTtlMs,
     now: options.now ?? Date.now,
     fetchImpl: options.fetchImpl ?? fetch,
+    instanceFetch: options.instanceFetch ?? options.fetchImpl ?? createLazyInstanceFetch(env.upstreamConnectTimeoutMs),
     logger: options.logger ?? defaultLogger,
     logRequests: options.logRequests ?? env.logRequests,
   }
@@ -578,11 +590,15 @@ async function proxyToInstance(input: {
 }) {
   let response: Response
   try {
-    response = await input.config.fetchImpl(buildProxyUrl(input.resolution.url, input.request.url), {
-      method: input.request.method,
-      headers: upstreamRequestHeaders(input.request.headers, input.resolution.clientToken, input.resolution.hostToken),
-      body: await requestBody(input.request),
-      redirect: "manual",
+    response = await fetchWithConnectRetry({
+      fetchImpl: input.config.instanceFetch,
+      url: buildProxyUrl(input.resolution.url, input.request.url),
+      init: {
+        method: input.request.method,
+        headers: upstreamRequestHeaders(input.request.headers, input.resolution.clientToken, input.resolution.hostToken),
+        body: await requestBody(input.request),
+        redirect: "manual",
+      },
     })
   } catch {
     return jsonResponse({ error: "gateway_upstream_failed" }, 502)

--- a/ee/apps/den-gateway/src/env.ts
+++ b/ee/apps/den-gateway/src/env.ts
@@ -9,6 +9,7 @@ const EnvSchema = z.object({
   RENDER_GIT_COMMIT: z.string().optional(),
   DEN_GATEWAY_WEB_ROOT: z.string().optional(),
   DEN_GATEWAY_RESOLVE_TTL_MS: z.string().optional(),
+  DEN_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_MS: z.string().optional(),
   DEN_GATEWAY_LOG_REQUESTS: z.string().optional(),
 })
 
@@ -79,5 +80,10 @@ export const env = {
   }),
   webRoot: optionalString(parsed.DEN_GATEWAY_WEB_ROOT),
   resolveTtlMs: parsePositiveInteger("DEN_GATEWAY_RESOLVE_TTL_MS", parsed.DEN_GATEWAY_RESOLVE_TTL_MS, 15_000),
+  upstreamConnectTimeoutMs: parsePositiveInteger(
+    "DEN_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_MS",
+    parsed.DEN_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_MS,
+    3_000,
+  ),
   logRequests: parseBoolean(parsed.DEN_GATEWAY_LOG_REQUESTS, true),
 }

--- a/ee/apps/den-gateway/src/instance-fetch.ts
+++ b/ee/apps/den-gateway/src/instance-fetch.ts
@@ -1,0 +1,107 @@
+import { Agent, fetch as undiciFetch } from "undici"
+
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>
+
+const connectPhaseErrorCodes = new Set([
+  "UND_ERR_CONNECT_TIMEOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "ECONNRESET",
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function isConnectPhaseError(error: unknown): boolean {
+  let current = error
+  const visited = new Set<object>()
+
+  while (isRecord(current) && !visited.has(current)) {
+    visited.add(current)
+    if ((typeof current.code === "string" && connectPhaseErrorCodes.has(current.code)) || current.name === "ConnectTimeoutError") {
+      return true
+    }
+    current = current.cause
+  }
+
+  return false
+}
+
+export async function fetchWithConnectRetry(input: {
+  fetchImpl: FetchLike
+  url: string
+  init: RequestInit
+  retries?: number
+}): Promise<Response> {
+  let retriesRemaining = input.retries ?? 1
+
+  while (true) {
+    try {
+      return await input.fetchImpl(input.url, input.init)
+    } catch (error) {
+      if (!isConnectPhaseError(error) || retriesRemaining <= 0) {
+        throw error
+      }
+      retriesRemaining -= 1
+    }
+  }
+}
+
+export function createInstanceFetch(options: { connectTimeoutMs: number }): FetchLike {
+  const agent = new Agent({
+    connect: {
+      timeout: options.connectTimeoutMs,
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 300,
+    },
+    keepAliveTimeout: 60_000,
+    keepAliveMaxTimeout: 300_000,
+    headersTimeout: 30_000,
+    bodyTimeout: 0,
+  })
+
+  return async (url, init) => {
+    const request = new Request(url, init)
+    const headers: Record<string, string> = {}
+    request.headers.forEach((value, name) => {
+      headers[name] = value
+    })
+    const response = await undiciFetch(url, {
+      method: request.method,
+      headers,
+      body: request.body ? await request.arrayBuffer() : undefined,
+      redirect: request.redirect,
+      dispatcher: agent,
+    })
+    const responseHeaders = new Headers()
+    response.headers.forEach((value, name) => {
+      responseHeaders.append(name, value)
+    })
+    let body: ReadableStream<Uint8Array> | null = null
+    if (response.body) {
+      const reader = response.body.getReader()
+      body = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          const chunk = await reader.read()
+          if (chunk.done) {
+            controller.close()
+            return
+          }
+          controller.enqueue(chunk.value)
+        },
+        cancel(reason: unknown) {
+          return reader.cancel(reason)
+        },
+      })
+    }
+
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
+  }
+}

--- a/ee/apps/den-gateway/test/gateway.test.mjs
+++ b/ee/apps/den-gateway/test/gateway.test.mjs
@@ -41,7 +41,7 @@ function serverBase(server) {
 }
 
 function startGateway(options) {
-  const app = createGatewayApp({ ...options, logger: silentLogger, logRequests: false })
+  const app = createGatewayApp({ fetchImpl: fetch, ...options, logger: silentLogger, logRequests: false })
   return startServer(app.fetch)
 }
 
@@ -76,6 +76,18 @@ function readyResolvePayload(url, input = {}) {
     clientToken: input.clientToken ?? "client-token",
     hostToken: input.hostToken ?? "host-token",
   }
+}
+
+function injectedInstanceFetch(instanceHandler) {
+  const observed = { upstreamCalls: 0 }
+  const fetchImpl = async (url, init) => {
+    if (new URL(url).pathname === "/v1/cloud/gateway/resolve") {
+      return Response.json(readyResolvePayload("https://instance.example"))
+    }
+    observed.upstreamCalls += 1
+    return instanceHandler(url, init, observed.upstreamCalls)
+  }
+  return { fetchImpl, observed }
 }
 
 function startPassthroughDenApi() {
@@ -234,6 +246,93 @@ describe("den-gateway static UI", () => {
 })
 
 describe("den-gateway proxy", () => {
+  test("retries one connect-phase failure and passes through success", async () => {
+    const injected = injectedInstanceFetch((_url, _init, call) => {
+      if (call === 1) {
+        throw new Error("connect failed", { cause: { code: "UND_ERR_CONNECT_TIMEOUT" } })
+      }
+      return new Response("ok")
+    })
+    const gateway = startGateway({ fetchImpl: injected.fetchImpl, denApiBase: "https://den.example", gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/status`, { headers: { Authorization: "Bearer den-token" } })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+    expect(injected.observed.upstreamCalls).toBe(2)
+  })
+
+  test("does not retry an instance request that succeeds first try", async () => {
+    const injected = injectedInstanceFetch(() => new Response("ok"))
+    const gateway = startGateway({ fetchImpl: injected.fetchImpl, denApiBase: "https://den.example", gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/status`, { headers: { Authorization: "Bearer den-token" } })
+
+    expect(response.status).toBe(200)
+    expect(injected.observed.upstreamCalls).toBe(1)
+  })
+
+  test("does not retry a non-connect instance failure", async () => {
+    const injected = injectedInstanceFetch(() => {
+      throw new Error("boom")
+    })
+    const gateway = startGateway({ fetchImpl: injected.fetchImpl, denApiBase: "https://den.example", gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/status`, { headers: { Authorization: "Bearer den-token" } })
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({ error: "gateway_upstream_failed" })
+    expect(injected.observed.upstreamCalls).toBe(1)
+  })
+
+  test("caps connect-phase retries at one", async () => {
+    const injected = injectedInstanceFetch(() => {
+      const error = new Error("connect failed")
+      error.code = "ECONNRESET"
+      throw error
+    })
+    const gateway = startGateway({ fetchImpl: injected.fetchImpl, denApiBase: "https://den.example", gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/status`, { headers: { Authorization: "Bearer den-token" } })
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({ error: "gateway_upstream_failed" })
+    expect(injected.observed.upstreamCalls).toBe(2)
+  })
+
+  test("resends identical buffered POST body bytes and headers after a connect failure", async () => {
+    const attempts = []
+    const injected = injectedInstanceFetch(async (_url, init, call) => {
+      attempts.push({
+        body: Array.from(new Uint8Array(init.body)),
+        contentType: new Headers(init.headers).get("content-type"),
+        testHeader: new Headers(init.headers).get("x-test-header"),
+      })
+      if (call === 1) {
+        throw new Error("connect failed", { cause: { code: "ETIMEDOUT" } })
+      }
+      return new Response("created", { status: 201 })
+    })
+    const gateway = startGateway({ fetchImpl: injected.fetchImpl, denApiBase: "https://den.example", gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/workspaces`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer den-token",
+        "Content-Type": "application/octet-stream",
+        "X-Test-Header": "preserved",
+      },
+      body: new Uint8Array([0, 1, 2, 255]),
+    })
+
+    expect(response.status).toBe(201)
+    expect(injected.observed.upstreamCalls).toBe(2)
+    expect(attempts).toEqual([
+      { body: [0, 1, 2, 255], contentType: "application/octet-stream", testHeader: "preserved" },
+      { body: [0, 1, 2, 255], contentType: "application/octet-stream", testHeader: "preserved" },
+    ])
+  })
+
   test("passes /api/den through to den-api with the caller bearer, no cookies, and the prefix stripped", async () => {
     const denApi = startPassthroughDenApi()
     const upstream = startUpstream()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,9 @@ importers:
       hono:
         specifier: 4.12.34
         version: 4.12.34
+      undici:
+        specifier: 7.29.0
+        version: 7.29.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -16599,8 +16602,7 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.29.0:
-    optional: true
+  undici@7.29.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Incident (live, 2026-08-15 ~13:00Z onward)
Fresh connections from the gateway (Render) to Daytona's preview edge intermittently lose SYNs: establishment stalls 17–18s (TCP retransmit ladder) while reused warm connections answer in 77–424ms. Clients cancel at ~3s → `GET /workspaces` 499s → the cloud UI renders an **empty workspace list** even though the sandbox is healthy (server-side `/workspaces` answers in 1ms with the user's workspace; verified in-sandbox). Same edge from an external vantage: ~350ms consistently. Network segment is outside our control; the gateway must stop amplifying it.

## What
- `src/instance-fetch.ts`: undici `Agent` for instance upstreams — keep-alive pooling (60s/300s) so requests overwhelmingly reuse proven-warm connections, `connect.timeout` 3s (env `DEN_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_MS`), happy-eyeballs (`autoSelectFamily`), `headersTimeout` 30s, `bodyTimeout: 0` (proxied SSE must never be idle-killed). Response bodies bridged as pull-based streams.
- `fetchWithConnectRetry`: exactly one retry, only for connect-phase failures (UND_ERR_CONNECT_TIMEOUT/ECONNREFUSED/ENOTFOUND/EAI_AGAIN/ETIMEDOUT/ECONNRESET via cause-chain walk) — safe for all methods because proxied bodies are fully buffered; a fresh SYN usually succeeds immediately.
- `proxyToInstance` uses the pooled fetch + retry; den-api proxy path untouched. Agent construction is lazy and never runs when tests inject `fetchImpl`.

## Verification
- `bun test --conditions development test/*.test.mjs` → **20 pass / 0 fail** (103 assertions): retry-once-then-success (exactly 2 upstream calls), no spurious retry on success, non-connect errors never retried (502 after 1 call), retry cap (502 after 2 calls), POST body bytes identical on resend.
- `pnpm exec tsc -p tsconfig.json --noEmit` clean.
- Undici agent options are inert wiring exercised at runtime; the retry/timeout decision logic carries the unit coverage (stated per verification policy).