### PR TITLE
fix(opencode): update session loop runtime

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -50,7 +50,7 @@
     "@lexical/react": "^0.35.0",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opencode-ai/sdk": "^1.17.11",
+    "@opencode-ai/sdk": "^1.18.15",
     "@openwork/install-config": "workspace:*",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -18,6 +18,17 @@ import {
   snapshotEngineState,
   snapshotOpenworkServerState,
 } from "./runtime.mjs";
+
+describe("bundled OpenCode runtime", () => {
+  it("pins the engine release containing the timestamp-based session loop repair", async () => {
+    const constantsPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../constants.json");
+    const constants = JSON.parse(await readFile(constantsPath, "utf8"));
+
+    // OpenCode #40990 stops old assistant messages with lexicographically
+    // later IDs from short-circuiting a newly appended user turn.
+    assert.equal(constants.opencodeVersion, "v1.18.18");
+  });
+});
 
 describe("engine rollover preference", () => {
   it("uses an explicit value and otherwise restores the persisted value", () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opencode-ai/sdk": "^1.17.11",
+    "@opencode-ai/sdk": "^1.18.15",
     "@openwork/enterprise-mcp-client": "workspace:*",
     "@openwork/paths": "workspace:*",
     "@sentry/electron": "^7.16.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opencode-ai/sdk": "^1.17.11",
+    "@opencode-ai/sdk": "^1.18.15",
     "@openwork/enterprise-mcp-client": "workspace:*",
     "better-sqlite3": "^13.0.2",
     "drizzle-orm": "^0.45.2",

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.17.11"
+  "opencodeVersion": "v1.18.18"
 }

--- a/evals/specs/connect-readiness-preseeded.slow.test.ts
+++ b/evals/specs/connect-readiness-preseeded.slow.test.ts
@@ -1,0 +1,346 @@
+import { expect, onTestFinished } from "vitest";
+import { createOrgConnection, deleteConnection, denFetch, evalIn, go } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import type { Surface } from "@openwork/cdp";
+import {
+  app,
+  eventually,
+  localMysqlIsRunning,
+  mcpMock,
+  needs,
+  readConnectState,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const remotePlacement = process.env.OPENWORK_EVAL_DAYTONA === "1" || Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const mysqlOpen = remotePlacement || await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "preseeded Connect readiness skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !mysqlOpen
+    ? "preseeded Connect readiness skipped — needs: MySQL on 127.0.0.1:3306 for local placement"
+    : "bundled engine connects to preseeded organization skills and connections";
+let requestId = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value).slice(0, 500)}`);
+  return value;
+}
+
+function toolText(result: unknown): string {
+  const record = requireRecord(result, "MCP tool result");
+  const first = Array.isArray(record.content) ? record.content[0] : null;
+  if (!isRecord(first) || typeof first.text !== "string") {
+    throw new Error(`MCP tool result had no text content: ${JSON.stringify(result).slice(0, 500)}`);
+  }
+  return first.text;
+}
+
+function toolJson(result: unknown): unknown {
+  return JSON.parse(toolText(result));
+}
+
+function searchMatches(result: unknown): Record<string, unknown>[] {
+  const payload = requireRecord(toolJson(result), "search_capabilities payload");
+  return Array.isArray(payload.matches) ? payload.matches.filter(isRecord) : [];
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = orgs[0] && typeof orgs[0].id === "string" ? orgs[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the provisioned organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function mintMcpToken(session: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(session, "/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId },
+    body: JSON.stringify({}),
+  });
+  const mcpToken = isRecord(result.body) && typeof result.body.token === "string" ? result.body.token : "";
+  if (!result.response.ok || !mcpToken.startsWith("ow_mcp_at_")) {
+    throw new Error(`Minting the member Connect token failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return mcpToken;
+}
+
+async function callTool(
+  apiUrl: string,
+  mcpToken: string,
+  name: "search_capabilities" | "execute_capability",
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: ++requestId,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP tools/call failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`MCP tools/call returned no SSE data frame: ${raw.slice(0, 500)}`);
+  const payload: unknown = JSON.parse(dataLine.slice(5));
+  const record = requireRecord(payload, "MCP JSON-RPC payload");
+  if (record.error) throw new Error(`MCP tools/call returned JSON-RPC error: ${JSON.stringify(record.error)}`);
+  return record.result;
+}
+
+async function readCloudMcpHealth(surface: Surface, workspaceId: string): Promise<Record<string, unknown>> {
+  const raw = await evalIn(surface, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return JSON.stringify({ error: "missing local server credentials" });
+    const response = await fetch(
+      "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/mcp/openwork-cloud/health?probe=1",
+      { headers: { Authorization: "Bearer " + token } },
+    );
+    const text = await response.text();
+    if (!response.ok) return JSON.stringify({ error: "HTTP " + response.status, body: text.slice(0, 500) });
+    return text;
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  if (typeof raw !== "string") throw new Error(`Cloud MCP health response was not text: ${JSON.stringify(raw)}`);
+  return requireRecord(JSON.parse(raw), "Cloud MCP health response");
+}
+
+function healthIsReady(health: Record<string, unknown>): boolean {
+  const engine = isRecord(health.engine) ? health.engine : null;
+  const tools = isRecord(health.tools) ? health.tools : null;
+  const direct = tools && isRecord(tools.direct) ? tools.direct : null;
+  return health.phase === "ready"
+    && health.usable === true
+    && engine?.status === "connected"
+    && Array.isArray(tools?.present)
+    && tools.present.includes("openwork-cloud_search_capabilities")
+    && tools.present.includes("openwork-cloud_execute_capability")
+    && Array.isArray(direct?.present)
+    && direct.present.includes("search_capabilities")
+    && direct.present.includes("execute_capability");
+}
+
+test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+  const run = Date.now();
+  const skillName = `pr3806-connect-proof-${run}`;
+  const connectionName = `PR 3806 readiness connector ${run}`;
+  const nonsenseName = `no-such-capability-${run}`;
+  const rawSourceText = `---\nname: ${skillName}\ndescription: Proves preseeded Connect skill discovery on OpenCode 1.18.18.\n---\n\nReturn the PR 3806 Connect proof phrase.`;
+
+  await using den = await server({
+    place,
+    org: {
+      name: `PR 3806 Connect Readiness ${run}`,
+      admin: {
+        email: `pr3806-connect-admin-${run}@openwork.test`,
+        name: "PR 3806 Connect Admin",
+        password: "OpenWorkEval123!",
+      },
+    },
+    mocks: { connector: mcpMock() },
+  });
+
+  const orgId = await organizationId(den.admin);
+  const createdSkill = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: skillName,
+      orgWide: true,
+      components: [{ type: "skill", input: { rawSourceText } }],
+    }),
+  });
+  const skillItem = isRecord(createdSkill.body) && isRecord(createdSkill.body.item) ? createdSkill.body.item : null;
+  const pluginId = skillItem && typeof skillItem.id === "string" ? skillItem.id : "";
+  if (!createdSkill.response.ok || !pluginId) {
+    throw new Error(`Creating the org-wide proof skill failed: HTTP ${createdSkill.response.status} ${createdSkill.text.slice(0, 500)}`);
+  }
+  onTestFinished(async () => {
+    await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}/archive`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId },
+    }).catch(() => undefined);
+  });
+
+  const connectionInput = {
+    name: connectionName,
+    url: den.mocks.connector.mcpUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  };
+  const connection = await createOrgConnection(den.admin, connectionInput);
+  onTestFinished(async () => deleteConnection(den.admin, connection.id).catch(() => undefined));
+  evidence.fact(
+    "The organization was seeded before desktop boot",
+    `Skill plugin ${pluginId} used components=[{type:"skill",input:{rawSourceText}}] with orgWide=true; connection input: ${JSON.stringify(connectionInput)}.`,
+    createdSkill.response.status === 201 && connection.name === connectionName,
+  );
+
+  await using desktopApp = await app({
+    den,
+    as: "admin",
+    place,
+    beforeSignIn: async (surface) => {
+      const signedOutState = await eventually(() => readConnectState(surface), {
+        within: 15_000,
+        label: "signed-out fresh-profile Connect state",
+        until: (state) => state.ok && state.status === "missing",
+      });
+      const signedOutNotAvailable = signedOutState.status !== "available";
+      expect(signedOutState.status).toBe("missing");
+      expect(signedOutState.connectEnabled).toBe(false);
+      expect(signedOutNotAvailable).toBe(true);
+      evidence.fact(
+        "A signed-out fresh profile has no Connect capability access",
+        `Observed Connect state before sign-in: ${JSON.stringify(signedOutState)}.`,
+        signedOutState.status === "missing" && signedOutState.connectEnabled === false && signedOutNotAvailable,
+      );
+      const shot = await screenshot(surface);
+      const seen = await validate(shot, [
+        "The OpenWork desktop is visible before organization sign-in",
+        "No crash or error dialog is visible",
+      ]);
+      expect(seen.ok, seen.why).toBe(true);
+    },
+  });
+
+  const signedInState = await eventually(() => readConnectState(desktopApp), {
+    within: 90_000,
+    label: "signed-in available Connect state",
+    until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+  });
+  const signedInNotMissing = signedInState.status !== "missing";
+  expect(signedInState.status).toBe("available");
+  expect(signedInState.connectEnabled).toBe(true);
+  expect(signedInNotMissing).toBe(true);
+  evidence.fact(
+    "Organization sign-in enables Connect",
+    `Observed Connect state after sign-in: ${JSON.stringify(signedInState)}.`,
+    signedInState.status === "available" && signedInState.connectEnabled === true && signedInNotMissing,
+  );
+
+  const health = await eventually(() => readCloudMcpHealth(desktopApp, desktopApp.workspaceId), {
+    within: 180_000,
+    label: "OpenCode 1.18.18 openwork-cloud engine and agent-tool readiness",
+    until: healthIsReady,
+  });
+  const engine = requireRecord(health.engine, "Cloud MCP engine health");
+  const tools = requireRecord(health.tools, "Cloud MCP tools health");
+  expect(health.phase).toBe("ready");
+  expect(health.usable).toBe(true);
+  expect(engine.status).toBe("connected");
+  expect(engine.status).not.toBe("needs_auth");
+  expect(engine.status).not.toBe("failed");
+  expect(engine.status).not.toBe("needs_client_registration");
+  expect(tools.present).toEqual(expect.arrayContaining([
+    "openwork-cloud_search_capabilities",
+    "openwork-cloud_execute_capability",
+  ]));
+  evidence.fact(
+    "OpenCode 1.18.18 connects openwork-cloud with both agent tools",
+    `Health payload: ${JSON.stringify({ phase: health.phase, usable: health.usable, engine, tools: tools.present })}.`,
+    healthIsReady(health)
+      && engine.status !== "needs_auth"
+      && engine.status !== "failed"
+      && engine.status !== "needs_client_registration",
+  );
+
+  const mcpToken = await mintMcpToken(den.admin, orgId);
+  const skillSearch = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: skillName,
+    limit: 20,
+    type: "skills",
+  });
+  const skillMatch = searchMatches(skillSearch).find((match) => (
+    match.kind === "skill" && typeof match.name === "string" && match.name.startsWith(`plugin:${pluginId}:`)
+  ));
+  if (!skillMatch || typeof skillMatch.name !== "string") throw new Error(`Connect did not discover the exact skill ${skillName}.`);
+  const capabilityName = skillMatch.name;
+  expect(skillMatch.kind).toBe("skill");
+  expect(capabilityName.startsWith(`plugin:${pluginId}:`)).toBe(true);
+  const execution = await callTool(den.ref.apiUrl, mcpToken, "execute_capability", { name: capabilityName });
+  expect(isRecord(execution) && execution.isError === true).toBe(false);
+  expect(toolJson(execution)).toMatchObject({ kind: "skill", content: rawSourceText });
+  evidence.fact(
+    "The member's Connect token discovers and executes the preseeded skill",
+    `Search query ${skillName} returned ${JSON.stringify(skillMatch)}; execution returned the exact ${rawSourceText.length}-character source.`,
+    skillMatch.kind === "skill" && capabilityName.startsWith(`plugin:${pluginId}:`) && JSON.stringify(toolJson(execution)).includes(rawSourceText),
+  );
+
+  const nonsenseSearch = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: nonsenseName,
+    limit: 20,
+    type: "skills",
+  });
+  const nonsenseSkillMatches = searchMatches(nonsenseSearch).filter((match) => (
+    match.kind === "skill" && JSON.stringify(match).includes(nonsenseName)
+  ));
+  expect(nonsenseSkillMatches).toEqual([]);
+  evidence.fact(
+    "Connect does not invent a nonexistent skill",
+    `Search query ${nonsenseName} returned no skill match naming that capability.`,
+    nonsenseSkillMatches.length === 0,
+  );
+
+  const connectionSearch = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: connectionName,
+    limit: 20,
+    type: "mcp",
+  });
+  const connectionMatch = searchMatches(connectionSearch).find((match) => {
+    const status = isRecord(match.connectionStatus) ? match.connectionStatus : null;
+    return status?.connectionName === connectionName || JSON.stringify(match).includes(connectionName);
+  });
+  if (!connectionMatch) throw new Error(`Connect did not discover the preseeded connection ${connectionName}.`);
+  const connectionStatus = isRecord(connectionMatch.connectionStatus) ? connectionMatch.connectionStatus : null;
+  const readiness = connectionStatus?.state === "needs_connection" && connectionStatus.actor === "member"
+    ? "needs_signin"
+    : connectionStatus?.actor === "organization_admin"
+      ? "needs_admin_setup"
+      : "ready";
+  expect(["ready", "needs_signin", "needs_admin_setup"]).toContain(readiness);
+  evidence.fact(
+    "The preseeded organization connection is discoverable with truthful readiness",
+    `Connection match: ${JSON.stringify(connectionMatch)}; normalized readiness=${readiness}.`,
+    Boolean(connectionMatch) && ["ready", "needs_signin", "needs_admin_setup"].includes(readiness),
+  );
+
+  const connectionsDeadline = Date.now() + 30_000;
+  while (Date.now() < connectionsDeadline) {
+    const settled = await evalIn(
+      desktopApp,
+      `document.body.innerText.includes(${JSON.stringify(connectionName)})`,
+      { timeoutMs: 5_000 },
+    ).catch(() => false);
+    if (settled === true) break;
+    await go(desktopApp, "/workspace/" + desktopApp.workspaceId + "/settings/extensions/connections").catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  }
+  expect(await evalIn(desktopApp, `document.body.innerText.includes(${JSON.stringify(connectionName)})`)).toBe(true);
+  const signedInShot = await screenshot(desktopApp);
+  const signedInSeen = await validate(signedInShot, [
+    `A Library view of skills, connections, and tools lists an organization connection card named '${connectionName}'`,
+    "No crash or error dialog is visible",
+  ]);
+  expect(signedInSeen.ok, signedInSeen.why).toBe(true);
+});

--- a/evals/specs/connect-readiness-preseeded.slow.test.ts
+++ b/evals/specs/connect-readiness-preseeded.slow.test.ts
@@ -142,7 +142,7 @@ test.skipIf(!appSpecsEnabled || !mysqlOpen)(title, async ({ evidence, place }) =
   needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
   const run = Date.now();
   const skillName = `pr3806-connect-proof-${run}`;
-  const connectionName = `PR 3806 readiness connector ${run}`;
+  const connectionName = `PR3806 conn ${String(run).slice(-6)}`;
   const nonsenseName = `no-such-capability-${run}`;
   const rawSourceText = `---\nname: ${skillName}\ndescription: Proves preseeded Connect skill discovery on OpenCode 1.18.18.\n---\n\nReturn the PR 3806 Connect proof phrase.`;
 

--- a/evals/specs/engine-restart-turn-freshness.slow.test.ts
+++ b/evals/specs/engine-restart-turn-freshness.slow.test.ts
@@ -1,0 +1,457 @@
+import { rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import {
+  control,
+  createAndSelectWorkspace,
+  evalIn,
+  selectModel,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { desktop, localHost } from "@openwork/hosts";
+import { eventually, needs, test } from "@openwork/testkit";
+
+const providerId = "engine-restart-freshness-mock";
+const modelId = "engine-restart-freshness-model";
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const title = appSpecsEnabled
+  ? "multiple sessions generate fresh replies after the bundled engine restarts"
+  : "engine restart turn freshness skipped — needs: set OPENWORK_EVAL_APP_SPECS=1";
+
+interface TranscriptMessage {
+  role: string;
+  text: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function newestSessionId(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0 || !isRecord(value[0]) || typeof value[0].sessionId !== "string") {
+    throw new Error(`session.list_sessions did not return a newest session: ${JSON.stringify(value)}`);
+  }
+  return value[0].sessionId;
+}
+
+function contentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(contentText).filter(Boolean).join("\n");
+  if (!isRecord(value)) return "";
+  if (typeof value.text === "string") return value.text;
+  return contentText(value.content);
+}
+
+function requestMessages(value: unknown): TranscriptMessage[] {
+  if (!isRecord(value) || !Array.isArray(value.messages)) return [];
+  return value.messages.flatMap((message) => {
+    if (!isRecord(message) || typeof message.role !== "string") return [];
+    return [{ role: message.role, text: contentText(message.content) }];
+  });
+}
+
+function requestContains(value: unknown, text: string): boolean {
+  return requestMessages(value).some((message) => message.text.includes(text));
+}
+
+function requestSnippet(value: unknown): string {
+  return JSON.stringify(requestMessages(value).filter((message) => message.role === "user" || message.role === "assistant"));
+}
+
+function parseTranscript(value: unknown, sessionId: string): TranscriptMessage[] {
+  if (!isRecord(value) || value.sessionId !== sessionId || !Array.isArray(value.messages)) {
+    throw new Error(`Unreadable transcript for ${sessionId}: ${JSON.stringify(value)}`);
+  }
+  return value.messages.flatMap((message) => {
+    if (!isRecord(message) || typeof message.role !== "string" || typeof message.text !== "string") return [];
+    return [{ role: message.role, text: message.text }];
+  });
+}
+
+function assistantHasText(text: string): string {
+  return `(() => [...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => (message.innerText ?? "").includes(${JSON.stringify(text)})))()`;
+}
+
+function routeHasSession(sessionId: string): string {
+  return `(() => {
+    const parts = window.__openworkControl.snapshot().route.split("/");
+    const index = parts.indexOf("session");
+    return index >= 0 && decodeURIComponent(parts[index + 1] ?? "") === ${JSON.stringify(sessionId)};
+  })()`;
+}
+
+async function openSession(app: Awaited<ReturnType<typeof desktop>>, sessionId: string): Promise<void> {
+  await control(app, "session.open", { sessionId }, { timeoutMs: 30_000 });
+  await waitFor(app, routeHasSession(sessionId), {
+    timeoutMs: 60_000,
+    label: `route reached session ${sessionId}`,
+  });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) =>
+    action.id === "session.read_transcript" && !action.disabled)`, {
+    timeoutMs: 60_000,
+    label: `transcript control ready for session ${sessionId}`,
+  });
+}
+
+async function readTranscript(app: Awaited<ReturnType<typeof desktop>>, sessionId: string): Promise<TranscriptMessage[]> {
+  return parseTranscript(
+    await control(app, "session.read_transcript", { count: 30 }, { timeoutMs: 30_000 }),
+    sessionId,
+  );
+}
+
+async function sendMessage(app: Awaited<ReturnType<typeof desktop>>, text: string): Promise<void> {
+  await waitFor(app, `window.__openworkControl.listActions().some((action) =>
+    action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer text action enabled",
+  });
+  await control(app, "composer.set_text", { text }, { timeoutMs: 30_000 });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) =>
+    action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer send action enabled",
+  });
+  await control(app, "composer.send", undefined, { timeoutMs: 30_000 });
+}
+
+async function waitForCompletionCall(completionBodies: unknown[], count: number, probe: string): Promise<void> {
+  await eventually(() => completionBodies.length, {
+    within: 30_000,
+    label: `completion request ${count} for ${probe}`,
+    until: (observed) => observed >= count,
+  });
+  expect(requestContains(completionBodies[count - 1], probe), requestSnippet(completionBodies[count - 1])).toBe(true);
+}
+
+function assertTranscript(
+  messages: TranscriptMessage[],
+  firstProbe: string,
+  secondProbe: string,
+  otherFirstProbe: string,
+  otherSecondProbe: string,
+): void {
+  expect(messages.filter((message) => message.role === "user"), JSON.stringify(messages)).toHaveLength(2);
+  expect(messages.filter((message) => message.role === "assistant"), JSON.stringify(messages)).toHaveLength(2);
+  expect(messages, JSON.stringify(messages)).toHaveLength(4);
+  const text = messages.map((message) => message.text).join("\n");
+  expect(text).toContain(`fresh-reply:${firstProbe}`);
+  expect(text).toContain(`fresh-reply:${secondProbe}`);
+  expect(text).not.toContain(`fresh-reply:${otherFirstProbe}`);
+  expect(text).not.toContain(`fresh-reply:${otherSecondProbe}`);
+  const secondUserIndex = messages.findIndex((message) => message.role === "user" && message.text.includes(secondProbe));
+  const secondReplyIndex = messages.findIndex((message) => message.role === "assistant" && message.text.includes(`fresh-reply:${secondProbe}`));
+  expect(secondUserIndex, `${secondProbe} user turn missing from ${JSON.stringify(messages)}`).toBeGreaterThanOrEqual(0);
+  expect(secondReplyIndex, `${secondProbe} reply missing from ${JSON.stringify(messages)}`).toBeGreaterThan(secondUserIndex);
+}
+
+test.skipIf(!appSpecsEnabled)(title, { timeout: 600_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const runId = Date.now();
+  const p1a = `P1a-${runId}`;
+  const p1b = `P1b-${runId}`;
+  const p2a = `P2a-${runId}`;
+  const p2b = `P2b-${runId}`;
+  const probes = [p1a, p1b, p2a, p2b];
+  const completionBodies: unknown[] = [];
+
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let rawBody = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { rawBody += chunk; });
+      request.on("end", () => {
+        let body: unknown;
+        try {
+          body = JSON.parse(rawBody);
+        } catch {
+          response.writeHead(400, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: { message: "invalid JSON request body" } }));
+          return;
+        }
+        completionBodies.push(body);
+        const messages = requestMessages(body);
+        const lastUser = [...messages].reverse().find((message) => message.role === "user");
+        const probe = probes.find((candidate) => lastUser?.text.includes(candidate));
+        if (!probe) {
+          response.writeHead(400, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: { message: `last user message had no freshness probe: ${lastUser?.text ?? "missing"}` } }));
+          return;
+        }
+        const reply = `fresh-reply:${probe}`;
+        const chunks = [
+          { id: `chatcmpl-${probe}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: `chatcmpl-${probe}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: reply }, finish_reason: null }] },
+          { id: `chatcmpl-${probe}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  const profileDir = `/tmp/openwork-engine-restart-freshness-${process.pid}-${runId}`;
+  const workspacePath = `${profileDir}/continuity-workspace`;
+  onTestFinished(async () => rm(profileDir, { recursive: true, force: true }));
+  await using host = localHost();
+
+  let workspaceId = "";
+  let s1 = "";
+  let s2 = "";
+  const firstApp = await desktop({ name: "engine-restart-turn-freshness", host, profileDir });
+  try {
+    const workspace = await createAndSelectWorkspace(firstApp, { path: workspacePath });
+    workspaceId = workspace.workspaceId;
+
+    const versionRaw = await evalIn(firstApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      if (!port || !token) return "missing local server credentials";
+      const response = await fetch("http://127.0.0.1:" + port + "/status", {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (!response.ok) return "status failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      const body = await response.json();
+      return typeof body.opencodeVersion === "string" ? body.opencodeVersion : "missing opencodeVersion: " + JSON.stringify(body);
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    const engineVersion = String(versionRaw).replace(/^v/, "");
+    evidence.fact(
+      "The local OpenWork server reports the fixed bundled OpenCode engine",
+      `GET /status observed ${JSON.stringify({ opencodeVersion: versionRaw })}.`,
+      engineVersion === "1.18.18" && !engineVersion.startsWith("1.17."),
+    );
+    expect(engineVersion, `stale 1.17.x engine reported by /status: ${engineVersion}`).not.toMatch(/^1\.17\./);
+    expect(engineVersion).toBe("1.18.18");
+
+    const configured = await evalIn(firstApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      if (!port || !token) return "missing local server credentials";
+      const request = async (path, init) => {
+        const response = await fetch("http://127.0.0.1:" + port + path, {
+          ...init,
+          headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+        });
+        if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+        return "ok";
+      };
+      const workspaceId = ${JSON.stringify(workspaceId)};
+      const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+        method: "PATCH",
+        body: JSON.stringify({
+          opencode: {
+            provider: {
+              [${JSON.stringify(providerId)}]: {
+                npm: "@ai-sdk/openai-compatible",
+                name: "Engine restart freshness mock",
+                options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-engine-restart-freshness" },
+                models: { [${JSON.stringify(modelId)}]: { name: "Engine restart freshness model" } },
+              },
+            },
+          },
+        }),
+      });
+      if (patched !== "ok") return patched;
+      const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+      if (reloaded !== "ok") return reloaded;
+      const raw = localStorage.getItem("openwork.preferences");
+      let preferences = {};
+      try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+      if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+      localStorage.setItem("openwork.preferences", JSON.stringify({
+        ...preferences,
+        defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+        modelVariant: null,
+        providerStepCompleted: true,
+      }));
+      localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+      localStorage.removeItem("openwork.sessionModels." + workspaceId);
+      return "ok";
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    expect(configured).toBe("ok");
+    const selectedModel = await selectModel(firstApp, modelId);
+    expect(selectedModel.id).toBe(modelId);
+    expect(selectedModel.providerName).toContain("Engine restart freshness mock");
+
+    await control(firstApp, "session.create_task", undefined, { timeoutMs: 30_000 });
+    s1 = newestSessionId(await control(firstApp, "session.list_sessions"));
+    await control(firstApp, "session.rename", { sessionId: s1, title: `Freshness S1 ${runId}` }, { timeoutMs: 30_000 });
+    await sendMessage(firstApp, `freshness probe ${p1a}`);
+    await waitForCompletionCall(completionBodies, 1, p1a);
+    await waitFor(firstApp, assistantHasText(`fresh-reply:${p1a}`), {
+      timeoutMs: 120_000,
+      label: `pre-restart assistant reply for ${p1a}`,
+    }).catch((error: unknown) => {
+      throw new Error(`P1a did not render; completion requests=${JSON.stringify(completionBodies.map(requestSnippet))}`, { cause: error });
+    });
+
+    await control(firstApp, "session.create_task", undefined, { timeoutMs: 30_000 });
+    s2 = newestSessionId(await control(firstApp, "session.list_sessions"));
+    expect(s2).not.toBe(s1);
+    await control(firstApp, "session.rename", { sessionId: s2, title: `Freshness S2 ${runId}` }, { timeoutMs: 30_000 });
+    await sendMessage(firstApp, `freshness probe ${p2a}`);
+    await waitForCompletionCall(completionBodies, 2, p2a);
+    await waitFor(firstApp, assistantHasText(`fresh-reply:${p2a}`), {
+      timeoutMs: 120_000,
+      label: `pre-restart assistant reply for ${p2a}`,
+    });
+
+    expect(completionBodies, completionBodies.map(requestSnippet).join("\n")).toHaveLength(2);
+    expect(requestContains(completionBodies[0], p1a), requestSnippet(completionBodies[0])).toBe(true);
+    expect(requestContains(completionBodies[0], p2a), requestSnippet(completionBodies[0])).toBe(false);
+    expect(requestContains(completionBodies[1], p2a), requestSnippet(completionBodies[1])).toBe(true);
+    expect(requestContains(completionBodies[1], p1a), requestSnippet(completionBodies[1])).toBe(false);
+    evidence.fact(
+      "Before restart, two real sessions each made exactly one isolated completion call",
+      `Observed completion request messages: ${JSON.stringify(completionBodies.map(requestSnippet))}.`,
+      true,
+    );
+
+    const preRestartShot = await screenshot(firstApp);
+    const preRestartSeen = await validate(preRestartShot, [
+      `The current session shows the user probe '${p2a}' followed by assistant reply 'fresh-reply:${p2a}'`,
+      `No reply containing 'fresh-reply:${p1a}' is visible in the current session`,
+      "No error dialog or crash message is visible",
+    ]);
+    expect(preRestartSeen.ok, preRestartSeen.why).toBe(true);
+  } finally {
+    await firstApp.stop();
+  }
+
+  const restartedApp = await desktop({ name: "engine-restart-turn-freshness", host, profileDir });
+  try {
+    await waitFor(restartedApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      if (!port || !token) return false;
+      try {
+        const response = await fetch("http://127.0.0.1:" + port + "/status", {
+          headers: { Authorization: "Bearer " + token },
+        });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    })()`, {
+      awaitPromise: true,
+      timeoutMs: 120_000,
+      label: "restarted local OpenWork server ready",
+    });
+    const reopenedWorkspace = await createAndSelectWorkspace(restartedApp, { path: workspacePath });
+    expect(reopenedWorkspace.workspaceId).toBe(workspaceId);
+
+    await openSession(restartedApp, s1);
+    await waitFor(restartedApp, assistantHasText(`fresh-reply:${p1a}`), {
+      timeoutMs: 60_000,
+      label: `persisted pre-restart reply for ${p1a}`,
+    });
+    const persistedS1 = await readTranscript(restartedApp, s1);
+    expect(persistedS1.map((message) => message.text).join("\n")).toContain(p1a);
+    expect(persistedS1.map((message) => message.text).join("\n")).toContain(`fresh-reply:${p1a}`);
+    evidence.fact(
+      "Restart reused the caller-owned profile and preserved S1 history",
+      `Reopened workspace ${workspaceId}, session ${s1}; transcript=${JSON.stringify(persistedS1)}.`,
+      true,
+    );
+    const historyShot = await screenshot(restartedApp);
+    const historySeen = await validate(historyShot, [
+      `After relaunch, session S1 still shows '${p1a}' and 'fresh-reply:${p1a}'`,
+      `No reply containing 'fresh-reply:${p2a}' is visible in S1`,
+      "No error dialog or crash message is visible",
+    ]);
+    expect(historySeen.ok, historySeen.why).toBe(true);
+
+    const restartedModel = await selectModel(restartedApp, modelId);
+    expect(restartedModel.id).toBe(modelId);
+    expect(restartedModel.providerName).toContain("Engine restart freshness mock");
+    await sendMessage(restartedApp, `freshness probe ${p1b}`);
+    await waitForCompletionCall(completionBodies, 3, p1b);
+    await waitFor(restartedApp, assistantHasText(`fresh-reply:${p1b}`), {
+      timeoutMs: 120_000,
+      label: `post-restart assistant reply for ${p1b}`,
+    });
+
+    await openSession(restartedApp, s2);
+    await waitFor(restartedApp, assistantHasText(`fresh-reply:${p2a}`), {
+      timeoutMs: 60_000,
+      label: `persisted pre-restart reply for ${p2a}`,
+    });
+    await sendMessage(restartedApp, `freshness probe ${p2b}`);
+    await waitForCompletionCall(completionBodies, 4, p2b);
+    await waitFor(restartedApp, assistantHasText(`fresh-reply:${p2b}`), {
+      timeoutMs: 120_000,
+      label: `post-restart assistant reply for ${p2b}`,
+    });
+
+    expect(completionBodies, completionBodies.map(requestSnippet).join("\n")).toHaveLength(4);
+    const p1bCall = completionBodies.find((body) => requestContains(body, p1b));
+    const p2bCall = completionBodies.find((body) => requestContains(body, p2b));
+    expect(p1bCall, `No request contained ${p1b}: ${completionBodies.map(requestSnippet).join("\n")}`).toBeDefined();
+    expect(p2bCall, `No request contained ${p2b}: ${completionBodies.map(requestSnippet).join("\n")}`).toBeDefined();
+    expect(requestContains(p1bCall, p1a), requestSnippet(p1bCall)).toBe(true);
+    expect(requestContains(p1bCall, `fresh-reply:${p1a}`), requestSnippet(p1bCall)).toBe(true);
+    expect(requestContains(p1bCall, p2a), requestSnippet(p1bCall)).toBe(false);
+    expect(requestContains(p1bCall, p2b), requestSnippet(p1bCall)).toBe(false);
+    expect(requestContains(p2bCall, p2a), requestSnippet(p2bCall)).toBe(true);
+    expect(requestContains(p2bCall, `fresh-reply:${p2a}`), requestSnippet(p2bCall)).toBe(true);
+    expect(requestContains(p2bCall, p1a), requestSnippet(p2bCall)).toBe(false);
+    expect(requestContains(p2bCall, p1b), requestSnippet(p2bCall)).toBe(false);
+    evidence.fact(
+      "After restart, each fresh turn assembled only its own session history",
+      `P1b request messages=${requestSnippet(p1bCall)}; P2b request messages=${requestSnippet(p2bCall)}; total calls=${completionBodies.length}.`,
+      true,
+    );
+
+    await openSession(restartedApp, s1);
+    const finalS1 = await readTranscript(restartedApp, s1);
+    assertTranscript(finalS1, p1a, p1b, p2a, p2b);
+    await openSession(restartedApp, s2);
+    const finalS2 = await readTranscript(restartedApp, s2);
+    assertTranscript(finalS2, p2a, p2b, p1a, p1b);
+    evidence.fact(
+      "Both UI transcripts contain exactly two fresh user/assistant turns with no cross-session replies",
+      `S1 transcript=${JSON.stringify(finalS1)}; S2 transcript=${JSON.stringify(finalS2)}.`,
+      true,
+    );
+
+    const finalShot = await screenshot(restartedApp);
+    const finalSeen = await validate(finalShot, [
+      `Session S2 shows exactly two user turns and two assistant replies, including 'fresh-reply:${p2a}' and 'fresh-reply:${p2b}'`,
+      `No reply containing 'fresh-reply:${p1a}' or 'fresh-reply:${p1b}' is visible in S2`,
+      "No error dialog or crash message is visible",
+    ]);
+    expect(finalSeen.ok, finalSeen.why).toBe(true);
+  } finally {
+    await restartedApp.stop();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
       '@opencode-ai/sdk':
-        specifier: ^1.17.11
-        version: 1.17.11
+        specifier: ^1.18.15
+        version: 1.18.18
       '@openwork/install-config':
         specifier: workspace:*
         version: link:../../packages/install-config
@@ -307,8 +307,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
       '@opencode-ai/sdk':
-        specifier: ^1.17.11
-        version: 1.17.11
+        specifier: ^1.18.15
+        version: 1.18.18
       '@openwork/enterprise-mcp-client':
         specifier: workspace:*
         version: link:../../packages/enterprise-mcp-client
@@ -377,8 +377,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
       '@opencode-ai/sdk':
-        specifier: ^1.17.11
-        version: 1.17.11
+        specifier: ^1.18.15
+        version: 1.18.18
       '@openwork/enterprise-mcp-client':
         specifier: workspace:*
         version: link:../../packages/enterprise-mcp-client
@@ -2876,8 +2876,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.17.11':
-    resolution: {integrity: sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw==}
+  '@opencode-ai/sdk@1.18.18':
+    resolution: {integrity: sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==}
 
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
@@ -4846,6 +4846,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -10779,7 +10780,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.17.11':
+  '@opencode-ai/sdk@1.18.18':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary
- update the bundled OpenCode sidecar to v1.18.18, which includes the timestamp-ordered legacy session loop repair from upstream #40990
- align OpenWork SDK consumers with the compatible 1.18.x SDK and lock 1.18.18
- pin the desktop runtime contract so future release bumps retain the repaired engine

## Why
OpenCode 1.17.11 compares persisted message IDs lexicographically in the legacy loop. When an old assistant ID sorts after a newly appended user turn, the engine can return the old assistant reply and exit without producing a new reply. The upstream repair selects messages by `time.created` and verifies the assistant belongs to the latest user turn.

## Verification
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server typecheck`
- `node --test --test-name-pattern="bundled OpenCode runtime" electron/runtime.test.mjs`
- `pnpm run prepare:sidecar` (downloaded sidecar reports `1.18.18`)

## Note
The full desktop suite ran 221 passing tests and one pre-existing environment-dependent CA-chain failure (`electron/runtime-ca.test.mjs`, OpenSSL exit -3).

Closes #3798