### PR TITLE
feat(app): add copy button for text artifacts in the artifact panel

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
+import { Check, Copy, Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
@@ -95,6 +95,8 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<number | null>(null);
   const lastSyncedRef = useRef<string | null>(null);
   const failedDraftRef = useRef<string | null>(null);
   const isDirectTextEdit = isTextContent(target) && target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target);
@@ -244,6 +246,30 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     }
   };
 
+  const copyContent = async () => {
+    if (data?.kind !== "text") return;
+
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copyTimeoutRef.current = null;
+      }, 1_500);
+    } catch {
+      // ignore clipboard failures
+    }
+  };
+
+  useEffect(() => () => {
+    if (copyTimeoutRef.current !== null) {
+      window.clearTimeout(copyTimeoutRef.current);
+    }
+  }, []);
+
   const isTextEditing = data?.kind === "text" && (editing || isDirectTextEdit);
   const isDirty = data?.kind === "text" && draft !== data.data;
 
@@ -301,6 +327,18 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
                 )}
               />
               <TooltipContent>{editing ? "Stop editing" : "Edit artifact"}</TooltipContent>
+            </Tooltip>
+          ) : null}
+          {data?.kind === "text" ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={() => void copyContent()} aria-label={copied ? "Copied" : "Copy artifact"}>
+                    {copied ? <Check /> : <Copy />}
+                  </Button>
+                )}
+              />
+              <TooltipContent>{copied ? "Copied" : "Copy artifact"}</TooltipContent>
             </Tooltip>
           ) : null}
           {target.kind === "file" ? (


### PR DESCRIPTION
## What

Adds a **Copy** button to the artifact panel toolbar for text-based artifacts (`.md`, `.csv`, `.txt`, code), per #3751.

- Shown only when the loaded artifact is text (`data.kind === "text"`) — binary artifacts (images, PDFs, `.xlsx`) and served URL artifacts never show it, and the copy uses the live draft so unsaved edits are included.
- Uses `navigator.clipboard.writeText`, the same clipboard approach as the rest of the app (e.g. `mcp-auth-modal.tsx`).
- After a successful copy the icon flips to a check and the label/tooltip reads "Copied" for ~1.5s, then reverts. Clipboard failures are ignored, matching the existing pattern.

Thin renderer-only change in `artifact-panel.tsx`; no new primitives or APIs.

## Verification

- `pnpm --filter @openwork/app typecheck` — pass.
- `pnpm --filter @openwork/app test` — 785 pass / 6 fail. The same 6 tests fail identically on a clean `dev` checkout (`7b76a2b50`), so they are pre-existing and unrelated (capability inventory, message-list loading, cloud workspace overlay, provider sync, extensions sidebar).
- Live UI check against `pnpm dev:headless-web` (local server, browser UI): opened a session, had the starter model create `copy-test.md`, opened it in the artifact panel, and observed:
  - "Copy artifact" button renders in the toolbar next to Download for the markdown artifact;
  - clicking it flips the accessible name to "Copied" — this state only renders after `navigator.clipboard.writeText` resolves, so the write itself succeeded;
  - after ~1.5s it reverts to "Copy artifact";
  - for a binary `test.png` artifact the toolbar shows Download/Close only, with no Copy button.

No testkit spec was added — this is a renderer-only affordance following the existing clipboard pattern (same as #2489, which also ships no spec), and the driving specs (`evals/specs/*.slow.test.ts`) require opt-in infra. Happy to add one if maintainers want this covered by the eval lane.

Closes #3751