### PR TITLE
feat(evals): Connect MCP connector claims in the mega journey + nightly lane

### DIFF
--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -76,6 +76,20 @@ jobs:
           set -euo pipefail
           pnpm install --frozen-lockfile
 
+      # The eval harness shells out to the daytona CLI (testkit daytonaAvailable
+      # gate and @openwork/hosts exec). Track the latest release so the CLI and
+      # the Daytona API stay aligned; the CLI itself warns on version drift.
+      - name: Install Daytona CLI
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber
+          sudo install -m 0755 /tmp/daytona /usr/local/bin/daytona
+          daytona --version
+
       - name: Run mega journey
         id: mega-run
         if: steps.config.outputs.enabled == 'true'
@@ -99,6 +113,18 @@ jobs:
           OPENWORK_EVAL_MODEL="${MODEL}" OPENWORK_EVAL_VISION=defer \
           pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/org-team-lifecycle-mega.slow.test.ts \
             2>&1 | tee /tmp/mega-run.log
+
+          # Skips are never passed: a spec that self-skips (unmet needs) exits 0,
+          # which would make the nightly vacuously green. Fail loudly instead.
+          sed -E 's/\x1B\[[0-9;]*m//g' /tmp/mega-run.log > /tmp/mega-run-plain.log
+          if grep -q "\[needs:" /tmp/mega-run-plain.log; then
+            echo "::error::The mega spec skipped instead of running (unmet needs above). Skips are never passed."
+            exit 1
+          fi
+          if ! grep -Eq "Tests[[:space:]]+1 passed" /tmp/mega-run-plain.log; then
+            echo "::error::The mega spec did not report '1 passed'."
+            exit 1
+          fi
 
       - name: Judge deferred vision claims
         if: steps.config.outputs.enabled == 'true'

--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -1,0 +1,158 @@
+# Runs the mega journey nightly on Daytona and judges deferred vision claims.
+# The mega spec self-skips without its opt-in environment variables, which this
+# workflow sets explicitly.
+name: Nightly Mega Eval
+
+on:
+  schedule:
+    - cron: "47 3 * * *"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Bare OpenAI model id"
+        required: false
+        default: "gpt-4o"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: nightly-mega-eval
+  cancel-in-progress: false
+
+jobs:
+  mega:
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 100
+
+    steps:
+      - name: Check nightly mega configuration
+        id: config
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          missing=""
+          [ -z "${DAYTONA_API_KEY:-}" ] && missing="$missing DAYTONA_API_KEY"
+          [ -z "${OPENAI_API_KEY:-}" ] && missing="$missing OPENAI_API_KEY"
+          if [ -n "$missing" ]; then
+            echo "::notice::Skipping nightly mega eval; missing GitHub configuration:$missing."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.config.outputs.enabled == 'true'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Node
+        if: steps.config.outputs.enabled == 'true'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        if: steps.config.outputs.enabled == 'true'
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+
+      - name: Run mega journey
+        id: mega-run
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DISPATCH_MODEL: ${{ inputs.model }}
+          EVENT_NAME: ${{ github.event_name }}
+          NIGHTLY_MODEL: ${{ vars.OPENWORK_EVAL_NIGHTLY_MODEL }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            MODEL="${DISPATCH_MODEL:-gpt-4o}"
+          else
+            MODEL="${NIGHTLY_MODEL:-gpt-4o}"
+          fi
+
+          OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MEGA_SPEC=1 \
+          OPENWORK_EVAL_MODEL="${MODEL}" OPENWORK_EVAL_VISION=defer \
+          pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/org-team-lifecycle-mega.slow.test.ts \
+            2>&1 | tee /tmp/mega-run.log
+
+      - name: Judge deferred vision claims
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          pnpm --dir evals fraimz:judge -- --roll latest
+
+      - name: Upload nightly mega roll
+        if: always() && steps.config.outputs.enabled == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-mega-roll
+          path: evals/results/rolls/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Report nightly mega failure
+        if: failure()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          gh label create nightly-eval \
+            --color "B60205" \
+            --description "Automated nightly evaluation failures" \
+            --force
+
+          issue_number="$(gh issue list \
+            --state open \
+            --label nightly-eval \
+            --search '"Nightly mega eval failed" in:title' \
+            --json number,title \
+            --jq 'map(select(.title == "Nightly mega eval failed"))[0].number // empty')"
+
+          if [ -z "$issue_number" ]; then
+            issue_url="$(gh issue create \
+              --title "Nightly mega eval failed" \
+              --label nightly-eval \
+              --body "The nightly mega evaluation has failed. Failure details are posted as comments.")"
+            issue_number="${issue_url##*/}"
+          fi
+
+          {
+            echo "Nightly mega eval failed: $RUN_URL"
+            echo
+            echo '```text'
+            if [ -f /tmp/mega-run.log ]; then
+              tail -n 40 /tmp/mega-run.log
+            else
+              echo "Vitest log unavailable."
+            fi
+            echo '```'
+          } > /tmp/nightly-mega-failure.md
+
+          gh issue comment "$issue_number" --body-file /tmp/nightly-mega-failure.md

--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -84,11 +84,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
         run: |
           set -euo pipefail
           gh release download --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber
           sudo install -m 0755 /tmp/daytona /usr/local/bin/daytona
           daytona --version
+          # The CLI requires a stored profile; the env var alone is not enough.
+          daytona login --api-key "$DAYTONA_API_KEY"
 
       - name: Run mega journey
         id: mega-run

--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -4,6 +4,11 @@
 name: Nightly Mega Eval
 
 on:
+  # TEMP(pre-merge validation): push trigger exercises this workflow from the
+  # PR branch; GitHub only honors schedule/workflow_dispatch on the default
+  # branch. Removed before merge.
+  push:
+    branches: [feat/nightly-mega-connect-mcp]
   schedule:
     - cron: "47 3 * * *"
   workflow_dispatch:
@@ -11,7 +16,7 @@ on:
       model:
         description: "Bare OpenAI model id"
         required: false
-        default: "gpt-4o"
+        default: "gpt-5.6-luna"
         type: string
 
 permissions:
@@ -85,9 +90,9 @@ jobs:
           set -euo pipefail
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            MODEL="${DISPATCH_MODEL:-gpt-4o}"
+            MODEL="${DISPATCH_MODEL:-gpt-5.6-luna}"
           else
-            MODEL="${NIGHTLY_MODEL:-gpt-4o}"
+            MODEL="${NIGHTLY_MODEL:-gpt-5.6-luna}"
           fi
 
           OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MEGA_SPEC=1 \

--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -4,11 +4,6 @@
 name: Nightly Mega Eval
 
 on:
-  # TEMP(pre-merge validation): push trigger exercises this workflow from the
-  # PR branch; GitHub only honors schedule/workflow_dispatch on the default
-  # branch. Removed before merge.
-  push:
-    branches: [feat/nightly-mega-connect-mcp]
   schedule:
     - cron: "47 3 * * *"
   workflow_dispatch:
@@ -181,7 +176,9 @@ jobs:
             echo "Nightly mega eval failed: $RUN_URL"
             echo
             echo '```text'
-            if [ -f /tmp/mega-run.log ]; then
+            if [ -f /tmp/mega-run-plain.log ]; then
+              tail -n 40 /tmp/mega-run-plain.log
+            elif [ -f /tmp/mega-run.log ]; then
               tail -n 40 /tmp/mega-run.log
             else
               echo "Vitest log unavailable."

--- a/evals/packages/testkit/src/state.ts
+++ b/evals/packages/testkit/src/state.ts
@@ -18,6 +18,16 @@ export interface ConnectState {
   raw: unknown;
 }
 
+export interface CloudMcpHealthSummary {
+  ok: boolean;
+  phase: string | null;
+  usable: boolean | null;
+  engineStatus: string | null;
+  tools: { present: string[]; missing: string[] };
+  direct: { checked: boolean; source: string | null; present: string[]; missing: string[] };
+  raw: unknown;
+}
+
 export interface ConnectStateFile {
   status: "missing" | "available" | "invalid";
   connectEnabled: boolean | null;
@@ -29,6 +39,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function nullableString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
 function errorCode(error: unknown): string | null {
@@ -112,6 +126,76 @@ export async function readConnectState(app: Surface): Promise<ConnectState> {
       : null,
     connectEnabled: typeof value.connectEnabled === "boolean" ? value.connectEnabled : null,
     raw: value.raw,
+  };
+}
+
+export async function readCloudMcpHealth(
+  app: Surface,
+  workspaceId: string,
+  opts?: { probe?: boolean; timeoutMs?: number },
+): Promise<CloudMcpHealthSummary> {
+  const value = await evalIn(app, `(async () => {
+    // Resolve the local server the same way the app does: live runtime info
+    // from the Electron bridge first (loopback port + token are ephemeral per
+    // boot), then the web-mode localStorage overrides as a fallback.
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    if (!baseUrl || !token) {
+      return { ok: false, raw: { error: "Local server credentials are unavailable." } };
+    }
+    try {
+      const response = await fetch(
+        baseUrl + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/mcp/openwork-cloud/health" + ${JSON.stringify(opts?.probe === true ? "?probe=1" : "")},
+        { headers: { Authorization: "Bearer " + token } },
+      );
+      const text = await response.text();
+      let raw = text;
+      try { raw = text ? JSON.parse(text) : null; } catch {}
+      return { ok: response.ok, raw };
+    } catch (error) {
+      return {
+        ok: false,
+        raw: { error: error instanceof Error ? error.message : String(error) },
+      };
+    }
+  })()`, { awaitPromise: true, timeoutMs: opts?.timeoutMs ?? 15_000 });
+  const result = isRecord(value) ? value : {};
+  const raw = result.raw;
+  const health = isRecord(raw) ? raw : {};
+  const engine = isRecord(health.engine) ? health.engine : {};
+  const tools = isRecord(health.tools) ? health.tools : {};
+  const direct = isRecord(tools.direct) ? tools.direct : {};
+  return {
+    ok: result.ok === true,
+    phase: nullableString(health.phase),
+    usable: typeof health.usable === "boolean" ? health.usable : null,
+    engineStatus: nullableString(engine.status),
+    tools: {
+      present: stringArray(tools.present),
+      missing: stringArray(tools.missing),
+    },
+    direct: {
+      checked: direct.checked === true,
+      source: nullableString(direct.source),
+      present: stringArray(direct.present),
+      missing: stringArray(direct.missing),
+    },
+    raw,
   };
 }
 

--- a/evals/specs/org-team-lifecycle-mega.slow.test.ts
+++ b/evals/specs/org-team-lifecycle-mega.slow.test.ts
@@ -26,6 +26,7 @@ import {
   inviteMember,
   mcpMock,
   needs,
+  readCloudMcpHealth,
   server,
   test,
   unmetNeeds,
@@ -38,6 +39,7 @@ import type { NeedsSpec } from "@openwork/testkit";
  * shares that skill through a person-scoped marketplace, and proves from a
  * sequential teammate desktop that the real model runs and the shared skill
  * uses the organization connector.
+ * It also claims each desktop's openwork-cloud MCP health and direct tool probe.
  *
  * Step-0 research (2026-08-09): the preferred path exists today. The signed-in
  * app reconciler requires an active org, mints a fresh token, and repairs the
@@ -455,6 +457,48 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
       true,
     );
 
+    // This doubles as a fail-fast gate: a broken connector fails here in seconds with a named phase instead of surfacing as the 420s authoring timeout downstream.
+    const adminCloudMcp = await eventually(
+      () => readCloudMcpHealth(appAdmin, appAdmin.workspaceId, { probe: true }),
+      {
+        within: 180_000,
+        intervalMs: 5_000,
+        label: "admin openwork-cloud MCP ready",
+        until: (h) => h.ok && h.phase === "ready" && h.direct.checked && h.direct.missing.length === 0,
+      },
+    );
+    expect(adminCloudMcp.phase).toBe("ready");
+    expect(adminCloudMcp.usable).toBe(true);
+    expect(adminCloudMcp.engineStatus).toBe("connected");
+    expect(adminCloudMcp.direct.source).toBe("mcp_tools_list");
+    expect(adminCloudMcp.direct.present).toEqual(expect.arrayContaining(["search_capabilities", "execute_capability"]));
+    expect(adminCloudMcp.direct.missing).toEqual([]);
+    expect(adminCloudMcp.tools.missing).toEqual([]);
+    expect(adminCloudMcp.direct.present).not.toContain("mock_echo");
+    expect(adminCloudMcp.tools.present).not.toContain("mock_echo");
+    const adminCloudMcpReady = adminCloudMcp.ok
+      && adminCloudMcp.phase === "ready"
+      && adminCloudMcp.usable === true
+      && adminCloudMcp.engineStatus === "connected"
+      && adminCloudMcp.direct.checked
+      && adminCloudMcp.direct.source === "mcp_tools_list"
+      && adminCloudMcp.direct.present.includes("search_capabilities")
+      && adminCloudMcp.direct.present.includes("execute_capability")
+      && adminCloudMcp.direct.missing.length === 0
+      && adminCloudMcp.tools.missing.length === 0;
+    evidence.fact(
+      "The admin desktop's OpenWork Connect MCP connector is registered and live-probed ready",
+      `Health phase=${adminCloudMcp.phase}, engine=${adminCloudMcp.engineStatus}, probed tools=${JSON.stringify(adminCloudMcp.direct.present)}.`,
+      adminCloudMcpReady,
+    );
+    const adminGatewaySurfaceOnly = !adminCloudMcp.direct.present.includes("mock_echo")
+      && !adminCloudMcp.tools.present.includes("mock_echo");
+    evidence.fact(
+      "The Connect tool list is exactly the gateway surface",
+      `mock_echo is absent from direct tools ${JSON.stringify(adminCloudMcp.direct.present)} and registered tools ${JSON.stringify(adminCloudMcp.tools.present)}.`,
+      adminGatewaySurfaceOnly,
+    );
+
     await sendComposerMessage(appAdmin, [
       "Create exactly one OpenWork Cloud skill, not a local skill.",
       "Load and follow the remote create-skill capability `skill:create-skill`, then verify the created plugin.",
@@ -642,6 +686,48 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
       "The teammate's real OpenAI model is selectable through workspace config",
       `Workspace ${appMate.workspaceId} selected ${teammateModelId} after the config patch and engine reload.`,
       true,
+    );
+
+    // This turns the later mock_echo connector witness into a checked-precondition round-trip rather than an inference.
+    const teammateCloudMcp = await eventually(
+      () => readCloudMcpHealth(appMate, appMate.workspaceId, { probe: true }),
+      {
+        within: 180_000,
+        intervalMs: 5_000,
+        label: "teammate openwork-cloud MCP ready",
+        until: (h) => h.ok && h.phase === "ready" && h.direct.checked && h.direct.missing.length === 0,
+      },
+    );
+    expect(teammateCloudMcp.phase).toBe("ready");
+    expect(teammateCloudMcp.usable).toBe(true);
+    expect(teammateCloudMcp.engineStatus).toBe("connected");
+    expect(teammateCloudMcp.direct.source).toBe("mcp_tools_list");
+    expect(teammateCloudMcp.direct.present).toEqual(expect.arrayContaining(["search_capabilities", "execute_capability"]));
+    expect(teammateCloudMcp.direct.missing).toEqual([]);
+    expect(teammateCloudMcp.tools.missing).toEqual([]);
+    expect(teammateCloudMcp.direct.present).not.toContain("mock_echo");
+    expect(teammateCloudMcp.tools.present).not.toContain("mock_echo");
+    const teammateCloudMcpReady = teammateCloudMcp.ok
+      && teammateCloudMcp.phase === "ready"
+      && teammateCloudMcp.usable === true
+      && teammateCloudMcp.engineStatus === "connected"
+      && teammateCloudMcp.direct.checked
+      && teammateCloudMcp.direct.source === "mcp_tools_list"
+      && teammateCloudMcp.direct.present.includes("search_capabilities")
+      && teammateCloudMcp.direct.present.includes("execute_capability")
+      && teammateCloudMcp.direct.missing.length === 0
+      && teammateCloudMcp.tools.missing.length === 0;
+    evidence.fact(
+      "The plain-member desktop's OpenWork Connect MCP connector is registered and live-probed ready",
+      `Health phase=${teammateCloudMcp.phase}, engine=${teammateCloudMcp.engineStatus}, probed tools=${JSON.stringify(teammateCloudMcp.direct.present)}.`,
+      teammateCloudMcpReady,
+    );
+    const teammateGatewaySurfaceOnly = !teammateCloudMcp.direct.present.includes("mock_echo")
+      && !teammateCloudMcp.tools.present.includes("mock_echo");
+    evidence.fact(
+      "The plain member's Connect tool list is exactly the gateway surface",
+      `mock_echo is absent from direct tools ${JSON.stringify(teammateCloudMcp.direct.present)} and registered tools ${JSON.stringify(teammateCloudMcp.tools.present)}.`,
+      teammateGatewaySurfaceOnly,
     );
 
     // Small models drop digits from long decimal runs when echoing verbatim


### PR DESCRIPTION
Prepares the mega journey for nightly operation and adds direct OpenWork Connect MCP connector coverage, per the approved spec plan.

## What's in here

**1. Connector claims inside `org-team-lifecycle-mega.slow.test.ts`** (new capability: `readCloudMcpHealth` in `@openwork/testkit`)
- On the **admin** and the **plain-member** desktop, the spec now requires `GET /workspace/:id/mcp/openwork-cloud/health?probe=1` to report `phase=ready`, `usable=true`, `engine.status=connected`, and a live `mcp_tools_list` probe serving `search_capabilities` + `execute_capability` with nothing missing.
- **Negative half:** the Connect tool list must be *exactly* the gateway surface — the org connector's downstream `mock_echo` must never appear in the desktop's MCP tool list (it is reachable only through `execute_capability`). This upgrades the existing `mock_echo` witness from an inference to a checked-precondition round-trip.
- The admin gate runs *before* the 420s authoring phase → a broken connector now fails in seconds with a named phase (`engine_needs_auth`, `cloud_tools_missing`, …) instead of an opaque authoring timeout. This already paid off during verification (below).

**2. `nightly-mega-eval.yml`** — cron `47 3 * * *` + `workflow_dispatch` (model input, default `gpt-4o`); Daytona lane; `OPENWORK_EVAL_VISION=defer` + `fraimz:judge` as second gate; roll artifact upload (14d); soft-skip with `::notice` when `DAYTONA_API_KEY`/`OPENAI_API_KEY` secrets are absent; failure auto-creates/comments the `nightly-eval` triage issue with the log tail. Note: GitHub only fires `schedule`/`workflow_dispatch` for workflows on the default branch — first live dispatch happens after merge.

## Verification — verdict: **Incomplete** (pre-existing red on clean dev; see control)

Static (all green on the PR head):
- `pnpm evals:typecheck` — identical error set with and without this diff (pre-existing errors in 3 unrelated specs; diff adds zero)
- `pnpm evals:test` — 168 pass / 0 fail
- spec collection: `vitest run --project stack specs/org-team-lifecycle-mega.slow.test.ts --testNamePattern __none__` — collects clean
- workflow YAML parses; actionlint's only complaint is the known Blacksmith runner-label false positive (same label as `daytona-snapshot-drift.yml`)

Runtime (Daytona lane, `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MEGA_SPEC=1 OPENWORK_EVAL_MODEL=gpt-4o OPENWORK_EVAL_VISION=defer`):

| Run | Tree | Result |
|---|---|---|
| 1 | branch @ 368aa23c2 | Daytona renderer wedge at composer (infra flake) |
| control | **clean origin/dev @ 368aa23c2, unmodified spec** | **timeout: "Cloud skill authored after one follow-up nudge" (420s)** — exit 1 |
| 2 | branch @ 368aa23c2 | Daytona proxy TLS handshake timeout at provisioning (infra flake) |
| 3 | branch @ 73ebae7da (rebase base) | **identical authoring timeout as control** — exit 1 |

Classification per diagnose-a-red-run: **the chat-authored Cloud skill phase is red on clean origin/dev** — the admin agent's `skill:create-skill` → `postPlugins` journey never materializes the plugin in Den within 420s. Reproduced with the *unmodified* spec at the merge base and with this branch at the rebase base. Last known green: 2026-08-11 (#3668 tapes). In runs that reached it, the **new connector health gate passed live** (phase=ready, both gateway tools probed present), pinning the failure to agent task completion — not connector transport. That is precisely the diagnostic this PR adds.

Repro: the runtime command above against current dev. Follow-up regression issue is linked below; the first nightly runs will keep the triage issue updated until it is fixed.


---

## Update: model + pre-merge GHA validation (2026-08-15)

- Nightly model default is now **`gpt-5.6-luna`** (exact OpenAI catalog id; `tool_call` + `reasoning`), replacing `gpt-4o` in the dispatch input and both fallbacks.
- The workflow was **executed for real from this branch** via a temporary push trigger (removed in the final commit), three runs:
  1. Run 31903542009 — exposed a **vacuous green**: no `daytona` CLI on the runner → spec self-skipped → exit 0. Fixed with a CLI install step (latest `daytona/clients` release) **and a skip guard: a skipped spec now fails the job** (skips are never passed).
  2. Run 31904138823 — exposed CLI profile auth (`no profiles found`); fixed with `daytona login --api-key`.
  3. Run 31904388637 — **full validation**: config gate ✅, install ✅, Daytona CLI ✅, real 11-min Daytona journey ✅ (Den sandbox + desktops provisioned from CI), failed only at the known #3813 authoring regression; failure path executed: roll artifact uploaded ✅, triage issue #3815 auto-created with run URL + log tail ✅. Judge step remains untested pending a green journey (blocked by #3813).
- Bonus signal for #3813: the authoring timeout reproduces with `gpt-5.6-luna` too — not a gpt-4o-specific behavior.

`OPENAI_API_KEY` repo secret was added (from the team vault) alongside the existing `DAYTONA_API_KEY`.
