### PR TITLE
fix(server): self-heal a dead managed engine and prevent dispose orphans

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -11,8 +11,10 @@ import {
   reapOrphanEngineInstances,
 } from "./engine-registry.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
+import { clearEnginePoolForConfig, computeEngineConfigFingerprint, type EnginePool, type EngineSpawnTemplate } from "./engine-pool.js";
 import {
   clearTrustedOpencodeProcess,
+  createEnginePoolForConfig,
   createServerLogger,
   registerTrustedOpencodeProcess,
   startServer,
@@ -43,6 +45,7 @@ const logger = createServerLogger(config);
 let managedOpencode: ManagedOpencodeServer | null = null;
 let managedOpencodeIdentity: string | null = null;
 let managedEngineRecordId: string | null = null;
+let enginePool: EnginePool | null = null;
 
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
@@ -72,18 +75,29 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
     await mkdir(managedOpencodeCwd, { recursive: true });
     await sweepLegacyOpenCodeConfig(config).catch(() => undefined);
     const opencodeModelsUrl = await resolveOpencodeModelsUrl();
+    const engineEnv: Record<string, string | undefined> = {
+      ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+      ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
+      OPENWORK_SERVER_URL: serverUrl,
+      OPENWORK_SERVER_TOKEN: config.token,
+      OPENCODE_CONFIG: runtimeConfigPath,
+      OPENCODE_MODELS_URL: opencodeModelsUrl,
+    };
+    const engineSpawnTemplate: EngineSpawnTemplate = {
+      bin: process.env.OPENWORK_OPENCODE_BIN,
+      cwd: managedOpencodeCwd,
+      runtimeConfigPath,
+      env: engineEnv,
+      reservedPorts: () => {
+        const poolPorts = enginePool?.connections().map((connection) => Number(new URL(connection.baseUrl).port) || 0) ?? [];
+        return [...new Set([config.port, ...poolPorts].filter((port) => port > 0))];
+      },
+    };
     managedOpencode = await createManagedOpencodeServer({
       bin: process.env.OPENWORK_OPENCODE_BIN,
       cwd: managedOpencodeCwd,
       excludedPorts: [config.port],
-      env: {
-        ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
-        ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
-        OPENWORK_SERVER_URL: serverUrl,
-        OPENWORK_SERVER_TOKEN: config.token,
-        OPENCODE_CONFIG: runtimeConfigPath,
-        OPENCODE_MODELS_URL: opencodeModelsUrl,
-      },
+      env: engineEnv,
     });
     config.opencodeBaseUrl = managedOpencode.url;
     config.opencodeUsername = managedOpencode.username;
@@ -121,6 +135,14 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
         bin: process.env.OPENWORK_OPENCODE_BIN?.trim() || "opencode",
       }).catch(() => undefined);
     }
+    enginePool = createEnginePoolForConfig({
+      config,
+      template: engineSpawnTemplate,
+      handle: managedOpencode,
+      fingerprint: await computeEngineConfigFingerprint(engineSpawnTemplate),
+      registryId: managedEngineRecordId,
+      trustedIdentity: managedOpencodeIdentity,
+    });
     logger.log("info", `Managed OpenCode listening on ${managedOpencode.url}`);
   }
 }
@@ -161,18 +183,23 @@ if (args.verbose) {
 
 const shutdown = async () => {
   workerActivityHeartbeat?.stop();
-  if (managedOpencodeIdentity) {
+  if (managedOpencodeIdentity && !enginePool) {
     clearTrustedOpencodeProcess(config, managedOpencodeIdentity);
   }
   // Await the engine teardown (SIGTERM → 1s → SIGKILL, bounded ~1.5s): a
   // synchronous process.exit here used to skip the escalation entirely and
   // orphan the OpenCode child to init.
   try {
-    await managedOpencode?.close();
+    if (enginePool) {
+      clearEnginePoolForConfig(config);
+      await enginePool.disposeAll();
+    } else {
+      await managedOpencode?.close();
+    }
   } catch {
     // Engine already exited.
   }
-  if (managedEngineRecordId) {
+  if (managedEngineRecordId && !enginePool) {
     await removeEngineInstance(config, managedEngineRecordId).catch(() => undefined);
   }
   (server as { stop?: (closeActiveConnections?: boolean) => void }).stop?.(true);

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -84,7 +84,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
     const identity = managedOpencodeIdentity;
     managedOpencodeIdentity = null;
-    if (identity) {
+    if (identity && !enginePool) {
       try {
         clearTrustedOpencodeProcess(config, identity);
       } catch (error) {
@@ -284,7 +284,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     void syncAllWorkspacesRuntimeMcpToEngine(config);
   }
 
-  if (managedOpencode && engineSpawnTemplate && config.engineRollover) {
+  if (managedOpencode && engineSpawnTemplate) {
     enginePool = createEnginePoolForConfig({
       config,
       template: engineSpawnTemplate,

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -58,6 +58,10 @@ export type EnginePoolHooks = {
   writeRuntimeConfigFile: (config: ServerConfig, workspaceId: string) => Promise<{ path: string }>;
   registerTrusted: (config: ServerConfig, generation: { baseUrl: string; identity: string; isAlive: () => boolean }) => void;
   clearTrusted: (config: ServerConfig, identity: string) => void;
+  spawn?: (template: EngineSpawnTemplate) => Promise<ManagedOpencodeServer>;
+  now?: () => number;
+  schedule?: (operation: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  waitForHealthy?: (handle: ManagedOpencodeServer) => Promise<void>;
   logger?: EnginePoolLogger;
 };
 
@@ -158,6 +162,24 @@ function portOf(url: string): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isConnectionRefusedClassError(error: unknown): boolean {
+  const visited = new Set<object>();
+  let current: unknown = error;
+  for (let depth = 0; depth < 6 && current !== null && current !== undefined; depth += 1) {
+    if (typeof current === "string") {
+      return /ECONNREFUSED|ECONNRESET|socket hang up/i.test(current);
+    }
+    if (!isRecord(current) || visited.has(current)) return false;
+    visited.add(current);
+    const code = current.code;
+    if (code === "ECONNREFUSED" || code === "ECONNRESET") return true;
+    const message = current.message;
+    if (typeof message === "string" && /ECONNREFUSED|ECONNRESET|socket hang up/i.test(message)) return true;
+    current = current.cause;
+  }
+  return false;
 }
 
 function isRoutableGeneration(
@@ -269,6 +291,12 @@ export class EnginePool {
   private inFlight: Promise<RolloverOutcome> | null = null;
   private pendingRollover: { reason: RolloverReason; workspace: WorkspaceInfo; manual: boolean } | null = null;
   private lastSpawnAt = 0;
+  private consecutiveConnectionFailures = 0;
+  private lastRecoveryAt = Number.NEGATIVE_INFINITY;
+  private recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  private recoveryWorkspace: WorkspaceInfo | null = null;
+  private recoveryInFlight: Promise<void> | null = null;
+  private recoveryOrphan: ManagedOpencodeServer | null = null;
   private disposed = false;
   private readonly sessionOwnership = new Map<string, string>();
   private readonly pinnedRequests = new Map<string, string>();
@@ -312,6 +340,22 @@ export class EnginePool {
   primaryProcess(): EnginePoolProcess | null {
     const primary = this.generations.find((entry) => entry.status === "primary") ?? null;
     return primary ? { pid: primary.handle.pid ?? null, isAlive: primary.handle.isAlive } : null;
+  }
+
+  reportRequestSuccess(baseUrl: string): void {
+    if (this.isPrimaryEndpoint(baseUrl)) this.consecutiveConnectionFailures = 0;
+  }
+
+  reportRequestFailure(baseUrl: string, error: unknown, workspace: WorkspaceInfo): void {
+    if (!this.isPrimaryEndpoint(baseUrl) || !isConnectionRefusedClassError(error)) return;
+    this.consecutiveConnectionFailures += 1;
+    if (this.consecutiveConnectionFailures < 3) return;
+    const now = this.now();
+    if (now - this.lastRecoveryAt < minSpawnIntervalMs()) return;
+    this.consecutiveConnectionFailures = 0;
+    this.lastRecoveryAt = now;
+    this.recoveryWorkspace = workspace;
+    void this.recoverDeadPrimary(workspace).catch(() => undefined);
   }
 
   connections(): EnginePoolConnection[] {
@@ -507,16 +551,7 @@ export class EnginePool {
     let handle: ManagedOpencodeServer;
     this.lastSpawnAt = Date.now();
     try {
-      handle = await createManagedOpencodeServer({
-        bin: this.template.bin,
-        cwd: this.template.cwd,
-        excludedPorts: this.template.reservedPorts(),
-        ...(this.template.spawnTimeoutMs ? { timeoutMs: this.template.spawnTimeoutMs } : {}),
-        env: {
-          ...this.template.env,
-          OPENCODE_CONFIG: this.template.runtimeConfigPath,
-        },
-      });
+      handle = await this.spawn();
     } catch (error) {
       this.hooks.logger?.log("error", "Engine rollover standby failed to start; the live engine is untouched.", {
         "engine.rollover.reason": reason,
@@ -700,7 +735,12 @@ export class EnginePool {
       }
       generation.trustedIdentity = null;
     }
-    await generation.handle.close().catch(() => undefined);
+    let closeError: unknown;
+    try {
+      await generation.handle.close();
+    } catch (error) {
+      closeError = error;
+    }
     if (generation.registryId) {
       await removeEngineInstance(this.config, generation.registryId).catch(() => undefined);
       generation.registryId = null;
@@ -713,28 +753,180 @@ export class EnginePool {
       this.pendingRollover = null;
       void this.requestRollover(next).catch(() => undefined);
     }
+    if (closeError !== undefined && cause === "shutdown") throw closeError;
   }
 
   /** Close every engine this pool owns. Draining generations go first. */
   async disposeAll(): Promise<void> {
     this.disposed = true;
     this.pendingRollover = null;
+    if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
+    this.recoveryTimer = null;
     this.abortEventProxies();
+    const errors: unknown[] = [];
+    const recoveryOrphan = this.recoveryOrphan;
+    this.recoveryOrphan = null;
+    if (recoveryOrphan) {
+      try {
+        await recoveryOrphan.close();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
     const ordered = [...this.generations].sort((left, right) => {
       if (left.status === right.status) return 0;
       return left.status === "draining" ? -1 : 1;
     });
     for (const generation of ordered) {
-      await this.retire(generation, "shutdown");
+      try {
+        await this.retire(generation, "shutdown");
+      } catch (error) {
+        errors.push(error);
+      }
     }
     this.generations = [];
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, "Failed to close managed engines");
   }
 
   private async currentFingerprint(): Promise<string> {
     return computeEngineConfigFingerprint(this.template);
   }
 
+  private async recoverDeadPrimary(workspace: WorkspaceInfo): Promise<void> {
+    if (this.disposed) return;
+    if (this.recoveryInFlight) return this.recoveryInFlight;
+    const recovery = this.runDeadPrimaryRecovery(workspace);
+    this.recoveryInFlight = recovery;
+    try {
+      await recovery;
+    } finally {
+      this.recoveryInFlight = null;
+    }
+  }
+
+  private async runDeadPrimaryRecovery(workspace: WorkspaceInfo): Promise<void> {
+    const previous = this.generations.find((entry) => entry.status === "primary") ?? null;
+    let replacement: ManagedOpencodeServer | null = null;
+    try {
+      if (this.recoveryOrphan) {
+        await this.recoveryOrphan.close();
+        if (this.recoveryOrphan.isAlive()) throw new Error("Failed replacement remained alive after close");
+        this.recoveryOrphan = null;
+      }
+      if (previous) {
+        if (previous.trustedIdentity) {
+          try {
+            this.hooks.clearTrusted(this.config, previous.trustedIdentity);
+          } catch {
+            // Advisory only; process teardown must still happen.
+          }
+        }
+        await previous.handle.close();
+        if (previous.handle.isAlive()) throw new Error("Managed OpenCode process remained alive after close");
+        previous.status = "dead";
+        if (previous.registryId) await removeEngineInstance(this.config, previous.registryId).catch(() => undefined);
+        this.generations = this.generations.filter((entry) => entry.id !== previous.id);
+      }
+
+      const handle = await this.spawn();
+      replacement = handle;
+      await this.waitForHealthy(handle);
+      const generation: Generation = {
+        id: randomUUID(),
+        handle,
+        status: "starting",
+        spawnedAt: this.now(),
+        fingerprint: await this.currentFingerprint(),
+        registryId: null,
+        trustedIdentity: null,
+        drainTimer: null,
+        drainDeadline: null,
+      };
+      this.generations.push(generation);
+      if (handle.pid) {
+        generation.registryId = randomUUID();
+        await registerEngineInstance(this.config, {
+          id: generation.registryId,
+          pid: handle.pid,
+          port: portOf(handle.url),
+          url: handle.url,
+          startedAt: generation.spawnedAt,
+          role: "starting",
+          serverRunId: generation.id,
+          ownerPid: process.pid,
+          authProbe: buildEngineAuthProbeHeader(handle.username, handle.password),
+          bin: this.template.bin?.trim() || "opencode",
+        }).catch(() => undefined);
+      }
+      this.flip(generation, null, [], []);
+      replacement = null;
+      this.consecutiveConnectionFailures = 0;
+      this.recoveryWorkspace = null;
+      if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = null;
+      void this.hooks.postRefreshSync(this.config, workspace).catch(() => undefined);
+    } catch (error) {
+      if (replacement) {
+        try {
+          await replacement.close();
+          if (replacement.isAlive()) this.recoveryOrphan = replacement;
+        } catch {
+          this.recoveryOrphan = replacement;
+        }
+      }
+      this.hooks.logger?.log("error", "Managed engine recovery failed; retry scheduled.", {
+        "engine.recovery.failure": error instanceof Error ? error.message : String(error),
+      });
+      this.scheduleRecovery(workspace);
+      throw error;
+    }
+  }
+
+  private scheduleRecovery(workspace: WorkspaceInfo): void {
+    if (this.disposed || this.recoveryTimer) return;
+    this.recoveryWorkspace = workspace;
+    const delayMs = Math.max(1, minSpawnIntervalMs() - (this.now() - this.lastRecoveryAt));
+    const schedule = this.hooks.schedule ?? ((operation: () => void, delay: number) => setTimeout(operation, delay));
+    this.recoveryTimer = schedule(() => {
+      this.recoveryTimer = null;
+      const pendingWorkspace = this.recoveryWorkspace;
+      if (!pendingWorkspace || this.disposed) return;
+      this.lastRecoveryAt = this.now();
+      void this.recoverDeadPrimary(pendingWorkspace).catch(() => undefined);
+    }, delayMs);
+    this.recoveryTimer.unref?.();
+  }
+
+  private spawn(): Promise<ManagedOpencodeServer> {
+    if (this.hooks.spawn) return this.hooks.spawn(this.template);
+    return createManagedOpencodeServer({
+      bin: this.template.bin,
+      cwd: this.template.cwd,
+      excludedPorts: this.template.reservedPorts(),
+      ...(this.template.spawnTimeoutMs ? { timeoutMs: this.template.spawnTimeoutMs } : {}),
+      env: {
+        ...this.template.env,
+        OPENCODE_CONFIG: this.template.runtimeConfigPath,
+      },
+    });
+  }
+
+  private now(): number {
+    return this.hooks.now?.() ?? Date.now();
+  }
+
+  private isPrimaryEndpoint(baseUrl: string): boolean {
+    try {
+      const primary = this.primaryUrl();
+      return primary !== null && new URL(primary).origin === new URL(baseUrl).origin;
+    } catch {
+      return false;
+    }
+  }
+
   private async waitForHealthy(handle: ManagedOpencodeServer, attempts = 10): Promise<void> {
+    if (this.hooks.waitForHealthy) return this.hooks.waitForHealthy(handle);
     const authorization = buildEngineAuthProbeHeader(handle.username, handle.password);
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       try {
@@ -844,6 +1036,10 @@ export function setEnginePoolForConfig(config: ServerConfig, pool: EnginePool): 
 
 export function enginePoolForConfig(config: ServerConfig): EnginePool | null {
   if (!config.engineRollover) return null;
+  return poolByConfig.get(config) ?? null;
+}
+
+export function managedEnginePoolForConfig(config: ServerConfig): EnginePool | null {
   return poolByConfig.get(config) ?? null;
 }
 

--- a/apps/server/src/engine-self-heal.test.ts
+++ b/apps/server/src/engine-self-heal.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { EnginePool, type EnginePoolHooks, type EngineSpawnTemplate } from "./engine-pool.js";
+import { createManagedProcessClose, type ManagedChildProcess, type ManagedOpencodeServer } from "./managed-opencode.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+const previousSpawnInterval = process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS;
+
+afterEach(() => {
+  if (previousSpawnInterval === undefined) delete process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS;
+  else process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS = previousSpawnInterval;
+});
+
+function managedHandle(port: number) {
+  let alive = true;
+  let closeCalls = 0;
+  const handle: ManagedOpencodeServer = {
+    url: `http://127.0.0.1:${port}`,
+    username: "user",
+    password: "password",
+    pid: null,
+    execution: { command: "opencode", args: [], cwd: "/tmp", env: [] },
+    isAlive: () => alive,
+    close: async () => {
+      closeCalls += 1;
+      alive = false;
+    },
+  };
+  return { handle, closeCalls: () => closeCalls };
+}
+
+function fixture(spawn: EnginePoolHooks["spawn"]) {
+  let now = 0;
+  const scheduled: Array<() => void> = [];
+  const workspace: WorkspaceInfo = {
+    id: "ws_self_heal",
+    name: "Self heal",
+    path: "/tmp/self-heal",
+    preset: "starter",
+    workspaceType: "local",
+  };
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 8787,
+    token: "token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [workspace],
+    authorizedRoots: [workspace.path],
+    readOnly: false,
+    startedAt: 0,
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const template: EngineSpawnTemplate = {
+    cwd: workspace.path,
+    runtimeConfigPath: "/tmp/runtime-opencode-config.json",
+    env: {},
+    reservedPorts: () => [],
+  };
+  const hooks: EnginePoolHooks = {
+    reloadInPlace: async () => undefined,
+    engineBusy: async () => false,
+    postRefreshSync: async () => undefined,
+    writeRuntimeConfigFile: async () => ({ path: template.runtimeConfigPath }),
+    registerTrusted: () => undefined,
+    clearTrusted: () => undefined,
+    spawn,
+    now: () => now,
+    schedule: (operation) => {
+      scheduled.push(operation);
+      return setTimeout(() => undefined, 60_000);
+    },
+    waitForHealthy: async () => undefined,
+  };
+  const pool = new EnginePool({ config, template, hooks });
+  return { pool, config, workspace, scheduled, setNow: (value: number) => { now = value; } };
+}
+
+async function settle(): Promise<void> {
+  await Bun.sleep(10);
+}
+
+function refused(): Error {
+  return Object.assign(new Error("connect ECONNREFUSED 127.0.0.1"), { code: "ECONNREFUSED" });
+}
+
+describe("managed engine self-heal", () => {
+  test("requires three consecutive connection failures and throttles later bursts", async () => {
+    process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS = "30000";
+    const old = managedHandle(41001);
+    const replacements = [managedHandle(41002), managedHandle(41003)];
+    let spawnCalls = 0;
+    const testFixture = fixture(async () => replacements[spawnCalls++]!.handle);
+    testFixture.pool.adoptPrimary({ handle: old.handle, fingerprint: "one", registryId: null, trustedIdentity: null });
+
+    testFixture.pool.reportRequestFailure(old.handle.url, refused(), testFixture.workspace);
+    testFixture.pool.reportRequestSuccess(old.handle.url);
+    testFixture.pool.reportRequestFailure(old.handle.url, refused(), testFixture.workspace);
+    testFixture.pool.reportRequestFailure(old.handle.url, refused(), testFixture.workspace);
+    await settle();
+    expect(spawnCalls).toBe(0);
+
+    testFixture.pool.reportRequestFailure(old.handle.url, refused(), testFixture.workspace);
+    await settle();
+    expect(spawnCalls).toBe(1);
+    expect(old.closeCalls()).toBe(1);
+
+    const firstReplacementUrl = testFixture.pool.primaryUrl();
+    if (!firstReplacementUrl) throw new Error("Expected replacement engine");
+    for (let failure = 0; failure < 3; failure += 1) {
+      testFixture.pool.reportRequestFailure(firstReplacementUrl, refused(), testFixture.workspace);
+    }
+    await settle();
+    expect(spawnCalls).toBe(1);
+
+    testFixture.setNow(30_001);
+    testFixture.pool.reportRequestFailure(firstReplacementUrl, refused(), testFixture.workspace);
+    await settle();
+    expect(spawnCalls).toBe(2);
+    await testFixture.pool.disposeAll();
+  });
+
+  test("kills the old generation before spawn and schedules retry when replacement fails", async () => {
+    process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS = "30000";
+    const old = managedHandle(42001);
+    let oldAliveAtSpawn = true;
+    const testFixture = fixture(async () => {
+      oldAliveAtSpawn = old.handle.isAlive();
+      throw new Error("replacement failed");
+    });
+    testFixture.pool.adoptPrimary({ handle: old.handle, fingerprint: "one", registryId: null, trustedIdentity: null });
+
+    for (let failure = 0; failure < 3; failure += 1) {
+      testFixture.pool.reportRequestFailure(old.handle.url, refused(), testFixture.workspace);
+    }
+    await settle();
+
+    expect(oldAliveAtSpawn).toBe(false);
+    expect(old.handle.isAlive()).toBe(false);
+    expect(testFixture.pool.primaryUrl()).toBeNull();
+    expect(testFixture.scheduled).toHaveLength(1);
+    await testFixture.pool.disposeAll();
+  });
+
+  test("dispose escalates an ignored SIGTERM and waits for the child exit", async () => {
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    const exitListeners: Array<() => void> = [];
+    const child: ManagedChildProcess = {
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      kill(signal) {
+        signals.push(signal);
+        if (signal === "SIGKILL") queueMicrotask(() => exitListeners.forEach((listener) => listener()));
+        return true;
+      },
+      once(event, listener) {
+        if (event === "exit") exitListeners.push(() => listener(0, "SIGKILL"));
+      },
+    };
+    const lifecycle = createManagedProcessClose(child, { termTimeoutMs: 1, killTimeoutMs: 50 });
+
+    await lifecycle.close();
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(lifecycle.isAlive()).toBe(false);
+  });
+});

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -2,6 +2,19 @@ import { spawn, type ChildProcess } from "node:child_process";
 import net from "node:net";
 import { randomUUID } from "node:crypto";
 
+export type ManagedChildProcess = {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  killed: boolean;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+  once: (event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) => unknown;
+};
+
+export type ManagedProcessCloseOptions = {
+  termTimeoutMs?: number;
+  killTimeoutMs?: number;
+};
+
 export type ManagedOpencodeServer = {
   url: string;
   username: string;
@@ -24,6 +37,56 @@ export type OpencodeExecutionSnapshot = {
   cwd: string;
   env: OpencodeExecutionEnvEntry[];
 };
+
+export function createManagedProcessClose(
+  child: ManagedChildProcess,
+  options: ManagedProcessCloseOptions = {},
+): { isAlive: () => boolean; close: () => Promise<void> } {
+  let closePromise: Promise<void> | null = null;
+  let exited = child.exitCode !== null || child.signalCode !== null;
+  const exitedPromise = new Promise<void>((resolve) => {
+    if (exited) {
+      resolve();
+      return;
+    }
+    child.once("exit", () => {
+      exited = true;
+      resolve();
+    });
+  });
+  const waitForExit = async (timeoutMs: number): Promise<boolean> => {
+    if (exited) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    });
+    const didExit = await Promise.race([exitedPromise.then(() => true), timedOut]);
+    if (timer !== undefined) clearTimeout(timer);
+    return didExit;
+  };
+  const isAlive = () => !exited && child.exitCode === null && child.signalCode === null;
+  const close = (): Promise<void> => {
+    closePromise ??= (async () => {
+      if (!isAlive()) return;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Re-check through the exit event before escalating.
+      }
+      if (await waitForExit(options.termTimeoutMs ?? 1_000)) return;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Re-check below; kill can race a natural exit.
+      }
+      if (!await waitForExit(options.killTimeoutMs ?? 500)) {
+        throw new Error("Managed OpenCode process did not exit after SIGKILL");
+      }
+    })();
+    return closePromise;
+  };
+  return { isAlive, close };
+}
 
 const SECRET_ENV_PATTERN = /(TOKEN|PASSWORD|USERNAME|AUTH|SECRET|KEY|CREDENTIAL)/i;
 
@@ -98,30 +161,7 @@ export async function createManagedOpencodeServer(options: {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  let closePromise: Promise<void> | null = null;
-  const exited = new Promise<void>((resolve) => {
-    child.once("exit", () => resolve());
-  });
-
-  const close = (): Promise<void> => {
-    closePromise ??= (async () => {
-      if (child.exitCode !== null) return;
-      if (!child.killed) child.kill("SIGTERM");
-      const timeout = new Promise<void>((resolve) => {
-        setTimeout(() => resolve(), 1000);
-      });
-      await Promise.race([exited, timeout]);
-      if (child.exitCode === null) {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Process already exited.
-        }
-        await Promise.race([exited, new Promise<void>((resolve) => setTimeout(() => resolve(), 500))]);
-      }
-    })();
-    return closePromise;
-  };
+  const processLifecycle = createManagedProcessClose(child);
 
   let url: string;
   try {
@@ -152,7 +192,7 @@ export async function createManagedOpencodeServer(options: {
       child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));
     });
   } catch (error) {
-    await close();
+    await processLifecycle.close();
     throw error;
   }
 
@@ -167,9 +207,7 @@ export async function createManagedOpencodeServer(options: {
       cwd: options.cwd,
       env: injectedEnv,
     },
-    isAlive() {
-      return child.exitCode === null && child.signalCode === null && !child.killed;
-    },
-    close,
+    isAlive: processLifecycle.isAlive,
+    close: processLifecycle.close,
   };
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -9,6 +9,7 @@ import { ApprovalService } from "./approvals.js";
 import {
   EnginePool,
   enginePoolForConfig,
+  managedEnginePoolForConfig,
   setEnginePoolForConfig,
   type EnginePoolConnection,
   type EngineEventProxyLease,
@@ -1280,17 +1281,23 @@ export async function proxyOpencodeRequest(input: {
       method,
       headers,
       body,
-    }).catch(() => {
+    }).then(() => {
+      managedEnginePoolForConfig(input.config)?.reportRequestSuccess(baseUrl);
+    }).catch((error: unknown) => {
+      if (workspace) managedEnginePoolForConfig(input.config)?.reportRequestFailure(baseUrl, error, workspace);
       // Command failures are surfaced through the OpenCode event stream.
     });
     return jsonResponse({ ok: true, accepted: true });
   }
   const forward = async () => {
-    const response = await loopbackFetch(targetUrl, {
-      method,
-      headers,
-      body,
-    });
+    let response: Response;
+    try {
+      response = await loopbackFetch(targetUrl, { method, headers, body });
+      managedEnginePoolForConfig(input.config)?.reportRequestSuccess(baseUrl);
+    } catch (error) {
+      if (workspace) managedEnginePoolForConfig(input.config)?.reportRequestFailure(baseUrl, error, workspace);
+      throw error;
+    }
 
     if (response.status === 404 && route?.fallback) {
       const fallbackHeaders = headersForEngineConnection(headers, route.fallback);
@@ -4104,7 +4111,7 @@ async function syncRuntimeMcpToOpencodeEngine(
   const failures: EngineMcpSyncFailure[] = [];
   const registrations: EngineMcpRegistrationResult[] = [];
   for (const [name, mcpConfig] of entries) {
-    const registration = await postMcpEntryWithRetry(url, headers, name, mcpConfig);
+    const registration = await postMcpEntryWithRetry(config, workspace, url, headers, name, mcpConfig);
     registrations.push(registration);
     if (registration.failure) failures.push(registration.failure);
   }
@@ -4158,6 +4165,8 @@ async function syncRuntimeMcpToOpencodeEngine(
 // (the engine is often mid-rebuild right after a dispose). 4xx responses
 // are not retried — they won't change.
 async function postMcpEntryWithRetry(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
   url: URL,
   headers: Record<string, string>,
   name: string,
@@ -4174,6 +4183,7 @@ async function postMcpEntryWithRetry(
         body: JSON.stringify({ name, config: mcpConfig }),
         signal: AbortSignal.timeout(15_000),
       });
+      managedEnginePoolForConfig(config)?.reportRequestSuccess(url.origin);
       if (response.ok) {
         // OpenCode's dynamic registration endpoint historically treats every
         // 2xx response as accepted delivery and Cloud readiness verifies the
@@ -4197,7 +4207,8 @@ async function postMcpEntryWithRetry(
         message: "OpenCode rejected the MCP registration request",
       };
       if (response.status < 500) return { name, status: "failed", source: "transport_failure", errorSummary: null, failure };
-    } catch {
+    } catch (error) {
+      managedEnginePoolForConfig(config)?.reportRequestFailure(url.origin, error, workspace);
       failure = {
         name,
         registrationStatus: "failed",


### PR DESCRIPTION
## Why
Today a cloud workspace's managed opencode engine died mid-reload-churn and openwork-server kept syncing MCPs into the dead port for hours (`Engine MCP sync failed … / Runtime MCP engine_reload sync crashed`, 113+ repeats) while an orphaned previous engine process kept running unsupervised. Engine-backed features were dead until a manual process kill. The engine registry file is written by the opencode binary (upstream); what we own — and what failed — is our handle lifecycle and process supervision.

## What
- `engine-pool.ts`: connection-refused-class failures (`ECONNREFUSED`/`ECONNRESET`/socket hang up via cause-chain walk) against the **managed primary endpoint only** are counted; **3 consecutive** failures trigger one dispose+rebuild of the primary, rate-limited by the existing spawn-interval backoff (no hot-looping). Any success resets the counter. Failed rebuilds schedule a bounded retry; recovery orphans are tracked and closed.
- `managed-opencode.ts`: `close()` now confirms exit — SIGTERM, bounded wait, SIGKILL escalation — so disposes cannot leak engine processes.
- `server.ts`: engine proxy + MCP-sync transports report success/failure into the pool (the detection signal).
- `cli.ts`/`embedded.ts`: CLI-managed engines get the same supervision; external `opencodeBaseUrl` (unmanaged) mode untouched — no behavior change while healthy.

## Verification
- `bun --conditions=development test` scoped: engine-self-heal (new, 172 lines) + embedded-lifecycle + mcp.engine-sync.e2e + cloud-provider-sync-reload-guard → **40 pass / 0 fail** (208 assertions).
- `pnpm typecheck` clean.
- Claims incl. negatives: single transient failure → no rebuild; 3 consecutive → exactly one rebuild; second burst within backoff window → suppressed, after window → allowed; SIGTERM-ignoring child → SIGKILL escalation with confirmed exit; unmanaged mode untouched.
- Runs on desktops too — thresholds conservative, reuses the existing rollover machinery from #3696 rather than a parallel lifecycle.