### PR TITLE
fix(ci): correct the poisoned Daytona CLI sha256 pin in both eval workflows

### DIFF
--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -73,8 +73,10 @@ jobs:
 
       # The eval harness shells out to the daytona CLI (testkit daytonaAvailable
       # gate and @openwork/hosts exec). The binary is pinned to a release tag
-      # and checksum-verified before it can run with CI secrets; bump both
-      # together when upgrading (shasum -a 256 of daytona-linux-amd64).
+      # and checksum-verified before it can run with CI secrets. When bumping,
+      # take the digest from GitHub's authoritative asset metadata, never from
+      # a local download (a truncating proxy once poisoned the pin):
+      #   gh api repos/daytona/clients/releases/tags/<tag> --jq '.assets[] | select(.name == "daytona-linux-amd64") | .digest'
       - name: Install Daytona CLI
         if: steps.config.outputs.enabled == 'true'
         shell: bash
@@ -82,7 +84,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_CLI_TAG: v0.204.0
-          DAYTONA_CLI_SHA256: 4f8cdccc3959d79767e1abe62c6c9010831bc0668509522cbdb046cd92206f97
+          DAYTONA_CLI_SHA256: 76701138c2ce93c14b30e7b10f51aa5ea2a9e156777bab933a4272237d81f14d
         run: |
           set -euo pipefail
           gh release download "$DAYTONA_CLI_TAG" --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber

--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -133,15 +133,17 @@ jobs:
 
       # The eval harness shells out to the daytona CLI (testkit daytonaAvailable
       # gate and @openwork/hosts exec). The binary is pinned to a release tag
-      # and checksum-verified before it can run with CI secrets; bump both
-      # together when upgrading (shasum -a 256 of daytona-linux-amd64).
+      # and checksum-verified before it can run with CI secrets. When bumping,
+      # take the digest from GitHub's authoritative asset metadata, never from
+      # a local download (a truncating proxy once poisoned the pin):
+      #   gh api repos/daytona/clients/releases/tags/<tag> --jq '.assets[] | select(.name == "daytona-linux-amd64") | .digest'
       - name: Install Daytona CLI
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_CLI_TAG: v0.204.0
-          DAYTONA_CLI_SHA256: 4f8cdccc3959d79767e1abe62c6c9010831bc0668509522cbdb046cd92206f97
+          DAYTONA_CLI_SHA256: 76701138c2ce93c14b30e7b10f51aa5ea2a9e156777bab933a4272237d81f14d
         run: |
           set -euo pipefail
           gh release download "$DAYTONA_CLI_TAG" --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber


### PR DESCRIPTION
Last night's scheduled Nightly Mega Eval (run 31925720222) and the full Slow Specs Sweep dispatch (run 31912754058, 45/45 jobs) failed at "Install Daytona CLI": `sha256sum: /tmp/daytona: FAILED`.

## Root cause — the pin was poisoned, the gate worked
The digest added in #3820 was computed from a **truncated download**: a network middlebox on the authoring machine cut the asset at ~10 MiB, twice, on the same path ("two independent downloads" were not independent). The evidence was visible at pin time — `file` reported an ELF section-header offset of 20,941,490 in a 10,481,664-byte file — i.e., the binary's own metadata pointed at the true ~20.9 MB size.

The checksum gate then did exactly its job on CI: it refused to execute the **real** binary because it didn't match the poisoned pin.

## Fix
- New digest from GitHub's authoritative per-asset metadata (not any local download):
  `gh api repos/daytona/clients/releases/tags/v0.204.0 --jq '.assets[] | select(.name == "daytona-linux-amd64") | .digest'`
  → `sha256:76701138c2ce93c14b30e7b10f51aa5ea2a9e156777bab933a4272237d81f14d` (size 20,941,923 — matches the ELF metadata).
- Same fix in both eval workflows; the bump comment now documents the authoritative source so this class of mistake is structurally excluded.
- Note: dev/release-daytona-snapshot workflows already use this pin+digest pattern (different asset); untouched.

## Post-merge verification plan
Re-dispatch the Slow Specs Sweep (full 45-spec matrix) and confirm the Install Daytona CLI step passes checksum + login; the nightly self-verifies on its next cron.
