### PR TITLE
fix(den-api): avoid MCP readiness row locks

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1359,7 +1359,7 @@ export async function listUsableExternalMcpConnections(input: {
 export async function externalMcpConnectionReadyForMember(
   connection: ExternalMcpConnectionRow,
   orgMembershipId: OrgMembershipId,
-  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpReadiness,
 ): Promise<boolean> {
   if (connection.oauthIssuerReviewRequiredAt) return false
   if (connection.authType === "none") return true
@@ -1391,7 +1391,7 @@ export async function listReadyExternalMcpConnections(input: {
 export async function readyExternalMcpConnectionsForMember(
   connections: ExternalMcpConnectionRow[],
   orgMembershipId: OrgMembershipId,
-  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpReadiness,
 ): Promise<ExternalMcpConnectionRow[]> {
   const readiness = await Promise.all(connections.map(async (connection) => ({
     connection,
@@ -1570,6 +1570,43 @@ function sameExternalMcpIdentity(
     && normalizeExternalMcpIdentityUrl(current.url) === normalizeExternalMcpIdentityUrl(expected.url)
     && current.authType === expected.authType
     && current.credentialMode === expected.credentialMode
+}
+
+async function readExternalMcpConnectionForIdentity(
+  connection: ExternalMcpConnectionRow,
+): Promise<ExternalMcpConnectionRow | null> {
+  const rows = await db
+    .select()
+    .from(ExternalMcpConnectionTable)
+    .where(and(
+      eq(ExternalMcpConnectionTable.organizationId, connection.organizationId),
+      eq(ExternalMcpConnectionTable.id, connection.id),
+    ))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+async function readConnectedAccountForExternalMcpReadiness(input: {
+  connection: ExternalMcpConnectionRow
+  orgMembershipId: OrgMembershipId
+}): Promise<ExternalMcpIdentityRead<typeof ConnectedAccountTable.$inferSelect>> {
+  const beforeAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
+  if (!beforeAccountRead || !sameExternalMcpIdentity(beforeAccountRead, input.connection)) return { current: false }
+  const rows = await db
+    .select()
+    .from(ConnectedAccountTable)
+    .where(and(
+      eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
+      eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
+      eq(ConnectedAccountTable.providerId, input.connection.id),
+    ))
+    .limit(1)
+  const afterAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
+  if (!afterAccountRead || !sameExternalMcpIdentity(afterAccountRead, input.connection)) return { current: false }
+  const value = rows[0]
+    ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
+    : null
+  return { current: true, value }
 }
 
 async function lockExternalMcpIdentity(

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -1,0 +1,94 @@
+import { expect, mock, test } from "bun:test"
+
+process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
+process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:3005"
+process.env.OPENWORK_DEV_MODE ??= "1"
+process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
+
+type QueryRows = Record<string, unknown>[]
+type FakeQuery = {
+  from: (table: unknown) => FakeQuery
+  where: (condition: unknown) => FakeQuery
+  limit: (count: number) => FakeQuery
+  for: (mode: string) => FakeQuery
+  then: Promise<QueryRows>["then"]
+}
+
+function fakeQuery(rows: QueryRows): FakeQuery {
+  const promise = Promise.resolve(rows)
+  const query: FakeQuery = {
+    from: () => query,
+    where: () => query,
+    limit: () => query,
+    for: () => {
+      throw new Error("Readiness must not lock rows")
+    },
+    then: promise.then.bind(promise),
+  }
+  return query
+}
+
+const connection = {
+  id: "emc_01k28e8q8pf8r9sff9mhyqxved",
+  organizationId: "org_01k28e8q8pf8r9sff9mhyqxved",
+  name: "Fixture MCP",
+  url: "https://mcp.example/sse",
+  authType: "oauth",
+  credentialMode: "per_member",
+  kind: "external_mcp",
+  nativeProviderKey: null,
+  oauthConfiguration: null,
+  toolPolicy: null,
+  apiKey: null,
+  accessToken: null,
+  refreshToken: null,
+  tokenType: null,
+  scope: null,
+  expiresAt: null,
+  pendingCodeVerifier: null,
+  credentialHealth: null,
+  oauthIssuerReviewRequiredAt: null,
+  connectedAt: null,
+  createdByOrgMembershipId: "mem_owner",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+const account = {
+  id: "ca_01k28e8q8pf8r9sff9mhyqxved",
+  organizationId: connection.organizationId,
+  orgMembershipId: "mem_01k28e8q8pf8r9sff9mhyqxved",
+  providerId: connection.id,
+  externalAccountId: null,
+  scopes: null,
+  accessToken: "member-token",
+  refreshToken: null,
+  tokenType: null,
+  expiresAt: null,
+  pendingCodeVerifier: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+const selectResults: QueryRows[] = [[connection], [account], [connection]]
+let transactionCalls = 0
+
+mock.module("../src/db.js", () => ({
+  db: {
+    select: () => fakeQuery(selectResults.shift() ?? []),
+    transaction: () => {
+      transactionCalls += 1
+      throw new Error("Readiness must not open a transaction")
+    },
+  },
+}))
+
+const { readyExternalMcpConnectionsForMember } = await import("../src/capability-sources/external-mcp-connections.js")
+
+test("per-member connection list readiness reads credentials without row locks", async () => {
+  await expect(readyExternalMcpConnectionsForMember(
+    [connection] as never,
+    account.orgMembershipId as never,
+  )).resolves.toEqual([connection])
+  expect(transactionCalls).toBe(0)
+  expect(selectResults).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary\n- fixes DEN-API-1Z by removing the transactional FOR UPDATE read from the /mcp/agent readiness path\n- keeps the existing locked identity helper for mutating OAuth credential flows\n- adds an isolated regression test that fails if connection-list readiness opens a transaction or calls .for("update")\n\n## Validation\n- pnpm --filter @openwork-ee/den-api exec bun test test/external-mcp-readiness.test.ts\n- pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false\n- pnpm --filter @openwork-ee/den-api exec bun test test/external-connection-proxy.test.ts could not run locally because this worktree does not have MySQL running on 127.0.0.1:3306\n\nFixes DEN-API-1Z