### PR TITLE
fix(den-api): avoid MCP read locks

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1359,7 +1359,7 @@ export async function listUsableExternalMcpConnections(input: {
 export async function externalMcpConnectionReadyForMember(
   connection: ExternalMcpConnectionRow,
   orgMembershipId: OrgMembershipId,
-  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpReadiness,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
 ): Promise<boolean> {
   if (connection.oauthIssuerReviewRequiredAt) return false
   if (connection.authType === "none") return true
@@ -1391,7 +1391,7 @@ export async function listReadyExternalMcpConnections(input: {
 export async function readyExternalMcpConnectionsForMember(
   connections: ExternalMcpConnectionRow[],
   orgMembershipId: OrgMembershipId,
-  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpReadiness,
+  readAccount: typeof readConnectedAccountForExternalMcpIdentity = readConnectedAccountForExternalMcpIdentity,
 ): Promise<ExternalMcpConnectionRow[]> {
   const readiness = await Promise.all(connections.map(async (connection) => ({
     connection,
@@ -1586,29 +1586,6 @@ async function readExternalMcpConnectionForIdentity(
   return rows[0] ?? null
 }
 
-async function readConnectedAccountForExternalMcpReadiness(input: {
-  connection: ExternalMcpConnectionRow
-  orgMembershipId: OrgMembershipId
-}): Promise<ExternalMcpIdentityRead<typeof ConnectedAccountTable.$inferSelect>> {
-  const beforeAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
-  if (!beforeAccountRead || !sameExternalMcpIdentity(beforeAccountRead, input.connection)) return { current: false }
-  const rows = await db
-    .select()
-    .from(ConnectedAccountTable)
-    .where(and(
-      eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
-      eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
-      eq(ConnectedAccountTable.providerId, input.connection.id),
-    ))
-    .limit(1)
-  const afterAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
-  if (!afterAccountRead || !sameExternalMcpIdentity(afterAccountRead, input.connection)) return { current: false }
-  const value = rows[0]
-    ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
-    : null
-  return { current: true, value }
-}
-
 async function lockExternalMcpIdentity(
   tx: ExternalMcpTransaction,
   expected: ExternalMcpConnectionRow,
@@ -1629,21 +1606,22 @@ async function lockExternalMcpIdentity(
 export async function readOrgOAuthClientForExternalMcpIdentity(
   connection: ExternalMcpConnectionRow,
 ): Promise<ExternalMcpIdentityRead<typeof OrgOAuthClientTable.$inferSelect>> {
-  return db.transaction(async (tx) => {
-    if (!await lockExternalMcpIdentity(tx, connection)) return { current: false }
-    const rows = await tx
-      .select()
-      .from(OrgOAuthClientTable)
-      .where(and(
-        eq(OrgOAuthClientTable.organizationId, connection.organizationId),
-        eq(OrgOAuthClientTable.providerId, connection.id),
-      ))
-      .limit(1)
-    const value = rows[0]
-      ? { ...rows[0], extra: normalizeOAuthClientExtra(rows[0].extra) }
-      : null
-    return { current: true, value }
-  })
+  const beforeClientRead = await readExternalMcpConnectionForIdentity(connection)
+  if (!beforeClientRead || !sameExternalMcpIdentity(beforeClientRead, connection)) return { current: false }
+  const rows = await db
+    .select()
+    .from(OrgOAuthClientTable)
+    .where(and(
+      eq(OrgOAuthClientTable.organizationId, connection.organizationId),
+      eq(OrgOAuthClientTable.providerId, connection.id),
+    ))
+    .limit(1)
+  const afterClientRead = await readExternalMcpConnectionForIdentity(connection)
+  if (!afterClientRead || !sameExternalMcpIdentity(afterClientRead, connection)) return { current: false }
+  const value = rows[0]
+    ? { ...rows[0], extra: normalizeOAuthClientExtra(rows[0].extra) }
+    : null
+  return { current: true, value }
 }
 
 export async function upsertOrgOAuthClientForExternalMcpIdentity(input: {
@@ -1727,22 +1705,23 @@ export async function readConnectedAccountForExternalMcpIdentity(input: {
   connection: ExternalMcpConnectionRow
   orgMembershipId: OrgMembershipId
 }): Promise<ExternalMcpIdentityRead<typeof ConnectedAccountTable.$inferSelect>> {
-  return db.transaction(async (tx) => {
-    if (!await lockExternalMcpIdentity(tx, input.connection)) return { current: false }
-    const rows = await tx
-      .select()
-      .from(ConnectedAccountTable)
-      .where(and(
-        eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
-        eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
-        eq(ConnectedAccountTable.providerId, input.connection.id),
-      ))
-      .limit(1)
-    const value = rows[0]
-      ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
-      : null
-    return { current: true, value }
-  })
+  const beforeAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
+  if (!beforeAccountRead || !sameExternalMcpIdentity(beforeAccountRead, input.connection)) return { current: false }
+  const rows = await db
+    .select()
+    .from(ConnectedAccountTable)
+    .where(and(
+      eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
+      eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
+      eq(ConnectedAccountTable.providerId, input.connection.id),
+    ))
+    .limit(1)
+  const afterAccountRead = await readExternalMcpConnectionForIdentity(input.connection)
+  if (!afterAccountRead || !sameExternalMcpIdentity(afterAccountRead, input.connection)) return { current: false }
+  const value = rows[0]
+    ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
+    : null
+  return { current: true, value }
 }
 
 export async function upsertConnectedAccountForExternalMcpIdentity(input: {

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -22,7 +22,7 @@ function fakeQuery(rows: QueryRows): FakeQuery {
     where: () => query,
     limit: () => query,
     for: () => {
-      throw new Error("Readiness must not lock rows")
+      throw new Error("Read-only external MCP checks must not lock rows")
     },
     then: promise.then.bind(promise),
   }
@@ -69,26 +69,67 @@ const account = {
   createdAt: new Date("2026-01-01T00:00:00Z"),
   updatedAt: new Date("2026-01-01T00:00:00Z"),
 }
-const selectResults: QueryRows[] = [[connection], [account], [connection]]
+const orgClient = {
+  id: "ooc_01k28e8q8pf8r9sff9mhyqxved",
+  organizationId: connection.organizationId,
+  providerId: connection.id,
+  clientId: "mcp-client-id",
+  clientSecret: null,
+  extra: null,
+  createdByOrgMembershipId: connection.createdByOrgMembershipId,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+let selectResults: QueryRows[] = []
 let transactionCalls = 0
+
+function queueSelectResults(results: QueryRows[]): void {
+  selectResults = results
+  transactionCalls = 0
+}
 
 mock.module("../src/db.js", () => ({
   db: {
     select: () => fakeQuery(selectResults.shift() ?? []),
     transaction: () => {
       transactionCalls += 1
-      throw new Error("Readiness must not open a transaction")
+      throw new Error("Read-only external MCP checks must not open a transaction")
     },
   },
 }))
 
-const { readyExternalMcpConnectionsForMember } = await import("../src/capability-sources/external-mcp-connections.js")
+const {
+  readConnectedAccountForExternalMcpIdentity,
+  readOrgOAuthClientForExternalMcpIdentity,
+  readyExternalMcpConnectionsForMember,
+} = await import("../src/capability-sources/external-mcp-connections.js")
 
 test("per-member connection list readiness reads credentials without row locks", async () => {
+  queueSelectResults([[connection], [account], [connection]])
   await expect(readyExternalMcpConnectionsForMember(
     [connection] as never,
     account.orgMembershipId as never,
   )).resolves.toEqual([connection])
+  expect(transactionCalls).toBe(0)
+  expect(selectResults).toHaveLength(0)
+})
+
+test("per-member connected account reads do not lock the shared connection row", async () => {
+  queueSelectResults([[connection], [account], [connection]])
+  await expect(readConnectedAccountForExternalMcpIdentity({
+    connection: connection as never,
+    orgMembershipId: account.orgMembershipId as never,
+  })).resolves.toEqual({ current: true, value: account })
+  expect(transactionCalls).toBe(0)
+  expect(selectResults).toHaveLength(0)
+})
+
+test("org OAuth client reads do not lock the shared connection row", async () => {
+  queueSelectResults([[connection], [orgClient], [connection]])
+  await expect(readOrgOAuthClientForExternalMcpIdentity(connection as never)).resolves.toEqual({
+    current: true,
+    value: orgClient,
+  })
   expect(transactionCalls).toBe(0)
   expect(selectResults).toHaveLength(0)
 })


### PR DESCRIPTION
## Summary
- remove shared external_mcp_connection row locks from read-only MCP credential/client reads
- reuse the non-locking identity read path for readiness and runtime token/client lookup
- extend regression coverage to fail if read-only checks open a transaction or call for update

## Verification
- pnpm exec bun test test/external-mcp-readiness.test.ts
- pnpm --filter @openwork-ee/den-api build
- git diff --check

Note: no @openwork/testkit tape was added because this change targets a database locking behavior covered by a focused den-api unit regression rather than an app-driving user flow.