### PR TITLE
Log desktop session abort sources

### DIFF
--- a/apps/app/src/app/lib/opencode-session.ts
+++ b/apps/app/src/app/lib/opencode-session.ts
@@ -11,6 +11,30 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 import type { Client, ModelRef } from "../types";
 import { unwrap } from "./opencode";
 
+export type AbortSessionLogContext = {
+  source: string;
+  initiator: "user" | "system" | "app";
+  reason?: string;
+};
+
+function logAbortSession(
+  phase: "start" | "done" | "error",
+  sessionID: string,
+  directory: string | undefined,
+  context: AbortSessionLogContext | undefined,
+  extra?: { aborted?: boolean; error?: string },
+) {
+  console.info("[opencode-session] abort", {
+    phase,
+    source: context?.source ?? "unknown",
+    initiator: context?.initiator ?? "app",
+    reason: context?.reason ?? null,
+    sessionID,
+    directoryScoped: Boolean(directory?.trim()),
+    ...(extra ?? {}),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Session helpers
 // ---------------------------------------------------------------------------
@@ -30,8 +54,19 @@ export async function abortSession(
   client: Client,
   sessionID: string,
   directory?: string,
+  logContext?: AbortSessionLogContext,
 ): Promise<boolean> {
-  return unwrap(await client.session.abort({ sessionID, directory })) === true;
+  logAbortSession("start", sessionID, directory, logContext);
+  try {
+    const aborted = unwrap(await client.session.abort({ sessionID, directory })) === true;
+    logAbortSession("done", sessionID, directory, logContext, { aborted });
+    return aborted;
+  } catch (error) {
+    logAbortSession("error", sessionID, directory, logContext, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
 }
 
 /**
@@ -43,9 +78,10 @@ export async function abortSessionSafe(
   client: Client,
   sessionID: string,
   directory?: string,
+  logContext?: AbortSessionLogContext,
 ): Promise<boolean> {
   try {
-    return await abortSession(client, sessionID, directory);
+    return await abortSession(client, sessionID, directory, logContext);
   } catch {
     // The session may already be idle or the server unreachable; callers
     // treat `false` as "nothing was aborted".

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1325,6 +1325,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
       opencodeClient,
       props.sessionId,
       props.workspaceRoot.trim() || undefined,
+      {
+        source: "composer.stop",
+        initiator: "user",
+        reason: "stop active session run",
+      },
     );
     if (!aborted) {
       setError({ message: t("session.stop_failed") });

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -618,7 +618,11 @@ export function createSessionActionsStore(options: {
     if (!c) return;
     const id = (sessionID ?? options.selectedSessionId() ?? "").trim();
     if (!id) return;
-    await abortSessionTyped(c, id);
+    await abortSessionTyped(c, id, undefined, {
+      source: "session.actions.abort_session",
+      initiator: "user",
+      reason: "session action requested abort",
+    });
   }
 
   function retryLastPrompt() {
@@ -683,7 +687,11 @@ export function createSessionActionsStore(options: {
     const sessionID = (options.selectedSessionId() ?? "").trim();
     if (!c || !sessionID) return;
 
-    await abortSessionSafe(c, sessionID);
+    await abortSessionSafe(c, sessionID, undefined, {
+      source: "session.undo_last_user_message.before_revert",
+      initiator: "user",
+      reason: "abort active run before undoing last user message",
+    });
 
     const users = options.messages().filter((message) => {
       const role = (message.info as { role?: string }).role;
@@ -711,7 +719,11 @@ export function createSessionActionsStore(options: {
     const sessionID = (options.selectedSessionId() ?? "").trim();
     if (!c || !sessionID) return;
 
-    await abortSessionSafe(c, sessionID);
+    await abortSessionSafe(c, sessionID, undefined, {
+      source: "session.redo_last_user_message.before_revert",
+      initiator: "user",
+      reason: "abort active run before redoing last user message",
+    });
 
     const revertMessageID = options.selectedSession()?.revert?.messageID ?? null;
     if (!revertMessageID) return;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1325,7 +1325,11 @@ export function SessionRoute() {
           send: async () => {
             await sendWithRevertRollback({
               revertMessageId: draft.revertMessageId,
-              abort: () => abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined),
+              abort: () => abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined, {
+                source: "session.edit_resend.before_revert",
+                initiator: "user",
+                reason: "abort active run before replacing a reverted message",
+              }),
               revert: async (messageId) => {
                 const reverted = await revertSession(opencodeClient, targetSessionId, messageId);
                 applySessionRevert(selectedWorkspaceId, reverted);
@@ -1455,7 +1459,11 @@ export function SessionRoute() {
         if (!targetSessionId) return false;
         try {
           // Abort any running generation first; OpenCode rejects revert on busy sessions.
-          await abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined);
+          await abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined, {
+            source: "session.revert_to_message.before_revert",
+            initiator: "user",
+            reason: "abort active run before reverting transcript",
+          });
           const reverted = await revertSession(opencodeClient, targetSessionId, messageId);
           // Stamp the revert cursor into the local caches so the transcript
           // rewinds immediately instead of waiting for a full reload.

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1501,7 +1501,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       activeSessions: () => activeReloadBlockingSessions,
       stopSession: async (sessionId) => {
         if (!activeClient) return;
-        await abortSessionSafe(activeClient, sessionId);
+        await abortSessionSafe(activeClient, sessionId, undefined, {
+          source: "settings.reload_workspace.stop_session",
+          initiator: "user",
+          reason: "stop active session before workspace engine reload",
+        });
       },
     });
   }, [
@@ -2701,7 +2705,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         isRemoteWorkspace={selectedWorkspace?.workspaceType === "remote"}
         onForceStopSession={async (sessionId) => {
           if (!activeClient) return;
-          await abortSessionSafe(activeClient, sessionId);
+          await abortSessionSafe(activeClient, sessionId, undefined, {
+            source: "settings.connections.force_stop_session",
+            initiator: "user",
+            reason: "force stop active session from connections modal",
+          });
         }}
         onReloadEngine={reloadCoordinator.reloadWorkspaceEngine}
         modalState={{

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -1020,11 +1020,35 @@ export class EnginePool {
   }
 
   private async abortSession(generation: Generation, sessionId: string): Promise<void> {
-    await loopbackFetch(new URL(`/session/${encodeURIComponent(sessionId)}/abort`, generation.handle.url).toString(), {
-      method: "POST",
-      headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
-      signal: AbortSignal.timeout(5_000),
+    this.hooks.logger?.log("info", "Aborting OpenCode session from engine pool.", {
+      "abort.source": "engine_pool.drain_timeout",
+      "abort.initiator": "system",
+      "abort.reason": "draining engine exceeded grace period",
+      "session.id": sessionId,
+      "engine.generation_id": generation.id,
     });
+    try {
+      await loopbackFetch(new URL(`/session/${encodeURIComponent(sessionId)}/abort`, generation.handle.url).toString(), {
+        method: "POST",
+        headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
+        signal: AbortSignal.timeout(5_000),
+      });
+      this.hooks.logger?.log("info", "OpenCode session abort from engine pool completed.", {
+        "abort.source": "engine_pool.drain_timeout",
+        "abort.initiator": "system",
+        "session.id": sessionId,
+        "engine.generation_id": generation.id,
+      });
+    } catch (error) {
+      this.hooks.logger?.log("error", "OpenCode session abort from engine pool failed.", {
+        "abort.source": "engine_pool.drain_timeout",
+        "abort.initiator": "system",
+        "session.id": sessionId,
+        "engine.generation_id": generation.id,
+        "error.message": error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 }
 

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -251,10 +251,35 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const sessionId = ctx.params.sessionId?.trim();
     if (!sessionId) throw new ApiError(400, "invalid_payload", "sessionId is required");
+    console.info("[openwork-server] abort", {
+      phase: "start",
+      source: "workspace.sessions.abort_route",
+      initiator: "user",
+      reason: "client requested session abort through OpenWork server route",
+      workspaceId: workspace.id,
+      sessionID: sessionId,
+      actorType: ctx.actor?.type ?? "unknown",
+    });
     const result = await createWorkspaceOpencodeClient(config, workspace, { sessionId }).session.abort({ sessionID: sessionId });
     if (result.error !== undefined) {
+      console.info("[openwork-server] abort", {
+        phase: "error",
+        source: "workspace.sessions.abort_route",
+        initiator: "user",
+        workspaceId: workspace.id,
+        sessionID: sessionId,
+        actorType: ctx.actor?.type ?? "unknown",
+      });
       throw new ApiError(502, "opencode_request_failed", "OpenCode abort failed");
     }
+    console.info("[openwork-server] abort", {
+      phase: "done",
+      source: "workspace.sessions.abort_route",
+      initiator: "user",
+      workspaceId: workspace.id,
+      sessionID: sessionId,
+      actorType: ctx.actor?.type ?? "unknown",
+    });
     return jsonResponse({ ok: true });
   });
 


### PR DESCRIPTION
## Summary
- add structured abort logs around shared OpenCode session abort helpers
- annotate user-facing abort call sites with source, initiator, and reason metadata
- log server-side abort proxy and engine-pool system aborts separately

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server test -- src/inbox-upload-approval.e2e.test.ts
- pnpm --filter @openwork/app test -- --runInBand apps/app/tests/attachment-file-part.test.ts

Refs DESKTOP-APP-C