### PR TITLE
fix(den-api): recover automation runner identity conflicts

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react"
 import { AUTOMATION_MODEL_ATTENTION_CAPABILITY } from "@openwork/types/automations"
 
-import { createDenClient, readDenSettings } from "@/app/lib/den"
+import { createDenClient, DenApiError, readDenSettings } from "@/app/lib/den"
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events"
 import { isDesktopRuntime } from "@/app/utils"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
@@ -16,6 +16,11 @@ function desktopRunnerId() {
   const created = crypto.randomUUID()
   localStorage.setItem(RUNNER_ID_KEY, created)
   return created
+}
+
+function resetDesktopRunnerId() {
+  localStorage.removeItem(RUNNER_ID_KEY)
+  return desktopRunnerId()
 }
 
 /** Keeps this signed-in, preview-enabled desktop registered as the owner's Automation runner. */
@@ -47,19 +52,36 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
       }
       try {
         const client = createDenClient({ baseUrl: settings.baseUrl, token: authToken })
-        const runnerId = desktopRunnerId()
+        let runnerId = desktopRunnerId()
         const build = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("appBuildInfo")
         const agent = navigator.userAgent
         const platform = /Mac/i.test(agent) ? "darwin" : /Win/i.test(agent) ? "win32" : "linux"
-        const runner = await client.mintAutomationRunnerToken(organizationId, {
-          runnerId,
-          protocolVersion: 1,
-          supportedExecutionTargets: ["desktop"],
-          capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-          appVersion: String(build?.version ?? "unknown"),
-          platform,
-          concurrency: 1,
-        })
+        let runner: Awaited<ReturnType<typeof client.mintAutomationRunnerToken>>
+        try {
+          runner = await client.mintAutomationRunnerToken(organizationId, {
+            runnerId,
+            protocolVersion: 1,
+            supportedExecutionTargets: ["desktop"],
+            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+            appVersion: String(build?.version ?? "unknown"),
+            platform,
+            concurrency: 1,
+          })
+        } catch (error) {
+          if (!(error instanceof DenApiError) || error.status !== 409 || error.code !== "automation_runner_identity_conflict") {
+            throw error
+          }
+          runnerId = resetDesktopRunnerId()
+          runner = await client.mintAutomationRunnerToken(organizationId, {
+            runnerId,
+            protocolVersion: 1,
+            supportedExecutionTargets: ["desktop"],
+            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+            appVersion: String(build?.version ?? "unknown"),
+            platform,
+            concurrency: 1,
+          })
+        }
         if (disposed) return
         await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("automationRunnerConfigure", {
           baseUrl: client.baseUrls.apiBaseUrl,

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -73,6 +73,9 @@ function scope(c: {
 
 function failure(error: unknown): { status: 400 | 403 | 404 | 409; body: { error: string; message?: string } } | null {
   if (!(error instanceof Error)) return null
+  if (error.message === "automation_runner_identity_conflict") {
+    return { status: 409, body: { error: error.message, message: "This desktop runner identity is already registered to a different organization member." } }
+  }
   if (error.message === "automation_not_found") return { status: 404, body: { error: "automation_not_found" } }
   if (error.message === "automation_action_target_mismatch") {
     return { status: 400, body: { error: "automation_action_target_mismatch", message: "Desktop creates local Automations; Web creates OpenWork Cloud Automations." } }
@@ -119,12 +122,21 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
       tags: ["Automations"], operationId: "mintAutomationRunnerToken", "x-mcp": false,
       summary: "Connect this desktop as an Automation runner",
       description: "Mints a time-limited runner-only credential for the desktop SSE connection and HTTP runner APIs.",
-      responses: { 200: jsonResponse("Runner credential minted.", automationRunnerTokenResponseSchema) },
+      responses: {
+        200: jsonResponse("Runner credential minted.", automationRunnerTokenResponseSchema),
+        409: jsonResponse("Runner identity conflict.", invalidRequestSchema),
+      },
     }),
     orgMemberRoute(), jsonValidator(automationDesktopRunnerRegistrationSchema),
     async (c) => {
       const registration = c.req.valid("json")
-      await service.registerDesktopRunner(scope(c), registration)
+      try {
+        await service.registerDesktopRunner(scope(c), registration)
+      } catch (error) {
+        const mapped = failure(error)
+        if (mapped) return c.json(mapped.body, mapped.status)
+        throw error
+      }
       return c.json(automationRunnerAuth.issue(
         {
           organizationId: scope(c).organizationId,

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -156,6 +156,8 @@ test("runner credential minting is never exposed as an MCP tool", () => {
   assert.match(routesSource, /operationId: "mintAutomationRunnerToken", "x-mcp": false/)
   assert.match(routesSource, /capabilities: registration\.capabilities/)
   assert.match(routesSource, /AUTOMATION_MODEL_ATTENTION_CAPABILITY_HEADER/)
+  assert.match(routesSource, /automation_runner_identity_conflict/)
+  assert.match(routesSource, /await service\.registerDesktopRunner\(scope\(c\), registration\)[\s\S]*const mapped = failure\(error\)/)
 })
 
 test("every runner endpoint re-checks that the token owner is still an active member", () => {


### PR DESCRIPTION
## Summary
- map `automation_runner_identity_conflict` from runner token minting to a controlled 409 instead of an unhandled 500
- rotate the desktop persisted runner ID and retry once when that exact conflict is returned
- add regression coverage that the runner token route handles the conflict through the automation failure mapper

Fixes DEN-API-15

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/automation-runner-protocol.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork-ee/den-api build`

## Evidence
- Local fallback lane used. No Daytona/testkit tape was produced for this route-level Sentry fix; verification is the targeted protocol regression, app typecheck, and DEN API build.