### PR TITLE
fix(server): handle managed engine loopback failures

### DIFF
--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -403,6 +403,24 @@ describe("engine pool", () => {
     expect(events).toContain(`"sessionID":"ses_${newPort}"`);
   });
 
+  test("returns a controlled 502 when the selected engine is unreachable", async () => {
+    const fixture = await createFixture();
+    const { primary } = await createPool(fixture);
+    await primary.close();
+    const url = new URL("http://127.0.0.1/opencode/config");
+
+    await expect(proxyOpencodeRequest({
+      config: fixture.config,
+      request: new Request(url, { method: "GET" }),
+      url,
+      workspace: fixture.workspace,
+      proxyPath: "/config",
+    })).rejects.toMatchObject({
+      status: 502,
+      code: "opencode_unreachable",
+    });
+  });
+
   test("ends existing event fan-in leases when a generation flips", async () => {
     const fixture = await createFixture();
     const { pool, primary } = await createPool(fixture);

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -164,22 +164,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function isConnectionRefusedClassError(error: unknown): boolean {
+export function isEngineConnectionFailure(error: unknown): boolean {
   const visited = new Set<object>();
   let current: unknown = error;
   for (let depth = 0; depth < 6 && current !== null && current !== undefined; depth += 1) {
     if (typeof current === "string") {
-      return /ECONNREFUSED|ECONNRESET|socket hang up/i.test(current);
+      return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|socket hang up|Unable to connect/i.test(current);
     }
     if (!isRecord(current) || visited.has(current)) return false;
     visited.add(current);
     const code = current.code;
-    if (code === "ECONNREFUSED" || code === "ECONNRESET") return true;
+    if (code === "ECONNREFUSED" || code === "ECONNRESET" || code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return true;
     const message = current.message;
-    if (typeof message === "string" && /ECONNREFUSED|ECONNRESET|socket hang up/i.test(message)) return true;
+    if (typeof message === "string" && /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|socket hang up|Unable to connect/i.test(message)) return true;
     current = current.cause;
   }
   return false;
+}
+
+export function isConnectionRefusedClassError(error: unknown): boolean {
+  return isEngineConnectionFailure(error);
 }
 
 function isRoutableGeneration(
@@ -347,7 +351,7 @@ export class EnginePool {
   }
 
   reportRequestFailure(baseUrl: string, error: unknown, workspace: WorkspaceInfo): void {
-    if (!this.isPrimaryEndpoint(baseUrl) || !isConnectionRefusedClassError(error)) return;
+    if (!this.isPrimaryEndpoint(baseUrl) || !isEngineConnectionFailure(error)) return;
     this.consecutiveConnectionFailures += 1;
     if (this.consecutiveConnectionFailures < 3) return;
     const now = this.now();

--- a/apps/server/src/engine-self-heal.test.ts
+++ b/apps/server/src/engine-self-heal.test.ts
@@ -88,6 +88,12 @@ function refused(): Error {
   return Object.assign(new Error("connect ECONNREFUSED 127.0.0.1"), { code: "ECONNREFUSED" });
 }
 
+function timedOut(): Error {
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error("connect ETIMEDOUT 127.0.0.1"), { code: "ETIMEDOUT" }),
+  });
+}
+
 describe("managed engine self-heal", () => {
   test("requires three consecutive connection failures and throttles later bursts", async () => {
     process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS = "30000";
@@ -143,6 +149,28 @@ describe("managed engine self-heal", () => {
     expect(old.handle.isAlive()).toBe(false);
     expect(testFixture.pool.primaryUrl()).toBeNull();
     expect(testFixture.scheduled).toHaveLength(1);
+    await testFixture.pool.disposeAll();
+  });
+
+  test("treats loopback connect timeouts as recoverable engine failures", async () => {
+    process.env.OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS = "30000";
+    const old = managedHandle(43001);
+    const replacement = managedHandle(43002);
+    let spawnCalls = 0;
+    const testFixture = fixture(async () => {
+      spawnCalls += 1;
+      return replacement.handle;
+    });
+    testFixture.pool.adoptPrimary({ handle: old.handle, fingerprint: "one", registryId: null, trustedIdentity: null });
+
+    for (let failure = 0; failure < 3; failure += 1) {
+      testFixture.pool.reportRequestFailure(old.handle.url, timedOut(), testFixture.workspace);
+    }
+    await settle();
+
+    expect(spawnCalls).toBe(1);
+    expect(old.handle.isAlive()).toBe(false);
+    expect(testFixture.pool.primaryUrl()).toBe(replacement.handle.url);
     await testFixture.pool.disposeAll();
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -9,6 +9,7 @@ import { ApprovalService } from "./approvals.js";
 import {
   EnginePool,
   enginePoolForConfig,
+  isEngineConnectionFailure,
   managedEnginePoolForConfig,
   setEnginePoolForConfig,
   type EnginePoolConnection,
@@ -1150,6 +1151,13 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
+function opencodeUnreachableError(error: unknown, path: string): ApiError {
+  return new ApiError(502, "opencode_unreachable", "OpenCode engine is unavailable", {
+    path,
+    cause: error instanceof Error ? error.message : String(error),
+  });
+}
+
 function buildOpencodeDirectoryHeader(directory: string) {
   return /[^\x00-\x7F]/.test(directory) ? encodeURIComponent(directory) : directory;
 }
@@ -1296,15 +1304,23 @@ export async function proxyOpencodeRequest(input: {
       managedEnginePoolForConfig(input.config)?.reportRequestSuccess(baseUrl);
     } catch (error) {
       if (workspace) managedEnginePoolForConfig(input.config)?.reportRequestFailure(baseUrl, error, workspace);
+      if (isEngineConnectionFailure(error)) throw opencodeUnreachableError(error, proxyPath);
       throw error;
     }
 
     if (response.status === 404 && route?.fallback) {
       const fallbackHeaders = headersForEngineConnection(headers, route.fallback);
-      const fallbackResponse = await loopbackFetch(
-        buildOpencodeProxyUrl(route.fallback.baseUrl, proxyPath, input.url.search),
-        { method, headers: fallbackHeaders, body },
-      );
+      let fallbackResponse: Response;
+      try {
+        fallbackResponse = await loopbackFetch(
+          buildOpencodeProxyUrl(route.fallback.baseUrl, proxyPath, input.url.search),
+          { method, headers: fallbackHeaders, body },
+        );
+      } catch (error) {
+        if (workspace) managedEnginePoolForConfig(input.config)?.reportRequestFailure(route.fallback.baseUrl, error, workspace);
+        if (isEngineConnectionFailure(error)) throw opencodeUnreachableError(error, proxyPath);
+        throw error;
+      }
       return sanitizeProxyResponse(fallbackResponse);
     }
 


### PR DESCRIPTION
## Summary
- classify managed OpenCode loopback timeouts as engine connection failures
- return controlled 502 opencode_unreachable responses from the opencode proxy instead of surfacing raw fetch errors to Sentry
- cover timeout-triggered self-heal and unreachable proxy behavior in server tests

Fixes DESKTOP-APP-3

## Verification
- pnpm --filter openwork-server test src/engine-self-heal.test.ts src/engine-pool.test.ts
- pnpm --filter openwork-server typecheck