### PR TITLE
fix(server): guard missing opencode base URL

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1192,6 +1192,13 @@ export function createWorkspaceOpencodeClient(
         authHeader: buildEngineAuthProbeHeader(poolRoute.target.username, poolRoute.target.password),
       }
     : resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim();
+  if (!baseUrl) {
+    throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace", {
+      workspaceId: workspace.id,
+      workspaceType: workspace.workspaceType,
+    });
+  }
   const directory = resolveOpencodeDirectory(workspace);
   const baseFetch = directory ? createOpencodeDirectoryFetch(directory) : globalThis.fetch;
   const clientFetch = options?.boundedDiagnosticsReads
@@ -1199,7 +1206,7 @@ export function createWorkspaceOpencodeClient(
     : directory ? baseFetch : undefined;
 
   return createOpencodeClient({
-    baseUrl: connection.baseUrl?.trim(),
+    baseUrl,
     ...(directory ? { directory } : {}),
     ...(clientFetch ? { fetch: clientFetch } : {}),
     ...(connection.authHeader ? { headers: { Authorization: connection.authHeader } } : {}),

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -140,7 +140,7 @@ function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promis
   return { server, requests };
 }
 
-async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string; readOnly?: boolean }) {
+async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl?: string; readOnly?: boolean }) {
   const config: ServerConfig = {
     host: "127.0.0.1",
     port: 0,
@@ -155,7 +155,7 @@ async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseU
         path: input.workspaceRoot,
         preset: "starter",
         workspaceType: "local",
-        baseUrl: input.opencodeBaseUrl,
+        ...(input.opencodeBaseUrl ? { baseUrl: input.opencodeBaseUrl } : {}),
       },
     ],
     authorizedRoots: [input.workspaceRoot],
@@ -417,6 +417,24 @@ describe("workspace session read APIs", () => {
       code: "opencode_invalid_response",
       message: "OpenCode returned invalid session list",
     });
+  });
 
+  test("returns a configured error instead of constructing an SDK request with a relative URL", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const openwork = await startOpenworkServer({ workspaceRoot });
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/sessions?limit=200`, {
+      headers: auth(openwork.token),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "opencode_unconfigured",
+      message: "OpenCode base URL is missing for this workspace",
+      details: {
+        workspaceId: "ws_1",
+        workspaceType: "local",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fail fast with `opencode_unconfigured` before constructing an OpenCode SDK client without a base URL.
- Add a regression for `GET /workspace/ws_1/sessions?limit=200` when the workspace has no engine URL configured.

## Sentry
Fixes DESKTOP-APP-5

## Tests
- `pnpm --filter openwork-server exec bun --conditions=development test src/session-read-model.e2e.test.ts`
- `pnpm --filter openwork-server typecheck`