### PR TITLE
fix(den-api): log automation runner registration failures

### DIFF
--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -32,6 +32,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
+import { appLogger } from "../observability/logger.js"
 import { automationUpdateChangedRows } from "./update-result.js"
 import { cloudArtifactStateUpdate } from "./cloud-artifact-state.js"
 
@@ -41,6 +42,7 @@ type RunRow = typeof AutomationRunTable.$inferSelect
 type EventRow = typeof AutomationRunEventTable.$inferSelect
 type DesktopClaim = { automation: Automation; revision: AutomationRevision; run: AutomationRun }
 
+const logger = appLogger.child({ component: "automation_repository" })
 const emptyUsage: AutomationUsage = { inputTokens: null, outputTokens: null, costMicros: null }
 
 const normalizeAutomationId = (value: string) => normalizeDenTypeId("automation", value)
@@ -51,6 +53,7 @@ const normalizeMemberId = (value: string) => normalizeDenTypeId("member", value)
 
 const ms = (value: Date | null): number | null => value?.getTime() ?? null
 const date = (value: number | null): Date | null => value === null ? null : new Date(value)
+const idPrefix = (value: string) => value.slice(0, 8)
 
 function mapAutomation(row: AutomationRow): Automation {
   return {
@@ -847,27 +850,45 @@ export class DenAutomationRepository implements AutomationRepository {
       existing[0].organizationId !== normalizeOrganizationId(input.organizationId)
       || existing[0].ownerMemberId !== normalizeMemberId(input.ownerMemberId)
     )) throw new Error("automation_runner_identity_conflict")
-    await db.insert(AutomationRunnerTable).values({
-      id: input.runnerId,
-      organization_id: normalizeOrganizationId(input.organizationId),
-      owner_member_id: normalizeMemberId(input.ownerMemberId),
-      protocol_version: input.protocolVersion,
-      supported_execution_targets: input.supportedExecutionTargets,
-      app_version: input.appVersion,
-      platform: input.platform,
-      concurrency: input.concurrency,
-      last_seen_at: now,
-      created_at: now,
-      updated_at: now,
-    }).onDuplicateKeyUpdate({ set: {
-      protocol_version: input.protocolVersion,
-      supported_execution_targets: input.supportedExecutionTargets,
-      app_version: input.appVersion,
-      platform: input.platform,
-      concurrency: input.concurrency,
-      last_seen_at: now,
-      updated_at: now,
-    } })
+    try {
+      await db.insert(AutomationRunnerTable).values({
+        id: input.runnerId,
+        organization_id: normalizeOrganizationId(input.organizationId),
+        owner_member_id: normalizeMemberId(input.ownerMemberId),
+        protocol_version: input.protocolVersion,
+        supported_execution_targets: input.supportedExecutionTargets,
+        app_version: input.appVersion,
+        platform: input.platform,
+        concurrency: input.concurrency,
+        last_seen_at: now,
+        created_at: now,
+        updated_at: now,
+      }).onDuplicateKeyUpdate({ set: {
+        protocol_version: input.protocolVersion,
+        supported_execution_targets: input.supportedExecutionTargets,
+        app_version: input.appVersion,
+        platform: input.platform,
+        concurrency: input.concurrency,
+        last_seen_at: now,
+        updated_at: now,
+      } })
+    } catch (error) {
+      logger.error("automation runner registration upsert failed", {
+        error,
+        runner_id_prefix: idPrefix(input.runnerId),
+        runner_id_length: input.runnerId.length,
+        organization_id: normalizeOrganizationId(input.organizationId),
+        owner_member_id: normalizeMemberId(input.ownerMemberId),
+        existing_runner: existing[0] ? "same_owner" : "none",
+        protocol_version: input.protocolVersion,
+        supported_execution_targets: input.supportedExecutionTargets.join(","),
+        supported_execution_target_count: input.supportedExecutionTargets.length,
+        app_version_length: input.appVersion.length,
+        platform: input.platform,
+        concurrency: input.concurrency,
+      })
+      throw error
+    }
   }
 
   async touchDesktopRunner(input: { organizationId: string; ownerMemberId: string; runnerId: string; now: number }) {

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -160,6 +160,17 @@ test("runner credential minting is never exposed as an MCP tool", () => {
   assert.match(routesSource, /await service\.registerDesktopRunner\(scope\(c\), registration\)[\s\S]*const mapped = failure\(error\)/)
 })
 
+test("runner registration upsert failures include non-secret diagnostics", () => {
+  const registration = repositorySource.slice(
+    repositorySource.indexOf("async registerDesktopRunner"),
+    repositorySource.indexOf("async touchDesktopRunner"),
+  )
+  assert.match(registration, /logger\.error\("automation runner registration upsert failed"/)
+  assert.match(registration, /runner_id_prefix/)
+  assert.match(registration, /runner_id_length/)
+  assert.doesNotMatch(registration, /token/)
+})
+
 test("every runner endpoint re-checks that the token owner is still an active member", () => {
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
   assert.match(routesSource, /service\.isActiveRunnerOwner\(identity\)/)


### PR DESCRIPTION
## Summary
- add targeted non-secret diagnostics around automation runner registration upsert failures
- include runner shape, normalized owner context, and sanitized DB error details for DEN-API-16 triage
- assert the runner protocol keeps these diagnostics and avoids token logging

## Tests
- pnpm --filter @openwork-ee/den-api exec bun test test/automation-runner-protocol.test.ts
- pnpm --filter @openwork-ee/den-api typecheck:automations

Refs DEN-API-16