### PR TITLE
fix(den-api): tolerate runner touch failures

### DIFF
--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -19,6 +19,7 @@ import type { CloudAgentExecution, CloudAgentExecutorInput } from "./cloud-agent
 import { appLogger } from "../observability/logger.js"
 
 const schedulerOwner = `den:${process.pid}:${randomUUID()}`
+const logger = appLogger.child({ component: "automations" })
 
 type OwnerScope = {
   organizationId: string
@@ -332,7 +333,16 @@ export class AutomationService {
   }
 
   async discoverDesktopRunnerWork(scope: DesktopRunnerScope) {
-    await this.touchDesktopRunner(scope)
+    try {
+      await this.touchDesktopRunner(scope)
+    } catch (error) {
+      logger.warn("automation desktop runner touch failed", {
+        organization_id: scope.organizationId,
+        owner_member_id: scope.ownerMemberId,
+        runner_id: scope.runnerId,
+        error,
+      })
+    }
     return automationRepository.discoverDesktopWork({ ...scope, now: Date.now(), limit: 4 })
   }
 

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -217,6 +217,18 @@ test("idle runner keepalives do not persist liveness in the database", () => {
   assert.doesNotMatch(repositorySource, /AutomationRunnerTable\.last_seen_at, new Date\(input\.seenAfter\)/)
 })
 
+test("work polling tolerates non-critical runner presence touch failures", () => {
+  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
+  const discover = serviceSource.slice(
+    serviceSource.indexOf("async discoverDesktopRunnerWork"),
+    serviceSource.indexOf("async claimDesktopRunner"),
+  )
+
+  assert.match(discover, /try \{\s*await this\.touchDesktopRunner\(scope\)/)
+  assert.match(discover, /catch \(error\) \{[\s\S]*logger\.warn\("automation desktop runner touch failed"/)
+  assert.match(discover, /return automationRepository\.discoverDesktopWork/)
+})
+
 test("every dispatch path revalidates the owner's model access", () => {
   const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const tick = serviceSource.slice(serviceSource.indexOf("async tick"), serviceSource.indexOf("async stop"))


### PR DESCRIPTION
## Summary
- Make desktop runner presence touch best-effort during /v1/automation-runner/work polling.
- Log sanitized runner context when the presence update fails.
- Add a runner protocol regression guard.

Fixes DEN-API-19

## Verification
- pnpm --filter @openwork-ee/den-api typecheck:automations
- pnpm --filter @openwork-ee/den-api exec bun test test/automation-runner-protocol.test.ts