### PR TITLE
fix(server): handle inaccessible workspace paths

### DIFF
--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -8,6 +8,7 @@ import {
   ensureWorkspaceFiles,
   ensureLocalWorkspaceFiles,
 } from "./workspace-init.js";
+import { ApiError } from "./errors.js";
 import { openworkExtensionsPreviewPluginPath, openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 
 async function withWorkspace(fn: (root: string) => Promise<void>) {
@@ -33,6 +34,32 @@ describe("ensureWorkspaceFiles", () => {
 
       const secondResult = await ensureWorkspaceFiles(root, "starter");
       expect(secondResult).toEqual({ changed: false, reloadReasons: [] });
+    });
+  });
+
+  test("reports inaccessible workspace paths as API errors", async () => {
+    await withWorkspace(async (root) => {
+      const blockedPath = join(root, "blocked");
+      await writeFile(blockedPath, "not a directory", "utf8");
+
+      await expect(ensureWorkspaceFiles(blockedPath, "starter")).rejects.toMatchObject({
+        status: 409,
+        code: "workspace_inaccessible",
+        message: "Workspace path is not accessible",
+      });
+
+      try {
+        await ensureWorkspaceFiles(blockedPath, "starter");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError);
+        if (!(error instanceof ApiError)) throw error;
+        expect(error.details).toMatchObject({
+          path: blockedPath,
+          fsPath: blockedPath,
+        });
+        return;
+      }
+      throw new Error("Expected workspace path bootstrap to fail");
     });
   });
 

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -32,6 +32,12 @@ function normalizePreset(preset: string | null | undefined): string {
   return trimmed;
 }
 
+function errorStringField(error: unknown, field: "code" | "path" | "syscall"): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const value = Object.getOwnPropertyDescriptor(error, field)?.value;
+  return typeof value === "string" ? value : undefined;
+}
+
 /**
  * Build the default per-workspace openwork config metadata. The openwork
  * config is now stored in the runtime DB (see
@@ -65,7 +71,16 @@ export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: s
   if (!workspaceRoot.trim()) {
     throw new ApiError(400, "invalid_workspace_path", "workspace path is required");
   }
-  await ensureDir(workspaceRoot);
+  try {
+    await ensureDir(workspaceRoot);
+  } catch (error) {
+    throw new ApiError(409, "workspace_inaccessible", "Workspace path is not accessible", {
+      path: workspaceRoot,
+      fsCode: errorStringField(error, "code"),
+      syscall: errorStringField(error, "syscall"),
+      fsPath: errorStringField(error, "path"),
+    });
+  }
   const reloadReasons = new Set<ReloadReason>();
   if (await ensureOpencodeConfig(workspaceRoot)) reloadReasons.add("config");
   // openwork config is seeded into the runtime DB by the caller, not written


### PR DESCRIPTION
## Summary
- convert workspace bootstrap filesystem failures into a handled workspace_inaccessible API error
- include filesystem code/syscall/path details for recovery and diagnostics
- add regression coverage for inaccessible workspace paths

## Verification
- pnpm --filter openwork-server test src/workspace-init.test.ts
- pnpm --filter openwork-server typecheck

Fixes DESKTOP-APP-2