### PR TITLE
fix(server): tolerate closed stdout pipe

### DIFF
--- a/apps/server/src/server-logger.test.ts
+++ b/apps/server/src/server-logger.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { createServerLogger } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+function serverConfig(logFormat: ServerConfig["logFormat"] = "pretty"): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 30000 },
+    corsOrigins: ["*"],
+    workspaces: [],
+    authorizedRoots: [],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat,
+    logRequests: true,
+  };
+}
+
+function brokenPipeError() {
+  const error = new Error("write EPIPE");
+  Object.defineProperty(error, "code", { value: "EPIPE", enumerable: true });
+  return error;
+}
+
+describe("createServerLogger", () => {
+  test("disables log writes after stdout closes", () => {
+    let attempts = 0;
+    const logger = createServerLogger(serverConfig(), () => {
+      attempts += 1;
+      throw brokenPipeError();
+    });
+
+    expect(() => logger.log("info", "GET / 200 1ms")).not.toThrow();
+    expect(() => logger.log("info", "GET /again 200 1ms")).not.toThrow();
+    expect(attempts).toBe(1);
+  });
+
+  test("still throws unexpected log write failures", () => {
+    const logger = createServerLogger(serverConfig(), () => {
+      throw new Error("unexpected stdout failure");
+    });
+
+    expect(() => logger.log("info", "GET / 200 1ms")).toThrow("unexpected stdout failure");
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -736,6 +736,8 @@ type ServerLogger = {
   log: (level: LogLevel, message: string, attributes?: LogAttributes) => void;
 };
 
+type ServerLogWriter = (line: string) => void;
+
 /** Adapt the server logger to the warn/error shape helpers expect. */
 function toManagedProviderAuthLogger(logger: ServerLogger) {
   return {
@@ -756,7 +758,35 @@ function toUnixNano(): string {
   return (BigInt(Date.now()) * 1_000_000n).toString();
 }
 
-export function createServerLogger(config: ServerConfig): ServerLogger {
+function isBrokenLogPipeError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED";
+}
+
+let stdoutLogWritesDisabled = false;
+let stdoutErrorHandlerInstalled = false;
+
+function ensureStdoutErrorHandler() {
+  if (stdoutErrorHandlerInstalled) return;
+  stdoutErrorHandlerInstalled = true;
+  process.stdout.on("error", (error: unknown) => {
+    if (isBrokenLogPipeError(error)) {
+      stdoutLogWritesDisabled = true;
+      return;
+    }
+    process.nextTick(() => {
+      throw error;
+    });
+  });
+}
+
+function writeStdoutLogLine(line: string) {
+  ensureStdoutErrorHandler();
+  if (stdoutLogWritesDisabled) return;
+  process.stdout.write(`${line}\n`);
+}
+
+export function createServerLogger(config: ServerConfig, writeLine: ServerLogWriter = writeStdoutLogLine): ServerLogger {
   const runId = process.env.OPENWORK_RUN_ID ?? shortId();
   const host = hostname().trim();
   const resource: Record<string, string> = {
@@ -771,6 +801,23 @@ export function createServerLogger(config: ServerConfig): ServerLogger {
     "run.id": runId,
     "process.pid": process.pid,
   };
+  let logWritesDisabled = false;
+
+  const writeLogLine = (line: string) => {
+    if (logWritesDisabled) return;
+    try {
+      writeLine(line);
+    } catch (error) {
+      if (isBrokenLogPipeError(error)) {
+        logWritesDisabled = true;
+        if (writeLine === writeStdoutLogLine) {
+          stdoutLogWritesDisabled = true;
+        }
+        return;
+      }
+      throw error;
+    }
+  };
 
   const emit = (level: LogLevel, message: string, attributes?: LogAttributes) => {
     const merged = { ...baseAttributes, ...(attributes ?? {}) };
@@ -783,10 +830,10 @@ export function createServerLogger(config: ServerConfig): ServerLogger {
         attributes: merged,
         resource,
       };
-      process.stdout.write(`${JSON.stringify(record)}\n`);
+      writeLogLine(JSON.stringify(record));
       return;
     }
-    process.stdout.write(`${message}\n`);
+    writeLogLine(message);
   };
 
   return { log: emit };


### PR DESCRIPTION
## Summary
- prevent server request logging from crashing when stdout closes with EPIPE or ERR_STREAM_DESTROYED
- disable further log writes after the server detects a broken stdout pipe
- add regression coverage for broken-pipe log writes while preserving unexpected write failures

## Sentry
Fixes DESKTOP-APP-F

## Verification
- pnpm --filter openwork-server test src/server-logger.test.ts
- pnpm --filter openwork-server typecheck