### PR TITLE
fix(server): surface invalid skill frontmatter

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -231,6 +231,7 @@ export type OpenworkSkillItem = {
   description: string;
   scope: "project" | "global";
   trigger?: string;
+  error?: string;
 };
 
 export type OpenworkSkillContent = {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,7 +35,7 @@ import {
   parseMcpAppSandboxCsp,
 } from "./mcp-app-sandbox.js";
 import { exportExtensions } from "./extensions-export.js";
-import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
+import { deleteSkill, listSkills, renderSkillContentForResponse, upsertSkill } from "./skills.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
 import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
@@ -2833,7 +2833,8 @@ function createRoutes(
     if (!item) {
       throw new ApiError(404, "skill_not_found", `Skill not found: ${name}`);
     }
-    const content = await readFile(item.path, "utf8");
+    const rawContent = await readFile(item.path, "utf8");
+    const content = renderSkillContentForResponse(item, rawContent);
     return jsonResponse({ item, content });
   });
 

--- a/apps/server/src/skills.test.ts
+++ b/apps/server/src/skills.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deleteSkill, listSkills } from "./skills.js";
+import { deleteSkill, listSkills, renderSkillContentForResponse } from "./skills.js";
 import { exists } from "./utils.js";
 
 let workspace: string;
@@ -43,5 +43,43 @@ describe("deleteSkill", () => {
 
   test("404s for unknown skills", async () => {
     await expect(deleteSkill(workspace, "does-not-exist")).rejects.toThrow("Skill not found");
+  });
+});
+
+describe("listSkills", () => {
+  test("returns skills with malformed YAML frontmatter as visible errors", async () => {
+    const validDir = join(workspace, ".opencode", "skills", "valid-skill");
+    await writeSkill(validDir, "valid-skill");
+
+    const invalidDir = join(workspace, ".opencode", "skills", "invalid-skill");
+    await mkdir(invalidDir, { recursive: true });
+    const invalidContent = `---\nname: invalid-skill\ndescription: Use when searching the web, looking up facts, researching technology: trends\n---\n\nBody\n`;
+    await writeFile(
+      join(invalidDir, "SKILL.md"),
+      invalidContent,
+      "utf8",
+    );
+
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    try {
+      const listed = await listSkills(workspace, false);
+      const names = listed.map((skill) => skill.name);
+      const invalid = listed.find((skill) => skill.name === "invalid-skill");
+
+      expect(names).toContain("valid-skill");
+      expect(names).toContain("invalid-skill");
+      expect(invalid?.description.startsWith("ERROR: Invalid skill frontmatter")).toBe(true);
+      expect(invalid?.error).toContain("Nested mappings are not allowed");
+      expect(invalid ? renderSkillContentForResponse(invalid, invalidContent) : "").toContain("ERROR: This skill has invalid YAML frontmatter");
+      expect(invalid ? renderSkillContentForResponse(invalid, invalidContent) : "").toContain(invalidContent);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.[0]).toBe("[openwork:skills] Found invalid skill frontmatter");
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });

--- a/apps/server/src/skills.ts
+++ b/apps/server/src/skills.ts
@@ -9,6 +9,29 @@ import { validateDescription, validateSkillName } from "./validators.js";
 import { ApiError } from "./errors.js";
 import { projectSkillsDir } from "./workspace-files.js";
 
+const INVALID_SKILL_DESCRIPTION = "ERROR: Invalid skill frontmatter";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function summarizeError(message: string): string {
+  return message.split(/\r?\n/, 1)[0] ?? "Unknown error";
+}
+
+export function renderSkillContentForResponse(item: SkillItem, content: string): string {
+  if (!item.error) return content;
+  return [
+    "ERROR: This skill has invalid YAML frontmatter and may not load correctly.",
+    "",
+    item.error,
+    "",
+    "Original SKILL.md:",
+    "",
+    content,
+  ].join("\n");
+}
+
 async function findWorkspaceRoots(workspaceRoot: string): Promise<string[]> {
   const roots: string[] = [];
   let current = resolve(workspaceRoot);
@@ -55,8 +78,46 @@ async function parseSkillEntry(
   entryName: string,
   scope: "project" | "global",
 ): Promise<SkillItem | null> {
-  const content = await readFile(skillPath, "utf8");
-  const { data, body } = parseFrontmatter(content);
+  let content: string;
+  try {
+    content = await readFile(skillPath, "utf8");
+  } catch (error) {
+    console.warn("[openwork:skills] Skipping unreadable skill file", {
+      path: skillPath,
+      entryName,
+      scope,
+      error: errorMessage(error),
+    });
+    return null;
+  }
+
+  let data: Record<string, unknown>;
+  let body: string;
+  try {
+    const parsed = parseFrontmatter(content);
+    data = parsed.data;
+    body = parsed.body;
+  } catch (error) {
+    const message = errorMessage(error);
+    try {
+      validateSkillName(entryName);
+    } catch {
+      return null;
+    }
+    console.warn("[openwork:skills] Found invalid skill frontmatter", {
+      path: skillPath,
+      entryName,
+      scope,
+      error: message,
+    });
+    return {
+      name: entryName,
+      description: `${INVALID_SKILL_DESCRIPTION}: ${summarizeError(message)}`,
+      path: skillPath,
+      scope,
+      error: message,
+    };
+  }
   const name = typeof data.name === "string" ? data.name : entryName;
   const description = typeof data.description === "string" ? data.description : "";
   const trigger =

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -197,6 +197,7 @@ export interface SkillItem {
   description: string;
   scope: "project" | "global";
   trigger?: string;
+  error?: string;
 }
 
 export interface CommandItem {


### PR DESCRIPTION
## Summary
- Keep malformed skill files visible in the skills catalog with an ERROR description.
- Return skill detail content with an ERROR block plus the original SKILL.md when YAML frontmatter parsing fails.
- Add regression coverage for malformed YAML descriptions with unquoted colons.

## Verification
- pnpm --filter openwork-server exec bun --conditions=development test src/skills.test.ts
- pnpm --filter openwork-server typecheck
- pnpm --filter @openwork/app typecheck

Fixes DESKTOP-APP-1