### PR TITLE
fix(server): classify engine header timeouts

### DIFF
--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -7,6 +7,7 @@ import {
   clearEnginePoolForConfig,
   EnginePool,
   computeEngineConfigFingerprint,
+  isEngineConnectionFailure,
   setEnginePoolForConfig,
   type EnginePoolHooks,
   type EngineSpawnTemplate,
@@ -258,6 +259,14 @@ async function createPool(fixture: Fixture): Promise<{ pool: EnginePool; primary
 }
 
 describe("engine pool", () => {
+  test("classifies undici header timeouts as engine connection failures", () => {
+    const error = new TypeError("fetch failed", {
+      cause: { code: "UND_ERR_HEADERS_TIMEOUT", message: "Headers Timeout Error" },
+    });
+
+    expect(isEngineConnectionFailure(error)).toBe(true);
+  });
+
   test("skips entirely when nothing the engine reads at build time changed", async () => {
     const fixture = await createFixture();
     const { pool } = await createPool(fixture);

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -169,14 +169,14 @@ export function isEngineConnectionFailure(error: unknown): boolean {
   let current: unknown = error;
   for (let depth = 0; depth < 6 && current !== null && current !== undefined; depth += 1) {
     if (typeof current === "string") {
-      return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|socket hang up|Unable to connect/i.test(current);
+      return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|socket hang up|Unable to connect|Headers Timeout Error/i.test(current);
     }
     if (!isRecord(current) || visited.has(current)) return false;
     visited.add(current);
     const code = current.code;
-    if (code === "ECONNREFUSED" || code === "ECONNRESET" || code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return true;
+    if (code === "ECONNREFUSED" || code === "ECONNRESET" || code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT" || code === "UND_ERR_HEADERS_TIMEOUT") return true;
     const message = current.message;
-    if (typeof message === "string" && /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|socket hang up|Unable to connect/i.test(message)) return true;
+    if (typeof message === "string" && /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|socket hang up|Unable to connect|Headers Timeout Error/i.test(message)) return true;
     current = current.cause;
   }
   return false;


### PR DESCRIPTION
## Summary
- classify undici `UND_ERR_HEADERS_TIMEOUT` / `Headers Timeout Error` as an OpenCode engine connection failure
- keep local engine header timeouts on the existing controlled `opencode_unreachable` 502 path instead of capturing them as unexpected server errors
- add a focused regression test for the Sentry error shape

Fixes DESKTOP-APP-G

## Verification
- `pnpm --filter openwork-server test src/engine-pool.test.ts`
- `pnpm --filter openwork-server typecheck`