### PR TITLE
fix(server): let malformed frontmatter throw again for visible skill errors

### DIFF
--- a/apps/server/src/frontmatter.test.ts
+++ b/apps/server/src/frontmatter.test.ts
@@ -10,11 +10,10 @@ describe("parseFrontmatter", () => {
     });
   });
 
-  test("returns empty data for malformed compact-mapping YAML", () => {
-    expect(parseFrontmatter("---\ndescription: foo: bar\n---\nbody text")).toEqual({
-      data: {},
-      body: "body text",
-    });
+  test("throws on malformed compact-mapping YAML so callers can surface it", () => {
+    expect(() => parseFrontmatter("---\ndescription: foo: bar\n---\nbody text")).toThrow(
+      "Nested mappings are not allowed",
+    );
   });
 
   test("returns empty data for non-object YAML frontmatter", () => {

--- a/apps/server/src/frontmatter.ts
+++ b/apps/server/src/frontmatter.ts
@@ -7,15 +7,13 @@ export function parseFrontmatter(content: string): { data: Record<string, unknow
   }
   const raw = match[1] ?? "";
   const body = content.slice(match[0].length);
-  try {
-    const parsed: unknown = parse(raw);
-    const data = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? Object.fromEntries(Object.entries(parsed))
-      : {};
-    return { data, body };
-  } catch {
-    return { data: {}, body };
-  }
+  // Malformed YAML throws (callers like listSkills catch it to surface a
+  // visible per-item error); non-mapping YAML normalizes to an empty record.
+  const parsed: unknown = parse(raw);
+  const data = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? Object.fromEntries(Object.entries(parsed))
+    : {};
+  return { data, body };
 }
 
 export function buildFrontmatter(data: Record<string, unknown>): string {


### PR DESCRIPTION
## Why

Dev is red on \`openwork-tests\`: #3829 (merged) made \`parseFrontmatter\` swallow YAML parse errors, while #3840 landed in parallel and depends on the throw — \`listSkills\` catches it per skill and renders a visible \`ERROR: Invalid skill frontmatter\` item. The swallow made #3840's test \`listSkills > returns skills with malformed YAML frontmatter as visible errors\` fail on dev (both Ubuntu and macOS legs).

## Fix

- \`parseFrontmatter\` throws again on malformed YAML (callers like \`parseSkillEntry\` catch and surface it — the original Sentry DESKTOP-APP-1 crash stays fixed via #3840's per-skill handling)
- Keeps the non-mapping normalization from #3829: string/array frontmatter parses to an empty record instead of leaking a mis-typed value
- Updated \`frontmatter.test.ts\`: the malformed-YAML case now asserts the throw

## Verification

\`\`\`
cd apps/server
bun --conditions=development test   # 728 pass, 8 skip — listSkills test green again
pnpm typecheck                      # clean
\`\`\`

The remaining local \`1 fail + 1 error\` is \`workspace-kv-store.node.test.ts\` failing to resolve \`node:sqlite\` under bun 1.3.8 — reproduced identically on clean \`origin/dev\` with no working-tree changes, so pre-existing and environment-only (CI's failure was only the \`listSkills\` test this PR fixes).

**Verdict: Passed** (unit lane; restores dev to green).