### PR TITLE
fix(desktop): type stdio error handlers for the electron typecheck

### DIFF
--- a/apps/desktop/electron/stdio-errors.mjs
+++ b/apps/desktop/electron/stdio-errors.mjs
@@ -4,6 +4,12 @@ export function isBrokenPipeError(error) {
   return Boolean(error && typeof error === "object" && error.code === "EPIPE");
 }
 
+/**
+ * Install once-per-stream error handlers. Only the EventEmitter surface is
+ * needed, so tests can pass plain emitters in place of process streams.
+ *
+ * @param {{ stdout?: NodeJS.EventEmitter, stderr?: NodeJS.EventEmitter }} [streams]
+ */
 export function installStdioErrorHandlers({ stdout = process.stdout, stderr = process.stderr } = {}) {
   for (const stream of [stdout, stderr]) {
     if (!stream || typeof stream.on !== "function" || guardedStreams.has(stream)) continue;

--- a/apps/desktop/electron/stdio-errors.test.mjs
+++ b/apps/desktop/electron/stdio-errors.test.mjs
@@ -4,10 +4,12 @@ import { EventEmitter } from "node:events";
 
 import { installStdioErrorHandlers, isBrokenPipeError } from "./stdio-errors.mjs";
 
+/**
+ * @param {string} code
+ * @returns {Error & { code: string }}
+ */
 function streamError(code) {
-  const error = new Error(code === "EPIPE" ? "write EPIPE" : "stream failed");
-  error.code = code;
-  return error;
+  return Object.assign(new Error(code === "EPIPE" ? "write EPIPE" : "stream failed"), { code });
 }
 
 describe("stdio error handling", () => {


### PR DESCRIPTION
## Why

Dev's \`openwork-tests\` has been red since #3841 on the **Typecheck Electron main against the IPC contract** step (\`checkJs\` over \`electron/**/*.mjs\`):

- \`error.code = code\` → TS2339 (\`code\` not on \`Error\`)
- test EventEmitters not assignable to the inferred \`WriteStream & { fd: 1|2 }\` params of \`installStdioErrorHandlers\`

(The server unit-test step is already green again after #3845.)

## Fix

- \`streamError\` builds the error via \`Object.assign\` with a \`@returns {Error & { code: string }}\` JSDoc type
- \`installStdioErrorHandlers\` declares its params as the \`NodeJS.EventEmitter\` surface it actually uses (\`.on\`), so real process streams and test emitters both type-check — runtime behavior unchanged

## Verification

\`\`\`
cd apps/server && pnpm exec tsc -p ../desktop/tsconfig.electron.json --noEmit   # clean (was 7 errors)
cd apps/desktop && node --test electron/stdio-errors.test.mjs                    # 3 pass, 0 fail
\`\`\`

Types/JSDoc-only change; no runtime behavior difference, so no runtime proof needed.

**Verdict: Passed** (restores the Electron typecheck step on dev).