### PR TITLE
ci: add openwork-tests-required merge gate for branch rulesets

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -170,3 +170,21 @@ jobs:
 
       - name: Run e2e tests
         run: pnpm --filter @openwork/app test:e2e
+
+  # Single stable context for branch rulesets to require. Green only when
+  # every openwork-tests matrix leg succeeded; runs even when legs fail or
+  # are cancelled so the required check always reports instead of hanging.
+  openwork-tests-required:
+    needs: openwork-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every openwork-tests matrix leg to pass
+        env:
+          RESULT: ${{ needs.openwork-tests.result }}
+        run: |
+          echo "openwork-tests result: $RESULT"
+          if [ "$RESULT" != "success" ]; then
+            echo "One or more OpenWork Tests matrix legs did not succeed; blocking merge." >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Why

PR #3841 merged into `dev` with **both `openwork-tests` matrix legs FAILING** (the `typecheck:electron` step), leaving dev CI red for five consecutive pushes until #3846 fixed it. Root cause of the *merge*: the branch ruleset on `dev` requires reviews, thread resolution, and CodeQL — but **no status checks**, so a red `OpenWork Tests` run never blocks the merge button.

Requiring the raw matrix contexts (`openwork-tests (macos-14)`, `openwork-tests (blacksmith-4vcpu-ubuntu-2204)`) in a ruleset is brittle: every matrix change silently desyncs the required-context list.

## What

Adds one aggregate job to the existing `OpenWork Tests` workflow:

- `openwork-tests-required` — `needs: openwork-tests`, `if: always()`, fails unless `needs.openwork-tests.result == 'success'` (i.e. green only when **every** matrix leg succeeded; reports a failure instead of hanging when legs fail or are cancelled).

This gives branch rulesets a single stable context to require, independent of matrix shape.

## Activation (settings, not code)

After this merges, a repo ruleset on `dev` will require the `openwork-tests-required` status check (done via API; activated only post-merge so open PRs whose CI predates the gate aren't bricked — they pick it up on their next push/rebase).

## Verification

Workflow-only YAML (inert config — no runtime testkit proof applies). Observable proof: the `openwork-tests-required` check reports on **this PR itself**, green only because both matrix legs pass. YAML parse verified; `actionlint` reports only a pre-existing unknown-runner-label warning for `blacksmith-4vcpu-ubuntu-2204` (reproduced identically on clean `origin/dev`).

Note: this PR touches `.github/`, so Warden clearance correctly refuses to self-approve — human review required.