### PR TITLE
perf(den-api): cache external MCP tool lists and bound capability search probes

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -304,11 +304,13 @@ export async function listExternalMcpTools(
   member?: ExternalMcpMemberContext,
   diagnosticReferenceId?: string,
   lifecycleDeadline?: ExternalMcpLifecycleDeadline,
+  operationTimeoutMs?: number,
 ) {
   return runEnterpriseMcpOperation({
     connection,
     diagnosticReferenceId,
     lifecycleDeadline,
+    operationTimeoutMs,
     operation: (client) => client.listTools({
       connection: toEnterpriseConnection(connection, member),
       redirectUri,

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -47,6 +47,11 @@ import {
   resolveCodemodeConnectionNamespaceContext,
   type CodemodeConnectionNamespaceContext,
 } from "./codemode-namespaces.js"
+import {
+  getExternalToolsSearchCache,
+  setExternalToolsSearchCache,
+  type ExternalToolsSearchCacheKey,
+} from "./external-tools-search-cache.js"
 
 /**
  * Merges org-level External MCP Connections (capability-sources/) into the
@@ -68,8 +73,10 @@ import {
 
 const EXTERNAL_CAPABILITY_PREFIX = "mcp:"
 export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT
-export const EXTERNAL_MCP_SEARCH_CONCURRENCY = 4
+export const EXTERNAL_MCP_SEARCH_CONCURRENCY = 8
 export const EXTERNAL_MCP_SEARCH_MATCH_LIMIT = 20
+const EXTERNAL_MCP_SEARCH_REQUEST_TIMEOUT_MS = 5_000
+const EXTERNAL_MCP_SEARCH_LIFECYCLE_TIMEOUT_MS = 8_000
 
 export function buildExternalCapabilityName(connectionId: string, toolName: string): string {
   return `${EXTERNAL_CAPABILITY_PREFIX}${connectionId}:${toolName}`
@@ -711,15 +718,31 @@ async function probeExternalMcpConnection(input: {
     ? { orgMembershipId: input.member.orgMembershipId }
     : undefined
   let tools: Awaited<ReturnType<typeof listExternalMcpTools>>
+  const cacheKey: ExternalToolsSearchCacheKey = {
+    organizationId: connection.organizationId,
+    connectionId: connection.id,
+    updatedAt: connection.updatedAt,
+    credentialMode: connection.credentialMode,
+    ...(connection.credentialMode === "per_member" ? { orgMembershipId: input.member.orgMembershipId } : {}),
+  }
+  const cachedProbe = getExternalToolsSearchCache(cacheKey)
   try {
-    tools = await listExternalMcpTools(
-      connection,
-      redirectUriFor(input.redirectUriBase, connection.id),
-      member,
-      undefined,
-      input.deadline,
-    )
+    if (cachedProbe?.outcome === "failure") throw cachedProbe.error
+    if (cachedProbe?.outcome === "success") {
+      tools = cachedProbe.tools
+    } else {
+      tools = await listExternalMcpTools(
+        connection,
+        redirectUriFor(input.redirectUriBase, connection.id),
+        member,
+        undefined,
+        input.deadline,
+        EXTERNAL_MCP_SEARCH_REQUEST_TIMEOUT_MS,
+      )
+      setExternalToolsSearchCache(cacheKey, { outcome: "success", tools })
+    }
   } catch (error) {
+    if (!cachedProbe) setExternalToolsSearchCache(cacheKey, { outcome: "failure", error })
     const message = upstreamErrorMessage(error)
     const diagnostic = error instanceof ExternalMcpDiagnosticError ? error.diagnostic : undefined
     const nameTokens = tokenize(connection.name)
@@ -800,7 +823,7 @@ export async function searchExternalCapabilities(input: {
   const requestedLimit = input.limit ?? 5
   if (!Number.isFinite(requestedLimit) || requestedLimit <= 0) return []
   const limit = Math.min(Math.max(1, Math.trunc(requestedLimit)), EXTERNAL_MCP_SEARCH_MATCH_LIMIT)
-  const deadline = createExternalMcpLifecycleDeadline()
+  const deadline = createExternalMcpLifecycleDeadline(EXTERNAL_MCP_SEARCH_LIFECYCLE_TIMEOUT_MS)
   const namespaceContext = input.includeScriptPaths
     ? input.namespaceContext ?? await resolveCodemodeConnectionNamespaceContext({
       organizationId: input.organizationId,

--- a/ee/apps/den-api/src/mcp/external-tools-search-cache.ts
+++ b/ee/apps/den-api/src/mcp/external-tools-search-cache.ts
@@ -1,0 +1,69 @@
+import type { listExternalMcpTools } from "../capability-sources/external-mcp-client-runtime.js"
+
+const SUCCESS_TTL_MS = 10 * 60_000
+const FAILURE_TTL_MS = 60_000
+export const EXTERNAL_TOOLS_SEARCH_CACHE_MAX_ENTRIES = 500
+const SHARED_CREDENTIAL_IDENTITY = "shared"
+
+export type ExternalToolsSearchCacheKey = {
+  organizationId: string
+  connectionId: string
+  updatedAt: Date
+  credentialMode: "shared" | "per_member"
+  orgMembershipId?: string
+}
+
+export type ExternalToolsSearchProbeResult =
+  | { outcome: "success"; tools: Awaited<ReturnType<typeof listExternalMcpTools>> }
+  | { outcome: "failure"; error: unknown }
+
+type CacheEntry = {
+  expiresAt: number
+  result: ExternalToolsSearchProbeResult
+}
+
+const entries = new Map<string, CacheEntry>()
+
+function cacheKey(input: ExternalToolsSearchCacheKey): string {
+  const identity = input.credentialMode === "per_member"
+    ? input.orgMembershipId
+    : SHARED_CREDENTIAL_IDENTITY
+  if (!identity) throw new Error("Per-member external MCP search cache keys require an organization membership id.")
+  return JSON.stringify([input.organizationId, input.connectionId, input.updatedAt.getTime(), identity])
+}
+
+export function getExternalToolsSearchCache(
+  key: ExternalToolsSearchCacheKey,
+  now: () => number = Date.now,
+): ExternalToolsSearchProbeResult | undefined {
+  const serializedKey = cacheKey(key)
+  const entry = entries.get(serializedKey)
+  if (!entry) return undefined
+  if (entry.expiresAt <= now()) {
+    entries.delete(serializedKey)
+    return undefined
+  }
+  return entry.result
+}
+
+export function setExternalToolsSearchCache(
+  key: ExternalToolsSearchCacheKey,
+  result: ExternalToolsSearchProbeResult,
+  now: () => number = Date.now,
+): void {
+  const serializedKey = cacheKey(key)
+  entries.delete(serializedKey)
+  entries.set(serializedKey, {
+    expiresAt: now() + (result.outcome === "success" ? SUCCESS_TTL_MS : FAILURE_TTL_MS),
+    result,
+  })
+  while (entries.size > EXTERNAL_TOOLS_SEARCH_CACHE_MAX_ENTRIES) {
+    const oldestKey = entries.keys().next().value
+    if (oldestKey === undefined) break
+    entries.delete(oldestKey)
+  }
+}
+
+export function clearExternalToolsSearchCache(): void {
+  entries.clear()
+}

--- a/ee/apps/den-api/test/external-tools-search-cache.test.ts
+++ b/ee/apps/den-api/test/external-tools-search-cache.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test } from "bun:test"
+import {
+  clearExternalToolsSearchCache,
+  EXTERNAL_TOOLS_SEARCH_CACHE_MAX_ENTRIES,
+  getExternalToolsSearchCache,
+  setExternalToolsSearchCache,
+  type ExternalToolsSearchCacheKey,
+  type ExternalToolsSearchProbeResult,
+} from "../src/mcp/external-tools-search-cache.js"
+
+const updatedAt = new Date("2026-08-16T12:00:00.000Z")
+const success: ExternalToolsSearchProbeResult = { outcome: "success", tools: [] }
+const failure: ExternalToolsSearchProbeResult = { outcome: "failure", error: new Error("provider unavailable") }
+
+function key(overrides: Partial<ExternalToolsSearchCacheKey> = {}): ExternalToolsSearchCacheKey {
+  return {
+    organizationId: "organization-one",
+    connectionId: "connection-one",
+    updatedAt,
+    credentialMode: "shared",
+    ...overrides,
+  }
+}
+
+beforeEach(clearExternalToolsSearchCache)
+
+test("keys per-member connections by organization membership", () => {
+  const first = key({ credentialMode: "per_member", orgMembershipId: "member-one" })
+  const second = key({ credentialMode: "per_member", orgMembershipId: "member-two" })
+  setExternalToolsSearchCache(first, success)
+  setExternalToolsSearchCache(second, failure)
+  expect(getExternalToolsSearchCache(first)).toBe(success)
+  expect(getExternalToolsSearchCache(second)).toBe(failure)
+})
+
+test("separates identical connection ids by organization", () => {
+  const first = key({ organizationId: "organization-one" })
+  const second = key({ organizationId: "organization-two" })
+  setExternalToolsSearchCache(first, success)
+  expect(getExternalToolsSearchCache(second)).toBeUndefined()
+})
+
+test("misses after the connection updatedAt changes", () => {
+  setExternalToolsSearchCache(key(), success)
+  expect(getExternalToolsSearchCache(key({ updatedAt: new Date(updatedAt.getTime() + 1) }))).toBeUndefined()
+})
+
+test("expires successful probes after ten minutes", () => {
+  let now = 1_000
+  const clock = () => now
+  setExternalToolsSearchCache(key(), success, clock)
+  now += 10 * 60_000 - 1
+  expect(getExternalToolsSearchCache(key(), clock)).toBe(success)
+  now += 1
+  expect(getExternalToolsSearchCache(key(), clock)).toBeUndefined()
+})
+
+test("expires failures after one minute while successes persist", () => {
+  let now = 1_000
+  const clock = () => now
+  const failureKey = key({ connectionId: "failure" })
+  const successKey = key({ connectionId: "success" })
+  setExternalToolsSearchCache(failureKey, failure, clock)
+  setExternalToolsSearchCache(successKey, success, clock)
+  now += 60_000
+  expect(getExternalToolsSearchCache(failureKey, clock)).toBeUndefined()
+  expect(getExternalToolsSearchCache(successKey, clock)).toBe(success)
+})
+
+test("evicts the oldest entry at the size cap", () => {
+  const oldest = key({ connectionId: "connection-0" })
+  for (let index = 0; index <= EXTERNAL_TOOLS_SEARCH_CACHE_MAX_ENTRIES; index += 1) {
+    setExternalToolsSearchCache(key({ connectionId: `connection-${index}` }), success)
+  }
+  expect(getExternalToolsSearchCache(oldest)).toBeUndefined()
+  expect(getExternalToolsSearchCache(key({ connectionId: `connection-${EXTERNAL_TOOLS_SEARCH_CACHE_MAX_ENTRIES}` }))).toBe(success)
+})

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -48,6 +48,8 @@ export interface StartMockMcpOptions {
   port?: number;
   scriptPath?: string;
   publicUrl?: string;
+  /** Advertised OAuth/resource origin when the mock sits behind a proxy; defaults to the mock's own URL. */
+  issuer?: string;
   profileId?: EnterpriseMcpProfileId;
   oauthClientSecret?: string;
   allowUnauthenticatedMcp?: boolean;
@@ -263,7 +265,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         ...process.env,
         HOST: "0.0.0.0",
         PORT: String(port),
-        ISSUER: url,
+        ISSUER: options.issuer ?? url,
         AUTO_APPROVE: "1",
         ...(options.allowUnauthenticatedMcp ? { MOCK_ALLOW_UNAUTHENTICATED_MCP: "1" } : {}),
       },

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -53,6 +53,8 @@ export interface StartMockMcpOptions {
   profileId?: EnterpriseMcpProfileId;
   oauthClientSecret?: string;
   allowUnauthenticatedMcp?: boolean;
+  /** Serve this many additional synthetic mock_tool_<i> tools for scale specs. */
+  extraToolCount?: number;
 }
 
 export type EnterpriseMcpProfileId =
@@ -268,6 +270,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         ISSUER: options.issuer ?? url,
         AUTO_APPROVE: "1",
         ...(options.allowUnauthenticatedMcp ? { MOCK_ALLOW_UNAUTHENTICATED_MCP: "1" } : {}),
+        ...(options.extraToolCount ? { MOCK_EXTRA_TOOL_COUNT: String(options.extraToolCount) } : {}),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/evals/specs/capability-search-latency.slow.test.ts
+++ b/evals/specs/capability-search-latency.slow.test.ts
@@ -1,0 +1,371 @@
+import { expect } from "vitest";
+import {
+  createOrgConnection,
+  deleteConnection,
+  denFetch,
+  evalIn,
+  waitFor,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { allocateFreePort, closeTarget, listTargets, navigate } from "@openwork/cdp";
+import type { Surface } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { startMockMcp } from "@openwork/labs";
+import type { MockMcpHandle } from "@openwork/labs";
+import {
+  faultProxy,
+  mcpMock,
+  needs,
+  server,
+  test,
+  unmetNeeds,
+} from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = {
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `capability search latency skipped — needs: ${missingRequirements.join(", ")}`
+  : "external MCP capability search is cached, bounded, and fresh across connection identities";
+
+interface MockRawRequest {
+  at?: string;
+  rpcMethods?: string[];
+}
+
+interface MockRawLog {
+  requests: MockRawRequest[];
+}
+
+interface Connection {
+  id: string;
+  name: string;
+}
+
+let requestId = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value).slice(0, 500)}`);
+  return value;
+}
+
+function toolText(result: unknown): string {
+  const record = requireRecord(result, "MCP tool result");
+  const first = Array.isArray(record.content) ? record.content[0] : null;
+  if (!isRecord(first) || typeof first.text !== "string") {
+    throw new Error(`MCP tool result had no text content: ${JSON.stringify(result).slice(0, 500)}`);
+  }
+  return first.text;
+}
+
+function toolJson(result: unknown): unknown {
+  return JSON.parse(toolText(result));
+}
+
+function searchMatches(result: unknown): Record<string, unknown>[] {
+  const payload = requireRecord(toolJson(result), "search_capabilities payload");
+  return Array.isArray(payload.matches) ? payload.matches.filter(isRecord) : [];
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const id = organizations[0] && typeof organizations[0].id === "string" ? organizations[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function mintMcpToken(session: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(session, "/v1/mcp/token", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({}),
+  });
+  const token = isRecord(result.body) && typeof result.body.token === "string" ? result.body.token : "";
+  if (!result.response.ok || !token.startsWith("ow_mcp_at_")) {
+    throw new Error(`Minting MCP token failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return token;
+}
+
+async function callTool(
+  apiUrl: string,
+  mcpToken: string,
+  name: "search_capabilities" | "execute_capability",
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: ++requestId,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP tools/call failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`MCP tools/call returned no SSE data frame: ${raw.slice(0, 500)}`);
+  const payload: unknown = JSON.parse(dataLine.slice(5));
+  const record = requireRecord(payload, "MCP JSON-RPC payload");
+  if (record.error) throw new Error(`MCP tools/call returned JSON-RPC error: ${JSON.stringify(record.error)}`);
+  return record.result;
+}
+
+function hasCapability(matches: Record<string, unknown>[], connectionId: string): boolean {
+  return matches.some((entry) => entry.name === `mcp:${connectionId}:mock_echo`);
+}
+
+async function toolsListCount(mock: MockMcpHandle): Promise<number> {
+  const response = await fetch(`${mock.url}/requests`, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) throw new Error(`Reading mock request log failed: HTTP ${response.status}`);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !Array.isArray(value.requests)) {
+    throw new Error(`Mock request log was malformed: ${JSON.stringify(value).slice(0, 500)}`);
+  }
+  const raw: MockRawLog = {
+    requests: value.requests.filter(isRecord).map((entry) => ({
+      at: typeof entry.at === "string" ? entry.at : undefined,
+      rpcMethods: Array.isArray(entry.rpcMethods)
+        ? entry.rpcMethods.filter((method): method is string => typeof method === "string")
+        : undefined,
+    })),
+  };
+  return raw.requests.filter(
+    (entry) => Array.isArray(entry.rpcMethods) && entry.rpcMethods.includes("tools/list"),
+  ).length;
+}
+
+async function oauthConnect(
+  browser: Surface,
+  denWebUrl: string,
+  connection: Connection,
+  mock: MockMcpHandle,
+): Promise<void> {
+  await navigate(browser.client, `${denWebUrl}/dashboard/your-connections`);
+  await waitFor(browser, `document.body.innerText.includes("Your Connections")
+    && document.body.innerText.includes(${JSON.stringify(connection.name)})`, {
+    timeoutMs: 60_000,
+    label: `${connection.name} row on Your Connections`,
+  });
+  const connectStartedAt = new Date().toISOString();
+  await waitFor(browser, `(() => {
+    const name = [...document.querySelectorAll("p")]
+      .find((entry) => (entry.textContent ?? "").trim() === ${JSON.stringify(connection.name)});
+    let row = name?.parentElement ?? null;
+    while (row && ![...row.querySelectorAll("button")].some((button) => (button.textContent ?? "").trim() === "Connect")) {
+      row = row.parentElement;
+    }
+    const connect = row ? [...row.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").trim() === "Connect" && !button.disabled) : null;
+    connect?.click();
+    return Boolean(connect);
+  })()`, { timeoutMs: 30_000, label: `Connect ${connection.name} org account` });
+  await mock.authorizeRequestSince(connectStartedAt, { timeoutMs: 120_000 });
+  await waitFor(browser, `Boolean(document.querySelector(${JSON.stringify(`[data-testid="toggle-mcp-tool-runner-${connection.id}"]`)}))`, {
+    timeoutMs: 120_000,
+    label: `${connection.name} connected tool tester action`,
+  });
+  const oauthTargets = (await listTargets(browser.handle.cdpUrl))
+    .filter((target) => target.type === "page" && !target.url.startsWith(denWebUrl));
+  for (const target of oauthTargets) await closeTarget(browser.handle.cdpUrl, target.id);
+}
+
+test(title, async ({ place, evidence, skip }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    mocks: { healthy: mcpMock() },
+  });
+  const flakyPort = await allocateFreePort();
+  const flakyUrl = `http://127.0.0.1:${flakyPort}`;
+  await using proxy = await faultProxy({
+    webUrl: flakyUrl,
+    apiUrl: flakyUrl,
+  });
+  await using flakyMock = await startMockMcp({ port: flakyPort, issuer: proxy.ref.webUrl });
+  const healthy = await createOrgConnection(den.admin, {
+    name: `Capability Search Healthy ${Date.now()}`,
+    url: `${den.mocks.healthy.url}/mcp`,
+    authType: "oauth",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  await using browser = await chrome({
+    name: "capability-search-latency",
+    startUrl: den.ref.webUrl,
+    headless: true,
+    host: place.host(),
+  });
+  await browser.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 1000,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin before admin auth token handoff",
+  });
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+  await oauthConnect(browser, den.ref.webUrl, healthy, den.mocks.healthy);
+  const flaky = await createOrgConnection(den.admin, {
+    name: `Capability Search Flaky ${Date.now()}`,
+    url: `${proxy.ref.webUrl}/mcp`,
+    authType: "oauth",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  await oauthConnect(browser, den.ref.webUrl, flaky, flakyMock);
+
+  const baselineHealthyCount = await toolsListCount(den.mocks.healthy);
+  const baselineFlakyCount = await toolsListCount(flakyMock);
+  const orgId = await organizationId(den.admin);
+  const mcpToken = await mintMcpToken(den.admin, orgId);
+
+  const coldStartedAt = Date.now();
+  const coldResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "mock echo",
+    limit: 20,
+  });
+  const coldDurationMs = Date.now() - coldStartedAt;
+  const coldMatches = searchMatches(coldResult);
+  const coldHealthyCount = await toolsListCount(den.mocks.healthy);
+  const coldBounded = coldDurationMs < 15_000;
+  const coldFoundHealthy = hasCapability(coldMatches, healthy.id);
+  const coldProbedHealthy = coldHealthyCount - baselineHealthyCount >= 1;
+  evidence.fact(
+    "A cold capability search is correct and bounded",
+    JSON.stringify({ coldDurationMs, baselineHealthyCount, baselineFlakyCount, coldHealthyCount, coldMatches }),
+    coldBounded && coldFoundHealthy && coldProbedHealthy,
+  );
+  expect(coldDurationMs).toBeLessThan(15_000);
+  expect(coldFoundHealthy).toBe(true);
+  expect(coldHealthyCount - baselineHealthyCount).toBeGreaterThanOrEqual(1);
+
+  const warmHealthyBefore = await toolsListCount(den.mocks.healthy);
+  const warmFlakyBefore = await toolsListCount(flakyMock);
+  const warmQueries = ["mock echo", "echo tool", "batch mock"];
+  const warmObservations: { durationMs: number; foundHealthy: boolean; query: string }[] = [];
+  for (const query of warmQueries) {
+    const startedAt = Date.now();
+    const result = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", { query, limit: 20 });
+    warmObservations.push({
+      durationMs: Date.now() - startedAt,
+      foundHealthy: hasCapability(searchMatches(result), healthy.id),
+      query,
+    });
+  }
+  const warmHealthyAfter = await toolsListCount(den.mocks.healthy);
+  const warmFlakyAfter = await toolsListCount(flakyMock);
+  const allWarmFastAndCorrect = warmObservations.every(
+    (observation) => observation.durationMs < 3_000 && observation.foundHealthy,
+  );
+  const warmHealthyReprobes = warmHealthyAfter - warmHealthyBefore;
+  const warmFlakyReprobes = warmFlakyAfter - warmFlakyBefore;
+  evidence.fact(
+    "Warm capability searches are fast and do not re-probe either connection",
+    JSON.stringify({ warmObservations, warmHealthyReprobes, warmFlakyReprobes }),
+    allWarmFastAndCorrect && warmHealthyReprobes === 0 && warmFlakyReprobes === 0,
+  );
+  for (const observation of warmObservations) {
+    expect(observation.durationMs).toBeLessThan(3_000);
+    expect(observation.foundHealthy).toBe(true);
+  }
+  expect(warmHealthyReprobes).toBe(0);
+  expect(warmFlakyReprobes).toBe(0);
+
+  const hangfresh = await createOrgConnection(den.admin, {
+    name: `Capability Search Hang Fresh ${Date.now()}`,
+    url: `${proxy.ref.webUrl}/mcp`,
+    authType: "oauth",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  await oauthConnect(browser, den.ref.webUrl, hangfresh, flakyMock);
+  // Arm the hang only after hangfresh is connected: the timed search below is
+  // then the first live probe of this connection, and it must not block results.
+  proxy.faults.latency("/mcp", 20_000, { times: 50 });
+  const hangingUpstreamBefore = await toolsListCount(flakyMock);
+  const hangingSearchStartedAt = Date.now();
+  const hangingResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "mock echo",
+    limit: 20,
+  });
+  const hangingDurationMs = Date.now() - hangingSearchStartedAt;
+  const hangingMatches = searchMatches(hangingResult);
+  const hangingFoundHealthy = hasCapability(hangingMatches, healthy.id);
+  // The hung probe is aborted by the search deadline: no hangfresh capability
+  // may appear, and no fresh tools/list may have reached the upstream mock.
+  // A 20s hang against a <12s bound is the proof the search did not wait.
+  const hangingFoundHangfresh = hasCapability(hangingMatches, hangfresh.id);
+  const hangingUpstreamAfter = await toolsListCount(flakyMock);
+  const hangingUpstreamProbes = hangingUpstreamAfter - hangingUpstreamBefore;
+  evidence.fact(
+    "A hanging provider cannot block healthy cached capability results",
+    JSON.stringify({ hangingDurationMs, hangingFoundHealthy, hangingFoundHangfresh, hangingUpstreamProbes }),
+    hangingDurationMs < 12_000 && hangingFoundHealthy && !hangingFoundHangfresh && hangingUpstreamProbes === 0,
+  );
+  expect(hangingDurationMs).toBeLessThan(12_000);
+  expect(hangingFoundHealthy).toBe(true);
+  expect(hangingFoundHangfresh).toBe(false);
+  expect(hangingUpstreamProbes).toBe(0);
+
+  await deleteConnection(den.admin, healthy.id);
+  const replacement = await createOrgConnection(den.admin, {
+    name: `Capability Search Replacement ${Date.now()}`,
+    url: `${den.mocks.healthy.url}/mcp`,
+    authType: "oauth",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  await oauthConnect(browser, den.ref.webUrl, replacement, den.mocks.healthy);
+  const replacementCountBefore = await toolsListCount(den.mocks.healthy);
+  const replacementStartedAt = Date.now();
+  const replacementResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "mock echo",
+    limit: 20,
+  });
+  const replacementDurationMs = Date.now() - replacementStartedAt;
+  const replacementMatches = searchMatches(replacementResult);
+  const replacementCountAfter = await toolsListCount(den.mocks.healthy);
+  const foundReplacement = hasCapability(replacementMatches, replacement.id);
+  const foundDeleted = replacementMatches.some(
+    (entry) => typeof entry.name === "string" && entry.name.includes(healthy.id),
+  );
+  const replacementProbeCount = replacementCountAfter - replacementCountBefore;
+  evidence.fact(
+    "Replacing a connection probes its fresh identity and never serves the deleted identity",
+    JSON.stringify({ replacementDurationMs, replacementMatches, replacementProbeCount }),
+    foundReplacement && !foundDeleted && replacementProbeCount >= 1,
+  );
+  expect(foundReplacement).toBe(true);
+  expect(foundDeleted).toBe(false);
+  expect(replacementProbeCount).toBeGreaterThanOrEqual(1);
+});

--- a/evals/specs/capability-search-scale.slow.test.ts
+++ b/evals/specs/capability-search-scale.slow.test.ts
@@ -1,0 +1,288 @@
+import { expect } from "vitest";
+import {
+  createOrgConnection,
+  denFetch,
+  evalIn,
+  waitFor,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { closeTarget, listTargets, navigate } from "@openwork/cdp";
+import type { Surface } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import type { MockMcpHandle } from "@openwork/labs";
+import {
+  mcpMock,
+  needs,
+  server,
+  test,
+  unmetNeeds,
+} from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = {
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `capability search scale skipped — needs: ${missingRequirements.join(", ")}`
+  : "capability search stays fast and accurate against a 400-tool connection";
+
+interface MockRawRequest {
+  at?: string;
+  rpcMethods?: string[];
+}
+
+interface MockRawLog {
+  requests: MockRawRequest[];
+}
+
+interface Connection {
+  id: string;
+  name: string;
+}
+
+let requestId = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value).slice(0, 500)}`);
+  return value;
+}
+
+function toolText(result: unknown): string {
+  const record = requireRecord(result, "MCP tool result");
+  const first = Array.isArray(record.content) ? record.content[0] : null;
+  if (!isRecord(first) || typeof first.text !== "string") {
+    throw new Error(`MCP tool result had no text content: ${JSON.stringify(result).slice(0, 500)}`);
+  }
+  return first.text;
+}
+
+function toolJson(result: unknown): unknown {
+  return JSON.parse(toolText(result));
+}
+
+function searchMatches(result: unknown): Record<string, unknown>[] {
+  const payload = requireRecord(toolJson(result), "search_capabilities payload");
+  return Array.isArray(payload.matches) ? payload.matches.filter(isRecord) : [];
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const id = organizations[0] && typeof organizations[0].id === "string" ? organizations[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function mintMcpToken(session: DenSession, orgId: string): Promise<string> {
+  const result = await denFetch(session, "/v1/mcp/token", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({}),
+  });
+  const token = isRecord(result.body) && typeof result.body.token === "string" ? result.body.token : "";
+  if (!result.response.ok || !token.startsWith("ow_mcp_at_")) {
+    throw new Error(`Minting MCP token failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return token;
+}
+
+async function callTool(
+  apiUrl: string,
+  mcpToken: string,
+  name: "search_capabilities" | "execute_capability",
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: ++requestId,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP tools/call failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new Error(`MCP tools/call returned no SSE data frame: ${raw.slice(0, 500)}`);
+  const payload: unknown = JSON.parse(dataLine.slice(5));
+  const record = requireRecord(payload, "MCP JSON-RPC payload");
+  if (record.error) throw new Error(`MCP tools/call returned JSON-RPC error: ${JSON.stringify(record.error)}`);
+  return record.result;
+}
+
+function hasCapability(matches: Record<string, unknown>[], connectionId: string, toolName: string): boolean {
+  return matches.some((entry) => entry.name === `mcp:${connectionId}:${toolName}`);
+}
+
+async function toolsListCount(mock: MockMcpHandle): Promise<number> {
+  const response = await fetch(`${mock.url}/requests`, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) throw new Error(`Reading mock request log failed: HTTP ${response.status}`);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !Array.isArray(value.requests)) {
+    throw new Error(`Mock request log was malformed: ${JSON.stringify(value).slice(0, 500)}`);
+  }
+  const raw: MockRawLog = {
+    requests: value.requests.filter(isRecord).map((entry) => ({
+      at: typeof entry.at === "string" ? entry.at : undefined,
+      rpcMethods: Array.isArray(entry.rpcMethods)
+        ? entry.rpcMethods.filter((method): method is string => typeof method === "string")
+        : undefined,
+    })),
+  };
+  return raw.requests.filter(
+    (entry) => Array.isArray(entry.rpcMethods) && entry.rpcMethods.includes("tools/list"),
+  ).length;
+}
+
+async function oauthConnect(
+  browser: Surface,
+  denWebUrl: string,
+  connection: Connection,
+  mock: MockMcpHandle,
+): Promise<void> {
+  await navigate(browser.client, `${denWebUrl}/dashboard/your-connections`);
+  await waitFor(browser, `document.body.innerText.includes("Your Connections")
+    && document.body.innerText.includes(${JSON.stringify(connection.name)})`, {
+    timeoutMs: 60_000,
+    label: `${connection.name} row on Your Connections`,
+  });
+  const connectStartedAt = new Date().toISOString();
+  await waitFor(browser, `(() => {
+    const name = [...document.querySelectorAll("p")]
+      .find((entry) => (entry.textContent ?? "").trim() === ${JSON.stringify(connection.name)});
+    let row = name?.parentElement ?? null;
+    while (row && ![...row.querySelectorAll("button")].some((button) => (button.textContent ?? "").trim() === "Connect")) {
+      row = row.parentElement;
+    }
+    const connect = row ? [...row.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").trim() === "Connect" && !button.disabled) : null;
+    connect?.click();
+    return Boolean(connect);
+  })()`, { timeoutMs: 30_000, label: `Connect ${connection.name} org account` });
+  await mock.authorizeRequestSince(connectStartedAt, { timeoutMs: 120_000 });
+  await waitFor(browser, `Boolean(document.querySelector(${JSON.stringify(`[data-testid="toggle-mcp-tool-runner-${connection.id}"]`)}))`, {
+    timeoutMs: 120_000,
+    label: `${connection.name} connected tool tester action`,
+  });
+  const oauthTargets = (await listTargets(browser.handle.cdpUrl))
+    .filter((target) => target.type === "page" && !target.url.startsWith(denWebUrl));
+  for (const target of oauthTargets) await closeTarget(browser.handle.cdpUrl, target.id);
+}
+
+test(title, async ({ place, evidence, skip }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    mocks: { scale: mcpMock({ extraToolCount: 400 }) },
+  });
+  const scale = await createOrgConnection(den.admin, {
+    name: `Capability Search Scale ${Date.now()}`,
+    url: den.mocks.scale.mcpUrl,
+    authType: "oauth",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  await using browser = await chrome({
+    name: "capability-search-scale",
+    startUrl: den.ref.webUrl,
+    headless: true,
+    host: place.host(),
+  });
+  await browser.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 1000,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin before admin auth token handoff",
+  });
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+  await oauthConnect(browser, den.ref.webUrl, scale, den.mocks.scale);
+
+  const baselineToolsListCount = await toolsListCount(den.mocks.scale);
+  const orgId = await organizationId(den.admin);
+  const mcpToken = await mintMcpToken(den.admin, orgId);
+
+  const coldStartedAt = Date.now();
+  const coldResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "mock_tool_237",
+    limit: 20,
+  });
+  const coldDurationMs = Date.now() - coldStartedAt;
+  const coldMatches = searchMatches(coldResult);
+  const coldToolsListCount = await toolsListCount(den.mocks.scale);
+  const coldToolsListIncrease = coldToolsListCount - baselineToolsListCount;
+  const coldFoundExact = hasCapability(coldMatches, scale.id, "mock_tool_237");
+  evidence.fact(
+    "Cold scale search is fast, bounded, accurate, and probes the provider",
+    JSON.stringify({ coldDurationMs, matchCount: coldMatches.length, coldFoundExact, coldToolsListIncrease }),
+    coldDurationMs < 15_000 && coldFoundExact && coldMatches.length <= 20 && coldToolsListIncrease >= 1,
+  );
+  expect(coldDurationMs).toBeLessThan(15_000);
+  expect(coldFoundExact).toBe(true);
+  expect(coldMatches.length).toBeLessThanOrEqual(20);
+  expect(coldToolsListIncrease).toBeGreaterThanOrEqual(1);
+
+  const warmStartedAt = Date.now();
+  const warmResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "mock_tool_351",
+    limit: 20,
+  });
+  const warmDurationMs = Date.now() - warmStartedAt;
+  const warmMatches = searchMatches(warmResult);
+  const warmToolsListCount = await toolsListCount(den.mocks.scale);
+  const warmToolsListIncrease = warmToolsListCount - coldToolsListCount;
+  const warmFoundExact = hasCapability(warmMatches, scale.id, "mock_tool_351");
+  evidence.fact(
+    "Warm scale search is fast, bounded, accurate, and served without a re-probe",
+    JSON.stringify({ warmDurationMs, matchCount: warmMatches.length, warmFoundExact, warmToolsListIncrease }),
+    warmDurationMs < 3_000 && warmFoundExact && warmMatches.length <= 20 && warmToolsListIncrease === 0,
+  );
+  expect(warmDurationMs).toBeLessThan(3_000);
+  expect(warmFoundExact).toBe(true);
+  expect(warmMatches.length).toBeLessThanOrEqual(20);
+  expect(warmToolsListIncrease).toBe(0);
+
+  const keywordResult = await callTool(den.ref.apiUrl, mcpToken, "search_capabilities", {
+    query: "kw42",
+    limit: 20,
+  });
+  const keywordMatches = searchMatches(keywordResult);
+  const keywordToolsListCount = await toolsListCount(den.mocks.scale);
+  const keywordToolsListIncrease = keywordToolsListCount - warmToolsListCount;
+  const keywordFoundExact = hasCapability(keywordMatches, scale.id, "mock_tool_42");
+  evidence.fact(
+    "Warm cached scale search finds a description token without a re-probe",
+    JSON.stringify({ matchCount: keywordMatches.length, keywordFoundExact, keywordToolsListIncrease }),
+    keywordFoundExact && keywordToolsListIncrease === 0,
+  );
+  expect(keywordFoundExact).toBe(true);
+  expect(keywordToolsListIncrease).toBe(0);
+});

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -5,6 +5,7 @@ import { createHash, randomUUID } from "node:crypto";
 const host = process.env.HOST || "127.0.0.1";
 const port = Number(process.env.PORT || 3978);
 const issuer = process.env.ISSUER || `http://${host}:${port}`;
+const extraToolCount = Number(process.env.MOCK_EXTRA_TOOL_COUNT || 0);
 const autoApprove = process.env.AUTO_APPROVE !== "0";
 const disableDcr = process.env.DISABLE_DCR === "1";
 const strictOAuth = process.argv.includes("--strict") || process.env.STRICT_OAUTH === "1";
@@ -31,6 +32,14 @@ const errorToolMode = (process.env.MOCK_ERROR_TOOL_MODE || "result").trim();
 const errorToolConnectUrl = (process.env.MOCK_ERROR_TOOL_CONNECT_URL || "https://connect.example.test/salesforce/start").trim();
 const errorToolProvider = (process.env.MOCK_ERROR_TOOL_PROVIDER || "salesforce").trim();
 const allowUnauthenticatedMcp = process.env.MOCK_ALLOW_UNAUTHENTICATED_MCP === "1";
+const syntheticTools = Array.from({ length: extraToolCount }, (_, index) => {
+  const i = index + 1;
+  return {
+    name: `mock_tool_${i}`,
+    description: `Synthetic scale tool ${i} for capability search volume testing; keyword kw${i}.`,
+    inputSchema: { type: "object", properties: {} },
+  };
+});
 
 const clients = new Map();
 const codes = new Map();
@@ -472,6 +481,7 @@ function mcpResult(message) {
               required: ["items"],
             },
           },
+          ...syntheticTools,
           ...(extraToolName ? [{
             name: extraToolName,
             title: extraToolTitle || extraToolName,
@@ -500,6 +510,16 @@ function mcpResult(message) {
             {
               type: "text",
               text: `Received ${Array.isArray(items) ? items.length : 0} items.`,
+            },
+          ],
+        };
+      }
+      if (syntheticTools.some((tool) => tool.name === message.params?.name)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${message.params.name} ok`,
             },
           ],
         };


### PR DESCRIPTION
## What

`search_capabilities` on the Den MCP gateway live-probed every eligible external MCP connection (fresh OAuth credential load → initialize → paginated tools/list → close) on **every search**, at concurrency 4 under a 45s deadline. In production (17 connections) a single search took **50–65s**, and code-mode scripts doing multiple searches timed out entirely. PlanetScale was clean the whole time (no query ≥1s during a live search) — the minute was pure MCP probe fanout.

- **Cache** external tools/list probe results per connection — key: `org + connection + updatedAt + member identity (per_member) | shared`; TTL 10min success / 60s failure; 500-entry cap; injectable clock (`ee/apps/den-api/src/mcp/external-tools-search-cache.ts`)
- **Bound** search-time probes: 5s per-request timeout, 8s overall deadline (was 45s), concurrency 4 → 8 — `execute_capability` paths and budgets untouched
- Testkit: `mcpMock`/`startMockMcp` gains an `issuer` option so a mock can advertise a fault-proxy origin (needed to OAuth-connect a connection through `faultProxy`)

## Voiceover → spec

`evals/specs/capability-search-latency.slow.test.ts` (one scenario, four phases):
1. **Cold search** correct + bounded (<15s, ≥1 tools/list witnessed)
2. **Warm variants** — 3 back-to-back searches each <3s, still correct, **zero** new tools/list on either connection (witnessed via the mock's raw rpc log)
3. **Hanging provider** (20s latency armed via faultProxy on a freshly connected third connection) — search returns <12s with healthy results, hung connection contributes nothing, zero upstream probes leak through
4. **Swap freshness** — delete + recreate connection: new identity probed live, deleted identity never served

`evals/specs/capability-search-scale.slow.test.ts` (400-tool catalog via the new `mcpMock({ extraToolCount })` / `MOCK_EXTRA_TOOL_COUNT` synthetic mock):
1. **Cold at volume** — search over a 402-tool connection returns <15s, finds the exact `mock_tool_237` among ≤20 capped matches, ≥1 `tools/list` witnessed
2. **Warm accuracy from cache** — `mock_tool_351` found <3s with **zero** re-probes (cache holds the full catalog, not a page)
3. **Description-token accuracy** — `kw42` resolves to `mock_tool_42` from cache, still zero re-probes

Negative cache-isolation claims (per-member keying, org separation, updatedAt bust, failure-TTL, eviction) are unit-tested: `ee/apps/den-api/test/external-tools-search-cache.test.ts` (6 tests).

## Verification (local lane — Daytona sandbox config unavailable in this shell)

| Check | Command | Result |
|---|---|---|
| Latency spec (PR head 5b90cf83f re-run, cold-boot `server()`) | `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/capability-search-latency.slow.test.ts` | **1 passed** (35.6s), tape gitSha = head |
| Scale spec (PR head 5b90cf83f, cold-boot `server()`) | same runner, `specs/capability-search-scale.slow.test.ts` | **1 passed** (22.4s), tape gitSha = head |
| Cache unit tests | `pnpm --filter @openwork-ee/den-api exec bun test test/external-tools-search-cache.test.ts` | **6 pass / 0 fail** |
| den-api typecheck | `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` | clean |
| Regression: `tool-tester-page.slow.test.ts` | same runner | Passed on this tree pre-commit; later reruns hit a **pre-existing vision-judge flake** (see below) |

**Regression flake classification** (per diagnose-a-red-run): repeated `tool-tester-page` runs stall in the final vision validation with a bare `TimeoutError`. Every failing tape shows **12/13 frames passed, 0 failed, 1 unvalidated** — all product claims (search presence, policy disable, `execute_capability` → `policy_blocked`) pass; only the judge stalls. Clean `origin/dev` control (`/tmp` worktree, same command): pass 13:13, **fail 13:32** (same signature), pass 13:35. Bisection: the hang reproduces with pristine `origin/dev` den-api sources in the same environment. Not introduced by this PR.

## Production context

Diagnosed live before this PR: prod search bracketed at ~60s with the response hint "External MCP search inspected 16 of 17 eligible connections"; Render `/mcp/agent` `duration_ms` is TTFB-only (streamed SSE) so dashboards under-report; PlanetScale processlist sampled every 2s during a live search showed zero slow queries.

Follow-ups (not this PR): `config_object_version` full-history loads during search readiness checks (74MB table in prod), telemetry/oauth token table hygiene.

