### PR TITLE
fix(mcp): hide provider tools when MCP Apps are disabled

### DIFF
--- a/apps/server/src/connect-mcp-server-catalog.test.ts
+++ b/apps/server/src/connect-mcp-server-catalog.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   CONNECT_MCP_SERVER_INDEX_URI,
   connectMcpRuntimeName,
+  type OpenWorkConnectMcpServerIndex,
   readOpenWorkConnectMcpServerIndex,
   reconcileOpenWorkConnectMcpServers,
 } from "./connect-mcp-server-catalog.js";
@@ -44,7 +45,15 @@ async function fixtureConfig(): Promise<ServerConfig> {
   };
 }
 
-function indexFetcher(requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }>) {
+function indexFetcher(
+  requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }>,
+  servers: OpenWorkConnectMcpServerIndex["servers"] = [{
+    connectionId: "emc_01k28e8q8pf8r9sff9mhyqxved",
+    name: "Project Atlas",
+    description: null,
+    url: "https://cloud.example/mcp/agent/connections/emc_01k28e8q8pf8r9sff9mhyqxved",
+  }],
+) {
   return async (url: string, init?: RequestInit) => {
     const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
     requests.push({ url, headers: new Headers(init?.headers), body });
@@ -61,12 +70,7 @@ function indexFetcher(requests: Array<{ url: string; headers: Headers; body: Rec
           mimeType: "application/json",
           text: JSON.stringify({
             schemaVersion: "openwork.connect/mcp-servers/1",
-            servers: [{
-              connectionId: "emc_01k28e8q8pf8r9sff9mhyqxved",
-              name: "Project Atlas",
-              description: null,
-              url: "https://cloud.example/mcp/agent/connections/emc_01k28e8q8pf8r9sff9mhyqxved",
-            }],
+            servers,
           }),
         }],
       },
@@ -141,5 +145,30 @@ describe("OpenWork Connect MCP server catalog", () => {
     });
     expect(result).toEqual({ status: "unavailable", names: [], removedNames: [] });
     expect((await readRuntimeOpencodeConfig(config, "ws_1")).mcp?.["openwork-connect-existing"]).toBeTruthy();
+  });
+
+  test("an empty index removes prior OpenWork-owned provider servers", async () => {
+    const config = await fixtureConfig();
+    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+      mcp: {
+        "user-server": { type: "remote", url: "https://user.example/mcp" },
+        "openwork-connect-existing": { type: "remote", url: "https://cloud.example/existing" },
+      },
+    }));
+    const result = await reconcileOpenWorkConnectMcpServers({
+      config,
+      workspace: config.workspaces[0]!,
+      cloudMcp: { type: "remote", url: "https://cloud.example/mcp/agent" },
+      fetcher: indexFetcher([], []),
+    });
+
+    expect(result).toEqual({
+      status: "synced",
+      names: [],
+      removedNames: ["openwork-connect-existing"],
+    });
+    const runtime = await readRuntimeOpencodeConfig(config, "ws_1");
+    expect(runtime.mcp?.["openwork-connect-existing"]).toBeUndefined();
+    expect(runtime.mcp?.["user-server"]).toEqual({ type: "remote", url: "https://user.example/mcp" });
   });
 });

--- a/docs/features/remote-mcp-apps/README.md
+++ b/docs/features/remote-mcp-apps/README.md
@@ -174,9 +174,10 @@ Successful installation emits `notifications/tools/list_changed` and
 same MCP capability gateway emit the same notifications; every subsequent
 list request is rebuilt from the current authorized Library state.
 
-The static adapter is independently disableable with
-`DEN_REMOTE_MCP_APPS_ENABLED`, but defaults on after the compatible Desktop
-host release. `DEN_GENERATED_ARTIFACT_VIEWS_ENABLED` remains off by default;
+Native provider MCP Apps and the static adapter fail closed behind two explicit
+gates: the deployment operator must set `DEN_REMOTE_MCP_APPS_ENABLED=true`, and
+a platform admin must enable **Native MCP Apps (preview)** for the organization
+in Den admin settings. Both gates default off. `DEN_GENERATED_ARTIFACT_VIEWS_ENABLED` remains off by default;
 while it is off, generated-view creation, source submission, React compilation,
 revision activation, resources, and launch tools are absent or rejected even
 if records already exist. This flag is independent from `codemodeScripts`:

--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -39,9 +39,9 @@ DEN_MCP_ADDITIONAL_RESOURCES=
 # Enable only after deploying a Desktop release that delivers render-tool
 # structuredContent through the stable MCP Apps bridge after initialization.
 DEN_GENERATED_ARTIFACT_VIEWS_ENABLED=false
-# The stable Desktop MCP Apps host supports imported apps by default. Set false
-# for an operator rollback. This does not enable generated Artifact views.
-DEN_REMOTE_MCP_APPS_ENABLED=true
+# Master opt-in for native and imported MCP Apps. Organizations must also have
+# the Native MCP Apps capability enabled in Den admin settings.
+DEN_REMOTE_MCP_APPS_ENABLED=false
 # Leave unset on hosted/multi-tenant deployments. Set to 1 only when Den runs
 # inside a private network and your MCP servers are on private addresses.
 # OPENWORK_DEV_MODE=1 already exempts local dev.

--- a/ee/apps/den-api/src/capability-sources/remote-mcp-apps-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/remote-mcp-apps-rollout.ts
@@ -1,0 +1,14 @@
+import { organizationHasCapability } from "../organization-capabilities.js"
+
+type MetadataInput = Record<string, unknown> | string | null | undefined
+
+/**
+ * Native and imported MCP Apps require both an operator deployment opt-in and
+ * an explicit per-organization opt-in. Either gate can fail the rollout closed.
+ */
+export function remoteMcpAppsEnabled(
+  metadata: MetadataInput,
+  options: { deploymentEnabled: boolean },
+): boolean {
+  return options.deploymentEnabled && organizationHasCapability(metadata, "remoteMcpApps")
+}

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -439,11 +439,10 @@ const mcpConnectionsGatingEnabled =
 const generatedArtifactViewsEnabled =
   (parsed.DEN_GENERATED_ARTIFACT_VIEWS_ENABLED ?? "false").trim().toLowerCase() === "true"
 
-// Native Connect and imported apps use the released stable Desktop MCP Apps
-// bridge and remain independently disableable without enabling agent-authored
-// generated views.
+// Native and imported MCP Apps require an explicit deployment opt-in plus an
+// explicit organization capability. Missing configuration always fails closed.
 const remoteMcpAppsEnabled =
-  (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "true").trim().toLowerCase() === "true"
+  (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "false").trim().toLowerCase() === "true"
 
 const devMode = (parsed.OPENWORK_DEV_MODE ?? "0").trim() === "1"
 const botIdProtectionEnabled = (parsed.DEN_BOTID_PROTECTION_ENABLED ?? "0").trim() === "1"

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -439,8 +439,9 @@ const mcpConnectionsGatingEnabled =
 const generatedArtifactViewsEnabled =
   (parsed.DEN_GENERATED_ARTIFACT_VIEWS_ENABLED ?? "false").trim().toLowerCase() === "true"
 
-// Imported apps use the released stable Desktop MCP Apps bridge and remain
-// independently disableable without enabling agent-authored generated views.
+// Native Connect and imported apps use the released stable Desktop MCP Apps
+// bridge and remain independently disableable without enabling agent-authored
+// generated views.
 const remoteMcpAppsEnabled =
   (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "true").trim().toLowerCase() === "true"
 

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -9,6 +9,7 @@ import type { Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import { z } from "zod"
 import { codemodeScriptsEnabled } from "../capability-sources/codemode-rollout.js"
+import { remoteMcpAppsEnabled } from "../capability-sources/remote-mcp-apps-rollout.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
@@ -418,7 +419,11 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       .from(OrganizationTable)
       .where(eq(OrganizationTable.id, organizationId))
       .limit(1)
-    const codemodeEnabled = codemodeScriptsEnabled(organizationRows[0]?.metadata)
+    const organizationMetadata = organizationRows[0]?.metadata
+    const codemodeEnabled = codemodeScriptsEnabled(organizationMetadata)
+    const remoteAppsEnabled = remoteMcpAppsEnabled(organizationMetadata, {
+      deploymentEnabled: env.remoteMcpAppsEnabled,
+    })
     const requestInfo = await mcpRequestInfo(c.req.raw)
     const method = requestInfo.method
     const redirectUriBase = resolvePublicOrigin(c.req.raw, env.apiPublicUrl)
@@ -432,7 +437,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       redirectUriBase,
       codemodeEnabled,
       generatedArtifactViewsEnabled: env.generatedArtifactViewsEnabled,
-      organizationMetadata: organizationRows[0]?.metadata,
+      organizationMetadata,
       mcpConnectionsGatingEnabled: env.mcpConnectionsGatingEnabled,
     })
     const { externalMcpConnectionsEnabled } = capabilityContext
@@ -472,7 +477,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         .sort((a, b) => a.name.localeCompare(b.name) || a.capability.localeCompare(b.capability))
     }
     const server = createAgentMcpServer()
-    if (env.remoteMcpAppsEnabled && libraryContext && memberIdentity && appCatalogMethod) {
+    if (remoteAppsEnabled && libraryContext && memberIdentity && appCatalogMethod) {
       registerAgentRemoteMcpApps({
         server,
         apps: await listActiveRemoteMcpApps({ context: libraryContext }),
@@ -497,8 +502,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       if (memberIdentity) {
         registerConnectMcpServerIndex({
           server,
-          enabled: env.remoteMcpAppsEnabled,
-          connections: env.remoteMcpAppsEnabled
+          enabled: remoteAppsEnabled,
+          connections: remoteAppsEnabled
             ? await listReadyExternalMcpConnections({
                 organizationId,
                 orgMembershipId: memberIdentity.orgMembershipId,

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -497,11 +497,14 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       if (memberIdentity) {
         registerConnectMcpServerIndex({
           server,
-          connections: await listReadyExternalMcpConnections({
-            organizationId,
-            orgMembershipId: memberIdentity.orgMembershipId,
-            teamIds: memberIdentity.teamIds,
-          }),
+          enabled: env.remoteMcpAppsEnabled,
+          connections: env.remoteMcpAppsEnabled
+            ? await listReadyExternalMcpConnections({
+                organizationId,
+                orgMembershipId: memberIdentity.orgMembershipId,
+                teamIds: memberIdentity.teamIds,
+              })
+            : [],
           publicOrigin: redirectUriBase,
         })
       }

--- a/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
+++ b/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
@@ -12,12 +12,13 @@ export type ConnectMcpServerIndexEntry = {
 }
 
 export function buildConnectMcpServerIndex(input: {
+  enabled: boolean
   connections: ExternalMcpConnectionRow[]
   publicOrigin: string
 }) {
   return {
     schemaVersion: CONNECT_MCP_SERVER_INDEX_SCHEMA_VERSION,
-    servers: input.connections
+    servers: (input.enabled ? input.connections : [])
       .map((connection): ConnectMcpServerIndexEntry => ({
         connectionId: connection.id,
         name: connection.name,
@@ -30,6 +31,7 @@ export function buildConnectMcpServerIndex(input: {
 
 export function registerConnectMcpServerIndex(input: {
   server: McpServer
+  enabled: boolean
   connections: ExternalMcpConnectionRow[]
   publicOrigin: string
 }) {

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -64,6 +64,31 @@ const externalMcpProxyRuntime: ExternalMcpProxyRuntime = {
   readResource: readExternalMcpResource,
 }
 
+export function createDisabledExternalConnectionProxyServer() {
+  const server = new McpServer({
+    name: "OpenWork Connect",
+    version: "1.0.0",
+  }, {
+    capabilities: {
+      tools: { listChanged: false },
+      resources: { listChanged: false, subscribe: false },
+    },
+    instructions: "Native provider MCP Apps are disabled for this OpenWork deployment.",
+  })
+
+  server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }))
+  server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }))
+  server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }))
+  server.server.setRequestHandler(CallToolRequestSchema, async () => {
+    throw new McpError(ErrorCode.InvalidRequest, "Native provider MCP Apps are disabled.")
+  })
+  server.server.setRequestHandler(ReadResourceRequestSchema, async () => {
+    throw new McpError(ErrorCode.InvalidRequest, "Native provider MCP Apps are disabled.")
+  })
+
+  return server
+}
+
 export function createExternalConnectionProxyServer(input: {
   descriptor: ExternalMcpProxyDescriptor
   operation: ExternalMcpProxyOperation
@@ -221,10 +246,7 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
   options: { enabled?: boolean } = {},
 ) {
   const path = "/mcp/agent/connections/:connectionId"
-  if (!(options.enabled ?? env.remoteMcpAppsEnabled)) {
-    app.all(path, (c) => c.notFound())
-    return
-  }
+  const enabled = options.enabled ?? env.remoteMcpAppsEnabled
 
   app.all(path, tokenRoute, async (c) => {
     const requestIdValue = c.get("requestId")
@@ -240,6 +262,12 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
 
     if (c.req.method !== "POST") {
       return new Response(null, { status: 405, headers: { allow: "POST" } })
+    }
+
+    if (!enabled) {
+      const server = createDisabledExternalConnectionProxyServer()
+      const response = await externalMcpProxyRequestDependencies.serve(server, c)
+      return response ?? new Response(null, { status: 204 })
     }
 
     let connectionId

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -11,6 +11,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import type { Context, Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import {
@@ -29,7 +31,9 @@ import {
 import { externalMcpDiagnosticForResponse } from "../capability-sources/external-mcp-diagnostics.js"
 import { evaluateToolPolicy } from "../capability-sources/external-mcp-tool-policy.js"
 import { env } from "../env.js"
+import { db } from "../db.js"
 import { tokenRoute } from "../middleware/index.js"
+import { remoteMcpAppsEnabled } from "../capability-sources/remote-mcp-apps-rollout.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { resolveMcpMemberIdentity } from "./external-capabilities.js"
@@ -264,7 +268,18 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
       return new Response(null, { status: 405, headers: { allow: "POST" } })
     }
 
-    if (!enabled) {
+    const organizationId = normalizeDenTypeId("organization", principal.organizationId)
+    const organizationRows = enabled
+      ? await db
+          .select({ metadata: OrganizationTable.metadata })
+          .from(OrganizationTable)
+          .where(eq(OrganizationTable.id, organizationId))
+          .limit(1)
+      : []
+    const remoteAppsEnabled = remoteMcpAppsEnabled(organizationRows[0]?.metadata, {
+      deploymentEnabled: enabled,
+    })
+    if (!remoteAppsEnabled) {
       const server = createDisabledExternalConnectionProxyServer()
       const response = await externalMcpProxyRequestDependencies.serve(server, c)
       return response ?? new Response(null, { status: 204 })
@@ -276,7 +291,6 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
     } catch {
       throw new McpError(ErrorCode.InvalidRequest, "The MCP connection id is invalid.")
     }
-    const organizationId = normalizeDenTypeId("organization", principal.organizationId)
     const member = await resolveMcpMemberIdentity({
       userId: principal.userId,
       organizationId,

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -216,8 +216,17 @@ export async function handleExternalConnectionProxyRequest(input: {
  * same-server execution boundary and prevents collisions between two servers
  * that legitimately advertise the same tool name.
  */
-export function registerExternalConnectionProxyRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(app: Hono<T>) {
-  app.all("/mcp/agent/connections/:connectionId", tokenRoute, async (c) => {
+export function registerExternalConnectionProxyRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(
+  app: Hono<T>,
+  options: { enabled?: boolean } = {},
+) {
+  const path = "/mcp/agent/connections/:connectionId"
+  if (!(options.enabled ?? env.remoteMcpAppsEnabled)) {
+    app.all(path, (c) => c.notFound())
+    return
+  }
+
+  app.all(path, tokenRoute, async (c) => {
     const requestIdValue = c.get("requestId")
     const requestId = typeof requestIdValue === "string" ? requestIdValue : "unknown"
     const principal = await verifyMcpRequest(

--- a/ee/apps/den-api/src/organization-capabilities.ts
+++ b/ee/apps/den-api/src/organization-capabilities.ts
@@ -11,7 +11,7 @@ import { z } from "zod"
  * Storage rides the existing organization metadata JSON column — the same
  * home as `limits`, `plan`, and `requireSso` — so no schema change is needed.
  */
-export const ORGANIZATION_CAPABILITY_KEYS = ["installLinks", "mcpConnections", "codemodeScripts", "cloud"] as const
+export const ORGANIZATION_CAPABILITY_KEYS = ["installLinks", "mcpConnections", "codemodeScripts", "remoteMcpApps", "cloud"] as const
 
 export const organizationCapabilityKeySchema = z.enum(ORGANIZATION_CAPABILITY_KEYS)
 
@@ -51,6 +51,7 @@ export function normalizeOrganizationCapabilities(metadata: MetadataInput): Orga
     installLinks: raw.installLinks === true,
     mcpConnections: raw.mcpConnections === true,
     codemodeScripts: raw.codemodeScripts === true,
+    remoteMcpApps: raw.remoteMcpApps === true,
     cloud: raw.cloud === true,
   }
 }
@@ -69,6 +70,9 @@ export function readOrganizationCapabilityOverrides(metadata: MetadataInput): Pa
   }
   if (typeof raw.codemodeScripts === "boolean") {
     capabilities.codemodeScripts = raw.codemodeScripts
+  }
+  if (typeof raw.remoteMcpApps === "boolean") {
+    capabilities.remoteMcpApps = raw.remoteMcpApps
   }
   if (typeof raw.cloud === "boolean") {
     capabilities.cloud = raw.cloud

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -86,6 +86,7 @@ const updateOrganizationCapabilitiesSchema = z.object({
     installLinks: z.boolean().nullable().optional(),
     mcpConnections: z.boolean().nullable().optional(),
     codemodeScripts: z.boolean().nullable().optional(),
+    remoteMcpApps: z.boolean().nullable().optional(),
     cloud: z.boolean().nullable().optional(),
   }),
 })
@@ -271,6 +272,7 @@ function readAdminVisibleOrganizationCapabilities(metadata: Record<string, unkno
     installLinks: organizationInstallLinksEnabled(metadata, { gatingEnabled: false }),
     mcpConnections: memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false }),
     codemodeScripts: codemodeScriptsEnabled(metadata),
+    remoteMcpApps: normalizeOrganizationCapabilities(metadata).remoteMcpApps,
     cloud: organizationCloudEnabled(metadata, { orgMode: env.orgMode }),
   }
 }
@@ -280,7 +282,7 @@ function readUnmanagedCapabilityMetadata(metadata: Record<string, unknown>): Rec
   const capabilities: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(raw)) {
-    if (key !== "installLinks" && key !== "mcpConnections" && key !== "codemodeScripts" && key !== "cloud") {
+    if (key !== "installLinks" && key !== "mcpConnections" && key !== "codemodeScripts" && key !== "remoteMcpApps" && key !== "cloud") {
       capabilities[key] = value
     }
   }
@@ -1406,6 +1408,14 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           delete capabilities.codemodeScripts
         } else {
           capabilities.codemodeScripts = codemodeScripts
+        }
+      }
+      const remoteMcpApps = body.data.capabilities.remoteMcpApps
+      if (remoteMcpApps !== undefined) {
+        if (remoteMcpApps === null) {
+          delete capabilities.remoteMcpApps
+        } else {
+          capabilities.remoteMcpApps = remoteMcpApps
         }
       }
       const cloud = body.data.capabilities.cloud

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -90,7 +90,7 @@ async function replaceOrganizationMetadata(metadata: Record<string, unknown>) {
     .where(drizzle.eq(schema.OrganizationTable.id, organizationId))
 }
 
-async function putCapabilities(capabilities: { installLinks?: boolean | null; mcpConnections?: boolean | null; cloud?: boolean | null }) {
+async function putCapabilities(capabilities: { installLinks?: boolean | null; mcpConnections?: boolean | null; remoteMcpApps?: boolean | null; cloud?: boolean | null }) {
   return routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`, {
     method: "PUT",
     headers: { "content-type": "application/json" },
@@ -187,12 +187,12 @@ test("admin capability routes show effective defaults while preserving raw overr
 
   const getAbsent = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
   expect(getAbsent.status).toBe(200)
-  await expect(getAbsent.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true, cloud: false } })
+  await expect(getAbsent.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true, remoteMcpApps: false, cloud: false } })
 
   const listAbsent = await routeApp().request(`http://den.local/v1/admin/organizations?search=${organizationId}`)
   expect(listAbsent.status).toBe(200)
   await expect(listAbsent.json()).resolves.toMatchObject({
-    organizations: [{ id: organizationId, capabilities: { installLinks: true, mcpConnections: true, cloud: false } }],
+    organizations: [{ id: organizationId, capabilities: { installLinks: true, mcpConnections: true, remoteMcpApps: false, cloud: false } }],
   })
 
   const enableInstallLinks = await putCapabilities({ installLinks: true })
@@ -220,6 +220,16 @@ test("admin capability routes show effective defaults while preserving raw overr
   expect(disableCloud.status).toBe(200)
   await expect(disableCloud.json()).resolves.toMatchObject({ capabilities: { cloud: false } })
   expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ installLinks: true, cloud: false })
+
+  const enableRemoteMcpApps = await putCapabilities({ remoteMcpApps: true })
+  expect(enableRemoteMcpApps.status).toBe(200)
+  await expect(enableRemoteMcpApps.json()).resolves.toMatchObject({ capabilities: { remoteMcpApps: true } })
+  expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ remoteMcpApps: true })
+
+  const clearRemoteMcpApps = await putCapabilities({ remoteMcpApps: null })
+  expect(clearRemoteMcpApps.status).toBe(200)
+  await expect(clearRemoteMcpApps.json()).resolves.toMatchObject({ capabilities: { remoteMcpApps: false } })
+  expect("remoteMcpApps" in readCapabilityMetadata(await readOrganizationMetadata())).toBe(false)
 
   await replaceOrganizationMetadata({ connectEnabled: true, capabilities: { installLinks: true } })
   const disableFlatEnabledConnect = await putCapabilities({ mcpConnections: false })

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { expect, test } from "bun:test"
+import { Hono } from "hono"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
 process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
@@ -11,6 +12,7 @@ process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 const {
   createExternalConnectionProxyServer,
   handleExternalConnectionProxyRequest,
+  registerExternalConnectionProxyRoutes,
 } = await import("../src/mcp/external-connection-proxy.js")
 const {
   externalMcpConnectionReadyForMember,
@@ -206,6 +208,23 @@ test("unsupported GET requests never trigger downstream discovery", async () => 
   expect(discoveryCalls).toBe(0)
 })
 
+test("the disabled MCP Apps rollout exposes neither native provider servers nor their proxy endpoint", async () => {
+  expect(buildConnectMcpServerIndex({
+    enabled: false,
+    connections: [connection],
+    publicOrigin: "https://openwork.example",
+  }).servers).toEqual([])
+
+  const app = new Hono<{ Variables: { requestId: string } }>()
+  registerExternalConnectionProxyRoutes(app, { enabled: false })
+  const response = await app.request(`https://openwork.example/mcp/agent/connections/${connection.id}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+  })
+  expect(response.status).toBe(404)
+})
+
 test("disconnected and issuer-blocked OAuth connections are not ready for the native server index", async () => {
   const memberId = "mem_01k28e8q8pf8r9sff9mhyqxved" as never
   const base = {
@@ -244,6 +263,7 @@ test("disconnected and issuer-blocked OAuth connections are not ready for the na
 
   const ready = await readyExternalMcpConnectionsForMember([base], memberId)
   expect(buildConnectMcpServerIndex({
+    enabled: true,
     connections: ready,
     publicOrigin: "https://openwork.example",
   }).servers).toEqual([])

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -1,7 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { expect, test } from "bun:test"
-import { Hono } from "hono"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
 process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
@@ -10,9 +9,9 @@ process.env.OPENWORK_DEV_MODE ??= "1"
 process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 
 const {
+  createDisabledExternalConnectionProxyServer,
   createExternalConnectionProxyServer,
   handleExternalConnectionProxyRequest,
-  registerExternalConnectionProxyRoutes,
 } = await import("../src/mcp/external-connection-proxy.js")
 const {
   externalMcpConnectionReadyForMember,
@@ -208,21 +207,28 @@ test("unsupported GET requests never trigger downstream discovery", async () => 
   expect(discoveryCalls).toBe(0)
 })
 
-test("the disabled MCP Apps rollout exposes neither native provider servers nor their proxy endpoint", async () => {
+test("the disabled MCP Apps rollout publishes no providers and gives stale clients an empty MCP surface", async () => {
   expect(buildConnectMcpServerIndex({
     enabled: false,
     connections: [connection],
     publicOrigin: "https://openwork.example",
   }).servers).toEqual([])
 
-  const app = new Hono<{ Variables: { requestId: string } }>()
-  registerExternalConnectionProxyRoutes(app, { enabled: false })
-  const response = await app.request(`https://openwork.example/mcp/agent/connections/${connection.id}`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
-  })
-  expect(response.status).toBe(404)
+  const server = createDisabledExternalConnectionProxyServer()
+  const client = new Client({ name: "stale-proxy-test", version: "1.0.0" }, { capabilities: {} })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  try {
+    expect(client.getServerCapabilities()?.tools).toEqual({ listChanged: false })
+    expect(client.getServerCapabilities()?.resources).toEqual({ listChanged: false, subscribe: false })
+    expect((await client.listTools()).tools).toEqual([])
+    expect((await client.listResources()).resources).toEqual([])
+    expect((await client.listResourceTemplates()).resourceTemplates).toEqual([])
+  } finally {
+    await client.close()
+    await server.close()
+  }
 })
 
 test("disconnected and issuer-blocked OAuth connections are not ready for the native server index", async () => {

--- a/ee/apps/den-api/test/organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/organization-capabilities.test.ts
@@ -5,7 +5,7 @@ import {
   readOrganizationCapabilityOverrides,
 } from "../src/organization-capabilities.js"
 
-const defaultCapabilities = { installLinks: false, mcpConnections: false, codemodeScripts: false, cloud: false }
+const defaultCapabilities = { installLinks: false, mcpConnections: false, codemodeScripts: false, remoteMcpApps: false, cloud: false }
 
 describe("normalizeOrganizationCapabilities", () => {
   test("defaults every capability to false when metadata is empty", () => {
@@ -19,12 +19,13 @@ describe("normalizeOrganizationCapabilities", () => {
     expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: true } })).toEqual({ ...defaultCapabilities, installLinks: true })
     expect(normalizeOrganizationCapabilities({ capabilities: { mcpConnections: true } })).toEqual({ ...defaultCapabilities, mcpConnections: true })
     expect(normalizeOrganizationCapabilities({ capabilities: { codemodeScripts: true } })).toEqual({ ...defaultCapabilities, codemodeScripts: true })
+    expect(normalizeOrganizationCapabilities({ capabilities: { remoteMcpApps: true } })).toEqual({ ...defaultCapabilities, remoteMcpApps: true })
     expect(normalizeOrganizationCapabilities({ capabilities: { cloud: true } })).toEqual({ ...defaultCapabilities, cloud: true })
     expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: false, mcpConnections: false } })).toEqual(defaultCapabilities)
   })
 
   test("reads an explicit opt-in from JSON string metadata", () => {
-    expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: true, codemodeScripts: true, cloud: true } }))).toEqual({ installLinks: true, mcpConnections: true, codemodeScripts: true, cloud: true })
+    expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: true, codemodeScripts: true, remoteMcpApps: true, cloud: true } }))).toEqual({ installLinks: true, mcpConnections: true, codemodeScripts: true, remoteMcpApps: true, cloud: true })
   })
 
   test("treats anything but literal true as off", () => {
@@ -74,12 +75,14 @@ describe("organizationHasCapability", () => {
     expect(organizationHasCapability(null, "installLinks")).toBe(false)
     expect(organizationHasCapability(null, "mcpConnections")).toBe(false)
     expect(organizationHasCapability(null, "cloud")).toBe(false)
+    expect(organizationHasCapability(null, "remoteMcpApps")).toBe(false)
     expect(organizationHasCapability({ capabilities: {} }, "installLinks")).toBe(false)
     expect(organizationHasCapability({ capabilities: {} }, "mcpConnections")).toBe(false)
     expect(organizationHasCapability({ capabilities: {} }, "cloud")).toBe(false)
     expect(organizationHasCapability({ capabilities: { installLinks: true } }, "installLinks")).toBe(true)
     expect(organizationHasCapability({ capabilities: { mcpConnections: true } }, "mcpConnections")).toBe(true)
     expect(organizationHasCapability({ capabilities: { cloud: true } }, "cloud")).toBe(true)
+    expect(organizationHasCapability({ capabilities: { remoteMcpApps: true } }, "remoteMcpApps")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { installLinks: true } }), "installLinks")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { mcpConnections: true } }), "mcpConnections")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { cloud: true } }), "cloud")).toBe(true)

--- a/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
+++ b/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
@@ -5,11 +5,8 @@ import { fileURLToPath } from "node:url"
 
 const denApiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 
-function probeRemoteMcpApps(value?: string) {
-  return spawnSync(process.execPath, ["--conditions", "development", "--eval", `
-    const { env } = await import("./src/env.ts")
-    console.log(JSON.stringify(env.remoteMcpAppsEnabled))
-  `], {
+function probe(script: string, value?: string) {
+  return spawnSync(process.execPath, ["--conditions", "development", "--eval", script], {
     cwd: denApiRoot,
     encoding: "utf8",
     env: {
@@ -28,6 +25,26 @@ function probeRemoteMcpApps(value?: string) {
   })
 }
 
+function probeRemoteMcpApps(value?: string) {
+  return probe(`
+    const { env } = await import("./src/env.ts")
+    console.log(JSON.stringify(env.remoteMcpAppsEnabled))
+  `, value)
+}
+
+function probeNativeMcpAppIndex(value: string) {
+  return probe(`
+    const { env } = await import("./src/env.ts")
+    const { buildConnectMcpServerIndex } = await import("./src/mcp/connect-mcp-server-index.ts")
+    const index = buildConnectMcpServerIndex({
+      enabled: env.remoteMcpAppsEnabled,
+      connections: [{ id: "emc_fixture", name: "Fixture MCP" }],
+      publicOrigin: "https://openwork.example",
+    })
+    console.log(JSON.stringify(index.servers.map((server) => server.name)))
+  `, value)
+}
+
 test("Remote MCP Apps default on after the compatible Desktop rollout and remain disableable", () => {
   const unset = probeRemoteMcpApps()
   const disabled = probeRemoteMcpApps("false")
@@ -39,4 +56,14 @@ test("Remote MCP Apps default on after the compatible Desktop rollout and remain
   expect(disabled.stdout.trim()).toBe("false")
   expect(enabled.status).toBe(0)
   expect(enabled.stdout.trim()).toBe("true")
+})
+
+test("the Remote MCP Apps flag controls native provider publication", () => {
+  const disabled = probeNativeMcpAppIndex("false")
+  const enabled = probeNativeMcpAppIndex("true")
+
+  expect(disabled.status).toBe(0)
+  expect(disabled.stdout.trim()).toBe("[]")
+  expect(enabled.status).toBe(0)
+  expect(enabled.stdout.trim()).toBe('["Fixture MCP"]')
 })

--- a/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
+++ b/ee/apps/den-api/test/remote-mcp-app-rollout.test.ts
@@ -32,12 +32,16 @@ function probeRemoteMcpApps(value?: string) {
   `, value)
 }
 
-function probeNativeMcpAppIndex(value: string) {
+function probeNativeMcpAppIndex(value: string | undefined, organizationEnabled: boolean) {
   return probe(`
     const { env } = await import("./src/env.ts")
+    const { remoteMcpAppsEnabled } = await import("./src/capability-sources/remote-mcp-apps-rollout.ts")
     const { buildConnectMcpServerIndex } = await import("./src/mcp/connect-mcp-server-index.ts")
     const index = buildConnectMcpServerIndex({
-      enabled: env.remoteMcpAppsEnabled,
+      enabled: remoteMcpAppsEnabled(
+        { capabilities: { remoteMcpApps: ${JSON.stringify(organizationEnabled)} } },
+        { deploymentEnabled: env.remoteMcpAppsEnabled },
+      ),
       connections: [{ id: "emc_fixture", name: "Fixture MCP" }],
       publicOrigin: "https://openwork.example",
     })
@@ -45,25 +49,31 @@ function probeNativeMcpAppIndex(value: string) {
   `, value)
 }
 
-test("Remote MCP Apps default on after the compatible Desktop rollout and remain disableable", () => {
+test("Remote MCP Apps deployment gate defaults off and requires an explicit true", () => {
   const unset = probeRemoteMcpApps()
   const disabled = probeRemoteMcpApps("false")
   const enabled = probeRemoteMcpApps("true")
 
   expect(unset.status).toBe(0)
-  expect(unset.stdout.trim()).toBe("true")
+  expect(unset.stdout.trim()).toBe("false")
   expect(disabled.status).toBe(0)
   expect(disabled.stdout.trim()).toBe("false")
   expect(enabled.status).toBe(0)
   expect(enabled.stdout.trim()).toBe("true")
 })
 
-test("the Remote MCP Apps flag controls native provider publication", () => {
-  const disabled = probeNativeMcpAppIndex("false")
-  const enabled = probeNativeMcpAppIndex("true")
+test("native provider publication requires both deployment and organization opt-ins", () => {
+  const absentDeployment = probeNativeMcpAppIndex(undefined, true)
+  const disabledDeployment = probeNativeMcpAppIndex("false", true)
+  const disabledOrganization = probeNativeMcpAppIndex("true", false)
+  const enabled = probeNativeMcpAppIndex("true", true)
 
-  expect(disabled.status).toBe(0)
-  expect(disabled.stdout.trim()).toBe("[]")
+  expect(absentDeployment.status).toBe(0)
+  expect(absentDeployment.stdout.trim()).toBe("[]")
+  expect(disabledDeployment.status).toBe(0)
+  expect(disabledDeployment.stdout.trim()).toBe("[]")
+  expect(disabledOrganization.status).toBe(0)
+  expect(disabledOrganization.stdout.trim()).toBe("[]")
   expect(enabled.status).toBe(0)
   expect(enabled.stdout.trim()).toBe('["Fixture MCP"]')
 })

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -241,6 +241,7 @@ export type DenOrgCapabilities = {
   installLinks: boolean;
   mcpConnections: boolean;
   codemodeScripts: boolean;
+  remoteMcpApps: boolean;
   cloud: boolean;
 };
 
@@ -936,13 +937,14 @@ function parseOrgAuthMethods(value: unknown): DenOrgAuthMethods {
 
 function parseOrgCapabilities(value: unknown): DenOrgCapabilities {
   if (!isRecord(value)) {
-    return { installLinks: false, mcpConnections: false, codemodeScripts: false, cloud: false };
+    return { installLinks: false, mcpConnections: false, codemodeScripts: false, remoteMcpApps: false, cloud: false };
   }
 
   return {
     installLinks: value.installLinks === true,
     mcpConnections: value.mcpConnections === true,
     codemodeScripts: value.codemodeScripts === true,
+    remoteMcpApps: value.remoteMcpApps === true,
     cloud: value.cloud === true,
   };
 }

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -102,6 +102,7 @@ type AdminOrganizationCapabilities = {
   installLinks: boolean;
   mcpConnections: boolean;
   codemodeScripts: boolean;
+  remoteMcpApps: boolean;
   cloud: boolean;
 };
 
@@ -388,6 +389,7 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
             installLinks: capabilities.installLinks === true,
             mcpConnections: capabilities.mcpConnections === true,
             codemodeScripts: capabilities.codemodeScripts === true,
+            remoteMcpApps: capabilities.remoteMcpApps === true,
             cloud: capabilities.cloud === true
           }
         };
@@ -726,7 +728,7 @@ function buildFixtureOrganization(index: number): AdminOrganization {
     freeSeatCount: target ? 25 : DEFAULT_FREE_SEAT_COUNT,
     seatsFreeAdditional: target ? 20 : 0,
     billableSeatCount: target ? 103 : 0,
-    capabilities: { installLinks: target, mcpConnections: target, codemodeScripts: false, cloud: false }
+    capabilities: { installLinks: target, mcpConnections: target, codemodeScripts: false, remoteMcpApps: false, cloud: false }
   };
 }
 
@@ -2348,6 +2350,19 @@ export function DenAdminPanel() {
                       <label className="inline-flex items-center gap-2 text-sm text-slate-700">
                         <input
                           type="checkbox"
+                          data-testid="admin-capability-remoteMcpApps"
+                          checked={org.capabilities.remoteMcpApps}
+                          disabled={savingCapabilityOrgId === org.id}
+                          onChange={(event) => {
+                            void saveOrganizationCapability(org, "remoteMcpApps", event.target.checked);
+                          }}
+                          className="h-4 w-4 rounded border-slate-300"
+                        />
+                        Native MCP Apps (preview)
+                      </label>
+                      <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                        <input
+                          type="checkbox"
                           data-testid="admin-capability-cloud"
                           checked={org.capabilities.cloud}
                           disabled={savingCapabilityOrgId === org.id}
@@ -2367,6 +2382,7 @@ export function DenAdminPanel() {
                     <p className="mt-1 text-xs text-slate-400">On by default. Turn off to stop workspace admins from minting desktop install links for this organization.</p>
                     <p className="mt-1 text-xs text-slate-400">On by default. Turn off to hide member-facing org connections, marketplace capabilities on the agent rail, and the desktop Connect tab.</p>
                     <p className="mt-1 text-xs text-slate-400">Confined multi-tool scripts run server-side for this organization.</p>
+                    <p className="mt-1 text-xs text-slate-400">Off by default. Requires the deployment master switch and exposes native provider MCP Apps and imported Apps for this organization.</p>
                     <p className="mt-1 text-xs text-slate-400">Off by default. Turn on to show Cloud alpha access in this organization.</p>
                   </div>
 

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -41,9 +41,9 @@ config:
     installLinksGatingEnabled: "false"
     # Enable only after compatible Desktop MCP Apps hosts are deployed.
     generatedArtifactViewsEnabled: "false"
-    # Imported, cached standard MCP Apps are on by default after the compatible
-    # Desktop host rollout. Set false for an operator rollback.
-    remoteMcpAppsEnabled: "true"
+    # Master opt-in for native and imported MCP Apps. Each organization must
+    # also be explicitly enabled in Den admin settings.
+    remoteMcpAppsEnabled: "false"
     connectLinkMode: exchange
     connectLinkKeyId: ""
     openworkAppConnectUrl: ""


### PR DESCRIPTION
## Summary

This PR fails the MCP Apps rollout closed and prevents connected-provider tools from appearing in clients without two explicit rollout decisions.

It also corrects the original flag-off boundary introduced by the MCP Apps work: disabling the rollout now removes OpenWork-managed provider MCP entries from Desktop while preserving user-authored MCP configuration and the bounded OpenWork Connect gateway.

## Rollout model

Native provider MCP Apps and imported Remote MCP Apps require **both** gates:

| Deployment master | Organization setting | Result |
| --- | --- | --- |
| missing or `false` | off | disabled |
| missing or `false` | on | disabled |
| `true` | off or missing | disabled |
| `true` | on | enabled for that organization |

The deployment master is `DEN_REMOTE_MCP_APPS_ENABLED`. It now defaults to `false` in application code, the Helm chart, and the example environment.

The organization opt-in is **Native MCP Apps (preview)** in the Den platform-admin organization capability panel. It is stored as the literal `metadata.capabilities.remoteMcpApps: true`; missing, malformed, or false values remain off.

This separation gives operators a global emergency stop while requiring platform admins to select each intended organization. An organization setting can never bypass the deployment rollback.

## Flag-off behavior

When either gate is off:

- Den does not enumerate ready provider connections for native MCP publication.
- The agent MCP publishes an empty native Connect server index.
- Desktop reconciliation removes only OpenWork-managed `openwork-connect-*` MCP entries and disconnects them.
- User-authored MCP configuration remains untouched.
- Previously synchronized provider URLs remain valid MCP endpoints but advertise empty tools, resources, and templates, avoiding both tool exposure and compatibility-breaking 404s.
- Imported Remote MCP App tools and resources are not registered.
- The ordinary `search_capabilities` / `execute_capability` gateway remains available.

When both gates are on, the existing MCP Apps behavior is preserved for members and provider connections that already pass normal organization, team, credential, and tool-policy authorization.

## Why

PR #3782 changed `DEN_REMOTE_MCP_APPS_ENABLED` from default-off to default-on in code, Helm, and the example environment. Separately, the native provider projection added by the MCP Apps work was not included in the original rollback boundary. Eligible users could therefore receive every allowed tool from connected providers without an explicit deployment or organization rollout decision.

This PR restores fail-closed defaults and makes organization rollout deliberate and visible in Den settings.

## Immediate hosted rollback

On 2026-08-17, the production Den environment was explicitly set to:

```
DEN_REMOTE_MCP_APPS_ENABLED=false
```

The repository’s **Den API Env** workflow updated the Render service and completed the redeploy successfully. This operational rollback is independent of merging this PR; the code changes make future hosted and self-hosted deployments fail closed as well.

## Verification

Passed locally on `cf6579b13814ad84091c5df09173035f616d9efd`:

- Remote MCP Apps rollout and organization capability tests: 12 passed, 0 failed
- Desktop Connect MCP catalog tests: 4 passed, 0 failed
- Den API TypeScript check: passed
- Den Web TypeScript check: passed
- Desktop server TypeScript check: passed
- diff validation: passed

Production operation:

- Den environment update: succeeded
- Render Den API redeploy: succeeded

## Remaining proof

- The MySQL-backed admin and external-proxy route suites still require the repository database fixture.
- The runtime-observable release gate still needs an exact-head MCP Apps testkit tape covering the two-gate truth table and flag-off Desktop reconciliation.

## Scope

This change is limited to the MCP Apps rollout work:

- deployment configuration and defaults
- Den organization capability administration
- agent MCP App registration and provider server index
- Desktop reconciliation of OpenWork-managed provider entries
- stale per-provider proxy behavior
- focused rollout, capability, and reconciliation tests

It does not change general Connect capability search, provider authorization, tool policy, ordinary user-authored MCPs, Code Mode, generated Artifact views, or unrelated client tool management.