### PR TITLE
fix(mcp): surface managed MCP connect failures in the Library UI

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -370,6 +370,7 @@ export function McpView(props: McpViewProps) {
   const useRoutedDetail = typeof props.onDetailIdChange === "function";
   const [detailTarget, setDetailTarget] = useState<ExtensionDetailTarget | null>(null);
   const detailEntry = detailTarget?.kind === "entry" ? detailTarget.entry : null;
+  const [mcpConnectFailure, setMcpConnectFailure] = useState<{ id: string; message: string } | null>(null);
   const detailSkill = detailTarget?.kind === "skill" ? detailTarget.skill : null;
   const detailConnectMcp = detailTarget?.kind === "connect-mcp" ? detailTarget.entry : null;
   const detailPlugin = detailTarget?.kind === "plugin" ? detailTarget.plugin : null;
@@ -461,11 +462,13 @@ export function McpView(props: McpViewProps) {
   const closeDetail = () => {
     setDetailTarget(null);
     setDetailSkillContent(null);
+    setMcpConnectFailure(null);
     props.onDetailIdChange?.(null);
   };
 
   const openDetail = (target: ExtensionDetailTarget) => {
     setDetailTarget(target);
+    setMcpConnectFailure(null);
     if (target.kind === "skill") {
       setDetailSkillContent(target.skill.content ?? null);
       if (!target.skill.content && target.skill.origin !== "openwork-connect" && props.readSkill) {
@@ -534,6 +537,12 @@ export function McpView(props: McpViewProps) {
       setDetailTarget(null);
     }
   }, [useRoutedDetail, detailEntry, quickConnectList]);
+
+  useEffect(() => {
+    setMcpConnectFailure((current) =>
+      current && (!detailEntry || current.id !== getMcpIdentityKey(detailEntry)) ? null : current
+    );
+  }, [detailEntry]);
 
   useEffect(() => {
     const refresh = () => setExtensionStateVersion((value) => value + 1);
@@ -788,6 +797,7 @@ export function McpView(props: McpViewProps) {
             uiControl={detailEntry.kind === "ui-control"}
             connected={isConnected}
             connecting={props.mcpConnectingName === detailEntry.name}
+            errorInfo={mcpConnectFailure?.id === getMcpIdentityKey(detailEntry) ? mcpConnectFailure.message : null}
             hidden={hidden}
             preview={detailEntry.preview}
             disabledReason={disabledReason}
@@ -803,9 +813,17 @@ export function McpView(props: McpViewProps) {
             onConnect={disabledReason ? undefined : isToggleOnlyExtension(detailEntry) ? () => {
               setOpenWorkExtensionEnabled(detailEntry, true);
               closeDetail();
-            } : hasConfigSlot ? undefined : () => {
-              props.connectMcp(detailEntry);
-              closeDetail();
+            } : hasConfigSlot ? undefined : async () => {
+              setMcpConnectFailure(null);
+              const result = await props.connectMcp(detailEntry);
+              if (result.ok) {
+                closeDetail();
+                return;
+              }
+              setMcpConnectFailure({
+                id: getMcpIdentityKey(detailEntry),
+                message: result.error.trim() ? result.error : t("mcp.connect_failed"),
+              });
             }}
             onUninstall={disabledReason ? undefined : isToggleOnlyExtension(detailEntry) && isConnected ? () => {
               setOpenWorkExtensionEnabled(detailEntry, false);
@@ -1107,8 +1125,15 @@ export function McpView(props: McpViewProps) {
         isConfigured={isEntryConfigured}
         enablementForEntry={props.enablementContext ? enablementForEntry : undefined}
         statusForEntry={quickConnectStatus}
-        onConnect={(entry) => {
-          void props.connectMcp(entry);
+        onConnect={async (entry) => {
+          setMcpConnectFailure(null);
+          const result = await props.connectMcp(entry);
+          if (result.ok) return;
+          openDetail({ kind: "entry", entry });
+          setMcpConnectFailure({
+            id: getMcpIdentityKey(entry),
+            message: result.error.trim() ? result.error : t("mcp.connect_failed"),
+          });
         }}
         onDetail={(entry) => openDetail({ kind: "entry", entry })}
         onSkillDetail={(skill) => openDetail({ kind: "skill", skill })}

--- a/apps/server/src/local-managed-mcp.e2e.test.ts
+++ b/apps/server/src/local-managed-mcp.e2e.test.ts
@@ -194,6 +194,7 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
       expect(created.status).toBe(502);
       expect(await created.json()).toMatchObject({
         code: "managed_mcp_connection_failed",
+        message: expect.stringContaining("Enterprise MCP failed during MCP connection handshake"),
       });
 
       const status = await fetch(
@@ -207,6 +208,70 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
       else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
       if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
       else process.env.OPENWORK_DEV_MODE = previousDevMode;
+    }
+  });
+
+  test("returns actionable input errors without persisting managed connections", async () => {
+    const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+    const previousDevMode = process.env.OPENWORK_DEV_MODE;
+    const previousAllowPrivateUrls = process.env.OPENWORK_ALLOW_PRIVATE_MCP_URLS;
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-local-managed-mcp-input-errors-"));
+    roots.push(workspaceRoot);
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    delete process.env.OPENWORK_DEV_MODE;
+    delete process.env.OPENWORK_ALLOW_PRIVATE_MCP_URLS;
+
+    try {
+      const engine = startMockOpencode();
+      const config = createConfig({
+        port: await freePort(),
+        workspaceRoot,
+        engineBaseUrl: `http://127.0.0.1:${engine.server.port}`,
+        vaultKey: randomBytes(32),
+      });
+      const server = await startServer(config);
+      stops.push(() => server.stop());
+      const openworkBaseUrl = `http://127.0.0.1:${server.port}`;
+      const cases = [
+        { name: "malformed-url", url: "not-a-url", code: "managed_mcp_url_invalid", message: "not-a-url" },
+        { name: "http-url", url: "http://example.com/mcp", code: "managed_mcp_url_not_allowed", message: "HTTPS" },
+        {
+          name: "unresolved-url",
+          url: "https://managed-mcp-does-not-resolve.invalid/mcp",
+          code: "managed_mcp_url_not_allowed",
+          message: "resolve",
+        },
+      ];
+
+      for (const input of cases) {
+        const created = await fetch(`${openworkBaseUrl}/workspace/ws_managed/mcp/managed`, {
+          method: "POST",
+          headers: clientHeaders(config.token),
+          body: JSON.stringify({ name: input.name, url: input.url, oauth: { applicationType: "native" } }),
+        });
+        expect(created.status).toBe(400);
+        expect(await created.json()).toMatchObject({
+          code: input.code,
+          message: expect.stringContaining(input.message),
+        });
+
+        const list = await fetch(`${openworkBaseUrl}/workspace/ws_managed/mcp`, {
+          headers: clientHeaders(config.token),
+        });
+        expect(list.status).toBe(200);
+        expect(JSON.stringify(await list.json())).not.toContain(`"name":"${input.name}"`);
+        const status = await fetch(`${openworkBaseUrl}/workspace/ws_managed/mcp/${input.name}/managed`, {
+          headers: clientHeaders(config.token),
+        });
+        expect(status.status).toBe(404);
+      }
+    } finally {
+      if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+      if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
+      else process.env.OPENWORK_DEV_MODE = previousDevMode;
+      if (previousAllowPrivateUrls === undefined) delete process.env.OPENWORK_ALLOW_PRIVATE_MCP_URLS;
+      else process.env.OPENWORK_ALLOW_PRIVATE_MCP_URLS = previousAllowPrivateUrls;
     }
   });
 

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -39,7 +39,11 @@ import {
 } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 import { isRecord } from "./workspace-kv-store.js";
-import { assertLocalManagedMcpUrl, createLocalManagedMcpGuardedFetch } from "./local-managed-mcp-url-guard.js";
+import {
+  assertLocalManagedMcpUrl,
+  createLocalManagedMcpGuardedFetch,
+  LocalManagedMcpPrivateUrlError,
+} from "./local-managed-mcp-url-guard.js";
 
 type LocalManagedMcpStatus = "needs_auth" | "connecting" | "connected" | "reconnect_required";
 
@@ -733,8 +737,21 @@ export async function reconcileLocalManagedMcpRuntimeEntries(config: ServerConfi
 }
 
 export async function createLocalManagedMcpConnection(config: ServerConfig, input: CreateLocalManagedMcpInput): Promise<LocalManagedMcpPublicConnection> {
-  const serverUrl = new URL(input.serverUrl).toString();
-  await assertLocalManagedMcpUrl(serverUrl);
+  let serverUrl: string;
+  try {
+    serverUrl = new URL(input.serverUrl).toString();
+  } catch {
+    throw new ApiError(400, "managed_mcp_url_invalid", `Managed MCP server URL "${input.serverUrl}" is invalid.`);
+  }
+  try {
+    await assertLocalManagedMcpUrl(serverUrl);
+  } catch (error) {
+    if (!(error instanceof LocalManagedMcpPrivateUrlError)) throw error;
+    const message = error.message.includes("managed MCP egress requires HTTPS")
+      ? `OpenWork-managed sign-in requires an HTTPS server URL. ${error.message}`
+      : error.message;
+    throw new ApiError(400, "managed_mcp_url_not_allowed", message);
+  }
   const now = Date.now();
   const connection = await withVaultMutation(config, (vault) => {
     const key = connectionKey(input.workspaceId, input.name);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3113,10 +3113,12 @@ function createRoutes(
         // so the failed Add request cannot leave a ghost connection behind.
         await deleteLocalManagedMcp(config, workspace.id, name).catch(() => undefined);
         if (error instanceof ApiError) throw error;
+        const cause = (error instanceof Error ? error.message : String(error)).trim().slice(0, 300);
         throw new ApiError(
           502,
           "managed_mcp_connection_failed",
-          "OpenWork could not start sign-in with this MCP server. Check the server URL, OAuth settings, and network connection, then try again.",
+          `OpenWork could not start sign-in with this MCP server. Check the server URL, OAuth settings, and network connection, then try again.${cause ? ` (${cause})` : ""}`,
+          cause ? { cause } : undefined,
         );
       }
     })();

--- a/evals/specs/library-mcp-connect-error.slow.test.ts
+++ b/evals/specs/library-mcp-connect-error.slow.test.ts
@@ -1,0 +1,345 @@
+import { expect } from "vitest";
+import { evalIn, waitFor } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import { app, eventually, mcpMock, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = {
+  optIn: ["OPENWORK_EVAL_APP_SPECS", "OPENWORK_EVAL_LOCAL_MANAGED_MCP"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `Library managed MCP connect error skipped — needs: ${missingRequirements.join(", ")}`
+  : "Library keeps a failed managed MCP out and connects it after the URL is fixed";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test(title, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    org: {
+      name: `Library MCP connect error ${Date.now()}`,
+      admin: { name: "Sarah" },
+    },
+    mocks: {
+      connector: mcpMock({ profileId: "synthetic-enterprise-oauth-mcp" }),
+    },
+  });
+  await using desktop = await app({ den, as: "admin", place });
+  const timestamp = Date.now();
+  const name = `lib-connect-err-${timestamp}`;
+  const invalidHostname = `managed-mcp-${timestamp}.invalid`;
+  const invalidUrl = `https://${invalidHostname}/mcp`;
+
+  await waitFor(
+    desktop,
+    `(() => {
+      const ready = window.location.hash.includes("/extensions")
+        && [...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library");
+      if (!ready) window.location.hash = ${JSON.stringify(`#${`/workspace/${desktop.workspaceId}/settings/extensions`}`)};
+      return ready;
+    })()`,
+    { timeoutMs: 60_000, label: "Library settings page" },
+  );
+
+  const expandedAdvanced = await evalIn(desktop, `(() => {
+    const advanced = [...document.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").includes("Advanced settings"));
+    if (!(advanced instanceof HTMLButtonElement)) return false;
+    advanced.click();
+    return true;
+  })()`);
+  expect(expandedAdvanced).toBe(true);
+  await waitFor(
+    desktop,
+    `document.body.innerText.includes("Config file") && !document.body.innerText.includes("Not loaded yet")`,
+    { timeoutMs: 30_000, label: "workspace MCP config loaded" },
+  );
+  await waitFor(
+    desktop,
+    `[...document.querySelectorAll("button")].some((button) => button.textContent?.trim() === "Add workspace MCP")`,
+    { timeoutMs: 10_000, label: "Add workspace MCP action" },
+  );
+  const openedDialog = await evalIn(desktop, `(() => {
+    const add = [...document.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Add workspace MCP");
+    if (!(add instanceof HTMLButtonElement)) return false;
+    add.click();
+    return true;
+  })()`);
+  expect(openedDialog).toBe(true);
+  await waitFor(desktop, `Boolean(document.querySelector('[role="dialog"]'))`, {
+    timeoutMs: 10_000,
+    label: "Add workspace MCP dialog",
+  });
+
+  const filledName = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return null;
+    const nameInput = [...dialog.querySelectorAll("input")]
+      .find((input) => input.labels?.[0]?.textContent?.includes("App name"));
+    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    if (!(nameInput instanceof HTMLInputElement) || !setValue) return null;
+    setValue.call(nameInput, ${JSON.stringify(name)});
+    nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+    return nameInput.value;
+  })()`);
+  expect(filledName).toBe(name);
+
+  const filledInvalidUrl = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return null;
+    const urlInput = [...dialog.querySelectorAll("input")]
+      .find((input) => input.labels?.[0]?.textContent?.includes("Server URL"));
+    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    if (!(urlInput instanceof HTMLInputElement) || !setValue) return null;
+    setValue.call(urlInput, ${JSON.stringify(invalidUrl)});
+    urlInput.dispatchEvent(new Event("input", { bubbles: true }));
+    return urlInput.value;
+  })()`);
+  expect(filledInvalidUrl).toBe(invalidUrl);
+  await waitFor(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return false;
+    const inputs = [...dialog.querySelectorAll("input")];
+    const nameInput = inputs.find((input) => input.labels?.[0]?.textContent?.includes("App name"));
+    const urlInput = inputs.find((input) => input.labels?.[0]?.textContent?.includes("Server URL"));
+    return nameInput?.value === ${JSON.stringify(name)} && urlInput?.value === ${JSON.stringify(invalidUrl)};
+  })()`, {
+    timeoutMs: 10_000,
+    label: "managed MCP name and invalid URL values",
+  });
+
+  const expandedOAuth = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return null;
+    const oauth = [...dialog.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").includes("OAuth on this device"));
+    if (!(oauth instanceof HTMLButtonElement)) return null;
+    oauth.click();
+    return "OAuth on this device";
+  })()`);
+  expect(expandedOAuth).toBe("OAuth on this device");
+  await waitFor(desktop, `document.querySelector('[role="dialog"]')?.textContent?.includes("OAuth client ID")`, {
+    timeoutMs: 10_000,
+    label: "OAuth on this device fields",
+  });
+
+  const submittedInvalidUrl = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return false;
+    const submit = [...dialog.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Add App");
+    if (!(submit instanceof HTMLButtonElement)) return false;
+    submit.click();
+    return true;
+  })()`);
+  expect(submittedInvalidUrl).toBe(true);
+
+  const failureText = await eventually(async () => {
+    const value = await evalIn(desktop, `document.querySelector('[role="dialog"]')?.textContent?.trim() ?? ""`);
+    return typeof value === "string" ? value : "";
+  }, {
+    within: 60_000,
+    intervalMs: 500,
+    label: "managed MCP discovery failure in the open dialog",
+    until: (text) => /could not start sign-in[\s\S]*\([^)]{3,}\)/i.test(text),
+  });
+  expect(failureText).toMatch(/could not start sign-in[\s\S]*\([^)]{3,}\)/i);
+  expect(await evalIn(desktop, `Boolean(document.querySelector('[role="dialog"]'))`)).toBe(true);
+  console.log(`[library-mcp-connect-error] dialog failure: ${failureText}`);
+
+  const revealedFailure = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return false;
+    const error = [...dialog.querySelectorAll("div")].find((entry) =>
+      /could not start sign-in/i.test(entry.textContent ?? "")
+      && ![...entry.children].some((child) => /could not start sign-in/i.test(child.textContent ?? ""))
+    );
+    if (!(error instanceof HTMLElement)) return false;
+    error.scrollIntoView({ block: "center" });
+    return true;
+  })()`);
+  expect(revealedFailure).toBe(true);
+
+  const failureShot = await screenshot(desktop);
+  const failureSeen = await validate(failureShot, [
+    "The open Add workspace MCP dialog shows the failed sign-in reason for the invalid server URL",
+  ]);
+  expect(failureSeen.ok, failureSeen.why).toBe(true);
+
+  const absent = await evalIn(desktop, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? info?.connectUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+    if (!baseUrl || !token) return { ok: false, error: "Local server credentials unavailable" };
+    const headers = { authorization: "Bearer " + token };
+    const statusResponse = await fetch(
+      baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp/${encodeURIComponent(name)}/managed",
+      { headers },
+    );
+    const listResponse = await fetch(
+      baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp",
+      { headers },
+    );
+    const listBody = await listResponse.json();
+    const items = Array.isArray(listBody?.items) ? listBody.items : [];
+    return {
+      ok: true,
+      status: statusResponse.status,
+      listStatus: listResponse.status,
+      count: items.filter((item) => item?.name === ${JSON.stringify(name)}).length,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(absent).toMatchObject({ ok: true, status: 404, listStatus: 200, count: 0 });
+  evidence.fact(
+    "A failed managed MCP attempt leaves no connection behind",
+    `${name} returned 404 from managed status and appeared zero times in the workspace MCP list.`,
+    isRecord(absent) && absent.status === 404 && absent.count === 0,
+  );
+
+  const filledRetryUrl = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return null;
+    const urlInput = [...dialog.querySelectorAll("input")]
+      .find((input) => input.labels?.[0]?.textContent?.includes("Server URL"));
+    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    if (!(urlInput instanceof HTMLInputElement) || !setValue) return null;
+    setValue.call(urlInput, ${JSON.stringify(den.mocks.connector.mcpUrl)});
+    urlInput.dispatchEvent(new Event("input", { bubbles: true }));
+    return urlInput.value;
+  })()`);
+  expect(filledRetryUrl).toBe(den.mocks.connector.mcpUrl);
+  await waitFor(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return false;
+    const urlInput = [...dialog.querySelectorAll("input")]
+      .find((input) => input.labels?.[0]?.textContent?.includes("Server URL"));
+    return urlInput?.value === ${JSON.stringify(den.mocks.connector.mcpUrl)};
+  })()`, {
+    timeoutMs: 10_000,
+    label: "managed MCP retry URL value",
+  });
+
+  const retried = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!(dialog instanceof HTMLElement)) return false;
+    const submit = [...dialog.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Add App");
+    if (!(submit instanceof HTMLButtonElement)) return false;
+    submit.click();
+    return true;
+  })()`);
+  expect(retried).toBe(true);
+
+  const pending = await eventually(async () => {
+    const value = await evalIn(desktop, `(async () => {
+      const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? info?.connectUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+      if (!baseUrl || !token) return { ok: false, error: "Local server credentials unavailable" };
+      const response = await fetch(
+        baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp/${encodeURIComponent(name)}/managed",
+        { headers: { authorization: "Bearer " + token } },
+      );
+      const body = response.ok ? await response.json() : null;
+      return { ok: response.ok, statusCode: response.status, status: body?.status };
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    return isRecord(value) ? value : {};
+  }, {
+    within: 30_000,
+    intervalMs: 100,
+    label: "managed MCP retry reaches needs_auth or auto-connects",
+    until: (value) => value.ok === true && (value.status === "needs_auth" || value.status === "connected"),
+  });
+  expect(pending).toMatchObject({ ok: true, statusCode: 200 });
+  expect(["needs_auth", "connected"]).toContain(pending.status);
+
+  if (pending.status === "needs_auth") {
+    const started = await evalIn(desktop, `(async () => {
+      const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? info?.connectUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+      if (!baseUrl || !token) return { ok: false, error: "Local server credentials unavailable" };
+      const response = await fetch(
+        baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp/${encodeURIComponent(name)}/managed/connect",
+        { method: "POST", headers: { authorization: "Bearer " + token } },
+      );
+      return { ok: response.ok, status: response.status, body: await response.json() };
+    })()`, { awaitPromise: true, timeoutMs: 60_000 });
+    if (!isRecord(started) || !isRecord(started.body) || typeof started.body.authorizeUrl !== "string") {
+      throw new Error(`Managed MCP connect response was invalid: ${JSON.stringify(started)}`);
+    }
+    expect(started.ok).toBe(true);
+    expect(started.body.status).toBe("needs_auth");
+
+    const authorization = await fetch(started.body.authorizeUrl, { redirect: "manual" });
+    expect(authorization.status).toBe(302);
+    const callbackUrl = authorization.headers.get("location");
+    if (!callbackUrl) throw new Error("Managed MCP authorization did not return a callback Location");
+    const callback = await fetch(callbackUrl);
+    expect(callback.ok).toBe(true);
+  }
+
+  await waitFor(desktop, `!document.querySelector('[role="dialog"]')`, {
+    timeoutMs: 90_000,
+    label: "dialog closes after managed MCP authorization completes",
+  });
+
+  const connected = await eventually(async () => {
+    const value = await evalIn(desktop, `(async () => {
+      const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? info?.connectUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+      if (!baseUrl || !token) return { ok: false };
+      const headers = { authorization: "Bearer " + token };
+      const statusResponse = await fetch(
+        baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp/${encodeURIComponent(name)}/managed",
+        { headers },
+      );
+      const listResponse = await fetch(baseUrl + "/workspace/${encodeURIComponent(desktop.workspaceId)}/mcp", { headers });
+      const statusBody = await statusResponse.json();
+      const listBody = await listResponse.json();
+      const items = Array.isArray(listBody?.items) ? listBody.items : [];
+      return {
+        ok: statusResponse.ok && listResponse.ok,
+        status: statusBody?.status,
+        hasCredential: statusBody?.hasCredential,
+        enabled: statusBody?.enabled,
+        count: items.filter((item) => item?.name === ${JSON.stringify(name)}).length,
+      };
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    return isRecord(value) ? value : {};
+  }, {
+    within: 60_000,
+    intervalMs: 500,
+    label: "managed MCP connected status and one list entry",
+    until: (value) => value.status === "connected"
+      && value.hasCredential === true
+      && value.enabled === true
+      && value.count === 1,
+  });
+  expect(connected).toMatchObject({ status: "connected", hasCredential: true, enabled: true, count: 1 });
+  expect(await evalIn(desktop, `!document.querySelector('[role="dialog"]')`)).toBe(true);
+  evidence.fact(
+    "Fixing the URL connects exactly one managed MCP",
+    `${name} reported connected, hasCredential=true, enabled=true, and appeared once in the workspace MCP list.`,
+    connected.status === "connected"
+      && connected.hasCredential === true
+      && connected.enabled === true
+      && connected.count === 1,
+  );
+
+  await waitFor(desktop, `document.body.innerText.includes(${JSON.stringify(name)})`, {
+    timeoutMs: 60_000,
+    label: "connected MCP visible in Library",
+  });
+  const connectedShot = await screenshot(desktop);
+  const connectedSeen = await validate(connectedShot, [
+    "The Library shows the connected managed MCP without the add-dialog error",
+  ]);
+  expect(connectedSeen.ok, connectedSeen.why).toBe(true);
+});


### PR DESCRIPTION
## What

A failed managed-MCP connect used to be console-only: the server collapsed pre-OAuth failures (malformed URL, plain HTTP, dead hostname) into a generic `500 Unexpected server error`, and the Library detail/grid connect paths fired-and-forgot, closing the panel with no visible explanation (the reporter's DevTools showed repeating `[mcp.connect] failed BigQuery … Unexpected server error`).

## Changes

**Server** (`apps/server`)
- `POST /workspace/:id/mcp/managed` returns `400 managed_mcp_url_invalid` for unparseable URLs and `400 managed_mcp_url_not_allowed` with the guard's reason for HTTP/private/unresolvable hosts — the HTTPS message names *OpenWork-managed sign-in* specifically (plain HTTP remains valid for regular custom MCPs; `OPENWORK_ALLOW_PRIVATE_MCP_URLS`/dev-mode escape hatch unchanged; SSRF guard untouched).
- The OAuth-start `502 managed_mcp_connection_failed` now appends the underlying cause to its message and carries `details.cause` — e.g. why a Google-style provider without dynamic client registration needs a pre-registered client ID.

**App** (`apps/app`)
- Library detail-panel Connect awaits the result: failure keeps the panel open with the server's message in the existing `errorInfo` alert (`role=alert`), spinner stops, Connect stays available; success closes as before.
- Grid tile Connect failures open the item's detail panel with the same inline error.
- The Add workspace MCP dialog already showed errors inline; it now receives the actionable server message instead of "Unexpected server error".

## Verification

- `pnpm --filter openwork-server run test -- src/local-managed-mcp.e2e.test.ts` — 7 pass / 0 fail (new: three 400 classifications + non-persistence + 502 cause pass-through). Known watcher SIGTRAP after results print.
- `pnpm --filter @openwork/app exec bun test tests/extension-detail-modal-error.test.tsx tests/add-mcp-submission.test.ts` — 5 pass / 0 fail.
- Typechecks: `openwork-server` and `@openwork/app` clean.
- New spec `evals/specs/library-mcp-connect-error.slow.test.ts` (stack lane, local fallback — no Daytona credentials in this environment): fails a managed add against a dead host, asserts the visible reason in the open dialog and that nothing persists (404 + zero list entries), fixes the URL to the mock provider, completes OAuth, asserts exactly one connected MCP. Tape being re-run on this head and published below.