### PR TITLE
fix(evals): pin the mega journey to the workspace OpenAI provider row

### DIFF
--- a/evals/packages/behaviors/src/models.ts
+++ b/evals/packages/behaviors/src/models.ts
@@ -145,21 +145,39 @@ export async function readAvailableModels(app: Surface): Promise<ModelFacts[]> {
   return parseModels(value);
 }
 
-export async function selectModel(app: Surface, name: string): Promise<ModelFacts> {
+export async function selectModel(app: Surface, name: string, options?: { provider?: string }): Promise<ModelFacts> {
   await openModelPicker(app);
   await fill(app, MODEL_SEARCH_INPUT, name);
   await waitFor(app, `(() => {
     const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
+    const expectedProvider = ${JSON.stringify(options?.provider?.trim())};
     return [...(dialog?.querySelectorAll("button") ?? [])].some((button) => {
       const id = button.querySelector("span.font-mono")?.textContent?.trim() ?? "";
-      return !button.disabled && (id === ${JSON.stringify(name)} || (button.textContent ?? "").includes(${JSON.stringify(name)}));
+      let group = button.parentElement;
+      while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
+      const providerHeader = group?.querySelector(':scope > div > button');
+      const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
+        ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+        ?? "";
+      return !button.disabled
+        && (id === ${JSON.stringify(name)} || (button.textContent ?? "").includes(${JSON.stringify(name)}))
+        && (expectedProvider === undefined || providerName === expectedProvider);
     });
   })()`, { timeoutMs: 30_000, label: `selectable model ${name}` });
   const selected = await evalIn(app, `(() => {
     const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
+    const expectedProvider = ${JSON.stringify(options?.provider?.trim())};
     const button = [...(dialog?.querySelectorAll("button") ?? [])].find((candidate) => {
       const id = candidate.querySelector("span.font-mono")?.textContent?.trim() ?? "";
-      return !candidate.disabled && (id === ${JSON.stringify(name)} || (candidate.textContent ?? "").includes(${JSON.stringify(name)}));
+      let group = candidate.parentElement;
+      while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
+      const providerHeader = group?.querySelector(':scope > div > button');
+      const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
+        ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+        ?? "";
+      return !candidate.disabled
+        && (id === ${JSON.stringify(name)} || (candidate.textContent ?? "").includes(${JSON.stringify(name)}))
+        && (expectedProvider === undefined || providerName === expectedProvider);
     });
     if (!button) return null;
     const id = button.querySelector("span.font-mono")?.textContent?.trim() ?? "";

--- a/evals/specs/org-team-lifecycle-mega.slow.test.ts
+++ b/evals/specs/org-team-lifecycle-mega.slow.test.ts
@@ -56,6 +56,12 @@ import type { NeedsSpec } from "@openwork/testkit";
  * (ee/apps/den-api/src/mcp/builtin-skills.ts:15-68). Therefore this spec asks
  * the admin's real chat agent to use `skill:create-skill`; Den plugin state is
  * the witness. The API-publish fallback is intentionally not used.
+ *
+ * Since #3703 (2026-08-12), org providers reach desktops, so the picker lists
+ * this model twice. The org `mega-eval-openai` copy uses
+ * `@ai-sdk/openai-compatible`, which sends `max_tokens`; current OpenAI reasoning
+ * models require `max_completion_tokens`. This journey therefore pins the native
+ * workspace-config "OpenAI" group, resolving the ambiguity tracked in #3813.
  */
 
 // 2026-08-10: the Den-hosted Automation phase was removed after Den never materialized a run row
@@ -245,12 +251,14 @@ async function configureWorkspaceOpenAi(appSurface: Surface, workspaceId: string
 async function selectableWorkspaceModel(appSurface: Surface, target: ProviderTarget): Promise<string> {
   const facts = await eventually(async () => {
     const models = await readAvailableModels(appSurface);
-    const match = models.find((model) => model.selectable && model.id === target.requestedModelId);
+    const match = models.find((model) => (
+      model.selectable && model.id === target.requestedModelId && model.providerName === "OpenAI"
+    ));
     return { match, models };
   }, {
     within: 180_000,
     intervalMs: 5_000,
-    label: `${target.requestedModelId} selectable through workspace config`,
+    label: `${target.requestedModelId} selectable in workspace-config OpenAI provider group`,
     until: (value) => Boolean(value.match),
   });
   if (!facts.match) throw new Error(`${target.requestedModelId} did not become selectable through workspace config.`);
@@ -361,7 +369,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
   const teammateEmail = `taylor.mega.${stamp}@acme.test`;
   const outsiderEmail = `riley.mega.${stamp}@acme.test`;
   const password = "OpenWorkEval123!";
-  const skillNonce = `mega-${stamp}`;
+  // The authored skill's marker must survive verbatim model reproduction, so keep it short (base36), like llmNonce below.
+  const skillNonce = `mega-${stamp.toString(36)}`;
   const skillName = `mega-echo-${stamp}`;
   const pluginName = `Mega Echo Plugin ${stamp}`;
   const skillMarker = `SKILL-USED-${skillNonce}`;
@@ -418,11 +427,9 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
     providerAbsentBeforePublish,
   );
 
-  // 2026-08-09: org-published providers do not currently materialize on desktops
-  // (regression on dev; see cloud-provider-auto-import failing and the pinned
-  // 2026-07-31 defect in models-available). Desktop-side org-provider claims stay
-  // owned by those specs; this journey runs its real model through workspace-scoped
-  // config below.
+  // Since #3703 (2026-08-12), org providers reach desktops and duplicate this model.
+  // The org openai-compatible copy sends rejected max_tokens, so #3813 is avoided by
+  // pinning this journey to the native workspace-config "OpenAI" group below.
   const providerId = await createProvider(den.admin, orgId, providerName, target);
   onTestFinished(async () => {
     await deleteProvider(den.admin, orgId, providerId).catch(() => undefined);
@@ -449,7 +456,7 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
     await configureWorkspaceOpenAi(appAdmin, appAdmin.workspaceId, target.apiKey);
     await go(appAdmin, `/workspace/${appAdmin.workspaceId}/session`);
     const adminModelId = await selectableWorkspaceModel(appAdmin, target);
-    const selectedAdminModel = await selectModel(appAdmin, adminModelId);
+    const selectedAdminModel = await selectModel(appAdmin, adminModelId, { provider: "OpenAI" });
     expect(selectedAdminModel.selected).toBe(true);
     evidence.fact(
       "The admin's real OpenAI model is selectable through workspace config",
@@ -680,7 +687,7 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
     await configureWorkspaceOpenAi(appMate, appMate.workspaceId, target.apiKey);
     await go(appMate, `/workspace/${appMate.workspaceId}/session`);
     const teammateModelId = await selectableWorkspaceModel(appMate, target);
-    const selectedTeammateModel = await selectModel(appMate, teammateModelId);
+    const selectedTeammateModel = await selectModel(appMate, teammateModelId, { provider: "OpenAI" });
     expect(selectedTeammateModel.selected).toBe(true);
     evidence.fact(
       "The teammate's real OpenAI model is selectable through workspace config",


### PR DESCRIPTION
Fixes the mega journey's 4-night-deterministic "Cloud skill authored" timeout by pinning model selection to the workspace-config native OpenAI provider row.

Closes #3813

## Root cause (found via chat-transcript instrumentation on the Daytona lane)

Since #3703 (2026-08-12) org-published LLM providers materialize on member desktops — which the mega spec's 2026-08-09 research note assumed would not happen. The spec publishes an org provider `mega-eval-openai` (`@ai-sdk/openai-compatible`) whose model carries the same bare id (`gpt-5.6-luna`) and the display name `OpenAI gpt-5.6-luna`, then configures the same model natively through workspace config. Post-#3703 the model picker lists the id **twice**, and `selectModel` clicked the first text match — the org `openai-compatible` copy. That chat-completions client serializes the output limit as `max_tokens`, which current OpenAI reasoning models reject:

```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

Both the initial turn and the 180s nudge turn died instantly on that provider rejection (captured in the chat DOM on the failing lane; the session footer showed the org copy's display name `OpenAI gpt-5.6-luna` instead of the native `GPT-5.6 Luna`). No tool call ever ran, Den state never changed, and the spec — which only watches Den — burned the full 420s budget and reported `last value: null`. This is the exact failure of Nightly Mega Eval runs 31904388637, 31906326371, 31993246469 (`openwork-server-20260817-040548`) and the #3812 clean-dev control, 5/5 deterministic across gpt-4o and gpt-5.6-luna.

Ruled out on the way (each with a dedicated app-less probe on the nightly SHA): den-api gateway search/execute, the `skill:create-skill` document, MCP token scopes (engine-held token creates plugins fine), the local-server Den proxy hop, Connect steering/skills catalog, engine catalog drift (models.openworklabs.com == models.dev == repo snapshot, `reasoning: true` everywhere), and the last-48h commits (failure predates them; the sweep/nightly history proves it).

## Changes

- `evals/packages/behaviors/src/models.ts` — `selectModel(app, name, options?: { provider?: string })`: optional exact (trimmed-equality) provider-group filter applied to both the waitFor and click predicates. Exact equality because `"Mega OpenAI Models …"` contains the substring `OpenAI`.
- `evals/specs/org-team-lifecycle-mega.slow.test.ts`
  - Admin and teammate phases select with `{ provider: "OpenAI" }`; `selectableWorkspaceModel` requires `providerName === "OpenAI"`.
  - Stale org-provider materialization notes refreshed (Step-0 research retained verbatim).
  - `skillNonce` is now base36: the authored skill's marker must survive verbatim model reproduction by the teammate agent, mirroring the spec's existing `llmNonce` rationale — the 13-digit decimal marker got truncated by gpt-5.6-luna on the lane (caught on the first post-fix full run).

## Verification

Lane: Daytona (`OPENWORK_EVAL_DAYTONA=1`), model `gpt-5.6-luna`, vision deferred then judged.

```
OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MEGA_SPEC=1 \
OPENWORK_EVAL_MODEL=gpt-5.6-luna OPENWORK_EVAL_VISION=defer \
pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/org-team-lifecycle-mega.slow.test.ts
pnpm --dir evals fraimz:judge -- --roll latest
```

- PR head `9cab31ec2`: **1 passed / 0 failed** (368.9s). Judged roll: **ok, 17/17 frames, 19/19 expectations, 0 pending** — tape published below.
- Pre-commit tree (same diff): 1 passed (376.4s) — first full green since 2026-08-11 and the first ever with gpt-5.6-luna.
- One additional head run hit an unrelated flake: the teammate's *connectivity* turn (`waitForAssistantReply`, spec line 752) produced no reply and no error bubble within 300s while the footer already showed the native `GPT-5.6 Luna` (pin in effect; authoring and all prior claims passed). Authoring is 3/3 post-fix vs 0/5 before. Filed separately as a follow-up issue.
- Static: collection clean; `pnpm evals:typecheck` shows only the 15 pre-existing unrelated errors (zero mentioning the touched files); `pnpm evals:test` 189 passed.
- Red control: the identical command on unmodified dev @ 34fbb7086 reproduces the authoring timeout with the `max_tokens` transcript (and matches the nightly tapes listed above).

**Verdict: Passed** — every claim in the journey has an observable assertion in the head-bound tape.

## Product observation (not fixed here)

Any org-published custom provider using `@ai-sdk/openai-compatible` against `api.openai.com` breaks member desktops for reasoning models the same way (`max_tokens` vs `max_completion_tokens`). Worth a Den-side mapping or guidance; noted in #3813 before closing.
