### PR TITLE
fix(cloud): recover stalled workspace wake

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -271,6 +271,8 @@ export type DenCloudInstanceUpdateResult =
   | { ok: true; status: "update_requested" }
   | { ok: false; error: "already_current" | "flush_failed" };
 
+export type DenCloudInstanceRecoveryResult = { ok: true; status: "recovery_requested" };
+
 export type DenMemoryContext = {
   id: string;
   snippet: string;
@@ -1564,6 +1566,14 @@ function parseCloudInstanceUpdateResult(payload: unknown): DenCloudInstanceUpdat
   return null;
 }
 
+function parseCloudInstanceRecoveryResult(payload: unknown): DenCloudInstanceRecoveryResult | null {
+  if (!isRecord(payload) || payload.ok !== true || payload.status !== "recovery_requested") {
+    return null;
+  }
+
+  return { ok: true, status: "recovery_requested" };
+}
+
 function getMcpToken(payload: unknown): DenMcpToken | null {
   if (
     !isRecord(payload) ||
@@ -2617,6 +2627,20 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       const result = parseCloudInstanceUpdateResult(payload);
       if (!result) {
         throw new DenApiError(500, "invalid_cloud_update_payload", "Cloud update response was invalid.");
+      }
+      return result;
+    },
+
+    async recoverCloudInstance(orgId: string): Promise<DenCloudInstanceRecoveryResult> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/cloud/instance/recover", {
+        method: "POST",
+        token,
+        organizationId: orgId,
+        body: {},
+      });
+      const result = parseCloudInstanceRecoveryResult(payload);
+      if (!result) {
+        throw new DenApiError(500, "invalid_cloud_recovery_payload", "Cloud recovery response was invalid.");
       }
       return result;
     },

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -14,6 +14,7 @@ import { useSessionActivityStore } from "@/react-app/domains/session/status/sess
 import { softCardClass } from "@/react-app/domains/workspace/modal-styles";
 import {
   cloudWorkspaceBootIsSlow,
+  cloudWorkspaceBootTimedOut,
   cloudWorkspaceBootStages,
   cloudWorkspaceTakeoverCopy,
   formatCloudWorkspaceElapsed,
@@ -34,8 +35,11 @@ type CloudWorkspaceStatusContextValue = {
   instance: DenCloudInstance | null;
   requestFailed: boolean;
   updating: boolean;
+  recovering: boolean;
+  recoverySequence: number;
   viewModel: CloudWorkspaceViewModel;
   refresh: () => Promise<void>;
+  recover: () => void;
   signOut: () => void;
   updateNow: () => void;
   /**
@@ -58,8 +62,11 @@ const fallbackCloudWorkspaceStatus: CloudWorkspaceStatusContextValue = {
   instance: null,
   requestFailed: false,
   updating: false,
+  recovering: false,
+  recoverySequence: 0,
   viewModel: fallbackViewModel,
   refresh: noopRefresh,
+  recover: noopAction,
   signOut: noopAction,
   updateNow: noopAction,
   takeoverActive: false,
@@ -93,6 +100,8 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
   const [instance, setInstance] = useState<DenCloudInstance | null>(null);
   const [requestFailed, setRequestFailed] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [recovering, setRecovering] = useState(false);
+  const [recoverySequence, setRecoverySequence] = useState(0);
   const [takeoverActive, setTakeoverActive] = useState(false);
   const lastAttemptedVersion = useRef<string | null>(null);
   const gatewayMode = isOpenworkGatewayRuntime();
@@ -179,6 +188,25 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
       });
   }, [denClient, gatewayMode, orgId, refresh, updating]);
 
+  const recover = useCallback(() => {
+    if (!gatewayMode || !orgId || recovering) return;
+    setRecovering(true);
+    setRequestFailed(false);
+    void denClient
+      .recoverCloudInstance(orgId)
+      .then(() => {
+        setInstance((current) => current ? { ...current, status: "waking", url: null } : null);
+        setRecoverySequence((current) => current + 1);
+        void refresh();
+      })
+      .catch(() => {
+        setRequestFailed(true);
+      })
+      .finally(() => {
+        setRecovering(false);
+      });
+  }, [denClient, gatewayMode, orgId, recovering, refresh]);
+
   useEffect(() => {
     const hasActiveRun = Object.values(useSessionActivityStore.getState().recordsByWorkspaceId)
       .some((records) => Object.values(records).some((record) => record.runActive));
@@ -204,13 +232,16 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
     instance,
     requestFailed,
     updating,
+    recovering,
+    recoverySequence,
     viewModel,
     refresh,
+    recover,
     signOut,
     updateNow,
     takeoverActive,
     setTakeoverActive,
-  }), [gatewayMode, instance, refresh, requestFailed, signOut, takeoverActive, updateNow, updating, viewModel, visible]);
+  }), [gatewayMode, instance, recover, recovering, recoverySequence, refresh, requestFailed, signOut, takeoverActive, updateNow, updating, viewModel, visible]);
 
   return (
     <CloudWorkspaceStatusContext.Provider value={value}>
@@ -277,6 +308,7 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
   const { setTakeoverActive } = cloudWorkspace;
   const reduceMotion = useReducedMotion() ?? false;
   const [elapsedMs, setElapsedMs] = useState(0);
+  const [retrySequence, setRetrySequence] = useState(0);
   const active = cloudWorkspace.gatewayMode && cloudWorkspace.visible && props.decision === "takeover";
 
   useEffect(() => {
@@ -290,25 +322,27 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
     setElapsedMs(0);
     const intervalId = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 1_000);
     return () => window.clearInterval(intervalId);
-  }, [active]);
+  }, [active, cloudWorkspace.recoverySequence, retrySequence]);
 
   if (!active) return null;
 
   const { viewModel } = cloudWorkspace;
   const failed = viewModel.variant === "failed";
+  const timedOut = !failed && cloudWorkspaceBootTimedOut(elapsedMs);
   const slow = !failed && cloudWorkspaceBootIsSlow(elapsedMs);
-  const copy = cloudWorkspaceTakeoverCopy({ variant: viewModel.variant, slow });
+  const attention = failed || timedOut;
+  const copy = cloudWorkspaceTakeoverCopy({ variant: viewModel.variant, slow, timedOut });
   const stages = cloudWorkspaceBootStages(viewModel.variant);
 
   return (
     <LazyMotion features={domMax}>
       <div
         className="flex h-full min-h-[420px] items-center justify-center px-6 py-16"
-        role={failed ? "alert" : "status"}
+        role={attention ? "alert" : "status"}
         aria-live="polite"
         data-testid="cloud-workspace-takeover"
         data-cloud-workspace-state={viewModel.variant}
-        data-cloud-workspace-wait={slow ? "slow" : "normal"}
+        data-cloud-workspace-wait={timedOut ? "timed-out" : slow ? "slow" : "normal"}
       >
         <m.div
           layout
@@ -317,7 +351,7 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
           transition={{ duration: 0.32, ease: "easeOut" }}
           className={cn(
             "w-full max-w-md rounded-[20px] border p-6 shadow-[var(--dls-card-shadow)]",
-            failed
+            attention
               ? "border-amber-7/35 bg-amber-3/30"
               : "border-dls-border bg-dls-surface",
           )}
@@ -326,12 +360,12 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
             <div
               className={cn(
                 "flex size-12 shrink-0 items-center justify-center rounded-2xl border",
-                failed
+                attention
                   ? "border-amber-7/35 bg-amber-3/60 text-amber-11"
                   : "border-dls-border bg-dls-hover text-dls-accent",
               )}
             >
-              {failed ? (
+              {attention ? (
                 <AlertTriangle className="size-5" aria-hidden="true" />
               ) : (
                 <m.span layoutId={gatewayIndicatorLayoutId} className="flex items-center justify-center">
@@ -360,7 +394,7 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
             </div>
           </div>
 
-          {stages.length ? (
+          {!attention && stages.length ? (
             <m.ul layout className={cn("mt-6 space-y-3.5", softCardClass)} data-testid="cloud-workspace-boot-stages">
               {stages.map((stage) => (
                 <BootStageRow key={stage.id} stage={stage} reduceMotion={reduceMotion} />
@@ -368,10 +402,28 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
             </m.ul>
           ) : null}
 
-          {failed || slow ? (
-            <m.div layout className="mt-5 flex items-center gap-2">
-              <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
-                Retry
+          {attention || slow ? (
+            <m.div layout className="mt-5 flex flex-wrap items-center gap-2">
+              {attention ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={cloudWorkspace.recover}
+                  disabled={cloudWorkspace.recovering}
+                >
+                  {cloudWorkspace.recovering ? "Starting…" : "Start a new sandbox"}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setRetrySequence((current) => current + 1);
+                  void cloudWorkspace.refresh();
+                }}
+              >
+                {attention ? "Try again" : "Check again"}
               </Button>
               <Button type="button" size="sm" variant="ghost" onClick={cloudWorkspace.signOut}>
                 Sign out
@@ -396,7 +448,9 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
 export function CloudWorkspaceStatusPanel(props: {
   viewModel: CloudWorkspaceViewModel;
   updating: boolean;
+  recovering: boolean;
   onRefresh: () => void;
+  onRecover: () => void;
   onSignOut: () => void;
   onUpdateNow: () => void;
 }) {
@@ -431,6 +485,11 @@ export function CloudWorkspaceStatusPanel(props: {
         </div>
       ) : null}
       <div className="flex items-center justify-end gap-2">
+        {viewModel.variant === "failed" ? (
+          <Button type="button" size="sm" onClick={props.onRecover} disabled={props.recovering}>
+            {props.recovering ? "Starting…" : "Start a new sandbox"}
+          </Button>
+        ) : null}
         {viewModel.showRetry ? (
           <Button type="button" size="sm" variant="outline" onClick={props.onRefresh}>
             Retry
@@ -505,7 +564,9 @@ function CloudWorkspaceOverlayInner() {
             <CloudWorkspaceStatusPanel
               viewModel={viewModel}
               updating={cloudWorkspace.updating}
+              recovering={cloudWorkspace.recovering}
               onRefresh={() => void cloudWorkspace.refresh()}
+              onRecover={cloudWorkspace.recover}
               onUpdateNow={cloudWorkspace.updateNow}
               onSignOut={() => {
                 cloudWorkspace.signOut();

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -69,9 +69,15 @@ export function cloudWorkspaceBootStages(variant: CloudWorkspacePillVariant): Cl
 
 /** Past this point "usually under a minute" stops being true, so the copy and the actions change. */
 export const CLOUD_WORKSPACE_SLOW_BOOT_MS = 45_000;
+/** A boot that has made no observable progress by this point becomes an actionable error. */
+export const CLOUD_WORKSPACE_BOOT_TIMEOUT_MS = 120_000;
 
 export function cloudWorkspaceBootIsSlow(elapsedMs: number): boolean {
   return elapsedMs >= CLOUD_WORKSPACE_SLOW_BOOT_MS;
+}
+
+export function cloudWorkspaceBootTimedOut(elapsedMs: number): boolean {
+  return elapsedMs >= CLOUD_WORKSPACE_BOOT_TIMEOUT_MS;
 }
 
 export function formatCloudWorkspaceElapsed(elapsedMs: number): string {
@@ -85,17 +91,24 @@ export function formatCloudWorkspaceElapsed(elapsedMs: number): string {
 export function cloudWorkspaceTakeoverCopy(input: {
   variant: CloudWorkspacePillVariant;
   slow: boolean;
+  timedOut?: boolean;
 }): { title: string; body: string } {
   if (input.variant === "failed") {
     return {
-      title: "Workspace needs attention",
-      body: "We couldn’t start the sandbox. Retry, or sign out and reconnect.",
+      title: "Workspace couldn’t start",
+      body: "We couldn’t bring this sandbox online. Try again, or start a new sandbox from your saved files.",
+    };
+  }
+  if (input.timedOut) {
+    return {
+      title: "Workspace couldn’t start",
+      body: "The sandbox didn’t come online in time. Try again, or start a new sandbox from your saved files.",
     };
   }
   if (input.slow) {
     return {
       title: "Still working on it…",
-      body: "This is taking longer than usual. Nothing is broken — wait it out, or retry.",
+      body: "This is taking longer than usual. You can keep waiting or check again.",
     };
   }
   if (input.variant === "provisioning") {

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -10,7 +10,9 @@ import {
 } from "../src/react-app/shell/cloud-workspace-overlay";
 import {
   CLOUD_WORKSPACE_SLOW_BOOT_MS,
+  CLOUD_WORKSPACE_BOOT_TIMEOUT_MS,
   cloudWorkspaceBootIsSlow,
+  cloudWorkspaceBootTimedOut,
   cloudWorkspaceBootStages,
   cloudWorkspaceStatusHasReadyContent,
   cloudWorkspaceTakeoverCopy,
@@ -230,19 +232,33 @@ describe("cloud workspace slow boot escalation", () => {
     expect(cloudWorkspaceBootIsSlow(0)).toBe(false);
     expect(cloudWorkspaceBootIsSlow(CLOUD_WORKSPACE_SLOW_BOOT_MS - 1)).toBe(false);
     expect(cloudWorkspaceBootIsSlow(CLOUD_WORKSPACE_SLOW_BOOT_MS)).toBe(true);
+    expect(cloudWorkspaceBootTimedOut(CLOUD_WORKSPACE_BOOT_TIMEOUT_MS - 1)).toBe(false);
+    expect(cloudWorkspaceBootTimedOut(CLOUD_WORKSPACE_BOOT_TIMEOUT_MS)).toBe(true);
 
     const early = cloudWorkspaceTakeoverCopy({ variant: "provisioning", slow: false });
     const late = cloudWorkspaceTakeoverCopy({ variant: "provisioning", slow: true });
 
     expect(early.title).toBe("Starting your workspace…");
     expect(late.title).toBe("Still working on it…");
-    expect(late.body).toContain("Nothing is broken");
+    expect(late.body).toContain("keep waiting");
+  });
+
+  test("turns a boot with no progress into a clear terminal error", () => {
+    const timedOut = cloudWorkspaceTakeoverCopy({
+      variant: "waking",
+      slow: true,
+      timedOut: true,
+    });
+
+    expect(timedOut.title).toBe("Workspace couldn’t start");
+    expect(timedOut.body).toContain("didn’t come online in time");
+    expect(timedOut.body).toContain("start a new sandbox");
   });
 
   test("keeps the failure message even when the wait has gone long", () => {
     const failed = cloudWorkspaceTakeoverCopy({ variant: "failed", slow: true });
 
-    expect(failed.title).toBe("Workspace needs attention");
+    expect(failed.title).toBe("Workspace couldn’t start");
   });
 
   test("formats elapsed time for both short and long waits", () => {
@@ -263,8 +279,11 @@ function renderTakeover(status: DenCloudInstance["status"]) {
         instance: instance({ status }),
         requestFailed: false,
         updating: false,
+        recovering: false,
+        recoverySequence: 0,
         viewModel,
         refresh: async () => {},
+        recover: () => {},
         signOut: () => {},
         updateNow: () => {},
         takeoverActive: true,
@@ -343,8 +362,9 @@ describe("cloud workspace boot takeover", () => {
     const html = renderTakeover("failed");
 
     expect(html).not.toContain("cloud-workspace-boot-stages");
-    expect(html).toContain("Workspace needs attention");
-    expect(html).toContain("Retry");
+    expect(html).toContain("Workspace couldn’t start");
+    expect(html).toContain("Start a new sandbox");
+    expect(html).toContain("Try again");
     expect(html).toContain("Sign out");
   });
 });
@@ -382,7 +402,9 @@ describe("cloud workspace overlay diagnostics", () => {
       <CloudWorkspaceStatusPanel
         viewModel={viewModel}
         updating={false}
+        recovering={false}
         onRefresh={() => {}}
+        onRecover={() => {}}
         onSignOut={() => {}}
         onUpdateNow={() => {}}
       />,
@@ -399,7 +421,9 @@ describe("cloud workspace overlay diagnostics", () => {
       <CloudWorkspaceStatusPanel
         viewModel={viewModel}
         updating={false}
+        recovering={false}
         onRefresh={() => {}}
+        onRecover={() => {}}
         onSignOut={() => {}}
         onUpdateNow={() => {}}
       />,

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -72,16 +72,20 @@ type CloudGatewayInstanceResponse = CloudInstanceResponse & {
 type CloudInstanceUpdateResponse =
   | { ok: true; status: "update_requested" }
   | { ok: false; error: "already_current" | "flush_failed" }
+type CloudInstanceRecoveryResponse = { ok: true; status: "recovery_requested" }
 type CloudWorkerStore = {
   getCloudWorker: (input: { orgId: OrgId; userId: UserId }) => Promise<CloudWorker | null>
   insertCloudWorker: (input: { workerId: WorkerId; orgId: OrgId; userId: UserId; name: string }) => Promise<void>
   insertWorkerTokens: (input: { workerId: WorkerId; hostToken: string; clientToken: string; activityToken: string }) => Promise<void>
   deleteCreateRaceLoser: (workerId: WorkerId) => Promise<void>
   claimFailedWorker: (workerId: WorkerId) => Promise<boolean>
+  claimFailedWorkerForWake: (workerId: WorkerId) => Promise<boolean>
   claimRecycleWorker: (workerId: WorkerId) => Promise<boolean>
+  prepareRecoveryWorker: (workerId: WorkerId) => Promise<void>
   getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
   markProvisioningWorkerFailed: (workerId: WorkerId) => Promise<void>
   markHealthyWorkerFailed: (workerId: WorkerId) => Promise<void>
+  markRecoveryWorkerFailed: (workerId: WorkerId) => Promise<void>
 }
 type EnsureCloudWorker = (input: {
   orgId: OrgId
@@ -120,6 +124,11 @@ const cloudInstanceUpdateResponseSchema = z.union([
     error: z.enum(["already_current", "flush_failed"]),
   }),
 ]).meta({ ref: "CloudInstanceUpdateResponse" })
+
+const cloudInstanceRecoveryResponseSchema = z.object({
+  ok: z.literal(true),
+  status: z.literal("recovery_requested"),
+}).meta({ ref: "CloudInstanceRecoveryResponse" })
 
 const cloudGatewayInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
@@ -310,13 +319,30 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
 
     return hasChangedRows(result)
   },
+  async claimFailedWorkerForWake(workerId) {
+    const result: unknown = await db
+      .update(WorkerTable)
+      .set({ status: "stopped" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "failed")))
+
+    return hasChangedRows(result)
+  },
   async claimRecycleWorker(workerId) {
     const result: unknown = await db
       .update(WorkerTable)
-      .set({ status: "provisioning" })
-      .where(and(eq(WorkerTable.id, workerId), inArray(WorkerTable.status, ["healthy", "stopped"])))
+      .set({ status: "stopped" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "healthy")))
 
     return hasChangedRows(result)
+  },
+  async prepareRecoveryWorker(workerId) {
+    await db
+      .update(WorkerTable)
+      .set({ status: "stopped", image_version: null })
+      .where(and(
+        eq(WorkerTable.id, workerId),
+        inArray(WorkerTable.status, ["provisioning", "healthy", "failed", "stopped"]),
+      ))
   },
   async getActiveTokens(workerId) {
     return db
@@ -335,6 +361,15 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
       .update(WorkerTable)
       .set({ status: "failed" })
       .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "healthy")))
+  },
+  async markRecoveryWorkerFailed(workerId) {
+    await db
+      .update(WorkerTable)
+      .set({ status: "failed" })
+      .where(and(
+        eq(WorkerTable.id, workerId),
+        inArray(WorkerTable.status, ["provisioning", "healthy", "stopped"]),
+      ))
   },
 }
 
@@ -538,7 +573,10 @@ async function resolveFailedCloudInstance(input: {
   failedHealAttempts.set(input.worker.id, now)
   const sandbox = await input.getSandboxRecord(input.worker.id)
   if (sandbox) {
-    const claimed = await input.store.claimFailedWorker(input.worker.id)
+    // The wake lifecycle owns the stopped -> provisioning reservation. Moving
+    // straight to provisioning here makes the wake routine reject its own
+    // handoff and leaves the member polling "waking" forever.
+    const claimed = await input.store.claimFailedWorkerForWake(input.worker.id)
     if (!claimed) {
       return { status: "failed", url: null }
     }
@@ -658,6 +696,13 @@ async function startStaleStoppedRecycle(input: {
     return false
   }
 
+  if (input.worker.status === "stopped") {
+    input.startWake(input.worker.id)
+    return true
+  }
+
+  // Hand the worker to the wake lifecycle in its accepted durable state. The
+  // lifecycle then atomically reserves stopped -> provisioning across replicas.
   const claimed = await input.store.claimRecycleWorker(input.worker.id)
   if (claimed) {
     input.startWake(input.worker.id)
@@ -681,7 +726,10 @@ async function recoverUnhealthyCloudSandbox(input: {
   }
 
   if (inspection?.state === "stopped") {
-    input.startWake(input.worker.id)
+    const claimed = await input.store.claimRecycleWorker(input.worker.id)
+    if (claimed || input.worker.status === "stopped") {
+      input.startWake(input.worker.id)
+    }
     return { status: "waking", url: null }
   }
 
@@ -931,6 +979,7 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   const now = options.now ?? Date.now
   const gatewayKey = options.gatewayKey !== undefined ? options.gatewayKey : env.gatewayKey
   const wakingWorkers = new Set<CloudWorker["id"]>()
+  const recoveringWorkers = new Set<CloudWorker["id"]>()
 
   function startWake(workerId: CloudWorker["id"]) {
     if (wakingWorkers.has(workerId)) {
@@ -942,6 +991,29 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
       .catch(() => undefined)
       .finally(() => {
         wakingWorkers.delete(workerId)
+      })
+  }
+
+  function startRecovery(workerId: CloudWorker["id"]) {
+    if (recoveringWorkers.has(workerId)) {
+      return
+    }
+
+    recoveringWorkers.add(workerId)
+    void (async () => {
+      // Stopping is intentionally the only provider action before the durable
+      // handoff. It preserves the shared customer volume and lets the normal
+      // wake path recycle onto a fresh sandbox from the last checkpoint.
+      await stopCloudWorker(workerId)
+      await store.prepareRecoveryWorker(workerId)
+      startWake(workerId)
+    })()
+      .catch(async (error) => {
+        await store.markRecoveryWorkerFailed(workerId).catch(() => undefined)
+        logger.error("cloud workspace recovery failed", { worker_id: workerId, error })
+      })
+      .finally(() => {
+        recoveringWorkers.delete(workerId)
       })
   }
 
@@ -1022,6 +1094,39 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
       })
 
       return c.json(result)
+    },
+  )
+
+  app.post(
+    "/v1/cloud/instance/recover",
+    describeRoute({
+      tags: ["Cloud"],
+      summary: "Recover the active organization's Cloud instance",
+      description: "Stops an unresponsive sandbox and starts a replacement from the member's retained workspace checkpoint.",
+      responses: {
+        200: jsonResponse("Cloud instance recovery request accepted.", cloudInstanceRecoveryResponseSchema),
+        401: jsonResponse("The caller must be signed in to recover Cloud.", unauthorizedSchema),
+        404: jsonResponse("Cloud is not available for this organization.", notFoundSchema),
+      },
+    }),
+    orgMemberRouteMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!cloudAvailable(payload, options)) {
+        return c.json(cloudNotFound(), 404)
+      }
+
+      const user = c.get("user")
+      if (!hasCloudUserId(user)) {
+        return c.json({ error: "unauthorized" }, 401)
+      }
+
+      const worker = await getCloudWorker(payload.organization.id, user.id, store)
+      if (worker) {
+        startRecovery(worker.id)
+      }
+
+      return c.json({ ok: true, status: "recovery_requested" } satisfies CloudInstanceRecoveryResponse)
     },
   )
 

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -177,7 +177,10 @@ function makeCloudWorkerStore(input: {
   const deletedWorkerIds: StoredCloudWorker["id"][] = []
   const deletedTokenWorkerIds: StoredCloudWorker["id"][] = []
   let claimAttempts = 0
+  let wakeClaimAttempts = 0
   let recycleClaimAttempts = 0
+  let recoveryPrepareAttempts = 0
+  let recoveryFailures = 0
   let healthyFailures = 0
   let provisioningFailures = 0
   const store: CloudWorkerStore = {
@@ -226,15 +229,33 @@ function makeCloudWorkerStore(input: {
       worker.status = "provisioning"
       return true
     },
-    async claimRecycleWorker(workerId) {
-      recycleClaimAttempts += 1
+    async claimFailedWorkerForWake(workerId) {
+      wakeClaimAttempts += 1
       const worker = workers.find((entry) => entry.id === workerId)
-      if (!worker || (worker.status !== "healthy" && worker.status !== "stopped")) {
+      if (!worker || worker.status !== "failed") {
         return false
       }
 
-      worker.status = "provisioning"
+      worker.status = "stopped"
       return true
+    },
+    async claimRecycleWorker(workerId) {
+      recycleClaimAttempts += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (!worker || worker.status !== "healthy") {
+        return false
+      }
+
+      worker.status = "stopped"
+      return true
+    },
+    async prepareRecoveryWorker(workerId) {
+      recoveryPrepareAttempts += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (worker) {
+        worker.status = "stopped"
+        worker.image_version = null
+      }
     },
     async getActiveTokens(workerId) {
       return tokens.filter((entry) => entry.workerId === workerId)
@@ -253,6 +274,13 @@ function makeCloudWorkerStore(input: {
         worker.status = "failed"
       }
     },
+    async markRecoveryWorkerFailed(workerId) {
+      recoveryFailures += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (worker && worker.status !== "failed") {
+        worker.status = "failed"
+      }
+    },
   }
 
   return {
@@ -264,8 +292,17 @@ function makeCloudWorkerStore(input: {
     get claimAttempts() {
       return claimAttempts
     },
+    get wakeClaimAttempts() {
+      return wakeClaimAttempts
+    },
     get recycleClaimAttempts() {
       return recycleClaimAttempts
+    },
+    get recoveryPrepareAttempts() {
+      return recoveryPrepareAttempts
+    },
+    get recoveryFailures() {
+      return recoveryFailures
     },
     get healthyFailures() {
       return healthyFailures
@@ -763,7 +800,7 @@ describe("Cloud instance route lifecycle states", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null, imageVersion: "openwork-0.18.7" }))
     expect(store.recycleClaimAttempts).toBe(1)
-    expect(worker.status).toBe("provisioning")
+    expect(worker.status).toBe("stopped")
     expect(wakeCalls).toBe(1)
     expect(probes).toBe(0)
   })
@@ -956,6 +993,80 @@ describe("Cloud instance update route", () => {
   })
 })
 
+describe("Cloud instance recovery route", () => {
+  test("stops a wedged worker and hands a fresh-sandbox wake the stopped state", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = { ...storedWorker({ orgId, userId, status: "provisioning" }), image_version: "openwork-0.18.8" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    const stopCalls: StoredCloudWorker["id"][] = []
+    let wakeCalls = 0
+    let statusAtWake: CloudWorkerStatus | null = null
+    let imageVersionAtWake: string | null | undefined
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      stopCloudWorker: async (workerId) => {
+        stopCalls.push(workerId)
+      },
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+        statusAtWake = worker.status
+        imageVersionAtWake = worker.image_version
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/recover", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, status: "recovery_requested" })
+    await flushMicrotasks()
+    expect(stopCalls).toEqual([worker.id])
+    expect(store.recoveryPrepareAttempts).toBe(1)
+    expect(statusAtWake).toBe("stopped")
+    expect(imageVersionAtWake).toBeNull()
+    expect(wakeCalls).toBe(1)
+    expect(store.recoveryFailures).toBe(0)
+  })
+
+  test("surfaces a provider stop failure as a failed worker instead of another endless wake", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = storedWorker({ orgId, userId, status: "provisioning" })
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let wakeCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      stopCloudWorker: async () => {
+        throw new Error("sandbox stop timed out")
+      },
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/recover", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, status: "recovery_requested" })
+    await flushMicrotasks()
+    expect(worker.status).toBe("failed")
+    expect(store.recoveryFailures).toBe(1)
+    expect(wakeCalls).toBe(0)
+  })
+})
+
 describe("Cloud instance per-user workers", () => {
   test("creates one worker per user and reuses the same user's canonical worker", async () => {
     const orgId = createDenTypeId("organization")
@@ -1100,7 +1211,7 @@ describe("Cloud instance failed self-heal", () => {
     await expect(first.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     await flushMicrotasks()
 
-    expect(store.claimAttempts).toBe(1)
+    expect(store.wakeClaimAttempts).toBe(1)
     expect(provisionCalls).toBe(0)
     expect(wakeCalls).toBe(1)
     expect(worker.status).not.toBe("failed")
@@ -1189,7 +1300,8 @@ describe("Cloud instance failed self-heal", () => {
 
 describe("Cloud instance ready liveness", () => {
   test("returns waking and starts wake when the preview is dead and the sandbox is stopped", async () => {
-    const worker = fakeWorker("healthy")
+    const worker = storedWorker({ status: "healthy" })
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
     let probes = 0
     let wakeCalls = 0
@@ -1200,6 +1312,7 @@ describe("Cloud instance ready liveness", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),
       refreshSignedPreview: async () => null,
       probeSignedPreview: async () => {
@@ -1217,6 +1330,8 @@ describe("Cloud instance ready liveness", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     expect(probes).toBe(1)
+    expect(store.recycleClaimAttempts).toBe(1)
+    expect(worker.status).toBe("stopped")
     expect(wakeCalls).toBe(1)
   })
 


### PR DESCRIPTION
## Summary

- Fix the Cloud workspace wake/recycle state handoff so stopped and failed sandboxes actually enter the wake lifecycle.
- Add an explicit replacement-sandbox recovery endpoint that preserves retained workspace state and turns provider stop failures into a terminal failed status.
- Replace endless Web loading with a two-minute actionable error and recovery controls: **Start a new sandbox**, **Try again**, and **Sign out**.

## Root cause

The Cloud route moved a worker to `provisioning` before calling the wake lifecycle, while that lifecycle only reserves workers in `stopped`. The wake call therefore returned without starting the sandbox, and polling kept rendering `provisioning` plus an existing sandbox record as “waking” forever.

## User impact

Old or stale Cloud workspaces no longer remain indefinitely on “Restoring your files.” After two minutes without progress, users see “Workspace couldn’t start” and can retry, start a replacement sandbox from their retained workspace files, or sign out.

## Validation

- `corepack pnpm --filter @openwork/app exec bun test tests/cloud-workspace-overlay.test.tsx` — 25 passed, 0 failed
- `corepack pnpm --filter @openwork-ee/den-api exec bun test test/cloud-instance-route.test.ts` — 35 passed, 0 failed
- `corepack pnpm --filter @openwork/app run typecheck` — passed
- `corepack pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — passed
- `git diff --check` — passed
- Local styled UI inspection completed for the timeout/recovery state

## Proof status

**Incomplete** — this runtime-observable change still requires an exact-head `@openwork/testkit` tape. The PR remains draft until that proof is run and published.