### PR TITLE
docs: add v0.18.26 release notes

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,18 @@
 ---
 title: "Changelog"
 ---
+<Update label="August 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
+
+  ## [v0.18.26](https://github.com/different-ai/openwork/compare/v0.18.13...v0.18.26): Automations graduate, MCP Apps come alive, and sessions stay resilient
+
+  - Automations are out of preview: propose recurring work from chat, choose a model and thinking level, review clearer receipts, restore earlier revisions, and run work on your desktop or in OpenWork Cloud.
+  - MCP Apps now bring interactive tools directly into conversations. Install external apps through Connect, open agent-generated views inline, and save reusable Code Mode Programs for future runs and Automations.
+  - Cloud setup is much smoother, with mobile and tablet support, automatic installer downloads, simpler organization sign-in, model-usage analytics, and a clearer dashboard organized around Work, Manage, Observability, and Team.
+  - Connect is more dependable: organization models appear automatically and refresh without restarting, OAuth works with more providers, and the Library clearly explains connection failures. Marketplace is now called Collections throughout OpenWork.
+  - Agent runs now survive provider updates, engine restarts, workspace switches, and intermittent cloud connection failures, alongside fixes for stuck uploads, startup failures, and interrupted sessions.
+
+</Update>
+
 <Update label="August 3rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.18.13](https://github.com/different-ai/openwork/compare/v0.18.12...v0.18.13): Extensions becomes the Library and skill sharing opens up


### PR DESCRIPTION
## Summary
- add the August 17 release entry for v0.18.26
- summarize user-facing changes since v0.18.13
- link the complete v0.18.13...v0.18.26 comparison

## Verification
- `git diff --check`
- Runtime proof skipped: docs-only change.