### PR TITLE
fix(den-web): keep the org switcher on screen when Settings expands

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -704,8 +704,8 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   );
 
   const sidebarContent = (
-    <div className="flex flex-1 flex-col">
-      <div className="border-b border-gray-100 px-4 pb-4 pt-5">
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-gray-100 px-4 pb-4 pt-5">
         <div className="flex items-center justify-between gap-3">
           <SidebarBrandMark
             metadata={orgContext?.organization.metadata}
@@ -722,7 +722,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         </div>
       </div>
 
-      <nav className="flex-1 overflow-y-auto px-3 py-5" data-testid="den-org-sidebar">
+      <nav className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 py-5" data-testid="den-org-sidebar">
         <div className="space-y-5">
           {navSections.map((section) => (
             <div key={section.label} data-sidebar-section={section.label.toLowerCase()}>
@@ -759,17 +759,17 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                         href={item.href}
                         data-testid={item.testId}
                         onClick={() => setSidebarOpen(false)}
-                        className={`flex items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-[13px] tracking-[-0.1px] transition-colors ${
+                        className={`flex min-w-0 items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-[13px] tracking-[-0.1px] transition-colors ${
                           selected
                             ? "bg-gray-100 text-gray-900"
                             : "text-gray-500 hover:bg-gray-50 hover:text-gray-700"
                         }`}
                       >
-                        <span className="flex items-center gap-3">
-                          <item.icon className="h-4 w-4" strokeWidth={1.8} />
-                          {item.label}
+                        <span className="flex min-w-0 items-center gap-3">
+                          <item.icon className="h-4 w-4 shrink-0" strokeWidth={1.8} />
+                          <span className="min-w-0 truncate">{item.label}</span>
                         </span>
-                        <span className="flex items-center gap-1.5">
+                        <span className="flex shrink-0 items-center gap-1.5">
                           {item.badge ? (
                             <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
                               {item.badge}
@@ -783,21 +783,21 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                         </span>
                       </Link>
                       {item.children && groupActive ? (
-                        <div className="ml-[22px] mt-1 space-y-0.5 border-l border-gray-100 pl-3">
+                        <div className="ml-[22px] mt-1 min-w-0 space-y-0.5 border-l border-gray-100 pl-3">
                           {item.children.map((child) => (
                             <Link
                               key={child.label}
                               href={child.href}
                               onClick={() => setSidebarOpen(false)}
-                              className={`flex items-center justify-between gap-3 rounded-lg px-2.5 py-1.5 text-[13px] tracking-[-0.1px] transition-colors ${
+                              className={`flex min-w-0 items-center justify-between gap-3 rounded-lg px-2.5 py-1.5 text-[13px] tracking-[-0.1px] transition-colors ${
                                 childActive(child)
                                   ? "font-medium text-gray-900"
                                   : "text-gray-500 hover:text-gray-700"
                               }`}
                             >
-                              {child.label}
+                              <span className="min-w-0 truncate">{child.label}</span>
                               {child.badge ? (
-                                <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                                <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
                                   {child.badge}
                                 </span>
                               ) : null}
@@ -814,7 +814,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         </div>
       </nav>
 
-      <div className="mt-auto p-3">
+      <div className="mt-auto shrink-0 p-3" data-testid="den-org-sidebar-footer">
         {orgSwitcher}
 
         {orgBusy ? (
@@ -831,7 +831,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen flex-col bg-[#fafafa] md:h-screen md:flex-row">
       <WorkspaceFavicon metadata={orgContext?.organization.metadata} />
       {/* Desktop sidebar — always visible at md+ */}
-      <aside className="hidden shrink-0 border-r border-gray-100 bg-white md:flex md:min-h-screen md:w-[260px] md:flex-col">
+      <aside className="hidden min-h-0 shrink-0 overflow-hidden border-r border-gray-100 bg-white md:flex md:h-screen md:w-[260px] md:flex-col">
         {sidebarContent}
       </aside>
 
@@ -839,7 +839,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       {sidebarOpen ? (
         <div className="fixed inset-0 z-50 md:hidden">
           <div className="absolute inset-0 bg-black/30" onClick={() => setSidebarOpen(false)} aria-hidden />
-          <aside className="relative z-10 flex h-full w-[280px] max-w-[85vw] flex-col overflow-y-auto bg-white shadow-xl">
+          <aside className="relative z-10 flex h-full min-h-0 w-[280px] max-w-[85vw] flex-col overflow-hidden bg-white shadow-xl">
             {sidebarContent}
           </aside>
         </div>

--- a/ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts
+++ b/ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts
@@ -14,6 +14,16 @@ describe("OrgDashboardShell layout", () => {
     expect(source).toMatch(/<main className="[^\"]*\bflex-1\b[^\"]*\boverflow-y-auto\b[^\"]*">/);
   });
 
+  test("pins the workspace switcher and scrolls only the nav when Settings expands", () => {
+    const source = readFileSync(shellPath, "utf8");
+
+    expect(source).toMatch(/<aside className="[^\"]*\boverflow-hidden\b[^\"]*\bmd:h-screen\b[^\"]*">/);
+    expect(source).toMatch(/<nav className="[^\"]*\bmin-h-0\b[^\"]*\boverflow-x-hidden\b[^\"]*\boverflow-y-auto\b[^\"]*" data-testid="den-org-sidebar">/);
+    expect(source).toContain('data-testid="den-org-sidebar-footer"');
+    expect(source).toMatch(/className="[^\"]*\bmt-auto\b[^\"]*\bshrink-0\b[^\"]*" data-testid="den-org-sidebar-footer"/);
+    expect(source).not.toMatch(/<aside className="[^\"]*\bmd:min-h-screen\b[^\"]*">/);
+  });
+
   test("bounds the workspace switcher and dismisses only outside pointer input", () => {
     const source = readFileSync(shellPath, "utf8");
 

--- a/evals/specs/den-sidebar-footer-pin.slow.test.ts
+++ b/evals/specs/den-sidebar-footer-pin.slow.test.ts
@@ -1,0 +1,150 @@
+import { expect } from "vitest";
+import { evalIn, waitFor } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = {
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `den sidebar footer pin skipped — needs: ${missingRequirements.join(", ")}`
+  : "expanded Settings keeps the workspace switcher in view while only the sidebar nav scrolls";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface SidebarPinLayout {
+  found: boolean;
+  viewportHeight: number;
+  navScrollHeight: number;
+  navClientHeight: number;
+  navOverflowY: string;
+  asideScrollTop: number;
+  asideClientHeight: number;
+  asideScrollHeight: number;
+  footerTop: number;
+  footerBottom: number;
+  footerHeight: number;
+  hasScim: boolean;
+}
+
+function parseLayout(value: unknown): SidebarPinLayout {
+  if (!isRecord(value) || value.found !== true) {
+    throw new Error(`Sidebar pin layout was not found: ${JSON.stringify(value)}`);
+  }
+  const layout = {
+    found: true,
+    viewportHeight: value.viewportHeight,
+    navScrollHeight: value.navScrollHeight,
+    navClientHeight: value.navClientHeight,
+    navOverflowY: value.navOverflowY,
+    asideScrollTop: value.asideScrollTop,
+    asideClientHeight: value.asideClientHeight,
+    asideScrollHeight: value.asideScrollHeight,
+    footerTop: value.footerTop,
+    footerBottom: value.footerBottom,
+    footerHeight: value.footerHeight,
+    hasScim: value.hasScim,
+  };
+  if (
+    typeof layout.viewportHeight !== "number"
+    || typeof layout.navScrollHeight !== "number"
+    || typeof layout.navClientHeight !== "number"
+    || typeof layout.navOverflowY !== "string"
+    || typeof layout.asideScrollTop !== "number"
+    || typeof layout.asideClientHeight !== "number"
+    || typeof layout.asideScrollHeight !== "number"
+    || typeof layout.footerTop !== "number"
+    || typeof layout.footerBottom !== "number"
+    || typeof layout.footerHeight !== "number"
+    || typeof layout.hasScim !== "boolean"
+  ) {
+    throw new Error(`Sidebar pin layout had an unexpected shape: ${JSON.stringify(value)}`);
+  }
+  return layout;
+}
+
+const readLayout = `(() => {
+  const nav = document.querySelector('[data-testid="den-org-sidebar"]');
+  const footer = document.querySelector('[data-testid="den-org-sidebar-footer"]');
+  const aside = nav?.closest("aside");
+  if (!(nav instanceof HTMLElement) || !(footer instanceof HTMLElement) || !(aside instanceof HTMLElement)) {
+    return { found: false };
+  }
+  const footerRect = footer.getBoundingClientRect();
+  return {
+    found: true,
+    viewportHeight: window.innerHeight,
+    navScrollHeight: nav.scrollHeight,
+    navClientHeight: nav.clientHeight,
+    navOverflowY: getComputedStyle(nav).overflowY,
+    asideScrollTop: aside.scrollTop,
+    asideClientHeight: aside.clientHeight,
+    asideScrollHeight: aside.scrollHeight,
+    footerTop: footerRect.top,
+    footerBottom: footerRect.bottom,
+    footerHeight: footerRect.height,
+    hasScim: [...nav.querySelectorAll("a")].some((link) => (link.textContent ?? "").includes("SCIM")),
+  };
+})()`;
+
+test(title, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    org: {
+      name: `Den Sidebar Footer Pin ${Date.now()}`,
+      admin: { name: "Sarah" },
+    },
+  });
+
+  await using browser = await chrome({
+    name: "den-sidebar-footer-pin",
+    startUrl: den.ref.webUrl,
+    headless: true,
+    host: place.host(),
+  });
+  await browser.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 720,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web origin before admin auth token handoff",
+  });
+
+  const adminTokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
+  })()`);
+  expect(adminTokenStored).toBe(true);
+  await navigate(browser.client, `${den.ref.webUrl}/dashboard/org-settings`);
+  await waitFor(browser, `Boolean(document.querySelector('[data-testid="den-org-sidebar-footer"]'))
+    && [...document.querySelectorAll('[data-testid="den-org-sidebar"] a')].some((link) => (link.textContent ?? "").includes("SCIM"))`, {
+    timeoutMs: 60_000,
+    label: "expanded Settings with pinned workspace switcher",
+  });
+
+  const layout = parseLayout(await evalIn(browser, readLayout));
+  const footerInView = layout.footerTop >= 0 && layout.footerBottom <= layout.viewportHeight;
+  const navIsScroller = layout.navScrollHeight > layout.navClientHeight + 8
+    && (layout.navOverflowY === "auto" || layout.navOverflowY === "scroll");
+  const asideDidNotSwallowFooter = layout.asideScrollTop === 0
+    && layout.asideScrollHeight <= layout.asideClientHeight + 1;
+
+  expect(layout.hasScim).toBe(true);
+  expect(footerInView).toBe(true);
+  expect(navIsScroller).toBe(true);
+  expect(asideDidNotSwallowFooter).toBe(true);
+  evidence.fact(
+    "Expanded Settings keeps the workspace switcher in the viewport while only the sidebar nav scrolls",
+    JSON.stringify(layout),
+    footerInView && navIsScroller && asideDidNotSwallowFooter && layout.hasScim,
+  );
+});


### PR DESCRIPTION
## Summary
- Expanding Settings made the whole Den sidebar taller than the viewport, so the workspace profile/org switcher was pushed below the fold and the left column became the scroller.
- The desktop sidebar is now viewport-tall with `min-h-0` containment: only the nav list scrolls, and the org switcher stays pinned at the bottom.
- Long nav labels truncate instead of forcing horizontal overflow that paired with `overflow-y: auto`.

## Test plan
- [x] `pnpm --filter @openwork-ee/den-web exec bun test tests/org-dashboard-shell-layout.test.ts tests/org-dashboard-sidebar-ia.test.ts`
- [x] `pnpm --filter @openwork-ee/den-web typecheck`
- [x] `OPENWORK_EVAL_REF=fix/den-sidebar-nav-overflow pnpm evals den-sidebar-footer-pin --daytona` at `17ec67c18` — 1 passed, 0 skipped
- [ ] Open org Settings at a short viewport and confirm SCIM can be reached by scrolling the nav while Different AI / the org switcher stays on screen


Made with [Cursor](https://cursor.com)