### PR TITLE
fix(evals): await complete mega model marker

### DIFF
--- a/evals/specs/org-team-lifecycle-mega.slow.test.ts
+++ b/evals/specs/org-team-lifecycle-mega.slow.test.ts
@@ -749,7 +749,12 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
       appMate,
       `This is an automated connectivity check of the newly configured model. Reply with the verification code ${llmMarker} to confirm the model is reachable.`,
     );
-    const llmReply = await waitForAssistantReply(appMate, { timeoutMs: 300_000 });
+    await waitFor(appMate, `([...document.querySelectorAll('[data-message-role="assistant"]')]
+      .some((message) => (message.innerText ?? "").includes(${JSON.stringify(llmMarker)})))`, {
+      timeoutMs: 300_000,
+      label: `complete assistant verification code ${JSON.stringify(llmMarker)}`,
+    });
+    const llmReply = await waitForAssistantReply(appMate, { timeoutMs: 10_000 });
     expect(llmReply.text).toContain(llmMarker);
     evidence.fact(
       "The teammate ran the workspace-configured real model",


### PR DESCRIPTION
## Summary

- wait for the complete streamed model verification marker before reading the assistant reply
- avoid asserting against the first partial assistant DOM text
- keep the existing first-text behavior of `waitForAssistantReply` for callers that rely on it

## Root cause

`waitForAssistantReply` intentionally returns once any assistant text exists. The mega spec asserted immediately and observed `LLM-OK-msx65r` while `LLM-OK-msx65r6k` was still streaming.

## Verification

**Verdict: Failed**

Daytona command:

`CI=true OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MEGA_SPEC=1 OPENWORK_EVAL_MODEL=gpt-4o OPENWORK_EVAL_VISION=defer infisical run --silent -- env -u DATABASE_HOST pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/org-team-lifecycle-mega.slow.test.ts`

Exit 1: 1 test file failed, 1 test failed, 0 skipped. On final head `ba67a0a58`, the run failed earlier at `sendComposerMessage` (line 509): the UI showed `Thinking` and `Stop`, but the user-message-count wait timed out. The complete mega proof is therefore still missing.

A prior committed-head Daytona run reached and passed the repaired LLM marker checkpoint, then failed later at the independent skill-marker assertion on line 783. This PR remains draft until a final-head run reaches the checkpoint and the full mega spec passes.