### PR TITLE
docs: add public cloud deployment guides

### DIFF
--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -444,10 +444,19 @@ config:
     bootstrapAdminEmails: "admin@acme.com"
 ```
 
-Open `https://openwork.example.com` and sign up with the owner email. OpenWork
-creates the singleton organization and makes that user the owner. Later users
-join the same organization. If `ownerEmails` is blank, the first user to reach
-the deployment can claim ownership, which is not recommended for production.
+For releases that include initial-administrator bootstrap, inject the
+release-documented one-time setup secret through the Kubernetes Secret referenced
+by `secret.existingSecret`. Do not store the code in the values file or a
+ConfigMap. Then open `https://openwork.example.com/setup`, enter the configured
+owner email and one-time operator code, and create the first account. OpenWork
+creates the singleton organization, grants owner and configured platform-admin
+access, signs the administrator in, and permanently consumes the setup claim.
+Public signup remains disabled.
+
+`ownerEmails` and `bootstrapAdminEmails` authorize roles; neither setting creates
+an account or password. There is no default administrator password. Chart
+versions without `/setup` do not support private initial-administrator bootstrap
+and must be upgraded before following this step.
 
 ## 9. Configure SSO with a test IdP
 

--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -70,20 +70,39 @@ aws sts get-caller-identity
 aws configure get region
 ```
 
-Install Helm and `eksctl` if they are missing:
+Install pinned Helm and `eksctl` releases if they are missing. Verify each
+archive against the checksum published for that exact release before installing
+the binary:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+HELM_VERSION=v3.18.4
+HELM_ARCHIVE="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}" -o "/tmp/${HELM_ARCHIVE}"
+printf '%s  %s\n' \
+  'f8180838c23d7c7d797b208861fecb591d9ce1690d8704ed1e4cb8e2add966c1' \
+  "/tmp/${HELM_ARCHIVE}" | sha256sum --check --strict
+tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
+sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
-curl -fsSL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" \
-  -o /tmp/eksctl.tar.gz
-tar -xzf /tmp/eksctl.tar.gz -C /tmp
-sudo mv /tmp/eksctl /usr/local/bin/eksctl
+EKSCTL_VERSION=v0.195.0
+EKSCTL_ARCHIVE=eksctl_Linux_amd64.tar.gz
+curl -fsSL \
+  "https://github.com/eksctl-io/eksctl/releases/download/${EKSCTL_VERSION}/${EKSCTL_ARCHIVE}" \
+  -o "/tmp/${EKSCTL_ARCHIVE}"
+printf '%s  %s\n' \
+  '1cc86fd94da2378687f4db7c537da3c7316f2dca1347a4223a2ed86ad94dd818' \
+  "/tmp/${EKSCTL_ARCHIVE}" | sha256sum --check --strict
+tar -xzf "/tmp/${EKSCTL_ARCHIVE}" -C /tmp
+sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 
 helm version
 eksctl version
 kubectl version --client
 ```
+
+The checksums above are the official Linux AMD64 values for Helm `v3.18.4` and
+`eksctl` `v0.195.0`. When updating either pin, replace its checksum from the
+corresponding official release rather than changing the version alone.
 
 ## 1. Create the EKS cluster
 

--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -608,10 +608,19 @@ config:
     bootstrapAdminEmails: "admin@acme.com"
 ```
 
-Open `https://openwork.example.com` and sign up with the owner email. OpenWork
-creates the singleton organization and makes that user the owner. Later users
-join the same organization. If `ownerEmails` is blank, the first user to reach
-the deployment can claim ownership, which is not recommended for production.
+For releases that include initial-administrator bootstrap, inject the
+release-documented one-time setup secret through the Kubernetes Secret referenced
+by `secret.existingSecret`. Do not store the code in the values file or a
+ConfigMap. Then open `https://openwork.example.com/setup`, enter the configured
+owner email and one-time operator code, and create the first account. OpenWork
+creates the singleton organization, grants owner and configured platform-admin
+access, signs the administrator in, and permanently consumes the setup claim.
+Public signup remains disabled.
+
+`ownerEmails` and `bootstrapAdminEmails` authorize roles; neither setting creates
+an account or password. There is no default administrator password. Chart
+versions without `/setup` do not support private initial-administrator bootstrap
+and must be upgraded before following this step.
 
 ## 10. Configure SSO with a test IdP
 

--- a/docs/gcp-gke-helm.md
+++ b/docs/gcp-gke-helm.md
@@ -47,7 +47,7 @@ guidance, not a different OpenWork packaging format.
 ## Prerequisites
 
 - Google Cloud CLI authenticated to the target project.
-- `kubectl` and `helm`.
+- `kubectl`, `helm`, and `gke-gcloud-auth-plugin`.
 - Permission to create GKE, Compute Engine networking and global addresses,
   Cloud SQL, Service Networking, DNS, IAM, and Kubernetes resources.
 - Enabled APIs: Kubernetes Engine API, Compute Engine API, Cloud SQL Admin API,
@@ -88,6 +88,9 @@ gcloud container clusters create-auto "$GKE_CLUSTER" \
   --location "$GCP_REGION" \
   --project "$GCP_PROJECT"
 
+# If the cluster command reports that the auth plugin is missing:
+gcloud components install gke-gcloud-auth-plugin --quiet
+
 gcloud container clusters get-credentials "$GKE_CLUSTER" \
   --location "$GCP_REGION" \
   --project "$GCP_PROJECT"
@@ -97,6 +100,11 @@ kubectl get nodes
 
 GKE enables HTTP load balancing by default. Do not disable it; GKE Ingress needs
 that add-on.
+
+Some standalone Google Cloud SDK installations do not include
+`gke-gcloud-auth-plugin`. If `kubectl` cannot authenticate after cluster
+creation, install the component as shown above, rerun `get-credentials`, and
+verify with `kubectl get nodes` before debugging Kubernetes resources.
 
 ## 2. Create Cloud SQL for MySQL
 
@@ -236,6 +244,8 @@ spec:
     type: HTTP
     requestPath: /ready
     port: 8788
+    checkIntervalSec: 15
+    timeoutSec: 5
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
@@ -246,6 +256,8 @@ spec:
     type: HTTP
     requestPath: /api/ready
     port: 3005
+    checkIntervalSec: 15
+    timeoutSec: 5
 YAML
 ```
 
@@ -475,10 +487,19 @@ config:
     bootstrapAdminEmails: "admin@acme.com"
 ```
 
-Open `https://openwork.example.com` and sign up with the owner email. OpenWork
-creates the singleton organization and makes that user the owner. Later users
-join the same organization. If `ownerEmails` is blank, the first user to reach
-the deployment can claim ownership, which is not recommended for production.
+For releases that include initial-administrator bootstrap, inject the
+release-documented one-time setup secret through the Kubernetes Secret referenced
+by `secret.existingSecret`. Do not store the code in the values file or a
+ConfigMap. Then open `https://openwork.example.com/setup`, enter the configured
+owner email and one-time operator code, and create the first account. OpenWork
+creates the singleton organization, grants owner and configured platform-admin
+access, signs the administrator in, and permanently consumes the setup claim.
+Public signup remains disabled.
+
+`ownerEmails` and `bootstrapAdminEmails` authorize roles; neither setting creates
+an account or password. There is no default administrator password. Chart
+versions without `/setup` do not support private initial-administrator bootstrap
+and must be upgraded before following this step.
 
 ## 10. Configure SSO with a test IdP
 
@@ -517,6 +538,7 @@ single organization. Password sign-in for that organization is rejected.
 |---|---|---|
 | Ingress does not reconcile | HTTP load balancing add-on is disabled or Ingress annotation is wrong | Keep HTTP load balancing enabled and use `kubernetes.io/ingress.class: gce` |
 | Backends are unhealthy | GKE load balancer health checks do not match OpenWork readiness endpoints | Apply the `BackendConfig` resources and keep the service annotations from the starter values |
+| Ingress events report `TimeoutSec should be less than checkIntervalSec` | The backend health-check timeout is greater than or equal to its effective interval | Set `checkIntervalSec: 15` and `timeoutSec: 5` on both `BackendConfig` resources |
 | Managed certificate is not `Active` | DNS does not point at the load balancer or provisioning is still running | Point both hosts at the reserved global IP and wait; check `kubectl describe managedcertificate` |
 | Migration Job fails to connect to MySQL | Private services access, VPC, credentials, IP, or TLS mode are wrong | Test from `mysql-client`, confirm the private IP, and confirm GKE and Cloud SQL share VPC reachability |
 | Migration Job logs show `self-signed certificate in certificate chain` | Strict certificate verification is being used without the cloud MySQL CA bundle | Use `?sslaccept=accept` for the smoke path or mount/configure the CA bundle before strict verification |

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -73,6 +73,16 @@
             ]
           },
           {
+            "group": "Deploy to your cloud",
+            "pages": [
+              "self-host/deploy-to-your-cloud/overview",
+              "self-host/deploy-to-your-cloud/aws",
+              "self-host/deploy-to-your-cloud/azure",
+              "self-host/deploy-to-your-cloud/google-cloud",
+              "self-host/deploy-to-your-cloud/first-administrator"
+            ]
+          },
+          {
             "group": "Plan your network",
             "pages": [
               "start-here/private-network-deployment",

--- a/packages/docs/self-host/deploy-to-your-cloud/aws.mdx
+++ b/packages/docs/self-host/deploy-to-your-cloud/aws.mdx
@@ -1,0 +1,29 @@
+---
+title: "Deploy on AWS"
+description: "Run OpenWork on Amazon EKS with Amazon RDS for MySQL."
+---
+
+The recommended AWS path is Helm on Amazon EKS with Amazon RDS for MySQL. For the smallest first deployment, use EKS Auto Mode and Kubernetes `LoadBalancer` Services so AWS provisions Network Load Balancers for Den web and Den API. Move to an ALB or an existing ingress platform when you need shared layer-7 routing, WAF policy, or more advanced certificate handling.
+
+## What AWS manages
+
+- EKS control plane, compute, pod networking, and load-balancer integration
+- VPCs, subnets, routing, security groups, and IAM
+- RDS for MySQL, encryption, backups, and failover
+- Route 53 DNS and ACM certificates when you use those services
+
+The OpenWork chart manages Deployments, Services, ConfigMaps, Secret references, probes, and the database migration Job.
+
+## AWS checklist
+
+1. Create an EKS Auto Mode cluster with `eksctl` `0.195.0` or newer.
+2. Create an RDS MySQL 8-compatible database in private subnets.
+3. Allow database port `3306` only from the EKS workload or node security boundary.
+4. Store `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `DEN_DB_ENCRYPTION_KEY` in a Kubernetes Secret.
+5. Start from the chart's `values.aws-load-balancer.yaml` example.
+6. Install the chart, verify migrations and readiness, then point DNS at the generated load balancers.
+7. Enable trusted HTTPS before creating the first administrator.
+
+For exact CLI commands, values, DNS/TLS choices, migration troubleshooting, verification, and cleanup, follow the [AWS EKS operator runbook](https://github.com/different-ai/openwork/blob/dev/docs/aws-eks-helm.md).
+
+Next: [Create the first administrator](/self-host/deploy-to-your-cloud/first-administrator).

--- a/packages/docs/self-host/deploy-to-your-cloud/azure.mdx
+++ b/packages/docs/self-host/deploy-to-your-cloud/azure.mdx
@@ -1,0 +1,29 @@
+---
+title: "Deploy on Azure"
+description: "Run OpenWork on Azure Kubernetes Service with Azure Database for MySQL."
+---
+
+The recommended Azure path is Helm on Azure Kubernetes Service with Azure Database for MySQL Flexible Server. Use the AKS application-routing add-on's managed NGINX Ingress controller for browser-facing HTTPS and host routing.
+
+## What Azure manages
+
+- AKS control plane, node pools, virtual networking, and managed identities
+- the managed NGINX ingress entry point and public IP
+- Azure Database for MySQL Flexible Server, encryption, backups, and failover
+- Azure DNS and certificate storage when you use those services
+
+The OpenWork chart manages Deployments, Services, ConfigMaps, Secret references, probes, the Ingress, and the database migration Job.
+
+## Azure checklist
+
+1. Confirm the subscription is enabled and register the required resource providers.
+2. Check regional vCPU quota and MySQL Flexible Server availability before creating AKS.
+3. Create AKS and MySQL in a VNet topology that permits private database traffic.
+4. Store `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `DEN_DB_ENCRYPTION_KEY` in a Kubernetes Secret.
+5. Start from the chart's `values.azure-ingress.yaml` example.
+6. Configure the ingress certificate, install the chart, and verify migrations and readiness.
+7. Point both hostnames at the ingress address and confirm trusted HTTPS.
+
+For exact Azure CLI commands, values, TLS options, migration troubleshooting, verification, and cleanup, follow the [Azure AKS operator runbook](https://github.com/different-ai/openwork/blob/dev/docs/azure-aks-helm.md).
+
+Next: [Create the first administrator](/self-host/deploy-to-your-cloud/first-administrator).

--- a/packages/docs/self-host/deploy-to-your-cloud/first-administrator.mdx
+++ b/packages/docs/self-host/deploy-to-your-cloud/first-administrator.mdx
@@ -1,0 +1,52 @@
+---
+title: "Create the first administrator"
+description: "Securely claim a new private OpenWork deployment without enabling public signup."
+---
+
+A private deployment should start with public signup disabled. Configuring an email in the owner or platform-admin allowlist authorizes that identity after authentication; it does not create an account, choose a password, or generate a default administrator password.
+
+Releases that include initial-administrator bootstrap provide a dedicated setup page at:
+
+```text
+https://<your-den-web-host>/setup
+```
+
+<Warning>
+  Chart versions without `/setup` do not support this private bootstrap flow. Upgrade before attempting first-user setup. Entering an allowlisted email on the normal sign-in page cannot create a missing account.
+</Warning>
+
+## Before installing
+
+1. Configure the initial administrator email as an eligible singleton-organization owner.
+2. Add the same email to the platform-admin allowlist only if that person also needs deployment-wide `/admin` access.
+3. Generate the release-documented one-time setup secret.
+4. Inject the secret through a Kubernetes Secret or your platform's secret store.
+5. Keep public signup disabled.
+
+Never place the setup code in a Helm values file, ConfigMap, container image, source-control file, support ticket, screenshot, logs, or PR.
+
+## Complete setup
+
+1. Wait until Den web, Den API, and the migration Job are healthy.
+2. Open `/setup` on the Den web hostname.
+3. Enter the configured administrator email and the one-time operator code.
+4. Choose the administrator's name and password.
+5. Confirm that OpenWork signs the administrator in and opens the singleton organization.
+
+The setup flow uses the existing Better Auth password and session protections. Successful setup creates the first account, creates or claims the singleton organization, grants the configured owner and platform-admin roles, and permanently consumes the setup claim.
+
+## Verify the boundary
+
+After setup:
+
+- revisiting `/setup` reports that setup is complete or unavailable;
+- the one-time code cannot be reused;
+- unknown users still cannot sign up;
+- the administrator can sign out and use normal password sign-in;
+- restarting or scaling Den API does not re-enable setup.
+
+If the deployment already contains a user, bootstrap must remain unavailable even if its setup Secret still exists. Rotating or restoring the Secret must not reopen a consumed deployment.
+
+## Configure SSO next
+
+Use the first owner as a break-glass account, then configure SAML or OIDC SSO and SCIM for normal workforce access. Protect the break-glass identity and recovery material according to your organization's access-control policy.

--- a/packages/docs/self-host/deploy-to-your-cloud/google-cloud.mdx
+++ b/packages/docs/self-host/deploy-to-your-cloud/google-cloud.mdx
@@ -1,0 +1,29 @@
+---
+title: "Deploy on Google Cloud"
+description: "Run OpenWork on GKE Autopilot with Cloud SQL for MySQL."
+---
+
+The recommended Google Cloud path is Helm on a regional GKE Autopilot cluster with Cloud SQL for MySQL. Use GKE Ingress, a reserved global IP address, Google-managed certificates, and explicit backend health checks for Den web and Den API.
+
+## What Google Cloud manages
+
+- GKE control plane and Autopilot compute lifecycle
+- VPC networking, Cloud Load Balancing, firewall rules, and IAM
+- Cloud SQL for MySQL, encryption, backups, and failover
+- Cloud DNS and Google-managed certificates when you use those services
+
+The OpenWork chart manages Deployments, Services, ConfigMaps, Secret references, probes, the Ingress, and the database migration Job. GKE `BackendConfig` and `ManagedCertificate` resources are applied alongside the chart.
+
+## Google Cloud checklist
+
+1. Enable the Kubernetes Engine, Compute Engine, Cloud SQL Admin, and Service Networking APIs.
+2. Create a regional GKE Autopilot cluster and install `gke-gcloud-auth-plugin` if your Cloud SDK does not include it.
+3. Configure private services access and create Cloud SQL for MySQL with a private IP.
+4. Reserve a global IPv4 address and create the GKE health-check and certificate resources.
+5. Store `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `DEN_DB_ENCRYPTION_KEY` in a Kubernetes Secret.
+6. Start from the chart's `values.gcp-ingress.yaml` example, install the chart, and verify migrations and readiness.
+7. Point both hostnames at the reserved address and wait for the managed certificate to become active.
+
+For exact `gcloud` commands, values, health checks, migration troubleshooting, verification, and cleanup, follow the [GKE operator runbook](https://github.com/different-ai/openwork/blob/dev/docs/gcp-gke-helm.md).
+
+Next: [Create the first administrator](/self-host/deploy-to-your-cloud/first-administrator).

--- a/packages/docs/self-host/deploy-to-your-cloud/overview.mdx
+++ b/packages/docs/self-host/deploy-to-your-cloud/overview.mdx
@@ -1,0 +1,61 @@
+---
+title: "Deploy to your cloud"
+description: "Run OpenWork in your AWS, Azure, or Google Cloud account with Kubernetes, Helm, and managed MySQL."
+---
+
+OpenWork's supported private-cloud shape uses the published Helm chart, a managed Kubernetes cluster, and a MySQL-compatible database in your own account. You control the network, DNS, certificates, database, backups, identity provider, and secrets; the chart deploys Den web, Den API, migrations, and the optional inference service.
+
+<CardGroup cols={3}>
+  <Card title="AWS" icon="cloud" href="/self-host/deploy-to-your-cloud/aws">
+    Deploy on EKS with Amazon RDS for MySQL.
+  </Card>
+  <Card title="Azure" icon="cloud" href="/self-host/deploy-to-your-cloud/azure">
+    Deploy on AKS with Azure Database for MySQL.
+  </Card>
+  <Card title="Google Cloud" icon="cloud" href="/self-host/deploy-to-your-cloud/google-cloud">
+    Deploy on GKE with Cloud SQL for MySQL.
+  </Card>
+</CardGroup>
+
+## Common architecture
+
+Every provider guide uses the same OpenWork boundaries:
+
+- Den web listens on port `3005` and serves the browser experience.
+- Den API listens on port `8788` and owns authentication, organizations, policy, and control-plane APIs.
+- A MySQL 8-compatible database stores shared control-plane state.
+- A migration Job runs before the application rollout.
+- The inference service is optional and disabled by default.
+- HTTPS hostnames expose web and API traffic through the provider's load-balancing layer.
+
+Use private database networking in production. Require TLS for public application traffic, encrypt storage and backups, and keep database and authentication secrets in the provider secret store or a Kubernetes Secret—not in a Helm values file.
+
+## Deployment sequence
+
+1. Create the Kubernetes cluster and private MySQL database in compatible networks.
+2. Reserve the public address or load-balancer entry point.
+3. Create the database, database user, and Kubernetes namespace.
+4. Generate independent database, Better Auth, and Den encryption secrets.
+5. Prepare provider-specific Helm values for the web and API hostnames.
+6. Install or upgrade the chart and wait for the migration Job and workloads.
+7. Point DNS at the load balancer and verify trusted HTTPS.
+8. [Create the first administrator](/self-host/deploy-to-your-cloud/first-administrator).
+9. Configure SAML or OIDC SSO and invite or provision members.
+
+## Before you start
+
+You need:
+
+- a cloud account with permission to create Kubernetes, networking, load-balancing, managed MySQL, DNS, certificates, and secrets;
+- `kubectl` and Helm, plus the provider CLI and Kubernetes authentication plugin;
+- two DNS names, normally one for Den web and one for Den API;
+- a real email address for the initial owner;
+- a backup, restore, upgrade, and rollback plan.
+
+<Note>
+  The provider pages give the supported architecture and point to the repository's detailed operator runbooks for exact commands. Pin a chart version in production and use the runbook from the matching release or branch.
+</Note>
+
+## After deployment
+
+Use [Private network deployment](/start-here/private-network-deployment) when Den is reachable only through a VPN or private network. Review [Outbound network access](/start-here/outbound-network-access), [Certificate trust and proxies](/start-here/certificate-trust-and-proxies), and [Air-gapped deployment](/start-here/air-gapped-deployment) before restricting egress.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -28,6 +28,8 @@ helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee
 
 The chart pulls the matching GHCR images for `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` unless you mirror them into an internal registry.
 
+Choose a tested provider path in [Deploy to your cloud](/self-host/deploy-to-your-cloud/overview). The public guides cover AWS, Azure, and Google Cloud, including managed MySQL, ingress, DNS, TLS, migrations, and secure creation of the first administrator.
+
 ## Plan the network
 
 Use the dedicated Self-host planning pages instead of copying hostname, certificate, proxy, and diagnostics details into this overview:
@@ -78,6 +80,8 @@ For a self-hosted production deployment, use a managed MySQL-compatible database
 ## Auth and SSO
 
 Den uses Better Auth. It runs in your deployment, uses your database, and is configured with your `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, trusted origins, and optional GitHub/Google OAuth credentials.
+
+Private deployments should keep public signup disabled and use the one-time [first-administrator setup flow](/self-host/deploy-to-your-cloud/first-administrator). Configuring an owner or platform-admin email does not create an account or password, and OpenWork does not ship a default administrator password.
 
 SSO (SAML/OIDC) is in the current rollout and is designed to run against your own identity provider. When enabled, callback URLs and trusted origins should point at your self-hosted Den web/controller hosts.
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -597,16 +597,31 @@ config:
     bootstrapAdminEmails: "admin@acme.com"
 ```
 
-After the release is installed and the web host is reachable, sign up or sign in
-with one of the emails in `config.tenancy.ownerEmails`. If the singleton
-organization does not exist yet, Den creates it with `singleOrgName` and
-`singleOrgSlug`, then makes that eligible first user the organization owner.
+For releases that include initial-administrator bootstrap, inject the
+release-documented one-time setup secret through the chart's Secret integration.
+Do not put the setup code in Helm values, a ConfigMap, source control, logs, or a
+PR. After the release is installed and the web host is reachable, open `/setup`,
+enter an email configured in `config.tenancy.ownerEmails`, and verify it with the
+one-time operator code. Den then creates the Better Auth account, creates or
+claims the singleton organization identified by `singleOrgName` and
+`singleOrgSlug`, grants owner and configured platform-admin access, and consumes
+the setup claim. The code cannot be reused and public signup remains disabled.
+
+Configuring `ownerEmails` or `bootstrapAdminEmails` does not create an account or
+password. `ownerEmails` controls singleton-organization ownership;
+`bootstrapAdminEmails` controls platform-admin allowlist access. Configure the
+initial administrator in both lists when that person needs both roles.
+
+Chart versions without the `/setup` route do not support this private bootstrap
+flow. Upgrade to a release that includes initial-administrator bootstrap before
+attempting first-user setup; entering the configured email on the normal sign-in
+page cannot create the account and no default administrator password exists.
 
 Later users are attached to the same singleton organization. They do not see an
 organization creation step, and attempts to create another organization return a
-single-org-mode error. If no `ownerEmails` are configured, the first user who
-reaches the deployment can claim the owner role, so production deployments
-should set `ownerEmails` explicitly.
+single-org-mode error. If no eligible initial-administrator email is configured,
+the private setup flow remains unavailable; it never falls back to allowing an
+arbitrary first visitor to claim ownership.
 
 For most production installs, use this first owner account as the break-glass
 setup path, then configure SAML/OIDC SSO and SCIM from the organization


### PR DESCRIPTION
## Summary

- add a public **Deploy to your cloud** section covering AWS, Azure, and Google Cloud
- document the secure one-time first-administrator setup flow and clarify that allowlisted emails do not create accounts or passwords
- align the Helm README and detailed provider operator guides with the new admin bootstrap method

## Validation

- `git diff --check origin/dev...HEAD`
- parsed `packages/docs/docs.json` and verified every navigation page exists
- verified local links in the new public deployment pages resolve

## Evidence

Documentation-only change; no runtime behavior changed, so no testkit tape is required under the repository verification policy.