### PR TITLE
test(server): keep MCP sync reconciliation local

### DIFF
--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -500,7 +500,7 @@ describe("runtime MCP engine sync", () => {
         body: JSON.stringify({
           config: {
             type: "remote",
-            url: "https://api.openworklabs.com/mcp/agent",
+            url: `http://127.0.0.1:${mock.server.port}/api/den/mcp/agent`,
             enabled: true,
             headers: { Authorization: "Bearer test-token" },
             oauth: false,


### PR DESCRIPTION
## Summary

- point the MCP synchronization concurrency test at its local mock Cloud endpoint
- prevent capability catalog discovery from reaching the production Cloud URL during unit tests
- preserve registration serialization and reconciliation assertions

## Verification

- `bun --conditions=development test src/mcp.engine-sync.e2e.test.ts --timeout 5000 --rerun-each 20` (440 pass)
- `bun --conditions=development test src` (744 pass, 103 files)
- Local macOS lane
