### PR TITLE
fix(den): stop routine reauth prompts

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -38,6 +38,7 @@ type MarketplaceGrantRow = Pick<typeof MarketplaceAccessGrantTable.$inferSelect,
 type PluginGrantRow = Pick<typeof PluginAccessGrantTable.$inferSelect, "orgMembershipId" | "orgWide" | "removedAt" | "role" | "teamId">
 type ConnectorInstanceGrantRow = Pick<typeof ConnectorInstanceAccessGrantTable.$inferSelect, "orgMembershipId" | "orgWide" | "removedAt" | "role" | "teamId">
 type GrantRow = ConfigObjectGrantRow | MarketplaceGrantRow | PluginGrantRow | ConnectorInstanceGrantRow
+type ExposureGrantRow = Pick<PluginGrantRow, "orgMembershipId" | "orgWide" | "teamId">
 
 type MarketplaceResourceLookupInput = {
   context: PluginArchActorContext
@@ -68,6 +69,8 @@ type ResourceLookupInput =
   | ConnectorInstanceResourceLookupInput
   | MarketplaceResourceLookupInput
   | ConfigObjectResourceLookupInput
+
+type ExposureResourceLookupInput = PluginResourceLookupInput | ConfigObjectResourceLookupInput
 
 type RequireResourceRoleInput = ResourceLookupInput & {
   requireFreshSession?: boolean
@@ -208,6 +211,74 @@ export function resolvePluginArchGrantRole(input: {
   }
 
   return resolved
+}
+
+export function pluginArchGrantExpandsAudience(grant: ExposureGrantRow, memberId: MemberId) {
+  return grant.orgWide
+    || grant.teamId !== null
+    || (grant.orgMembershipId !== null && grant.orgMembershipId !== memberId)
+}
+
+async function pluginIdsHaveExpandedAudience(context: PluginArchActorContext, pluginIds: PluginId[]) {
+  if (pluginIds.length === 0) return false
+
+  const organizationId = context.organizationContext.organization.id
+  const memberId = context.organizationContext.currentMember.id
+  const grants = await db
+    .select({
+      orgMembershipId: PluginAccessGrantTable.orgMembershipId,
+      orgWide: PluginAccessGrantTable.orgWide,
+      teamId: PluginAccessGrantTable.teamId,
+    })
+    .from(PluginAccessGrantTable)
+    .where(and(
+      eq(PluginAccessGrantTable.organizationId, organizationId),
+      inArray(PluginAccessGrantTable.pluginId, pluginIds),
+      isNull(PluginAccessGrantTable.removedAt),
+    ))
+  if (grants.some((grant) => pluginArchGrantExpandsAudience(grant, memberId))) return true
+
+  const marketplaceMemberships = await db
+    .select({ id: MarketplacePluginTable.id })
+    .from(MarketplacePluginTable)
+    .where(and(
+      eq(MarketplacePluginTable.organizationId, organizationId),
+      inArray(MarketplacePluginTable.pluginId, pluginIds),
+      isNull(MarketplacePluginTable.removedAt),
+    ))
+  return marketplaceMemberships.length > 0
+}
+
+export async function pluginArchResourceHasExpandedAudience(input: ExposureResourceLookupInput) {
+  if (input.resourceKind === "plugin") {
+    return pluginIdsHaveExpandedAudience(input.context, [input.resourceId])
+  }
+
+  const organizationId = input.context.organizationContext.organization.id
+  const memberId = input.context.organizationContext.currentMember.id
+  const grants = await db
+    .select({
+      orgMembershipId: ConfigObjectAccessGrantTable.orgMembershipId,
+      orgWide: ConfigObjectAccessGrantTable.orgWide,
+      teamId: ConfigObjectAccessGrantTable.teamId,
+    })
+    .from(ConfigObjectAccessGrantTable)
+    .where(and(
+      eq(ConfigObjectAccessGrantTable.organizationId, organizationId),
+      eq(ConfigObjectAccessGrantTable.configObjectId, input.resourceId),
+      isNull(ConfigObjectAccessGrantTable.removedAt),
+    ))
+  if (grants.some((grant) => pluginArchGrantExpandsAudience(grant, memberId))) return true
+
+  const memberships = await db
+    .select({ pluginId: PluginConfigObjectTable.pluginId })
+    .from(PluginConfigObjectTable)
+    .where(and(
+      eq(PluginConfigObjectTable.organizationId, organizationId),
+      eq(PluginConfigObjectTable.configObjectId, input.resourceId),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  return pluginIdsHaveExpandedAudience(input.context, memberships.map((membership) => membership.pluginId))
 }
 
 async function resolveGrantRole(input: {

--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -375,9 +375,9 @@ export async function resolvePluginArchResourceRole(input: ResourceLookupInput) 
   return resolved
 }
 
-export async function requirePluginArchCapability(context: PluginArchActorContext, capability: PluginArchCapability) {
+export async function requirePluginArchCapability(context: PluginArchActorContext, capability: PluginArchCapability, requireFreshSession?: boolean) {
   if (hasPluginArchCapability(context, capability)) {
-    ensureFreshPluginArchAdmin(context)
+    if (requireFreshSession !== false) ensureFreshPluginArchAdmin(context)
     return
   }
 

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -724,13 +724,13 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     async (c: OrgContext) => {
       try {
         const context = actorContext(c)
-        await requirePluginArchCapability(context, "plugin.create")
         const body = validJson<PluginCreateBody>(c)
+        await requirePluginArchCapability(context, "plugin.create", body.orgWide === true || Boolean(body.marketplaceId))
         if (body.orgWide === true && !isPluginArchOrgAdmin(context)) {
           throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can create org-wide plugins.")
         }
         if ((body.components?.length ?? 0) > 0) {
-          await requirePluginArchCapability(context, "config_object.create")
+          await requirePluginArchCapability(context, "config_object.create", false)
         }
         return c.json({
           ok: true,

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -396,7 +396,6 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
           context,
           objectType: body.type,
           pluginIds: body.pluginIds,
-          requireFreshSession: false,
           sourceMode: body.sourceMode,
           value: body.input,
         })

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -390,12 +390,13 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     async (c: OrgContext) => {
       try {
         const context = actorContext(c)
-        await requirePluginArchCapability(context, "config_object.create")
+        await requirePluginArchCapability(context, "config_object.create", false)
         const body = validJson<any>(c)
         const item = await createConfigObject({
           context,
           objectType: body.type,
           pluginIds: body.pluginIds,
+          requireFreshSession: false,
           sourceMode: body.sourceMode,
           value: body.input,
         })

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1757,7 +1757,7 @@ export async function createConfigObjectVersion(input: { context: PluginArchActo
   if (!row) {
     throw new PluginArchRouteFailure(404, "config_object_not_found", "Config object not found.")
   }
-  await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "config_object", role: "editor" })
+  await requirePluginArchResourceRole({ context: input.context, requireFreshSession: false, resourceId: row.id, resourceKind: "config_object", role: "editor" })
 
   const now = new Date()
   const projection = deriveProjection({ objectType: row.objectType, value: input.value })

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -29,7 +29,7 @@ import {
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { hasSkillFrontmatterName, parseSkillMarkdown } from "@openwork-ee/utils"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
-import { isPluginArchOrgAdmin, PluginArchAuthorizationError, requirePluginArchResourceRole, resolvePluginArchGrantRole, resolvePluginArchResourceRole } from "./access.js"
+import { isPluginArchOrgAdmin, PluginArchAuthorizationError, pluginArchResourceHasExpandedAudience, requirePluginArchResourceRole, resolvePluginArchGrantRole, resolvePluginArchResourceRole } from "./access.js"
 import { clampCodePoints, clampUtf8Bytes, PROJECTION_TEXT_MAX_BYTES, PROJECTION_TITLE_MAX_CHARS } from "./projection-text.js"
 import {
   buildGithubAppInstallUrl,
@@ -1625,8 +1625,11 @@ export async function createConfigObject(input: {
     throw new PluginArchRouteFailure(400, "invalid_request", "Connector-managed config objects must be created through connector sync.")
   }
 
+  const targetExposure = await Promise.all((input.pluginIds ?? []).map((pluginId) =>
+    pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: pluginId, resourceKind: "plugin" })))
+  const requireFreshSession = input.requireFreshSession ?? targetExposure.some(Boolean)
   for (const pluginId of input.pluginIds ?? []) {
-    await ensureEditablePlugin(input.context, pluginId, input.requireFreshSession)
+    await ensureEditablePlugin(input.context, pluginId, requireFreshSession)
   }
 
   const now = new Date()
@@ -1757,7 +1760,8 @@ export async function createConfigObjectVersion(input: { context: PluginArchActo
   if (!row) {
     throw new PluginArchRouteFailure(404, "config_object_not_found", "Config object not found.")
   }
-  await requirePluginArchResourceRole({ context: input.context, requireFreshSession: false, resourceId: row.id, resourceKind: "config_object", role: "editor" })
+  const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: row.id, resourceKind: "config_object" })
+  await requirePluginArchResourceRole({ context: input.context, requireFreshSession, resourceId: row.id, resourceKind: "config_object", role: "editor" })
 
   const now = new Date()
   const projection = deriveProjection({ objectType: row.objectType, value: input.value })
@@ -1797,7 +1801,8 @@ export async function setConfigObjectLifecycle(input: { context: PluginArchActor
   if (!row) {
     throw new PluginArchRouteFailure(404, "config_object_not_found", "Config object not found.")
   }
-  await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "config_object", role: "manager" })
+  const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: row.id, resourceKind: "config_object" })
+  await requirePluginArchResourceRole({ context: input.context, requireFreshSession, resourceId: row.id, resourceKind: "config_object", role: "manager" })
   const now = new Date()
   const patch = input.action === "archive"
     ? { deletedAt: null, status: "archived" as const, updatedAt: now }
@@ -2733,7 +2738,8 @@ export async function createPluginBundle(input: {
 }
 
 export async function updatePlugin(input: { context: PluginArchActorContext; description?: string | null; name?: string; pluginId: PluginId }) {
-  const row = await ensureEditablePlugin(input.context, input.pluginId)
+  const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: input.pluginId, resourceKind: "plugin" })
+  const row = await ensureEditablePlugin(input.context, input.pluginId, requireFreshSession)
   const updatedAt = new Date()
   await db.update(PluginTable).set({
     description: input.description === undefined ? row.description : normalizeOptionalString(input.description ?? undefined),
@@ -2745,7 +2751,8 @@ export async function updatePlugin(input: { context: PluginArchActorContext; des
 
 export async function setPluginLifecycle(input: { action: "archive" | "restore"; context: PluginArchActorContext; pluginId: PluginId }) {
   const row = await ensureVisiblePlugin(input.context, input.pluginId)
-  await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "plugin", role: "manager" })
+  const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: row.id, resourceKind: "plugin" })
+  await requirePluginArchResourceRole({ context: input.context, requireFreshSession, resourceId: row.id, resourceKind: "plugin", role: "manager" })
   const updatedAt = new Date()
   await db.update(PluginTable).set({
     deletedAt: input.action === "archive" ? row.deletedAt : null,

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2702,6 +2702,7 @@ export async function createPluginBundle(input: {
       context: input.context,
       objectType: component.type,
       pluginIds: [plugin.id],
+      requireFreshSession: false,
       sourceMode: "cloud",
       value: component.value,
     })

--- a/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
+++ b/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
@@ -32,3 +32,19 @@ test("access mutations retain the default fresh-session requirement", () => {
   expect(mutations).toContain("export async function deleteResourceAccessGrant")
   expect(mutations).not.toContain("requireFreshSession: false")
 })
+
+test("routine plugin and config-object mutations derive freshness from audience exposure", () => {
+  for (const functionName of [
+    "createConfigObject",
+    "createConfigObjectVersion",
+    "setConfigObjectLifecycle",
+    "updatePlugin",
+    "setPluginLifecycle",
+  ]) {
+    const start = storeSource.indexOf(`export async function ${functionName}`)
+    expect(start).toBeGreaterThan(-1)
+    const nextExport = storeSource.indexOf("export async function ", start + 1)
+    const source = storeSource.slice(start, nextExport === -1 ? undefined : nextExport)
+    expect(source).toContain("pluginArchResourceHasExpandedAudience")
+  }
+})

--- a/ee/apps/den-api/test/plugin-system-access.test.ts
+++ b/ee/apps/den-api/test/plugin-system-access.test.ts
@@ -106,3 +106,26 @@ test("removed grants are ignored during resolution", () => {
     teamIds: [],
   })).toBeNull()
 })
+
+test("audience expansion excludes only the caller's private direct grant", () => {
+  expect(accessModule.pluginArchGrantExpandsAudience({
+    orgMembershipId: "member_current",
+    orgWide: false,
+    teamId: null,
+  }, "member_current")).toBe(false)
+  expect(accessModule.pluginArchGrantExpandsAudience({
+    orgMembershipId: "member_other",
+    orgWide: false,
+    teamId: null,
+  }, "member_current")).toBe(true)
+  expect(accessModule.pluginArchGrantExpandsAudience({
+    orgMembershipId: null,
+    orgWide: false,
+    teamId: "team_alpha",
+  }, "member_current")).toBe(true)
+  expect(accessModule.pluginArchGrantExpandsAudience({
+    orgMembershipId: null,
+    orgWide: true,
+    teamId: null,
+  }, "member_current")).toBe(true)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
@@ -13,7 +13,7 @@ import { getMcpConnectionsRoute } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { ConnectorQuickAddGrid } from "./connector-quick-add-grid";
-import { useMcpConnectionPresets, useMcpConnections, useTelegramConnection } from "./mcp-connections-data";
+import { useMcpConnectionPresets, useMcpConnections, useTelegramCapabilityStatus } from "./mcp-connections-data";
 import { OrganizationDownloadCard } from "./organization-download-card";
 
 /* ── Types ── */
@@ -88,7 +88,7 @@ export function DashboardOverviewScreen() {
   const { user } = useDenFlow();
   const { data: connections = [] } = useMcpConnections();
   const { data: presets = [] } = useMcpConnectionPresets();
-  const telegramConnection = useTelegramConnection(true);
+  const telegramConnected = useTelegramCapabilityStatus(true);
 
   const { data: adoption } = useQuery({
     queryKey: ["telemetry", "adoption"],
@@ -135,7 +135,7 @@ export function DashboardOverviewScreen() {
         <ConnectorQuickAddGrid
           connections={connections}
           presets={presets}
-          telegramConnected={Boolean(telegramConnection.data)}
+          telegramConnected={telegramConnected.data === true}
           filter=""
           onSelect={(id) => {
             router.push(`${getMcpConnectionsRoute(activeOrg?.slug)}?quickAdd=${encodeURIComponent(id)}`);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -260,6 +260,7 @@ export const mcpConnectionQueryKeys = {
   nativeProviderClient: (orgId?: string | null, providerId?: string | null) =>
     [...mcpConnectionQueryKeys.all, "native-provider-client", orgId ?? "none", providerId ?? "none"],
   telegram: (orgId?: string | null) => [...mcpConnectionQueryKeys.all, "telegram", orgId ?? "none"] as const,
+  telegramStatus: (orgId?: string | null) => [...mcpConnectionQueryKeys.telegram(orgId), "status"] as const,
 };
 
 function isExternalMcpTool(value: unknown): value is ExternalMcpTool {
@@ -1192,6 +1193,24 @@ export function useTelegramConnection(enabled: boolean) {
       });
       if (!loaded) throw new Error("Telegram connection response was incomplete.");
       return connection;
+    },
+  });
+}
+
+export function useTelegramCapabilityStatus(enabled: boolean) {
+  const { orgId } = useOrgDashboard();
+  return useQuery({
+    enabled: enabled && Boolean(orgId),
+    queryKey: mcpConnectionQueryKeys.telegramStatus(orgId),
+    retry: false,
+    queryFn: async (): Promise<boolean> => {
+      const { response, payload } = await requestJson(
+        "/v1/capabilities/telegram/status",
+        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+        15000,
+      );
+      if (!response.ok) throw getRequestError(payload, response, `Failed to load Telegram status (${response.status}).`);
+      return isRecord(payload) && isRecord(payload.connection) && payload.connection.connected === true;
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
@@ -178,17 +178,20 @@ export function useUpdateSkill(pluginId: string) {
 
 export function useDeleteSkill(pluginId: string) {
   const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (skillId: string): Promise<string> => {
-      const { response, payload } = await requestJson(
-        `/v1/config-objects/${encodeURIComponent(skillId)}/delete`,
-        { method: "POST" },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to delete skill (${response.status}).`);
-      }
+      await runReauthableAction("delete-skill", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/config-objects/${encodeURIComponent(skillId)}/delete`,
+          { method: "POST" },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to delete skill (${response.status}).`);
+        }
+      });
       return skillId;
     },
     onSuccess: async () => {

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -55,10 +55,14 @@ describe("connector and marketplace polish", () => {
   test("reuses Quick add on the admin dashboard and opens the selected connector flow", () => {
     const home = readDashboardComponent("dashboard-home-screen.tsx");
     const overview = readDashboardComponent("dashboard-overview-screen.tsx");
+    const data = readDashboardComponent("mcp-connections-data.tsx");
     const connectorScreen = readDashboardComponent("mcp-connections-screen.tsx");
 
     expect(home).toContain("return access.isAdmin ? <DashboardOverviewScreen /> : <MemberDashboardScreen />");
     expect(overview).toContain("<ConnectorQuickAddGrid");
+    expect(overview).toContain("useTelegramCapabilityStatus(true)");
+    expect(overview).not.toContain("useTelegramConnection(true)");
+    expect(data).toContain('"/v1/capabilities/telegram/status"');
     expect(overview).toContain("?quickAdd=${encodeURIComponent(id)}");
     expect(connectorScreen).toContain('searchParams.get("quickAdd")');
   });

--- a/ee/apps/den-web/tests/skill-crud-ui.test.ts
+++ b/ee/apps/den-web/tests/skill-crud-ui.test.ts
@@ -47,6 +47,7 @@ describe("Den plugin skill CRUD UI contract", () => {
     expect(data).toContain('sourceMode: "cloud"');
     expect(data).toContain("/versions`");
     expect(data).toContain("/delete`");
+    expect(data).toContain('runReauthableAction("delete-skill"');
     expect(data).toContain("organizationId");
     expect(data).toContain("pluginQueryKeys.detail(pluginId)");
   });

--- a/evals/specs/dashboard-telegram-status-freshness.slow.test.ts
+++ b/evals/specs/dashboard-telegram-status-freshness.slow.test.ts
@@ -1,0 +1,76 @@
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { expect } from "vitest";
+import { localMysqlIsRunning, needs, queryDenDatabase, server, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "dashboard Telegram status freshness skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "dashboard Telegram status freshness skipped — needs a real local Den"
+    : !mysqlOpen
+      ? "dashboard Telegram status freshness skipped — needs MySQL on 127.0.0.1:3306"
+      : "opening the dashboard reads redacted Telegram status without requiring fresh authentication";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession, orgId?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${session.token}`,
+    ...(orgId ? { "x-openwork-org-id": orgId } : {}),
+  };
+}
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  await using den = await server({ place, org: { name: `Dashboard Telegram ${Date.now().toString(36)}` } });
+  const databaseUrl = den.database?.url;
+  if (!databaseUrl) throw new Error("dashboard Telegram freshness requires the local isolated database handle");
+
+  const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: auth(den.admin) });
+  expect(orgs.response.status).toBe(200);
+  const organizations = isRecord(orgs.body) && Array.isArray(orgs.body.orgs) ? orgs.body.orgs.filter(isRecord) : [];
+  const orgId = organizations.length === 1 && typeof organizations[0]?.id === "string" ? organizations[0].id : "";
+  expect(orgId).toMatch(/^org_/);
+
+  await queryDenDatabase(
+    databaseUrl,
+    "UPDATE `session` SET created_at = DATE_SUB(NOW(3), INTERVAL 25 HOUR) WHERE token = ?",
+    [den.admin.token],
+  );
+
+  const passiveStatus = await denFetch(den.admin, "/v1/capabilities/telegram/status", {
+    headers: auth(den.admin, orgId),
+  });
+  expect(passiveStatus.response.status).toBe(200);
+  expect(passiveStatus.body).toEqual({ connection: null });
+  evidence.fact(
+    "The dashboard can read redacted Telegram status without reauthentication",
+    "A session older than the 24-hour connection-management window received HTTP 200 and no credential material from the capability status endpoint.",
+    passiveStatus.response.status === 200
+      && isRecord(passiveStatus.body)
+      && passiveStatus.body.connection === null,
+  );
+
+  const managementDetail = await denFetch(den.admin, "/v1/telegram/connection", {
+    headers: auth(den.admin, orgId),
+  });
+  expect(managementDetail.response.status).toBe(403);
+  expect(managementDetail.body).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: "For security, confirm it's you before changing workspace settings.",
+  });
+  evidence.fact(
+    "Detailed Telegram management remains step-up protected",
+    "The same stale session received exact HTTP 403 reauth/fresh_auth_required from the management endpoint.",
+    managementDetail.response.status === 403
+      && isRecord(managementDetail.body)
+      && managementDetail.body.reason === "fresh_auth_required",
+  );
+});

--- a/evals/specs/skill-authoring-session-freshness.slow.test.ts
+++ b/evals/specs/skill-authoring-session-freshness.slow.test.ts
@@ -50,6 +50,41 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ e
   const orgId = organization && typeof organization.id === "string" ? organization.id : "";
   expect(orgId).toMatch(/^org_/);
 
+  const exposedSkillName = `exposed-session-skill-${unique}`;
+  const exposedInitialSource = `---\nname: ${exposedSkillName}\ndescription: Proves exposed authoring requires freshness.\n---\n\nReturn the initial exposed skill source.`;
+  const exposedPluginResult = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      name: `Exposed Session Plugin ${unique}`,
+      orgWide: true,
+    }),
+  });
+  expect(exposedPluginResult.response.status).toBe(201);
+  const exposedPlugin = requireItem(exposedPluginResult.body, "Exposed plugin creation");
+  const exposedPluginId = typeof exposedPlugin.id === "string" ? exposedPlugin.id : "";
+  expect(exposedPluginId).toMatch(/^plg_/);
+
+  const exposedSkillResult = await denFetch(den.admin, "/v1/config-objects", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      type: "skill",
+      pluginIds: [exposedPluginId],
+      sourceMode: "cloud",
+      input: { rawSourceText: exposedInitialSource },
+    }),
+  });
+  expect(exposedSkillResult.response.status).toBe(201);
+  const exposedSkill = requireItem(exposedSkillResult.body, "Exposed skill creation");
+  const exposedConfigObjectId = typeof exposedSkill.id === "string" ? exposedSkill.id : "";
+  expect(exposedConfigObjectId).toMatch(/^cob_/);
+  evidence.fact(
+    "The freshness boundary has an exposed plugin and existing skill",
+    `Fresh setup created org-wide plugin ${exposedPluginId} with skill ${exposedConfigObjectId}.`,
+    exposedPluginId.startsWith("plg_") && exposedConfigObjectId.startsWith("cob_"),
+  );
+
   await queryDenDatabase(
     databaseUrl,
     "UPDATE `session` SET created_at = DATE_SUB(NOW(3), INTERVAL 20 MINUTE) WHERE token = ?",
@@ -133,6 +168,25 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ e
     created.response.status === 201 && configObjectId.startsWith("cob_"),
   );
 
+  const renamedPluginName = `Renamed Private Plugin ${unique}`;
+  const renamedPlugin = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}`, {
+    method: "PATCH",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({ name: renamedPluginName }),
+  });
+  expect(renamedPlugin.response.status).toBe(200);
+  const renamedPluginDetail = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}`, {
+    headers: auth(den.admin, orgId),
+  });
+  expect(renamedPluginDetail.response.status).toBe(200);
+  const observedRenamedPlugin = requireItem(renamedPluginDetail.body, "Renamed private plugin");
+  expect(observedRenamedPlugin.name).toBe(renamedPluginName);
+  evidence.fact(
+    "The stale credential can rename a private plugin",
+    `A subsequent plugin detail read returned the exact name ${renamedPluginName}.`,
+    renamedPlugin.response.status === 200 && observedRenamedPlugin.name === renamedPluginName,
+  );
+
   const updatedSource = `---\nname: ${skillName}\ndescription: Proves stale-session private authoring.\n---\n\nReturn the updated private skill source: ${unique}.`;
   const versioned = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}/versions`, {
     method: "POST",
@@ -156,6 +210,101 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ e
     "The stale credential can save and read a new private skill version",
     "The config object's latest immutable version exposes the exact updated SKILL.md source rather than the initial source.",
     versioned.response.status === 201 && observedSource === updatedSource && observedSource !== initialSource,
+  );
+
+  const deletedSkill = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}/delete`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+  });
+  expect(deletedSkill.response.status).toBe(200);
+  expect(requireItem(deletedSkill.body, "Deleted private skill").status).toBe("deleted");
+  const restoredSkill = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}/restore`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+  });
+  expect(restoredSkill.response.status).toBe(200);
+  expect(requireItem(restoredSkill.body, "Restored private skill").status).toBe("active");
+  evidence.fact(
+    "The stale credential can delete and restore a private skill",
+    "The lifecycle responses exposed deleted and then active status for the same private config object.",
+    requireItem(deletedSkill.body, "Deleted private skill evidence").status === "deleted"
+      && requireItem(restoredSkill.body, "Restored private skill evidence").status === "active",
+  );
+
+  const archivedPlugin = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}/archive`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+  });
+  expect(archivedPlugin.response.status).toBe(200);
+  expect(requireItem(archivedPlugin.body, "Archived private plugin").status).toBe("archived");
+  const restoredPlugin = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}/restore`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+  });
+  expect(restoredPlugin.response.status).toBe(200);
+  expect(requireItem(restoredPlugin.body, "Restored private plugin").status).toBe("active");
+  evidence.fact(
+    "The stale credential can archive and restore a private plugin",
+    "The lifecycle responses exposed archived and then active status for the same private plugin.",
+    requireItem(archivedPlugin.body, "Archived private plugin evidence").status === "archived"
+      && requireItem(restoredPlugin.body, "Restored private plugin evidence").status === "active",
+  );
+
+  const blockedSkillName = `blocked-exposed-skill-${unique}`;
+  const blockedCreate = await denFetch(den.admin, "/v1/config-objects", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      type: "skill",
+      pluginIds: [exposedPluginId],
+      sourceMode: "cloud",
+      input: {
+        rawSourceText: `---\nname: ${blockedSkillName}\ndescription: Must not be written.\n---\n\nBlocked exposed content.`,
+      },
+    }),
+  });
+  expect(blockedCreate.response.status).toBe(403);
+  expect(blockedCreate.body).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: "For security, confirm it's you before changing workspace settings.",
+  });
+  const blockedRows = await queryDenDatabase(
+    databaseUrl,
+    "SELECT id FROM config_object WHERE organization_id = ? AND title = ?",
+    [orgId, blockedSkillName],
+  );
+  expect(blockedRows).toHaveLength(0);
+  evidence.fact(
+    "Stale authentication is rejected before writing content to an exposed plugin",
+    "POST returned exact HTTP 403 reauth/fresh_auth_required and the isolated database contains no config_object with the requested title.",
+    blockedCreate.response.status === 403
+      && isRecord(blockedCreate.body)
+      && blockedCreate.body.reason === "fresh_auth_required"
+      && blockedRows.length === 0,
+  );
+
+  const blockedRevision = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(exposedConfigObjectId)}/versions`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      input: { rawSourceText: `${exposedInitialSource}\n\nBlocked revision ${unique}.` },
+      reason: "spec: stale-session exposed skill edit",
+    }),
+  });
+  expect(blockedRevision.response.status).toBe(403);
+  expect(blockedRevision.body).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: "For security, confirm it's you before changing workspace settings.",
+  });
+  evidence.fact(
+    "Revising an existing exposed skill requires fresh authentication",
+    "The stale credential received exact HTTP 403 reauth/fresh_auth_required when creating a version for the org-wide plugin's skill.",
+    blockedRevision.response.status === 403
+      && isRecord(blockedRevision.body)
+      && blockedRevision.body.error === "reauth"
+      && blockedRevision.body.reason === "fresh_auth_required",
   );
 
   const audienceChange = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {

--- a/evals/specs/skill-authoring-session-freshness.slow.test.ts
+++ b/evals/specs/skill-authoring-session-freshness.slow.test.ts
@@ -12,7 +12,7 @@ const title = !appSpecsEnabled
     ? "skill authoring session freshness skipped — needs a real local Den"
     : !mysqlOpen
       ? "skill authoring session freshness skipped — needs MySQL on 127.0.0.1:3306"
-      : "a stale admin session can author a private skill but cannot expand its audience org-wide";
+      : "a stale admin session can author a private plugin and skill but cannot expand its audience org-wide";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -50,21 +50,6 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ e
   const orgId = organization && typeof organization.id === "string" ? organization.id : "";
   expect(orgId).toMatch(/^org_/);
 
-  const skillName = `stale-session-skill-${unique}`;
-  const initialSource = `---\nname: ${skillName}\ndescription: Proves stale-session private authoring.\n---\n\nReturn the initial private skill source.`;
-  const pluginResult = await denFetch(den.admin, "/v1/plugins", {
-    method: "POST",
-    headers: auth(den.admin, orgId),
-    body: JSON.stringify({
-      name: `Stale Session Plugin ${unique}`,
-      orgWide: false,
-    }),
-  });
-  expect(pluginResult.response.status).toBe(201);
-  const plugin = requireItem(pluginResult.body, "Private plugin creation");
-  const pluginId = typeof plugin.id === "string" ? plugin.id : "";
-  expect(pluginId).toMatch(/^plg_/);
-
   await queryDenDatabase(
     databaseUrl,
     "UPDATE `session` SET created_at = DATE_SUB(NOW(3), INTERVAL 20 MINUTE) WHERE token = ?",
@@ -83,6 +68,49 @@ test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ e
     "The admin credential is older than the privileged-session window",
     `The credential's database session is ${ageSeconds} seconds old, beyond the 900-second freshness limit.`,
     ageSeconds > 15 * 60,
+  );
+
+  const orgWidePlugin = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      name: `Blocked Org-wide Plugin ${unique}`,
+      orgWide: true,
+    }),
+  });
+  expect(orgWidePlugin.response.status).toBe(403);
+  expect(orgWidePlugin.body).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: "For security, confirm it's you before changing workspace settings.",
+  });
+  evidence.fact(
+    "Creating an org-wide plugin still requires fresh authentication",
+    "The stale credential received exact HTTP 403 reauth/fresh_auth_required before creating an org-wide plugin.",
+    orgWidePlugin.response.status === 403
+      && isRecord(orgWidePlugin.body)
+      && orgWidePlugin.body.error === "reauth"
+      && orgWidePlugin.body.reason === "fresh_auth_required",
+  );
+
+  const skillName = `stale-session-skill-${unique}`;
+  const initialSource = `---\nname: ${skillName}\ndescription: Proves stale-session private authoring.\n---\n\nReturn the initial private skill source.`;
+  const pluginResult = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      name: `Stale Session Plugin ${unique}`,
+      orgWide: false,
+    }),
+  });
+  expect(pluginResult.response.status).toBe(201);
+  const plugin = requireItem(pluginResult.body, "Private plugin creation");
+  const pluginId = typeof plugin.id === "string" ? plugin.id : "";
+  expect(pluginId).toMatch(/^plg_/);
+  evidence.fact(
+    "The stale credential can create a private plugin",
+    `POST /v1/plugins returned HTTP ${pluginResult.response.status} without expanding the plugin audience.`,
+    pluginResult.response.status === 201 && pluginId.startsWith("plg_"),
   );
 
   const created = await denFetch(den.admin, "/v1/config-objects", {

--- a/evals/specs/skill-authoring-session-freshness.slow.test.ts
+++ b/evals/specs/skill-authoring-session-freshness.slow.test.ts
@@ -1,0 +1,152 @@
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { expect } from "vitest";
+import { localMysqlIsRunning, needs, queryDenDatabase, server, test } from "@openwork/testkit";
+
+const appSpecsEnabled = process.env.OPENWORK_EVAL_APP_SPECS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !appSpecsEnabled
+  ? "skill authoring session freshness skipped — needs: set OPENWORK_EVAL_APP_SPECS=1"
+  : !localPlacement
+    ? "skill authoring session freshness skipped — needs a real local Den"
+    : !mysqlOpen
+      ? "skill authoring session freshness skipped — needs MySQL on 127.0.0.1:3306"
+      : "a stale admin session can author a private skill but cannot expand its audience org-wide";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireItem(body: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(body) || !isRecord(body.item)) {
+    throw new Error(`${label} returned no item: ${JSON.stringify(body).slice(0, 500)}`);
+  }
+  return body.item;
+}
+
+function auth(session: DenSession, orgId?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${session.token}`,
+    ...(orgId ? { "x-openwork-org-id": orgId } : {}),
+  };
+}
+
+test.skipIf(!appSpecsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_APP_SPECS"] });
+
+  const unique = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const organizationName = `Skill Freshness ${unique}`;
+  await using den = await server({ place, org: { name: organizationName } });
+  const databaseUrl = den.database?.url;
+  if (!databaseUrl) throw new Error("skill authoring freshness requires the local isolated database handle");
+
+  const orgsResult = await denFetch(den.admin, "/v1/me/orgs", { headers: auth(den.admin) });
+  expect(orgsResult.response.status).toBe(200);
+  const organizations = isRecord(orgsResult.body) && Array.isArray(orgsResult.body.orgs)
+    ? orgsResult.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === organizationName);
+  const orgId = organization && typeof organization.id === "string" ? organization.id : "";
+  expect(orgId).toMatch(/^org_/);
+
+  const skillName = `stale-session-skill-${unique}`;
+  const initialSource = `---\nname: ${skillName}\ndescription: Proves stale-session private authoring.\n---\n\nReturn the initial private skill source.`;
+  const pluginResult = await denFetch(den.admin, "/v1/plugins", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      name: `Stale Session Plugin ${unique}`,
+      orgWide: false,
+    }),
+  });
+  expect(pluginResult.response.status).toBe(201);
+  const plugin = requireItem(pluginResult.body, "Private plugin creation");
+  const pluginId = typeof plugin.id === "string" ? plugin.id : "";
+  expect(pluginId).toMatch(/^plg_/);
+
+  await queryDenDatabase(
+    databaseUrl,
+    "UPDATE `session` SET created_at = DATE_SUB(NOW(3), INTERVAL 20 MINUTE) WHERE token = ?",
+    [den.admin.token],
+  );
+  const sessionRows = await queryDenDatabase(
+    databaseUrl,
+    "SELECT created_at, TIMESTAMPDIFF(SECOND, created_at, NOW(3)) AS age_seconds FROM `session` WHERE token = ?",
+    [den.admin.token],
+  );
+  expect(sessionRows).toHaveLength(1);
+  const sessionRow = sessionRows[0];
+  const ageSeconds = isRecord(sessionRow) && typeof sessionRow.age_seconds === "number" ? sessionRow.age_seconds : 0;
+  expect(ageSeconds).toBeGreaterThan(15 * 60);
+  evidence.fact(
+    "The admin credential is older than the privileged-session window",
+    `The credential's database session is ${ageSeconds} seconds old, beyond the 900-second freshness limit.`,
+    ageSeconds > 15 * 60,
+  );
+
+  const created = await denFetch(den.admin, "/v1/config-objects", {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({
+      type: "skill",
+      pluginIds: [pluginId],
+      sourceMode: "cloud",
+      input: { rawSourceText: initialSource },
+    }),
+  });
+  expect(created.response.status).toBe(201);
+  const skill = requireItem(created.body, "Private skill creation");
+  const configObjectId = typeof skill.id === "string" ? skill.id : "";
+  expect(configObjectId).toMatch(/^cob_/);
+  evidence.fact(
+    "The same stale credential can create private skill content",
+    `POST /v1/config-objects returned HTTP ${created.response.status} while adding a private skill to the admin's plugin.`,
+    created.response.status === 201 && configObjectId.startsWith("cob_"),
+  );
+
+  const updatedSource = `---\nname: ${skillName}\ndescription: Proves stale-session private authoring.\n---\n\nReturn the updated private skill source: ${unique}.`;
+  const versioned = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}/versions`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({ input: { rawSourceText: updatedSource }, reason: "spec: stale-session skill edit" }),
+  });
+  expect(versioned.response.status).toBe(201);
+
+  const detail = await denFetch(den.admin, `/v1/config-objects/${encodeURIComponent(configObjectId)}`, {
+    headers: auth(den.admin, orgId),
+  });
+  expect(detail.response.status).toBe(200);
+  const updatedItem = requireItem(detail.body, "Updated config object");
+  const latestVersion = isRecord(updatedItem.latestVersion) ? updatedItem.latestVersion : null;
+  const observedSource = latestVersion && typeof latestVersion.rawSourceText === "string"
+    ? latestVersion.rawSourceText
+    : "";
+  expect(observedSource).toBe(updatedSource);
+  expect(observedSource).not.toBe(initialSource);
+  evidence.fact(
+    "The stale credential can save and read a new private skill version",
+    "The config object's latest immutable version exposes the exact updated SKILL.md source rather than the initial source.",
+    versioned.response.status === 201 && observedSource === updatedSource && observedSource !== initialSource,
+  );
+
+  const audienceChange = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, {
+    method: "POST",
+    headers: auth(den.admin, orgId),
+    body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  expect(audienceChange.response.status).toBe(403);
+  expect(audienceChange.body).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: "For security, confirm it's you before changing workspace settings.",
+  });
+  evidence.fact(
+    "Expanding the plugin audience still requires fresh authentication",
+    "The same stale credential received exact HTTP 403 reauth/fresh_auth_required when granting org-wide viewer access.",
+    audienceChange.response.status === 403
+      && isRecord(audienceChange.body)
+      && audienceChange.body.error === "reauth"
+      && audienceChange.body.reason === "fresh_auth_required",
+  );
+});


### PR DESCRIPTION
## Summary
- keep private plugin creation, metadata edits, lifecycle changes, skill creation, versioning, and lifecycle changes free of 15-minute reauth prompts
- derive step-up requirements from effective audience exposure instead of applying a blanket exception
- load redacted Telegram connection status on the dashboard without invoking the 24-hour management-detail freshness check
- retain fresh authentication for org-wide plugins, marketplace membership, team/member sharing, access changes, detailed connection management, and Telegram mutations

## Verification
- `pnpm exec bun test test/plugin-system-access.test.ts test/plugin-system-access-list-freshness.test.ts test/plugin-system-create-bundle.test.ts`
- `pnpm exec bun test tests/skill-crud-ui.test.ts`
- `pnpm exec bun test tests/connector-marketplace-polish.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `OPENWORK_EVAL_APP_SPECS=1 pnpm exec vitest run --config vitest.config.ts specs/skill-authoring-session-freshness.slow.test.ts`
- `OPENWORK_EVAL_APP_SPECS=1 pnpm exec vitest run --config vitest.config.ts specs/dashboard-telegram-status-freshness.slow.test.ts`