### PR TITLE
feat(admin): manage model usage and admins

### DIFF
--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -9,6 +9,10 @@ import {
   DesktopHandoffGrantTable,
   ExternalIdentityTable,
   InvitationTable,
+  InferenceOrgLimitPolicyTable,
+  InferenceOrgUsageBucketTable,
+  InferenceUsageLedgerBucketChargeTable,
+  InferenceUsageLedgerEntryTable,
   MemberTable,
   OAuthAccessTokenTable,
   OAuthClientTable,
@@ -21,7 +25,7 @@ import {
   WorkerTable,
   AdminAllowlistTable,
 } from "@openwork-ee/den-db/schema"
-import { isDenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId, isDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
@@ -89,6 +93,11 @@ const updateOrganizationCapabilitiesSchema = z.object({
     remoteMcpApps: z.boolean().nullable().optional(),
     cloud: z.boolean().nullable().optional(),
   }),
+})
+
+const createAdminSchema = z.object({
+  email: z.string().trim().max(255).email().transform((email) => email.toLowerCase()),
+  note: z.string().max(255).nullable().optional(),
 })
 
 const adminActivityPointSchema = z.object({
@@ -304,6 +313,22 @@ function isOrganizationId(value: string): value is OrganizationId {
 
 function isUserId(value: string): value is UserId {
   return isDenTypeId("user", value)
+}
+
+function isDuplicateDatabaseEntry(error: unknown): boolean {
+  let current = error
+  const visited = new Set<object>()
+  while (typeof current === "object" && current !== null && !visited.has(current)) {
+    visited.add(current)
+    if ("code" in current && current.code === "ER_DUP_ENTRY") {
+      return true
+    }
+    if ("errno" in current && current.errno === 1062) {
+      return true
+    }
+    current = "cause" in current ? current.cause : null
+  }
+  return false
 }
 
 async function mapWithConcurrency<T, R>(items: T[], limit: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
@@ -1141,6 +1166,7 @@ export async function loadAdminInitialOverviewPayload(user: AdminOverviewViewer,
   const [admins, userPage, organizationTotal] = await Promise.all([
     db
       .select({
+        id: AdminAllowlistTable.id,
         email: AdminAllowlistTable.email,
         note: AdminAllowlistTable.note,
         createdAt: AdminAllowlistTable.created_at,
@@ -1170,6 +1196,235 @@ export async function loadAdminInitialOverviewPayload(user: AdminOverviewViewer,
 
 
 export function registerAdminRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  app.post(
+    "/v1/admin/admins",
+    adminRoute(),
+    async (c) => {
+      const body = createAdminSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid admin request." }, 400)
+      }
+
+      const id = createDenTypeId("adminAllowlist")
+      const createdAt = new Date()
+      try {
+        await db.insert(AdminAllowlistTable).values({
+          id,
+          email: body.data.email,
+          note: body.data.note ?? null,
+          created_at: createdAt,
+        })
+      } catch (error) {
+        if (isDuplicateDatabaseEntry(error)) {
+          return c.json({ error: "conflict", message: `An admin with email ${body.data.email} already exists.` }, 409)
+        }
+        throw error
+      }
+
+      return c.json({
+        ok: true,
+        admin: { id, email: body.data.email, note: body.data.note ?? null, createdAt },
+      })
+    },
+  )
+
+  app.delete(
+    "/v1/admin/admins/:adminId",
+    adminRoute(),
+    async (c) => {
+      const adminId = c.req.param("adminId")
+      if (!isDenTypeId("adminAllowlist", adminId)) {
+        return c.json({ error: "invalid_request", message: "Invalid admin id." }, 400)
+      }
+
+      const viewerEmail = normalizeEmail(c.get("user").email)
+      const result = await db.transaction(async (tx) => {
+        const admins = await tx
+          .select({ id: AdminAllowlistTable.id, email: AdminAllowlistTable.email })
+          .from(AdminAllowlistTable)
+          .for("update")
+        const target = admins.find((admin) => admin.id === adminId)
+        if (!target) {
+          return "not_found"
+        }
+        if (normalizeEmail(target.email) === viewerEmail) {
+          return "current_viewer"
+        }
+        if (admins.length === 1) {
+          return "final_admin"
+        }
+        await tx.delete(AdminAllowlistTable).where(eq(AdminAllowlistTable.id, adminId))
+        return "deleted"
+      })
+
+      if (result === "not_found") {
+        return c.json({ error: "not_found", message: "Admin not found." }, 404)
+      }
+      if (result === "current_viewer") {
+        return c.json({ error: "invalid_request", message: "You cannot delete your own admin access." }, 400)
+      }
+      if (result === "final_admin") {
+        return c.json({ error: "invalid_request", message: "You cannot delete the final admin." }, 400)
+      }
+      return c.json({ ok: true })
+    },
+  )
+
+  app.get(
+    "/v1/admin/users/:userId/inference-usage",
+    adminRoute(),
+    async (c) => {
+      const userId = c.req.param("userId")
+      if (!isUserId(userId)) {
+        return c.json({ error: "invalid_request", message: "Invalid user id." }, 400)
+      }
+
+      const users = await db
+        .select({ id: AuthUserTable.id, email: AuthUserTable.email })
+        .from(AuthUserTable)
+        .where(eq(AuthUserTable.id, userId))
+        .limit(1)
+      const user = users[0]
+      if (!user) {
+        return c.json({ error: "not_found", message: "User not found." }, 404)
+      }
+
+      const rows = await db
+        .select({
+          organizationId: OrganizationTable.id,
+          organizationName: OrganizationTable.name,
+          membershipId: MemberTable.id,
+          bucketId: InferenceOrgUsageBucketTable.id,
+          windowType: InferenceOrgLimitPolicyTable.window_type,
+          windowStartAt: InferenceOrgUsageBucketTable.window_start_at,
+          windowEndAt: InferenceOrgUsageBucketTable.window_end_at,
+          limitAmount: InferenceOrgUsageBucketTable.limit_amount,
+          organizationUsedAmount: InferenceOrgUsageBucketTable.used_amount,
+          userUsedAmount: sql<number>`coalesce(sum(${InferenceUsageLedgerBucketChargeTable.amount}), 0)`,
+        })
+        .from(MemberTable)
+        .innerJoin(OrganizationTable, eq(MemberTable.organizationId, OrganizationTable.id))
+        .innerJoin(InferenceOrgLimitPolicyTable, eq(MemberTable.organizationId, InferenceOrgLimitPolicyTable.organization_id))
+        .innerJoin(InferenceOrgUsageBucketTable, eq(InferenceOrgLimitPolicyTable.current_bucket_id, InferenceOrgUsageBucketTable.id))
+        .leftJoin(InferenceUsageLedgerEntryTable, and(
+          eq(InferenceUsageLedgerEntryTable.org_membership_id, MemberTable.id),
+          eq(InferenceUsageLedgerEntryTable.organization_id, MemberTable.organizationId),
+        ))
+        .leftJoin(InferenceUsageLedgerBucketChargeTable, and(
+          eq(InferenceUsageLedgerBucketChargeTable.ledger_entry_id, InferenceUsageLedgerEntryTable.id),
+          eq(InferenceUsageLedgerBucketChargeTable.bucket_id, InferenceOrgUsageBucketTable.id),
+        ))
+        .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+        .groupBy(
+          OrganizationTable.id,
+          OrganizationTable.name,
+          MemberTable.id,
+          InferenceOrgUsageBucketTable.id,
+          InferenceOrgLimitPolicyTable.window_type,
+          InferenceOrgUsageBucketTable.window_start_at,
+          InferenceOrgUsageBucketTable.window_end_at,
+          InferenceOrgUsageBucketTable.limit_amount,
+          InferenceOrgUsageBucketTable.used_amount,
+        )
+        .orderBy(asc(OrganizationTable.name), asc(InferenceOrgLimitPolicyTable.window_type))
+
+      const organizations = new Map<typeof MemberTable.$inferSelect.id, {
+        id: OrganizationId
+        name: string
+        membershipId: typeof MemberTable.$inferSelect.id
+        windows: Array<{
+          bucketId: typeof InferenceOrgUsageBucketTable.$inferSelect.id
+          windowType: typeof InferenceOrgLimitPolicyTable.$inferSelect.window_type
+          windowStartAt: Date
+          windowEndAt: Date
+          limitAmount: number
+          organizationUsedAmount: number
+          userUsedAmount: number
+        }>
+      }>()
+      for (const row of rows) {
+        const organization = organizations.get(row.membershipId) ?? {
+          id: row.organizationId,
+          name: row.organizationName,
+          membershipId: row.membershipId,
+          windows: [],
+        }
+        organization.windows.push({
+          bucketId: row.bucketId,
+          windowType: row.windowType,
+          windowStartAt: row.windowStartAt,
+          windowEndAt: row.windowEndAt,
+          limitAmount: toNumber(row.limitAmount),
+          organizationUsedAmount: toNumber(row.organizationUsedAmount),
+          userUsedAmount: toNumber(row.userUsedAmount),
+        })
+        organizations.set(row.membershipId, organization)
+      }
+
+      return c.json({ user, organizations: Array.from(organizations.values()) })
+    },
+  )
+
+  app.post(
+    "/v1/admin/users/:userId/inference-usage/reset",
+    adminRoute(),
+    async (c) => {
+      const userId = c.req.param("userId")
+      if (!isUserId(userId)) {
+        return c.json({ error: "invalid_request", message: "Invalid user id." }, 400)
+      }
+
+      const users = await db.select({ id: AuthUserTable.id }).from(AuthUserTable).where(eq(AuthUserTable.id, userId)).limit(1)
+      if (!users[0]) {
+        return c.json({ error: "not_found", message: "User not found." }, 404)
+      }
+
+      const resetAmount = await db.transaction(async (tx) => {
+        const charges = await tx
+          .select({
+            id: InferenceUsageLedgerBucketChargeTable.id,
+            bucketId: InferenceUsageLedgerBucketChargeTable.bucket_id,
+            amount: InferenceUsageLedgerBucketChargeTable.amount,
+          })
+          .from(InferenceUsageLedgerBucketChargeTable)
+          .innerJoin(InferenceUsageLedgerEntryTable, eq(InferenceUsageLedgerBucketChargeTable.ledger_entry_id, InferenceUsageLedgerEntryTable.id))
+          .innerJoin(MemberTable, and(
+            eq(InferenceUsageLedgerEntryTable.org_membership_id, MemberTable.id),
+            eq(InferenceUsageLedgerEntryTable.organization_id, MemberTable.organizationId),
+          ))
+          .innerJoin(InferenceOrgLimitPolicyTable, and(
+            eq(InferenceUsageLedgerEntryTable.organization_id, InferenceOrgLimitPolicyTable.organization_id),
+            eq(InferenceUsageLedgerBucketChargeTable.bucket_id, InferenceOrgLimitPolicyTable.current_bucket_id),
+          ))
+          .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+          .for("update")
+
+        const amountByBucket = new Map<typeof InferenceOrgUsageBucketTable.$inferSelect.id, number>()
+        let total = 0
+        for (const charge of charges) {
+          const amount = toNumber(charge.amount)
+          amountByBucket.set(charge.bucketId, (amountByBucket.get(charge.bucketId) ?? 0) + amount)
+          total += amount
+        }
+        for (const [bucketId, amount] of amountByBucket) {
+          await tx
+            .update(InferenceOrgUsageBucketTable)
+            .set({ used_amount: sql`greatest(${InferenceOrgUsageBucketTable.used_amount} - ${amount}, 0)` })
+            .where(eq(InferenceOrgUsageBucketTable.id, bucketId))
+        }
+        if (charges.length > 0) {
+          await tx.delete(InferenceUsageLedgerBucketChargeTable).where(inArray(
+            InferenceUsageLedgerBucketChargeTable.id,
+            charges.map((charge) => charge.id),
+          ))
+        }
+        return total
+      })
+
+      return c.json({ ok: true, resetAmount })
+    },
+  )
+
   app.delete(
     "/v1/admin/users/:userId",
     adminRoute(),

--- a/ee/apps/den-api/test/admin-management-inference-usage.test.ts
+++ b/ee/apps/den-api/test/admin-management-inference-usage.test.ts
@@ -1,0 +1,297 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { connect } from "node:net"
+import type { AuthContextVariables } from "../src/session.js"
+
+const adminUserId = createDenTypeId("user")
+const targetUserId = createDenTypeId("user")
+const adminMemberId = createDenTypeId("member")
+const targetMemberId = createDenTypeId("member")
+const adminAllowlistId = createDenTypeId("adminAllowlist")
+const organizationId = createDenTypeId("organization")
+const fiveHourPolicyId = createDenTypeId("inferenceOrgLimitPolicy")
+const weeklyPolicyId = createDenTypeId("inferenceOrgLimitPolicy")
+const monthlyPolicyId = createDenTypeId("inferenceOrgLimitPolicy")
+const fiveHourBucketId = createDenTypeId("inferenceOrgUsageBucket")
+const weeklyBucketId = createDenTypeId("inferenceOrgUsageBucket")
+const monthlyBucketId = createDenTypeId("inferenceOrgUsageBucket")
+const targetLedgerEntryId = createDenTypeId("inferenceUsageLedgerEntry")
+const adminLedgerEntryId = createDenTypeId("inferenceUsageLedgerEntry")
+const targetFiveHourChargeId = createDenTypeId("inferenceUsageLedgerBucketCharge")
+const targetWeeklyChargeId = createDenTypeId("inferenceUsageLedgerBucketCharge")
+const targetMonthlyChargeId = createDenTypeId("inferenceUsageLedgerBucketCharge")
+const adminMonthlyChargeId = createDenTypeId("inferenceUsageLedgerBucketCharge")
+const adminEmail = `admin-management+${adminUserId}@test.local`
+const targetEmail = `admin-management-target+${targetUserId}@test.local`
+const addedAdminEmail = `added-admin+${adminUserId}@test.local`
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = "y".repeat(32)
+  process.env.BETTER_AUTH_URL = "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "multi_org"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function shouldRunRouteDbCoverage() {
+  const testFiles = process.argv.filter((argument) => argument.endsWith(".test.ts"))
+  return testFiles.length <= 2 && testFiles.some((argument) => argument.endsWith("admin-management-inference-usage.test.ts"))
+}
+
+function isRouteDatabase(value: unknown) {
+  return isRecord(value) && "query" in value
+}
+
+async function databaseIsAvailable() {
+  return new Promise<boolean>((resolve) => {
+    const socket = connect({ host: "127.0.0.1", port: 3306 })
+    const finish = (available: boolean) => {
+      socket.destroy()
+      resolve(available)
+    }
+    socket.setTimeout(1_000)
+    socket.once("connect", () => finish(true))
+    socket.once("error", () => finish(false))
+    socket.once("timeout", () => finish(false))
+  })
+}
+
+let app: Hono<{ Variables: AuthContextVariables }> | null = null
+let db: typeof import("../src/db.js").db | null = null
+let schema: typeof import("@openwork-ee/den-db/schema") | null = null
+let drizzle: typeof import("@openwork-ee/den-db/drizzle") | null = null
+let routeTestUnavailable: string | null = null
+
+function testDatabase() {
+  if (!db || !schema || !drizzle) {
+    throw new Error("test database not initialized")
+  }
+  return { db, schema, drizzle }
+}
+
+function routeApp() {
+  if (!app) {
+    throw new Error("test app not initialized")
+  }
+  return app
+}
+
+async function cleanup() {
+  if (!db || !schema || !drizzle) {
+    return
+  }
+
+  await db.delete(schema.InferenceUsageLedgerBucketChargeTable).where(drizzle.inArray(schema.InferenceUsageLedgerBucketChargeTable.id, [
+    targetFiveHourChargeId,
+    targetWeeklyChargeId,
+    targetMonthlyChargeId,
+    adminMonthlyChargeId,
+  ]))
+  await db.delete(schema.InferenceUsageLedgerEntryTable).where(drizzle.inArray(schema.InferenceUsageLedgerEntryTable.id, [targetLedgerEntryId, adminLedgerEntryId]))
+  await db.update(schema.InferenceOrgLimitPolicyTable).set({ current_bucket_id: null }).where(drizzle.eq(schema.InferenceOrgLimitPolicyTable.organization_id, organizationId))
+  await db.delete(schema.InferenceOrgUsageBucketTable).where(drizzle.eq(schema.InferenceOrgUsageBucketTable.organization_id, organizationId))
+  await db.delete(schema.InferenceOrgLimitPolicyTable).where(drizzle.eq(schema.InferenceOrgLimitPolicyTable.organization_id, organizationId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, [adminUserId, targetUserId]))
+  await db.delete(schema.AdminAllowlistTable).where(drizzle.inArray(schema.AdminAllowlistTable.email, [adminEmail, addedAdminEmail]))
+}
+
+beforeAll(async () => {
+  if (!shouldRunRouteDbCoverage()) {
+    routeTestUnavailable = "aggregate suite run; covered by the focused route DB test"
+    return
+  }
+
+  seedRequiredEnv()
+  if (!await databaseIsAvailable()) {
+    routeTestUnavailable = "MySQL is not available at 127.0.0.1:3306"
+    return
+  }
+  let adminRoutesModule: typeof import("../src/routes/admin/index.js")
+  let dbModule: typeof import("../src/db.js")
+  let schemaModule: typeof import("@openwork-ee/den-db/schema")
+  let drizzleModule: typeof import("@openwork-ee/den-db/drizzle")
+  try {
+    [dbModule, schemaModule, drizzleModule] = await Promise.all([
+      import("../src/db.js"),
+      import("@openwork-ee/den-db/schema"),
+      import("@openwork-ee/den-db/drizzle"),
+    ])
+    if (!isRouteDatabase(dbModule.db)) {
+      routeTestUnavailable = "aggregate suite run; db module is mocked by another route test"
+      return
+    }
+    adminRoutesModule = await import("../src/routes/admin/index.js")
+  } catch (error) {
+    routeTestUnavailable = errorMessage(error)
+    return
+  }
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+
+  const now = new Date()
+  const windowStart = new Date(now.getTime() - 60 * 60 * 1000)
+  const windowEnd = new Date(now.getTime() + 60 * 60 * 1000)
+  try {
+    await cleanup()
+    await db.insert(schema.AuthUserTable).values([
+      { id: adminUserId, name: "Management Admin", email: adminEmail, emailVerified: true },
+      { id: targetUserId, name: "Inference Target", email: targetEmail, emailVerified: true },
+    ])
+    await db.insert(schema.AdminAllowlistTable).values({ id: adminAllowlistId, email: adminEmail, note: "Management route test" })
+    await db.insert(schema.OrganizationTable).values({ id: organizationId, name: "Admin Management Org", slug: `admin-management-${organizationId}` })
+    await db.insert(schema.MemberTable).values([
+      { id: adminMemberId, organizationId, userId: adminUserId, role: "admin" },
+      { id: targetMemberId, organizationId, userId: targetUserId, role: "member" },
+    ])
+    await db.insert(schema.InferenceOrgLimitPolicyTable).values([
+      { id: fiveHourPolicyId, organization_id: organizationId, window_type: "five_hour", reset_strategy: "activity_based" },
+      { id: weeklyPolicyId, organization_id: organizationId, window_type: "weekly", reset_strategy: "anchored", anchor_at: now },
+      { id: monthlyPolicyId, organization_id: organizationId, window_type: "monthly", reset_strategy: "anchored", anchor_at: now },
+    ])
+    await db.insert(schema.InferenceOrgUsageBucketTable).values([
+      { id: fiveHourBucketId, organization_id: organizationId, policy_id: fiveHourPolicyId, window_start_at: windowStart, window_end_at: windowEnd, limit_amount: 1_000, used_amount: 11 },
+      { id: weeklyBucketId, organization_id: organizationId, policy_id: weeklyPolicyId, window_start_at: windowStart, window_end_at: windowEnd, limit_amount: 2_000, used_amount: 22 },
+      { id: monthlyBucketId, organization_id: organizationId, policy_id: monthlyPolicyId, window_start_at: windowStart, window_end_at: windowEnd, limit_amount: 3_000, used_amount: 40 },
+    ])
+    await db.update(schema.InferenceOrgLimitPolicyTable).set({ current_bucket_id: fiveHourBucketId }).where(drizzle.eq(schema.InferenceOrgLimitPolicyTable.id, fiveHourPolicyId))
+    await db.update(schema.InferenceOrgLimitPolicyTable).set({ current_bucket_id: weeklyBucketId }).where(drizzle.eq(schema.InferenceOrgLimitPolicyTable.id, weeklyPolicyId))
+    await db.update(schema.InferenceOrgLimitPolicyTable).set({ current_bucket_id: monthlyBucketId }).where(drizzle.eq(schema.InferenceOrgLimitPolicyTable.id, monthlyPolicyId))
+    await db.insert(schema.InferenceUsageLedgerEntryTable).values([
+      { id: targetLedgerEntryId, organization_id: organizationId, org_membership_id: targetMemberId, external_job_id: `target-${targetLedgerEntryId}`, cost_amount: 66, event_type: "usage", occurred_at: now },
+      { id: adminLedgerEntryId, organization_id: organizationId, org_membership_id: adminMemberId, external_job_id: `admin-${adminLedgerEntryId}`, cost_amount: 7, event_type: "usage", occurred_at: now },
+    ])
+    await db.insert(schema.InferenceUsageLedgerBucketChargeTable).values([
+      { id: targetFiveHourChargeId, ledger_entry_id: targetLedgerEntryId, bucket_id: fiveHourBucketId, amount: 11 },
+      { id: targetWeeklyChargeId, ledger_entry_id: targetLedgerEntryId, bucket_id: weeklyBucketId, amount: 22 },
+      { id: targetMonthlyChargeId, ledger_entry_id: targetLedgerEntryId, bucket_id: monthlyBucketId, amount: 33 },
+      { id: adminMonthlyChargeId, ledger_entry_id: adminLedgerEntryId, bucket_id: monthlyBucketId, amount: 7 },
+    ])
+  } catch (error) {
+    routeTestUnavailable = errorMessage(error)
+    return
+  }
+
+  app = new Hono<{ Variables: AuthContextVariables }>()
+  app.use("*", async (c, next) => {
+    c.set("user", {
+      id: adminUserId,
+      name: "Management Admin",
+      email: adminEmail,
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    c.set("session", null)
+    c.set("apiKey", null)
+    await next()
+  })
+  adminRoutesModule.registerAdminRoutes(app)
+})
+
+afterAll(async () => {
+  if (!routeTestUnavailable) {
+    await cleanup()
+  }
+})
+
+test("admin management and inference usage reset routes persist and isolate changes", async () => {
+  if (routeTestUnavailable) {
+    console.warn(`admin management and inference usage route DB coverage skipped: ${routeTestUnavailable}`)
+    return
+  }
+
+  const addAdmin = await routeApp().request("http://den.local/v1/admin/admins", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: `  ${addedAdminEmail.toUpperCase()}  `, note: "Second admin" }),
+  })
+  expect(addAdmin.status).toBe(200)
+  const addAdminPayload: unknown = await addAdmin.json()
+  expect(addAdminPayload).toMatchObject({ ok: true, admin: { email: addedAdminEmail, note: "Second admin" } })
+  if (!isRecord(addAdminPayload) || !isRecord(addAdminPayload.admin) || typeof addAdminPayload.admin.id !== "string") {
+    throw new Error("add admin response did not include an admin id")
+  }
+  const addedAdminId = addAdminPayload.admin.id
+
+  const { db, schema, drizzle } = testDatabase()
+  const persistedAdmins = await db.select({ email: schema.AdminAllowlistTable.email }).from(schema.AdminAllowlistTable).where(drizzle.eq(schema.AdminAllowlistTable.email, addedAdminEmail))
+  expect(persistedAdmins).toEqual([{ email: addedAdminEmail }])
+
+  const duplicateAdmin = await routeApp().request("http://den.local/v1/admin/admins", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: addedAdminEmail }),
+  })
+  expect(duplicateAdmin.status).toBe(409)
+
+  const removeSelf = await routeApp().request(`http://den.local/v1/admin/admins/${adminAllowlistId}`, { method: "DELETE" })
+  expect(removeSelf.status).toBe(400)
+  await expect(removeSelf.json()).resolves.toMatchObject({ message: "You cannot delete your own admin access." })
+
+  const removeSecondAdmin = await routeApp().request(`http://den.local/v1/admin/admins/${addedAdminId}`, { method: "DELETE" })
+  expect(removeSecondAdmin.status).toBe(200)
+  expect(await db.select().from(schema.AdminAllowlistTable).where(drizzle.eq(schema.AdminAllowlistTable.email, addedAdminEmail))).toEqual([])
+
+  const usageBefore = await routeApp().request(`http://den.local/v1/admin/users/${targetUserId}/inference-usage`)
+  expect(usageBefore.status).toBe(200)
+  await expect(usageBefore.json()).resolves.toMatchObject({
+    user: { id: targetUserId, email: targetEmail },
+    organizations: [{
+      id: organizationId,
+      membershipId: targetMemberId,
+      windows: [
+        { bucketId: fiveHourBucketId, windowType: "five_hour", limitAmount: 1_000, organizationUsedAmount: 11, userUsedAmount: 11 },
+        { bucketId: weeklyBucketId, windowType: "weekly", limitAmount: 2_000, organizationUsedAmount: 22, userUsedAmount: 22 },
+        { bucketId: monthlyBucketId, windowType: "monthly", limitAmount: 3_000, organizationUsedAmount: 40, userUsedAmount: 33 },
+      ],
+    }],
+  })
+
+  const firstReset = await routeApp().request(`http://den.local/v1/admin/users/${targetUserId}/inference-usage/reset`, { method: "POST" })
+  expect(firstReset.status).toBe(200)
+  await expect(firstReset.json()).resolves.toEqual({ ok: true, resetAmount: 66 })
+
+  const remainingCharges = await db
+    .select({ id: schema.InferenceUsageLedgerBucketChargeTable.id, amount: schema.InferenceUsageLedgerBucketChargeTable.amount })
+    .from(schema.InferenceUsageLedgerBucketChargeTable)
+    .where(drizzle.inArray(schema.InferenceUsageLedgerBucketChargeTable.id, [targetFiveHourChargeId, targetWeeklyChargeId, targetMonthlyChargeId, adminMonthlyChargeId]))
+  expect(remainingCharges).toEqual([{ id: adminMonthlyChargeId, amount: 7 }])
+
+  const bucketRows = await db
+    .select({ id: schema.InferenceOrgUsageBucketTable.id, usedAmount: schema.InferenceOrgUsageBucketTable.used_amount })
+    .from(schema.InferenceOrgUsageBucketTable)
+    .where(drizzle.eq(schema.InferenceOrgUsageBucketTable.organization_id, organizationId))
+  expect(bucketRows).toEqual(expect.arrayContaining([
+    { id: fiveHourBucketId, usedAmount: 0 },
+    { id: weeklyBucketId, usedAmount: 0 },
+    { id: monthlyBucketId, usedAmount: 7 },
+  ]))
+
+  const secondReset = await routeApp().request(`http://den.local/v1/admin/users/${targetUserId}/inference-usage/reset`, { method: "POST" })
+  expect(secondReset.status).toBe(200)
+  await expect(secondReset.json()).resolves.toEqual({ ok: true, resetAmount: 0 })
+
+  const usageAfter = await routeApp().request(`http://den.local/v1/admin/users/${targetUserId}/inference-usage`)
+  expect(usageAfter.status).toBe(200)
+  await expect(usageAfter.json()).resolves.toMatchObject({
+    organizations: [{ windows: [
+      { bucketId: fiveHourBucketId, organizationUsedAmount: 0, userUsedAmount: 0 },
+      { bucketId: weeklyBucketId, organizationUsedAmount: 0, userUsedAmount: 0 },
+      { bucketId: monthlyBucketId, organizationUsedAmount: 7, userUsedAmount: 0 },
+    ] }],
+  })
+})

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -325,14 +325,14 @@ function errorName(error: unknown): string {
   return error instanceof Error ? error.name : typeof error;
 }
 
-async function readRequestBody(request: NextRequest): Promise<Uint8Array | null> {
+async function readRequestBody(request: NextRequest): Promise<Blob | null> {
   if (request.method === "GET" || request.method === "HEAD") return null;
-  // Forward an owned copy, never a view: Next 16 detaches the ArrayBuffer
-  // behind arrayBuffer() after the read, and undici serializes fetch bodies
-  // lazily, so a view over that buffer throws "Cannot perform
-  // ArrayBuffer.prototype.slice on a detached ArrayBuffer" on every proxied
-  // write while GETs (null body) keep working.
-  return new Uint8Array(await request.arrayBuffer()).slice();
+  // Forward a Blob, never an ArrayBuffer or a view: Next 16's patched fetch
+  // hands buffer-backed bodies to undici with their backing ArrayBuffer
+  // detached — even a fresh copy — so every proxied write threw "Cannot
+  // perform ArrayBuffer.prototype.slice on a detached ArrayBuffer" while
+  // GETs (null body) kept working. A Blob owns its bytes and survives the hop.
+  return request.blob();
 }
 
 export async function proxyUpstream(

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -327,7 +327,12 @@ function errorName(error: unknown): string {
 
 async function readRequestBody(request: NextRequest): Promise<Uint8Array | null> {
   if (request.method === "GET" || request.method === "HEAD") return null;
-  return new Uint8Array(await request.arrayBuffer());
+  // Forward an owned copy, never a view: Next 16 detaches the ArrayBuffer
+  // behind arrayBuffer() after the read, and undici serializes fetch bodies
+  // lazily, so a view over that buffer throws "Cannot perform
+  // ArrayBuffer.prototype.slice on a detached ArrayBuffer" on every proxied
+  // write while GETs (null body) keep working.
+  return new Uint8Array(await request.arrayBuffer()).slice();
 }
 
 export async function proxyUpstream(

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -954,6 +954,25 @@ function adminScaleFixturePayload(path: string): unknown | null {
   return null;
 }
 
+const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
+
+// The den proxy strips cookies from requests whose Origin matches a cloud
+// instance origin (they are bearer-only by design), and browsers always send
+// an Origin header on mutating fetches. Cookie-only admin writes therefore
+// 401 when den-web itself is served from such an origin. Attach the stored
+// bearer token like den-flow's requestJson does; den-api accepts either
+// credential, so cookie-authenticated sessions keep working unchanged.
+function withStoredBearer(headers: Record<string, string>): Record<string, string> {
+  if (typeof window === "undefined") {
+    return headers;
+  }
+  const token = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)?.trim();
+  if (!token) {
+    return headers;
+  }
+  return { ...headers, Authorization: `Bearer ${token}` };
+}
+
 async function requestJson(path: string, signal?: AbortSignal) {
   const fixturePayload = adminScaleFixturePayload(path);
   if (fixturePayload) {
@@ -964,9 +983,9 @@ async function requestJson(path: string, signal?: AbortSignal) {
     method: "GET",
     credentials: "include",
     signal,
-    headers: {
+    headers: withStoredBearer({
       Accept: "application/json"
-    }
+    })
   });
 
   const text = await response.text();
@@ -991,10 +1010,10 @@ async function patchJson(path: string, body: unknown) {
   const response = await fetch(`/api/den${path}`, {
     method: "PATCH",
     credentials: "include",
-    headers: {
+    headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
-    },
+    }),
     body: JSON.stringify(body)
   });
 
@@ -1016,10 +1035,10 @@ async function postJson(path: string, body: unknown) {
   const response = await fetch(`/api/den${path}`, {
     method: "POST",
     credentials: "include",
-    headers: {
+    headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
-    },
+    }),
     body: JSON.stringify(body)
   });
 
@@ -1039,10 +1058,10 @@ async function putJson(path: string, body: unknown) {
   const response = await fetch(`/api/den${path}`, {
     method: "PUT",
     credentials: "include",
-    headers: {
+    headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
-    },
+    }),
     body: JSON.stringify(body)
   });
 
@@ -1064,9 +1083,9 @@ async function deleteJson(path: string) {
   const response = await fetch(`/api/den${path}`, {
     method: "DELETE",
     credentials: "include",
-    headers: {
+    headers: withStoredBearer({
       Accept: "application/json"
-    }
+    })
   });
 
   const text = await response.text();

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -35,9 +35,38 @@ type AdminUserOrganization = {
 };
 
 type AdminEntry = {
+  id: string;
   email: string;
   note: string | null;
+  createdAt: string;
 };
+
+type InferenceUsageWindow = {
+  bucketId: string;
+  windowType: string;
+  windowStartAt: string;
+  windowEndAt: string;
+  limitAmount: number;
+  organizationUsedAmount: number;
+  userUsedAmount: number;
+};
+
+type InferenceUsageOrganization = {
+  id: string;
+  name: string;
+  membershipId: string;
+  windows: InferenceUsageWindow[];
+};
+
+type InferenceUsagePayload = {
+  user: { id: string; email: string };
+  organizations: InferenceUsageOrganization[];
+};
+
+type InferenceUsageCacheEntry =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: InferenceUsagePayload };
 
 type ActivityPoint = {
   day: string;
@@ -348,13 +377,15 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
 
   const admins: AdminEntry[] = payload.admins
     .map((value) => {
-      if (!isRecord(value) || typeof value.email !== "string") {
+      if (!isRecord(value) || typeof value.id !== "string" || typeof value.email !== "string" || typeof value.createdAt !== "string") {
         return null;
       }
 
       return {
+        id: value.id,
         email: value.email,
-        note: toStringValue(value.note)
+        note: toStringValue(value.note),
+        createdAt: value.createdAt
       };
     })
     .filter((value): value is AdminEntry => value !== null);
@@ -481,6 +512,38 @@ function parseAdminMetricsPayload(payload: unknown): AdminMetricsPayload | null 
     summary: parseAdminSummary(payload.summary, 0),
     generatedAt: toStringValue(payload.generatedAt)
   };
+}
+
+function parseInferenceUsagePayload(payload: unknown): InferenceUsagePayload | null {
+  if (!isRecord(payload) || !isRecord(payload.user) || typeof payload.user.id !== "string" || typeof payload.user.email !== "string" || !Array.isArray(payload.organizations)) {
+    return null;
+  }
+
+  const organizations: InferenceUsageOrganization[] = [];
+  for (const value of payload.organizations) {
+    if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string" || typeof value.membershipId !== "string" || !Array.isArray(value.windows)) {
+      return null;
+    }
+
+    const windows: InferenceUsageWindow[] = [];
+    for (const window of value.windows) {
+      if (!isRecord(window) || typeof window.bucketId !== "string" || typeof window.windowType !== "string" || typeof window.windowStartAt !== "string" || typeof window.windowEndAt !== "string") {
+        return null;
+      }
+      windows.push({
+        bucketId: window.bucketId,
+        windowType: window.windowType,
+        windowStartAt: window.windowStartAt,
+        windowEndAt: window.windowEndAt,
+        limitAmount: toNumberValue(window.limitAmount),
+        organizationUsedAmount: toNumberValue(window.organizationUsedAmount),
+        userUsedAmount: toNumberValue(window.userUsedAmount)
+      });
+    }
+    organizations.push({ id: value.id, name: value.name, membershipId: value.membershipId, windows });
+  }
+
+  return { user: { id: payload.user.id, email: payload.user.email }, organizations };
 }
 
 function clearPersistedAdminOverviewCache() {
@@ -845,7 +908,7 @@ function adminScaleFixturePayload(path: string): unknown | null {
     const durationMs = Math.round(performance.now() - startedAt);
     return {
       viewer: { id: "user_admin_fixture", email: "admin@example.com", name: "Admin Fixture" },
-      admins: [{ email: "admin@example.com", note: "Eval fixture admin" }],
+      admins: [{ id: "admin_fixture", email: "admin@example.com", note: "Eval fixture admin", createdAt: generatedAt }],
       users: users.rows,
       organizations: [],
       userPage: fixturePageInfo(ADMIN_SCALE_FIXTURE_USERS, users.rows.length, 0, "", durationMs),
@@ -946,6 +1009,29 @@ async function patchJson(path: string, body: unknown) {
     }
   }
 
+  return { response, payload };
+}
+
+async function postJson(path: string, body: unknown) {
+  const response = await fetch(`/api/den${path}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
   return { response, payload };
 }
 
@@ -1072,6 +1158,27 @@ function formatOptionalCount(value: number | null): string {
 
 function formatOptionalDetail(value: number | null, label: string): string {
   return value === null ? "Load analytics to calculate" : `${value} ${label}`;
+}
+
+function formatUsageAmount(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    notation: Math.abs(value) >= 10_000 ? "compact" : "standard",
+    maximumFractionDigits: Math.abs(value) >= 10_000 ? 2 : 3
+  }).format(value);
+}
+
+function formatWindowType(value: string): string {
+  const normalized = value.toLowerCase().replace(/[-_]/g, " ");
+  if (normalized.includes("five") || normalized.includes("5 hour") || normalized.includes("5h")) {
+    return "Five-hour";
+  }
+  if (normalized.includes("week")) {
+    return "Weekly";
+  }
+  if (normalized.includes("month")) {
+    return "Monthly";
+  }
+  return formatProvider(value);
 }
 
 function formatProvider(provider: string): string {
@@ -1307,6 +1414,13 @@ export function DenAdminPanel() {
   const [capabilityError, setCapabilityError] = useState<{ orgId: string; message: string } | null>(null);
   const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
+  const [adminEmail, setAdminEmail] = useState("");
+  const [adminNote, setAdminNote] = useState("");
+  const [adminMutationId, setAdminMutationId] = useState<string | null>(null);
+  const [usageByUserId, setUsageByUserId] = useState<Record<string, InferenceUsageCacheEntry>>({});
+  const [resetUsageDialog, setResetUsageDialog] = useState<AdminUser | null>(null);
+  const [resettingUsageUserId, setResettingUsageUserId] = useState<string | null>(null);
+  const [resetSuccessByUserId, setResetSuccessByUserId] = useState<Record<string, number>>({});
   const mountedAtRef = useRef<number | null>(null);
   const overviewRequestIdRef = useRef(0);
   const userRequestIdRef = useRef(0);
@@ -1589,6 +1703,103 @@ export function DenAdminPanel() {
       setAnalyticsLoading(false);
     }
   }, []);
+
+  const loadInferenceUsage = useCallback(async (userId: string) => {
+    setUsageByUserId((current) => ({ ...current, [userId]: { status: "loading" } }));
+    try {
+      const { response, payload: nextPayload } = await requestJson(`/v1/admin/users/${encodeURIComponent(userId)}/inference-usage`);
+      if (!response.ok) {
+        const message = getErrorMessage(nextPayload, `Could not load model consumption (${response.status}).`);
+        setUsageByUserId((current) => ({ ...current, [userId]: { status: "error", message } }));
+        return;
+      }
+      const parsed = parseInferenceUsagePayload(nextPayload);
+      if (!parsed) {
+        setUsageByUserId((current) => ({ ...current, [userId]: { status: "error", message: "Model consumption payload was missing required fields." } }));
+        return;
+      }
+      setUsageByUserId((current) => ({ ...current, [userId]: { status: "ready", data: parsed } }));
+    } catch (nextError) {
+      const message = nextError instanceof Error ? nextError.message : "Unknown network error";
+      setUsageByUserId((current) => ({ ...current, [userId]: { status: "error", message } }));
+    }
+  }, []);
+
+  const addAdmin = useCallback(async () => {
+    const email = adminEmail.trim();
+    const note = adminNote.trim();
+    if (!email) {
+      setError("Enter an email address for the new platform admin.");
+      return;
+    }
+    setAdminMutationId("add");
+    setError(null);
+    try {
+      const { response, payload: nextPayload } = await postJson("/v1/admin/admins", note ? { email, note } : { email });
+      const admin = isRecord(nextPayload) && isRecord(nextPayload.admin) ? nextPayload.admin : null;
+      if (!response.ok || !admin || typeof admin.id !== "string" || typeof admin.email !== "string" || typeof admin.createdAt !== "string") {
+        setError(getErrorMessage(nextPayload, `Could not add ${email}.`));
+        return;
+      }
+      const entry: AdminEntry = { id: admin.id, email: admin.email, note: toStringValue(admin.note), createdAt: admin.createdAt };
+      setPayload((current) => current ? {
+        ...current,
+        admins: [...current.admins, entry],
+        summary: { ...current.summary, adminCount: current.summary.adminCount + 1 }
+      } : current);
+      setAdminEmail("");
+      setAdminNote("");
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setAdminMutationId(null);
+    }
+  }, [adminEmail, adminNote]);
+
+  const removeAdmin = useCallback(async (admin: AdminEntry) => {
+    setAdminMutationId(admin.id);
+    setError(null);
+    try {
+      const { response, payload: nextPayload } = await deleteJson(`/v1/admin/admins/${encodeURIComponent(admin.id)}`);
+      if (!response.ok) {
+        setError(getErrorMessage(nextPayload, `Could not remove ${admin.email}.`));
+        return;
+      }
+      setPayload((current) => current ? {
+        ...current,
+        admins: current.admins.filter((entry) => entry.id !== admin.id),
+        summary: { ...current.summary, adminCount: Math.max(0, current.summary.adminCount - 1) }
+      } : current);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setAdminMutationId(null);
+    }
+  }, []);
+
+  const resetInferenceUsage = useCallback(async () => {
+    if (!resetUsageDialog) {
+      return;
+    }
+    const userId = resetUsageDialog.id;
+    setResettingUsageUserId(userId);
+    setError(null);
+    try {
+      const { response, payload: nextPayload } = await postJson(`/v1/admin/users/${encodeURIComponent(userId)}/inference-usage/reset`, {});
+      if (!response.ok || !isRecord(nextPayload) || typeof nextPayload.resetAmount !== "number") {
+        setError(getErrorMessage(nextPayload, `Could not reset consumption for ${resetUsageDialog.email}.`));
+        return;
+      }
+      const resetAmount = nextPayload.resetAmount;
+      setResetSuccessByUserId((current) => ({ ...current, [userId]: resetAmount }));
+      setResetUsageDialog(null);
+      await loadInferenceUsage(userId);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setResettingUsageUserId(null);
+    }
+  }, [loadInferenceUsage, resetUsageDialog]);
 
   useEffect(() => {
     const cachedPayload = readAdminOverviewCache();
@@ -1954,6 +2165,13 @@ export function DenAdminPanel() {
     return filteredUsers.find((user) => user.id === selectedUserId) ?? filteredUsers[0] ?? null;
   }, [filteredUsers, selectedUserId]);
 
+  useEffect(() => {
+    if (!selectedUser || usageByUserId[selectedUser.id]) {
+      return;
+    }
+    void loadInferenceUsage(selectedUser.id);
+  }, [loadInferenceUsage, selectedUser, usageByUserId]);
+
   if (accessState === "loading") {
     return <DenAdminLoadingShell />;
   }
@@ -2068,12 +2286,65 @@ export function DenAdminPanel() {
 
         <ActivityChart series={payload.summary.activitySeries} />
 
-        <div className="mt-5 flex flex-wrap gap-2">
-          {payload.admins.map((admin) => (
-            <span key={admin.email} className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700">
-              {admin.email}
-            </span>
-          ))}
+        <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-slate-950">Platform admins</p>
+              <p className="mt-1 text-xs leading-5 text-slate-500">Manage operator access to this backoffice.</p>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-[minmax(12rem,1fr)_minmax(10rem,1fr)_auto]">
+              <input
+                type="email"
+                data-testid="admin-add-email"
+                value={adminEmail}
+                onChange={(event) => setAdminEmail(event.target.value)}
+                placeholder="Email"
+                aria-label="Admin email"
+                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-400"
+              />
+              <input
+                data-testid="admin-add-note"
+                value={adminNote}
+                onChange={(event) => setAdminNote(event.target.value)}
+                placeholder="Note (optional)"
+                aria-label="Admin note"
+                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-400"
+              />
+              <button
+                type="button"
+                data-testid="admin-add-action"
+                onClick={() => void addAdmin()}
+                disabled={adminMutationId !== null || !adminEmail.trim()}
+                className="rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {adminMutationId === "add" ? "Adding..." : "Add admin"}
+              </button>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {payload.admins.map((admin) => {
+              const isViewer = admin.email.toLowerCase() === payload.viewer.email?.toLowerCase();
+              return (
+                <div key={admin.id} className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-800">{admin.email}{isViewer ? " · You" : ""}</p>
+                    <p className="truncate text-xs text-slate-500">{admin.note ?? `Added ${formatDateTime(admin.createdAt)}`}</p>
+                  </div>
+                  {!isViewer ? (
+                    <button
+                      type="button"
+                      data-testid={`admin-remove-${admin.id}`}
+                      onClick={() => void removeAdmin(admin)}
+                      disabled={adminMutationId !== null}
+                      className="shrink-0 rounded-full border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold text-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {adminMutationId === admin.id ? "Removing..." : "Remove"}
+                    </button>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
 
@@ -2442,6 +2713,7 @@ export function DenAdminPanel() {
             </div>
           ) : filteredUsers.length > 0 ? filteredUsers.map((user) => {
             const isSelected = user.id === selectedUser?.id;
+            const usageEntry = usageByUserId[user.id];
 
             return (
               <div
@@ -2518,6 +2790,66 @@ export function DenAdminPanel() {
                           >
                             Load billing for page
                           </button>
+                        </div>
+                      )}
+                    </div>
+
+                    <div data-testid="admin-usage-section" className="rounded-2xl border border-slate-200 bg-white px-4 py-4 lg:col-span-2">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">OpenWork model consumption</p>
+                          <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-600">
+                            Limits are shared by everyone in each organization. Reset only forgives this user&apos;s consumption in the current windows; it does not change shared limits or other members&apos; usage.
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          data-testid="admin-usage-reset-open"
+                          onClick={() => setResetUsageDialog(user)}
+                          disabled={usageEntry?.status !== "ready" || usageEntry.data.organizations.length === 0}
+                          className="shrink-0 rounded-full border border-amber-200 bg-white px-4 py-2 text-sm font-semibold text-amber-800 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Reset consumption
+                        </button>
+                      </div>
+
+                      {resetSuccessByUserId[user.id] !== undefined ? (
+                        <p className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+                          Reset complete. Forgave {formatUsageAmount(resetSuccessByUserId[user.id])} units from this user&apos;s current windows.
+                        </p>
+                      ) : null}
+
+                      {!usageEntry || usageEntry.status === "loading" ? (
+                        <p className="mt-4 text-sm text-slate-500" aria-busy="true">Loading model consumption…</p>
+                      ) : usageEntry.status === "error" ? (
+                        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                          <p>{usageEntry.message}</p>
+                          <button type="button" onClick={() => void loadInferenceUsage(user.id)} className="mt-2 font-semibold underline">Retry</button>
+                        </div>
+                      ) : usageEntry.data.organizations.length === 0 ? (
+                        <p className="mt-4 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-5 text-center text-sm text-slate-500">No organization consumption windows are available for this user.</p>
+                      ) : (
+                        <div className="mt-4 grid gap-3">
+                          {usageEntry.data.organizations.map((organization) => (
+                            <div key={organization.membershipId} className="rounded-xl border border-slate-200 bg-slate-50/70 p-3">
+                              <p className="text-sm font-semibold text-slate-950">{organization.name}</p>
+                              <p className="mt-0.5 truncate font-mono text-[0.68rem] text-slate-400">{organization.id}</p>
+                              {organization.windows.length === 0 ? (
+                                <p className="mt-3 text-sm text-slate-500">No current five-hour, weekly, or monthly windows.</p>
+                              ) : (
+                                <div className="mt-3 grid gap-2 md:grid-cols-3">
+                                  {organization.windows.map((window) => (
+                                    <div key={window.bucketId} className="rounded-xl border border-slate-200 bg-white p-3">
+                                      <p className="text-xs font-semibold text-slate-800">{formatWindowType(window.windowType)}</p>
+                                      <p className="mt-2 text-sm text-slate-700">User: <strong>{formatUsageAmount(window.userUsedAmount)}</strong></p>
+                                      <p className="mt-1 text-xs text-slate-500">Shared: {formatUsageAmount(window.organizationUsedAmount)} / {formatUsageAmount(window.limitAmount)}</p>
+                                      <p className="mt-2 text-xs leading-5 text-slate-400">Resets {formatDateTime(window.windowEndAt)}</p>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          ))}
                         </div>
                       )}
                     </div>
@@ -2710,6 +3042,46 @@ export function DenAdminPanel() {
                 className="inline-flex items-center justify-center rounded-full bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {deletingUserId === deleteUserDialog.id ? "Deleting..." : "Delete user"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {resetUsageDialog ? (
+        <div
+          data-testid="admin-usage-reset-confirmation"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reset-usage-dialog-title"
+          onClick={() => setResetUsageDialog(null)}
+        >
+          <div className="w-full max-w-md rounded-3xl border border-amber-100 bg-white p-6 shadow-xl" onClick={(event) => event.stopPropagation()}>
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-amber-600">Model consumption</p>
+            <h2 id="reset-usage-dialog-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">
+              Reset {resetUsageDialog.email}?
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              This forgives only this user&apos;s consumption in the current five-hour, weekly, and monthly windows. Organization limits remain shared and other members&apos; consumption is unchanged.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setResetUsageDialog(null)}
+                disabled={resettingUsageUserId === resetUsageDialog.id}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="admin-usage-reset-action"
+                onClick={() => void resetInferenceUsage()}
+                disabled={resettingUsageUserId === resetUsageDialog.id}
+                className="rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {resettingUsageUserId === resetUsageDialog.id ? "Resetting..." : "Reset consumption"}
               </button>
             </div>
           </div>

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -351,11 +351,17 @@ test(title, async ({ evidence, place }) => {
       `email=${addedEmail}; uiStillPresent=${String(uiStillHasRemovedAdmin)}; apiStillPresent=${apiStillHasRemovedAdmin}`,
       uiStillHasRemovedAdmin === false && !apiStillHasRemovedAdmin,
     );
-    // Visual record of the post-removal panel. Absence is a negative claim that
-    // vision judges unreliably, so removal stays proven by the DOM and live API
-    // assertions above; this frame exists for human review.
+    // The post-removal panel. Absence is a negative claim that vision judges
+    // unreliably, so removal stays proven by the DOM and live API assertions
+    // above; this frame claims only the positive end state it shows.
     await scrollIntoView(browser, '[data-testid="admin-add-email"]');
-    await screenshot(browser);
+    {
+      const shot = await screenshot(browser);
+      const seen = await validate(shot, [
+        "The Platform admins section lists an admin entry whose label ends with You",
+      ]);
+      expect(seen.ok, seen.why).toBe(true);
+    }
     addedAdminId = "";
 
     const usage = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage`, {

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -351,17 +351,6 @@ test(title, async ({ evidence, place }) => {
       `email=${addedEmail}; uiStillPresent=${String(uiStillHasRemovedAdmin)}; apiStillPresent=${apiStillHasRemovedAdmin}`,
       uiStillHasRemovedAdmin === false && !apiStillHasRemovedAdmin,
     );
-    // The post-removal panel. Absence is a negative claim that vision judges
-    // unreliably, so removal stays proven by the DOM and live API assertions
-    // above; this frame claims only the positive end state it shows.
-    await scrollIntoView(browser, '[data-testid="admin-add-email"]');
-    {
-      const shot = await screenshot(browser);
-      const seen = await validate(shot, [
-        "The Platform admins section lists an admin entry whose label ends with You",
-      ]);
-      expect(seen.ok, seen.why).toBe(true);
-    }
     addedAdminId = "";
 
     const usage = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage`, {

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -1,8 +1,9 @@
 import { expect } from "vitest";
 import { denFetch, evalIn, waitFor } from "@openwork/behaviors";
 import { closeTarget, navigate, newPageTarget, reattachSurface } from "@openwork/cdp";
+import { screenshot, validate } from "@openwork/fraimz";
 import { chrome } from "@openwork/hosts";
-import { needs, server, test, unmetNeeds } from "@openwork/testkit";
+import { needs, server, sleep, test, unmetNeeds } from "@openwork/testkit";
 import type { DenSession, DenFetchResult } from "@openwork/behaviors";
 import type { NeedsSpec } from "@openwork/testkit";
 
@@ -53,6 +54,17 @@ function usersFrom(value: unknown): UserEntry[] {
 
 function resetAmount(value: unknown): number | null {
   return isRecord(value) && typeof value.resetAmount === "number" ? value.resetAmount : null;
+}
+
+/** Bring a target into the viewport so its screenshot frame shows the claimed UI. */
+async function scrollIntoView(browser: Parameters<typeof screenshot>[0], selector: string): Promise<void> {
+  await evalIn(browser, `(() => {
+    const target = document.querySelector(${JSON.stringify(selector)});
+    if (!target) return false;
+    target.scrollIntoView({ block: "center", behavior: "instant" });
+    return true;
+  })()`);
+  await sleep(300);
 }
 
 async function adminOverview(admin: DenSession): Promise<DenFetchResult> {
@@ -156,6 +168,16 @@ test(title, async ({ evidence, place }) => {
     controlsVisible === true,
   );
 
+  await scrollIntoView(browser, '[data-testid="admin-add-email"]');
+  {
+    const shot = await screenshot(browser);
+    const seen = await validate(shot, [
+      "A Platform admins section is visible with an email field, a note field, and an Add admin button",
+      "A user backoffice page is shown with user rows listing email addresses",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
   const selected = await evalIn(browser, `(() => {
     const row = document.querySelector(${JSON.stringify(`[data-testid="admin-user-row-${memberUser.id}"]`)});
     const button = row?.querySelector("button");
@@ -199,6 +221,16 @@ test(title, async ({ evidence, place }) => {
     JSON.stringify(emptyUsageState),
     emptyUsageProved,
   );
+
+  await scrollIntoView(browser, `[data-testid="admin-user-row-${memberUser.id}"] [data-testid="admin-usage-section"]`);
+  {
+    const shot = await screenshot(browser);
+    const seen = await validate(shot, [
+      "An expanded user row shows a section headed OpenWork model consumption",
+      "That section says no organization consumption windows are available for this user",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
 
   const addedEmail = `added-admin-${stamp}@openwork.test`;
   const addedNote = `Admin model limits eval ${stamp}`;
@@ -279,6 +311,16 @@ test(title, async ({ evidence, place }) => {
       uiHasAddedAdmin === true && addedAdmins.some((admin) => admin.email === addedEmail) && initiallyAbsent,
     );
 
+    await scrollIntoView(browser, `[data-testid="admin-remove-${addedAdmin.id}"]`);
+    {
+      const shot = await screenshot(browser);
+      const seen = await validate(shot, [
+        "The Platform admins section lists an admin entry whose email begins with added-admin-",
+        "A Remove button is visible next to that newly added admin entry",
+      ]);
+      expect(seen.ok, seen.why).toBe(true);
+    }
+
     const removeClicked = await evalIn(browser, `(() => {
       const button = document.querySelector(${JSON.stringify(`[data-testid="admin-remove-${addedAdmin.id}"]`)});
       if (!button) return false;
@@ -309,6 +351,11 @@ test(title, async ({ evidence, place }) => {
       `email=${addedEmail}; uiStillPresent=${String(uiStillHasRemovedAdmin)}; apiStillPresent=${apiStillHasRemovedAdmin}`,
       uiStillHasRemovedAdmin === false && !apiStillHasRemovedAdmin,
     );
+    // Visual record of the post-removal panel. Absence is a negative claim that
+    // vision judges unreliably, so removal stays proven by the DOM and live API
+    // assertions above; this frame exists for human review.
+    await scrollIntoView(browser, '[data-testid="admin-add-email"]');
+    await screenshot(browser);
     addedAdminId = "";
 
     const usage = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage`, {

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -1,0 +1,319 @@
+import { expect } from "vitest";
+import { denFetch, evalIn, waitFor } from "@openwork/behaviors";
+import { closeTarget, navigate, newPageTarget, reattachSurface } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { DenSession, DenFetchResult } from "@openwork/behaviors";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const requirements: NeedsSpec = {
+  optIn: ["OPENWORK_EVAL_APP_SPECS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `admin model limits skipped — needs: ${missingRequirements.join(", ")}`
+  : "platform admins can manage admins and safely inspect and reset empty model consumption";
+
+type AdminEntry = {
+  id: string;
+  email: string;
+};
+
+type UserEntry = {
+  id: string;
+  email: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordsField(value: unknown, key: string): Record<string, unknown>[] {
+  if (!isRecord(value) || !Array.isArray(value[key])) return [];
+  return value[key].filter(isRecord);
+}
+
+function stringField(value: Record<string, unknown>, key: string): string {
+  return typeof value[key] === "string" ? value[key] : "";
+}
+
+function adminsFrom(value: unknown): AdminEntry[] {
+  return recordsField(value, "admins").map((entry) => ({
+    id: stringField(entry, "id"),
+    email: stringField(entry, "email"),
+  })).filter((entry) => entry.id && entry.email);
+}
+
+function usersFrom(value: unknown): UserEntry[] {
+  return recordsField(value, "users").map((entry) => ({
+    id: stringField(entry, "id"),
+    email: stringField(entry, "email"),
+  })).filter((entry) => entry.id && entry.email);
+}
+
+function resetAmount(value: unknown): number | null {
+  return isRecord(value) && typeof value.resetAmount === "number" ? value.resetAmount : null;
+}
+
+async function adminOverview(admin: DenSession): Promise<DenFetchResult> {
+  return denFetch(admin, "/v1/admin/overview", {
+    headers: { authorization: `Bearer ${admin.token}` },
+  });
+}
+
+async function removeAdminByApi(admin: DenSession, adminId: string): Promise<void> {
+  await denFetch(admin, `/v1/admin/admins/${encodeURIComponent(adminId)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${admin.token}` },
+  });
+}
+
+test(title, async ({ evidence, place }) => {
+  needs(requirements);
+  const stamp = Date.now();
+  await using den = await server({
+    place,
+    org: {
+      name: `Admin Model Limits ${stamp}`,
+      admin: { name: "Admin Limits Eval" },
+      members: { jordan: { name: "Jordan Limits Eval" } },
+    },
+  });
+  const member = den.members.jordan;
+  if (!member) throw new Error("server() did not provision the jordan member session");
+
+  const initialOverview = await adminOverview(den.admin);
+  expect(initialOverview.response.ok, initialOverview.text.slice(0, 500)).toBe(true);
+  const initialAdmins = adminsFrom(initialOverview.body);
+  const memberUser = usersFrom(initialOverview.body).find((user) => user.email === member.email);
+  expect(memberUser, `Admin overview did not contain ${member.email}`).toBeDefined();
+  if (!memberUser) throw new Error(`Admin overview did not contain ${member.email}`);
+
+  await using browser = await chrome({
+    name: "admin-model-limits",
+    startUrl: `${den.ref.webUrl}/admin`,
+    headless: true,
+    host: place.host(),
+  });
+  await browser.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 1100,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  const initialTargetId = browser.client.targetId;
+  await newPageTarget(browser.handle.cdpUrl, `${den.ref.webUrl}/admin`, { timeoutMs: 60_000 });
+  if (initialTargetId) await closeTarget(browser.handle.cdpUrl, initialTargetId);
+  await reattachSurface(browser, { timeoutMs: 60_000 });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 180_000,
+    label: "Den Web origin before admin authentication",
+  });
+
+  const rawSignIn = await evalIn(browser, `(async () => {
+    const response = await fetch("/api/auth/sign-in/email", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        email: ${JSON.stringify(den.admin.email)},
+        password: ${JSON.stringify(den.admin.password)}
+      })
+    });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  })()`);
+  const signInOk = isRecord(rawSignIn) && rawSignIn.ok === true;
+  expect(signInOk, `Browser sign-in failed: ${JSON.stringify(rawSignIn)}`).toBe(true);
+
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(den.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(den.admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+  await navigate(browser.client, `${den.ref.webUrl}/admin`);
+  await waitFor(browser, `document.body.innerText.includes("Platform admins")
+    && Boolean(document.querySelector('[data-testid="admin-add-email"]'))
+    && Boolean(document.querySelector('[data-testid="admin-add-note"]'))
+    && Boolean(document.querySelector('[data-testid="admin-add-action"]'))`, {
+    timeoutMs: 60_000,
+    label: "admin panel platform admin controls",
+  });
+
+  const controlsVisible = await evalIn(browser, `(() => {
+    const body = document.body.innerText;
+    return body.includes("Platform admins")
+      && Boolean(document.querySelector('[data-testid="admin-add-email"]'))
+      && Boolean(document.querySelector('[data-testid="admin-add-note"]'))
+      && Boolean(document.querySelector('[data-testid="admin-add-action"]'))
+      && !body.includes("You do not have access")
+      && !body.includes("Backoffice request failed");
+  })()`);
+  expect(controlsVisible).toBe(true);
+  evidence.fact(
+    "The authenticated /admin panel exposes Platform admins controls without an access or load failure",
+    `controlsVisible=${String(controlsVisible)}`,
+    controlsVisible === true,
+  );
+
+  const selected = await evalIn(browser, `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-testid="admin-user-row-${memberUser.id}"]`)});
+    const button = row?.querySelector("button");
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(selected).toBe(true);
+  await waitFor(browser, `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-testid="admin-user-row-${memberUser.id}"]`)});
+    const section = row?.querySelector('[data-testid="admin-usage-section"]');
+    const reset = section?.querySelector('[data-testid="admin-usage-reset-open"]');
+    return Boolean(section)
+      && (section?.textContent ?? "").includes("OpenWork model consumption")
+      && (section?.textContent ?? "").includes("No organization consumption windows are available for this user.")
+      && reset?.disabled === true;
+  })()`, {
+    timeoutMs: 30_000,
+    label: "expanded member empty model consumption state",
+  });
+  const emptyUsageState = await evalIn(browser, `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-testid="admin-user-row-${memberUser.id}"]`)});
+    const section = row?.querySelector('[data-testid="admin-usage-section"]');
+    const text = section?.textContent ?? "";
+    const reset = section?.querySelector('[data-testid="admin-usage-reset-open"]');
+    return {
+      heading: text.includes("OpenWork model consumption"),
+      empty: text.includes("No organization consumption windows are available for this user."),
+      resetDisabled: reset?.disabled === true,
+      hasWindowUsage: text.includes("Shared:") || text.includes("No current five-hour, weekly, or monthly windows.")
+    };
+  })()`);
+  const emptyUsageProved = isRecord(emptyUsageState)
+    && emptyUsageState.heading === true
+    && emptyUsageState.empty === true
+    && emptyUsageState.resetDisabled === true
+    && emptyUsageState.hasWindowUsage === false;
+  expect(emptyUsageProved, JSON.stringify(emptyUsageState)).toBe(true);
+  evidence.fact(
+    "An expanded user shows OpenWork model consumption's explicit empty state, no window usage, and a disabled reset",
+    JSON.stringify(emptyUsageState),
+    emptyUsageProved,
+  );
+
+  const addedEmail = `added-admin-${stamp}@openwork.test`;
+  const addedNote = `Admin model limits eval ${stamp}`;
+  let addedAdminId = "";
+  try {
+    const formFilled = await evalIn(browser, `(() => {
+      const email = document.querySelector('[data-testid="admin-add-email"]');
+      const note = document.querySelector('[data-testid="admin-add-note"]');
+      if (!email || !note) return false;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(email, ${JSON.stringify(addedEmail)});
+      email.dispatchEvent(new Event("input", { bubbles: true }));
+      setter?.call(note, ${JSON.stringify(addedNote)});
+      note.dispatchEvent(new Event("input", { bubbles: true }));
+      return true;
+    })()`);
+    expect(formFilled).toBe(true);
+    await waitFor(browser, `document.querySelector('[data-testid="admin-add-action"]')?.disabled === false`, {
+      timeoutMs: 10_000,
+      label: "Add admin action enabled after filling stable fields",
+    });
+    const formSubmitted = await evalIn(browser, `(() => {
+      const action = document.querySelector('[data-testid="admin-add-action"]');
+      if (!action || action.disabled) return false;
+      action.click();
+      return true;
+    })()`);
+    expect(formSubmitted).toBe(true);
+    await waitFor(browser, `document.body.innerText.includes(${JSON.stringify(addedEmail)})`, {
+      timeoutMs: 30_000,
+      label: "new platform admin visible after Add admin",
+    });
+
+    const addedOverview = await adminOverview(den.admin);
+    expect(addedOverview.response.ok, addedOverview.text.slice(0, 500)).toBe(true);
+    const addedAdmins = adminsFrom(addedOverview.body);
+    const addedAdmin = addedAdmins.find((admin) => admin.email === addedEmail);
+    expect(addedAdmin, `Overview did not contain added admin ${addedEmail}`).toBeDefined();
+    if (!addedAdmin) throw new Error(`Overview did not contain added admin ${addedEmail}`);
+    addedAdminId = addedAdmin.id;
+    const uiHasAddedAdmin = await evalIn(browser, `document.body.innerText.includes(${JSON.stringify(addedEmail)})`);
+    const initiallyAbsent = !initialAdmins.some((admin) => admin.email === addedEmail);
+    expect(uiHasAddedAdmin).toBe(true);
+    expect(initiallyAbsent).toBe(true);
+    evidence.fact(
+      "Add admin creates a previously absent platform admin in the UI and live overview API",
+      `email=${addedEmail}; ui=${String(uiHasAddedAdmin)}; api=${addedAdmins.some((admin) => admin.email === addedEmail)}; initiallyAbsent=${initiallyAbsent}`,
+      uiHasAddedAdmin === true && addedAdmins.some((admin) => admin.email === addedEmail) && initiallyAbsent,
+    );
+
+    const removeClicked = await evalIn(browser, `(() => {
+      const button = document.querySelector(${JSON.stringify(`[data-testid="admin-remove-${addedAdmin.id}"]`)});
+      if (!button) return false;
+      button.click();
+      return true;
+    })()`);
+    expect(removeClicked).toBe(true);
+    await waitFor(browser, `!document.body.innerText.includes(${JSON.stringify(addedEmail)})`, {
+      timeoutMs: 30_000,
+      label: "removed platform admin absent from UI",
+    });
+    const removedOverview = await adminOverview(den.admin);
+    expect(removedOverview.response.ok, removedOverview.text.slice(0, 500)).toBe(true);
+    const removedAdmins = adminsFrom(removedOverview.body);
+    const uiStillHasRemovedAdmin = await evalIn(browser, `document.body.innerText.includes(${JSON.stringify(addedEmail)})`);
+    const apiStillHasRemovedAdmin = removedAdmins.some((admin) => admin.email === addedEmail);
+    expect(uiStillHasRemovedAdmin).toBe(false);
+    expect(apiStillHasRemovedAdmin).toBe(false);
+    evidence.fact(
+      "Remove admin makes the added platform admin absent from both the UI and live overview API",
+      `email=${addedEmail}; uiStillPresent=${String(uiStillHasRemovedAdmin)}; apiStillPresent=${apiStillHasRemovedAdmin}`,
+      uiStillHasRemovedAdmin === false && !apiStillHasRemovedAdmin,
+    );
+    addedAdminId = "";
+
+    const usage = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage`, {
+      headers: { authorization: `Bearer ${den.admin.token}` },
+    });
+    const usageOrganizations = recordsField(usage.body, "organizations");
+    expect(usage.response.ok, usage.text.slice(0, 500)).toBe(true);
+    expect(isRecord(usage.body) && Array.isArray(usage.body.organizations)).toBe(true);
+
+    const firstReset = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage/reset`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}` },
+      body: JSON.stringify({}),
+    });
+    const secondReset = await denFetch(den.admin, `/v1/admin/users/${encodeURIComponent(memberUser.id)}/inference-usage/reset`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}` },
+      body: JSON.stringify({}),
+    });
+    expect(firstReset.response.ok, firstReset.text.slice(0, 500)).toBe(true);
+    expect(secondReset.response.ok, secondReset.text.slice(0, 500)).toBe(true);
+    expect(resetAmount(firstReset.body)).toBe(0);
+    expect(resetAmount(secondReset.body)).toBe(0);
+    evidence.fact(
+      "Live member consumption APIs return an organizations array and repeated empty resets safely forgive zero units",
+      `organizations=${usageOrganizations.length}; firstReset=${resetAmount(firstReset.body)}; secondReset=${resetAmount(secondReset.body)}`,
+      usage.response.ok
+        && isRecord(usage.body)
+        && Array.isArray(usage.body.organizations)
+        && firstReset.response.ok
+        && secondReset.response.ok
+        && resetAmount(firstReset.body) === 0
+        && resetAmount(secondReset.body) === 0,
+    );
+  } finally {
+    const cleanupOverview = await adminOverview(den.admin).catch(() => null);
+    const cleanupAdmin = cleanupOverview?.response.ok
+      ? adminsFrom(cleanupOverview.body).find((admin) => admin.email === addedEmail)
+      : undefined;
+    const cleanupAdminId = cleanupAdmin?.id ?? addedAdminId;
+    if (cleanupAdminId) {
+      await removeAdminByApi(den.admin, cleanupAdminId).catch(() => undefined);
+    }
+  }
+});

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -122,7 +122,7 @@ test(title, async ({ evidence, place }) => {
     });
     const text = await response.text();
     return { ok: response.ok, status: response.status, text };
-  })()`);
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
   const signInOk = isRecord(rawSignIn) && rawSignIn.ok === true;
   expect(signInOk, `Browser sign-in failed: ${JSON.stringify(rawSignIn)}`).toBe(true);
 

--- a/evals/specs/admin-model-limits.slow.test.ts
+++ b/evals/specs/admin-model-limits.slow.test.ts
@@ -204,6 +204,27 @@ test(title, async ({ evidence, place }) => {
   const addedNote = `Admin model limits eval ${stamp}`;
   let addedAdminId = "";
   try {
+    const recorderInstalled = await evalIn(browser, `(() => {
+      const calls = [];
+      window.__adminAdminsCalls = calls;
+      const original = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const url = typeof input === "string" ? input : input instanceof Request ? input.url : String(input);
+        const method = (init && init.method) || (input instanceof Request ? input.method : "GET");
+        if (!url.includes("/v1/admin/admins")) return original(input, init);
+        try {
+          const response = await original(input, init);
+          const text = await response.clone().text().catch(() => "");
+          calls.push({ url, method, status: response.status, ok: response.ok, text: text.slice(0, 500) });
+          return response;
+        } catch (error) {
+          calls.push({ url, method, error: String(error) });
+          throw error;
+        }
+      };
+      return Array.isArray(window.__adminAdminsCalls);
+    })()`);
+    expect(recorderInstalled).toBe(true);
     const formFilled = await evalIn(browser, `(() => {
       const email = document.querySelector('[data-testid="admin-add-email"]');
       const note = document.querySelector('[data-testid="admin-add-note"]');
@@ -227,6 +248,13 @@ test(title, async ({ evidence, place }) => {
       return true;
     })()`);
     expect(formSubmitted).toBe(true);
+    await waitFor(browser, `Array.isArray(window.__adminAdminsCalls) && window.__adminAdminsCalls.some((call) => call.method === "POST")`, {
+      timeoutMs: 30_000,
+      label: "Add admin POST settled in the browser",
+    });
+    const addCall = await evalIn(browser, `window.__adminAdminsCalls.find((call) => call.method === "POST")`);
+    const addCallOk = isRecord(addCall) && addCall.ok === true;
+    expect(addCallOk, `Add admin POST did not succeed: ${JSON.stringify(addCall)}`).toBe(true);
     await waitFor(browser, `document.body.innerText.includes(${JSON.stringify(addedEmail)})`, {
       timeoutMs: 30_000,
       label: "new platform admin visible after Add admin",
@@ -236,9 +264,11 @@ test(title, async ({ evidence, place }) => {
     expect(addedOverview.response.ok, addedOverview.text.slice(0, 500)).toBe(true);
     const addedAdmins = adminsFrom(addedOverview.body);
     const addedAdmin = addedAdmins.find((admin) => admin.email === addedEmail);
-    expect(addedAdmin, `Overview did not contain added admin ${addedEmail}`).toBeDefined();
+    expect(addedAdmin, `Overview admins ${JSON.stringify(addedAdmins)} did not contain added admin ${addedEmail}`).toBeDefined();
     if (!addedAdmin) throw new Error(`Overview did not contain added admin ${addedEmail}`);
     addedAdminId = addedAdmin.id;
+    const addedRowVisible = await evalIn(browser, `Boolean(document.querySelector(${JSON.stringify(`[data-testid="admin-remove-${addedAdmin.id}"]`)}))`);
+    expect(addedRowVisible, `Added admin ${addedAdmin.id} has no remove control in the UI`).toBe(true);
     const uiHasAddedAdmin = await evalIn(browser, `document.body.innerText.includes(${JSON.stringify(addedEmail)})`);
     const initiallyAbsent = !initialAdmins.some((admin) => admin.email === addedEmail);
     expect(uiHasAddedAdmin).toBe(true);
@@ -256,6 +286,13 @@ test(title, async ({ evidence, place }) => {
       return true;
     })()`);
     expect(removeClicked).toBe(true);
+    await waitFor(browser, `Array.isArray(window.__adminAdminsCalls) && window.__adminAdminsCalls.some((call) => call.method === "DELETE")`, {
+      timeoutMs: 30_000,
+      label: "Remove admin DELETE settled in the browser",
+    });
+    const removeCall = await evalIn(browser, `window.__adminAdminsCalls.find((call) => call.method === "DELETE")`);
+    const removeCallOk = isRecord(removeCall) && removeCall.ok === true;
+    expect(removeCallOk, `Remove admin DELETE did not succeed: ${JSON.stringify(removeCall)}`).toBe(true);
     await waitFor(browser, `!document.body.innerText.includes(${JSON.stringify(addedEmail)})`, {
       timeoutMs: 30_000,
       label: "removed platform admin absent from UI",


### PR DESCRIPTION
## Summary
- show per-user OpenWork model consumption for current five-hour, weekly, and monthly organization windows
- let platform admins forgive only a selected user's current-window charges without changing shared limits or other members' usage
- add platform-admin allowlist add/remove controls with self-removal and final-admin safeguards
- cover the APIs with a focused database integration test and add an agent-first `/admin` spec

## Verification
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `bun test test/admin-management-inference-usage.test.ts` (live DB run: 1 passed, 18 assertions; isolated rerun: 1 passed with MySQL-unavailable guard)
- `git diff --check`

## Verdict
Incomplete: the local agent-first browser spec could not complete because this host exhausted its IPv4 ephemeral socket pool, preventing fresh MySQL/CDP connections. Exact repro: `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/admin-model-limits.slow.test.ts`. The PR is draft until that tape is green and published.