### PR TITLE
feat(automations): steer runner channels to the API origin, off the Den Web proxy

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect } from "react"
-import { AUTOMATION_MODEL_ATTENTION_CAPABILITY } from "@openwork/types/automations"
+import { AUTOMATION_MODEL_ATTENTION_CAPABILITY, type AutomationDesktopRunnerRegistration } from "@openwork/types/automations"
 
 import { createDenClient, DenApiError, readDenSettings } from "@/app/lib/den"
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events"
@@ -56,35 +56,42 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
         const build = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("appBuildInfo")
         const agent = navigator.userAgent
         const platform = /Mac/i.test(agent) ? "darwin" : /Win/i.test(agent) ? "win32" : "linux"
-        let runner: Awaited<ReturnType<typeof client.mintAutomationRunnerToken>>
+        const registration = (id: string, protocolVersion: 1 | 2): AutomationDesktopRunnerRegistration => ({
+          runnerId: id,
+          protocolVersion,
+          supportedExecutionTargets: ["desktop"],
+          capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+          appVersion: String(build?.version ?? "unknown"),
+          platform,
+          concurrency: 1,
+        })
+        const mint = async (id: string) => {
+          try {
+            return await client.mintAutomationRunnerToken(organizationId, registration(id, 2))
+          } catch (error) {
+            // Older Den APIs only accept protocol v1 registrations; those
+            // credentials stay on the proxied base URL this client already uses.
+            if (error instanceof DenApiError && error.status === 400 && error.code === "invalid_request") {
+              return client.mintAutomationRunnerToken(organizationId, registration(id, 1))
+            }
+            throw error
+          }
+        }
+        let runner: Awaited<ReturnType<typeof mint>>
         try {
-          runner = await client.mintAutomationRunnerToken(organizationId, {
-            runnerId,
-            protocolVersion: 1,
-            supportedExecutionTargets: ["desktop"],
-            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-            appVersion: String(build?.version ?? "unknown"),
-            platform,
-            concurrency: 1,
-          })
+          runner = await mint(runnerId)
         } catch (error) {
           if (!(error instanceof DenApiError) || error.status !== 409 || error.code !== "automation_runner_identity_conflict") {
             throw error
           }
           runnerId = resetDesktopRunnerId()
-          runner = await client.mintAutomationRunnerToken(organizationId, {
-            runnerId,
-            protocolVersion: 1,
-            supportedExecutionTargets: ["desktop"],
-            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-            appVersion: String(build?.version ?? "unknown"),
-            platform,
-            concurrency: 1,
-          })
+          runner = await mint(runnerId)
         }
         if (disposed) return
         await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("automationRunnerConfigure", {
-          baseUrl: client.baseUrls.apiBaseUrl,
+          // The minted baseUrl is the credential's signed audience; sending the
+          // runner anywhere else would fail the desktop's binding check.
+          baseUrl: runner.baseUrl ?? client.baseUrls.apiBaseUrl,
           token: runner.token,
           runnerId,
         })

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -127,6 +127,26 @@ test("a v1 runner credential cannot use an untrusted HTTPS endpoint", async () =
   assert.deepEqual(attempted, [])
 })
 
+test("a v2 runner credential bound to the direct API origin connects there", async () => {
+  const attempted = []
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      attempted.push(String(url))
+      throw new Error("no network in test")
+    },
+  })
+  runner.configure({
+    baseUrl: "https://api.example.com",
+    token: runnerTokenFor("https://api.example.com"),
+    runnerId: "runner-1",
+  })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  runner.stop()
+  assert.ok(attempted.length > 0)
+  assert.ok(attempted.every((url) => url.startsWith("https://api.example.com/v1/")))
+})
+
 test("a runner credential bound elsewhere reports why this desktop stays disconnected", async () => {
   const logged = []
   const attempted = []

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -45,6 +45,26 @@ export function automationRunnerAudienceFromRequestUrl(requestUrl: string): stri
 }
 
 /**
+ * Runner channels held open through the Den Web serverless proxy bill for the
+ * entire held connection, so protocol v2 runners are bound to the API's own
+ * public origin whenever one is configured. Only destinations a desktop will
+ * accept are eligible — https, or http on loopback — because desktops refuse
+ * plaintext runner destinations; anything else falls back to the
+ * request-derived audience so a misconfigured public URL cannot silently
+ * disconnect every runner.
+ */
+export function automationRunnerDirectAudience(apiPublicUrl: string | undefined): string | null {
+  if (!apiPublicUrl) return null
+  const audience = normalizeRunnerAudience(apiPublicUrl)
+  if (!audience) return null
+  const parsed = new URL(audience)
+  const loopback = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname)
+    || parsed.hostname.endsWith(".localhost")
+  if (parsed.protocol !== "https:" && !loopback) return null
+  return audience
+}
+
+/**
  * Bind proxied runner credentials to the public Den route the desktop will
  * actually use. The Den Web proxy strips caller-supplied forwarding headers
  * and writes its own, while trustedForwardedOrigin limits the destination to
@@ -91,7 +111,14 @@ export class AutomationRunnerAuth {
       e: expiresAt,
     })).toString("base64url")
     const token = `${payload}.${this.sign(payload)}`
-    return { token, expiresAt, eventsPath: "/v1/automation-runners/events" as const }
+    return {
+      token,
+      expiresAt,
+      eventsPath: "/v1/automation-runners/events" as const,
+      // Desktops verify that the configured destination matches the signed
+      // audience, so the credential response names that destination outright.
+      baseUrl: normalizedAudience,
+    }
   }
 
   authenticate(authorization: string | undefined): AutomationRunnerIdentity | null {

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -31,7 +31,7 @@ import {
 } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
-import { automationRunnerAudienceFromRequest, automationRunnerAuth } from "../../automations/runner-auth.js"
+import { automationRunnerAudienceFromRequest, automationRunnerAuth, automationRunnerDirectAudience } from "../../automations/runner-auth.js"
 import { env } from "../../env.js"
 import {
   RUNNER_KEEPALIVE_INTERVAL_MS,
@@ -137,6 +137,15 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
         if (mapped) return c.json(mapped.body, mapped.status)
         throw error
       }
+      // Protocol v2 runners follow the minted baseUrl, so their long-lived
+      // SSE and work-poll channels go to the API origin directly instead of
+      // being held open through the Den Web serverless proxy.
+      const audience = (registration.protocolVersion >= 2
+        ? automationRunnerDirectAudience(env.apiPublicUrl)
+        : null)
+        ?? automationRunnerAudienceFromRequest(c.req.raw, {
+          trustedOrigins: env.publicProxyTrustedOrigins,
+        })
       return c.json(automationRunnerAuth.issue(
         {
           organizationId: scope(c).organizationId,
@@ -144,9 +153,7 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
           runnerId: registration.runnerId,
           capabilities: registration.capabilities,
         },
-        automationRunnerAudienceFromRequest(c.req.raw, {
-          trustedOrigins: env.publicProxyTrustedOrigins,
-        }),
+        audience,
       ))
     },
   )

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -12,10 +12,11 @@ function seedRequiredEnv() {
 let AutomationRunnerAuth: typeof import("../src/automations/runner-auth.js")["AutomationRunnerAuth"]
 let automationRunnerAudienceFromRequest: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequest"]
 let automationRunnerAudienceFromRequestUrl: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequestUrl"]
+let automationRunnerDirectAudience: typeof import("../src/automations/runner-auth.js")["automationRunnerDirectAudience"]
 
 beforeAll(async () => {
   seedRequiredEnv()
-  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequest, automationRunnerAudienceFromRequestUrl } = await import("../src/automations/runner-auth.js"))
+  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequest, automationRunnerAudienceFromRequestUrl, automationRunnerDirectAudience } = await import("../src/automations/runner-auth.js"))
 })
 
 describe("Automation runner credentials", () => {
@@ -107,6 +108,30 @@ describe("Automation runner credentials", () => {
     expect(automationRunnerAudienceFromRequest(request, {
       trustedOrigins: ["https://app.openworklabs.com"],
     })).toBe("https://api.openworklabs.com")
+  })
+
+  test("names the bound destination on the minted credential", () => {
+    const issued = new AutomationRunnerAuth("runner-auth-test-secret".repeat(3)).issue({
+      organizationId: "org_test",
+      ownerMemberId: "member_test",
+      runnerId: "desktop-test",
+      capabilities: [],
+    }, "https://api.example.com/")
+
+    expect(issued.baseUrl).toBe("https://api.example.com")
+    expect(new AutomationRunnerAuth("runner-auth-test-secret".repeat(3))
+      .authenticate(`Bearer ${issued.token}`)?.audience).toBe("https://api.example.com")
+  })
+
+  test("binds direct credentials only to destinations a desktop will accept", () => {
+    expect(automationRunnerDirectAudience("https://api.openworklabs.com")).toBe("https://api.openworklabs.com")
+    expect(automationRunnerDirectAudience("https://api.openworklabs.com/")).toBe("https://api.openworklabs.com")
+    expect(automationRunnerDirectAudience("http://127.0.0.1:8790")).toBe("http://127.0.0.1:8790")
+    expect(automationRunnerDirectAudience("http://den.localhost:8790")).toBe("http://den.localhost:8790")
+    // Desktops refuse plaintext runner destinations off loopback; falling back
+    // to the request-derived audience keeps those runners connected.
+    expect(automationRunnerDirectAudience("http://api.internal:8790")).toBeNull()
+    expect(automationRunnerDirectAudience(undefined)).toBeNull()
   })
 
   test("keeps legacy v1 credentials capability-free", () => {

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -7,6 +7,7 @@ import {
   automationRunnerEventRequestSchema,
   automationRunnerHeartbeatResponseSchema,
   automationRunnerNotificationSchema,
+  automationRunnerTokenResponseSchema,
   automationRunnerUnavailableOutcomeSchema,
 } from "@openwork/types/automations"
 import { readFileSync } from "node:fs"
@@ -55,6 +56,14 @@ test("runner registration and assignment reject unsupported targets", () => {
   assert.equal(automationDesktopRunnerRegistrationSchema.safeParse({
     ...registration,
     supportedExecutionTargets: ["sandbox"],
+  }).success, false)
+  assert.equal(automationDesktopRunnerRegistrationSchema.safeParse({
+    ...registration,
+    protocolVersion: 2,
+  }).success, true)
+  assert.equal(automationDesktopRunnerRegistrationSchema.safeParse({
+    ...registration,
+    protocolVersion: 3,
   }).success, false)
   assert.equal(automationDesktopRunnerAssignmentSchema.safeParse({
     executionTarget: "sandbox",
@@ -142,6 +151,24 @@ test("a no-op heartbeat renewal is reported as a lost lease", () => {
   )
   assert.match(heartbeat, /if \(!automationUpdateChangedRows\(renewal\)\) return null/)
   assert.match(heartbeat, /gt\(AutomationRunTable\.lease_expires_at, new Date\(input\.now\)\)/)
+})
+
+test("runner credentials name their destination and tolerate older servers omitting it", () => {
+  const base = {
+    token: "t".repeat(64),
+    expiresAt: Date.now() + 60_000,
+    eventsPath: "/v1/automation-runners/events",
+  }
+  assert.equal(automationRunnerTokenResponseSchema.safeParse(base).success, true)
+  const parsed = automationRunnerTokenResponseSchema.parse({
+    ...base,
+    baseUrl: "https://api.openworklabs.com",
+  })
+  assert.equal(parsed.baseUrl, "https://api.openworklabs.com")
+  // Protocol v2 runners send their long-lived SSE and work-poll channels to
+  // the minted destination; the route must derive it from the registration.
+  const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
+  assert.match(routesSource, /registration\.protocolVersion >= 2\s*\?\s*automationRunnerDirectAudience\(env\.apiPublicUrl\)/)
 })
 
 test("runner credential minting is never exposed as an MCP tool", () => {

--- a/evals/specs/automation-runner-direct-connect.test.ts
+++ b/evals/specs/automation-runner-direct-connect.test.ts
@@ -1,0 +1,139 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expect } from "vitest";
+import { test, eventually, sleep } from "@openwork/testkit";
+import { createDesktopAutomationRunner } from "../../apps/desktop/electron/automation-runner.mjs";
+
+// den-api reads its environment at module load, so the runner-auth module is
+// imported dynamically after these are present. Values mirror the den-api unit
+// test setup; nothing here talks to a database.
+process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test";
+process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32);
+process.env.BETTER_AUTH_SECRET ??= "y".repeat(32);
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790";
+
+type WitnessRequest = { path: string; authorization: string; accept: string };
+
+function startApiOriginWitness() {
+  const requests: WitnessRequest[] = [];
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    requests.push({
+      path: request.url ?? "",
+      authorization: request.headers.authorization ?? "",
+      accept: request.headers.accept ?? "",
+    });
+    if (request.url === "/v1/automation-runners/events") {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write("event: keepalive\ndata: {}\n\n");
+      return; // Held open like the real SSE endpoint.
+    }
+    if (request.url === "/v1/automation-runner/work") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+  return new Promise<{ requests: WitnessRequest[]; origin: string; close: () => void }>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo;
+      resolve({
+        requests,
+        origin: `http://127.0.0.1:${address.port}`,
+        close: () => {
+          server.closeAllConnections();
+          server.close();
+        },
+      });
+    });
+  });
+}
+
+test("protocol v2 runner credentials steer long-lived channels to the API origin, not the proxy", async ({ evidence }) => {
+  const { AutomationRunnerAuth, automationRunnerDirectAudience } = await import(
+    "../../ee/apps/den-api/src/automations/runner-auth.js"
+  );
+  const witness = await startApiOriginWitness();
+  const runners: { stop: () => void }[] = [];
+  try {
+    // Server half: the configured public API origin becomes the credential's
+    // bound destination, and the credential authenticates back on the API.
+    const direct = automationRunnerDirectAudience(witness.origin);
+    expect(direct).toBe(witness.origin);
+    const auth = new AutomationRunnerAuth("runner-direct-spec-secret".repeat(2));
+    const issued = auth.issue(
+      { organizationId: "org_spec", ownerMemberId: "member_spec", runnerId: "runner-spec", capabilities: [] },
+      direct ?? "",
+    );
+    expect(issued.baseUrl).toBe(witness.origin);
+    expect(auth.authenticate(`Bearer ${issued.token}`)?.audience).toBe(witness.origin);
+    // Negative half: a plaintext non-loopback public URL is never minted as a
+    // destination (desktops refuse it), so those deployments keep the
+    // request-derived audience instead of stranding every runner.
+    expect(automationRunnerDirectAudience("http://api.internal:8790")).toBeNull();
+    evidence.fact(
+      "Direct destinations are minted only when a desktop will accept them",
+      `The credential is bound and returned as ${witness.origin}; a plaintext non-loopback public URL yields no direct destination.`,
+      true,
+    );
+
+    // Desktop half: the real Electron runner configured with the minted
+    // destination opens its SSE and work-poll channels against that origin.
+    const runner = createDesktopAutomationRunner({
+      getLocalRuntime: async () => null,
+      log: () => undefined,
+    });
+    runners.push(runner);
+    runner.configure({ baseUrl: issued.baseUrl, token: issued.token, runnerId: "runner-spec" });
+    const seen = await eventually(
+      () => witness.requests.map((request) => request.path),
+      {
+        within: 5_000,
+        label: "runner channels reach the API origin witness",
+        until: (paths) =>
+          paths.includes("/v1/automation-runners/events") && paths.includes("/v1/automation-runner/work"),
+      },
+    );
+    expect(seen).toContain("/v1/automation-runners/events");
+    expect(seen).toContain("/v1/automation-runner/work");
+    const sse = witness.requests.find((request) => request.path === "/v1/automation-runners/events");
+    expect(sse?.authorization).toBe(`Bearer ${issued.token}`);
+    expect(sse?.accept).toBe("text/event-stream");
+    evidence.fact(
+      "The runner holds its live channels against the minted API origin",
+      "The loopback API-origin witness observed the SSE subscribe (Accept: text/event-stream) and the work poll, both presenting the minted bearer credential.",
+      true,
+    );
+
+    // Negative half: the same credential pointed at a proxy-shaped base URL is
+    // refused outright — no request leaves the desktop.
+    const attempted: string[] = [];
+    const refusals: string[] = [];
+    const proxyRunner = createDesktopAutomationRunner({
+      getLocalRuntime: async () => null,
+      fetchImpl: async (url: unknown) => {
+        attempted.push(String(url));
+        throw new Error("unreachable in spec");
+      },
+      log: (line: unknown) => refusals.push(String(line)),
+    });
+    runners.push(proxyRunner);
+    proxyRunner.configure({
+      baseUrl: "https://app.openworklabs.com/api/den",
+      token: issued.token,
+      runnerId: "runner-spec",
+    });
+    await sleep(100);
+    expect(attempted).toEqual([]);
+    expect(refusals.some((line) => line.includes("rejected runner credential"))).toBe(true);
+    evidence.fact(
+      "A directly bound credential never rides the Den Web proxy",
+      "Configured with a proxy-shaped base URL, the runner refuses the credential, logs the rejection, and attempts zero requests.",
+      true,
+    );
+  } finally {
+    for (const runner of runners) runner.stop();
+    witness.close();
+  }
+});

--- a/packages/types/src/automations.ts
+++ b/packages/types/src/automations.ts
@@ -182,7 +182,14 @@ export type AutomationDesktopRunnerCapability = z.infer<typeof automationDesktop
 
 export const automationDesktopRunnerRegistrationSchema = z.object({
   runnerId: idSchema.min(8),
-  protocolVersion: z.literal(1),
+  /**
+   * 1: the runner talks to whatever base URL the renderer configured
+   *    (typically the Den Web `/api/den` proxy).
+   * 2: the runner honors the `baseUrl` minted with its credential, so the
+   *    server can steer long-lived runner channels at the API origin directly
+   *    instead of holding SSE connections open through the serverless proxy.
+   */
+  protocolVersion: z.union([z.literal(1), z.literal(2)]),
   supportedExecutionTargets: z.array(z.literal("desktop")).length(1),
   capabilities: z.array(automationDesktopRunnerCapabilitySchema).max(1).default([]),
   appVersion: z.string().trim().min(1).max(80),
@@ -257,6 +264,12 @@ export const automationRunnerTokenResponseSchema = z.object({
   token: z.string().trim().min(32).max(512),
   expiresAt: timestampSchema,
   eventsPath: z.literal("/v1/automation-runners/events"),
+  /**
+   * The base URL this credential is bound to; protocol v2 runners connect
+   * here. Absent on older servers, whose credentials stay on the base URL the
+   * client already uses.
+   */
+  baseUrl: z.string().trim().min(1).max(2048).optional(),
 })
 export type AutomationRunnerTokenResponse = z.infer<typeof automationRunnerTokenResponseSchema>
 


### PR DESCRIPTION
## Why

The hosted Den Web proxy (`openwork-den` on Vercel) has been burning its on-demand budget on held-open serverless functions: desktop runners keep three long-lived channels (`/v1/automation-runners/events` SSE, `/v1/automation-runner/work` polling, MCP) open through the `/api/den/[...path]` proxy. Each held connection pins a fluid function until the 300s `functionTimeout` kills it, then the client reconnects — ~2.9M timed-out invocations and ~492k timeout GB-hours in the current billing cycle, ~75% of the infra overage (Fluid Provisioned Memory). The API origin (`api.openworklabs.com`) is a persistent server where held connections cost nothing; only browser clients need the cookie-stripping proxy. Runners are bearer-token fetches from the Electron main process and gain nothing from it.

## What

- `packages/types`: runner registration `protocolVersion` widens to `1 | 2`; the token response gains an optional `baseUrl` (the credential's bound destination).
- `den-api`: protocol v2 registrations mint the runner credential bound to the configured public API origin (`DEN_API_PUBLIC_URL`) via `automationRunnerDirectAudience`; v1 registrations and deployments without a public URL keep the request-derived audience. `issue()` now names the bound destination on the response. Plaintext non-loopback public URLs are never minted as destinations (desktops refuse them) and fall back to the request-derived audience.
- `apps/app` bridge: registers with protocol v2, falls back to v1 on `400 invalid_request` from older self-hosted servers, and configures the Electron runner with `runner.baseUrl ?? apiBaseUrl`.
- Desktop main process: unchanged — its existing audience-binding check (`token audience === configured baseUrl`) is what makes the minted destination safe.

## Compatibility

| Client | Server | Behavior |
|---|---|---|
| v2 (this) | this + `DEN_API_PUBLIC_URL` | runner channels go direct to the API origin |
| v2 (this) | this, no public URL | request-derived audience — same as today |
| v2 (this) | older | `400 invalid_request` → retries as v1, proxied — same as today |
| older (v1) | this | request-derived audience — same as today |

## Verification

Testkit spec (PR lane, local): `pnpm evals:spec specs/automation-runner-direct-connect.test.ts` — **1 passed**, exit 0. The spec runs the real den-api auth code and the real Electron runner: mints a v2 credential bound to a loopback API-origin witness, observes the runner's SSE subscribe (`Accept: text/event-stream`) and work poll arrive there carrying the minted bearer token, and proves the same credential pointed at a proxy-shaped base URL is refused with zero requests. Tape published on this PR.

Unit suites on the PR head:
- `pnpm --filter @openwork-ee/den-api exec bun test test/automation-runner-auth.test.ts test/automation-runner-protocol.test.ts` — 29 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api typecheck:automations` — clean
- `pnpm --filter @openwork/desktop test` — 233 pass / 0 fail / 1 pre-existing platform skip (includes new positive case: v2 credential bound to the direct origin connects there)
- `pnpm --filter @openwork/app exec bun test tests/automation-availability.test.ts` — 5 pass / 0 fail
- `pnpm --filter @openwork/app typecheck` — clean

Pre-existing failures verified against a clean `origin/dev` (b3219ac94) control with identical commands and signatures (not introduced here):
- `pnpm --filter @openwork/app test` crashes with SIGTRAP (bun 1.3.8 `--isolate`) on dev too; the affected file passes standalone.
- Stack-lane `specs/automations-den-hosted.slow.test.ts` on Daytona (`OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_AUTOMATIONS_SPEC=1 OPENWORK_EVAL_MODEL=big-pickle OPENWORK_EVAL_VISION=defer`) fails on dev control with the same signature: `Timed out after 30000ms waiting for enabled button: Create Automation` stuck on the `/session` route. Lane ran on Daytona both times; a first attempt also hit a transient Daytona `unexpected EOF` on sandbox creation.
- `pnpm --dir evals run typecheck` fails on dev (unknown tsc options).

`packages/docs/openapi.json` was left untouched: it is already stale on dev (regenerating pulls in 176 unrelated diffs) and nothing enforces it; regenerate with `pnpm --filter @openwork-ee/den-api openapi:snapshot` when desired.

Note for the hosted rollout: the cost fix activates once `DEN_API_PUBLIC_URL` is set on the hosted den-api (it already is for MCP OAuth) and desktops update. Old desktops keep working through the proxy; consider a short `maxDuration` on the den-web proxy route as a tourniquet until the fleet updates.