### PR TITLE
test(evals): speed up the full slow-spec sweep

### DIFF
--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -1,4 +1,5 @@
-# Runs every slow eval spec independently on the Daytona lane with bounded parallelism.
+# Runs every slow eval spec in three balanced Daytona batches. Each batch keeps
+# one prewarmed Den + desktop pair and reuses it across its assigned specs.
 # Unlike the nightly, legitimate skips stay green and are reported as incomplete needs.
 # The mega spec is excluded because the Nightly Mega Eval workflow owns it.
 # Specs that drive raw desktop() from @openwork/hosts are excluded dynamically:
@@ -29,7 +30,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       enabled: ${{ steps.config.outputs.enabled }}
-      specs: ${{ steps.matrix.outputs.specs }}
+      batches: ${{ steps.matrix.outputs.batches }}
 
     steps:
       - name: Check slow specs sweep configuration
@@ -101,27 +102,47 @@ jobs:
                   | map(select($only == "" or contains($only)))
                 '
           )"
+          batches="$(
+            echo "$specs" | jq -c '
+              . as $specs
+              | [
+                  range(0; 3) as $index
+                  | {
+                      name: "batch-\($index + 1)",
+                      specs: [
+                        $specs
+                        | to_entries[]
+                        | select((.key % 3) == $index)
+                        | .value
+                      ]
+                    }
+                ]
+              | map(select(.specs | length > 0))
+            '
+          )"
 
           {
             echo "### Sweep plan"
             echo
-            echo "Matrix specs: $(echo "$specs" | jq 'length')"
+            echo "Matrix specs: $(echo "$specs" | jq 'length') across $(echo "$batches" | jq 'length') batches"
+            echo "$batches" | jq -r '.[] | "- `\(.name)`: \(.specs | length) specs"'
             echo
             echo "Excluded (local-only placement, incompatible Daytona mock, or raw desktop()): $(echo "$excluded_json" | jq 'length')"
             echo "$excluded_json" | jq -r '.[] | "- `\(.)`"'
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "specs=$specs" >> "$GITHUB_OUTPUT"
-          echo "Spec matrix: $specs"
+          echo "batches=$batches" >> "$GITHUB_OUTPUT"
+          echo "Batch matrix: $batches"
 
   spec:
     needs: plan
     if: needs.plan.outputs.enabled == 'true'
+    name: spec (${{ matrix.batch.name }})
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
-        spec: ${{ fromJSON(needs.plan.outputs.specs) }}
+        batch: ${{ fromJSON(needs.plan.outputs.batches) }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
 
@@ -167,49 +188,57 @@ jobs:
           # The CLI requires a stored profile; the env var alone is not enough.
           daytona login --api-key "$DAYTONA_API_KEY"
 
-      - name: Run spec
+      - name: Run batch
         id: run
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NO_COLOR: "1"
-          SPEC: ${{ matrix.spec }}
+          BATCH_NAME: ${{ matrix.batch.name }}
+          SPECS_JSON: ${{ toJSON(matrix.batch.specs) }}
         run: |
           set -euo pipefail
 
+          mapfile -t specs < <(jq -r '.[] | "specs/" + .' <<< "$SPECS_JSON")
+          if [ "${#specs[@]}" -eq 0 ]; then
+            echo "No specs were assigned to $BATCH_NAME." >&2
+            exit 1
+          fi
+
           set +e
           OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_APP_SPECS=1 \
+          OPENWORK_EVAL_MAX_WORKERS=1 \
           OPENWORK_EVAL_AUTOMATIONS_SPEC=1 OPENWORK_EVAL_CONNECTOR_SPEC=1 \
           OPENWORK_EVAL_LOCAL_MANAGED_MCP=1 OPENWORK_EVAL_GENERATED_ARTIFACT_VIEWS_SPEC=1 \
           OPENWORK_EVAL_SAVED_SCRIPT_AUTOMATIONS_SPEC=1 OPENWORK_EVAL_ENGINE_ROLLOVER_SPEC=1 \
           OPENWORK_EVAL_MODEL=big-pickle OPENWORK_EVAL_VISION=defer \
-          pnpm --dir evals exec vitest run --config vitest.config.ts --project stack "specs/${SPEC}" \
+          pnpm --dir evals exec vitest run --config vitest.config.ts --project stack "${specs[@]}" \
             2>&1 | tee /tmp/spec-run.log
           vitest_status="${PIPESTATUS[0]}"
           set -e
 
           sed -E 's/\x1B\[[0-9;]*m//g' /tmp/spec-run.log > /tmp/spec-run-plain.log
-          detail=""
-          if [ "$vitest_status" -eq 0 ] && grep -Eq "Tests[[:space:]]+1 passed" /tmp/spec-run-plain.log; then
-            result="passed"
-          elif [ "$vitest_status" -eq 0 ] && grep -Eq "Tests[[:space:]]+[0-9]+ skipped" /tmp/spec-run-plain.log; then
-            result="skipped"
-            needs_tag="$(grep -om1 '\[needs:[^]]*\]' /tmp/spec-run-plain.log || true)"
-            needs_reason="${needs_tag#\[needs:}"
-            needs_reason="${needs_reason%\]}"
-            detail="needs: ${needs_reason}"
-          else
+          detail="${#specs[@]} specs"
+          if [ "$vitest_status" -ne 0 ]; then
             result="failed"
+          elif grep -Eq "Tests[[:space:]].*skipped" /tmp/spec-run-plain.log; then
+            result="skipped"
+            needs_reasons="$(grep -o '\[needs:[^]]*\]' /tmp/spec-run-plain.log | sort -u | paste -sd ';' - || true)"
+            if [ -n "$needs_reasons" ]; then
+              detail="$detail; $needs_reasons"
+            fi
+          else
+            result="passed"
           fi
 
           echo "result=$result" >> "$GITHUB_OUTPUT"
           {
-            echo "### $SPEC"
+            echo "### $BATCH_NAME"
             echo
-            echo "| Spec | Result | Detail |"
+            echo "| Batch | Result | Detail |"
             echo "| --- | --- | --- |"
-            echo "| $SPEC | $result | $detail |"
+            echo "| $BATCH_NAME | $result | $detail |"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Vitest exit code: $vitest_status"
 
@@ -218,13 +247,15 @@ jobs:
           fi
 
       - name: Judge deferred vision claims
-        if: steps.run.outputs.result == 'passed'
+        if: steps.run.outputs.result != 'failed'
         shell: bash
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          pnpm --dir evals fraimz:judge -- --roll latest
+          while IFS= read -r -d '' roll; do
+            pnpm --dir evals fraimz:judge -- --roll "$roll"
+          done < <(find "$GITHUB_WORKSPACE/evals/results/rolls" -mindepth 1 -maxdepth 1 -type d -print0)
 
       - name: Upload spec roll
         if: always()

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -339,6 +339,7 @@ async function runPrepareScript(scriptPath: string, outDir: string, desktopRoot:
 }
 
 async function prepareSharedElectronResources(repoRoot: string, log: (message: string) => void): Promise<void> {
+  if (process.env.OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED === "1") return;
   if (!prepareSharedResourcesPromise) {
     prepareSharedResourcesPromise = (async () => {
       const desktopRoot = join(repoRoot, "apps", "desktop");
@@ -534,7 +535,7 @@ export function createLocalHost(options: LocalHostOptions): DisposableHost {
   const surfacesRootOverride = process.env.OPENWORK_EVAL_SURFACES_DIR?.trim();
   const rootDir = options.rootDir ?? (surfacesRootOverride
     ? surfacesRootOverride
-    : join(options.repoRoot, "evals", "results", ".surfaces"));
+    : join(options.repoRoot, "evals", "results", ".surfaces", String(process.pid)));
   const log = options.log;
   const spawnedSurfaces = new Set<SurfaceHandle>();
   const denPorts = new Set<number>();
@@ -619,8 +620,8 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
   await new Promise<void>((resolve) => {
     execFile("pkill", ["--full", rootDir], () => resolve());
   });
-  // Safe because surfaces run one at a time (vitest fileParallelism is off) and
-  // the pkill above already assumes exclusive ownership of rootDir.
+  // The default root is worker-scoped, so parallel files cannot kill or remove
+  // another worker's desktop while pruning their own stale profiles.
   const stale = await readdir(rootDir).catch(() => []);
   let removed = 0;
   for (const entry of stale) {

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -175,7 +175,11 @@ function sandboxTimestamp(): string {
 }
 
 export function desktopSandboxName(name: string): string {
-  const safeName = name.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "") || "surface";
+  // Split/join rather than trimming with /^-+|-+$/g: that pattern backtracks
+  // quadratically on a mid-string run of hyphens (~1s at 40KB), which CodeQL
+  // flags as polynomial ReDoS. This form cannot backtrack and also collapses
+  // internal runs, so "a_-_b" yields "a-b" instead of "a---b".
+  const safeName = name.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean).join("-") || "surface";
   return `openwork-connector-${safeName}-${sandboxTimestamp()}-${process.pid}-${randomBytes(4).toString("hex")}`;
 }
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -174,6 +174,11 @@ function sandboxTimestamp(): string {
   return new Date().toISOString().replace(/[-:]/g, "").replace("T", "-").slice(0, 15);
 }
 
+export function desktopSandboxName(name: string): string {
+  const safeName = name.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "") || "surface";
+  return `openwork-connector-${safeName}-${sandboxTimestamp()}-${process.pid}-${randomBytes(4).toString("hex")}`;
+}
+
 export function serverSandboxName(): string {
   return `openwork-server-${sandboxTimestamp()}-${process.pid}-${randomBytes(4).toString("hex")}`;
 }
@@ -214,7 +219,7 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
       if (!id) {
         throw new Error(`Snapshot gate failed: snapshot ${snapshot} is missing. Output tail: ${outputTail(listed)}`);
       }
-      sandbox = `openwork-connector-${options.name}-${sandboxTimestamp()}`;
+      sandbox = desktopSandboxName(options.name);
       await checkedExec(
         exec,
         [
@@ -511,15 +516,24 @@ function sandboxFromServerOutput(output: string): string | null {
 
 
 async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Promise<string> {
-  const result = await checkedExec(
-    exec,
-    ["preview-url", sandbox, "-p", String(port)],
-    `preview URL gate for ${sandbox}:${port}`,
-    { timeoutMs: 60_000 },
-  );
-  const url = firstHttpsUrl(result.stdout);
-  if (!url) throw new Error(`Preview URL gate failed for ${sandbox}:${port}: no https URL in output tail: ${outputTail(result)}`);
-  return url;
+  let lastError = "not attempted";
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    try {
+      const result = await checkedExec(
+        exec,
+        ["preview-url", sandbox, "-p", String(port)],
+        `preview URL gate for ${sandbox}:${port}`,
+        { timeoutMs: 60_000 },
+      );
+      const url = firstHttpsUrl(result.stdout);
+      if (url) return url;
+      lastError = `no https URL in output tail: ${outputTail(result)}`;
+    } catch (error) {
+      lastError = messageText(error);
+    }
+    if (attempt < 4) await delay(attempt * 1_000);
+  }
+  throw new Error(`Preview URL gate failed for ${sandbox}:${port} after 4 attempts: ${lastError}`);
 }
 
 async function proveDenSeed(apiUrl: string, webUrl: string, sandbox: string, reused: boolean): Promise<void> {

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   deleteSandboxes,
+  desktopSandboxName,
   parseConnectorSpecEnv,
   provisionDesktopSandbox,
   renderConnectorSpecEnv,
@@ -78,6 +79,14 @@ test("server sandbox names are unique within the same CI process and second", ()
   const second = serverSandboxName();
 
   assert.match(first, new RegExp(`^openwork-server-\\d{8}-\\d{6}-${process.pid}-[0-9a-f]{8}$`));
+  assert.notEqual(first, second);
+});
+
+test("desktop sandbox names stay unique when parallel workers use the same surface name", () => {
+  const first = desktopSandboxName("testkit admin");
+  const second = desktopSandboxName("testkit admin");
+
+  assert.match(first, new RegExp(`^openwork-connector-testkit-admin-\\d{8}-\\d{6}-${process.pid}-[0-9a-f]{8}$`));
   assert.notEqual(first, second);
 });
 
@@ -183,6 +192,27 @@ test("startMockOnSandbox rejects a health response with the wrong issuer", async
     /https:\/\/wrong-issuer\.example\.test.*https:\/\/mock\.example\.test/,
   );
   assertRemoteCommandsAreSingleArgument(calls);
+});
+
+test("Daytona preview URL lookup retries a transient control-plane failure", async () => {
+  let previewAttempts = 0;
+  const exec: DaytonaExec = async (args) => {
+    if (args[0] === "preview-url") {
+      previewAttempts += 1;
+      return previewAttempts === 1
+        ? { stdout: "", stderr: "unexpected EOF", code: 1 }
+        : { stdout: "Preview URL: https://mock.example.test\n", stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  const fetchImpl: typeof fetch = async () => new Response(
+    JSON.stringify({ ok: true, issuer: "https://mock.example.test" }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+
+  await startMockOnSandbox({ sandbox: "den-1", exec, fetchImpl, log: () => undefined });
+
+  assert.equal(previewAttempts, 2);
 });
 
 test("startFaultProxyOnSandbox uploads and detaches the proxy after resolving its preview URL", async () => {

--- a/evals/packages/testkit/src/place.ts
+++ b/evals/packages/testkit/src/place.ts
@@ -165,13 +165,24 @@ class DaytonaPlacementHost implements Host {
   readonly kind = "daytona";
   readonly workspaceRoot = "/workspace";
   readonly #ref: string;
+  readonly #preparedSandbox: string | undefined;
+  readonly #preparedHost: Host | undefined;
   readonly #surfaces = new Map<SurfaceHandle, PlacedSurface>();
 
-  constructor(ref: string) {
+  constructor(ref: string, preparedSandbox?: string) {
     this.#ref = ref;
+    this.#preparedSandbox = preparedSandbox;
+    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox) : undefined;
   }
 
   async #provision(name: string): Promise<PlacedSurface> {
+    if (this.#preparedSandbox && this.#preparedHost) {
+      return {
+        host: this.#preparedHost,
+        sandbox: this.#preparedSandbox,
+        created: false,
+      };
+    }
     const provisioned = await provisionDesktopSandbox({
       ref: this.#ref,
       name,
@@ -233,9 +244,9 @@ class DaytonaPlace implements Place {
   readonly #ref: string;
   readonly #host: Host;
 
-  constructor(ref: string) {
+  constructor(ref: string, preparedDesktopSandbox?: string) {
     this.#ref = ref;
-    this.#host = new DaytonaPlacementHost(ref);
+    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox);
   }
 
   host(): Host {
@@ -264,7 +275,7 @@ export function resolvePlace(env: NodeJS.ProcessEnv = process.env): Place {
   const useDaytona = env.OPENWORK_EVAL_DAYTONA?.trim() === "1";
   if (useDaytona) {
     const ref = env.OPENWORK_EVAL_REF?.trim() || env.GITHUB_SHA?.trim() || "dev";
-    return new DaytonaPlace(ref);
+    return new DaytonaPlace(ref, env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim());
   }
   return new LocalPlace(env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);
 }

--- a/evals/packages/testkit/src/self-host.ts
+++ b/evals/packages/testkit/src/self-host.ts
@@ -60,9 +60,15 @@ function spawnService(
   logPath: string,
 ): SpawnedService {
   const logFd = openSync(logPath, "a");
-  const child = spawn("pnpm", [script], {
+  const prepared = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1";
+  const args = prepared
+    ? label === "den-api"
+      ? ["--filter", "@openwork-ee/den-api", "exec", "tsx", "src/main.ts"]
+      : ["--filter", "@openwork-ee/den-web", "exec", "next", "start", "--hostname", "127.0.0.1", "--port", String(port)]
+    : [script];
+  const child = spawn("pnpm", args, {
     cwd: REPO_ROOT,
-    env,
+    env: prepared && label === "den-api" ? { ...env, PORT: String(port) } : env,
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -125,16 +131,25 @@ async function waitForAuthProbe(ref: DenRef, service: SpawnedService): Promise<v
 // mirrored from server.ts (keep in sync)
 async function runDbPush(databaseUrl: string): Promise<void> {
   try {
-    await execFileAsync("pnpm", ["--filter", "@openwork-ee/den-db", "db:push"], {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        DATABASE_URL: databaseUrl,
-        DEN_DB_ENCRYPTION_KEY: DATABASE_ENCRYPTION_KEY,
-      },
-      maxBuffer: 16 * 1024 * 1024,
-      timeout: 180_000,
-    });
+    const commands = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1"
+      ? [
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "push", "--config", "drizzle.config.ts"],
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-fulltext-indexes.ts"],
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-schema-repairs.ts"],
+        ]
+      : [["--filter", "@openwork-ee/den-db", "db:push"]];
+    for (const args of commands) {
+      await execFileAsync("pnpm", args, {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl,
+          DEN_DB_ENCRYPTION_KEY: DATABASE_ENCRYPTION_KEY,
+        },
+        maxBuffer: 16 * 1024 * 1024,
+        timeout: 180_000,
+      });
+    }
   } catch (error) {
     const stderr = typeof error === "object" && error !== null && typeof Reflect.get(error, "stderr") === "string"
       ? Reflect.get(error, "stderr")

--- a/evals/packages/testkit/src/server.ts
+++ b/evals/packages/testkit/src/server.ts
@@ -89,7 +89,7 @@ interface SpawnedService {
 interface ProvisionedOrganization {
   admin: DenSession;
   members: Record<string, DenSession>;
-  createdOrg: boolean;
+  createdOrgId: string | null;
 }
 
 interface PlatformAdminGrant {
@@ -317,15 +317,17 @@ async function createOrSignInAccount(
   }
 }
 
-async function createOrganization(admin: DenSession, name: string): Promise<void> {
+async function createOrganization(admin: DenSession, name: string): Promise<string> {
   const created = await denFetch(admin, "/v1/org", {
     method: "POST",
     headers: auth(admin),
     body: JSON.stringify({ name }),
   });
-  if (!created.response.ok) {
+  const organizationId = stringField(recordField(created.body, "organization"), "id");
+  if (!created.response.ok || !organizationId) {
     throw new Error(`Organization create failed: HTTP ${created.response.status} ${created.text.slice(0, 500)}`);
   }
+  return organizationId;
 }
 
 async function createMember(
@@ -384,12 +386,14 @@ async function provisionOrganization(
   const admin = options.fallbackAdmin && !shape.admin
     ? await signIn(ref, { email: adminPerson.email, password: adminPerson.password })
     : await createOrSignInAccount(ref, adminPerson, options.databaseUrl);
-  if (options.createOrg) await createOrganization(admin, shape.name?.trim() || `OpenWork Eval ${runId}`);
+  const createdOrgId = options.createOrg
+    ? await createOrganization(admin, shape.name?.trim() || `OpenWork Eval ${runId}`)
+    : null;
   const members: Record<string, DenSession> = {};
   for (const [key, memberShape] of Object.entries(shape.members ?? {})) {
     members[key] = await createMember(ref, admin, personDefaults(key, memberShape, runId), options.databaseUrl);
   }
-  return { admin, members, createdOrg: options.createOrg };
+  return { admin, members, createdOrgId };
 }
 
 async function provisionReusedMembers(
@@ -482,10 +486,19 @@ async function stopServices(services: SpawnedService[]): Promise<void> {
   }
 }
 
-async function deleteCreatedOrganization(admin: DenSession): Promise<void> {
-  const active = await freshSession(admin);
+async function deleteCreatedOrganization(admin: DenSession, organizationId: string): Promise<void> {
+  const active = await freshSession(admin).catch(() => admin);
+  const selected = await denFetch(active, "/v1/me/active-organization", {
+    method: "POST",
+    headers: auth(active),
+    body: JSON.stringify({ organizationId }),
+  });
+  if (selected.response.status === 404) return;
+  if (!selected.response.ok) {
+    throw new Error(`Organization cleanup selection returned HTTP ${selected.response.status}: ${selected.text.slice(0, 500)}`);
+  }
   const deleted = await denFetch(active, "/v1/org", { method: "DELETE", headers: auth(active) });
-  if (!deleted.response.ok) {
+  if (!deleted.response.ok && deleted.response.status !== 404) {
     throw new Error(`Organization cleanup returned HTTP ${deleted.response.status}: ${deleted.text.slice(0, 500)}`);
   }
 }
@@ -512,7 +525,7 @@ export async function server(options: ServerOptions): Promise<Den> {
     const bootedMocks = await bootLocalMocks(options.place, options.mocks ?? {});
     try {
       const organization = options.provision === false
-        ? { admin: emptySession(reuse), members: {}, createdOrg: false }
+        ? { admin: emptySession(reuse), members: {}, createdOrgId: null }
         : await provisionOrganization(
             reuse,
             options.org ?? {},
@@ -537,8 +550,8 @@ export async function server(options: ServerOptions): Promise<Den> {
         async [Symbol.asyncDispose](): Promise<void> {
           if (disposed) return;
           disposed = true;
-          if (organization.createdOrg) {
-            await deleteCreatedOrganization(organization.admin).catch((error: unknown) => {
+          if (organization.createdOrgId) {
+            await deleteCreatedOrganization(organization.admin, organization.createdOrgId).catch((error: unknown) => {
               console.error(`[openwork/testkit] reused Den org cleanup failed: ${messageText(error)}`);
             });
           }
@@ -559,6 +572,7 @@ export async function server(options: ServerOptions): Promise<Den> {
     if (base.kind !== "daytona") throw new Error("Daytona place returned a local Den base.");
     const preparedSandbox = process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX?.trim();
     const orgShape = options.org ?? {};
+    const isolatePreparedSpec = Boolean(preparedSandbox && options.provision !== false);
     const bootstrapAdmin = personDefaults("admin", orgShape.admin, runId);
     const provisioned = await provisionDenSandbox({
       ref: base.ref,
@@ -571,14 +585,14 @@ export async function server(options: ServerOptions): Promise<Den> {
       bootedMocks = await bootDaytonaMocks(provisioned.sandbox, options.mocks ?? {});
       const ref = { apiUrl: cleanUrl(provisioned.apiUrl), webUrl: cleanUrl(provisioned.webUrl) };
       const organization = options.provision === false
-        ? { admin: emptySession(ref), members: {}, createdOrg: false }
+        ? { admin: emptySession(ref), members: {}, createdOrgId: null }
         : await provisionOrganization(
             ref,
             orgShape,
             runId,
             {
-              createOrg: Boolean(options.org),
-              fallbackAdmin: options.org?.admin ? undefined : defaultReuseAdmin(),
+              createOrg: isolatePreparedSpec || Boolean(options.org),
+              fallbackAdmin: (isolatePreparedSpec || options.org?.admin) ? undefined : defaultReuseAdmin(),
             },
           );
       let platformAdminGrant: PlatformAdminGrant | null = null;
@@ -586,7 +600,9 @@ export async function server(options: ServerOptions): Promise<Den> {
         try {
           platformAdminGrant = await grantPreparedPlatformAdmin(ref, organization.admin.email);
         } catch (error) {
-          if (organization.createdOrg) await deleteCreatedOrganization(organization.admin).catch(() => undefined);
+          if (organization.createdOrgId) {
+            await deleteCreatedOrganization(organization.admin, organization.createdOrgId).catch(() => undefined);
+          }
           throw error;
         }
       }
@@ -610,8 +626,8 @@ export async function server(options: ServerOptions): Promise<Den> {
         async [Symbol.asyncDispose](): Promise<void> {
           if (disposed) return;
           disposed = true;
-          if (organization.createdOrg) {
-            await deleteCreatedOrganization(organization.admin).catch((error: unknown) => {
+          if (organization.createdOrgId) {
+            await deleteCreatedOrganization(organization.admin, organization.createdOrgId).catch((error: unknown) => {
               console.error(`[openwork/testkit] Daytona Den org cleanup failed: ${messageText(error)}`);
             });
           }
@@ -697,7 +713,7 @@ export async function server(options: ServerOptions): Promise<Den> {
     if (web) await waitForHttp(`${ref.webUrl}/api/ready`, web, (response) => response.ok);
     await waitForAuthProbe(ref, api);
     const organization = options.provision === false
-      ? { admin: emptySession(ref), members: {}, createdOrg: false }
+      ? { admin: emptySession(ref), members: {}, createdOrgId: null }
       : await provisionOrganization(
           ref,
           orgShape,
@@ -719,8 +735,8 @@ export async function server(options: ServerOptions): Promise<Den> {
       async [Symbol.asyncDispose](): Promise<void> {
         if (disposed) return;
         disposed = true;
-        if (organization.createdOrg) {
-          await deleteCreatedOrganization(organization.admin).catch((error: unknown) => {
+        if (organization.createdOrgId) {
+          await deleteCreatedOrganization(organization.admin, organization.createdOrgId).catch((error: unknown) => {
             console.error(`[openwork/testkit] local Den org cleanup failed: ${messageText(error)}`);
           });
         }

--- a/evals/packages/testkit/src/server.ts
+++ b/evals/packages/testkit/src/server.ts
@@ -92,6 +92,11 @@ interface ProvisionedOrganization {
   createdOrg: boolean;
 }
 
+interface PlatformAdminGrant {
+  id: string;
+  owner: DenSession;
+}
+
 function messageText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -106,6 +111,12 @@ function stringField(value: unknown, key: string): string | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   const field = Reflect.get(value, key);
   return typeof field === "string" ? field : null;
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const field = Reflect.get(value, key);
+  return typeof field === "object" && field !== null && !Array.isArray(field) ? field : null;
 }
 
 function auth(session: DenSession): Record<string, string> {
@@ -136,6 +147,33 @@ function defaultReuseAdmin(): Required<PersonShape> {
   };
 }
 
+async function grantPreparedPlatformAdmin(ref: DenRef, email: string): Promise<PlatformAdminGrant | null> {
+  const ownerPerson = defaultReuseAdmin();
+  if (ownerPerson.email.toLowerCase() === email.toLowerCase()) return null;
+  const owner = await signIn(ref, { email: ownerPerson.email, password: ownerPerson.password });
+  const result = await denFetch(owner, "/v1/admin/admins", {
+    method: "POST",
+    headers: auth(owner),
+    body: JSON.stringify({ email, note: "Temporary prepared eval admin" }),
+  });
+  if (result.response.status === 409) return null;
+  const id = stringField(recordField(result.body, "admin"), "id");
+  if (!result.response.ok || !id) {
+    throw new Error(`Prepared Daytona admin grant failed for ${email}: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return { id, owner };
+}
+
+async function revokePreparedPlatformAdmin(grant: PlatformAdminGrant): Promise<void> {
+  const result = await denFetch(grant.owner, `/v1/admin/admins/${encodeURIComponent(grant.id)}`, {
+    method: "DELETE",
+    headers: auth(grant.owner),
+  });
+  if (!result.response.ok && result.response.status !== 404) {
+    throw new Error(`Prepared Daytona admin cleanup returned HTTP ${result.response.status}: ${result.text.slice(0, 500)}`);
+  }
+}
+
 function emptySession(ref: DenRef): DenSession {
   return { ...ref, token: "", email: "", password: "" };
 }
@@ -157,9 +195,15 @@ function spawnService(
   logPath: string,
 ): SpawnedService {
   const logFd = openSync(logPath, "a");
-  const child = spawn("pnpm", [script], {
+  const prepared = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1";
+  const args = prepared
+    ? label === "den-api"
+      ? ["--filter", "@openwork-ee/den-api", "exec", "tsx", "src/main.ts"]
+      : ["--filter", "@openwork-ee/den-web", "exec", "next", "start", "--hostname", "127.0.0.1", "--port", String(port)]
+    : [script];
+  const child = spawn("pnpm", args, {
     cwd: REPO_ROOT,
-    env,
+    env: prepared && label === "den-api" ? { ...env, PORT: String(port) } : env,
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -218,16 +262,25 @@ async function waitForAuthProbe(ref: DenRef, service: SpawnedService): Promise<v
 
 async function runDbPush(databaseUrl: string): Promise<void> {
   try {
-    await execFileAsync("pnpm", ["--filter", "@openwork-ee/den-db", "db:push"], {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        DATABASE_URL: databaseUrl,
-        DEN_DB_ENCRYPTION_KEY: DATABASE_ENCRYPTION_KEY,
-      },
-      maxBuffer: 16 * 1024 * 1024,
-      timeout: 180_000,
-    });
+    const commands = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1"
+      ? [
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "push", "--config", "drizzle.config.ts"],
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-fulltext-indexes.ts"],
+          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-schema-repairs.ts"],
+        ]
+      : [["--filter", "@openwork-ee/den-db", "db:push"]];
+    for (const args of commands) {
+      await execFileAsync("pnpm", args, {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl,
+          DEN_DB_ENCRYPTION_KEY: DATABASE_ENCRYPTION_KEY,
+        },
+        maxBuffer: 16 * 1024 * 1024,
+        timeout: 180_000,
+      });
+    }
   } catch (error) {
     const stderr = typeof error === "object" && error !== null && typeof Reflect.get(error, "stderr") === "string"
       ? Reflect.get(error, "stderr")
@@ -504,10 +557,12 @@ export async function server(options: ServerOptions): Promise<Den> {
     }
     const base = options.place.denBase();
     if (base.kind !== "daytona") throw new Error("Daytona place returned a local Den base.");
+    const preparedSandbox = process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX?.trim();
     const orgShape = options.org ?? {};
     const bootstrapAdmin = personDefaults("admin", orgShape.admin, runId);
     const provisioned = await provisionDenSandbox({
       ref: base.ref,
+      reuse: preparedSandbox,
       bootstrapAdminEmail: bootstrapAdmin.email,
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
@@ -526,6 +581,15 @@ export async function server(options: ServerOptions): Promise<Den> {
               fallbackAdmin: options.org?.admin ? undefined : defaultReuseAdmin(),
             },
           );
+      let platformAdminGrant: PlatformAdminGrant | null = null;
+      if (preparedSandbox && options.provision !== false) {
+        try {
+          platformAdminGrant = await grantPreparedPlatformAdmin(ref, organization.admin.email);
+        } catch (error) {
+          if (organization.createdOrg) await deleteCreatedOrganization(organization.admin).catch(() => undefined);
+          throw error;
+        }
+      }
       let disposed = false;
       return {
         ref,
@@ -549,6 +613,11 @@ export async function server(options: ServerOptions): Promise<Den> {
           if (organization.createdOrg) {
             await deleteCreatedOrganization(organization.admin).catch((error: unknown) => {
               console.error(`[openwork/testkit] Daytona Den org cleanup failed: ${messageText(error)}`);
+            });
+          }
+          if (platformAdminGrant) {
+            await revokePreparedPlatformAdmin(platformAdminGrant).catch((error: unknown) => {
+              console.error(`[openwork/testkit] Daytona platform-admin cleanup failed: ${messageText(error)}`);
             });
           }
           await stopMocks(bootedMocks.handles);

--- a/evals/runner/prepare-stack.ts
+++ b/evals/runner/prepare-stack.ts
@@ -1,0 +1,119 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { deleteSandboxes, provisionDenSandbox, provisionDesktopSandbox } from "../packages/hosts/src/provision.ts";
+import { shouldPrepareSuite, suiteWorkerCount } from "./stack-suite.ts";
+import type { TestProject } from "vitest/node";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+export type StackPreparation =
+  | { kind: "none" }
+  | { kind: "local"; runtimePrepared: true; electronPrepared: true }
+  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string }[] };
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    openworkStackPreparation: StackPreparation;
+  }
+}
+
+async function run(command: string, args: string[], cwd = REPO_ROOT): Promise<void> {
+  await execFileAsync(command, args, {
+    cwd,
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: 20 * 60 * 1_000,
+  });
+}
+
+async function readable(path: string): Promise<boolean> {
+  return access(path, constants.R_OK).then(() => true).catch(() => false);
+}
+
+async function prepareLocal(): Promise<StackPreparation> {
+  console.error("[openwork/evals] preparing shared local Den and Electron runtime once...");
+  const runtimeBuilds = [
+    "@openwork/email",
+    "@openwork/install-config",
+    "@openwork/connect-link",
+    "@openwork/enterprise-mcp-client",
+    "@openwork/codemode",
+    "@openwork/headless-threads",
+  ].map((pkg) => run("pnpm", ["--filter", pkg, "build"]));
+  await Promise.all(runtimeBuilds);
+  await run("pnpm", ["--filter", "@openwork-ee/den-db", "build"]);
+
+  await Promise.all([
+    run("pnpm", ["--filter", "@openwork/ui", "build"]),
+    run("pnpm", ["--filter", "@openwork-ee/utils", "build"]),
+    run(process.execPath, [join(REPO_ROOT, "apps/desktop/scripts/prepare-sidecar.mjs"), "--force", "--outdir", join(REPO_ROOT, "apps/desktop/resources/sidecars")], join(REPO_ROOT, "apps/desktop")),
+    run(process.execPath, [join(REPO_ROOT, "apps/desktop/scripts/prepare-computer-use-helper.mjs"), "--force", "--outdir", join(REPO_ROOT, "apps/desktop/resources/helpers")], join(REPO_ROOT, "apps/desktop")),
+  ]);
+
+  const nextEnvPath = join(REPO_ROOT, "ee/apps/den-web/next-env.d.ts");
+  const hadNextEnv = await readable(nextEnvPath);
+  const nextEnv = hadNextEnv ? await readFile(nextEnvPath) : null;
+  try {
+    await run("pnpm", ["--filter", "@openwork-ee/den-web", "build"]);
+  } finally {
+    if (nextEnv) await writeFile(nextEnvPath, nextEnv);
+    else if (!hadNextEnv) await rm(nextEnvPath, { force: true });
+  }
+  return { kind: "local", runtimePrepared: true, electronPrepared: true };
+}
+
+async function prepareDaytona(argv: readonly string[]): Promise<{ preparation: StackPreparation; cleanup: () => Promise<void> }> {
+  const workerCount = suiteWorkerCount(argv, process.env);
+  const ref = process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev";
+  const created = new Set<string>();
+  const log = (line: string): void => console.error(`[openwork/evals] ${line}`);
+  try {
+    const slots = await Promise.all(Array.from({ length: workerCount }, async (_, index) => {
+      const [den, desktop] = await Promise.all([
+        provisionDenSandbox({
+          ref,
+          bootstrapAdminEmail: process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test",
+          log,
+        }).then((result) => {
+          if (result.created) created.add(result.sandbox);
+          return result;
+        }),
+        provisionDesktopSandbox({ ref, name: `suite-${index + 1}`, log }).then((result) => {
+          if (result.created) created.add(result.sandbox);
+          return result;
+        }),
+      ]);
+      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox };
+    }));
+    console.error(`[openwork/evals] prepared ${slots.length} isolated Daytona worker slot${slots.length === 1 ? "" : "s"}.`);
+    return {
+      preparation: { kind: "daytona", slots },
+      cleanup: async () => {
+        await deleteSandboxes([...created], { log });
+      },
+    };
+  } catch (error) {
+    await deleteSandboxes([...created], { log }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export default async function setup(project: TestProject): Promise<() => Promise<void>> {
+  if (!shouldPrepareSuite(process.argv) || process.env.OPENWORK_EVAL_DEN_API_URL?.trim()) {
+    project.provide("openworkStackPreparation", { kind: "none" });
+    return async () => undefined;
+  }
+  if (process.env.OPENWORK_EVAL_DAYTONA?.trim() === "1") {
+    const prepared = await prepareDaytona(process.argv);
+    project.provide("openworkStackPreparation", prepared.preparation);
+    return prepared.cleanup;
+  }
+  const preparation = await prepareLocal();
+  project.provide("openworkStackPreparation", preparation);
+  return async () => undefined;
+}

--- a/evals/runner/stack-env.ts
+++ b/evals/runner/stack-env.ts
@@ -1,0 +1,16 @@
+import { inject } from "vitest";
+import { workerSlot } from "./stack-suite.ts";
+
+const preparation = inject("openworkStackPreparation");
+
+if (preparation.kind === "local") {
+  process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED = "1";
+  process.env.OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED = "1";
+}
+
+if (preparation.kind === "daytona") {
+  const slot = preparation.slots[workerSlot(process.env.VITEST_WORKER_ID, preparation.slots.length)];
+  if (!slot) throw new Error("Vitest worker did not resolve to a prepared Daytona slot.");
+  process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX = slot.denSandbox;
+  process.env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX = slot.desktopSandbox;
+}

--- a/evals/runner/stack-suite.test.ts
+++ b/evals/runner/stack-suite.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldPrepareSuite, suiteWorkerCount, workerSlot } from "./stack-suite.ts";
+
+test("single explicit specs keep their one-off setup", () => {
+  assert.equal(shouldPrepareSuite(["vitest", "specs/example.slow.test.ts"]), false);
+});
+
+test("multi-file, glob, and whole-project runs prepare shared stack resources", () => {
+  assert.equal(shouldPrepareSuite(["vitest", "specs/a.slow.test.ts", "specs/b.slow.test.ts"]), true);
+  assert.equal(shouldPrepareSuite(["vitest", "specs/*.slow.test.ts"]), true);
+  assert.equal(shouldPrepareSuite(["vitest"]), true);
+});
+
+test("Daytona defaults to two workers and never prepares more slots than explicit files", () => {
+  assert.equal(suiteWorkerCount(["vitest", "specs/a.test.ts", "specs/b.test.ts"], { OPENWORK_EVAL_DAYTONA: "1" }), 2);
+  assert.equal(suiteWorkerCount(["vitest", "specs/a.test.ts"], { OPENWORK_EVAL_DAYTONA: "1", OPENWORK_EVAL_MAX_WORKERS: "8" }), 1);
+  assert.equal(suiteWorkerCount(["vitest", "specs/*.test.ts"], { OPENWORK_EVAL_DAYTONA: "1", OPENWORK_EVAL_MAX_WORKERS: "4" }), 4);
+});
+
+test("worker ids wrap onto the prepared slot pool", () => {
+  assert.equal(workerSlot("1", 2), 0);
+  assert.equal(workerSlot("2", 2), 1);
+  assert.equal(workerSlot("3", 2), 0);
+  assert.equal(workerSlot(undefined, 2), 0);
+});

--- a/evals/runner/stack-suite.ts
+++ b/evals/runner/stack-suite.ts
@@ -1,0 +1,30 @@
+const TEST_FILE = /\.test\.[cm]?[jt]sx?$/;
+const GLOB_MARKER = /[*?{}[\]]/;
+
+function explicitTestFiles(argv: readonly string[]): string[] {
+  return argv.filter((argument) => TEST_FILE.test(argument) && !GLOB_MARKER.test(argument));
+}
+
+export function shouldPrepareSuite(argv: readonly string[]): boolean {
+  const testArguments = argv.filter((argument) => argument.includes(".test.") || GLOB_MARKER.test(argument));
+  return testArguments.length !== 1 || explicitTestFiles(testArguments).length !== 1;
+}
+
+function configuredWorkerCount(env: NodeJS.ProcessEnv): number {
+  const configured = Number.parseInt(env.OPENWORK_EVAL_MAX_WORKERS?.trim() ?? "", 10);
+  if (Number.isInteger(configured) && configured > 0) return configured;
+  return env.OPENWORK_EVAL_DAYTONA?.trim() === "1" ? 2 : 3;
+}
+
+export function suiteWorkerCount(argv: readonly string[], env: NodeJS.ProcessEnv): number {
+  const fileCount = explicitTestFiles(argv).length;
+  const workers = configuredWorkerCount(env);
+  return fileCount > 0 ? Math.min(fileCount, workers) : workers;
+}
+
+export function workerSlot(workerId: string | undefined, slotCount: number): number {
+  if (!Number.isInteger(slotCount) || slotCount < 1) throw new Error("Stack preparation requires at least one worker slot.");
+  const parsed = Number.parseInt(workerId ?? "", 10);
+  const worker = Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+  return (worker - 1) % slotCount;
+}

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -1,14 +1,21 @@
 import { defineConfig } from "vitest/config";
+import { shouldPrepareSuite, suiteWorkerCount } from "./runner/stack-suite.ts";
 
 const common = {
   environment: "node",
   testTimeout: 120_000,
 };
 
+const prepareSuite = shouldPrepareSuite(process.argv);
+const attachedDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const managedStack = prepareSuite && !attachedDen;
+const stackWorkers = managedStack ? suiteWorkerCount(process.argv, process.env) : 1;
+
 export default defineConfig({
   test: {
     ...common,
-    fileParallelism: false,
+    fileParallelism: managedStack,
+    maxWorkers: stackWorkers,
     projects: [
       {
         test: {
@@ -25,6 +32,8 @@ export default defineConfig({
           name: "stack",
           testTimeout: 600_000,
           hookTimeout: 600_000,
+          globalSetup: ["./runner/prepare-stack.ts"],
+          setupFiles: ["./runner/stack-env.ts"],
           include: ["specs/**/*.test.ts"],
         },
       },


### PR DESCRIPTION
## Summary

- change the GitHub Actions slow-spec sweep from one job per spec to three balanced batches
- reuse one prewarmed Daytona Den + desktop pair inside each batch while keeping every spec in its own temporary account and organization
- prepare shared local build artifacts once and use a bounded two-slot Daytona pool for general multi-file runs
- harden parallel provisioning with collision-resistant sandbox names, preview URL retries, and temporary platform-admin grants
- replace a polynomial sandbox-name trim flagged by CodeQL

## Why

The old sweep paid dependency setup and Daytona provisioning for every spec, then queued most of its 47 jobs behind a three-job concurrency limit. Setup and queueing dominated the actual test work.

The new sweep runs 53 selected spec files in three 18/18/17 batches. Each batch provisions once, runs serially inside its isolated worker slot, uploads all rolls, and tears the slot down once.

## Full-sweep performance

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| End-to-end GitHub Actions wall time | [8h 19m 54s](https://github.com/different-ai/openwork/actions/runs/32064025102) | [9m 21s](https://github.com/different-ai/openwork/actions/runs/32143003538) | 98.1% less / 53.5x faster |
| Aggregate active spec-job time | 1h 56m 28s | 22m 04s | 81.1% less / 5.28x faster |
| Active time discounting failing slow specs | 1h 28m 36s | ~18m 18s | 79.3% less / 4.84x faster |

The after run covered six more spec files than the before run. Its three batches started together without queueing and finished in 6m13s, 7m20s, and 8m31s.

The discounted after figure subtracts the measured runtime of the six failing spec files while retaining setup, teardown, passing specs, and legitimate skips. It is an estimate because failed and passing specs now share batch jobs.

The focused same-two-spec Daytona benchmark also improved from 8m34.52s to 3m16.80s (61.8% less / 2.61x faster).

## Sweep result

The final 53-file sweep produced 24 passing files, 23 legitimate skips/incomplete needs, and 6 failing files. All six failures were already red in the old sweep:

- `automation-model-needs-attention.slow.test.ts`
- `automations-den-hosted.slow.test.ts`
- `codemode-scripts.slow.test.ts`
- `generated-artifact-views.slow.test.ts`
- `local-managed-mcp-oauth.slow.test.ts`
- `saved-script-automations.slow.test.ts`

The initial batching run exposed organization-state leakage. The final run uses a unique temporary account and organization per spec: the batching-only `automation-runtime-placement` regression is gone, `automation-proposal-model-resolution` is green, and `den-sidebar-ia` improved from old-sweep red to green.

Batch 1's test command passed all 6 runnable specs (12 more skipped for unmet needs); its job is red only because the deferred OpenAI vision judge returned HTTP 500 and left 2 claims pending.

## Verification

- `pnpm --dir evals test` — 201/201 passed
- full GitHub Actions sweep — 53 files executed in 9m21s; rolls uploaded by every batch
- focused Daytona reuse run — 3/3 slow specs passed in 3m19.33s, with both worker pairs deleted during teardown
- single explicit Daytona spec — one-off behavior preserved
- `git diff --check` — passed

The standalone eval TypeScript command is not a usable repository gate today: its configured compiler rejects the suite's existing `await using` syntax before typechecking this change.
