### PR TITLE
fix(server): contain expected runtime failures

### DIFF
--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -66,6 +66,7 @@ const DYNAMIC_URL_CANARY = "https://labels.invalid/mcp?access_token=DYNAMIC_URL_
 const DYNAMIC_PATH_CANARY = "/Users/diagnostics/private/mcp.json";
 const execFileAsync = promisify(execFile);
 const nativeFetch = globalThis.fetch;
+const nativeTelemetry = globalThis.__openworkDesktopTelemetry;
 const roots: string[] = [];
 const stops: Array<() => void | Promise<void>> = [];
 
@@ -488,10 +489,12 @@ async function snapshotTree(root: string): Promise<Record<string, string>> {
 
 beforeEach(() => {
   globalThis.fetch = nativeFetch;
+  globalThis.__openworkDesktopTelemetry = nativeTelemetry;
 });
 
 afterEach(async () => {
   globalThis.fetch = nativeFetch;
+  globalThis.__openworkDesktopTelemetry = nativeTelemetry;
   while (stops.length) await stops.pop()?.();
   while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
 });
@@ -2070,6 +2073,50 @@ describe("agent context diagnostics route", () => {
       code: "engine_diagnostics_request_failed",
     });
     expect(await snapshotTree(fixture.root)).toEqual(before);
+  });
+
+  test.serial("types the server-owned diagnostics deadline without capturing it", async () => {
+    const previousTimeout = process.env.OPENWORK_AGENT_DIAGNOSTICS_TIMEOUT_MS;
+    process.env.OPENWORK_AGENT_DIAGNOSTICS_TIMEOUT_MS = "50";
+    const fixture = await createFixture({
+      withRuntime: false,
+      workspace: { id: "ws_agent_diagnostics_server_timeout" },
+    });
+    const base = await startOpenwork(fixture.config);
+    const captured: unknown[] = [];
+    globalThis.__openworkDesktopTelemetry = {
+      captureException(error) {
+        captured.push(error);
+        return true;
+      },
+    };
+    globalThis.fetch = Object.assign(
+      (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const signal = input instanceof Request ? input.signal : init?.signal;
+        if (!signal) return Promise.reject(new Error("Expected diagnostics fetch signal"));
+        return new Promise<Response>((_resolve, reject) => {
+          const abort = () => reject(signal.reason);
+          if (signal.aborted) abort();
+          else signal.addEventListener("abort", abort, { once: true });
+        });
+      },
+      { preconnect: nativeFetch.preconnect },
+    );
+
+    try {
+      const response = await nativeFetch(`${base}/workspace/${fixture.workspace.id}/diagnostics/agent-context`, {
+        method: "POST",
+        headers: clientHeaders(),
+        body: JSON.stringify(emptyObservedRequest),
+      });
+
+      expect(response.status).toBe(504);
+      expect(await response.json()).toMatchObject({ code: "agent_diagnostics_timeout" });
+      expect(captured).toEqual([]);
+    } finally {
+      if (previousTimeout === undefined) delete process.env.OPENWORK_AGENT_DIAGNOSTICS_TIMEOUT_MS;
+      else process.env.OPENWORK_AGENT_DIAGNOSTICS_TIMEOUT_MS = previousTimeout;
+    }
   });
 
   test("rejects a viewer before diagnostics or any downstream fetch", async () => {

--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -13,7 +13,7 @@ import {
   type EngineSpawnTemplate,
 } from "./engine-pool.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
-import { proxyOpencodeRequest } from "./server.js";
+import { proxyOpencodeRequest, startServer } from "./server.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 const ENV_NAMES = [
@@ -265,6 +265,11 @@ describe("engine pool", () => {
     });
 
     expect(isEngineConnectionFailure(error)).toBe(true);
+  });
+
+  test("classifies a cause-less fetch failure only in the engine transport classifier", () => {
+    expect(isEngineConnectionFailure(new TypeError("fetch failed"))).toBe(true);
+    expect(isEngineConnectionFailure(new Error("fetch failed"))).toBe(false);
   });
 
   test("skips entirely when nothing the engine reads at build time changed", async () => {
@@ -532,6 +537,40 @@ describe("engine pool", () => {
       status: 502,
       code: "opencode_unreachable",
     });
+  });
+
+  test.serial("returns an uncaptured 502 for a cause-less loopback proxy fetch failure", async () => {
+    const fixture = await createFixture();
+    await createPool(fixture);
+    const originalFetch = globalThis.fetch;
+    const originalTelemetry = globalThis.__openworkDesktopTelemetry;
+    const captured: unknown[] = [];
+    const server = await startServer(fixture.config);
+    globalThis.__openworkDesktopTelemetry = {
+      captureException(error) {
+        captured.push(error);
+        return true;
+      },
+    };
+    globalThis.fetch = Object.assign(
+      async () => {
+        throw new TypeError("fetch failed");
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+
+    try {
+      const response = await originalFetch(`http://127.0.0.1:${server.port}/opencode/config`, {
+        headers: { Authorization: `Bearer ${fixture.config.token}` },
+      });
+      expect(response.status).toBe(502);
+      expect(await response.json()).toMatchObject({ code: "opencode_unreachable" });
+      expect(captured).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.__openworkDesktopTelemetry = originalTelemetry;
+      await server.stop();
+    }
   });
 
   test("ends existing event fan-in leases when a generation flips", async () => {

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -169,6 +169,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function isEngineConnectionFailure(error: unknown): boolean {
+  // Node/undici occasionally drops the transport cause. This classifier is
+  // only used for managed OpenCode engine traffic, never external egress.
+  if (error instanceof TypeError && error.message === "fetch failed" && error.cause === undefined) return true;
   const visited = new Set<object>();
   let current: unknown = error;
   for (let depth = 0; depth < 6 && current !== null && current !== undefined; depth += 1) {

--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -1,0 +1,91 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createManagedOpencodeServer } from "./managed-opencode.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (roots.length > 0) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function createRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-managed-opencode-"));
+  roots.push(root);
+  return root;
+}
+
+async function writeExecutable(root: string, name: string, lines: string[]): Promise<string> {
+  const path = join(root, name);
+  await writeFile(path, ["#!/usr/bin/env bun", ...lines].join("\n"));
+  await chmod(path, 0o755);
+  return path;
+}
+
+describe("managed OpenCode startup", () => {
+  test("waits for inherited diagnostic streams before retrying a code-1 EADDRINUSE exit", async () => {
+    const root = await createRoot();
+    const attemptsPath = join(root, "attempts.log");
+    const markerPath = join(root, "first-attempt");
+    const diagnosticPath = join(root, "delayed-eaddrinuse.mjs");
+    await writeFile(diagnosticPath, [
+      "const port = process.argv[2];",
+      "setTimeout(() => console.error(`listen EADDRINUSE: address already in use 127.0.0.1:${port}`), 50);",
+    ].join("\n"));
+    const bin = await writeExecutable(root, "retry-eaddrinuse.mjs", [
+      "import { spawn } from 'node:child_process';",
+      "import { appendFileSync, existsSync, writeFileSync } from 'node:fs';",
+      "const port = Number(process.argv[process.argv.indexOf('--port') + 1]);",
+      "appendFileSync(process.env.ATTEMPTS_PATH, `start:${port}\\n`);",
+      "if (!existsSync(process.env.MARKER_PATH)) {",
+      "  writeFileSync(process.env.MARKER_PATH, 'claimed');",
+      "  spawn(process.execPath, [process.env.DIAGNOSTIC_PATH, String(port)], { stdio: ['ignore', 'inherit', 'inherit'] }).unref();",
+      "  process.exit(1);",
+      "}",
+      "const server = Bun.serve({ hostname: '127.0.0.1', port, fetch: () => Response.json({ ok: true }) });",
+      "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
+      "process.on('SIGTERM', () => { appendFileSync(process.env.ATTEMPTS_PATH, 'SIGTERM\\n'); server.stop(true); process.exit(0); });",
+    ]);
+    const managed = await createManagedOpencodeServer({
+      bin,
+      cwd: root,
+      env: { ATTEMPTS_PATH: attemptsPath, DIAGNOSTIC_PATH: diagnosticPath, MARKER_PATH: markerPath },
+    });
+
+    await managed.close();
+
+    const lines = (await readFile(attemptsPath, "utf8")).trim().split("\n");
+    const ports = lines.filter((line) => line.startsWith("start:")).map((line) => line.slice("start:".length));
+    expect(ports).toHaveLength(2);
+    expect(new Set(ports).size).toBe(2);
+    expect(lines.filter((line) => line === "SIGTERM")).toHaveLength(1);
+  });
+
+  test("keeps an unknown code-1 exit actionable and does not retry it", async () => {
+    const root = await createRoot();
+    const attemptsPath = join(root, "attempts.log");
+    const bin = await writeExecutable(root, "unknown-code-one.mjs", [
+      "import { appendFileSync } from 'node:fs';",
+      "appendFileSync(process.env.ATTEMPTS_PATH, 'start\\n');",
+      "console.log('startup diagnostics from stdout');",
+      "console.error('fatal provider configuration mismatch');",
+      "process.exit(1);",
+    ]);
+    let thrown: unknown;
+
+    try {
+      await createManagedOpencodeServer({ bin, cwd: root, env: { ATTEMPTS_PATH: attemptsPath } });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) throw new Error("Expected managed OpenCode startup to fail");
+    expect(thrown.message).toContain("OpenCode server exited with code 1");
+    expect(thrown.message).toContain("startup diagnostics from stdout");
+    expect(thrown.message).toContain("fatal provider configuration mismatch");
+    expect((await readFile(attemptsPath, "utf8")).trim().split("\n")).toEqual(["start"]);
+  });
+});

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -119,7 +119,7 @@ async function findFreePort(hostname: string, excludedPorts: number[] = []): Pro
   throw new Error("Failed to resolve free port outside the excluded set");
 }
 
-export async function createManagedOpencodeServer(options: {
+type ManagedOpencodeServerOptions = {
   bin?: string;
   cwd: string;
   hostname?: string;
@@ -127,9 +127,28 @@ export async function createManagedOpencodeServer(options: {
   excludedPorts?: number[];
   timeoutMs?: number;
   env?: Record<string, string | undefined>;
-}): Promise<ManagedOpencodeServer> {
-  const hostname = options.hostname ?? "127.0.0.1";
-  const port = options.port ?? await findFreePort(hostname, options.excludedPorts);
+};
+
+class ManagedOpencodeExitError extends Error {
+  readonly exitCode: number | null;
+
+  constructor(exitCode: number | null, output: string) {
+    super(`OpenCode server exited with code ${exitCode}${output.trim() ? `\n${output}` : ""}`);
+    this.exitCode = exitCode;
+  }
+}
+
+function isRetryableAddressInUseExit(error: unknown): boolean {
+  return error instanceof ManagedOpencodeExitError &&
+    error.exitCode === 1 &&
+    /\bEADDRINUSE\b/.test(error.message);
+}
+
+async function startManagedOpencodeServer(
+  options: ManagedOpencodeServerOptions,
+  hostname: string,
+  port: number,
+): Promise<ManagedOpencodeServer> {
   const username = randomSecret();
   const password = randomSecret();
   const args = ["serve", "--hostname", hostname, "--port", String(port), "--cors", "*"];
@@ -189,7 +208,9 @@ export async function createManagedOpencodeServer(options: {
         output += chunk.toString();
       });
       child.once("error", fail);
-      child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));
+      // ChildProcess can emit "exit" before its stdio pipes have drained. Wait
+      // for "close" so retry classification includes every diagnostic line.
+      child.once("close", (code) => fail(new ManagedOpencodeExitError(code, output)));
     });
   } catch (error) {
     await processLifecycle.close();
@@ -210,4 +231,19 @@ export async function createManagedOpencodeServer(options: {
     isAlive: processLifecycle.isAlive,
     close: processLifecycle.close,
   };
+}
+
+export async function createManagedOpencodeServer(options: ManagedOpencodeServerOptions): Promise<ManagedOpencodeServer> {
+  const hostname = options.hostname ?? "127.0.0.1";
+  const port = options.port ?? await findFreePort(hostname, options.excludedPorts);
+  try {
+    return await startManagedOpencodeServer(options, hostname, port);
+  } catch (error) {
+    // The automatic free-port probe is necessarily racy. Retry exactly once on
+    // the one startup failure that a new port can safely fix; explicit ports
+    // and all other code-1 exits remain actionable.
+    if (options.port !== undefined || !isRetryableAddressInUseExit(error)) throw error;
+    const retryPort = await findFreePort(hostname, [...(options.excludedPorts ?? []), port]);
+    return startManagedOpencodeServer(options, hostname, retryPort);
+  }
 }

--- a/apps/server/src/serve-node.test.ts
+++ b/apps/server/src/serve-node.test.ts
@@ -1,10 +1,67 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ServerResponse } from "node:http";
+import { connect } from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 import { serve, writeWebResponse } from "./serve-node.js";
 
 describe("serve", () => {
+  test("handles a malformed raw Node TRACE request without an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (error: unknown) => {
+      unhandled.push(error);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    let fetchCalls = 0;
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => {
+        fetchCalls += 1;
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      const response = await new Promise<string>((resolve, reject) => {
+        let received = "";
+        const socket = connect({ host: "127.0.0.1", port: server.port }, () => {
+          socket.write([
+            "TRACE http://example.com/ HTTP/1.1",
+            `Host: 127.0.0.1:${server.port}`,
+            "Connection: close",
+            "",
+            "",
+          ].join("\r\n"));
+        });
+        const timeout = setTimeout(() => {
+          socket.destroy(new Error("Timed out waiting for the TRACE response"));
+        }, 1_000);
+        socket.setEncoding("utf8");
+        socket.on("data", (chunk) => {
+          received += chunk;
+        });
+        socket.once("end", () => {
+          clearTimeout(timeout);
+          resolve(received);
+        });
+        socket.once("error", (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+      });
+
+      await delay(25);
+      expect(response).toContain("HTTP/1.1 500 Internal Server Error");
+      expect(response).toEndWith(JSON.stringify({ error: "internal_error" }));
+      expect(fetchCalls).toBe(0);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+      await server.stop();
+    }
+  });
+
   test("cancels a streaming response body when the client disconnects", async () => {
     let cancelled = false;
     const events = new EventEmitter();
@@ -151,6 +208,43 @@ describe("serve", () => {
       expect(await health.json()).toEqual({ ok: true });
     } finally {
       console.error = originalError;
+      await server.stop();
+    }
+  });
+
+  test("aborts the Web request signal when the client cancels", async () => {
+    let markStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let observedAbort: unknown;
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => new Promise<Response>((_resolve, reject) => {
+        markStarted();
+        const onAbort = () => {
+          observedAbort = request.signal.reason;
+          reject(request.signal.reason);
+        };
+        if (request.signal.aborted) onAbort();
+        else request.signal.addEventListener("abort", onAbort, { once: true });
+      }),
+    });
+    const controller = new AbortController();
+    const pending = fetch(`http://127.0.0.1:${server.port}/cancel`, { signal: controller.signal });
+
+    try {
+      await started;
+      controller.abort();
+      await pending.catch(() => undefined);
+      for (let attempt = 0; attempt < 20 && observedAbort === undefined; attempt += 1) {
+        await delay(10);
+      }
+
+      expect(observedAbort).toBeInstanceOf(DOMException);
+      expect(observedAbort).toMatchObject({ name: "AbortError" });
+    } finally {
       await server.stop();
     }
   });

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -79,10 +79,25 @@ async function waitForDrainOrClose(nodeRes: ServerResponse): Promise<void> {
 /**
  * Convert a Node.js IncomingMessage into a Web API Request.
  */
-function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number): Request {
+function toWebRequest(
+  nodeReq: IncomingMessage,
+  hostname: string,
+  port: number,
+): { request: Request; detachCancellation: () => void } {
   const url = `http://${hostname}:${port}${nodeReq.url ?? "/"}`;
   const method = nodeReq.method ?? "GET";
   const headers = new Headers();
+  const controller = new AbortController();
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(new DOMException("The operation was aborted", "AbortError"));
+    }
+  };
+  if (nodeReq.aborted) abort();
+  else {
+    nodeReq.once("aborted", abort);
+    nodeReq.socket.once("close", abort);
+  }
 
   // Node headers can be string | string[] | undefined
   for (const [key, value] of Object.entries(nodeReq.headers)) {
@@ -102,13 +117,21 @@ function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number):
     ? (Readable.toWeb(nodeReq) as unknown as ReadableStream<Uint8Array>)
     : null;
 
-  return new Request(url, {
+  const request = new Request(url, {
     method,
     headers,
     body,
+    signal: controller.signal,
     // @ts-expect-error duplex is required for streaming request bodies in Node
     duplex: hasBody ? "half" : undefined,
   });
+  return {
+    request,
+    detachCancellation: () => {
+      nodeReq.off("aborted", abort);
+      nodeReq.socket.off("close", abort);
+    },
+  };
 }
 
 /**
@@ -178,9 +201,11 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
       console.error("[serve-node] Response stream error:", error);
     });
 
+    let detachCancellation: (() => void) | undefined;
     try {
-      const webReq = toWebRequest(nodeReq, hostname, boundPort);
-      const webRes = await fetchHandler(webReq);
+      const webRequest = toWebRequest(nodeReq, hostname, boundPort);
+      detachCancellation = webRequest.detachCancellation;
+      const webRes = await fetchHandler(webRequest.request);
       await writeWebResponse(webRes, nodeRes);
     } catch (error) {
       if (isExpectedConnectionAbort(error)) {
@@ -195,6 +220,8 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
         nodeRes.writeHead(500, { "Content-Type": "application/json" });
       }
       endResponse(nodeRes, JSON.stringify({ error: "internal_error" }));
+    } finally {
+      detachCancellation?.();
     }
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -95,7 +95,7 @@ import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } 
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
-import { captureServerException } from "./telemetry.js";
+import { captureServerException, isExpectedRequestCancellation } from "./telemetry.js";
 import {
   completeLocalManagedMcpAuthorization,
   createLocalManagedMcpConnection,
@@ -1066,12 +1066,15 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           const response = await proxyOpencodeRequest({ config, request, url, workspace, proxyPath: mount.restPath });
           return finalize(response);
         } catch (error) {
-          if (!(error instanceof ApiError)) {
-            captureServerException(error, { method: request.method, route: "/workspace/:id/opencode/*" });
+          const requestCanceled = isExpectedRequestCancellation(error, request.signal);
+          if (!(error instanceof ApiError) && !requestCanceled) {
+            captureServerException(error, { method: request.method, route: "/workspace/:id/opencode/*", requestSignal: request.signal });
           }
           const apiError = error instanceof ApiError
             ? error
-            : new ApiError(500, "internal_error", "Unexpected server error");
+            : requestCanceled
+              ? new ApiError(499, "request_aborted", "Request was canceled")
+              : new ApiError(500, "internal_error", "Unexpected server error");
           recordApiError(apiError);
           return finalize(jsonResponse(formatError(apiError), apiError.status));
         }
@@ -1118,12 +1121,15 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           const response = await proxyOpencodeRequest({ config, request, url, workspace: config.workspaces[0] });
           return finalize(response);
         } catch (error) {
-          if (!(error instanceof ApiError)) {
-            captureServerException(error, { method: request.method, route: "/opencode/*" });
+          const requestCanceled = isExpectedRequestCancellation(error, request.signal);
+          if (!(error instanceof ApiError) && !requestCanceled) {
+            captureServerException(error, { method: request.method, route: "/opencode/*", requestSignal: request.signal });
           }
           const apiError = error instanceof ApiError
             ? error
-            : new ApiError(500, "internal_error", "Unexpected server error");
+            : requestCanceled
+              ? new ApiError(499, "request_aborted", "Request was canceled")
+              : new ApiError(500, "internal_error", "Unexpected server error");
           recordApiError(apiError);
           return finalize(jsonResponse(formatError(apiError), apiError.status));
         }
@@ -1159,13 +1165,16 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         });
         return finalize(response);
       } catch (error) {
-        if (!(error instanceof ApiError)) {
-          captureServerException(error, { method: request.method, route: url.pathname });
+        const requestCanceled = isExpectedRequestCancellation(error, request.signal);
+        if (!(error instanceof ApiError) && !requestCanceled) {
+          captureServerException(error, { method: request.method, route: url.pathname, requestSignal: request.signal });
           console.error("[openwork-server] Unhandled error:", error);
         }
         const apiError = error instanceof ApiError
           ? error
-          : new ApiError(500, "internal_error", "Unexpected server error");
+          : requestCanceled
+            ? new ApiError(499, "request_aborted", "Request was canceled")
+            : new ApiError(500, "internal_error", "Unexpected server error");
         recordApiError(apiError);
         const response = jsonResponse(formatError(apiError), apiError.status);
         const isAgentDiagnosticsRequest =
@@ -1246,6 +1255,11 @@ function opencodeUnreachableError(error: unknown, path: string): ApiError {
     path,
     cause: error instanceof Error ? error.message : String(error),
   });
+}
+
+function agentDiagnosticsTimeoutMs(): number {
+  const configured = Number(process.env.OPENWORK_AGENT_DIAGNOSTICS_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : 24_000;
 }
 
 function buildOpencodeDirectoryHeader(directory: string) {
@@ -2107,33 +2121,42 @@ function createRoutes(
         throw new ApiError(400, "invalid_agent_diagnostics_request", "Agent diagnostics request is invalid");
       }
       const opencode = createWorkspaceOpencodeClient(config, workspace, { boundedDiagnosticsReads: true });
-      const diagnosticsSignal = AbortSignal.any([ctx.request.signal, AbortSignal.timeout(24_000)]);
-      const response = jsonResponse(await runAgentContextDiagnostics({
-        config,
-        workspace,
-        request: parsed.data,
-        inspectRegistration: (name, mcpConfig) =>
-          inspectEngineMcpRegistrationInState(
-            config,
-            engineMcpServerState,
-            workspace,
-            name,
-            mcpConfig,
-          ),
-        dependencies: {
-          signal: diagnosticsSignal,
-          inspectEffectiveEngine: async (signal) => {
-            const [configResult, agentResult] = await Promise.all([
-              opencode.config.get({}, { signal }),
-              opencode.app.agents({}, { signal }),
-            ]);
-            return {
-              config: unwrapOpencodeResult(configResult, "/config"),
-              agents: unwrapOpencodeResult(agentResult, "/agent"),
-            };
+      const timeoutSignal = AbortSignal.timeout(agentDiagnosticsTimeoutMs());
+      const diagnosticsSignal = AbortSignal.any([ctx.request.signal, timeoutSignal]);
+      let response: Response;
+      try {
+        response = jsonResponse(await runAgentContextDiagnostics({
+          config,
+          workspace,
+          request: parsed.data,
+          inspectRegistration: (name, mcpConfig) =>
+            inspectEngineMcpRegistrationInState(
+              config,
+              engineMcpServerState,
+              workspace,
+              name,
+              mcpConfig,
+            ),
+          dependencies: {
+            signal: diagnosticsSignal,
+            inspectEffectiveEngine: async (signal) => {
+              const [configResult, agentResult] = await Promise.all([
+                opencode.config.get({}, { signal }),
+                opencode.app.agents({}, { signal }),
+              ]);
+              return {
+                config: unwrapOpencodeResult(configResult, "/config"),
+                agents: unwrapOpencodeResult(agentResult, "/agent"),
+              };
+            },
           },
-        },
-      }));
+        }));
+      } catch (error) {
+        if (timeoutSignal.aborted && !ctx.request.signal.aborted) {
+          throw new ApiError(504, "agent_diagnostics_timeout", "Agent diagnostics timed out");
+        }
+        throw error;
+      }
       response.headers.set("Cache-Control", "no-store");
       return response;
     } finally {

--- a/apps/server/src/telemetry.test.ts
+++ b/apps/server/src/telemetry.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { captureServerException } from "./telemetry.js";
+
+const originalTelemetry = globalThis.__openworkDesktopTelemetry;
+
+afterEach(() => {
+  globalThis.__openworkDesktopTelemetry = originalTelemetry;
+});
+
+describe("server telemetry", () => {
+  test("drops request-owned cancellation while preserving unrelated fetch failures", () => {
+    const captured: unknown[] = [];
+    globalThis.__openworkDesktopTelemetry = {
+      captureException(error) {
+        captured.push(error);
+        return true;
+      },
+    };
+    const controller = new AbortController();
+    const cancellation = new DOMException("The operation was aborted", "AbortError");
+    controller.abort(cancellation);
+
+    expect(captureServerException(cancellation, { requestSignal: controller.signal })).toBe(false);
+    expect(captured).toEqual([]);
+
+    const externalFailure = new TypeError("fetch failed");
+    expect(captureServerException(externalFailure, { requestSignal: controller.signal })).toBe(true);
+    expect(captured).toEqual([externalFailure]);
+  });
+});

--- a/apps/server/src/telemetry.ts
+++ b/apps/server/src/telemetry.ts
@@ -2,6 +2,8 @@ export type ServerTelemetryContext = {
   method?: string;
   route?: string;
   surface?: string;
+  /** Internal-only context; never forwarded to the desktop telemetry host. */
+  requestSignal?: AbortSignal;
 };
 
 export type OpenworkDesktopTelemetry = {
@@ -14,9 +16,37 @@ declare global {
   var __openworkDesktopTelemetry: OpenworkDesktopTelemetry | undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isExpectedRequestCancellation(error: unknown, requestSignal: AbortSignal | undefined): boolean {
+  if (!requestSignal?.aborted) return false;
+  const visited = new Set<object>();
+  let current: unknown = error;
+  for (let depth = 0; depth < 6 && current !== null && current !== undefined; depth += 1) {
+    if (current === requestSignal.reason) return true;
+    if (!isRecord(current) || visited.has(current)) return false;
+    visited.add(current);
+    if (current.name === "AbortError") return true;
+    if (
+      current.code === "ABORT_ERR" ||
+      current.code === "ECONNRESET" ||
+      current.code === "ERR_STREAM_PREMATURE_CLOSE" ||
+      current.code === "UND_ERR_SOCKET"
+    ) return true;
+    const message = current.message;
+    if (typeof message === "string" && /^(?:The operation was )?aborted\.?$|^terminated$/i.test(message)) return true;
+    current = current.cause;
+  }
+  return false;
+}
+
 export function captureServerException(error: unknown, context: ServerTelemetryContext = {}): boolean {
+  const { requestSignal, ...telemetryContext } = context;
+  if (isExpectedRequestCancellation(error, requestSignal)) return false;
   return globalThis.__openworkDesktopTelemetry?.captureException(error, {
     surface: "server",
-    ...context,
+    ...telemetryContext,
   }) ?? false;
 }

--- a/evals/specs/server-error-boundaries.test.ts
+++ b/evals/specs/server-error-boundaries.test.ts
@@ -1,0 +1,89 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import { isEngineConnectionFailure } from "../../apps/server/src/engine-pool";
+import { createManagedOpencodeServer } from "../../apps/server/src/managed-opencode";
+import { captureServerException } from "../../apps/server/src/telemetry";
+
+test("server error boundaries contain expected noise without hiding actionable failures", async ({ evidence }) => {
+  const originalTelemetry = globalThis.__openworkDesktopTelemetry;
+  const captured: unknown[] = [];
+  const request = new AbortController();
+  const cancellation = new DOMException("The operation was aborted", "AbortError");
+  const unrelatedError = new TypeError("fetch failed");
+  request.abort(cancellation);
+
+  try {
+    globalThis.__openworkDesktopTelemetry = {
+      captureException(error) {
+        captured.push(error);
+        return true;
+      },
+    };
+
+    expect(captureServerException(cancellation, { requestSignal: request.signal })).toBe(false);
+    expect(captured).toEqual([]);
+    evidence.fact(
+      "Positive: request-owned aborts stay out of server telemetry",
+      "An aborted request carrying its AbortError returned false and delivered zero exceptions to the telemetry host.",
+      true,
+    );
+
+    expect(captureServerException(unrelatedError, { requestSignal: request.signal })).toBe(true);
+    expect(captured).toEqual([unrelatedError]);
+    evidence.fact(
+      "Negative: unrelated server errors remain observable",
+      "A TypeError unrelated to the already-aborted request returned true and was the sole captured exception.",
+      true,
+    );
+  } finally {
+    globalThis.__openworkDesktopTelemetry = originalTelemetry;
+  }
+
+  expect(isEngineConnectionFailure(new TypeError("fetch failed"))).toBe(true);
+  expect(isEngineConnectionFailure(new Error("fetch failed"))).toBe(false);
+  evidence.fact(
+    "Cause-less loopback fetch failures retain a narrow transport type",
+    "The engine transport classifier accepted a cause-less TypeError('fetch failed') while rejecting the same message on a plain Error.",
+    true,
+  );
+
+  const root = await mkdtemp(join(tmpdir(), "openwork-server-boundaries-"));
+  const attemptsPath = join(root, "attempts.log");
+  const bin = join(root, "unknown-code-one.mjs");
+  await writeFile(bin, [
+    "#!/usr/bin/env bun",
+    "import { appendFileSync } from 'node:fs';",
+    "appendFileSync(process.env.ATTEMPTS_PATH, 'start\\n');",
+    "console.log('startup diagnostics from stdout');",
+    "console.error('fatal provider configuration mismatch');",
+    "process.exit(1);",
+  ].join("\n"));
+  await chmod(bin, 0o755);
+
+  try {
+    let failure: unknown;
+    try {
+      await createManagedOpencodeServer({ bin, cwd: root, env: { ATTEMPTS_PATH: attemptsPath } });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) throw new Error("Expected managed OpenCode startup to fail");
+    expect(failure.message).toContain("OpenCode server exited with code 1");
+    expect(failure.message).toContain("startup diagnostics from stdout");
+    expect(failure.message).toContain("fatal provider configuration mismatch");
+    expect((await readFile(attemptsPath, "utf8")).trim().split("\n")).toEqual(["start"]);
+    evidence.fact(
+      "Unknown code-1 startup failures stay actionable and bounded",
+      "A non-EADDRINUSE code-1 exit ran once, rejected with its exit code, and retained diagnostics from both stdout and stderr.",
+      true,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- contain request-owned cancellations without suppressing unrelated server telemetry
- classify managed-engine transport failures narrowly and keep non-EADDRINUSE startup exits actionable
- harden Node response cancellation, managed process teardown, and bounded address-in-use retries
- add app-less testkit coverage with 4 evidence facts

## Tests
- `pnpm --filter openwork-server exec bun --conditions=development test src/agent-context-diagnostics.test.ts src/engine-pool.test.ts src/managed-opencode.test.ts src/serve-node.test.ts src/telemetry.test.ts` — 93 passed, 0 failed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm evals:spec specs/server-error-boundaries.test.ts` — 1 file passed, 1 test passed, 0 skipped, 4 evidence facts (local lane)