### PR TITLE
fix(desktop): contain untargeted Electron errors

### DIFF
--- a/apps/desktop/electron/app-menu.mjs
+++ b/apps/desktop/electron/app-menu.mjs
@@ -3,7 +3,9 @@
 // and Windows/Linux menu-bar visibility. Extracted from main.mjs as a
 // factory (createRuntimeManager pattern); the NATIVE_MENU_* channels are
 // consumed by the preload bridge.
-import { BrowserWindow, Menu, shell } from "electron";
+import { BrowserWindow, Menu } from "electron";
+
+import { openExternalUrl } from "./open-external.mjs";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
@@ -207,8 +209,8 @@ export function createApplicationMenu({ appName, docsUrl, getWindow }) {
               ]),
           {
             label: "Docs",
-            click: async () => {
-              await shell.openExternal(docsUrl);
+            click: () => {
+              void openExternalUrl(docsUrl);
             },
           },
         ],

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -4,7 +4,15 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, WebContentsView, clipboard, session, shell } from "electron";
+import { app, WebContentsView, clipboard, session } from "electron";
+
+import {
+  isLoopbackWebUrl,
+  isSupportedExternalUrl,
+  loadBrowserTabUrl,
+  openExternalUrl,
+  routeOpenworkDeepLink,
+} from "./open-external.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BROWSER_SESSION_PARTITION = "persist:openwork-browser";
@@ -93,7 +101,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     if (url.startsWith("file://") || url.startsWith("data:")) return true;
     try {
       const target = new URL(url);
-      if (target.hostname === "127.0.0.1" || target.hostname === "localhost" || target.hostname === "[::1]") return true;
+      if (isLoopbackWebUrl(url)) return true;
       const currentUrl = window()?.webContents.getURL();
       if (!currentUrl || currentUrl === "about:blank") return true;
       const current = new URL(currentUrl);
@@ -152,10 +160,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       throw new Error(`Browser provider is not available yet: ${requestedProvider}`);
     }
     const url = normalizeBrowserUrl(rawUrl);
-    const tab = createBrowserTab("about:blank", { select: true });
+    const tab = createBrowserTab("about:blank", { select: true, load: false });
     await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
     const targetId = await resolveBrowserCdpTargetId(tab.tabId);
-    await tab.view.webContents.loadURL(url);
+    await loadBrowserTabUrl(url, (targetUrl) => tab.view.webContents.loadURL(targetUrl));
     return {
       provider: "builtin",
       browser_url: cdpBrowserUrl(),
@@ -399,7 +407,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         if (request.url) clipboard.writeText(request.url);
         break;
       case "open-external":
-        if (request.url && isHttpUrl(request.url)) void shell.openExternal(request.url);
+        if (request.url && isHttpUrl(request.url)) void openExternalUrl(request.url);
         break;
       case "close-tab":
         if (tab) closeBrowserTab(tab.tabId);
@@ -469,7 +477,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     callback(browserProxy.username, browserProxy.password);
   });
 
-  function createBrowserTab(url = "about:blank", { select = true } = {}) {
+  function createBrowserTab(url = "about:blank", { select = true, load = true } = {}) {
     const tabId = createBrowserTabId();
     const view = new WebContentsView({
       webPreferences: {
@@ -484,11 +492,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     const tab = { tabId, view, favicon: null };
     browserTabs.set(tabId, tab);
     browserTabOrder.push(tabId);
-    // Load about:blank immediately to preempt persistent-session restore.
-    // Cookies live on the session object, not the document — they survive this.
-    view.webContents.loadURL("about:blank");
     view.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
-      void shell.openExternal(targetUrl);
+      if (!routeOpenworkDeepLink(targetUrl, onDeepLink) && isSupportedExternalUrl(targetUrl)) {
+        void openExternalUrl(targetUrl);
+      }
       return { action: "deny" };
     });
     view.webContents.on("did-start-navigation", (_event, targetUrl, isInPlace, isMainFrame) => {
@@ -499,10 +506,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       if (target === "about:blank" || target.startsWith("data:")) return;
       // Intercept openwork:// deep links (e.g. den-auth handoff grants) so
       // in-app browser auth works without the system protocol handler.
-      if (target.startsWith("openwork://") || target.startsWith("openwork-dev://")) {
-        if (typeof onDeepLink === "function") {
-          onDeepLink([target]);
-        }
+      if (routeOpenworkDeepLink(target, onDeepLink)) {
         // Navigate the tab to about:blank to prevent the custom-scheme load
         // from erroring, then hide the panel. Avoid closing the tab
         // synchronously during a navigation event to prevent renderer crashes.
@@ -549,8 +553,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       sendBrowserState();
     }
     const finalUrl = normalizeBrowserUrl(url, "about:blank");
-    if (finalUrl !== "about:blank") {
-      view.webContents.loadURL(finalUrl);
+    // Loading once both preempts persistent-session restore and avoids aborting
+    // an initial about:blank promise when this tab has an immediate destination.
+    // Cookies live on the session object, not the document — they survive this.
+    if (load) {
+      void loadBrowserTabUrl(finalUrl, (targetUrl) => view.webContents.loadURL(targetUrl)).catch((error) => {
+        console.warn(`[browser] failed to load tab URL "${finalUrl}"`, error);
+      });
     }
     return tab;
   }
@@ -748,8 +757,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     ipcMain.handle("openwork:browser:hide", () => hideBrowserView());
     ipcMain.handle("openwork:browser:openUrl", (_event, url, provider) => openBrowserUrlForAutomation(url, provider));
     ipcMain.handle("openwork:browser:navigate", (_event, url) => {
-      const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
-      view.webContents.loadURL(normalizeBrowserUrl(url));
+      const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true, load: false }).view;
+      const targetUrl = normalizeBrowserUrl(url);
+      return loadBrowserTabUrl(targetUrl, (nextUrl) => view.webContents.loadURL(nextUrl));
     });
     ipcMain.handle("openwork:browser:back", () => {
       const webContents = getActiveWebContents();

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -50,7 +50,12 @@ import {
   persistConnectLinkBranding,
 } from "./connect-link-branding.mjs";
 import { resolveConnectLinkPublicKeys } from "./connect-link-keys.mjs";
-import { openExternalUrl } from "./open-external.mjs";
+import {
+  isLoopbackHttpUrl,
+  isSupportedExternalUrl,
+  openExternalUrl,
+  routeOpenworkDeepLink,
+} from "./open-external.mjs";
 import { resolveAppIdentifier, resolveUserDataPath } from "./dev-profile.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
 import {
@@ -2456,22 +2461,23 @@ async function createMainWindow() {
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("file://")) {
       try {
-        void shell.openPath(fileURLToPath(url));
-      } catch {
-        void openExternalUrl(url);
+        const targetPath = fileURLToPath(url);
+        void shell.openPath(targetPath).then((error) => {
+          if (error?.trim()) console.error(`[shell] openPath failed for "${targetPath}":`, error);
+        }).catch((error) => {
+          console.error(`[shell] openPath failed for "${targetPath}":`, error);
+        });
+      } catch (error) {
+        console.error("[shell] invalid file URL:", error);
       }
 
       return { action: "deny" };
     }
 
-    const local =
-      url.startsWith("http://127.0.0.1") ||
-      url.startsWith("http://localhost");
-    if (!local) {
-      void openExternalUrl(url);
-      return { action: "deny" };
-    }
-    return { action: "allow" };
+    if (isLoopbackHttpUrl(url)) return { action: "allow" };
+    if (routeOpenworkDeepLink(url, queueDeepLinks)) return { action: "deny" };
+    if (isSupportedExternalUrl(url)) void openExternalUrl(url);
+    return { action: "deny" };
   });
 
   mainWindow.webContents.on("will-navigate", (event, url) => {

--- a/apps/desktop/electron/open-external.mjs
+++ b/apps/desktop/electron/open-external.mjs
@@ -1,6 +1,9 @@
 import { spawn } from "node:child_process";
 
 const DEFAULT_TIMEOUT_MS = 4000;
+const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+const OPENWORK_PROTOCOLS = new Set(["openwork:", "openwork-dev:"]);
 
 function describeError(error) {
   if (error instanceof Error && error.message.trim()) return error.message;
@@ -15,7 +18,63 @@ async function defaultOpenExternal(url) {
   await electron.shell.openExternal(url);
 }
 
+function parseUrl(url) {
+  if (typeof url !== "string" || !url.trim()) return null;
+  try {
+    return new URL(url.trim());
+  } catch {
+    return null;
+  }
+}
+
+export function isSupportedExternalUrl(url) {
+  const parsed = parseUrl(url);
+  return Boolean(parsed && EXTERNAL_PROTOCOLS.has(parsed.protocol));
+}
+
+export function isLoopbackHttpUrl(url) {
+  const parsed = parseUrl(url);
+  return Boolean(parsed && parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()));
+}
+
+export function isLoopbackWebUrl(url) {
+  const parsed = parseUrl(url);
+  return Boolean(
+    parsed &&
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()),
+  );
+}
+
+export function routeOpenworkDeepLink(url, onDeepLink) {
+  const parsed = parseUrl(url);
+  if (!parsed || !OPENWORK_PROTOCOLS.has(parsed.protocol)) return false;
+  if (typeof onDeepLink === "function") onDeepLink([url.trim()]);
+  return true;
+}
+
+export function isCancelledNavigationError(error) {
+  const code = typeof error?.code === "string" ? error.code : "";
+  return code === "ERR_ABORTED";
+}
+
+export async function loadBrowserTabUrl(url, loadUrl) {
+  try {
+    return await loadUrl(url);
+  } catch (error) {
+    if (isCancelledNavigationError(error)) return undefined;
+    throw error;
+  }
+}
+
 export async function openExternalUrl(url, deps = {}) {
+  const target = typeof url === "string" ? url.trim() : "";
+  const parsed = parseUrl(target);
+  if (!parsed) return { ok: false, error: "invalid url" };
+  if (!EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+    return { ok: false, error: `External URL protocol "${parsed.protocol}" is not allowed.` };
+  }
+
   const env = deps.env ?? process.env;
   if (env.OPENWORK_SIMULATE_OPEN_EXTERNAL_FAILURE === "1") {
     const message = "simulated failure";
@@ -31,7 +90,7 @@ export async function openExternalUrl(url, deps = {}) {
   try {
     // why: shell.openExternal can hang forever on Windows machines with broken https URL associations; silence is the bug we're fixing.
     await Promise.race([
-      Promise.resolve().then(() => openExternal(url)),
+      Promise.resolve().then(() => openExternal(target)),
       new Promise((_, reject) => {
         timeoutId = setTimeout(() => {
           reject(new Error(`timed out after ${timeoutMs}ms`));
@@ -48,7 +107,7 @@ export async function openExternalUrl(url, deps = {}) {
       const spawnProcess = deps.spawnProcess ?? spawn;
       try {
         console.error("[shell] attempting rundll32 browser fallback");
-        const child = spawnProcess("rundll32", ["url.dll,FileProtocolHandler", url], {
+        const child = spawnProcess("rundll32", ["url.dll,FileProtocolHandler", target], {
           detached: true,
           stdio: "ignore",
         });

--- a/apps/desktop/electron/open-external.test.mjs
+++ b/apps/desktop/electron/open-external.test.mjs
@@ -1,9 +1,97 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { openExternalUrl } from "./open-external.mjs";
+import {
+  isCancelledNavigationError,
+  isLoopbackHttpUrl,
+  isLoopbackWebUrl,
+  isSupportedExternalUrl,
+  loadBrowserTabUrl,
+  openExternalUrl,
+  routeOpenworkDeepLink,
+} from "./open-external.mjs";
+
+describe("external URL policy", () => {
+  it("allows supported external protocols and rejects unsupported schemes", () => {
+    assert.equal(isSupportedExternalUrl("https://example.com"), true);
+    assert.equal(isSupportedExternalUrl("http://example.com"), true);
+    assert.equal(isSupportedExternalUrl("mailto:hello@example.com"), true);
+    assert.equal(isSupportedExternalUrl("file:///tmp/report.html"), false);
+    assert.equal(isSupportedExternalUrl("javascript:alert(1)"), false);
+    assert.equal(isSupportedExternalUrl("openwork://connect"), false);
+    assert.equal(isSupportedExternalUrl("not a url"), false);
+  });
+
+  it("recognizes exact loopback hosts without accepting lookalikes", () => {
+    assert.equal(isLoopbackHttpUrl("http://localhost:4096"), true);
+    assert.equal(isLoopbackHttpUrl("http://127.0.0.1:4096"), true);
+    assert.equal(isLoopbackHttpUrl("http://[::1]:4096"), true);
+    assert.equal(isLoopbackWebUrl("https://localhost:4096"), true);
+    assert.equal(isLoopbackHttpUrl("http://localhost.example.com"), false);
+    assert.equal(isLoopbackHttpUrl("http://127.0.0.1.example.com"), false);
+    assert.equal(isLoopbackHttpUrl("http://localhost@evil.example"), false);
+    assert.equal(isLoopbackHttpUrl("https://localhost:4096"), false);
+  });
+
+  it("routes both OpenWork popup protocols through the deep-link callback", () => {
+    const routed = [];
+    const onDeepLink = (urls) => routed.push(urls);
+
+    assert.equal(routeOpenworkDeepLink("openwork://connect?token=prod", onDeepLink), true);
+    assert.equal(routeOpenworkDeepLink("openwork-dev://connect?token=dev", onDeepLink), true);
+    assert.equal(routeOpenworkDeepLink("https://example.com", onDeepLink), false);
+    assert.deepEqual(routed, [
+      ["openwork://connect?token=prod"],
+      ["openwork-dev://connect?token=dev"],
+    ]);
+  });
+});
+
+describe("browser tab navigation errors", () => {
+  it("ignores only a coded ERR_ABORTED cancellation", async () => {
+    const aborted = Object.assign(new Error("navigation aborted"), { code: "ERR_ABORTED" });
+    assert.equal(isCancelledNavigationError(aborted), true);
+    assert.equal(
+      await loadBrowserTabUrl("https://example.com", async () => { throw aborted; }),
+      undefined,
+    );
+
+    const messageOnly = new Error("ERR_ABORTED while loading https://example.com");
+    assert.equal(isCancelledNavigationError(messageOnly), false);
+    await assert.rejects(
+      () => loadBrowserTabUrl("https://example.com", async () => { throw messageOnly; }),
+      messageOnly,
+    );
+  });
+
+  it("returns remote connection resets as controlled failures", async () => {
+    const reset = Object.assign(new Error("connection reset"), { code: "ERR_CONNECTION_RESET" });
+    assert.equal(isCancelledNavigationError(reset), false);
+    await assert.rejects(
+      () => loadBrowserTabUrl("https://example.com", async () => { throw reset; }),
+      reset,
+    );
+
+    const messageOnly = new Error("ERR_CONNECTION_RESET (-101) loading 'https://example.com'");
+    await assert.rejects(
+      () => loadBrowserTabUrl("https://example.com", async () => { throw messageOnly; }),
+      messageOnly,
+    );
+  });
+});
 
 describe("openExternalUrl", () => {
+  it("rejects unsupported protocols without calling shell.openExternal", async () => {
+    let opened = false;
+    const result = await openExternalUrl("file:///tmp/report.html", {
+      env: {},
+      openExternal: async () => { opened = true; },
+    });
+
+    assert.deepEqual(result, { ok: false, error: 'External URL protocol "file:" is not allowed.' });
+    assert.equal(opened, false);
+  });
+
   it("reports success when shell.openExternal resolves", async () => {
     let openedUrl = "";
     const result = await openExternalUrl("https://example.com", {

--- a/apps/desktop/electron/sentry.mjs
+++ b/apps/desktop/electron/sentry.mjs
@@ -6,6 +6,7 @@ let sentry = null;
 let initialized = false;
 let telemetryActive = false;
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const GPU_ABNORMAL_EXIT_WINDOW_MS = 60_000;
 
 function envFlagEnabled(name) {
   const value = process.env[name]?.trim().toLowerCase();
@@ -15,6 +16,26 @@ function envFlagEnabled(name) {
 function normalizeIdentifier(value) {
   const trimmed = String(value ?? "").trim();
   return trimmed || null;
+}
+
+export function isNoisyGpuAbnormalExitEvent(event) {
+  return event?.level === "warning"
+    && event?.message === "'GPU' process exited with 'abnormal-exit'"
+    && event?.tags?.["event.process"] === "GPU";
+}
+
+export function createGpuAbnormalExitSuppressor({
+  now = Date.now,
+  windowMs = GPU_ABNORMAL_EXIT_WINDOW_MS,
+} = {}) {
+  let suppressedAt = null;
+  return (event) => {
+    if (!isNoisyGpuAbnormalExitEvent(event)) return false;
+    const observedAt = now();
+    if (suppressedAt !== null && observedAt - suppressedAt < windowMs) return false;
+    suppressedAt = observedAt;
+    return true;
+  };
 }
 
 export function resolveOpenworkSentryAppVersion({ app, packageMetadata }) {
@@ -60,6 +81,7 @@ export async function initOpenworkSentry({ app, distribution, packageMetadata })
   const appVersion = resolveOpenworkSentryAppVersion({ app, packageMetadata });
   const release = resolveOpenworkSentryRelease({ appVersion });
   const sampleRate = buildConfig.tracesSampleRate;
+  const suppressGpuAbnormalExit = createGpuAbnormalExitSuppressor();
 
   sentry.init({
     dsn,
@@ -70,7 +92,7 @@ export async function initOpenworkSentry({ app, distribution, packageMetadata })
       (integration) => !["BrowserWindowSession", "ElectronMinidump", "MainProcessSession", "SentryMinidump"].includes(integration.name),
     ),
     tracesSampler: () => telemetryActive ? sampleRate : 0,
-    beforeSend: (event) => telemetryActive ? event : null,
+    beforeSend: (event) => telemetryActive && !suppressGpuAbnormalExit(event) ? event : null,
     beforeSendTransaction: (event) => telemetryActive ? event : null,
     initialScope: {
       tags: {

--- a/apps/desktop/electron/sentry.test.mjs
+++ b/apps/desktop/electron/sentry.test.mjs
@@ -2,9 +2,70 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createGpuAbnormalExitSuppressor,
+  isNoisyGpuAbnormalExitEvent,
   resolveOpenworkSentryAppVersion,
   resolveOpenworkSentryRelease,
 } from "./sentry.mjs";
+
+test("only the known GPU abnormal-exit message is treated as Sentry noise", () => {
+  assert.equal(isNoisyGpuAbnormalExitEvent({
+    level: "warning",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "GPU" },
+  }), true);
+
+  assert.equal(isNoisyGpuAbnormalExitEvent({
+    level: "warning",
+    message: "'Utility' process exited with 'abnormal-exit'",
+    tags: { "event.process": "Utility" },
+  }), false);
+  assert.equal(isNoisyGpuAbnormalExitEvent({
+    level: "warning",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "Utility" },
+  }), false);
+  assert.equal(isNoisyGpuAbnormalExitEvent({
+    level: "warning",
+    message: "GPU initialization failed with abnormal-exit",
+    tags: { "event.process": "GPU" },
+  }), false);
+});
+
+test("actionable GPU process failures remain reportable", () => {
+  for (const reason of ["crashed", "oom", "launch-failed", "integrity-failure"]) {
+    assert.equal(isNoisyGpuAbnormalExitEvent({
+      level: "error",
+      message: `'GPU' process exited with '${reason}'`,
+      tags: { "event.process": "GPU" },
+    }), false, reason);
+  }
+
+  assert.equal(isNoisyGpuAbnormalExitEvent({
+    level: "error",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "GPU" },
+  }), false);
+});
+
+test("only the first recoverable GPU warning is suppressed in a bounded interval", () => {
+  let now = 1_000;
+  const shouldSuppress = createGpuAbnormalExitSuppressor({
+    now: () => now,
+    windowMs: 60_000,
+  });
+  const warning = {
+    level: "warning",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "GPU" },
+  };
+
+  assert.equal(shouldSuppress(warning), true);
+  now += 1_000;
+  assert.equal(shouldSuppress(warning), false);
+  now += 59_000;
+  assert.equal(shouldSuppress(warning), true);
+});
 
 test("unpackaged Sentry release uses the desktop package version", () => {
   const appVersion = resolveOpenworkSentryAppVersion({

--- a/evals/specs/electron-error-boundaries.test.ts
+++ b/evals/specs/electron-error-boundaries.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  loadBrowserTabUrl,
+  openExternalUrl,
+  routeOpenworkDeepLink,
+} from "../../apps/desktop/electron/open-external.mjs";
+import {
+  createGpuAbnormalExitSuppressor,
+  isNoisyGpuAbnormalExitEvent,
+} from "../../apps/desktop/electron/sentry.mjs";
+
+test("Electron contains expected platform errors without hiding actionable failures", async ({ evidence }) => {
+  const openedUrls: string[] = [];
+  const unsupportedResults = await Promise.all([
+    "file:///tmp/report.html",
+    "javascript:alert(1)",
+    "openwork://connect?token=private",
+  ].map((url) => openExternalUrl(url, {
+    env: {},
+    openExternal: async (target) => {
+      openedUrls.push(target);
+    },
+  })));
+
+  expect(unsupportedResults.every((result) => result.ok === false)).toBe(true);
+  expect(openedUrls).toEqual([]);
+  evidence.fact(
+    "Unsupported external protocols never reach the operating system",
+    "file:, javascript:, and openwork: were all rejected before the injected shell.openExternal witness could observe a URL.",
+    unsupportedResults.every((result) => result.ok === false) && openedUrls.length === 0,
+  );
+
+  const routedDeepLinks: string[][] = [];
+  const onDeepLink = (urls: string[]) => routedDeepLinks.push(urls);
+  const productionRouted = routeOpenworkDeepLink("openwork://connect?token=prod", onDeepLink);
+  const developmentRouted = routeOpenworkDeepLink("openwork-dev://connect?token=dev", onDeepLink);
+  const webRouted = routeOpenworkDeepLink("https://example.com", onDeepLink);
+
+  expect(productionRouted).toBe(true);
+  expect(developmentRouted).toBe(true);
+  expect(webRouted).toBe(false);
+  expect(routedDeepLinks).toEqual([
+    ["openwork://connect?token=prod"],
+    ["openwork-dev://connect?token=dev"],
+  ]);
+  evidence.fact(
+    "OpenWork deep links route only to the desktop callback",
+    "Both production and development OpenWork protocols reached the callback unchanged, while an https URL did not.",
+    productionRouted && developmentRouted && !webRouted && routedDeepLinks.length === 2,
+  );
+
+  const aborted = Object.assign(new Error("navigation aborted"), { code: "ERR_ABORTED" });
+  const reset = Object.assign(new Error("connection reset"), { code: "ERR_CONNECTION_RESET" });
+  const contained = await loadBrowserTabUrl("https://example.com/aborted", async () => {
+    throw aborted;
+  });
+
+  expect(contained).toBeUndefined();
+  await expect(loadBrowserTabUrl("https://example.com/reset", async () => {
+    throw reset;
+  })).rejects.toBe(reset);
+  evidence.fact(
+    "Only cancelled navigation is contained",
+    "A coded ERR_ABORTED resolved as an expected cancellation, while ERR_CONNECTION_RESET rejected with the original failure.",
+    contained === undefined,
+  );
+
+  let now = 1_000;
+  const shouldSuppress = createGpuAbnormalExitSuppressor({ now: () => now, windowMs: 60_000 });
+  const recoverableWarning = {
+    level: "warning",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "GPU" },
+  };
+  const severeFailure = {
+    level: "error",
+    message: "'GPU' process exited with 'abnormal-exit'",
+    tags: { "event.process": "GPU" },
+  };
+  const firstSuppressed = shouldSuppress(recoverableWarning);
+  now += 1_000;
+  const repeatedSuppressed = shouldSuppress(recoverableWarning);
+  const severeSuppressed = shouldSuppress(severeFailure);
+
+  expect(firstSuppressed).toBe(true);
+  expect(repeatedSuppressed).toBe(false);
+  expect(isNoisyGpuAbnormalExitEvent(severeFailure)).toBe(false);
+  expect(severeSuppressed).toBe(false);
+  evidence.fact(
+    "GPU noise suppression stays bounded and severity-aware",
+    "The first known recoverable warning was suppressed; a repeat inside the window and the same message at error severity both remained reportable.",
+    firstSuppressed && !repeatedSuppressed && !severeSuppressed,
+  );
+});


### PR DESCRIPTION
## Summary
- restore the focused Electron error-boundary changes from `569cff727`
- allow only supported external protocols, route OpenWork deep links internally, and contain only coded navigation cancellations
- suppress only the first known recoverable GPU warning in a bounded interval while preserving repeated and severe events
- add an app-less `@openwork/testkit` spec with four observable facts

## Verification
- `pnpm --filter @openwork/desktop test` — 241 passed, 1 platform-specific skip
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm evals:spec specs/electron-error-boundaries.test.ts` — 1 passed, 4 evidence facts

Validation ran locally as requested. Evidence was not published.