### PR TITLE
fix(uploads): enforce safe filename boundaries

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -44,6 +44,8 @@ type UploadedChatAttachment = {
 };
 
 const WORKSPACE_INBOX_ROOT = ".opencode/openwork/inbox";
+const MAX_PATH_COMPONENT_BYTES = 255;
+const UTF8_ENCODER = new TextEncoder();
 
 const EXTENSION_MIME_TYPES: Record<string, string> = {
   jpg: "image/jpeg",
@@ -189,11 +191,40 @@ function normalizeFilenameExtension(filename: string, mime: string) {
   return `${stem.trim() || "attachment"}.${preferredExtension}`;
 }
 
-export function safeAttachmentFilename(filename: string) {
+function utf8ByteLength(value: string) {
+  return UTF8_ENCODER.encode(value).byteLength;
+}
+
+function truncateUtf8(value: string, maxBytes: number) {
+  let result = "";
+  let resultBytes = 0;
+  for (const character of value) {
+    const characterBytes = utf8ByteLength(character);
+    if (resultBytes + characterBytes > maxBytes) break;
+    result += character;
+    resultBytes += characterBytes;
+  }
+  return result;
+}
+
+function byteBoundedFilename(filename: string, maxBytes: number) {
+  if (utf8ByteLength(filename) <= maxBytes) return filename;
+
+  const dot = filename.lastIndexOf(".");
+  const extension = dot > 0 && dot < filename.length - 1 ? filename.slice(dot) : "";
+  const extensionBytes = utf8ByteLength(extension);
+  if (!extension || extensionBytes >= maxBytes) return truncateUtf8(filename, maxBytes);
+
+  const stem = filename.slice(0, -extension.length);
+  return `${truncateUtf8(stem, maxBytes - extensionBytes)}${extension}`;
+}
+
+export function safeAttachmentFilename(filename: string, maxBytes = MAX_PATH_COMPONENT_BYTES) {
   const normalized = filename.replace(/\\/g, "/");
   const basename = normalized.split("/").filter(Boolean).pop()?.trim() ?? "";
   const safe = basename.replace(/[\u0000-\u001f\u007f<>:"|?*]/g, "_").trim();
-  return safe && safe !== "." && safe !== ".." ? safe : "attachment";
+  const resolved = safe && safe !== "." && safe !== ".." ? safe : "attachment";
+  return byteBoundedFilename(resolved, maxBytes);
 }
 
 function safePathSegment(value: string, fallback: string) {
@@ -240,8 +271,9 @@ function randomAttachmentId() {
 export function buildChatAttachmentInboxPath(input: { sessionId: string; filename: string; id: string }) {
   const session = safePathSegment(input.sessionId, "session");
   const id = safePathSegment(input.id, "attachment");
-  const filename = safeAttachmentFilename(input.filename);
-  return `chat-attachments/${session}/${id}-${filename}`;
+  const prefix = `${id}-`;
+  const filename = safeAttachmentFilename(input.filename, MAX_PATH_COMPONENT_BYTES - utf8ByteLength(prefix));
+  return `chat-attachments/${session}/${prefix}${filename}`;
 }
 
 export function workspaceInboxPath(inboxRelativePath: string) {

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -291,6 +291,33 @@ describe("composer attachment file parts", () => {
     expect(workspaceInboxPath(inboxPath)).toBe(".opencode/openwork/inbox/chat-attachments/ses_123/nonce-abc-scan one 李.pdf");
   });
 
+  test("bounds long ASCII attachment names while preserving extension and unique id", () => {
+    const filename = `${"a".repeat(400)}.pdf`;
+    const first = buildChatAttachmentInboxPath({ sessionId: "ses_long", id: "nonce-a", filename });
+    const repeated = buildChatAttachmentInboxPath({ sessionId: "ses_long", id: "nonce-a", filename });
+    const second = buildChatAttachmentInboxPath({ sessionId: "ses_long", id: "nonce-b", filename });
+    const basename = first.split("/").pop();
+    if (!basename) throw new Error("Expected attachment basename");
+
+    expect(new TextEncoder().encode(basename).byteLength).toBe(255);
+    expect(basename.startsWith("nonce-a-")).toBe(true);
+    expect(basename.endsWith(".pdf")).toBe(true);
+    expect(first).toBe(repeated);
+    expect(first).not.toBe(second);
+  });
+
+  test("bounds long multibyte attachment names on UTF-8 character boundaries", () => {
+    const filename = `${"李".repeat(200)}.pdf`;
+    const path = buildChatAttachmentInboxPath({ sessionId: "ses_long", id: "nonce-a", filename });
+    const basename = path.split("/").pop();
+    if (!basename) throw new Error("Expected attachment basename");
+
+    expect(new TextEncoder().encode(basename).byteLength).toBe(255);
+    expect(basename.startsWith("nonce-a-")).toBe(true);
+    expect(basename.endsWith(".pdf")).toBe(true);
+    expect(basename).not.toContain("�");
+  });
+
   test("uploads exact bytes to the endpoint workspace id and exposes a worker file URL plus path note", async () => {
     const { endpoint, calls } = uploadRecorder("server-workspace-42");
     const file = new File([PDF_BYTES], "image-only scan.pdf", { type: "application/pdf" });

--- a/apps/server/src/inbox-upload-approval.e2e.test.ts
+++ b/apps/server/src/inbox-upload-approval.e2e.test.ts
@@ -14,6 +14,7 @@ const stops: Array<() => void | Promise<void>> = [];
 const roots: string[] = [];
 
 afterEach(async () => {
+  globalThis.__openworkDesktopTelemetry = undefined;
   while (stops.length) await stops.pop()?.();
   while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
 });
@@ -45,6 +46,95 @@ async function startManualApprovalServer() {
 }
 
 describe("inbox uploads under manual approval mode", () => {
+  test("malformed multipart is a stable client error without unexpected telemetry", async () => {
+    const { base, token } = await startManualApprovalServer();
+    const captured: unknown[] = [];
+    globalThis.__openworkDesktopTelemetry = {
+      captureException: (error) => {
+        captured.push(error);
+        return true;
+      },
+    };
+
+    const response = await fetch(`${base}/workspace/ws_1/inbox`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "multipart/form-data; boundary=openwork-test",
+      },
+      body: "not a multipart body",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "invalid_payload",
+      message: "Malformed multipart/form-data",
+    });
+    expect(captured).toEqual([]);
+  });
+
+  test("rejects an oversized destination path component as invalid_path", async () => {
+    const { base, token } = await startManualApprovalServer();
+    const form = new FormData();
+    form.append("file", new File(["valid"], "valid.txt", { type: "text/plain" }));
+    const inboxPath = `chat-attachments/session-1/${"a".repeat(256)}.txt`;
+
+    const response = await fetch(
+      `${base}/workspace/ws_1/inbox?path=${encodeURIComponent(inboxPath)}`,
+      { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: form },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "invalid_path",
+      message: "Path components must not exceed 255 UTF-8 bytes",
+    });
+  });
+
+  test("preserves a valid upload whose destination basename is exactly 255 bytes", async () => {
+    const { base, token, root } = await startManualApprovalServer();
+    const bytes = new TextEncoder().encode("boundary upload");
+    const form = new FormData();
+    form.append("file", new File([bytes], "valid.txt", { type: "text/plain" }));
+    const basename = `${"a".repeat(251)}.txt`;
+    const inboxPath = `chat-attachments/session-1/${basename}`;
+
+    const response = await fetch(
+      `${base}/workspace/ws_1/inbox?path=${encodeURIComponent(inboxPath)}`,
+      { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: form },
+    );
+
+    expect(new TextEncoder().encode(basename).byteLength).toBe(255);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, path: inboxPath, bytes: bytes.length });
+    const dest = join(root, ".opencode", "openwork", "inbox", inboxPath);
+    expect(Array.from(new Uint8Array(await readFile(dest)))).toEqual(Array.from(bytes));
+  });
+
+  test("rejects Windows-unsafe destination segments before an approval-free upload", async () => {
+    const { base, token, root } = await startManualApprovalServer();
+    const inboxPaths = [
+      "chat-attachments/session-1/CON.txt",
+      "chat-attachments/session-1/screenshot.png:metadata",
+      "chat-attachments/session-1/screenshot.png.",
+      "chat-attachments/session-1/screenshot.png ",
+      "chat-attachments/session-1./screenshot.png",
+    ];
+
+    for (const inboxPath of inboxPaths) {
+      const form = new FormData();
+      form.append("file", new File(["unsafe"], "valid.txt", { type: "text/plain" }));
+      const response = await fetch(
+        `${base}/workspace/ws_1/inbox?path=${encodeURIComponent(inboxPath)}`,
+        { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: form },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ code: "invalid_path" });
+      await expect(stat(join(root, ".opencode", "openwork", "inbox", inboxPath))).rejects.toThrow();
+    }
+  });
+
   test("chat-attachment inbox upload succeeds immediately without host approval", async () => {
     const { base, token, root } = await startManualApprovalServer();
     const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -16,6 +16,8 @@ const FILE_SESSION_MAX_BATCH_ITEMS = 64;
 const FILE_SESSION_MAX_FILE_BYTES = 5_000_000;
 const FILE_SESSION_CATALOG_DEFAULT_LIMIT = 2000;
 const FILE_SESSION_CATALOG_MAX_LIMIT = 10000;
+const MAX_PATH_COMPONENT_BYTES = 255;
+const WINDOWS_RESERVED_PATH_COMPONENT = /^(?:con|prn|aux|nul|clock\$|conin\$|conout\$|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i;
 
 type JsonResponse = (data: unknown, status?: number) => Response;
 type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
@@ -44,12 +46,17 @@ function resolveOutboxDir(workspaceRoot: string): string {
 }
 
 export function normalizeWorkspaceRelativePath(input: string, options: { allowSubdirs: boolean }): string {
-  const raw = String(input ?? "").trim();
+  const inputValue = String(input ?? "");
+  const hasTrailingSpace = / \s*$/.test(inputValue);
+  const raw = inputValue.trim();
   if (!raw) {
     throw new ApiError(400, "invalid_path", "Path is required");
   }
   if (raw.includes("\u0000")) {
     throw new ApiError(400, "invalid_path", "Path contains null byte");
+  }
+  if (hasTrailingSpace) {
+    throw new ApiError(400, "invalid_path", "Path components must not end with a dot or space");
   }
 
   // A lot of user-facing surfaces (artifacts, tool logs) reference files as
@@ -74,8 +81,28 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
     if (part === "." || part === "..") {
       throw new ApiError(400, "invalid_path", "Path traversal is not allowed");
     }
+    if (part.includes(":")) {
+      throw new ApiError(400, "invalid_path", "Path components must not contain colons");
+    }
+    if (/[. ]$/.test(part)) {
+      throw new ApiError(400, "invalid_path", "Path components must not end with a dot or space");
+    }
+    if (WINDOWS_RESERVED_PATH_COMPONENT.test(part)) {
+      throw new ApiError(400, "invalid_path", "Path components must not use Windows reserved device names");
+    }
+    if (Buffer.byteLength(part, "utf8") > MAX_PATH_COMPONENT_BYTES) {
+      throw new ApiError(400, "invalid_path", `Path components must not exceed ${MAX_PATH_COMPONENT_BYTES} UTF-8 bytes`);
+    }
   }
   return parts.join("/");
+}
+
+async function parseMultipartFormData(request: Request): Promise<FormData> {
+  try {
+    return await request.formData();
+  } catch {
+    throw new ApiError(400, "invalid_payload", "Malformed multipart/form-data");
+  }
 }
 
 export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean {
@@ -204,8 +231,8 @@ export async function resolveWorkspaceArtifactTargets(workspaceRoot: string, inp
     if (!item || typeof item !== "object") continue;
     const target = item as ArtifactTargetInput;
     const kind = target.kind === "url" ? "url" : "file";
-    const rawValue = typeof target.value === "string" ? target.value.trim() : "";
-    if (!rawValue) continue;
+    const rawValue = typeof target.value === "string" ? target.value.trimStart() : "";
+    if (!rawValue.trim()) continue;
     const confidence = typeof target.confidence === "number" && Number.isFinite(target.confidence) ? target.confidence : 0;
     const reason = typeof target.reason === "string" ? target.reason : "server";
 
@@ -370,9 +397,8 @@ function parseSessionCursor(input: string | null): number {
 
 function parseCatalogPathFilter(input: string | null): string | null {
   if (!input) return null;
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  return normalizeWorkspaceRelativePath(trimmed, { allowSubdirs: true });
+  if (!input.trim()) return null;
+  return normalizeWorkspaceRelativePath(input, { allowSubdirs: true });
 }
 
 function matchesCatalogFilter(path: string, filter: string | null): boolean {
@@ -586,15 +612,15 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
     if (!contentType.toLowerCase().includes("multipart/form-data")) {
       throw new ApiError(400, "invalid_payload", "Expected multipart/form-data");
     }
-    const form = await ctx.request.formData();
+    const form = await parseMultipartFormData(ctx.request);
     const file = form.get("file");
     if (!(file instanceof File)) {
       throw new ApiError(400, "file_required", "Form field 'file' is required");
     }
 
-    const queryPath = (ctx.url.searchParams.get("path") ?? "").trim();
-    const formPath = typeof form.get("path") === "string" ? String(form.get("path") || "").trim() : "";
-    const requestedPath = queryPath || formPath || file.name;
+    const queryPath = ctx.url.searchParams.get("path") ?? "";
+    const formPath = typeof form.get("path") === "string" ? String(form.get("path") || "") : "";
+    const requestedPath = queryPath.trim() ? queryPath : formPath.trim() ? formPath : file.name;
 
     const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
     const inboxRoot = resolveInboxDir(workspace.path);
@@ -613,7 +639,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
 
     await ensureDir(dirname(dest));
     const bytes = Buffer.from(await file.arrayBuffer());
-    const tmp = `${dest}.tmp-${shortId()}`;
+    const tmp = join(dirname(dest), `.upload-${shortId()}.tmp`);
     await writeFile(tmp, bytes);
     await rename(tmp, dest);
 
@@ -1027,7 +1053,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
 
   addRoute(routes, "GET", "/workspace/:id/files/content", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const requested = ctx.url.searchParams.get("path") ?? "";
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
     if (!isSupportedWorkspaceTextFilePath(relativePath)) {
       throw new ApiError(400, "invalid_path", "Only supported text artifact files can be read inline");
@@ -1053,7 +1079,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
 
   addRoute(routes, "GET", "/workspace/:id/files/stat", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const requested = ctx.url.searchParams.get("path") ?? "";
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
     const absPath = resolveSafeChildPath(workspace.path, relativePath);
     if (!(await exists(absPath))) {
@@ -1072,7 +1098,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
 
   addRoute(routes, "GET", "/workspace/:id/files/raw", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const requested = ctx.url.searchParams.get("path") ?? "";
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
     const absPath = resolveSafeChildPath(workspace.path, relativePath);
     if (!(await exists(absPath))) {

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -4,6 +4,7 @@ import { isSupportedWorkspaceTextFilePath, normalizeWorkspaceRelativePath } from
 describe("normalizeWorkspaceRelativePath", () => {
   test("accepts a plain workspace-relative path", () => {
     expect(normalizeWorkspaceRelativePath("notes.md", { allowSubdirs: true })).toBe("notes.md");
+    expect(normalizeWorkspaceRelativePath("  notes.md\n", { allowSubdirs: true })).toBe("notes.md");
   });
 
   test("strips workspace/ prefix", () => {
@@ -37,6 +38,53 @@ describe("normalizeWorkspaceRelativePath", () => {
   test("treats workspace/ with no file as invalid", () => {
     expect(() => normalizeWorkspaceRelativePath("workspace/", { allowSubdirs: true })).toThrow();
     expect(() => normalizeWorkspaceRelativePath("/workspace/", { allowSubdirs: true })).toThrow();
+  });
+
+  test("rejects Windows reserved device names in any segment", () => {
+    for (const path of [
+      "CON",
+      "reports/con.txt",
+      "reports/NUL.json",
+      "PRN.csv",
+      "AUX",
+      "COM1.log",
+      "reports/com9",
+      "LPT1.txt",
+      "reports/lpt9.json",
+      "CLOCK$",
+      "CONIN$.txt",
+      "CONOUT$",
+    ]) {
+      expect(() => normalizeWorkspaceRelativePath(path, { allowSubdirs: true }))
+        .toThrow("Path components must not use Windows reserved device names");
+    }
+  });
+
+  test("rejects alternate data stream colons in any segment", () => {
+    for (const path of ["reports/summary.txt:secret", "reports:secret/summary.txt", "C:/summary.txt"]) {
+      expect(() => normalizeWorkspaceRelativePath(path, { allowSubdirs: true }))
+        .toThrow("Path components must not contain colons");
+    }
+  });
+
+  test("rejects path segments with trailing dots or spaces", () => {
+    for (const path of ["reports/summary.txt.", "reports/summary.txt ", "reports./summary.txt", "reports /summary.txt"]) {
+      expect(() => normalizeWorkspaceRelativePath(path, { allowSubdirs: true }))
+        .toThrow("Path components must not end with a dot or space");
+    }
+  });
+
+  test("retains ordinary names that merely resemble Windows devices", () => {
+    for (const path of [
+      "reports/console.txt",
+      "reports/auxiliary.txt",
+      "reports/com0.txt",
+      "reports/com10.txt",
+      "reports/lpt10.txt",
+      "reports/revenue report.v1.txt",
+    ]) {
+      expect(normalizeWorkspaceRelativePath(path, { allowSubdirs: true })).toBe(path);
+    }
   });
 });
 

--- a/evals/specs/upload-error-boundaries.test.ts
+++ b/evals/specs/upload-error-boundaries.test.ts
@@ -6,7 +6,7 @@ import { normalizeWorkspaceRelativePath } from "../../apps/server/src/routes/fil
 
 const encoder = new TextEncoder();
 
-test("upload filenames fit filesystem component limits without losing their extensions", ({ evidence }) => {
+test("upload filename and path boundaries reject unsafe writes", ({ evidence }) => {
   const asciiInput = `${"a".repeat(400)}.pdf`;
   const multibyteInput = `${"李".repeat(200)}.txt`;
   const asciiName = safeAttachmentFilename(asciiInput);
@@ -27,9 +27,6 @@ test("upload filenames fit filesystem component limits without losing their exte
     `The ${encoder.encode(asciiInput).byteLength}-byte ASCII and ${encoder.encode(multibyteInput).byteLength}-byte multibyte inputs became ${encoder.encode(asciiName).byteLength}-byte .pdf and ${encoder.encode(multibyteName).byteLength}-byte .txt names without a broken UTF-8 character.`,
     true,
   );
-});
-
-test("upload paths reject Windows-unsafe and oversized components", ({ evidence }) => {
   const unsafePaths = [
     ["reports/CON.txt", "Windows reserved device names"],
     ["reports/screenshot.png:metadata", "must not contain colons"],

--- a/evals/specs/upload-error-boundaries.test.ts
+++ b/evals/specs/upload-error-boundaries.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { safeAttachmentFilename } from "../../apps/app/src/react-app/domains/session/sync/attachment-file-part";
+import { normalizeWorkspaceRelativePath } from "../../apps/server/src/routes/files";
+
+const encoder = new TextEncoder();
+
+test("upload filenames fit filesystem component limits without losing their extensions", ({ evidence }) => {
+  const asciiInput = `${"a".repeat(400)}.pdf`;
+  const multibyteInput = `${"李".repeat(200)}.txt`;
+  const asciiName = safeAttachmentFilename(asciiInput);
+  const multibyteName = safeAttachmentFilename(multibyteInput);
+
+  expect(encoder.encode(asciiInput).byteLength).toBeGreaterThan(255);
+  expect(encoder.encode(multibyteInput).byteLength).toBeGreaterThan(255);
+  expect(encoder.encode(asciiName).byteLength).toBeLessThanOrEqual(255);
+  expect(encoder.encode(multibyteName).byteLength).toBeLessThanOrEqual(255);
+  expect(asciiName.endsWith(".pdf")).toBe(true);
+  expect(multibyteName.endsWith(".txt")).toBe(true);
+  expect(asciiName).not.toBe(asciiInput);
+  expect(multibyteName).not.toBe(multibyteInput);
+  expect(multibyteName).not.toContain("�");
+
+  evidence.fact(
+    "Oversized ASCII and multibyte upload names are bounded with extensions preserved",
+    `The ${encoder.encode(asciiInput).byteLength}-byte ASCII and ${encoder.encode(multibyteInput).byteLength}-byte multibyte inputs became ${encoder.encode(asciiName).byteLength}-byte .pdf and ${encoder.encode(multibyteName).byteLength}-byte .txt names without a broken UTF-8 character.`,
+    true,
+  );
+});
+
+test("upload paths reject Windows-unsafe and oversized components", ({ evidence }) => {
+  const unsafePaths = [
+    ["reports/CON.txt", "Windows reserved device names"],
+    ["reports/screenshot.png:metadata", "must not contain colons"],
+    ["reports/screenshot.png.", "must not end with a dot or space"],
+    ["reports/screenshot.png ", "must not end with a dot or space"],
+  ] as const;
+
+  for (const [path, message] of unsafePaths) {
+    expect(() => normalizeWorkspaceRelativePath(path, { allowSubdirs: true })).toThrow(message);
+  }
+
+  for (const segment of ["a".repeat(256), "李".repeat(86)]) {
+    expect(encoder.encode(segment).byteLength).toBeGreaterThan(255);
+    expect(() => normalizeWorkspaceRelativePath(`reports/${segment}`, { allowSubdirs: true }))
+      .toThrow("Path components must not exceed 255 UTF-8 bytes");
+  }
+
+  const boundaryName = `${"a".repeat(251)}.txt`;
+  expect(encoder.encode(boundaryName).byteLength).toBe(255);
+  expect(normalizeWorkspaceRelativePath(`reports/${boundaryName}`, { allowSubdirs: true }))
+    .toBe(`reports/${boundaryName}`);
+  expect(normalizeWorkspaceRelativePath("reports/console.txt", { allowSubdirs: true }))
+    .toBe("reports/console.txt");
+
+  evidence.fact(
+    "Windows-unsafe and oversized upload path components are rejected at the server boundary",
+    "Reserved-device, alternate-data-stream, trailing-dot, trailing-space, 256-byte ASCII, and 258-byte multibyte components all threw their expected invalid-path messages; an exact 255-byte filename and an ordinary lookalike remained valid.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- bound attachment basenames to 255 UTF-8 bytes while preserving extensions and unique attachment prefixes
- reject Windows-unsafe and oversized workspace path components, and return a stable 400 for malformed multipart uploads without telemetry
- add focused app, server, and app-less testkit coverage for upload error boundaries

## Testing
- `pnpm --dir apps/app exec bun test --isolate tests/attachment-file-part.test.ts`
- `pnpm --dir apps/server exec bun --conditions=development test src/inbox-upload-approval.e2e.test.ts src/server.normalizeWorkspaceRelativePath.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm evals:spec specs/upload-error-boundaries.test.ts`