### PR TITLE
fix(desktop): bound Windows workspace roots

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -8,7 +8,13 @@ import path from "node:path";
 import tls from "node:tls";
 import { fileURLToPath } from "node:url";
 import { pathToFileURL } from "node:url";
-import { desktopBootstrapPath, openworkEnvStorePath, openworkServerConfigPath, resolveWorkspaceOpencodeConfigPath } from "@openwork/paths";
+import {
+  desktopBootstrapPath,
+  normalizeWorkspaceRootPath,
+  openworkEnvStorePath,
+  openworkServerConfigPath,
+  resolveWorkspaceOpencodeConfigPath,
+} from "@openwork/paths";
 import {
   dedupeCertificates,
   resolveSystemCaBundle,
@@ -144,26 +150,63 @@ function appendOutput(state, key, chunk) {
   state[key] = truncateOutput(next);
 }
 
-function normalizeWorkspaceKey(value) {
-  const trimmed = String(value ?? "").trim();
-  if (!trimmed) return "";
-  return path.resolve(trimmed).replace(/\\/g, "/").toLowerCase();
+function normalizeWorkspaceKey(value, platform = process.platform) {
+  try {
+    const normalized = normalizeWorkspaceRootPath(value, { platform });
+    if (!normalized) return "";
+    const paths = platform === "win32" ? path.win32 : path;
+    return paths.resolve(normalized).replace(/\\/g, "/").toLowerCase();
+  } catch {
+    return "";
+  }
 }
 
-export function prioritizeWorkspacePaths(preferredPath, workspacePaths = []) {
-  const preferred = String(preferredPath ?? "").trim();
+export function prioritizeWorkspacePaths(preferredPath, workspacePaths = [], options = {}) {
+  const platform = options.platform ?? process.platform;
   const paths = [];
   const seen = new Set();
   const add = (value) => {
-    const workspacePath = String(value ?? "").trim();
-    const key = normalizeWorkspaceKey(workspacePath);
+    let workspacePath;
+    try {
+      workspacePath = normalizeWorkspaceRootPath(value, { platform });
+    } catch {
+      return;
+    }
+    const key = normalizeWorkspaceKey(workspacePath, platform);
     if (!workspacePath || !key || seen.has(key)) return;
     paths.push(workspacePath);
     seen.add(key);
   };
-  add(preferred);
+  add(preferredPath);
   for (const workspacePath of workspacePaths) add(workspacePath);
   return paths;
+}
+
+function workspaceInaccessibleError(workspacePath, cause) {
+  if (cause && typeof cause === "object" && cause.code === "workspace_inaccessible") return cause;
+  const error = new Error(`Workspace path is not accessible: ${workspacePath}`, { cause });
+  Object.defineProperties(error, {
+    code: { value: "workspace_inaccessible", enumerable: true },
+    workspacePath: { value: workspacePath, enumerable: true },
+  });
+  return error;
+}
+
+export async function prepareRuntimeWorkspaceRoot(projectDir, options = {}) {
+  const rawProjectDir = String(projectDir ?? "").trim();
+  try {
+    const workspaceRoot = normalizeWorkspaceRootPath(rawProjectDir, {
+      platform: options.platform ?? process.platform,
+    });
+    if (!workspaceRoot) throw new Error("projectDir is required");
+    await (options.mkdirImpl ?? mkdir)(workspaceRoot, { recursive: true });
+    if (typeof options.ensureConfig === "function") {
+      await options.ensureConfig(workspaceRoot);
+    }
+    return workspaceRoot;
+  } catch (error) {
+    throw workspaceInaccessibleError(rawProjectDir, error);
+  }
 }
 
 export function resolveOpenworkServerConfigPath(env = process.env) {
@@ -1241,7 +1284,14 @@ export function mergeSystemCaChildEnv(baseEnv = {}, caEnv = {}, extra = {}) {
   };
 }
 
-export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths, localManagedMcpVaultKey }) {
+export function createRuntimeManager({
+  app,
+  desktopRoot,
+  listLocalWorkspacePaths,
+  localManagedMcpVaultKey,
+  workspaceMkdir = mkdir,
+  workspacePlatform = process.platform,
+}) {
   const inheritedProcessEnv = { ...process.env };
   let injectedUserEnvKeys = new Set();
   const engineState = createEngineState();
@@ -1324,7 +1374,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
 
   async function loadOrCreateWorkspaceTokens(workspaceKey) {
     const store = await loadTokenStore();
-    const normalized = normalizeWorkspaceKey(workspaceKey);
+    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
     if (store.workspaces?.[normalized]) {
       return store.workspaces[normalized];
     }
@@ -1342,7 +1392,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
 
   async function persistWorkspaceOwnerToken(workspaceKey, ownerToken) {
     const store = await loadTokenStore();
-    const normalized = normalizeWorkspaceKey(workspaceKey);
+    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
     if (!store.workspaces?.[normalized]) return;
     store.workspaces[normalized].ownerToken = ownerToken;
     store.workspaces[normalized].updatedAt = nowMs();
@@ -1351,7 +1401,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
 
   async function readPreferredOpenworkPort(workspaceKey) {
     const state = await loadPortState();
-    const normalized = normalizeWorkspaceKey(workspaceKey);
+    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
     if (normalized && state.workspacePorts?.[normalized]) {
       return state.workspacePorts[normalized];
     }
@@ -1360,7 +1410,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
 
   async function persistPreferredOpenworkPort(workspaceKey, port) {
     const state = await loadPortState();
-    const normalized = normalizeWorkspaceKey(workspaceKey);
+    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
     state.version = 4;
     state.workspacePorts ??= {};
     if (normalized) {
@@ -1810,7 +1860,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // the server config loader will ignore server.json and lose server-created
     // workspaces after restart.
     const serverConfigPath = resolveOpenworkServerConfigPath(process.env);
-    const requestedWorkspacePaths = (options.workspacePaths ?? []).filter((value) => value.trim().length > 0);
+    const requestedWorkspacePaths = prioritizeWorkspacePaths("", options.workspacePaths, {
+      platform: workspacePlatform,
+    });
     const workspacePaths = seedWorkspacePathsForEmbeddedServer(
       requestedWorkspacePaths,
       existsSync(serverConfigPath),
@@ -1944,6 +1996,16 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     lifecycleState = "idle";
   }
 
+  function settleAfterWorkspacePreparationFailure() {
+    if (snapshotOpenworkServerState(openworkServerState).running) {
+      lifecycleState = "healthy";
+      return;
+    }
+    Object.assign(engineState, createEngineState());
+    Object.assign(openworkServerState, createOpenworkServerState());
+    lifecycleState = "idle";
+  }
+
   async function ensureOpenwork(options) {
     let openworkServer;
     try {
@@ -1966,9 +2028,16 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function engineStart(projectDir, options = {}) {
-    const safeProjectDir = String(projectDir ?? "").trim();
-    if (!safeProjectDir) {
+    const rawProjectDir = String(projectDir ?? "").trim();
+    if (!rawProjectDir) {
       throw new Error("projectDir is required");
+    }
+    let safeProjectDir;
+    try {
+      safeProjectDir = normalizeWorkspaceRootPath(rawProjectDir, { platform: workspacePlatform });
+    } catch (error) {
+      settleAfterWorkspacePreparationFailure();
+      throw workspaceInaccessibleError(rawProjectDir, error);
     }
 
     // Reuse a healthy server instead of tearing it down. During boot the
@@ -1987,7 +2056,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       options.forceRestart !== true &&
       openworkServerState.inProcess &&
       lifecycleState === "healthy" &&
-      normalizeWorkspaceKey(engineState.projectDir) === normalizeWorkspaceKey(safeProjectDir) &&
+      normalizeWorkspaceKey(engineState.projectDir, workspacePlatform) === normalizeWorkspaceKey(safeProjectDir, workspacePlatform) &&
       openworkServerState.remoteAccessEnabled === requestedRemoteAccess &&
       openworkServerState.engineRollover === requestedEngineRollover
     ) {
@@ -1997,13 +2066,22 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       }
     }
 
-    await mkdir(safeProjectDir, { recursive: true });
-    await ensureOpencodeConfig(safeProjectDir);
+    lifecycleState = "starting";
+    try {
+      safeProjectDir = await prepareRuntimeWorkspaceRoot(safeProjectDir, {
+        platform: workspacePlatform,
+        mkdirImpl: workspaceMkdir,
+        ensureConfig: ensureOpencodeConfig,
+      });
+    } catch (error) {
+      settleAfterWorkspacePreparationFailure();
+      throw error;
+    }
     await prepareFreshRuntime();
 
-    const workspacePaths = [safeProjectDir, ...((options.workspacePaths ?? []).filter(Boolean))].filter(
-      (value, index, list) => list.indexOf(value) === index,
-    );
+    const workspacePaths = prioritizeWorkspacePaths(safeProjectDir, options.workspacePaths, {
+      platform: workspacePlatform,
+    });
     const runtime = DIRECT_RUNTIME;
 
     try {
@@ -2078,7 +2156,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function openworkServerRestart(options = {}) {
-    const workspacePaths = prioritizeWorkspacePaths(engineState.projectDir, await listLocalWorkspacePaths());
+    const workspacePaths = prioritizeWorkspacePaths(engineState.projectDir, await listLocalWorkspacePaths(), {
+      platform: workspacePlatform,
+    });
     const shouldManageOpencode = Boolean(
       openworkServerState.managedOpencodeBinPath || engineState.opencodeBinPath || !engineState.baseUrl,
     );

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -7,7 +7,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   commandMatchesPackagedSidecar,
+  createRuntimeManager,
   embeddedServerImportUrl,
+  prepareRuntimeWorkspaceRoot,
   prioritizeWorkspacePaths,
   resetRuntimeStatesAfterFailedServerStart,
   resolveEngineRolloverPreference,
@@ -18,6 +20,64 @@ import {
   snapshotEngineState,
   snapshotOpenworkServerState,
 } from "./runtime.mjs";
+
+describe("workspace root preparation", () => {
+  it("reports an inaccessible Windows drive as a controlled recoverable error", async () => {
+    const mkdirError = Object.assign(new Error("drive is unavailable"), { code: "ENOENT" });
+    let attemptedPath = null;
+
+    await assert.rejects(
+      prepareRuntimeWorkspaceRoot("\\\\?\\Z:\\Disconnected\\Workspace", {
+        platform: "win32",
+        mkdirImpl: async (workspaceRoot) => {
+          attemptedPath = workspaceRoot;
+          throw mkdirError;
+        },
+      }),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.ok("code" in error);
+        assert.ok("workspacePath" in error);
+        assert.equal(error.code, "workspace_inaccessible");
+        assert.equal(error.workspacePath, "\\\\?\\Z:\\Disconnected\\Workspace");
+        assert.equal(error.cause, mkdirError);
+        return true;
+      },
+    );
+    assert.equal(attemptedPath, "Z:\\Disconnected\\Workspace");
+  });
+
+  it("returns the runtime lifecycle to idle after root preparation fails", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwork-runtime-root-"));
+    try {
+      const manager = createRuntimeManager({
+        app: {
+          getPath: (name) => name === "exe" ? path.join(root, "OpenWork.exe") : root,
+          isPackaged: false,
+        },
+        desktopRoot: path.dirname(fileURLToPath(import.meta.url)),
+        listLocalWorkspacePaths: async () => [],
+        localManagedMcpVaultKey: "test-key",
+        workspaceMkdir: async () => {
+          throw Object.assign(new Error("network share disconnected"), { code: "ENOENT" });
+        },
+        workspacePlatform: "win32",
+      });
+
+      await assert.rejects(
+        manager.engineStart("\\\\server\\share\\Workspace"),
+        (error) => error instanceof Error && "code" in error && error.code === "workspace_inaccessible",
+      );
+      const status = await manager.runtimeStatus();
+      assert.equal(status.lifecycleState, "idle");
+      assert.equal(status.engine.running, false);
+      assert.equal(status.engine.projectDir, null);
+      assert.equal(status.openworkServer.running, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("bundled OpenCode runtime", () => {
   it("pins the engine release containing the timestamp-based session loop repair", async () => {

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -9,6 +9,7 @@ import path from "node:path";
 import {
   desktopBootstrapPath as resolveDesktopBootstrapPath,
   legacyDesktopBootstrapPath as resolveLegacyDesktopBootstrapPath,
+  normalizeWorkspaceRootPath,
   openworkServerConfigPath as resolveOpenworkServerConfigPath,
 } from "@openwork/paths";
 
@@ -525,25 +526,26 @@ export function createWorkspaceStore({
       : trimmed.startsWith("~/") || trimmed.startsWith("~\\")
         ? path.join(os.homedir(), trimmed.slice(2))
         : trimmed;
-    const resolved = path.resolve(expanded);
+    const normalized = normalizeWorkspaceRootPath(expanded, { platform: process.platform });
+    const resolved = path.resolve(normalized);
     return realpath(resolved).catch(() => resolved);
   }
 
   function normalizeWorkspacePathKey(value) {
-    const trimmed = String(value ?? "").trim();
-    return trimmed ? path.resolve(trimmed).replace(/\\/g, "/").toLowerCase() : "";
+    try {
+      const normalized = normalizeWorkspaceRootPath(value, { platform: process.platform });
+      return normalized ? path.resolve(normalized).replace(/\\/g, "/").toLowerCase() : "";
+    } catch {
+      return "";
+    }
   }
 
   function normalizeRecoveredWorkspacePath(value) {
-    const trimmed = String(value ?? "").trim();
-    if (!trimmed) return "";
-    if (process.platform !== "win32") return trimmed;
-    return trimmed
-      .replace(/^\\\\\?\\UNC\\/i, "\\\\")
-      .replace(/^\\\\\?\\/i, "")
-      .replace(/^\/\/\?\/UNC\//i, "//")
-      .replace(/^\/\/\?\//i, "")
-      .replace(/\//g, "\\");
+    try {
+      return normalizeWorkspaceRootPath(value, { platform: process.platform });
+    } catch {
+      return "";
+    }
   }
 
   function isRecord(value) {

--- a/evals/specs/windows-workspace-root-boundaries.test.ts
+++ b/evals/specs/windows-workspace-root-boundaries.test.ts
@@ -1,0 +1,90 @@
+import { expect } from "vitest";
+import { briefTest, claim, specBrief } from "@openwork/testkit";
+import { normalizeWorkspaceRootPath } from "../../packages/paths/index.mjs";
+import { prepareRuntimeWorkspaceRoot } from "../../apps/desktop/electron/runtime.mjs";
+
+briefTest(specBrief({
+  behavior: "Windows workspace roots stay within filesystem path boundaries and fail recoverably when unavailable.",
+  claims: {
+    verbatimNormalization: claim("valid verbatim drive and UNC roots normalize to ordinary Windows filesystem paths", {
+      never: "retain a Windows device namespace prefix",
+    }),
+    deviceRejection: claim("Win32 device namespace roots are rejected", {
+      never: "treat named pipes or physical devices as workspaces",
+    }),
+    disconnectedRetention: claim("a normal disconnected drive root remains unchanged", {
+      never: "resolve it against a different drive or consult its availability during normalization",
+    }),
+    inaccessibleRecovery: claim("an inaccessible root reports workspace_inaccessible and can be retried", {
+      never: "surface the injected filesystem error unwrapped or lose the requested workspace path",
+    }),
+  },
+}), async ({ prove }) => {
+  const driveRoot = normalizeWorkspaceRootPath("\\\\?\\C:\\Users\\Ada\\Workspace", { platform: "win32" });
+  const uncRoot = normalizeWorkspaceRootPath("\\\\?\\UNC\\server\\share\\Workspace", { platform: "win32" });
+  expect(driveRoot).toBe("C:\\Users\\Ada\\Workspace");
+  expect(uncRoot).toBe("\\\\server\\share\\Workspace");
+  expect(driveRoot).not.toMatch(/^\\\\[?.]\\/);
+  expect(uncRoot).not.toMatch(/^\\\\[?.]\\/);
+  prove.verbatimNormalization(
+    true,
+    `The verbatim drive normalized to ${driveRoot} and the verbatim UNC root normalized to ${uncRoot}; neither retained a device namespace prefix.`,
+  );
+
+  const deviceRoots = [
+    "\\\\.\\pipe\\openwork",
+    "//./PIPE/openwork",
+    "\\\\.\\PhysicalDrive0",
+  ];
+  for (const deviceRoot of deviceRoots) {
+    let thrown: unknown;
+    try {
+      normalizeWorkspaceRootPath(deviceRoot, { platform: "win32" });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(TypeError);
+    expect(thrown).toMatchObject({ code: "invalid_workspace_root" });
+  }
+  prove.deviceRejection(
+    true,
+    `All ${deviceRoots.length} injected device namespace roots threw TypeError with invalid_workspace_root instead of becoming workspaces.`,
+  );
+
+  const disconnectedRoot = "Z:\\Disconnected\\Workspace";
+  const retainedRoot = normalizeWorkspaceRootPath(disconnectedRoot, { platform: "win32" });
+  expect(retainedRoot).toBe(disconnectedRoot);
+  expect(retainedRoot).not.toMatch(/^C:/i);
+  prove.disconnectedRetention(
+    true,
+    `${disconnectedRoot} was retained byte-for-byte and was not resolved onto the current drive.`,
+  );
+
+  const rawInaccessibleRoot = "\\\\?\\Z:\\Disconnected\\Workspace";
+  const normalizedInaccessibleRoot = "Z:\\Disconnected\\Workspace";
+  const filesystemError = Object.assign(new Error("drive is unavailable"), { code: "ENOENT" });
+  const attemptedRoots: string[] = [];
+  await expect(prepareRuntimeWorkspaceRoot(rawInaccessibleRoot, {
+    platform: "win32",
+    mkdirImpl: async (workspaceRoot: string) => {
+      attemptedRoots.push(workspaceRoot);
+      throw filesystemError;
+    },
+  })).rejects.toMatchObject({
+    code: "workspace_inaccessible",
+    workspacePath: rawInaccessibleRoot,
+    cause: filesystemError,
+  });
+  const retriedRoot = await prepareRuntimeWorkspaceRoot(rawInaccessibleRoot, {
+    platform: "win32",
+    mkdirImpl: async (workspaceRoot: string) => {
+      attemptedRoots.push(workspaceRoot);
+    },
+  });
+  expect(attemptedRoots).toEqual([normalizedInaccessibleRoot, normalizedInaccessibleRoot]);
+  expect(retriedRoot).toBe(normalizedInaccessibleRoot);
+  prove.inaccessibleRecovery(
+    true,
+    `The injected ENOENT was wrapped as workspace_inaccessible for ${rawInaccessibleRoot}; a retry targeted ${normalizedInaccessibleRoot} again and succeeded.`,
+  );
+});

--- a/packages/paths/index.d.ts
+++ b/packages/paths/index.d.ts
@@ -9,6 +9,7 @@ export interface PathOptions {
 
 export declare const MAX_CONFIG_ROOT_LENGTH: 4096;
 
+export declare function normalizeWorkspaceRootPath(value: unknown, opts?: PathOptions): string;
 export declare function openworkConfigDir(opts?: PathOptions): string;
 export declare function openworkServerConfigPath(opts?: PathOptions): string;
 export declare function openworkEnvStorePath(opts?: PathOptions): string;

--- a/packages/paths/index.mjs
+++ b/packages/paths/index.mjs
@@ -9,6 +9,56 @@ function pathApi(platform) {
   return platform === "win32" ? path.win32 : path.posix;
 }
 
+function invalidWindowsWorkspaceRoot(value) {
+  const error = new TypeError(`Invalid Windows workspace root: ${value}`);
+  Object.defineProperty(error, "code", { value: "invalid_workspace_root" });
+  return error;
+}
+
+function isWindowsDeviceNamespace(value) {
+  return /^\\\\[?.]\\/.test(value);
+}
+
+/**
+ * Normalizes Windows verbatim drive and UNC paths without consulting the
+ * filesystem. Missing drives and disconnected shares must remain unchanged so
+ * callers can report their real accessibility error instead of resolving them
+ * against another drive.
+ */
+export function normalizeWorkspaceRootPath(value, opts) {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed || optionPlatform(opts) !== "win32") return trimmed;
+
+  const windowsPath = trimmed.replace(/\//g, "\\");
+  let normalized = windowsPath;
+  if (windowsPath.startsWith("\\\\?\\")) {
+    const verbatimPath = windowsPath.slice(4);
+    if (/^UNC(?:\\|$)/i.test(verbatimPath)) {
+      const uncPath = verbatimPath.slice(3).replace(/^\\/, "");
+      const [server, share] = uncPath.split("\\");
+      if (!server || !share) throw invalidWindowsWorkspaceRoot(trimmed);
+      normalized = `\\\\${uncPath}`;
+    } else {
+      if (!/^[A-Za-z]:\\/.test(verbatimPath)) throw invalidWindowsWorkspaceRoot(trimmed);
+      normalized = verbatimPath;
+    }
+  }
+
+  if (isWindowsDeviceNamespace(normalized)) {
+    throw invalidWindowsWorkspaceRoot(trimmed);
+  }
+
+  if (/^[A-Za-z]:(?!\\)/.test(normalized)) {
+    throw invalidWindowsWorkspaceRoot(trimmed);
+  }
+  if (normalized.startsWith("\\")) {
+    if (!normalized.startsWith("\\\\")) throw invalidWindowsWorkspaceRoot(trimmed);
+    const [server, share] = normalized.slice(2).split("\\");
+    if (!server || !share) throw invalidWindowsWorkspaceRoot(trimmed);
+  }
+  return normalized;
+}
+
 function optionEnv(opts) {
   return opts?.env ?? process.env;
 }

--- a/packages/paths/test/paths.test.mjs
+++ b/packages/paths/test/paths.test.mjs
@@ -8,6 +8,7 @@ import {
   globalOpencodeConfigDir,
   legacyDesktopBootstrapPath,
   MAX_CONFIG_ROOT_LENGTH,
+  normalizeWorkspaceRootPath,
   openworkEnvStorePath,
   openworkServerConfigPath,
   resolveGlobalOpencodeConfigPath,
@@ -23,6 +24,61 @@ async function withTempDir(callback) {
     await rm(root, { recursive: true, force: true });
   }
 }
+
+describe("workspace root paths", () => {
+  test("normalizes valid Windows verbatim drive and UNC paths cross-platform", () => {
+    const opts = { platform: "win32" };
+    expect(normalizeWorkspaceRootPath("\\\\?\\C:\\Users\\Ada\\Workspace", opts))
+      .toBe("C:\\Users\\Ada\\Workspace");
+    expect(normalizeWorkspaceRootPath("\\\\?\\C:\\", opts)).toBe("C:\\");
+    expect(normalizeWorkspaceRootPath("//?/UNC/server/share/Workspace", opts))
+      .toBe("\\\\server\\share\\Workspace");
+    expect(normalizeWorkspaceRootPath("\\\\?\\UNC\\server\\share", opts))
+      .toBe("\\\\server\\share");
+  });
+
+  test("preserves valid normal drives and UNC shares without checking availability", () => {
+    const opts = { platform: "win32" };
+    expect(normalizeWorkspaceRootPath("Z:\\Disconnected\\Workspace", opts))
+      .toBe("Z:\\Disconnected\\Workspace");
+    expect(normalizeWorkspaceRootPath("\\\\offline-server\\share\\Workspace", opts))
+      .toBe("\\\\offline-server\\share\\Workspace");
+    expect(normalizeWorkspaceRootPath("\\\\offline-server\\pipe\\Workspace", opts))
+      .toBe("\\\\offline-server\\pipe\\Workspace");
+  });
+
+  test("rejects Win32 device namespace roots", () => {
+    const opts = { platform: "win32" };
+    for (const value of [
+      "\\\\.\\pipe\\openwork",
+      "//./PIPE/openwork",
+      "\\\\.\\PhysicalDrive0",
+      "\\\\?\\UNC\\.\\pipe\\openwork",
+      "\\\\?\\UNC\\?\\PhysicalDrive0",
+    ]) {
+      expect(() => normalizeWorkspaceRootPath(value, opts)).toThrow("Invalid Windows workspace root");
+    }
+  });
+
+  test("rejects incomplete Windows drive and UNC roots", () => {
+    const opts = { platform: "win32" };
+    for (const value of [
+      "C:",
+      "\\\\?\\",
+      "\\\\?\\C:",
+      "\\\\?\\C:Workspace",
+      "\\\\?\\UNC",
+      "\\\\?\\UNC\\server",
+      "\\\\server",
+    ]) {
+      expect(() => normalizeWorkspaceRootPath(value, opts)).toThrow("Invalid Windows workspace root");
+    }
+  });
+
+  test("applies Windows validation only when Windows is injected", () => {
+    expect(normalizeWorkspaceRootPath("\\\\?\\C:", { platform: "linux" })).toBe("\\\\?\\C:");
+  });
+});
 
 describe("openwork server config paths", () => {
   test("uses APPDATA on Windows", () => {


### PR DESCRIPTION
## Summary
- normalize valid Windows drive and UNC workspace roots without probing disconnected locations
- reject Win32 device namespaces and wrap inaccessible runtime roots as recoverable `workspace_inaccessible` failures
- add focused app-less testkit coverage for the Windows workspace root boundaries

## Testing
- `pnpm --filter @openwork/paths test`
- `pnpm --filter @openwork/paths typecheck`
- `pnpm --dir apps/desktop exec node --test electron/runtime.test.mjs electron/workspace-store.test.mjs`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm evals:spec specs/windows-workspace-root-boundaries.test.ts`