### PR TITLE
fix(server): classify managed MCP handshake failures

### DIFF
--- a/apps/server/src/local-managed-mcp.e2e.test.ts
+++ b/apps/server/src/local-managed-mcp.e2e.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { EnterpriseMcpClientError } from "@openwork/enterprise-mcp-client";
 
 import { ApiError } from "./errors.js";
 import {
@@ -95,6 +96,119 @@ async function startOAuthProvider(port: number): Promise<string> {
   const baseUrl = `http://127.0.0.1:${port}`;
   await waitFor(async () => (await fetch(`${baseUrl}/health`)).ok ? baseUrl : null, "OAuth MCP mock");
   return baseUrl;
+}
+
+type HandshakeFailure = "oauth-client-registration" | "mcp-initialize" | "unexpected-sdk-failure";
+
+function startHandshakeFailureProvider(failure: HandshakeFailure): string {
+  const nestedSecret = `${failure}-nested-secret`;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const origin = url.origin;
+      if (url.pathname === "/.well-known/oauth-protected-resource"
+        || url.pathname === "/.well-known/oauth-protected-resource/mcp"
+        || url.pathname === "/mcp/.well-known/oauth-protected-resource") {
+        return Response.json({
+          resource: `${origin}/mcp`,
+          authorization_servers: [origin],
+          scopes_supported: ["mcp:read"],
+        });
+      }
+      if (url.pathname === "/.well-known/oauth-authorization-server"
+        || url.pathname === "/.well-known/oauth-authorization-server/mcp") {
+        return Response.json({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          registration_endpoint: `${origin}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+          scopes_supported: ["mcp:read"],
+        });
+      }
+      if (url.pathname === "/register" && request.method === "POST") {
+        if (failure === "oauth-client-registration") {
+          return Response.json({
+            error: "invalid_client_metadata",
+            error_description: nestedSecret,
+            client_secret: nestedSecret,
+          }, { status: 400 });
+        }
+        if (failure === "unexpected-sdk-failure") {
+          return Response.json({ client_id: 42 }, { status: 201 });
+        }
+        const body: unknown = await request.json();
+        const redirectUris = typeof body === "object" && body !== null && "redirect_uris" in body
+          && Array.isArray(body.redirect_uris)
+          ? body.redirect_uris.filter((value): value is string => typeof value === "string")
+          : [];
+        return Response.json({
+          client_id: "handshake-witness-client",
+          client_id_issued_at: Math.floor(Date.now() / 1_000),
+          token_endpoint_auth_method: "none",
+          redirect_uris: redirectUris,
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          scope: "mcp:read",
+        }, { status: 201 });
+      }
+      if (url.pathname === "/authorize" && request.method === "GET") {
+        const callback = new URL(url.searchParams.get("redirect_uri") ?? "");
+        callback.searchParams.set("code", "handshake-witness-code");
+        callback.searchParams.set("state", url.searchParams.get("state") ?? "");
+        return new Response(null, { status: 302, headers: { location: callback.toString() } });
+      }
+      if (url.pathname === "/token" && request.method === "POST") {
+        return Response.json({
+          access_token: "handshake-witness-access-token",
+          refresh_token: "handshake-witness-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "mcp:read",
+        });
+      }
+      if (url.pathname === "/mcp") {
+        if (request.headers.get("authorization") !== "Bearer handshake-witness-access-token") {
+          return Response.json({ error: "missing_token" }, {
+            status: 401,
+            headers: { "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"` },
+          });
+        }
+        const body: unknown = await request.json().catch(() => null);
+        const method = typeof body === "object" && body !== null && "method" in body ? body.method : null;
+        const id = typeof body === "object" && body !== null && "id" in body ? body.id : null;
+        if (method === "initialize") {
+          if (failure === "mcp-initialize") {
+            return Response.json({
+              error: "provider_initialize_failed",
+              cause: { client_secret: nestedSecret },
+            }, { status: 503 });
+          }
+          return Response.json({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: {} },
+              serverInfo: { name: "handshake-witness", version: "1.0.0" },
+            },
+          });
+        }
+        if (method === "notifications/initialized") return new Response(null, { status: 202 });
+        if (method === "tools/list") {
+          return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+        }
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop());
+  return `http://127.0.0.1:${server.port}`;
 }
 
 function createConfig(input: {
@@ -194,7 +308,7 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
       expect(created.status).toBe(502);
       expect(await created.json()).toMatchObject({
         code: "managed_mcp_connection_failed",
-        message: expect.stringContaining("Enterprise MCP failed during MCP connection handshake"),
+        message: "OpenWork could not connect to this MCP server. Check its OAuth settings and availability, then try again.",
       });
 
       const status = await fetch(
@@ -210,6 +324,134 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
       else process.env.OPENWORK_DEV_MODE = previousDevMode;
     }
   });
+
+  test("returns safe connection errors for DCR reconnect and callback initialize failures", async () => {
+    const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+    const previousDevMode = process.env.OPENWORK_DEV_MODE;
+    const previousTelemetry = globalThis.__openworkDesktopTelemetry;
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-local-managed-mcp-handshake-errors-"));
+    roots.push(workspaceRoot);
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    process.env.OPENWORK_DEV_MODE = "1";
+    const captured: unknown[] = [];
+    globalThis.__openworkDesktopTelemetry = {
+      captureException: (error) => {
+        captured.push(error);
+        return true;
+      },
+    };
+
+    try {
+      const engine = startMockOpencode();
+      const config = createConfig({
+        port: await freePort(),
+        workspaceRoot,
+        engineBaseUrl: `http://127.0.0.1:${engine.server.port}`,
+        vaultKey: randomBytes(32),
+      });
+      const server = await startServer(config);
+      stops.push(() => server.stop());
+      const openworkBaseUrl = `http://127.0.0.1:${server.port}`;
+      const expectedMessage = "OpenWork could not connect to this MCP server. Check its OAuth settings and availability, then try again.";
+
+      const registrationProvider = startHandshakeFailureProvider("oauth-client-registration");
+      await createLocalManagedMcpConnection(config, {
+        workspaceId: "ws_managed",
+        name: "registration-failure",
+        serverUrl: `${registrationProvider}/mcp`,
+        oauth: { applicationType: "native", requestedScopes: ["mcp:read"] },
+      });
+      const reconnect = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/registration-failure/managed/connect`,
+        { method: "POST", headers: clientHeaders(config.token) },
+      );
+      expect(reconnect.status).toBe(502);
+      const reconnectBody = await reconnect.json();
+      expect(reconnectBody).toEqual({
+        code: "managed_mcp_connection_failed",
+        message: expectedMessage,
+      });
+      expect(JSON.stringify(reconnectBody)).not.toContain("oauth-client-registration-nested-secret");
+      const reconnectStatus = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/registration-failure/managed`,
+        { headers: clientHeaders(config.token) },
+      );
+      expect(await reconnectStatus.json()).toMatchObject({
+        status: "reconnect_required",
+        lastError: expectedMessage,
+        hasCredential: false,
+      });
+
+      const initializeProvider = startHandshakeFailureProvider("mcp-initialize");
+      await createLocalManagedMcpConnection(config, {
+        workspaceId: "ws_managed",
+        name: "initialize-failure",
+        serverUrl: `${initializeProvider}/mcp`,
+        oauth: { applicationType: "native", requestedScopes: ["mcp:read"] },
+      });
+      const started = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/initialize-failure/managed/connect`,
+        { method: "POST", headers: clientHeaders(config.token) },
+      );
+      expect(started.status).toBe(200);
+      const startedBody: unknown = await started.json();
+      if (typeof startedBody !== "object" || startedBody === null
+        || !("authorizeUrl" in startedBody) || typeof startedBody.authorizeUrl !== "string") {
+        throw new Error("Expected an OAuth authorization URL.");
+      }
+      expect(startedBody).toMatchObject({ status: "needs_auth" });
+      const authorization = await fetch(startedBody.authorizeUrl, { redirect: "manual" });
+      expect(authorization.status).toBe(302);
+      const callback = await fetch(authorization.headers.get("location")!);
+      expect(callback.status).toBe(502);
+      const callbackBody = await callback.json();
+      expect(callbackBody).toEqual({
+        code: "managed_mcp_connection_failed",
+        message: expectedMessage,
+      });
+      expect(JSON.stringify(callbackBody)).not.toContain("mcp-initialize-nested-secret");
+      const callbackStatus = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/initialize-failure/managed`,
+        { headers: clientHeaders(config.token) },
+      );
+      expect(await callbackStatus.json()).toMatchObject({
+        status: "reconnect_required",
+        lastError: expectedMessage,
+        hasCredential: false,
+      });
+      expect(captured).toEqual([]);
+
+      const internalProvider = startHandshakeFailureProvider("unexpected-sdk-failure");
+      await createLocalManagedMcpConnection(config, {
+        workspaceId: "ws_managed",
+        name: "unexpected-sdk-failure",
+        serverUrl: `${internalProvider}/mcp`,
+        oauth: { applicationType: "native", requestedScopes: ["mcp:read"] },
+      });
+      const internalFailure = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/unexpected-sdk-failure/managed/connect`,
+        { method: "POST", headers: clientHeaders(config.token) },
+      );
+      expect(internalFailure.status).toBe(500);
+      expect(await internalFailure.json()).toEqual({
+        code: "internal_error",
+        message: "Unexpected server error",
+      });
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toBeInstanceOf(EnterpriseMcpClientError);
+      expect(captured[0]).not.toBeInstanceOf(ApiError);
+      expect(captured[0]).toMatchObject({
+        code: "MCP_CONNECTION_HANDSHAKE_FAILED",
+        requestPhase: "mcp-initialize",
+      });
+    } finally {
+      globalThis.__openworkDesktopTelemetry = previousTelemetry;
+      if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+      if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
+      else process.env.OPENWORK_DEV_MODE = previousDevMode;
+    }
+  }, 30_000);
 
   test("returns actionable input errors without persisting managed connections", async () => {
     const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -10,7 +10,9 @@ import {
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { OAuthError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { OAuthClientInformationMixed } from "@modelcontextprotocol/sdk/shared/auth.js";
 import {
@@ -21,12 +23,15 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   createEnterpriseMcpClient,
+  EnterpriseMcpClientError,
   type EnterpriseMcpConnection,
+  type EnterpriseMcpDiagnosticEvent,
   type EnterpriseMcpOAuthAuthorizationHandle,
   type EnterpriseMcpOAuthClientRegistration,
   type EnterpriseMcpOAuthCredential,
   type EnterpriseMcpOAuthPersistence,
   type EnterpriseMcpPersistenceContext,
+  type EnterpriseMcpRequestPhase,
 } from "@openwork/enterprise-mcp-client";
 import { ApiError } from "./errors.js";
 import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
@@ -155,6 +160,12 @@ const VAULT_AAD = Buffer.from("openwork-local-managed-mcp-v1", "utf8");
 const VAULT_RECOVERY_REASON = "secure_storage_changed";
 const VAULT_RECOVERED_LAST_ERROR =
   "Secure storage on this device changed, so saved sign-ins were cleared. Reconnect to restore this connection.";
+const MANAGED_MCP_CONNECTION_FAILED_MESSAGE =
+  "OpenWork could not connect to this MCP server. Check its OAuth settings and availability, then try again.";
+const EXTERNAL_HANDSHAKE_REQUEST_PHASES = new Set<EnterpriseMcpRequestPhase>([
+  "oauth-client-registration",
+  "mcp-initialize",
+]);
 const vaultQueueByPath = new Map<string, Promise<void>>();
 const vaultKeyByConfig = new WeakMap<ServerConfig, Promise<Buffer>>();
 const gatewaySecretByConfig = new WeakMap<ServerConfig, Buffer>();
@@ -670,12 +681,13 @@ async function enterpriseConnection(config: ServerConfig, workspaceId: string, n
   };
 }
 
-function enterpriseClient() {
+function enterpriseClient(diagnostics?: EnterpriseMcpDiagnosticEvent[]) {
   return createEnterpriseMcpClient({
     fetch: guardedFetch,
     clientName: "OpenWork Local MCP Gateway",
     clientVersion: "1.0.0",
     operationTimeoutMs: 45_000,
+    ...(diagnostics ? { diagnosticSink: (event) => diagnostics.push(event) } : {}),
   });
 }
 
@@ -960,9 +972,116 @@ async function updateConnectionStatus(
   });
 }
 
-async function verifyTools(config: ServerConfig, workspaceId: string, name: string, redirectUri: string): Promise<void> {
+type CompletedRequestDiagnostic = {
+  requestPhase: EnterpriseMcpRequestPhase;
+  outcome: "succeeded" | "failed";
+  httpStatus?: number;
+};
+
+const NETWORK_FAILURE_CODES = new Set([
+  "ConnectionRefused",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+]);
+
+function lastHandshakeRequestDiagnostic(
+  diagnostics: EnterpriseMcpDiagnosticEvent[],
+): CompletedRequestDiagnostic | null {
+  for (let index = diagnostics.length - 1; index >= 0; index -= 1) {
+    const event = diagnostics[index];
+    if (!event
+      || event.kind !== "request"
+      || event.outcome === "started"
+      || event.requestPhase === null
+      || !EXTERNAL_HANDSHAKE_REQUEST_PHASES.has(event.requestPhase)) {
+      continue;
+    }
+    return {
+      requestPhase: event.requestPhase,
+      outcome: event.outcome,
+      ...(event.httpStatus === undefined ? {} : { httpStatus: event.httpStatus }),
+    };
+  }
+  return null;
+}
+
+function errorCauseChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+  for (let depth = 0; depth < 6 && current !== undefined && current !== null && !seen.has(current); depth += 1) {
+    chain.push(current);
+    seen.add(current);
+    current = isRecord(current) ? current.cause : undefined;
+  }
+  return chain;
+}
+
+function hasConcreteRequestCause(error: EnterpriseMcpClientError, diagnostic: CompletedRequestDiagnostic): boolean {
+  const chain = errorCauseChain(error.cause);
+  if (diagnostic.httpStatus !== undefined) {
+    return diagnostic.httpStatus >= 400
+      && diagnostic.httpStatus <= 599
+      && chain.some((cause) => cause instanceof OAuthError || cause instanceof StreamableHTTPError);
+  }
+  return chain.some((cause) => cause instanceof LocalManagedMcpPrivateUrlError
+    || (cause instanceof TypeError && cause.message === "fetch failed")
+    || (isRecord(cause) && typeof cause.code === "string" && NETWORK_FAILURE_CODES.has(cause.code)));
+}
+
+function externalHandshakeApiError(
+  error: unknown,
+  diagnostics: EnterpriseMcpDiagnosticEvent[],
+): ApiError | null {
+  if (!(error instanceof EnterpriseMcpClientError)
+    || error.cause instanceof AggregateError
+    || error.requestPhase === null) {
+    return null;
+  }
+  const recognizedHandshake = (error.operationPhase === "connection-handshake"
+      && error.code === "MCP_CONNECTION_HANDSHAKE_FAILED")
+    || (error.operationPhase === "authorization-callback"
+      && error.code === "MCP_AUTHORIZATION_CALLBACK_FAILED");
+  if (!recognizedHandshake) return null;
+  const request = lastHandshakeRequestDiagnostic(diagnostics);
+  if (!request || request.outcome !== "failed" || !hasConcreteRequestCause(error, request)) return null;
+  return new ApiError(502, "managed_mcp_connection_failed", MANAGED_MCP_CONNECTION_FAILED_MESSAGE);
+}
+
+async function rethrowConnectionFailure(
+  config: ServerConfig,
+  workspaceId: string,
+  name: string,
+  error: unknown,
+  diagnostics: EnterpriseMcpDiagnosticEvent[],
+  internalFallback: string,
+): Promise<never> {
+  const apiError = externalHandshakeApiError(error, diagnostics);
+  await updateConnectionStatus(
+    config,
+    workspaceId,
+    name,
+    "reconnect_required",
+    apiError?.message ?? internalFallback,
+  );
+  throw apiError ?? error;
+}
+
+async function verifyTools(
+  config: ServerConfig,
+  workspaceId: string,
+  name: string,
+  redirectUri: string,
+  diagnostics: EnterpriseMcpDiagnosticEvent[],
+): Promise<void> {
   const connection = await enterpriseConnection(config, workspaceId, name);
-  await enterpriseClient().listTools({ connection, redirectUri });
+  await enterpriseClient(diagnostics).listTools({ connection, redirectUri });
   await updateConnectionStatus(config, workspaceId, name, "connected");
 }
 
@@ -999,18 +1118,18 @@ export async function startLocalManagedMcpAuthorization(config: ServerConfig, wo
   await writeManagedRuntimeEntry(config, workspaceId, name, true);
   const authorizationId = await createAuthorizationState(config, workspaceId, name);
   const redirectUri = localManagedMcpCallbackUrl(config);
+  const diagnostics: EnterpriseMcpDiagnosticEvent[] = [];
   try {
     const connection = await enterpriseConnection(config, workspaceId, name);
-    const result = await enterpriseClient().connect({ connection, redirectUri, authorizationId });
+    const result = await enterpriseClient(diagnostics).connect({ connection, redirectUri, authorizationId });
     if (result.status === "connected") {
-      await verifyTools(config, workspaceId, name, redirectUri);
+      await verifyTools(config, workspaceId, name, redirectUri, diagnostics);
       return { status: "connected" as const };
     }
     await updateConnectionStatus(config, workspaceId, name, "needs_auth");
     return { status: "needs_auth" as const, authorizeUrl: result.authorizeUrl };
   } catch (error) {
-    await updateConnectionStatus(config, workspaceId, name, "reconnect_required", error instanceof Error ? error.message : "Connection failed");
-    throw error;
+    return rethrowConnectionFailure(config, workspaceId, name, error, diagnostics, "Connection failed");
   }
 }
 
@@ -1020,23 +1139,23 @@ export async function completeLocalManagedMcpAuthorization(
   code: string,
 ): Promise<{ connection: LocalManagedMcpPublicConnection; workspaceId: string }> {
   const payload = await verifyAuthorizationState(config, state);
+  const diagnostics: EnterpriseMcpDiagnosticEvent[] = [];
   try {
     const connection = await enterpriseConnection(config, payload.workspaceId, payload.name);
-    await enterpriseClient().completeAuthorization({
+    await enterpriseClient(diagnostics).completeAuthorization({
       connection,
       redirectUri: payload.redirectUri,
       code,
       authorizationId: state,
     });
-    await verifyTools(config, payload.workspaceId, payload.name, payload.redirectUri);
+    await verifyTools(config, payload.workspaceId, payload.name, payload.redirectUri, diagnostics);
     await writeManagedRuntimeEntry(config, payload.workspaceId, payload.name, true);
     return {
       connection: await getLocalManagedMcpConnection(config, payload.workspaceId, payload.name),
       workspaceId: payload.workspaceId,
     };
   } catch (error) {
-    await updateConnectionStatus(config, payload.workspaceId, payload.name, "reconnect_required", error instanceof Error ? error.message : "Authorization failed");
-    throw error;
+    return rethrowConnectionFailure(config, payload.workspaceId, payload.name, error, diagnostics, "Authorization failed");
   }
 }
 

--- a/evals/specs/managed-mcp-handshake-boundaries.test.ts
+++ b/evals/specs/managed-mcp-handshake-boundaries.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const witnessName = "returns safe connection errors for DCR reconnect and callback initialize failures";
+
+test("managed MCP handshake boundaries separate provider failures from internal defects", ({ evidence }) => {
+  const result = spawnSync("pnpm", [
+    "--filter",
+    "openwork-server",
+    "test",
+    "src/local-managed-mcp.e2e.test.ts",
+    "--test-name-pattern",
+    witnessName,
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const output = `${result.stdout}${result.stderr}`;
+
+  expect(result.error, output).toBeUndefined();
+  expect(result.status, output).toBe(0);
+  expect(output).toContain("1 pass");
+  expect(output).toContain("0 fail");
+  expect(output).toContain("18 expect() calls");
+
+  evidence.fact(
+    "Provider DCR and initialize failures cross a safe reconnect boundary",
+    "The focused HTTP witness requires both deterministic provider failures to return exactly managed_mcp_connection_failed/502, omit nested provider secrets, and persist reconnect_required with no credential.",
+    true,
+  );
+  evidence.fact(
+    "Recognized provider handshake failures stay out of telemetry",
+    "The same witness requires the telemetry capture list to remain empty after the DCR and callback-initialize failures.",
+    true,
+  );
+  evidence.fact(
+    "Malformed SDK data remains an actionable internal defect",
+    "The malformed registration witness must return the generic internal 500 while capturing exactly one non-ApiError EnterpriseMcpClientError with MCP_CONNECTION_HANDSHAKE_FAILED at mcp-initialize.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- map concrete provider DCR and MCP initialize failures to a safe typed 502 and reconnect-required state
- keep malformed SDK/programming failures on the internal error and telemetry path
- add a focused app-less testkit spec that reuses the deterministic server witness

## Tests
- `pnpm --filter openwork-server test src/local-managed-mcp.e2e.test.ts --test-name-pattern "returns safe connection errors for DCR reconnect and callback initialize failures"`
- `pnpm --filter openwork-server typecheck`
- `pnpm evals:spec specs/managed-mcp-handshake-boundaries.test.ts`

Evidence publication intentionally left to the orchestrator.