### PR TITLE
ci: retry EE image push once after a transient GHCR denial

### DIFF
--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -237,7 +237,35 @@ jobs:
         # Build every image except the ones whose Sentry-enabled step below owns
         # them. Stated as an exclusion so a newly added matrix entry builds by
         # default instead of silently skipping and failing the smoke step.
+        id: build_no_sentry
         if: ${{ !((matrix.image == 'openwork-den-api' && steps.sentry_sourcemaps.outputs.den_api_upload == 'true') || (matrix.image == 'openwork-den-web' && steps.sentry_sourcemaps.outputs.den_web_upload == 'true')) }}
+        # On publish runs GHCR occasionally rejects the push with a transient
+        # "failed to fetch oauth token: denied" even though sibling images push
+        # fine with the same token; let the retry step below absorb one flake.
+        # PR runs keep fail-fast behavior because they never push.
+        continue-on-error: ${{ needs.artifact-version.outputs.publish == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev') && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ needs.artifact-version.outputs.publish == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          build-args: |
+            ${{ matrix.image == 'openwork-den-api' && format('DEN_API_VERSION={0}', needs.artifact-version.outputs.chart_version || github.sha) || '' }}
+            ${{ matrix.image == 'openwork-den-gateway' && format('DEN_GATEWAY_VERSION={0}', needs.artifact-version.outputs.chart_version || github.sha) || '' }}
+            ${{ matrix.image == 'openwork-den-api' && 'DEN_UPLOAD_SENTRY_SOURCEMAPS=0' || '' }}
+            ${{ matrix.image == 'openwork-den-web' && 'DEN_WEB_UPLOAD_SENTRY_SOURCEMAPS=0' || '' }}
+
+      - name: Retry push after transient registry failure
+        # Layers are still warm in the local BuildKit store, so this re-runs in
+        # seconds and only repeats the export/push. A second failure fails the
+        # job for real.
+        if: ${{ steps.build_no_sentry.outcome == 'failure' }}
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Why

Run [32146762506](https://github.com/different-ai/openwork/actions/runs/32146762506) failed publishing `ghcr.io/different-ai/openwork-den-gateway:dev` with:

```
ERROR: failed to push ghcr.io/different-ai/openwork-den-gateway:dev: failed to authorize: failed to fetch oauth token: denied: denied
```

This was not a permissions problem:

- the same run pushed `openwork-den-api`, `openwork-den-web`, and `openwork-inference` with the same `GITHUB_TOKEN`,
- the previous dev push ([32142972354](https://github.com/different-ai/openwork/actions/runs/32142972354)) pushed the same gateway package fine 40 minutes earlier,
- the GHCR login step was green in the failing job.

It is the known intermittent GHCR `denied` on buildx's per-push token fetch. One flake currently fails dev CD (and skips the Render gateway redeploy).

## What

- Give the non-Sentry build/push step `continue-on-error` **on publish runs only** (`publish == 'true'`), so PR runs keep today's fail-fast behavior.
- Add an identical retry step gated on `steps.build_no_sentry.outcome == 'failure'`. Layers are still warm in the local BuildKit store, so the retry re-runs in seconds and only repeats the export/push. A second failure fails the job for real.

The Sentry-owned step is left untouched: it is currently dormant (`den_api_upload=false` / `den_web_upload=false` in recent runs since Sentry secrets are unset).

## Verification

- `actionlint .github/workflows/publish-ee-images.yml` — OK.
- This PR touches the workflow file, so its path filter triggers the full `ee-images` matrix in PR mode (build + smoke, no push) on this PR — that run is the proof the edited workflow is well-formed and unchanged for PRs.
- The retry path itself only activates on a publish-run push flake, which cannot be forced deterministically from a PR; behavior there is bounded to "one extra attempt, then fail".
- CI config change — no runtime/testkit surface; no app code touched.

Unblock for the failed run: re-ran the failed job (`gh run rerun 32146762506 --failed`) so `:dev` / `sha-cf58a4c` publish and the Render redeploy fires.