### PR TITLE
ci(evals): add soft spec impact snapshot

### DIFF
--- a/.github/workflows/spec-impact.yml
+++ b/.github/workflows/spec-impact.yml
@@ -1,0 +1,30 @@
+name: Spec Impact Snapshot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  advise:
+    if: github.event.pull_request.draft == false
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Compare implementation contracts with mapped specs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          node evals/scripts/spec-impact.mjs
+          --base "$BASE_SHA"
+          --head "$HEAD_SHA"
+          --summary "$GITHUB_STEP_SUMMARY"

--- a/evals/scripts/spec-impact.mjs
+++ b/evals/scripts/spec-impact.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process"
+import { appendFileSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
+const defaultSnapshot = resolve(repoRoot, "evals/specs/contracts.snapshot.json")
+
+function matches(pathname, pattern) {
+  if (pattern.endsWith("/**")) return pathname.startsWith(pattern.slice(0, -3))
+  return pathname === pattern
+}
+
+function strings(value, label) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
+    throw new Error(`${label} must be a non-empty string array`)
+  }
+  return value
+}
+
+export function validateSnapshot(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("snapshot must be an object")
+  if (Reflect.get(value, "version") !== 1) throw new Error("snapshot version must be 1")
+  const rawContracts = Reflect.get(value, "contracts")
+  if (!Array.isArray(rawContracts) || rawContracts.length === 0) throw new Error("snapshot contracts must be a non-empty array")
+  const ids = new Set()
+  return rawContracts.map((contract, index) => {
+    if (typeof contract !== "object" || contract === null || Array.isArray(contract)) {
+      throw new Error(`contracts[${index}] must be an object`)
+    }
+    const id = Reflect.get(contract, "id")
+    const description = Reflect.get(contract, "description")
+    if (typeof id !== "string" || id.length === 0) throw new Error(`contracts[${index}].id must be a string`)
+    if (ids.has(id)) throw new Error(`duplicate contract id: ${id}`)
+    ids.add(id)
+    if (typeof description !== "string" || description.length === 0) {
+      throw new Error(`contracts[${index}].description must be a string`)
+    }
+    return {
+      id,
+      description,
+      implementation: strings(Reflect.get(contract, "implementation"), `${id}.implementation`),
+      specs: strings(Reflect.get(contract, "specs"), `${id}.specs`),
+    }
+  })
+}
+
+export function analyzeImpact(contracts, changedFiles) {
+  const changed = [...new Set(changedFiles.map((entry) => entry.trim()).filter(Boolean))].sort()
+  const impacted = contracts.flatMap((contract) => {
+    const implementation = changed.filter((pathname) => contract.implementation.some((pattern) => matches(pathname, pattern)))
+    if (implementation.length === 0) return []
+    const specs = changed.filter((pathname) => contract.specs.includes(pathname))
+    return [{ ...contract, changedImplementation: implementation, changedSpecs: specs, covered: specs.length > 0 }]
+  })
+  return {
+    changed,
+    impacted,
+    attention: impacted.filter((contract) => !contract.covered),
+  }
+}
+
+function markdown(result) {
+  const lines = ["### Soft spec-impact snapshot", ""]
+  if (result.impacted.length === 0) {
+    lines.push("No mapped implementation contract changed.", "")
+    return lines.join("\n")
+  }
+  lines.push("| Contract | Result | Changed implementation | Mapped specs |", "| --- | --- | --- | --- |")
+  for (const contract of result.impacted) {
+    const status = contract.covered ? "Covered by a changed spec" : "Needs attention"
+    const implementation = contract.changedImplementation.map((entry) => `\`${entry}\``).join("<br>")
+    const specs = contract.specs.map((entry) => `\`${entry}\``).join("<br>")
+    lines.push(`| \`${contract.id}\` | ${status} | ${implementation} | ${specs} |`)
+  }
+  lines.push("")
+  if (result.attention.length > 0) {
+    lines.push("This check is advisory: confirm the existing mapped spec still proves the contract, or update/add a spec.", "")
+  }
+  return lines.join("\n")
+}
+
+function annotation(value) {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")
+}
+
+function parseArgs(args) {
+  const options = { changedFiles: [] }
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === "--strict") options.strict = true
+    else if (argument === "--json") options.json = true
+    else if (["--base", "--head", "--snapshot", "--summary", "--changed-file"].includes(argument)) {
+      const value = args[index + 1]
+      if (!value) throw new Error(`${argument} requires a value`)
+      index += 1
+      if (argument === "--changed-file") options.changedFiles.push(value)
+      else options[argument.slice(2)] = value
+    } else throw new Error(`unknown argument: ${argument}`)
+  }
+  return options
+}
+
+function gitChangedFiles(base, head) {
+  if (!base || !head) throw new Error("pass both --base and --head, or one or more --changed-file values")
+  return execFileSync("git", ["diff", "--name-only", "--diff-filter=ACMR", `${base}...${head}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).split("\n").filter(Boolean)
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const snapshotPath = resolve(repoRoot, options.snapshot ?? defaultSnapshot)
+  const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"))
+  const contracts = validateSnapshot(snapshot)
+  const changedFiles = options.changedFiles.length > 0
+    ? options.changedFiles
+    : gitChangedFiles(options.base, options.head)
+  const result = analyzeImpact(contracts, changedFiles)
+  const report = markdown(result)
+  if (options.summary) appendFileSync(options.summary, report)
+  if (options.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+  else process.stdout.write(report)
+  for (const contract of result.attention) {
+    process.stdout.write(`::warning title=Spec impact snapshot::${annotation(`${contract.id} changed without a mapped spec change`)}\n`)
+  }
+  if (options.strict && result.attention.length > 0) process.exitCode = 2
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -1,0 +1,74 @@
+{
+  "version": 1,
+  "contracts": [
+    {
+      "id": "desktop.automations",
+      "description": "Desktop Automation navigation, editing, execution, and needs-attention behavior",
+      "implementation": [
+        "apps/app/src/react-app/domains/automations/**",
+        "apps/app/src/react-app/shell/session-route.tsx",
+        "apps/app/src/react-app/shell/workspace-routes.ts",
+        "ee/apps/den-api/src/automations/**",
+        "ee/apps/den-api/src/routes/automations/**"
+      ],
+      "specs": [
+        "evals/specs/automation-model-needs-attention.slow.test.ts",
+        "evals/specs/automation-proposal-model-resolution.slow.test.ts",
+        "evals/specs/automation-revision-revert.slow.test.ts",
+        "evals/specs/automation-runtime-placement.slow.test.ts",
+        "evals/specs/automations-den-hosted.slow.test.ts",
+        "evals/specs/saved-script-automations.slow.test.ts"
+      ]
+    },
+    {
+      "id": "den.codemode-receipts",
+      "description": "Code Mode execution receipts, saved-script promotion, and generated Artifact views",
+      "implementation": [
+        "ee/apps/den-api/src/codemode-runs.ts",
+        "ee/apps/den-api/src/codemode-scripts.ts",
+        "ee/apps/den-api/src/mcp/codemode-run.ts",
+        "ee/apps/den-api/src/mcp/generated-artifact-views.ts",
+        "ee/apps/den-api/src/mcp/saved-codemode-script-service.ts",
+        "ee/apps/den-api/src/routes/org/codemode-runs.ts",
+        "ee/apps/den-api/src/routes/org/codemode-scripts.ts",
+        "ee/packages/den-db/src/schema/codemode.ts"
+      ],
+      "specs": [
+        "evals/specs/codemode-scripts.slow.test.ts",
+        "evals/specs/generated-artifact-views.slow.test.ts",
+        "evals/specs/saved-script-automations.slow.test.ts"
+      ]
+    },
+    {
+      "id": "evals.mock-placement",
+      "description": "Local and Daytona mock placement, authentication, and eligibility",
+      "implementation": [
+        "evals/packages/testkit/src/mock.ts",
+        "evals/packages/testkit/src/needs.ts",
+        "evals/packages/testkit/src/place.ts",
+        "evals/packages/testkit/src/server.ts",
+        "evals/packages/hosts/src/provision.ts"
+      ],
+      "specs": [
+        "evals/specs/codemode-scripts.slow.test.ts",
+        "evals/specs/local-managed-mcp-oauth.slow.test.ts",
+        "evals/specs/saved-script-automations.slow.test.ts",
+        "evals/specs/testkit-selftest.slow.test.ts"
+      ]
+    },
+    {
+      "id": "evals.slow-sweep",
+      "description": "Slow-spec runner selection, placement, batching, and shared-stack lifecycle",
+      "implementation": [
+        ".github/workflows/slow-specs-sweep.yml",
+        "evals/runner/prepare-stack.ts",
+        "evals/runner/stack-env.ts",
+        "evals/runner/stack-suite.ts"
+      ],
+      "specs": [
+        "evals/specs/spec-impact.test.ts",
+        "evals/specs/testkit-selftest.slow.test.ts"
+      ]
+    }
+  ]
+}

--- a/evals/specs/spec-impact.test.ts
+++ b/evals/specs/spec-impact.test.ts
@@ -1,0 +1,32 @@
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { expect } from "vitest"
+import { test } from "@openwork/testkit"
+
+const script = fileURLToPath(new URL("../scripts/spec-impact.mjs", import.meta.url))
+
+function run(...changedFiles: string[]): string {
+  return execFileSync(process.execPath, [script, ...changedFiles.flatMap((file) => ["--changed-file", file])], {
+    encoding: "utf8",
+  })
+}
+
+test("the soft spec-impact snapshot identifies uncovered and covered contract changes", ({ evidence }) => {
+  const uncovered = run("ee/apps/den-api/src/codemode-runs.ts")
+  expect(uncovered).toContain("Needs attention")
+  expect(uncovered).toContain("den.codemode-receipts")
+  expect(uncovered).toContain("::warning title=Spec impact snapshot::")
+
+  const covered = run(
+    "ee/apps/den-api/src/codemode-runs.ts",
+    "evals/specs/generated-artifact-views.slow.test.ts",
+  )
+  expect(covered).toContain("Covered by a changed spec")
+  expect(covered).not.toContain("::warning title=Spec impact snapshot::")
+
+  evidence.fact(
+    "Implementation changes map to their proof specs",
+    "The advisory report warned without a mapped spec change and cleared when the generated Artifact view spec changed.",
+    true,
+  )
+})


### PR DESCRIPTION
## What changed

- Adds a deterministic snapshot of test-owned product contracts.
- Adds a small analyzer that reports when changed implementation files overlap those contracts.
- Runs the check on a Blacksmith runner in pull requests.
- Keeps the signal advisory by default so ordinary implementation work is not blocked by a heuristic.

## Why

This gives reviewers a soft, programmatic warning that a product change may require an eval/spec update. It is deliberately separate from the slow-test repairs so the heuristic can be reviewed and tuned independently.

## Validation

- `spec-impact.test.ts`: 1 passed.
- Snapshot generation is deterministic against the committed contract snapshot.

## Follow-up

Tune the mappings as false positives/negatives are observed. The workflow can later be made strict once the signal has enough history to justify blocking merges.
