### PR TITLE
test(evals): prove Den providers through LiteLLM

### DIFF
--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -42,7 +42,17 @@ export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSess
     label: "auth.exchange-grant action registered",
   });
   const grant = await createDesktopHandoffGrant(member);
-  await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
+  try {
+    await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
+  } catch (error) {
+    const message = messageText(error);
+    if (!message.includes("Already acting: auth.exchange-grant")) throw error;
+    await waitFor(app, "Boolean(window.__openworkControl?.listActions?.().some((action) => action.id === 'auth.exchange-grant' && action.disabled === false))", {
+      timeoutMs: 30_000,
+      label: "auth.exchange-grant action available after conflicting exchange",
+    });
+    await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
+  }
   await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
     timeoutMs: 45_000,
     label: "persisted den auth token",

--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -42,17 +42,7 @@ export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSess
     label: "auth.exchange-grant action registered",
   });
   const grant = await createDesktopHandoffGrant(member);
-  try {
-    await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
-  } catch (error) {
-    const message = messageText(error);
-    if (!message.includes("Already acting: auth.exchange-grant")) throw error;
-    await waitFor(app, "Boolean(window.__openworkControl?.listActions?.().some((action) => action.id === 'auth.exchange-grant' && action.disabled === false))", {
-      timeoutMs: 30_000,
-      label: "auth.exchange-grant action available after conflicting exchange",
-    });
-    await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
-  }
+  await control(app, "auth.exchange-grant", { grant, baseUrl: den.webUrl });
   await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
     timeoutMs: 45_000,
     label: "persisted den auth token",

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -6,6 +6,7 @@ export * from "./brief.ts";
 export * from "./eventually.ts";
 export * from "./faults.ts";
 export * from "./link.ts";
+export * from "./litellm.ts";
 export * from "./mock.ts";
 export * from "./needs.ts";
 export * from "./place.ts";

--- a/evals/packages/testkit/src/litellm.ts
+++ b/evals/packages/testkit/src/litellm.ts
@@ -1,0 +1,243 @@
+import { execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SkipError } from "./needs.ts";
+
+const IMAGE = "ghcr.io/berriai/litellm:v1.97.0";
+const COMMAND_TIMEOUT_MS = 180_000;
+const STARTUP_TIMEOUT_MS = 90_000;
+
+export interface LiteLlmUpstreamRequest {
+  receivedAt: string;
+  model: string;
+  tokenId: string;
+  bodyText: string;
+}
+
+export interface LiteLlmHandle extends AsyncDisposable {
+  baseUrl: string;
+  apiKey: string;
+  upstreamKey: string;
+  tokenId(key: string): string;
+  waitForUpstreamRequest(input: { model: string; key: string; since: string; timeoutMs: number }): Promise<LiteLlmUpstreamRequest>;
+  upstreamRequests(input: { since: string }): LiteLlmUpstreamRequest[];
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+function run(command: string, args: string[], timeout = COMMAND_TIMEOUT_MS): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { timeout, maxBuffer: 4 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${command} failed: ${error.message}\n${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function tokenId(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+function bearerToken(value: string | undefined): string {
+  return value?.startsWith("Bearer ") ? value.slice("Bearer ".length).trim() : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+function redact(text: string, secrets: string[]): string {
+  return secrets.reduce((result, secret) => result.split(secret).join("[REDACTED]"), text);
+}
+
+function startWitness(modelId: string, reply: string, requests: LiteLlmUpstreamRequest[]): Promise<{ server: Server; port: number }> {
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    if (request.method === "GET" && path === "/v1/models") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model", owned_by: "openwork-testkit" }] }));
+      return;
+    }
+    if (request.method !== "POST" || (path !== "/v1/chat/completions" && path !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "not found" } }));
+      return;
+    }
+
+    let bodyText = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => { bodyText += chunk; });
+    request.on("end", () => {
+      let body: unknown = null;
+      try { body = JSON.parse(bodyText); } catch { body = null; }
+      const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      requests.push({
+        receivedAt: new Date().toISOString(),
+        model,
+        tokenId: tokenId(bearerToken(request.headers.authorization)),
+        bodyText,
+      });
+      const id = `chatcmpl-${randomBytes(8).toString("hex")}`;
+      if (isRecord(body) && body.stream === true) {
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant", content: reply }, finish_reason: null }] })}\n\n`);
+        response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
+        response.end("data: [DONE]\n\n");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        id,
+        object: "chat.completion",
+        choices: [{ index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 8, completion_tokens: 8, total_tokens: 16 },
+      }));
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("LiteLLM upstream witness did not bind a TCP port."));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+async function mappedPort(container: string): Promise<number> {
+  const result = await run("docker", ["port", container, "4000/tcp"], 10_000);
+  const match = result.stdout.match(/:(\d+)\s*$/m);
+  const port = match ? Number(match[1]) : 0;
+  if (!Number.isInteger(port) || port <= 0) throw new Error(`docker port returned an invalid mapping: ${result.stdout.trim()}`);
+  return port;
+}
+
+async function waitForProxy(container: string, apiKey: string, modelId: string): Promise<number> {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  let port = 0;
+  let last = "proxy not queried";
+  while (Date.now() < deadline) {
+    try {
+      port ||= await mappedPort(container);
+      const response = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+        headers: { authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(3_000),
+      });
+      const body: unknown = await response.json();
+      const models = isRecord(body) && Array.isArray(body.data) ? body.data.filter(isRecord) : [];
+      if (response.ok && models.some((model) => model.id === modelId)) return port;
+      last = `HTTP ${response.status}`;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(500);
+  }
+  throw new Error(`LiteLLM did not expose model ${modelId} within ${STARTUP_TIMEOUT_MS}ms (last observation: ${last}).`);
+}
+
+export async function liteLlm(input: { modelId: string; reply: string }): Promise<LiteLlmHandle> {
+  try {
+    await run("docker", ["info"], 15_000);
+  } catch {
+    throw new SkipError("Docker daemon is unavailable");
+  }
+
+  const requests: LiteLlmUpstreamRequest[] = [];
+  const masterKey = `sk-openwork-master-${randomBytes(24).toString("hex")}`;
+  const upstreamKey = `sk-openwork-upstream-${randomBytes(24).toString("hex")}`;
+  const container = `openwork-litellm-${randomBytes(8).toString("hex")}`;
+  let root = "";
+  let witness: Server | null = null;
+  try {
+    const startedWitness = await startWitness(input.modelId, input.reply, requests);
+    witness = startedWitness.server;
+    root = await realpath(await mkdtemp(join(tmpdir(), "openwork-litellm-")));
+    const configPath = join(root, "config.yaml");
+    await writeFile(configPath, JSON.stringify({
+      model_list: [{
+        model_name: input.modelId,
+        litellm_params: {
+          model: `openai/${input.modelId}`,
+          api_base: `http://host.docker.internal:${startedWitness.port}/v1`,
+          api_key: upstreamKey,
+        },
+      }],
+      general_settings: { master_key: masterKey },
+    }), { mode: 0o600 });
+    await run("docker", [
+      "create", "--name", container,
+      "--add-host", "host.docker.internal:host-gateway",
+      "--publish", "127.0.0.1::4000",
+      IMAGE, "--config", "/app/config.yaml", "--port", "4000",
+    ]);
+    await run("docker", ["cp", configPath, `${container}:/app/config.yaml`], 30_000);
+    await run("docker", ["start", container], 30_000);
+    const port = await waitForProxy(container, masterKey, input.modelId);
+    let disposed = false;
+    return {
+      baseUrl: `http://127.0.0.1:${port}/v1`,
+      apiKey: masterKey,
+      upstreamKey,
+      tokenId,
+      upstreamRequests({ since }) {
+        return requests.filter((request) => request.receivedAt >= since).map((request) => ({ ...request }));
+      },
+      async waitForUpstreamRequest({ model, key, since, timeoutMs }) {
+        const deadline = Date.now() + timeoutMs;
+        const expectedTokenId = tokenId(key);
+        while (Date.now() < deadline) {
+          const found = requests.find((request) => request.receivedAt >= since && request.model === model && request.tokenId === expectedTokenId);
+          if (found) return { ...found };
+          await sleep(100);
+        }
+        const observed = requests.filter((request) => request.receivedAt >= since).map(({ receivedAt, model: observedModel, tokenId: observedTokenId }) => ({ receivedAt, model: observedModel, tokenId: observedTokenId }));
+        throw new Error(`Upstream did not receive model ${model} with token fingerprint ${expectedTokenId}. Observed: ${JSON.stringify(observed)}`);
+      },
+      async [Symbol.asyncDispose]() {
+        if (disposed) return;
+        disposed = true;
+        await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          closeServer(startedWitness.server),
+        ]);
+      },
+    };
+  } catch (error) {
+    const logs = await run("docker", ["logs", container], 10_000).then((result) => result.stdout + result.stderr, () => "");
+    await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
+    if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    if (witness) await closeServer(witness).catch(() => undefined);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(redact(`${message}${logs ? `\nDocker logs:\n${logs}` : ""}`, [masterKey, upstreamKey]));
+  }
+}

--- a/evals/packages/testkit/src/litellm.ts
+++ b/evals/packages/testkit/src/litellm.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SkipError } from "./needs.ts";
 
-const IMAGE = "ghcr.io/berriai/litellm:v1.97.0";
+const IMAGE = "ghcr.io/berriai/litellm:v1.97.0@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834";
 const COMMAND_TIMEOUT_MS = 180_000;
 const STARTUP_TIMEOUT_MS = 90_000;
 

--- a/evals/packages/testkit/src/needs.ts
+++ b/evals/packages/testkit/src/needs.ts
@@ -1,7 +1,10 @@
+import { spawnSync } from "node:child_process";
+
 export interface NeedsSpec {
   model?: "tool-capable";
   env?: string[];
   optIn?: string[];
+  commands?: string[];
   daytona?: boolean;
 }
 
@@ -26,6 +29,10 @@ export function unmetNeeds(spec: NeedsSpec, env: NodeJS.ProcessEnv): string[] {
   }
   for (const name of spec.optIn ?? []) {
     if (env[name]?.trim() !== "1") missing.push(`set ${name}=1`);
+  }
+  for (const command of spec.commands ?? []) {
+    const result = spawnSync(command, ["--version"], { stdio: "ignore", timeout: 10_000 });
+    if (result.error || result.status !== 0) missing.push(`install ${command}`);
   }
   if (spec.model === "tool-capable") {
     if (!present(env, "OPENWORK_EVAL_MODEL")) missing.push("set OPENWORK_EVAL_MODEL");

--- a/evals/packages/testkit/test/testkit.test.ts
+++ b/evals/packages/testkit/test/testkit.test.ts
@@ -47,6 +47,14 @@ test("needs only accepts opt-in gates set exactly to 1", () => {
   assert.doesNotThrow(() => checkNeeds({ optIn: ["EXACT_OPT_IN"] }, { EXACT_OPT_IN: "1" }));
 });
 
+test("needs reports an unavailable command", () => {
+  const command = "openwork-impossible-command-for-testkit-test";
+  assert.throws(
+    () => checkNeeds({ commands: [command] }, {}),
+    (error) => error instanceof SkipError && error.message.includes(`install ${command}`),
+  );
+});
+
 test("needs reads process.env at the call site", () => {
   const name = "OPENWORK_TESTKIT_UNIT_RESOURCE";
   const previous = process.env[name];

--- a/evals/specs/den-litellm-provider.slow.test.ts
+++ b/evals/specs/den-litellm-provider.slow.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "vitest";
 import {
+  createAndSelectWorkspace,
   denFetch,
   evalIn,
   fill,
@@ -12,8 +13,8 @@ import {
 } from "@openwork/behaviors";
 import type { DenSession, ModelFacts } from "@openwork/behaviors";
 import { screenshot, validate } from "@openwork/fraimz";
+import { desktop as launchDesktop } from "@openwork/hosts";
 import {
-  app,
   eventually,
   liteLlm,
   needs,
@@ -168,6 +169,42 @@ async function runDirectProviderSync(
   return value;
 }
 
+async function seedRendererDenSession(
+  desktop: Parameters<typeof evalIn>[0],
+  input: { token: string; orgId: string; webUrl: string },
+): Promise<void> {
+  const value = await evalIn(desktop, `(async () => {
+    const { seedDenDesktopConfigConnectPolicy, writeDenSettings } = await import("/src/app/lib/den.ts");
+    const { dispatchDenSessionUpdated } = await import("/src/app/lib/den-session-events.ts");
+    writeDenSettings({
+      baseUrl: ${JSON.stringify(input.webUrl)},
+      authToken: ${JSON.stringify(input.token)},
+      activeOrgId: ${JSON.stringify(input.orgId)},
+      activeOrgSlug: null,
+      activeOrgName: ${JSON.stringify(ORGANIZATION_NAME)},
+    });
+    seedDenDesktopConfigConnectPolicy({
+      organizationId: ${JSON.stringify(input.orgId)},
+      connectEnabled: true,
+    });
+    dispatchDenSessionUpdated({
+      status: "success",
+      baseUrl: ${JSON.stringify(input.webUrl)},
+      token: ${JSON.stringify(input.token)},
+      user: null,
+      email: null,
+    });
+    return { ok: true };
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  if (!isRecord(value) || value.ok !== true) {
+    throw new Error(`Seeding the renderer Den session failed: ${JSON.stringify(value)}`);
+  }
+  await waitFor(desktop, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
+    timeoutMs: 45_000,
+    label: "persisted Den auth token after session seed",
+  });
+}
+
 test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, async ({ evidence, place }) => {
   needs(requirements);
   if (place.kind !== "local" || process.env.OPENWORK_EVAL_DEN_API_URL?.trim()) {
@@ -192,14 +229,21 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, asy
       await deleteProvider(den.admin, orgId, cloudProviderId).catch(() => undefined);
     },
   };
-  await using desktop = await app({ den, as: "member", place });
-  // Avoid making this provider test depend on first-request Next.js dev proxy compilation.
-  await runDirectProviderSync(desktop, { baseUrl: den.ref.apiUrl, token: member.token, orgId });
-  await go(desktop, `/workspace/${desktop.workspaceId}/session`);
-  await waitFor(desktop, "Boolean(window.__openworkControl)", {
-    timeoutMs: 120_000,
-    label: "desktop session control",
+  await using desktop = await launchDesktop({
+    name: "den-litellm-provider",
+    host: place.host(),
+    bootstrap: {
+      baseUrl: den.ref.webUrl,
+      apiBaseUrl: den.ref.webUrl,
+      requireSignin: false,
+    },
   });
+  await seedRendererDenSession(desktop, {
+    token: member.token,
+    orgId,
+    webUrl: den.ref.webUrl,
+  });
+  await runDirectProviderSync(desktop, { baseUrl: den.ref.apiUrl, token: member.token, orgId });
 
   const sync = await eventually(() => readSyncStatus(desktop), {
     within: 120_000,
@@ -217,6 +261,12 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, asy
     synced,
   );
   expect(synced, `Cloud provider sync failed: ${sync.lastRunMessage || "no message"}; skipped: ${JSON.stringify(sync.skippedProviders)}; payload: ${JSON.stringify(sync.raw)}`).toBe(true);
+  const { workspaceId } = await createAndSelectWorkspace(desktop, { path: `/tmp/openwork-litellm-${Date.now()}` });
+  await go(desktop, `/workspace/${workspaceId}/session`);
+  await waitFor(desktop, "Boolean(window.__openworkControl)", {
+    timeoutMs: 120_000,
+    label: "desktop session control",
+  });
 
   const models = await eventually(() => readAvailableModels(desktop), {
     within: 60_000,

--- a/evals/specs/den-litellm-provider.slow.test.ts
+++ b/evals/specs/den-litellm-provider.slow.test.ts
@@ -1,0 +1,311 @@
+import { expect } from "vitest";
+import {
+  denFetch,
+  evalIn,
+  fill,
+  go,
+  readAvailableModels,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+  waitForAssistantReply,
+} from "@openwork/behaviors";
+import type { DenSession, ModelFacts } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/fraimz";
+import {
+  app,
+  eventually,
+  liteLlm,
+  needs,
+  server,
+  SkipError,
+  test,
+  unmetNeeds,
+} from "@openwork/testkit";
+import type { NeedsSpec } from "@openwork/testkit";
+
+const ORGANIZATION_NAME = "LiteLLM Provider Route";
+const PROVIDER_NAME = "Deterministic LiteLLM";
+const PROVIDER_KEY = "openwork-litellm-witness";
+const MODEL_ID = "openwork-litellm-witness-model";
+const MODEL_NAME = "Deterministic Witness Model";
+const PROVIDER_ENV = "LITELLM_WITNESS_API_KEY";
+const REPLY = "The deterministic local route is working.";
+const REQUEST_TIMEOUT_MS = 10_000;
+const requirements: NeedsSpec = { optIn: ["OPENWORK_EVAL_APP_SPECS"], commands: ["docker"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `Den LiteLLM provider route skipped — needs: ${missingRequirements.join(", ")}`
+  : "a Den provider syncs to desktop and reaches its upstream through LiteLLM";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function createProvider(admin: DenSession, orgId: string, baseUrl: string, apiKey: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: [PROVIDER_ENV],
+        api: baseUrl,
+        models: [{ id: MODEL_ID, name: MODEL_NAME }],
+      },
+      apiKey,
+      allMembers: true,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider) ? result.body.llmProvider : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  if (result.response.status !== 201 || !id) {
+    throw new Error(`Creating the LiteLLM provider failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function deleteProvider(admin: DenSession, orgId: string, providerId: string): Promise<void> {
+  await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "DELETE",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+interface SyncFacts {
+  lastRunStatus: string;
+  lastRunMessage: string;
+  providerIds: string[];
+  skippedProviders: unknown[];
+  raw: Record<string, unknown>;
+}
+
+async function readSyncStatus(desktop: Parameters<typeof evalIn>[0]): Promise<SyncFacts> {
+  const value = await evalIn(desktop, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return { error: "missing local server credentials" };
+    const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/status", {
+      headers: { Authorization: "Bearer " + token },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok) return { error: "HTTP " + response.status };
+    return await response.json();
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.error === "string") {
+    throw new Error(`Reading cloud provider sync status failed: ${JSON.stringify(value)}`);
+  }
+  const lastRun = isRecord(value.lastRun) ? value.lastRun : {};
+  const providers = Array.isArray(value.providers) ? value.providers.filter(isRecord) : [];
+  return {
+    lastRunStatus: typeof lastRun.status === "string" ? lastRun.status : "",
+    lastRunMessage: typeof lastRun.message === "string" ? lastRun.message : "",
+    providerIds: providers.flatMap((provider) => typeof provider.cloudProviderId === "string" ? [provider.cloudProviderId] : []),
+    skippedProviders: Array.isArray(value.skippedProviders) ? value.skippedProviders : [],
+    raw: value,
+  };
+}
+
+async function runDirectProviderSync(
+  desktop: Parameters<typeof evalIn>[0],
+  input: { baseUrl: string; token: string; orgId: string },
+): Promise<Record<string, unknown>> {
+  const value = await evalIn(desktop, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl || !info.hostToken) return { error: "local_server_unavailable" };
+    const request = async (path, method, body) => {
+      const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + path, {
+        method,
+        headers: {
+          Authorization: "Bearer " + String(info.hostToken),
+          "Content-Type": "application/json",
+          "x-openwork-host-token": String(info.hostToken),
+        },
+        body: JSON.stringify(body),
+      });
+      const text = await response.text();
+      let payload = text;
+      try { payload = text ? JSON.parse(text) : null; } catch {}
+      return { status: response.status, body: payload };
+    };
+    const session = await request("/den-session", "PUT", ${JSON.stringify(input)});
+    if (session.status !== 204) return { error: "den_session_failed", session };
+    const sync = await request("/cloud-provider-sync/run", "POST", { reason: "eval_litellm_provider" });
+    if (sync.status !== 200) return { error: "sync_run_failed", sync };
+    return sync.body;
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  if (!isRecord(value) || typeof value.error === "string") {
+    throw new Error(`Triggering direct local provider sync failed: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  if (place.kind !== "local" || process.env.OPENWORK_EVAL_DEN_API_URL?.trim()) {
+    throw new SkipError("LiteLLM loopback topology requires local placement and a cold local Den");
+  }
+
+  await using gateway = await liteLlm({ modelId: MODEL_ID, reply: REPLY });
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      admin: { name: "Provider Admin" },
+      members: { member: { name: "Provider Member" } },
+    },
+  });
+  const member = den.members.member;
+  if (!member) throw new Error("The cold local Den did not provision the member.");
+  const orgId = await organizationId(den.admin);
+  const cloudProviderId = await createProvider(den.admin, orgId, gateway.baseUrl, gateway.apiKey);
+  await using publishedProvider = {
+    async [Symbol.asyncDispose]() {
+      await deleteProvider(den.admin, orgId, cloudProviderId).catch(() => undefined);
+    },
+  };
+  await using desktop = await app({ den, as: "member", place });
+  // Avoid making this provider test depend on first-request Next.js dev proxy compilation.
+  await runDirectProviderSync(desktop, { baseUrl: den.ref.apiUrl, token: member.token, orgId });
+  await go(desktop, `/workspace/${desktop.workspaceId}/session`);
+  await waitFor(desktop, "Boolean(window.__openworkControl)", {
+    timeoutMs: 120_000,
+    label: "desktop session control",
+  });
+
+  const sync = await eventually(() => readSyncStatus(desktop), {
+    within: 120_000,
+    intervalMs: 2_000,
+    label: "terminal LiteLLM provider sync",
+    until: (status) => status.lastRunStatus === "failed"
+      || (status.providerIds.includes(cloudProviderId)
+        && (status.lastRunStatus === "applied" || status.lastRunStatus === "noop")),
+  });
+  const synced = sync.providerIds.includes(cloudProviderId)
+    && (sync.lastRunStatus === "applied" || sync.lastRunStatus === "noop");
+  evidence.fact(
+    "Den's custom provider reached a terminal desktop sync outcome",
+    `Provider appeared in sync status with lastRun=${sync.lastRunStatus}; payload: ${JSON.stringify(sync.raw)}`,
+    synced,
+  );
+  expect(synced, `Cloud provider sync failed: ${sync.lastRunMessage || "no message"}; skipped: ${JSON.stringify(sync.skippedProviders)}; payload: ${JSON.stringify(sync.raw)}`).toBe(true);
+
+  const models = await eventually(() => readAvailableModels(desktop), {
+    within: 60_000,
+    intervalMs: 2_000,
+    label: "selectable LiteLLM witness model",
+    until: (available) => available.some((model) => model.selectable && (model.id === MODEL_ID || model.id.endsWith(`/${MODEL_ID}`))),
+  });
+  const model = models.find((candidate) => candidate.selectable && (candidate.id === MODEL_ID || candidate.id.endsWith(`/${MODEL_ID}`)));
+  const modelAvailable = model !== undefined;
+  evidence.fact(
+    "The synced provider's model became selectable in the desktop",
+    `Selectable model ids: ${JSON.stringify(models.filter((candidate) => candidate.selectable).map((candidate) => candidate.id))}`,
+    modelAvailable,
+  );
+  expect(modelAvailable).toBe(true);
+  if (!model) throw new Error("The LiteLLM witness model was not selectable.");
+  await fill(desktop, 'input[placeholder="Search providers and models..."]', MODEL_NAME);
+  await waitFor(desktop, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    return Boolean(dialog
+      && dialog.innerText.includes(${JSON.stringify(PROVIDER_NAME)})
+      && dialog.innerText.includes(${JSON.stringify(MODEL_NAME)}));
+  })()`, { timeoutMs: 30_000, label: "LiteLLM provider and model in picker" });
+  const pickerLayout = await evalIn(desktop, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    const model = [...(dialog?.querySelectorAll("button") ?? [])].find((element) =>
+      (element.textContent ?? "").includes(${JSON.stringify(MODEL_NAME)}));
+    const rect = model?.getBoundingClientRect();
+    return {
+      dialogVisible: Boolean(dialog && dialog.getBoundingClientRect().height > 100),
+      modelVisible: Boolean(rect && rect.width > 0 && rect.height > 0
+        && rect.top >= 0 && rect.bottom <= window.innerHeight),
+    };
+  })()`);
+  const pickerReady = isRecord(pickerLayout)
+    && pickerLayout.dialogVisible === true
+    && pickerLayout.modelVisible === true;
+  evidence.fact(
+    "The Den-managed LiteLLM model is structurally visible in the model picker",
+    `Model picker layout probe: ${JSON.stringify(pickerLayout)}`,
+    pickerReady,
+  );
+  expect(pickerReady).toBe(true);
+  const pickerShot = await screenshot(desktop);
+  const pickerSeen = await validate(pickerShot, [
+    `The model picker visibly shows provider ${PROVIDER_NAME} and model ${MODEL_NAME}`,
+    "The LiteLLM model is presented as selectable, without unavailable, credential, syncing, or error text",
+    "The model picker is polished and legible with no overlap, clipping, blank panel, or stray overlay",
+  ]);
+  expect(pickerSeen.ok, pickerSeen.why).toBe(true);
+  const selected: ModelFacts = await selectModel(desktop, model.id);
+  expect(selected.selected).toBe(true);
+
+  const prompt = "Please answer with one short sentence confirming this local test route works.";
+  expect(prompt).not.toContain(PROVIDER_KEY);
+  expect(prompt).not.toContain(MODEL_ID);
+  expect(prompt).not.toContain(orgId);
+  const since = new Date().toISOString();
+  await sendComposerMessage(desktop, prompt);
+  const upstreamRequest = await gateway.waitForUpstreamRequest({
+    model: MODEL_ID,
+    key: gateway.upstreamKey,
+    since,
+    timeoutMs: 120_000,
+  });
+  const requestUsedUpstreamKey = upstreamRequest.tokenId === gateway.tokenId(gateway.upstreamKey);
+  const requestContainsPrompt = upstreamRequest.bodyText.includes(prompt);
+  const masterKeyReachedUpstream = gateway.upstreamRequests({ since })
+    .some((request) => request.tokenId === gateway.tokenId(gateway.apiKey));
+  evidence.fact(
+    "The desktop request traversed LiteLLM and LiteLLM rewrote the bearer key for the deterministic upstream",
+    `Upstream saw model ${upstreamRequest.model}, token fingerprint ${upstreamRequest.tokenId}, and no master-key fingerprint after submission.`,
+    requestUsedUpstreamKey && requestContainsPrompt && !masterKeyReachedUpstream,
+  );
+  expect(requestContainsPrompt).toBe(true);
+  expect(requestUsedUpstreamKey).toBe(true);
+  expect(masterKeyReachedUpstream).toBe(false);
+
+  await waitFor(desktop, `([...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => (message.innerText ?? "").includes(${JSON.stringify(REPLY)})))`, {
+    timeoutMs: 120_000,
+    label: "complete deterministic LiteLLM reply",
+  });
+  const assistant = await waitForAssistantReply(desktop, { timeoutMs: 10_000 });
+  const rendered = assistant.text.includes(REPLY);
+  evidence.fact(
+    "The deterministic upstream reply rendered in the desktop conversation",
+    `Latest assistant message contained ${JSON.stringify(REPLY)}.`,
+    rendered,
+  );
+  expect(rendered).toBe(true);
+});

--- a/evals/specs/den-litellm-provider.slow.test.ts
+++ b/evals/specs/den-litellm-provider.slow.test.ts
@@ -25,11 +25,11 @@ import {
 } from "@openwork/testkit";
 import type { NeedsSpec } from "@openwork/testkit";
 
-const ORGANIZATION_NAME = "LiteLLM Provider Route";
-const PROVIDER_NAME = "Deterministic LiteLLM";
+const ORGANIZATION_NAME = "Den Lab";
+const PROVIDER_NAME = "LiteLLM Gateway";
 const PROVIDER_KEY = "openwork-litellm-witness";
 const MODEL_ID = "openwork-litellm-witness-model";
-const MODEL_NAME = "Deterministic Witness Model";
+const MODEL_NAME = "Witness Model";
 const PROVIDER_ENV = "LITELLM_WITNESS_API_KEY";
 const REPLY = "The deterministic local route is working.";
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -261,7 +261,13 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, asy
     synced,
   );
   expect(synced, `Cloud provider sync failed: ${sync.lastRunMessage || "no message"}; skipped: ${JSON.stringify(sync.skippedProviders)}; payload: ${JSON.stringify(sync.raw)}`).toBe(true);
-  const { workspaceId } = await createAndSelectWorkspace(desktop, { path: `/tmp/openwork-litellm-${Date.now()}` });
+  const { workspaceId } = await createAndSelectWorkspace(desktop, { path: "/tmp/litellm-demo" });
+  await desktop.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
   await go(desktop, `/workspace/${workspaceId}/session`);
   await waitFor(desktop, "Boolean(window.__openworkControl)", {
     timeoutMs: 120_000,


### PR DESCRIPTION
## Summary

- add a reusable real LiteLLM Docker fixture backed by a deterministic OpenAI-compatible witness
- pin the LiteLLM `v1.97.0` image to its reviewed multi-architecture digest
- prove a Den-managed custom provider syncs into the desktop model picker
- prove a desktop chat request traverses LiteLLM, uses the rewritten upstream key, and renders the deterministic reply

## User flow

![OpenWork model picker showing the Den-managed LiteLLM Gateway and selectable Witness Model](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr/den-litellm-provider/litellm-model-picker.png)

## Verification

Verdict: **Passed** on the local lane. This spec intentionally exercises a local Docker LiteLLM gateway; Daytona/cross-sandbox placement will be handled separately.

- `pnpm --dir evals test`
  - exit 0; 202 passed, 0 failed, 0 skipped
- `OPENAI_API_KEY="$(infisical secrets get OPENAI_API_KEY --plain --silent)" env -u OPENWORK_EVAL_DAYTONA -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL -u DATABASE_HOST OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/den-litellm-provider.slow.test.ts`
  - exit 0; 1 passed, 0 failed, 0 skipped
  - tape: 6/6 frames and 8/8 expectations passed on `535ebeeaced00233d7b40dd020cd604f69096b55`
- `docker buildx imagetools inspect ghcr.io/berriai/litellm:v1.97.0`
  - verified pinned index digest `sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834`

## Follow-up

A separate PR will add Daytona-aware LiteLLM placement so the gateway and deterministic witness can be reached across sandboxes.