### PR TITLE
Fix Okta SAML callback configuration and add setup docs

### DIFF
--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -155,6 +155,7 @@ async function registerBetterAuthSsoProvider(input: OrganizationSsoRegistrationI
           entryPoint: input.entryPoint,
           cert: input.cert,
           audience,
+          callbackUrl: getSsoAcsUrl(providerId),
           idpMetadata: {
             entityID: input.issuer,
           },

--- a/ee/apps/den-api/test/sso-provider-rotation.test.ts
+++ b/ee/apps/den-api/test/sso-provider-rotation.test.ts
@@ -249,6 +249,10 @@ test("legacy SSO connections move to the canonical provider and recover a strand
     providerId: canonicalProviderIds.first,
     domain: "first.example.test",
   })
+  expect(JSON.parse(firstProviders[0]?.samlConfig ?? "{}")).toMatchObject({
+    audience: "http://127.0.0.1:8790",
+    callbackUrl: `http://127.0.0.1:8790/api/auth/sso/saml2/sp/acs/${canonicalProviderIds.first}`,
+  })
   expect(recoveryProviders).toHaveLength(1)
   expect(recoveryProviders[0]).toMatchObject({
     providerId: canonicalProviderIds.recovery,

--- a/evals/specs/scim-okta-lifecycle.slow.test.ts
+++ b/evals/specs/scim-okta-lifecycle.slow.test.ts
@@ -104,8 +104,9 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
     throw new Error(`Organization lookup failed: HTTP ${organizations.response.status} ${organizations.text.slice(0, 500)}`);
   }
 
-  // The org-scoped token route requires an enabled SSO connection. Manual
-  // endpoints keep this API-only journey self-contained; no IdP is contacted.
+  // The org-scoped token route requires an enabled SSO connection. Register an
+  // Okta-shaped SAML provider so this API-only journey also proves the ACS
+  // callback configuration without contacting an IdP.
   const adminSignIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
     method: "POST",
     body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
@@ -119,26 +120,41 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
     cookie: sessionCookie,
     "x-openwork-org-id": organizationId,
   };
-  const sso = await denFetch(den.ref, "/v1/sso/oidc", {
+  const sso = await denFetch(den.ref, "/v1/sso/saml", {
     method: "POST",
     headers: adminHeaders,
     body: JSON.stringify({
-      issuer: "https://okta.example.test",
+      issuer: `http://www.okta.com/exk-${runId}`,
       domain: managedDomain,
-      clientId: `okta-client-${runId}`,
-      clientSecret: `okta-secret-${runId}`,
-      scopes: ["openid", "email", "profile"],
-      skipDiscovery: true,
-      authorizationEndpoint: "https://okta.example.test/oauth2/v1/authorize",
-      tokenEndpoint: "https://okta.example.test/oauth2/v1/token",
-      jwksEndpoint: "https://okta.example.test/oauth2/v1/keys",
-      userInfoEndpoint: "https://okta.example.test/oauth2/v1/userinfo",
-      tokenEndpointAuthentication: "client_secret_basic",
+      entryPoint: `https://okta.example.test/app/openwork/exk-${runId}/sso/saml`,
+      cert: "okta-test-signing-certificate",
+      audience: den.ref.apiUrl,
     }),
   });
   if (!sso.response.ok) {
     throw new Error(`SSO prerequisite failed: HTTP ${sso.response.status} ${sso.text.slice(0, 500)}`);
   }
+
+  const ssoConnection = isRecord(sso.body) && isRecord(sso.body.connection) ? sso.body.connection : null;
+  const acsUrl = stringField(ssoConnection, "acsUrl");
+  if (!acsUrl) {
+    throw new Error(`SAML registration did not advertise an ACS URL: ${sso.text.slice(0, 500)}`);
+  }
+  const malformedSaml = await fetch(acsUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ SAMLResponse: "not-base64-xml" }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const malformedSamlBody: unknown = await malformedSaml.json();
+  expect(stringField(malformedSamlBody, "error")).toBe("invalid_encoding");
+  expect(stringField(malformedSamlBody, "error")).not.toBe("invalid_saml_configuration");
+  evidence.fact(
+    "Okta SAML registration persists a usable ACS callback configuration",
+    `POSTing a deliberately malformed assertion to the advertised ACS URL reached response-policy validation and returned invalid_encoding, not invalid_saml_configuration.`,
+    malformedSaml.status === 400
+      && stringField(malformedSamlBody, "error") === "invalid_encoding",
+  );
 
   // ── Frame 1: Den issues the org's Okta bearer, never a raw BA token ──────
   const scimBasePath = "/api/auth/scim/v2";

--- a/packages/docs/cloud/members-and-rbac.mdx
+++ b/packages/docs/cloud/members-and-rbac.mdx
@@ -60,7 +60,8 @@ You can use teams to control access to marketplaces and LLM providers without as
 
 Organizations using SCIM can open `SCIM` and enable **Create teams from SCIM groups**. OpenWork then creates a team for each provisioned Group and keeps its membership synchronized from the identity provider. These teams are labeled **Managed by SCIM** and must be changed in the identity provider; manually created teams and memberships remain independent.
 
-To connect Microsoft Entra ID, follow
+To connect an identity provider, follow
+[Okta SCIM provisioning](/cloud/scim-okta) or
 [Microsoft Entra SCIM provisioning](/cloud/scim-microsoft-entra).
 
 When SCIM deprovisions a user, OpenWork retains a disconnected member record for organization history. The global user is deleted only when they have no other active organization memberships. Reactivate the user through SCIM before they can regain SAML access.

--- a/packages/docs/cloud/scim-okta.mdx
+++ b/packages/docs/cloud/scim-okta.mdx
@@ -1,0 +1,160 @@
+---
+title: "Okta SCIM provisioning"
+description: "Provision OpenWork members and teams from Okta"
+---
+
+Use Okta Lifecycle Management to create, update, deactivate, and reactivate
+OpenWork members. Okta groups can also become SCIM-managed OpenWork teams.
+
+## Before you start
+
+You need:
+
+- A working and domain-verified [Okta SAML SSO](/cloud/sso-okta) connection.
+- An OpenWork owner, or a member who can manage security configuration.
+- An Okta administrator who can configure provisioning for the SAML app.
+- An Okta plan that supports the provisioning and group-push features you
+  intend to use.
+
+Keep OpenWork SSO enforcement off until both SAML and a narrowly scoped SCIM
+test pass. Make sure at least one OpenWork owner can sign in through Okta.
+
+## 1. Create the OpenWork SCIM connector
+
+In OpenWork, select the organization, then open **Settings → SCIM**. Confirm
+the page reports that SAML/SSO is active, then:
+
+1. Select **Create connector**.
+2. Copy the **SCIM base URL**.
+3. Copy the bearer token immediately. OpenWork displays the full token only
+   after creating or rotating the connector.
+4. Leave **Create teams from SCIM groups** off until user provisioning works.
+
+Treat the bearer token like a password. Do not put it in tickets, screenshots,
+logs, or documentation. Rotating it invalidates the previous token, so update
+Okta during the same maintenance window.
+
+<Note>
+Use the base URL OpenWork displays. In a split-host Helm deployment it may use
+the web auth origin even when a separate Den API origin also exists. Do not
+rewrite the hostname.
+</Note>
+
+## 2. Enable SCIM on the Okta application
+
+Use the same Okta application as SAML SSO:
+
+1. Open **Applications → Applications → OpenWork**.
+2. Open **General** and edit **App Settings**.
+3. Enable **SCIM** under **Provisioning**, then save.
+4. Open the new **Provisioning** tab.
+5. Select **Configure API Integration**.
+6. Enable **API Integration**.
+
+Enter:
+
+| Okta field | Value |
+| --- | --- |
+| SCIM connector base URL | OpenWork **SCIM base URL** |
+| Unique identifier field for users | `userName` |
+| Supported provisioning actions | Push new users, push profile updates, and push groups as needed |
+| Authentication mode | HTTP Header |
+| Authorization | OpenWork SCIM bearer token |
+
+Select **Test API Credentials**. Save only after Okta reports a successful
+connection.
+
+## 3. Configure provisioning to OpenWork
+
+Open **Provisioning → To App**, then enable:
+
+- **Create Users**
+- **Update User Attributes**
+- **Deactivate Users**
+
+Do not enable password synchronization. SCIM creates federated membership; it
+does not create an OpenWork password credential.
+
+Review the attribute mappings. At minimum, keep these identity values aligned:
+
+| Okta value | SCIM attribute |
+| --- | --- |
+| Stable work email or Okta username | `userName` |
+| Primary work email | `emails[type eq "work"].value` |
+| First name | `name.givenName` |
+| Last name | `name.familyName` |
+| Display name | `displayName` |
+
+The SAML NameID and SCIM `userName` must identify the same person. A mismatch
+can create a duplicate OpenWork member instead of linking SSO and SCIM.
+
+## 4. Provision one assigned user
+
+Start with the user already assigned during the SAML test:
+
+1. Open the Okta application's **Assignments** tab.
+2. Confirm the test user is assigned and their application username is the
+   same email used for SAML NameID and SCIM `userName`.
+3. Open the assignment's provisioning status or Okta **System Log**.
+4. Confirm Okta's lookup and create or update operations succeed.
+5. In OpenWork, open **Members** and verify the same member appears without a
+   second password-backed account.
+
+Do not broaden assignments until the test user's create, update, deactivate,
+and reactivate lifecycle works.
+
+## 5. Verify the user lifecycle
+
+For the assigned test user, verify:
+
+1. Changing the profile name in Okta updates the OpenWork member.
+2. Unassigning or deactivating the user removes active organization access.
+3. The user cannot regain access through password sign-up while SCIM marks the
+   identity inactive.
+4. Reactivating and reassigning the user restores the same OpenWork identity.
+5. An unrelated OpenWork member remains unchanged throughout the test.
+
+OpenWork retains a disconnected member record for organization history. The
+global user is deleted only after their final active organization membership
+is removed.
+
+## 6. Push Okta groups as OpenWork teams
+
+After user provisioning works:
+
+1. In OpenWork **Settings → SCIM**, enable
+   **Create teams from SCIM groups**.
+2. In Okta, open the application's **Push Groups** tab.
+3. Select **Push Groups** and choose a small test group by name or rule.
+4. Confirm Okta creates the group and pushes its current membership.
+5. In OpenWork, open **Members → Teams** and verify a team labeled
+   **Managed by SCIM** appears with the expected members.
+6. Add and remove one member in Okta and verify the OpenWork team follows.
+
+Manage pushed groups in Okta, not in OpenWork. Manually created OpenWork teams
+remain independent.
+
+## 7. Expand scope and enforce SSO
+
+After the lifecycle and group tests pass:
+
+1. Assign the intended Okta users and groups to the application.
+2. Review Okta provisioning events for failures.
+3. Review OpenWork's SCIM health and unresolved-failure count.
+4. Confirm at least one owner has working Okta SAML access.
+5. Only then consider enabling **Require SSO for this organization**.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| **Create connector** is disabled | OpenWork does not see an enabled SSO provider | Complete and test Okta SAML first; if SAML returns `invalid_saml_configuration`, upgrade and save the connection again |
+| **Test API Credentials** fails | Incorrect base URL, stale token, whitespace, or a rewritten hostname | Copy both values again from OpenWork and use the advertised base URL unchanged |
+| Okta creates a duplicate member | SAML NameID and SCIM `userName` differ | Map both to the same stable work email |
+| Assignment succeeds but no member appears | To App provisioning is disabled or the user is outside assignment scope | Enable **Create Users** and confirm the person is assigned to the application |
+| Deactivation does not remove access | **Deactivate Users** is disabled or Okta has not sent the event | Enable it and inspect the Okta System Log and OpenWork SCIM health |
+| A pushed group does not create a team | OpenWork team synchronization is off | Enable **Create teams from SCIM groups**, then retry the Okta group push |
+| A group is pushed without members | Its members are not assigned or provisioned to the application | Assign and provision the users before validating group membership |
+
+For member and team behavior after provisioning, see
+[Members and RBAC](/cloud/members-and-rbac).

--- a/packages/docs/cloud/sso-okta.mdx
+++ b/packages/docs/cloud/sso-okta.mdx
@@ -1,0 +1,169 @@
+---
+title: "Okta SAML SSO"
+description: "Connect Okta to OpenWork Cloud or a self-hosted OpenWork deployment with SAML"
+---
+
+Use this guide to let organization members sign in to OpenWork through an
+Okta application integration. It works for OpenWork Cloud and for a Helm
+deployment with a public HTTPS web origin.
+
+After SAML sign-in works, use [Okta SCIM provisioning](/cloud/scim-okta) to
+synchronize members and groups.
+
+## Before you start
+
+You need:
+
+- An OpenWork owner, or a member who can manage security configuration.
+- An Okta administrator who can create and assign application integrations.
+- Control of DNS for the email domain you will associate with the connection.
+- The final HTTPS OpenWork web origin, for example
+  `https://openwork.example.com`.
+
+Keep **Require SSO for this organization** off until an owner has completed a
+fresh SAML sign-in. Keep password access available as a recovery path during
+setup.
+
+<Note>
+For a Helm deployment with separate web and API hosts, use the URLs OpenWork
+shows in **Settings → SSO**. Do not replace their host with the separate API
+origin. SAML uses the deployment's configured auth origin, which is normally
+the public web origin when `/api/auth` is proxied through the web host.
+</Note>
+
+## 1. Get the organization ID
+
+In OpenWork, select the organization and open **Settings → General**. Copy the
+organization ID. OpenWork creates the SAML provider ID as:
+
+```text
+openwork-sso-<organization-id>
+```
+
+The corresponding assertion consumer service URL is:
+
+```text
+https://<openwork-web-origin>/api/auth/sso/saml2/sp/acs/openwork-sso-<organization-id>
+```
+
+You can confirm the exact generated URL after saving the OpenWork connection.
+
+## 2. Create the Okta SAML application
+
+In the Okta Admin Console:
+
+1. Open **Applications → Applications**.
+2. Select **Create App Integration**.
+3. Choose **SAML 2.0**, then select **Next**.
+4. Set **App name** to `OpenWork` or another recognizable workspace name.
+5. Select **Next**.
+
+## 3. Configure SAML in Okta
+
+Under **General**, enter:
+
+| Okta field | Value |
+| --- | --- |
+| Single sign-on URL | The OpenWork ACS URL from step 1 |
+| Use this for Recipient URL and Destination URL | Enabled |
+| Audience URI (SP Entity ID) | The OpenWork web origin, for example `https://openwork.example.com` |
+| Default RelayState | Leave blank |
+| Name ID format | `EmailAddress` |
+| Application username | `Okta username` |
+
+Open **Show Advanced Settings** and confirm:
+
+- **Response**: `Signed`
+- **Assertion Signature**: `Signed`
+- **Signature Algorithm**: `RSA-SHA256`
+- **Digest Algorithm**: `SHA256`
+- **Assertion Encryption**: `Unencrypted`
+
+OpenWork requires a signed assertion. Keep the Okta username and NameID equal
+to the stable work email that SCIM will later send as `userName`.
+
+Select **Next**, mark the integration as an internal application when
+appropriate, then select **Finish**.
+
+## 4. Copy Okta values into OpenWork
+
+In the Okta application's **Sign On** tab, select
+**View SAML setup instructions**. Copy:
+
+- **Identity Provider Single Sign-On URL**
+- **Identity Provider Issuer**
+- **X.509 Certificate**, including the `BEGIN CERTIFICATE` and
+  `END CERTIFICATE` lines
+
+In OpenWork, open **Settings → SSO**, select **SAML**, and enter:
+
+| OpenWork field | Okta value |
+| --- | --- |
+| IdP Issuer URL | **Identity Provider Issuer** |
+| Domain | The members' email domain, for example `example.com` |
+| SAML Entry Point | **Identity Provider Single Sign-On URL** |
+| Audience URL | Leave blank to use the configured OpenWork auth origin |
+| IdP Certificate | **X.509 Certificate** |
+
+Save the connection. Compare the generated **ACS URL** with Okta's
+**Single sign-on URL** character for character. Also copy the generated
+OpenWork **Sign-in URL**; use this URL for the first test.
+
+## 5. Verify the email domain
+
+Select **Request token** under **Domain verification**. Create a DNS TXT
+record for the email domain:
+
+| DNS field | Value |
+| --- | --- |
+| Type | `TXT` |
+| Name | `_better-auth-token-<provider-id>` |
+| Value | The token OpenWork displays |
+
+For example, provider `openwork-sso-org_123` for `example.com` produces:
+
+```text
+_better-auth-token-openwork-sso-org_123.example.com
+```
+
+In a DNS console that automatically appends the zone, enter only
+`_better-auth-token-<provider-id>` in the name field. The token is valid for
+seven days. After the TXT record resolves publicly, select **Verify domain**
+in OpenWork and confirm the connection shows **Domain verified: Yes**.
+
+## 6. Assign a test user in Okta
+
+In the Okta application:
+
+1. Open **Assignments**.
+2. Select **Assign → Assign to People**.
+3. Assign one OpenWork owner or another controlled test user.
+4. Confirm the application username is that user's stable work email.
+
+Do not assign broad groups until the test user can complete the full flow.
+
+## 7. Test SP-initiated sign-in
+
+Open the organization-specific OpenWork **Sign-in URL** in a fresh browser
+session. Confirm that:
+
+1. OpenWork redirects to the expected Okta tenant.
+2. Okta authenticates the assigned user.
+3. Okta posts the assertion to the generated OpenWork ACS URL.
+4. OpenWork returns the user to the intended organization.
+5. The member identity in OpenWork uses the same email that Okta sent as
+   NameID.
+
+Only after this succeeds should you configure SCIM or enable
+**Require SSO for this organization**.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `Provider domain has not been verified` | The TXT record is missing, attached to the zone apex, or has not propagated | Put the token at `_better-auth-token-<provider-id>.<domain>`, wait for public DNS, then select **Verify domain** |
+| `invalid_saml_configuration` | The OpenWork build did not persist the generated ACS callback URL in the SAML provider | Upgrade to a build containing the SAML callback configuration fix, then edit and save the connection again |
+| `invalid_audience` | Okta's Audience URI does not match OpenWork's configured auth origin | Use the OpenWork web/auth origin shown by the deployment; do not substitute a separate API host |
+| `invalid_destination` or `invalid_recipient` | Okta is posting to a different URL than OpenWork expects | Copy the generated OpenWork ACS URL into Okta and keep **Use this for Recipient URL and Destination URL** enabled |
+| `Invalid SAML response` | The assertion is unsigned, uses a deprecated algorithm, or the active Okta certificate differs from OpenWork | Sign the assertion with RSA-SHA256 and paste Okta's current active X.509 certificate into OpenWork |
+| Okta refuses access | The person is not assigned to the application | Assign the test user under **Assignments** |

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -148,6 +148,8 @@
             ]
           },
           "cloud/members-and-rbac",
+          "cloud/sso-okta",
+          "cloud/scim-okta",
           "cloud/sso-microsoft-entra",
           "cloud/scim-microsoft-entra",
           "cloud/security-and-operations",


### PR DESCRIPTION
## Summary
- persist the generated SAML ACS callback URL when registering an SSO provider
- add an Okta-shaped testkit journey covering SAML callback readiness and the SCIM lifecycle
- document Okta SAML SSO and SCIM setup for hosted and split-host Helm deployments

## Why
- Okta could post to the advertised ACS URL, but the deployed provider lacked `samlConfig.callbackUrl`, causing `invalid_saml_configuration`
- operators need an end-to-end guide for the DNS verification name, SAML settings, SCIM token, mappings, and group push

## Issue
- N/A

## Scope
- Den SAML provider registration
- SSO provider rotation regression coverage
- Okta SAML/SCIM lifecycle evidence
- Mintlify Okta setup documentation and navigation

## Out of scope
- deploying the patched Den image to the GCP Helm environment
- changing SSO enforcement or broadening Okta assignments

## Testing
### Ran
- `DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_sso_provider_rotation pnpm --dir ee/apps/den-api exec bun test test/sso-provider-rotation.test.ts`
- `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/scim-okta-lifecycle.slow.test.ts`
- `pnpm --filter @openwork-ee/den-api build`
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8'))"`
- `git diff --check`

### Result
- pass: SSO provider test, 1/1 test with 11 assertions
- pass: Okta SAML/SCIM lifecycle, 1/1 test in 217.53s
- pass: testkit tape, 8/8 frames and 8/8 expectations
- pass: Den API production build
- pass: docs navigation parse and diff check
- lane: local fallback; Daytona was installed but its service was unavailable

## CI status
- pass: local targeted tests and production build
- code-related failures: none
- external/env/auth blockers: none for PR verification

## Manual verification
1. Created and assigned a test Okta SAML application against `gcp.openworklabs.com`.
2. Verified `openworklabs.com` using the provider-scoped Better Auth TXT record.
3. Confirmed the current deployed image reaches the ACS and returns `invalid_saml_configuration`; the regression spec proves the patched provider proceeds to assertion validation instead.

## Evidence
- `@openwork/testkit` tape: `scim-okta-lifecycle.slow.test.ts`, 8 passing frames; published in the PR evidence comment.

## Risk
- low: the runtime change adds the already-advertised ACS URL to the provider's stored SAML configuration; existing OIDC and SCIM behavior is unchanged

## Rollback
- revert this commit; existing providers can be saved again after deploying a build with the callback fix
