### PR TITLE
Gate SSO on domain verification

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -61,6 +61,7 @@ import {
   ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
   ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
 } from "./sso-saml-policy.js";
+import { SSO_DOMAIN_VERIFICATION_TOKEN_PREFIX } from "./sso-domain-verification.js";
 import {
   getOrganizationContextForUser,
   listAssignableRoles,
@@ -1173,6 +1174,7 @@ export const auth = betterAuth({
       provisionUserOnEveryLogin: true,
       domainVerification: {
         enabled: true,
+        tokenPrefix: SSO_DOMAIN_VERIFICATION_TOKEN_PREFIX,
       },
       organizationProvisioning: {
         disabled: false,

--- a/ee/apps/den-api/src/enterprise-auth-requirement.ts
+++ b/ee/apps/den-api/src/enterprise-auth-requirement.ts
@@ -78,6 +78,7 @@ async function findEnterpriseAuthRequirement(where: ReturnType<typeof and>) {
     .innerJoin(SsoProviderTable, and(
       eq(SsoConnectionTable.providerId, SsoProviderTable.providerId),
       eq(OrganizationTable.id, SsoProviderTable.organizationId),
+      eq(SsoProviderTable.domainVerified, true),
     ))
     .where(and(
       where,

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -11,6 +11,7 @@ import {
   ScimProviderTable,
   ScimUserTombstoneTable,
   SsoConnectionTable,
+  SsoProviderTable,
   TeamMemberTable,
   TeamTable,
 } from "@openwork-ee/den-db/schema"
@@ -1108,7 +1109,15 @@ export async function getSingletonSsoStatus() {
   const rows = await db
     .select({ signInPath: SsoConnectionTable.signInPath })
     .from(SsoConnectionTable)
-    .where(eq(SsoConnectionTable.organizationId, organization.id))
+    .innerJoin(SsoProviderTable, and(
+      eq(SsoConnectionTable.providerId, SsoProviderTable.providerId),
+      eq(SsoConnectionTable.organizationId, SsoProviderTable.organizationId),
+      eq(SsoProviderTable.domainVerified, true),
+    ))
+    .where(and(
+      eq(SsoConnectionTable.organizationId, organization.id),
+      eq(SsoConnectionTable.status, "enabled"),
+    ))
     .limit(1)
   const signInPath = rows[0]?.signInPath || fallbackSignInPath
 

--- a/ee/apps/den-api/src/routes/org/sso.ts
+++ b/ee/apps/den-api/src/routes/org/sso.ts
@@ -16,6 +16,10 @@ import {
   getSsoProviderForConnection,
   registerOrganizationSsoConnection,
 } from "../../sso.js"
+import {
+  getSsoDomainVerificationDnsName,
+  getSsoDomainVerificationHost,
+} from "../../sso-domain-verification.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureSsoManager, ensureSsoReader, orgAccessFailureStatus } from "./shared.js"
@@ -95,6 +99,8 @@ const ssoConnectionSchema = z.object({
   acsUrl: z.string().url().nullable(),
   metadataUrl: z.string().url().nullable(),
   domainVerified: z.boolean(),
+  domainVerificationHost: z.string(),
+  domainVerificationDnsName: z.string(),
   oidc: oidcConnectionConfigSchema.nullable(),
   saml: samlConnectionConfigSchema.nullable(),
   lastTestedAt: z.string().datetime().nullable(),
@@ -175,13 +181,15 @@ function serializeConnection(input: {
     kind: connection.kind === "saml" ? "saml" : "oidc",
     issuer: connection.issuer,
     domain: connection.domain,
-    status: connection.status,
+    status: domainVerified && connection.status === "enabled" ? "enabled" : "pending_verification",
     signInPath: connection.signInPath,
     signInUrl,
     redirectUrl,
     acsUrl,
     metadataUrl,
     domainVerified,
+    domainVerificationHost: getSsoDomainVerificationHost(connection.providerId),
+    domainVerificationDnsName: getSsoDomainVerificationDnsName(connection.providerId, connection.domain),
     oidc,
     saml,
     lastTestedAt: connection.lastTestedAt ? connection.lastTestedAt.toISOString() : null,

--- a/ee/apps/den-api/src/sso-domain-verification.ts
+++ b/ee/apps/den-api/src/sso-domain-verification.ts
@@ -1,0 +1,9 @@
+export const SSO_DOMAIN_VERIFICATION_TOKEN_PREFIX = "better-auth-token"
+
+export function getSsoDomainVerificationHost(providerId: string) {
+  return `_${SSO_DOMAIN_VERIFICATION_TOKEN_PREFIX}-${providerId}`
+}
+
+export function getSsoDomainVerificationDnsName(providerId: string, domain: string) {
+  return `${getSsoDomainVerificationHost(providerId)}.${domain}`
+}

--- a/ee/apps/den-api/src/sso-readiness.ts
+++ b/ee/apps/den-api/src/sso-readiness.ts
@@ -1,6 +1,6 @@
 export function isOrganizationSsoReady(input: {
   connection: { status: string } | null
-  providerExists: boolean
+  provider: { domainVerified: boolean } | null
 }) {
-  return input.connection?.status === "enabled" && input.providerExists
+  return input.connection?.status === "enabled" && input.provider?.domainVerified === true
 }

--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -433,5 +433,5 @@ export async function hasEnabledOrganizationSsoConnection(organizationId: Organi
   }
 
   const provider = await getSsoProviderForConnection(connection)
-  return isOrganizationSsoReady({ connection, providerExists: Boolean(provider) })
+  return isOrganizationSsoReady({ connection, provider })
 }

--- a/ee/apps/den-api/test/sso-readiness.test.ts
+++ b/ee/apps/den-api/test/sso-readiness.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { isOrganizationSsoReady } from "../src/sso-readiness.js"
 
 describe("isOrganizationSsoReady", () => {
-  test("requires both an enabled connection and its provider record", () => {
-    expect(isOrganizationSsoReady({ connection: null, providerExists: false })).toBe(false)
-    expect(isOrganizationSsoReady({ connection: { status: "disabled" }, providerExists: true })).toBe(false)
-    expect(isOrganizationSsoReady({ connection: { status: "enabled" }, providerExists: false })).toBe(false)
-    expect(isOrganizationSsoReady({ connection: { status: "enabled" }, providerExists: true })).toBe(true)
+  test("requires an enabled connection with a verified provider", () => {
+    expect(isOrganizationSsoReady({ connection: null, provider: null })).toBe(false)
+    expect(isOrganizationSsoReady({ connection: { status: "disabled" }, provider: { domainVerified: true } })).toBe(false)
+    expect(isOrganizationSsoReady({ connection: { status: "enabled" }, provider: null })).toBe(false)
+    expect(isOrganizationSsoReady({ connection: { status: "enabled" }, provider: { domainVerified: false } })).toBe(false)
+    expect(isOrganizationSsoReady({ connection: { status: "enabled" }, provider: { domainVerified: true } })).toBe(true)
   })
 })

--- a/ee/apps/den-api/test/sso-resolve-route.test.ts
+++ b/ee/apps/den-api/test/sso-resolve-route.test.ts
@@ -173,6 +173,7 @@ test("login-options returns SSO as the first step for verified SSO domains", asy
     email: "invited@verified.example.test",
     nextStep: "sso",
     allowPublicSignup: true,
+    allowInvitationSignup: false,
     organizationSlug: "invite-sso",
     signInPath: "/sso/invite-sso",
     signInUrl: "http://127.0.0.1:8790/sso/invite-sso",

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -168,6 +168,8 @@ export type DenOrgSsoConnection = {
   acsUrl: string | null;
   metadataUrl: string | null;
   domainVerified: boolean;
+  domainVerificationHost: string;
+  domainVerificationDnsName: string;
   oidc: {
     clientId: string | null;
     scopes: string[];
@@ -1164,11 +1166,13 @@ export function parseOrgSsoPayload(payload: unknown): {
         const signInPath = asString(rawConnection.signInPath);
         const signInUrl = asString(rawConnection.signInUrl);
         const redirectUrl = asString(rawConnection.redirectUrl);
+        const domainVerificationHost = asString(rawConnection.domainVerificationHost);
+        const domainVerificationDnsName = asString(rawConnection.domainVerificationDnsName);
         const rawOidc = isRecord(rawConnection.oidc) ? rawConnection.oidc : null;
         const rawSaml = isRecord(rawConnection.saml) ? rawConnection.saml : null;
         const tokenEndpointAuthentication = asString(rawOidc?.tokenEndpointAuthentication);
 
-        if (!id || !providerId || !issuer || !domain || !status || !signInPath || !signInUrl || !redirectUrl || (kind !== "oidc" && kind !== "saml")) {
+        if (!id || !providerId || !issuer || !domain || !status || !signInPath || !signInUrl || !redirectUrl || !domainVerificationHost || !domainVerificationDnsName || (kind !== "oidc" && kind !== "saml")) {
           return null;
         }
 
@@ -1185,6 +1189,8 @@ export function parseOrgSsoPayload(payload: unknown): {
           acsUrl: asString(rawConnection.acsUrl),
           metadataUrl: asString(rawConnection.metadataUrl),
           domainVerified: asBoolean(rawConnection.domainVerified),
+          domainVerificationHost,
+          domainVerificationDnsName,
           oidc: rawOidc
             ? {
                 clientId: asString(rawOidc.clientId),

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, KeyRound, RefreshCw, Shield, Trash2 } from "lucide-react";
+import { CheckCircle2, Copy, KeyRound, RefreshCw, Shield, ShieldAlert, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
@@ -443,20 +443,80 @@ export function SsoScreen() {
 
             {connection ? (
               <div className="mt-5 space-y-4">
-                {[
-                  ["Sign-in URL", connection.signInUrl, "signin"],
-                  ["Redirect URL", connection.redirectUrl, "redirect"],
-                  ["ACS URL", connection.acsUrl, "acs"],
-                  ["Metadata URL", connection.metadataUrl, "metadata"],
-                ].map(([label, value, key]) => (
-                  <div key={key as string} className="rounded-[20px] border border-gray-200 bg-gray-50 p-4">
-                    <div className="mb-2 flex items-center justify-between gap-3">
-                      <p className="text-[13px] font-semibold uppercase tracking-[0.12em] text-gray-500">{label as string}</p>
-                      <DenButton variant="secondary" icon={Copy} onClick={() => void copyValue((value as string | null) ?? null, key as string)} disabled={!value}>{copiedValue === key ? "Copied" : "Copy"}</DenButton>
+                {!connection.domainVerified ? (
+                  <section data-testid="sso-domain-verification" className="overflow-hidden rounded-[24px] border border-amber-300 bg-[#FFFBEB] text-[14px] text-amber-950 shadow-[0_18px_46px_-34px_rgba(146,64,14,0.55)]">
+                    <div className="flex flex-col gap-4 border-b border-amber-200 bg-amber-100/70 px-5 py-5 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="flex items-start gap-3">
+                        <span className="mt-0.5 rounded-full bg-amber-900 p-2 text-amber-50"><ShieldAlert size={18} aria-hidden="true" /></span>
+                        <div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="text-[16px] font-semibold tracking-[-0.02em]">Verify your domain first</p>
+                            <span className="rounded-full border border-amber-300 bg-white/80 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-amber-800">Pending verification</span>
+                          </div>
+                          <p className="mt-1 max-w-2xl leading-6 text-amber-900/80">
+                            SSO remains inactive and is not offered to users until this DNS check proves that your workspace controls <strong>{connection.domain}</strong>.
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 flex-wrap gap-2">
+                        <DenButton variant="secondary" icon={KeyRound} onClick={() => void handleRequestDomainToken()} disabled={requestingDomainToken || !access.canManageSso}>
+                          {requestingDomainToken ? "Requesting..." : "Request token"}
+                        </DenButton>
+                        <DenButton variant="primary" icon={RefreshCw} onClick={() => void handleVerifyDomain()} disabled={verifyingDomain || !access.canManageSso || !domainVerificationToken}>
+                          {verifyingDomain ? "Verifying..." : "Verify domain"}
+                        </DenButton>
+                      </div>
                     </div>
-                    <code className="block break-all text-[13px] leading-6 text-gray-700">{(value as string | null) ?? "Not applicable"}</code>
+
+                    <div className="grid gap-px bg-amber-200 md:grid-cols-2">
+                      {[
+                        { label: "Record type", value: "TXT", key: "domain-record-type" },
+                        { label: "Host / name", value: connection.domainVerificationHost, key: "domain-record-host" },
+                        { label: "Full DNS name", value: connection.domainVerificationDnsName, key: "domain-record-name" },
+                        { label: "Value", value: domainVerificationToken, key: "domain-token" },
+                      ].map((record) => (
+                        <div key={record.key} className="bg-[#FFFEF7] px-5 py-4">
+                          <div className="mb-2 flex items-center justify-between gap-3">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-700">{record.label}</p>
+                            {record.value ? (
+                              <button type="button" className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-[12px] font-medium text-amber-900 transition hover:bg-amber-100" onClick={() => void copyValue(record.value, record.key)}>
+                                <Copy size={13} aria-hidden="true" /> {copiedValue === record.key ? "Copied" : "Copy"}
+                              </button>
+                            ) : null}
+                          </div>
+                          <code className="block break-all text-[13px] leading-6 text-gray-800">{record.value ?? "Request a token to reveal the TXT value"}</code>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className="grid gap-3 px-5 py-4 text-[13px] leading-5 text-amber-900/80 sm:grid-cols-2">
+                      <p><strong className="text-amber-950">DNS providers differ:</strong> use the host value when your provider appends the domain automatically; otherwise use the full DNS name.</p>
+                      <p><strong className="text-amber-950">One-time proof:</strong> tokens expire after seven days. After verification succeeds, you may remove the TXT record. Changing the domain requires verification again.</p>
+                    </div>
+                  </section>
+                ) : (
+                  <div className="flex items-start gap-3 rounded-[20px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-900">
+                    <CheckCircle2 className="mt-0.5 shrink-0" size={18} aria-hidden="true" />
+                    <div><p className="font-semibold">Domain verified · SSO active</p><p className="mt-1 text-emerald-800">The DNS TXT record was a one-time proof and may now be removed.</p></div>
                   </div>
-                ))}
+                )}
+
+                <div data-testid="sso-provider-setup" className="space-y-4">
+                  {[
+                    ["Sign-in URL", connection.signInUrl, "signin"],
+                    ["Redirect URL", connection.redirectUrl, "redirect"],
+                    ["ACS URL", connection.acsUrl, "acs"],
+                    ["Metadata URL", connection.metadataUrl, "metadata"],
+                  ].map(([label, value, key]) => (
+                    <div key={key as string} className="rounded-[20px] border border-gray-200 bg-gray-50 p-4">
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <p className="text-[13px] font-semibold uppercase tracking-[0.12em] text-gray-500">{label as string}</p>
+                        <DenButton variant="secondary" icon={Copy} onClick={() => void copyValue((value as string | null) ?? null, key as string)} disabled={!value}>{copiedValue === key ? "Copied" : "Copy"}</DenButton>
+                      </div>
+                      <code className="block break-all text-[13px] leading-6 text-gray-700">{(value as string | null) ?? "Not applicable"}</code>
+                    </div>
+                  ))}
+                </div>
 
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="rounded-[20px] border border-gray-200 bg-gray-50 p-4 text-[14px] text-gray-700">
@@ -472,34 +532,6 @@ export function SsoScreen() {
                     <p className="mt-2">Updated: {formatDateTime(connection.updatedAt)}</p>
                   </div>
                 </div>
-
-                {!connection.domainVerified ? (
-                  <div className="rounded-[20px] border border-violet-200 bg-violet-50 p-4 text-[14px] text-violet-900">
-                    <p className="font-medium">Domain verification</p>
-                    <p className="mt-2 text-violet-800">
-                      Request a DNS TXT token, publish it for `{connection.domain}`, then verify the domain before using this connection in production.
-                    </p>
-                    <div className="mt-4 flex flex-wrap gap-3">
-                      <DenButton variant="secondary" icon={KeyRound} onClick={() => void handleRequestDomainToken()} disabled={requestingDomainToken || !access.canManageSso}>
-                        {requestingDomainToken ? "Requesting..." : "Request token"}
-                      </DenButton>
-                      <DenButton variant="secondary" icon={RefreshCw} onClick={() => void handleVerifyDomain()} disabled={verifyingDomain || !access.canManageSso}>
-                        {verifyingDomain ? "Verifying..." : "Verify domain"}
-                      </DenButton>
-                    </div>
-                    {domainVerificationToken ? (
-                      <div className="mt-4 rounded-[16px] border border-violet-200 bg-white px-4 py-3">
-                        <div className="mb-2 flex items-center justify-between gap-3">
-                          <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-violet-500">TXT token</p>
-                          <DenButton variant="secondary" icon={Copy} onClick={() => void copyValue(domainVerificationToken, "domain-token")}>
-                            {copiedValue === "domain-token" ? "Copied" : "Copy"}
-                          </DenButton>
-                        </div>
-                        <code className="block break-all text-[13px] leading-6 text-gray-700">{domainVerificationToken}</code>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
 
                 {connection.lastError ? <div className="rounded-[20px] border border-red-200 bg-red-50 p-4 text-[14px] text-red-700">{connection.lastError}</div> : null}
               </div>

--- a/evals/specs/sso-domain-verification.slow.test.ts
+++ b/evals/specs/sso-domain-verification.slow.test.ts
@@ -1,0 +1,191 @@
+import { expect } from "vitest";
+import { denFetch, evalIn, provisionOrg, waitFor } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { startMockIdpLab } from "@openwork/labs";
+import { localMysqlIsRunning, server, test } from "@openwork/testkit";
+
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !localPlacement
+  ? "SSO domain verification skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+  : !mysqlOpen
+    ? "SSO domain verification skipped — needs MySQL on 127.0.0.1:3306"
+    : "an unverified SSO connection stays pending and gives the owner complete DNS instructions";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, key: string): string {
+  return isRecord(value) && typeof value[key] === "string" ? value[key] : "";
+}
+
+test.skipIf(!localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  const ssoDomain = `pending-sso-${Date.now()}.test`;
+  await using idp = await startMockIdpLab({
+    issuer: "http://0.0.0.0:19191",
+    domain: ssoDomain,
+  });
+  await using den = await server({ place, trustedOrigins: [new URL(idp.issuer).origin] });
+  const org = await provisionOrg(den.ref, { members: [] });
+
+  const signedIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: org.admin.email, password: org.admin.password }),
+  });
+  const sessionCookie = signedIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  expect(sessionCookie).toBeTruthy();
+
+  const organizations = await denFetch(den.ref, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${org.admin.token}` },
+  });
+  const organization = isRecord(organizations.body)
+    && Array.isArray(organizations.body.orgs)
+    && isRecord(organizations.body.orgs[0])
+    ? organizations.body.orgs[0]
+    : null;
+  const organizationSlug = readString(organization, "slug");
+  expect(organizationSlug).toBeTruthy();
+
+  const registration = idp.registration();
+  const registered = await denFetch(den.ref, "/v1/sso/oidc", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${org.admin.token}`,
+      cookie: sessionCookie,
+      "x-openwork-org-id": org.orgId,
+    },
+    body: JSON.stringify({
+      issuer: registration.issuer,
+      domain: registration.domain,
+      clientId: registration.clientId,
+      clientSecret: registration.clientSecret,
+      scopes: registration.scopes,
+      skipDiscovery: registration.skipDiscovery,
+      authorizationEndpoint: registration.authorizationEndpoint,
+      tokenEndpoint: registration.tokenEndpoint,
+      jwksEndpoint: registration.jwksEndpoint,
+      userInfoEndpoint: registration.userInfoEndpoint,
+      tokenEndpointAuthentication: registration.tokenEndpointAuthentication,
+    }),
+  });
+  expect(registered.response.ok, registered.text).toBe(true);
+  const registeredConnection = isRecord(registered.body) && isRecord(registered.body.connection)
+    ? registered.body.connection
+    : null;
+  const providerId = readString(registeredConnection, "providerId");
+  const domainVerificationToken = readString(registered.body, "domainVerificationToken");
+  const expectedHost = `_better-auth-token-${providerId}`;
+  const expectedDnsName = `${expectedHost}.${ssoDomain}`;
+  expect(domainVerificationToken).toBeTruthy();
+  expect(registeredConnection?.domainVerified).toBe(false);
+  expect(readString(registeredConnection, "status")).toBe("pending_verification");
+  expect(readString(registeredConnection, "domainVerificationHost")).toBe(expectedHost);
+  expect(readString(registeredConnection, "domainVerificationDnsName")).toBe(expectedDnsName);
+
+  const loginOptions = await denFetch(
+    den.ref,
+    `/v1/auth/login-options?email=${encodeURIComponent(`new-user@${ssoDomain}`)}`,
+  );
+  expect(loginOptions.response.ok, loginOptions.text).toBe(true);
+  expect(readString(loginOptions.body, "nextStep")).not.toBe("sso");
+
+  const directSso = await denFetch(den.ref, "/api/auth/sign-in/sso", {
+    method: "POST",
+    body: JSON.stringify({
+      organizationSlug,
+      callbackURL: `${den.ref.webUrl}/dashboard`,
+    }),
+  });
+  expect(directSso.response.ok).toBe(false);
+  expect(directSso.text).toMatch(/has not been verified/i);
+  evidence.fact(
+    "Unverified SSO is configured but inactive",
+    `status=${readString(registeredConnection, "status")}; login next step=${readString(loginOptions.body, "nextStep")}; direct SSO HTTP ${directSso.response.status}`,
+    readString(registeredConnection, "status") === "pending_verification"
+      && readString(loginOptions.body, "nextStep") !== "sso"
+      && !directSso.response.ok,
+  );
+
+  await using browser = await chrome({
+    name: "sso-domain-verification",
+    startUrl: den.ref.webUrl,
+    headless: true,
+    host: place.host(),
+  });
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, {
+    timeoutMs: 60_000,
+    label: "Den Web before owner auth handoff",
+  });
+  const cookieSeparator = sessionCookie.indexOf("=");
+  const browserSessionCookie = await browser.client.send("Network.setCookie", {
+    name: sessionCookie.slice(0, cookieSeparator),
+    value: sessionCookie.slice(cookieSeparator + 1),
+    url: den.ref.webUrl,
+    httpOnly: true,
+  });
+  expect(browserSessionCookie.success).toBe(true);
+  const tokenStored = await evalIn(browser, `(() => {
+    localStorage.setItem("openwork:web:auth-token", ${JSON.stringify(org.admin.token)});
+    return localStorage.getItem("openwork:web:auth-token") === ${JSON.stringify(org.admin.token)};
+  })()`);
+  expect(tokenStored).toBe(true);
+  await navigate(browser.client, `${den.ref.webUrl}/dashboard/sso`);
+  await waitFor(browser, `Boolean(document.querySelector('[data-testid="sso-domain-verification"]'))`, {
+    timeoutMs: 60_000,
+    label: "pending SSO verification card",
+  });
+
+  const requested = await evalIn(browser, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((candidate) => /request token/i.test(candidate.textContent ?? ""));
+    button?.click();
+    return Boolean(button);
+  })()`);
+  expect(requested).toBe(true);
+  await waitFor(browser, `document.body.innerText.includes(${JSON.stringify(expectedDnsName)}) && document.body.innerText.includes(${JSON.stringify(domainVerificationToken)})`, {
+    timeoutMs: 30_000,
+    label: "complete DNS verification record with token value",
+  });
+
+  const ui: unknown = JSON.parse(String(await evalIn(browser, `(() => {
+    const verification = document.querySelector('[data-testid="sso-domain-verification"]');
+    const setup = document.querySelector('[data-testid="sso-provider-setup"]');
+    const text = verification?.textContent?.replace(/\\s+/g, " ").trim() ?? "";
+    return JSON.stringify({
+      appearsBeforeProviderSetup: Boolean(verification && setup && (verification.compareDocumentPosition(setup) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      hasTxtType: /TXT/.test(text),
+      hasHost: text.includes(${JSON.stringify(expectedHost)}),
+      hasFullName: text.includes(${JSON.stringify(expectedDnsName)}),
+      hasToken: text.includes(${JSON.stringify(domainVerificationToken)}),
+      saysPending: /pending verification/i.test(text),
+      saysRemovable: /remove.*TXT record/i.test(text),
+      hasSkip: /skip verification/i.test(text),
+      text,
+    });
+  })()`)));
+  expect(ui).toMatchObject({
+    appearsBeforeProviderSetup: true,
+    hasTxtType: true,
+    hasHost: true,
+    hasFullName: true,
+    hasToken: true,
+    saysPending: true,
+    saysRemovable: true,
+    hasSkip: false,
+  });
+  evidence.fact(
+    "The owner sees domain verification first with complete, one-time DNS instructions",
+    readString(ui, "text"),
+    isRecord(ui)
+      && ui.appearsBeforeProviderSetup === true
+      && ui.hasTxtType === true
+      && ui.hasHost === true
+      && ui.hasFullName === true
+      && ui.hasToken === true
+      && ui.saysPending === true
+      && ui.saysRemovable === true
+      && ui.hasSkip === false,
+  );
+});


### PR DESCRIPTION
## Summary

- keep configured SSO pending until domain ownership is verified
- show complete DNS TXT instructions at the top of Den SSO settings, including the exact host, FQDN, token, expiry, and removal guidance
- prevent unverified SSO from login discovery, enforcement, single-org routing, and SCIM readiness
- intentionally do not add a verification bypass because it would defeat the ownership security boundary

## Verification

- `CHROME_BIN='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser' pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/sso-domain-verification.slow.test.ts` — passed (1 test)
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec tsc -p ee/apps/den-api/tsconfig.json --noEmit --pretty false` — passed
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web test` — passed (116 tests)
- `pnpm exec bun test ee/apps/den-api/test/sso-resolve-route.test.ts` — passed (7 tests)
- `pnpm exec bun test ee/apps/den-api/test/sso-resolve-helpers.test.ts ee/apps/den-api/test/sso-readiness.test.ts` — passed (4 tests)
- `pnpm exec bun test ee/apps/den-api/test/single-org-route-guards.test.ts` — passed (9 tests)