### PR TITLE
test(evals): run LiteLLM provider proof on Daytona

### DIFF
--- a/evals/packages/testkit/src/litellm.ts
+++ b/evals/packages/testkit/src/litellm.ts
@@ -374,9 +374,9 @@ function makeHandle(input: HandleInput): LiteLlmHandle {
     },
     async [Symbol.asyncDispose]() {
       if (disposed) return;
-      disposed = true;
       try {
         await input.dispose();
+        disposed = true;
       } catch (error) {
         throw redactedError(error, secrets);
       }
@@ -575,12 +575,12 @@ async function startLocalLiteLlm(
       fetchImpl: fetch,
       async dispose(): Promise<void> {
         if (placementDisposed) return;
-        placementDisposed = true;
         await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
         await Promise.all([
           rm(root, { recursive: true, force: true }),
           closeServer(startedWitness.server),
         ]);
+        placementDisposed = true;
       },
     });
   } catch (error) {
@@ -612,8 +612,7 @@ function uploadCommands(content: string, remotePath: string): string[] {
     `base64 -d ${encodedPath} > ${remotePath} || decode_status=$?`,
     `actual_bytes=$(wc -c < ${remotePath})`,
     `rm -f ${encodedPath}`,
-    'test "$decode_status" -eq 0',
-    `test "$actual_bytes" -eq ${source.byteLength}`,
+    `test "$decode_status" -eq 0 && test "$actual_bytes" -eq ${source.byteLength}`,
   ].join("; "));
   return commands;
 }
@@ -659,7 +658,7 @@ async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Pro
     `LiteLLM preview URL gate for ${sandbox}:${port}`,
     { timeoutMs: 60_000 },
   );
-  const url = firstHttpsUrl(`${result.stdout}\n${result.stderr}`);
+  const url = firstHttpsUrl(result.stdout);
   if (!url) throw new Error(`LiteLLM preview URL gate for ${sandbox}:${port} did not return an HTTPS URL.`);
   return url;
 }
@@ -807,8 +806,8 @@ async function startDaytonaLiteLlm(
       fetchImpl,
       async dispose(): Promise<void> {
         if (placementDisposed) return;
-        placementDisposed = true;
         await deleteSandboxes([sandbox], { exec, log: () => undefined });
+        placementDisposed = true;
       },
     });
   } catch (error) {

--- a/evals/packages/testkit/src/litellm.ts
+++ b/evals/packages/testkit/src/litellm.ts
@@ -2,17 +2,182 @@ import { execFile } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
-import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  checkedExec,
+  defaultDaytonaExec,
+  deleteSandboxes,
+  execInSandbox,
+} from "@openwork/hosts";
+import type { Server, ServerResponse } from "node:http";
+import type { DaytonaExec, DaytonaExecResult } from "@openwork/hosts";
 import { SkipError } from "./needs.ts";
+import type { Place } from "./place.ts";
 
 const IMAGE = "ghcr.io/berriai/litellm:v1.97.0@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834";
 const COMMAND_TIMEOUT_MS = 180_000;
 const STARTUP_TIMEOUT_MS = 90_000;
+const EXEC_READY_TIMEOUT_MS = 180_000;
+const PREVIEW_EXPIRY_SECONDS = 7_200;
+const DAYTONA_PROXY_PORT = 4_000;
+const DAYTONA_WITNESS_PORT = 4_001;
+const DAYTONA_CONFIG = "/tmp/openwork-litellm-config.json";
+const DAYTONA_WITNESS = "/tmp/openwork-litellm-witness.py";
+const DAYTONA_LOG = "/tmp/openwork-litellm.log";
+const DAYTONA_WITNESS_LOG = "/tmp/openwork-litellm-witness.log";
+const BASE64_CHUNK_LENGTH = 8 * 1_024;
+const MAX_DAYTONA_COMMAND_LENGTH = 12 * 1_024;
+
+const DAYTONA_DOCKERFILE = `FROM ${IMAGE}
+USER root
+ENTRYPOINT ["/usr/bin/bash", "-lc"]
+CMD ["sleep infinity"]
+`;
+
+const DAYTONA_WITNESS_SOURCE = `import argparse
+import base64
+import hashlib
+import hmac
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
+
+MAX_BODY_BYTES = 1048576
+REQUESTS = []
+SEQUENCE = 0
+LOCK = threading.Lock()
+
+
+def fingerprint(value):
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+    def send_json(self, status, value):
+        payload = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def token_fingerprint(self):
+        authorization = self.headers.get("authorization", "")
+        token = authorization[7:].strip() if authorization.startswith("Bearer ") else ""
+        return fingerprint(token)
+
+    def control_authorized(self):
+        return hmac.compare_digest(self.token_fingerprint(), OPTIONS.control_token_id)
+
+    def do_GET(self):
+        parsed = urlsplit(self.path)
+        if parsed.path == "/v1/models":
+            self.send_json(200, {
+                "object": "list",
+                "data": [{"id": MODEL, "object": "model", "owned_by": "openwork-testkit"}],
+            })
+            return
+        if parsed.path not in ("/__openwork_litellm/health", "/__openwork_litellm/requests"):
+            self.send_json(404, {"error": {"message": "not found"}})
+            return
+        if not self.control_authorized():
+            self.send_json(401, {"error": "unauthorized"})
+            return
+        with LOCK:
+            sequence = SEQUENCE
+            if parsed.path == "/__openwork_litellm/health":
+                self.send_json(200, {"ok": True, "sequence": sequence})
+                return
+            values = parse_qs(parsed.query).get("after", ["0"])
+            try:
+                after = int(values[0])
+            except ValueError:
+                self.send_json(400, {"error": "invalid cursor"})
+                return
+            if after < 0:
+                self.send_json(400, {"error": "invalid cursor"})
+                return
+            requests = [entry.copy() for entry in REQUESTS if entry["sequence"] > after]
+        self.send_json(200, {"sequence": sequence, "requests": requests})
+
+    def do_POST(self):
+        global SEQUENCE
+        path = urlsplit(self.path).path
+        if path not in ("/v1/chat/completions", "/chat/completions"):
+            self.send_json(404, {"error": {"message": "not found"}})
+            return
+        try:
+            length = int(self.headers.get("content-length", "0"))
+        except ValueError:
+            self.send_json(400, {"error": {"message": "invalid content length"}})
+            return
+        if length < 0 or length > MAX_BODY_BYTES:
+            self.send_json(413, {"error": {"message": "request body too large"}})
+            return
+        body_text = self.rfile.read(length).decode("utf-8", errors="replace")
+        try:
+            body = json.loads(body_text)
+        except json.JSONDecodeError:
+            body = None
+        model = body.get("model", "") if isinstance(body, dict) and isinstance(body.get("model"), str) else ""
+        token_id = self.token_fingerprint()
+        with LOCK:
+            SEQUENCE += 1
+            sequence = SEQUENCE
+            REQUESTS.append({
+                "sequence": sequence,
+                "model": model,
+                "tokenId": token_id,
+                "bodyText": body_text,
+            })
+        if not hmac.compare_digest(token_id, OPTIONS.upstream_token_id):
+            self.send_json(401, {"error": {"message": "unauthorized"}})
+            return
+        completion_id = "chatcmpl-openwork-" + str(sequence)
+        if isinstance(body, dict) and body.get("stream") is True:
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("cache-control", "no-cache")
+            self.send_header("connection", "close")
+            self.end_headers()
+            chunks = [
+                {"id": completion_id, "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"role": "assistant", "content": REPLY}, "finish_reason": None}]},
+                {"id": completion_id, "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+            ]
+            for chunk in chunks:
+                self.wfile.write(("data: " + json.dumps(chunk, separators=(",", ":")) + "\\n\\n").encode("utf-8"))
+            self.wfile.write(b"data: [DONE]\\n\\n")
+            self.wfile.flush()
+            return
+        self.send_json(200, {
+            "id": completion_id,
+            "object": "chat.completion",
+            "model": model,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": REPLY}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 8, "total_tokens": 16},
+        })
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--port", type=int, required=True)
+parser.add_argument("--model-b64", required=True)
+parser.add_argument("--reply-b64", required=True)
+parser.add_argument("--upstream-token-id", required=True)
+parser.add_argument("--control-token-id", required=True)
+OPTIONS = parser.parse_args()
+MODEL = base64.b64decode(OPTIONS.model_b64).decode("utf-8")
+REPLY = base64.b64decode(OPTIONS.reply_b64).decode("utf-8")
+ThreadingHTTPServer(("0.0.0.0", OPTIONS.port), Handler).serve_forever()
+`;
 
 export interface LiteLlmUpstreamRequest {
-  receivedAt: string;
+  sequence: number;
   model: string;
   tokenId: string;
   bodyText: string;
@@ -23,8 +188,9 @@ export interface LiteLlmHandle extends AsyncDisposable {
   apiKey: string;
   upstreamKey: string;
   tokenId(key: string): string;
-  waitForUpstreamRequest(input: { model: string; key: string; since: string; timeoutMs: number }): Promise<LiteLlmUpstreamRequest>;
-  upstreamRequests(input: { since: string }): LiteLlmUpstreamRequest[];
+  checkpoint(): Promise<number>;
+  waitForUpstreamRequest(input: { after: number; model: string; key: string; timeoutMs: number }): Promise<LiteLlmUpstreamRequest>;
+  upstreamRequests(input: { after: number }): Promise<LiteLlmUpstreamRequest[]>;
 }
 
 interface CommandResult {
@@ -32,9 +198,27 @@ interface CommandResult {
   stderr: string;
 }
 
+interface WitnessState {
+  requests: LiteLlmUpstreamRequest[];
+  sequence: number;
+}
+
+interface LiteLlmSecrets {
+  masterKey: string;
+  upstreamKey: string;
+  controlKey: string;
+}
+
+interface HandleInput extends LiteLlmSecrets {
+  baseUrl: string;
+  controlUrl: string;
+  fetchImpl: typeof fetch;
+  dispose(): Promise<void>;
+}
+
 function run(command: string, args: string[], timeout = COMMAND_TIMEOUT_MS): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { timeout, maxBuffer: 4 * 1024 * 1024 }, (error, stdout, stderr) => {
+    execFile(command, args, { timeout, maxBuffer: 4 * 1_024 * 1_024 }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(`${command} failed: ${error.message}\n${stderr}`));
         return;
@@ -56,14 +240,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function closeServer(server: Server): Promise<void> {
   if (!server.listening) return;
   await new Promise<void>((resolve, reject) => {
     server.close((error) => error ? reject(error) : resolve());
+    server.closeAllConnections();
   });
 }
 
@@ -71,17 +256,171 @@ function redact(text: string, secrets: string[]): string {
   return secrets.reduce((result, secret) => result.split(secret).join("[REDACTED]"), text);
 }
 
-function startWitness(modelId: string, reply: string, requests: LiteLlmUpstreamRequest[]): Promise<{ server: Server; port: number }> {
+function redactedError(error: unknown, secrets: string[]): Error {
+  return new Error(redact(messageText(error), secrets));
+}
+
+function writeJson(response: ServerResponse, status: number, body: unknown): void {
+  const text = JSON.stringify(body);
+  response.writeHead(status, { "content-type": "application/json", "content-length": Buffer.byteLength(text) });
+  response.end(text);
+}
+
+function validCursor(value: number): number {
+  if (!Number.isInteger(value) || value < 0) throw new Error("LiteLLM sequence cursor must be a non-negative integer.");
+  return value;
+}
+
+function parseUpstreamRequest(value: unknown): LiteLlmUpstreamRequest {
+  if (!isRecord(value)
+    || typeof value.sequence !== "number"
+    || !Number.isInteger(value.sequence)
+    || value.sequence < 1
+    || typeof value.model !== "string"
+    || typeof value.tokenId !== "string"
+    || typeof value.bodyText !== "string") {
+    throw new Error("LiteLLM witness request response has an invalid shape.");
+  }
+  return {
+    sequence: value.sequence,
+    model: value.model,
+    tokenId: value.tokenId,
+    bodyText: value.bodyText,
+  };
+}
+
+function parseHealth(value: unknown): number {
+  if (!isRecord(value)
+    || value.ok !== true
+    || typeof value.sequence !== "number"
+    || !Number.isInteger(value.sequence)
+    || value.sequence < 0) {
+    throw new Error("LiteLLM witness health response has an invalid shape.");
+  }
+  return value.sequence;
+}
+
+function parseRequests(value: unknown, after: number): LiteLlmUpstreamRequest[] {
+  if (!isRecord(value) || !Array.isArray(value.requests)) {
+    throw new Error("LiteLLM witness requests response has an invalid shape.");
+  }
+  return value.requests.map(parseUpstreamRequest).filter((request) => request.sequence > after);
+}
+
+async function controlJson(fetchImpl: typeof fetch, controlUrl: string, controlKey: string, path: string): Promise<unknown> {
+  const response = await fetchImpl(`${controlUrl}${path}`, {
+    headers: { authorization: `Bearer ${controlKey}` },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`LiteLLM witness control ${path} failed with HTTP ${response.status}.`);
+  try {
+    const value: unknown = await response.json();
+    return value;
+  } catch {
+    throw new Error(`LiteLLM witness control ${path} returned invalid JSON.`);
+  }
+}
+
+function makeHandle(input: HandleInput): LiteLlmHandle {
+  const secrets = [input.masterKey, input.upstreamKey, input.controlKey];
+  let disposed = false;
+  const upstreamRequests = async ({ after }: { after: number }): Promise<LiteLlmUpstreamRequest[]> => {
+    const cursor = validCursor(after);
+    try {
+      return parseRequests(
+        await controlJson(input.fetchImpl, input.controlUrl, input.controlKey, `/__openwork_litellm/requests?after=${cursor}`),
+        cursor,
+      );
+    } catch (error) {
+      throw redactedError(error, secrets);
+    }
+  };
+  return {
+    baseUrl: input.baseUrl,
+    apiKey: input.masterKey,
+    upstreamKey: input.upstreamKey,
+    tokenId,
+    async checkpoint(): Promise<number> {
+      try {
+        return parseHealth(await controlJson(
+          input.fetchImpl,
+          input.controlUrl,
+          input.controlKey,
+          "/__openwork_litellm/health",
+        ));
+      } catch (error) {
+        throw redactedError(error, secrets);
+      }
+    },
+    upstreamRequests,
+    async waitForUpstreamRequest({ after, model, key, timeoutMs }) {
+      const cursor = validCursor(after);
+      if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("LiteLLM request timeout must be positive.");
+      const deadline = Date.now() + timeoutMs;
+      const expectedTokenId = tokenId(key);
+      let observed: LiteLlmUpstreamRequest[] = [];
+      while (Date.now() < deadline) {
+        observed = await upstreamRequests({ after: cursor });
+        const found = observed.find((request) => request.model === model && request.tokenId === expectedTokenId);
+        if (found) return found;
+        await delay(100);
+      }
+      const summary = observed.map((request) => ({
+        sequence: request.sequence,
+        model: request.model,
+        tokenId: request.tokenId,
+      }));
+      throw new Error(`Upstream did not receive model ${model} with token fingerprint ${expectedTokenId}. Observed: ${JSON.stringify(summary)}`);
+    },
+    async [Symbol.asyncDispose]() {
+      if (disposed) return;
+      disposed = true;
+      try {
+        await input.dispose();
+      } catch (error) {
+        throw redactedError(error, secrets);
+      }
+    },
+  };
+}
+
+function startWitness(
+  modelId: string,
+  reply: string,
+  upstreamTokenId: string,
+  controlTokenId: string,
+  state: WitnessState,
+): Promise<{ server: Server; port: number }> {
   const server = createServer((request, response) => {
-    const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
-    if (request.method === "GET" && path === "/v1/models") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model", owned_by: "openwork-testkit" }] }));
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/v1/models") {
+      writeJson(response, 200, { object: "list", data: [{ id: modelId, object: "model", owned_by: "openwork-testkit" }] });
       return;
     }
-    if (request.method !== "POST" || (path !== "/v1/chat/completions" && path !== "/chat/completions")) {
-      response.writeHead(404, { "content-type": "application/json" });
-      response.end(JSON.stringify({ error: { message: "not found" } }));
+    if (request.method === "GET"
+      && (url.pathname === "/__openwork_litellm/health" || url.pathname === "/__openwork_litellm/requests")) {
+      if (tokenId(bearerToken(request.headers.authorization)) !== controlTokenId) {
+        writeJson(response, 401, { error: "unauthorized" });
+        return;
+      }
+      if (url.pathname === "/__openwork_litellm/health") {
+        writeJson(response, 200, { ok: true, sequence: state.sequence });
+        return;
+      }
+      const afterText = url.searchParams.get("after") ?? "0";
+      const after = Number(afterText);
+      if (!Number.isInteger(after) || after < 0) {
+        writeJson(response, 400, { error: "invalid cursor" });
+        return;
+      }
+      writeJson(response, 200, {
+        sequence: state.sequence,
+        requests: state.requests.filter((entry) => entry.sequence > after),
+      });
+      return;
+    }
+    if (request.method !== "POST" || (url.pathname !== "/v1/chat/completions" && url.pathname !== "/chat/completions")) {
+      writeJson(response, 404, { error: { message: "not found" } });
       return;
     }
 
@@ -92,31 +431,33 @@ function startWitness(modelId: string, reply: string, requests: LiteLlmUpstreamR
       let body: unknown = null;
       try { body = JSON.parse(bodyText); } catch { body = null; }
       const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
-      requests.push({
-        receivedAt: new Date().toISOString(),
-        model,
-        tokenId: tokenId(bearerToken(request.headers.authorization)),
-        bodyText,
-      });
-      const id = `chatcmpl-${randomBytes(8).toString("hex")}`;
+      const requestTokenId = tokenId(bearerToken(request.headers.authorization));
+      state.sequence += 1;
+      const sequence = state.sequence;
+      state.requests.push({ sequence, model, tokenId: requestTokenId, bodyText });
+      if (requestTokenId !== upstreamTokenId) {
+        writeJson(response, 401, { error: { message: "unauthorized" } });
+        return;
+      }
+      const id = `chatcmpl-openwork-${sequence}`;
       if (isRecord(body) && body.stream === true) {
         response.writeHead(200, {
           "content-type": "text/event-stream",
           "cache-control": "no-cache",
-          connection: "keep-alive",
+          connection: "close",
         });
         response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant", content: reply }, finish_reason: null }] })}\n\n`);
         response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
         response.end("data: [DONE]\n\n");
         return;
       }
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({
+      writeJson(response, 200, {
         id,
         object: "chat.completion",
+        model,
         choices: [{ index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" }],
         usage: { prompt_tokens: 8, completion_tokens: 8, total_tokens: 16 },
-      }));
+      });
     });
   });
 
@@ -133,6 +474,20 @@ function startWitness(modelId: string, reply: string, requests: LiteLlmUpstreamR
   });
 }
 
+function liteLlmConfig(modelId: string, apiBase: string, masterKey: string, upstreamKey: string): string {
+  return JSON.stringify({
+    model_list: [{
+      model_name: modelId,
+      litellm_params: {
+        model: `openai/${modelId}`,
+        api_base: apiBase,
+        api_key: upstreamKey,
+      },
+    }],
+    general_settings: { master_key: masterKey },
+  }, null, 2);
+}
+
 async function mappedPort(container: string): Promise<number> {
   const result = await run("docker", ["port", container, "4000/tcp"], 10_000);
   const match = result.stdout.match(/:(\d+)\s*$/m);
@@ -141,7 +496,12 @@ async function mappedPort(container: string): Promise<number> {
   return port;
 }
 
-async function waitForProxy(container: string, apiKey: string, modelId: string): Promise<number> {
+function modelIds(value: unknown): string[] {
+  if (!isRecord(value) || !Array.isArray(value.data)) return [];
+  return value.data.flatMap((entry) => isRecord(entry) && typeof entry.id === "string" ? [entry.id] : []);
+}
+
+async function waitForLocalProxy(container: string, apiKey: string, modelId: string): Promise<number> {
   const deadline = Date.now() + STARTUP_TIMEOUT_MS;
   let port = 0;
   let last = "proxy not queried";
@@ -153,91 +513,337 @@ async function waitForProxy(container: string, apiKey: string, modelId: string):
         signal: AbortSignal.timeout(3_000),
       });
       const body: unknown = await response.json();
-      const models = isRecord(body) && Array.isArray(body.data) ? body.data.filter(isRecord) : [];
-      if (response.ok && models.some((model) => model.id === modelId)) return port;
+      if (response.ok && modelIds(body).includes(modelId)) return port;
       last = `HTTP ${response.status}`;
     } catch (error) {
-      last = error instanceof Error ? error.message : String(error);
+      last = messageText(error);
     }
-    await sleep(500);
+    await delay(500);
   }
   throw new Error(`LiteLLM did not expose model ${modelId} within ${STARTUP_TIMEOUT_MS}ms (last observation: ${last}).`);
 }
 
-export async function liteLlm(input: { modelId: string; reply: string }): Promise<LiteLlmHandle> {
+async function startLocalLiteLlm(
+  input: { modelId: string; reply: string },
+  secrets: LiteLlmSecrets,
+): Promise<LiteLlmHandle> {
   try {
     await run("docker", ["info"], 15_000);
   } catch {
     throw new SkipError("Docker daemon is unavailable");
   }
 
-  const requests: LiteLlmUpstreamRequest[] = [];
-  const masterKey = `sk-openwork-master-${randomBytes(24).toString("hex")}`;
-  const upstreamKey = `sk-openwork-upstream-${randomBytes(24).toString("hex")}`;
+  const state: WitnessState = { requests: [], sequence: 0 };
   const container = `openwork-litellm-${randomBytes(8).toString("hex")}`;
   let root = "";
   let witness: Server | null = null;
   try {
-    const startedWitness = await startWitness(input.modelId, input.reply, requests);
+    const startedWitness = await startWitness(
+      input.modelId,
+      input.reply,
+      tokenId(secrets.upstreamKey),
+      tokenId(secrets.controlKey),
+      state,
+    );
     witness = startedWitness.server;
     root = await realpath(await mkdtemp(join(tmpdir(), "openwork-litellm-")));
-    const configPath = join(root, "config.yaml");
-    await writeFile(configPath, JSON.stringify({
-      model_list: [{
-        model_name: input.modelId,
-        litellm_params: {
-          model: `openai/${input.modelId}`,
-          api_base: `http://host.docker.internal:${startedWitness.port}/v1`,
-          api_key: upstreamKey,
-        },
-      }],
-      general_settings: { master_key: masterKey },
-    }), { mode: 0o600 });
+    const configPath = join(root, "config.json");
+    await writeFile(
+      configPath,
+      liteLlmConfig(
+        input.modelId,
+        `http://host.docker.internal:${startedWitness.port}/v1`,
+        secrets.masterKey,
+        secrets.upstreamKey,
+      ),
+      { mode: 0o600 },
+    );
     await run("docker", [
       "create", "--name", container,
       "--add-host", "host.docker.internal:host-gateway",
       "--publish", "127.0.0.1::4000",
-      IMAGE, "--config", "/app/config.yaml", "--port", "4000",
+      IMAGE, "--config", "/app/config.json", "--port", "4000",
     ]);
-    await run("docker", ["cp", configPath, `${container}:/app/config.yaml`], 30_000);
+    await run("docker", ["cp", configPath, `${container}:/app/config.json`], 30_000);
     await run("docker", ["start", container], 30_000);
-    const port = await waitForProxy(container, masterKey, input.modelId);
-    let disposed = false;
-    return {
+    const port = await waitForLocalProxy(container, secrets.masterKey, input.modelId);
+    let placementDisposed = false;
+    return makeHandle({
+      ...secrets,
       baseUrl: `http://127.0.0.1:${port}/v1`,
-      apiKey: masterKey,
-      upstreamKey,
-      tokenId,
-      upstreamRequests({ since }) {
-        return requests.filter((request) => request.receivedAt >= since).map((request) => ({ ...request }));
-      },
-      async waitForUpstreamRequest({ model, key, since, timeoutMs }) {
-        const deadline = Date.now() + timeoutMs;
-        const expectedTokenId = tokenId(key);
-        while (Date.now() < deadline) {
-          const found = requests.find((request) => request.receivedAt >= since && request.model === model && request.tokenId === expectedTokenId);
-          if (found) return { ...found };
-          await sleep(100);
-        }
-        const observed = requests.filter((request) => request.receivedAt >= since).map(({ receivedAt, model: observedModel, tokenId: observedTokenId }) => ({ receivedAt, model: observedModel, tokenId: observedTokenId }));
-        throw new Error(`Upstream did not receive model ${model} with token fingerprint ${expectedTokenId}. Observed: ${JSON.stringify(observed)}`);
-      },
-      async [Symbol.asyncDispose]() {
-        if (disposed) return;
-        disposed = true;
+      controlUrl: `http://127.0.0.1:${startedWitness.port}`,
+      fetchImpl: fetch,
+      async dispose(): Promise<void> {
+        if (placementDisposed) return;
+        placementDisposed = true;
         await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
         await Promise.all([
           rm(root, { recursive: true, force: true }),
           closeServer(startedWitness.server),
         ]);
       },
-    };
+    });
   } catch (error) {
     const logs = await run("docker", ["logs", container], 10_000).then((result) => result.stdout + result.stderr, () => "");
     await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
     if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
     if (witness) await closeServer(witness).catch(() => undefined);
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(redact(`${message}${logs ? `\nDocker logs:\n${logs}` : ""}`, [masterKey, upstreamKey]));
+    throw redactedError(
+      `${messageText(error)}${logs ? `\nDocker logs:\n${logs.slice(-4_000)}` : ""}`,
+      [secrets.masterKey, secrets.upstreamKey, secrets.controlKey],
+    );
   }
+}
+
+export function liteLlmSandboxName(): string {
+  return `openwork-litellm-eval-${process.pid}-${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
+}
+
+function uploadCommands(content: string, remotePath: string): string[] {
+  const source = Buffer.from(content);
+  const encoded = source.toString("base64");
+  const encodedPath = `${remotePath}.b64`;
+  const commands = [`: > ${encodedPath}`];
+  for (let offset = 0; offset < encoded.length; offset += BASE64_CHUNK_LENGTH) {
+    commands.push(`printf %s ${encoded.slice(offset, offset + BASE64_CHUNK_LENGTH)} >> ${encodedPath}`);
+  }
+  commands.push([
+    "decode_status=0",
+    `base64 -d ${encodedPath} > ${remotePath} || decode_status=$?`,
+    `actual_bytes=$(wc -c < ${remotePath})`,
+    `rm -f ${encodedPath}`,
+    'test "$decode_status" -eq 0',
+    `test "$actual_bytes" -eq ${source.byteLength}`,
+  ].join("; "));
+  return commands;
+}
+
+async function remoteExec(
+  exec: DaytonaExec,
+  sandbox: string,
+  script: string,
+  context: string,
+  timeoutMs = 30_000,
+): Promise<DaytonaExecResult> {
+  const commandLength = ["exec", sandbox, "--", `bash -lc '${script}'`].join(" ").length;
+  if (commandLength > MAX_DAYTONA_COMMAND_LENGTH) {
+    throw new Error(`LiteLLM Daytona command is ${commandLength} characters; maximum is ${MAX_DAYTONA_COMMAND_LENGTH}.`);
+  }
+  return execInSandbox(exec, sandbox, script, { context, timeoutMs });
+}
+
+async function waitForExecReady(exec: DaytonaExec, sandbox: string): Promise<void> {
+  const deadline = Date.now() + EXEC_READY_TIMEOUT_MS;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      await remoteExec(exec, sandbox, "true", `LiteLLM sandbox exec-ready gate for ${sandbox}`, 15_000);
+      return;
+    } catch (error) {
+      last = messageText(error);
+    }
+    await delay(2_000);
+  }
+  throw new Error(`LiteLLM sandbox ${sandbox} did not become exec-ready within ${EXEC_READY_TIMEOUT_MS}ms. Last: ${last}`);
+}
+
+function firstHttpsUrl(text: string): string | null {
+  const match = /https:\/\/[^\s"'<>)]+/.exec(text);
+  return match ? match[0].replace(/[.,;:]+$/, "") : null;
+}
+
+async function previewUrl(exec: DaytonaExec, sandbox: string, port: number): Promise<string> {
+  const result = await checkedExec(
+    exec,
+    ["preview-url", sandbox, "-p", String(port), "--expires", String(PREVIEW_EXPIRY_SECONDS)],
+    `LiteLLM preview URL gate for ${sandbox}:${port}`,
+    { timeoutMs: 60_000 },
+  );
+  const url = firstHttpsUrl(`${result.stdout}\n${result.stderr}`);
+  if (!url) throw new Error(`LiteLLM preview URL gate for ${sandbox}:${port} did not return an HTTPS URL.`);
+  return url;
+}
+
+async function waitForDaytonaReady(
+  fetchImpl: typeof fetch,
+  gatewayUrl: string,
+  controlUrl: string,
+  modelId: string,
+  secrets: LiteLlmSecrets,
+): Promise<void> {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    let healthResponse: Response;
+    try {
+      healthResponse = await fetchImpl(`${controlUrl}/__openwork_litellm/health`, {
+        headers: { authorization: `Bearer ${secrets.controlKey}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+    } catch (error) {
+      last = `control: ${messageText(error)}`;
+      await delay(1_000);
+      continue;
+    }
+    if (!healthResponse.ok) {
+      last = `control HTTP ${healthResponse.status}`;
+      await delay(1_000);
+      continue;
+    }
+    let health: unknown;
+    try {
+      health = await healthResponse.json();
+    } catch {
+      throw new Error("LiteLLM authenticated control health returned invalid JSON.");
+    }
+    parseHealth(health);
+
+    let modelsResponse: Response;
+    try {
+      modelsResponse = await fetchImpl(`${gatewayUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${secrets.masterKey}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+    } catch (error) {
+      last = `models: ${messageText(error)}`;
+      await delay(1_000);
+      continue;
+    }
+    if (!modelsResponse.ok) {
+      last = `models HTTP ${modelsResponse.status}`;
+      await delay(1_000);
+      continue;
+    }
+    let models: unknown;
+    try {
+      models = await modelsResponse.json();
+    } catch {
+      throw new Error("LiteLLM /v1/models readiness gate returned invalid JSON.");
+    }
+    if (!modelIds(models).includes(modelId)) {
+      throw new Error(`LiteLLM /v1/models readiness gate did not include model ${modelId}.`);
+    }
+    return;
+  }
+  throw new Error(`LiteLLM Daytona readiness gate timed out after ${STARTUP_TIMEOUT_MS}ms. Last: ${last}`);
+}
+
+function launchCommand(input: { modelId: string; reply: string; upstreamTokenId: string; controlTokenId: string }): string {
+  const model = Buffer.from(input.modelId).toString("base64");
+  const reply = Buffer.from(input.reply).toString("base64");
+  return `/app/.venv/bin/python3 - <<PYEOF
+import subprocess
+witness_log = open("${DAYTONA_WITNESS_LOG}", "ab", buffering=0)
+subprocess.Popen(["/app/.venv/bin/python3", "${DAYTONA_WITNESS}", "--port", "${DAYTONA_WITNESS_PORT}", "--model-b64", "${model}", "--reply-b64", "${reply}", "--upstream-token-id", "${input.upstreamTokenId}", "--control-token-id", "${input.controlTokenId}"], stdin=subprocess.DEVNULL, stdout=witness_log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+proxy_log = open("${DAYTONA_LOG}", "ab", buffering=0)
+subprocess.Popen(["/app/.venv/bin/litellm", "--config", "${DAYTONA_CONFIG}", "--host", "0.0.0.0", "--port", "${DAYTONA_PROXY_PORT}"], stdin=subprocess.DEVNULL, stdout=proxy_log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+PYEOF
+echo detached`;
+}
+
+async function startDaytonaLiteLlm(
+  input: { modelId: string; reply: string; daytonaExec?: DaytonaExec; fetchImpl?: typeof fetch },
+  secrets: LiteLlmSecrets,
+): Promise<LiteLlmHandle> {
+  const exec = input.daytonaExec ?? defaultDaytonaExec;
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const sandbox = liteLlmSandboxName();
+  let root = "";
+  let createAttempted = false;
+  try {
+    root = await realpath(await mkdtemp(join(tmpdir(), "openwork-litellm-daytona-")));
+    const dockerfile = join(root, "Dockerfile");
+    await writeFile(dockerfile, DAYTONA_DOCKERFILE, { mode: 0o600 });
+    createAttempted = true;
+    await checkedExec(
+      exec,
+      [
+        "create",
+        "--name", sandbox,
+        "--dockerfile", dockerfile,
+        "--auto-stop", "60",
+        "--auto-delete", "0",
+        "--ttl", "120",
+        "--public",
+        "--target", "us",
+      ],
+      `LiteLLM sandbox creation gate for ${sandbox}`,
+      { timeoutMs: 300_000 },
+    );
+    await rm(root, { recursive: true, force: true });
+    root = "";
+    await waitForExecReady(exec, sandbox);
+
+    const config = liteLlmConfig(
+      input.modelId,
+      `http://127.0.0.1:${DAYTONA_WITNESS_PORT}/v1`,
+      secrets.masterKey,
+      secrets.upstreamKey,
+    );
+    const uploads = [
+      ...uploadCommands(config, DAYTONA_CONFIG),
+      ...uploadCommands(DAYTONA_WITNESS_SOURCE, DAYTONA_WITNESS),
+    ];
+    for (const [index, command] of uploads.entries()) {
+      await remoteExec(exec, sandbox, command, `LiteLLM upload ${index + 1}/${uploads.length} for ${sandbox}`);
+    }
+    await remoteExec(exec, sandbox, launchCommand({
+      modelId: input.modelId,
+      reply: input.reply,
+      upstreamTokenId: tokenId(secrets.upstreamKey),
+      controlTokenId: tokenId(secrets.controlKey),
+    }), `LiteLLM process launch for ${sandbox}`);
+
+    const [gatewayUrl, controlUrl] = await Promise.all([
+      previewUrl(exec, sandbox, DAYTONA_PROXY_PORT),
+      previewUrl(exec, sandbox, DAYTONA_WITNESS_PORT),
+    ]);
+    await waitForDaytonaReady(fetchImpl, gatewayUrl, controlUrl, input.modelId, secrets);
+    let placementDisposed = false;
+    return makeHandle({
+      ...secrets,
+      baseUrl: `${gatewayUrl}/v1`,
+      controlUrl,
+      fetchImpl,
+      async dispose(): Promise<void> {
+        if (placementDisposed) return;
+        placementDisposed = true;
+        await deleteSandboxes([sandbox], { exec, log: () => undefined });
+      },
+    });
+  } catch (error) {
+    const logs = createAttempted
+      ? await remoteExec(
+        exec,
+        sandbox,
+        `tail -80 ${DAYTONA_WITNESS_LOG} 2>&1 || true; tail -80 ${DAYTONA_LOG} 2>&1 || true`,
+        `LiteLLM failure log capture for ${sandbox}`,
+      ).then((result) => `${result.stdout}${result.stderr}`.slice(-4_000), () => "")
+      : "";
+    if (createAttempted) {
+      await deleteSandboxes([sandbox], { exec, log: () => undefined }).catch(() => undefined);
+    }
+    if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    throw redactedError(
+      `${messageText(error)}${logs ? `\nDaytona logs:\n${logs}` : ""}`,
+      [secrets.masterKey, secrets.upstreamKey, secrets.controlKey],
+    );
+  }
+}
+
+export async function liteLlm(input: {
+  place: Place;
+  modelId: string;
+  reply: string;
+  daytonaExec?: DaytonaExec;
+  fetchImpl?: typeof fetch;
+}): Promise<LiteLlmHandle> {
+  const secrets: LiteLlmSecrets = {
+    masterKey: `sk-openwork-master-${randomBytes(24).toString("hex")}`,
+    upstreamKey: `sk-openwork-upstream-${randomBytes(24).toString("hex")}`,
+    controlKey: `sk-openwork-control-${randomBytes(24).toString("hex")}`,
+  };
+  return input.place.kind === "daytona"
+    ? startDaytonaLiteLlm(input, secrets)
+    : startLocalLiteLlm(input, secrets);
 }

--- a/evals/packages/testkit/test/litellm.test.ts
+++ b/evals/packages/testkit/test/litellm.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { liteLlm, liteLlmSandboxName } from "../src/litellm.ts";
+import type { DaytonaExec } from "@openwork/hosts";
+import type { LiteLlmUpstreamRequest, Place } from "../src/index.ts";
+
+const MODEL_ID = "openwork-litellm-unit-model";
+const PINNED_IMAGE = "ghcr.io/berriai/litellm:v1.97.0@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834";
+
+interface ExecCall {
+  args: string[];
+  opts?: { input?: string; timeoutMs?: number };
+}
+
+interface FakeOptions {
+  invalidHealth?: boolean;
+  requests?: () => LiteLlmUpstreamRequest[];
+}
+
+const daytonaPlace: Place = {
+  kind: "daytona",
+  host() {
+    return undefined;
+  },
+  async db() {
+    throw new Error("unused test database");
+  },
+  async exposeMock(handle) {
+    return new URL(handle.url);
+  },
+  denBase() {
+    return { kind: "daytona", ref: "unit-test" };
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function remoteScript(args: string[]): string {
+  const wrapped = args[3] ?? "";
+  const prefix = "bash -lc '";
+  return wrapped.startsWith(prefix) && wrapped.endsWith("'")
+    ? wrapped.slice(prefix.length, -1)
+    : "";
+}
+
+function makeFake(options: FakeOptions = {}): {
+  calls: ExecCall[];
+  exec: DaytonaExec;
+  fetchImpl: typeof fetch;
+  dockerfile(): string;
+  masterKey(): string;
+  upstreamKey(): string;
+  controlKey(): string;
+} {
+  const calls: ExecCall[] = [];
+  const uploads = new Map<string, string>();
+  let dockerfile = "";
+  let masterKey = "";
+  let upstreamKey = "";
+  let controlKey = "";
+  const exec: DaytonaExec = async (args, opts) => {
+    calls.push({ args: [...args], opts });
+    if (args[0] === "create") {
+      const dockerfileIndex = args.indexOf("--dockerfile") + 1;
+      dockerfile = await readFile(args[dockerfileIndex] ?? "", "utf8");
+      return { stdout: "created\n", stderr: "", code: 0 };
+    }
+    if (args[0] === "preview-url") {
+      const port = args[args.indexOf("-p") + 1] ?? "";
+      return { stdout: `Preview URL: https://port-${port}.example.test\n`, stderr: "", code: 0 };
+    }
+    if (args[0] !== "exec") return { stdout: "", stderr: "", code: 0 };
+
+    const script = remoteScript(args);
+    const chunk = /^printf %s ([A-Za-z0-9+/=]+) >> (\/tmp\/[A-Za-z0-9._/-]+\.b64)$/.exec(script);
+    if (chunk?.[1] && chunk[2]) uploads.set(chunk[2], `${uploads.get(chunk[2]) ?? ""}${chunk[1]}`);
+    const finalize = /base64 -d (\/tmp\/[A-Za-z0-9._/-]+\.b64) > (\/tmp\/[A-Za-z0-9._/-]+)/.exec(script);
+    if (finalize?.[1] && finalize[2]) {
+      const content = Buffer.from(uploads.get(finalize[1]) ?? "", "base64").toString("utf8");
+      if (finalize[2].endsWith("config.json")) {
+        const parsed: unknown = JSON.parse(content);
+        const general = isRecord(parsed) && isRecord(parsed.general_settings) ? parsed.general_settings : {};
+        const models = isRecord(parsed) && Array.isArray(parsed.model_list) ? parsed.model_list.filter(isRecord) : [];
+        const params = models[0] && isRecord(models[0].litellm_params) ? models[0].litellm_params : {};
+        masterKey = typeof general.master_key === "string" ? general.master_key : "";
+        upstreamKey = typeof params.api_key === "string" ? params.api_key : "";
+      }
+    }
+    if (script.includes("tail -80")) {
+      return { stdout: `${masterKey}\n${upstreamKey}\n${controlKey}\n`, stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/__openwork_litellm/health") {
+      const authorization = new Headers(init?.headers).get("authorization") ?? "";
+      controlKey = authorization.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : "";
+      return Response.json(options.invalidHealth ? { ok: false, sequence: 0 } : { ok: true, sequence: 3 });
+    }
+    if (url.pathname === "/__openwork_litellm/requests") {
+      return Response.json({ sequence: 3, requests: options.requests?.() ?? [] });
+    }
+    if (url.pathname === "/v1/models") {
+      return Response.json({ object: "list", data: [{ id: MODEL_ID }] });
+    }
+    return Response.json({ error: "not found" }, { status: 404 });
+  };
+  return {
+    calls,
+    exec,
+    fetchImpl,
+    dockerfile: () => dockerfile,
+    masterKey: () => masterKey,
+    upstreamKey: () => upstreamKey,
+    controlKey: () => controlKey,
+  };
+}
+
+test("LiteLLM Daytona sandbox names are safe and unique", () => {
+  const first = liteLlmSandboxName();
+  const second = liteLlmSandboxName();
+
+  assert.match(first, /^openwork-litellm-eval-[0-9]+-[a-z0-9]+-[0-9a-f]{8}$/);
+  assert.notEqual(first, second);
+});
+
+test("Daytona LiteLLM pins its image, verifies bounded uploads, exposes both ports, and uses sequence cursors", async () => {
+  let upstreamFingerprint = "";
+  const fake = makeFake({
+    requests: () => [
+      { sequence: 1, model: "older", tokenId: "older-token", bodyText: "older" },
+      { sequence: 2, model: MODEL_ID, tokenId: upstreamFingerprint, bodyText: "probe" },
+      { sequence: 3, model: MODEL_ID, tokenId: "other-token", bodyText: "chat" },
+    ],
+  });
+  const gateway = await liteLlm({
+    place: daytonaPlace,
+    modelId: MODEL_ID,
+    reply: "deterministic reply",
+    daytonaExec: fake.exec,
+    fetchImpl: fake.fetchImpl,
+  });
+  upstreamFingerprint = gateway.tokenId(gateway.upstreamKey);
+
+  const create = fake.calls.find((call) => call.args[0] === "create");
+  assert(create);
+  assert.match(fake.dockerfile(), new RegExp(`^FROM ${PINNED_IMAGE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  assert.match(fake.dockerfile(), /^ENTRYPOINT \["\/usr\/bin\/bash", "-lc"\]$/m);
+  assert.match(fake.dockerfile(), /^CMD \["sleep infinity"\]$/m);
+  for (const [flag, value] of [
+    ["--auto-stop", "60"],
+    ["--auto-delete", "0"],
+    ["--ttl", "120"],
+    ["--target", "us"],
+  ]) {
+    assert.equal(create.args[create.args.indexOf(flag) + 1], value);
+  }
+  assert(create.args.includes("--dockerfile"));
+  assert(create.args.includes("--public"));
+
+  const launchIndex = fake.calls.findIndex((call) => remoteScript(call.args).includes("/app/.venv/bin/litellm"));
+  assert(launchIndex > 0);
+  const uploadCalls = fake.calls
+    .map((call, index) => ({ index, script: remoteScript(call.args) }))
+    .filter(({ script }) => script.includes(".b64"));
+  assert(uploadCalls.length > 4);
+  assert(uploadCalls.every(({ index }) => index < launchIndex));
+  const chunks = uploadCalls.flatMap(({ script }) => {
+    const match = /^printf %s ([A-Za-z0-9+/=]+) >> /.exec(script);
+    return match?.[1] ? [match[1]] : [];
+  });
+  assert(chunks.length >= 2);
+  assert(chunks.every((chunk) => chunk.length <= 8 * 1_024));
+  const finalizers = uploadCalls.filter(({ script }) => script.includes("actual_bytes=$(wc -c"));
+  assert.equal(finalizers.length, 2);
+  assert(finalizers.every(({ script }) => script.includes('test "$decode_status" -eq 0')));
+  assert(finalizers.every(({ script }) => /test "\$actual_bytes" -eq [1-9][0-9]*/.test(script)));
+
+  const previews = fake.calls.filter((call) => call.args[0] === "preview-url");
+  assert.deepEqual(
+    previews.map((call) => ({
+      port: call.args[call.args.indexOf("-p") + 1],
+      expires: call.args[call.args.indexOf("--expires") + 1],
+    })),
+    [{ port: "4000", expires: "7200" }, { port: "4001", expires: "7200" }],
+  );
+  assert.equal(gateway.baseUrl, "https://port-4000.example.test/v1");
+  assert.equal(await gateway.checkpoint(), 3);
+  assert.deepEqual((await gateway.upstreamRequests({ after: 1 })).map((request) => request.sequence), [2, 3]);
+  assert.equal((await gateway.waitForUpstreamRequest({
+    after: 1,
+    model: MODEL_ID,
+    key: gateway.upstreamKey,
+    timeoutMs: 1_000,
+  })).sequence, 2);
+
+  await gateway[Symbol.asyncDispose]();
+  await gateway[Symbol.asyncDispose]();
+  const deletions = fake.calls.filter((call) => call.args[0] === "delete");
+  assert.equal(deletions.length, 1);
+  assert.equal(deletions[0]?.opts?.input, "y\n");
+});
+
+test("Daytona LiteLLM redacts every key and deletes its sandbox after startup failure", async () => {
+  const fake = makeFake({ invalidHealth: true });
+  let failure: unknown;
+  try {
+    await liteLlm({
+      place: daytonaPlace,
+      modelId: MODEL_ID,
+      reply: "deterministic reply",
+      daytonaExec: fake.exec,
+      fetchImpl: fake.fetchImpl,
+    });
+  } catch (error) {
+    failure = error;
+  }
+
+  assert(failure instanceof Error);
+  for (const secret of [fake.masterKey(), fake.upstreamKey(), fake.controlKey()]) {
+    assert(secret.length > 20);
+    assert(!failure.message.includes(secret));
+  }
+  assert.match(failure.message, /\[REDACTED\]/);
+  assert.match(failure.message, /Daytona logs/);
+  assert.equal(fake.calls.filter((call) => call.args[0] === "delete").length, 1);
+});

--- a/evals/packages/testkit/test/litellm.test.ts
+++ b/evals/packages/testkit/test/litellm.test.ts
@@ -14,7 +14,9 @@ interface ExecCall {
 }
 
 interface FakeOptions {
+  deleteFailures?: number;
   invalidHealth?: boolean;
+  previewOnStderr?: boolean;
   requests?: () => LiteLlmUpstreamRequest[];
 }
 
@@ -61,6 +63,7 @@ function makeFake(options: FakeOptions = {}): {
   let masterKey = "";
   let upstreamKey = "";
   let controlKey = "";
+  let deleteAttempts = 0;
   const exec: DaytonaExec = async (args, opts) => {
     calls.push({ args: [...args], opts });
     if (args[0] === "create") {
@@ -70,7 +73,17 @@ function makeFake(options: FakeOptions = {}): {
     }
     if (args[0] === "preview-url") {
       const port = args[args.indexOf("-p") + 1] ?? "";
+      if (options.previewOnStderr) {
+        return { stdout: "", stderr: "Upgrade at https://updates.example.test\n", code: 0 };
+      }
       return { stdout: `Preview URL: https://port-${port}.example.test\n`, stderr: "", code: 0 };
+    }
+    if (args[0] === "delete") {
+      deleteAttempts += 1;
+      if (deleteAttempts <= (options.deleteFailures ?? 0)) {
+        return { stdout: "transient deletion failure\n", stderr: "", code: 1 };
+      }
+      return { stdout: "deleted\n", stderr: "", code: 0 };
     }
     if (args[0] !== "exec") return { stdout: "", stderr: "", code: 0 };
 
@@ -177,7 +190,7 @@ test("Daytona LiteLLM pins its image, verifies bounded uploads, exposes both por
   assert(chunks.every((chunk) => chunk.length <= 8 * 1_024));
   const finalizers = uploadCalls.filter(({ script }) => script.includes("actual_bytes=$(wc -c"));
   assert.equal(finalizers.length, 2);
-  assert(finalizers.every(({ script }) => script.includes('test "$decode_status" -eq 0')));
+  assert(finalizers.every(({ script }) => script.includes('test "$decode_status" -eq 0 && test "$actual_bytes"')));
   assert(finalizers.every(({ script }) => /test "\$actual_bytes" -eq [1-9][0-9]*/.test(script)));
 
   const previews = fake.calls.filter((call) => call.args[0] === "preview-url");
@@ -228,4 +241,35 @@ test("Daytona LiteLLM redacts every key and deletes its sandbox after startup fa
   assert.match(failure.message, /\[REDACTED\]/);
   assert.match(failure.message, /Daytona logs/);
   assert.equal(fake.calls.filter((call) => call.args[0] === "delete").length, 1);
+});
+
+test("Daytona LiteLLM ignores unrelated HTTPS URLs on CLI stderr", async () => {
+  const fake = makeFake({ previewOnStderr: true });
+
+  await assert.rejects(
+    liteLlm({
+      place: daytonaPlace,
+      modelId: MODEL_ID,
+      reply: "deterministic reply",
+      daytonaExec: fake.exec,
+      fetchImpl: fake.fetchImpl,
+    }),
+    /did not return an HTTPS URL/,
+  );
+  assert.equal(fake.calls.filter((call) => call.args[0] === "delete").length, 1);
+});
+
+test("Daytona LiteLLM disposal retries a transient sandbox deletion failure", async () => {
+  const fake = makeFake({ deleteFailures: 1 });
+  const gateway = await liteLlm({
+    place: daytonaPlace,
+    modelId: MODEL_ID,
+    reply: "deterministic reply",
+    daytonaExec: fake.exec,
+    fetchImpl: fake.fetchImpl,
+  });
+
+  await assert.rejects(gateway[Symbol.asyncDispose](), /Sandbox deletion gate failed/);
+  await gateway[Symbol.asyncDispose]();
+  assert.equal(fake.calls.filter((call) => call.args[0] === "delete").length, 2);
 });

--- a/evals/specs/den-litellm-provider.slow.test.ts
+++ b/evals/specs/den-litellm-provider.slow.test.ts
@@ -31,9 +31,11 @@ const PROVIDER_KEY = "openwork-litellm-witness";
 const MODEL_ID = "openwork-litellm-witness-model";
 const MODEL_NAME = "Witness Model";
 const PROVIDER_ENV = "LITELLM_WITNESS_API_KEY";
-const REPLY = "The deterministic local route is working.";
+const REPLY = "The deterministic LiteLLM route is working.";
 const REQUEST_TIMEOUT_MS = 10_000;
-const requirements: NeedsSpec = { optIn: ["OPENWORK_EVAL_APP_SPECS"], commands: ["docker"] };
+const TEST_CONNECTION_TIMEOUT_MS = 60_000;
+const placementCommand = process.env.OPENWORK_EVAL_DAYTONA?.trim() === "1" ? "daytona" : "docker";
+const requirements: NeedsSpec = { optIn: ["OPENWORK_EVAL_APP_SPECS"], commands: [placementCommand] };
 const missingRequirements = unmetNeeds(requirements, process.env);
 const title = missingRequirements.length > 0
   ? `Den LiteLLM provider route skipped — needs: ${missingRequirements.join(", ")}`
@@ -61,6 +63,19 @@ async function organizationId(session: DenSession): Promise<string> {
     throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
   }
   return id;
+}
+
+async function testConnection(admin: DenSession, orgId: string, baseUrl: string, apiKey: string): Promise<Record<string, unknown>> {
+  const response = await denFetch(admin, "/v1/llm-providers/test-connection", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({ api: baseUrl, apiKey, modelIds: [MODEL_ID] }),
+    signal: AbortSignal.timeout(TEST_CONNECTION_TIMEOUT_MS),
+  });
+  if (!response.response.ok || !isRecord(response.body)) {
+    throw new Error(`Testing the LiteLLM connection failed: HTTP ${response.response.status} ${response.text.slice(0, 500)}`);
+  }
+  return response.body;
 }
 
 async function createProvider(admin: DenSession, orgId: string, baseUrl: string, apiKey: string): Promise<string> {
@@ -164,7 +179,7 @@ async function runDirectProviderSync(
     return sync.body;
   })()`, { awaitPromise: true, timeoutMs: 30_000 });
   if (!isRecord(value) || typeof value.error === "string") {
-    throw new Error(`Triggering direct local provider sync failed: ${JSON.stringify(value)}`);
+    throw new Error(`Triggering direct provider sync failed: ${JSON.stringify(value)}`);
   }
   return value;
 }
@@ -205,13 +220,13 @@ async function seedRendererDenSession(
   });
 }
 
-test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, async ({ evidence, place }) => {
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, async ({ evidence, place }) => {
   needs(requirements);
-  if (place.kind !== "local" || process.env.OPENWORK_EVAL_DEN_API_URL?.trim()) {
-    throw new SkipError("LiteLLM loopback topology requires local placement and a cold local Den");
+  if (process.env.OPENWORK_EVAL_DEN_API_URL?.trim()) {
+    throw new SkipError("The LiteLLM provider proof requires a cold managed Den");
   }
 
-  await using gateway = await liteLlm({ modelId: MODEL_ID, reply: REPLY });
+  await using gateway = await liteLlm({ place, modelId: MODEL_ID, reply: REPLY });
   await using den = await server({
     place,
     org: {
@@ -221,8 +236,40 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, asy
     },
   });
   const member = den.members.member;
-  if (!member) throw new Error("The cold local Den did not provision the member.");
+  if (!member) throw new Error("The cold managed Den did not provision the member.");
   const orgId = await organizationId(den.admin);
+  const probeCheckpoint = await gateway.checkpoint();
+  const probeResponse = await testConnection(den.admin, orgId, gateway.baseUrl, gateway.apiKey);
+  const probeResult = isRecord(probeResponse.result) ? probeResponse.result : {};
+  const discoveredModels = Array.isArray(probeResult.models) ? probeResult.models.filter(isRecord) : [];
+  const verifications = Array.isArray(probeResponse.verifications) ? probeResponse.verifications.filter(isRecord) : [];
+  const verification = verifications.find((entry) => entry.id === MODEL_ID);
+  expect(probeResult.ok).toBe(true);
+  expect(discoveredModels.some((entry) => entry.id === MODEL_ID)).toBe(true);
+  expect(verification?.status).toBe("ok");
+
+  const probeRequest = await gateway.waitForUpstreamRequest({
+    after: probeCheckpoint,
+    model: MODEL_ID,
+    key: gateway.upstreamKey,
+    timeoutMs: 120_000,
+  });
+  const probeRequests = await gateway.upstreamRequests({ after: probeCheckpoint });
+  const probeUsedUpstreamKey = probeRequest.tokenId === gateway.tokenId(gateway.upstreamKey);
+  const probeMasterKeyReachedUpstream = probeRequests
+    .some((request) => request.tokenId === gateway.tokenId(gateway.apiKey));
+  evidence.fact(
+    "Den verified the discovered LiteLLM model through the deterministic upstream",
+    `The endpoint probe discovered ${MODEL_ID}, verification was ${String(verification?.status)}, and upstream sequence ${probeRequest.sequence} carried only the rewritten token fingerprint.`,
+    probeResult.ok === true
+      && discoveredModels.some((entry) => entry.id === MODEL_ID)
+      && verification?.status === "ok"
+      && probeUsedUpstreamKey
+      && !probeMasterKeyReachedUpstream,
+  );
+  expect(probeUsedUpstreamKey).toBe(true);
+  expect(probeMasterKeyReachedUpstream).toBe(false);
+
   const cloudProviderId = await createProvider(den.admin, orgId, gateway.baseUrl, gateway.apiKey);
   await using publishedProvider = {
     async [Symbol.asyncDispose]() {
@@ -326,21 +373,21 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 15 * 60_000 }, asy
   const selected: ModelFacts = await selectModel(desktop, model.id);
   expect(selected.selected).toBe(true);
 
-  const prompt = "Please answer with one short sentence confirming this local test route works.";
+  const prompt = "Please answer with one short sentence confirming this test route works.";
   expect(prompt).not.toContain(PROVIDER_KEY);
   expect(prompt).not.toContain(MODEL_ID);
   expect(prompt).not.toContain(orgId);
-  const since = new Date().toISOString();
+  const desktopCheckpoint = await gateway.checkpoint();
   await sendComposerMessage(desktop, prompt);
   const upstreamRequest = await gateway.waitForUpstreamRequest({
+    after: desktopCheckpoint,
     model: MODEL_ID,
     key: gateway.upstreamKey,
-    since,
     timeoutMs: 120_000,
   });
   const requestUsedUpstreamKey = upstreamRequest.tokenId === gateway.tokenId(gateway.upstreamKey);
   const requestContainsPrompt = upstreamRequest.bodyText.includes(prompt);
-  const masterKeyReachedUpstream = gateway.upstreamRequests({ since })
+  const masterKeyReachedUpstream = (await gateway.upstreamRequests({ after: desktopCheckpoint }))
     .some((request) => request.tokenId === gateway.tokenId(gateway.apiKey));
   evidence.fact(
     "The desktop request traversed LiteLLM and LiteLLM rewrote the bearer key for the deterministic upstream",


### PR DESCRIPTION
## Summary

- make the real LiteLLM fixture placement-aware while preserving its local Docker lane
- run LiteLLM and an authenticated deterministic witness in a dedicated short-lived Daytona sandbox
- replace timestamp filtering with sequence cursors so cross-sandbox clock skew cannot misattribute requests
- prove Den model discovery and completion through `/v1/llm-providers/test-connection` before proving desktop sync and chat
- harden remote uploads, preview URL parsing, secret redaction, and retryable sandbox cleanup

## Daytona topology

`Den sandbox -> signed LiteLLM preview -> local witness in the LiteLLM sandbox`

`Desktop sandbox -> signed LiteLLM preview -> local witness in the LiteLLM sandbox`

The gateway uses the immutable `ghcr.io/berriai/litellm:v1.97.0@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834` image. The control preview requires a separate generated bearer token and returns only request sequences, bodies, model IDs, and key fingerprints.

## User flow

![OpenWork model picker in the Daytona desktop showing the Den-managed LiteLLM Gateway and selectable Witness Model](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr/daytona-litellm-provider/05-the-model-picker-visibly-shows-provider-litellm-gateway-and-model-witness-model.png)

## Verification

Verdict: **Passed** on both Daytona and local lanes at `dcd21380c110369a8969e271d51d3cc56b4e6684`.

- `pnpm --dir evals test`
  - exit 0; 207 passed, 0 failed, 0 skipped
- local: `OPENAI_API_KEY="$(infisical secrets get OPENAI_API_KEY --plain --silent)" env -u OPENWORK_EVAL_DAYTONA -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL -u OPENWORK_EVAL_DAYTONA_DEN_SANDBOX -u OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX -u DATABASE_HOST OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/den-litellm-provider.slow.test.ts`
  - exit 0; 1 passed, 0 failed, 0 skipped; 95.00s
- Daytona: `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=evals/daytona-litellm-provider OPENWORK_EVAL_APP_SPECS=1 OPENWORK_EVAL_MAX_WORKERS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/den-litellm-provider.slow.test.ts`
  - exit 0; 1 passed, 0 failed, 0 skipped; 308.34s
  - tape: 7/7 frames and 9/9 expectations passed
  - Den checked out `dcd21380c110`; desktop checked out `dcd21380c110`
  - exact Den and desktop sandboxes were deleted; no `openwork-litellm-eval-*` sandbox remains
- isolated real Daytona fixture smoke
  - authenticated model discovery and completion passed; witness observed the rewritten upstream key; sandbox deleted