### PR TITLE
ci(evals): alert developers on slow test failures

### DIFF
--- a/.github/workflows/nightly-mega-eval.yml
+++ b/.github/workflows/nightly-mega-eval.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: nightly-mega-eval
@@ -147,49 +146,3 @@ jobs:
           path: evals/results/rolls/
           retention-days: 14
           if-no-files-found: warn
-
-      - name: Report nightly mega failure
-        if: failure()
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          gh label create nightly-eval \
-            --color "B60205" \
-            --description "Automated nightly evaluation failures" \
-            --force
-
-          issue_number="$(gh issue list \
-            --state open \
-            --label nightly-eval \
-            --search '"Nightly mega eval failed" in:title' \
-            --json number,title \
-            --jq 'map(select(.title == "Nightly mega eval failed"))[0].number // empty')"
-
-          if [ -z "$issue_number" ]; then
-            issue_url="$(gh issue create \
-              --title "Nightly mega eval failed" \
-              --label nightly-eval \
-              --body "The nightly mega evaluation has failed. Failure details are posted as comments.")"
-            issue_number="${issue_url##*/}"
-          fi
-
-          {
-            echo "Nightly mega eval failed: $RUN_URL"
-            echo
-            echo '```text'
-            if [ -f /tmp/mega-run-plain.log ]; then
-              tail -n 40 /tmp/mega-run-plain.log
-            elif [ -f /tmp/mega-run.log ]; then
-              tail -n 40 /tmp/mega-run.log
-            else
-              echo "Vitest log unavailable."
-            fi
-            echo '```'
-          } > /tmp/nightly-mega-failure.md
-
-          gh issue comment "$issue_number" --body-file /tmp/nightly-mega-failure.md

--- a/.github/workflows/slow-test-failure-alerts.yml
+++ b/.github/workflows/slow-test-failure-alerts.yml
@@ -1,0 +1,95 @@
+# Opens a developer-facing issue when either slow-test workflow fails or times out.
+# Set SLOW_TEST_ALERT_MENTION to route alerts to a GitHub team instead of the
+# developer who triggered the run.
+name: Slow Test Failure Alerts
+
+on:
+  workflow_run:
+    workflows:
+      - Nightly Mega Eval
+      - Slow Specs Sweep
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      (github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Notify developers
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ALERT_MENTION: ${{ vars.SLOW_TEST_ALERT_MENTION }}
+        run: |
+          set -euo pipefail
+
+          case "$RUN_NAME" in
+            "Nightly Mega Eval") issue_title="Nightly mega eval failed" ;;
+            "Slow Specs Sweep") issue_title="Slow specs sweep failed" ;;
+            *) echo "Unexpected workflow: $RUN_NAME" >&2; exit 1 ;;
+          esac
+
+          gh label create slow-test-failure \
+            --color B60205 \
+            --description "Automated slow-test workflow failures" \
+            --force
+
+          issue_number="$(gh issue list \
+            --state open \
+            --search "\"$issue_title\" in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"$issue_title\"))[0].number // empty")"
+
+          if [ -z "$issue_number" ]; then
+            issue_url="$(gh issue create \
+              --title "$issue_title" \
+              --label slow-test-failure \
+              --body "This issue tracks failures from the **$RUN_NAME** workflow. Each failed run is posted as a comment.")"
+            issue_number="${issue_url##*/}"
+          else
+            gh issue edit "$issue_number" --add-label slow-test-failure
+          fi
+
+          mention="${ALERT_MENTION:-@$RUN_ACTOR}"
+          failed_jobs="$(gh api --paginate "repos/$GH_REPO/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "- [\(.name)](\(.html_url))"')"
+
+          {
+            echo "$mention, **$RUN_NAME** completed with \`$RUN_CONCLUSION\`."
+            echo
+            echo "- Run: [$RUN_ID (attempt $RUN_ATTEMPT)]($RUN_URL)"
+            echo "- Branch: \`$RUN_BRANCH\`"
+            echo "- Commit: \`$RUN_SHA\`"
+            echo
+            echo "### Failed jobs"
+            echo
+            if [ -n "$failed_jobs" ]; then
+              echo "$failed_jobs"
+            else
+              echo "No failed job metadata was returned. Open the workflow run for details."
+            fi
+          } > "$RUNNER_TEMP/slow-test-failure.md"
+
+          gh issue comment "$issue_number" --body-file "$RUNNER_TEMP/slow-test-failure.md"
+          gh issue edit "$issue_number" --add-assignee "$RUN_ACTOR" || true
+          echo "Developer alert: $GITHUB_SERVER_URL/$GH_REPO/issues/$issue_number" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add a centralized `workflow_run` alert for Nightly Mega Eval and Slow Specs Sweep failures or timeouts.
- Open or update one issue per workflow, mention and assign the triggering developer, and link failed jobs.
- Remove the older inline mega reporter to avoid duplicate notifications and reduce its token permissions.

## Why
- Slow-test failures need a durable developer notification beyond the Actions failure state.
- GitHub issues work with existing repository permissions; no Slack secret exists, and Warden/Sentry serve different concerns.

## Issue
- N/A

## Scope
- `.github/workflows/nightly-mega-eval.yml`
- `.github/workflows/slow-test-failure-alerts.yml`

## Out of scope
- Slack webhook provisioning, Warden review behavior, and Sentry runtime alerts.

## Testing
### Ran
- `actionlint .github/workflows/slow-test-failure-alerts.yml`
- `actionlint -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/nightly-mega-eval.yml .github/workflows/slow-specs-sweep.yml .github/workflows/slow-test-failure-alerts.yml`
- `pnpm exec prettier --check .github/workflows/nightly-mega-eval.yml .github/workflows/slow-test-failure-alerts.yml`
- `git diff --check origin/dev...HEAD`
- Read-only failed-job query against sweep run `32178989795`

### Result
- Static workflow validation passed.
- The real-run query returned failed `spec (batch-3)` and `verdict` job links as expected.
- Verdict: **Incomplete**. GitHub activates `workflow_run` listeners only from the default branch, so live issue delivery cannot be observed before merge.

## CI status
- pass: pending
- code-related failures: none
- external/env/auth blockers: none

## Manual verification
1. Merge the workflow onto `dev`.
2. Observe the next failed or timed-out Nightly Mega Eval or Slow Specs Sweep run.
3. Confirm the watcher updates the matching issue, comments failed job links, and assigns the triggering developer.

## Evidence
- No testkit tape: this change only handles GitHub Actions completion events and cannot be activated from the PR branch.

## Risk
- The watcher has `issues: write` and `actions: read`, but does not check out or execute code from the triggering workflow.
- Repeated failures update a deduplicated issue rather than creating issue spam.

## Rollback
- Revert `590dec7cb` to restore the inline nightly reporter and remove the centralized watcher.