### PR TITLE
ci: run matching slow specs on PRs

### DIFF
--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -9,9 +9,9 @@
 name: Slow Specs Sweep
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [dev]
+  workflow_run:
+    workflows: [Warden]
+    types: [completed]
   workflow_dispatch:
     inputs:
       only:
@@ -20,7 +20,9 @@ on:
         default: ""
         type: string
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
   group: slow-specs-sweep
@@ -31,8 +33,9 @@ jobs:
     if: >-
       github.repository == 'different-ai/openwork' &&
       (github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-      github.event.pull_request.head.repo.full_name == github.repository))
+      (github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
@@ -41,8 +44,51 @@ jobs:
       has_specs: ${{ steps.matrix.outputs.has_specs }}
 
     steps:
+      - name: Authorize Warden-cleared pull request
+        id: authorize
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/warden-summary
+          gh run download "$RUN_ID" --repo "$REPO" --name warden-summary --dir /tmp/warden-summary
+          summary_sha="$(jq -r '.head_sha' /tmp/warden-summary/warden-summary.json)"
+          blocking="$(jq -r '.blocking_count // .findings_count' /tmp/warden-summary/warden-summary.json)"
+          current_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+
+          if [ "$summary_sha" != "$HEAD_SHA" ] || [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "::error::Warden summary or pull request head does not match $HEAD_SHA."
+            exit 1
+          fi
+          if [ "$blocking" != "0" ]; then
+            echo "::notice::Slow proof withheld: Warden reported $blocking blocking finding(s)."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          guarded="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+            | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+          if [ -n "$guarded" ]; then
+            echo "::notice::Slow proof withheld: PR changes trusted review machinery."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Authorize manual sweep
+        id: authorize-manual
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "authorized=true" >> "$GITHUB_OUTPUT"
+
       - name: Check slow specs sweep configuration
         id: config
+        if: steps.authorize.outputs.authorized == 'true' || steps.authorize-manual.outputs.authorized == 'true'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -63,6 +109,9 @@ jobs:
       - name: Checkout
         if: steps.config.outputs.enabled == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
 
       - name: Build spec matrix
         id: matrix
@@ -71,8 +120,8 @@ jobs:
         env:
           ONLY_FILTER: ${{ inputs.only }}
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
@@ -97,7 +146,7 @@ jobs:
           )"
           excluded_json="$(printf '%s\n' "$excluded" | jq -Rsc 'split("\n") | map(select(length > 0))')"
 
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
             matched_specs="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-specs)"
             only_filter=""
           else
@@ -140,7 +189,7 @@ jobs:
             echo "### Sweep plan"
             echo
             echo "Matrix specs: $(echo "$specs" | jq 'length') across $(echo "$batches" | jq 'length') batches"
-            if [ "$EVENT_NAME" = "pull_request" ] && [ "$(echo "$specs" | jq 'length')" -eq 0 ]; then
+            if [ "$EVENT_NAME" = "workflow_run" ] && [ "$(echo "$specs" | jq 'length')" -eq 0 ]; then
               echo "Warden suggestion: add or update an evals/specs/<feature>.slow.test.ts proof for this PR."
             fi
             echo "$batches" | jq -r '.[] | "- `\(.name)`: \(.specs | length) specs"'
@@ -176,6 +225,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -214,6 +214,9 @@ jobs:
     needs: plan
     if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_specs == 'true'
     name: spec (${{ matrix.batch.name }})
+    # This environment requires maintainer approval before PR-controlled code
+    # can execute or access repository secrets.
+    environment: pr-slow-specs
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -9,6 +9,9 @@
 name: Slow Specs Sweep
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev]
   workflow_dispatch:
     inputs:
       only:
@@ -25,12 +28,17 @@ concurrency:
 
 jobs:
   plan:
-    if: github.repository == 'different-ai/openwork'
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
       enabled: ${{ steps.config.outputs.enabled }}
       batches: ${{ steps.matrix.outputs.batches }}
+      has_specs: ${{ steps.matrix.outputs.has_specs }}
 
     steps:
       - name: Check slow specs sweep configuration
@@ -62,6 +70,9 @@ jobs:
         shell: bash
         env:
           ONLY_FILTER: ${{ inputs.only }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -86,14 +97,23 @@ jobs:
           )"
           excluded_json="$(printf '%s\n' "$excluded" | jq -Rsc 'split("\n") | map(select(length > 0))')"
 
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            matched_specs="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-specs)"
+            only_filter=""
+          else
+            matched_specs='[]'
+            only_filter="$ONLY_FILTER"
+          fi
+
           specs="$(
             printf '%s\n' evals/specs/*.slow.test.ts \
               | sed 's#^evals/specs/##' \
-              | jq -Rsc --arg only "$ONLY_FILTER" --argjson excluded "$excluded_json" '
+              | jq -Rsc --arg only "$only_filter" --argjson matched "$matched_specs" --argjson excluded "$excluded_json" '
                   split("\n")
                   | map(select(length > 0))
                   | map(select(. != "org-team-lifecycle-mega.slow.test.ts"))
                   | map(select(. as $s | $excluded | index($s) | not))
+                  | map(select(($matched | length == 0) or (($matched | index($s)) != null)))
                   | map(select($only == "" or contains($only)))
                 '
           )"
@@ -120,6 +140,9 @@ jobs:
             echo "### Sweep plan"
             echo
             echo "Matrix specs: $(echo "$specs" | jq 'length') across $(echo "$batches" | jq 'length') batches"
+            if [ "$EVENT_NAME" = "pull_request" ] && [ "$(echo "$specs" | jq 'length')" -eq 0 ]; then
+              echo "Warden suggestion: add or update an evals/specs/<feature>.slow.test.ts proof for this PR."
+            fi
             echo "$batches" | jq -r '.[] | "- `\(.name)`: \(.specs | length) specs"'
             echo
             echo "Excluded (profile-incompatible or raw desktop()): $(echo "$excluded_json" | jq 'length')"
@@ -130,12 +153,17 @@ jobs:
             '
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "batches=$batches" >> "$GITHUB_OUTPUT"
-          echo "Batch matrix: $batches"
+           echo "batches=$batches" >> "$GITHUB_OUTPUT"
+           if [ "$(echo "$specs" | jq 'length')" -gt 0 ]; then
+             echo "has_specs=true" >> "$GITHUB_OUTPUT"
+           else
+             echo "has_specs=false" >> "$GITHUB_OUTPUT"
+           fi
+           echo "Batch matrix: $batches"
 
   spec:
     needs: plan
-    if: needs.plan.outputs.enabled == 'true'
+    if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_specs == 'true'
     name: spec (${{ matrix.batch.name }})
     strategy:
       fail-fast: false

--- a/.github/workflows/slow-specs-sweep.yml
+++ b/.github/workflows/slow-specs-sweep.yml
@@ -112,6 +112,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build spec matrix
         id: matrix
@@ -230,6 +231,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Match slow proof
         env:

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout pull request
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30deaf803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -38,6 +38,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Match slow proof
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          node evals/scripts/spec-impact.mjs \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -22,22 +22,19 @@ concurrency:
   group: warden-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-env:
-  WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
-  WARDEN_OPENAI_API_KEY: ${{ secrets.WARDEN_OPENAI_API_KEY }}
-
 jobs:
-  warden:
-    # Skip drafts and fork PRs: forks have no secrets, so analysis cannot
-    # run (and clearance is fork-blocked in warden-clearance.yml anyway).
+  slow-proof:
+    # Keep PR-controlled matching code isolated from Warden credentials.
     if: >-
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    permissions:
+      contents: read
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Checkout pull request
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30deaf803 # v6
         with:
           fetch-depth: 0
 
@@ -52,6 +49,20 @@ jobs:
             --head "$HEAD_SHA" \
             --summary "$GITHUB_STEP_SUMMARY"
 
+  warden:
+    # Skip drafts and fork PRs: forks have no secrets, so analysis cannot
+    # run (and clearance is fork-blocked in warden-clearance.yml anyway).
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_OPENAI_API_KEY: ${{ secrets.WARDEN_OPENAI_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Analyze
         id: analyze
         uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0

--- a/changelog/release-tracker-2026-08-18.md
+++ b/changelog/release-tracker-2026-08-18.md
@@ -1,0 +1,215 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.27
+
+#### Commit
+`802906bfaa2fbf5347076bd8ac404a5623b7374f`
+
+#### Released at
+`2026-08-17T19:28:29Z`
+
+#### Title
+Safer organization setup and signed Windows releases
+
+#### One-line summary
+Adds private-admin organization bootstrap, public cloud deployment guidance, stronger Okta setup, and signed Windows builds.
+
+#### Main changes
+- Added the initial private-admin bootstrap flow for Den organizations.
+- Added public cloud deployment guides and improved Okta SSO/SCIM setup.
+- Windows builds are signed by default, and Sentry events now include the app version.
+
+#### Lines of code changed since previous release
+61026 lines changed since `v0.18.26` (60881 insertions, 145 deletions).
+
+#### Release importance
+Major release: improves organization provisioning, enterprise identity setup, and Windows release trust.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+3
+
+#### Major improvement details
+- Added private-admin bootstrap for Den organizations.
+- Added public cloud deployment guides and improved Okta SSO/SCIM setup.
+- Enabled default signing for Windows builds.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+1
+
+#### Major bug fix details
+- Added the app version to Sentry events for more actionable desktop diagnostics.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.28
+
+#### Commit
+`ecf5549afdb77d6cf1ce8d84d37363cbfa12f1f5`
+
+#### Released at
+`2026-08-18T00:00:39Z`
+
+#### Title
+Connections move into the Library
+
+#### One-line summary
+Unifies Library and composer Connections while laying the foundation for private native MCP App hosting.
+
+#### Main changes
+- Library and composer Connections now share one consistent experience for discovering and using organization capabilities.
+- Added the foundation for hosting native MCP Apps in the desktop's private host.
+- Improved Code Mode routing, public API proxying, and MCP synchronization reliability.
+
+#### Lines of code changed since previous release
+5993 lines changed since `v0.18.27` (4860 insertions, 1133 deletions).
+
+#### Release importance
+Major release: unifies capability discovery and adds the private MCP App host foundation.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+2
+
+#### Major improvement details
+- Unified Library and composer Connections.
+- Added the foundation for a private native MCP App host.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+1
+
+#### Major bug fix details
+- Improved Code Mode, public API proxying, and MCP synchronization reliability.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.29
+
+#### Commit
+`7043a8c292f4e86a67be40c8c90cb603740d129a`
+
+#### Released at
+`2026-08-18T19:09:00Z`
+
+#### Title
+SSO setup respects verified domains
+
+#### One-line summary
+Gates SSO configuration on domain verification and adds the Okta SAML callback setup path.
+
+#### Main changes
+- SSO configuration is now gated on domain verification.
+- Added the Okta SAML callback configuration and setup documentation.
+
+#### Lines of code changed since previous release
+24135 lines changed since `v0.18.28` (18266 insertions, 5869 deletions).
+
+#### Release importance
+Minor release: hardens enterprise identity setup with focused SSO validation and documentation.
+
+#### Major improvements
+False
+
+#### Number of major improvements
+0
+
+#### Major improvement details
+None.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+2
+
+#### Major bug fix details
+- Prevented SSO from being enabled before the organization's domain is verified.
+- Added the missing Okta SAML callback configuration path.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.30
+
+#### Commit
+`50935ba1f696812c53930f9ef76b467c4e7d144c`
+
+#### Released at
+`2026-08-18T20:57:03Z`
+
+#### Title
+Queue follow-ups and simplify the session workspace
+
+#### One-line summary
+Makes queued follow-up messages run sequentially, streamlines the model picker and sidebar, and strengthens release validation.
+
+#### Main changes
+- Follow-up messages now run sequentially, so queued work stays ordered instead of competing with the active turn.
+- The model picker is more compact and the session sidebar is denser, leaving more room for the conversation.
+- Improved slow-spec coverage, LiteLLM provider proof, and runtime failure handling make releases easier to validate.
+
+#### Lines of code changed since previous release
+4147 lines changed since `v0.18.29` (3158 insertions, 989 deletions).
+
+#### Release importance
+Minor release: improves the core session workflow and release validation without changing the product model.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+1
+
+#### Major improvement details
+- Added sequential execution for queued follow-up messages.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+2
+
+#### Major bug fix details
+- Simplified model and sidebar controls to preserve conversation space.
+- Hardened slow-spec and LiteLLM provider validation plus expected runtime failure handling.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.

--- a/evals/scripts/spec-impact.mjs
+++ b/evals/scripts/spec-impact.mjs
@@ -47,6 +47,7 @@ export function validateSnapshot(value) {
 
 export function analyzeImpact(contracts, changedFiles) {
   const changed = [...new Set(changedFiles.map((entry) => entry.trim()).filter(Boolean))].sort()
+  const changedSlowSpecs = changed.filter((pathname) => pathname.startsWith("evals/specs/") && pathname.endsWith(".slow.test.ts"))
   const impacted = contracts.flatMap((contract) => {
     const implementation = changed.filter((pathname) => contract.implementation.some((pattern) => matches(pathname, pattern)))
     if (implementation.length === 0) return []
@@ -57,7 +58,7 @@ export function analyzeImpact(contracts, changedFiles) {
     changed,
     impacted,
     attention: impacted.filter((contract) => !contract.covered),
-    matchedSpecs: [...new Set(impacted.flatMap((contract) => contract.specs))].sort(),
+    matchedSpecs: [...new Set([...impacted.flatMap((contract) => contract.specs), ...changedSlowSpecs])].sort(),
   }
 }
 

--- a/evals/scripts/spec-impact.mjs
+++ b/evals/scripts/spec-impact.mjs
@@ -57,13 +57,18 @@ export function analyzeImpact(contracts, changedFiles) {
     changed,
     impacted,
     attention: impacted.filter((contract) => !contract.covered),
+    matchedSpecs: [...new Set(impacted.flatMap((contract) => contract.specs))].sort(),
   }
 }
 
 function markdown(result) {
   const lines = ["### Soft spec-impact snapshot", ""]
   if (result.impacted.length === 0) {
-    lines.push("No mapped implementation contract changed.", "")
+    lines.push(
+      "No mapped implementation contract changed.",
+      "Warden suggestion: add or update an `evals/specs/<feature>.slow.test.ts` proof for this change if it affects app behavior.",
+      "",
+    )
     return lines.join("\n")
   }
   lines.push("| Contract | Result | Changed implementation | Mapped specs |", "| --- | --- | --- | --- |")
@@ -77,6 +82,7 @@ function markdown(result) {
   if (result.attention.length > 0) {
     lines.push("This check is advisory: confirm the existing mapped spec still proves the contract, or update/add a spec.", "")
   }
+  lines.push(`Matched slow specs: ${result.matchedSpecs.map((spec) => `\`${spec}\``).join(", ") || "none"}`, "")
   return lines.join("\n")
 }
 
@@ -90,6 +96,7 @@ function parseArgs(args) {
     const argument = args[index]
     if (argument === "--strict") options.strict = true
     else if (argument === "--json") options.json = true
+    else if (argument === "--matched-specs") options.matchedSpecs = true
     else if (["--base", "--head", "--snapshot", "--summary", "--changed-file"].includes(argument)) {
       const value = args[index + 1]
       if (!value) throw new Error(`${argument} requires a value`)
@@ -120,6 +127,10 @@ function main() {
   const result = analyzeImpact(contracts, changedFiles)
   const report = markdown(result)
   if (options.summary) appendFileSync(options.summary, report)
+  if (options.matchedSpecs) {
+    process.stdout.write(`${JSON.stringify(result.matchedSpecs)}\n`)
+    return
+  }
   if (options.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
   else process.stdout.write(report)
   for (const contract of result.attention) {

--- a/evals/specs/spec-impact.test.ts
+++ b/evals/specs/spec-impact.test.ts
@@ -51,3 +51,13 @@ test("the spec-impact report suggests a slow spec for unmapped changes", ({ evid
     true,
   )
 })
+
+test("the spec-impact matcher always selects changed slow specs", ({ evidence }) => {
+  const matched = JSON.parse(runMatched("evals/specs/new-unmapped-feature.slow.test.ts"))
+  expect(matched).toEqual(["evals/specs/new-unmapped-feature.slow.test.ts"])
+  evidence.fact(
+    "New slow specs enter the PR sweep without a contract mapping",
+    "The matcher selected a changed unmapped slow spec directly.",
+    true,
+  )
+})

--- a/evals/specs/spec-impact.test.ts
+++ b/evals/specs/spec-impact.test.ts
@@ -11,11 +11,18 @@ function run(...changedFiles: string[]): string {
   })
 }
 
+function runMatched(...changedFiles: string[]): string {
+  return execFileSync(process.execPath, [script, "--matched-specs", ...changedFiles.flatMap((file) => ["--changed-file", file])], {
+    encoding: "utf8",
+  })
+}
+
 test("the soft spec-impact snapshot identifies uncovered and covered contract changes", ({ evidence }) => {
   const uncovered = run("ee/apps/den-api/src/codemode-runs.ts")
   expect(uncovered).toContain("Needs attention")
   expect(uncovered).toContain("den.codemode-receipts")
   expect(uncovered).toContain("::warning title=Spec impact snapshot::")
+  expect(uncovered).toContain("Matched slow specs:")
 
   const covered = run(
     "ee/apps/den-api/src/codemode-runs.ts",
@@ -24,9 +31,23 @@ test("the soft spec-impact snapshot identifies uncovered and covered contract ch
   expect(covered).toContain("Covered by a changed spec")
   expect(covered).not.toContain("::warning title=Spec impact snapshot::")
 
+  const matched = JSON.parse(runMatched("ee/apps/den-api/src/codemode-runs.ts"))
+  expect(matched).toContain("evals/specs/codemode-scripts.slow.test.ts")
+  expect(matched).toContain("evals/specs/generated-artifact-views.slow.test.ts")
+
   evidence.fact(
     "Implementation changes map to their proof specs",
     "The advisory report warned without a mapped spec change and cleared when the generated Artifact view spec changed.",
+    true,
+  )
+})
+
+test("the spec-impact report suggests a slow spec for unmapped changes", ({ evidence }) => {
+  const report = run("apps/app/src/react-app/unmapped-feature.ts")
+  expect(report).toContain("Warden suggestion: add or update an `evals/specs/<feature>.slow.test.ts`")
+  evidence.fact(
+    "Unmapped app changes receive a slow-spec suggestion",
+    "Warden reports an actionable slow-test suggestion when no contract matches.",
     true,
   )
 })

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,33 @@
 ---
 title: "Changelog"
 ---
+<Update label="August 18th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
+
+  ## [v0.18.30](https://github.com/different-ai/openwork/compare/v0.18.29...v0.18.30): Queue follow-ups and simplify the session workspace
+
+  - Follow-up messages now run sequentially, so queued work stays ordered instead of competing with the active turn.
+  - The model picker is more compact and the session sidebar is denser, leaving more room for the conversation.
+  - Improved slow-spec coverage, LiteLLM provider proof, and runtime failure handling make releases easier to validate.
+
+  ## [v0.18.29](https://github.com/different-ai/openwork/compare/v0.18.28...v0.18.29): SSO setup respects verified domains
+
+  - SSO configuration is now gated on domain verification, preventing an organization from enabling an identity provider before its domain is trusted.
+  - Added the Okta SAML callback configuration and setup documentation.
+
+  ## [v0.18.28](https://github.com/different-ai/openwork/compare/v0.18.27...v0.18.28): Connections move into the Library
+
+  - Library and composer Connections now share one consistent experience for discovering and using organization capabilities.
+  - Added the foundation for hosting native MCP Apps in the desktop's private host.
+  - Improved Code Mode routing, public API proxying, and MCP synchronization reliability.
+
+  ## [v0.18.27](https://github.com/different-ai/openwork/compare/v0.18.26...v0.18.27): Safer organization setup and signed Windows releases
+
+  - Added the initial private-admin bootstrap flow for Den organizations.
+  - Added public cloud deployment guides and improved Okta SSO/SCIM setup.
+  - Windows builds are signed by default, and Sentry events now include the app version.
+
+</Update>
+
 <Update label="August 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.18.26](https://github.com/different-ai/openwork/compare/v0.18.13...v0.18.26): Automations graduate, MCP Apps come alive, and sessions stay resilient


### PR DESCRIPTION
## Summary

- Add a Warden slow-proof check for eligible pull requests.
- Match changed implementation contracts to mapped `.slow.test.ts` specs.
- Always include newly added or edited slow specs, even without a contract mapping.
- Run only selected slow specs after Warden clears the exact PR SHA.
- Suggest adding a slow spec when no contract matches.
- Keep empty matches out of the matrix safely.
- Isolate PR-controlled matching from Warden credentials and withhold secret-bearing runs for PRs that change review machinery.

## Verification

- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/spec-impact.test.ts` (3 passed, 0 failed, 0 skipped)
- `node --check evals/scripts/spec-impact.mjs`
- `git diff --check`
- Workflow YAML parsed successfully with Ruby Psych.

Runtime app-driving proof was not required for this CI/configuration change. `actionlint` was unavailable locally.