### PR TITLE
test(evals): verify SSO before SCIM lifecycle

### DIFF
--- a/evals/specs/scim-okta-lifecycle.slow.test.ts
+++ b/evals/specs/scim-okta-lifecycle.slow.test.ts
@@ -104,9 +104,10 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
     throw new Error(`Organization lookup failed: HTTP ${organizations.response.status} ${organizations.text.slice(0, 500)}`);
   }
 
-  // The org-scoped token route requires an enabled SSO connection. Register an
-  // Okta-shaped SAML provider so this API-only journey also proves the ACS
-  // callback configuration without contacting an IdP.
+  // The org-scoped token route requires a verified, enabled SSO connection.
+  // Den's dev-loopback issuer path makes domain verification deterministic in
+  // the eval while the Okta-shaped entry point, certificate, and ACS contract
+  // remain real.
   const adminSignIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
     method: "POST",
     body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
@@ -124,7 +125,7 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
     method: "POST",
     headers: adminHeaders,
     body: JSON.stringify({
-      issuer: `http://www.okta.com/exk-${runId}`,
+      issuer: `http://127.0.0.1/okta/exk-${runId}`,
       domain: managedDomain,
       entryPoint: `https://okta.example.test/app/openwork/exk-${runId}/sso/saml`,
       cert: "okta-test-signing-certificate",
@@ -136,6 +137,8 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
   }
 
   const ssoConnection = isRecord(sso.body) && isRecord(sso.body.connection) ? sso.body.connection : null;
+  expect(ssoConnection?.domainVerified).toBe(true);
+  expect(stringField(ssoConnection, "status")).toBe("enabled");
   const acsUrl = stringField(ssoConnection, "acsUrl");
   if (!acsUrl) {
     throw new Error(`SAML registration did not advertise an ACS URL: ${sso.text.slice(0, 500)}`);


### PR DESCRIPTION
## Summary
- use the supported dev-loopback SAML issuer so the SCIM prerequisite is domain-verified in local evals
- assert the SSO connection is verified and enabled before issuing the SCIM token

## Verification
- `bun test ee/apps/den-api/test/sso-readiness.test.ts` (1 passed)
- `OPENWORK_EVAL_APP_SPECS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project stack specs/scim-okta-lifecycle.slow.test.ts` (1 passed)
- Local fallback lane used; Daytona credentials were unavailable.