### PR TITLE
fix(server): keep env.json beside the active server config

### DIFF
--- a/apps/server/src/env-file.test.ts
+++ b/apps/server/src/env-file.test.ts
@@ -9,7 +9,9 @@ import {
   InvalidEnvKeyError,
   isReservedEnvKey,
   isValidEnvKey,
+  resolveDefaultEnvStorePath,
 } from "./env-file.js";
+import type { ServerConfig } from "./types.js";
 
 describe("env-file", () => {
   let dir: string;
@@ -184,5 +186,36 @@ describe("env-file", () => {
     const svc = new EnvService({ path });
     await expect(svc.upsertMany([{ key: "SAFE", value: "new" }])).rejects.toBeInstanceOf(EnvStoreReadError);
     expect(readFileSync(path, "utf8")).toBe("{ this is not json");
+  });
+});
+
+describe("resolveDefaultEnvStorePath", () => {
+  const previousOverride = process.env.OPENWORK_ENV_STORE;
+
+  beforeEach(() => {
+    delete process.env.OPENWORK_ENV_STORE;
+  });
+
+  afterEach(() => {
+    if (previousOverride === undefined) delete process.env.OPENWORK_ENV_STORE;
+    else process.env.OPENWORK_ENV_STORE = previousOverride;
+  });
+
+  // tokens.json and runtime.sqlite already sit beside the active config, so an
+  // isolated `--config` / OPENWORK_SERVER_CONFIG run must not leave env.json
+  // pointing at the default store.
+  test("places env.json beside the active server config", () => {
+    const config = { configPath: "/srv/profile/server.json" } as ServerConfig;
+    expect(resolveDefaultEnvStorePath(config)).toBe(join("/srv", "profile", "env.json"));
+  });
+
+  test("OPENWORK_ENV_STORE still wins over the config directory", () => {
+    process.env.OPENWORK_ENV_STORE = join("/explicit", "env.json");
+    const config = { configPath: "/srv/profile/server.json" } as ServerConfig;
+    expect(resolveDefaultEnvStorePath(config)).toBe(join("/explicit", "env.json"));
+  });
+
+  test("falls back to the default store when no config path is known", () => {
+    expect(resolveDefaultEnvStorePath()).toBe(resolveDefaultEnvStorePath({} as ServerConfig));
   });
 });

--- a/apps/server/src/env-file.ts
+++ b/apps/server/src/env-file.ts
@@ -3,6 +3,7 @@ import { chmod, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { openworkEnvStorePath } from "@openwork/paths";
 
+import type { ServerConfig } from "./types.js";
 import { ensureDir, exists } from "./utils.js";
 
 // User-level environment variables, persisted so the desktop shell can inject
@@ -51,7 +52,14 @@ function isInternalEnvKey(key: string): boolean {
   return RESERVED_PREFIXES.some((prefix) => key.startsWith(prefix));
 }
 
-export function resolveDefaultEnvStorePath(): string {
+// Sits beside the active server config, matching resolveTokenStorePath and
+// runtimeDbPath. Without this a --config or OPENWORK_SERVER_CONFIG run keeps
+// reading the default store while its tokens and runtime DB have moved.
+export function resolveDefaultEnvStorePath(config?: ServerConfig): string {
+  const configPath = config?.configPath?.trim();
+  if (configPath && !(process.env.OPENWORK_ENV_STORE ?? "").trim()) {
+    return join(dirname(configPath), "env.json");
+  }
   return openworkEnvStorePath();
 }
 
@@ -160,8 +168,8 @@ export class EnvService {
   private mutationQueue: Promise<void> = Promise.resolve();
   private variables: EnvRecord[] = [];
 
-  constructor(options?: { path?: string }) {
-    this.path = options?.path ? resolve(options.path) : resolveDefaultEnvStorePath();
+  constructor(options?: { path?: string; config?: ServerConfig }) {
+    this.path = options?.path ? resolve(options.path) : resolveDefaultEnvStorePath(options?.config);
   }
 
   private async ensureLoaded(): Promise<void> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -949,7 +949,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
   const tokens = new TokenService(config);
-  const env = new EnvService();
+  const env = new EnvService({ config });
   envServicesByConfig.set(config, env);
   const logger = createServerLogger(config);
   try {


### PR DESCRIPTION
## Summary
- `resolveDefaultEnvStorePath` now resolves `env.json` from the active server config path, the way `tokens.json` and `runtime.sqlite` already do.

## Why

The server keeps three files next to its config. Two of them follow the active config path:

```ts
// tokens.ts — resolveTokenStorePath
const configDir = configPath ? dirname(configPath) : openworkConfigDir()
return join(configDir, "tokens.json")

// runtime-db.ts — runtimeDbPath
const configDir = configPath ? dirname(configPath) : openworkConfigDir()
return join(configDir, "runtime.sqlite")
```

`env.json` did not. `resolveDefaultEnvStorePath` ignored the config entirely and always returned `openworkEnvStorePath()`, which resolves against the *default* config dir.

So a run started with `--config` or `OPENWORK_SERVER_CONFIG` put its tokens and runtime DB in the chosen directory but kept reading and writing the default env store. The two lines are adjacent in `startServer`:

```ts
const tokens = new TokenService(config)   // follows config
const env = new EnvService()              // does not
```

That store is not incidental state — `env-file.ts` describes it as user-level service credentials, and the reserved-key list names `ANTHROPIC_API_KEY`, `GCLOUD_*`, `OPENWORK_API_KEY`. An isolated profile therefore read, and could overwrite, the real user's keys.

`pnpm dev:headless-web` hits this today. It points `OPENWORK_SERVER_CONFIG` at `tmp/headless-server.json` but leaves `OPENWORK_ENV_STORE` unset, unlike `blank-slate-profile.mjs`, which sets `OPENWORK_SERVER_CONFIG`, `OPENWORK_ENV_STORE`, `OPENWORK_TOKEN_STORE` and `OPENWORK_RUNTIME_DB` together. Resolved against the shipping helpers:

```
server config : /repo/tmp/headless-server.json
config dir    : /repo/tmp
env store     : /home/dev/.config/openwork/env.json   ← escapes the profile
```

## Issue
- No existing issue; found while reading the config-path helpers. Happy to file one if you'd prefer it tracked separately.

## Scope
- `resolveDefaultEnvStorePath(config?)` resolves from `config.configPath` when present.
- `EnvService` accepts `{ config }` and forwards it; `startServer` passes the config it already has.
- Regression tests in the existing `env-file.test.ts`.

## Out of scope
- `dev-headless-web.ts` is left alone — it is fixed by this change rather than by adding another env var, and the same fix covers `--config` runs, which an env var would not.
- `openworkEnvStorePath` in `@openwork/paths` still ignores `OPENWORK_SERVER_CONFIG` while `openworkConfigDir` honours it. Left as is: `config.configPath` already covers both `--config` and the env var, and changing the shared helper would relocate the store for anyone relying on today's behavior.
- The other isolation gaps in `dev-headless-web` (`OPENWORK_TOKEN_STORE`, `OPENWORK_DATA_DIR`, XDG vars) are untouched.

## Testing
### Ran
- `bun test apps/server/src/env-file.test.ts`
- `bun test apps/server/src/env-file.test.ts apps/server/src/tokens.test.ts apps/server/src/config.test.ts`
- `bun test packages/paths/test/paths.test.mjs`

### Result
- pass/fail: **pass** — 20/20, 29/29, 21/21 respectively.
- Three tests added. The key one fails on `dev` for the right reason:

```
error: expect(received).toBe(expected)
Expected: "/srv/profile/env.json"
Received: "/Users/…/.config/openwork/env.json"
(fail) resolveDefaultEnvStorePath > places env.json beside the active server config
```

The other two are guards — `OPENWORK_ENV_STORE` still wins, and the default is unchanged with no config path — and pass either way by design.

## CI status
- pass: not yet run on this branch.
- code-related failures: none known.
- external/env/auth blockers: `pnpm install --frozen-lockfile` aborted here on a registry timeout, so I ran the affected suites under `bun` with `@openwork/paths` linked locally rather than the full workspace install. The `evals/` testkit lane was not run for the same reason — flagging that explicitly against the AGENTS.md proof bar, since this is a runtime-observable change and the tape is missing. Happy to add an `evals/specs` spec if you want one before review.

## Manual verification
1. `openworkServerConfigPath` / `openworkConfigDir` / `openworkEnvStorePath` evaluated against the exact env `dev-headless-web.ts` builds, showing the env store landing outside the profile (output above).
2. Confirmed `config.configPath` is the shared source of truth — `config.ts` sets it from `cli.configPath ?? openworkServerConfigPath()`, so it covers both `--config` and `OPENWORK_SERVER_CONFIG`.
3. Confirmed `tokens.ts` and `runtime-db.ts` use the identical `configPath ? dirname(configPath) : openworkConfigDir()` shape this change adopts.

## Evidence
- `N/A` — no UI surface. The behavior is a resolved file path, asserted directly by the new tests; the before/after paths are quoted above.

## Risk
- Low, and scoped to runs that set `--config` or `OPENWORK_SERVER_CONFIG`. Those runs start reading `env.json` from the config directory instead of the default one, so a profile that had been implicitly borrowing the default store will now start empty and need its variables set — which is the intended isolation. `OPENWORK_ENV_STORE` continues to override, and behavior is unchanged when no config path is known.

## Rollback
- Revert the commit; no migration, schema, or on-disk format change.