### PR TITLE
ci: cut release workflow runtime by more than half

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -431,6 +431,10 @@ jobs:
   verify-release:
     name: Verify Release Versions
     needs: resolve-release
+    # Benchmark mode intentionally skips resolve-production. Override the
+    # implicit success() check so that skipped sibling does not propagate
+    # through the selected release context and suppress verification.
+    if: always() && needs.resolve-release.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -457,7 +461,11 @@ jobs:
   publish-electron:
     name: Build + publish Electron (${{ matrix.artifact }})
     needs: [resolve-release, verify-release]
-    if: needs.resolve-release.outputs.build_electron == 'true'
+    if: |
+      always() &&
+      needs.resolve-release.result == 'success' &&
+      needs.verify-release.result == 'success' &&
+      needs.resolve-release.outputs.build_electron == 'true'
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 120
     env:

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -458,7 +458,7 @@ jobs:
       - name: Release review (strict)
         run: node scripts/release/review.mjs --strict
 
-  publish-electron:
+  publish-electron-unix:
     name: Build + publish Electron (${{ matrix.artifact }})
     needs: [resolve-release, verify-release]
     if: |
@@ -520,25 +520,6 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-windows-x64
-            builder_config: electron-builder.yml
-            asset_prefix: openwork
-            manifest_pattern: latest*.yml
-            electron_args: "--win --x64"
-            target_triple: x86_64-pc-windows-msvc
-          # Electron Builder cross-packages ARM64 on the faster x64 runner.
-          # pnpm-workspace.yaml installs both Windows CPU variants so native
-          # optional dependencies remain correct in the ARM64 artifact.
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-windows-arm64
-            builder_config: electron-builder.yml
-            asset_prefix: openwork
-            manifest_pattern: latest*.yml
-            electron_args: "--win --arm64"
-            target_triple: aarch64-pc-windows-msvc
           - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-cloud-macos-arm64
@@ -571,22 +552,6 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-cloud-windows-x64
-            builder_config: electron-builder.cloud.yml
-            asset_prefix: openwork-cloud
-            manifest_pattern: cloud*.yml
-            electron_args: "--win --x64"
-            target_triple: x86_64-pc-windows-msvc
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-cloud-windows-arm64
-            builder_config: electron-builder.cloud.yml
-            asset_prefix: openwork-cloud
-            manifest_pattern: cloud*.yml
-            electron_args: "--win --arm64"
-            target_triple: aarch64-pc-windows-msvc
           - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-enterprise-macos-arm64
@@ -619,24 +584,8 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-enterprise-windows-x64
-            builder_config: electron-builder.enterprise.yml
-            asset_prefix: openwork-enterprise
-            manifest_pattern: enterprise*.yml
-            electron_args: "--win --x64"
-            target_triple: x86_64-pc-windows-msvc
-          - platform: blacksmith-8vcpu-windows-2025
-            os_type: windows
-            artifact: electron-enterprise-windows-arm64
-            builder_config: electron-builder.enterprise.yml
-            asset_prefix: openwork-enterprise
-            manifest_pattern: enterprise*.yml
-            electron_args: "--win --arm64"
-            target_triple: aarch64-pc-windows-msvc
 
-    steps:
+    steps: &electron-build-steps
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -832,112 +781,8 @@ jobs:
           fi
           printf '%s\n' "${manifests[@]}"
 
-      - name: Upload unsigned Windows bundle for Azure signing
-        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: unsigned-${{ matrix.artifact }}
-          path: |
-            apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*
-            apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Upload Electron release assets
-        if: (matrix.os_type != 'windows' || env.SIGN_WINDOWS != 'true') && env.BENCHMARK_ONLY != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          assets=(apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*)
-          if [ ${#assets[@]} -eq 0 ]; then
-            echo "No Electron release assets found in apps/desktop/dist-electron" >&2
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
-
-      - name: Retain benchmark Electron assets
-        if: env.BENCHMARK_ONLY == 'true' && matrix.os_type != 'windows'
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-${{ matrix.artifact }}
-          path: |
-            apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*
-            apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Upload Electron updater manifest artifact
-        if: matrix.os_type != 'windows' || env.SIGN_WINDOWS != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
-          if-no-files-found: error
-
-  sign-and-publish-windows:
-    name: Sign + publish all Windows builds
-    needs: [resolve-release, verify-release, publish-electron]
-    if: |
-      always() &&
-      needs.resolve-release.outputs.build_electron == 'true' &&
-      needs.resolve-release.outputs.sign_windows == 'true' &&
-      needs.resolve-release.result == 'success' &&
-      needs.verify-release.result == 'success' &&
-      needs.publish-electron.result == 'success'
-    runs-on: blacksmith-8vcpu-windows-2025
-    environment: windows-signing
-    timeout-minutes: 30
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    env:
-      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
-      BENCHMARK_ONLY: ${{ needs.resolve-release.outputs.benchmark_only }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 1
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.4.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Get pnpm store path
-        id: pnpm-store
-        shell: bash
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        continue-on-error: true
-        with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: windows-electron-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            windows-electron-pnpm-
-
-      - name: Install dependencies
-        run: pnpm --filter @openwork/desktop... --filter @openwork/app... --filter openwork-server... install --frozen-lockfile --prefer-offline
-
-      - name: Download all unsigned Windows bundles
-        uses: actions/download-artifact@v4
-        with:
-          pattern: unsigned-electron-*windows-*
-          path: ${{ runner.temp }}/windows-artifacts
-
       - name: Validate Azure Artifact Signing configuration
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
         shell: pwsh
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID || secrets.AZURE_CLIENT_ID }}
@@ -960,85 +805,182 @@ jobs:
             throw "Missing windows-signing environment variables: $($missing -join ', ')"
           }
 
-          $installers = Get-ChildItem "$env:RUNNER_TEMP/windows-artifacts" -Recurse -Filter "*.exe"
-          if ($installers.Count -ne 6) {
-            throw "Expected 6 unsigned Windows installers, found $($installers.Count)"
+          $dist = Join-Path $env:GITHUB_WORKSPACE "apps\desktop\dist-electron"
+          $installers = Get-ChildItem $dist -Filter "*.exe"
+          if ($installers.Count -ne 1) {
+            throw "Expected one unsigned Windows installer, found $($installers.Count)"
           }
 
       - name: Azure login with GitHub OIDC
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
         uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID || secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID || secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID || secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Sign all Windows installers
+      - name: Sign Windows installer
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         with:
           endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT || secrets.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT || secrets.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE || secrets.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE }}
-          files-folder: ${{ runner.temp }}\windows-artifacts
+          files-folder: ${{ github.workspace }}\apps\desktop\dist-electron
           files-folder-filter: exe
-          files-folder-recurse: true
+          files-folder-recurse: false
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      - name: Verify every Windows signature
+      - name: Verify Windows signature
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
         shell: pwsh
         run: |
-          $installers = Get-ChildItem "$env:RUNNER_TEMP/windows-artifacts" -Recurse -Filter "*.exe"
-          if ($installers.Count -ne 6) {
-            throw "Expected 6 signed Windows installers, found $($installers.Count)"
+          $dist = Join-Path $env:GITHUB_WORKSPACE "apps\desktop\dist-electron"
+          $installers = Get-ChildItem $dist -Filter "*.exe"
+          if ($installers.Count -ne 1) {
+            throw "Expected one signed Windows installer, found $($installers.Count)"
           }
 
-          foreach ($installer in $installers) {
-            $signature = Get-AuthenticodeSignature $installer.FullName
-            Write-Host "$($installer.Name): $($signature.Status) - $($signature.SignerCertificate.Subject)"
-            if ($signature.Status -ne "Valid") {
-              throw "$($installer.Name) signature is $($signature.Status)"
-            }
+          $signature = Get-AuthenticodeSignature $installers[0].FullName
+          Write-Host "$($installers[0].Name): $($signature.Status) - $($signature.SignerCertificate.Subject)"
+          if ($signature.Status -ne "Valid") {
+            throw "$($installers[0].Name) signature is $($signature.Status)"
           }
 
-      - name: Refresh signed installer blockmaps and manifests
+      - name: Refresh signed installer blockmap and manifest
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
         shell: bash
-        run: node scripts/release/refresh-signed-windows-artifacts.mjs "$RUNNER_TEMP/windows-artifacts" 6
+        run: node scripts/release/refresh-signed-windows-artifacts.mjs apps/desktop/dist-electron 1
 
-      - name: Publish signed Windows assets
+      - name: Upload Electron release assets
         if: env.BENCHMARK_ONLY != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: node scripts/release/publish-electron-assets.mjs "$RUNNER_TEMP/windows-artifacts" "$RELEASE_TAG"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No Electron release assets found in apps/desktop/dist-electron" >&2
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
 
-      - name: Retain signed benchmark Windows assets
+      - name: Retain benchmark Electron assets
         if: env.BENCHMARK_ONLY == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-electron-windows-signed
-          path: ${{ runner.temp }}/windows-artifacts/**/*
+          name: benchmark-${{ matrix.artifact }}
+          path: |
+            apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*
+            apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
           if-no-files-found: error
           retention-days: 1
 
-      - name: Upload signed Windows updater manifest artifact
+      - name: Upload Electron updater manifest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: electron-windows-signed
-          path: ${{ runner.temp }}/windows-artifacts/**/*.yml
+          name: ${{ matrix.artifact }}
+          path: apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
           if-no-files-found: error
+
+  publish-electron-windows:
+    name: Build + publish Electron (${{ matrix.artifact }})
+    needs: [resolve-release, verify-release]
+    if: |
+      always() &&
+      needs.resolve-release.result == 'success' &&
+      needs.verify-release.result == 'success' &&
+      needs.resolve-release.outputs.build_electron == 'true'
+    runs-on: ${{ matrix.platform }}
+    environment: windows-signing
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      RELEASE_VERSION: ${{ needs.resolve-release.outputs.release_version }}
+      MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
+      SIGN_WINDOWS: ${{ needs.resolve-release.outputs.sign_windows }}
+      BENCHMARK_ONLY: ${{ needs.resolve-release.outputs.benchmark_only }}
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
+      OPENWORK_DESKTOP_SENTRY_DSN: ${{ secrets.OPENWORK_DESKTOP_SENTRY_DSN || vars.OPENWORK_DESKTOP_SENTRY_DSN }}
+      OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE || '0.01' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-windows-x64
+            builder_config: electron-builder.yml
+            asset_prefix: openwork
+            manifest_pattern: latest*.yml
+            electron_args: "--win --x64"
+            target_triple: x86_64-pc-windows-msvc
+          # electron-builder cross-packages ARM64 on the faster x64 runner.
+          # pnpm-workspace.yaml installs both Windows CPU variants so native
+          # optional dependencies remain correct in the ARM64 artifact.
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-windows-arm64
+            builder_config: electron-builder.yml
+            asset_prefix: openwork
+            manifest_pattern: latest*.yml
+            electron_args: "--win --arm64"
+            target_triple: aarch64-pc-windows-msvc
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-cloud-windows-x64
+            builder_config: electron-builder.cloud.yml
+            asset_prefix: openwork-cloud
+            manifest_pattern: cloud*.yml
+            electron_args: "--win --x64"
+            target_triple: x86_64-pc-windows-msvc
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-cloud-windows-arm64
+            builder_config: electron-builder.cloud.yml
+            asset_prefix: openwork-cloud
+            manifest_pattern: cloud*.yml
+            electron_args: "--win --arm64"
+            target_triple: aarch64-pc-windows-msvc
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-enterprise-windows-x64
+            builder_config: electron-builder.enterprise.yml
+            asset_prefix: openwork-enterprise
+            manifest_pattern: enterprise*.yml
+            electron_args: "--win --x64"
+            target_triple: x86_64-pc-windows-msvc
+          - platform: blacksmith-8vcpu-windows-2025
+            os_type: windows
+            artifact: electron-enterprise-windows-arm64
+            builder_config: electron-builder.enterprise.yml
+            asset_prefix: openwork-enterprise
+            manifest_pattern: enterprise*.yml
+            electron_args: "--win --arm64"
+            target_triple: aarch64-pc-windows-msvc
+
+    steps: *electron-build-steps
 
   publish-electron-assets:
     name: Publish Electron Assets
-    needs: [resolve-release, verify-release, publish-electron, sign-and-publish-windows]
+    needs: [resolve-release, verify-release, publish-electron-unix, publish-electron-windows]
     if: |
       always() &&
       needs.resolve-release.outputs.build_electron == 'true' &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
-      needs.publish-electron.result == 'success' &&
-      needs.resolve-release.outputs.benchmark_only != 'true' &&
-      (needs.resolve-release.outputs.sign_windows != 'true' || needs.sign-and-publish-windows.result == 'success')
+      needs.publish-electron-unix.result == 'success' &&
+      needs.publish-electron-windows.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -1194,12 +1136,12 @@ jobs:
 
   aur-publish:
     name: Publish AUR
-    needs: [resolve-release, publish-electron, publish-release]
+    needs: [resolve-release, publish-electron-unix, publish-release]
     if: |
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.resolve-release.outputs.benchmark_only != 'true' &&
-      needs.publish-electron.result == 'success' &&
+      needs.publish-electron-unix.result == 'success' &&
       needs.publish-release.result == 'success'
     # AUR is a community distribution channel hosted on aur.archlinux.org.
     # Outages there (e.g. "The AUR is down due to maintenance", 2026-08-04)
@@ -1239,7 +1181,8 @@ jobs:
     needs:
       - resolve-release
       - verify-release
-      - publish-electron
+      - publish-electron-unix
+      - publish-electron-windows
       - publish-electron-assets
       - publish-npm
       - publish-daytona-snapshot
@@ -1254,7 +1197,8 @@ jobs:
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
       needs.resolve-release.outputs.benchmark_only != 'true' &&
-      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron.result == 'success') &&
+      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-unix.result == 'success') &&
+      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-windows.result == 'success') &&
       (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-assets.result == 'success') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       needs.publish-daytona-snapshot.result != 'cancelled'

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -6,6 +6,11 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      benchmark_only:
+        description: "Build the release matrix for timing only; never create tags or publish artifacts"
+        required: false
+        type: boolean
+        default: false
       bump:
         description: "Cut a fresh release: bump from the highest v* tag and tag origin/dev HEAD"
         required: false
@@ -78,9 +83,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  resolve-release:
+  resolve-production:
     name: Resolve Release Metadata
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # WARDEN_PRIVATE_KEY lives in this environment; its deployment policy
     # (dev + v* tags) means the key is only reachable from reviewed code —
     # a feature-branch workflow edit cannot mint the tag-push token.
@@ -90,7 +95,7 @@ jobs:
     # GITHUB_TOKEN). The dispatch run that created the tag owns the release,
     # so the duplicate push run skips here — and with it every job that
     # needs resolve-release.
-    if: github.event_name != 'push' || github.actor != 'diff-warden[bot]'
+    if: github.event.inputs.benchmark_only != 'true' && (github.event_name != 'push' || github.actor != 'diff-warden[bot]')
     outputs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_version: ${{ steps.resolve.outputs.release_version }}
@@ -104,6 +109,7 @@ jobs:
       sign_windows: ${{ steps.resolve.outputs.sign_windows }}
       publish_npm: ${{ steps.resolve.outputs.publish_npm }}
       publish_daytona_snapshot: ${{ steps.resolve.outputs.publish_daytona_snapshot }}
+      benchmark_only: "false"
     steps:
       # Tag creation was admin-only before the app-token flow (the v* tag
       # ruleset gated it at push time). The app token would let ANY dispatch
@@ -367,10 +373,65 @@ jobs:
             --notes-file "$BODY_FILE" \
             --draft $PRERELEASE_FLAG
 
+  resolve-benchmark:
+    name: Resolve Benchmark Metadata
+    if: github.event.inputs.benchmark_only == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      release_version: ${{ steps.resolve.outputs.release_version }}
+      release_mode: ${{ steps.resolve.outputs.release_mode }}
+      notarize: ${{ steps.resolve.outputs.notarize }}
+      build_electron: ${{ steps.resolve.outputs.build_electron }}
+      sign_windows: ${{ steps.resolve.outputs.sign_windows }}
+      publish_npm: ${{ steps.resolve.outputs.publish_npm }}
+      publish_daytona_snapshot: ${{ steps.resolve.outputs.publish_daytona_snapshot }}
+      benchmark_only: ${{ steps.resolve.outputs.benchmark_only }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
+    steps:
+      - name: Resolve non-publishing benchmark context
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "release_tag=${GITHUB_SHA}"
+            echo "release_version=0.0.0-benchmark.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+            echo "release_mode=benchmark"
+            echo "notarize=true"
+            echo "build_electron=true"
+            echo "sign_windows=true"
+            echo "publish_npm=false"
+            echo "publish_daytona_snapshot=false"
+            echo "benchmark_only=true"
+            echo "prerelease=true"
+          } >> "$GITHUB_OUTPUT"
+
+  resolve-release:
+    name: Select Release Context
+    needs: [resolve-production, resolve-benchmark]
+    if: |
+      always() &&
+      (needs.resolve-production.result == 'success' || needs.resolve-benchmark.result == 'success')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      release_tag: ${{ needs.resolve-production.outputs.release_tag || needs.resolve-benchmark.outputs.release_tag }}
+      release_version: ${{ needs.resolve-production.outputs.release_version || needs.resolve-benchmark.outputs.release_version }}
+      release_mode: ${{ needs.resolve-production.outputs.release_mode || needs.resolve-benchmark.outputs.release_mode }}
+      notarize: ${{ needs.resolve-production.outputs.notarize || needs.resolve-benchmark.outputs.notarize }}
+      build_electron: ${{ needs.resolve-production.outputs.build_electron || needs.resolve-benchmark.outputs.build_electron }}
+      sign_windows: ${{ needs.resolve-production.outputs.sign_windows || needs.resolve-benchmark.outputs.sign_windows }}
+      publish_npm: ${{ needs.resolve-production.outputs.publish_npm || needs.resolve-benchmark.outputs.publish_npm }}
+      publish_daytona_snapshot: ${{ needs.resolve-production.outputs.publish_daytona_snapshot || needs.resolve-benchmark.outputs.publish_daytona_snapshot }}
+      benchmark_only: ${{ needs.resolve-production.outputs.benchmark_only || needs.resolve-benchmark.outputs.benchmark_only }}
+      prerelease: ${{ needs.resolve-production.outputs.prerelease || needs.resolve-benchmark.outputs.prerelease }}
+    steps:
+      - run: true
+
   verify-release:
     name: Verify Release Versions
     needs: resolve-release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       RELEASE_MODE: ${{ needs.resolve-release.outputs.release_mode }}
@@ -387,6 +448,7 @@ jobs:
           node-version: 24
 
       - name: Verify release tag
+        if: needs.resolve-release.outputs.benchmark_only != 'true'
         run: node scripts/release/verify-tag.mjs --tag "$RELEASE_TAG" --mode "$RELEASE_MODE"
 
       - name: Release review (strict)
@@ -403,6 +465,7 @@ jobs:
       RELEASE_VERSION: ${{ needs.resolve-release.outputs.release_version }}
       MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
       SIGN_WINDOWS: ${{ needs.resolve-release.outputs.sign_windows }}
+      BENCHMARK_ONLY: ${{ needs.resolve-release.outputs.benchmark_only }}
       OPENWORK_DESKTOP_SENTRY_DSN: ${{ secrets.OPENWORK_DESKTOP_SENTRY_DSN || vars.OPENWORK_DESKTOP_SENTRY_DSN }}
       OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE || '0.01' }}
 
@@ -410,7 +473,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-macos-arm64
             builder_config: electron-builder.yml
@@ -418,7 +481,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--mac --arm64"
             target_triple: aarch64-apple-darwin
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-macos-x64
             builder_config: electron-builder.yml
@@ -426,7 +489,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: ubuntu-22.04
+          - platform: blacksmith-8vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-linux-x64
             builder_config: electron-builder.yml
@@ -434,7 +497,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: ubuntu-22.04-arm
+          - platform: blacksmith-8vcpu-ubuntu-2204-arm
             os_type: linux
             artifact: electron-linux-arm64
             builder_config: electron-builder.yml
@@ -442,7 +505,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: windows-2022
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-windows-x64
             builder_config: electron-builder.yml
@@ -450,7 +513,10 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--win --x64"
             target_triple: x86_64-pc-windows-msvc
-          - platform: windows-11-arm
+          # Electron Builder cross-packages ARM64 on the faster x64 runner.
+          # pnpm-workspace.yaml installs both Windows CPU variants so native
+          # optional dependencies remain correct in the ARM64 artifact.
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-windows-arm64
             builder_config: electron-builder.yml
@@ -458,7 +524,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--win --arm64"
             target_triple: aarch64-pc-windows-msvc
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-cloud-macos-arm64
             builder_config: electron-builder.cloud.yml
@@ -466,7 +532,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--mac --arm64"
             target_triple: aarch64-apple-darwin
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-cloud-macos-x64
             builder_config: electron-builder.cloud.yml
@@ -474,7 +540,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: ubuntu-22.04
+          - platform: blacksmith-8vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-cloud-linux-x64
             builder_config: electron-builder.cloud.yml
@@ -482,7 +548,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: ubuntu-22.04-arm
+          - platform: blacksmith-8vcpu-ubuntu-2204-arm
             os_type: linux
             artifact: electron-cloud-linux-arm64
             builder_config: electron-builder.cloud.yml
@@ -490,7 +556,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: windows-2022
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-cloud-windows-x64
             builder_config: electron-builder.cloud.yml
@@ -498,7 +564,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--win --x64"
             target_triple: x86_64-pc-windows-msvc
-          - platform: windows-11-arm
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-cloud-windows-arm64
             builder_config: electron-builder.cloud.yml
@@ -506,7 +572,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--win --arm64"
             target_triple: aarch64-pc-windows-msvc
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-enterprise-macos-arm64
             builder_config: electron-builder.enterprise.yml
@@ -514,7 +580,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--mac --arm64"
             target_triple: aarch64-apple-darwin
-          - platform: macos-14
+          - platform: blacksmith-12vcpu-macos-15
             os_type: macos
             artifact: electron-enterprise-macos-x64
             builder_config: electron-builder.enterprise.yml
@@ -522,7 +588,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: ubuntu-22.04
+          - platform: blacksmith-8vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-enterprise-linux-x64
             builder_config: electron-builder.enterprise.yml
@@ -530,7 +596,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: ubuntu-22.04-arm
+          - platform: blacksmith-8vcpu-ubuntu-2204-arm
             os_type: linux
             artifact: electron-enterprise-linux-arm64
             builder_config: electron-builder.enterprise.yml
@@ -538,7 +604,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--linux --arm64"
             target_triple: aarch64-unknown-linux-gnu
-          - platform: windows-2022
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-enterprise-windows-x64
             builder_config: electron-builder.enterprise.yml
@@ -546,7 +612,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--win --x64"
             target_triple: x86_64-pc-windows-msvc
-          - platform: windows-11-arm
+          - platform: blacksmith-8vcpu-windows-2025
             os_type: windows
             artifact: electron-enterprise-windows-arm64
             builder_config: electron-builder.enterprise.yml
@@ -564,7 +630,7 @@ jobs:
           # workflow definition runs from github.ref), while the shipped code
           # stays exactly what the tag names.
           ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Enable git long paths (Windows)
         if: matrix.os_type == 'windows'
@@ -602,7 +668,7 @@ jobs:
             ${{ runner.os }}-electron-pnpm-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --filter @openwork/desktop... --filter @openwork/app... --filter openwork-server... install --frozen-lockfile --prefer-offline
 
       # The repo commits a permanent 0.0.0-dev placeholder; the release
       # version exists only as the git tag. Stamp it into the workspace so
@@ -763,7 +829,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Electron release assets
-        if: matrix.os_type != 'windows' || env.SIGN_WINDOWS != 'true'
+        if: (matrix.os_type != 'windows' || env.SIGN_WINDOWS != 'true') && env.BENCHMARK_ONLY != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -776,6 +842,17 @@ jobs:
             exit 1
           fi
           gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Retain benchmark Electron assets
+        if: env.BENCHMARK_ONLY == 'true' && matrix.os_type != 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ matrix.artifact }}
+          path: |
+            apps/desktop/dist-electron/${{ matrix.asset_prefix }}-*
+            apps/desktop/dist-electron/${{ matrix.manifest_pattern }}
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Upload Electron updater manifest artifact
         if: matrix.os_type != 'windows' || env.SIGN_WINDOWS != 'true'
@@ -795,7 +872,7 @@ jobs:
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
       needs.publish-electron.result == 'success'
-    runs-on: windows-2022
+    runs-on: blacksmith-8vcpu-windows-2025
     environment: windows-signing
     timeout-minutes: 30
     permissions:
@@ -804,12 +881,13 @@ jobs:
       id-token: write
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      BENCHMARK_ONLY: ${{ needs.resolve-release.outputs.benchmark_only }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -836,7 +914,7 @@ jobs:
             windows-electron-pnpm-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --filter @openwork/desktop... --filter @openwork/app... --filter openwork-server... install --frozen-lockfile --prefer-offline
 
       - name: Download all unsigned Windows bundles
         uses: actions/download-artifact@v4
@@ -913,10 +991,20 @@ jobs:
         run: node scripts/release/refresh-signed-windows-artifacts.mjs "$RUNNER_TEMP/windows-artifacts" 6
 
       - name: Publish signed Windows assets
+        if: env.BENCHMARK_ONLY != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: node scripts/release/publish-electron-assets.mjs "$RUNNER_TEMP/windows-artifacts" "$RELEASE_TAG"
+
+      - name: Retain signed benchmark Windows assets
+        if: env.BENCHMARK_ONLY == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-electron-windows-signed
+          path: ${{ runner.temp }}/windows-artifacts/**/*
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Upload signed Windows updater manifest artifact
         uses: actions/upload-artifact@v4
@@ -934,6 +1022,7 @@ jobs:
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
       needs.publish-electron.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
       (needs.resolve-release.outputs.sign_windows != 'true' || needs.sign-and-publish-windows.result == 'success')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
@@ -968,6 +1057,7 @@ jobs:
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
       needs.resolve-release.outputs.publish_npm == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
@@ -978,7 +1068,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -1079,6 +1169,7 @@ jobs:
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       needs.resolve-release.outputs.publish_daytona_snapshot == 'true'
     uses: ./.github/workflows/release-daytona-snapshot.yml
@@ -1092,6 +1183,7 @@ jobs:
     if: |
       always() &&
       needs.resolve-release.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
       needs.publish-electron.result == 'success' &&
       needs.publish-release.result == 'success'
     # AUR is a community distribution channel hosted on aur.archlinux.org.
@@ -1146,6 +1238,7 @@ jobs:
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
       (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron.result == 'success') &&
       (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-assets.result == 'success') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -970,42 +970,78 @@ jobs:
 
     steps: *electron-build-steps
 
-  publish-electron-assets:
-    name: Publish Electron Assets
-    needs: [resolve-release, verify-release, publish-electron-unix, publish-electron-windows]
+  publish-release:
+    name: Publish Electron Assets + GitHub Release
+    needs:
+      - resolve-release
+      - verify-release
+      - publish-electron-unix
+      - publish-electron-windows
+      - publish-npm
+      - publish-daytona-snapshot
+    # publish-daytona-snapshot is allowed to fail without blocking the release:
+    # the sandbox snapshot is rebuildable after the fact, while installable
+    # desktop artifacts should never be held back by it.
     if: |
       always() &&
-      needs.resolve-release.outputs.build_electron == 'true' &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
-      needs.publish-electron-unix.result == 'success' &&
-      needs.publish-electron-windows.result == 'success' &&
-      needs.resolve-release.outputs.benchmark_only != 'true'
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
+      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-unix.result == 'success') &&
+      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-windows.result == 'success') &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
+      needs.publish-daytona-snapshot.result != 'cancelled'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
     steps:
       - name: Checkout
+        if: needs.resolve-release.outputs.build_electron == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node
+        if: needs.resolve-release.outputs.build_electron == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Download Electron updater manifest artifacts
+        if: needs.resolve-release.outputs.build_electron == 'true'
         uses: actions/download-artifact@v4
         with:
           pattern: electron-*
           path: ${{ runner.temp }}/electron-dist
 
       - name: Upload merged updater manifests
+        if: needs.resolve-release.outputs.build_electron == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: node scripts/release/publish-electron-assets.mjs --manifests-only "${{ runner.temp }}/electron-dist" "$RELEASE_TAG"
+
+      - name: Publish release after assets are ready
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Dispatch-based recovery runs default draft=false but may target a
+          # draft release created by an earlier tag push; always flip drafts
+          # here so AUR and updater feeds see public download URLs.
+          is_draft="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft -q .isDraft)"
+          if [ "$is_draft" != "true" ]; then
+            echo "Release $RELEASE_TAG is already published; nothing to do."
+            exit 0
+          fi
+
+          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
+          else
+            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          fi
 
   publish-npm:
     name: Publish openwork-server
@@ -1175,55 +1211,3 @@ jobs:
             exit 0
           fi
           scripts/aur/publish-aur.sh "$RELEASE_TAG"
-
-  publish-release:
-    name: Publish GitHub Release
-    needs:
-      - resolve-release
-      - verify-release
-      - publish-electron-unix
-      - publish-electron-windows
-      - publish-electron-assets
-      - publish-npm
-      - publish-daytona-snapshot
-    # publish-daytona-snapshot is allowed to FAIL without blocking the release
-    # (result != 'cancelled' instead of == 'success'): the sandbox snapshot is
-    # rebuildable after the fact by re-running this workflow with the same tag,
-    # while desktop artifacts users install and update from should never be
-    # held back by it. v0.18.15 (2026-08-05) was fully built but never
-    # published solely because this job failed.
-    if: |
-      always() &&
-      needs.resolve-release.result == 'success' &&
-      needs.verify-release.result == 'success' &&
-      needs.resolve-release.outputs.benchmark_only != 'true' &&
-      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-unix.result == 'success') &&
-      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-windows.result == 'success') &&
-      (needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-assets.result == 'success') &&
-      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
-      needs.publish-daytona-snapshot.result != 'cancelled'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
-      RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
-    steps:
-      - name: Publish release after assets are ready
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          # Dispatch-based recovery runs default draft=false but may target a
-          # draft release created by an earlier tag push; always flip drafts
-          # here so AUR and updater feeds see public download URLs.
-          is_draft="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft -q .isDraft)"
-          if [ "$is_draft" != "true" ]; then
-            echo "Release $RELEASE_TAG is already published; nothing to do."
-            exit 0
-          fi
-
-          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
-          else
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
-          fi

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -474,6 +474,10 @@ jobs:
       MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
       SIGN_WINDOWS: ${{ needs.resolve-release.outputs.sign_windows }}
       BENCHMARK_ONLY: ${{ needs.resolve-release.outputs.benchmark_only }}
+      # A filtered frozen install already materializes the complete desktop
+      # dependency closure. Without this, pnpm may "repair" the intentionally
+      # partial workspace with a second all-workspace install before scripts.
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
       OPENWORK_DESKTOP_SENTRY_DSN: ${{ secrets.OPENWORK_DESKTOP_SENTRY_DSN || vars.OPENWORK_DESKTOP_SENTRY_DSN }}
       OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.OPENWORK_DESKTOP_SENTRY_TRACES_SAMPLE_RATE || '0.01' }}
 
@@ -497,7 +501,7 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: blacksmith-8vcpu-ubuntu-2204
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-linux-x64
             builder_config: electron-builder.yml
@@ -505,7 +509,10 @@ jobs:
             manifest_pattern: latest*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-ubuntu-2204-arm
+          # electron-builder can package ARM64 without executing the target
+          # binaries. Cross-package on the faster x64 compression runner; the
+          # workspace installs both CPU variants of optional native packages.
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-linux-arm64
             builder_config: electron-builder.yml
@@ -548,7 +555,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: blacksmith-8vcpu-ubuntu-2204
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-cloud-linux-x64
             builder_config: electron-builder.cloud.yml
@@ -556,7 +563,7 @@ jobs:
             manifest_pattern: cloud*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-ubuntu-2204-arm
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-cloud-linux-arm64
             builder_config: electron-builder.cloud.yml
@@ -596,7 +603,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--mac --x64"
             target_triple: x86_64-apple-darwin
-          - platform: blacksmith-8vcpu-ubuntu-2204
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-enterprise-linux-x64
             builder_config: electron-builder.enterprise.yml
@@ -604,7 +611,7 @@ jobs:
             manifest_pattern: enterprise*.yml
             electron_args: "--linux --x64"
             target_triple: x86_64-unknown-linux-gnu
-          - platform: blacksmith-8vcpu-ubuntu-2204-arm
+          - platform: blacksmith-16vcpu-ubuntu-2204
             os_type: linux
             artifact: electron-enterprise-linux-arm64
             builder_config: electron-builder.enterprise.yml

--- a/evals/specs/windows-artifact-signing.test.ts
+++ b/evals/specs/windows-artifact-signing.test.ts
@@ -19,58 +19,58 @@ const installers = [
   ["openwork-enterprise-win-arm64-1.2.3.exe", "enterprise.yml"],
 ] as const;
 
-const unsignedArtifactNames = [
-  "unsigned-electron-windows-x64",
-  "unsigned-electron-windows-arm64",
-  "unsigned-electron-cloud-windows-x64",
-  "unsigned-electron-cloud-windows-arm64",
-  "unsigned-electron-enterprise-windows-x64",
-  "unsigned-electron-enterprise-windows-arm64",
+const windowsMatrixArtifacts = [
+  "electron-windows-x64",
+  "electron-windows-arm64",
+  "electron-cloud-windows-x64",
+  "electron-cloud-windows-arm64",
+  "electron-enterprise-windows-x64",
+  "electron-enterprise-windows-arm64",
 ] as const;
 
-test("one Azure OIDC job signs and publishes every Windows installer", async ({ evidence }) => {
+test("the Windows matrix signs every installer in place before publication", async ({ evidence }) => {
   const workflow = await readFile(workflowPath, "utf8");
-  const signingJobHeader = workflow.match(/sign-and-publish-windows:[\s\S]*?\n    steps:/)?.[0] ?? "";
+  const sharedBuildSteps = workflow.match(/steps: &electron-build-steps[\s\S]*?\n  publish-electron-windows:/)?.[0] ?? "";
+  const windowsJob = workflow.match(/publish-electron-windows:[\s\S]*?\n    steps: \*electron-build-steps/)?.[0] ?? "";
+  const windowsJobHeader = windowsJob.match(/[\s\S]*?\n    strategy:/)?.[0] ?? "";
 
   expect(workflow.match(/uses: azure\/artifact-signing-action@[0-9a-f]{40} # v2/g)).toHaveLength(1);
-  expect(workflow).toContain("pattern: unsigned-electron-*windows-*");
-  expect(workflow).toContain("sign-and-publish-windows:");
-  expect(workflow).toContain("runs-on: windows-2022");
-  expect(workflow).toContain("environment: windows-signing");
-  expect(workflow).toContain("id-token: write");
-  expect(workflow).toContain("files-folder-recurse: true");
-  expect(workflow).toContain("Expected 6 signed Windows installers");
+  expect(windowsJob.match(/artifact: electron-(?:cloud-|enterprise-)?windows-(?:x64|arm64)/g)).toHaveLength(6);
+  expect(windowsJob).toContain("runs-on: ${{ matrix.platform }}");
+  expect(windowsJob).toContain("environment: windows-signing");
+  expect(windowsJob).toContain("id-token: write");
+  expect(sharedBuildSteps).toContain("if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'");
+  expect(sharedBuildSteps).toContain("files-folder-recurse: false");
+  expect(sharedBuildSteps).toContain("Expected one signed Windows installer");
+  expect(sharedBuildSteps).toContain("refresh-signed-windows-artifacts.mjs apps/desktop/dist-electron 1");
+  expect(sharedBuildSteps.indexOf("Refresh signed installer blockmap and manifest")).toBeLessThan(
+    sharedBuildSteps.indexOf("Upload Electron release assets"),
+  );
   expect(workflow).toMatch(/sign_windows:\n(?: {8}.+\n)* {8}default: true/);
-  expect(workflow).toContain("needs.sign-and-publish-windows.result == 'success'");
-  expect(workflow).toContain("needs.resolve-release.outputs.build_electron != 'true' || needs.publish-electron-assets.result == 'success'");
+  expect(workflow).toContain("needs.publish-electron-windows.result == 'success'");
   expect(workflow).toContain("vars.AZURE_CLIENT_ID || secrets.AZURE_CLIENT_ID");
-  expect(signingJobHeader).not.toContain("AZURE_CLIENT_ID");
+  expect(windowsJobHeader).not.toContain("AZURE_CLIENT_ID");
 
   evidence.fact(
-    "Windows signing is the default and one protected Azure OIDC job gates publication",
-    "Manual releases default sign_windows to true. The release workflow has one Artifact Signing action on windows-2022, recursively signs six installers, verifies every signature, blocks merged-manifest publication until signing succeeds, blocks public release publication until merged Electron assets publish, and keeps Azure config out of job-wide environment scope.",
+    "Windows signing is the default and every matrix build signs before upload",
+    "Manual releases default sign_windows to true. Six Windows matrix targets use the protected windows-signing environment and OIDC permission. Shared build steps sign exactly one installer, verify its signature, refresh its signed blockmap and manifest, and only then upload release assets. Azure values remain scoped to signing steps rather than the job-wide environment.",
     true,
   );
 });
 
-test("Azure signing artifact pattern downloads public, cloud, and enterprise Windows bundles", async ({ evidence }) => {
+test("public, cloud, and enterprise Windows targets avoid an unsigned artifact transfer", async ({ evidence }) => {
   const workflow = await readFile(workflowPath, "utf8");
-  const artifactPattern = workflow.match(/pattern:\s+(unsigned-electron-\*windows-\*)/)?.[1];
-  expect(artifactPattern).toBe("unsigned-electron-*windows-*");
+  const windowsJob = workflow.match(/publish-electron-windows:[\s\S]*?\n    steps: \*electron-build-steps/)?.[0] ?? "";
 
-  const regex = new RegExp(
-    `^${artifactPattern
-      .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
-      .replaceAll("*", ".*")}$`,
-  );
-
-  for (const artifactName of unsignedArtifactNames) {
-    expect(artifactName, `${artifactName} should match ${artifactPattern}`).toMatch(regex);
+  for (const artifactName of windowsMatrixArtifacts) {
+    expect(windowsJob).toContain(`artifact: ${artifactName}`);
   }
+  expect(workflow).not.toContain("unsigned-electron");
+  expect(workflow).not.toContain("sign-and-publish-windows:");
 
   evidence.fact(
-    "The Azure signing download pattern includes all unsigned Windows artifact families",
-    `The pattern ${artifactPattern} matches ${unsignedArtifactNames.join(", ")}.`,
+    "All Windows artifact families are signed without a serial artifact hop",
+    `The Windows matrix contains ${windowsMatrixArtifacts.join(", ")}. None uploads an unsigned-electron intermediate or waits for a sign-and-publish-windows aggregation job.`,
     true,
   );
 });
@@ -88,17 +88,13 @@ test("signed Windows metadata is regenerated for every distribution and architec
       join(artifactDir, manifestName),
       `version: 1.2.3\nfiles:\n  - url: ${installerName}\n    sha512: unsigned\n    size: 1\npath: ${installerName}\nsha512: unsigned\n`,
     );
-  }
 
-  const result = spawnSync(process.execPath, [refreshScriptPath, fixtureRoot, "6"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
-  expect(result.status, result.stderr || result.stdout).toBe(0);
+    const result = spawnSync(process.execPath, [refreshScriptPath, artifactDir, "1"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
 
-  for (const [index, [installerName, manifestName]] of installers.entries()) {
-    const artifactDir = join(fixtureRoot, `artifact-${index}`);
-    const installerPath = join(artifactDir, installerName);
     const expectedSha512 = createHash("sha512").update(await readFile(installerPath)).digest("base64");
     const manifest = await readFile(join(artifactDir, manifestName), "utf8");
     expect(manifest).toContain(expectedSha512);
@@ -106,8 +102,8 @@ test("signed Windows metadata is regenerated for every distribution and architec
   }
 
   evidence.fact(
-    "All six signed installers receive byte-accurate updater metadata",
-    `The refresh helper regenerated blockmaps and SHA-512 manifest entries for ${installers.map(([name]) => basename(name)).join(", ")}.`,
+    "Each signed matrix installer receives byte-accurate updater metadata",
+    `Six independent helper invocations regenerated blockmaps and SHA-512 manifest entries for ${installers.map(([name]) => basename(name)).join(", ")}.`,
     true,
   );
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,15 @@ catalogs:
     react-dom: 18.2.0
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+supportedArchitectures:
+  # Release jobs cross-package the second CPU architecture on the current OS.
+  # Keeping both optional-native variants makes those artifacts runnable while
+  # avoiding the cost of installing optional dependencies for other OSes.
+  os:
+    - current
+  cpu:
+    - x64
+    - arm64
 overrides:
   "@babel/code-frame@<7.29.6": 7.29.7
   "@babel/compat-data@<7.29.6": 7.29.7


### PR DESCRIPTION
## What changed

- add a `benchmark_only` dispatch lane that builds, notarizes, and signs without creating a tag or publishing to GitHub Releases, npm, Daytona, or AUR
- move release builds to sized Blacksmith runners: 12-vCPU macOS, 16-vCPU Linux, and 8-vCPU Windows
- cross-package Linux and Windows ARM64 on x64 while installing both target CPU variants of optional native packages
- narrow the frozen pnpm install to the desktop dependency closure and disable the redundant workspace-wide pre-run repair install
- split Unix and Windows matrices so every Windows installer is signed, verified, and blockmap-refreshed in its existing build job, in parallel
- merge updater-manifest publication and final GitHub Release publication into one tail job

## Why

The reference release spent most of its critical path in an 18-way GitHub-hosted matrix, Windows ARM dependency setup, Linux archive compression, macOS runner queueing, and a second serial Windows signing runner.

| Boundary | Reference | Optimized safe benchmark | Improvement |
| --- | ---: | ---: | ---: |
| Dispatch to all builds + signatures complete | 18m17s | 8m25s | 54.0% faster |
| Whole workflow | 20m22s | about 10m projected | about half |

Reference: https://github.com/different-ai/openwork/actions/runs/32183295582

Final non-publishing benchmark: https://github.com/different-ai/openwork/actions/runs/32188969735

The whole-workflow figure is conservative: the safe benchmark intentionally excludes real publishing. The reference post-sign tail was 2m05s, while this change also removes one of its two serial publishing runners.

## Release safety

- `benchmark_only=true` skips the protected production metadata job, so it cannot create a tag or GitHub Release
- npm, Daytona snapshot, AUR, merged release assets, and final release publication are explicitly gated off
- benchmark artifacts use GitHub Actions storage with one-day retention
- after the final benchmark, there was no SHA-named tag or release; latest public release remained `v0.18.30`; `openwork-server` remained `0.18.30`
- all six Windows installers passed Azure signing, Authenticode verification, and signed blockmap/manifest refresh

## Validation

- final safe benchmark: 18/18 Electron matrix jobs passed, including notarization and signing
- `node --test scripts/release/*.test.mjs ...`: 77 passed, 0 failed, 0 skipped
- `node scripts/release/review.mjs --strict`: passed
- `pnpm install --frozen-lockfile`: passed
- `pnpm --filter @openwork/desktop build:electron`: passed
- workflow YAML parse, `actionlint` with Blacksmith labels registered as custom runners, and `git diff --check`: passed