### PR TITLE
fix(den): enforce TypeIDs for linked accounts

### DIFF
--- a/ee/apps/den-api/src/account-id-policy.ts
+++ b/ee/apps/den-api/src/account-id-policy.ts
@@ -1,0 +1,12 @@
+import { createDenTypeId, isDenTypeId } from "@openwork-ee/utils/typeid";
+
+// Better Auth keeps the provider subject in accountId. This policy only
+// normalizes the local account-row primary key that Den stores as a TypeID.
+export function ensureDenAccountId<TAccount extends { id?: unknown }>(account: TAccount) {
+  return {
+    ...account,
+    id: isDenTypeId("account", account.id)
+      ? account.id
+      : createDenTypeId("account"),
+  };
+}

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -23,6 +23,7 @@ import {
   DEN_SESSION_UPDATE_AGE_IN_SECONDS,
 } from "./session-lifetime.js";
 import { DEN_ACCOUNT_CONFIG } from "./account-linking-policy.js";
+import { ensureDenAccountId } from "./account-id-policy.js";
 import { cache } from "./cache.js";
 import { SCIM_TOKEN_STORAGE_STRATEGY } from "./scim-token-storage.js";
 import { syncDenSignupContact } from "./loops.js";
@@ -579,6 +580,15 @@ export const auth = betterAuth({
     freshAge: 15 * 60,
   },
   databaseHooks: {
+    // Account-linking flows can arrive with Better Auth's opaque local row ID.
+    // Enforce Den's persisted account TypeID without touching the IdP accountId.
+    account: {
+      create: {
+        before: async (account) => ({
+          data: ensureDenAccountId(account),
+        }),
+      },
+    },
     user: {
       update: {
         after: async (user) => {

--- a/ee/apps/den-api/test/account-id-policy.test.ts
+++ b/ee/apps/den-api/test/account-id-policy.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { isDenTypeId } from "@openwork-ee/utils/typeid"
+import { ensureDenAccountId } from "../src/account-id-policy.js"
+
+test("assigns a Den TypeID when Better Auth supplies no local account ID", () => {
+  const account = ensureDenAccountId({
+    accountId: "owner@openworklabs.com",
+    providerId: "openwork-sso-org_example",
+  })
+
+  expect(isDenTypeId("account", account.id)).toBe(true)
+  expect(account.accountId).toBe("owner@openworklabs.com")
+})
+
+test("replaces a foreign local account ID without changing the IdP account ID", () => {
+  const account = ensureDenAccountId({
+    id: "5Y5SfV3e1PaIhwtbz5RD7uN8bMX9U",
+    accountId: "owner@openworklabs.com",
+    providerId: "openwork-sso-org_example",
+  })
+
+  expect(isDenTypeId("account", account.id)).toBe(true)
+  expect(account.id).not.toBe("5Y5SfV3e1PaIhwtbz5RD7uN8bMX9U")
+  expect(account.accountId).toBe("owner@openworklabs.com")
+})
+
+test("preserves an existing valid Den account TypeID", () => {
+  const original = ensureDenAccountId({ accountId: "owner@openworklabs.com" }).id
+  const account = ensureDenAccountId({
+    id: original,
+    accountId: "owner@openworklabs.com",
+  })
+
+  expect(account.id).toBe(original)
+})

--- a/evals/specs/sso-account-id-policy.test.ts
+++ b/evals/specs/sso-account-id-policy.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { isDenTypeId } from "../../ee/packages/utils/src/typeid.js";
+import { ensureDenAccountId } from "../../ee/apps/den-api/src/account-id-policy.js";
+
+test(
+  "SSO account linking keeps the IdP subject separate from Den's local account TypeID",
+  async ({ evidence }) => {
+    const idpSubject = "owner@openworklabs.com";
+    const betterAuthDefaultId = "5Y5SfV3e1PaIhwtbz5RD7uN8bMX9U";
+    const account = ensureDenAccountId({
+      id: betterAuthDefaultId,
+      accountId: idpSubject,
+      providerId: "openwork-sso-org_example",
+    });
+
+    expect(isDenTypeId("account", account.id)).toBe(true);
+    expect(account.id).not.toBe(betterAuthDefaultId);
+    expect(account.accountId).toBe(idpSubject);
+    evidence.fact(
+      "SSO account rows use a Den TypeID without rewriting the IdP subject",
+      `The foreign local ID was replaced with ${account.id}, while accountId remained ${account.accountId}.`,
+      isDenTypeId("account", account.id)
+        && account.id !== betterAuthDefaultId
+        && account.accountId === idpSubject,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- enforce Den acc_ TypeIDs at the Better Auth account create hook
- preserve valid local account IDs and keep the IdP subject unchanged in accountId
- add focused Bun regression coverage and a testkit evidence spec

## Validation

- PASS: pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false
- PASS: pnpm --filter @openwork-ee/den-api exec bun test test/account-id-policy.test.ts test/sso-account-linking-policy.test.ts test/sso-jit.test.ts (6 passed)
- PASS: pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/sso-account-id-policy.test.ts (1 passed)
- PASS: pnpm --filter @openwork-ee/den-api build
- EXISTING TOOLCHAIN FAILURE: pnpm --dir evals typecheck reports repository-wide syntax errors across untouched eval specs, utils, and dependency declarations; the focused testkit project passes.

## Context

A live Okta SAML callback reached account linking, then Drizzle rejected a Better Auth opaque local ID because the Den account primary-key column requires an acc_ TypeID. The provider NameID remains separate in accountId.