### PR TITLE
fix(ci): restore npm trusted publishing

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1053,6 +1053,9 @@ jobs:
       needs.resolve-release.outputs.benchmark_only != 'true' &&
       needs.resolve-release.outputs.publish_npm == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.resolve-release.outputs.release_version }}

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1043,8 +1043,8 @@ jobs:
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
           fi
 
-  publish-npm:
-    name: Publish openwork-server
+  prepare-npm:
+    name: Prepare openwork-server npm package
     needs: [resolve-release, verify-release]
     if: |
       always() &&
@@ -1053,9 +1053,8 @@ jobs:
       needs.resolve-release.outputs.benchmark_only != 'true' &&
       needs.resolve-release.outputs.publish_npm == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-      id-token: write
+    outputs:
+      publish_server: ${{ steps.npm-versions.outputs.publish_server }}
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.resolve-release.outputs.release_version }}
@@ -1131,32 +1130,48 @@ jobs:
             echo "publish_any=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Ensure npm auth
-        id: npm-auth
-        shell: bash
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          PUBLISH_ANY: ${{ steps.npm-versions.outputs.publish_any }}
-        run: |
-          set -euo pipefail
+      - name: Prepare openwork-server
+        if: steps.npm-versions.outputs.publish_server == 'true'
+        run: pnpm --filter openwork-server prepare:npm
 
-          if [ "${PUBLISH_ANY}" != "true" ]; then
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+      - name: Upload npm package
+        if: steps.npm-versions.outputs.publish_server == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openwork-server-npm-${{ env.RELEASE_VERSION }}
+          path: apps/server/dist/npm
+          if-no-files-found: error
 
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "NPM_TOKEN not set; skipping npm publish."
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+  publish-npm:
+    name: Publish openwork-server
+    needs: [resolve-release, verify-release, prepare-npm]
+    if: |
+      always() &&
+      needs.resolve-release.result == 'success' &&
+      needs.verify-release.result == 'success' &&
+      needs.prepare-npm.result == 'success' &&
+      needs.prepare-npm.outputs.publish_server == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.resolve-release.outputs.release_version }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
 
-          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: openwork-server-npm-${{ env.RELEASE_VERSION }}
+          path: ${{ runner.temp }}/openwork-server-npm
 
       - name: Publish openwork-server
-        if: steps.npm-auth.outputs.enabled == 'true' && steps.npm-versions.outputs.publish_server == 'true'
-        run: pnpm --filter openwork-server publish:npm --access public
+        run: npm publish "$RUNNER_TEMP/openwork-server-npm" --access public --provenance
 
   publish-daytona-snapshot:
     name: Build + Push Daytona Snapshot

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,7 @@
     "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "pnpm build:enterprise-mcp-client && bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "pnpm build:enterprise-mcp-client && bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
+    "prepare:npm": "pnpm build:bin && node scripts/publish-npm.mjs --prepare-only",
     "publish:npm": "pnpm build:bin && node scripts/publish-npm.mjs",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/server/scripts/publish-npm.mjs
+++ b/apps/server/scripts/publish-npm.mjs
@@ -41,12 +41,15 @@ async function main() {
     `${JSON.stringify(publishedPackage, null, 2)}\n`
   );
 
+  const args = process.argv.slice(2);
+  if (args.includes("--prepare-only")) return;
+
   const pnpmCli = process.env.npm_execpath;
   if (!pnpmCli) throw new Error("pnpm executable path is unavailable");
 
   const result = spawnSync(
     process.execPath,
-    [pnpmCli, "--config.git-checks=false", "publish", ...process.argv.slice(2)],
+    [pnpmCli, "--config.git-checks=false", "publish", ...args],
     { cwd: outputRoot, stdio: "inherit" }
   );
   if (result.error) throw result.error;


### PR DESCRIPTION
## Summary
- grant the npm release job GitHub OIDC permission
- keep its repository access read-only
- unblock recovery of the existing `v0.18.32` draft release

## Failure
Release run 32222825888 failed with `ERR_PNPM_ID_TOKEN_GITHUB_WORKFLOW_INCORRECT_PERMISSIONS`, then the fallback npm token was rejected.

## Verification
- `git diff --check`
- runtime proof will be the existing-tag `v0.18.32` recovery run after merge