### PR TITLE
fix(desktop): back off failed automation reconnects

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -193,6 +193,8 @@ export function runnerTokenAudience(token) {
 
 export function createDesktopAutomationRunner(options) {
   const fetchImpl = options.fetchImpl ?? fetch
+  const random = options.random ?? Math.random
+  const waitBeforeReconnect = options.waitBeforeReconnect ?? ((ms) => sleep(ms, new AbortController().signal))
   const legacyBaseUrls = new Set((options.legacyBaseUrls ?? [])
     .map((value) => normalizeRunnerBaseUrl(value))
     .filter(Boolean))
@@ -295,11 +297,12 @@ export function createDesktopAutomationRunner(options) {
     return reconcilePromise
   }
 
-  const consumeSse = async (response, localGeneration) => {
+  const consumeSse = async (response, localGeneration, onHealthy) => {
     if (!response.ok || !response.body) throw new Error(`SSE returned ${response.status}`)
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
     let buffer = ""
+    let healthy = false
     while (!stopped && localGeneration === generation) {
       const { done, value } = await reader.read()
       if (done) return
@@ -310,6 +313,7 @@ export function createDesktopAutomationRunner(options) {
         buffer = buffer.slice(boundary + 2)
         let eventType = "message"
         let eventData = null
+        let parsedData = false
         for (const line of block.split("\n")) {
           if (line.startsWith("id:")) {
             const value = Number(line.slice(3).trim())
@@ -317,9 +321,10 @@ export function createDesktopAutomationRunner(options) {
           }
           if (line.startsWith("event:")) eventType = line.slice(6).trim()
           if (line.startsWith("data:")) {
-            try { eventData = JSON.parse(line.slice(5).trim()) } catch { eventData = null }
+            try { eventData = JSON.parse(line.slice(5).trim()); parsedData = true } catch { eventData = null }
           }
         }
+        if (parsedData && !healthy) { healthy = true; onHealthy() }
         await heartbeat().catch(() => undefined)
         if (
           eventType !== "keepalive"
@@ -345,14 +350,13 @@ export function createDesktopAutomationRunner(options) {
           signal: connectionController.signal,
         })
         options.log?.("SSE connected")
-        reconnectAttempt = 0
-        await consumeSse(response, localGeneration)
+        await consumeSse(response, localGeneration, () => { reconnectAttempt = 0 })
       } catch (error) {
         if (stopped || localGeneration !== generation) return
         options.log?.(`SSE reconnecting: ${error instanceof Error ? error.message : String(error)}`)
       }
       const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
-      await sleep(Math.round(backoff * (0.5 + Math.random())), new AbortController().signal)
+      await waitBeforeReconnect(Math.round(backoff * (0.5 + random())))
     }
   }
 

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -19,6 +19,50 @@ function legacyRunnerToken() {
   return `${payload}.test-signature`
 }
 
+const EXPECTED_RECONNECT_DELAYS = [500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000]
+
+async function observeHttpFailureBackoff(status) {
+  const paths = []
+  const delays = []
+  const done = new AbortController()
+  let runner = null
+  runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      paths.push(new URL(url).pathname)
+      return Response.json({ message: "injected HTTP failure" }, { status })
+    },
+    random: () => 0.5,
+    waitBeforeReconnect: async (ms) => {
+      delays.push(ms)
+      await new Promise((resolve) => setImmediate(resolve))
+      if (delays.length === EXPECTED_RECONNECT_DELAYS.length) {
+        runner.stop()
+        done.abort()
+      }
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  if (!done.signal.aborted) {
+    await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
+  }
+  return { paths, delays }
+}
+
+function requestBudget(delays, windowMs) {
+  let attempts = 0
+  let nextAttemptAt = 0
+  while (nextAttemptAt < windowMs) {
+    nextAttemptAt += delays[Math.min(attempts, delays.length - 1)]
+    attempts += 1
+  }
+  return attempts * 2
+}
+
 test("model-not-found failures become a repairable Automation error", () => {
   assert.deepEqual(classifyAutomationExecutionError({
     name: "ProviderModelNotFoundError",
@@ -150,6 +194,100 @@ test("a runner credential bound elsewhere reports why this desktop stays disconn
     "rejected runner credential for https://den.example.com/api/den"
       + ": token audience https://api.example.com",
   ])
+})
+
+for (const status of [502, 401]) {
+  test(`repeated HTTP ${status} responses retain exponential runner reconnect backoff`, async () => {
+    const { paths, delays } = await observeHttpFailureBackoff(status)
+    assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
+    assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
+    assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 10)
+  })
+}
+
+test("runner HTTP failure request budget drops from the reset-on-response baseline", () => {
+  const previousResetOnResponseDelays = Array(10).fill(500)
+  assert.equal(requestBudget(previousResetOnResponseDelays, 60_000), 240)
+  assert.equal(requestBudget(EXPECTED_RECONNECT_DELAYS, 60_000), 14)
+  assert.equal(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0), 5_000)
+  assert.equal(EXPECTED_RECONNECT_DELAYS.reduce((total, delay) => total + delay, 0), 151_500)
+})
+
+test("a healthy SSE response resets runner reconnect backoff", async () => {
+  const delays = []
+  let eventRequests = 0
+  const done = new AbortController()
+  let runner = null
+  runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      const path = new URL(url).pathname
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      eventRequests += 1
+      if (eventRequests <= 3) return new Response(null, { status: 502 })
+      return new Response("event: keepalive\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    },
+    random: () => 0.5,
+    waitBeforeReconnect: async (ms) => {
+      delays.push(ms)
+      await new Promise((resolve) => setImmediate(resolve))
+      if (delays.length === 4) {
+        runner.stop()
+        done.abort()
+      }
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  if (!done.signal.aborted) {
+    await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
+  }
+  assert.deepEqual(delays, [500, 1_000, 2_000, 500])
+})
+
+test("a parsed SSE event resets backoff before an abrupt stream error", async () => {
+  const delays = []
+  let eventRequests = 0
+  const done = new AbortController()
+  let runner = null
+  runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      const path = new URL(url).pathname
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      eventRequests += 1
+      if (eventRequests <= 3) return new Response(null, { status: 502 })
+      return new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("event: keepalive\ndata: {}\n\n"))
+          setImmediate(() => controller.error(new Error("injected stream failure")))
+        },
+      }), { headers: { "Content-Type": "text/event-stream" } })
+    },
+    random: () => 0.5,
+    waitBeforeReconnect: async (ms) => {
+      delays.push(ms)
+      await new Promise((resolve) => setImmediate(resolve))
+      if (delays.length === 4) {
+        runner.stop()
+        done.abort()
+      }
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  if (!done.signal.aborted) {
+    await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
+  }
+  assert.deepEqual(delays, [500, 1_000, 2_000, 500])
 })
 
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const expectedDelays = [500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000];
+const runnerUnitTest = fileURLToPath(new URL("../../apps/desktop/electron/automation-runner.test.mjs", import.meta.url));
+
+function requestBudget(delays: number[], windowMs: number): number {
+  let attempts = 0;
+  let nextAttemptAt = 0;
+  while (nextAttemptAt < windowMs) {
+    nextAttemptAt += delays[Math.min(attempts, delays.length - 1)];
+    attempts += 1;
+  }
+  return attempts * 2;
+}
+
+test("desktop Automation runners back off repeated HTTP failures", async ({ evidence }) => {
+  const unit = spawnSync(process.execPath, [
+    "--test",
+    "--test-reporter=tap",
+    runnerUnitTest,
+  ], { encoding: "utf8" });
+  expect(unit.status, unit.stderr || unit.stdout).toBe(0);
+  expect(unit.stdout).toContain("repeated HTTP 502 responses retain exponential runner reconnect backoff");
+  expect(unit.stdout).toContain("repeated HTTP 401 responses retain exponential runner reconnect backoff");
+  expect(unit.stdout).toContain("a healthy SSE response resets runner reconnect backoff");
+  expect(unit.stdout).toContain("a parsed SSE event resets backoff before an abrupt stream error");
+  expect(unit.stdout).not.toContain("not ok");
+  expect(unit.stdout).toMatch(/# tests 15\b/);
+  expect(unit.stdout).toMatch(/# pass 15\b/);
+  expect(unit.stdout).toMatch(/# fail 0\b/);
+  expect(unit.stdout).toMatch(/# skipped 0\b/);
+  expect(unit.stdout).toMatch(/# todo 0\b/);
+  evidence.fact(
+    "Repeated HTTP failures retain capped exponential backoff",
+    "Both ten-response 502 and 401 sequences produced 500, 1000, 2000, 4000, 8000, 16000, then four 30000ms delays, with exactly one work and one SSE request per attempt. After three 502s, a parsed keepalive followed by an abrupt stream error reset the next delay to 500ms.",
+    true,
+  );
+
+  const previousResetOnResponseDelays = Array(10).fill(500);
+  expect(requestBudget(previousResetOnResponseDelays, 60_000)).toBe(240);
+  expect(requestBudget(expectedDelays, 60_000)).toBe(14);
+  expect(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0)).toBe(5_000);
+  expect(expectedDelays.reduce((total, delay) => total + delay, 0)).toBe(151_500);
+  evidence.fact(
+    "Reconnect request budget is bounded during an outage",
+    "At midpoint jitter, the pre-fix reset behavior budgets 240 work-plus-SSE requests in 60 seconds; capped exponential backoff budgets 14. Across ten failures, waiting rises from 5 seconds to 151.5 seconds.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- preserve exponential reconnect backoff when runner SSE returns HTTP 401 or 502
- reset backoff only after a valid parsed SSE frame, including streams that later disconnect abruptly
- add deterministic request-budget proof: 240 to 14 work-plus-SSE requests per failing runner-minute at midpoint jitter

## Incident correlation
- runner work/events generated 96% of API 401s in the sampled 24h
- the runner routes plus `/mcp/agent` accounted for about 91% of 502s
- the prior reset-on-response behavior kept invalid runners at the first 250-750ms delay

## Verification
- `pnpm --filter @openwork/desktop exec node --test electron/automation-runner.test.mjs` (15 passed, 0 failed/skipped)
- `infisical run --silent -- env OPENWORK_EVAL_DAYTONA=1 pnpm evals:spec specs/automation-runner-reconnect-backoff.test.ts` (1 passed, 0 skipped)

## 502 coverage
Repeated HTTP 502 responses retain capped exponential backoff, and a healthy parsed keepalive resets the next delay even when the stream then fails abruptly.