### PR TITLE
fix(server): bound cloud MCP health probes

### DIFF
--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -7,6 +7,7 @@ import {
   cloudMcpDeliveryState,
   CloudMcpDeliveryStateStore,
   calculateCloudMcpDesiredRevision,
+  clearOpenworkCloudMcpProbeFlights,
   OPENWORK_CLOUD_EXPECTED_TOOLS,
   OPENWORK_CLOUD_PLUGIN_CANARIES,
   readOpenworkCloudMcpHealth,
@@ -30,7 +31,7 @@ const roots: string[] = [];
 const runtimeDbRoots: string[] = [];
 const stops: Array<() => void> = [];
 
-type DirectProbeMode = "ok" | "missing" | "unauthorized";
+type DirectProbeMode = "ok" | "missing" | "unauthorized" | "bad_gateway";
 type ReadHealthOptions = {
   probe?: boolean;
   beforeRead?: (directUrl: string) => void;
@@ -39,6 +40,7 @@ type ReadHealthOptions = {
 afterEach(async () => {
   globalThis.fetch = previousFetch;
   cloudMcpDeliveryState.clear();
+  clearOpenworkCloudMcpProbeFlights();
   while (stops.length) stops.pop()?.();
   while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
   if (process.platform === "win32") {
@@ -68,7 +70,40 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function startMockOpencode(mode: DirectProbeMode) {
+function requestBarrier() {
+  let entries = 0;
+  let releaseRequests: () => void = () => undefined;
+  const released = new Promise<void>((resolve) => {
+    releaseRequests = resolve;
+  });
+  const waiters: Array<{ target: number; resolve: () => void }> = [];
+  return {
+    async enter(): Promise<void> {
+      entries += 1;
+      for (let index = waiters.length - 1; index >= 0; index -= 1) {
+        const waiter = waiters[index];
+        if (waiter && entries >= waiter.target) {
+          waiters.splice(index, 1);
+          waiter.resolve();
+        }
+      }
+      await released;
+    },
+    waitForEntries(target: number): Promise<void> {
+      if (entries >= target) return Promise.resolve();
+      return new Promise((resolve) => waiters.push({ target, resolve }));
+    },
+    release(): void {
+      releaseRequests();
+    },
+  };
+}
+
+function startMockOpencode(initialMode: DirectProbeMode) {
+  let mode = initialMode;
+  let toolIdsBarrier: ReturnType<typeof requestBarrier> | null = null;
+  let initializeBarrier: ReturnType<typeof requestBarrier> | null = null;
+  const directOperations: string[] = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -81,10 +116,16 @@ function startMockOpencode(mode: DirectProbeMode) {
           "sibling-remote": { status: "failed", error: "fetch failed" },
         });
       }
-      if (url.pathname === "/experimental/tool/ids") return Response.json([...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES]);
+      if (url.pathname === "/experimental/tool/ids") {
+        if (toolIdsBarrier) await toolIdsBarrier.enter();
+        return Response.json([...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES]);
+      }
       if (url.pathname === "/cloud-mcp/mcp/agent" && request.method === "POST") {
-        if (mode === "unauthorized") return Response.json({ error: "invalid token" }, { status: 401 });
         const body: unknown = await request.json();
+        const method = isRecord(body) && typeof body.method === "string" ? body.method : "unknown";
+        directOperations.push(method);
+        if (method === "initialize" && initializeBarrier) await initializeBarrier.enter();
+        if (mode === "unauthorized") return Response.json({ error: "invalid token" }, { status: 401 });
         const id = isRecord(body) && (typeof body.id === "string" || typeof body.id === "number" || body.id === null) ? body.id : 1;
         if (isRecord(body) && body.method === "notifications/initialized") return new Response(null, { status: 202 });
         if (isRecord(body) && body.method === "initialize") {
@@ -99,6 +140,7 @@ function startMockOpencode(mode: DirectProbeMode) {
           });
         }
         if (isRecord(body) && body.method === "tools/list") {
+          if (mode === "bad_gateway") return Response.json({ error: "upstream unavailable" }, { status: 502 });
           const tools = mode === "missing"
             ? [{ name: "search_capabilities", inputSchema: {} }]
             : [
@@ -113,7 +155,35 @@ function startMockOpencode(mode: DirectProbeMode) {
     },
   });
   stops.push(() => server.stop(true));
-  return server;
+  return {
+    server,
+    directOperations,
+    setMode(nextMode: DirectProbeMode): void {
+      mode = nextMode;
+    },
+    blockToolIds() {
+      const barrier = requestBarrier();
+      toolIdsBarrier = barrier;
+      return {
+        waitForEntries: barrier.waitForEntries,
+        release(): void {
+          if (toolIdsBarrier === barrier) toolIdsBarrier = null;
+          barrier.release();
+        },
+      };
+    },
+    blockInitialize() {
+      const barrier = requestBarrier();
+      initializeBarrier = barrier;
+      return {
+        waitForEntries: barrier.waitForEntries,
+        release(): void {
+          if (initializeBarrier === barrier) initializeBarrier = null;
+          barrier.release();
+        },
+      };
+    },
+  };
 }
 
 function serverConfig(root: string, testWorkspace: WorkspaceInfo): ServerConfig {
@@ -136,43 +206,69 @@ function serverConfig(root: string, testWorkspace: WorkspaceInfo): ServerConfig 
   } satisfies ServerConfig;
 }
 
-async function readHealthForDirectProbe(mode: DirectProbeMode, options: ReadHealthOptions = {}) {
-  const root = await createRoot("openwork-cloud-health-");
+async function setupDirectProbeHarness(mode: DirectProbeMode, workspaceIds = ["ws_probe"]) {
   const engine = startMockOpencode(mode);
-  const baseUrl = `http://127.0.0.1:${engine.port}`;
-  const directUrl = `${baseUrl}/cloud-mcp/mcp/agent`;
-  const testWorkspace: WorkspaceInfo = {
-    id: `ws_${mode}`,
-    name: `Workspace ${mode}`,
-    path: root,
-    preset: "starter",
-    workspaceType: "local",
-    baseUrl,
-  };
-  const config = serverConfig(root, testWorkspace);
+  const baseUrl = `http://127.0.0.1:${engine.server.port}`;
+  const workspaces: WorkspaceInfo[] = [];
+  for (const id of workspaceIds) {
+    const root = await createRoot(`openwork-cloud-health-${id}-`);
+    workspaces.push({
+      id,
+      name: `Workspace ${id}`,
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl,
+    });
+  }
+  const primary = workspaces[0];
+  if (!primary) throw new Error("At least one direct-probe workspace is required");
+  const config = serverConfig(primary.path, primary);
+  config.workspaces = workspaces;
+  config.authorizedRoots = workspaces.map((entry) => entry.path);
   process.env.OPENWORK_RUNTIME_DB = await createRuntimeDbPath("openwork-cloud-health-runtime-");
-  await writeRuntimeOpencodeConfig(config, testWorkspace.id, (current) => ({
-    ...current,
-    mcp: {
-      ...current.mcp,
-      "openwork-cloud": {
-        type: "remote",
-        url: directUrl,
-        enabled: true,
-        headers: { Authorization: "Bearer owt_health_cloud_token" },
-        oauth: false,
+  const directUrl = `${baseUrl}/cloud-mcp/mcp/agent`;
+  const desiredConfig = {
+    type: "remote",
+    url: directUrl,
+    enabled: true,
+    headers: { Authorization: "Bearer owt_health_cloud_token" },
+    oauth: false,
+  };
+  for (const testWorkspace of workspaces) {
+    await writeRuntimeOpencodeConfig(config, testWorkspace.id, (current) => ({
+      ...current,
+      mcp: {
+        ...current.mcp,
+        "openwork-cloud": desiredConfig,
       },
-    },
-  }));
-  options.beforeRead?.(directUrl);
-  const health = await readOpenworkCloudMcpHealth({
-    config,
-    workspace: testWorkspace,
-    directory: root,
-    probe: options.probe,
-    createWorkspaceOpencodeClient: () => createOpencodeClient({ baseUrl }),
+    }));
+  }
+  const read = async (workspaceId = primary.id, providerModel?: { provider: string; model: string }) => {
+    const testWorkspace = workspaces.find((entry) => entry.id === workspaceId);
+    if (!testWorkspace) throw new Error(`Unknown direct-probe workspace ${workspaceId}`);
+    return readOpenworkCloudMcpHealth({
+      config,
+      workspace: testWorkspace,
+      directory: testWorkspace.path,
+      providerModel,
+      probe: true,
+      createWorkspaceOpencodeClient: () => createOpencodeClient({ baseUrl }),
+    });
+  };
+  return { ...engine, config, desiredConfig, directUrl, primary, read, workspaces };
+}
+
+async function readHealthForDirectProbe(mode: DirectProbeMode, options: ReadHealthOptions = {}) {
+  const harness = await setupDirectProbeHarness(mode, [`ws_${mode}`]);
+  options.beforeRead?.(harness.directUrl);
+  const health = options.probe ? await harness.read() : await readOpenworkCloudMcpHealth({
+    config: harness.config,
+    workspace: harness.primary,
+    directory: harness.primary.path,
+    createWorkspaceOpencodeClient: () => createOpencodeClient({ baseUrl: `http://127.0.0.1:${harness.server.port}` }),
   });
-  return { health, directUrl };
+  return { health, directUrl: harness.directUrl };
 }
 
 function watchDirectFetches(directUrl: string, onFetch: () => void): void {
@@ -338,6 +434,147 @@ describe("cloud MCP health foundation", () => {
 
     expect(health.delivery.state).toBe("ready");
     expect(health.delivery.appliedRevision).toBe(health.desired.revision);
+  });
+
+  test("direct Cloud probe budget single-flights blocked concurrent checks but keeps sequential probes fresh", async () => {
+    const harness = await setupDirectProbeHarness("ok");
+    const checkCount = 6;
+    const toolIds = harness.blockToolIds();
+    const initialize = harness.blockInitialize();
+    const checks = Array.from({ length: checkCount }, () => harness.read());
+
+    await toolIds.waitForEntries(checkCount);
+    toolIds.release();
+    await initialize.waitForEntries(1);
+    expect(harness.directOperations).toEqual(["initialize"]);
+    initialize.release();
+
+    const concurrent = await Promise.all(checks);
+    const concurrentOperations = harness.directOperations.length;
+    expect(concurrent.every((health) => health.usable)).toBe(true);
+    expect(concurrentOperations).toBe(3);
+
+    expect((await harness.read()).usable).toBe(true);
+    expect(harness.directOperations).toHaveLength(6);
+    console.info(`cloud-mcp-probe-operation-benchmark concurrent=${checkCount} pre=${checkCount * 3} post=${concurrentOperations} sequential_explicit=3`);
+  });
+
+  test("direct Cloud probe budget evicts an upstream 502 flight and retries the full handshake", async () => {
+    const harness = await setupDirectProbeHarness("bad_gateway");
+
+    const failed = await harness.read();
+    expect(failed.firstFailure).toMatchObject({ code: "cloud_tools_missing", retryable: true });
+    expect(failed.tools.direct.trace?.steps.at(-1)).toMatchObject({ step: "tools_list", ok: false, httpStatus: 502 });
+
+    harness.setMode("ok");
+    const recovered = await harness.read();
+
+    expect(recovered.usable).toBe(true);
+    expect(harness.directOperations).toEqual([
+      "initialize", "notifications/initialized", "tools/list",
+      "initialize", "notifications/initialized", "tools/list",
+    ]);
+  });
+
+  test("direct Cloud probe budget keys flights by workspace and revision without provider or model fragmentation", async () => {
+    const harness = await setupDirectProbeHarness("ok", ["ws_a", "ws_b"]);
+    const workspaceA = harness.workspaces.find((entry) => entry.id === "ws_a");
+    if (!workspaceA) throw new Error("ws_a missing from direct-probe harness");
+
+    const providerToolIds = harness.blockToolIds();
+    const providerInitialize = harness.blockInitialize();
+    const providerChecks = [
+      harness.read("ws_a", { provider: "anthropic", model: "claude" }),
+      harness.read("ws_a", { provider: "openwork", model: "gpt-5" }),
+    ];
+    await providerToolIds.waitForEntries(2);
+    providerToolIds.release();
+    await providerInitialize.waitForEntries(1);
+    expect(harness.directOperations).toEqual(["initialize"]);
+    providerInitialize.release();
+    await Promise.all(providerChecks);
+    expect(harness.directOperations).toHaveLength(3);
+
+    harness.directOperations.length = 0;
+    const workspaceToolIds = harness.blockToolIds();
+    const workspaceInitialize = harness.blockInitialize();
+    const workspaceChecks = [harness.read("ws_a"), harness.read("ws_b")];
+    await workspaceToolIds.waitForEntries(2);
+    workspaceToolIds.release();
+    await workspaceInitialize.waitForEntries(2);
+    expect(harness.directOperations).toEqual(["initialize", "initialize"]);
+    workspaceInitialize.release();
+    await Promise.all(workspaceChecks);
+    expect(harness.directOperations).toHaveLength(6);
+
+    harness.directOperations.length = 0;
+    const authToolIds = harness.blockToolIds();
+    const authInitialize = harness.blockInitialize();
+    const originalAuthCheck = harness.read("ws_a");
+    await authToolIds.waitForEntries(1);
+    authToolIds.release();
+    await authInitialize.waitForEntries(1);
+    const changedConfig = {
+      ...harness.desiredConfig,
+      headers: { Authorization: "Bearer owt_health_cloud_token_changed" },
+    };
+    await writeRuntimeOpencodeConfig(harness.config, workspaceA.id, (current) => ({
+      ...current,
+      mcp: { ...current.mcp, "openwork-cloud": changedConfig },
+    }));
+    const changedAuthToolIds = harness.blockToolIds();
+    const changedAuthCheck = harness.read("ws_a");
+    await changedAuthToolIds.waitForEntries(1);
+    changedAuthToolIds.release();
+    await authInitialize.waitForEntries(2);
+    authInitialize.release();
+    await Promise.all([originalAuthCheck, changedAuthCheck]);
+    expect(harness.directOperations.filter((method) => method === "tools/list")).toHaveLength(2);
+
+    harness.directOperations.length = 0;
+    const orgAMetadata = {
+      token: { present: true, metadata: { organizationId: "org_a" } },
+      org: { id: "org_a" },
+      connectCatalogEnabled: true,
+      updatedAt: Date.now(),
+    };
+    const orgARevision = calculateCloudMcpDesiredRevision(changedConfig, orgAMetadata);
+    cloudMcpDeliveryState.markDesired(workspaceA, workspaceA.path, orgARevision, orgAMetadata);
+    const orgAToolIds = harness.blockToolIds();
+    const orgInitialize = harness.blockInitialize();
+    const orgACheck = harness.read("ws_a");
+    await orgAToolIds.waitForEntries(1);
+    orgAToolIds.release();
+    await orgInitialize.waitForEntries(1);
+    const orgBMetadata = {
+      token: { present: true, metadata: { organizationId: "org_b" } },
+      org: { id: "org_b" },
+      connectCatalogEnabled: true,
+      updatedAt: Date.now(),
+    };
+    const orgBRevision = calculateCloudMcpDesiredRevision(changedConfig, orgBMetadata);
+    cloudMcpDeliveryState.markDesired(workspaceA, workspaceA.path, orgBRevision, orgBMetadata);
+    const orgBToolIds = harness.blockToolIds();
+    const orgBCheck = harness.read("ws_a");
+    await orgBToolIds.waitForEntries(1);
+    orgBToolIds.release();
+    await orgInitialize.waitForEntries(2);
+    orgInitialize.release();
+    await Promise.all([orgACheck, orgBCheck]);
+    expect(harness.directOperations.filter((method) => method === "tools/list")).toHaveLength(2);
+  });
+
+  test("direct Cloud probe budget heals a healthy same-revision delivery state", async () => {
+    const harness = await setupDirectProbeHarness("ok");
+    const first = await harness.read();
+    const revision = first.desired.revision;
+    if (!revision) throw new Error("direct-probe desired revision missing");
+    cloudMcpDeliveryState.markRegistering(harness.primary, harness.primary.path, revision);
+
+    const healed = await harness.read();
+
+    expect(healed.delivery.state).toBe("ready");
+    expect(healed.delivery.appliedRevision).toBe(revision);
   });
 
   test("keeps Cloud usable when only the direct probe transport is unreachable", async () => {

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -395,6 +395,12 @@ type DirectCloudToolsSnapshot = {
   failure?: CloudMcpFailure;
 };
 
+const directCloudToolsProbeFlights = new Map<string, Promise<DirectCloudToolsSnapshot>>();
+
+export function clearOpenworkCloudMcpProbeFlights(): void {
+  directCloudToolsProbeFlights.clear();
+}
+
 type ProviderProjectionSnapshot = {
   checked: boolean;
   provider?: string;
@@ -1355,6 +1361,40 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
   }
 }
 
+function successfulDirectCloudToolsProbe(value: DirectCloudToolsSnapshot): boolean {
+  return value.checked
+    && value.failure === undefined
+    && value.missing.length === 0
+    && value.trace !== undefined
+    && value.trace.steps.length > 0
+    && value.trace.steps.every((step) => step.ok);
+}
+
+async function readDirectCloudToolsSingleFlight(input: {
+  serverConfig: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  desiredConfig: Record<string, unknown>;
+  desiredRevision: string;
+}): Promise<DirectCloudToolsSnapshot> {
+  const key = hashString(JSON.stringify({
+    configPath: input.serverConfig.configPath,
+    serverStartedAt: input.serverConfig.startedAt,
+    workspaceId: input.workspace.id,
+    directory: input.directory,
+    desiredRevision: input.desiredRevision,
+  }));
+  const active = directCloudToolsProbeFlights.get(key);
+  if (active) return active;
+
+  const value = readDirectCloudTools(input.desiredConfig)
+    .finally(() => {
+      if (directCloudToolsProbeFlights.get(key) === value) directCloudToolsProbeFlights.delete(key);
+    });
+  directCloudToolsProbeFlights.set(key, value);
+  return value;
+}
+
 async function readMcpStatus(
   opencode: WorkspaceOpencodeClient,
   directory: string | null,
@@ -1677,6 +1717,8 @@ async function inspectOpenworkCloud(input: {
   workspace: WorkspaceInfo;
   directory: string | null;
   desiredConfig: Record<string, unknown>;
+  desiredRevision: string;
+  directProbeReuse?: DirectProbeReuse;
   providerModel?: CloudMcpProviderModelContext;
   probe: boolean;
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
@@ -1753,7 +1795,19 @@ async function inspectOpenworkCloud(input: {
   const ids = idsResult.data ?? [];
   const experimentalToolIds = experimentalToolIdsFromSplit(splitPresentMissing(ids, expectedTools()));
   const pluginCanaries = splitPresentMissing(ids, expectedCanaries());
-  const directTools = input.probe ? await readDirectCloudTools(input.desiredConfig) : emptyDirectTools;
+  const reusableDirectTools = input.directProbeReuse?.desiredRevision === input.desiredRevision
+    && successfulDirectCloudToolsProbe(input.directProbeReuse.value)
+    ? input.directProbeReuse.value
+    : null;
+  const directTools = input.probe
+    ? reusableDirectTools ?? await readDirectCloudToolsSingleFlight({
+      serverConfig: input.config,
+      workspace: input.workspace,
+      directory: input.directory,
+      desiredConfig: input.desiredConfig,
+      desiredRevision: input.desiredRevision,
+    })
+    : emptyDirectTools;
   if (input.probe) {
     // The engine is authoritative; a probe-only transport failure must stay diagnostic and not veto steering/delivery.
     if (directTools.failure && directTools.failure.code !== "probe_unreachable") {
@@ -1956,7 +2010,7 @@ async function compatibilitySnapshot(input: {
   };
 }
 
-export async function readOpenworkCloudMcpHealth(input: {
+type ReadOpenworkCloudMcpHealthInput = {
   config: ServerConfig;
   workspace: WorkspaceInfo;
   directory: string | null;
@@ -1965,7 +2019,16 @@ export async function readOpenworkCloudMcpHealth(input: {
   probe?: boolean;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
-}): Promise<CloudMcpHealth> {
+};
+
+type DirectProbeReuse = {
+  desiredRevision: string;
+  value: CloudMcpHealth["tools"]["direct"];
+};
+
+async function readOpenworkCloudMcpHealthInternal(
+  input: ReadOpenworkCloudMcpHealthInput & { directProbeReuse?: DirectProbeReuse },
+): Promise<CloudMcpHealth> {
   const checkedAt = new Date().toISOString();
   const startedAtMs = Date.now();
   const desired = await readDesiredState({ config: input.config, workspace: input.workspace, directory: input.directory });
@@ -2021,13 +2084,15 @@ export async function readOpenworkCloudMcpHealth(input: {
     opencodeVersion: { expectedVersion: input.serverMetadata?.expectedOpencodeVersion ?? null, actualVersion: null, probe: "not_checked" },
     failures: [],
   };
-  if (desired.present && desired.config && !desired.validationProblem && input.directory && baseUrlConfigured(input.config, input.workspace)) {
+  if (desired.present && desired.config && desired.revision && !desired.validationProblem && input.directory && baseUrlConfigured(input.config, input.workspace)) {
     inspection = await inspectOpenworkCloud({
       opencode: input.createWorkspaceOpencodeClient(input.config, input.workspace),
       config: input.config,
       workspace: input.workspace,
       directory: input.directory,
       desiredConfig: desired.config,
+      desiredRevision: desired.revision,
+      directProbeReuse: input.directProbeReuse,
       providerModel: input.providerModel,
       probe: input.probe === true,
       refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
@@ -2035,7 +2100,12 @@ export async function readOpenworkCloudMcpHealth(input: {
     failures.push(...inspection.failures);
   }
 
-  if (desired.present && desired.revision && failures.length === 0 && delivery.appliedRevision !== desired.revision) {
+  if (
+    desired.present
+    && desired.revision
+    && failures.length === 0
+    && (delivery.appliedRevision !== desired.revision || delivery.state !== "ready")
+  ) {
     cloudMcpDeliveryState.markDesired(input.workspace, input.directory, desired.revision, desired.metadata);
     cloudMcpDeliveryState.markReady(input.workspace, input.directory, desired.revision);
     delivery = cloudMcpDeliveryState.snapshot(input.workspace, input.directory, desired.revision);
@@ -2107,6 +2177,10 @@ export async function readOpenworkCloudMcpHealth(input: {
     checkedAt,
     durationMs: Date.now() - startedAtMs,
   };
+}
+
+export async function readOpenworkCloudMcpHealth(input: ReadOpenworkCloudMcpHealthInput): Promise<CloudMcpHealth> {
+  return readOpenworkCloudMcpHealthInternal(input);
 }
 
 async function persistDesiredConfig(config: ServerConfig, workspaceId: string, desiredConfig: Record<string, unknown>): Promise<void> {
@@ -2185,6 +2259,12 @@ function healthWithFailure(health: CloudMcpHealth, firstFailure: CloudMcpFailure
   };
 }
 
+function reusableDirectProbeFromHealth(health: CloudMcpHealth): DirectProbeReuse | undefined {
+  return health.desired.revision && successfulDirectCloudToolsProbe(health.tools.direct)
+    ? { desiredRevision: health.desired.revision, value: health.tools.direct }
+    : undefined;
+}
+
 export async function reconcileOpenworkCloudMcp(input: {
   config: ServerConfig;
   workspace: WorkspaceInfo;
@@ -2196,7 +2276,7 @@ export async function reconcileOpenworkCloudMcp(input: {
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<CloudMcpHealth> {
-  const readHealth = () => readOpenworkCloudMcpHealth({
+  const readHealth = (directProbeReuse?: DirectProbeReuse) => readOpenworkCloudMcpHealthInternal({
     config: input.config,
     workspace: input.workspace,
     directory: input.directory,
@@ -2204,6 +2284,7 @@ export async function reconcileOpenworkCloudMcp(input: {
     serverMetadata: input.serverMetadata,
     createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
     probe: true,
+    directProbeReuse,
     refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
   });
   const configBody = input.body.config ?? input.body;
@@ -2281,14 +2362,15 @@ export async function reconcileOpenworkCloudMcp(input: {
   }
 
   const health = await readHealth();
+  const directProbeReuse = reusableDirectProbeFromHealth(health);
 
   if (health.firstFailure) {
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, health.firstFailure);
-    return healthWithFailure(await readHealth(), health.firstFailure);
+    return healthWithFailure(await readHealth(directProbeReuse), health.firstFailure);
   }
 
   cloudMcpDeliveryState.markReady(input.workspace, input.directory, desiredRevision);
-  return readHealth();
+  return readHealth(directProbeReuse);
 }
 
 export async function reconcilePersistedOpenworkCloudMcp(input: {

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES, cloudMcpDeliveryState } from "./cloud-mcp-health.js";
+import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES, clearOpenworkCloudMcpProbeFlights, cloudMcpDeliveryState } from "./cloud-mcp-health.js";
 import {
   CONNECT_MCP_SERVER_INDEX_SCHEMA_VERSION,
   CONNECT_MCP_SERVER_INDEX_URI,
@@ -59,6 +59,7 @@ const cloudConfigsByOpenworkBase = new Map<string, CloudConfig>();
 
 afterEach(async () => {
   cloudMcpDeliveryState.clear();
+  clearOpenworkCloudMcpProbeFlights();
   while (stops.length) await stops.pop()?.();
   while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
   if (process.platform === "win32") {
@@ -355,6 +356,11 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
     expect(mcpPosts.length).toBe(1);
     expectDirectoryQuery(mcpPosts[0]?.search, root);
+    const directProbeMethods = mock.requests
+      .filter((request) => request.pathname.endsWith("/mcp/agent") && isRecord(request.body) && typeof request.body.method === "string")
+      .map((request) => isRecord(request.body) && typeof request.body.method === "string" ? request.body.method : "unknown");
+    expect(directProbeMethods).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+    console.info(`cloud-mcp-reconcile-operation-benchmark pre=6 post=${directProbeMethods.length}`);
   });
 
   test("keeps provider descriptors private while purging stale runtime endpoints", async () => {

--- a/evals/specs/cloud-mcp-health-probe-budget.test.ts
+++ b/evals/specs/cloud-mcp-health-probe-budget.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("direct Cloud MCP health checks stay within a scoped handshake budget", ({ evidence }) => {
+  const budgetResult = spawnSync("pnpm", [
+    "--filter",
+    "openwork-server",
+    "test",
+    "src/cloud-mcp-health.test.ts",
+    "--test-name-pattern",
+    "direct Cloud probe budget",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const budgetOutput = `${budgetResult.stdout}${budgetResult.stderr}`;
+  const reconcileResult = spawnSync("pnpm", [
+    "--filter",
+    "openwork-server",
+    "test",
+    "src/cloud-mcp-reconcile.e2e.test.ts",
+    "--test-name-pattern",
+    "clean ready persists desired config",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const reconcileOutput = `${reconcileResult.stdout}${reconcileResult.stderr}`;
+
+  expect(budgetResult.error, budgetOutput).toBeUndefined();
+  expect(budgetResult.status, budgetOutput).toBe(0);
+  expect(budgetOutput).toContain("4 pass");
+  expect(budgetOutput).toContain("0 fail");
+  expect(budgetOutput).toContain("cloud-mcp-probe-operation-benchmark concurrent=6 pre=18 post=3 sequential_explicit=3");
+  expect(reconcileResult.error, reconcileOutput).toBeUndefined();
+  expect(reconcileResult.status, reconcileOutput).toBe(0);
+  expect(reconcileOutput).toContain("1 pass");
+  expect(reconcileOutput).toContain("0 fail");
+  expect(reconcileOutput).toContain("cloud-mcp-reconcile-operation-benchmark pre=6 post=3");
+
+  evidence.fact(
+    "Only concurrent health checks share a direct handshake",
+    "Six checks are released together through deterministic barriers and reduce the 18-operation protocol baseline to 3; the next settled explicit check performs 3 fresh operations.",
+    true,
+  );
+  evidence.fact(
+    "Successful reconcile does not repeat tools/list",
+    "The focused reconcile witness completes ready and reduces its two direct handshakes from 6 operations to exactly 3 by reusing only its operation-local success.",
+    true,
+  );
+  evidence.fact(
+    "Upstream failures remain retryable",
+    "A tools/list 502 is asserted retryable and the next settled check must perform a complete new initialize, initialized notification, and tools/list handshake.",
+    true,
+  );
+  evidence.fact(
+    "In-flight reuse is correctness-scoped",
+    "Blocked checks require distinct flights across workspaces and Authorization or organization revisions, while provider/model differences share the same direct tools/list flight.",
+    true,
+  );
+  evidence.fact(
+    "Healthy same-revision delivery state heals",
+    "A registering delivery entry with the already-applied revision is required to return to ready after a healthy inspection.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- single-flight concurrent direct cloud MCP health handshakes by workspace and desired revision
- reuse a successful direct probe only within one reconcile invocation
- keep settled explicit probes fresh and evict failed 502 flights immediately

## Incident correlation
- `/mcp/agent` represented 43.9% of API traffic and 55.4% of 502s in the sampled 24h
- each direct health check performs initialize, notifications/initialized, and tools/list
- successful reconcile previously repeated that three-operation handshake

## Benchmarks
- six concurrent checks: 18 protocol operations to 3
- reconcile: 6 protocol operations to 3
- next settled explicit check still performs 3 fresh operations

## Verification
- `pnpm --filter openwork-server typecheck`
- health tests: 19 passed
- reconcile tests: 25 passed
- `infisical run --silent -- env OPENWORK_EVAL_DAYTONA=1 pnpm evals:spec specs/cloud-mcp-health-probe-budget.test.ts` (1 passed, 0 skipped)

## 502 coverage
A tools/list 502 is never retained after settlement; the next check must execute and pass a complete new three-operation handshake.