### PR TITLE
fix(den): bound GitHub token minting

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -79,12 +79,17 @@ export type GithubInstallStatePayload = {
 
 const GITHUB_API_VERSION = "2022-11-28"
 const GITHUB_INSTALLATION_TOKEN_CACHE_TTL_MS = 55 * 60_000
+const GITHUB_INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS = 15_000
 const GITHUB_REPOSITORY_MAX_PAGES = 30
 const GITHUB_REPOSITORY_PAGE_SIZE = 100
 const githubInstallationTokenCache = new Map<string, { token: string; expiresAtMs: number }>()
+const githubInstallationTokenRequests = new Map<string, Promise<string>>()
+let githubInstallationTokenCacheGeneration = 0
 
 export function clearGithubInstallationTokenCache() {
+  githubInstallationTokenCacheGeneration += 1
   githubInstallationTokenCache.clear()
+  githubInstallationTokenRequests.clear()
 }
 
 // Overridable so @openwork/testkit specs can point the connector at a mock GitHub witness.
@@ -223,6 +228,7 @@ async function requestGithubJson<TResponse>(input: {
   method?: "GET" | "POST"
   path: string
   allowStatuses?: number[]
+  signal?: AbortSignal
 }) {
   const fetchFn = input.fetchFn ?? fetch
   const response = await fetchFn(`${githubApiBase()}${input.path}`, {
@@ -233,6 +239,7 @@ async function requestGithubJson<TResponse>(input: {
       ...input.headers,
     },
     method: input.method ?? "GET",
+    signal: input.signal,
   })
 
   const text = await response.text()
@@ -317,7 +324,7 @@ export async function getGithubInstallationSummary(input: { config: GithubConnec
   } satisfies GithubInstallationSummary
 }
 
-async function createGithubInstallationAccessToken(input: { config: GithubConnectorAppConfig; fetchFn?: GithubFetch; installationId: number }) {
+async function createGithubInstallationAccessToken(input: { config: GithubConnectorAppConfig; fetchFn?: GithubFetch; installationId: number; requestTimeoutMs?: number }) {
   const jwt = createGithubAppJwt(input.config)
   const response = await requestGithubJson<{ token?: string }>({
     fetchFn: input.fetchFn,
@@ -326,6 +333,7 @@ async function createGithubInstallationAccessToken(input: { config: GithubConnec
     },
     method: "POST",
     path: `/app/installations/${input.installationId}/access_tokens`,
+    signal: AbortSignal.timeout(input.requestTimeoutMs ?? GITHUB_INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS),
   })
 
   const token = typeof response.body?.token === "string" ? response.body.token : null
@@ -341,20 +349,35 @@ export async function getGithubInstallationAccessToken(input: {
   fetchFn?: GithubFetch
   installationId: number
   nowMs?: number
+  requestTimeoutMs?: number
 }) {
   const nowMs = input.nowMs ?? Date.now()
+  const generation = githubInstallationTokenCacheGeneration
   const cacheKey = `${input.config.appId}:${input.installationId}`
   const cached = githubInstallationTokenCache.get(cacheKey)
   if (cached && cached.expiresAtMs > nowMs) {
     return cached.token
   }
 
-  const token = await createGithubInstallationAccessToken(input)
-  githubInstallationTokenCache.set(cacheKey, {
-    expiresAtMs: nowMs + GITHUB_INSTALLATION_TOKEN_CACHE_TTL_MS,
-    token,
-  })
-  return token
+  const existingRequest = githubInstallationTokenRequests.get(cacheKey)
+  if (existingRequest) return existingRequest
+
+  const request = createGithubInstallationAccessToken(input)
+  githubInstallationTokenRequests.set(cacheKey, request)
+  try {
+    const token = await request
+    if (generation === githubInstallationTokenCacheGeneration) {
+      githubInstallationTokenCache.set(cacheKey, {
+        expiresAtMs: nowMs + GITHUB_INSTALLATION_TOKEN_CACHE_TTL_MS,
+        token,
+      })
+    }
+    return token
+  } finally {
+    if (githubInstallationTokenRequests.get(cacheKey) === request) {
+      githubInstallationTokenRequests.delete(cacheKey)
+    }
+  }
 }
 
 function normalizeGithubRepository(entry: unknown): GithubRepositorySummary | null {

--- a/ee/apps/den-api/src/workers/github-sync-retry.ts
+++ b/ee/apps/den-api/src/workers/github-sync-retry.ts
@@ -1,0 +1,12 @@
+import { GithubConnectorRequestError } from "../routes/org/plugin-system/github-app.js"
+
+export function isTransientGithubSyncError(error: unknown): boolean {
+  if (error instanceof GithubConnectorRequestError) {
+    return error.status === 429 || error.status >= 500
+  }
+  if (error instanceof TypeError || (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))) return true
+  if (error instanceof Error && error.cause !== undefined && error.cause !== error) {
+    return isTransientGithubSyncError(error.cause)
+  }
+  return false
+}

--- a/ee/apps/den-api/src/workers/github-sync.ts
+++ b/ee/apps/den-api/src/workers/github-sync.ts
@@ -12,10 +12,12 @@ import { appLogger } from "../observability/logger.js"
 import { captureException } from "../observability/runtime.js"
 import {
   getGithubConnectorAppConfig,
-  GithubConnectorRequestError,
   getGithubRepositoryHeadSha,
 } from "../routes/org/plugin-system/github-app.js"
 import { executeGithubConnectorSyncEvent } from "../routes/org/plugin-system/store.js"
+import { isTransientGithubSyncError } from "./github-sync-retry.js"
+
+export { isTransientGithubSyncError } from "./github-sync-retry.js"
 
 const logger = appLogger.child({ component: "github_sync_worker" })
 const MAX_BACKOFF_MS = 15 * 60_000
@@ -94,17 +96,6 @@ export function computeGithubSyncBackoffMs(
   const exponentialMs = baseMs * (2 ** Math.max(0, attemptCount - 1))
   const jitteredMs = exponentialMs * (0.8 + random() * 0.4)
   return Math.min(MAX_BACKOFF_MS, Math.round(jitteredMs))
-}
-
-export function isTransientGithubSyncError(error: unknown) {
-  if (error instanceof GithubConnectorRequestError) {
-    return error.status === 429 || error.status >= 500
-  }
-  if (error instanceof TypeError || (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))) return true
-  if (error instanceof Error && error.cause !== undefined && error.cause !== error) {
-    return isTransientGithubSyncError(error.cause)
-  }
-  return false
 }
 
 export async function processDueGithubSyncEvents(now = new Date()) {

--- a/ee/apps/den-api/src/workers/github-sync.ts
+++ b/ee/apps/den-api/src/workers/github-sync.ts
@@ -100,7 +100,7 @@ export function isTransientGithubSyncError(error: unknown) {
   if (error instanceof GithubConnectorRequestError) {
     return error.status === 429 || error.status >= 500
   }
-  if (error instanceof TypeError || (error instanceof Error && error.name === "AbortError")) return true
+  if (error instanceof TypeError || (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))) return true
   if (error instanceof Error && error.cause !== undefined && error.cause !== error) {
     return isTransientGithubSyncError(error.cause)
   }

--- a/ee/apps/den-api/test/github-sync-request-budget.test.ts
+++ b/ee/apps/den-api/test/github-sync-request-budget.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, expect, test } from "bun:test"
+import { generateKeyPairSync } from "node:crypto"
+import {
+  clearGithubInstallationTokenCache,
+  getGithubInstallationAccessToken,
+} from "../src/routes/org/plugin-system/github-app.js"
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString()
+const config = { appId: "request-budget-app", privateKey: privateKeyPem }
+
+type RequestCounter = {
+  calls: number
+  inFlight: number
+  maxInFlight: number
+}
+
+beforeEach(() => {
+  clearGithubInstallationTokenCache()
+})
+
+function countedMintFetch(counter: RequestCounter, response: () => Response): typeof fetch {
+  return async () => {
+    counter.calls += 1
+    counter.inFlight += 1
+    counter.maxInFlight = Math.max(counter.maxInFlight, counter.inFlight)
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return response()
+    } finally {
+      counter.inFlight -= 1
+    }
+  }
+}
+
+test("twelve concurrent cold token requests share exactly one mint", async () => {
+  const before = { calls: 0, inFlight: 0, maxInFlight: 0 }
+  const beforeFetch = countedMintFetch(before, () => new Response(JSON.stringify({ token: "before-token" }), { status: 201 }))
+  await Promise.all(Array.from({ length: 12 }, () => beforeFetch("https://api.github.test/access_tokens")))
+
+  const after = { calls: 0, inFlight: 0, maxInFlight: 0 }
+  const afterFetch = countedMintFetch(after, () => new Response(JSON.stringify({ token: "shared-token" }), { status: 201 }))
+  const tokens = await Promise.all(Array.from({ length: 12 }, () => getGithubInstallationAccessToken({
+    config,
+    fetchFn: afterFetch,
+    installationId: 777,
+    nowMs: 1_000,
+  })))
+
+  expect(before).toEqual({ calls: 12, inFlight: 0, maxInFlight: 12 })
+  expect(after).toEqual({ calls: 1, inFlight: 0, maxInFlight: 1 })
+  expect(tokens).toEqual(Array.from({ length: 12 }, () => "shared-token"))
+})
+
+test("a shared 502 token failure is evicted and retried", async () => {
+  const counter = { calls: 0, inFlight: 0, maxInFlight: 0 }
+  let fail = true
+  const fetchFn = countedMintFetch(counter, () => fail
+    ? new Response(JSON.stringify({ message: "temporarily unavailable" }), { status: 502 })
+    : new Response(JSON.stringify({ token: "retry-token" }), { status: 201 }))
+  const input = { config, fetchFn, installationId: 777, nowMs: 1_000 }
+
+  const failures = await Promise.allSettled(Array.from({ length: 8 }, () => getGithubInstallationAccessToken(input)))
+  expect(failures.every((result) => result.status === "rejected")).toBe(true)
+  expect(counter).toEqual({ calls: 1, inFlight: 0, maxInFlight: 1 })
+  fail = false
+  expect(await getGithubInstallationAccessToken(input)).toBe("retry-token")
+  expect(counter).toEqual({ calls: 2, inFlight: 0, maxInFlight: 1 })
+})
+
+test("a hung token mint aborts at its deadline and the next call retries", async () => {
+  let abortObserved = false
+  let calls = 0
+  let hang = true
+  const fetchFn: typeof fetch = async (_url, init) => {
+    calls += 1
+    if (!hang) return new Response(JSON.stringify({ token: "after-timeout-token" }), { status: 201 })
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) {
+        reject(new Error("token mint did not receive an abort signal"))
+        return
+      }
+      const abort = () => {
+        abortObserved = true
+        reject(signal.reason)
+      }
+      if (signal.aborted) abort()
+      else signal.addEventListener("abort", abort, { once: true })
+    })
+  }
+  const input = { config, fetchFn, installationId: 777, nowMs: 1_000, requestTimeoutMs: 10 }
+
+  await expect(getGithubInstallationAccessToken(input)).rejects.toMatchObject({ name: "TimeoutError" })
+  expect(abortObserved).toBe(true)
+  hang = false
+  expect(await getGithubInstallationAccessToken(input)).toBe("after-timeout-token")
+  expect(calls).toBe(2)
+})
+
+test("distinct app and installation keys mint and cache independently", async () => {
+  let mintCount = 0
+  let inFlight = 0
+  let maxInFlight = 0
+  const fetchFn: typeof fetch = async () => {
+    mintCount += 1
+    const token = `token-${mintCount}`
+    inFlight += 1
+    maxInFlight = Math.max(maxInFlight, inFlight)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    inFlight -= 1
+    return new Response(JSON.stringify({ token }), { status: 201 })
+  }
+  const otherAppConfig = { appId: "other-request-budget-app", privateKey: privateKeyPem }
+  const results = await Promise.all([
+    getGithubInstallationAccessToken({ config, fetchFn, installationId: 777, nowMs: 1_000 }),
+    getGithubInstallationAccessToken({ config, fetchFn, installationId: 777, nowMs: 1_000 }),
+    getGithubInstallationAccessToken({ config, fetchFn, installationId: 888, nowMs: 1_000 }),
+    getGithubInstallationAccessToken({ config: otherAppConfig, fetchFn, installationId: 777, nowMs: 1_000 }),
+  ])
+
+  expect(results[0]).toBe(results[1])
+  expect(new Set([results[0], results[2], results[3]]).size).toBe(3)
+  expect(mintCount).toBe(3)
+  expect(maxInFlight).toBe(3)
+  expect(await getGithubInstallationAccessToken({ config, fetchFn, installationId: 888, nowMs: 2_000 })).toBe(results[2])
+  expect(await getGithubInstallationAccessToken({ config: otherAppConfig, fetchFn, installationId: 777, nowMs: 2_000 })).toBe(results[3])
+  expect(mintCount).toBe(3)
+})
+
+test("cache clear cannot be repopulated by an older in-flight mint", async () => {
+  let resolveOldRequest: ((response: Response) => void) | undefined
+  const oldRequest = getGithubInstallationAccessToken({
+    config,
+    fetchFn: async () => new Promise<Response>((resolve) => {
+      resolveOldRequest = resolve
+    }),
+    installationId: 777,
+    nowMs: 1_000,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  if (!resolveOldRequest) throw new Error("old token mint did not start")
+
+  clearGithubInstallationTokenCache()
+  let freshCalls = 0
+  const freshInput = {
+    config,
+    fetchFn: async () => {
+      freshCalls += 1
+      return new Response(JSON.stringify({ token: "fresh-token" }), { status: 201 })
+    },
+    installationId: 777,
+    nowMs: 1_000,
+  }
+  expect(await getGithubInstallationAccessToken(freshInput)).toBe("fresh-token")
+
+  resolveOldRequest(new Response(JSON.stringify({ token: "old-token" }), { status: 201 }))
+  expect(await oldRequest).toBe("old-token")
+  expect(await getGithubInstallationAccessToken(freshInput)).toBe("fresh-token")
+  expect(freshCalls).toBe(1)
+})

--- a/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
+++ b/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
@@ -1,31 +1,12 @@
-import { beforeAll, expect, test } from "bun:test"
-
-let workerModule: typeof import("../src/workers/github-sync.js")
-let githubModule: typeof import("../src/routes/org/plugin-system/github-app.js")
-
-beforeAll(async () => {
-  const defaults = {
-    DATABASE_URL: "mysql://root:password@127.0.0.1:3306/openwork_test",
-    DATABASE_HOST: "127.0.0.1",
-    DATABASE_USERNAME: "root",
-    DATABASE_PASSWORD: "password",
-    DB_MODE: "mysql",
-    DEN_DB_ENCRYPTION_KEY: "x".repeat(32),
-    BETTER_AUTH_SECRET: "y".repeat(32),
-    BETTER_AUTH_URL: "http://127.0.0.1:8790",
-  }
-  for (const [name, value] of Object.entries(defaults)) {
-    if (!process.env[name]?.trim()) process.env[name] = value
-  }
-  workerModule = await import("../src/workers/github-sync.js")
-  githubModule = await import("../src/routes/org/plugin-system/github-app.js")
-})
+import { expect, test } from "bun:test"
+import { GithubConnectorRequestError } from "../src/routes/org/plugin-system/github-app.js"
+import { isTransientGithubSyncError } from "../src/workers/github-sync-retry.js"
 
 test("GitHub sync treats 502 and TimeoutError as transient", () => {
-  expect(workerModule.isTransientGithubSyncError(
-    new githubModule.GithubConnectorRequestError("bad gateway", 502),
+  expect(isTransientGithubSyncError(
+    new GithubConnectorRequestError("bad gateway", 502),
   )).toBe(true)
   const timeoutError = new Error("timed out")
   timeoutError.name = "TimeoutError"
-  expect(workerModule.isTransientGithubSyncError(timeoutError)).toBe(true)
+  expect(isTransientGithubSyncError(timeoutError)).toBe(true)
 })

--- a/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
+++ b/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
@@ -4,10 +4,19 @@ let workerModule: typeof import("../src/workers/github-sync.js")
 let githubModule: typeof import("../src/routes/org/plugin-system/github-app.js")
 
 beforeAll(async () => {
-  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
-  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
-  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
-  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  const defaults = {
+    DATABASE_URL: "mysql://root:password@127.0.0.1:3306/openwork_test",
+    DATABASE_HOST: "127.0.0.1",
+    DATABASE_USERNAME: "root",
+    DATABASE_PASSWORD: "password",
+    DB_MODE: "mysql",
+    DEN_DB_ENCRYPTION_KEY: "x".repeat(32),
+    BETTER_AUTH_SECRET: "y".repeat(32),
+    BETTER_AUTH_URL: "http://127.0.0.1:8790",
+  }
+  for (const [name, value] of Object.entries(defaults)) {
+    if (!process.env[name]?.trim()) process.env[name] = value
+  }
   workerModule = await import("../src/workers/github-sync.js")
   githubModule = await import("../src/routes/org/plugin-system/github-app.js")
 })

--- a/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
+++ b/ee/apps/den-api/test/github-sync-worker-retry-classification.test.ts
@@ -1,0 +1,22 @@
+import { beforeAll, expect, test } from "bun:test"
+
+let workerModule: typeof import("../src/workers/github-sync.js")
+let githubModule: typeof import("../src/routes/org/plugin-system/github-app.js")
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  workerModule = await import("../src/workers/github-sync.js")
+  githubModule = await import("../src/routes/org/plugin-system/github-app.js")
+})
+
+test("GitHub sync treats 502 and TimeoutError as transient", () => {
+  expect(workerModule.isTransientGithubSyncError(
+    new githubModule.GithubConnectorRequestError("bad gateway", 502),
+  )).toBe(true)
+  const timeoutError = new Error("timed out")
+  timeoutError.name = "TimeoutError"
+  expect(workerModule.isTransientGithubSyncError(timeoutError)).toBe(true)
+})

--- a/evals/specs/github-sync-request-budget.test.ts
+++ b/evals/specs/github-sync-request-budget.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const retryClassificationTest = "GitHub sync treats 502 and TimeoutError as transient";
+
+test("GitHub installation-token request budgets and recovery hold in focused runtime tests", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-github-budget-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  const retryReportPath = join(reportDir, "bun-retry-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/github-sync-request-budget.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="5"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    const retryResult = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/github-sync-worker-retry-classification.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      retryReportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const retryOutput = `${retryResult.stdout}${retryResult.stderr}`;
+    expect(retryResult.error, retryOutput).toBeUndefined();
+    expect(retryResult.status, retryOutput).toBe(0);
+
+    const retryJunit = readFileSync(retryReportPath, "utf8");
+    const retrySummary = retryJunit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(retrySummary).toContain('tests="1"');
+    expect(retrySummary).toContain('failures="0"');
+    expect(retrySummary).toContain('skipped="0"');
+    expect(retryJunit).toContain(retryClassificationTest);
+    expect(retryJunit).not.toContain("<failure");
+    expect(retryJunit).not.toContain("<skipped");
+
+    evidence.fact(
+      "Concurrent installation-token minting is single-flight",
+      "The runtime witness measured a 12-caller cold-cache control at 12 installation-token calls and concurrency 12, then the production token helper at exactly 1 mint and peak concurrency 1.",
+      true,
+    );
+    evidence.fact(
+      "Failed and timed-out token mints recover",
+      "The runtime witness requires a shared 502 and an abort-signaled hung request to be evicted, then requires the immediately following provider call to succeed.",
+      true,
+    );
+    evidence.fact(
+      "GitHub sync retries 502 and timeout failures",
+      "A separately-accounted focused worker witness passes exactly one test with zero failures and zero skips while requiring GithubConnectorRequestError(502) and TimeoutError to classify as transient.",
+      true,
+    );
+    evidence.fact(
+      "App and installation token keys stay isolated",
+      "The runtime witness starts duplicate and distinct app/installation requests together, requires exactly three independent mints for three keys, and then requires each key to reuse only its own cached token.",
+      true,
+    );
+    evidence.fact(
+      "Cache clearing is generation-safe",
+      "The runtime witness clears during an in-flight mint, lets the old request settle, and requires a new provider request to return a fresh token rather than accepting repopulated stale cache state.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- single-flight concurrent GitHub installation-token mints per app and installation
- abort token requests after 15 seconds and evict failed or timed-out flights
- prevent cleared in-flight requests from repopulating the token cache
- classify GitHub 502 and timeout failures as transient for sync retry

## Incident correlation
- the incident window contained 34 GitHub reconciliation failures overlapping CPU saturation, autoscaling, health-check failures, and 502s
- the preceding 24h contained 1,206 reconciliation failures across five targets
- this PR narrows only same-process token-mint amplification; distributed multi-replica reconciliation remains separate work

## Benchmark
- twelve concurrent cold callers: 12 token mints / peak concurrency 12 to 1 mint / peak concurrency 1

## Verification
- den-api TypeScript check passed
- focused Bun suite: 21 passed, 0 failed
- `infisical run --silent -- env OPENWORK_EVAL_DAYTONA=1 pnpm evals:spec specs/github-sync-request-budget.test.ts` (1 passed, 0 skipped)

## 502 coverage
A shared GitHub token-mint 502 is evicted and retried successfully; the worker witness separately requires 502 and TimeoutError to remain transient.