### PR TITLE
fix(ci): prepare npm package from recovery tags

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1132,7 +1132,7 @@ jobs:
 
       - name: Prepare openwork-server
         if: steps.npm-versions.outputs.publish_server == 'true'
-        run: pnpm --filter openwork-server prepare:npm
+        run: pnpm --filter openwork-server publish:npm --dry-run
 
       - name: Upload npm package
         if: steps.npm-versions.outputs.publish_server == 'true'


### PR DESCRIPTION
## Summary
- prepare the npm artifact through the release tag’s existing `publish:npm` script in hardcoded dry-run mode
- keep package preparation uncredentialed and the OIDC-enabled publish job isolated

## Why
Recovery run [32227060484](https://github.com/different-ai/openwork/actions/runs/32227060484) checked out `v0.18.32`, which predates the new `prepare:npm` package script, and failed with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`.

## Verification
- exact `v0.18.32` tag: `pnpm --filter openwork-server publish:npm --dry-run`
- exact `v0.18.32` tag: `npm pack --dry-run --json apps/server/dist/npm` produced `openwork-server@0.18.32` with four files
- `node --test scripts/release/*.test.mjs` passed 27/27
- `git diff --check`