### PR TITLE
fix(desktop): recover rejected automation credentials

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -83,6 +83,9 @@ declare global {
         command: C,
         ...args: DesktopCommandArgs<C>
       ) => Promise<DesktopCommandResult<C>>;
+      automationRunner?: {
+        onCredentialRejected?: (callback: () => void) => () => void;
+      };
       shell?: {
         openExternal?: (url: string) => Promise<{ ok: boolean; error?: string } | void>;
         relaunch?: () => Promise<void>;

--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -6,6 +6,7 @@ import { createDenClient, DenApiError, readDenSettings } from "@/app/lib/den"
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events"
 import { isDesktopRuntime } from "@/app/utils"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { createAutomationRunnerConnectCoordinator } from "./automation-runner-connect-coordinator"
 
 const RUNNER_TOKEN_REFRESH_MS = 5 * 60_000
 const RUNNER_ID_KEY = "openwork.automations.desktop-runner-id"
@@ -29,78 +30,78 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
 
   useEffect(() => {
     if (!isDesktopRuntime() || !window.__OPENWORK_ELECTRON__?.invokeDesktop) return
-    let disposed = false
-    let timer: ReturnType<typeof setTimeout> | undefined
 
     const disconnect = () => window.__OPENWORK_ELECTRON__?.invokeDesktop?.("automationRunnerConfigure", null)
       .catch(() => undefined)
-    const connect = async () => {
-      if (timer) {
-        clearTimeout(timer)
-        timer = undefined
-      }
-      if (disposed || !enabled || status !== "signed_in") {
-        await disconnect()
-        return
-      }
-      const settings = readDenSettings()
-      const authToken = settings.authToken?.trim() ?? ""
-      const organizationId = settings.activeOrgId?.trim() ?? ""
-      if (!authToken || !organizationId) {
-        await disconnect()
-        return
-      }
-      try {
-        const client = createDenClient({ baseUrl: settings.baseUrl, token: authToken })
-        let runnerId = desktopRunnerId()
-        const build = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("appBuildInfo")
-        const agent = navigator.userAgent
-        const platform = /Mac/i.test(agent) ? "darwin" : /Win/i.test(agent) ? "win32" : "linux"
-        let runner: Awaited<ReturnType<typeof client.mintAutomationRunnerToken>>
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: RUNNER_TOKEN_REFRESH_MS,
+      connect: async (isCurrent) => {
+        if (!enabled || status !== "signed_in") {
+          await disconnect()
+          return
+        }
+        const settings = readDenSettings()
+        const authToken = settings.authToken?.trim() ?? ""
+        const organizationId = settings.activeOrgId?.trim() ?? ""
+        if (!authToken || !organizationId) {
+          await disconnect()
+          return
+        }
         try {
-          runner = await client.mintAutomationRunnerToken(organizationId, {
+          const client = createDenClient({ baseUrl: settings.baseUrl, token: authToken })
+          let runnerId = desktopRunnerId()
+          const build = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("appBuildInfo")
+          if (!isCurrent()) return
+          const agent = navigator.userAgent
+          const platform = /Mac/i.test(agent) ? "darwin" : /Win/i.test(agent) ? "win32" : "linux"
+          let runner: Awaited<ReturnType<typeof client.mintAutomationRunnerToken>>
+          try {
+            runner = await client.mintAutomationRunnerToken(organizationId, {
+              runnerId,
+              protocolVersion: 1,
+              supportedExecutionTargets: ["desktop"],
+              capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+              appVersion: String(build?.version ?? "unknown"),
+              platform,
+              concurrency: 1,
+            })
+          } catch (error) {
+            if (!(error instanceof DenApiError) || error.status !== 409 || error.code !== "automation_runner_identity_conflict") {
+              throw error
+            }
+            if (!isCurrent()) return
+            runnerId = resetDesktopRunnerId()
+            runner = await client.mintAutomationRunnerToken(organizationId, {
+              runnerId,
+              protocolVersion: 1,
+              supportedExecutionTargets: ["desktop"],
+              capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+              appVersion: String(build?.version ?? "unknown"),
+              platform,
+              concurrency: 1,
+            })
+          }
+          if (!isCurrent()) return
+          await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("automationRunnerConfigure", {
+            baseUrl: client.baseUrls.apiBaseUrl,
+            token: runner.token,
             runnerId,
-            protocolVersion: 1,
-            supportedExecutionTargets: ["desktop"],
-            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-            appVersion: String(build?.version ?? "unknown"),
-            platform,
-            concurrency: 1,
           })
         } catch (error) {
-          if (!(error instanceof DenApiError) || error.status !== 409 || error.code !== "automation_runner_identity_conflict") {
-            throw error
-          }
-          runnerId = resetDesktopRunnerId()
-          runner = await client.mintAutomationRunnerToken(organizationId, {
-            runnerId,
-            protocolVersion: 1,
-            supportedExecutionTargets: ["desktop"],
-            capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-            appVersion: String(build?.version ?? "unknown"),
-            platform,
-            concurrency: 1,
-          })
+          if (isCurrent()) console.warn("[automation-runner] registration failed", error)
         }
-        if (disposed) return
-        await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("automationRunnerConfigure", {
-          baseUrl: client.baseUrls.apiBaseUrl,
-          token: runner.token,
-          runnerId,
-        })
-      } catch (error) {
-        console.warn("[automation-runner] registration failed", error)
-      } finally {
-        if (!disposed) timer = setTimeout(() => void connect(), RUNNER_TOKEN_REFRESH_MS)
-      }
-    }
+      },
+    })
 
-    const handleSettingsChanged = () => void connect()
+    const requestConnect = () => void coordinator.request().catch(() => undefined)
+    const handleSettingsChanged = () => requestConnect()
     window.addEventListener(denSettingsChangedEvent, handleSettingsChanged)
-    void connect()
+    const unsubscribeCredentialRejected = window.__OPENWORK_ELECTRON__.automationRunner
+      ?.onCredentialRejected?.(() => coordinator.credentialRejected())
+    requestConnect()
     return () => {
-      disposed = true
-      if (timer) clearTimeout(timer)
+      coordinator.dispose()
+      unsubscribeCredentialRejected?.()
       window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged)
       void disconnect()
     }

--- a/apps/app/src/react-app/domains/automations/automation-runner-connect-coordinator.ts
+++ b/apps/app/src/react-app/domains/automations/automation-runner-connect-coordinator.ts
@@ -1,0 +1,82 @@
+type Schedule = (callback: () => void, delayMs: number) => () => void
+
+type AutomationRunnerConnectCoordinatorOptions = {
+  connect: (isCurrent: () => boolean) => Promise<void>
+  refreshMs: number
+  schedule?: Schedule
+}
+
+function defaultSchedule(callback: () => void, delayMs: number) {
+  const timer = setTimeout(callback, delayMs)
+  return () => clearTimeout(timer)
+}
+
+export function createAutomationRunnerConnectCoordinator(
+  options: AutomationRunnerConnectCoordinatorOptions,
+) {
+  let disposed = false
+  let revision = 0
+  let running: Promise<void> | undefined
+  let cancelRefresh: (() => void) | undefined
+  let rejectionAttempt = 0
+  const schedule = options.schedule ?? defaultSchedule
+
+  const clearRefresh = () => {
+    cancelRefresh?.()
+    cancelRefresh = undefined
+  }
+
+  const request = (resetRejections = true) => {
+    if (disposed) return Promise.resolve()
+    clearRefresh()
+    if (resetRejections) rejectionAttempt = 0
+    revision += 1
+    if (running) return running
+    const drain = async () => {
+      while (!disposed) {
+        const connectRevision = revision
+        await options.connect(() => !disposed && revision === connectRevision)
+        if (connectRevision === revision) return
+      }
+    }
+    const task = drain()
+    running = task
+    const settle = () => {
+      if (running !== task) return
+      running = undefined
+      if (!disposed && !cancelRefresh) {
+        cancelRefresh = schedule(() => {
+          cancelRefresh = undefined
+          void request().catch(() => undefined)
+        }, options.refreshMs)
+      }
+    }
+    void task.then(settle, settle)
+    return task
+  }
+
+  return {
+    request: () => request(),
+    credentialRejected() {
+      if (disposed) return
+      clearRefresh()
+      const delayMs = rejectionAttempt === 0
+        ? 0
+        : Math.min(30_000, 500 * (2 ** (rejectionAttempt - 1)))
+      rejectionAttempt += 1
+      if (delayMs === 0) {
+        void request(false).catch(() => undefined)
+        return
+      }
+      cancelRefresh = schedule(() => {
+        cancelRefresh = undefined
+        void request(false).catch(() => undefined)
+      }, delayMs)
+    },
+    dispose() {
+      disposed = true
+      revision += 1
+      clearRefresh()
+    },
+  }
+}

--- a/apps/app/tests/automation-availability.test.ts
+++ b/apps/app/tests/automation-availability.test.ts
@@ -39,6 +39,16 @@ describe("Automations availability", () => {
     expect(bridge).toContain("!enabled || status !== \"signed_in\"")
     expect(bridge).toContain("[enabled, status]")
     expect(bridge).toContain('automationRunnerConfigure", null')
+    expect(bridge).toContain("onCredentialRejected?.(() => coordinator.credentialRejected())")
+  })
+
+  test("credential rejection crosses only the Automation runner Electron bridge", () => {
+    const main = read("../desktop/electron/main.mjs")
+    const preload = read("../desktop/electron/preload.mjs")
+    expect(main).toContain('"openwork:automation-runner:credential-rejected"')
+    expect(main).toContain("onCredentialRejected: () =>")
+    expect(preload).toContain("onCredentialRejected(callback)")
+    expect(preload).toContain("ipcRenderer.on(AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT, handler)")
   })
 
   test("the in-chat proposal tool only blocks on sign-in", () => {

--- a/apps/app/tests/automation-runner-connect-coordinator.test.ts
+++ b/apps/app/tests/automation-runner-connect-coordinator.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test"
+
+import { createAutomationRunnerConnectCoordinator } from "../src/react-app/domains/automations/automation-runner-connect-coordinator"
+
+function deferred() {
+  let resolve = () => {}
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
+function scheduler() {
+  const entries: Array<{ active: boolean; callback: () => void; delayMs: number }> = []
+  return {
+    entries,
+    schedule(callback: () => void, delayMs: number) {
+      const entry = { active: true, callback, delayMs }
+      entries.push(entry)
+      return () => { entry.active = false }
+    },
+    activeCount() {
+      return entries.filter((entry) => entry.active).length
+    },
+    fireActive() {
+      const entry = entries.find((candidate) => candidate.active)
+      if (!entry) throw new Error("no scheduled refresh")
+      entry.active = false
+      entry.callback()
+    },
+  }
+}
+
+describe("Automation runner connect lifecycle", () => {
+  test("a rejection request remints immediately without duplicating the refresh timer", async () => {
+    const timers = scheduler()
+    let connects = 0
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: 300_000,
+      schedule: timers.schedule,
+      connect: async () => { connects += 1 },
+    })
+
+    await coordinator.request()
+    await Promise.resolve()
+    expect(connects).toBe(1)
+    expect(timers.activeCount()).toBe(1)
+
+    await coordinator.request()
+    await Promise.resolve()
+    expect(connects).toBe(2)
+    expect(timers.activeCount()).toBe(1)
+    coordinator.dispose()
+    expect(timers.activeCount()).toBe(0)
+  })
+
+  test("a failed immediate remint leaves one periodic retry", async () => {
+    const timers = scheduler()
+    const configured: number[] = []
+    let connects = 0
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: 300_000,
+      schedule: timers.schedule,
+      connect: async () => {
+        connects += 1
+        if (connects === 2) throw new Error("mint failed")
+        configured.push(connects)
+      },
+    })
+
+    await coordinator.request()
+    await expect(coordinator.request()).rejects.toThrow("mint failed")
+    await Promise.resolve()
+    expect(configured).toEqual([1])
+    expect(timers.activeCount()).toBe(1)
+
+    timers.fireActive()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(configured).toEqual([1, 3])
+    expect(timers.activeCount()).toBe(1)
+    coordinator.dispose()
+  })
+
+  test("connects never overlap and an older mint cannot configure over newer settings", async () => {
+    const timers = scheduler()
+    const firstMint = deferred()
+    const configured: number[] = []
+    let attempts = 0
+    let active = 0
+    let maximumActive = 0
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: 300_000,
+      schedule: timers.schedule,
+      connect: async (isCurrent) => {
+        attempts += 1
+        const attempt = attempts
+        active += 1
+        maximumActive = Math.max(maximumActive, active)
+        if (attempt === 1) await firstMint.promise
+        if (isCurrent()) configured.push(attempt)
+        active -= 1
+      },
+    })
+
+    const first = coordinator.request()
+    await Promise.resolve()
+    const latest = coordinator.request()
+    expect(attempts).toBe(1)
+    expect(active).toBe(1)
+    firstMint.resolve()
+    await Promise.all([first, latest])
+    await Promise.resolve()
+
+    expect(attempts).toBe(2)
+    expect(maximumActive).toBe(1)
+    expect(configured).toEqual([2])
+    expect(timers.activeCount()).toBe(1)
+    coordinator.dispose()
+  })
+
+  test("repeated fresh credential rejections use capped remint backoff", async () => {
+    const timers = scheduler()
+    let connects = 0
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: 300_000,
+      schedule: timers.schedule,
+      connect: async () => { connects += 1 },
+    })
+
+    await coordinator.request()
+    coordinator.credentialRejected()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(connects).toBe(2)
+
+    coordinator.credentialRejected()
+    expect(connects).toBe(2)
+    expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(500)
+    timers.fireActive()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(connects).toBe(3)
+
+    coordinator.credentialRejected()
+    expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(1_000)
+    coordinator.dispose()
+  })
+
+  test("a settling mint cannot add a refresh timer beside a rejection retry", async () => {
+    const timers = scheduler()
+    const secondMint = deferred()
+    let connects = 0
+    const coordinator = createAutomationRunnerConnectCoordinator({
+      refreshMs: 300_000,
+      schedule: timers.schedule,
+      connect: async () => {
+        connects += 1
+        if (connects === 2) await secondMint.promise
+      },
+    })
+
+    await coordinator.request()
+    coordinator.credentialRejected()
+    await Promise.resolve()
+    expect(connects).toBe(2)
+    coordinator.credentialRejected()
+    expect(timers.entries.filter((entry) => entry.active).map((entry) => entry.delayMs)).toEqual([500])
+
+    secondMint.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(timers.entries.filter((entry) => entry.active).map((entry) => entry.delayMs)).toEqual([500])
+    coordinator.dispose()
+  })
+})

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -28,7 +28,10 @@ export function classifyAutomationExecutionError(error) {
 
 function sleep(ms, signal) {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms)
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort)
+      resolve()
+    }, ms)
     const abort = () => {
       clearTimeout(timer)
       reject(signal.reason instanceof Error ? signal.reason : new Error("Automation run cancelled"))
@@ -178,10 +181,13 @@ function runnerTokenBinding(token) {
     const [payload, signature, extra] = String(token).split(".")
     if (!payload || !signature || extra) return null
     const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
-    if (decoded?.v === 1) return { version: 1, audience: null }
+    const scope = [decoded?.o, decoded?.m, decoded?.r].every((value) => typeof value === "string")
+      ? `${decoded.o}\n${decoded.m}\n${decoded.r}`
+      : null
+    if (decoded?.v === 1) return { version: 1, audience: null, scope }
     if (decoded?.v !== 2 || typeof decoded.a !== "string") return null
     const audience = normalizeRunnerBaseUrl(decoded.a)
-    return audience ? { version: 2, audience } : null
+    return audience ? { version: 2, audience, scope } : null
   } catch {
     return null
   }
@@ -194,46 +200,107 @@ export function runnerTokenAudience(token) {
 export function createDesktopAutomationRunner(options) {
   const fetchImpl = options.fetchImpl ?? fetch
   const random = options.random ?? Math.random
-  const waitBeforeReconnect = options.waitBeforeReconnect ?? ((ms) => sleep(ms, new AbortController().signal))
+  const waitBeforeReconnect = options.waitBeforeReconnect ?? sleep
   const legacyBaseUrls = new Set((options.legacyBaseUrls ?? [])
     .map((value) => normalizeRunnerBaseUrl(value))
     .filter(Boolean))
-  let configuration = null
-  let connectionController = null
   let generation = 0
-  let lastEventId = 0
-  let reconcilePromise = null
-  let active = null
+  let current = null
+  let pendingConfiguration = null
+  let rejectedCursor = null
   let stopped = false
+  const rejectedCredentials = new Set()
 
-  const runnerRequest = (requestPath, request = {}) => requestJson(
-    fetchImpl,
-    configuration.baseUrl,
-    configuration.token,
-    requestPath,
-    request,
-  )
+  const credentialKey = (configuration) => `${configuration.baseUrl}\n${configuration.token}`
+  const isCurrent = (state) => !stopped
+    && current === state
+    && current.generation === state.generation
+    && !state.retired
+  const retire = (state, reason) => {
+    if (state.retired) return
+    state.retired = true
+    state.controller.abort(reason)
+    state.active?.controller.abort(reason)
+    if (current === state) current = null
+  }
 
-  const heartbeat = async () => {
-    if (!active) return
+  const rejectCredential = (state, status) => {
+    if (state.credentialRejected) return
+    state.credentialRejected = true
+    const key = credentialKey(state.configuration)
+    rejectedCredentials.add(key)
+    const affectedCurrent = current === state || (current && credentialKey(current.configuration) === key)
+      ? current
+      : null
+    if (affectedCurrent) {
+      const affectedBinding = runnerTokenBinding(affectedCurrent.configuration.token)
+      rejectedCursor = affectedBinding?.scope
+        ? {
+            baseUrl: affectedCurrent.configuration.baseUrl,
+            scope: affectedBinding.scope,
+            lastEventId: affectedCurrent.lastEventId,
+          }
+        : null
+    }
+    retire(state, new Error(`Automation runner credential rejected with HTTP ${status}`))
+    if (affectedCurrent && affectedCurrent !== state) {
+      affectedCurrent.credentialRejected = true
+      retire(affectedCurrent, new Error(`Automation runner credential rejected with HTTP ${status}`))
+    }
+    if (pendingConfiguration && credentialKey(pendingConfiguration) === key) pendingConfiguration = null
+    options.log?.(`runner credential rejected with HTTP ${status}`)
+    if (affectedCurrent) options.onCredentialRejected?.()
+    if (affectedCurrent && pendingConfiguration) {
+      const next = pendingConfiguration
+      pendingConfiguration = null
+      activateConfiguration(next)
+    }
+  }
+
+  const runnerRequest = async (state, requestPath, request = {}) => {
+    if (!isCurrent(state)) {
+      throw state.controller.signal.reason ?? new Error("Automation runner generation retired")
+    }
+    try {
+      return await requestJson(
+        fetchImpl,
+        state.configuration.baseUrl,
+        state.configuration.token,
+        requestPath,
+        { ...request, signal: state.controller.signal },
+      )
+    } catch (error) {
+      if ([401, 403].includes(error?.status)) rejectCredential(state, error.status)
+      throw error
+    }
+  }
+
+  const heartbeat = async (state) => {
+    const active = state.active
+    if (!active || !isCurrent(state)) return
     const response = await runnerRequest(
+      state,
       `/v1/automation-runs/${encodeURIComponent(active.assignment.runId)}/heartbeat`,
       { method: "POST", body: { attempt: active.assignment.attempt } },
     )
-    if (response.cancelRequested || response.leaseValid !== true) {
+    if (state.active === active && (response.cancelRequested || response.leaseValid !== true)) {
       active.controller.abort(new Error("Automation run cancelled or lease lost"))
     }
   }
 
-  const runAssignment = async (assignment) => {
+  let activateConfiguration
+
+  const runAssignment = async (state, assignment) => {
     const controller = new AbortController()
-    active = { assignment, controller }
+    const active = { assignment, controller }
+    state.active = active
     let sequence = 0
     const event = (type, payload) => runnerRequest(
+      state,
       `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/events`,
       { method: "POST", body: { attempt: assignment.attempt, sequence: ++sequence, type, payload, createdAt: Date.now() } },
     )
-    const heartbeatTimer = setInterval(() => void heartbeat().catch((error) => controller.abort(error)), 10_000)
+    const heartbeatTimer = setInterval(() => void heartbeat(state).catch((error) => controller.abort(error)), 10_000)
     let result
     try {
       await event("user", { text: assignment.instructions, executionTarget: "desktop" })
@@ -271,39 +338,59 @@ export function createDesktopAutomationRunner(options) {
     }
     try {
       await event("terminal", { status: result.status, executionTarget: "desktop", sessionId: result.sessionId })
-      await runnerRequest(`/v1/automation-runs/${encodeURIComponent(assignment.runId)}/complete`, {
+      await runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/complete`, {
         method: "POST",
         body: { ...result, attempt: assignment.attempt },
       })
     } finally {
-      active = null
+      if (state.active === active) state.active = null
+      if (isCurrent(state) && pendingConfiguration) {
+        const next = pendingConfiguration
+        pendingConfiguration = null
+        activateConfiguration(next)
+      }
     }
   }
 
-  const reconcile = () => {
-    if (!configuration || stopped) return Promise.resolve()
-    if (reconcilePromise) return reconcilePromise
-    reconcilePromise = (async () => {
-      while (configuration && !stopped) {
-        const response = await runnerRequest("/v1/automation-runner/work")
+  const reconcile = (state) => {
+    if (!isCurrent(state)) return Promise.resolve()
+    if (state.reconcilePromise) return state.reconcilePromise
+    const promise = (async () => {
+      while (isCurrent(state)) {
+        const response = await runnerRequest(state, "/v1/automation-runner/work")
+        if (!isCurrent(state)) break
         const item = response?.items?.[0]
         if (!item?.runId) break
-        const claimed = await runnerRequest(`/v1/automation-runs/${encodeURIComponent(item.runId)}/claim`, { method: "POST", body: {} })
+        state.claimInFlight = true
+        let claimed
+        try {
+          claimed = await runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(item.runId)}/claim`, { method: "POST", body: {} })
+        } finally {
+          state.claimInFlight = false
+        }
         if (!claimed?.assignment) break
-        await runAssignment(claimed.assignment)
+        await runAssignment(state, claimed.assignment)
       }
     })().catch((error) => options.log?.(`reconcile failed: ${error instanceof Error ? error.message : String(error)}`))
-      .finally(() => { reconcilePromise = null })
-    return reconcilePromise
+      .finally(() => {
+        if (state.reconcilePromise === promise) state.reconcilePromise = null
+        if (isCurrent(state) && pendingConfiguration && !state.active) {
+          const next = pendingConfiguration
+          pendingConfiguration = null
+          activateConfiguration(next)
+        }
+      })
+    state.reconcilePromise = promise
+    return promise
   }
 
-  const consumeSse = async (response, localGeneration, onHealthy) => {
+  const consumeSse = async (state, response, onHealthy) => {
     if (!response.ok || !response.body) throw new Error(`SSE returned ${response.status}`)
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
     let buffer = ""
     let healthy = false
-    while (!stopped && localGeneration === generation) {
+    while (isCurrent(state)) {
       const { done, value } = await reader.read()
       if (done) return
       buffer += decoder.decode(value, { stream: true }).replaceAll("\r\n", "\n")
@@ -317,7 +404,7 @@ export function createDesktopAutomationRunner(options) {
         for (const line of block.split("\n")) {
           if (line.startsWith("id:")) {
             const value = Number(line.slice(3).trim())
-            if (Number.isSafeInteger(value) && value > lastEventId) lastEventId = value
+            if (Number.isSafeInteger(value) && value > state.lastEventId) state.lastEventId = value
           }
           if (line.startsWith("event:")) eventType = line.slice(6).trim()
           if (line.startsWith("data:")) {
@@ -325,39 +412,77 @@ export function createDesktopAutomationRunner(options) {
           }
         }
         if (parsedData && !healthy) { healthy = true; onHealthy() }
-        await heartbeat().catch(() => undefined)
+        await heartbeat(state).catch(() => undefined)
         if (
           eventType !== "keepalive"
-          && eventData?.cursor === String(lastEventId)
+          && eventData?.cursor === String(state.lastEventId)
           && ["automation_work_available", "automation_cancellation_available"].includes(eventData?.type)
-        ) void reconcile()
+        ) void reconcile(state)
       }
     }
   }
 
-  const connectLoop = async (localGeneration) => {
+  const connectLoop = async (state) => {
     let reconnectAttempt = 0
-    while (!stopped && configuration && localGeneration === generation) {
-      connectionController = new AbortController()
-      void reconcile()
+    while (isCurrent(state)) {
+      void reconcile(state)
       try {
-        const response = await fetchImpl(`${configuration.baseUrl.replace(/\/+$/, "")}/v1/automation-runners/events`, {
+        const response = await fetchImpl(`${state.configuration.baseUrl.replace(/\/+$/, "")}/v1/automation-runners/events`, {
           headers: {
             Accept: "text/event-stream",
-            Authorization: `Bearer ${configuration.token}`,
-            ...(lastEventId > 0 ? { "Last-Event-ID": String(lastEventId) } : {}),
+            Authorization: `Bearer ${state.configuration.token}`,
+            ...(state.lastEventId > 0 ? { "Last-Event-ID": String(state.lastEventId) } : {}),
           },
-          signal: connectionController.signal,
+          signal: state.controller.signal,
         })
+        if ([401, 403].includes(response.status)) {
+          rejectCredential(state, response.status)
+          return
+        }
         options.log?.("SSE connected")
-        await consumeSse(response, localGeneration, () => { reconnectAttempt = 0 })
+        await consumeSse(state, response, () => { reconnectAttempt = 0 })
       } catch (error) {
-        if (stopped || localGeneration !== generation) return
+        if (!isCurrent(state)) return
         options.log?.(`SSE reconnecting: ${error instanceof Error ? error.message : String(error)}`)
       }
+      if (!isCurrent(state)) return
       const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
-      await waitBeforeReconnect(Math.round(backoff * (0.5 + random())))
+      try {
+        await waitBeforeReconnect(Math.round(backoff * (0.5 + random())), state.controller.signal)
+      } catch (error) {
+        if (!isCurrent(state)) return
+        options.log?.(`SSE reconnect wait failed: ${error instanceof Error ? error.message : String(error)}`)
+      }
     }
+  }
+
+  activateConfiguration = (configuration) => {
+    const previous = current
+    const previousBinding = previous ? runnerTokenBinding(previous.configuration.token) : null
+    const nextBinding = configuration ? runnerTokenBinding(configuration.token) : null
+    const cursor = previousBinding?.scope
+      ? { baseUrl: previous.configuration.baseUrl, scope: previousBinding.scope, lastEventId: previous.lastEventId }
+      : rejectedCursor
+    const lastEventId = cursor?.scope && cursor.scope === nextBinding?.scope && cursor.baseUrl === configuration?.baseUrl
+      ? cursor.lastEventId
+      : 0
+    rejectedCursor = null
+    generation += 1
+    if (previous) retire(previous, new Error("Automation runner configuration changed"))
+    if (!configuration || stopped) return
+    const state = {
+      generation,
+      configuration,
+      controller: new AbortController(),
+      lastEventId,
+      reconcilePromise: null,
+      claimInFlight: false,
+      active: null,
+      retired: false,
+      credentialRejected: false,
+    }
+    current = state
+    void connectLoop(state)
   }
 
   return {
@@ -379,22 +504,32 @@ export function createDesktopAutomationRunner(options) {
         options.log?.(`rejected runner credential for ${baseUrl ?? "an unusable base URL"}`
           + `: token audience ${binding?.audience ?? (binding ? "v1 (untrusted here)" : "unreadable")}`)
       }
-      if (configuration?.baseUrl === normalized?.baseUrl && configuration?.token === normalized?.token) {
-        return { connected: Boolean(connectionController && !connectionController.signal.aborted) }
+      if (normalized && rejectedCredentials.has(credentialKey(normalized))) {
+        return { connected: false }
       }
-      configuration = normalized
-      generation += 1
-      connectionController?.abort()
-      connectionController = null
-      if (!configuration) active?.controller.abort(new Error("Automation runner disconnected"))
-      if (configuration && !stopped) void connectLoop(generation)
+      if (
+        normalized
+        && current?.configuration.baseUrl === normalized.baseUrl
+        && current.configuration.token === normalized.token
+      ) {
+        pendingConfiguration = null
+        return { connected: !current.controller.signal.aborted }
+      }
+      if (normalized && (current?.active || current?.claimInFlight)) {
+        pendingConfiguration = normalized
+        return { connected: !current.controller.signal.aborted }
+      }
+      pendingConfiguration = null
+      if (!normalized) rejectedCursor = null
+      activateConfiguration(normalized)
       return { connected: false }
     },
     stop() {
       stopped = true
       generation += 1
-      connectionController?.abort()
-      active?.controller.abort(new Error("Desktop is shutting down"))
+      pendingConfiguration = null
+      rejectedCursor = null
+      if (current) retire(current, new Error("Desktop is shutting down"))
     },
   }
 }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -9,8 +9,14 @@ import {
   runnerTokenAudience,
 } from "./automation-runner.mjs"
 
-function runnerTokenFor(audience) {
-  const payload = Buffer.from(JSON.stringify({ v: 2, a: audience })).toString("base64url")
+function runnerTokenFor(audience, organizationId = "org-1") {
+  const payload = Buffer.from(JSON.stringify({
+    v: 2,
+    o: organizationId,
+    m: "member-1",
+    r: "runner-1",
+    a: audience,
+  })).toString("base64url")
   return `${payload}.test-signature`
 }
 
@@ -51,6 +57,169 @@ async function observeHttpFailureBackoff(status) {
     await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
   }
   return { paths, delays }
+}
+
+async function flushTasks() {
+  for (let index = 0; index < 5; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+}
+
+function withTimeout(promise, message) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), 1_000)
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value) },
+      (error) => { clearTimeout(timer); reject(error) },
+    )
+  })
+}
+
+async function observeCredentialRejection(status, deniedRequest) {
+  const paths = []
+  const delays = []
+  const rejections = []
+  let resolveRejected
+  const rejected = new Promise((resolve) => { resolveRejected = resolve })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const path = new URL(url).pathname
+      paths.push(path)
+      if (path === deniedRequest) {
+        return Response.json({ message: "invalid runner credential" }, { status })
+      }
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      return new Promise((resolve, reject) => {
+        const abort = () => reject(options.signal?.reason ?? new Error("aborted"))
+        if (options.signal?.aborted) abort()
+        else options.signal?.addEventListener("abort", abort, { once: true })
+      })
+    },
+    waitBeforeReconnect: async (ms) => { delays.push(ms) },
+    onCredentialRejected: () => {
+      rejections.push(status)
+      resolveRejected()
+    },
+  })
+  const configuration = {
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  }
+  runner.configure(configuration)
+  await withTimeout(rejected, "credential rejection timed out")
+  await flushTasks()
+  for (let index = 0; index < 20; index += 1) runner.configure(configuration)
+  await flushTasks()
+  runner.stop()
+  return { paths, delays, rejections }
+}
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 1_000
+  while (!predicate() && Date.now() < deadline) await new Promise((resolve) => setImmediate(resolve))
+  assert.ok(predicate(), message)
+}
+
+function testAssignment() {
+  return {
+    executionTarget: "desktop",
+    runId: "run-1",
+    automationId: "automation-1",
+    automationName: "Daily brief",
+    instructions: "Prepare the brief",
+    model: { providerId: "opencode", modelId: "big-pickle" },
+    timeoutMs: 30_000,
+    leaseExpiresAt: Date.now() + 60_000,
+    attempt: 1,
+  }
+}
+
+async function observeAssignmentCredentialRejection(status, deniedRoute) {
+  const denRequests = []
+  const eventStream = new TransformStream()
+  const eventWriter = eventStream.writable.getWriter()
+  let workRequests = 0
+  let snapshotStarted = false
+  let resolveRejected
+  const rejected = new Promise((resolve) => { resolveRejected = resolve })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        if (parsed.pathname === "/workspaces") {
+          return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+          return Response.json({ item: { id: "session-1" } }, { status: 201 })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
+          snapshotStarted = true
+          if (deniedRoute === "heartbeat") {
+            return new Promise((resolve, reject) => {
+              const abort = () => reject(options.signal?.reason ?? new Error("aborted"))
+              if (options.signal?.aborted) abort()
+              else options.signal?.addEventListener("abort", abort, { once: true })
+            })
+          }
+          return Response.json({ item: {
+            status: { type: "idle" },
+            messages: [{
+              info: { role: "assistant", tokens: { input: 1, output: 1 } },
+              parts: [{ type: "text", text: "Finished" }],
+            }],
+          } })
+        }
+        throw new Error(`Unexpected local request ${parsed.pathname}`)
+      }
+
+      denRequests.push(parsed.pathname)
+      if (parsed.pathname === "/v1/automation-runners/events") {
+        return new Response(eventStream.readable, { headers: { "Content-Type": "text/event-stream" } })
+      }
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        workRequests += 1
+        return Response.json({ items: workRequests === 1 ? [{ runId: "run-1" }] : [] })
+      }
+      if (parsed.pathname.endsWith("/claim")) {
+        if (deniedRoute === "claim") return Response.json({ message: "expired" }, { status })
+        return Response.json({ assignment: testAssignment() })
+      }
+      if (parsed.pathname.endsWith("/events")) {
+        if (deniedRoute === "events") return Response.json({ message: "expired" }, { status })
+        return Response.json({ ok: true })
+      }
+      if (parsed.pathname.endsWith("/heartbeat")) {
+        if (deniedRoute === "heartbeat") return Response.json({ message: "expired" }, { status })
+        return Response.json({ leaseValid: true, cancelRequested: false })
+      }
+      if (parsed.pathname.endsWith("/complete")) {
+        if (deniedRoute === "complete") return Response.json({ message: "expired" }, { status })
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    onCredentialRejected: resolveRejected,
+  })
+  const configuration = {
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  }
+  runner.configure(configuration)
+  if (deniedRoute === "heartbeat") {
+    await waitFor(() => snapshotStarted, "assignment did not start before heartbeat")
+    await eventWriter.write(new TextEncoder().encode("event: keepalive\ndata: {}\n\n"))
+  }
+  await withTimeout(rejected, `${deniedRoute} credential rejection timed out`)
+  await flushTasks()
+  runner.configure(configuration)
+  await flushTasks()
+  runner.stop()
+  await eventWriter.close()
+  return denRequests
 }
 
 function requestBudget(delays, windowMs) {
@@ -196,14 +365,383 @@ test("a runner credential bound elsewhere reports why this desktop stays disconn
   ])
 })
 
-for (const status of [502, 401]) {
-  test(`repeated HTTP ${status} responses retain exponential runner reconnect backoff`, async () => {
-    const { paths, delays } = await observeHttpFailureBackoff(status)
-    assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
-    assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
-    assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 10)
+test("repeated HTTP 502 responses retain exponential runner reconnect backoff", async () => {
+  const { paths, delays } = await observeHttpFailureBackoff(502)
+  assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
+  assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
+  assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 10)
+})
+
+for (const status of [401, 403]) {
+  test(`HTTP ${status} from work or events retires exactly that credential without reconnecting`, async () => {
+    for (const deniedRequest of ["/v1/automation-runner/work", "/v1/automation-runners/events"]) {
+      const { paths, delays, rejections } = await observeCredentialRejection(status, deniedRequest)
+      assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 1)
+      assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 1)
+      assert.deepEqual(delays, [])
+      assert.deepEqual(rejections, [status])
+    }
   })
 }
+
+test("HTTP 401 and 403 from every assignment route retire the credential", async () => {
+  const routeSuffix = {
+    claim: "/v1/automation-runs/run-1/claim",
+    events: "/v1/automation-runs/run-1/events",
+    heartbeat: "/v1/automation-runs/run-1/heartbeat",
+    complete: "/v1/automation-runs/run-1/complete",
+  }
+  for (const status of [401, 403]) {
+    for (const deniedRoute of Object.keys(routeSuffix)) {
+      const requests = await observeAssignmentCredentialRejection(status, deniedRoute)
+      assert.equal(requests.filter((path) => path === routeSuffix[deniedRoute]).length, 1)
+      assert.equal(requests.filter((path) => path === "/v1/automation-runner/work").length, 1)
+      assert.equal(requests.filter((path) => path === "/v1/automation-runners/events").length, 1)
+    }
+  }
+})
+
+test("a new credential reconciles immediately and a late rejection cannot retire it", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${runnerTokenFor("https://den.example.com")}-fresh`
+  const requests = []
+  const delays = []
+  const rejections = []
+  let aWorkStarted = false
+  let aEventsStarted = false
+  let aEventsResponse = null
+  const bEventStream = new TransformStream()
+  const bEventWriter = bEventStream.writable.getWriter()
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const path = new URL(url).pathname
+      const authorization = new Headers(options.headers).get("Authorization")
+      requests.push({ path, authorization })
+      if (authorization === `Bearer ${tokenA}`) {
+        if (path === "/v1/automation-runner/work") {
+          aWorkStarted = true
+          return Response.json({ items: [] })
+        }
+        aEventsStarted = true
+        while (aEventsResponse === null) await new Promise((resolve) => setImmediate(resolve))
+        return aEventsResponse
+      }
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      return new Response(bEventStream.readable, { headers: { "Content-Type": "text/event-stream" } })
+    },
+    waitBeforeReconnect: async (ms) => { delays.push(ms) },
+    onCredentialRejected: () => { rejections.push("rejected") },
+  })
+
+  runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" })
+  await waitFor(() => aWorkStarted && aEventsStarted, "token A requests did not start")
+  const bRequestStart = requests.length
+  runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" })
+  await waitFor(
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    "token B did not reconcile while token A was pending",
+  )
+
+  aEventsResponse = Response.json({ message: "expired" }, { status: 401 })
+  await flushTasks()
+  assert.deepEqual(rejections, [])
+  assert.deepEqual(delays, [])
+  assert.equal(runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" }).connected, false)
+  assert.equal(runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" }).connected, true)
+
+  await bEventWriter.write(new TextEncoder().encode(
+    'id: 1\nevent: message\ndata: {"cursor":"1","type":"automation_work_available"}\n\n',
+  ))
+  await waitFor(
+    () => requests.filter((request) => request.path === "/v1/automation-runner/work" && request.authorization === `Bearer ${tokenB}`).length === 2,
+    "token B stopped reconciling after token A rejected",
+  )
+  assert.ok(requests.slice(bRequestStart).every((request) => request.authorization === `Bearer ${tokenB}`))
+  runner.stop()
+  await bEventWriter.close()
+})
+
+test("a late rejection retires a newer generation that reused the same credential", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  const pendingA = []
+  const requests = []
+  const rejections = []
+  const eventStreams = []
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const path = new URL(url).pathname
+      const authorization = new Headers(options.headers).get("Authorization")
+      requests.push({ path, authorization })
+      const requestNumber = requests.filter((request) => request.path === path && request.authorization === authorization).length
+      if (authorization === `Bearer ${tokenA}` && path === "/v1/automation-runners/events" && requestNumber === 1) {
+        return new Promise((resolve) => { pendingA.push(() => resolve(Response.json({ message: "expired" }, { status: 401 }))) })
+      }
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      const stream = new TransformStream()
+      eventStreams.push(stream.writable.getWriter())
+      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+    },
+    onCredentialRejected: () => { rejections.push("rejected") },
+  })
+  const configurationA = { baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" }
+  const configurationB = { baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" }
+
+  runner.configure(configurationA)
+  await waitFor(() => pendingA.length === 1, "first token A generation did not start")
+  runner.configure(configurationB)
+  await waitFor(
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    "token B generation did not start",
+  )
+  runner.configure(configurationA)
+  await waitFor(
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length === 4,
+    "second token A generation did not start",
+  )
+  for (const resolve of pendingA) resolve()
+  await waitFor(() => rejections.length === 1, "reused token A was not retired")
+  assert.equal(runner.configure(configurationA).connected, false)
+  await flushTasks()
+  assert.equal(requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length, 4)
+  runner.stop()
+  await Promise.all(eventStreams.map((writer) => writer.close()))
+})
+
+test("routine credential rotation waits for the active assignment to complete", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  const requests = []
+  const eventWriters = []
+  let offeredAssignment = false
+  let snapshotStarted = false
+  let finishSnapshot = false
+  let localAborts = 0
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        if (parsed.pathname === "/workspace/workspace-1/sessions") return Response.json({ item: { id: "session-1" } })
+        if (parsed.pathname.endsWith("/abort")) { localAborts += 1; return Response.json({ ok: true }) }
+        if (parsed.pathname.endsWith("/snapshot")) {
+          snapshotStarted = true
+          while (!finishSnapshot) await new Promise((resolve) => setImmediate(resolve))
+          return Response.json({ item: {
+            status: { type: "idle" },
+            messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
+          } })
+        }
+      }
+      const path = parsed.pathname
+      const authorization = new Headers(options.headers).get("Authorization")
+      requests.push({ path, authorization })
+      if (path === "/v1/automation-runner/work") {
+        if (!offeredAssignment && authorization === `Bearer ${tokenA}`) {
+          offeredAssignment = true
+          return Response.json({ items: [{ runId: "run-1" }] })
+        }
+        return Response.json({ items: [] })
+      }
+      if (path.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (path === "/v1/automation-runners/events") {
+        const stream = new TransformStream()
+        eventWriters.push(stream.writable.getWriter())
+        return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+      }
+      return Response.json({ ok: true })
+    },
+  })
+  const configurationA = { baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" }
+  const configurationB = { baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" }
+  runner.configure(configurationA)
+  await waitFor(() => snapshotStarted, "assignment did not start")
+  assert.equal(runner.configure(configurationB).connected, true)
+  await flushTasks()
+  assert.equal(requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length, 0)
+  assert.equal(localAborts, 0)
+
+  finishSnapshot = true
+  await waitFor(
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    "fresh credential did not connect after assignment completion",
+  )
+  assert.equal(localAborts, 0)
+  assert.ok(requests.some((request) => request.path.endsWith("/complete") && request.authorization === `Bearer ${tokenA}`))
+  runner.stop()
+  await Promise.all(eventWriters.map((writer) => writer.close()))
+})
+
+test("routine credential rotation waits for an in-flight claim", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  const requests = []
+  const eventWriters = []
+  /** @type {(response: Response) => void} */
+  let resolveClaim = () => {}
+  const claimResponse = new Promise((resolve) => { resolveClaim = resolve })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        if (parsed.pathname === "/workspace/workspace-1/sessions") return Response.json({ item: { id: "session-1" } })
+        if (parsed.pathname.endsWith("/snapshot")) {
+          return Response.json({ item: {
+            status: { type: "idle" },
+            messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
+          } })
+        }
+      }
+      const path = parsed.pathname
+      const authorization = new Headers(options.headers).get("Authorization")
+      requests.push({ path, authorization })
+      if (path === "/v1/automation-runner/work") {
+        const offered = requests.some((request) => request.path.endsWith("/claim"))
+        return Response.json({ items: offered ? [] : [{ runId: "run-1" }] })
+      }
+      if (path.endsWith("/claim")) return claimResponse
+      if (path === "/v1/automation-runners/events") {
+        const stream = new TransformStream()
+        eventWriters.push(stream.writable.getWriter())
+        return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+      }
+      return Response.json({ ok: true })
+    },
+  })
+  const configurationA = { baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" }
+  const configurationB = { baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" }
+  runner.configure(configurationA)
+  await waitFor(() => requests.some((request) => request.path.endsWith("/claim")), "claim did not start")
+  assert.equal(runner.configure(configurationB).connected, true)
+  await flushTasks()
+  assert.equal(requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length, 0)
+
+  resolveClaim(Response.json({ assignment: testAssignment() }))
+  await waitFor(
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    "fresh credential did not connect after the claimed assignment completed",
+  )
+  assert.ok(requests.some((request) => request.path.endsWith("/complete") && request.authorization === `Bearer ${tokenA}`))
+  runner.stop()
+  await Promise.all(eventWriters.map((writer) => writer.close()))
+})
+
+test("routine credential rotation preserves the SSE cursor only for the same runner scope", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  const tokenC = runnerTokenFor("https://den.example.com", "org-2")
+  const eventRequests = []
+  const eventWriters = []
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const path = new URL(url).pathname
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      const headers = new Headers(options.headers)
+      eventRequests.push({
+        authorization: headers.get("Authorization"),
+        lastEventId: headers.get("Last-Event-ID"),
+      })
+      const stream = new TransformStream()
+      eventWriters.push(stream.writable.getWriter())
+      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+    },
+  })
+  const configuration = (token) => ({ baseUrl: "https://den.example.com", token, runnerId: "runner-1" })
+  runner.configure(configuration(tokenA))
+  await waitFor(() => eventRequests.length === 1, "first SSE connection did not start")
+  await eventWriters[0].write(new TextEncoder().encode("id: 7\nevent: keepalive\ndata: {}\n\n"))
+  await flushTasks()
+
+  runner.configure(configuration(tokenB))
+  await waitFor(() => eventRequests.length === 2, "rotated SSE connection did not start")
+  assert.equal(eventRequests[1].lastEventId, "7")
+
+  runner.configure(configuration(tokenC))
+  await waitFor(() => eventRequests.length === 3, "new organization SSE connection did not start")
+  assert.equal(eventRequests[2].lastEventId, null)
+  runner.stop()
+  await Promise.all(eventWriters.map((writer) => writer.close()))
+})
+
+test("credential rejection preserves the SSE cursor for a same-scope remint", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  const eventRequests = []
+  const eventWriters = []
+  let tokenAWorkRequests = 0
+  /** @type {() => void} */
+  let resolveRejected = () => {}
+  const rejected = new Promise((resolve) => { resolveRejected = () => resolve() })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const path = new URL(url).pathname
+      const headers = new Headers(options.headers)
+      const authorization = headers.get("Authorization")
+      if (path === "/v1/automation-runner/work") {
+        if (authorization === `Bearer ${tokenA}`) {
+          tokenAWorkRequests += 1
+          if (tokenAWorkRequests === 2) return Response.json({ message: "expired" }, { status: 401 })
+        }
+        return Response.json({ items: [] })
+      }
+      eventRequests.push({ authorization, lastEventId: headers.get("Last-Event-ID") })
+      const stream = new TransformStream()
+      eventWriters.push(stream.writable.getWriter())
+      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+    },
+    onCredentialRejected: () => {
+      runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" })
+      resolveRejected()
+    },
+  })
+  runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" })
+  await waitFor(() => eventWriters.length === 1, "first SSE connection did not start")
+  await flushTasks()
+  await eventWriters[0].write(new TextEncoder().encode(
+    'id: 7\nevent: message\ndata: {"cursor":"7","type":"automation_work_available"}\n\n',
+  ))
+  await withTimeout(rejected, "credential rejection did not trigger remint")
+  await waitFor(() => eventRequests.some((request) => request.authorization === `Bearer ${tokenB}`), "reminted SSE did not connect")
+  const reminted = eventRequests.find((request) => request.authorization === `Bearer ${tokenB}`)
+  assert.equal(reminted.lastEventId, "7")
+  runner.stop()
+  await Promise.all(eventWriters.map((writer) => writer.close()))
+})
+
+test("retiring a generation cancels its reconnect wait", async () => {
+  const tokenA = runnerTokenFor("https://den.example.com")
+  const tokenB = `${tokenA}-fresh`
+  /** @type {AbortSignal | null} */
+  let waitSignal = null
+  const reconnectWaitAborted = () => waitSignal?.aborted === true
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url) => {
+      const path = new URL(url).pathname
+      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
+      if (path === "/v1/automation-runners/events") return new Response(null, { status: 502 })
+      throw new Error(`Unexpected request ${path}`)
+    },
+    waitBeforeReconnect: async (_ms, signal) => {
+      waitSignal = signal
+      await new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+      })
+    },
+  })
+  runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" })
+  await waitFor(() => waitSignal !== null, "reconnect wait did not start")
+  runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" })
+  assert.equal(reconnectWaitAborted(), true)
+  runner.stop()
+})
 
 test("runner HTTP failure request budget drops from the reset-on-response baseline", () => {
   const previousResetOnResponseDelays = Array(10).fill(500)

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -103,6 +103,7 @@ const {
 } = require("electron");
 const pty = require(["node", "pty"].join("-"));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
+const AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT = "openwork:automation-runner:credential-rejected";
 const isDevMode = process.env.OPENWORK_DEV_MODE === "1";
 const DESKTOP_DISTRIBUTION = resolveDesktopDistribution({
   isPackaged: app.isPackaged,
@@ -1256,6 +1257,10 @@ const desktopAutomationRunner = createDesktopAutomationRunner({
     return { baseUrl: server.baseUrl, token: server.clientToken ?? server.ownerToken };
   },
   log: (state) => console.info(`[automation-runner] ${state}`),
+  onCredentialRejected: () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    mainWindow.webContents.send(AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT);
+  },
 });
 
 let runtimeDisposedForQuit = false;

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -5,6 +5,7 @@ const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
+const AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT = "openwork:automation-runner:credential-rejected";
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -61,6 +62,13 @@ try {
 contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
   invokeDesktop(command, ...args) {
     return ipcRenderer.invoke("openwork:desktop", command, ...args);
+  },
+  automationRunner: {
+    onCredentialRejected(callback) {
+      const handler = () => callback();
+      ipcRenderer.on(AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT, handler);
+      return () => ipcRenderer.removeListener(AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT, handler);
+    },
   },
   shell: {
     openExternal(url) {

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -5,6 +5,7 @@ import { expect } from "vitest";
 
 const expectedDelays = [500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000];
 const runnerUnitTest = fileURLToPath(new URL("../../apps/desktop/electron/automation-runner.test.mjs", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 function requestBudget(delays: number[], windowMs: number): number {
   let attempts = 0;
@@ -16,7 +17,7 @@ function requestBudget(delays: number[], windowMs: number): number {
   return attempts * 2;
 }
 
-test("desktop Automation runners back off repeated HTTP failures", async ({ evidence }) => {
+test("desktop Automation runner retires rejected credentials without changing transient backoff", async () => {
   const unit = spawnSync(process.execPath, [
     "--test",
     "--test-reporter=tap",
@@ -24,29 +25,49 @@ test("desktop Automation runners back off repeated HTTP failures", async ({ evid
   ], { encoding: "utf8" });
   expect(unit.status, unit.stderr || unit.stdout).toBe(0);
   expect(unit.stdout).toContain("repeated HTTP 502 responses retain exponential runner reconnect backoff");
-  expect(unit.stdout).toContain("repeated HTTP 401 responses retain exponential runner reconnect backoff");
+  expect(unit.stdout).toContain("HTTP 401 from work or events retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("HTTP 403 from work or events retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("HTTP 401 and 403 from every assignment route retire the credential");
+  expect(unit.stdout).toContain("a new credential reconciles immediately and a late rejection cannot retire it");
+  expect(unit.stdout).toContain("a late rejection retires a newer generation that reused the same credential");
+  expect(unit.stdout).toContain("routine credential rotation waits for the active assignment to complete");
+  expect(unit.stdout).toContain("routine credential rotation waits for an in-flight claim");
+  expect(unit.stdout).toContain("routine credential rotation preserves the SSE cursor only for the same runner scope");
+  expect(unit.stdout).toContain("credential rejection preserves the SSE cursor for a same-scope remint");
+  expect(unit.stdout).toContain("retiring a generation cancels its reconnect wait");
   expect(unit.stdout).toContain("a healthy SSE response resets runner reconnect backoff");
   expect(unit.stdout).toContain("a parsed SSE event resets backoff before an abrupt stream error");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 15\b/);
-  expect(unit.stdout).toMatch(/# pass 15\b/);
+  expect(unit.stdout).toMatch(/# tests 24\b/);
+  expect(unit.stdout).toMatch(/# pass 24\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
-  evidence.fact(
-    "Repeated HTTP failures retain capped exponential backoff",
-    "Both ten-response 502 and 401 sequences produced 500, 1000, 2000, 4000, 8000, 16000, then four 30000ms delays, with exactly one work and one SSE request per attempt. After three 502s, a parsed keepalive followed by an abrupt stream error reset the next delay to 500ms.",
-    true,
-  );
+
+  const bridge = spawnSync("pnpm", [
+    "--dir",
+    "apps/app",
+    "exec",
+    "bun",
+    "test",
+    "--isolate",
+    "tests/automation-runner-connect-coordinator.test.ts",
+    "tests/automation-availability.test.ts",
+  ], { cwd: repoRoot, encoding: "utf8" });
+  const bridgeOutput = `${bridge.stdout}${bridge.stderr}`;
+  expect(bridge.error, bridgeOutput).toBeUndefined();
+  expect(bridge.status, bridgeOutput).toBe(0);
+  expect(bridgeOutput).toContain("11 pass");
+  expect(bridgeOutput).toContain("0 fail");
 
   const previousResetOnResponseDelays = Array(10).fill(500);
   expect(requestBudget(previousResetOnResponseDelays, 60_000)).toBe(240);
-  expect(requestBudget(expectedDelays, 60_000)).toBe(14);
+  const preFix401FirstMinute = requestBudget(expectedDelays, 60_000);
+  const preFix401TenMinutes = requestBudget(expectedDelays, 10 * 60_000);
+  const transient502FirstMinute = requestBudget(expectedDelays, 60_000);
+  expect(preFix401FirstMinute).toBe(14);
+  expect(preFix401TenMinutes).toBe(50);
+  expect(transient502FirstMinute).toBe(14);
   expect(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0)).toBe(5_000);
   expect(expectedDelays.reduce((total, delay) => total + delay, 0)).toBe(151_500);
-  evidence.fact(
-    "Reconnect request budget is bounded during an outage",
-    "At midpoint jitter, the pre-fix reset behavior budgets 240 work-plus-SSE requests in 60 seconds; capped exponential backoff budgets 14. Across ten failures, waiting rises from 5 seconds to 151.5 seconds.",
-    true,
-  );
 });

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -17,7 +17,7 @@ function requestBudget(delays: number[], windowMs: number): number {
   return attempts * 2;
 }
 
-test("desktop Automation runner retires rejected credentials without changing transient backoff", async () => {
+test("desktop Automation runner retires rejected credentials without changing transient backoff", async ({ evidence }) => {
   const unit = spawnSync(process.execPath, [
     "--test",
     "--test-reporter=tap",
@@ -59,6 +59,11 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridge.status, bridgeOutput).toBe(0);
   expect(bridgeOutput).toContain("11 pass");
   expect(bridgeOutput).toContain("0 fail");
+  evidence.recordAssertionEvidence(
+    "Rejected runner credentials stop and remint without disrupting valid work",
+    "The runner and bridge suites passed 35 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, and same-scope SSE cursor continuity.",
+    true,
+  );
 
   const previousResetOnResponseDelays = Array(10).fill(500);
   expect(requestBudget(previousResetOnResponseDelays, 60_000)).toBe(240);
@@ -70,4 +75,9 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(transient502FirstMinute).toBe(14);
   expect(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0)).toBe(5_000);
   expect(expectedDelays.reduce((total, delay) => total + delay, 0)).toBe(151_500);
+  evidence.recordAssertionEvidence(
+    "Transient runner failures retain capped exponential backoff",
+    "At midpoint jitter, repeated 502 responses budget 14 work-plus-SSE requests in the first minute, with delays rising from 500ms to a 30-second cap instead of resetting after every HTTP response.",
+    true,
+  );
 });

--- a/evals/specs/cloud-mcp-health-probe-budget.test.ts
+++ b/evals/specs/cloud-mcp-health-probe-budget.test.ts
@@ -46,27 +46,27 @@ test("direct Cloud MCP health checks stay within a scoped handshake budget", ({ 
   expect(reconcileOutput).toContain("0 fail");
   expect(reconcileOutput).toContain("cloud-mcp-reconcile-operation-benchmark pre=6 post=3");
 
-  evidence.fact(
+  evidence.recordAssertionEvidence(
     "Only concurrent health checks share a direct handshake",
     "Six checks are released together through deterministic barriers and reduce the 18-operation protocol baseline to 3; the next settled explicit check performs 3 fresh operations.",
     true,
   );
-  evidence.fact(
+  evidence.recordAssertionEvidence(
     "Successful reconcile does not repeat tools/list",
     "The focused reconcile witness completes ready and reduces its two direct handshakes from 6 operations to exactly 3 by reusing only its operation-local success.",
     true,
   );
-  evidence.fact(
+  evidence.recordAssertionEvidence(
     "Upstream failures remain retryable",
     "A tools/list 502 is asserted retryable and the next settled check must perform a complete new initialize, initialized notification, and tools/list handshake.",
     true,
   );
-  evidence.fact(
+  evidence.recordAssertionEvidence(
     "In-flight reuse is correctness-scoped",
     "Blocked checks require distinct flights across workspaces and Authorization or organization revisions, while provider/model differences share the same direct tools/list flight.",
     true,
   );
-  evidence.fact(
+  evidence.recordAssertionEvidence(
     "Healthy same-revision delivery state heals",
     "A registering delivery entry with the already-applied revision is required to return to ready after a healthy inspection.",
     true,

--- a/evals/specs/github-sync-request-budget.test.ts
+++ b/evals/specs/github-sync-request-budget.test.ts
@@ -70,27 +70,27 @@ test("GitHub installation-token request budgets and recovery hold in focused run
     expect(retryJunit).not.toContain("<failure");
     expect(retryJunit).not.toContain("<skipped");
 
-    evidence.fact(
+    evidence.recordAssertionEvidence(
       "Concurrent installation-token minting is single-flight",
       "The runtime witness measured a 12-caller cold-cache control at 12 installation-token calls and concurrency 12, then the production token helper at exactly 1 mint and peak concurrency 1.",
       true,
     );
-    evidence.fact(
+    evidence.recordAssertionEvidence(
       "Failed and timed-out token mints recover",
       "The runtime witness requires a shared 502 and an abort-signaled hung request to be evicted, then requires the immediately following provider call to succeed.",
       true,
     );
-    evidence.fact(
+    evidence.recordAssertionEvidence(
       "GitHub sync retries 502 and timeout failures",
       "A separately-accounted focused worker witness passes exactly one test with zero failures and zero skips while requiring GithubConnectorRequestError(502) and TimeoutError to classify as transient.",
       true,
     );
-    evidence.fact(
+    evidence.recordAssertionEvidence(
       "App and installation token keys stay isolated",
       "The runtime witness starts duplicate and distinct app/installation requests together, requires exactly three independent mints for three keys, and then requires each key to reuse only its own cached token.",
       true,
     );
-    evidence.fact(
+    evidence.recordAssertionEvidence(
       "Cache clearing is generation-safe",
       "The runtime witness clears during an in-flight mint, lets the old request settle, and requires a new provider request to return a fresh token rather than accepting repopulated stale cache state.",
       true,


### PR DESCRIPTION
## Summary
- retire only the rejected automation credential generation on HTTP 401/403 and remint through the Electron bridge
- preserve active assignments, claim leases, and same-scope SSE cursors across routine token rotation
- bound repeated fresh-token remints while retaining transient 5xx reconnect backoff

## Verification
- `node --test apps/desktop/electron/automation-runner.test.mjs` (24 passed)
- `pnpm --dir apps/app exec bun test --isolate tests/automation-runner-connect-coordinator.test.ts tests/automation-availability.test.ts` (11 passed)
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --filter @openwork/desktop check:electron`
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/automation-runner-reconnect-backoff.test.ts` (1 passed, 0 skipped; local PR lane)