### PR TITLE
fix(desktop): reduce automation runner polling

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -8,7 +8,7 @@ import { isDesktopRuntime } from "@/app/utils"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
 import { createAutomationRunnerConnectCoordinator } from "./automation-runner-connect-coordinator"
 
-const RUNNER_TOKEN_REFRESH_MS = 5 * 60_000
+const RUNNER_TOKEN_REFRESH_MS = 30 * 60_000
 const RUNNER_ID_KEY = "openwork.automations.desktop-runner-id"
 
 function desktopRunnerId() {

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -55,6 +55,9 @@ import type { AutomationProviderCatalog } from "./automation-model-options"
 import { automationModelOptions, describeAutomationModel } from "./automation-model-options"
 
 const ACTIVE_RUN_STATUSES = new Set<AutomationRun["status"]>(["queued", "claimed", "running"])
+const AUTOMATIONS_PAGE_FAST_POLL_MS = 10_000
+const AUTOMATIONS_PAGE_SLOW_POLL_MS = 60_000
+const AUTOMATIONS_PAGE_FAST_POLL_WINDOW_MS = 5 * 60_000
 
 function stateLabel(state: AutomationState) {
   if (state === "needs_attention") return "Needs attention"
@@ -157,6 +160,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
   const selectedRunId = searchParams.get("run")?.trim() || null
   const selectedThreadId = searchParams.get("thread")?.trim() || null
   const creating = searchParams.get("create") === "1"
+  const [pageMountedAt] = useState(() => Date.now())
   const ready = denAuth.isSignedIn && Boolean(client && organizationId)
   const queryRoot = ["den", "automations", organizationId]
   const zenModelRestricted = useDesktopRestriction("allowZenModel")
@@ -168,7 +172,9 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     queryKey: [...queryRoot, "list"],
     queryFn: () => client!.listAutomations(organizationId!, { limit: 100 }),
     enabled: ready,
-    refetchInterval: 15_000,
+    refetchInterval: () => Date.now() - pageMountedAt < AUTOMATIONS_PAGE_FAST_POLL_WINDOW_MS
+      ? AUTOMATIONS_PAGE_FAST_POLL_MS
+      : AUTOMATIONS_PAGE_SLOW_POLL_MS,
   })
   const providersQuery = useQuery({
     queryKey: [...queryRoot, "models"],
@@ -184,7 +190,9 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     queryKey: [...queryRoot, "runs", selectedId],
     queryFn: () => client!.listAutomationRuns(organizationId!, selectedId!, { limit: 100 }),
     enabled: ready && Boolean(selectedId),
-    refetchInterval: 5_000,
+    refetchInterval: (queryState) => queryState.state.data?.items.some((run) => ACTIVE_RUN_STATUSES.has(run.status))
+      ? AUTOMATIONS_PAGE_FAST_POLL_MS
+      : AUTOMATIONS_PAGE_SLOW_POLL_MS,
   })
   const receiptQuery = useQuery({
     queryKey: [...queryRoot, "receipt", selectedRunId],
@@ -192,7 +200,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     enabled: ready && Boolean(selectedRunId),
     refetchInterval: (queryState) => {
       const run = queryState.state.data?.run
-      return run && ACTIVE_RUN_STATUSES.has(run.status) ? 3_000 : false
+      return run && ACTIVE_RUN_STATUSES.has(run.status) ? AUTOMATIONS_PAGE_FAST_POLL_MS : false
     },
   })
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -506,7 +506,7 @@ export function SessionRoute() {
         });
     };
     refreshAutomationState();
-    const interval = window.setInterval(refreshAutomationState, 15_000);
+    const interval = window.setInterval(refreshAutomationState, 5 * 60_000);
     window.addEventListener(automationsStateChangedEvent, refreshAutomationState);
     return () => {
       cancelled = true;

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -1,4 +1,5 @@
 const EMPTY_USAGE = { inputTokens: null, outputTokens: null, costMicros: null }
+const RUNNER_WORK_POLL_MS = 60_000
 
 function serializedError(value) {
   if (value instanceof Error) return value.message
@@ -201,13 +202,13 @@ export function createDesktopAutomationRunner(options) {
   const fetchImpl = options.fetchImpl ?? fetch
   const random = options.random ?? Math.random
   const waitBeforeReconnect = options.waitBeforeReconnect ?? sleep
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? 10_000
   const legacyBaseUrls = new Set((options.legacyBaseUrls ?? [])
     .map((value) => normalizeRunnerBaseUrl(value))
     .filter(Boolean))
   let generation = 0
   let current = null
   let pendingConfiguration = null
-  let rejectedCursor = null
   let stopped = false
   const rejectedCredentials = new Set()
 
@@ -232,16 +233,6 @@ export function createDesktopAutomationRunner(options) {
     const affectedCurrent = current === state || (current && credentialKey(current.configuration) === key)
       ? current
       : null
-    if (affectedCurrent) {
-      const affectedBinding = runnerTokenBinding(affectedCurrent.configuration.token)
-      rejectedCursor = affectedBinding?.scope
-        ? {
-            baseUrl: affectedCurrent.configuration.baseUrl,
-            scope: affectedBinding.scope,
-            lastEventId: affectedCurrent.lastEventId,
-          }
-        : null
-    }
     retire(state, new Error(`Automation runner credential rejected with HTTP ${status}`))
     if (affectedCurrent && affectedCurrent !== state) {
       affectedCurrent.credentialRejected = true
@@ -300,7 +291,7 @@ export function createDesktopAutomationRunner(options) {
       `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/events`,
       { method: "POST", body: { attempt: assignment.attempt, sequence: ++sequence, type, payload, createdAt: Date.now() } },
     )
-    const heartbeatTimer = setInterval(() => void heartbeat(state).catch((error) => controller.abort(error)), 10_000)
+    const heartbeatTimer = setInterval(() => void heartbeat(state).catch((error) => controller.abort(error)), heartbeatIntervalMs)
     let result
     try {
       await event("user", { text: assignment.instructions, executionTarget: "desktop" })
@@ -371,102 +362,42 @@ export function createDesktopAutomationRunner(options) {
         if (!claimed?.assignment) break
         await runAssignment(state, claimed.assignment)
       }
-    })().catch((error) => options.log?.(`reconcile failed: ${error instanceof Error ? error.message : String(error)}`))
-      .finally(() => {
-        if (state.reconcilePromise === promise) state.reconcilePromise = null
-        if (isCurrent(state) && pendingConfiguration && !state.active) {
-          const next = pendingConfiguration
-          pendingConfiguration = null
-          activateConfiguration(next)
-        }
-      })
+    })().finally(() => {
+      if (state.reconcilePromise === promise) state.reconcilePromise = null
+      if (isCurrent(state) && pendingConfiguration && !state.active) {
+        const next = pendingConfiguration
+        pendingConfiguration = null
+        activateConfiguration(next)
+      }
+    })
     state.reconcilePromise = promise
     return promise
-  }
-
-  const consumeSse = async (state, response, onHealthy) => {
-    if (!response.ok || !response.body) throw new Error(`SSE returned ${response.status}`)
-    const reader = response.body.getReader()
-    const decoder = new TextDecoder()
-    let buffer = ""
-    let healthy = false
-    while (isCurrent(state)) {
-      const { done, value } = await reader.read()
-      if (done) return
-      buffer += decoder.decode(value, { stream: true }).replaceAll("\r\n", "\n")
-      let boundary
-      while ((boundary = buffer.indexOf("\n\n")) >= 0) {
-        const block = buffer.slice(0, boundary)
-        buffer = buffer.slice(boundary + 2)
-        let eventType = "message"
-        let eventData = null
-        let parsedData = false
-        for (const line of block.split("\n")) {
-          if (line.startsWith("id:")) {
-            const value = Number(line.slice(3).trim())
-            if (Number.isSafeInteger(value) && value > state.lastEventId) state.lastEventId = value
-          }
-          if (line.startsWith("event:")) eventType = line.slice(6).trim()
-          if (line.startsWith("data:")) {
-            try { eventData = JSON.parse(line.slice(5).trim()); parsedData = true } catch { eventData = null }
-          }
-        }
-        if (parsedData && !healthy) { healthy = true; onHealthy() }
-        await heartbeat(state).catch(() => undefined)
-        if (
-          eventType !== "keepalive"
-          && eventData?.cursor === String(state.lastEventId)
-          && ["automation_work_available", "automation_cancellation_available"].includes(eventData?.type)
-        ) void reconcile(state)
-      }
-    }
   }
 
   const connectLoop = async (state) => {
     let reconnectAttempt = 0
     while (isCurrent(state)) {
-      void reconcile(state)
       try {
-        const response = await fetchImpl(`${state.configuration.baseUrl.replace(/\/+$/, "")}/v1/automation-runners/events`, {
-          headers: {
-            Accept: "text/event-stream",
-            Authorization: `Bearer ${state.configuration.token}`,
-            ...(state.lastEventId > 0 ? { "Last-Event-ID": String(state.lastEventId) } : {}),
-          },
-          signal: state.controller.signal,
-        })
-        if ([401, 403].includes(response.status)) {
-          rejectCredential(state, response.status)
-          return
+        await reconcile(state)
+        reconnectAttempt = 0
+        await waitBeforeReconnect(RUNNER_WORK_POLL_MS, state.controller.signal)
+      } catch (error) {
+        if (!isCurrent(state)) return
+        if ([401, 403].includes(error?.status)) return
+        options.log?.(`runner polling failed: ${error instanceof Error ? error.message : String(error)}`)
+        const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
+        try {
+          await waitBeforeReconnect(Math.round(backoff * (0.5 + random())), state.controller.signal)
+        } catch (waitError) {
+          if (!isCurrent(state)) return
+          options.log?.(`runner polling wait failed: ${waitError instanceof Error ? waitError.message : String(waitError)}`)
         }
-        options.log?.("SSE connected")
-        await consumeSse(state, response, () => { reconnectAttempt = 0 })
-      } catch (error) {
-        if (!isCurrent(state)) return
-        options.log?.(`SSE reconnecting: ${error instanceof Error ? error.message : String(error)}`)
-      }
-      if (!isCurrent(state)) return
-      const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
-      try {
-        await waitBeforeReconnect(Math.round(backoff * (0.5 + random())), state.controller.signal)
-      } catch (error) {
-        if (!isCurrent(state)) return
-        options.log?.(`SSE reconnect wait failed: ${error instanceof Error ? error.message : String(error)}`)
       }
     }
   }
 
   activateConfiguration = (configuration) => {
     const previous = current
-    const previousBinding = previous ? runnerTokenBinding(previous.configuration.token) : null
-    const nextBinding = configuration ? runnerTokenBinding(configuration.token) : null
-    const cursor = previousBinding?.scope
-      ? { baseUrl: previous.configuration.baseUrl, scope: previousBinding.scope, lastEventId: previous.lastEventId }
-      : rejectedCursor
-    const lastEventId = cursor?.scope && cursor.scope === nextBinding?.scope && cursor.baseUrl === configuration?.baseUrl
-      ? cursor.lastEventId
-      : 0
-    rejectedCursor = null
     generation += 1
     if (previous) retire(previous, new Error("Automation runner configuration changed"))
     if (!configuration || stopped) return
@@ -474,7 +405,6 @@ export function createDesktopAutomationRunner(options) {
       generation,
       configuration,
       controller: new AbortController(),
-      lastEventId,
       reconcilePromise: null,
       claimInFlight: false,
       active: null,
@@ -520,7 +450,6 @@ export function createDesktopAutomationRunner(options) {
         return { connected: !current.controller.signal.aborted }
       }
       pendingConfiguration = null
-      if (!normalized) rejectedCursor = null
       activateConfiguration(normalized)
       return { connected: false }
     },
@@ -528,7 +457,6 @@ export function createDesktopAutomationRunner(options) {
       stopped = true
       generation += 1
       pendingConfiguration = null
-      rejectedCursor = null
       if (current) retire(current, new Error("Desktop is shutting down"))
     },
   }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -96,7 +96,12 @@ async function observeCredentialRejection(status, deniedRequest) {
         else options.signal?.addEventListener("abort", abort, { once: true })
       })
     },
-    waitBeforeReconnect: async (ms) => { delays.push(ms) },
+    waitBeforeReconnect: async (ms, signal) => {
+      delays.push(ms)
+      await new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+      })
+    },
     onCredentialRejected: () => {
       rejections.push(status)
       resolveRejected()
@@ -138,8 +143,6 @@ function testAssignment() {
 
 async function observeAssignmentCredentialRejection(status, deniedRoute) {
   const denRequests = []
-  const eventStream = new TransformStream()
-  const eventWriter = eventStream.writable.getWriter()
   let workRequests = 0
   let snapshotStarted = false
   let resolveRejected
@@ -176,9 +179,6 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
       }
 
       denRequests.push(parsed.pathname)
-      if (parsed.pathname === "/v1/automation-runners/events") {
-        return new Response(eventStream.readable, { headers: { "Content-Type": "text/event-stream" } })
-      }
       if (parsed.pathname === "/v1/automation-runner/work") {
         workRequests += 1
         return Response.json({ items: workRequests === 1 ? [{ runId: "run-1" }] : [] })
@@ -202,6 +202,7 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
       throw new Error(`Unexpected Den request ${parsed.pathname}`)
     },
     onCredentialRejected: resolveRejected,
+    heartbeatIntervalMs: 1,
   })
   const configuration = {
     baseUrl: "https://den.example.com",
@@ -209,16 +210,12 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
     runnerId: "runner-1",
   }
   runner.configure(configuration)
-  if (deniedRoute === "heartbeat") {
-    await waitFor(() => snapshotStarted, "assignment did not start before heartbeat")
-    await eventWriter.write(new TextEncoder().encode("event: keepalive\ndata: {}\n\n"))
-  }
+  if (deniedRoute === "heartbeat") await waitFor(() => snapshotStarted, "assignment did not start before heartbeat")
   await withTimeout(rejected, `${deniedRoute} credential rejection timed out`)
   await flushTasks()
   runner.configure(configuration)
   await flushTasks()
   runner.stop()
-  await eventWriter.close()
   return denRequests
 }
 
@@ -369,18 +366,16 @@ test("repeated HTTP 502 responses retain exponential runner reconnect backoff", 
   const { paths, delays } = await observeHttpFailureBackoff(502)
   assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
   assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
-  assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 10)
+  assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 0)
 })
 
 for (const status of [401, 403]) {
-  test(`HTTP ${status} from work or events retires exactly that credential without reconnecting`, async () => {
-    for (const deniedRequest of ["/v1/automation-runner/work", "/v1/automation-runners/events"]) {
-      const { paths, delays, rejections } = await observeCredentialRejection(status, deniedRequest)
-      assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 1)
-      assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 1)
-      assert.deepEqual(delays, [])
-      assert.deepEqual(rejections, [status])
-    }
+  test(`HTTP ${status} from work retires exactly that credential without reconnecting`, async () => {
+    const { paths, delays, rejections } = await observeCredentialRejection(status, "/v1/automation-runner/work")
+    assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 1)
+    assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 0)
+    assert.deepEqual(delays, [])
+    assert.deepEqual(rejections, [status])
   })
 }
 
@@ -396,7 +391,7 @@ test("HTTP 401 and 403 from every assignment route retire the credential", async
       const requests = await observeAssignmentCredentialRejection(status, deniedRoute)
       assert.equal(requests.filter((path) => path === routeSuffix[deniedRoute]).length, 1)
       assert.equal(requests.filter((path) => path === "/v1/automation-runner/work").length, 1)
-      assert.equal(requests.filter((path) => path === "/v1/automation-runners/events").length, 1)
+      assert.equal(requests.filter((path) => path === "/v1/automation-runners/events").length, 0)
     }
   }
 })
@@ -408,10 +403,7 @@ test("a new credential reconciles immediately and a late rejection cannot retire
   const delays = []
   const rejections = []
   let aWorkStarted = false
-  let aEventsStarted = false
-  let aEventsResponse = null
-  const bEventStream = new TransformStream()
-  const bEventWriter = bEventStream.writable.getWriter()
+  let aWorkResponse = null
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url, options = {}) => {
@@ -421,45 +413,40 @@ test("a new credential reconciles immediately and a late rejection cannot retire
       if (authorization === `Bearer ${tokenA}`) {
         if (path === "/v1/automation-runner/work") {
           aWorkStarted = true
-          return Response.json({ items: [] })
+          while (aWorkResponse === null && !options.signal?.aborted) await new Promise((resolve) => setImmediate(resolve))
+          if (options.signal?.aborted) throw options.signal.reason ?? new Error("aborted")
+          return aWorkResponse
         }
-        aEventsStarted = true
-        while (aEventsResponse === null) await new Promise((resolve) => setImmediate(resolve))
-        return aEventsResponse
       }
       if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      return new Response(bEventStream.readable, { headers: { "Content-Type": "text/event-stream" } })
+      throw new Error(`Unexpected Den request ${path}`)
     },
-    waitBeforeReconnect: async (ms) => { delays.push(ms) },
+    waitBeforeReconnect: async (ms, signal) => {
+      delays.push(ms)
+      await new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+      })
+    },
     onCredentialRejected: () => { rejections.push("rejected") },
   })
 
   runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" })
-  await waitFor(() => aWorkStarted && aEventsStarted, "token A requests did not start")
+  await waitFor(() => aWorkStarted, "token A request did not start")
   const bRequestStart = requests.length
   runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" })
   await waitFor(
-    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 1,
     "token B did not reconcile while token A was pending",
   )
 
-  aEventsResponse = Response.json({ message: "expired" }, { status: 401 })
+  aWorkResponse = Response.json({ message: "expired" }, { status: 401 })
   await flushTasks()
   assert.deepEqual(rejections, [])
-  assert.deepEqual(delays, [])
-  assert.equal(runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" }).connected, false)
+  assert.deepEqual(delays, [60_000])
   assert.equal(runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" }).connected, true)
 
-  await bEventWriter.write(new TextEncoder().encode(
-    'id: 1\nevent: message\ndata: {"cursor":"1","type":"automation_work_available"}\n\n',
-  ))
-  await waitFor(
-    () => requests.filter((request) => request.path === "/v1/automation-runner/work" && request.authorization === `Bearer ${tokenB}`).length === 2,
-    "token B stopped reconciling after token A rejected",
-  )
   assert.ok(requests.slice(bRequestStart).every((request) => request.authorization === `Bearer ${tokenB}`))
   runner.stop()
-  await bEventWriter.close()
 })
 
 test("a late rejection retires a newer generation that reused the same credential", async () => {
@@ -468,7 +455,6 @@ test("a late rejection retires a newer generation that reused the same credentia
   const pendingA = []
   const requests = []
   const rejections = []
-  const eventStreams = []
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url, options = {}) => {
@@ -476,13 +462,11 @@ test("a late rejection retires a newer generation that reused the same credentia
       const authorization = new Headers(options.headers).get("Authorization")
       requests.push({ path, authorization })
       const requestNumber = requests.filter((request) => request.path === path && request.authorization === authorization).length
-      if (authorization === `Bearer ${tokenA}` && path === "/v1/automation-runners/events" && requestNumber === 1) {
+      if (authorization === `Bearer ${tokenA}` && path === "/v1/automation-runner/work" && requestNumber === 1) {
         return new Promise((resolve) => { pendingA.push(() => resolve(Response.json({ message: "expired" }, { status: 401 }))) })
       }
       if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      const stream = new TransformStream()
-      eventStreams.push(stream.writable.getWriter())
-      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
+      throw new Error(`Unexpected Den request ${path}`)
     },
     onCredentialRejected: () => { rejections.push("rejected") },
   })
@@ -493,28 +477,26 @@ test("a late rejection retires a newer generation that reused the same credentia
   await waitFor(() => pendingA.length === 1, "first token A generation did not start")
   runner.configure(configurationB)
   await waitFor(
-    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 1,
     "token B generation did not start",
   )
   runner.configure(configurationA)
   await waitFor(
-    () => requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length === 4,
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length === 2,
     "second token A generation did not start",
   )
   for (const resolve of pendingA) resolve()
   await waitFor(() => rejections.length === 1, "reused token A was not retired")
   assert.equal(runner.configure(configurationA).connected, false)
   await flushTasks()
-  assert.equal(requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length, 4)
+  assert.equal(requests.filter((request) => request.authorization === `Bearer ${tokenA}`).length, 2)
   runner.stop()
-  await Promise.all(eventStreams.map((writer) => writer.close()))
 })
 
 test("routine credential rotation waits for the active assignment to complete", async () => {
   const tokenA = runnerTokenFor("https://den.example.com")
   const tokenB = `${tokenA}-fresh`
   const requests = []
-  const eventWriters = []
   let offeredAssignment = false
   let snapshotStarted = false
   let finishSnapshot = false
@@ -547,11 +529,6 @@ test("routine credential rotation waits for the active assignment to complete", 
         return Response.json({ items: [] })
       }
       if (path.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
-      if (path === "/v1/automation-runners/events") {
-        const stream = new TransformStream()
-        eventWriters.push(stream.writable.getWriter())
-        return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
-      }
       return Response.json({ ok: true })
     },
   })
@@ -566,20 +543,18 @@ test("routine credential rotation waits for the active assignment to complete", 
 
   finishSnapshot = true
   await waitFor(
-    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 1,
     "fresh credential did not connect after assignment completion",
   )
   assert.equal(localAborts, 0)
   assert.ok(requests.some((request) => request.path.endsWith("/complete") && request.authorization === `Bearer ${tokenA}`))
   runner.stop()
-  await Promise.all(eventWriters.map((writer) => writer.close()))
 })
 
 test("routine credential rotation waits for an in-flight claim", async () => {
   const tokenA = runnerTokenFor("https://den.example.com")
   const tokenB = `${tokenA}-fresh`
   const requests = []
-  const eventWriters = []
   /** @type {(response: Response) => void} */
   let resolveClaim = () => {}
   const claimResponse = new Promise((resolve) => { resolveClaim = resolve })
@@ -605,11 +580,6 @@ test("routine credential rotation waits for an in-flight claim", async () => {
         return Response.json({ items: offered ? [] : [{ runId: "run-1" }] })
       }
       if (path.endsWith("/claim")) return claimResponse
-      if (path === "/v1/automation-runners/events") {
-        const stream = new TransformStream()
-        eventWriters.push(stream.writable.getWriter())
-        return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
-      }
       return Response.json({ ok: true })
     },
   })
@@ -623,96 +593,11 @@ test("routine credential rotation waits for an in-flight claim", async () => {
 
   resolveClaim(Response.json({ assignment: testAssignment() }))
   await waitFor(
-    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 2,
+    () => requests.filter((request) => request.authorization === `Bearer ${tokenB}`).length === 1,
     "fresh credential did not connect after the claimed assignment completed",
   )
   assert.ok(requests.some((request) => request.path.endsWith("/complete") && request.authorization === `Bearer ${tokenA}`))
   runner.stop()
-  await Promise.all(eventWriters.map((writer) => writer.close()))
-})
-
-test("routine credential rotation preserves the SSE cursor only for the same runner scope", async () => {
-  const tokenA = runnerTokenFor("https://den.example.com")
-  const tokenB = `${tokenA}-fresh`
-  const tokenC = runnerTokenFor("https://den.example.com", "org-2")
-  const eventRequests = []
-  const eventWriters = []
-  const runner = createDesktopAutomationRunner({
-    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
-    fetchImpl: async (url, options = {}) => {
-      const path = new URL(url).pathname
-      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      const headers = new Headers(options.headers)
-      eventRequests.push({
-        authorization: headers.get("Authorization"),
-        lastEventId: headers.get("Last-Event-ID"),
-      })
-      const stream = new TransformStream()
-      eventWriters.push(stream.writable.getWriter())
-      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
-    },
-  })
-  const configuration = (token) => ({ baseUrl: "https://den.example.com", token, runnerId: "runner-1" })
-  runner.configure(configuration(tokenA))
-  await waitFor(() => eventRequests.length === 1, "first SSE connection did not start")
-  await eventWriters[0].write(new TextEncoder().encode("id: 7\nevent: keepalive\ndata: {}\n\n"))
-  await flushTasks()
-
-  runner.configure(configuration(tokenB))
-  await waitFor(() => eventRequests.length === 2, "rotated SSE connection did not start")
-  assert.equal(eventRequests[1].lastEventId, "7")
-
-  runner.configure(configuration(tokenC))
-  await waitFor(() => eventRequests.length === 3, "new organization SSE connection did not start")
-  assert.equal(eventRequests[2].lastEventId, null)
-  runner.stop()
-  await Promise.all(eventWriters.map((writer) => writer.close()))
-})
-
-test("credential rejection preserves the SSE cursor for a same-scope remint", async () => {
-  const tokenA = runnerTokenFor("https://den.example.com")
-  const tokenB = `${tokenA}-fresh`
-  const eventRequests = []
-  const eventWriters = []
-  let tokenAWorkRequests = 0
-  /** @type {() => void} */
-  let resolveRejected = () => {}
-  const rejected = new Promise((resolve) => { resolveRejected = () => resolve() })
-  const runner = createDesktopAutomationRunner({
-    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
-    fetchImpl: async (url, options = {}) => {
-      const path = new URL(url).pathname
-      const headers = new Headers(options.headers)
-      const authorization = headers.get("Authorization")
-      if (path === "/v1/automation-runner/work") {
-        if (authorization === `Bearer ${tokenA}`) {
-          tokenAWorkRequests += 1
-          if (tokenAWorkRequests === 2) return Response.json({ message: "expired" }, { status: 401 })
-        }
-        return Response.json({ items: [] })
-      }
-      eventRequests.push({ authorization, lastEventId: headers.get("Last-Event-ID") })
-      const stream = new TransformStream()
-      eventWriters.push(stream.writable.getWriter())
-      return new Response(stream.readable, { headers: { "Content-Type": "text/event-stream" } })
-    },
-    onCredentialRejected: () => {
-      runner.configure({ baseUrl: "https://den.example.com", token: tokenB, runnerId: "runner-1" })
-      resolveRejected()
-    },
-  })
-  runner.configure({ baseUrl: "https://den.example.com", token: tokenA, runnerId: "runner-1" })
-  await waitFor(() => eventWriters.length === 1, "first SSE connection did not start")
-  await flushTasks()
-  await eventWriters[0].write(new TextEncoder().encode(
-    'id: 7\nevent: message\ndata: {"cursor":"7","type":"automation_work_available"}\n\n',
-  ))
-  await withTimeout(rejected, "credential rejection did not trigger remint")
-  await waitFor(() => eventRequests.some((request) => request.authorization === `Bearer ${tokenB}`), "reminted SSE did not connect")
-  const reminted = eventRequests.find((request) => request.authorization === `Bearer ${tokenB}`)
-  assert.equal(reminted.lastEventId, "7")
-  runner.stop()
-  await Promise.all(eventWriters.map((writer) => writer.close()))
 })
 
 test("retiring a generation cancels its reconnect wait", async () => {
@@ -725,8 +610,7 @@ test("retiring a generation cancels its reconnect wait", async () => {
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url) => {
       const path = new URL(url).pathname
-      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      if (path === "/v1/automation-runners/events") return new Response(null, { status: 502 })
+      if (path === "/v1/automation-runner/work") return new Response(null, { status: 502 })
       throw new Error(`Unexpected request ${path}`)
     },
     waitBeforeReconnect: async (_ms, signal) => {
@@ -751,21 +635,19 @@ test("runner HTTP failure request budget drops from the reset-on-response baseli
   assert.equal(EXPECTED_RECONNECT_DELAYS.reduce((total, delay) => total + delay, 0), 151_500)
 })
 
-test("a healthy SSE response resets runner reconnect backoff", async () => {
+test("a healthy work poll resets runner reconnect backoff", async () => {
   const delays = []
-  let eventRequests = 0
+  let workRequests = 0
   const done = new AbortController()
   let runner = null
   runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url) => {
       const path = new URL(url).pathname
-      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      eventRequests += 1
-      if (eventRequests <= 3) return new Response(null, { status: 502 })
-      return new Response("event: keepalive\ndata: {}\n\n", {
-        headers: { "Content-Type": "text/event-stream" },
-      })
+      assert.equal(path, "/v1/automation-runner/work")
+      workRequests += 1
+      if (workRequests <= 3) return new Response(null, { status: 502 })
+      return Response.json({ items: [] })
     },
     random: () => 0.5,
     waitBeforeReconnect: async (ms) => {
@@ -785,47 +667,7 @@ test("a healthy SSE response resets runner reconnect backoff", async () => {
   if (!done.signal.aborted) {
     await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
   }
-  assert.deepEqual(delays, [500, 1_000, 2_000, 500])
-})
-
-test("a parsed SSE event resets backoff before an abrupt stream error", async () => {
-  const delays = []
-  let eventRequests = 0
-  const done = new AbortController()
-  let runner = null
-  runner = createDesktopAutomationRunner({
-    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
-    fetchImpl: async (url) => {
-      const path = new URL(url).pathname
-      if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
-      eventRequests += 1
-      if (eventRequests <= 3) return new Response(null, { status: 502 })
-      return new Response(new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("event: keepalive\ndata: {}\n\n"))
-          setImmediate(() => controller.error(new Error("injected stream failure")))
-        },
-      }), { headers: { "Content-Type": "text/event-stream" } })
-    },
-    random: () => 0.5,
-    waitBeforeReconnect: async (ms) => {
-      delays.push(ms)
-      await new Promise((resolve) => setImmediate(resolve))
-      if (delays.length === 4) {
-        runner.stop()
-        done.abort()
-      }
-    },
-  })
-  runner.configure({
-    baseUrl: "https://den.example.com",
-    token: runnerTokenFor("https://den.example.com"),
-    runnerId: "runner-1",
-  })
-  if (!done.signal.aborted) {
-    await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
-  }
-  assert.deepEqual(delays, [500, 1_000, 2_000, 500])
+  assert.deepEqual(delays, [500, 1_000, 2_000, 60_000])
 })
 
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -226,7 +226,7 @@ function requestBudget(delays, windowMs) {
     nextAttemptAt += delays[Math.min(attempts, delays.length - 1)]
     attempts += 1
   }
-  return attempts * 2
+  return attempts
 }
 
 test("model-not-found failures become a repairable Automation error", () => {
@@ -629,8 +629,8 @@ test("retiring a generation cancels its reconnect wait", async () => {
 
 test("runner HTTP failure request budget drops from the reset-on-response baseline", () => {
   const previousResetOnResponseDelays = Array(10).fill(500)
-  assert.equal(requestBudget(previousResetOnResponseDelays, 60_000), 240)
-  assert.equal(requestBudget(EXPECTED_RECONNECT_DELAYS, 60_000), 14)
+  assert.equal(requestBudget(previousResetOnResponseDelays, 60_000), 120)
+  assert.equal(requestBudget(EXPECTED_RECONNECT_DELAYS, 60_000), 7)
   assert.equal(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0), 5_000)
   assert.equal(EXPECTED_RECONNECT_DELAYS.reduce((total, delay) => total + delay, 0), 151_500)
 })

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -14,7 +14,7 @@ function requestBudget(delays: number[], windowMs: number): number {
     nextAttemptAt += delays[Math.min(attempts, delays.length - 1)];
     attempts += 1;
   }
-  return attempts * 2;
+  return attempts;
 }
 
 test("desktop Automation runner retires rejected credentials without changing transient backoff", async ({ evidence }) => {
@@ -25,21 +25,18 @@ test("desktop Automation runner retires rejected credentials without changing tr
   ], { encoding: "utf8" });
   expect(unit.status, unit.stderr || unit.stdout).toBe(0);
   expect(unit.stdout).toContain("repeated HTTP 502 responses retain exponential runner reconnect backoff");
-  expect(unit.stdout).toContain("HTTP 401 from work or events retires exactly that credential without reconnecting");
-  expect(unit.stdout).toContain("HTTP 403 from work or events retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("HTTP 401 from work retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("HTTP 403 from work retires exactly that credential without reconnecting");
   expect(unit.stdout).toContain("HTTP 401 and 403 from every assignment route retire the credential");
   expect(unit.stdout).toContain("a new credential reconciles immediately and a late rejection cannot retire it");
   expect(unit.stdout).toContain("a late rejection retires a newer generation that reused the same credential");
   expect(unit.stdout).toContain("routine credential rotation waits for the active assignment to complete");
   expect(unit.stdout).toContain("routine credential rotation waits for an in-flight claim");
-  expect(unit.stdout).toContain("routine credential rotation preserves the SSE cursor only for the same runner scope");
-  expect(unit.stdout).toContain("credential rejection preserves the SSE cursor for a same-scope remint");
   expect(unit.stdout).toContain("retiring a generation cancels its reconnect wait");
-  expect(unit.stdout).toContain("a healthy SSE response resets runner reconnect backoff");
-  expect(unit.stdout).toContain("a parsed SSE event resets backoff before an abrupt stream error");
+  expect(unit.stdout).toContain("a healthy work poll resets runner reconnect backoff");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 24\b/);
-  expect(unit.stdout).toMatch(/# pass 24\b/);
+  expect(unit.stdout).toMatch(/# tests 21\b/);
+  expect(unit.stdout).toMatch(/# pass 21\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -61,23 +58,23 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 35 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, and same-scope SSE cursor continuity.",
+    "The runner and bridge suites passed 32 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, and work-only polling.",
     true,
   );
 
   const previousResetOnResponseDelays = Array(10).fill(500);
-  expect(requestBudget(previousResetOnResponseDelays, 60_000)).toBe(240);
+  expect(requestBudget(previousResetOnResponseDelays, 60_000)).toBe(120);
   const preFix401FirstMinute = requestBudget(expectedDelays, 60_000);
   const preFix401TenMinutes = requestBudget(expectedDelays, 10 * 60_000);
   const transient502FirstMinute = requestBudget(expectedDelays, 60_000);
-  expect(preFix401FirstMinute).toBe(14);
-  expect(preFix401TenMinutes).toBe(50);
-  expect(transient502FirstMinute).toBe(14);
+  expect(preFix401FirstMinute).toBe(7);
+  expect(preFix401TenMinutes).toBe(25);
+  expect(transient502FirstMinute).toBe(7);
   expect(previousResetOnResponseDelays.reduce((total, delay) => total + delay, 0)).toBe(5_000);
   expect(expectedDelays.reduce((total, delay) => total + delay, 0)).toBe(151_500);
   evidence.recordAssertionEvidence(
     "Transient runner failures retain capped exponential backoff",
-    "At midpoint jitter, repeated 502 responses budget 14 work-plus-SSE requests in the first minute, with delays rising from 500ms to a 30-second cap instead of resetting after every HTTP response.",
+    "At midpoint jitter, repeated 502 responses budget 7 work-poll requests in the first minute, with delays rising from 500ms to a 30-second cap instead of resetting after every HTTP response.",
     true,
   );
 });


### PR DESCRIPTION
## Summary
- replace the long-lived automation runner SSE connection with 60s work polling
- reduce idle automation state refreshes from 15s to 5 minutes
- keep the Automations page responsive with 10s polling initially/for active runs, backing off to 60s

## Verification
- node --test apps/desktop/electron/automation-runner.test.mjs
- pnpm --filter @openwork/app typecheck
- git diff --check