### PR TITLE
fix(evals): honor explicit local-only placement

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -53,9 +53,12 @@ OPENWORK_EVAL_E2E_TESTS=1 \
   --project e2e specs/<slug>.e2e.test.ts
 ```
 
-Set `OPENWORK_EVAL_DAYTONA=1` to place supported resources in Daytona
-sandboxes. Leave it unset for isolated local resources. See `run-tests` for
-environment requirements and the cold-boot verdict check.
+Use `--local` to force isolated local resources even when the invoking shell
+contains inherited Daytona or attached-Den placement variables. Use `--daytona`
+to place supported resources in Daytona sandboxes, or `--den <url>` to attach a
+running Den. Without an explicit flag, the runner preserves the ambient
+placement environment. See `run-tests` for environment requirements and the
+cold-boot verdict check.
 
 ## Authoring contract
 

--- a/evals/bin/evals.mjs
+++ b/evals/bin/evals.mjs
@@ -12,8 +12,9 @@ const usage = `Usage: node evals/bin/evals.mjs [test-names...] [flags]
 
 Run E2E tests:
   --with-llm-vision  Judge vision claims inline (default: defer judging)
-  --daytona         Set OPENWORK_EVAL_DAYTONA=1
-  --den <url>       Set OPENWORK_EVAL_DEN_API_URL=<url>
+  --local            Force isolated local resources and clear inherited remote placement
+  --daytona          Set OPENWORK_EVAL_DAYTONA=1
+  --den <url>        Set OPENWORK_EVAL_DEN_API_URL=<url>
 
 Judge then publish evidence:
   --publish         Enter judge-then-publish mode
@@ -26,7 +27,7 @@ Other:
   --help, -h        Show this help
 
 Publish mode cannot be combined with test names, --with-llm-vision, --daytona,
-or --den. Named tests auto-consent to opt-in flags declared in their source;
+--local, or --den. Named tests auto-consent to opt-in flags declared in their source;
 value-bearing environment variables are never auto-set.
 
 Run exit codes:
@@ -65,6 +66,7 @@ export function parseArgs(args) {
   const options = {
     testNames: [],
     withLlmVision: false,
+    local: false,
     daytona: false,
     publish: false,
     dryRun: false,
@@ -76,6 +78,7 @@ export function parseArgs(args) {
     const arg = args[index];
     if (arg === "--help" || arg === "-h") options.help = true;
     else if (arg === "--with-llm-vision") options.withLlmVision = true;
+    else if (arg === "--local") options.local = true;
     else if (arg === "--daytona") options.daytona = true;
     else if (arg === "--publish") options.publish = true;
     else if (arg === "--dry-run") options.dryRun = true;
@@ -93,10 +96,18 @@ export function parseArgs(args) {
     }
   }
 
+  if (options.local && (options.daytona || options.den !== undefined)) {
+    const conflicts = [];
+    if (options.daytona) conflicts.push("--daytona");
+    if (options.den !== undefined) conflicts.push("--den");
+    throw new Error(`--local is mutually exclusive with ${conflicts.join(" and ")}.`);
+  }
+
   if (options.publish) {
     const conflicts = [];
     if (options.testNames.length > 0) conflicts.push("test names");
     if (options.withLlmVision) conflicts.push("--with-llm-vision");
+    if (options.local) conflicts.push("--local");
     if (options.daytona) conflicts.push("--daytona");
     if (options.den !== undefined) conflicts.push("--den");
     if (conflicts.length > 0) {
@@ -117,6 +128,28 @@ export function parseArgs(args) {
   }
 
   return options;
+}
+
+const REMOTE_PLACEMENT_ENV = [
+  "OPENWORK_EVAL_DAYTONA",
+  "OPENWORK_EVAL_DAYTONA_SANDBOX",
+  "OPENWORK_EVAL_DAYTONA_SANDBOX_ID",
+  "OPENWORK_EVAL_DAYTONA_DEN_SANDBOX",
+  "OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX",
+  "OPENWORK_EVAL_DEN_API_URL",
+  "OPENWORK_EVAL_DEN_WEB_URL",
+];
+
+/** Resolve the child environment before any test process can provision resources. */
+export function resolveRunEnvironment(options, env = process.env) {
+  const childEnv = { ...env };
+  if (options.local) {
+    for (const name of REMOTE_PLACEMENT_ENV) delete childEnv[name];
+    return childEnv;
+  }
+  if (options.daytona) childEnv.OPENWORK_EVAL_DAYTONA = "1";
+  if (options.den !== undefined) childEnv.OPENWORK_EVAL_DEN_API_URL = options.den;
+  return childEnv;
 }
 
 function testFiles(directory = testsDir) {
@@ -236,7 +269,8 @@ function publish(options) {
 
 function run(options) {
   const resolved = resolveTestNames(options.testNames);
-  const childEnv = { ...process.env, OPENWORK_EVAL_E2E_TESTS: "1" };
+  const childEnv = resolveRunEnvironment(options);
+  childEnv.OPENWORK_EVAL_E2E_TESTS = "1";
   const consented = new Set(["OPENWORK_EVAL_E2E_TESTS"]);
 
   for (const file of resolved) {
@@ -248,9 +282,6 @@ function run(options) {
   }
   if (options.withLlmVision) delete childEnv.OPENWORK_EVAL_VISION;
   else childEnv.OPENWORK_EVAL_VISION = "defer";
-  if (options.daytona) childEnv.OPENWORK_EVAL_DAYTONA = "1";
-  if (options.den !== undefined) childEnv.OPENWORK_EVAL_DEN_API_URL = options.den;
-
   const outputDir = join(evalsDir, "results/.testkit");
   mkdirSync(outputDir, { recursive: true });
   const outputFile = join(outputDir, `cli-run-${Date.now()}.json`);
@@ -280,7 +311,14 @@ function run(options) {
   process.stdout.write(`${JSON.stringify({
     command: "evals:e2e",
     lane: "e2e",
-    daytona: options.daytona,
+    daytona: childEnv.OPENWORK_EVAL_DAYTONA?.trim() === "1",
+    placement: options.local
+      ? "local"
+      : options.daytona
+        ? "daytona"
+        : options.den !== undefined
+          ? "attached"
+          : "automatic",
     vision: options.withLlmVision ? "inline" : "defer",
     files: options.testNames.length > 0 ? options.testNames : ["all"],
     ...summary,

--- a/evals/bin/evals.test.mjs
+++ b/evals/bin/evals.test.mjs
@@ -5,6 +5,7 @@ import {
   consentVarsFromSource,
   exitCodeFor,
   parseArgs,
+  resolveRunEnvironment,
   summarize,
   verdictFor,
 } from "./evals.mjs";
@@ -38,6 +39,7 @@ test("parseArgs maps run and publish flags", () => {
   assert.deepEqual(parseArgs(["app-smoke", "--with-llm-vision", "--daytona", "--den", "https://den.example"]), {
     testNames: ["app-smoke"],
     withLlmVision: true,
+    local: false,
     daytona: true,
     publish: false,
     dryRun: false,
@@ -48,6 +50,7 @@ test("parseArgs maps run and publish flags", () => {
   assert.deepEqual(parseArgs(["--publish", "--pr", "42", "--test-run", "latest", "--dry-run", "--force"]), {
     testNames: [],
     withLlmVision: false,
+    local: false,
     daytona: false,
     publish: true,
     dryRun: true,
@@ -62,7 +65,44 @@ test("parseArgs validates values, exclusivity, and unknown flags", () => {
   assert.throws(() => parseArgs(["--den"]), /--den requires a value/);
   assert.throws(() => parseArgs(["--publish", "--dry-run", "app-smoke"]), /mutually exclusive with test names/);
   assert.throws(() => parseArgs(["--publish", "--pr", "1", "--den", "x"]), /mutually exclusive with --den/);
+  assert.throws(() => parseArgs(["app-smoke", "--local", "--daytona"]), /--local is mutually exclusive with --daytona/);
+  assert.throws(() => parseArgs(["app-smoke", "--local", "--den", "https:\/\/den.example"]), /--local is mutually exclusive with --den/);
   assert.throws(() => parseArgs(["--unknown"]), /Unknown flag: --unknown/);
+});
+
+test("explicit local placement removes inherited remote provisioning inputs", () => {
+  const options = parseArgs(["app-smoke", "--local"]);
+  const childEnv = resolveRunEnvironment(options, {
+    PATH: "/bin",
+    OPENWORK_EVAL_DAYTONA: "1",
+    OPENWORK_EVAL_DAYTONA_SANDBOX: "desktop-sandbox",
+    OPENWORK_EVAL_DAYTONA_SANDBOX_ID: "legacy-sandbox",
+    OPENWORK_EVAL_DAYTONA_DEN_SANDBOX: "den-sandbox",
+    OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX: "prepared-desktop",
+    OPENWORK_EVAL_DEN_API_URL: "https://den-api.example.test",
+    OPENWORK_EVAL_DEN_WEB_URL: "https://den.example.test",
+  });
+
+  assert.deepEqual(childEnv, { PATH: "/bin" });
+});
+
+test("explicit Daytona and attached Den placement retain their existing behavior", () => {
+  const daytona = resolveRunEnvironment(parseArgs(["app-smoke", "--daytona"]), {
+    OPENWORK_EVAL_DEN_API_URL: "https://attached.example.test",
+  });
+  assert.equal(daytona.OPENWORK_EVAL_DAYTONA, "1");
+  assert.equal(daytona.OPENWORK_EVAL_DEN_API_URL, "https://attached.example.test");
+
+  const attached = resolveRunEnvironment(parseArgs(["app-smoke", "--den", "https://den.example.test"]), {});
+  assert.equal(attached.OPENWORK_EVAL_DEN_API_URL, "https://den.example.test");
+});
+
+test("automatic placement preserves the caller environment", () => {
+  const ambient = {
+    OPENWORK_EVAL_DAYTONA: "1",
+    OPENWORK_EVAL_DEN_API_URL: "https://den.example.test",
+  };
+  assert.deepEqual(resolveRunEnvironment(parseArgs(["app-smoke"]), ambient), ambient);
 });
 
 test("verdict and exit mapping covers failed, incomplete, and passed runs", () => {


### PR DESCRIPTION
## Summary

- add an explicit `--local` E2E runner mode
- clear inherited Daytona, prepared-sandbox, and attached-Den placement inputs before spawning Vitest in local-only mode
- reject `--local` combined with `--daytona` or `--den`
- preserve existing explicit Daytona, attached-Den, and automatic placement behavior
- report the selected placement mode in the CLI summary

## Root cause

The E2E CLI inherited placement environment from its parent process. A caller intending an isolated local run had no explicit local-only flag, so stale Daytona or attached-Den variables could select remote resources before the test started.

## Verification

Base: `ff5d298ee1a12e348b7021310aef893570df54a3`

Exact head: `17141eb1738bbdda0b4bb7d0f86a04a9abc73550`

### Passed

- `node --check evals/bin/evals.mjs` — exit 0
- `node --test evals/bin/evals.test.mjs` — 8 passed, 0 failed, 0 skipped
- `pnpm evals:e2e app-smoke --local` with inherited Daytona and attached-Den inputs populated — 1 passed, 0 failed, 0 skipped; summary reported `daytona: false` and `placement: local`
- required CI suites passed on the exact head
- Warden approved the exact head with no blocking findings

No required checks failed, skipped, or remain deferred.

## Repository-wide typecheck

`pnpm evals:typecheck` exits 2 with the same 30 diagnostics on this branch and detached clean `origin/dev@ff5d298ee1a12e348b7021310aef893570df54a3`. The matching failures span NodeNext import extensions, declarations for imported `.mjs` modules, testkit/MySQL typing, and unrelated spec witness types. Neither touched file appears in the diagnostics, so this PR does not mix those independent cleanup families into the placement fix.

## Rollback

Revert this commit to remove the explicit local-only CLI contract and restore the previous automatic placement behavior.
