### PR TITLE
fix(den): tolerate OAuth reconnect bursts

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -25,6 +25,7 @@ import {
 import { DEN_ACCOUNT_CONFIG } from "./account-linking-policy.js";
 import { cache } from "./cache.js";
 import { SCIM_TOKEN_STORAGE_STRATEGY } from "./scim-token-storage.js";
+import { OAUTH_TOKEN_RATE_LIMIT_MAX, OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS } from "./oauth-token-rate-limit-observability.js";
 import { syncDenSignupContact } from "./loops.js";
 import { sendEmail } from "./utils/email/send-email.js";
 import {
@@ -933,6 +934,10 @@ export const auth = betterAuth({
       "/email-otp/verify-email": {
         window: 300,
         max: 10,
+      },
+      "/oauth2/token": {
+        window: OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS,
+        max: OAUTH_TOKEN_RATE_LIMIT_MAX,
       },
       "/request-password-reset": {
         window: 3600,

--- a/ee/apps/den-api/src/oauth-token-rate-limit-observability.ts
+++ b/ee/apps/den-api/src/oauth-token-rate-limit-observability.ts
@@ -1,0 +1,64 @@
+import { createHash } from "node:crypto"
+
+export const OAUTH_TOKEN_RATE_LIMIT_MAX = 120
+export const OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60
+
+const KNOWN_GRANT_TYPES = new Set([
+  "authorization_code",
+  "client_credentials",
+  "refresh_token",
+  "urn:ietf:params:oauth:grant-type:device_code",
+])
+
+export function readBasicAuthClientId(headers: Headers) {
+  const authorization = headers.get("authorization")?.trim() ?? ""
+  const match = authorization.match(/^Basic\s+(.+)$/i)
+  if (!match?.[1]) return null
+
+  try {
+    const decoded = atob(match[1])
+    const separator = decoded.indexOf(":")
+    return separator > 0 ? decoded.slice(0, separator) : null
+  } catch {
+    return null
+  }
+}
+
+function fingerprintClientId(clientId: string | null) {
+  if (!clientId) return undefined
+  return `sha256:${createHash("sha256").update(clientId).digest("hex").slice(0, 16)}`
+}
+
+function userAgentCategory(userAgent: string | null) {
+  if (!userAgent) return "missing"
+  if (/cursor/i.test(userAgent)) return "cursor"
+  if (/claude-code/i.test(userAgent)) return "claude_code"
+  if (/codex-mcp-client/i.test(userAgent)) return "codex"
+  if (/opencode/i.test(userAgent)) return "opencode"
+  if (/openwork/i.test(userAgent)) return "openwork"
+  if (/mozilla\//i.test(userAgent)) return "browser"
+  if (/curl|wget|httpie/i.test(userAgent)) return "cli"
+  return "other"
+}
+
+export async function getOAuthTokenRateLimitLogFields(request: Request, response: Response) {
+  const pathname = new URL(request.url).pathname.replace(/\/+$/, "")
+  if (request.method.toUpperCase() !== "POST" || !pathname.endsWith("/oauth2/token") || response.status !== 429) {
+    return null
+  }
+
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? ""
+  const body = contentType.includes("application/x-www-form-urlencoded")
+    ? new URLSearchParams(await request.clone().text().catch(() => ""))
+    : new URLSearchParams()
+  const grantType = body.get("grant_type")
+  const clientId = readBasicAuthClientId(request.headers) ?? body.get("client_id")
+  const retryAfter = response.headers.get("retry-after")?.trim().slice(0, 128)
+
+  return {
+    grant_type: grantType && KNOWN_GRANT_TYPES.has(grantType) ? grantType : grantType ? "other" : "missing",
+    client_id_fingerprint: fingerprintClientId(clientId),
+    retry_after: retryAfter || undefined,
+    user_agent_category: userAgentCategory(request.headers.get("user-agent")),
+  }
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -32,6 +32,7 @@ import {
 import { getInvalidMcpOAuthRedirectUris, isAllowedMcpOAuthRedirectUri, MCP_OAUTH_REDIRECT_URI_ERROR_DESCRIPTION } from "../../mcp/oauth-client-policy.js"
 import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, queryValidator, tokenRoute } from "../../middleware/index.js"
+import { getOAuthTokenRateLimitLogFields, readBasicAuthClientId } from "../../oauth-token-rate-limit-observability.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
 import { cache } from "../../cache.js"
@@ -96,20 +97,6 @@ function readStoredOAuthClientScopes(scopes: string | null) {
     // Better Auth has used both JSON arrays and space-delimited strings for scopes.
   }
   return readOAuthScopeList(scopes)
-}
-
-function readBasicAuthClientId(headers: Headers) {
-  const authorization = headers.get("authorization")?.trim() ?? ""
-  const match = authorization.match(/^Basic\s+(.+)$/i)
-  if (!match?.[1]) return null
-
-  try {
-    const decoded = atob(match[1])
-    const separator = decoded.indexOf(":")
-    return separator > 0 ? decoded.slice(0, separator) : null
-  } catch {
-    return null
-  }
 }
 
 async function registeredClientHasMcpScope(clientId: string) {
@@ -675,6 +662,10 @@ async function handleAuthRequest(c: Context) {
     await revokeBearerSession(authRequest.headers)
   }
 
+  const observabilityRequest = authRequest.method === "POST"
+    && getBetterAuthProxyPath(new URL(authRequest.url).pathname) === "/oauth2/token"
+    ? authRequest.clone()
+    : null
   let response: Response
   try {
     response = await auth.handler(authRequest)
@@ -697,6 +688,12 @@ async function handleAuthRequest(c: Context) {
   }
   if (emailSignInAttempt) {
     await recordEmailSignInResult(emailSignInAttempt, response)
+  }
+  if (observabilityRequest) {
+    const rateLimitFields = await getOAuthTokenRateLimitLogFields(observabilityRequest, response)
+    if (rateLimitFields) {
+      logger.warn("oauth token request rate limited", rateLimitFields)
+    }
   }
   return response
 }

--- a/ee/apps/den-api/test/oauth-token-rate-limit-observability.test.ts
+++ b/ee/apps/den-api/test/oauth-token-rate-limit-observability.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import {
+  getOAuthTokenRateLimitLogFields,
+  OAUTH_TOKEN_RATE_LIMIT_MAX,
+  OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS,
+} from "../src/oauth-token-rate-limit-observability.js"
+
+test("allows reconnect bursts above the observed 64 requests per minute", () => {
+  expect(OAUTH_TOKEN_RATE_LIMIT_MAX).toBe(120)
+  expect(OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS).toBe(60)
+})
+
+test("builds safe OAuth token rate-limit diagnostics from Basic auth", async () => {
+  const clientId = "desktop client"
+  const clientSecret = "never-log-this-secret"
+  const request = new Request("https://api.example.com/api/auth/oauth2/token", {
+    method: "POST",
+    headers: {
+      authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+      "content-type": "application/x-www-form-urlencoded",
+      "user-agent": "OpenWork Desktop/1.2.3",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "never-log-this-refresh-token",
+      client_id: "body-client-must-not-win",
+    }),
+  })
+  const fields = await getOAuthTokenRateLimitLogFields(request, new Response(null, {
+    status: 429,
+    headers: { "retry-after": "42" },
+  }))
+
+  expect(fields).toEqual({
+    grant_type: "refresh_token",
+    client_id_fingerprint: "sha256:1d87be5e8568249d",
+    retry_after: "42",
+    user_agent_category: "openwork",
+  })
+  const serialized = JSON.stringify(fields)
+  for (const secret of [clientId, clientSecret, "never-log-this-refresh-token", "body-client-must-not-win"]) {
+    expect(serialized).not.toContain(secret)
+  }
+})
+
+test("does not expose arbitrary body values and only observes token 429 responses", async () => {
+  const request = new Request("https://api.example.com/api/auth/oauth2/token", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "user-agent": "Mozilla/5.0",
+    },
+    body: new URLSearchParams({ grant_type: "secret-grant-value", code: "secret-code" }),
+  })
+
+  expect(await getOAuthTokenRateLimitLogFields(request, new Response(null, { status: 400 }))).toBeNull()
+  const fields = await getOAuthTokenRateLimitLogFields(request, new Response(null, { status: 429 }))
+  expect(fields).toEqual({
+    grant_type: "other",
+    client_id_fingerprint: undefined,
+    retry_after: undefined,
+    user_agent_category: "browser",
+  })
+  expect(JSON.stringify(fields)).not.toContain("secret")
+})
+
+test("categorizes MCP clients without logging raw user agents", async () => {
+  const clients = [
+    ["Cursor/3.17.3", "cursor"],
+    ["claude-code/2.1.235", "claude_code"],
+    ["codex-mcp-client/0.148.0", "codex"],
+    ["opencode/1.18.18", "opencode"],
+  ] as const
+
+  for (const [userAgent, category] of clients) {
+    const request = new Request("https://api.example.com/api/auth/oauth2/token", {
+      method: "POST",
+      headers: { "user-agent": userAgent },
+    })
+    const fields = await getOAuthTokenRateLimitLogFields(request, new Response(null, { status: 429 }))
+    expect(fields?.user_agent_category).toBe(category)
+    expect(JSON.stringify(fields)).not.toContain(userAgent)
+  }
+})

--- a/evals/specs/oauth-token-rate-limit-observability.test.ts
+++ b/evals/specs/oauth-token-rate-limit-observability.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("OAuth token reconnect bursts remain available with safe rate-limit diagnostics", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-oauth-rate-limit-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/oauth-token-rate-limit-observability.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="4"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    evidence.recordAssertionEvidence(
+      "Legitimate OAuth reconnect bursts exceed the observed production peak",
+      "The focused runtime witness requires a 120-request allowance in a 60-second window, above the observed 64 token requests per minute.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Rate-limit diagnostics do not expose OAuth credentials",
+      "The focused runtime witness rejects raw client IDs, client secrets, refresh tokens, authorization codes, and raw user-agent strings while retaining a client fingerprint and category.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- raise the temporary OAuth token limit to 120 requests per 60 seconds
- log safe structured diagnostics when token requests are rate-limited
- fingerprint client IDs and categorize MCP clients without logging credentials or raw user agents

## Verification
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/oauth-token-rate-limit-observability.test.ts` (1 passed)
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm --filter @openwork-ee/den-api exec bun test test/oauth-token-rate-limit-observability.test.ts` (4 passed)