### PR TITLE
fix(den): preserve thrown HTTPException status on operational routes

### DIFF
--- a/ee/apps/den-api/src/observability/hono.ts
+++ b/ee/apps/den-api/src/observability/hono.ts
@@ -98,12 +98,12 @@ export function createTelemetryErrorSanitizerMiddleware(): MiddlewareHandler {
   }
 }
 
-type ErrorResponseFactory<E extends Env> = (error: Error, c: Context<E>, requestId: string) => Response | undefined
+type ErrorResponseFactory<E extends Env> = (error: Error, c: Context<E>, requestId: string) => Response | undefined | Promise<Response | undefined>
 
 export function registerAppErrorHandler<E extends Env>(app: Hono<E>, responseForError?: ErrorResponseFactory<E>) {
   const logger = appLogger.child({ component: "http" })
 
-  app.onError((error, c) => {
+  app.onError(async (error, c) => {
     const safeError = sanitizeRequestError(error)
     const status = statusFromError(safeError)
     const requestId = c.get("requestId")
@@ -121,7 +121,7 @@ export function registerAppErrorHandler<E extends Env>(app: Hono<E>, responseFor
       logger.warn("request rejected", fields)
     }
 
-    const customResponse = responseForError?.(safeError, c, requestId)
+    const customResponse = await responseForError?.(safeError, c, requestId)
     if (customResponse) {
       return customResponse
     }

--- a/ee/apps/den-api/src/operational-errors.ts
+++ b/ee/apps/den-api/src/operational-errors.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono"
+import { HTTPException } from "hono/http-exception"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -149,11 +150,15 @@ export async function normalizeOperationalErrorResponse(path: string, response: 
   })
 }
 
-export function operationalErrorResponse(error: Error, c: Context, requestId: string) {
+export async function operationalErrorResponse(error: Error, c: Context, requestId: string) {
   const path = c.req.path
   if (!isOperationalErrorPath(path)) {
     console.error(error)
     return new Response("Internal Server Error", { status: 500 })
+  }
+
+  if (error instanceof HTTPException) {
+    return normalizeOperationalErrorResponse(path, error.getResponse(), requestId)
   }
 
   console.error("[operational_error]", {

--- a/ee/apps/den-api/test/operational-errors.test.ts
+++ b/ee/apps/den-api/test/operational-errors.test.ts
@@ -1,10 +1,94 @@
 import { expect, test } from "bun:test"
 import { Hono } from "hono"
+import { HTTPException } from "hono/http-exception"
 import { normalizeOperationalErrorResponse, operationalErrorResponse } from "../src/operational-errors.js"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
+
+function operationalErrorApp(path: string, error: Error, requestId: string) {
+  const app = new Hono()
+  app.onError((safeError, c) => operationalErrorResponse(safeError, c, requestId))
+  app.get(path, () => {
+    throw error
+  })
+  return app
+}
+
+test("thrown MCP HTTPException preserves its response and gains a support reference", async () => {
+  const error = new HTTPException(404, {
+    res: new Response(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      error: { code: -32000, message: "Unsupported protocol version" },
+    }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    }),
+  })
+  const response = await operationalErrorApp("/mcp/agent", error, "req_mcp_404").request("/mcp/agent")
+
+  expect(response.status).toBe(404)
+  const body: unknown = await response.json()
+  expect(body).toMatchObject({
+    jsonrpc: "2.0",
+    id: 7,
+    error: {
+      code: -32000,
+      message: "Unsupported protocol version",
+      data: { referenceId: "req_mcp_404" },
+    },
+  })
+})
+
+test("thrown plain MCP errors remain sanitized 500 responses", async () => {
+  const response = await operationalErrorApp(
+    "/mcp/agent",
+    new Error("provider secret must not escape"),
+    "req_mcp_500",
+  ).request("/mcp/agent")
+
+  expect(response.status).toBe(500)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "internal_server_error",
+    message: "An unexpected server error occurred.",
+    referenceId: "req_mcp_500",
+  })
+  expect(JSON.stringify(body)).not.toContain("provider secret")
+})
+
+test("thrown OAuth HTTPException preserves status, fields, headers, and gains a support reference", async () => {
+  const error = new HTTPException(401, {
+    res: new Response(JSON.stringify({
+      error: "invalid_client",
+      error_description: "Client authentication failed.",
+    }), {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "www-authenticate": "Basic realm=oauth",
+      },
+    }),
+  })
+  const response = await operationalErrorApp(
+    "/api/auth/oauth2/token",
+    error,
+    "req_oauth_401",
+  ).request("/api/auth/oauth2/token")
+
+  expect(response.status).toBe(401)
+  expect(response.headers.get("Cache-Control")).toBe("no-store")
+  expect(response.headers.get("Pragma")).toBe("no-cache")
+  expect(response.headers.get("www-authenticate")).toBe("Basic realm=oauth")
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "invalid_client",
+    error_description: "Client authentication failed.",
+    reference_id: "req_oauth_401",
+  })
+})
 
 test("OAuth token errors include cache headers and a support reference", async () => {
   const response = await normalizeOperationalErrorResponse(

--- a/evals/specs/mcp-operational-error-status.test.ts
+++ b/evals/specs/mcp-operational-error-status.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("operational routes preserve HTTPException responses without exposing unexpected errors", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-operational-errors-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/operational-errors.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="12"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    evidence.recordAssertionEvidence(
+      "MCP HTTPException responses retain client status and JSON-RPC fields",
+      "The focused runtime test throws an HTTPException(404) through the sanitized Hono error flow and requires its JSON-RPC response fields plus a nested referenceId.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Unexpected MCP errors remain sanitized",
+      "The focused runtime test throws a plain Error and requires a sanitized 500 body with no provider-controlled exception text.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "OAuth HTTPException responses retain status and normalized OAuth metadata",
+      "The focused runtime test requires a thrown OAuth HTTPException to keep status, OAuth fields, and WWW-Authenticate while gaining no-store headers and reference_id.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- thrown Hono HTTPExceptions on /mcp, /mcp/agent, /mcp/admin, and OAuth paths were converted to fabricated 500s by operationalErrorResponse, masking real client statuses (production: @hono/mcp protocol-version 404s surfaced to Claude as 500s during MCP sign-in)
- preserve the exception response and pass it through normalizeOperationalErrorResponse so status, JSON-RPC fields, and headers survive while the support reference id is attached
- unexpected plain errors keep the sanitized 500 behavior

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/operational-errors.test.ts` (12 passed)
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/mcp-operational-error-status.test.ts` (1 passed)