### PR TITLE
fix(ci): isolate daytona runs for e2e tests 

### DIFF
--- a/.github/workflows/daytona-e2e-regression-suite.yml
+++ b/.github/workflows/daytona-e2e-regression-suite.yml
@@ -25,8 +25,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: daytona-e2e-regression-suite
-  cancel-in-progress: false
+  group: daytona-e2e-regression-suite-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   plan:

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/daytona-e2e-regression-suite.yml", import.meta.url),
+);
+
+test("Daytona E2E regression concurrency is isolated by pull request", async ({ evidence }) => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  expect(workflow).toContain(
+    "group: daytona-e2e-regression-suite-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}",
+  );
+  expect(workflow).toContain("cancel-in-progress: true");
+  expect(workflow).not.toContain("group: daytona-e2e-regression-suite\n");
+
+  evidence.recordAssertionEvidence(
+    "A waiting Daytona regression run cannot block unrelated pull requests",
+    "The workflow uses a PR-scoped concurrency key, falls back to a unique manual-run key, and supersedes only an older run with the same key.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- scope Daytona E2E regression concurrency by pull request
- cancel only superseded runs for the same pull request
- keep manual dispatches independent with a run-ID fallback
- add a focused testkit contract for the workflow configuration

## Verification
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/daytona-e2e-regression-concurrency.test.ts`
- Passed: 1 test, 0 failed, 0 skipped (local app-less PR lane)

## Verdict
Passed