### PR TITLE
fix(den): key OAuth token limits by client with failure budget

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -25,7 +25,6 @@ import {
 import { DEN_ACCOUNT_CONFIG } from "./account-linking-policy.js";
 import { cache } from "./cache.js";
 import { SCIM_TOKEN_STORAGE_STRATEGY } from "./scim-token-storage.js";
-import { OAUTH_TOKEN_RATE_LIMIT_MAX, OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS } from "./oauth-token-rate-limit-observability.js";
 import { syncDenSignupContact } from "./loops.js";
 import { sendEmail } from "./utils/email/send-email.js";
 import {
@@ -935,10 +934,7 @@ export const auth = betterAuth({
         window: 300,
         max: 10,
       },
-      "/oauth2/token": {
-        window: OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS,
-        max: OAUTH_TOKEN_RATE_LIMIT_MAX,
-      },
+      "/oauth2/token": false,
       "/request-password-reset": {
         window: 3600,
         max: 5,

--- a/ee/apps/den-api/src/oauth-token-rate-limit-observability.ts
+++ b/ee/apps/den-api/src/oauth-token-rate-limit-observability.ts
@@ -1,8 +1,5 @@
 import { createHash } from "node:crypto"
 
-export const OAUTH_TOKEN_RATE_LIMIT_MAX = 120
-export const OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60
-
 const KNOWN_GRANT_TYPES = new Set([
   "authorization_code",
   "client_credentials",

--- a/ee/apps/den-api/src/oauth-token-rate-limit.ts
+++ b/ee/apps/den-api/src/oauth-token-rate-limit.ts
@@ -1,0 +1,132 @@
+import { createHash } from "node:crypto"
+import { readBasicAuthClientId } from "./oauth-token-rate-limit-observability.js"
+
+const OAUTH_TOKEN_ATTEMPT_MAX = 60
+const OAUTH_TOKEN_ANONYMOUS_MAX = 20
+const OAUTH_TOKEN_IP_MAX = 300
+const OAUTH_TOKEN_ATTEMPT_WINDOW_MS = 60_000
+const OAUTH_TOKEN_FAILURE_MAX = 15
+const OAUTH_TOKEN_FAILURE_WINDOW_MS = 300_000
+
+export type OAuthTokenRateLimitCheck = (
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+  now: number,
+  consume?: boolean,
+) => Promise<number | null>
+
+type OAuthTokenRateLimitAdmission = {
+  failureKey: string
+  response: Response | null
+}
+
+async function defaultRateLimitCheck(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+  now: number,
+  consume = true,
+) {
+  const { checkRateLimit } = await import("./utils/rate-limit.js")
+  return checkRateLimit(key, maxRequests, windowMs, now, consume)
+}
+
+function requestAddress(headers: Headers) {
+  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
+}
+
+function rateLimitHash(value: string) {
+  return createHash("sha256").update(value).digest("hex").slice(0, 32)
+}
+
+async function readFormClientId(request: Request) {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? ""
+  if (!contentType.includes("application/x-www-form-urlencoded")) return null
+  const clientId = new URLSearchParams(await request.clone().text().catch(() => "")).get("client_id")
+  return clientId || null
+}
+
+async function oauthTokenRateLimitKeys(request: Request) {
+  const ipHash = rateLimitHash(requestAddress(request.headers))
+  const clientId = readBasicAuthClientId(request.headers) ?? await readFormClientId(request)
+  const clientHash = clientId ? rateLimitHash(clientId) : null
+
+  return {
+    attempt: clientHash ? `oauth-token:client:${clientHash}` : `oauth-token:anon:${ipHash}`,
+    failure: `oauth-token:fail:${clientHash ?? ipHash}`,
+    ip: `oauth-token:ip:${ipHash}`,
+  }
+}
+
+function longestRetryAfter(values: readonly (number | null)[]) {
+  let longest: number | null = null
+  for (const value of values) {
+    if (value !== null) {
+      longest = longest === null ? value : Math.max(longest, value)
+    }
+  }
+  return longest
+}
+
+function oauthTokenRateLimitedResponse(retryAfter: number) {
+  return new Response(JSON.stringify({
+    error: "rate_limited",
+    error_description: "Too many OAuth token requests. Try again later.",
+  }), {
+    status: 429,
+    headers: {
+      "Cache-Control": "no-store",
+      "content-type": "application/json",
+      Pragma: "no-cache",
+      "Retry-After": String(retryAfter),
+    },
+  })
+}
+
+export async function checkOAuthTokenRateLimit(
+  request: Request,
+  rateLimitCheck: OAuthTokenRateLimitCheck = defaultRateLimitCheck,
+  now = Date.now(),
+): Promise<OAuthTokenRateLimitAdmission> {
+  const keys = await oauthTokenRateLimitKeys(request)
+  const failureRetryAfter = await rateLimitCheck(
+    keys.failure,
+    OAUTH_TOKEN_FAILURE_MAX,
+    OAUTH_TOKEN_FAILURE_WINDOW_MS,
+    now,
+    false,
+  )
+  const ipRetryAfter = await rateLimitCheck(
+    keys.ip,
+    OAUTH_TOKEN_IP_MAX,
+    OAUTH_TOKEN_ATTEMPT_WINDOW_MS,
+    now,
+  )
+  // client_id in a form body is attacker-controlled. Per-client buckets isolate
+  // legitimate NAT peers, while the always-consumed IP ceiling bounds clients
+  // that rotate random IDs to obtain fresh 60-request budgets.
+  const attemptRetryAfter = await rateLimitCheck(
+    keys.attempt,
+    keys.attempt.startsWith("oauth-token:anon:") ? OAUTH_TOKEN_ANONYMOUS_MAX : OAUTH_TOKEN_ATTEMPT_MAX,
+    OAUTH_TOKEN_ATTEMPT_WINDOW_MS,
+    now,
+  )
+  const retryAfter = longestRetryAfter([failureRetryAfter, ipRetryAfter, attemptRetryAfter])
+
+  return {
+    failureKey: keys.failure,
+    response: retryAfter === null ? null : oauthTokenRateLimitedResponse(retryAfter),
+  }
+}
+
+export async function recordOAuthTokenFailure(
+  failureKey: string,
+  response: Response,
+  rateLimitCheck: OAuthTokenRateLimitCheck = defaultRateLimitCheck,
+  now = Date.now(),
+) {
+  if (response.status !== 400 && response.status !== 401 && response.status !== 403) return
+  await rateLimitCheck(failureKey, OAUTH_TOKEN_FAILURE_MAX, OAUTH_TOKEN_FAILURE_WINDOW_MS, now)
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -32,6 +32,7 @@ import {
 import { getInvalidMcpOAuthRedirectUris, isAllowedMcpOAuthRedirectUri, MCP_OAUTH_REDIRECT_URI_ERROR_DESCRIPTION } from "../../mcp/oauth-client-policy.js"
 import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, queryValidator, tokenRoute } from "../../middleware/index.js"
+import { checkOAuthTokenRateLimit, recordOAuthTokenFailure } from "../../oauth-token-rate-limit.js"
 import { getOAuthTokenRateLimitLogFields, readBasicAuthClientId } from "../../oauth-token-rate-limit-observability.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
@@ -602,6 +603,20 @@ async function isInvitationSignupAllowed(request: Request) {
 
 async function handleAuthRequest(c: Context) {
   const request = c.req.raw
+  const observabilityRequest = request.method === "POST"
+    && getBetterAuthProxyPath(new URL(request.url).pathname) === "/oauth2/token"
+    ? request.clone()
+    : null
+  const oauthTokenRateLimit = observabilityRequest
+    ? await checkOAuthTokenRateLimit(request, checkRateLimit)
+    : null
+  if (observabilityRequest && oauthTokenRateLimit?.response) {
+    const rateLimitFields = await getOAuthTokenRateLimitLogFields(observabilityRequest, oauthTokenRateLimit.response)
+    if (rateLimitFields) {
+      logger.warn("oauth token request rate limited", rateLimitFields)
+    }
+    return oauthTokenRateLimit.response
+  }
   const authRequest = await normalizeMcpOAuthRequest(request)
   if (authRequest instanceof Response) {
     return authRequest
@@ -662,10 +677,6 @@ async function handleAuthRequest(c: Context) {
     await revokeBearerSession(authRequest.headers)
   }
 
-  const observabilityRequest = authRequest.method === "POST"
-    && getBetterAuthProxyPath(new URL(authRequest.url).pathname) === "/oauth2/token"
-    ? authRequest.clone()
-    : null
   let response: Response
   try {
     response = await auth.handler(authRequest)
@@ -688,6 +699,9 @@ async function handleAuthRequest(c: Context) {
   }
   if (emailSignInAttempt) {
     await recordEmailSignInResult(emailSignInAttempt, response)
+  }
+  if (oauthTokenRateLimit) {
+    await recordOAuthTokenFailure(oauthTokenRateLimit.failureKey, response, checkRateLimit)
   }
   if (observabilityRequest) {
     const rateLimitFields = await getOAuthTokenRateLimitLogFields(observabilityRequest, response)

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -619,6 +619,12 @@ async function handleAuthRequest(c: Context) {
   }
   const authRequest = await normalizeMcpOAuthRequest(request)
   if (authRequest instanceof Response) {
+    if (oauthTokenRateLimit) {
+      // Malformed token requests rejected before auth.handler must still
+      // consume the failure budget, or repeated invalid-resource submissions
+      // would only ever pay the looser attempt buckets.
+      await recordOAuthTokenFailure(oauthTokenRateLimit.failureKey, authRequest, checkRateLimit)
+    }
     return authRequest
   }
   const invitationSignupAllowed = await isInvitationSignupAllowed(authRequest)

--- a/ee/apps/den-api/src/utils/rate-limit.ts
+++ b/ee/apps/den-api/src/utils/rate-limit.ts
@@ -124,8 +124,11 @@ async function claimExistingRateLimit(key: string, maxRequests: number, windowMs
   return latestRow ? retryAfterSeconds(latestRow, maxRequests, windowMs, now) : null
 }
 
-export async function checkRateLimit(key: string, maxRequests: number, windowMs: number, now: number) {
+export async function checkRateLimit(key: string, maxRequests: number, windowMs: number, now: number, consume = true) {
   const row = await readRateLimit(key)
+  if (!consume) {
+    return row ? retryAfterSeconds(row, maxRequests, windowMs, now) : null
+  }
   if (row) {
     return claimExistingRateLimit(key, maxRequests, windowMs, now, row)
   }

--- a/ee/apps/den-api/test/oauth-token-rate-limit-observability.test.ts
+++ b/ee/apps/den-api/test/oauth-token-rate-limit-observability.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from "bun:test"
 import {
   getOAuthTokenRateLimitLogFields,
-  OAUTH_TOKEN_RATE_LIMIT_MAX,
-  OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS,
+  readBasicAuthClientId,
 } from "../src/oauth-token-rate-limit-observability.js"
 
-test("allows reconnect bursts above the observed 64 requests per minute", () => {
-  expect(OAUTH_TOKEN_RATE_LIMIT_MAX).toBe(120)
-  expect(OAUTH_TOKEN_RATE_LIMIT_WINDOW_SECONDS).toBe(60)
+test("reads a client ID from valid Basic authentication only", () => {
+  expect(readBasicAuthClientId(new Headers({ authorization: `Basic ${btoa("desktop-client:secret")}` }))).toBe("desktop-client")
+  expect(readBasicAuthClientId(new Headers({ authorization: "Basic not-base64" }))).toBeNull()
+  expect(readBasicAuthClientId(new Headers({ authorization: `Bearer ${btoa("desktop-client:secret")}` }))).toBeNull()
 })
 
 test("builds safe OAuth token rate-limit diagnostics from Basic auth", async () => {

--- a/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
+++ b/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto"
+import { expect, test } from "bun:test"
+import {
+  checkOAuthTokenRateLimit,
+  recordOAuthTokenFailure,
+  type OAuthTokenRateLimitCheck,
+} from "../src/oauth-token-rate-limit.js"
+
+type Bucket = {
+  count: number
+  lastRequest: number
+}
+
+type CheckCall = {
+  consume: boolean
+  key: string
+}
+
+function createInMemoryRateLimit() {
+  const buckets = new Map<string, Bucket>()
+  const calls: CheckCall[] = []
+  const check: OAuthTokenRateLimitCheck = async (key, maxRequests, windowMs, now, consume = true) => {
+    calls.push({ consume, key })
+    const bucket = buckets.get(key)
+    if (!bucket) {
+      if (consume) buckets.set(key, { count: 1, lastRequest: now })
+      return null
+    }
+
+    const elapsed = now - bucket.lastRequest
+    if (elapsed > windowMs) {
+      if (consume) buckets.set(key, { count: 1, lastRequest: now })
+      return null
+    }
+    if (bucket.count >= maxRequests) {
+      return Math.max(1, Math.ceil((windowMs - elapsed) / 1000))
+    }
+    if (consume) {
+      bucket.count += 1
+      bucket.lastRequest = now
+    }
+    return null
+  }
+
+  return { buckets, calls, check }
+}
+
+function tokenRequest(clientId: string | null, ip: string, basic = false) {
+  const headers = new Headers({
+    "content-type": "application/x-www-form-urlencoded",
+    "x-forwarded-for": `${ip}, 10.0.0.1`,
+  })
+  const body = new URLSearchParams({ grant_type: "refresh_token" })
+  if (clientId && basic) {
+    headers.set("authorization", `Basic ${btoa(`${clientId}:never-store-this-secret`)}`)
+  } else if (clientId) {
+    body.set("client_id", clientId)
+  }
+  return new Request("https://api.example.com/api/auth/oauth2/token", {
+    method: "POST",
+    headers,
+    body,
+  })
+}
+
+async function exchange(
+  request: Request,
+  handlerStatus: number,
+  check: OAuthTokenRateLimitCheck,
+  now: number,
+) {
+  const admission = await checkOAuthTokenRateLimit(request, check, now)
+  if (admission.response) return { handlerRan: false, response: admission.response }
+
+  const response = new Response(null, { status: handlerStatus })
+  await recordOAuthTokenFailure(admission.failureKey, response, check, now)
+  return { handlerRan: true, response }
+}
+
+function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex").slice(0, 32)
+}
+
+test("clients behind one IP have independent attempt budgets", async () => {
+  const limiter = createInMemoryRateLimit()
+  const now = Date.now()
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = await exchange(tokenRequest("client-a", "203.0.113.10"), 200, limiter.check, now)
+    expect(result.response.status).toBe(200)
+  }
+
+  expect((await exchange(tokenRequest("client-a", "203.0.113.10"), 200, limiter.check, now)).response.status).toBe(429)
+  expect((await exchange(tokenRequest("client-b", "203.0.113.10"), 200, limiter.check, now)).response.status).toBe(200)
+})
+
+test("fifteen failed exchanges block the next request before authentication", async () => {
+  const limiter = createInMemoryRateLimit()
+  const request = tokenRequest("failing-client", "203.0.113.11", true)
+  const now = Date.now()
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    const result = await exchange(request, attempt % 2 === 0 ? 401 : 403, limiter.check, now)
+    expect(result.handlerRan).toBeTrue()
+    expect(result.response.status === 401 || result.response.status === 403).toBeTrue()
+  }
+
+  const blocked = await exchange(request, 401, limiter.check, now)
+  expect(blocked.handlerRan).toBeFalse()
+  expect(blocked.response.status).toBe(429)
+  expect(blocked.response.headers.get("retry-after")).toBe("300")
+  expect(blocked.response.headers.get("cache-control")).toBe("no-store")
+  expect(blocked.response.headers.get("pragma")).toBe("no-cache")
+  expect(await blocked.response.json()).toEqual({
+    error: "rate_limited",
+    error_description: "Too many OAuth token requests. Try again later.",
+  })
+})
+
+test("successful exchanges never consume the failure budget", async () => {
+  const limiter = createInMemoryRateLimit()
+  const clientId = "successful-client"
+  const request = tokenRequest(clientId, "203.0.113.12")
+  const failureKey = `oauth-token:fail:${hash(clientId)}`
+  const now = Date.now()
+
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    expect((await exchange(request, 200, limiter.check, now)).response.status).toBe(200)
+  }
+  expect(limiter.buckets.has(failureKey)).toBeFalse()
+
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    expect((await exchange(request, 400, limiter.check, now)).response.status).toBe(400)
+  }
+  expect(limiter.buckets.get(failureKey)?.count).toBe(15)
+  expect((await exchange(request, 200, limiter.check, now)).handlerRan).toBeFalse()
+})
+
+test("hashed keys bound rotating and anonymous clients without storing raw identities", async () => {
+  const identityLimiter = createInMemoryRateLimit()
+  const rotatingLimiter = createInMemoryRateLimit()
+  const ip = "203.0.113.13"
+  const now = Date.now()
+  await exchange(tokenRequest("raw-basic-client", ip, true), 200, identityLimiter.check, now)
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const result = await exchange(tokenRequest(`rotating-client-${attempt}`, ip), 200, rotatingLimiter.check, now)
+    expect(result.response.status).toBe(200)
+  }
+  expect((await exchange(tokenRequest("rotating-client-300", ip), 200, rotatingLimiter.check, now)).response.status).toBe(429)
+
+  const anonymousLimiter = createInMemoryRateLimit()
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    expect((await exchange(tokenRequest(null, ip), 200, anonymousLimiter.check, now)).response.status).toBe(200)
+  }
+  expect((await exchange(tokenRequest(null, ip), 200, anonymousLimiter.check, now)).response.status).toBe(429)
+
+  const keys = [...identityLimiter.calls, ...rotatingLimiter.calls, ...anonymousLimiter.calls].map((call) => call.key)
+  expect(keys).toContain(`oauth-token:ip:${hash(ip)}`)
+  expect(keys).toContain(`oauth-token:client:${hash("raw-basic-client")}`)
+  expect(keys).toContain(`oauth-token:anon:${hash(ip)}`)
+  expect(keys).toContain(`oauth-token:fail:${hash(ip)}`)
+  for (const key of keys) {
+    expect(key).not.toContain(ip)
+    expect(key).not.toContain("raw-basic-client")
+    expect(key).not.toContain("rotating-client")
+    expect(key).not.toContain("never-store-this-secret")
+    expect(key.length).toBeLessThan(512)
+  }
+})

--- a/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
+++ b/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
@@ -115,6 +115,28 @@ test("fifteen failed exchanges block the next request before authentication", as
   })
 })
 
+test("pre-handler normalization rejections consume the failure budget", async () => {
+  const limiter = createInMemoryRateLimit()
+  const request = tokenRequest("malformed-client", "203.0.113.14", true)
+  const now = Date.now()
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    const admission = await checkOAuthTokenRateLimit(request, limiter.check, now)
+    expect(admission.response).toBeNull()
+    // Model handleAuthRequest rejecting the request in normalization, before
+    // auth.handler ever runs.
+    await recordOAuthTokenFailure(
+      admission.failureKey,
+      new Response(JSON.stringify({ error: "invalid_request" }), { status: 400 }),
+      limiter.check,
+      now,
+    )
+  }
+
+  const blocked = await checkOAuthTokenRateLimit(request, limiter.check, now)
+  expect(blocked.response?.status).toBe(429)
+  expect(limiter.buckets.get(`oauth-token:fail:${hash("malformed-client")}`)?.count).toBe(15)
+})
+
 test("successful exchanges never consume the failure budget", async () => {
   const limiter = createInMemoryRateLimit()
   const clientId = "successful-client"

--- a/evals/specs/oauth-token-rate-limit-observability.test.ts
+++ b/evals/specs/oauth-token-rate-limit-observability.test.ts
@@ -7,7 +7,7 @@ import { test } from "@openwork/testkit";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
-test("OAuth token reconnect bursts remain available with safe rate-limit diagnostics", ({ evidence }) => {
+test("OAuth token rate-limit diagnostics remain safe", ({ evidence }) => {
   const reportDir = mkdtempSync(join(tmpdir(), "openwork-oauth-rate-limit-"));
   const reportPath = join(reportDir, "bun-junit.xml");
   try {
@@ -39,11 +39,6 @@ test("OAuth token reconnect bursts remain available with safe rate-limit diagnos
     expect(junit).not.toContain("<failure");
     expect(junit).not.toContain("<skipped");
 
-    evidence.recordAssertionEvidence(
-      "Legitimate OAuth reconnect bursts exceed the observed production peak",
-      "The focused runtime witness requires a 120-request allowance in a 60-second window, above the observed 64 token requests per minute.",
-      true,
-    );
     evidence.recordAssertionEvidence(
       "Rate-limit diagnostics do not expose OAuth credentials",
       "The focused runtime witness rejects raw client IDs, client secrets, refresh tokens, authorization codes, and raw user-agent strings while retaining a client fingerprint and category.",

--- a/evals/specs/oauth-token-rate-limit.test.ts
+++ b/evals/specs/oauth-token-rate-limit.test.ts
@@ -33,7 +33,7 @@ test("OAuth token clients receive isolated attempt and failure budgets", ({ evid
 
     const junit = readFileSync(reportPath, "utf8");
     const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
-    expect(summary).toContain('tests="4"');
+    expect(summary).toContain('tests="5"');
     expect(summary).toContain('failures="0"');
     expect(summary).toContain('skipped="0"');
     expect(junit).not.toContain("<failure");
@@ -47,6 +47,11 @@ test("OAuth token clients receive isolated attempt and failure budgets", ({ evid
     evidence.recordAssertionEvidence(
       "Repeated authentication failures trigger a stricter budget",
       "The focused runtime witness observes only 15 failed handler exchanges before the next request is rejected before authentication with an OAuth-compatible 429.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Pre-handler normalization rejections consume the failure budget",
+      "The focused runtime witness records 15 pre-handler 400 rejections without running the token handler and requires the 16th request to be blocked with a 429 while the failure bucket shows exactly 15 entries.",
       true,
     );
     evidence.recordAssertionEvidence(

--- a/evals/specs/oauth-token-rate-limit.test.ts
+++ b/evals/specs/oauth-token-rate-limit.test.ts
@@ -1,0 +1,65 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("OAuth token clients receive isolated attempt and failure budgets", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-oauth-token-rate-limit-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/oauth-token-rate-limit.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="4"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    evidence.recordAssertionEvidence(
+      "OAuth clients behind one public IP have independent attempt budgets",
+      "The focused runtime witness exhausts client A's 60-request bucket, observes its 429, and then observes a successful exchange for client B on the same IP.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Repeated authentication failures trigger a stricter budget",
+      "The focused runtime witness observes only 15 failed handler exchanges before the next request is rejected before authentication with an OAuth-compatible 429.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Successful token exchanges do not consume the failure budget",
+      "The focused runtime witness observes no failure bucket after 30 successful exchanges and requires 15 actual failures before pre-handler rejection.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Durable OAuth rate-limit keys contain no raw identities",
+      "The focused runtime witness inspects every generated key, requires hashed IP/client buckets, and rejects raw client IDs and IP addresses while also proving anonymous and rotating-client ceilings.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
Follow-up to #3938 and its Warden security note: the interim flat 120/min-per-IP token limit is replaced with client-identity keying plus stricter failure throttling.

- registered clients (Basic auth or form client_id) get an independent 60/60s bucket keyed by hashed client_id, so legitimate MCP clients behind one office NAT no longer exhaust each other
- an always-consumed hashed-IP emergency ceiling (300/60s) bounds attackers rotating random client IDs; requests without a client_id get a stricter 20/60s per-IP bucket
- failed token exchanges (400/401/403) consume a 15-per-5-minutes failure budget that blocks further attempts pre-handler, answering the flag that unauthenticated invalid attempts needed a tighter budget than reconnect bursts
- Better Auth's built-in flat /oauth2/token rule is disabled (`false`) so limiting is owned by the Den route layer; 429s stay OAuth-compatible with Retry-After and flow through the #3938 safe diagnostics logging
- rate-limit keys store only truncated SHA-256 hashes, never raw client IDs or IPs

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/oauth-token-rate-limit.test.ts test/oauth-token-rate-limit-observability.test.ts` (8 passed)
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/oauth-token-rate-limit.test.ts` (1 passed)
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/oauth-token-rate-limit-observability.test.ts` (1 passed)