### PR TITLE
fix(automations): report Desktop outcomes and open their execution threads

### DIFF
--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -351,7 +351,8 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     const modelNeedsAttention = task.needsAttentionReason?.code === "model_access_lost"
       || task.needsAttentionReason?.code === "provider_unavailable"
     const runs = runsQuery.data?.items ?? []
-    const selectedReceipt = receiptQuery.data
+    const selectedReceipt = receiptQuery.data?.run.id === selectedRunId ? receiptQuery.data : undefined
+    const receiptIsLoading = receiptQuery.isLoading || (receiptQuery.isFetching && !selectedReceipt)
     const threadMatches = !selectedThreadId || selectedReceipt?.run.executionThread?.id === selectedThreadId
 
     if (editing && (detail.revision.executionTarget ?? "desktop") === "desktop") {
@@ -577,7 +578,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             <CardContent>
               {!selectedRunId ? (
                 <div className="py-10 text-center text-sm text-muted-foreground">No run selected.</div>
-              ) : receiptQuery.isLoading ? (
+              ) : receiptIsLoading ? (
                 <Skeleton className="h-48 rounded-xl" />
               ) : receiptQuery.error || !selectedReceipt ? (
                 <Alert variant="warning"><AlertCircle /><AlertDescription>{describeError(receiptQuery.error)}</AlertDescription></Alert>
@@ -668,6 +669,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             <button
               key={item.automation.id}
               type="button"
+              data-automation-id={item.automation.id}
               {...(item.automation.state === "needs_attention" ? { "data-automation-needs-attention": true } : {})}
               className="rounded-2xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/40"
               onClick={() => openAutomation(item.automation.id)}

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -4,6 +4,8 @@ const RUNNER_WORK_POLL_MS = 60_000
 function serializedError(value) {
   if (value instanceof Error) return value.message
   if (typeof value === "string") return value
+  if (typeof value?.message === "string") return value.message
+  if (typeof value?.data?.message === "string") return value.data.message
   try { return JSON.stringify(value) } catch { return String(value) }
 }
 
@@ -73,6 +75,7 @@ function assistantResult(snapshot) {
   let outputTokens = 0
   let sawInput = false
   let sawOutput = false
+  let sawCompletedTool = false
   for (const message of assistants) {
     const tokens = message?.info?.tokens
     if (Number.isFinite(tokens?.input)) { inputTokens += Number(tokens.input); sawInput = true }
@@ -81,16 +84,30 @@ function assistantResult(snapshot) {
       if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
         resultSummary = part.text.trim().slice(0, 20_000)
       }
+      if (part?.type === "tool" && (part?.toolStatus === "completed" || part?.state?.status === "completed")) {
+        sawCompletedTool = true
+      }
     }
   }
   return {
     resultSummary,
+    hasCompletedOutput: Boolean(resultSummary) || sawCompletedTool,
     usage: {
       inputTokens: sawInput ? inputTokens : null,
       outputTokens: sawOutput ? outputTokens : null,
       costMicros: null,
     },
   }
+}
+
+function assistantFailure(snapshot) {
+  const messages = Array.isArray(snapshot?.messages) ? snapshot.messages : []
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.info?.role !== "assistant" || !message.info.error) continue
+    return classifyAutomationExecutionError(message.info.error)
+  }
+  return null
 }
 
 /** Runs the assignment as a normal visible local OpenWork thread. */
@@ -135,20 +152,34 @@ export async function executeDesktopAutomation(assignment, options) {
       )
       const snapshot = response?.item
       const output = assistantResult(snapshot)
-      const snapshotError = classifyAutomationExecutionError(snapshot)
-      if (snapshotError.code === "model_access_lost") {
+      const snapshotError = assistantFailure(snapshot)
+      if (snapshotError) {
         const error = new Error(snapshotError.message)
         Object.defineProperty(error, "code", { value: snapshotError.code })
         throw error
       }
-      if (snapshot?.status?.type === "idle" && output.resultSummary) {
-        return { sessionId, workspaceId, ...output }
+      if (snapshot?.status?.type === "idle" && output.hasCompletedOutput) {
+        return {
+          sessionId,
+          workspaceId,
+          resultSummary: output.resultSummary,
+          usage: output.usage,
+        }
       }
       if (snapshot?.status?.type === "idle" && Date.now() - startedAt > 10_000) {
         throw new Error("Desktop Automation finished without an assistant result")
       }
       await sleep(500, options.signal)
     }
+  } catch (error) {
+    const contextualError = error instanceof Error ? error : new Error(serializedError(error))
+    if (Reflect.get(contextualError, "sessionId") === undefined) {
+      Object.defineProperty(contextualError, "sessionId", { value: sessionId })
+    }
+    if (Reflect.get(contextualError, "workspaceId") === undefined) {
+      Object.defineProperty(contextualError, "workspaceId", { value: workspaceId })
+    }
+    throw contextualError
   } finally {
     options.signal.removeEventListener("abort", abort)
   }
@@ -318,8 +349,8 @@ export function createDesktopAutomationRunner(options) {
       const classified = classifyAutomationExecutionError(error)
       result = {
         status: cancelled ? "cancelled" : "failed",
-        sessionId: null,
-        workspaceId: null,
+        sessionId: typeof error?.sessionId === "string" ? error.sessionId : null,
+        workspaceId: typeof error?.workspaceId === "string" ? error.workspaceId : null,
         resultSummary: null,
         usage: EMPTY_USAGE,
         error: {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -866,6 +866,224 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
   })
 })
 
+test("desktop Automation execution accepts a completed tool-only assistant turn", async () => {
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === "/workspaces") {
+      return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+      return Response.json({ item: { id: "session-tool-only" }, started: true }, { status: 201 })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions/session-tool-only/snapshot") {
+      return Response.json({ item: {
+        status: { type: "idle" },
+        messages: [{
+          info: { role: "assistant", tokens: { input: 9, output: 3 } },
+          parts: [{ type: "tool", tool: "example", state: { status: "completed", output: "done" } }],
+        }],
+      } })
+    }
+    throw new Error(`Unexpected request ${parsed.pathname}`)
+  }
+
+  const result = await executeDesktopAutomation(testAssignment(), {
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+    fetchImpl,
+    signal: new AbortController().signal,
+  })
+
+  assert.deepEqual(result, {
+    sessionId: "session-tool-only",
+    workspaceId: "workspace-1",
+    resultSummary: null,
+    usage: { inputTokens: 9, outputTokens: 3, costMicros: null },
+  })
+})
+
+test("failed desktop assignments retain their created local thread in the Den completion", async () => {
+  let offered = false
+  const completions = []
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        if (parsed.pathname === "/workspaces") {
+          return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+          return Response.json({ item: { id: "session-failed" }, started: true }, { status: 201 })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions/session-failed/snapshot") {
+          return Response.json({ item: {
+            status: { type: "idle" },
+            messages: [{
+              info: {
+                role: "assistant",
+                error: {
+                  name: "ProviderModelNotFoundError",
+                  message: "Model not found: opencode/removed-model",
+                },
+              },
+              parts: [],
+            }],
+          } })
+        }
+        throw new Error(`Unexpected local request ${parsed.pathname}`)
+      }
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push(JSON.parse(options.body))
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await withTimeout(completed, "failed assignment completion timed out")
+  runner.stop()
+
+  const completionBody = completions[0]
+  assert.ok(completionBody, "the failed assignment never reached a completion")
+  assert.equal(completionBody.status, "failed")
+  assert.equal(completionBody.sessionId, "session-failed")
+  assert.equal(completionBody.workspaceId, "workspace-1")
+  assert.equal(completionBody.error.code, "model_access_lost")
+})
+
+test("cancellation during execution preserves the local thread and reaches a terminal completion", async () => {
+  let offered = false
+  let snapshotStarted = false
+  const completions = []
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        if (parsed.pathname === "/workspaces") {
+          return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+          return Response.json({ item: { id: "session-cancelled" }, started: true }, { status: 201 })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/sessions/session-cancelled/snapshot") {
+          snapshotStarted = true
+          return new Promise((resolve, reject) => {
+            const abort = () => reject(options.signal?.reason ?? new Error("cancelled"))
+            if (options.signal?.aborted) abort()
+            else options.signal?.addEventListener("abort", abort, { once: true })
+          })
+        }
+        if (parsed.pathname.endsWith("/abort")) return Response.json({ ok: true })
+        throw new Error(`Unexpected local request ${parsed.pathname}`)
+      }
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/heartbeat")) {
+        return Response.json({ leaseValid: true, cancelRequested: snapshotStarted })
+      }
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push(JSON.parse(options.body))
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    heartbeatIntervalMs: 1,
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await withTimeout(completed, "cancelled assignment completion timed out")
+  runner.stop()
+
+  const completionBody = completions[0]
+  assert.ok(completionBody, "the cancelled assignment never reached a completion")
+  assert.equal(completionBody.status, "cancelled")
+  assert.equal(completionBody.sessionId, "session-cancelled")
+  assert.equal(completionBody.workspaceId, "workspace-1")
+  assert.equal(completionBody.error.code, "cancelled")
+})
+
+test("an explicit assistant provider failure terminates immediately with its local thread", async () => {
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === "/workspaces") {
+      return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+      return Response.json({ item: { id: "session-provider-failure" }, started: true }, { status: 201 })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/sessions/session-provider-failure/snapshot") {
+      return Response.json({ item: {
+        status: { type: "idle" },
+        messages: [{
+          info: {
+            role: "assistant",
+            error: {
+              name: "APIError",
+              data: { message: "Provider returned HTTP 503 and is temporarily unavailable", statusCode: 503 },
+            },
+          },
+          parts: [],
+        }],
+      } })
+    }
+    throw new Error(`Unexpected request ${parsed.pathname}`)
+  }
+
+  await assert.rejects(
+    executeDesktopAutomation(testAssignment(), {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+      fetchImpl,
+      signal: new AbortController().signal,
+    }),
+    (error) => error instanceof Error
+      && Reflect.get(error, "code") === "execution_failed"
+      && Reflect.get(error, "sessionId") === "session-provider-failure"
+      && Reflect.get(error, "workspaceId") === "workspace-1"
+      && error.message === "Provider returned HTTP 503 and is temporarily unavailable",
+  )
+})
+
+test("a temporarily unavailable workspace fails clearly before session creation", async () => {
+  await assert.rejects(
+    executeDesktopAutomation(testAssignment(), {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+      fetchImpl: async (url) => {
+        const parsed = new URL(url)
+        if (parsed.pathname === "/workspaces") return Response.json({ items: [], activeId: null })
+        throw new Error(`Unexpected request ${parsed.pathname}`)
+      },
+      signal: new AbortController().signal,
+    }),
+    /No local workspace is available/,
+  )
+})
+
 test("desktop Automation execution surfaces a missing pinned model", async () => {
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
@@ -911,6 +1129,8 @@ test("desktop Automation execution surfaces a missing pinned model", async () =>
     }),
     (error) => error instanceof Error
       && Reflect.get(error, "code") === "model_access_lost"
+      && Reflect.get(error, "sessionId") === "session-1"
+      && Reflect.get(error, "workspaceId") === "workspace-1"
       && /Choose a supported model/.test(error.message),
   )
 })

--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -98,7 +98,7 @@ function mapRevision(row: RevisionRow): AutomationRevision {
 }
 
 function mapRun(row: RunRow): AutomationRun {
-  const receipt = row.execution_target === "cloud" && typeof row.engine_receipt === "object" && row.engine_receipt !== null
+  const receipt = typeof row.engine_receipt === "object" && row.engine_receipt !== null
     ? row.engine_receipt as Record<string, unknown>
     : null
   const nativeThreadId = typeof receipt?.nativeThreadId === "string" ? receipt.nativeThreadId : null
@@ -762,6 +762,7 @@ export class DenAutomationRepository implements AutomationRepository {
         result_summary: input.resultSummary,
         usage: input.usage,
         error: input.error,
+        ...(input.engineReceipt === undefined ? {} : { engine_receipt: input.engineReceipt }),
         finished_at: new Date(input.now),
         lease_expires_at: null,
         heartbeat_at: new Date(input.now),

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -443,6 +443,10 @@ export class AutomationService {
       resultSummary: result.resultSummary,
       usage: result.usage,
       error: result.error,
+      engineReceipt: {
+        ...(result.sessionId ? { nativeThreadId: result.sessionId } : {}),
+        ...(result.workspaceId ? { workspaceId: result.workspaceId } : {}),
+      },
       attempt: result.attempt,
       now,
     })

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -21,6 +21,7 @@ import { automationUpdateChangedRows } from "../src/automations/update-result.js
 import { isMcpOperationAllowed } from "../src/mcp/policy.js"
 
 const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
+const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
 
 test("runner notifications contain only a resumable cursor and wake-up type", () => {
   assert.deepEqual(automationRunnerNotificationSchema.parse({
@@ -141,7 +142,6 @@ test("desktop occurrences stay claimable through the recovery window with named 
 })
 
 test("runner presence is a read-only view of existing liveness data", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const presence = serviceSource.slice(
     serviceSource.indexOf("async desktopRunnerPresence"),
     serviceSource.indexOf("async discoverDesktopRunnerWork"),
@@ -157,6 +157,26 @@ test("runner presence is a read-only view of existing liveness data", () => {
   assert.doesNotMatch(presence, /update|insert|touchDesktopRunner/i)
   assert.match(reader, /db\.select\(/)
   assert.doesNotMatch(reader, /db\.(update|insert)/)
+})
+
+test("Desktop completion durably exposes its native local thread", () => {
+  const completion = serviceSource.slice(
+    serviceSource.indexOf("async completeDesktopRunner"),
+    serviceSource.indexOf("runnerNotifications"),
+  )
+  const mapRun = repositorySource.slice(
+    repositorySource.indexOf("function mapRun"),
+    repositorySource.indexOf("function normalizedDefinition"),
+  )
+  const persist = repositorySource.slice(
+    repositorySource.indexOf("async complete(input"),
+    repositorySource.indexOf("async recoverExpiredLeases"),
+  )
+
+  assert.match(completion, /engineReceipt:[\s\S]*nativeThreadId: result\.sessionId[\s\S]*workspaceId: result\.workspaceId/)
+  assert.match(persist, /engine_receipt: input\.engineReceipt/)
+  assert.match(mapRun, /receipt\?\.nativeThreadId[\s\S]*receipt\?\.workspaceId/)
+  assert.doesNotMatch(mapRun, /row\.execution_target === "cloud"/)
 })
 
 test("expired lease recovery cannot clobber a concurrently renewed lease", () => {
@@ -245,7 +265,6 @@ test("idle runner notification polling backs off without delaying keepalives", (
 
 test("idle runner keepalives do not persist liveness in the database", () => {
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
   const sse = routesSource.slice(
     routesSource.indexOf("/v1/automation-runners/events\", async"),
@@ -265,7 +284,6 @@ test("idle runner keepalives do not persist liveness in the database", () => {
 })
 
 test("work polling tolerates non-critical runner presence touch failures", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const discover = serviceSource.slice(
     serviceSource.indexOf("async discoverDesktopRunnerWork"),
     serviceSource.indexOf("async claimDesktopRunner"),
@@ -277,7 +295,6 @@ test("work polling tolerates non-critical runner presence touch failures", () =>
 })
 
 test("every dispatch path revalidates the owner's model access", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const tick = serviceSource.slice(serviceSource.indexOf("async tick"), serviceSource.indexOf("async stop"))
   assert.match(tick, /resolveAutomationModelAccess\(\{\s*organizationId: item\.automation\.organizationId/)
   assert.match(tick, /shouldApplyAutomationModelAccessFailure\(\{[\s\S]*modelAttentionCapable: \(item\.revision\.executionTarget \?\? "desktop"\) === "cloud"/)
@@ -303,7 +320,6 @@ test("every dispatch path revalidates the owner's model access", () => {
 })
 
 test("Cloud placement never inherits the legacy Desktop model exception", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const create = serviceSource.slice(serviceSource.indexOf("async create"), serviceSource.indexOf("async update"))
   const update = serviceSource.slice(serviceSource.indexOf("async update"), serviceSource.indexOf("async activate"))
   const reconcile = serviceSource.slice(serviceSource.indexOf("private async reconcileModelAttention"))

--- a/evals/specs/automation-desktop-lifecycle.e2e.test.ts
+++ b/evals/specs/automation-desktop-lifecycle.e2e.test.ts
@@ -1,0 +1,784 @@
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import {
+  clickButton,
+  clickText,
+  denFetch,
+  evalIn,
+  go,
+  readAvailableModels,
+  visibleText,
+  waitForText,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import {
+  app,
+  eventually,
+  needs,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const PROVIDER_NAME = "Automation Reliability Gateway";
+const PROVIDER_KEY = "automation-reliability-gateway";
+const PROVIDER_ENV = "AUTOMATION_RELIABILITY_API_KEY";
+const MODEL_ID = "automation-reliability-model";
+const MODEL_NAME = "Automation Reliability Model";
+const REPLY = "The synthetic Automation lifecycle completed successfully.";
+const PROVIDER_API_KEY = "sk-automation-reliability-local-only";
+const REQUEST_TIMEOUT_MS = 10_000;
+const RUN_TIMEOUT_MS = 180_000;
+const AUTOMATION_MODEL_ATTENTION_CAPABILITY = "model_attention_v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+function startProviderMock(
+  completionBodies: unknown[],
+  control: { unavailable?: boolean } = {},
+): Promise<string> {
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: MODEL_ID, object: "model" }] }));
+      return;
+    }
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let rawBody = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { rawBody += chunk; });
+      request.on("end", () => {
+        let body: unknown;
+        try {
+          body = JSON.parse(rawBody);
+        } catch {
+          response.writeHead(400, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: { message: "invalid JSON request body" } }));
+          return;
+        }
+        completionBodies.push(body);
+        if (control.unavailable) {
+          response.writeHead(503, { "content-type": "application/json" });
+          response.end(JSON.stringify({
+            error: { message: "Synthetic provider is temporarily unavailable", type: "provider_unavailable" },
+          }));
+          return;
+        }
+        const chunks = [
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: REPLY }, finish_reason: null }] },
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  return new Promise((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", () => {
+      const address = mock.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Automation provider mock did not bind a TCP port."));
+        return;
+      }
+      onTestFinished(async () => {
+        await new Promise<void>((closeResolve, closeReject) => {
+          mock.close((error) => error ? closeReject(error) : closeResolve());
+          mock.closeAllConnections();
+        });
+      });
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) ? records(result.body.orgs) : [];
+  const active = organizations.find((organization) => organization.isActive === true) ?? organizations[0];
+  const id = active && typeof active.id === "string" ? active.id : "";
+  expect(result.response.status, result.text).toBe(200);
+  expect(id).not.toBe("");
+  return id;
+}
+
+async function createProvider(
+  admin: DenSession,
+  orgId: string,
+  baseUrl: string,
+  apiKey: string,
+): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: [PROVIDER_ENV],
+        api: baseUrl,
+        models: [{ id: MODEL_ID, name: MODEL_NAME }],
+      },
+      apiKey,
+      allMembers: true,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider)
+    ? result.body.llmProvider
+    : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  expect(result.response.status, result.text).toBe(201);
+  expect(id).not.toBe("");
+  return id;
+}
+
+async function createAutomation(
+  admin: DenSession,
+  orgId: string,
+  input: { name: string; instructions: string; providerId: string },
+): Promise<{ automationId: string; revisionId: string }> {
+  const result = await denFetch(admin, "/v1/automations", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: input.name,
+      instructions: input.instructions,
+      schedule: { kind: "daily", timezone: "UTC", hour: 23, minute: 59 },
+      model: { providerId: input.providerId, modelId: MODEL_ID, variant: null },
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const automation = isRecord(result.body) && isRecord(result.body.automation)
+    ? result.body.automation
+    : null;
+  const revision = isRecord(result.body) && isRecord(result.body.revision)
+    ? result.body.revision
+    : null;
+  const automationId = automation && typeof automation.id === "string" ? automation.id : "";
+  const revisionId = revision && typeof revision.id === "string" ? revision.id : "";
+  expect(result.response.status, result.text).toBe(201);
+  expect(automation?.state).toBe("active");
+  expect(automationId).not.toBe("");
+  expect(revisionId).not.toBe("");
+  expect(revision?.schedule).toEqual({ kind: "daily", timezone: "UTC", hour: 23, minute: 59 });
+  expect(revision?.model).toEqual({ providerId: input.providerId, modelId: MODEL_ID, variant: null });
+  return { automationId, revisionId };
+}
+
+async function listRuns(admin: DenSession, automationId: string): Promise<Record<string, unknown>[]> {
+  const result = await denFetch(admin, `/v1/automations/${encodeURIComponent(automationId)}/runs`, {
+    headers: auth(admin),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status, result.text).toBe(200);
+  return isRecord(result.body) ? records(result.body.items) : [];
+}
+
+async function waitForNewRun(
+  admin: DenSession,
+  automationId: string,
+  before: Set<string>,
+  trigger: "manual" | "scheduled",
+): Promise<Record<string, unknown>> {
+  const run = await eventually(async () => {
+    const runs = await listRuns(admin, automationId);
+    return runs.find((run) => run.trigger === trigger
+      && typeof run.id === "string"
+      && !before.has(run.id));
+  }, {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 500,
+    label: `new ${trigger} Automation run`,
+    until: (run) => isRecord(run),
+  });
+  if (!run) throw new Error(`The ${trigger} Automation run disappeared after it was observed.`);
+  return run;
+}
+
+async function waitForTerminalReceipt(
+  admin: DenSession,
+  runId: string,
+): Promise<Record<string, unknown>> {
+  return eventually(async () => {
+    const result = await denFetch(admin, `/v1/automation-runs/${encodeURIComponent(runId)}`, {
+      headers: auth(admin),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    expect(result.response.status, result.text).toBe(200);
+    return isRecord(result.body) ? result.body : {};
+  }, {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 500,
+    label: `terminal receipt for ${runId}`,
+    until: (receipt) => {
+      const run = isRecord(receipt.run) ? receipt.run : null;
+      return run !== null && ["succeeded", "failed", "cancelled", "skipped"].includes(String(run.status));
+    },
+  });
+}
+
+async function assertSucceededReceipt(
+  receipt: Record<string, unknown>,
+  expected: { automationId: string; revisionId?: string },
+): Promise<{ runId: string; sessionId: string }> {
+  const run = isRecord(receipt.run) ? receipt.run : {};
+  const thread = isRecord(run.executionThread) ? run.executionThread : {};
+  const events = records(receipt.events);
+  const runId = typeof run.id === "string" ? run.id : "";
+  const sessionId = typeof thread.nativeThreadId === "string" ? thread.nativeThreadId : "";
+  expect(run.status).toBe("succeeded");
+  expect(run.automationId).toBe(expected.automationId);
+  if (expected.revisionId) expect(run.revisionId).toBe(expected.revisionId);
+  expect(run.error).toBeNull();
+  expect(run.resultSummary).toContain(REPLY);
+  expect(thread).toMatchObject({
+    threadKind: "automation",
+    executionLocation: "desktop",
+    automationId: expected.automationId,
+    automationRunId: runId,
+    engineKind: "openwork-desktop-runner-v1",
+  });
+  expect(sessionId).not.toBe("");
+  expect(typeof thread.workspaceId).toBe("string");
+  expect(events.map((event) => event.type)).toEqual(["user", "assistant", "usage", "terminal"]);
+  expect(events.map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+  return { runId, sessionId };
+}
+
+async function openAutomation(surface: Surface, automationId: string, name: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await go(surface, "/automations");
+    try {
+      await eventually(() => evalIn(surface, "window.location.hash"), {
+        within: 30_000,
+        intervalMs: 250,
+        label: "Automations list route",
+        until: (hash) => typeof hash === "string" && /^#\/automations(?:\?|$)/.test(hash),
+      });
+      await clickText(surface, name, {
+        selector: `button[data-automation-id="${automationId}"]`,
+        timeoutMs: 30_000,
+      });
+      await waitForText(surface, "Run now", { timeoutMs: 30_000 });
+      return;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+}
+
+async function waitForSyntheticModel(surface: Surface): Promise<void> {
+  const availableModels = await eventually(() => readAvailableModels(surface), {
+    within: 120_000,
+    intervalMs: 2_000,
+    label: "synced synthetic Automation model",
+    until: (models) => models.some((model) => model.selectable
+      && (model.id === MODEL_ID || model.id.endsWith(`/${MODEL_ID}`))),
+  });
+  expect(availableModels.some((model) => model.selectable
+    && (model.id === MODEL_ID || model.id.endsWith(`/${MODEL_ID}`)))).toBe(true);
+}
+
+async function triggerManualRun(
+  admin: DenSession,
+  automationId: string,
+): Promise<Record<string, unknown>> {
+  const before = new Set((await listRuns(admin, automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const response = await denFetch(admin, `/v1/automations/${encodeURIComponent(automationId)}/run`, {
+    method: "POST",
+    headers: auth(admin),
+  });
+  expect(response.response.status, response.text).toBe(202);
+  return waitForNewRun(admin, automationId, before, "manual");
+}
+
+test("a Desktop Automation completes through UI, API, schedule, thread, and receipt", { timeout: 20 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Reliability ${Date.now()}`,
+      admin: { name: "Automation Admin" },
+      members: { member: { name: "Automation Member" } },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const stamp = Date.now();
+  const automationName = `Synthetic lifecycle ${stamp}`;
+  const instructions = `Return one concise synthetic reliability result for marker ${stamp}.`;
+
+  const invalid = await denFetch(den.admin, "/v1/automations", {
+    method: "POST",
+    headers: { ...auth(den.admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: `Invalid lifecycle ${stamp}`,
+      instructions,
+      schedule: { kind: "daily", timezone: "Not/A-Timezone", hour: 9, minute: 0 },
+      model: { providerId, modelId: MODEL_ID, variant: null },
+    }),
+  });
+  expect(invalid.response.status).toBe(400);
+  expect((await denFetch(den.admin, "/v1/automations", { headers: auth(den.admin) })).text)
+    .not.toContain(`Invalid lifecycle ${stamp}`);
+  evidence.recordAssertionEvidence(
+    "Invalid Automation configuration fails without a runnable record",
+    "Den rejected the invalid timezone with HTTP 400 and the invalid name was absent from the owner list.",
+    true,
+  );
+
+  const created = await createAutomation(den.admin, orgId, {
+    name: automationName,
+    instructions,
+    providerId,
+  });
+  const denied = await denFetch(den.members.member, `/v1/automations/${encodeURIComponent(created.automationId)}`, {
+    headers: auth(den.members.member),
+  });
+  expect(denied.response.status).toBe(404);
+  evidence.recordAssertionEvidence(
+    "Automation ownership remains member-scoped",
+    "A different organization member received HTTP 404 for the owner's Automation.",
+    true,
+  );
+
+  await using desktop = await app({ den, as: "admin", place });
+  await waitForSyntheticModel(desktop);
+
+  await openAutomation(desktop, created.automationId, automationName);
+  const beforeUiRun = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const firstProviderCheckpoint = completionBodies.length;
+  await clickButton(desktop, "Run now");
+  const uiRun = await waitForNewRun(den.admin, created.automationId, beforeUiRun, "manual");
+  const uiRunId = typeof uiRun.id === "string" ? uiRun.id : "";
+  const uiReceipt = await waitForTerminalReceipt(den.admin, uiRunId);
+  const first = await assertSucceededReceipt(uiReceipt, created);
+  const firstRequest = await eventually(() => completionBodies[firstProviderCheckpoint], {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 250,
+    label: "first synthetic provider completion",
+    until: (request) => request !== undefined,
+  });
+  expect(JSON.stringify(firstRequest)).toContain(String(stamp));
+  evidence.recordAssertionEvidence(
+    "Run now reaches a real desktop session and durable receipt",
+    `UI run ${first.runId} created native thread ${first.sessionId}, returned the deterministic assistant result, and committed four ordered events.`,
+    true,
+  );
+
+  const receipts: Record<string, unknown>[] = [uiReceipt];
+  for (let index = 0; index < 2; index += 1) {
+    const before = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+      typeof run.id === "string" ? [run.id] : []));
+    const response = await denFetch(den.admin, `/v1/automations/${encodeURIComponent(created.automationId)}/run`, {
+      method: "POST",
+      headers: auth(den.admin),
+    });
+    expect(response.response.status, response.text).toBe(202);
+    const run = await waitForNewRun(den.admin, created.automationId, before, "manual");
+    const runId = typeof run.id === "string" ? run.id : "";
+    const receipt = await waitForTerminalReceipt(den.admin, runId);
+    await assertSucceededReceipt(receipt, created);
+    receipts.push(receipt);
+  }
+
+  const scheduledAt = Date.now() + 45_000;
+  const scheduleResponse = await denFetch(
+    den.admin,
+    `/v1/automations/${encodeURIComponent(created.automationId)}`,
+    {
+      method: "PATCH",
+      headers: auth(den.admin),
+      body: JSON.stringify({ schedule: { kind: "once", timezone: "UTC", at: scheduledAt } }),
+    },
+  );
+  expect(scheduleResponse.response.status, scheduleResponse.text).toBe(200);
+  const scheduledRevision = isRecord(scheduleResponse.body) && isRecord(scheduleResponse.body.revision)
+    ? scheduleResponse.body.revision
+    : {};
+  expect(scheduledRevision.schedule).toEqual({ kind: "once", timezone: "UTC", at: scheduledAt });
+  const beforeScheduled = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const scheduledRun = await waitForNewRun(den.admin, created.automationId, beforeScheduled, "scheduled");
+  const scheduledRunId = typeof scheduledRun.id === "string" ? scheduledRun.id : "";
+  const scheduledReceipt = await waitForTerminalReceipt(den.admin, scheduledRunId);
+  await assertSucceededReceipt(scheduledReceipt, {
+    automationId: created.automationId,
+    revisionId: typeof scheduledRevision.id === "string" ? scheduledRevision.id : undefined,
+  });
+  receipts.push(scheduledReceipt);
+
+  const runIds = receipts.flatMap((receipt) => {
+    const run = isRecord(receipt.run) ? receipt.run : {};
+    return typeof run.id === "string" ? [run.id] : [];
+  });
+  const sessionIds = receipts.flatMap((receipt) => {
+    const run = isRecord(receipt.run) ? receipt.run : {};
+    const thread = isRecord(run.executionThread) ? run.executionThread : {};
+    return typeof thread.nativeThreadId === "string" ? [thread.nativeThreadId] : [];
+  });
+  expect(new Set(runIds).size).toBe(4);
+  expect(new Set(sessionIds).size).toBe(4);
+  expect(completionBodies.slice(firstProviderCheckpoint)).toHaveLength(4);
+  evidence.recordAssertionEvidence(
+    "Repeated and scheduled runs remain exactly-once",
+    "Three sequential manual runs and one scheduled occurrence produced four unique runs, four unique native sessions, four deterministic model requests, and four terminal receipts.",
+    true,
+  );
+
+  const scheduledTerminalRun = isRecord(scheduledReceipt.run) ? scheduledReceipt.run : {};
+  const scheduledThread = isRecord(scheduledTerminalRun.executionThread)
+    ? scheduledTerminalRun.executionThread
+    : {};
+  const scheduledWorkspaceId = typeof scheduledThread.workspaceId === "string" ? scheduledThread.workspaceId : "";
+  const scheduledSessionId = typeof scheduledThread.nativeThreadId === "string" ? scheduledThread.nativeThreadId : "";
+  expect(scheduledWorkspaceId).not.toBe("");
+  expect(scheduledSessionId).not.toBe("");
+  evidence.recordAssertionEvidence(
+    "A terminal receipt durably exposes its native desktop execution identity",
+    `The scheduled receipt carried workspace ${scheduledWorkspaceId} and native session ${scheduledSessionId} through the run contract, ready for a management surface to open.`,
+    true,
+  );
+
+  await openAutomation(desktop, created.automationId, automationName);
+  const detailText = await visibleText(desktop);
+  expect(detailText).toContain("succeeded");
+  expect(detailText).toContain(MODEL_NAME);
+  expect(detailText).not.toMatch(/running|waiting|no assistant result/i);
+  evidence.recordAssertionEvidence(
+    "The Automation UI reflects the terminal result and configured model",
+    `The detail view showed succeeded with ${MODEL_NAME}, without a stale running, waiting, or missing-result message.`,
+    true,
+  );
+});
+
+test("a Desktop Automation recovers across restart before execution and while work is queued", { timeout: 20 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Recovery ${Date.now()}`,
+      admin: { name: "Automation Recovery Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const stamp = Date.now();
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic recovery ${stamp}`,
+    instructions: `Return one concise synthetic recovery result for marker ${stamp}.`,
+    providerId,
+  });
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-automation-recovery-"));
+  onTestFinished(() => rm(profileDir, { recursive: true, force: true }));
+  let desktop: Awaited<ReturnType<typeof app>> | null = null;
+
+  try {
+    desktop = await app({ den, as: "admin", place, profileDir });
+    await waitForSyntheticModel(desktop);
+    await desktop.stop();
+    desktop = null;
+
+    desktop = await app({ den, as: "admin", place, profileDir });
+    await waitForSyntheticModel(desktop);
+    const postRestartRun = await triggerManualRun(den.admin, created.automationId);
+    const postRestartRunId = typeof postRestartRun.id === "string" ? postRestartRun.id : "";
+    const postRestartReceipt = await waitForTerminalReceipt(den.admin, postRestartRunId);
+    const first = await assertSucceededReceipt(postRestartReceipt, created);
+    evidence.recordAssertionEvidence(
+      "Desktop restart before execution preserves runner readiness",
+      `The same isolated profile relaunched before execution, reminted its runner authority, and run ${first.runId} completed in native session ${first.sessionId}.`,
+      true,
+    );
+
+    await desktop.stop();
+    desktop = null;
+    const providerRequestsBeforeConcurrentRuns = completionBodies.length;
+    const concurrentResponses = await Promise.all(Array.from({ length: 3 }, () =>
+      denFetch(den.admin, `/v1/automations/${encodeURIComponent(created.automationId)}/run`, {
+        method: "POST",
+        headers: auth(den.admin),
+      })));
+    for (const response of concurrentResponses) {
+      expect(response.response.status, response.text).toBe(202);
+    }
+    const concurrentRuns = concurrentResponses.map((response) =>
+      isRecord(response.body) && isRecord(response.body.run) ? response.body.run : {});
+    expect(concurrentRuns.map((run) => run.status).sort()).toEqual(["queued", "skipped", "skipped"]);
+    const queuedConcurrentRun = concurrentRuns.find((run) => run.status === "queued");
+    const queuedConcurrentRunId = queuedConcurrentRun && typeof queuedConcurrentRun.id === "string"
+      ? queuedConcurrentRun.id
+      : "";
+    const cancelResponse = await denFetch(
+      den.admin,
+      `/v1/automation-runs/${encodeURIComponent(queuedConcurrentRunId)}/cancel`,
+      { method: "POST", headers: auth(den.admin) },
+    );
+    const cancelledRun = isRecord(cancelResponse.body) && isRecord(cancelResponse.body.run)
+      ? cancelResponse.body.run
+      : {};
+    expect(cancelResponse.response.status, cancelResponse.text).toBe(200);
+    expect(cancelledRun.status).toBe("cancelled");
+    expect(cancelledRun.executionThread).toBeNull();
+    expect(completionBodies).toHaveLength(providerRequestsBeforeConcurrentRuns);
+    evidence.recordAssertionEvidence(
+      "Concurrent manual requests overlap safely and cancellation before claim is terminal",
+      "Three simultaneous manual requests with Desktop absent produced one queued run and two durable overlap skips; cancelling the queued run returned cancelled with no execution thread and no provider request.",
+      true,
+    );
+
+    const waitingRun = await triggerManualRun(den.admin, created.automationId);
+    const waitingRunId = typeof waitingRun.id === "string" ? waitingRun.id : "";
+    expect(waitingRun.status).toBe("queued");
+
+    desktop = await app({ den, as: "admin", place, profileDir });
+    const waitingReceipt = await waitForTerminalReceipt(den.admin, waitingRunId);
+    const second = await assertSucceededReceipt(waitingReceipt, created);
+    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(completionBodies).toHaveLength(2);
+    evidence.recordAssertionEvidence(
+      "Queued work survives Desktop absence and relaunch",
+      `Run ${second.runId} remained queued while Desktop was stopped; after relaunch a fresh runner credential claimed that same run and exactly one new native session ${second.sessionId} reached a terminal receipt.`,
+      true,
+    );
+  } finally {
+    await desktop?.stop();
+  }
+});
+
+test("a Desktop Automation records a provider outage and succeeds after recovery", { timeout: 10 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerControl = { unavailable: true };
+  const providerBaseUrl = await startProviderMock(completionBodies, providerControl);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Provider Recovery ${Date.now()}`,
+      admin: { name: "Automation Provider Recovery Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic provider recovery ${Date.now()}`,
+    instructions: "Return a result after the synthetic provider recovers.",
+    providerId,
+  });
+  await using desktop = await app({ den, as: "admin", place });
+  await waitForSyntheticModel(desktop);
+
+  const failedRun = await triggerManualRun(den.admin, created.automationId);
+  const failedRunId = typeof failedRun.id === "string" ? failedRun.id : "";
+  const failedReceipt = await waitForTerminalReceipt(den.admin, failedRunId);
+  const failed = isRecord(failedReceipt.run) ? failedReceipt.run : {};
+  const failedThread = isRecord(failed.executionThread) ? failed.executionThread : {};
+  expect(failed.status).toBe("failed");
+  expect(failed.error).toMatchObject({ code: "execution_failed", retryable: false });
+  expect(JSON.stringify(failed.error)).toMatch(/temporarily unavailable|503/i);
+  expect(typeof failedThread.nativeThreadId).toBe("string");
+  expect(typeof failedThread.workspaceId).toBe("string");
+  expect(records(failedReceipt.events).map((event) => event.type)).toEqual(["user", "terminal"]);
+  evidence.recordAssertionEvidence(
+    "A provider outage fails promptly with a linked local execution thread",
+    `Run ${failedRunId} received synthetic HTTP 503 responses and reached failed/execution_failed with its native session and workspace preserved; its event sequence ended at terminal instead of remaining running or waiting.`,
+    true,
+  );
+
+  providerControl.unavailable = false;
+  const recoveredRun = await triggerManualRun(den.admin, created.automationId);
+  const recoveredRunId = typeof recoveredRun.id === "string" ? recoveredRun.id : "";
+  const recoveredReceipt = await waitForTerminalReceipt(den.admin, recoveredRunId);
+  const recovered = await assertSucceededReceipt(recoveredReceipt, created);
+  expect(recovered.sessionId).not.toBe(failedThread.nativeThreadId);
+  evidence.recordAssertionEvidence(
+    "A later run succeeds after the provider recovers",
+    `Without editing or recreating the Automation, run ${recovered.runId} completed in a new native session after the provider began serving successful responses.`,
+    true,
+  );
+});
+
+test("Desktop runner claims are idempotent and expired leases recover safely", { timeout: 5 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    env: {
+      DEN_AUTOMATIONS_LEASE_MS: "2500",
+      DEN_AUTOMATIONS_POLL_INTERVAL_MS: "1000",
+      DEN_AUTOMATIONS_RUNNER_CLAIM_DEADLINE_MS: "30000",
+    },
+    org: {
+      name: `Automation Lease Recovery ${Date.now()}`,
+      admin: { name: "Automation Lease Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic lease recovery ${Date.now()}`,
+    instructions: "This synthetic run must never reach a provider.",
+    providerId,
+  });
+  const registration = (runnerId: string) => ({
+    runnerId,
+    protocolVersion: 1,
+    supportedExecutionTargets: ["desktop"],
+    capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+    appVersion: "automation-reliability-eval",
+    platform: "darwin",
+    concurrency: 1,
+  });
+  const mintRunner = async (runnerId: string): Promise<string> => {
+    const response = await denFetch(den.admin, "/v1/automation-runners/token", {
+      method: "POST",
+      headers: auth(den.admin),
+      body: JSON.stringify(registration(runnerId)),
+    });
+    const token = isRecord(response.body) && typeof response.body.token === "string"
+      ? response.body.token
+      : "";
+    expect(response.response.status, response.text).toBe(200);
+    expect(token).not.toBe("");
+    return token;
+  };
+  const runnerRequest = (token: string, path: string, options: RequestInit = {}) =>
+    denFetch(den.admin, path, {
+      ...options,
+      headers: { ...options.headers, authorization: `Bearer ${token}` },
+    });
+
+  const firstRunnerToken = await mintRunner(`synthetic-runner-primary-${Date.now()}`);
+  const secondRunnerToken = await mintRunner(`synthetic-runner-secondary-${Date.now()}`);
+  const run = await triggerManualRun(den.admin, created.automationId);
+  const runId = typeof run.id === "string" ? run.id : "";
+  const work = await runnerRequest(firstRunnerToken, "/v1/automation-runner/work");
+  expect(work.response.status, work.text).toBe(200);
+  expect(JSON.stringify(work.body)).toContain(runId);
+
+  const firstClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  const duplicateClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  expect(firstClaim.response.status, firstClaim.text).toBe(200);
+  expect(duplicateClaim.response.status, duplicateClaim.text).toBe(200);
+  const firstAssignment = isRecord(firstClaim.body) && isRecord(firstClaim.body.assignment)
+    ? firstClaim.body.assignment
+    : {};
+  const duplicateAssignment = isRecord(duplicateClaim.body) && isRecord(duplicateClaim.body.assignment)
+    ? duplicateClaim.body.assignment
+    : {};
+  expect(firstAssignment).toMatchObject({ runId, attempt: 1 });
+  expect(duplicateAssignment).toMatchObject({ runId, attempt: 1 });
+
+  const competingClaim = await runnerRequest(
+    secondRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  expect(competingClaim.response.status, competingClaim.text).toBe(200);
+  expect(isRecord(competingClaim.body) ? competingClaim.body.assignment : undefined).toBeNull();
+
+  await eventually(async () => {
+    const receipt = await denFetch(den.admin, `/v1/automation-runs/${encodeURIComponent(runId)}`, {
+      headers: auth(den.admin),
+    });
+    return isRecord(receipt.body) && isRecord(receipt.body.run) ? receipt.body.run : {};
+  }, {
+    within: 30_000,
+    intervalMs: 250,
+    label: "first expired lease requeued for recovery",
+    until: (recoveredRun) => recoveredRun.status === "queued" && recoveredRun.attemptCount === 1,
+  });
+
+  const recoveryClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  const recoveryAssignment = isRecord(recoveryClaim.body) && isRecord(recoveryClaim.body.assignment)
+    ? recoveryClaim.body.assignment
+    : {};
+  expect(recoveryClaim.response.status, recoveryClaim.text).toBe(200);
+  expect(recoveryAssignment).toMatchObject({ runId, attempt: 2 });
+
+  const staleCompletion = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/complete`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        attempt: 1,
+        status: "succeeded",
+        sessionId: "stale-session-must-not-win",
+        workspaceId: "stale-workspace-must-not-win",
+        resultSummary: "stale completion",
+        usage: { inputTokens: 1, outputTokens: 1, costMicros: null },
+        error: null,
+      }),
+    },
+  );
+  expect(staleCompletion.response.status, staleCompletion.text).toBe(409);
+  expect(staleCompletion.body).toEqual({ error: "runner_lease_lost" });
+
+  const terminalReceipt = await waitForTerminalReceipt(den.admin, runId);
+  const terminalRun = isRecord(terminalReceipt.run) ? terminalReceipt.run : {};
+  expect(terminalRun).toMatchObject({
+    status: "failed",
+    attemptCount: 2,
+    error: { code: "lease_lost", retryable: false },
+  });
+  expect(terminalRun.resultSummary).toBeNull();
+  expect(completionBodies).toHaveLength(0);
+  evidence.recordAssertionEvidence(
+    "Duplicate claims and expired leases cannot duplicate execution or accept stale completion",
+    `Runner one received the same attempt-1 assignment twice, runner two could not claim it, the first expiry requeued attempt 1, attempt 2 rejected the stale attempt-1 completion with HTTP 409, and the second expiry ended run ${runId} as failed/lease_lost with no provider request.`,
+    true,
+  );
+});

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -37,9 +37,13 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("waking the machine polls for work immediately without new credentials");
   expect(unit.stdout).toContain("waking during an active run keeps its lease and starts no second claim loop");
   expect(unit.stdout).toContain("a work poll left hanging by a suspended machine times out and retries");
+  expect(unit.stdout).toContain("desktop Automation execution accepts a completed tool-only assistant turn");
+  expect(unit.stdout).toContain("failed desktop assignments retain their created local thread in the Den completion");
+  expect(unit.stdout).toContain("cancellation during execution preserves the local thread and reaches a terminal completion");
+  expect(unit.stdout).toContain("an explicit assistant provider failure terminates immediately with its local thread");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 25\b/);
-  expect(unit.stdout).toMatch(/# pass 25\b/);
+  expect(unit.stdout).toMatch(/# tests 30\b/);
+  expect(unit.stdout).toMatch(/# pass 30\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -61,7 +65,7 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 36 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, and work-only polling.",
+    "The runner and bridge suites passed 41 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
     true,
   );
 

--- a/packages/automations/src/ports.ts
+++ b/packages/automations/src/ports.ts
@@ -78,6 +78,7 @@ export interface AutomationRepository {
     resultSummary: string | null
     usage: AutomationUsage
     error: AutomationError | null
+    engineReceipt?: Record<string, unknown> | null
     attempt?: number
     now: number
   }): Awaitable<AutomationRun>


### PR DESCRIPTION
## Summary

This PR now carries the two remaining layers of the Desktop Automation reliability stack, rebased onto current `dev` after #3775 merged. #3945 was reviewed and merged into this branch (its stack base), so its change lands on `dev` here.

- Report nested and explicit execution failures as failures instead of successes.
- Accept tool-only successful runs that finish without assistant text.
- Preserve the native Desktop session and workspace on success, failure, and cancellation.
- Persist that execution identity through Den's run receipt, with stale selected-run receipts kept out of the panel. The Automations UI starts consuming the persisted identity (an "Open local thread" action) in a follow-up PR, so client consumption stays decoupled from this API rollout.

## Root cause

Two related gaps sat at the boundary between the Desktop execution engine and the Automation contract:

- The runner recognized only one narrow failure shape (a top-level `model_access_lost`). Assistant-level errors that arrive nested in the session snapshot — provider 5xx failures, removed models mid-run — left the session `idle`, so the run was reported as succeeded or as a generic timeout. Runs whose only output is completed tool work were reported as failures ("finished without an assistant result"), and every failure or cancellation discarded the session and workspace identifiers, so the receipt could not point at the thread that actually ran.
- Den then dropped that identity anyway: `mapRun` read `engine_receipt` only for cloud runs and the desktop completion path never wrote one, so the executed thread's identity never survived into the run receipt, and the receipt panel rendered whatever receipt query resolved last — a stale response from a previously selected run could be shown and acted on against the current one.

## What changed

Execution-outcome correctness (reviewed as this PR):

- `assistantFailure()` scans the snapshot's assistant messages for explicit error results and classifies the most recent one; `serializedError()` unwraps nested `message` / `data.message` shapes.
- `assistantResult()` counts a completed tool part as completed output, so tool-only runs succeed with their usage recorded; the 10-second idle grace period still catches truly empty runs.
- `executeDesktopAutomation` attaches the session and workspace to every error thrown after thread creation; the completion path forwards them on failure and cancellation instead of `null`, preserving reconnect/backoff, wake, and duplicate-claim behavior.

Receipt persistence (server side of the change reviewed as #3945, merged into this branch; its client-side navigation follows in a separate PR):

- `completeDesktopRunner` writes the runner-reported session and workspace into the run's `engine_receipt`; the repository `complete()` takes an additive optional `engineReceipt`; `mapRun` reads the receipt for every execution target. Older rows keep `executionThread: null` and render as before; only terminal completions write the field.
- The receipt panel accepts a receipt only when it belongs to the currently selected run, so a stale response cannot leak into another run's panel.
- New den-api protocol pin for the durable-thread path, a deterministic list selector for runtime proof, and the Desktop lifecycle spec described under Verification.

## Maintainer impact

Automation run status now reflects what the execution engine actually did: real failures surface as failures with their recorded cause, tool-only work counts as success, and every terminal run — including failed and cancelled ones — durably retains the native Desktop context it ran in. The follow-up PR turns that persisted identity into one-click navigation from the receipt. The recovery-window, missed-cause, and presence behavior that #3775 landed is preserved unchanged.

## Compatibility and rollout

All protocol fields were already part of the runner contract (`sessionId` / `workspaceId` on completion); the Den receipt field is additive, and no client in this PR consumes it — the Automations UI starts reading it in a follow-up PR once the fields exist on the server, per the desktop↔den sync review. No deployment-order dependency in either direction.

## Verification

Unit, typecheck, protocol, and recovery-window commands ran against this PR's exact head (`40563d538`): current `dev` (`5bc8b480d`, including #3775 as merged) plus the reviewed execution-outcome change and the server side of the reviewed #3945 change. The Desktop lifecycle suite's four passes ran against this identical two-commit change applied to `dev` at `1b7fe88c1` (#3949, one commit ahead of this branch's base); repository CI on this exact head is green on both platforms.

Passed

- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/automation-desktop-lifecycle.e2e.test.ts` — all 4 tests passed with zero skipped or partial assertions, on this change rebased one commit ahead as described above. The full-file invocation lost its first test to a local `fetch failed` infrastructure drop mid-run (the other three passed in it); that test then passed in a clean follow-up invocation, so the four passes span two invocations. Coverage: UI-triggered, repeated manual, and scheduled runs reach durable succeeded receipts whose execution thread carries the unique native session and workspace; restart with queued work executes exactly once; concurrent requests overlap safely and pre-claim cancellation is terminal; a provider outage fails promptly with the native session preserved on the failed receipt and a later run succeeds after recovery; duplicate claims stay idempotent, expired leases requeue exactly once, and a stale attempt-1 completion is rejected with HTTP 409 after attempt 2 exists.
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/automation-desktop-recovery-window.e2e.test.ts` — passed; #3775's recovery window, named missed causes, presence semantics, and manual one-minute deadline hold on top of these changes.
- `node --test apps/desktop/electron/automation-runner.test.mjs` — 30 pass, 0 fail, 0 skipped, including nested assistant failures, explicit provider failure, tool-only completion, session preservation on failure and cancellation, wake-time polling, and bounded idle polls.
- `bun test test/automation-runner-protocol.test.ts test/automation-runner-auth.test.ts` (`ee/apps/den-api`) — 30 pass, 0 fail, including the durable-thread pin.
- `bun test src` (`packages/automations`) — 18 pass, 0 fail.
- `bun test --isolate tests/automation-cloud-thread.test.ts tests/automation-runner-visibility.test.ts tests/automation-runner-presence-client.test.ts` (`apps/app`) — 10 pass, 0 fail.
- `tsc --noEmit` for `apps/app`, `ee/apps/den-api`, and `packages/automations`; `pnpm --filter @openwork/desktop typecheck:electron` — clean.
- `git diff --check` — clean.

Failed — none.

Skipped — none.

Deferred

- Daytona placement for the tapes: per-test `DEN_AUTOMATIONS_*` tuning applies only to a locally provisioned Den (`server({ env })` is not forwarded into a Daytona server sandbox), so both ran on the local lane.

## Stack

Final layer of the Automation reliability stack; base `dev`.

- #3775 — desktop occurrence recovery and missed-cause diagnosis (merged).
- #3945 — receipt persistence and thread linkage (reviewed and merged into this branch; lands on `dev` here).
