### PR TITLE
fix(den): count OAuth normalization failures

### DIFF
--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -619,6 +619,9 @@ async function handleAuthRequest(c: Context) {
   }
   const authRequest = await normalizeMcpOAuthRequest(request)
   if (authRequest instanceof Response) {
+    if (oauthTokenRateLimit) {
+      await recordOAuthTokenFailure(oauthTokenRateLimit.failureKey, authRequest, checkRateLimit)
+    }
     return authRequest
   }
   const invitationSignupAllowed = await isInvitationSignupAllowed(authRequest)

--- a/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
+++ b/ee/apps/den-api/test/oauth-token-rate-limit.test.ts
@@ -115,6 +115,23 @@ test("fifteen failed exchanges block the next request before authentication", as
   })
 })
 
+test("fifteen normalization failures block the next request before authentication", async () => {
+  const limiter = createInMemoryRateLimit()
+  const request = tokenRequest("invalid-target-client", "203.0.113.14")
+  const now = Date.now()
+
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    const admission = await checkOAuthTokenRateLimit(request, limiter.check, now)
+    expect(admission.response).toBeNull()
+
+    const response = new Response(JSON.stringify({ error: "invalid_target" }), { status: 400 })
+    await recordOAuthTokenFailure(admission.failureKey, response, limiter.check, now)
+  }
+
+  const blocked = await checkOAuthTokenRateLimit(request, limiter.check, now)
+  expect(blocked.response?.status).toBe(429)
+})
+
 test("successful exchanges never consume the failure budget", async () => {
   const limiter = createInMemoryRateLimit()
   const clientId = "successful-client"

--- a/evals/specs/oauth-token-rate-limit.test.ts
+++ b/evals/specs/oauth-token-rate-limit.test.ts
@@ -33,7 +33,7 @@ test("OAuth token clients receive isolated attempt and failure budgets", ({ evid
 
     const junit = readFileSync(reportPath, "utf8");
     const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
-    expect(summary).toContain('tests="4"');
+    expect(summary).toContain('tests="5"');
     expect(summary).toContain('failures="0"');
     expect(summary).toContain('skipped="0"');
     expect(junit).not.toContain("<failure");
@@ -47,6 +47,11 @@ test("OAuth token clients receive isolated attempt and failure budgets", ({ evid
     evidence.recordAssertionEvidence(
       "Repeated authentication failures trigger a stricter budget",
       "The focused runtime witness observes only 15 failed handler exchanges before the next request is rejected before authentication with an OAuth-compatible 429.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "OAuth normalization failures consume the stricter failure budget",
+      "The focused runtime witness records 15 invalid-target responses produced before authentication and rejects the next request with an OAuth-compatible 429.",
       true,
     );
     evidence.recordAssertionEvidence(


### PR DESCRIPTION
## Summary

- record OAuth token normalization `400 invalid_target` responses before returning
- make those pre-handler failures consume the 15-per-5-minute failure budget introduced by #3941
- add a focused regression witness and testkit assertion for the blocked 16th request

This is intentionally stacked on #3941 and contains only the unresolved normalization-failure follow-up.

## Verification

Passed locally on commit `fcc5668a705277ffe891020962a5f993ff8df586`:

- `pnpm --dir ee/apps/den-api exec bun test test/oauth-token-rate-limit.test.ts` — 5 passed
- `pnpm --filter @openwork/mcp-apps build`
- `pnpm --dir ee/apps/den-api exec tsc --noEmit --pretty false`
- `pnpm evals:pr specs/oauth-token-rate-limit.test.ts` — 1 passed, 0 skipped

## Proof status

**Incomplete** — the local testkit tape passes, but Daytona credentials are unavailable in this session, so no remote exact-head tape has been published. The PR remains draft.

A broader existing normalization suite was also attempted and fails during Better Auth initialization because its DB test double does not implement `db.insert`; that failure occurs before the assertions touched by this patch.