### PR TITLE
fix(mcp): tolerate newer protocol-version headers

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -16,6 +16,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { DEN_MCP_APP_HOST_SCOPE, DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { normalizeMcpProtocolVersionHeader } from "./protocol-version.js"
 import {
   compareCapabilityMatches,
   EXECUTE_CAPABILITY_TOOL_NAME,
@@ -424,6 +425,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
     if (preflightResponse) {
       return preflightResponse
     }
+
+    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", requestId)
 
     const catalog = await getCatalog(app as unknown as Hono, c.env)
     // External MCP connections are scoped to the calling MEMBER (grants +

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -16,6 +16,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { DEN_MCP_APP_HOST_SCOPE, DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { appLogger } from "../observability/logger.js"
 import { normalizeMcpProtocolVersionHeader } from "./protocol-version.js"
 import {
   compareCapabilityMatches,
@@ -79,6 +80,8 @@ import {
 } from "./connect-mcp-server-index.js"
 import { registerAgentSkillCreatedApp } from "./skill-created-app.js"
 import { createPluginBundle, listPluginMemberships, PluginArchRouteFailure } from "../routes/org/plugin-system/store.js"
+
+const protocolVersionLogger = appLogger.child({ component: "mcp_protocol_version" })
 
 export { externalToolContent } from "./tool-content.js"
 export { externalCapabilityErrorToolResult, externalCapabilitySuccessToolResult }
@@ -426,7 +429,9 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       return preflightResponse
     }
 
-    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", requestId)
+    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", requestId, (message, fields) => {
+      protocolVersionLogger.warn(message, fields)
+    })
 
     const catalog = await getCatalog(app as unknown as Hono, c.env)
     // External MCP connections are scoped to the calling MEMBER (grants +

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -9,6 +9,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { normalizeMcpProtocolVersionHeader } from "./protocol-version.js"
 import { getDenAuthIssuer } from "./jwt-policy.js"
 import { DEN_MCP_REQUESTED_SCOPES } from "./scopes.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
@@ -76,6 +77,8 @@ export function registerMcpRoutes<T extends { Variables: RequestIdVariables & Re
     if (preflightResponse) {
       return preflightResponse
     }
+
+    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "mcp", requestId)
 
     const catalog = await getCatalog(app as unknown as Hono, c.env)
     const server = new McpServer({

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -9,10 +9,13 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { appLogger } from "../observability/logger.js"
 import { normalizeMcpProtocolVersionHeader } from "./protocol-version.js"
 import { getDenAuthIssuer } from "./jwt-policy.js"
 import { DEN_MCP_REQUESTED_SCOPES } from "./scopes.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
+
+const protocolVersionLogger = appLogger.child({ component: "mcp_protocol_version" })
 
 const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 
@@ -78,7 +81,9 @@ export function registerMcpRoutes<T extends { Variables: RequestIdVariables & Re
       return preflightResponse
     }
 
-    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "mcp", requestId)
+    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "mcp", requestId, (message, fields) => {
+      protocolVersionLogger.warn(message, fields)
+    })
 
     const catalog = await getCatalog(app as unknown as Hono, c.env)
     const server = new McpServer({

--- a/ee/apps/den-api/src/mcp/protocol-version.ts
+++ b/ee/apps/den-api/src/mcp/protocol-version.ts
@@ -1,9 +1,11 @@
 import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js"
-import { appLogger } from "../observability/logger.js"
-
-const logger = appLogger.child({ component: "mcp_protocol_version" })
 
 const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+
+// Callers inject their structured logger; this module stays free of the
+// observability import chain so focused runtime tests can load it without
+// building workspace packages.
+export type McpProtocolVersionWarn = (message: string, fields: Record<string, string>) => void
 
 /**
  * The pinned MCP SDK rejects any `mcp-protocol-version` value outside its
@@ -17,7 +19,12 @@ const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
  * - unknown values are removed so the transport falls back to the SDK default,
  *   and the observed value is logged so support can be added deliberately.
  */
-export function normalizeMcpProtocolVersionHeader(headers: Headers, endpoint: string, referenceId: string) {
+export function normalizeMcpProtocolVersionHeader(
+  headers: Headers,
+  endpoint: string,
+  referenceId: string,
+  warn: McpProtocolVersionWarn,
+) {
   const raw = headers.get(MCP_PROTOCOL_VERSION_HEADER)
   if (raw === null) {
     return
@@ -25,10 +32,10 @@ export function normalizeMcpProtocolVersionHeader(headers: Headers, endpoint: st
 
   const distinct = [...new Set(raw.split(",").map((value) => value.trim()).filter(Boolean))]
   const single = distinct.length === 1 ? distinct[0] : null
-  if (single !== null && SUPPORTED_PROTOCOL_VERSIONS.includes(single)) {
+  if (single !== undefined && single !== null && SUPPORTED_PROTOCOL_VERSIONS.includes(single)) {
     if (single !== raw) {
       headers.set(MCP_PROTOCOL_VERSION_HEADER, single)
-      logger.warn("mcp protocol version header collapsed", {
+      warn("mcp protocol version header collapsed", {
         endpoint,
         reference_id: referenceId,
         protocol_version: single,
@@ -38,7 +45,7 @@ export function normalizeMcpProtocolVersionHeader(headers: Headers, endpoint: st
   }
 
   headers.delete(MCP_PROTOCOL_VERSION_HEADER)
-  logger.warn("mcp protocol version unsupported", {
+  warn("mcp protocol version unsupported", {
     endpoint,
     reference_id: referenceId,
     protocol_version: raw.slice(0, 128),

--- a/ee/apps/den-api/src/mcp/protocol-version.ts
+++ b/ee/apps/den-api/src/mcp/protocol-version.ts
@@ -1,0 +1,47 @@
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js"
+import { appLogger } from "../observability/logger.js"
+
+const logger = appLogger.child({ component: "mcp_protocol_version" })
+
+const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+
+/**
+ * The pinned MCP SDK rejects any `mcp-protocol-version` value outside its
+ * supported list with a thrown JSON-RPC 404, which breaks clients that
+ * negotiated a newer spec revision (observed in production with claude.ai's
+ * connector) or whose proxies duplicate the header into a comma-joined value.
+ *
+ * Den's MCP endpoints are stateless per request, so instead of failing the
+ * request:
+ * - identical duplicated copies of a supported version collapse to that value,
+ * - unknown values are removed so the transport falls back to the SDK default,
+ *   and the observed value is logged so support can be added deliberately.
+ */
+export function normalizeMcpProtocolVersionHeader(headers: Headers, endpoint: string, referenceId: string) {
+  const raw = headers.get(MCP_PROTOCOL_VERSION_HEADER)
+  if (raw === null) {
+    return
+  }
+
+  const distinct = [...new Set(raw.split(",").map((value) => value.trim()).filter(Boolean))]
+  const single = distinct.length === 1 ? distinct[0] : null
+  if (single !== null && SUPPORTED_PROTOCOL_VERSIONS.includes(single)) {
+    if (single !== raw) {
+      headers.set(MCP_PROTOCOL_VERSION_HEADER, single)
+      logger.warn("mcp protocol version header collapsed", {
+        endpoint,
+        reference_id: referenceId,
+        protocol_version: single,
+      })
+    }
+    return
+  }
+
+  headers.delete(MCP_PROTOCOL_VERSION_HEADER)
+  logger.warn("mcp protocol version unsupported", {
+    endpoint,
+    reference_id: referenceId,
+    protocol_version: raw.slice(0, 128),
+    supported_versions: SUPPORTED_PROTOCOL_VERSIONS.join(", "),
+  })
+}

--- a/ee/apps/den-api/test/mcp-protocol-version.test.ts
+++ b/ee/apps/den-api/test/mcp-protocol-version.test.ts
@@ -2,7 +2,15 @@ import { expect, test } from "bun:test"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { Hono } from "hono"
-import { normalizeMcpProtocolVersionHeader } from "../src/mcp/protocol-version.js"
+import { normalizeMcpProtocolVersionHeader, type McpProtocolVersionWarn } from "../src/mcp/protocol-version.js"
+
+function recordingWarn() {
+  const warnings: { message: string; fields: Record<string, string> }[] = []
+  const warn: McpProtocolVersionWarn = (message, fields) => {
+    warnings.push({ message, fields })
+  }
+  return { warn, warnings }
+}
 
 function requestHeaders(protocolVersion?: string) {
   const request = new Request("https://api.example.com/mcp/agent", {
@@ -16,35 +24,50 @@ function requestHeaders(protocolVersion?: string) {
 }
 
 test("supported and missing protocol versions pass through untouched", () => {
+  const { warn, warnings } = recordingWarn()
   const supported = requestHeaders("2025-06-18")
-  normalizeMcpProtocolVersionHeader(supported, "agent", "req_supported")
+  normalizeMcpProtocolVersionHeader(supported, "agent", "req_supported", warn)
   expect(supported.get("mcp-protocol-version")).toBe("2025-06-18")
 
   const missing = requestHeaders()
-  normalizeMcpProtocolVersionHeader(missing, "agent", "req_missing")
+  normalizeMcpProtocolVersionHeader(missing, "agent", "req_missing", warn)
   expect(missing.get("mcp-protocol-version")).toBeNull()
+  expect(warnings).toEqual([])
 })
 
 test("duplicated copies of a negotiated version collapse to one value", () => {
+  const { warn, warnings } = recordingWarn()
   const headers = requestHeaders("2025-06-18")
   headers.append("mcp-protocol-version", "2025-06-18")
   expect(headers.get("mcp-protocol-version")).toBe("2025-06-18, 2025-06-18")
 
-  normalizeMcpProtocolVersionHeader(headers, "agent", "req_duplicated")
+  normalizeMcpProtocolVersionHeader(headers, "agent", "req_duplicated", warn)
   expect(headers.get("mcp-protocol-version")).toBe("2025-06-18")
+  expect(warnings).toEqual([{
+    message: "mcp protocol version header collapsed",
+    fields: {
+      endpoint: "agent",
+      reference_id: "req_duplicated",
+      protocol_version: "2025-06-18",
+    },
+  }])
 })
 
-test("unknown protocol versions are removed from request-guarded headers", () => {
+test("unknown protocol versions are removed and logged from request-guarded headers", () => {
+  const { warn, warnings } = recordingWarn()
   const headers = requestHeaders("2026-03-26")
-  normalizeMcpProtocolVersionHeader(headers, "agent", "req_unknown")
+  normalizeMcpProtocolVersionHeader(headers, "agent", "req_unknown", warn)
   expect(headers.get("mcp-protocol-version")).toBeNull()
+  expect(warnings.length).toBe(1)
+  expect(warnings[0]?.message).toBe("mcp protocol version unsupported")
+  expect(warnings[0]?.fields.protocol_version).toBe("2026-03-26")
 })
 
 function statelessMcpApp(normalize: boolean) {
   const app = new Hono()
   app.all("/mcp/agent", async (c) => {
     if (normalize) {
-      normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", "req_transport")
+      normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", "req_transport", () => {})
     }
     const server = new McpServer({ name: "witness", version: "1.0.0" })
     const transport = new StreamableHTTPTransport()

--- a/ee/apps/den-api/test/mcp-protocol-version.test.ts
+++ b/ee/apps/den-api/test/mcp-protocol-version.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { StreamableHTTPTransport } from "@hono/mcp"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Hono } from "hono"
+import { normalizeMcpProtocolVersionHeader } from "../src/mcp/protocol-version.js"
+
+function requestHeaders(protocolVersion?: string) {
+  const request = new Request("https://api.example.com/mcp/agent", {
+    method: "POST",
+    headers: protocolVersion === undefined
+      ? { "content-type": "application/json" }
+      : { "content-type": "application/json", "mcp-protocol-version": protocolVersion },
+    body: "{}",
+  })
+  return request.headers
+}
+
+test("supported and missing protocol versions pass through untouched", () => {
+  const supported = requestHeaders("2025-06-18")
+  normalizeMcpProtocolVersionHeader(supported, "agent", "req_supported")
+  expect(supported.get("mcp-protocol-version")).toBe("2025-06-18")
+
+  const missing = requestHeaders()
+  normalizeMcpProtocolVersionHeader(missing, "agent", "req_missing")
+  expect(missing.get("mcp-protocol-version")).toBeNull()
+})
+
+test("duplicated copies of a negotiated version collapse to one value", () => {
+  const headers = requestHeaders("2025-06-18")
+  headers.append("mcp-protocol-version", "2025-06-18")
+  expect(headers.get("mcp-protocol-version")).toBe("2025-06-18, 2025-06-18")
+
+  normalizeMcpProtocolVersionHeader(headers, "agent", "req_duplicated")
+  expect(headers.get("mcp-protocol-version")).toBe("2025-06-18")
+})
+
+test("unknown protocol versions are removed from request-guarded headers", () => {
+  const headers = requestHeaders("2026-03-26")
+  normalizeMcpProtocolVersionHeader(headers, "agent", "req_unknown")
+  expect(headers.get("mcp-protocol-version")).toBeNull()
+})
+
+function statelessMcpApp(normalize: boolean) {
+  const app = new Hono()
+  app.all("/mcp/agent", async (c) => {
+    if (normalize) {
+      normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", "req_transport")
+    }
+    const server = new McpServer({ name: "witness", version: "1.0.0" })
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    const response = await transport.handleRequest(c)
+    return response ?? new Response(null, { status: 204 })
+  })
+  return app
+}
+
+function initializedNotification(protocolVersion: string) {
+  return new Request("https://api.example.com/mcp/agent", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-protocol-version": protocolVersion,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  })
+}
+
+test("without normalization a newer negotiated version fails stateless requests with 404", async () => {
+  const response = await statelessMcpApp(false).request(initializedNotification("2026-03-26"))
+  expect(response.status).toBe(404)
+  const body: unknown = await response.json()
+  expect(JSON.stringify(body)).toContain("Unsupported protocol version")
+})
+
+test("with normalization the same request is accepted", async () => {
+  const response = await statelessMcpApp(true).request(initializedNotification("2026-03-26"))
+  expect(response.status).toBe(202)
+})

--- a/evals/specs/mcp-protocol-version-compat.test.ts
+++ b/evals/specs/mcp-protocol-version-compat.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("MCP endpoints tolerate newer or duplicated protocol-version headers", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-protocol-version-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/mcp-protocol-version.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="5"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    evidence.recordAssertionEvidence(
+      "A newer negotiated protocol version no longer fails stateless MCP requests",
+      "The focused runtime witness sends notifications/initialized with an unknown mcp-protocol-version through the real StreamableHTTPTransport, observes the JSON-RPC 404 control without normalization, and observes 202 with normalization.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Duplicated negotiated headers collapse instead of failing",
+      "The focused runtime witness appends an identical mcp-protocol-version copy, observes the comma-joined value, and requires normalization to restore the single negotiated version.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Supported and missing headers pass through untouched",
+      "The focused runtime witness requires normalization to leave a supported version and an absent header exactly as received.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
Production diagnosis of the claude.ai connector failure (after #3939 unmasked it): `POST /mcp/agent` returned a JSON-RPC 404 thrown by `@hono/mcp`'s `#validateProtocolVersion`. With our stateless transport the only reachable 404 is an `mcp-protocol-version` value outside the pinned SDK list (`2025-11-25 … 2024-10-07`) — a newer negotiated revision or a proxy-duplicated comma-joined value.

- collapse identical duplicated copies of a supported version back to the negotiated value
- remove unknown values so the stateless transport falls back to the SDK default instead of failing the request, and log the observed value (`mcp protocol version unsupported`) so support can be added deliberately
- applied on `/mcp` and `/mcp/agent`; `/mcp/admin` stays strict

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-protocol-version.test.ts` (5 passed, includes a real StreamableHTTPTransport witness: 404 control without normalization, 202 with it)
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/mcp-protocol-version-compat.test.ts` (1 passed)