### PR TITLE
fix(automations): persist and open Desktop execution threads

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-cloud-thread.ts
+++ b/apps/app/src/react-app/domains/automations/automation-cloud-thread.ts
@@ -1,4 +1,5 @@
 import type { AutomationExecutionThread } from "@openwork/types/automations"
+import { workspaceSessionRoute } from "@/react-app/shell/workspace-routes"
 
 export type AutomationExecutionIdentity = {
   icon: "desktop" | "cloud"
@@ -22,4 +23,13 @@ export function automationExecutionThreadRoute(
     thread: thread.id,
   })
   return `/automations?${query.toString()}`
+}
+
+export function automationLocalSessionRoute(
+  thread: Pick<AutomationExecutionThread, "executionLocation" | "nativeThreadId" | "workspaceId">,
+) {
+  if (thread.executionLocation !== "desktop") return null
+  const sessionId = thread.nativeThreadId?.trim()
+  const workspaceId = thread.workspaceId?.trim()
+  return sessionId && workspaceId ? workspaceSessionRoute(workspaceId, sessionId) : null
 }

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -49,7 +49,7 @@ import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal"
 import { AutomationEditor } from "./automation-editor"
 import { dispatchAutomationsStateChanged } from "./automation-events"
-import { automationExecutionThreadRoute, automationExecutionIdentity } from "./automation-cloud-thread"
+import { automationExecutionThreadRoute, automationExecutionIdentity, automationLocalSessionRoute } from "./automation-cloud-thread"
 import { formatAutomationSchedule, formatAutomationTime } from "./automation-format"
 import type { AutomationProviderCatalog } from "./automation-model-options"
 import { automationModelOptions, describeAutomationModel } from "./automation-model-options"
@@ -351,8 +351,12 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     const modelNeedsAttention = task.needsAttentionReason?.code === "model_access_lost"
       || task.needsAttentionReason?.code === "provider_unavailable"
     const runs = runsQuery.data?.items ?? []
-    const selectedReceipt = receiptQuery.data
+    const selectedReceipt = receiptQuery.data?.run.id === selectedRunId ? receiptQuery.data : undefined
+    const receiptIsLoading = receiptQuery.isLoading || (receiptQuery.isFetching && !selectedReceipt)
     const threadMatches = !selectedThreadId || selectedReceipt?.run.executionThread?.id === selectedThreadId
+    const localSessionRoute = selectedReceipt?.run.executionThread
+      ? automationLocalSessionRoute(selectedReceipt.run.executionThread)
+      : null
 
     if (editing && (detail.revision.executionTarget ?? "desktop") === "desktop") {
       return (
@@ -577,7 +581,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             <CardContent>
               {!selectedRunId ? (
                 <div className="py-10 text-center text-sm text-muted-foreground">No run selected.</div>
-              ) : receiptQuery.isLoading ? (
+              ) : receiptIsLoading ? (
                 <Skeleton className="h-48 rounded-xl" />
               ) : receiptQuery.error || !selectedReceipt ? (
                 <Alert variant="warning"><AlertCircle /><AlertDescription>{describeError(receiptQuery.error)}</AlertDescription></Alert>
@@ -594,6 +598,17 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
                     ) : (
                       <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? <Cloud className="mr-1 h-3 w-3" /> : <Monitor className="mr-1 h-3 w-3" />}{selectedReceipt.run.executionTarget === "cloud" ? "OpenWork Cloud" : "Desktop"}</Badge>
                     )}
+                    {localSessionRoute ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        data-automation-run-id={selectedReceipt.run.id}
+                        onClick={() => navigate(localSessionRoute)}
+                      >
+                        Open local thread
+                      </Button>
+                    ) : null}
                   </div>
                   {selectedReceipt.run.error ? (
                     <Alert variant="destructive"><AlertCircle /><AlertTitle>{selectedReceipt.run.error.code}</AlertTitle><AlertDescription>{selectedReceipt.run.error.message}</AlertDescription></Alert>
@@ -668,6 +683,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
             <button
               key={item.automation.id}
               type="button"
+              data-automation-id={item.automation.id}
               {...(item.automation.state === "needs_attention" ? { "data-automation-needs-attention": true } : {})}
               className="rounded-2xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/40"
               onClick={() => openAutomation(item.automation.id)}

--- a/apps/app/tests/automation-cloud-thread.test.ts
+++ b/apps/app/tests/automation-cloud-thread.test.ts
@@ -3,6 +3,7 @@ import type { AutomationExecutionThread } from "@openwork/types/automations"
 import {
   automationExecutionThreadRoute,
   automationExecutionIdentity,
+  automationLocalSessionRoute,
 } from "../src/react-app/domains/automations/automation-cloud-thread"
 
 function desktopThread(engineKind: string): AutomationExecutionThread {
@@ -39,5 +40,19 @@ describe("Automation execution thread UI", () => {
       icon: "cloud",
       label: "OpenWork Cloud",
     })
+  })
+
+  test("opens a linked Desktop run in its native local session", () => {
+    expect(automationLocalSessionRoute({
+      ...desktopThread("openwork-desktop-runner-v1"),
+      workspaceId: "ws with spaces",
+      nativeThreadId: "ses/failed",
+    })).toBe("/workspace/ws%20with%20spaces/session/ses%2Ffailed")
+    expect(automationLocalSessionRoute(desktopThread("openwork-desktop-runner-v1"))).toBeNull()
+    expect(automationLocalSessionRoute({
+      ...cloudThread(),
+      workspaceId: "ws_cloud",
+      nativeThreadId: "ses_cloud",
+    })).toBeNull()
   })
 })

--- a/ee/apps/den-api/src/automations/repository.ts
+++ b/ee/apps/den-api/src/automations/repository.ts
@@ -98,7 +98,7 @@ function mapRevision(row: RevisionRow): AutomationRevision {
 }
 
 function mapRun(row: RunRow): AutomationRun {
-  const receipt = row.execution_target === "cloud" && typeof row.engine_receipt === "object" && row.engine_receipt !== null
+  const receipt = typeof row.engine_receipt === "object" && row.engine_receipt !== null
     ? row.engine_receipt as Record<string, unknown>
     : null
   const nativeThreadId = typeof receipt?.nativeThreadId === "string" ? receipt.nativeThreadId : null
@@ -762,6 +762,7 @@ export class DenAutomationRepository implements AutomationRepository {
         result_summary: input.resultSummary,
         usage: input.usage,
         error: input.error,
+        ...(input.engineReceipt === undefined ? {} : { engine_receipt: input.engineReceipt }),
         finished_at: new Date(input.now),
         lease_expires_at: null,
         heartbeat_at: new Date(input.now),

--- a/ee/apps/den-api/src/automations/service.ts
+++ b/ee/apps/den-api/src/automations/service.ts
@@ -443,6 +443,10 @@ export class AutomationService {
       resultSummary: result.resultSummary,
       usage: result.usage,
       error: result.error,
+      engineReceipt: {
+        ...(result.sessionId ? { nativeThreadId: result.sessionId } : {}),
+        ...(result.workspaceId ? { workspaceId: result.workspaceId } : {}),
+      },
       attempt: result.attempt,
       now,
     })

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -21,6 +21,7 @@ import { automationUpdateChangedRows } from "../src/automations/update-result.js
 import { isMcpOperationAllowed } from "../src/mcp/policy.js"
 
 const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
+const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
 
 test("runner notifications contain only a resumable cursor and wake-up type", () => {
   assert.deepEqual(automationRunnerNotificationSchema.parse({
@@ -141,7 +142,6 @@ test("desktop occurrences stay claimable through the recovery window with named 
 })
 
 test("runner presence is a read-only view of existing liveness data", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const presence = serviceSource.slice(
     serviceSource.indexOf("async desktopRunnerPresence"),
     serviceSource.indexOf("async discoverDesktopRunnerWork"),
@@ -157,6 +157,26 @@ test("runner presence is a read-only view of existing liveness data", () => {
   assert.doesNotMatch(presence, /update|insert|touchDesktopRunner/i)
   assert.match(reader, /db\.select\(/)
   assert.doesNotMatch(reader, /db\.(update|insert)/)
+})
+
+test("Desktop completion durably exposes its native local thread", () => {
+  const completion = serviceSource.slice(
+    serviceSource.indexOf("async completeDesktopRunner"),
+    serviceSource.indexOf("runnerNotifications"),
+  )
+  const mapRun = repositorySource.slice(
+    repositorySource.indexOf("function mapRun"),
+    repositorySource.indexOf("function normalizedDefinition"),
+  )
+  const persist = repositorySource.slice(
+    repositorySource.indexOf("async complete(input"),
+    repositorySource.indexOf("async recoverExpiredLeases"),
+  )
+
+  assert.match(completion, /engineReceipt:[\s\S]*nativeThreadId: result\.sessionId[\s\S]*workspaceId: result\.workspaceId/)
+  assert.match(persist, /engine_receipt: input\.engineReceipt/)
+  assert.match(mapRun, /receipt\?\.nativeThreadId[\s\S]*receipt\?\.workspaceId/)
+  assert.doesNotMatch(mapRun, /row\.execution_target === "cloud"/)
 })
 
 test("expired lease recovery cannot clobber a concurrently renewed lease", () => {
@@ -245,7 +265,6 @@ test("idle runner notification polling backs off without delaying keepalives", (
 
 test("idle runner keepalives do not persist liveness in the database", () => {
   const routesSource = readFileSync(join(import.meta.dir, "../src/routes/automations/index.ts"), "utf8")
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const repositorySource = readFileSync(join(import.meta.dir, "../src/automations/repository.ts"), "utf8")
   const sse = routesSource.slice(
     routesSource.indexOf("/v1/automation-runners/events\", async"),
@@ -265,7 +284,6 @@ test("idle runner keepalives do not persist liveness in the database", () => {
 })
 
 test("work polling tolerates non-critical runner presence touch failures", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const discover = serviceSource.slice(
     serviceSource.indexOf("async discoverDesktopRunnerWork"),
     serviceSource.indexOf("async claimDesktopRunner"),
@@ -277,7 +295,6 @@ test("work polling tolerates non-critical runner presence touch failures", () =>
 })
 
 test("every dispatch path revalidates the owner's model access", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const tick = serviceSource.slice(serviceSource.indexOf("async tick"), serviceSource.indexOf("async stop"))
   assert.match(tick, /resolveAutomationModelAccess\(\{\s*organizationId: item\.automation\.organizationId/)
   assert.match(tick, /shouldApplyAutomationModelAccessFailure\(\{[\s\S]*modelAttentionCapable: \(item\.revision\.executionTarget \?\? "desktop"\) === "cloud"/)
@@ -303,7 +320,6 @@ test("every dispatch path revalidates the owner's model access", () => {
 })
 
 test("Cloud placement never inherits the legacy Desktop model exception", () => {
-  const serviceSource = readFileSync(join(import.meta.dir, "../src/automations/service.ts"), "utf8")
   const create = serviceSource.slice(serviceSource.indexOf("async create"), serviceSource.indexOf("async update"))
   const update = serviceSource.slice(serviceSource.indexOf("async update"), serviceSource.indexOf("async activate"))
   const reconcile = serviceSource.slice(serviceSource.indexOf("private async reconcileModelAttention"))

--- a/evals/specs/automation-desktop-lifecycle.e2e.test.ts
+++ b/evals/specs/automation-desktop-lifecycle.e2e.test.ts
@@ -1,0 +1,804 @@
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import {
+  clickButton,
+  clickText,
+  denFetch,
+  evalIn,
+  go,
+  readAvailableModels,
+  visibleText,
+  waitForText,
+} from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import {
+  app,
+  eventually,
+  needs,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const PROVIDER_NAME = "Automation Reliability Gateway";
+const PROVIDER_KEY = "automation-reliability-gateway";
+const PROVIDER_ENV = "AUTOMATION_RELIABILITY_API_KEY";
+const MODEL_ID = "automation-reliability-model";
+const MODEL_NAME = "Automation Reliability Model";
+const REPLY = "The synthetic Automation lifecycle completed successfully.";
+const PROVIDER_API_KEY = "sk-automation-reliability-local-only";
+const REQUEST_TIMEOUT_MS = 10_000;
+const RUN_TIMEOUT_MS = 180_000;
+const AUTOMATION_MODEL_ATTENTION_CAPABILITY = "model_attention_v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+function startProviderMock(
+  completionBodies: unknown[],
+  control: { unavailable?: boolean } = {},
+): Promise<string> {
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: MODEL_ID, object: "model" }] }));
+      return;
+    }
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let rawBody = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { rawBody += chunk; });
+      request.on("end", () => {
+        let body: unknown;
+        try {
+          body = JSON.parse(rawBody);
+        } catch {
+          response.writeHead(400, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: { message: "invalid JSON request body" } }));
+          return;
+        }
+        completionBodies.push(body);
+        if (control.unavailable) {
+          response.writeHead(503, { "content-type": "application/json" });
+          response.end(JSON.stringify({
+            error: { message: "Synthetic provider is temporarily unavailable", type: "provider_unavailable" },
+          }));
+          return;
+        }
+        const chunks = [
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: REPLY }, finish_reason: null }] },
+          { id: `chatcmpl-automation-${completionBodies.length}`, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  return new Promise((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", () => {
+      const address = mock.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Automation provider mock did not bind a TCP port."));
+        return;
+      }
+      onTestFinished(async () => {
+        await new Promise<void>((closeResolve, closeReject) => {
+          mock.close((error) => error ? closeReject(error) : closeResolve());
+          mock.closeAllConnections();
+        });
+      });
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) ? records(result.body.orgs) : [];
+  const active = organizations.find((organization) => organization.isActive === true) ?? organizations[0];
+  const id = active && typeof active.id === "string" ? active.id : "";
+  expect(result.response.status, result.text).toBe(200);
+  expect(id).not.toBe("");
+  return id;
+}
+
+async function createProvider(
+  admin: DenSession,
+  orgId: string,
+  baseUrl: string,
+  apiKey: string,
+): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: [PROVIDER_ENV],
+        api: baseUrl,
+        models: [{ id: MODEL_ID, name: MODEL_NAME }],
+      },
+      apiKey,
+      allMembers: true,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider)
+    ? result.body.llmProvider
+    : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  expect(result.response.status, result.text).toBe(201);
+  expect(id).not.toBe("");
+  return id;
+}
+
+async function createAutomation(
+  admin: DenSession,
+  orgId: string,
+  input: { name: string; instructions: string; providerId: string },
+): Promise<{ automationId: string; revisionId: string }> {
+  const result = await denFetch(admin, "/v1/automations", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: input.name,
+      instructions: input.instructions,
+      schedule: { kind: "daily", timezone: "UTC", hour: 23, minute: 59 },
+      model: { providerId: input.providerId, modelId: MODEL_ID, variant: null },
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const automation = isRecord(result.body) && isRecord(result.body.automation)
+    ? result.body.automation
+    : null;
+  const revision = isRecord(result.body) && isRecord(result.body.revision)
+    ? result.body.revision
+    : null;
+  const automationId = automation && typeof automation.id === "string" ? automation.id : "";
+  const revisionId = revision && typeof revision.id === "string" ? revision.id : "";
+  expect(result.response.status, result.text).toBe(201);
+  expect(automation?.state).toBe("active");
+  expect(automationId).not.toBe("");
+  expect(revisionId).not.toBe("");
+  expect(revision?.schedule).toEqual({ kind: "daily", timezone: "UTC", hour: 23, minute: 59 });
+  expect(revision?.model).toEqual({ providerId: input.providerId, modelId: MODEL_ID, variant: null });
+  return { automationId, revisionId };
+}
+
+async function listRuns(admin: DenSession, automationId: string): Promise<Record<string, unknown>[]> {
+  const result = await denFetch(admin, `/v1/automations/${encodeURIComponent(automationId)}/runs`, {
+    headers: auth(admin),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status, result.text).toBe(200);
+  return isRecord(result.body) ? records(result.body.items) : [];
+}
+
+async function waitForNewRun(
+  admin: DenSession,
+  automationId: string,
+  before: Set<string>,
+  trigger: "manual" | "scheduled",
+): Promise<Record<string, unknown>> {
+  const run = await eventually(async () => {
+    const runs = await listRuns(admin, automationId);
+    return runs.find((run) => run.trigger === trigger
+      && typeof run.id === "string"
+      && !before.has(run.id));
+  }, {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 500,
+    label: `new ${trigger} Automation run`,
+    until: (run) => isRecord(run),
+  });
+  if (!run) throw new Error(`The ${trigger} Automation run disappeared after it was observed.`);
+  return run;
+}
+
+async function waitForTerminalReceipt(
+  admin: DenSession,
+  runId: string,
+): Promise<Record<string, unknown>> {
+  return eventually(async () => {
+    const result = await denFetch(admin, `/v1/automation-runs/${encodeURIComponent(runId)}`, {
+      headers: auth(admin),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    expect(result.response.status, result.text).toBe(200);
+    return isRecord(result.body) ? result.body : {};
+  }, {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 500,
+    label: `terminal receipt for ${runId}`,
+    until: (receipt) => {
+      const run = isRecord(receipt.run) ? receipt.run : null;
+      return run !== null && ["succeeded", "failed", "cancelled", "skipped"].includes(String(run.status));
+    },
+  });
+}
+
+async function assertSucceededReceipt(
+  receipt: Record<string, unknown>,
+  expected: { automationId: string; revisionId?: string },
+): Promise<{ runId: string; sessionId: string }> {
+  const run = isRecord(receipt.run) ? receipt.run : {};
+  const thread = isRecord(run.executionThread) ? run.executionThread : {};
+  const events = records(receipt.events);
+  const runId = typeof run.id === "string" ? run.id : "";
+  const sessionId = typeof thread.nativeThreadId === "string" ? thread.nativeThreadId : "";
+  expect(run.status).toBe("succeeded");
+  expect(run.automationId).toBe(expected.automationId);
+  if (expected.revisionId) expect(run.revisionId).toBe(expected.revisionId);
+  expect(run.error).toBeNull();
+  expect(run.resultSummary).toContain(REPLY);
+  expect(thread).toMatchObject({
+    threadKind: "automation",
+    executionLocation: "desktop",
+    automationId: expected.automationId,
+    automationRunId: runId,
+    engineKind: "openwork-desktop-runner-v1",
+  });
+  expect(sessionId).not.toBe("");
+  expect(typeof thread.workspaceId).toBe("string");
+  expect(events.map((event) => event.type)).toEqual(["user", "assistant", "usage", "terminal"]);
+  expect(events.map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+  return { runId, sessionId };
+}
+
+async function openAutomation(surface: Surface, automationId: string, name: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await go(surface, "/automations");
+    try {
+      await eventually(() => evalIn(surface, "window.location.hash"), {
+        within: 30_000,
+        intervalMs: 250,
+        label: "Automations list route",
+        until: (hash) => typeof hash === "string" && /^#\/automations(?:\?|$)/.test(hash),
+      });
+      await clickText(surface, name, {
+        selector: `button[data-automation-id="${automationId}"]`,
+        timeoutMs: 30_000,
+      });
+      await waitForText(surface, "Run now", { timeoutMs: 30_000 });
+      return;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+}
+
+async function waitForSyntheticModel(surface: Surface): Promise<void> {
+  const availableModels = await eventually(() => readAvailableModels(surface), {
+    within: 120_000,
+    intervalMs: 2_000,
+    label: "synced synthetic Automation model",
+    until: (models) => models.some((model) => model.selectable
+      && (model.id === MODEL_ID || model.id.endsWith(`/${MODEL_ID}`))),
+  });
+  expect(availableModels.some((model) => model.selectable
+    && (model.id === MODEL_ID || model.id.endsWith(`/${MODEL_ID}`)))).toBe(true);
+}
+
+async function triggerManualRun(
+  admin: DenSession,
+  automationId: string,
+): Promise<Record<string, unknown>> {
+  const before = new Set((await listRuns(admin, automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const response = await denFetch(admin, `/v1/automations/${encodeURIComponent(automationId)}/run`, {
+    method: "POST",
+    headers: auth(admin),
+  });
+  expect(response.response.status, response.text).toBe(202);
+  return waitForNewRun(admin, automationId, before, "manual");
+}
+
+test("a Desktop Automation completes through UI, API, schedule, thread, and receipt", { timeout: 20 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Reliability ${Date.now()}`,
+      admin: { name: "Automation Admin" },
+      members: { member: { name: "Automation Member" } },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const stamp = Date.now();
+  const automationName = `Synthetic lifecycle ${stamp}`;
+  const instructions = `Return one concise synthetic reliability result for marker ${stamp}.`;
+
+  const invalid = await denFetch(den.admin, "/v1/automations", {
+    method: "POST",
+    headers: { ...auth(den.admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: `Invalid lifecycle ${stamp}`,
+      instructions,
+      schedule: { kind: "daily", timezone: "Not/A-Timezone", hour: 9, minute: 0 },
+      model: { providerId, modelId: MODEL_ID, variant: null },
+    }),
+  });
+  expect(invalid.response.status).toBe(400);
+  expect((await denFetch(den.admin, "/v1/automations", { headers: auth(den.admin) })).text)
+    .not.toContain(`Invalid lifecycle ${stamp}`);
+  evidence.recordAssertionEvidence(
+    "Invalid Automation configuration fails without a runnable record",
+    "Den rejected the invalid timezone with HTTP 400 and the invalid name was absent from the owner list.",
+    true,
+  );
+
+  const created = await createAutomation(den.admin, orgId, {
+    name: automationName,
+    instructions,
+    providerId,
+  });
+  const denied = await denFetch(den.members.member, `/v1/automations/${encodeURIComponent(created.automationId)}`, {
+    headers: auth(den.members.member),
+  });
+  expect(denied.response.status).toBe(404);
+  evidence.recordAssertionEvidence(
+    "Automation ownership remains member-scoped",
+    "A different organization member received HTTP 404 for the owner's Automation.",
+    true,
+  );
+
+  await using desktop = await app({ den, as: "admin", place });
+  await waitForSyntheticModel(desktop);
+
+  await openAutomation(desktop, created.automationId, automationName);
+  const beforeUiRun = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const firstProviderCheckpoint = completionBodies.length;
+  await clickButton(desktop, "Run now");
+  const uiRun = await waitForNewRun(den.admin, created.automationId, beforeUiRun, "manual");
+  const uiRunId = typeof uiRun.id === "string" ? uiRun.id : "";
+  const uiReceipt = await waitForTerminalReceipt(den.admin, uiRunId);
+  const first = await assertSucceededReceipt(uiReceipt, created);
+  const firstRequest = await eventually(() => completionBodies[firstProviderCheckpoint], {
+    within: RUN_TIMEOUT_MS,
+    intervalMs: 250,
+    label: "first synthetic provider completion",
+    until: (request) => request !== undefined,
+  });
+  expect(JSON.stringify(firstRequest)).toContain(String(stamp));
+  evidence.recordAssertionEvidence(
+    "Run now reaches a real desktop session and durable receipt",
+    `UI run ${first.runId} created native thread ${first.sessionId}, returned the deterministic assistant result, and committed four ordered events.`,
+    true,
+  );
+
+  const receipts: Record<string, unknown>[] = [uiReceipt];
+  for (let index = 0; index < 2; index += 1) {
+    const before = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+      typeof run.id === "string" ? [run.id] : []));
+    const response = await denFetch(den.admin, `/v1/automations/${encodeURIComponent(created.automationId)}/run`, {
+      method: "POST",
+      headers: auth(den.admin),
+    });
+    expect(response.response.status, response.text).toBe(202);
+    const run = await waitForNewRun(den.admin, created.automationId, before, "manual");
+    const runId = typeof run.id === "string" ? run.id : "";
+    const receipt = await waitForTerminalReceipt(den.admin, runId);
+    await assertSucceededReceipt(receipt, created);
+    receipts.push(receipt);
+  }
+
+  const scheduledAt = Date.now() + 45_000;
+  const scheduleResponse = await denFetch(
+    den.admin,
+    `/v1/automations/${encodeURIComponent(created.automationId)}`,
+    {
+      method: "PATCH",
+      headers: auth(den.admin),
+      body: JSON.stringify({ schedule: { kind: "once", timezone: "UTC", at: scheduledAt } }),
+    },
+  );
+  expect(scheduleResponse.response.status, scheduleResponse.text).toBe(200);
+  const scheduledRevision = isRecord(scheduleResponse.body) && isRecord(scheduleResponse.body.revision)
+    ? scheduleResponse.body.revision
+    : {};
+  expect(scheduledRevision.schedule).toEqual({ kind: "once", timezone: "UTC", at: scheduledAt });
+  const beforeScheduled = new Set((await listRuns(den.admin, created.automationId)).flatMap((run) =>
+    typeof run.id === "string" ? [run.id] : []));
+  const scheduledRun = await waitForNewRun(den.admin, created.automationId, beforeScheduled, "scheduled");
+  const scheduledRunId = typeof scheduledRun.id === "string" ? scheduledRun.id : "";
+  const scheduledReceipt = await waitForTerminalReceipt(den.admin, scheduledRunId);
+  await assertSucceededReceipt(scheduledReceipt, {
+    automationId: created.automationId,
+    revisionId: typeof scheduledRevision.id === "string" ? scheduledRevision.id : undefined,
+  });
+  receipts.push(scheduledReceipt);
+
+  const runIds = receipts.flatMap((receipt) => {
+    const run = isRecord(receipt.run) ? receipt.run : {};
+    return typeof run.id === "string" ? [run.id] : [];
+  });
+  const sessionIds = receipts.flatMap((receipt) => {
+    const run = isRecord(receipt.run) ? receipt.run : {};
+    const thread = isRecord(run.executionThread) ? run.executionThread : {};
+    return typeof thread.nativeThreadId === "string" ? [thread.nativeThreadId] : [];
+  });
+  expect(new Set(runIds).size).toBe(4);
+  expect(new Set(sessionIds).size).toBe(4);
+  expect(completionBodies.slice(firstProviderCheckpoint)).toHaveLength(4);
+  evidence.recordAssertionEvidence(
+    "Repeated and scheduled runs remain exactly-once",
+    "Three sequential manual runs and one scheduled occurrence produced four unique runs, four unique native sessions, four deterministic model requests, and four terminal receipts.",
+    true,
+  );
+
+  const scheduledTerminalRun = isRecord(scheduledReceipt.run) ? scheduledReceipt.run : {};
+  const scheduledThread = isRecord(scheduledTerminalRun.executionThread)
+    ? scheduledTerminalRun.executionThread
+    : {};
+  const scheduledThreadId = typeof scheduledThread.id === "string" ? scheduledThread.id : "";
+  const scheduledWorkspaceId = typeof scheduledThread.workspaceId === "string" ? scheduledThread.workspaceId : "";
+  const scheduledSessionId = typeof scheduledThread.nativeThreadId === "string" ? scheduledThread.nativeThreadId : "";
+  const receiptQuery = new URLSearchParams({
+    automation: created.automationId,
+    run: scheduledRunId,
+    thread: scheduledThreadId,
+  });
+  await go(desktop, `/automations?${receiptQuery.toString()}`);
+  await clickText(desktop, "Open local thread", {
+    selector: `button[data-automation-run-id="${scheduledRunId}"]`,
+    timeoutMs: 30_000,
+  });
+  await eventually(
+    () => evalIn(desktop, "window.location.hash"),
+    {
+      within: 30_000,
+      intervalMs: 250,
+      label: "native Automation session route",
+      until: (hash) => typeof hash === "string"
+        && hash.includes(`/workspace/${encodeURIComponent(scheduledWorkspaceId)}/session/${encodeURIComponent(scheduledSessionId)}`),
+    },
+  );
+  await waitForText(desktop, REPLY, { timeoutMs: 30_000 });
+  evidence.recordAssertionEvidence(
+    "A receipt opens the actual local execution thread",
+    `The scheduled receipt exposed workspace ${scheduledWorkspaceId} and session ${scheduledSessionId}; Open local thread navigated to that session and rendered the deterministic assistant result.`,
+    true,
+  );
+
+  await openAutomation(desktop, created.automationId, automationName);
+  const detailText = await visibleText(desktop);
+  expect(detailText).toContain("succeeded");
+  expect(detailText).toContain(MODEL_NAME);
+  expect(detailText).not.toMatch(/running|waiting|no assistant result/i);
+  evidence.recordAssertionEvidence(
+    "The Automation UI reflects the terminal result and configured model",
+    `The detail view showed succeeded with ${MODEL_NAME}, without a stale running, waiting, or missing-result message.`,
+    true,
+  );
+});
+
+test("a Desktop Automation recovers across restart before execution and while work is queued", { timeout: 20 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Recovery ${Date.now()}`,
+      admin: { name: "Automation Recovery Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const stamp = Date.now();
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic recovery ${stamp}`,
+    instructions: `Return one concise synthetic recovery result for marker ${stamp}.`,
+    providerId,
+  });
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-automation-recovery-"));
+  onTestFinished(() => rm(profileDir, { recursive: true, force: true }));
+  let desktop: Awaited<ReturnType<typeof app>> | null = null;
+
+  try {
+    desktop = await app({ den, as: "admin", place, profileDir });
+    await waitForSyntheticModel(desktop);
+    await desktop.stop();
+    desktop = null;
+
+    desktop = await app({ den, as: "admin", place, profileDir });
+    await waitForSyntheticModel(desktop);
+    const postRestartRun = await triggerManualRun(den.admin, created.automationId);
+    const postRestartRunId = typeof postRestartRun.id === "string" ? postRestartRun.id : "";
+    const postRestartReceipt = await waitForTerminalReceipt(den.admin, postRestartRunId);
+    const first = await assertSucceededReceipt(postRestartReceipt, created);
+    evidence.recordAssertionEvidence(
+      "Desktop restart before execution preserves runner readiness",
+      `The same isolated profile relaunched before execution, reminted its runner authority, and run ${first.runId} completed in native session ${first.sessionId}.`,
+      true,
+    );
+
+    await desktop.stop();
+    desktop = null;
+    const providerRequestsBeforeConcurrentRuns = completionBodies.length;
+    const concurrentResponses = await Promise.all(Array.from({ length: 3 }, () =>
+      denFetch(den.admin, `/v1/automations/${encodeURIComponent(created.automationId)}/run`, {
+        method: "POST",
+        headers: auth(den.admin),
+      })));
+    for (const response of concurrentResponses) {
+      expect(response.response.status, response.text).toBe(202);
+    }
+    const concurrentRuns = concurrentResponses.map((response) =>
+      isRecord(response.body) && isRecord(response.body.run) ? response.body.run : {});
+    expect(concurrentRuns.map((run) => run.status).sort()).toEqual(["queued", "skipped", "skipped"]);
+    const queuedConcurrentRun = concurrentRuns.find((run) => run.status === "queued");
+    const queuedConcurrentRunId = queuedConcurrentRun && typeof queuedConcurrentRun.id === "string"
+      ? queuedConcurrentRun.id
+      : "";
+    const cancelResponse = await denFetch(
+      den.admin,
+      `/v1/automation-runs/${encodeURIComponent(queuedConcurrentRunId)}/cancel`,
+      { method: "POST", headers: auth(den.admin) },
+    );
+    const cancelledRun = isRecord(cancelResponse.body) && isRecord(cancelResponse.body.run)
+      ? cancelResponse.body.run
+      : {};
+    expect(cancelResponse.response.status, cancelResponse.text).toBe(200);
+    expect(cancelledRun.status).toBe("cancelled");
+    expect(cancelledRun.executionThread).toBeNull();
+    expect(completionBodies).toHaveLength(providerRequestsBeforeConcurrentRuns);
+    evidence.recordAssertionEvidence(
+      "Concurrent manual requests overlap safely and cancellation before claim is terminal",
+      "Three simultaneous manual requests with Desktop absent produced one queued run and two durable overlap skips; cancelling the queued run returned cancelled with no execution thread and no provider request.",
+      true,
+    );
+
+    const waitingRun = await triggerManualRun(den.admin, created.automationId);
+    const waitingRunId = typeof waitingRun.id === "string" ? waitingRun.id : "";
+    expect(waitingRun.status).toBe("queued");
+
+    desktop = await app({ den, as: "admin", place, profileDir });
+    const waitingReceipt = await waitForTerminalReceipt(den.admin, waitingRunId);
+    const second = await assertSucceededReceipt(waitingReceipt, created);
+    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(completionBodies).toHaveLength(2);
+    evidence.recordAssertionEvidence(
+      "Queued work survives Desktop absence and relaunch",
+      `Run ${second.runId} remained queued while Desktop was stopped; after relaunch a fresh runner credential claimed that same run and exactly one new native session ${second.sessionId} reached a terminal receipt.`,
+      true,
+    );
+  } finally {
+    await desktop?.stop();
+  }
+});
+
+test("a Desktop Automation records a provider outage and succeeds after recovery", { timeout: 10 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerControl = { unavailable: true };
+  const providerBaseUrl = await startProviderMock(completionBodies, providerControl);
+  await using den = await server({
+    place,
+    org: {
+      name: `Automation Provider Recovery ${Date.now()}`,
+      admin: { name: "Automation Provider Recovery Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic provider recovery ${Date.now()}`,
+    instructions: "Return a result after the synthetic provider recovers.",
+    providerId,
+  });
+  await using desktop = await app({ den, as: "admin", place });
+  await waitForSyntheticModel(desktop);
+
+  const failedRun = await triggerManualRun(den.admin, created.automationId);
+  const failedRunId = typeof failedRun.id === "string" ? failedRun.id : "";
+  const failedReceipt = await waitForTerminalReceipt(den.admin, failedRunId);
+  const failed = isRecord(failedReceipt.run) ? failedReceipt.run : {};
+  const failedThread = isRecord(failed.executionThread) ? failed.executionThread : {};
+  expect(failed.status).toBe("failed");
+  expect(failed.error).toMatchObject({ code: "execution_failed", retryable: false });
+  expect(JSON.stringify(failed.error)).toMatch(/temporarily unavailable|503/i);
+  expect(typeof failedThread.nativeThreadId).toBe("string");
+  expect(typeof failedThread.workspaceId).toBe("string");
+  expect(records(failedReceipt.events).map((event) => event.type)).toEqual(["user", "terminal"]);
+  evidence.recordAssertionEvidence(
+    "A provider outage fails promptly with a linked local execution thread",
+    `Run ${failedRunId} received synthetic HTTP 503 responses and reached failed/execution_failed with its native session and workspace preserved; its event sequence ended at terminal instead of remaining running or waiting.`,
+    true,
+  );
+
+  providerControl.unavailable = false;
+  const recoveredRun = await triggerManualRun(den.admin, created.automationId);
+  const recoveredRunId = typeof recoveredRun.id === "string" ? recoveredRun.id : "";
+  const recoveredReceipt = await waitForTerminalReceipt(den.admin, recoveredRunId);
+  const recovered = await assertSucceededReceipt(recoveredReceipt, created);
+  expect(recovered.sessionId).not.toBe(failedThread.nativeThreadId);
+  evidence.recordAssertionEvidence(
+    "A later run succeeds after the provider recovers",
+    `Without editing or recreating the Automation, run ${recovered.runId} completed in a new native session after the provider began serving successful responses.`,
+    true,
+  );
+});
+
+test("Desktop runner claims are idempotent and expired leases recover safely", { timeout: 5 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const completionBodies: unknown[] = [];
+  const providerBaseUrl = await startProviderMock(completionBodies);
+  await using den = await server({
+    place,
+    env: {
+      DEN_AUTOMATIONS_LEASE_MS: "2500",
+      DEN_AUTOMATIONS_POLL_INTERVAL_MS: "1000",
+      DEN_AUTOMATIONS_RUNNER_CLAIM_DEADLINE_MS: "30000",
+    },
+    org: {
+      name: `Automation Lease Recovery ${Date.now()}`,
+      admin: { name: "Automation Lease Admin" },
+    },
+  });
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, providerBaseUrl, PROVIDER_API_KEY);
+  const created = await createAutomation(den.admin, orgId, {
+    name: `Synthetic lease recovery ${Date.now()}`,
+    instructions: "This synthetic run must never reach a provider.",
+    providerId,
+  });
+  const registration = (runnerId: string) => ({
+    runnerId,
+    protocolVersion: 1,
+    supportedExecutionTargets: ["desktop"],
+    capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+    appVersion: "automation-reliability-eval",
+    platform: "darwin",
+    concurrency: 1,
+  });
+  const mintRunner = async (runnerId: string): Promise<string> => {
+    const response = await denFetch(den.admin, "/v1/automation-runners/token", {
+      method: "POST",
+      headers: auth(den.admin),
+      body: JSON.stringify(registration(runnerId)),
+    });
+    const token = isRecord(response.body) && typeof response.body.token === "string"
+      ? response.body.token
+      : "";
+    expect(response.response.status, response.text).toBe(200);
+    expect(token).not.toBe("");
+    return token;
+  };
+  const runnerRequest = (token: string, path: string, options: RequestInit = {}) =>
+    denFetch(den.admin, path, {
+      ...options,
+      headers: { ...options.headers, authorization: `Bearer ${token}` },
+    });
+
+  const firstRunnerToken = await mintRunner(`synthetic-runner-primary-${Date.now()}`);
+  const secondRunnerToken = await mintRunner(`synthetic-runner-secondary-${Date.now()}`);
+  const run = await triggerManualRun(den.admin, created.automationId);
+  const runId = typeof run.id === "string" ? run.id : "";
+  const work = await runnerRequest(firstRunnerToken, "/v1/automation-runner/work");
+  expect(work.response.status, work.text).toBe(200);
+  expect(JSON.stringify(work.body)).toContain(runId);
+
+  const firstClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  const duplicateClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  expect(firstClaim.response.status, firstClaim.text).toBe(200);
+  expect(duplicateClaim.response.status, duplicateClaim.text).toBe(200);
+  const firstAssignment = isRecord(firstClaim.body) && isRecord(firstClaim.body.assignment)
+    ? firstClaim.body.assignment
+    : {};
+  const duplicateAssignment = isRecord(duplicateClaim.body) && isRecord(duplicateClaim.body.assignment)
+    ? duplicateClaim.body.assignment
+    : {};
+  expect(firstAssignment).toMatchObject({ runId, attempt: 1 });
+  expect(duplicateAssignment).toMatchObject({ runId, attempt: 1 });
+
+  const competingClaim = await runnerRequest(
+    secondRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  expect(competingClaim.response.status, competingClaim.text).toBe(200);
+  expect(isRecord(competingClaim.body) ? competingClaim.body.assignment : undefined).toBeNull();
+
+  await eventually(async () => {
+    const receipt = await denFetch(den.admin, `/v1/automation-runs/${encodeURIComponent(runId)}`, {
+      headers: auth(den.admin),
+    });
+    return isRecord(receipt.body) && isRecord(receipt.body.run) ? receipt.body.run : {};
+  }, {
+    within: 30_000,
+    intervalMs: 250,
+    label: "first expired lease requeued for recovery",
+    until: (recoveredRun) => recoveredRun.status === "queued" && recoveredRun.attemptCount === 1,
+  });
+
+  const recoveryClaim = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/claim`,
+    { method: "POST" },
+  );
+  const recoveryAssignment = isRecord(recoveryClaim.body) && isRecord(recoveryClaim.body.assignment)
+    ? recoveryClaim.body.assignment
+    : {};
+  expect(recoveryClaim.response.status, recoveryClaim.text).toBe(200);
+  expect(recoveryAssignment).toMatchObject({ runId, attempt: 2 });
+
+  const staleCompletion = await runnerRequest(
+    firstRunnerToken,
+    `/v1/automation-runs/${encodeURIComponent(runId)}/complete`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        attempt: 1,
+        status: "succeeded",
+        sessionId: "stale-session-must-not-win",
+        workspaceId: "stale-workspace-must-not-win",
+        resultSummary: "stale completion",
+        usage: { inputTokens: 1, outputTokens: 1, costMicros: null },
+        error: null,
+      }),
+    },
+  );
+  expect(staleCompletion.response.status, staleCompletion.text).toBe(409);
+  expect(staleCompletion.body).toEqual({ error: "runner_lease_lost" });
+
+  const terminalReceipt = await waitForTerminalReceipt(den.admin, runId);
+  const terminalRun = isRecord(terminalReceipt.run) ? terminalReceipt.run : {};
+  expect(terminalRun).toMatchObject({
+    status: "failed",
+    attemptCount: 2,
+    error: { code: "lease_lost", retryable: false },
+  });
+  expect(terminalRun.resultSummary).toBeNull();
+  expect(completionBodies).toHaveLength(0);
+  evidence.recordAssertionEvidence(
+    "Duplicate claims and expired leases cannot duplicate execution or accept stale completion",
+    `Runner one received the same attempt-1 assignment twice, runner two could not claim it, the first expiry requeued attempt 1, attempt 2 rejected the stale attempt-1 completion with HTTP 409, and the second expiry ended run ${runId} as failed/lease_lost with no provider request.`,
+    true,
+  );
+});

--- a/packages/automations/src/ports.ts
+++ b/packages/automations/src/ports.ts
@@ -78,6 +78,7 @@ export interface AutomationRepository {
     resultSummary: string | null
     usage: AutomationUsage
     error: AutomationError | null
+    engineReceipt?: Record<string, unknown> | null
     attempt?: number
     now: number
   }): Awaitable<AutomationRun>


### PR DESCRIPTION
## Summary

- Persist the native Desktop execution receipt through Den on success, failure, and cancellation.
- Expose the persisted thread through the existing Automation run contract.
- Open the correct local Desktop thread from a selected Automation run.
- Prevent a stale selected-run receipt from rendering or navigating against another run.

## Root cause

The Desktop runner reports the native session and workspace of each execution — as of the parent PR, on every terminal outcome — but Den only retained an engine receipt for cloud runs: `mapRun` ignored `engine_receipt` for desktop rows and the desktop completion path never wrote one. The identity of the local thread therefore never survived into the run receipt, the Automations UI had no way to open the thread a run actually executed in, and the receipt panel rendered whatever receipt query last resolved, so a response belonging to a previously selected run could be shown — and acted on — against the currently selected one.

## What changed

- **Den persistence.** `completeDesktopRunner` writes the runner-reported session and workspace into the run's `engine_receipt`; the repository `complete()` takes an additive optional `engineReceipt`; `mapRun` reads the receipt for every execution target instead of only cloud. The field is additive and backward-compatible: older rows keep `executionThread: null` and render exactly as before, and nothing about the receipt persists on idle paths — only terminal completions write it.
- **App linkage.** `automationLocalSessionRoute` resolves a desktop execution thread to its local workspace session route; the selected run's receipt shows an **Open local thread** action when that resolution exists; and a receipt is accepted only when it belongs to the currently selected run (`receiptQuery.data?.run.id === selectedRunId`), so a stale response cannot leak into another run's panel or navigation.
- **Deterministic selectors.** `data-automation-id` on list entries and `data-automation-run-id` on the thread action, for reliable runtime proof.
- **Protocol pin.** A new den-api test asserts the completion path builds the receipt, the repository persists and maps it, and the cloud-only gate is gone.
- **Lifecycle coverage.** A new Desktop lifecycle spec drives the real desktop app against a real Den (details under Verification).

## Maintainer impact

Each terminal Automation run — succeeded, failed, or cancelled during execution — now retains and can open the native Desktop execution context. Diagnosing a failed scheduled run becomes one click from the receipt instead of hunting session titles, and the parent PRs' recovery and missed-cause behavior is preserved unchanged.

## Verification

All commands ran against this PR's exact head (`eef334cf9`).

Passed

- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/automation-desktop-lifecycle.e2e.test.ts` — 4 passed, 0 failed, 0 skips in one 10m11s invocation (evidence in the test-evidence comment below). One earlier invocation on a loaded machine timed out twice waiting for the synthetic model to sync before any Automation behavior ran; the recorded head-matching run is the clean pass.
  1. UI-triggered, repeated manual, and scheduled Desktop runs each reach a durable succeeded receipt with a unique native session; the receipt's **Open local thread** navigates to that exact workspace session and renders the deterministic assistant reply; invalid configuration is rejected without a runnable record; another member gets 404 for the owner's Automation.
  2. Desktop restart before execution preserves runner readiness; three concurrent manual requests produce one queued run and two durable overlap skips; cancelling the queued run is terminal with no execution thread and no provider request; queued work survives Desktop absence and executes exactly once after relaunch.
  3. A provider outage fails promptly as `failed`/`execution_failed` with the native session and workspace preserved on the failed receipt, and a later run succeeds after the provider recovers.
  4. Duplicate claims return the same attempt idempotently, a competing runner gets no assignment, expired leases requeue exactly once, and a stale attempt-1 completion is rejected with HTTP 409 `runner_lease_lost` after attempt 2 exists.
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/automation-desktop-recovery-window.e2e.test.ts` — passed on this head; the parent PRs' recovery window, missed causes, presence, and manual-deadline behavior hold with receipt persistence in place.
- `bun test test/automation-runner-protocol.test.ts test/automation-runner-auth.test.ts` (`ee/apps/den-api`) — 30 pass, including the new durable-thread pin.
- `bun test --isolate tests/automation-cloud-thread.test.ts tests/automation-runner-visibility.test.ts tests/automation-runner-presence-client.test.ts` (`apps/app`) — 10 pass.
- `bun test --isolate tests/` (`apps/app`) — 828 pass, 6 fail; the identical 6 fail on a clean `dev` checkout at the merge base (`3573b5044`), none touch Automations, and the same suite is green in CI.
- `node --test apps/desktop/electron/automation-runner.test.mjs` — 30 pass (inherited; unchanged here).
- `bun test src` (`packages/automations`) — 18 pass.
- `tsc --noEmit` for `apps/app`, `ee/apps/den-api`, and `packages/automations` — clean; `pnpm --filter @openwork/desktop typecheck:electron` — clean.
- `pnpm evals:typecheck` — 30 pre-existing errors, all in specs this stack does not touch; a clean `dev` control at the merge base reports the identical 30, and the three specs this stack adds or edits contribute none.
- `git diff --check` — clean.

Failed — none.

Skipped — none.

Deferred

- Daytona placement for both tapes: per-test `DEN_AUTOMATIONS_*` tuning applies only to a locally provisioned Den (`server({ env })` is not forwarded into a Daytona server sandbox), so both ran on the local lane.

## Stack

3 of 3 — depends on #3942 and #3775; base branch `fix/automation-desktop-execution-results`; merge after #3942. After its parent merges, this branch is retargeted to `dev`, refreshed, and its exact-head proof re-runs if the base or history changes.

- 1 of 3: #3775 — desktop occurrence recovery and missed-cause diagnosis.
- 2 of 3: #3942 — Desktop execution-result correctness.
