### PR TITLE
feat(den): scope MCP token liveness to OAuth grants

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -172,7 +172,7 @@ export const DEN_MCP_RESOURCE_CLAIM = `${env.mcpClaimNamespace}/resource`;
 export const DEN_MCP_GRANT_ID_CLAIM = `${env.mcpClaimNamespace}/grant_id`;
 export const DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX = "ow_mcp_at_";
 const DEN_MCP_REFRESH_TOKEN_PREFIX = "ow_mcp_rt_";
-const INVALID_MCP_SESSION_GRANT_DESCRIPTION = "The session backing this grant has been signed out or expired. Re-authorize the connection.";
+const INVALID_MCP_SESSION_GRANT_DESCRIPTION = "The authorization backing this grant has been revoked. Re-authorize the connection.";
 export { DEN_MCP_SCOPES } from "./mcp/scopes.js";
 
 export function normalizeMcpOAuthResource(resource: string): string | null {

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -7,6 +7,12 @@ import {
   deleteMcpOAuthGrantFamilyForSession,
   getMcpSessionLiveness,
 } from "./mcp/session-liveness.js";
+import { contributeMcpGrantClaim } from "./mcp/grant-claims.js";
+import {
+  assertLiveMcpRefreshGrant,
+  McpRefreshGrantRevokedError,
+  type McpRefreshGrantRow,
+} from "./mcp/refresh-grant-liveness.js";
 import { deriveDenMcpAgentResource, deriveDenMcpResource, mcpEndpointResource } from "./mcp/resource.js";
 import { getDenAuthIssuer, getDenJwtOptions } from "./mcp/jwt-policy.js";
 import {
@@ -163,6 +169,7 @@ export const DEN_MCP_OAUTH_VALID_AUDIENCES = [DEN_MCP_OAUTH_RESOURCE];
 export const DEN_MCP_TOKEN_USE_CLAIM = `${env.mcpClaimNamespace}/token_use`;
 export const DEN_MCP_ORG_ID_CLAIM = `${env.mcpClaimNamespace}/org_id`;
 export const DEN_MCP_RESOURCE_CLAIM = `${env.mcpClaimNamespace}/resource`;
+export const DEN_MCP_GRANT_ID_CLAIM = `${env.mcpClaimNamespace}/grant_id`;
 export const DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX = "ow_mcp_at_";
 const DEN_MCP_REFRESH_TOKEN_PREFIX = "ow_mcp_rt_";
 const INVALID_MCP_SESSION_GRANT_DESCRIPTION = "The session backing this grant has been signed out or expired. Re-authorize the connection.";
@@ -428,27 +435,33 @@ async function assertLiveMcpSessionForRefreshGrant(ctx: Parameters<Parameters<ty
     return;
   }
 
-  const grant = await ctx.context.adapter.findOne<{ sessionId?: string | null }>({
+  const grant = await ctx.context.adapter.findOne<McpRefreshGrantRow>({
     model: "oauthRefreshToken",
     where: [{ field: "token", value: hashOAuthProviderToken(tokenSecret) }],
   });
-  const sessionId = typeof grant?.sessionId === "string" && grant.sessionId.trim()
-    ? grant.sessionId.trim()
-    : null;
-  if (!sessionId) {
-    return;
+  try {
+    await assertLiveMcpRefreshGrant({
+      grant,
+      getSessionLiveness: getMcpSessionLiveness,
+      findConsent: ({ clientId, userId, referenceId }) => ctx.context.adapter.findOne<{ id: string }>({
+        model: "oauthConsent",
+        where: [
+          { field: "clientId", value: clientId },
+          { field: "userId", value: userId },
+          { field: "referenceId", value: referenceId },
+        ],
+      }),
+      deleteGrantFamily: deleteMcpOAuthGrantFamilyForSession,
+    });
+  } catch (error) {
+    if (!(error instanceof McpRefreshGrantRevokedError)) {
+      throw error;
+    }
+    throw new APIError("BAD_REQUEST", {
+      error: "invalid_grant",
+      error_description: INVALID_MCP_SESSION_GRANT_DESCRIPTION,
+    });
   }
-
-  const sessionLiveness = await getMcpSessionLiveness(sessionId);
-  if (sessionLiveness === "alive" || sessionLiveness === "check_failed") {
-    return;
-  }
-
-  await deleteMcpOAuthGrantFamilyForSession(sessionId);
-  throw new APIError("BAD_REQUEST", {
-    error: "invalid_grant",
-    error_description: INVALID_MCP_SESSION_GRANT_DESCRIPTION,
-  });
 }
 
 async function assertBetterAuthInvitationRoleAssignment(input: {
@@ -1128,8 +1141,27 @@ export const auth = betterAuth({
           DEN_MCP_TOKEN_USE_CLAIM,
           DEN_MCP_ORG_ID_CLAIM,
           DEN_MCP_RESOURCE_CLAIM,
+          DEN_MCP_GRANT_ID_CLAIM,
         ],
       },
+      extensions: [{
+        claims: {
+          accessToken: ({ ctx, client, user, referenceId }) => contributeMcpGrantClaim({
+            claimName: DEN_MCP_GRANT_ID_CLAIM,
+            clientId: client.clientId,
+            userId: user?.id,
+            referenceId,
+            findConsent: ({ clientId, userId, referenceId: consentReferenceId }) => ctx.context.adapter.findOne<{ id: string }>({
+              model: "oauthConsent",
+              where: [
+                { field: "clientId", value: clientId },
+                { field: "userId", value: userId },
+                { field: "referenceId", value: consentReferenceId },
+              ],
+            }),
+          }),
+        },
+      }],
       postLogin: {
         page: `${env.betterAuthUrl}/mcp/select-organization`,
         shouldRedirect: async ({ session, scopes }) => {
@@ -1169,6 +1201,9 @@ export const auth = betterAuth({
         }
         return claims;
       },
+      // Better Auth refresh-family teardown and /oauth2/revoke intentionally do
+      // not remove durable consent. Already minted JWT exposure remains bounded
+      // by the configured 45-minute MCP access-token lifetime.
       prefix: {
         opaqueAccessToken: DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX,
         refreshToken: DEN_MCP_REFRESH_TOKEN_PREFIX,

--- a/ee/apps/den-api/src/cache.ts
+++ b/ee/apps/den-api/src/cache.ts
@@ -1,5 +1,5 @@
 import { asc, and, eq, gt, isNull, lt, lte } from "@openwork-ee/den-db/drizzle"
-import { AuthSessionTable, AuthUserTable, InvitationTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema"
+import { AuthSessionTable, AuthUserTable, InvitationTable, MemberTable, OAuthConsentTable, OrganizationTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId, type DenTypeId, type DenTypeIdName } from "@openwork-ee/utils/typeid"
 import { createHash } from "node:crypto"
 import Redis from "ioredis"
@@ -11,9 +11,10 @@ import { getDenSessionExpiresAt, getDenSessionRefreshCutoff } from "./session-li
 type OrgId = typeof OrganizationTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
 type UserId = typeof AuthUserTable.$inferSelect.id
+type OAuthConsentId = typeof OAuthConsentTable.$inferSelect.id
 
 type CacheParent = "auth" | "org"
-type CacheChild = "member" | "members" | "session" | "session-id" | "session-revoked" | "session-id-revoked"
+type CacheChild = "grant" | "grant-revoked" | "member" | "members" | "session" | "session-id" | "session-revoked" | "session-id-revoked"
 
 type CacheKeyInput = {
   parent: CacheParent
@@ -99,6 +100,7 @@ let activeOrgMembersLoader = loadOrgMembers
 let activeOrgMembershipLoader = loadOrgMembership
 let activeAuthSessionLoader = loadAuthSession
 let activeAuthSessionIdLoader = loadActiveSessionId
+let activeAuthGrantLoader = loadActiveGrant
 
 function cacheKey(input: CacheKeyInput) {
   return `cache:${input.parent}:${input.child}:${input.id}`
@@ -281,6 +283,25 @@ function parseCachedActiveSessionId(raw: string | null) {
   const id = readDenId("session", parsed.id)
   const expiresAt = readDate(parsed.expiresAt)
   return id && expiresAt && expiresAt > new Date() ? { id, expiresAt } : null
+}
+
+function parseCachedActiveGrant(raw: string | null) {
+  if (!raw) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) {
+    return null
+  }
+
+  const id = readDenId("oauthConsent", parsed.id)
+  return id ? { id } : null
 }
 
 function parseCachedAuthSession(raw: string | null, now: Date): CachedAuthSession | null {
@@ -505,6 +526,17 @@ async function loadActiveSessionId(sessionId: DenTypeId<"session">, now: Date) {
   }
 }
 
+async function loadActiveGrant(grantId: OAuthConsentId) {
+  const rows = await db
+    .select({ id: OAuthConsentTable.id })
+    .from(OAuthConsentTable)
+    .where(eq(OAuthConsentTable.id, grantId))
+    .limit(1)
+
+  const row = rows[0]
+  return row ? { id: normalizeDenTypeId("oauthConsent", row.id) } : null
+}
+
 async function loadOrgMembership(input: { organizationId: OrgId; userId: UserId }): Promise<CachedOrgMembership | null> {
   const rows = await db
     .select({ id: MemberTable.id, role: MemberTable.role })
@@ -597,6 +629,39 @@ async function getActiveSessionId(sessionId: DenTypeId<"session">) {
   return loaded
 }
 
+async function getActiveGrant(grantId: OAuthConsentId) {
+  const keyInput: CacheKeyInput = { parent: "auth", child: "grant", id: grantId }
+  const revokedKeyInput: CacheKeyInput = { parent: "auth", child: "grant-revoked", id: grantId }
+  const key = cacheKey(keyInput)
+  const revokedKey = cacheKey(revokedKeyInput)
+  const redis = activeRedisClient
+  if (redis) {
+    try {
+      if (await redis.get(revokedKey)) {
+        return null
+      }
+      const cached = parseCachedActiveGrant(await redis.get(key))
+      if (cached) {
+        return cached
+      }
+    } catch (error) {
+      console.error("openwork_cache_get_failed", { ...cacheLogDetails(keyInput), error })
+    }
+  }
+
+  const loaded = await activeAuthGrantLoader(grantId)
+  if (!loaded || !redis) {
+    return loaded
+  }
+
+  try {
+    await setUnlessRevoked({ redis, key, revokedKey, value: JSON.stringify(loaded), ttlSeconds: DEFAULT_CACHE_TTL_SECONDS })
+  } catch (error) {
+    console.error("openwork_cache_set_failed", { ...cacheLogDetails(keyInput), error })
+  }
+  return loaded
+}
+
 async function deleteAuthSession(token: string) {
   const keyInput = { parent: "auth", child: "session", id: token } as const
   const key = cacheKey(keyInput)
@@ -637,6 +702,17 @@ async function revokeAuthSessionId(sessionId: DenTypeId<"session">) {
   try {
     await activeRedisClient?.set(cacheKey(revokedKeyInput), "1", "EX", AUTH_SESSION_MAX_TTL_SECONDS)
     await deleteAuthSessionId(sessionId)
+  } catch (error) {
+    console.error("openwork_cache_delete_failed", { ...cacheLogDetails(revokedKeyInput), error })
+  }
+}
+
+async function revokeAuthGrant(grantId: OAuthConsentId) {
+  const keyInput: CacheKeyInput = { parent: "auth", child: "grant", id: grantId }
+  const revokedKeyInput: CacheKeyInput = { parent: "auth", child: "grant-revoked", id: grantId }
+  try {
+    await activeRedisClient?.set(cacheKey(revokedKeyInput), "1", "EX", AUTH_SESSION_MAX_TTL_SECONDS)
+    await activeRedisClient?.del(cacheKey(keyInput))
   } catch (error) {
     console.error("openwork_cache_delete_failed", { ...cacheLogDetails(revokedKeyInput), error })
   }
@@ -718,18 +794,21 @@ async function deleteAuthSessionsForUser(userId: UserId) {
  * way. Auth sessions are DB-authoritative and cached for at most one hour;
  * Cached hits must not perform live DB checks. Any operation that changes the
  * source rows instead calls the dedicated invalidators below: user sign-out and
- * session mutation clear auth session keys; org deletion, member removal, member
- * addition, role transfer, and role edits clear org member/membership keys.
+ * session mutation clear auth session keys; consent deletion writes grant
+ * tombstones; org deletion, member removal, member addition, role transfer, and
+ * role edits clear org member/membership keys.
  */
 export const cache = {
   auth: {
     session: getAuthSession,
     sessionResult: getAuthSessionResult,
     activeSessionId: getActiveSessionId,
+    grant: getActiveGrant,
     deleteSession: deleteAuthSession,
     revokeSession: revokeAuthSession,
     deleteSessionId: deleteAuthSessionId,
     revokeSessionId: revokeAuthSessionId,
+    revokeGrant: revokeAuthGrant,
     deleteSessionsForUser: deleteAuthSessionsForUser,
   },
   org: {
@@ -755,12 +834,14 @@ export function setCacheDependenciesForTest(input: {
   orgMembersLoader?: (organizationId: OrgId) => Promise<CachedOrgMember[]>
   authSessionLoader?: (token: string, now: Date) => Promise<CachedAuthSession | null>
   authSessionIdLoader?: (sessionId: DenTypeId<"session">, now: Date) => Promise<{ id: DenTypeId<"session">; expiresAt: Date } | null>
+  authGrantLoader?: (grantId: OAuthConsentId) => Promise<{ id: OAuthConsentId } | null>
   orgMembershipLoader?: (input: { organizationId: OrgId; userId: UserId }) => Promise<CachedOrgMembership | null>
 }) {
   const previousRedis = activeRedisClient
   const previousOrgMembersLoader = activeOrgMembersLoader
   const previousAuthSessionLoader = activeAuthSessionLoader
   const previousAuthSessionIdLoader = activeAuthSessionIdLoader
+  const previousAuthGrantLoader = activeAuthGrantLoader
   const previousOrgMembershipLoader = activeOrgMembershipLoader
   if ("redis" in input) {
     activeRedisClient = input.redis ?? null
@@ -774,6 +855,9 @@ export function setCacheDependenciesForTest(input: {
   if (input.authSessionIdLoader) {
     activeAuthSessionIdLoader = input.authSessionIdLoader
   }
+  if (input.authGrantLoader) {
+    activeAuthGrantLoader = input.authGrantLoader
+  }
   if (input.orgMembershipLoader) {
     activeOrgMembershipLoader = input.orgMembershipLoader
   }
@@ -782,6 +866,7 @@ export function setCacheDependenciesForTest(input: {
     activeOrgMembersLoader = previousOrgMembersLoader
     activeAuthSessionLoader = previousAuthSessionLoader
     activeAuthSessionIdLoader = previousAuthSessionIdLoader
+    activeAuthGrantLoader = previousAuthGrantLoader
     activeOrgMembershipLoader = previousOrgMembershipLoader
   }
 }

--- a/ee/apps/den-api/src/cache.ts
+++ b/ee/apps/den-api/src/cache.ts
@@ -710,11 +710,19 @@ async function revokeAuthSessionId(sessionId: DenTypeId<"session">) {
 async function revokeAuthGrant(grantId: OAuthConsentId) {
   const keyInput: CacheKeyInput = { parent: "auth", child: "grant", id: grantId }
   const revokedKeyInput: CacheKeyInput = { parent: "auth", child: "grant-revoked", id: grantId }
+  // The database row is already gone; these writes only bound cache staleness.
+  // Attempt both independently so a failed tombstone write still clears the
+  // positive entry — a lone tombstone or a lone delete each end acceptance,
+  // and a total Redis outage converges at the positive entry's TTL.
   try {
     await activeRedisClient?.set(cacheKey(revokedKeyInput), "1", "EX", AUTH_SESSION_MAX_TTL_SECONDS)
-    await activeRedisClient?.del(cacheKey(keyInput))
   } catch (error) {
     console.error("openwork_cache_delete_failed", { ...cacheLogDetails(revokedKeyInput), error })
+  }
+  try {
+    await activeRedisClient?.del(cacheKey(keyInput))
+  } catch (error) {
+    console.error("openwork_cache_delete_failed", { ...cacheLogDetails(keyInput), error })
   }
 }
 

--- a/ee/apps/den-api/src/credential-revocation.ts
+++ b/ee/apps/den-api/src/credential-revocation.ts
@@ -3,6 +3,7 @@ import {
   AuthSessionTable,
   MemberTable,
   OAuthAccessTokenTable,
+  OAuthConsentTable,
   OAuthRefreshTokenTable,
 } from "@openwork-ee/den-db/schema"
 import { cache } from "./cache.js"
@@ -55,6 +56,21 @@ export async function revokeMembershipSessionCredentials(input: {
     await db
       .delete(OAuthAccessTokenTable)
       .where(inArray(OAuthAccessTokenTable.id, oauthAccessTokens.map((token) => token.id)))
+  }
+
+  const oauthConsents = await db
+    .select({ id: OAuthConsentTable.id })
+    .from(OAuthConsentTable)
+    .where(and(
+      eq(OAuthConsentTable.userId, input.userId),
+      eq(OAuthConsentTable.referenceId, input.organizationId),
+    ))
+
+  if (oauthConsents.length > 0) {
+    await db
+      .delete(OAuthConsentTable)
+      .where(inArray(OAuthConsentTable.id, oauthConsents.map((consent) => consent.id)))
+    await Promise.all(oauthConsents.map((consent) => cache.auth.revokeGrant(consent.id)))
   }
 
   const oauthRefreshTokens = await db

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -7,6 +7,7 @@ import {
   auth,
   DEN_MCP_FIRST_PARTY_CLIENT_ID,
   DEN_MCP_FIRST_PARTY_RESOURCES,
+  DEN_MCP_GRANT_ID_CLAIM,
   DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX,
   DEN_MCP_ORG_ID_CLAIM,
   DEN_MCP_OAUTH_RESOURCE,
@@ -21,6 +22,7 @@ import { publicRequestUrl } from "../request-url.js"
 import { DEN_JWT_SIGNING_ALGORITHM, getDenAuthIssuer } from "./jwt-policy.js"
 import { mcpProtectedResourceMetadataUrl, mcpRouteResource, resolveMcpResourceFromRequest, type McpResourceRoute } from "./resource.js"
 import { DEN_MCP_REQUESTED_SCOPE } from "./scopes.js"
+import { getMcpGrantLiveness } from "./grant-liveness.js"
 import { getMcpSessionLiveness } from "./session-liveness.js"
 export { hasActiveMcpSession } from "./session-liveness.js"
 
@@ -300,6 +302,8 @@ async function verifyOpaqueMcpToken(token: string) {
 
   const storedScopes = readStoredScopes(accessToken.scopes)
   const resource = accessToken.clientId === DEN_MCP_FIRST_PARTY_CLIENT_ID ? DEN_MCP_RESOURCE : DEN_MCP_OAUTH_RESOURCE
+  // Only first-party opaque tokens are accepted below. Those skip OAuth consent,
+  // so they intentionally remain session-coupled through the compatibility path.
   return {
     sub: accessToken.userId,
     scope: storedScopes.join(" "),
@@ -388,34 +392,56 @@ export async function verifyMcpRequest(headers: Headers, optionsInput?: string |
     }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
   }
 
-  const sessionId = readStringClaim(payload, "sid")
-  if (!sessionId) {
-    const message = "The MCP bearer token is not tied to an active session."
-    return mcpJsonResponse(401, {
-      error: "mcp_session_required",
-      oauthError: "invalid_token",
-      message,
-      referenceId,
-    }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
-  }
+  const grantId = readStringClaim(payload, DEN_MCP_GRANT_ID_CLAIM)
+  if (grantId) {
+    const grantLiveness = await getMcpGrantLiveness(grantId)
+    if (grantLiveness === "check_failed") {
+      return mcpJsonResponse(503, {
+        error: "mcp_grant_check_unavailable",
+        message: "OpenWork could not verify the token grant. Retry shortly.",
+        referenceId,
+      }, undefined, { "retry-after": "10" })
+    }
 
-  const sessionLiveness = await getMcpSessionLiveness(sessionId)
-  if (sessionLiveness === "check_failed") {
-    return mcpJsonResponse(503, {
-      error: "mcp_session_check_unavailable",
-      message: "OpenWork could not verify the token session. Retry shortly.",
-      referenceId,
-    }, undefined, { "retry-after": "10" })
-  }
+    if (grantLiveness === "missing") {
+      const message = "The MCP bearer token grant is missing or revoked."
+      return mcpJsonResponse(401, {
+        error: "mcp_grant_revoked",
+        oauthError: "invalid_token",
+        message,
+        referenceId,
+      }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
+    }
+  } else {
+    const sessionId = readStringClaim(payload, "sid")
+    if (!sessionId) {
+      const message = "The MCP bearer token is not tied to an active session."
+      return mcpJsonResponse(401, {
+        error: "mcp_session_required",
+        oauthError: "invalid_token",
+        message,
+        referenceId,
+      }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
+    }
 
-  if (sessionLiveness === "missing") {
-    const message = "The MCP bearer token session is missing, expired, or revoked."
-    return mcpJsonResponse(401, {
-      error: "mcp_session_revoked",
-      oauthError: "invalid_token",
-      message,
-      referenceId,
-    }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
+    const sessionLiveness = await getMcpSessionLiveness(sessionId)
+    if (sessionLiveness === "check_failed") {
+      return mcpJsonResponse(503, {
+        error: "mcp_session_check_unavailable",
+        message: "OpenWork could not verify the token session. Retry shortly.",
+        referenceId,
+      }, undefined, { "retry-after": "10" })
+    }
+
+    if (sessionLiveness === "missing") {
+      const message = "The MCP bearer token session is missing, expired, or revoked."
+      return mcpJsonResponse(401, {
+        error: "mcp_session_revoked",
+        oauthError: "invalid_token",
+        message,
+        referenceId,
+      }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
+    }
   }
 
   if (!(await hasActiveMcpMembership({ userId, organizationId }))) {

--- a/ee/apps/den-api/src/mcp/grant-claims.ts
+++ b/ee/apps/den-api/src/mcp/grant-claims.ts
@@ -1,0 +1,24 @@
+export type McpConsentLookup = (input: {
+  clientId: string
+  userId: string
+  referenceId: string
+}) => Promise<{ id: string } | null>
+
+export async function contributeMcpGrantClaim(input: {
+  claimName: string
+  clientId: string
+  userId?: string | null
+  referenceId?: string
+  findConsent: McpConsentLookup
+}): Promise<Record<string, string>> {
+  if (!input.userId || !input.referenceId) {
+    return {}
+  }
+
+  const consent = await input.findConsent({
+    clientId: input.clientId,
+    userId: input.userId,
+    referenceId: input.referenceId,
+  })
+  return consent ? { [input.claimName]: consent.id } : {}
+}

--- a/ee/apps/den-api/src/mcp/grant-liveness.ts
+++ b/ee/apps/den-api/src/mcp/grant-liveness.ts
@@ -1,0 +1,52 @@
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { cache } from "../cache.js"
+
+export type McpGrantLiveness = "live" | "missing" | "check_failed"
+
+function normalizeMcpGrantId(grantId: string) {
+  return normalizeDenTypeId("oauthConsent", grantId)
+}
+
+type NormalizedMcpGrantId = ReturnType<typeof normalizeMcpGrantId>
+type McpGrantSelect = (input: { normalizedGrantId: NormalizedMcpGrantId }) => Promise<readonly { id: NormalizedMcpGrantId }[]>
+
+function livenessLogDetails(grantId: NormalizedMcpGrantId, error: unknown) {
+  return {
+    grantId: grantId.slice(0, 12),
+    error: String(error).slice(0, 200),
+  }
+}
+
+const selectActiveMcpGrant: McpGrantSelect = async ({ normalizedGrantId }) => {
+  const grant = await cache.auth.grant(normalizedGrantId)
+  return grant ? [{ id: grant.id }] : []
+}
+
+let activeMcpGrantSelect = selectActiveMcpGrant
+
+export function setMcpGrantLivenessDependenciesForTest(input: {
+  select?: McpGrantSelect
+}) {
+  const previousSelect = activeMcpGrantSelect
+  if (input.select) activeMcpGrantSelect = input.select
+  return () => {
+    activeMcpGrantSelect = previousSelect
+  }
+}
+
+export async function getMcpGrantLiveness(grantId: string): Promise<McpGrantLiveness> {
+  let normalizedGrantId: NormalizedMcpGrantId
+  try {
+    normalizedGrantId = normalizeMcpGrantId(grantId)
+  } catch {
+    return "missing"
+  }
+
+  try {
+    const rows = await activeMcpGrantSelect({ normalizedGrantId })
+    return rows.length > 0 ? "live" : "missing"
+  } catch (error) {
+    console.error("mcp_grant_liveness_check_failed", livenessLogDetails(normalizedGrantId, error))
+    return "check_failed"
+  }
+}

--- a/ee/apps/den-api/src/mcp/refresh-grant-liveness.ts
+++ b/ee/apps/den-api/src/mcp/refresh-grant-liveness.ts
@@ -1,0 +1,53 @@
+import type { McpSessionLiveness } from "./session-liveness.js"
+
+export type McpRefreshGrantRow = {
+  sessionId?: string | null
+  clientId?: string | null
+  userId?: string | null
+  referenceId?: string | null
+}
+
+export class McpRefreshGrantRevokedError extends Error {
+  constructor() {
+    super("MCP refresh grant consent is no longer live")
+    this.name = "McpRefreshGrantRevokedError"
+  }
+}
+
+export async function assertLiveMcpRefreshGrant(input: {
+  grant: McpRefreshGrantRow | null
+  getSessionLiveness: (sessionId: string) => Promise<McpSessionLiveness>
+  findConsent: (identity: { clientId: string; userId: string; referenceId: string }) => Promise<{ id: string } | null>
+  deleteGrantFamily: (sessionId: string) => Promise<void>
+}) {
+  const sessionId = typeof input.grant?.sessionId === "string" && input.grant.sessionId.trim()
+    ? input.grant.sessionId.trim()
+    : null
+  if (!sessionId) {
+    return
+  }
+
+  const sessionLiveness = await input.getSessionLiveness(sessionId)
+  if (sessionLiveness === "alive" || sessionLiveness === "check_failed") {
+    return
+  }
+
+  const clientId = typeof input.grant?.clientId === "string" && input.grant.clientId.trim()
+    ? input.grant.clientId.trim()
+    : null
+  const userId = typeof input.grant?.userId === "string" && input.grant.userId.trim()
+    ? input.grant.userId.trim()
+    : null
+  const referenceId = typeof input.grant?.referenceId === "string" && input.grant.referenceId.trim()
+    ? input.grant.referenceId.trim()
+    : null
+  const consent = clientId && userId && referenceId
+    ? await input.findConsent({ clientId, userId, referenceId })
+    : null
+  if (consent) {
+    return
+  }
+
+  await input.deleteGrantFamily(sessionId)
+  throw new McpRefreshGrantRevokedError()
+}

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -1459,13 +1459,17 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         .select({ id: AuthSessionTable.id, token: AuthSessionTable.token })
         .from(AuthSessionTable)
         .where(eq(AuthSessionTable.userId, userId))
-      const oauthConsentRows = await db
-        .select({ id: OAuthConsentTable.id })
-        .from(OAuthConsentTable)
-        .where(eq(OAuthConsentTable.userId, userId))
-
-      await db.transaction(async (tx) => {
+      // Grant tombstones must cover exactly the deleted consent set. Snapshot
+      // the ids inside the transaction with a locking read so a concurrently
+      // authorized consent cannot slip between the snapshot and the delete
+      // (Warden RUD-WDK).
+      const oauthConsentRows = await db.transaction(async (tx) => {
         const removedAt = new Date()
+        const consentRows = await tx
+          .select({ id: OAuthConsentTable.id })
+          .from(OAuthConsentTable)
+          .where(eq(OAuthConsentTable.userId, userId))
+          .for("update")
 
         await tx.delete(OAuthAccessTokenTable).where(eq(OAuthAccessTokenTable.userId, userId))
         await tx.delete(OAuthRefreshTokenTable).where(eq(OAuthRefreshTokenTable.userId, userId))
@@ -1486,6 +1490,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         await tx.update(MemberTable).set({ removedAt }).where(eq(MemberTable.userId, userId))
         await tx.update(WorkerTable).set({ created_by_user_id: null }).where(eq(WorkerTable.created_by_user_id, userId))
         await tx.delete(AuthUserTable).where(eq(AuthUserTable.id, userId))
+        return consentRows
       })
       // Auth session cache hits intentionally avoid a DB liveness check; user deletion must clear
       // both token and session-id cache entries for every deleted session instead.

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -1459,6 +1459,10 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         .select({ id: AuthSessionTable.id, token: AuthSessionTable.token })
         .from(AuthSessionTable)
         .where(eq(AuthSessionTable.userId, userId))
+      const oauthConsentRows = await db
+        .select({ id: OAuthConsentTable.id })
+        .from(OAuthConsentTable)
+        .where(eq(OAuthConsentTable.userId, userId))
 
       await db.transaction(async (tx) => {
         const removedAt = new Date()
@@ -1489,6 +1493,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         cache.auth.revokeSession(session.token),
         cache.auth.revokeSessionId(session.id),
       ]))
+      await Promise.all(oauthConsentRows.map((consent) => cache.auth.revokeGrant(consent.id)))
 
       const organizationIds = Array.from(new Set(activeMembershipRows.map((row) => row.organizationId).filter(isOrganizationId)))
       // Admin user deletion soft-removes memberships; clear affected org membership caches.

--- a/ee/apps/den-api/src/user-deletion.ts
+++ b/ee/apps/den-api/src/user-deletion.ts
@@ -28,6 +28,10 @@ export async function deleteGlobalAuthUser(userId: UserId) {
     .select({ id: AuthSessionTable.id, token: AuthSessionTable.token })
     .from(AuthSessionTable)
     .where(eq(AuthSessionTable.userId, userId))
+  const oauthConsents = await db
+    .select({ id: OAuthConsentTable.id })
+    .from(OAuthConsentTable)
+    .where(eq(OAuthConsentTable.userId, userId))
 
   await db.transaction(async (tx) => {
     await tx.delete(OAuthAccessTokenTable).where(eq(OAuthAccessTokenTable.userId, userId))
@@ -51,4 +55,5 @@ export async function deleteGlobalAuthUser(userId: UserId) {
     cache.auth.revokeSession(session.token),
     cache.auth.revokeSessionId(session.id),
   ]))
+  await Promise.all(oauthConsents.map((consent) => cache.auth.revokeGrant(consent.id)))
 }

--- a/ee/apps/den-api/src/user-deletion.ts
+++ b/ee/apps/den-api/src/user-deletion.ts
@@ -28,12 +28,15 @@ export async function deleteGlobalAuthUser(userId: UserId) {
     .select({ id: AuthSessionTable.id, token: AuthSessionTable.token })
     .from(AuthSessionTable)
     .where(eq(AuthSessionTable.userId, userId))
-  const oauthConsents = await db
-    .select({ id: OAuthConsentTable.id })
-    .from(OAuthConsentTable)
-    .where(eq(OAuthConsentTable.userId, userId))
-
-  await db.transaction(async (tx) => {
+  // Grant tombstones must cover exactly the deleted consent set. Snapshot the
+  // ids inside the transaction with a locking read so a concurrently authorized
+  // consent cannot slip between the snapshot and the delete (Warden RUD-WDK).
+  const oauthConsents = await db.transaction(async (tx) => {
+    const consentRows = await tx
+      .select({ id: OAuthConsentTable.id })
+      .from(OAuthConsentTable)
+      .where(eq(OAuthConsentTable.userId, userId))
+      .for("update")
     await tx.delete(OAuthAccessTokenTable).where(eq(OAuthAccessTokenTable.userId, userId))
     await tx.delete(OAuthRefreshTokenTable).where(eq(OAuthRefreshTokenTable.userId, userId))
     await tx.delete(OAuthConsentTable).where(eq(OAuthConsentTable.userId, userId))
@@ -47,6 +50,7 @@ export async function deleteGlobalAuthUser(userId: UserId) {
     await tx.update(MemberTable).set({ userId: null }).where(eq(MemberTable.userId, userId))
     await tx.update(WorkerTable).set({ created_by_user_id: null }).where(eq(WorkerTable.created_by_user_id, userId))
     await tx.delete(AuthUserTable).where(eq(AuthUserTable.id, userId))
+    return consentRows
   })
   await Promise.all(Array.from(new Set(memberships.map((membership) => membership.organizationId))).map((organizationId) => cache.org.deleteMembers(organizationId)))
   // Auth session cache hits intentionally avoid a DB liveness check; user deletion must clear

--- a/ee/apps/den-api/test/credential-revocation.test.ts
+++ b/ee/apps/den-api/test/credential-revocation.test.ts
@@ -2,12 +2,14 @@ import { beforeAll, expect, mock, test } from "bun:test"
 import {
   AuthSessionTable,
   OAuthAccessTokenTable,
+  OAuthConsentTable,
   OAuthRefreshTokenTable,
 } from "@openwork-ee/den-db/schema"
 
 const selectedRows = {
   sessions: [{ id: "session_one" }, { id: "session_two" }],
   oauthAccessTokens: [{ id: "oauth_access_one" }],
+  oauthConsents: [{ id: "oauth_consent_one" }],
   oauthRefreshTokens: [{ id: "oauth_refresh_one" }],
 }
 
@@ -25,6 +27,9 @@ function rowsForTable(table: unknown) {
   if (table === OAuthRefreshTokenTable) {
     return selectedRows.oauthRefreshTokens
   }
+  if (table === OAuthConsentTable) {
+    return selectedRows.oauthConsents
+  }
   return []
 }
 
@@ -37,6 +42,11 @@ function resetCalls() {
 let credentialRevocationModule: typeof import("../src/credential-revocation.js")
 
 beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+
   mock.module("../src/db.js", () => ({
     db: {
       select: () => ({
@@ -80,10 +90,11 @@ test("membership credential revocation deletes sessions and org-scoped OAuth acc
     oauthAccessTokens: 1,
     oauthRefreshTokens: 1,
   })
-  expect(selectCalls).toBe(3)
+  expect(selectCalls).toBe(4)
   expect(deleteCalls).toEqual([
     AuthSessionTable,
     OAuthAccessTokenTable,
+    OAuthConsentTable,
   ])
   expect(updateCalls).toHaveLength(1)
   expect(updateCalls[0]?.table).toBe(OAuthRefreshTokenTable)

--- a/ee/apps/den-api/test/mcp-access-token-contract.test.ts
+++ b/ee/apps/den-api/test/mcp-access-token-contract.test.ts
@@ -22,6 +22,7 @@ const parentResource = apiOrigin + "/mcp"
 const tokenUseClaim = "https://openworklabs.com/token_use"
 const resourceClaim = "https://openworklabs.com/resource"
 const orgIdClaim = "https://openworklabs.com/org_id"
+const grantIdClaim = "https://openworklabs.com/grant_id"
 const userId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
 const sessionId = createDenTypeId("session")
@@ -69,6 +70,7 @@ mock.module("./src/auth.js", () => ({
   DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
   DEN_MCP_FIRST_PARTY_CLIENT_ID: firstPartyClientId,
   DEN_MCP_FIRST_PARTY_RESOURCES: [parentResource, agentResource, parentResource + "/admin"],
+  DEN_MCP_GRANT_ID_CLAIM: grantIdClaim,
   DEN_MCP_ORG_ID_CLAIM: orgIdClaim,
   DEN_MCP_OAUTH_RESOURCE: agentResource,
   DEN_MCP_RESOURCE: parentResource,
@@ -107,7 +109,7 @@ const db = {
             return Promise.resolve([{ id: sessionId }])
           }
           if (table === schema.MemberTable) {
-            return Promise.resolve([{ id: memberId }])
+            return Promise.resolve([{ id: memberId, role: "member" }])
           }
           return Promise.resolve([])
         },

--- a/ee/apps/den-api/test/mcp-grant-cache.test.ts
+++ b/ee/apps/den-api/test/mcp-grant-cache.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+
+const grantId = createDenTypeId("oauthConsent")
+const cachedValues = new Map<string, string>()
+const setCalls: Array<{ key: string; value: string; mode: string; ttl: number }> = []
+let loaderCalls = 0
+let cacheModule: typeof import("../src/cache.js")
+let restoreCacheDependencies: (() => void) | null = null
+
+const AuthSessionTable = { id: "session.id" }
+const AuthUserTable = { id: "user.id" }
+const InvitationTable = { id: "invitation.id" }
+const MemberTable = { id: "member.id" }
+const OAuthConsentTable = { id: "consent.id" }
+const OrganizationTable = { id: "organization.id" }
+
+const redis = {
+  get: (key: string) => Promise.resolve(cachedValues.get(key) ?? null),
+  set: (key: string, value: string, mode: string, ttl: number) => {
+    setCalls.push({ key, value, mode, ttl })
+    cachedValues.set(key, value)
+    return Promise.resolve("OK")
+  },
+  del: (...keys: string[]) => {
+    for (const key of keys) {
+      cachedValues.delete(key)
+    }
+    return Promise.resolve(keys.length)
+  },
+}
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+
+  mock.module("@openwork-ee/den-db/schema", () => ({
+    AuthSessionTable,
+    AuthUserTable,
+    InvitationTable,
+    MemberTable,
+    OAuthConsentTable,
+    OrganizationTable,
+  }))
+  mock.module("@openwork-ee/den-db/drizzle", () => ({
+    and: (...conditions: unknown[]) => ({ conditions }),
+    asc: (field: unknown) => field,
+    eq: (field: unknown, value: unknown) => ({ field, value }),
+    gt: (field: unknown, value: unknown) => ({ field, value }),
+    isNull: (field: unknown) => ({ field }),
+    lt: (field: unknown, value: unknown) => ({ field, value }),
+    lte: (field: unknown, value: unknown) => ({ field, value }),
+  }))
+  mock.module("../src/db.js", () => ({ db: {} }))
+
+  cacheModule = await import("../src/cache.js")
+  restoreCacheDependencies = cacheModule.setCacheDependenciesForTest({
+    redis,
+    authGrantLoader: (requestedGrantId) => {
+      loaderCalls += 1
+      return Promise.resolve({ id: requestedGrantId })
+    },
+  })
+})
+
+beforeEach(() => {
+  cachedValues.clear()
+  setCalls.length = 0
+  loaderCalls = 0
+})
+
+afterAll(() => {
+  restoreCacheDependencies?.()
+  mock.restore()
+})
+
+test("grant liveness cache hits avoid repeated loader calls", async () => {
+  const first = await cacheModule.cache.auth.grant(grantId)
+  const second = await cacheModule.cache.auth.grant(grantId)
+
+  expect(first).toEqual({ id: grantId })
+  expect(second).toEqual(first)
+  expect(loaderCalls).toBe(1)
+  expect(setCalls).toContainEqual({
+    key: `cache:auth:grant:${grantId}`,
+    value: JSON.stringify({ id: grantId }),
+    mode: "EX",
+    ttl: 60,
+  })
+})
+
+test("grant revocation tombstones block stale cache repopulation", async () => {
+  await cacheModule.cache.auth.revokeGrant(grantId)
+  const resolved = await cacheModule.cache.auth.grant(grantId)
+
+  expect(resolved).toBeNull()
+  expect(loaderCalls).toBe(0)
+  expect(cachedValues.get(`cache:auth:grant-revoked:${grantId}`)).toBe("1")
+  expect(cachedValues.has(`cache:auth:grant:${grantId}`)).toBe(false)
+})

--- a/ee/apps/den-api/test/mcp-grant-cache.test.ts
+++ b/ee/apps/den-api/test/mcp-grant-cache.test.ts
@@ -15,9 +15,14 @@ const MemberTable = { id: "member.id" }
 const OAuthConsentTable = { id: "consent.id" }
 const OrganizationTable = { id: "organization.id" }
 
+let failSetForKeyPrefix: string | null = null
+
 const redis = {
   get: (key: string) => Promise.resolve(cachedValues.get(key) ?? null),
   set: (key: string, value: string, mode: string, ttl: number) => {
+    if (failSetForKeyPrefix && key.startsWith(failSetForKeyPrefix)) {
+      return Promise.reject(new Error("redis set unavailable"))
+    }
     setCalls.push({ key, value, mode, ttl })
     cachedValues.set(key, value)
     return Promise.resolve("OK")
@@ -69,6 +74,7 @@ beforeEach(() => {
   cachedValues.clear()
   setCalls.length = 0
   loaderCalls = 0
+  failSetForKeyPrefix = null
 })
 
 afterAll(() => {
@@ -89,6 +95,21 @@ test("grant liveness cache hits avoid repeated loader calls", async () => {
     mode: "EX",
     ttl: 60,
   })
+})
+
+test("a failed tombstone write still clears the stale positive grant entry", async () => {
+  await cacheModule.cache.auth.grant(grantId)
+  expect(cachedValues.has(`cache:auth:grant:${grantId}`)).toBe(true)
+
+  failSetForKeyPrefix = "cache:auth:grant-revoked:"
+  await cacheModule.cache.auth.revokeGrant(grantId)
+
+  expect(cachedValues.has(`cache:auth:grant:${grantId}`)).toBe(false)
+  const resolved = await cacheModule.cache.auth.grant(grantId)
+  expect(resolved).toEqual({ id: grantId })
+  // The stale positive entry is gone, so liveness re-consults the loader
+  // (database-authoritative) instead of serving the pre-revocation cache hit.
+  expect(loaderCalls).toBe(2)
 })
 
 test("grant revocation tombstones block stale cache repopulation", async () => {

--- a/ee/apps/den-api/test/mcp-grant-deletion-tombstones.test.ts
+++ b/ee/apps/den-api/test/mcp-grant-deletion-tombstones.test.ts
@@ -1,0 +1,119 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+
+const AuthAccountTable = { userId: "account.userId" }
+const AuthApiKeyTable = { referenceId: "apiKey.referenceId" }
+const AuthSessionTable = { id: "session.id", token: "session.token", userId: "session.userId" }
+const AuthUserTable = { id: "user.id" }
+const DesktopHandoffGrantTable = { user_id: "handoff.user_id" }
+const ExternalIdentityTable = { userId: "externalIdentity.userId" }
+const MemberTable = { organizationId: "member.organizationId", userId: "member.userId" }
+const OAuthAccessTokenTable = { userId: "access.userId" }
+const OAuthClientTable = { userId: "client.userId" }
+const OAuthConsentTable = { id: "consent.id", userId: "consent.userId" }
+const OAuthRefreshTokenTable = { userId: "refresh.userId" }
+const ScimSyncEventTable = { userId: "scim.userId" }
+const WorkerTable = { created_by_user_id: "worker.created_by_user_id" }
+
+const snapshotConsentId = "oauthConsent_snapshot"
+// Authorized concurrently with the deletion: only visible to the locking
+// in-transaction read, never to a pre-transaction snapshot.
+const lateConsentId = "oauthConsent_late_authorized"
+
+const tombstonedGrants: string[] = []
+const transactionConsentSelects: { forUpdate: boolean }[] = []
+let consentDeletedInTransaction = false
+let userDeletion: typeof import("../src/user-deletion.js")
+
+function transactionFake() {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = table === OAuthConsentTable ? [{ id: snapshotConsentId }, { id: lateConsentId }] : []
+          const resolved = Promise.resolve(rows)
+          return Object.assign(resolved, {
+            for: (mode: string) => {
+              if (table === OAuthConsentTable) {
+                transactionConsentSelects.push({ forUpdate: mode === "update" })
+              }
+              return Promise.resolve(rows)
+            },
+          })
+        },
+      }),
+    }),
+    delete: (table: unknown) => ({
+      where: () => {
+        if (table === OAuthConsentTable) {
+          consentDeletedInTransaction = true
+        }
+        return Promise.resolve()
+      },
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => Promise.resolve(),
+      }),
+    }),
+  }
+}
+
+beforeAll(async () => {
+  mock.module("@openwork-ee/den-db/schema", () => ({
+    AuthAccountTable,
+    AuthApiKeyTable,
+    AuthSessionTable,
+    AuthUserTable,
+    DesktopHandoffGrantTable,
+    ExternalIdentityTable,
+    MemberTable,
+    OAuthAccessTokenTable,
+    OAuthClientTable,
+    OAuthConsentTable,
+    OAuthRefreshTokenTable,
+    ScimSyncEventTable,
+    WorkerTable,
+  }))
+  mock.module("@openwork-ee/den-db/drizzle", () => ({
+    eq: (field: unknown, value: unknown) => ({ operator: "eq", field, value }),
+  }))
+  mock.module("../src/cache.js", () => ({
+    cache: {
+      auth: {
+        revokeSession: () => Promise.resolve(),
+        revokeSessionId: () => Promise.resolve(),
+        revokeGrant: (grantId: string) => {
+          tombstonedGrants.push(grantId)
+          return Promise.resolve()
+        },
+      },
+      org: {
+        deleteMembers: () => Promise.resolve(),
+      },
+    },
+  }))
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+      transaction: async (run: (tx: ReturnType<typeof transactionFake>) => Promise<unknown>) => run(transactionFake()),
+    },
+  }))
+
+  userDeletion = await import("../src/user-deletion.js")
+})
+
+test("user deletion tombstones the transactional consent snapshot, including late-authorized consents", async () => {
+  tombstonedGrants.length = 0
+  transactionConsentSelects.length = 0
+  consentDeletedInTransaction = false
+
+  await userDeletion.deleteGlobalAuthUser("user_target")
+
+  expect(transactionConsentSelects).toEqual([{ forUpdate: true }])
+  expect(consentDeletedInTransaction).toBe(true)
+  expect(tombstonedGrants.sort()).toEqual([lateConsentId, snapshotConsentId])
+})

--- a/ee/apps/den-api/test/mcp-grant-request-liveness.test.ts
+++ b/ee/apps/den-api/test/mcp-grant-request-liveness.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { McpAuthResourceContext } from "../src/mcp/auth.js"
+
+const GRANT_CLAIM = "https://openworklabs.com/grant_id"
+const AGENT_RESOURCE = "http://127.0.0.1:8790/mcp/agent"
+let jwtPayload: Record<string, unknown> = {}
+let mcpAuth: typeof import("../src/mcp/auth.js")
+let grantLiveness: typeof import("../src/mcp/grant-liveness.js")
+let sessionLiveness: typeof import("../src/mcp/session-liveness.js")
+
+const AuthSessionTable = { id: "session.id", expiresAt: "session.expiresAt" }
+const AuthUserTable = { id: "user.id" }
+const InvitationTable = { id: "invitation.id" }
+const MemberTable = { id: "member.id", userId: "member.userId", organizationId: "member.organizationId", removedAt: "member.removedAt" }
+const OAuthAccessTokenTable = { token: "access.token", sessionId: "access.sessionId" }
+const OAuthConsentTable = { id: "consent.id" }
+const OAuthRefreshTokenTable = { sessionId: "refresh.sessionId" }
+const OrganizationTable = { id: "organization.id" }
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+function agentResourceContext(requestId: string): McpAuthResourceContext {
+  return {
+    route: "agent",
+    resourceUrl: AGENT_RESOURCE,
+    metadataUrl: "http://127.0.0.1:8790/.well-known/oauth-protected-resource/mcp/agent",
+    oauthResources: [AGENT_RESOURCE],
+    firstPartyResources: ["http://127.0.0.1:8790/mcp", AGENT_RESOURCE],
+    requestId,
+  }
+}
+
+function validMcpJwtPayload(includeGrant: boolean) {
+  const payload: Record<string, unknown> = {
+    sub: createDenTypeId("user"),
+    aud: AGENT_RESOURCE,
+    scope: "mcp:read mcp:write",
+    sid: createDenTypeId("session"),
+    "https://openworklabs.com/token_use": "mcp",
+    "https://openworklabs.com/resource": AGENT_RESOURCE,
+    "https://openworklabs.com/org_id": createDenTypeId("organization"),
+  }
+  if (includeGrant) {
+    payload[GRANT_CLAIM] = createDenTypeId("oauthConsent")
+  }
+  return payload
+}
+
+async function verify(requestId: string) {
+  return mcpAuth.verifyMcpRequest(new Headers({
+    authorization: "Bearer header.payload.signature",
+  }), agentResourceContext(requestId))
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.module("@openwork-ee/den-db/schema", () => ({
+    AuthSessionTable,
+    AuthUserTable,
+    InvitationTable,
+    MemberTable,
+    OAuthAccessTokenTable,
+    OAuthConsentTable,
+    OAuthRefreshTokenTable,
+    OrganizationTable,
+  }))
+  mock.module("@openwork-ee/den-db/drizzle", () => ({
+    and: (...conditions: unknown[]) => ({ conditions }),
+    asc: (field: unknown) => field,
+    eq: (field: unknown, value: unknown) => ({ field, value }),
+    gt: (field: unknown, value: unknown) => ({ field, value }),
+    isNull: (field: unknown) => ({ field }),
+    lt: (field: unknown, value: unknown) => ({ field, value }),
+    lte: (field: unknown, value: unknown) => ({ field, value }),
+  }))
+  mock.module("../src/auth.js", () => ({
+    auth: {
+      handler: () => Promise.resolve(Response.json({ keys: [] })),
+    },
+    DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+    DEN_MCP_FIRST_PARTY_CLIENT_ID: "openwork-desktop",
+    DEN_MCP_FIRST_PARTY_RESOURCES: ["http://127.0.0.1:8790/mcp", AGENT_RESOURCE],
+    DEN_MCP_GRANT_ID_CLAIM: GRANT_CLAIM,
+    DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+    DEN_MCP_OAUTH_RESOURCE: AGENT_RESOURCE,
+    DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+    DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+  }))
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([{ id: createDenTypeId("member"), role: "member" }]),
+          }),
+        }),
+      }),
+    },
+  }))
+  mock.module("better-auth/oauth2", () => ({
+    verifyJwsAccessToken: () => Promise.resolve(jwtPayload),
+  }))
+
+  const modules = await Promise.all([
+    import("../src/mcp/auth.js"),
+    import("../src/mcp/grant-liveness.js"),
+    import("../src/mcp/session-liveness.js"),
+  ])
+  mcpAuth = modules[0]
+  grantLiveness = modules[1]
+  sessionLiveness = modules[2]
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test("grant-claim tokens stay valid without consulting their dead login session", async () => {
+  jwtPayload = validMcpJwtPayload(true)
+  let grantChecks = 0
+  let sessionChecks = 0
+  const restoreGrant = grantLiveness.setMcpGrantLivenessDependenciesForTest({
+    select: ({ normalizedGrantId }) => {
+      grantChecks += 1
+      return Promise.resolve([{ id: normalizedGrantId }])
+    },
+  })
+  const restoreSession = sessionLiveness.setMcpSessionLivenessDependenciesForTest({
+    select: () => {
+      sessionChecks += 1
+      return Promise.resolve([])
+    },
+  })
+
+  try {
+    const principal = await verify("req_live_grant")
+    expect(principal).not.toBeInstanceOf(Response)
+    if (!(principal instanceof Response)) {
+      expect(principal.organizationId).toBe(jwtPayload["https://openworklabs.com/org_id"])
+    }
+    expect(grantChecks).toBe(1)
+    expect(sessionChecks).toBe(0)
+  } finally {
+    restoreGrant()
+    restoreSession()
+  }
+})
+
+test("missing grant claims return an invalid_token revocation response", async () => {
+  jwtPayload = validMcpJwtPayload(true)
+  const restoreGrant = grantLiveness.setMcpGrantLivenessDependenciesForTest({
+    select: () => Promise.resolve([]),
+  })
+
+  try {
+    const response = await verify("req_missing_grant")
+    expect(response).toBeInstanceOf(Response)
+    if (response instanceof Response) {
+      expect(response.status).toBe(401)
+      expect(response.headers.get("www-authenticate") ?? "").toContain('error="invalid_token"')
+      await expect(response.json()).resolves.toMatchObject({
+        error: "mcp_grant_revoked",
+        oauthError: "invalid_token",
+        referenceId: "req_missing_grant",
+      })
+    }
+  } finally {
+    restoreGrant()
+  }
+})
+
+test("grant liveness outages return retryable 503 responses", async () => {
+  jwtPayload = validMcpJwtPayload(true)
+  const originalError = console.error
+  console.error = () => undefined
+  const restoreGrant = grantLiveness.setMcpGrantLivenessDependenciesForTest({
+    select: () => Promise.reject(new Error("grant store unavailable")),
+  })
+
+  try {
+    const response = await verify("req_grant_failure")
+    expect(response).toBeInstanceOf(Response)
+    if (response instanceof Response) {
+      expect(response.status).toBe(503)
+      expect(response.headers.get("retry-after")).toBe("10")
+      expect(response.headers.get("www-authenticate")).toBeNull()
+      await expect(response.json()).resolves.toMatchObject({
+        error: "mcp_grant_check_unavailable",
+        referenceId: "req_grant_failure",
+      })
+    }
+  } finally {
+    restoreGrant()
+    console.error = originalError
+  }
+})
+
+test("older sid-only tokens still die with their revoked session", async () => {
+  jwtPayload = validMcpJwtPayload(false)
+  let grantChecks = 0
+  const restoreGrant = grantLiveness.setMcpGrantLivenessDependenciesForTest({
+    select: () => {
+      grantChecks += 1
+      return Promise.resolve([])
+    },
+  })
+  const restoreSession = sessionLiveness.setMcpSessionLivenessDependenciesForTest({
+    select: () => Promise.resolve([]),
+  })
+
+  try {
+    const response = await verify("req_dead_legacy_session")
+    expect(response).toBeInstanceOf(Response)
+    if (response instanceof Response) {
+      expect(response.status).toBe(401)
+      await expect(response.json()).resolves.toMatchObject({
+        error: "mcp_session_revoked",
+        oauthError: "invalid_token",
+        referenceId: "req_dead_legacy_session",
+      })
+    }
+    expect(grantChecks).toBe(0)
+  } finally {
+    restoreGrant()
+    restoreSession()
+  }
+})

--- a/ee/apps/den-api/test/mcp-grant-revocation.test.ts
+++ b/ee/apps/den-api/test/mcp-grant-revocation.test.ts
@@ -1,0 +1,134 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+
+const AuthSessionTable = {
+  id: "session.id",
+  token: "session.token",
+  userId: "session.userId",
+}
+const MemberTable = {
+  organizationId: "member.organizationId",
+}
+const OAuthAccessTokenTable = {
+  id: "access.id",
+  userId: "access.userId",
+  referenceId: "access.referenceId",
+}
+const OAuthConsentTable = {
+  id: "consent.id",
+  userId: "consent.userId",
+  referenceId: "consent.referenceId",
+}
+const OAuthRefreshTokenTable = {
+  id: "refresh.id",
+  userId: "refresh.userId",
+  referenceId: "refresh.referenceId",
+  revoked: "refresh.revoked",
+}
+
+type QueryCall = {
+  table: unknown
+  where: unknown
+}
+
+const selectCalls: QueryCall[] = []
+const deleteCalls: QueryCall[] = []
+const tombstonedGrants: string[] = []
+const targetGrantId = "oauthConsent_target"
+const otherOrganizationGrantId = "oauthConsent_other_org"
+let credentialRevocation: typeof import("../src/credential-revocation.js")
+
+function rowsForTable(table: unknown) {
+  if (table === AuthSessionTable) {
+    return [{ id: "session_target", token: "session-token-target" }]
+  }
+  if (table === OAuthAccessTokenTable) {
+    return [{ id: "oauthAccessToken_target" }]
+  }
+  if (table === OAuthConsentTable) {
+    return [{ id: targetGrantId }]
+  }
+  if (table === OAuthRefreshTokenTable) {
+    return [{ id: "oauthRefreshToken_target" }]
+  }
+  return []
+}
+
+beforeAll(async () => {
+  mock.module("@openwork-ee/den-db/schema", () => ({
+    AuthSessionTable,
+    MemberTable,
+    OAuthAccessTokenTable,
+    OAuthConsentTable,
+    OAuthRefreshTokenTable,
+  }))
+  mock.module("@openwork-ee/den-db/drizzle", () => ({
+    and: (...conditions: unknown[]) => ({ operator: "and", conditions }),
+    eq: (field: unknown, value: unknown) => ({ operator: "eq", field, value }),
+    inArray: (field: unknown, values: unknown[]) => ({ operator: "inArray", field, values }),
+    isNull: (field: unknown) => ({ operator: "isNull", field }),
+  }))
+  mock.module("../src/cache.js", () => ({
+    cache: {
+      auth: {
+        revokeSession: () => Promise.resolve(),
+        revokeSessionId: () => Promise.resolve(),
+        revokeGrant: (grantId: string) => {
+          tombstonedGrants.push(grantId)
+          return Promise.resolve()
+        },
+      },
+    },
+  }))
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: (where: unknown) => {
+            selectCalls.push({ table, where })
+            return Promise.resolve(rowsForTable(table))
+          },
+        }),
+      }),
+      delete: (table: unknown) => ({
+        where: (where: unknown) => {
+          deleteCalls.push({ table, where })
+          return Promise.resolve()
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => Promise.resolve(),
+        }),
+      }),
+    },
+  }))
+
+  credentialRevocation = await import("../src/credential-revocation.js")
+})
+
+test("membership removal deletes and tombstones only the target organization's grants", async () => {
+  selectCalls.length = 0
+  deleteCalls.length = 0
+  tombstonedGrants.length = 0
+
+  await credentialRevocation.revokeMembershipSessionCredentials({
+    organizationId: "organization_target",
+    userId: "user_target",
+  })
+
+  const consentSelect = selectCalls.find((call) => call.table === OAuthConsentTable)
+  expect(consentSelect?.where).toEqual({
+    operator: "and",
+    conditions: [
+      { operator: "eq", field: OAuthConsentTable.userId, value: "user_target" },
+      { operator: "eq", field: OAuthConsentTable.referenceId, value: "organization_target" },
+    ],
+  })
+  expect(deleteCalls.find((call) => call.table === OAuthConsentTable)?.where).toEqual({
+    operator: "inArray",
+    field: OAuthConsentTable.id,
+    values: [targetGrantId],
+  })
+  expect(tombstonedGrants).toEqual([targetGrantId])
+  expect(tombstonedGrants).not.toContain(otherOrganizationGrantId)
+})

--- a/ee/apps/den-api/test/mcp-membership-revocation.test.ts
+++ b/ee/apps/den-api/test/mcp-membership-revocation.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, expect, mock, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { Hono } from "hono"
+import type { MiddlewareHandler } from "hono"
 import type { McpAuthResourceContext } from "../src/mcp/auth.js"
 
 function seedRequiredEnv() {
@@ -11,7 +12,7 @@ function seedRequiredEnv() {
 }
 
 type SelectedRow =
-  | { id: string }
+  | { id: string; role?: string }
   | {
     token: string
     clientId: string
@@ -35,6 +36,9 @@ let registerAdminMcpRoutes: typeof import("../src/mcp/admin.js")["registerAdminM
 
 const OPAQUE_SECRET = "mcp_test_secret"
 const OPAQUE_TOKEN = `ow_mcp_at_${OPAQUE_SECRET}`
+const allowAdminMiddleware: MiddlewareHandler = async (_context, next) => {
+  await next()
+}
 
 function nextSelectedRows() {
   return selectedRowBatches.shift() ?? selectedRows
@@ -54,6 +58,7 @@ beforeAll(async () => {
       "http://127.0.0.1:8790/mcp/agent",
       "http://127.0.0.1:8790/mcp/admin",
     ],
+    DEN_MCP_GRANT_ID_CLAIM: "https://openworklabs.com/grant_id",
     DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
     DEN_MCP_OAUTH_RESOURCE: "http://127.0.0.1:8790/mcp/agent",
     DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
@@ -88,6 +93,7 @@ beforeAll(async () => {
 
   mock.module("../src/middleware/admin.js", () => ({
     isPlatformAdminUserId: () => Promise.resolve(platformAdmin),
+    requireAdminMiddleware: allowAdminMiddleware,
   }))
 
   mcpAuth = await import("../src/mcp/auth.js")
@@ -104,7 +110,7 @@ test("MCP principals require an active organization membership", async () => {
   const userId = createDenTypeId("user")
   const organizationId = createDenTypeId("organization")
 
-  selectedRows = [{ id: createDenTypeId("member") }]
+  selectedRows = [{ id: createDenTypeId("member"), role: "member" }]
   await expect(mcpAuth.hasActiveMcpMembership({
     userId,
     organizationId,
@@ -127,19 +133,15 @@ test("MCP membership check rejects malformed principals", async () => {
 
 test("MCP bearer tokens tied to deleted sessions are rejected", async () => {
   const sessionId = createDenTypeId("session")
-  const now = new Date("2026-07-09T12:00:00.000Z")
-
   sessionUpdates = []
   selectedRows = [{ id: sessionId }]
-  await expect(mcpAuth.hasActiveMcpSession(sessionId, now)).resolves.toBe(true)
-  expect(sessionUpdates).toEqual([{
-    updatedAt: now,
-    expiresAt: new Date("2026-07-16T12:00:00.000Z"),
-  }])
+  await expect(mcpAuth.hasActiveMcpSession(sessionId)).resolves.toBe(true)
+  expect(sessionUpdates).toHaveLength(1)
+  expect(sessionUpdates[0]?.expiresAt.getTime() - sessionUpdates[0]?.updatedAt.getTime()).toBe(7 * 24 * 60 * 60 * 1000)
 
   selectedRows = []
   selectedRowBatches = []
-  await expect(mcpAuth.hasActiveMcpSession(sessionId, now)).resolves.toBe(false)
+  await expect(mcpAuth.hasActiveMcpSession(sessionId)).resolves.toBe(false)
   await expect(mcpAuth.hasActiveMcpSession("not-a-session-id")).resolves.toBe(false)
 })
 
@@ -192,7 +194,7 @@ function validMcpJwtPayload(input: { resource: string; clientId?: string }) {
 
 function selectActiveSessionAndMembership() {
   selectedRows = []
-  selectedRowBatches = [[{ id: createDenTypeId("session") }], [{ id: createDenTypeId("member") }]]
+  selectedRowBatches = [[{ id: createDenTypeId("session") }], [{ id: createDenTypeId("member"), role: "member" }]]
 }
 
 function validFirstPartyOpaqueTokenRow() {
@@ -213,7 +215,7 @@ function selectActiveOpaqueTokenSessionAndMembership() {
   selectedRowBatches = [
     [validFirstPartyOpaqueTokenRow()],
     [{ id: createDenTypeId("session") }],
-    [{ id: createDenTypeId("member") }],
+    [{ id: createDenTypeId("member"), role: "member" }],
   ]
 }
 

--- a/ee/apps/den-api/test/mcp-oauth-grant-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-grant-policy.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { contributeMcpGrantClaim } from "../src/mcp/grant-claims.js"
+import {
+  assertLiveMcpRefreshGrant,
+  McpRefreshGrantRevokedError,
+  type McpRefreshGrantRow,
+} from "../src/mcp/refresh-grant-liveness.js"
+
+const GRANT_CLAIM = "https://openworklabs.com/grant_id"
+
+function refreshGrant(sessionId: string | null): McpRefreshGrantRow {
+  return {
+    sessionId,
+    clientId: "client_mcp_grant_policy",
+    userId: createDenTypeId("user"),
+    referenceId: createDenTypeId("organization"),
+  }
+}
+
+test("access-token claims stamp exactly the durable consent id, never the session id", async () => {
+  const consentId = createDenTypeId("oauthConsent")
+  const sessionId = createDenTypeId("session")
+  const claims = await contributeMcpGrantClaim({
+    claimName: GRANT_CLAIM,
+    clientId: "client_mcp_claim",
+    userId: createDenTypeId("user"),
+    referenceId: createDenTypeId("organization"),
+    findConsent: () => Promise.resolve({ id: consentId }),
+  })
+
+  expect(claims).toEqual({ [GRANT_CLAIM]: consentId })
+  expect(Object.values(claims)).not.toContain(sessionId)
+  expect(JSON.stringify(claims)).not.toContain("session")
+})
+
+test("access-token claims omit grant identity when no consent exists", async () => {
+  const claims = await contributeMcpGrantClaim({
+    claimName: GRANT_CLAIM,
+    clientId: "client_mcp_claim",
+    userId: createDenTypeId("user"),
+    referenceId: createDenTypeId("organization"),
+    findConsent: () => Promise.resolve(null),
+  })
+
+  expect(claims).toEqual({})
+  expect(claims[GRANT_CLAIM]).toBeUndefined()
+})
+
+test("refresh survives a dead session while its consent remains live", async () => {
+  const deletedFamilies: string[] = []
+  let consentChecks = 0
+  await assertLiveMcpRefreshGrant({
+    grant: refreshGrant(createDenTypeId("session")),
+    getSessionLiveness: () => Promise.resolve("missing"),
+    findConsent: () => {
+      consentChecks += 1
+      return Promise.resolve({ id: createDenTypeId("oauthConsent") })
+    },
+    deleteGrantFamily: (sessionId) => {
+      deletedFamilies.push(sessionId)
+      return Promise.resolve()
+    },
+  })
+
+  expect(consentChecks).toBe(1)
+  expect(deletedFamilies).toEqual([])
+})
+
+test("refresh rejects a dead session after consent deletion and clears its family", async () => {
+  const sessionId = createDenTypeId("session")
+  const deletedFamilies: string[] = []
+  const promise = assertLiveMcpRefreshGrant({
+    grant: refreshGrant(sessionId),
+    getSessionLiveness: () => Promise.resolve("missing"),
+    findConsent: () => Promise.resolve(null),
+    deleteGrantFamily: (deletedSessionId) => {
+      deletedFamilies.push(deletedSessionId)
+      return Promise.resolve()
+    },
+  })
+
+  await expect(promise).rejects.toBeInstanceOf(McpRefreshGrantRevokedError)
+  expect(deletedFamilies).toEqual([sessionId])
+})
+
+test("sessionless refresh rows remain exempt from liveness checks", async () => {
+  let sessionChecks = 0
+  let consentChecks = 0
+  let familyDeletes = 0
+  await assertLiveMcpRefreshGrant({
+    grant: refreshGrant(null),
+    getSessionLiveness: () => {
+      sessionChecks += 1
+      return Promise.resolve("missing")
+    },
+    findConsent: () => {
+      consentChecks += 1
+      return Promise.resolve(null)
+    },
+    deleteGrantFamily: () => {
+      familyDeletes += 1
+      return Promise.resolve()
+    },
+  })
+
+  expect(sessionChecks).toBe(0)
+  expect(consentChecks).toBe(0)
+  expect(familyDeletes).toBe(0)
+})
+
+test("refresh liveness check failures fail open without consent checks or cleanup", async () => {
+  let consentChecks = 0
+  let familyDeletes = 0
+  await assertLiveMcpRefreshGrant({
+    grant: refreshGrant(createDenTypeId("session")),
+    getSessionLiveness: () => Promise.resolve("check_failed"),
+    findConsent: () => {
+      consentChecks += 1
+      return Promise.resolve(null)
+    },
+    deleteGrantFamily: () => {
+      familyDeletes += 1
+      return Promise.resolve()
+    },
+  })
+
+  expect(consentChecks).toBe(0)
+  expect(familyDeletes).toBe(0)
+})

--- a/ee/apps/den-api/test/mcp-oauth-refresh-lifecycle.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-refresh-lifecycle.test.ts
@@ -170,6 +170,7 @@ let db: typeof import("../src/db.js").db
 let schema: typeof import("@openwork-ee/den-db/schema")
 let drizzle: typeof import("@openwork-ee/den-db/drizzle")
 let setMcpSessionLivenessDependenciesForTest: typeof import("../src/mcp/session-liveness.js").setMcpSessionLivenessDependenciesForTest
+let setMcpGrantLivenessDependenciesForTest: typeof import("../src/mcp/grant-liveness.js").setMcpGrantLivenessDependenciesForTest
 
 const userId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
@@ -193,12 +194,14 @@ beforeAll(async () => {
     import("@openwork-ee/den-db/schema"),
     import("@openwork-ee/den-db/drizzle"),
     import("../src/mcp/session-liveness.js"),
+    import("../src/mcp/grant-liveness.js"),
   ])
   app = modules[0].default
   db = modules[1].db
   schema = modules[2]
   drizzle = modules[3]
   setMcpSessionLivenessDependenciesForTest = modules[4].setMcpSessionLivenessDependenciesForTest
+  setMcpGrantLivenessDependenciesForTest = modules[5].setMcpGrantLivenessDependenciesForTest
 
   await db.insert(schema.AuthUserTable).values({
     id: userId,
@@ -385,6 +388,7 @@ async function fetchAgentToolsWithAccessToken(accessToken: string, id: string) {
   return app.fetch(new Request(AGENT_RESOURCE, {
     method: "POST",
     headers: {
+      accept: "application/json, text/event-stream",
       authorization: `Bearer ${accessToken}`,
       "content-type": "application/json",
     },
@@ -450,7 +454,7 @@ childTest("refresh_token grant with a live backing session still rotates", async
   expect(requireRefreshToken(tokens)).toStartWith("ow_mcp_rt_")
 }, 8_000)
 
-childTest("refresh_token grant with a deleted backing session returns invalid_grant and clears the grant family", async () => {
+childTest("refresh_token grant with a deleted backing session still rotates while consent is live", async () => {
   const grant = await issueOAuthGrant()
   const clientId = grant.clientInformation.client_id
   await db.insert(schema.OAuthAccessTokenTable).values({
@@ -464,6 +468,59 @@ childTest("refresh_token grant with a deleted backing session returns invalid_gr
     scopes: JSON.stringify(MCP_SCOPE.split(" ")),
   })
   await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
+
+  const refresh = await refreshOAuthToken({
+    clientId,
+    refreshToken: requireRefreshToken(grant.tokens),
+  })
+
+  expect(refresh.status).toBe(200)
+  const tokens = OAuthTokensSchema.parse(refresh.body)
+  expect(tokens.access_token).toBeTruthy()
+  expect(requireRefreshToken(tokens)).toStartWith("ow_mcp_rt_")
+
+  const refreshGrants = await db
+    .select({ id: schema.OAuthRefreshTokenTable.id })
+    .from(schema.OAuthRefreshTokenTable)
+    .where(drizzle.eq(schema.OAuthRefreshTokenTable.sessionId, grant.sessionId))
+  const accessGrants = await db
+    .select({ id: schema.OAuthAccessTokenTable.id })
+    .from(schema.OAuthAccessTokenTable)
+    .where(drizzle.eq(schema.OAuthAccessTokenTable.sessionId, grant.sessionId))
+  expect(refreshGrants.length).toBeGreaterThan(0)
+  expect(accessGrants.length).toBeGreaterThan(0)
+}, 8_000)
+
+childTest("refresh_token grant with an expired backing session still rotates while consent is live", async () => {
+  const grant = await issueOAuthGrant()
+  await db.update(schema.AuthSessionTable)
+    .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
+    .where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
+
+  const refresh = await refreshOAuthToken({
+    clientId: grant.clientInformation.client_id,
+    refreshToken: requireRefreshToken(grant.tokens),
+  })
+
+  expect(refresh.status).toBe(200)
+  expect(OAuthTokensSchema.parse(refresh.body).access_token).toBeTruthy()
+}, 8_000)
+
+childTest("refresh_token grant with a dead session and deleted consent returns invalid_grant and clears the grant family", async () => {
+  const grant = await issueOAuthGrant()
+  const clientId = grant.clientInformation.client_id
+  await db.insert(schema.OAuthAccessTokenTable).values({
+    id: createDenTypeId("oauthAccessToken"),
+    token: hashStoredOAuthToken(`revoked-consent-access-${grant.sessionId}`),
+    clientId,
+    sessionId: grant.sessionId,
+    userId,
+    referenceId: organizationId,
+    expiresAt: new Date(Date.now() + 60_000),
+    scopes: JSON.stringify(MCP_SCOPE.split(" ")),
+  })
+  await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
+  await db.delete(schema.OAuthConsentTable).where(drizzle.eq(schema.OAuthConsentTable.clientId, clientId))
 
   const refresh = await refreshOAuthToken({
     clientId,
@@ -486,23 +543,6 @@ childTest("refresh_token grant with a deleted backing session returns invalid_gr
     .where(drizzle.eq(schema.OAuthAccessTokenTable.sessionId, grant.sessionId))
   expect(refreshGrants).toHaveLength(0)
   expect(accessGrants).toHaveLength(0)
-}, 8_000)
-
-childTest("refresh_token grant with an expired backing session returns invalid_grant", async () => {
-  const grant = await issueOAuthGrant()
-  await db.update(schema.AuthSessionTable)
-    .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
-    .where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
-
-  const refresh = await refreshOAuthToken({
-    clientId: grant.clientInformation.client_id,
-    refreshToken: requireRefreshToken(grant.tokens),
-  })
-
-  expect(refresh.status).toBe(400)
-  if (!isRecord(refresh.body)) throw new Error("Expected OAuth error response body")
-  expect(refresh.body.error).toBe("invalid_grant")
-  expect(refresh.body.error_description).toBe("The session backing this grant has been signed out or expired. Re-authorize the connection.")
 }, 8_000)
 
 childTest("refresh_token grant with no session_id remains valid", async () => {
@@ -535,10 +575,11 @@ childTest("authorization_code grant path still issues session-bound refresh toke
 childTest("session liveness check failures 503 resource requests but fail open refresh grants", async () => {
   const grant = await issueOAuthGrant()
   const clientId = grant.clientInformation.client_id
+  const failOpenAccessSecret = `fail-open-access-${grant.sessionId}`
   await db.insert(schema.OAuthAccessTokenTable).values({
     id: createDenTypeId("oauthAccessToken"),
-    token: hashStoredOAuthToken(`fail-open-access-${grant.sessionId}`),
-    clientId,
+    token: hashStoredOAuthToken(failOpenAccessSecret),
+    clientId: "openwork-desktop",
     sessionId: grant.sessionId,
     userId,
     referenceId: organizationId,
@@ -557,7 +598,7 @@ childTest("session liveness check failures 503 resource requests but fail open r
   })
 
   try {
-    const response = await fetchAgentToolsWithAccessToken(grant.tokens.access_token, "liveness-check-failed")
+    const response = await fetchAgentToolsWithAccessToken(`ow_mcp_at_${failOpenAccessSecret}`, "liveness-check-failed")
     expect(response.status).toBe(503)
     expect(response.headers.get("www-authenticate")).toBeNull()
     expect(response.headers.get("retry-after")).toBe("10")
@@ -588,14 +629,20 @@ childTest("session liveness check failures 503 resource requests but fail open r
   expect(accessGrants.length).toBeGreaterThan(0)
 }, 8_000)
 
-childTest("session liveness accepts cached session-id checks", async () => {
+childTest("grant liveness accepts cached consent-id checks", async () => {
   const grant = await issueOAuthGrant()
   const provider = new HarnessOAuthProvider(grant)
+  const [consent] = await db
+    .select({ id: schema.OAuthConsentTable.id })
+    .from(schema.OAuthConsentTable)
+    .where(drizzle.eq(schema.OAuthConsentTable.clientId, grant.clientInformation.client_id))
+    .limit(1)
+  if (!consent) throw new Error("OAuth grant did not create consent")
   let selectCount = 0
-  const restoreLiveness = setMcpSessionLivenessDependenciesForTest({
+  const restoreLiveness = setMcpGrantLivenessDependenciesForTest({
     select: async () => {
       selectCount += 1
-      return [{ id: grant.sessionId }]
+      return [{ id: consent.id }]
     },
   })
 
@@ -746,23 +793,39 @@ childTest("reusing a rotated refresh token within grace succeeds, but stale repl
   }
 }, 8_000)
 
-childTest("revoked bound sessions currently make the MCP resource reject an otherwise unexpired access token", async () => {
+childTest("dead sessions leave consent-bound tokens valid while sid-only tokens are rejected", async () => {
   const grant = await issueOAuthGrant()
   await db.update(schema.AuthSessionTable)
     .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
     .where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
 
-  const response = await app.fetch(new Request(AGENT_RESOURCE, {
+  const grantResponse = await app.fetch(new Request(AGENT_RESOURCE, {
     method: "POST",
     headers: {
+      accept: "application/json, text/event-stream",
       authorization: `Bearer ${grant.tokens.access_token}`,
       "content-type": "application/json",
     },
     body: JSON.stringify({ jsonrpc: "2.0", id: "revoked-session", method: "tools/list", params: {} }),
   }))
 
-  expect(response.status).toBe(401)
-  expect(response.headers.get("www-authenticate") ?? "").toContain('error="invalid_token"')
-  const body: unknown = await response.json()
+  expect(grantResponse.status).toBe(200)
+
+  const sidOnlyAccessSecret = `sid-only-access-${grant.sessionId}`
+  await db.insert(schema.OAuthAccessTokenTable).values({
+    id: createDenTypeId("oauthAccessToken"),
+    token: hashStoredOAuthToken(sidOnlyAccessSecret),
+    clientId: "openwork-desktop",
+    sessionId: grant.sessionId,
+    userId,
+    referenceId: organizationId,
+    expiresAt: new Date(Date.now() + 60_000),
+    scopes: JSON.stringify(MCP_SCOPE.split(" ")),
+  })
+  const sidOnlyResponse = await fetchAgentToolsWithAccessToken(`ow_mcp_at_${sidOnlyAccessSecret}`, "revoked-sid-only-session")
+
+  expect(sidOnlyResponse.status).toBe(401)
+  expect(sidOnlyResponse.headers.get("www-authenticate") ?? "").toContain('error="invalid_token"')
+  const body: unknown = await sidOnlyResponse.json()
   expect(isRecord(body) && body.error).toBe("mcp_session_revoked")
 }, 8_000)

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -10,6 +10,20 @@ const repoRoot = resolve(import.meta.dirname, "../..");
 test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evidence }) => {
   const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-grant-liveness-"));
   try {
+    // The witnesses exercise real den-api modules whose import chains reach
+    // @openwork-ee/utils and @openwork-ee/den-db. Bun resolves those package
+    // exports through dist, which the eval lane does not prebuild.
+    for (const workspacePackage of ["@openwork-ee/utils", "@openwork-ee/den-db"]) {
+      const build = spawnSync("pnpm", ["--filter", workspacePackage, "build"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120_000,
+      });
+      expect(build.error, `${workspacePackage} build`).toBeUndefined();
+      expect(build.status, `${build.stdout}${build.stderr}`).toBe(0);
+    }
+
     const witnesses = [
       { file: "test/mcp-grant-request-liveness.test.ts", tests: 4 },
       { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -29,7 +29,7 @@ test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evide
       { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },
       { file: "test/mcp-grant-revocation.test.ts", tests: 1 },
       { file: "test/mcp-grant-deletion-tombstones.test.ts", tests: 1 },
-      { file: "test/mcp-grant-cache.test.ts", tests: 2 },
+      { file: "test/mcp-grant-cache.test.ts", tests: 3 },
     ];
     for (const [index, witness] of witnesses.entries()) {
       const reportPath = join(reportDir, `bun-junit-${index}.xml`);

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-grant-liveness-"));
+  try {
+    const witnesses = [
+      { file: "test/mcp-grant-request-liveness.test.ts", tests: 4 },
+      { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },
+      { file: "test/mcp-grant-revocation.test.ts", tests: 1 },
+      { file: "test/mcp-grant-cache.test.ts", tests: 2 },
+    ];
+    for (const [index, witness] of witnesses.entries()) {
+      const reportPath = join(reportDir, `bun-junit-${index}.xml`);
+      const result = spawnSync("pnpm", [
+        "--filter",
+        "@openwork-ee/den-api",
+        "exec",
+        "bun",
+        "test",
+        witness.file,
+        "--reporter=junit",
+        "--reporter-outfile",
+        reportPath,
+      ], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 60_000,
+      });
+      const output = `${result.stdout}${result.stderr}`;
+      expect(result.error, output).toBeUndefined();
+      expect(result.status, output).toBe(0);
+
+      const junit = readFileSync(reportPath, "utf8");
+      const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+      expect(summary).toContain(`tests="${witness.tests}"`);
+      expect(summary).toContain('failures="0"');
+      expect(summary).toContain('skipped="0"');
+      expect(junit).not.toContain("<failure");
+      expect(junit).not.toContain("<skipped");
+    }
+
+    evidence.recordAssertionEvidence(
+      "Sign-out leaves grant-claim tokens valid while sid-only tokens still die",
+      "The runtime witness accepts a live-consent token without consulting its dead session and rejects a legacy token without a grant claim as mcp_session_revoked.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Consent revocation rejects access and refresh without penalizing live grants",
+      "The runtime witness accepts live grant and refresh consent, returns mcp_grant_revoked for a missing grant, and rejects plus cleans a dead-session refresh family only after consent deletion.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Membership removal revokes only that organization's grants",
+      "The runtime witness requires the consent query to include both user and target organization, tombstones exactly the selected consent id, and rejects tombstoning the other-organization id.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Grant claims and cache entries remain durable and revocation-safe",
+      "The runtime witness stamps only the consent id, omits absent consent, reuses cached liveness without another loader call, and prevents tombstoned grants from repopulating.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -28,6 +28,7 @@ test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evide
       { file: "test/mcp-grant-request-liveness.test.ts", tests: 4 },
       { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },
       { file: "test/mcp-grant-revocation.test.ts", tests: 1 },
+      { file: "test/mcp-grant-deletion-tombstones.test.ts", tests: 1 },
       { file: "test/mcp-grant-cache.test.ts", tests: 2 },
     ];
     for (const [index, witness] of witnesses.entries()) {
@@ -74,6 +75,11 @@ test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evide
     evidence.recordAssertionEvidence(
       "Membership removal revokes only that organization's grants",
       "The runtime witness requires the consent query to include both user and target organization, tombstones exactly the selected consent id, and rejects tombstoning the other-organization id.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "User deletion tombstones the transactional consent snapshot",
+      "The runtime witness requires the consent snapshot to be a locking read inside the deletion transaction and requires a consent authorized concurrently with deletion to be tombstoned alongside the snapshot, closing the pre-transaction race.",
       true,
     );
     evidence.recordAssertionEvidence(


### PR DESCRIPTION
## Summary
Decouples inbound MCP OAuth grant lifetime from Better Auth login sessions (design items 1+2 from the Claude-connector incident review):

- MCP access tokens now carry a durable `<ns>/grant_id` claim — the `oauthConsent` row id for (client, user, organization), minted via an oauth-provider claims extension; consent is upserted on re-authorization so the id survives reconnects
- `verifyMcpRequest` checks grant liveness first (new `getMcpGrantLiveness`, cache-backed with the same tombstone pattern as session-id caching); tokens without the claim (older tokens, first-party opaque) keep the existing `sid` session-liveness path — new codes `mcp_grant_revoked`/`mcp_grant_check_unavailable` mirror the session contract
- refresh with a dead login session now succeeds while the consent is alive (sign-out no longer kills connectors); when consent is gone the family is deleted and `invalid_grant` returned as before
- revocation moves to meaningful events: membership removal/role downgrade deletes org-scoped consents + tombstones grants (other orgs untouched); user self-deletion and admin deletion tombstone all the user's grants
- Better Auth reuse-detection teardown and `/oauth2/revoke` intentionally leave consent; minted-JWT exposure stays bounded by the 45-minute access TTL (same as today)

## Verification
- 13 new focused bun tests (4 files) + 49 existing area tests, all green per-file: `pnpm --filter @openwork-ee/den-api exec bun test <file>` (bun `mock.module` bleeds across files in one process — combining files fails identically on clean `origin/dev`, e.g. `test/mcp-membership-revocation.test.ts test/cache.test.ts`)
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/mcp-grant-scoped-liveness.test.ts` (1 passed)
- MySQL integration: `test/mcp-oauth-refresh-lifecycle.test.ts` updated (sign-out survival, consent-deleted refresh rejection, sid-only compat) — grant-related cases pass locally against MySQL; two rotation tests are red but **pre-existing**: the same `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-oauth-refresh-lifecycle.test.ts` fails the identical two tests ("two concurrent SDK requests after access expiry recover during refresh rotation grace", "reusing a rotated refresh token within grace succeeds, but stale replay revokes the token family") on a clean `origin/dev` worktree at ff5d298ee (9 pass / 2 fail there vs 10 pass / 2 fail here)

## Notes for review
- Draft pending: decision on whether first-party opaque tokens should also move to grant scoping (currently intentionally session-coupled, documented in `verifyOpaqueMcpToken`)
- Follow-up candidates (out of scope): explicit per-connector disconnect surface for inbound grants; org policy flag for session-bound mode

## Decisions
- First-party opaque tokens intentionally remain session-coupled: device sign-out must disconnect that device's cloud control, and the desktop client re-authenticates silently. Third-party grant-scoping problems (fleet tokens, sign-out storms) do not apply to it.
- Sign-out/web-session expiry no longer disconnect third-party MCP connectors by design; revocation surfaces are membership removal, admin action, provider-side disconnect, and refresh-reuse detection. A per-connector disconnect UI is a follow-up.
