### PR TITLE
fix(app): bound managed MCP server recovery

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -63,6 +63,22 @@ type SetStateAction<T> = T | ((current: T) => T);
 // den-api): when the two were equal, the marker was stale the instant it
 // was written and every sync tick re-wrote the MCP config.
 const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
+const LOCAL_OPENWORK_SERVER_RECOVERY_TIMEOUT_MS = 30_000;
+
+async function withLocalOpenworkServerRecoveryTimeout<T>(
+  task: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(t("mcp.connect_failed"))), timeoutMs);
+  });
+  try {
+    return await Promise.race([task, timeout]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}
 
 export type ConnectionsStoreSnapshot = {
   mcpServers: McpServerEntry[];
@@ -96,6 +112,7 @@ export function createConnectionsStore(options: {
   openworkServer: OpenworkServerStore;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
+  localOpenworkServerRecoveryTimeoutMs?: number;
   setProjectDir?: (value: string) => void;
   developerMode: () => boolean;
   markReloadRequired?: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
@@ -201,7 +218,10 @@ export function createConnectionsStore(options: {
     if ((!openworkClient || !openworkWorkspaceId || openworkSnapshot.openworkServerStatus !== "connected")
       && isDesktopRuntime()
       && options.workspaceType() === "local") {
-      openworkClient = await options.openworkServer.ensureLocalOpenworkServerClient();
+      openworkClient = await withLocalOpenworkServerRecoveryTimeout(
+        options.openworkServer.ensureLocalOpenworkServerClient(),
+        options.localOpenworkServerRecoveryTimeoutMs ?? LOCAL_OPENWORK_SERVER_RECOVERY_TIMEOUT_MS,
+      );
       openworkSnapshot = getOpenworkSnapshot();
       openworkWorkspaceId = options.runtimeWorkspaceId()?.trim()
         || (await options.ensureRuntimeWorkspaceId?.())?.trim()

--- a/apps/app/tests/mcp-local-server-recovery.test.ts
+++ b/apps/app/tests/mcp-local-server-recovery.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { McpDirectoryInfo } from "../src/app/constants";
+import { submitMcpEntry } from "../src/react-app/domains/connections/modals/add-mcp-submission";
+import type { OpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
+import { createConnectionsStore } from "../src/react-app/domains/connections/store";
+
+const originalWindow = globalThis.window;
+
+function installDesktopWindow() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { __OPENWORK_ELECTRON__: {} },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("local MCP server recovery", () => {
+  test("returns submission feedback when local server recovery never settles", async () => {
+    installDesktopWindow();
+    let recoveryAttempts = 0;
+    const stalledRecovery = new Promise<never>(() => undefined);
+    const openworkServer = {
+      getSnapshot: () => ({
+        openworkServerStatus: "disconnected",
+        openworkServerClient: null,
+        openworkServerCapabilities: null,
+      }),
+      ensureLocalOpenworkServerClient: () => {
+        recoveryAttempts += 1;
+        return stalledRecovery;
+      },
+    } as unknown as OpenworkServerStore;
+    const store = createConnectionsStore({
+      client: () => null,
+      setClient: () => undefined,
+      projectDir: () => "/tmp/openwork-mcp-recovery",
+      selectedWorkspaceId: () => "workspace_local",
+      selectedWorkspaceRoot: () => "/tmp/openwork-mcp-recovery",
+      workspaceType: () => "local",
+      openworkServer,
+      runtimeWorkspaceId: () => null,
+      ensureRuntimeWorkspaceId: async () => "workspace_local",
+      localOpenworkServerRecoveryTimeoutMs: 10,
+      developerMode: () => false,
+    });
+    const entry: McpDirectoryInfo = {
+      name: "Stalled recovery",
+      description: "",
+      type: "remote",
+      url: "https://example.com/mcp",
+      oauth: true,
+      managedOAuth: true,
+    };
+
+    const result = await Promise.race([
+      submitMcpEntry(store.connectMcp, entry, "Fallback error"),
+      new Promise<"still pending">((resolve) => setTimeout(() => resolve("still pending"), 250)),
+    ]);
+
+    expect(recoveryAttempts).toBe(1);
+    expect(result).not.toBe("still pending");
+    expect(result).not.toBeNull();
+    expect(store.getSnapshot().mcpConnectingName).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- bound on-demand local OpenWork server recovery during MCP setup to 30 seconds
- return normal inline connection feedback when desktop server recovery does not settle
- add a focused regression test with a deliberately never-resolving recovery promise

## Root cause

Managed MCP setup recovers a stale local server target before deciding whether MCP writes are available. That recovery can enter the Electron runtime lifecycle queue and embedded-server startup, which do not have an end-to-end deadline. If the recovery promise never settles, the Add App submission promise also never settles and the dialog remains loading indefinitely.

## Fix

Race the local-server recovery against a bounded deadline. A timeout rejects through the existing MCP submission feedback path, allowing the dialog to clear its submitting state and remain retryable. The successful recovery path, workspace resolution, capability checks, authentication, and remote-workspace behavior are unchanged.

## Verification

Base: `221be74777884c07d1bc489b7ef6627700390837`

Exact head: `c5d0f1738866bc66c9c7c7a413c1249fd2ecde1e`

### Passed

- `bun test tests/mcp-local-server-recovery.test.ts tests/add-mcp-submission.test.ts` — 5 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — exit 0
- `OPENWORK_EVAL_DAYTONA=0 pnpm evals:e2e library-mcp-connect-error` — 1 passed, 0 failed, 0 skipped
- `OPENWORK_EVAL_DAYTONA=0 pnpm evals:e2e connect-readiness-preseeded` — 1 passed, 0 failed, 0 skipped
- `OPENWORK_EVAL_DAYTONA=0 pnpm evals:e2e enterprise-invite-install-connect` — 1 passed, 0 failed, 0 skipped
- `OPENWORK_EVAL_DAYTONA=0 pnpm evals:e2e app-smoke` — 1 passed, 0 failed, 0 skipped

### Failed

- None on the exact head.

### Skipped

- None.

### Deferred

- None.

## Rollback

Revert this commit to remove the recovery deadline and focused regression coverage.
