### PR TITLE
fix(automations): open Desktop execution threads

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-cloud-thread.ts
+++ b/apps/app/src/react-app/domains/automations/automation-cloud-thread.ts
@@ -1,4 +1,5 @@
 import type { AutomationExecutionThread } from "@openwork/types/automations"
+import { workspaceSessionRoute } from "@/react-app/shell/workspace-routes"
 
 export type AutomationExecutionIdentity = {
   icon: "desktop" | "cloud"
@@ -22,4 +23,13 @@ export function automationExecutionThreadRoute(
     thread: thread.id,
   })
   return `/automations?${query.toString()}`
+}
+
+export function automationLocalSessionRoute(
+  thread: Pick<AutomationExecutionThread, "executionLocation" | "nativeThreadId" | "workspaceId">,
+) {
+  if (thread.executionLocation !== "desktop") return null
+  const sessionId = thread.nativeThreadId?.trim()
+  const workspaceId = thread.workspaceId?.trim()
+  return sessionId && workspaceId ? workspaceSessionRoute(workspaceId, sessionId) : null
 }

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -49,7 +49,7 @@ import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal"
 import { AutomationEditor } from "./automation-editor"
 import { dispatchAutomationsStateChanged } from "./automation-events"
-import { automationExecutionThreadRoute, automationExecutionIdentity } from "./automation-cloud-thread"
+import { automationExecutionThreadRoute, automationExecutionIdentity, automationLocalSessionRoute } from "./automation-cloud-thread"
 import { formatAutomationSchedule, formatAutomationTime } from "./automation-format"
 import type { AutomationProviderCatalog } from "./automation-model-options"
 import { automationModelOptions, describeAutomationModel } from "./automation-model-options"
@@ -354,6 +354,9 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
     const selectedReceipt = receiptQuery.data?.run.id === selectedRunId ? receiptQuery.data : undefined
     const receiptIsLoading = receiptQuery.isLoading || (receiptQuery.isFetching && !selectedReceipt)
     const threadMatches = !selectedThreadId || selectedReceipt?.run.executionThread?.id === selectedThreadId
+    const localSessionRoute = selectedReceipt?.run.executionThread
+      ? automationLocalSessionRoute(selectedReceipt.run.executionThread)
+      : null
 
     if (editing && (detail.revision.executionTarget ?? "desktop") === "desktop") {
       return (
@@ -595,6 +598,17 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
                     ) : (
                       <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? <Cloud className="mr-1 h-3 w-3" /> : <Monitor className="mr-1 h-3 w-3" />}{selectedReceipt.run.executionTarget === "cloud" ? "OpenWork Cloud" : "Desktop"}</Badge>
                     )}
+                    {localSessionRoute ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        data-automation-run-id={selectedReceipt.run.id}
+                        onClick={() => navigate(localSessionRoute)}
+                      >
+                        Open local thread
+                      </Button>
+                    ) : null}
                   </div>
                   {selectedReceipt.run.error ? (
                     <Alert variant="destructive"><AlertCircle /><AlertTitle>{selectedReceipt.run.error.code}</AlertTitle><AlertDescription>{selectedReceipt.run.error.message}</AlertDescription></Alert>

--- a/apps/app/tests/automation-cloud-thread.test.ts
+++ b/apps/app/tests/automation-cloud-thread.test.ts
@@ -3,6 +3,7 @@ import type { AutomationExecutionThread } from "@openwork/types/automations"
 import {
   automationExecutionThreadRoute,
   automationExecutionIdentity,
+  automationLocalSessionRoute,
 } from "../src/react-app/domains/automations/automation-cloud-thread"
 
 function desktopThread(engineKind: string): AutomationExecutionThread {
@@ -39,5 +40,19 @@ describe("Automation execution thread UI", () => {
       icon: "cloud",
       label: "OpenWork Cloud",
     })
+  })
+
+  test("opens a linked Desktop run in its native local session", () => {
+    expect(automationLocalSessionRoute({
+      ...desktopThread("openwork-desktop-runner-v1"),
+      workspaceId: "ws with spaces",
+      nativeThreadId: "ses/failed",
+    })).toBe("/workspace/ws%20with%20spaces/session/ses%2Ffailed")
+    expect(automationLocalSessionRoute(desktopThread("openwork-desktop-runner-v1"))).toBeNull()
+    expect(automationLocalSessionRoute({
+      ...cloudThread(),
+      workspaceId: "ws_cloud",
+      nativeThreadId: "ses_cloud",
+    })).toBeNull()
   })
 })

--- a/evals/specs/automation-desktop-lifecycle.e2e.test.ts
+++ b/evals/specs/automation-desktop-lifecycle.e2e.test.ts
@@ -467,13 +467,33 @@ test("a Desktop Automation completes through UI, API, schedule, thread, and rece
   const scheduledThread = isRecord(scheduledTerminalRun.executionThread)
     ? scheduledTerminalRun.executionThread
     : {};
+  const scheduledThreadId = typeof scheduledThread.id === "string" ? scheduledThread.id : "";
   const scheduledWorkspaceId = typeof scheduledThread.workspaceId === "string" ? scheduledThread.workspaceId : "";
   const scheduledSessionId = typeof scheduledThread.nativeThreadId === "string" ? scheduledThread.nativeThreadId : "";
-  expect(scheduledWorkspaceId).not.toBe("");
-  expect(scheduledSessionId).not.toBe("");
+  const receiptQuery = new URLSearchParams({
+    automation: created.automationId,
+    run: scheduledRunId,
+    thread: scheduledThreadId,
+  });
+  await go(desktop, `/automations?${receiptQuery.toString()}`);
+  await clickText(desktop, "Open local thread", {
+    selector: `button[data-automation-run-id="${scheduledRunId}"]`,
+    timeoutMs: 30_000,
+  });
+  await eventually(
+    () => evalIn(desktop, "window.location.hash"),
+    {
+      within: 30_000,
+      intervalMs: 250,
+      label: "native Automation session route",
+      until: (hash) => typeof hash === "string"
+        && hash.includes(`/workspace/${encodeURIComponent(scheduledWorkspaceId)}/session/${encodeURIComponent(scheduledSessionId)}`),
+    },
+  );
+  await waitForText(desktop, REPLY, { timeoutMs: 30_000 });
   evidence.recordAssertionEvidence(
-    "A terminal receipt durably exposes its native desktop execution identity",
-    `The scheduled receipt carried workspace ${scheduledWorkspaceId} and native session ${scheduledSessionId} through the run contract, ready for a management surface to open.`,
+    "A receipt opens the actual local execution thread",
+    `The scheduled receipt exposed workspace ${scheduledWorkspaceId} and session ${scheduledSessionId}; Open local thread navigated to that session and rendered the deterministic assistant result.`,
     true,
   );
 


### PR DESCRIPTION
## Summary

- Open the native local Desktop thread from a selected Automation run's receipt.
- Completes the receipt work #3942 landed: Den has persisted each terminal run's native session and workspace since that change; this adds the client that uses it.

## Root cause

#3942 made Den persist the native session and workspace of every terminal Desktop run in the run receipt, but no surface consumed the identity yet: inspecting what a run actually did still meant hunting session titles in the sidebar. The consumption was split from the API rollout deliberately, per the desktop↔den sync review on #3942, so a desktop release could never depend on a same-release Den deployment.

## What changed

- `automationLocalSessionRoute` resolves a desktop execution thread to its local workspace session route, and returns null unless the receipt carries both a trimmed `nativeThreadId` and `workspaceId`.
- The selected run's receipt panel shows an **Open local thread** action when that resolution exists, navigating to the exact workspace session the run executed in.
- `automation-cloud-thread.test.ts` pins the resolution, its URL encoding, and the degraded cases (a receipt without the identity fields and a cloud thread both resolve to null, so no action renders).
- The Desktop lifecycle spec's first journey now drives the full path: a scheduled run's receipt exposes its native identity, **Open local thread** navigates to that session, and the deterministic assistant reply renders there.

## Compatibility and rollout

The receipt fields this reads have been persisted by Den since #3942, which is already on `dev`; the fields are optional in the contract, and a receipt without them (any run completed before #3942, or a Den not yet carrying it) simply renders no action — the panel is otherwise unchanged. No deployment-order dependency.

## Verification

All commands ran against this PR's exact head (`ea8c563ad`).

Passed

- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/automation-desktop-lifecycle.e2e.test.ts -t "completes through UI"` — passed (evidence in the test-evidence comment below): the UI-triggered, repeated manual, and scheduled runs reach durable receipts, and the scheduled receipt's **Open local thread** navigated to the exact workspace session and rendered the deterministic assistant reply.
- `bun test --isolate tests/automation-cloud-thread.test.ts tests/automation-runner-visibility.test.ts tests/automation-runner-presence-client.test.ts` (`apps/app`) — 10 pass, 0 fail, including the new local-session resolution cases.
- `tsc --noEmit` (`apps/app`) — clean.
- `git diff --check` — clean.

Failed — none.

Skipped — none.

Deferred

- Daytona placement for the tape: the suite's Den tuning applies only to a locally provisioned Den, so it ran on the local lane.

## Stack

Final follow-up of the Desktop Automation reliability work; base `dev`.

- #3775 — occurrence recovery and missed-cause diagnosis (merged).
- #3942 — execution-outcome correctness and receipt persistence (merged; split this consumption out per its sync review).
- #3945 — the original receipt-linkage review; its server side landed via #3942 and this completes its client side.
