### PR TITLE
fix(desktop): keep server credentials coherent

### DIFF
--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -682,9 +682,17 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
 
       if (hostInfo?.clientToken?.trim() && options.startupPreference() !== "server") {
         const liveToken = hostInfo.clientToken.trim();
+        const liveHostToken = hostInfo.hostToken?.trim() ?? "";
         const settings = state.openworkServerSettings;
-        if ((settings.token?.trim() ?? "") !== liveToken) {
-          updateOpenworkServerSettings({ ...settings, token: liveToken });
+        if (
+          (settings.token?.trim() ?? "") !== liveToken ||
+          (settings.hostToken?.trim() ?? "") !== liveHostToken
+        ) {
+          updateOpenworkServerSettings({
+            ...settings,
+            token: liveToken,
+            hostToken: liveHostToken || undefined,
+          });
         }
       }
 

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -59,9 +59,9 @@ function getRequestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-function createTestOpenworkServerStore() {
+function createTestOpenworkServerStore(startupPreference: "local" | "server" = "server") {
   return createOpenworkServerStore({
-    startupPreference: () => "server",
+    startupPreference: () => startupPreference,
     documentVisible: () => true,
     developerMode: () => false,
     runtimeWorkspaceId: () => "workspace_test",
@@ -85,6 +85,7 @@ function installWindow(options: {
   electronInfo?: {
     baseUrl: string;
     ownerToken: string;
+    clientToken?: string;
     hostToken?: string;
   };
   /** Raw openworkServerInfo response for non-ready/restarting server states. */
@@ -100,6 +101,8 @@ function installWindow(options: {
     value: {
       localStorage,
       dispatchEvent: () => true,
+      setTimeout: () => 1,
+      clearTimeout: () => undefined,
       location: { origin: options.origin },
       __OPENWORK_GATEWAY__: options.gateway ? { version: 1 } : undefined,
       __OPENWORK_BOOTSTRAP__: options.bootstrapToken ? { token: options.bootstrapToken } : undefined,
@@ -119,6 +122,7 @@ function installWindow(options: {
                 running: true,
                 baseUrl: options.electronInfo?.baseUrl,
                 ownerToken: options.electronInfo?.ownerToken,
+                clientToken: options.electronInfo?.clientToken,
                 hostToken: options.electronInfo?.hostToken,
               };
             },
@@ -522,6 +526,37 @@ describe("non-gateway connection modes", () => {
     expect(connection.resolvedToken).toBe("owner-token");
     expect(connection.resolvedHostToken).toBe("host-token");
     expect(connection.source).toBe("desktop-runtime");
+  });
+
+  test("desktop reconnect persists the complete live server credential bundle", async () => {
+    const storage = installWindow({
+      origin: "https://instance.example.com",
+      electronInfo: {
+        baseUrl: "http://127.0.0.1:8787",
+        ownerToken: "owner-token",
+        clientToken: "live-client-token",
+        hostToken: "live-host-token",
+      },
+    });
+    storage.setItem("openwork.server.token", "stale-client-token");
+    storage.setItem("openwork.server.hostToken", "stale-host-token");
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async () => new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    });
+
+    const store = createTestOpenworkServerStore("local");
+
+    expect(await store.reconnectOpenworkServer()).toBe(true);
+    expect(readOpenworkServerSettings().token).toBe("live-client-token");
+    expect(readOpenworkServerSettings().hostToken).toBe("live-host-token");
+    expect(store.getSnapshot().openworkServerAuth).toEqual({
+      token: "live-client-token",
+      hostToken: "live-host-token",
+    });
   });
 
   test("a restarting desktop server invalidates stored loopback settings instead of resolving a dead port", async () => {

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -161,6 +161,52 @@ function normalizeWorkspaceKey(value, platform = process.platform) {
   }
 }
 
+function normalizeServerCredentials(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const clientToken = typeof value.clientToken === "string" && value.clientToken.trim()
+    ? value.clientToken
+    : null;
+  const hostToken = typeof value.hostToken === "string" && value.hostToken.trim()
+    ? value.hostToken
+    : null;
+  if (!clientToken || !hostToken) return null;
+  return {
+    clientToken,
+    hostToken,
+    ownerToken: typeof value.ownerToken === "string" && value.ownerToken.trim()
+      ? value.ownerToken
+      : null,
+    updatedAt: typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt)
+      ? value.updatedAt
+      : 0,
+  };
+}
+
+export function migrateOpenworkServerTokenStore(value) {
+  const source = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  const sourceWorkspaces = source.workspaces && typeof source.workspaces === "object" && !Array.isArray(source.workspaces)
+    ? source.workspaces
+    : {};
+  const workspaceEntries = Object.entries(sourceWorkspaces);
+  const legacyCredentials = workspaceEntries
+    .flatMap(([workspaceKey, entry]) => {
+      const credentials = normalizeServerCredentials(entry);
+      return credentials ? [{ workspaceKey, credentials }] : [];
+    })
+    .sort((left, right) => {
+      const updatedAtDifference = right.credentials.updatedAt - left.credentials.updatedAt;
+      if (updatedAtDifference !== 0) return updatedAtDifference;
+      return left.workspaceKey < right.workspaceKey ? -1 : left.workspaceKey > right.workspaceKey ? 1 : 0;
+    })[0]?.credentials;
+  const credentials = normalizeServerCredentials(source.credentials) ?? legacyCredentials ?? {
+    clientToken: randomUUID(),
+    hostToken: randomUUID(),
+    ownerToken: null,
+    updatedAt: nowMs(),
+  };
+  return { version: 2, credentials };
+}
+
 export function prioritizeWorkspacePaths(preferredPath, workspacePaths = [], options = {}) {
   const platform = options.platform ?? process.platform;
   const paths = [];
@@ -1348,7 +1394,12 @@ export function createRuntimeManager({
   }
 
   async function loadTokenStore() {
-    return readJsonFile(openworkServerTokenStorePath(), { version: 1, workspaces: {} });
+    const stored = await readJsonFile(openworkServerTokenStorePath(), { version: 1, workspaces: {} });
+    const migrated = migrateOpenworkServerTokenStore(stored);
+    if (JSON.stringify(stored) !== JSON.stringify(migrated)) {
+      await saveTokenStore(migrated);
+    }
+    return migrated;
   }
 
   async function saveTokenStore(store) {
@@ -1372,30 +1423,15 @@ export function createRuntimeManager({
     await writeFile(filePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
   }
 
-  async function loadOrCreateWorkspaceTokens(workspaceKey) {
+  async function loadServerCredentials() {
     const store = await loadTokenStore();
-    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
-    if (store.workspaces?.[normalized]) {
-      return store.workspaces[normalized];
-    }
-    const next = {
-      clientToken: randomUUID(),
-      hostToken: randomUUID(),
-      ownerToken: null,
-      updatedAt: nowMs(),
-    };
-    store.workspaces ??= {};
-    store.workspaces[normalized] = next;
-    await saveTokenStore(store);
-    return next;
+    return store.credentials;
   }
 
-  async function persistWorkspaceOwnerToken(workspaceKey, ownerToken) {
+  async function persistServerOwnerToken(ownerToken) {
     const store = await loadTokenStore();
-    const normalized = normalizeWorkspaceKey(workspaceKey, workspacePlatform);
-    if (!store.workspaces?.[normalized]) return;
-    store.workspaces[normalized].ownerToken = ownerToken;
-    store.workspaces[normalized].updatedAt = nowMs();
+    store.credentials.ownerToken = ownerToken;
+    store.credentials.updatedAt = nowMs();
     await saveTokenStore(store);
   }
 
@@ -1869,7 +1905,7 @@ export function createRuntimeManager({
     );
     const activeWorkspace = selectStickyOpenworkPortWorkspace(requestedWorkspacePaths, workspacePaths);
     const portSelection = await resolveOpenworkPort(host, activeWorkspace, currentPort);
-    const tokens = await loadOrCreateWorkspaceTokens(activeWorkspace);
+    const tokens = await loadServerCredentials();
 
     // One call: resolve config, spawn managed OpenCode, start HTTP server.
     // Dev must prefer apps/server/dist; build output also stages a packaged
@@ -1945,7 +1981,7 @@ export function createRuntimeManager({
     ownerToken ||= await issueOwnerToken(baseUrl, tokens.hostToken);
     openworkServerState.ownerToken = ownerToken;
     if (ownerToken) {
-      await persistWorkspaceOwnerToken(activeWorkspace, ownerToken);
+      await persistServerOwnerToken(ownerToken);
     }
     if (ownerToken) {
       try {

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -9,6 +9,7 @@ import {
   commandMatchesPackagedSidecar,
   createRuntimeManager,
   embeddedServerImportUrl,
+  migrateOpenworkServerTokenStore,
   prepareRuntimeWorkspaceRoot,
   prioritizeWorkspacePaths,
   resetRuntimeStatesAfterFailedServerStart,
@@ -247,6 +248,45 @@ describe("resolveOpenworkServerConfigPath", () => {
       resolveOpenworkServerConfigPath({ XDG_CONFIG_HOME: "/tmp/xdg" }),
       "/tmp/xdg/openwork/server.json",
     );
+  });
+});
+
+describe("OpenWork server credential persistence", () => {
+  it("deterministically migrates legacy workspace credentials into one server bundle", () => {
+    const migrated = migrateOpenworkServerTokenStore({
+      version: 1,
+      workspaces: {
+        "/workspace/z": {
+          clientToken: "client-z",
+          hostToken: "host-z",
+          ownerToken: "owner-z",
+          updatedAt: 20,
+        },
+        "/workspace/a": {
+          clientToken: "client-a",
+          hostToken: "host-a",
+          ownerToken: "owner-a",
+          updatedAt: 20,
+        },
+        "/workspace/old": {
+          clientToken: "client-old",
+          hostToken: "host-old",
+          ownerToken: "owner-old",
+          updatedAt: 10,
+        },
+      },
+    });
+
+    assert.deepEqual(migrated, {
+      version: 2,
+      credentials: {
+        clientToken: "client-a",
+        hostToken: "host-a",
+        ownerToken: "owner-a",
+        updatedAt: 20,
+      },
+    });
+    assert.deepEqual(migrateOpenworkServerTokenStore(migrated), migrated);
   });
 });
 

--- a/evals/specs/desktop-server-credential-coherence.test.ts
+++ b/evals/specs/desktop-server-credential-coherence.test.ts
@@ -1,0 +1,68 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import { migrateOpenworkServerTokenStore } from "../../apps/desktop/electron/runtime.mjs";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+test("desktop server credentials remain coherent across workspaces and reconnects", ({ evidence }) => {
+  const migrated = migrateOpenworkServerTokenStore({
+    version: 1,
+    workspaces: {
+      "/workspace/older": {
+        clientToken: "older-client",
+        hostToken: "older-host",
+        ownerToken: "older-owner",
+        updatedAt: 10,
+      },
+      "/workspace/current": {
+        clientToken: "current-client",
+        hostToken: "current-host",
+        ownerToken: "current-owner",
+        updatedAt: 20,
+      },
+    },
+  });
+
+  expect(migrated).toEqual({
+    version: 2,
+    credentials: {
+      clientToken: "current-client",
+      hostToken: "current-host",
+      ownerToken: "current-owner",
+      updatedAt: 20,
+    },
+  });
+  expect(migrated).not.toHaveProperty("workspaces");
+  expect(migrateOpenworkServerTokenStore(migrated)).toEqual(migrated);
+
+  const reconnect = spawnSync("pnpm", [
+    "--dir",
+    "apps/app",
+    "exec",
+    "bun",
+    "test",
+    "--isolate",
+    "--test-name-pattern",
+    "desktop reconnect persists the complete live server credential bundle",
+    "tests/gateway-runtime.test.ts",
+  ], { cwd: repoRoot, encoding: "utf8" });
+  const output = `${reconnect.stdout}${reconnect.stderr}`;
+  expect(reconnect.error, output).toBeUndefined();
+  expect(reconnect.status, output).toBe(0);
+  expect(output).toContain("1 pass");
+  expect(output).toContain("0 fail");
+
+  evidence.recordAssertionEvidence(
+    "One desktop server owns one credential bundle",
+    "Legacy workspace credentials migrate to one global client, host, and owner token bundle with no workspace-scoped credentials remaining.",
+    !Object.hasOwn(migrated, "workspaces"),
+  );
+  evidence.recordAssertionEvidence(
+    "Reconnect cannot combine credentials from different server generations",
+    "The renderer regression suite confirms that reconnect replaces both stale client and host tokens with the live server pair.",
+    reconnect.status === 0,
+  );
+});


### PR DESCRIPTION
## Summary
- replace workspace-scoped desktop server tokens with one persistent server credential bundle
- migrate existing token stores deterministically using the newest complete legacy bundle
- synchronize client and host tokens together during renderer reconnects
- add unit and testkit regression coverage for migration and reconnect coherence

## Verification
- `pnpm --dir apps/desktop exec node --test electron/runtime.test.mjs electron/workspace-store.test.mjs` (43 passed)
- `pnpm --dir apps/app exec bun test --isolate tests/gateway-runtime.test.ts` (25 passed)
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --filter @openwork/app typecheck`
- `pnpm evals:pr specs/desktop-server-credential-coherence.test.ts` (1 passed, 0 skipped)

Verdict: Passed (local PR lane; no external services required).