### PR TITLE
fix(mcp): render connection cards outside collapsed work

### DIFF
--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -133,6 +133,7 @@ export function CapabilityCallLine({
     const quote = getCapabilityCallQuote(part)
     const initial = sentence.service?.charAt(0).toUpperCase() ?? null
     return (
+      <>
       <Collapsible
         data-capability-call={part.toolName}
         open={open}
@@ -224,6 +225,8 @@ export function CapabilityCallLine({
           </div>
         </CollapsibleContent>
       </Collapsible>
+      <McpAppFrame part={part} />
+      </>
     )
   }
 

--- a/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
@@ -1,5 +1,11 @@
 import type { DynamicToolUIPart, JSONValue, ProviderMetadata, TextUIPart } from "ai";
 import type { ToolPart } from "@opencode-ai/sdk/v2/client";
+import {
+  connectionActionAppResourceUri,
+  connectionActionAppSchemaVersion,
+  connectionActionPayloadSchema,
+  connectionActionToolName,
+} from "@openwork/types/connection-action-app";
 
 import { safeStringify } from "@/app/utils";
 import { normalizeErrorText } from "@/lib/error-text";
@@ -19,13 +25,55 @@ function isJsonValue(value: unknown, depth = 0): value is JSONValue {
   return entries.length <= 4_096 && entries.every((entry) => isJsonValue(entry, depth + 1));
 }
 
+function connectionActionMcpResultFromError(error: string): JSONValue | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(error);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.connectionStatus)) return null;
+  const status = parsed.connectionStatus;
+  const action = isRecord(status.action) ? status.action : null;
+  const payload = connectionActionPayloadSchema.safeParse({
+    schemaVersion: connectionActionAppSchemaVersion,
+    connectionId: status.connectionId,
+    connectionName: status.connectionName,
+    state: status.state,
+    actor: status.actor,
+    message: status.message,
+    action: action
+      ? {
+          type: action.type,
+          label: action.label,
+          surface: action.surface,
+          ...(typeof action.url === "string" ? { url: action.url } : {}),
+        }
+      : null,
+  });
+  if (!payload.success) return null;
+  return {
+    content: [{ type: "text", text: error }],
+    structuredContent: payload.data,
+    _meta: {
+      "openwork/mcpApp": {
+        toolName: connectionActionToolName,
+        resourceUri: connectionActionAppResourceUri,
+        arguments: { connectionId: payload.data.connectionId },
+      },
+    },
+  };
+}
+
 function toolCallProviderMetadata(part: ToolPart): ProviderMetadata {
   const stateMetadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {};
-  const mcpResult = isJsonValue(stateMetadata.openworkMcpResult)
+  const persistedMcpResult = isJsonValue(stateMetadata.openworkMcpResult)
     ? stateMetadata.openworkMcpResult
     : isJsonValue(stateMetadata.openworkMcpApp)
       ? stateMetadata.openworkMcpApp
       : null;
+  const mcpResult = persistedMcpResult
+    ?? (part.state.status === "error" ? connectionActionMcpResultFromError(part.state.error) : null);
   return {
     opencode: { partId: part.id },
     ...(mcpResult ? { openwork: { mcpResult } } : {}),

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -136,6 +136,48 @@ describe("tool part mapper", () => {
     });
   });
 
+  test("recovers a connection-action MCP App from an errored capability result", () => {
+    const error = JSON.stringify({
+      error: "needs_connection",
+      message: "Connect Acme Tracker.",
+      connectionStatus: {
+        connectionId: "emc_acme",
+        connectionName: "Acme Tracker",
+        state: "needs_connection",
+        actor: "member",
+        message: "Acme Tracker is not connected.",
+        action: {
+          type: "connect",
+          label: "Connect Acme Tracker",
+          surface: "openwork_your_connections",
+          url: "https://app.openworklabs.com/dashboard/your-connections?connectionId=emc_acme",
+        },
+      },
+    });
+
+    expect(parseDynamicToolUIPart(writeToolPart("error", {}, {}, error))).toMatchObject({
+      state: "output-error",
+      callProviderMetadata: {
+        openwork: {
+          mcpResult: {
+            structuredContent: {
+              schemaVersion: "1",
+              connectionId: "emc_acme",
+              state: "needs_connection",
+            },
+            _meta: {
+              "openwork/mcpApp": {
+                toolName: "connection_action",
+                resourceUri: "ui://openwork/connection-action/v1/view.html",
+                arguments: { connectionId: "emc_acme" },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
   test("summarizes and clamps huge HTML tool errors at ingestion", () => {
     const htmlError = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>${"x".repeat(1_024 * 1_024)}</body></html>`;
     const parsed = parseDynamicToolUIPart(writeToolPart("error", {}, {}, htmlError));

--- a/ee/apps/den-api/src/mcp/connection-action-app.ts
+++ b/ee/apps/den-api/src/mcp/connection-action-app.ts
@@ -7,8 +7,10 @@ import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { connectionActionAppHtml } from "@openwork/mcp-apps/connection-action"
 import {
+  connectionActionAppResourceUri,
   connectionActionAppSchemaVersion,
   connectionActionPayloadSchema,
+  connectionActionToolName,
   type ConnectionActionPayload,
 } from "@openwork/types/connection-action-app"
 import { z } from "zod"
@@ -16,8 +18,8 @@ import type { ExternalConnectionStatus } from "./external-capabilities.js"
 
 export { connectionActionPayloadSchema } from "@openwork/types/connection-action-app"
 
-export const CONNECTION_ACTION_APP_RESOURCE_URI = "ui://openwork/connection-action/v1/view.html"
-export const CONNECTION_ACTION_TOOL_NAME = "connection_action"
+export const CONNECTION_ACTION_APP_RESOURCE_URI = connectionActionAppResourceUri
+export const CONNECTION_ACTION_TOOL_NAME = connectionActionToolName
 export const CONNECTION_ACTION_APP_HTML = connectionActionAppHtml
 
 export type ConnectionActionProbeResult =

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -21,7 +21,7 @@ const title = !e2eTestsEnabled
     ? "connection-action MCP App skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
     : !mysqlOpen
       ? "connection-action MCP App skipped — needs MySQL on 127.0.0.1:3306"
-      : "a connection_status capability renders the first-party connection-action MCP App"
+      : "a failed capability result renders the first-party connection-action MCP App"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -144,7 +144,6 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     credentialMode: "per_member",
     access: { orgWide: true },
   })
-  const statusCapability = `mcp:${connection.id}:*`
   const realToolCapability = `mcp:${connection.id}:list_charges`
 
   let modelExecuteCalls = 0
@@ -159,7 +158,7 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
         const parsed: unknown = JSON.parse(await readBody(request))
         if (!isRecord(parsed)) throw new Error("Mock provider received a non-object request.")
         const completed = completedToolCount(parsed)
-        if (completed >= 2) {
+        if (completed >= 1) {
           sendStream(response, [
             streamChunk({ role: "assistant" }),
             streamChunk({ content: closingReply }),
@@ -170,19 +169,16 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
         const toolName = projectedExecuteCapabilityTool(parsed)
         if (!toolName) throw new Error("The execute_capability tool was not projected to the model.")
         modelExecuteCalls += 1
-        // Mirrors the real steering flow: first a concrete provider tool call
-        // that fails with needs_connection, then the connection status probe.
-        const capability = completed === 0 ? realToolCapability : statusCapability
         sendStream(response, [
           streamChunk({ role: "assistant" }),
           streamChunk({
             tool_calls: [{
               index: 0,
-              id: completed === 0 ? "call_list_acme_charges" : "call_probe_acme_tracker",
+              id: "call_list_acme_charges",
               type: "function",
               function: {
                 name: toolName,
-                arguments: JSON.stringify({ name: capability }),
+                arguments: JSON.stringify({ name: realToolCapability }),
               },
             }],
           }),
@@ -323,17 +319,15 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     timeoutMs: 70_000,
   })
   expect(task, JSON.stringify(task)).toMatchObject({ ok: true })
-  await waitFor(app, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
-    timeoutMs: 30_000,
-    label: "composer ready",
-  })
-  const focused = await evalIn(app, `(() => {
+  await waitFor(app, `(() => {
     const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
     if (!(editor instanceof HTMLElement)) return false;
     editor.focus();
     return true;
-  })()`)
-  expect(focused).toBe(true)
+  })()`, {
+    timeoutMs: 30_000,
+    label: "composer focused",
+  })
   await app.client.send("Input.insertText", {
     text: "Check whether the Acme Tracker connection is ready to use.",
   })
@@ -343,7 +337,7 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     timeoutMs: 120_000,
     label: "connection-action closing reply",
   })
-  expect(modelExecuteCalls).toBe(2)
+  expect(modelExecuteCalls).toBe(1)
 
   const persistedTools = await evalIn(app, `(async () => {
     const port = localStorage.getItem("openwork.server.port");
@@ -371,10 +365,10 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const parts = isRecord(persistedTools) && Array.isArray(persistedTools.parts)
     ? persistedTools.parts.filter(isRecord)
     : []
-  expect(parts.length, JSON.stringify(persistedTools)).toBe(2)
+  expect(parts.length, JSON.stringify(persistedTools)).toBe(1)
   expect(parts[parts.length - 1], JSON.stringify(persistedTools)).toMatchObject({
     tool: "openwork-cloud_execute_capability",
-    state: "completed",
+    state: "error",
   })
 
   await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${resourceUri}"] iframe`)}))`, {
@@ -406,9 +400,9 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   await screenshot(app)
 
   evidence.recordAssertionEvidence(
-    "A failed provider tool call steers into the live status probe",
-    "The model first called a concrete provider tool that failed with needs_connection, then executed the exact mcp:<connection>:* probe, which returned a successful status report instead of an error result.",
-    modelExecuteCalls === 2,
+    "A failed provider tool call renders its attached connection card directly",
+    "The model called only the concrete provider tool, which failed with needs_connection; Desktop rendered the MCP App attached to that error without a second connection-status probe.",
+    modelExecuteCalls === 1,
   )
   evidence.recordAssertionEvidence(
     "Connection steering renders its standard MCP App",

--- a/packages/types/src/connection-action-app.ts
+++ b/packages/types/src/connection-action-app.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 const idSchema = z.string().trim().min(1).max(160)
 
 export const connectionActionAppSchemaVersion = "1" as const
+export const connectionActionAppResourceUri = "ui://openwork/connection-action/v1/view.html"
+export const connectionActionToolName = "connection_action"
 
 /**
  * Data contract for the first-party connection-action MCP App: one live


### PR DESCRIPTION
## Summary
- render connection-action MCP Apps directly from failed capability results without requiring a second status probe
- place MCP App results at the assistant-turn result layer so they stay visible while Worked/Used details remain collapsed
- stabilize preserved MCP result identity so transcript updates do not tear down and recreate the iframe

## Test plan
- [x] `pnpm typecheck` (`apps/app`)
- [x] `pnpm exec bun test --isolate tests/mcp-app-frame.test.ts tests/session-sync-tool-parts.test.ts` (`apps/app` — 23 passed)
- [x] `pnpm exec bun test test/mcp-connection-action-app.test.ts` (`ee/apps/den-api` — 4 passed)
- [x] `pnpm build` (`packages/types`)
- [x] `pnpm exec vitest run --config vitest.config.ts --project pr specs/connect-flow-mcp-apps.test.ts` (`evals` — 1 passed)
- [x] `OPENWORK_EVAL_E2E_TESTS=1 pnpm exec vitest run --config vitest.config.ts --project e2e specs/connection-action-mcp-app.e2e.test.ts` (`evals` — 1 passed, local lane; card visibly rendered while Worked remained collapsed)