### PR TITLE
fix(evals): build MCP app before Daytona Den startup

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -140,6 +140,9 @@ fi
 echo "==> Pushing Den DB schema..."
 pnpm --filter @openwork-ee/den-db db:push > /tmp/den-db-push.log 2>&1
 
+echo "==> Building Den API runtime assets..."
+pnpm --filter @openwork-ee/den-api run build:mcp-apps
+
 echo "==> Starting Den API on :$DEN_API_PORT..."
 # The den-api process cmdline is "tsx watch src/main.ts" (cwd-relative), so a
 # pattern anchored on the repo path never matches and restarts silently keep

--- a/evals/specs/skill-created-mcp-app.test.ts
+++ b/evals/specs/skill-created-mcp-app.test.ts
@@ -1,9 +1,19 @@
 import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { expect } from "vitest"
 import { test } from "@openwork/testkit"
 
 const repoRoot = resolve(import.meta.dirname, "../..")
+
+test("Daytona provisioning builds the skill-created MCP App before Den starts", () => {
+  const script = readFileSync(resolve(repoRoot, ".devcontainer/start-daytona-server.sh"), "utf8")
+  const build = "pnpm --filter @openwork-ee/den-api run build:mcp-apps"
+  const start = "pnpm --filter @openwork-ee/den-api exec tsx watch src/main.ts"
+
+  expect(script.split(build)).toHaveLength(2)
+  expect(script.indexOf(build)).toBeLessThan(script.indexOf(start))
+})
 
 test("create_skill publishes a standard MCP App contract and text fallback", ({ evidence }) => {
   const build = spawnSync("pnpm", ["--filter", "@openwork-ee/den-api", "run", "build:mcp-apps"], {

--- a/evals/specs/skill-created-mcp-app.test.ts
+++ b/evals/specs/skill-created-mcp-app.test.ts
@@ -6,13 +6,18 @@ import { test } from "@openwork/testkit"
 
 const repoRoot = resolve(import.meta.dirname, "../..")
 
-test("Daytona provisioning builds the skill-created MCP App before Den starts", () => {
+test("Daytona provisioning builds the skill-created MCP App before Den starts", ({ evidence }) => {
   const script = readFileSync(resolve(repoRoot, ".devcontainer/start-daytona-server.sh"), "utf8")
   const build = "pnpm --filter @openwork-ee/den-api run build:mcp-apps"
   const start = "pnpm --filter @openwork-ee/den-api exec tsx watch src/main.ts"
 
   expect(script.split(build)).toHaveLength(2)
   expect(script.indexOf(build)).toBeLessThan(script.indexOf(start))
+  evidence.recordAssertionEvidence(
+    "Fresh Daytona Den startup builds generated MCP App assets",
+    "The server bootstrap invokes the Den-owned MCP App build exactly once before launching the Den API process.",
+    true,
+  )
 })
 
 test("create_skill publishes a standard MCP App contract and text fallback", ({ evidence }) => {


### PR DESCRIPTION
## Summary
- build the generated `@openwork/mcp-apps` runtime module before launching Den in fresh Daytona sandboxes
- add a regression assertion that the build remains before the Den startup command

## Root cause
The nightly critical-path run at `ff5d298ee1a12e348b7021310aef893570df54a3` timed out waiting for `/health`, while `/tmp/den-api.log` showed `ERR_MODULE_NOT_FOUND` for `@openwork/mcp-apps/dist/skill-created.js`. Fresh provisioning installed the workspace package but did not build its generated export.

## Verification
- `pnpm evals:pr specs/skill-created-mcp-app.test.ts` (2 passed, 0 failed, 0 skipped)
- `bash -n .devcontainer/start-daytona-server.sh`
- exact failed Daytona sandbox reached `DEN_API_READY` after building `@openwork/mcp-apps`
