### PR TITLE
fix(mcp): keep apps outside collapsed work

### DIFF
--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -21,7 +21,6 @@ import { normalizeErrorText } from "@/lib/error-text"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
-import { McpAppFrame } from "./mcp-app-frame"
 
 type CapabilityCallLineProps = ChatToolReconnectCallbacks & {
   part: DynamicToolUIPart
@@ -133,7 +132,6 @@ export function CapabilityCallLine({
     const quote = getCapabilityCallQuote(part)
     const initial = sentence.service?.charAt(0).toUpperCase() ?? null
     return (
-      <>
       <Collapsible
         data-capability-call={part.toolName}
         open={open}
@@ -225,15 +223,12 @@ export function CapabilityCallLine({
           </div>
         </CollapsibleContent>
       </Collapsible>
-      <McpAppFrame part={part} />
-      </>
     )
   }
 
   const sentence = getCapabilityCallSentence(part)
   const line = inFlight ? sentence.present : sentence.past
   return (
-    <>
     <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
       <div className="flex min-w-0 items-center gap-2">
         <CollapsibleTrigger
@@ -255,7 +250,5 @@ export function CapabilityCallLine({
         <TechnicalDetailsPanel part={part} />
       </CollapsibleContent>
     </Collapsible>
-    {part.state === "output-available" ? <McpAppFrame part={part} /> : null}
-    </>
   )
 }

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -75,6 +75,10 @@ function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null 
   }
 }
 
+export function hasPreservedMcpAppResult(part: DynamicToolUIPart): boolean {
+  return preservedResult(part) !== null
+}
+
 export function gatewayMcpAppLaunch(meta: unknown): OpenworkMcpAppLaunchReference | null {
   if (!isRecord(meta) || !isRecord(meta["openwork/mcpApp"])) return null
   const launch = meta["openwork/mcpApp"]
@@ -194,7 +198,16 @@ export function isActionableMcpAppResolutionError(cause: unknown): boolean {
 
 export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const { openworkServerClient, workspaceId } = useWorkspace()
-  const result = useMemo(() => preservedResult(part), [part])
+  const nextResult = preservedResult(part)
+  const nextResultSignature = JSON.stringify(nextResult)
+  const resultCache = useRef<{ signature: string; value: PreservedMcpAppResult | null }>({
+    signature: nextResultSignature,
+    value: nextResult,
+  })
+  if (resultCache.current.signature !== nextResultSignature) {
+    resultCache.current = { signature: nextResultSignature, value: nextResult }
+  }
+  const result = resultCache.current.value
   const launch = useMemo(() => gatewayMcpAppLaunch(result?._meta), [result])
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -82,6 +82,7 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import { hasPreservedMcpAppResult, McpAppFrame } from "@/components/chat/mcp-app-frame"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
@@ -929,6 +930,23 @@ interface AssistantMessageGroupProps {
   isStreaming: boolean
 }
 
+function collectMcpAppParts(items: UIMessageWithIndex[]): DynamicToolUIPart[] {
+  const parts = new Map<string, DynamicToolUIPart>()
+  for (const item of items) {
+    if (item.message.role !== "assistant" || isSessionErrorMessage(item.message)) continue
+    for (const part of item.message.parts) {
+      if (
+        part.type === "dynamic-tool"
+        && (part.state === "output-available" || part.state === "output-error")
+        && hasPreservedMcpAppResult(part)
+      ) {
+        parts.set(part.toolCallId, part)
+      }
+    }
+  }
+  return [...parts.values()]
+}
+
 function MessageGroup({
   items,
   messages,
@@ -957,6 +975,7 @@ function MessageGroup({
 
   const renderableItems = getRenderableMessages(items)
   const lastTextMessage = getLastTextPart(lastItem.message)
+  const mcpAppParts = collectMcpAppParts(items)
 
   // Leading messages without prose (tool/reasoning steps) render inside a
   // height-capped scroll area so long runs stay compact; messages with text
@@ -1098,6 +1117,14 @@ function MessageGroup({
           </div>
         )
       ) : null}
+      {mcpAppParts.map((part) => (
+        <Message
+          key={`mcp-app-${part.toolCallId}`}
+          className="mx-auto flex w-full max-w-3xl flex-col px-2 empty:hidden md:px-10"
+        >
+          <McpAppFrame part={part} />
+        </Message>
+      ))}
       {renderItems(proseItems, stepItems.length, collapseSteps)}
       {/* Paper artifact strip: one FILES row per turn, at the end. */}
       <ArtifactList

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -82,6 +82,16 @@ function projectedExecuteCapabilityTool(payload: Record<string, unknown>): strin
   return null
 }
 
+function projectedSearchCapabilitiesTool(payload: Record<string, unknown>): string | null {
+  if (!Array.isArray(payload.tools)) return null
+  for (const tool of payload.tools) {
+    if (!isRecord(tool) || !isRecord(tool.function)) continue
+    const name = tool.function.name
+    if (typeof name === "string" && name.endsWith("_search_capabilities")) return name
+  }
+  return null
+}
+
 function completedToolCount(payload: Record<string, unknown>): number {
   return Array.isArray(payload.messages)
     ? payload.messages.filter((message) => isRecord(message) && message.role === "tool").length
@@ -145,6 +155,12 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     access: { orgWide: true },
   })
   const realToolCapability = `mcp:${connection.id}:list_charges`
+  const searchQueries = [
+    "Stripe revenue",
+    "Stripe balance payments revenue",
+    "list Stripe charges subscriptions invoices",
+    "Stripe charges",
+  ]
 
   let modelExecuteCalls = 0
   const fixture = createServer((request, response) => {
@@ -158,7 +174,7 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
         const parsed: unknown = JSON.parse(await readBody(request))
         if (!isRecord(parsed)) throw new Error("Mock provider received a non-object request.")
         const completed = completedToolCount(parsed)
-        if (completed >= 1) {
+        if (completed >= searchQueries.length + 1) {
           sendStream(response, [
             streamChunk({ role: "assistant" }),
             streamChunk({ content: closingReply }),
@@ -166,19 +182,24 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
           ])
           return
         }
-        const toolName = projectedExecuteCapabilityTool(parsed)
-        if (!toolName) throw new Error("The execute_capability tool was not projected to the model.")
-        modelExecuteCalls += 1
+        const searching = completed < searchQueries.length
+        const toolName = searching
+          ? projectedSearchCapabilitiesTool(parsed)
+          : projectedExecuteCapabilityTool(parsed)
+        if (!toolName) throw new Error(`The ${searching ? "search_capabilities" : "execute_capability"} tool was not projected to the model.`)
+        if (!searching) modelExecuteCalls += 1
         sendStream(response, [
           streamChunk({ role: "assistant" }),
           streamChunk({
             tool_calls: [{
               index: 0,
-              id: "call_list_acme_charges",
+              id: searching ? `call_search_acme_${completed}` : "call_list_acme_charges",
               type: "function",
               function: {
                 name: toolName,
-                arguments: JSON.stringify({ name: realToolCapability }),
+                arguments: JSON.stringify(searching
+                  ? { query: searchQueries[completed] }
+                  : { name: realToolCapability }),
               },
             }],
           }),
@@ -394,6 +415,24 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   const remounted = await waitForMountedConnectionCard(app, 30_000)
   expect(remounted.mounted, remounted.text).toBe(true)
   await evalIn(app, `document.querySelector('[data-mcp-app-resource="${resourceUri}"]')?.scrollIntoView({ block: "center" })`)
+  await waitFor(app, `(() => {
+    const card = document.querySelector('[data-mcp-app-resource="${resourceUri}"]');
+    if (!(card instanceof HTMLElement)) return false;
+    const worked = [...document.querySelectorAll("button")].find((button) => button.textContent?.trim().startsWith("Worked for"));
+    if (!(worked instanceof HTMLElement) || worked.getAttribute("aria-expanded") !== "false") return false;
+    const cardRect = card.getBoundingClientRect();
+    if (cardRect.width <= 0 || cardRect.height <= 0) return false;
+    for (let node = card.parentElement; node; node = node.parentElement) {
+      const style = getComputedStyle(node);
+      const rect = node.getBoundingClientRect();
+      if (style.display === "none" || style.visibility === "hidden") return false;
+      if ((style.overflowY === "hidden" || style.overflowY === "clip") && rect.height === 0) return false;
+    }
+    return true;
+  })()`, {
+    timeoutMs: 30_000,
+    label: "connection-action card visible outside collapsed work",
+  })
   await new Promise((resolve) => setTimeout(resolve, 500))
   // Ambient visual evidence of the rendered card; the iframe text assertions
   // above are the enforced proof of its contents.
@@ -408,5 +447,10 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     "Connection steering renders its standard MCP App",
     "Desktop mounted ui://openwork/connection-action/v1/view.html showing Connection needed, the connection name, Not connected, and a Connect action rather than only JSON steering text.",
     mounted.mounted,
+  )
+  evidence.recordAssertionEvidence(
+    "The connection card remains visible outside collapsed work details",
+    "The card has visible layout while the Worked section remains collapsed; no Worked or Used expansion is required.",
+    true,
   )
 })


### PR DESCRIPTION
## Summary
- render MCP App results at the assistant-turn result layer instead of inside Worked/Used tool details
- keep iframes mounted across transcript updates by stabilizing preserved MCP result identity
- extend the connection-card E2E to reproduce a multi-step search run and prove the card is visible while Worked remains collapsed

## Test plan
- [x] `pnpm typecheck` (`apps/app`)
- [x] `pnpm exec bun test --isolate tests/mcp-app-frame.test.ts tests/session-sync-tool-parts.test.ts` (`apps/app` — 23 passed)
- [x] `OPENWORK_EVAL_E2E_TESTS=1 pnpm exec vitest run --config vitest.config.ts --project e2e specs/connection-action-mcp-app.e2e.test.ts` (`evals` — 1 passed, local lane; card visible while Worked remained collapsed)

Made with [Cursor](https://cursor.com)