### PR TITLE
docs: align vocabulary with product — MCP Gateway, Library, connectors, OpenWork Web, skill creation

### DIFF
--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Model Context Protocol (MCP)"
+title: "OpenWork MCP Gateway"
 sidebarTitle: "Overview"
-description: "The OpenWork MCP server is a hosted endpoint that lets your AI agent use OpenWork from Claude Code, Codex, Claude Desktop, Cursor, VS Code, or any MCP client."
+description: "The OpenWork MCP Gateway is one hosted endpoint that brings your organization's skills, plugins, and connections into Claude Code, Codex, Claude Desktop, Cursor, VS Code, or any MCP client."
 ---
 
 import { OpenWorkConnectInstaller } from "/snippets/openwork-connect-installer.jsx";
 
-The OpenWork Connect MCP server lets your AI agent use the OpenWork capabilities your organization has made available to you. The public hosted endpoint is:
+The OpenWork MCP Gateway is one MCP endpoint for everything your organization has made available to you: skills, plugins, workflows, and connections. Instead of configuring one MCP server per service, your agent connects to the gateway once and discovers capabilities on demand. The public hosted endpoint is:
 
 ```text
 https://api.openworklabs.com/mcp/agent
@@ -186,16 +186,22 @@ Clients normally refresh automatically. The values matter when diagnosing reconn
 - Successor grants remain normal rotating grants. If an old refresh grant is replayed after the overlap, expired, or revoked, the client may receive `invalid_grant` and the client/user refresh-token family is revoked. Reconnect by logging out of the MCP entry and authenticating again.
 - Access is rechecked against the active OpenWork session and organization membership, so removing a member or revoking the session cuts off MCP access.
 
-## What the server exposes
+## What the gateway exposes
 
-`/mcp/agent` exposes two MCP tools:
+Instead of flooding your client with hundreds of tool definitions, the gateway keeps the tool list small and constant. `/mcp/agent` exposes two discovery tools:
 
 - `search_capabilities` searches the capabilities available to the signed-in member.
 - `execute_capability` runs an exact capability name returned by `search_capabilities`.
 
-Search can include OpenWork Cloud resources such as config objects, connectors, plugins, marketplaces, skills, workers, members, roles, teams, model providers, and org-connected external MCP tools when those capabilities are enabled and shared with the member.
+Search can include OpenWork Cloud resources such as skills, plugins, connectors, marketplaces, workers, members, roles, teams, model providers, and org-connected external MCP tools when those capabilities are enabled and shared with the member.
 
 Availability is governed by organization membership, role, policy, and exposure allowlists. It intentionally does not expose authentication internals, admin-only system routes, webhooks, API-key creation or deletion, or credential-returning endpoints.
+
+## MCP Apps
+
+Some gateway results come back as MCP Apps: rich, interactive UI rendered from a tool result instead of plain text — great for dynamic interfaces like a created-skill confirmation card or a workflow result view. OpenWork implements the standard [MCP Apps extension](https://modelcontextprotocol.io/docs/extensions/apps) (`ui://` resources declared on tools), so first-party OpenWork apps render in any MCP client that supports the extension, and fall back to readable text everywhere else.
+
+MCP Apps from third-party providers — apps shipped by an MCP server your organization added as a connector — currently render in the OpenWork desktop app, where connectors are enabled as a native MCP Apps preview per organization. Rendering third-party apps in external clients requires exposing that connector as a full MCP server, an option that is planned but not available yet.
 
 ## Troubleshooting
 

--- a/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
@@ -1,32 +1,31 @@
 ---
-title: "Open Cloud in your browser"
+title: "Open OpenWork Web in your browser"
 description: "Open a full OpenWork instance in your browser with nothing to install"
 ---
 
-OpenWork Cloud is currently marked `Alpha` in the dashboard. When your organization has Cloud enabled, you can open a full OpenWork instance in your browser. There is nothing to install and nothing to set up on your computer.
+OpenWork Web is currently available for select customers. When your organization has it enabled, you can open a full OpenWork instance in your browser. There is nothing to install and nothing to set up on your computer.
 
 ## Who can use it
 
-Cloud is enabled per organization by an OpenWork admin. If you do not see `Cloud` in the sidebar, your organization does not have the alpha enabled yet.
+OpenWork Web is enabled per organization. If you do not see it in the sidebar, your organization does not have access yet — contact OpenWork to request it.
 
-Cloud is only available on hosted OpenWork Cloud organizations. It is not available on self-hosted deployments.
+OpenWork Web is only available on hosted OpenWork organizations. It is not available on self-hosted deployments.
 
-## Open Cloud
+## Open OpenWork Web
 
-1. Sign in to OpenWork Cloud.
-2. Open your organization dashboard.
-3. Click `Cloud` in the sidebar.
-4. Wait a few seconds while Cloud starts.
-5. Open the new browser tab when it is ready.
+1. Sign in to your organization dashboard.
+2. Click `OpenWork Web` in the sidebar.
+3. Wait a few seconds while the workspace starts.
+4. Open the new browser tab when it is ready.
 
 You are now looking at the full OpenWork interface in your browser.
 
 ## Sleep and persistence
 
-The Cloud instance sleeps when it is idle and wakes when you open Cloud again. Files in the workspace persist across sleep, so you can close the tab and come back later without losing your work.
+The hosted instance sleeps when it is idle and wakes when you open it again. Files in the workspace persist across sleep, so you can close the tab and come back later without losing your work.
 
-## Alpha limitation
+## Early-access limitation
 
-During the alpha, the Cloud instance URL is itself the credential. Do not share it, paste it into public chats, or publish it anywhere public.
+During early access, the instance URL is itself the credential. Do not share it, paste it into public chats, or publish it anywhere public.
 
 If you accidentally share the URL, ask an OpenWork admin for help.

--- a/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
@@ -1,33 +1,33 @@
 ---
-title: "Deploying a shared workspace"
-description: "Launch a cloud worker in OpenWork Cloud and open it from the desktop app"
+title: "OpenWork Web"
+description: "Run a full OpenWork workspace in the browser, hosted by OpenWork — available for select customers"
 ---
 
-OpenWork Cloud currently labels shared workers as `Shared Workspaces` in the web dashboard. Once the workspace is ready, the desktop app opens it through the normal remote connect flow.
+OpenWork Web gives your team a full OpenWork workspace in the browser, hosted and managed for you — nothing to install. It is currently available for select customers; contact OpenWork if your organization wants access.
 
-## Deploy the shared workspace
+## Deploy a hosted workspace
 
 1. Open your org dashboard and go to `Shared Workspace`.
 2. Click `Add workspace`.
 3. Wait until the status becomes `Ready`.
 4. Click `Connect`.
 
-From the connection drawer you can choose `Open in desktop`, `Open in web`, or copy the `Connection URL` plus `Owner token` / `Client token`.
+From the connection drawer you can choose `Open in web` to use OpenWork Web directly in the browser, `Open in desktop`, or copy the `Connection URL` plus `Owner token` / `Client token`.
 
 ## Open it from the desktop app
 
-From the connection drawer, click `Connect` and copy the `Connection URL` plus
-`Owner token` / `Client token`. In the desktop app, choose `Add workspace ->
-Connect custom remote`, paste the connection URL and token, then click
-`Connect remote`.
+The same hosted workspace also opens in the desktop app. From the connection
+drawer, click `Connect` and copy the `Connection URL` plus `Owner token` /
+`Client token`. In the desktop app, choose `Add workspace -> Connect custom
+remote`, paste the connection URL and token, then click `Connect remote`.
 
-## When to use this flow
+## When to use OpenWork Web
 
-Use a shared workspace when your team needs a hosted OpenWork runtime, a stable place for long-running tasks or messaging connectors, or one workspace that several people can open from the same org.
+Use OpenWork Web when your team needs a hosted OpenWork runtime, a stable place for long-running tasks or messaging connectors, or one workspace that several people can open from the same org — especially for teammates who should not have to install anything.
 
 ## Notes
 
-- This area is currently marked `Alpha` in the Cloud dashboard.
-- A workspace must be `Ready` before the desktop app can open it.
-- OpenWork Cloud plan limits apply to hosted workspaces.
-- If you prefer to self-host a runtime instead of using Cloud, run `openwork-server` and connect the desktop app to that server URL.
+- OpenWork Web is available for select customers. If you do not see it in your dashboard, contact OpenWork.
+- A workspace must be `Ready` before it can be opened.
+- Hosted workspace limits follow your OpenWork plan.
+- If you prefer to self-host a runtime instead, run `openwork-server` and connect the desktop app to that server URL.

--- a/packages/docs/cloud/share-with-your-team/team-templates.mdx
+++ b/packages/docs/cloud/share-with-your-team/team-templates.mdx
@@ -8,7 +8,7 @@ Team templates are the Cloud path for giving a team the same starting workspace 
 ## When to use templates
 
 - Use a template for repeated team setups, client onboarding, or internal operating systems.
-- Use a marketplace plugin (`Settings -> Extensions -> Marketplace` in the desktop app) when you only need to distribute skills or MCPs.
+- Use a shared plugin when you only need to distribute skills or MCP servers — members receive it in `Settings` > `Library` in the desktop app.
 - Use [managed providers](/cloud/share-with-your-team/managed-llm-provider) when the only shared piece is model access.
 
 ## Recommended flow
@@ -17,13 +17,13 @@ Team templates are the Cloud path for giving a team the same starting workspace 
 2. Add the skills, MCP servers, commands, agents, and providers the team should start with.
 3. Share the setup to your OpenWork Cloud organization.
 4. Assign the template to the right team.
-5. Ask teammates to import the template from `Settings -> Cloud`.
+5. Teammates import the template when they join the workspace.
 
 ## Keep it maintainable
 
 - Keep secrets out of templates.
 - Put shared model credentials in Cloud providers instead of config files.
-- Keep reusable skills in a marketplace plugin when several templates need the same skill set.
+- Keep reusable skills in a shared plugin when several templates need the same skill set.
 - Create separate templates for separate teams or client environments.
 
 Team templates are meant to stay boring: one known-good starting point, assigned to the people who need it, imported into the desktop app when they join the workflow.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -131,7 +131,7 @@
             ]
           },
           {
-            "group": "Model Context Protocol (MCP)",
+            "group": "MCP Gateway",
             "pages": [
               "cloud/run-in-the-cloud/cloud-mcp",
               "model-context-protocol/opencode",

--- a/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
@@ -10,10 +10,10 @@ managed services, follow [Connect your services](/start-here/connect-your-stack/
 
 Connecting a custom app with OpenWork takes four clicks.
 
-- In the desktop app, open `Settings` \> `Extensions`, then click `Add Custom App`
+- In the desktop app, open `Settings` \> `Library`, then click `Add Custom App`
 
 <Frame>
-  ![Extensions page listing available and connected apps](/images/mcp-extensions-advanced-settings.png)
+  ![Library page listing available and connected apps](/images/mcp-extensions-advanced-settings.png)
 </Frame>
 
 You can add the app to this workspace or to your global configuration for all workspaces.

--- a/packages/docs/start-here/connect-your-stack/connect-services.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-services.mdx
@@ -46,15 +46,18 @@ then executes an exact match. If an account still needs attention, it should
 send you back to `Settings` > `OpenWork Connect` with the action to take instead of
 telling you to add an MCP server.
 
-## Connect, Connections, and MCP servers
+## Connect, connectors, and connections
 
 - **Connect** is the member-facing page in the desktop app for signing in to
   services and checking connection readiness.
-- **Connections** is the organization-admin dashboard in OpenWork Cloud for
-  publishing a service, choosing whose account it uses, and granting member or
-  team access.
-- **OpenWork Connect MCP** is the hosted endpoint that lets external MCP
-  clients use capabilities from an OpenWork organization.
+- A **connector** is an MCP service your organization adds on its own, without
+  wrapping it in a plugin. Organization admins publish connectors from the
+  OpenWork Cloud `Connections` dashboard and grant member or team access.
+- A **connection** is your own signed-in instance of a connector — one
+  connector, instantiated per user with that user's account.
+- The **MCP Gateway** is the hosted endpoint that lets external MCP clients
+  use capabilities from an OpenWork organization. See
+  [OpenWork MCP Gateway](/cloud/run-in-the-cloud/cloud-mcp).
 - **Add an MCP server** is the advanced path for a custom or local server that
   your organization does not provide through Connect.
 

--- a/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
@@ -64,12 +64,12 @@ Use this table to pick scopes by capability:
 | Read user profiles and email | `users:read`, `users:read.email` |
 | List channel members | `channels:read`, `groups:read`, `mpim:read` |
 
-## Open Extensions
+## Open the Library
 
-In OpenWork, open your workspace and go to `Settings` > `Extensions`. Click `Add Custom App`.
+In OpenWork, open your workspace and go to `Settings` > `Library`. Click `Add Custom App`.
 
 <Frame>
-  ![OpenWork Extensions page with Add Custom App button](/images/slack-mcp-extensions-page.png)
+  ![OpenWork Library page with Add Custom App button](/images/slack-mcp-extensions-page.png)
 </Frame>
 
 ## Add the Slack MCP server

--- a/packages/docs/start-here/do-work-with-it/control-the-browser.mdx
+++ b/packages/docs/start-here/do-work-with-it/control-the-browser.mdx
@@ -12,6 +12,6 @@ Today, the supported path is the first-party `OpenWork Browser` extension.
 ## Requirements
 
 - Use the desktop app or a remote worker that exposes the OpenWork Browser.
-- Keep `OpenWork Browser` enabled in `Settings > Extensions`.
+- Keep `OpenWork Browser` enabled in `Settings > Library`.
 
 Then go back to the session view and ask OpenWork to open a website.

--- a/packages/docs/start-here/do-work-with-it/create-a-skill-from-chat.mdx
+++ b/packages/docs/start-here/do-work-with-it/create-a-skill-from-chat.mdx
@@ -10,13 +10,24 @@ Do the work once in chat before you turn it into instructions.
 1. Finish the task in chat and keep the thread open.
 2. Ask in plain English: `Turn what we just did into a reusable skill for me`.
 3. OpenWork saves the skill in your OpenWork Cloud organization as a private plugin. It is not written into your workspace and it is not shared with your organization.
-4. Give the skill a clear name if OpenWork asks, then let it confirm what it saved.
+4. Give the skill a clear name if OpenWork asks, then let it confirm what it saved. In the desktop app you get a rich confirmation card with the skill name and a link to it in your Library.
 5. Use it later by name in chat, or describe the same kind of task and let OpenWork trigger it when it matches.
+
+## Other ways to create a skill
+
+Every path creates the same thing: a skill inside a plugin in your OpenWork Cloud organization.
+
+- **Desktop, from the Library**: open `Settings` > `Library`, filter to `Skills`, and click `Add skill`. This requires being signed in to OpenWork Cloud; the skill is created as a private plugin in your organization.
+- **Cloud dashboard**: organization admins create and edit skills inside a plugin from `Dashboard` > `Plugins` — open a plugin and add a skill to it.
+- **From chat**, as described above.
 
 ## Change or share it only when you choose
 
 1. To refine it, ask for the change in chat, such as `Make the skill ask before sending email`.
 2. To share it with teammates, publish it or grant access later by following [Publish and copy a skill](/start-here/do-work-with-it/publish-and-copy-a-skill).
-3. If you ask for a workspace-local skill instead, OpenWork should create only that local copy, not both.
 
 <Note>Creating the skill does not publish it. Sharing is a separate step you choose.</Note>
+
+## Local skills (legacy)
+
+A local skill is a `SKILL.md` file inside your workspace (for example `.opencode/skills/<name>/SKILL.md`). OpenWork still reads local skills, but they are no longer the default way to create one: they stay on one machine, cannot be shared through your organization, and are not listed in your Cloud Library. If you explicitly ask for a local skill in chat, OpenWork creates only that local file and does not make a Cloud copy. Prefer Cloud skills unless you have a specific reason to keep a skill on one workspace.

--- a/packages/docs/start-here/do-work-with-it/publish-and-copy-a-skill.mdx
+++ b/packages/docs/start-here/do-work-with-it/publish-and-copy-a-skill.mdx
@@ -10,6 +10,6 @@ Publishing is an admin action in OpenWork Cloud, not a desktop marketplace edito
 1. In the Cloud dashboard, an admin creates an organization marketplace with `New marketplace` and `Create marketplace`.
 2. When a plugin is published to that marketplace, its skills show up for teammates who have access.
 3. Marketplace access can be everyone in the organization, specific teams, or individual members. Follow the full admin path in [Team quickstart](/cloud/team-quickstart).
-4. The desktop app shows assigned marketplace content in `Settings > Extensions`; it does not create or fork marketplaces.
+4. The desktop app shows assigned marketplace content in `Settings > Library`; it does not create or fork marketplaces.
 5. To change a shared skill without affecting others, make your own copy in a marketplace you control and edit that copy.
 6. For lighter changes, write a new skill that tells the agent to use the standard skill first, then add your extra instructions.

--- a/packages/docs/start-here/do-work-with-it/share-your-setup.mdx
+++ b/packages/docs/start-here/do-work-with-it/share-your-setup.mdx
@@ -7,7 +7,7 @@ OpenWork no longer shares skills from a `Workspace > Skills` screen. The desktop
 
 ## Find shared skills
 
-1. Open `Settings > Extensions` in the desktop app.
+1. Open `Settings > Library` in the desktop app.
 2. Use the `Skills` filter or search to find skills from your workspace and organization.
 3. Click a skill and choose `View details` to read its description; local skills can be revealed or removed, while OpenWork Connect skills are read-only.
 4. Click `Refresh` if an admin just published a marketplace or changed your access.

--- a/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
+++ b/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
@@ -3,23 +3,25 @@ title: "Connectors, skills, and plugins"
 description: "Use connectors for systems and plugins for the skills that make a system usable"
 ---
 
-OpenWork gives agents three building blocks. The connector reaches the system; the skill is the playbook; the plugin is the bundle.
+OpenWork gives agents a small set of building blocks. The connector reaches the system; the skill is the playbook; the plugin is the bundle; the Library is where you see what you have.
 
 ## Choose the right unit
 
 | Use | Means | Reach for it when |
 | --- | --- | --- |
-| Connector | How OpenWork reaches mail, calendar, CRM, or your ticketing system. | The agent needs to act in that system after you connect it once. |
+| Connector | An MCP service your organization adds standalone, without wrapping it in a plugin. | The agent needs to act in that system after you connect it once. |
+| Connection | Your own signed-in instance of a connector, one per user. | You sign in so the agent acts as you in that system. |
 | Skill | Written instructions the agent loads when a task matches. | One repeatable way of doing work needs a playbook. |
-| Plugin | A bundle OpenWork can install or distribute as one thing. | Several related skills should travel together. |
+| Plugin | A bundle — skills, MCP servers, and other components packaged and distributed as one thing. | Several related pieces should travel together. |
+| Library | The list of active elements you have access to, in the desktop app and the Cloud dashboard. | You want to see or manage what is already available to you. |
 
-MCP is the open standard underneath many connectors, but day to day you can think in terms of apps, connectors, skills, and plugins.
+MCP is the open standard underneath many connectors, and the [OpenWork MCP Gateway](/cloud/run-in-the-cloud/cloud-mcp) is how all of it reaches your agent — but day to day you can think in terms of connectors, skills, plugins, and your Library.
 
 ## Connect the system first
 
 Use connectors for the apps themselves. In the desktop app, start in `Settings` > `OpenWork Connect`; for the click-by-click flow, see [Connect your services](/start-here/connect-your-stack/connect-services).
 
-Everything your agent can use is listed in `Settings` > `Extensions`, under `Available apps` and `Your apps`. Use `Add Custom App` to connect something we do not list yet.
+Everything your agent can use is listed in `Settings` > `Library`, under `Available apps` and `Your apps`. Use `Add Custom App` to connect something we do not list yet.
 
 ## Add skills when the connector is thin
 

--- a/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
+++ b/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
@@ -64,7 +64,7 @@ State which world you are in:
 9. If a stale local server process is still listening: show the process, then stop it, so nothing can silently serve old answers again.
 10. Tell me to do these steps in OpenWork, then wait:
     - Restart the OpenWork app.
-    - In the affected workspace, open Settings → Extensions and click Refresh (re-mints the token and rewrites the Cloud MCP config).
+    - In the affected workspace, open Settings → Library and click Refresh (re-mints the token and rewrites the Cloud MCP config).
     - Click Show hidden, then verify OpenWork Cloud Control under Your apps.
     - Run Reload OpenCode config from the command palette.
     - Start a NEW task so it receives the current tool set.
@@ -144,7 +144,7 @@ Finish with a concise redacted report. Never reveal bearer tokens, Authorization
 
 **Verify inside OpenWork**
 
-1. In the affected workspace, open **Settings → Extensions** and click **Refresh**.
+1. In the affected workspace, open **Settings → Library** and click **Refresh**.
 2. Click **Show hidden**, then find **OpenWork Cloud Control** under **Your apps**. This row shows live OpenCode MCP status; the catalog card only proves that the entry is configured.
 3. Expand the row and retain its status and non-secret error: **Ready**, **Issue**, **Sign in needed**, **Offline**, or **Paused**.
 4. Return to the task, open the command palette, run **Reload OpenCode config**, and create a new task in the same workspace.


### PR DESCRIPTION
Docs-only vocabulary and structure pass, aligning the docs with the canonical user-facing surfaces:

| Term | Meaning |
| --- | --- |
| Plugin | Bundle: skills + MCP servers + other components packaged and shared as one unit |
| Connector | An MCP added standalone, without wrapping it in a plugin |
| Connection | Per-user instantiation of a connector |
| Library | The list of active elements a user has access to |
| MCP Gateway | Our hosted MCP endpoint (one URL, discovery meta-tools) |
| MCP Apps | Rich UI for MCP output; spec-compliant (ext-apps) |

## Changes

- **MCP Gateway section**: renamed the Cloud nav group "Model Context Protocol (MCP)" → **"MCP Gateway"** and repositioned `cloud-mcp.mdx` as the gateway overview ("one endpoint for everything", constant-size tool list framing).
- **New MCP Apps section** on the gateway overview: what they are, spec compliance, and the current limitation — third-party provider apps render in the OpenWork desktop app only; full-MCP passthrough for external clients is tracked in #3960.
- **Skill creation** (`create-a-skill-from-chat.mdx`): documents all three current paths (chat with rich confirmation card, desktop `Settings > Library > Skills > Add skill`, Cloud dashboard via Plugins) and renames the workspace-file path to **"Local skills (legacy)"** — explicit-request only, verified against `apps/app/.../library.ts` ("Library Add always creates in OpenWork Cloud") and `builtin-skills.ts`.
- **Connector/connection terminology** (`connect-services.mdx`, `skills-plugins-and-mcp.mdx`): connector = org-added standalone MCP; connection = the member's signed-in instance; added Library and Gateway to the building-blocks table.
- **`Settings > Extensions` → `Settings > Library`** across 7 pages (the UI renamed in v0.18.13; docs lagged).
- **Team templates**: removed deprecated `Settings -> Extensions -> Marketplace` and `Settings -> Cloud` paths.
- **OpenWork Web**: `shared-workspace.mdx` and `open-cloud-in-browser.mdx` rewritten around **OpenWork Web, available for select customers**, dropping the "Cloud (Alpha)" framing.

## Follow-up issues

- #3959 — screenshots for the updated pages (old Extensions-era images flagged)
- #3960 — "Make full MCP" per-connector option (referenced by the new MCP Apps section)
- #3961 — team-quickstart refresh (left untouched here; it needs its own screenshot/IA pass)

## Verification

Docs-only change — no runtime behavior; skipping testkit runtime proof per AGENTS.md (docs/comments lane). All UI-flow claims were verified against code on dev @ 28713907d: `apps/app/src/react-app/domains/settings/library.ts` (Library Add is Cloud-only), `ee/apps/den-api/src/mcp/skill-created-app.ts` (create_skill → plugin + App card), `ee/apps/den-web/.../plugins/[pluginId]/skills/new` (dashboard editor), `ee/apps/den-api/src/mcp/external-connection-proxy.ts` (no full-MCP passthrough exists today), `docs/features/remote-mcp-apps/README.md` (desktop-only rendering, preview gates).