### PR TITLE
fix(workflows): preserve resolved plugin wire type

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -907,7 +907,13 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     async (c: OrgContext) => {
       try {
         const params = validParam<any>(c)
-        return c.json(await listPluginMemberships({ context: actorContext(c), includeConfigObjects: true, onlyActive: true, pluginId: params.pluginId }))
+        return c.json(await listPluginMemberships({
+          context: actorContext(c),
+          includeConfigObjects: true,
+          legacyWorkflowObjectType: true,
+          onlyActive: true,
+          pluginId: params.pluginId,
+        }))
       } catch (error) {
         return routeErrorResponse(c, error)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2736,7 +2736,7 @@ export async function setPluginLifecycle(input: { action: "archive" | "restore";
   return getPluginDetail(input.context, row.id)
 }
 
-export async function listPluginMemberships(input: { context: PluginArchActorContext; pluginId: PluginId; includeConfigObjects?: boolean; onlyActive?: boolean }) {
+export async function listPluginMemberships(input: { context: PluginArchActorContext; pluginId: PluginId; includeConfigObjects?: boolean; legacyWorkflowObjectType?: boolean; onlyActive?: boolean }) {
   await ensureVisiblePlugin(input.context, input.pluginId)
   const memberships = await db
     .select()
@@ -2757,7 +2757,12 @@ export async function listPluginMemberships(input: { context: PluginArchActorCon
     ? memberships.filter((membership) => resolvedConfigObjectIds.has(membership.configObjectId))
     : memberships
   const latestVersions = await getLatestVersions(resolvedConfigObjects.map((row) => row.id))
-  const byId = new Map<string, ReturnType<typeof serializeConfigObject>>(resolvedConfigObjects.map((row) => [row.id, serializeConfigObject(row, latestVersions.get(row.id) ?? null)]))
+  const byId = new Map<string, ReturnType<typeof serializeConfigObject>>(resolvedConfigObjects.map((row) => {
+    const serialized = serializeConfigObject(row, latestVersions.get(row.id) ?? null)
+    return [row.id, input.legacyWorkflowObjectType && serialized.objectType === "workflow"
+      ? { ...serialized, objectType: "script" }
+      : serialized]
+  }))
   return { items: resolvedMemberships.map((membership) => serializeMembership(membership, byId.get(membership.configObjectId))), nextCursor: null }
 }
 

--- a/evals/specs/generated-artifact-views.e2e.test.ts
+++ b/evals/specs/generated-artifact-views.e2e.test.ts
@@ -311,6 +311,23 @@ test("the agent MCP exposes the custom Artifact view authoring lifecycle", { tim
     }),
   })
   expect(legacyPlugin.response.status, legacyPlugin.text).toBe(201)
+  const legacyPluginId = String(requireRecord(requireRecord(legacyPlugin.body, "legacy plugin response").item, "legacy plugin").id ?? "")
+  expect(legacyPluginId).toMatch(/^plg_/)
+  const resolvedLegacyPlugin = await denFetch(den.admin, `/v1/plugins/${encodeURIComponent(legacyPluginId)}/resolved`, {
+    headers: {
+      authorization: `Bearer ${den.admin.token}`,
+      "x-openwork-org-id": organizationId,
+    },
+  })
+  expect(resolvedLegacyPlugin.response.ok, resolvedLegacyPlugin.text).toBe(true)
+  const resolvedLegacyItems = isRecord(resolvedLegacyPlugin.body) && Array.isArray(resolvedLegacyPlugin.body.items)
+    ? resolvedLegacyPlugin.body.items.filter(isRecord)
+    : []
+  const resolvedLegacyObjects = resolvedLegacyItems
+    .map((item) => item.configObject)
+    .filter(isRecord)
+  expect(resolvedLegacyObjects.some((item) => item.objectType === "workflow")).toBe(false)
+  expect(resolvedLegacyObjects.some((item) => item.objectType === "script")).toBe(true)
   const desktopCapabilities = await denFetch(den.admin, "/v1/resources/marketplace-capabilities", {
     headers: {
       authorization: `Bearer ${den.admin.token}`,
@@ -340,8 +357,8 @@ test("the agent MCP exposes the custom Artifact view authoring lifecycle", { tim
   expect(JSON.stringify(legacyRun)).toContain('"legacy":"compatible"')
   evidence.recordAssertionEvidence(
     "A persisted legacy script remains a canonical executable Workflow",
-    `A type:script component was accepted, the desktop wire surface retained script, and MCP discovered and executed canonical Workflow ${legacyCapabilityName}.`,
-    legacyPlugin.response.status === 201 && desktopCapabilityItems.every((item) => item.objectType !== "workflow") && legacyCapability?.kind === "workflow" && JSON.stringify(legacyRun).includes('"legacy":"compatible"'),
+    `A type:script component was accepted, desktop capability and resolved-plugin surfaces retained script, and MCP discovered and executed canonical Workflow ${legacyCapabilityName}.`,
+    legacyPlugin.response.status === 201 && resolvedLegacyObjects.every((item) => item.objectType !== "workflow") && desktopCapabilityItems.every((item) => item.objectType !== "workflow") && legacyCapability?.kind === "workflow" && JSON.stringify(legacyRun).includes('"legacy":"compatible"'),
   )
 
   const legacyRender = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {


### PR DESCRIPTION
## Summary
- preserve the legacy `script` object type on the published desktop resolved-plugin route
- keep canonical `workflow` semantics on MCP and internal API surfaces
- add end-to-end assertions for both desktop compatibility surfaces

## Context
Follow-up to #3952 for the final Warden finding: published desktop clients filter unknown `workflow` memberships returned by `/v1/plugins/:pluginId/resolved`.

## Verification
- Den API typecheck passed
- real-MySQL `marketplace-codemode-scripts.test.ts`: 12 passed
- exact-SHA Daytona `generated-artifact-views.e2e.test.ts`: 1 passed, 0 failed, 0 skipped
- test evidence published on this PR
- Warden security clearance: clear at `2f5c00193f581faabd5ea50841b4dcb7ec39ee0c`
- all CI checks passed