### PR TITLE
docs: document enterprise desktop deployment (enterprise binary + optional MDM push)

### DIFF
--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -151,8 +151,14 @@ the same standard installer through the same direct or mounted route.
 
 ## MDM alternative
 
-Managed deployments can skip the deep-link handoff by deploying the public
-installer and writing `desktop-bootstrap.json` directly:
+Customer-facing guidance for this path is published at
+[`packages/docs/start-here/enterprise-desktop-deployment.mdx`](../packages/docs/start-here/enterprise-desktop-deployment.mdx).
+
+Managed deployments can skip the deep-link handoff by deploying a standard
+binary — typically the enterprise distribution
+(`openwork-enterprise-<os>-<arch>-<version>.<ext>`, published on the
+`enterprise` release channel), or the public installer — and writing
+`desktop-bootstrap.json` directly:
 
 | OS | Canonical path |
 |---|---|

--- a/packages/docs/cloud/enterprise.mdx
+++ b/packages/docs/cloud/enterprise.mdx
@@ -19,3 +19,9 @@ OpenWork can be deployed inside your VPC or on-prem, with SSO, audit logs, and c
 - Rollout plan and support model
 
 Prefer email? Reach us at [team@openworklabs.com](mailto:team@openworklabs.com?subject=Enterprise%20deployment).
+
+## How desktop deployment works
+
+Rolling OpenWork out to a fleet does not involve a custom installer build. You deploy the standard **OpenWork Enterprise binary** — a dedicated distribution that requires sign-in and administrator activation, on its own update channel — and optionally push a single `desktop-bootstrap.json` file through your MDM so every machine targets your Den server on first launch. Certificates come from the OS trust stores you already manage, and desktop policies are delivered by the server after sign-in, so no MDM scripting is needed beyond that one file.
+
+See [Enterprise desktop deployment](/start-here/enterprise-desktop-deployment) for the full reference.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -94,6 +94,7 @@
           {
             "group": "Install and operate",
             "pages": [
+              "start-here/enterprise-desktop-deployment",
               "start-here/installer-delivery",
               "start-here/on-prem-branding",
               "start-here/github-connector-helm"

--- a/packages/docs/start-here/enterprise-desktop-deployment.mdx
+++ b/packages/docs/start-here/enterprise-desktop-deployment.mdx
@@ -1,0 +1,76 @@
+---
+title: "Enterprise desktop deployment"
+description: "Deploy the OpenWork Enterprise binary with your existing software distribution, optionally pushing one configuration file through MDM."
+---
+
+Enterprise deployment is the standard **OpenWork Enterprise binary** plus an optional MDM push of one configuration file. There is no customer-specific installer build, no wrapping, and no repackaging — the signed release artifacts are never modified, so normal macOS and Windows signature verification is preserved.
+
+## The enterprise binary
+
+OpenWork ships a dedicated enterprise distribution alongside the public one. Both are published on [GitHub Releases](https://github.com/different-ai/openwork/releases); enterprise artifacts follow the `enterprise` update channel.
+
+| Platform | Artifact |
+| --- | --- |
+| macOS (Apple Silicon / Intel) | `openwork-enterprise-mac-arm64-<version>.dmg`, `openwork-enterprise-mac-x64-<version>.dmg` |
+| Windows (x64 / ARM64) | `openwork-enterprise-win-x64-<version>.exe`, `openwork-enterprise-win-arm64-<version>.exe` |
+| Linux | `openwork-enterprise-linux-x86_64-<version>.AppImage`, `openwork-enterprise-linux-arm64-<version>.AppImage`, `.tar.gz` variants |
+
+The enterprise distribution differs from the public build in ways that are baked into the package metadata at build time — not toggled by configuration:
+
+- The product is named **OpenWork Enterprise**.
+- Sign-in is always required.
+- **Activation is always required**: before an administrator-provisioned activation completes, the app exposes only the minimal surface needed to accept a connect link and read or write its bootstrap configuration. Chat, tools, and workspace access stay locked.
+- Auto-update follows the `enterprise` release channel, so enterprise installs never pick up public-channel artifacts.
+
+A packaged public build can never be turned into an enterprise build with environment variables or configuration files; the distribution flavor is read only from immutable package metadata.
+
+## Optional MDM push: `desktop-bootstrap.json`
+
+If you manage the fleet with MDM (Jamf, Intune, or similar), distribute the enterprise binary the way you distribute any other app, and optionally write one JSON file during provisioning so the first launch already knows your Den server:
+
+| OS | Canonical path |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\openwork\desktop-bootstrap.json` (`%XDG_CONFIG_HOME%\openwork\desktop-bootstrap.json` wins if set) |
+| macOS / Linux | `$XDG_CONFIG_HOME/openwork/desktop-bootstrap.json`, falling back to `~/.config/openwork/desktop-bootstrap.json` |
+
+```json
+{
+  "baseUrl": "https://openwork.example.com",
+  "apiBaseUrl": "https://openwork.example.com/api/den",
+  "requireSignin": true,
+  "brandAppName": "Example Corp OpenWork",
+  "writtenAt": "2026-08-20T12:00:00.000Z"
+}
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `baseUrl` | Yes | Your Den web origin. The desktop derives API and MCP paths through this origin's `/api/den` proxy. |
+| `apiBaseUrl` | No | Separate Den API base, only if you publish one. In a single-origin topology, omit it or use the `/api/den` proxy path. |
+| `requireSignin` | Yes | Whether the app requires organization sign-in before use. Enterprise builds enforce sign-in regardless of this value. |
+| `requireActivation` | No | Ignored by enterprise builds, which always require activation. Lets a public build opt into the activation gate. |
+| `brandAppName`, `brandLogoUrl`, `brandIconUrl` | No | Organization branding shown in the app. |
+| `writtenAt` | Yes | ISO 8601 timestamp. When more than one bootstrap file exists, the valid configuration with the newest `writtenAt` wins. |
+
+Deployment details worth knowing:
+
+- Older builds read a legacy `~/.config/openwork` path on every OS. Current builds still read it for compatibility; the newest `writtenAt` decides which file applies.
+- Clearing cloud configuration in the app removes bootstrap files entirely, so a fresh MDM-dropped config wins on the next launch.
+- `OPENWORK_DESKTOP_BOOTSTRAP_PATH` points a machine at an isolated bootstrap file for testing; legacy global configuration never crosses that boundary.
+
+## What you do not push through MDM
+
+- **Activation.** The app writes `enterpriseActivation` into `desktop-bootstrap.json` only after a signed activation claim verifies. Do not provision this record yourself; a hand-written entry is not proof of a provisioned tenant, and the app treats it as incomplete.
+- **Certificates.** The desktop builds its trust bundle from the OS trust stores — Windows machine and user Root/CA stores, and the macOS administrator-controlled System keychains. Deploy enterprise CAs the way you already do; no OpenWork-specific certificate file exists. See [Certificate trust and proxies](/start-here/certificate-trust-and-proxies).
+- **Desktop policies.** Version pinning and feature policies are delivered by your Den server after sign-in and enforced by the app automatically — no MDM scripting. Manage them in the organization dashboard.
+
+## Choosing between install links and MDM
+
+| | Organization install links | Enterprise binary + MDM |
+| --- | --- | --- |
+| Best for | Self-serve onboarding, no device management required | Managed fleets with existing software distribution |
+| Binary | Standard public installer, delivered by Den or GitHub ([Installer delivery](/start-here/installer-delivery)) | Enterprise artifacts, distributed by your MDM |
+| Server configuration | Browser deep-link handoff after install | `desktop-bootstrap.json` written at provisioning time |
+| First launch | User confirms the exact organization and server | App already targets your Den server |
+
+Both paths end at the same place: normal organization sign-in against your Den deployment. For fully isolated networks, combine this page with the [Air-gapped deployment](/start-here/air-gapped-deployment) checklist — with MDM distribution, installer bytes never need to transit Den at all.

--- a/packages/docs/start-here/installer-delivery.mdx
+++ b/packages/docs/start-here/installer-delivery.mdx
@@ -35,8 +35,6 @@ For normal signed-in desktop traffic, prefer one desktop-facing Den web origin. 
 
 If `DEN_API_PUBLIC_URL` is configured as a separate API origin, the one-time **Open OpenWork** install-link exchange must also reach that API origin. External MCP clients that use the published MCP URL must reach it too. This does not mean every steady-state desktop request needs both origins in the single-origin topology.
 
-## MDM bootstrap alternative
+## Managed fleets: enterprise binary + MDM
 
-Managed fleets can skip the install-link handoff by deploying the standard installer through MDM and writing the desktop bootstrap configuration file during provisioning. Use that path when you already have reliable software distribution and want the first launch to know the Den base URL without a browser deep-link step.
-
-See the repository guide for the exact bootstrap file paths, JSON shape, and security properties.
+This page covers install-link delivery of the standard installer. Managed fleets typically skip the install-link handoff entirely: deploy the **OpenWork Enterprise binary** through MDM and write `desktop-bootstrap.json` during provisioning so the first launch already targets your Den server. See [Enterprise desktop deployment](/start-here/enterprise-desktop-deployment) for the artifact names, bootstrap file reference, and what MDM does not need to push.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -38,7 +38,8 @@ Use the dedicated Self-host planning pages instead of copying hostname, certific
 - [Air-gapped deployment](/start-here/air-gapped-deployment): definitions and the checklist for full isolation.
 - [Outbound network access](/start-here/outbound-network-access): the canonical customer IT destination inventory and "what breaks when blocked" guidance.
 - [Certificate trust and proxies](/start-here/certificate-trust-and-proxies): desktop, sidecar, Den, and MySQL trust surfaces.
-- [Installer delivery](/start-here/installer-delivery): GitHub redirect, mounted artifacts, and MDM bootstrap choices.
+- [Enterprise desktop deployment](/start-here/enterprise-desktop-deployment): the enterprise binary, MDM distribution, and the `desktop-bootstrap.json` reference.
+- [Installer delivery](/start-here/installer-delivery): GitHub redirect and mounted artifacts for organization install links.
 - [Network diagnostics](/start-here/network-diagnostics): Windows doctor, Cloud catalog diagnostic trust, and Den outbound checks.
 
 If you want self-hosted repository imports and sync from GitHub, configure the [GitHub connector for Helm](/start-here/github-connector-helm) after the core Den web and Den controller hosts are reachable.


### PR DESCRIPTION
## What

Customer-facing docs previously only described the standard-installer / install-link path. The enterprise deployment model that exists in code — a dedicated **OpenWork Enterprise binary** plus an optional MDM push of `desktop-bootstrap.json` — was undocumented.

- **New page** `packages/docs/start-here/enterprise-desktop-deployment.mdx`:
  - Enterprise artifacts (`openwork-enterprise-<os>-<arch>-<version>.<ext>`) on the `enterprise` release channel, with build-time flavor properties (always require sign-in + activation, pre-activation command gate, no env/config escalation from public builds) per `apps/desktop/electron-builder.enterprise.yml` and `apps/desktop/electron/desktop-distribution.mjs`.
  - Full `desktop-bootstrap.json` reference matching `packages/install-config/src/index.ts` (per-OS canonical paths, newest-`writtenAt`-wins, legacy path compatibility, `OPENWORK_DESKTOP_BOOTSTRAP_PATH` isolation).
  - What MDM does **not** push: `enterpriseActivation` (app-written after signed activation, `apps/server/src/enterprise-den-origin.ts`), certificates (OS trust stores), desktop policies (server-delivered).
  - Decision table: install links vs enterprise binary + MDM.
- `installer-delivery.mdx`: replaced the thin "MDM bootstrap alternative" stub with a scoped pointer to the new page.
- `cloud/enterprise.mdx`: added a "How desktop deployment works" section so the sales page reflects the real model.
- `docs/org-install-links.md`: MDM section no longer says "deploy the public installer" only; names the enterprise artifacts and links the published page.
- `self-host.mdx` + `docs.json`: navigation and planning-list entries.

## Verification

Docs-only change (prose + nav JSON); no runtime behavior touched, so runtime proof is skipped per repo policy. `docs.json` validated as JSON. Facts cross-checked against code and the live v0.18.33 GitHub release assets (enterprise dmg/exe/AppImage + `enterprise*.yml` channel feeds present).