### PR TITLE
fix: collapse leading system messages for OpenAI-compatible providers

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
     "test": "bun --conditions=development test",
     "test:artifacts": "bun --conditions=development test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build:enterprise-mcp-client": "pnpm --filter @openwork/enterprise-mcp-client build",
-    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts src/opencode-plugins/openwork-openai-compatible-system.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "pnpm build:enterprise-mcp-client && bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "pnpm build:enterprise-mcp-client && bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "prepare:npm": "pnpm build:bin && node scripts/publish-npm.mjs --prepare-only",

--- a/apps/server/src/opencode-plugins/openwork-openai-compatible-system.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-openai-compatible-system.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { OpenWorkOpenAiCompatibleSystem } from "./openwork-openai-compatible-system.js"
+
+const calls: { input: unknown; init: RequestInit | undefined }[] = []
+const fakeBase = Object.assign(async (input: unknown, init?: RequestInit) => {
+  calls.push({ input, init })
+  return new Response("{}")
+}, globalThis.fetch)
+
+const originalFetch = globalThis.fetch
+let patchedFetch: typeof fetch
+
+beforeAll(async () => {
+  globalThis.fetch = fakeBase as unknown as typeof fetch
+  await OpenWorkOpenAiCompatibleSystem()
+  patchedFetch = globalThis.fetch
+  globalThis.fetch = originalFetch
+})
+
+afterAll(() => {
+  globalThis.fetch = originalFetch
+})
+
+const JSON_HEADERS = { "content-type": "application/json" }
+const ANTHROPIC_HEADERS = { "anthropic-version": "2023-06-01", "content-type": "application/json" }
+
+// Reproduces what Hetzner Inference (vLLM, Qwen3.8-27B) rejects with
+// {"error":{"message":"System message must be at the beginning.","code":400}}
+// once openwork-capabilities-knowledge and openwork-extensions-preview have
+// each pushed their own entry onto `output.system`.
+const openworkShapedRequest = {
+  model: "Qwen3.8-27B",
+  messages: [
+    { role: "system", content: "You are OpenWork." },
+    { role: "system", content: "OPENWORK_CAPABILITIES_KNOWLEDGE" },
+    { role: "system", content: "routing instructions" },
+    { role: "user", content: "hi" },
+  ],
+}
+
+async function send(body: unknown, headers: Record<string, string> = JSON_HEADERS) {
+  calls.length = 0
+  await patchedFetch("https://inference.hetzner.com/api/v1/chat/completions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+  const sent = calls[0]?.init?.body
+  return typeof sent === "string" ? JSON.parse(sent) : undefined
+}
+
+describe("OpenWorkOpenAiCompatibleSystem", () => {
+  test("merges consecutive leading system messages into one", async () => {
+    const sent = await send(openworkShapedRequest)
+    expect(sent.messages).toEqual([
+      {
+        role: "system",
+        content: "You are OpenWork.\n\nOPENWORK_CAPABILITIES_KNOWLEDGE\n\nrouting instructions",
+      },
+      { role: "user", content: "hi" },
+    ])
+  })
+
+  test("leaves a single system message untouched", async () => {
+    const body = { model: "m", messages: [{ role: "system", content: "A" }, { role: "user", content: "hi" }] }
+    const sent = await send(body)
+    expect(sent).toEqual(body)
+  })
+
+  test("leaves a request without any system message untouched", async () => {
+    const body = { model: "m", messages: [{ role: "user", content: "hi" }] }
+    const sent = await send(body)
+    expect(sent).toEqual(body)
+  })
+
+  test("does not reorder a system message that appears mid-conversation", async () => {
+    const body = {
+      model: "m",
+      messages: [
+        { role: "system", content: "A" },
+        { role: "user", content: "hi" },
+        { role: "system", content: "late" },
+      ],
+    }
+    const sent = await send(body)
+    expect(sent).toEqual(body)
+  })
+
+  test("keeps structured content parts as an array", async () => {
+    const sent = await send({
+      model: "m",
+      messages: [
+        { role: "system", content: [{ type: "text", text: "A" }] },
+        { role: "system", content: "B" },
+        { role: "user", content: "hi" },
+      ],
+    })
+    expect(sent.messages[0].content).toEqual([
+      { type: "text", text: "A" },
+      { type: "text", text: "B" },
+    ])
+  })
+
+  test("preserves other fields on the merged message and on the body", async () => {
+    const sent = await send({
+      model: "m",
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: "A", name: "primary" },
+        { role: "system", content: "B" },
+        { role: "user", content: "hi" },
+      ],
+    })
+    expect(sent.temperature).toBe(0.2)
+    expect(sent.messages[0].name).toBe("primary")
+  })
+
+  test("ignores anthropic requests so system blocks keep their cache breakpoints", async () => {
+    const sent = await send(openworkShapedRequest, ANTHROPIC_HEADERS)
+    expect(sent).toEqual(openworkShapedRequest)
+  })
+
+  test("forwards a non-JSON body unchanged", async () => {
+    calls.length = 0
+    await patchedFetch("https://inference.hetzner.com/api/v1/chat/completions", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: 'not json but mentions "system"',
+    })
+    expect(calls[0]?.init?.body).toBe('not json but mentions "system"')
+  })
+})

--- a/apps/server/src/opencode-plugins/openwork-openai-compatible-system.ts
+++ b/apps/server/src/opencode-plugins/openwork-openai-compatible-system.ts
@@ -1,0 +1,133 @@
+/**
+ * OpenWork OpenAI-Compatible System Prompt Plugin
+ *
+ * Strict OpenAI-compatible servers accept exactly one system message, at index
+ * 0. vLLM serving a Qwen chat template is the common case, and that is what
+ * most European inference providers run, so a second system message is
+ * rejected outright:
+ *
+ *   {"error":{"message":"System message must be at the beginning.",
+ *             "type":"BadRequestError","code":400}}
+ *
+ * OpenWork reliably sends more than one. `openwork-capabilities-knowledge` and
+ * `openwork-extensions-preview` each append to `output.system` in
+ * `experimental.chat.system.transform`, and `@ai-sdk/openai-compatible`
+ * serialises every array entry as its own `{"role":"system"}` message, so a
+ * request from the `openwork` agent carries three to five of them and fails on
+ * the first turn of a new session.
+ *
+ * Merging inside those plugins only works if their transforms happen to run
+ * last (see #2339), and a normalizer plugin registered late is still defeated
+ * by a user-installed plugin registered after it. This plugin therefore
+ * flattens at the wire boundary instead, patching the engine's global fetch
+ * the same way `openwork-anthropic-tool-schema` does. That is order-independent
+ * by construction and also covers third-party plugins.
+ *
+ * Anthropic requests are excluded, detected via the `anthropic-version` header:
+ * there the array form is deliberate, because each entry becomes its own system
+ * block with its own cache breakpoint.
+ *
+ * Only the leading run is merged. A system message that appears after a user or
+ * assistant message is left in place; that would be a different bug, and
+ * silently reordering it would change the conversation the model sees.
+ */
+
+const SYSTEM_ROLE = "system";
+const JOIN = "\n\n";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSystemMessage(value: unknown): value is JsonRecord {
+  return isRecord(value) && value.role === SYSTEM_ROLE;
+}
+
+/** Number of consecutive system messages at the head of the list. */
+function leadingSystemCount(messages: unknown[]): number {
+  let count = 0;
+  while (count < messages.length && isSystemMessage(messages[count])) count += 1;
+  return count;
+}
+
+/**
+ * Merge the `content` fields of several system messages. Content is either a
+ * plain string or an array of content parts, and the two forms can be mixed
+ * within one request. Strings are joined by a blank line; as soon as any part
+ * array is involved the result stays an array so no structured part is
+ * flattened away.
+ */
+function mergeContent(messages: JsonRecord[]): unknown {
+  const anyArray = messages.some((message) => Array.isArray(message.content));
+  if (!anyArray) {
+    return messages
+      .map((message) => (typeof message.content === "string" ? message.content : ""))
+      .filter((text) => text.length > 0)
+      .join(JOIN);
+  }
+  const parts: unknown[] = [];
+  for (const message of messages) {
+    if (Array.isArray(message.content)) parts.push(...message.content);
+    else if (typeof message.content === "string" && message.content.length > 0) {
+      parts.push({ type: "text", text: message.content });
+    }
+  }
+  return parts;
+}
+
+/**
+ * Returns the rewritten body, or null when nothing needed changing so the
+ * caller can forward the original string untouched.
+ */
+function collapseLeadingSystemMessages(body: string): string | null {
+  if (!body.includes(`"${SYSTEM_ROLE}"`)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) return null;
+
+  const messages = parsed.messages;
+  const count = leadingSystemCount(messages);
+  if (count < 2) return null;
+
+  const head = messages.slice(0, count) as JsonRecord[];
+  const merged: JsonRecord = { ...head[0], content: mergeContent(head) };
+  return JSON.stringify({ ...parsed, messages: [merged, ...messages.slice(count)] });
+}
+
+function hasAnthropicVersionHeader(headers: HeadersInit | undefined): boolean {
+  if (!headers) return false;
+  if (headers instanceof Headers) return headers.has("anthropic-version");
+  if (Array.isArray(headers)) {
+    return headers.some((entry) => entry[0]?.toLowerCase() === "anthropic-version");
+  }
+  return Object.keys(headers).some((name) => name.toLowerCase() === "anthropic-version");
+}
+
+let installed = false;
+
+function installOpenAiCompatibleFetchPatch(): void {
+  if (installed) return;
+  installed = true;
+  const base = globalThis.fetch;
+  const patched: typeof fetch = async (input, init) => {
+    if (init && typeof init.body === "string" && !hasAnthropicVersionHeader(init.headers)) {
+      const collapsed = collapseLeadingSystemMessages(init.body);
+      if (collapsed !== null) return base(input, { ...init, body: collapsed });
+    }
+    return base(input, init);
+  };
+  globalThis.fetch = Object.assign(patched, base);
+}
+
+// Single export: the OpenCode plugin loader treats every export of a plugin
+// module as a plugin factory, so helpers must stay module-private.
+export const OpenWorkOpenAiCompatibleSystem = async () => {
+  installOpenAiCompatibleFetchPatch();
+  return {};
+};

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -36,3 +36,4 @@ export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath(
 export const openworkAnthropicAdaptiveThinkingPluginPath = () => openworkPluginPath("openwork-anthropic-adaptive-thinking");
 export const openworkAnthropicToolSchemaPluginPath = () => openworkPluginPath("openwork-anthropic-tool-schema");
 export const openworkOfficeAttachmentsPluginPath = () => openworkPluginPath("openwork-office-attachments");
+export const openworkOpenAiCompatibleSystemPluginPath = () => openworkPluginPath("openwork-openai-compatible-system");

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -21,6 +21,7 @@ import {
   openworkAnthropicAdaptiveThinkingPluginPath,
   openworkAnthropicToolSchemaPluginPath,
   openworkOfficeAttachmentsPluginPath,
+  openworkOpenAiCompatibleSystemPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import { runtimeStorageDir } from "./runtime-db.js";
@@ -129,6 +130,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
       openworkOfficeAttachmentsPluginPath(),
       openworkAnthropicAdaptiveThinkingPluginPath(),
       openworkAnthropicToolSchemaPluginPath(),
+      openworkOpenAiCompatibleSystemPluginPath(),
       ...runtimePluginList(runtimeConfig),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),


### PR DESCRIPTION
Closes #2099. Supersedes #2339.

## Relationship to #2339

#2339 addressed the same bug and was closed unmerged on 2026-08-06. The review objection there is worth restating, because this PR is shaped by it: @Pablosinyores pointed out that flattening inside each plugin only yields a single system message *if those transforms happen to run last*, and asked for "a single centralized flatten applied once, after all `system.transform` hooks have run".

That objection is correct, and a normalizer plugin registered late — the refactor #2339 moved to — only partly answers it. Registration order is still load-bearing, and a user-installed plugin registered after the normalizer reintroduces the bug silently.

This PR applies the flatten at the wire boundary instead: a one-time `globalThis.fetch` patch on the serialised request body. That is order-independent by construction, cannot be defeated by plugin registration order, and covers third-party plugins that no `system.transform` hook can see. It follows the pattern `openwork-anthropic-tool-schema.ts` already established in this codebase.

## Problem

Strict OpenAI-compatible servers accept exactly **one** system message, at index 0. vLLM serving a Qwen chat template is the common case, and that is what most European inference providers run (Hetzner Inference, and by the same template OVHcloud / Scaleway / Nebius style endpoints).

OpenWork always sends more than one. Two bundled plugins append to `output.system` in `experimental.chat.system.transform`:

```js
// openwork-capabilities-knowledge.js
output.system.push(OPENWORK_CAPABILITIES_KNOWLEDGE)

// openwork-extensions-preview.js
output.system.push(...composeAgentInstructions(sections))   // routing, agent-surface, skill-authoring, …
```

`output.system` is an array. For Anthropic that is deliberate and desirable — each entry becomes its own system block with its own cache breakpoint. For `@ai-sdk/openai-compatible` each entry is serialised as a separate `{"role":"system"}` message, so a request from the `openwork` agent carries three to five of them and is rejected on the **first turn of a brand-new session**:

```
level=ERROR message="stream error" providerID=hetzner modelID=Qwen3.8-27B
  agent=openwork mode=primary
  error.error="AI_APICallError: System message must be at the beginning."
```

The trigger is the *count*, not the position — which is why the server's wording is misleading. Confirmed against Hetzner Inference with two curl calls that differ only by one added system message:

| Request | Result |
|---|---|
| `[system A, user hi]` | `200 OK`, 55 prompt tokens, completion returned |
| `[system A, system B, user hi]` | `400 BadRequestError: System message must be at the beginning.` |

Ollama accepts multiple system messages without complaint, which is why this never shows up in a purely local setup and only appears the moment a user switches to a hosted provider.

## Change

Adds `src/opencode-plugins/openwork-openai-compatible-system.ts`, which merges the leading run of system messages into one before the request leaves the process.

It follows the pattern already established by `openwork-anthropic-tool-schema.ts`: a one-time `globalThis.fetch` patch that rewrites the serialised body. That was chosen over another `experimental.chat.system.transform` hook on purpose — a hook would have to be registered *after* every plugin that pushes onto `output.system`, making correctness depend on plugin array order. Patching at the wire boundary is order-independent and also covers any future plugin, first-party or user-installed.

Behaviour:

- **Anthropic requests are never touched** — detected via the `anthropic-version` header, the same way `openwork-anthropic-tool-schema` detects them, so system blocks keep their cache breakpoints.
- **Only the leading run is merged.** A system message appearing after a user or assistant message is left in place; that would be a separate bug, and silently reordering it would change the conversation the model sees.
- **String and structured content are both handled.** Strings are joined by a blank line. If any entry uses content parts, the result stays an array so no structured part is flattened away.
- **Fewer than two leading system messages, unparseable bodies, and bodies without a `messages` array return `null`** and the original body is forwarded untouched.

Merging leading system messages is semantically equivalent on every OpenAI-compatible server, including the tolerant ones, so no provider allowlist is needed.

## Registration

The plugin is wired in at the three places the existing plugins use:

- `openwork-extensions-plugin-path.ts` — path export
- `openwork-runtime-config.ts` — import and entry in the `plugin: [...]` array
- `apps/server/package.json` — added to the `bun build` list, since plugins are bundled into `dist/opencode-plugins` by name and would otherwise be missing from a packaged build

It is listed **last** in the plugin array, so that if a future maintainer prefers to move the logic into a `system.transform` hook, the ordering is already correct.

## Tests

`src/opencode-plugins/openwork-openai-compatible-system.test.ts` — eight cases:

- three leading system messages collapse to one, joined by a blank line
- a single system message is forwarded unchanged
- a request with no system message is forwarded unchanged
- a system message mid-conversation is **not** reordered
- structured content parts stay an array
- unrelated body fields and unrelated message fields survive
- Anthropic requests are ignored
- a non-JSON body containing the word `"system"` is forwarded byte-for-byte

## Verification

Reproduced and verified on macOS 26 / Apple Silicon against Hetzner Inference (`Qwen3.8-27B` and `Qwen/Qwen3.6-35B-A3B-FP8`). Before the change every request fails in ~320 ms; after it the same session runs, including tool calls.

Control group for the diagnosis: the standalone `opencode` CLI, same machine, same provider config, same API key, default `build` agent and therefore none of these plugins — works unchanged.

## Note for reviewers

If the maintainers would rather see this fixed upstream in opencode's openai-compatible conversion path, that is the cleaner long-term home and I'll happily close this in favour of it. This PR exists because #2099 has been open since June, #2339 stalled, and the bug currently blocks every EU-hosted inference provider in OpenWork.

## Related

This is not specific to OpenWork. The same failure is reported against opencode itself whenever a plugin contributes to the system array, so far without a diagnosis:

- anomalyco/opencode#20785 — same error, triggered by the Superpowers plugin (open)
- anomalyco/opencode#16560 — same error, nvidia provider (open)
- anomalyco/opencode#20813 — same error, qwen3.6-plus with image input (closed as not planned)

The cleanest long-term home for this is opencode's openai-compatible conversion path, where leading system messages would be merged for every consumer at once. This PR fixes it inside OpenWork now, and is small enough to remove later if that upstream change lands.
