### PR TITLE
feat(policies): fully locked desktop policy — block local skill creation and MCP additions

### DIFF
--- a/apps/app/src/app/cloud/desktop-app-restrictions.ts
+++ b/apps/app/src/app/cloud/desktop-app-restrictions.ts
@@ -17,6 +17,22 @@ export function checkDesktopAppRestriction(input: {
   return input.config?.[input.restriction] === false;
 }
 
+export function resolveDesktopExtensionRestrictions(
+  checkRestriction: DesktopAppRestrictionChecker,
+) {
+  const extensionManagementRestricted = checkRestriction({
+    restriction: "allowManageExtensions",
+  });
+  return {
+    skillCreationRestricted:
+      checkRestriction({ restriction: "allowCreateSkills" }) ||
+      extensionManagementRestricted,
+    mcpAddRestricted:
+      checkRestriction({ restriction: "allowAddMcpServers" }) ||
+      extensionManagementRestricted,
+  };
+}
+
 export function isDesktopProviderBlocked(input: {
   providerId: string;
   checkRestriction: DesktopAppRestrictionChecker;

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -808,6 +808,17 @@ export type OpenworkConnectState = {
   googleWorkspace: { legacyConfigured: boolean };
 };
 
+export type OpenworkDesktopPolicyStateValue = {
+  allowCreateSkills: boolean;
+  allowAddMcpServers: boolean;
+};
+
+export type OpenworkDesktopPolicyState = {
+  ok: boolean;
+  schemaVersion: number;
+  state: OpenworkDesktopPolicyStateValue & { updatedAt: number };
+};
+
 export type OpenworkExtensionActionCall = {
   extensionId: string;
   action: string;
@@ -1529,6 +1540,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         timeoutMs: timeouts.config,
       })),
     setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),
+    setDesktopPolicyState: (state: OpenworkDesktopPolicyStateValue) => requestJson<OpenworkDesktopPolicyState>(baseUrl, "/experimental/desktop-policy/state", { token, hostToken, method: "PUT", body: state, timeoutMs: timeouts.config }),
     callExtensionAction: (payload: OpenworkExtensionActionCall) =>
       requestJson<OpenworkExtensionActionResult>(baseUrl, "/experimental/extensions/call", {
         token,

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -14,6 +14,7 @@ import { desktopPolicyKeys } from "@openwork/types/den/desktop-policies";
 
 import {
   checkDesktopAppRestriction,
+  resolveDesktopExtensionRestrictions,
   type DesktopAppRestrictionChecker,
 } from "../../../app/cloud/desktop-app-restrictions";
 import {
@@ -30,7 +31,10 @@ import {
   type DenDesktopConfig,
 } from "../../../app/lib/den";
 import { applyBrandAppName, applyBrandIcon, getBrandIconState } from "../../../app/lib/desktop";
-import { createOpenworkServerClient } from "../../../app/lib/openwork-server";
+import {
+  createOpenworkServerClient,
+  type OpenworkDesktopPolicyStateValue,
+} from "../../../app/lib/openwork-server";
 import {
   denSessionUpdatedEvent,
   denSettingsChangedEvent,
@@ -77,6 +81,19 @@ const DESKTOP_CONFIG_ITEMS = [
 
 export function resolveConnectStateToPush(config: DenDesktopConfig): boolean | null {
   return typeof config.connectEnabled === "boolean" ? config.connectEnabled : null;
+}
+
+export function resolveDesktopPolicyStateToPush(
+  config: DenDesktopConfig | null,
+): OpenworkDesktopPolicyStateValue | null {
+  if (!config) return null;
+  const restrictions = resolveDesktopExtensionRestrictions(({ restriction }) =>
+    checkDesktopAppRestriction({ config, restriction })
+  );
+  return {
+    allowCreateSkills: !restrictions.skillCreationRestricted,
+    allowAddMcpServers: !restrictions.mcpAddRestricted,
+  };
 }
 
 export const CONNECT_STATE_PUSH_RETRY_DELAY_MS = 3_000;
@@ -214,6 +231,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
   const refreshRunRef = useRef(0);
   const lastPushedConnectEnabledRef = useRef<boolean | null>(null);
+  const lastPushedDesktopPolicyStateRef = useRef<string | null>(null);
   // Safe in-memory copy of the last config we actually applied. State drives
   // rendering, while this ref lets the handler compare without stale closures.
   const currentDesktopConfigRef = useRef<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
@@ -390,6 +408,10 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   }, [desktopConfigHandler, isSignedIn]);
 
   const connectEnabled = resolveConnectStateToPush(config);
+  const desktopPolicyState = resolveDesktopPolicyStateToPush(isSignedIn ? config : null);
+  const desktopPolicyStateKey = desktopPolicyState
+    ? `${desktopPolicyState.allowCreateSkills}:${desktopPolicyState.allowAddMcpServers}`
+    : null;
 
   useEffect(() => {
     if (loading) return;
@@ -420,6 +442,36 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       cancelled = true;
     };
   }, [connectEnabled, loading]);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!desktopPolicyState || !desktopPolicyStateKey) return;
+    if (lastPushedDesktopPolicyStateRef.current === desktopPolicyStateKey) return;
+    let cancelled = false;
+
+    void deliverConnectState(
+      async () => {
+        const connection = await resolveOpenworkConnection();
+        if (!connection.normalizedBaseUrl || !connection.resolvedHostToken) return false;
+        await createOpenworkServerClient({
+          baseUrl: connection.normalizedBaseUrl,
+          token: connection.resolvedToken,
+          hostToken: connection.resolvedHostToken,
+        }).setDesktopPolicyState(desktopPolicyState);
+        return true;
+      },
+      (delayMs) => new Promise((resolveWait) => window.setTimeout(resolveWait, delayMs)),
+      () => cancelled,
+    ).then((delivered) => {
+      if (delivered && !cancelled) {
+        lastPushedDesktopPolicyStateRef.current = desktopPolicyStateKey;
+      }
+    }).catch(() => null);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopPolicyStateKey, loading]);
 
   // Dev-only: expose a bridge so evals can inject config directly without
   // requiring a cloud sign-in. This simply applies the config to React state.

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -192,6 +192,10 @@ export type McpViewProps = {
   enablementContext?: import("../../../../app/enablement").EnablementContext;
   /** Organization policy restriction for OpenWork-provided built-in extensions. */
   builtInExtensionsDisabled?: boolean;
+  /** Organization policy restriction for creating skills. */
+  skillCreationDisabled?: boolean;
+  /** Organization policy restriction for adding MCP servers. */
+  mcpAddDisabled?: boolean;
   /** Preview a Claude Code plugin bundle from a GitHub URL ("Will install" disclosure). */
   previewClaudePlugin?: (url: string) => Promise<OpenworkClaudePluginPreview>;
   /** Install a Claude Code plugin bundle from a GitHub URL. */
@@ -543,9 +547,19 @@ export function McpView(props: McpViewProps) {
   const libraryAddOptions = {
     cloudSignedIn: cloudSession.isSignedIn,
   };
-  const libraryAddKinds = libraryAddKindsForFilter(filter).filter((kind) => (
-    libraryAddAction(kind, libraryAddOptions) !== null
-  ));
+  const libraryAddKinds = libraryAddKindsForFilter(filter).filter((kind) => {
+    if (kind === "skill" && props.skillCreationDisabled) return false;
+    if (kind === "mcp" && props.mcpAddDisabled) return false;
+    return libraryAddAction(kind, libraryAddOptions) !== null;
+  });
+  const policyNotices = [
+    ...(props.skillCreationDisabled
+      ? ["Your organization administrator has disabled creating skills on this device."]
+      : []),
+    ...(props.mcpAddDisabled
+      ? ["Your organization administrator has disabled adding MCP servers on this device."]
+      : []),
+  ];
   const handleAddKind = (kind: LibraryAddKind) => {
     const action = libraryAddAction(kind, libraryAddOptions);
     if (!action) return;
@@ -1280,6 +1294,12 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
+      {policyNotices.length > 0 ? (
+        <div className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11">
+          {policyNotices.join(" ")}
+        </div>
+      ) : null}
+
       {libraryAddKinds.length > 0 ? (
         <div className="mb-5 flex justify-end">
           <LibraryAddControl kinds={libraryAddKinds} onSelect={handleAddKind} />
@@ -1541,21 +1561,23 @@ export function McpView(props: McpViewProps) {
         onToggle={() => setShowAdvanced((current) => !current)}
         onScopeChange={setConfigScope}
         onReveal={revealConfig}
-        onAddMcp={() => setAddMcpModalOpen(true)}
+        onAddMcp={props.mcpAddDisabled ? undefined : () => setAddMcpModalOpen(true)}
         onImportFromGithub={
-          props.previewClaudePlugin && props.installClaudePlugin
+          !props.mcpAddDisabled && props.previewClaudePlugin && props.installClaudePlugin
             ? () => setClaudeImportOpen(true)
             : undefined
         }
       />
 
-      <AddMcpModal
-        open={addMcpModalOpen}
-        onClose={() => setAddMcpModalOpen(false)}
-        onAdd={props.connectMcp}
-        busy={props.busy}
-        isRemoteWorkspace={props.isRemoteWorkspace}
-      />
+      {!props.mcpAddDisabled ? (
+        <AddMcpModal
+          open={addMcpModalOpen}
+          onClose={() => setAddMcpModalOpen(false)}
+          onAdd={props.connectMcp}
+          busy={props.busy}
+          isRemoteWorkspace={props.isRemoteWorkspace}
+        />
+      ) : null}
 
       <AddLibraryItemModal
         open={addAuthorableKind !== null}
@@ -1566,7 +1588,7 @@ export function McpView(props: McpViewProps) {
         onCreate={handleCreateLibraryItem}
       />
 
-      {props.previewClaudePlugin && props.installClaudePlugin ? (
+      {!props.mcpAddDisabled && props.previewClaudePlugin && props.installClaudePlugin ? (
         <ClaudePluginImportModal
           open={claudeImportOpen}
           onClose={() => setClaudeImportOpen(false)}
@@ -2290,7 +2312,7 @@ function McpAdvancedConfigSection(props: {
   onToggle: () => void;
   onScopeChange: (scope: ConfigScope) => void;
   onReveal: () => Promise<void>;
-  onAddMcp: () => void;
+  onAddMcp?: () => void;
   onImportFromGithub?: () => void;
 }) {
   return (
@@ -2312,10 +2334,12 @@ function McpAdvancedConfigSection(props: {
           <div className="flex flex-col gap-2">
             <div className="text-xs text-dls-secondary">{t("mcp.custom_app_cta_hint")}</div>
             <div className="flex flex-wrap items-center gap-2">
-              <Button variant="outline" onClick={props.onAddMcp}>
-                <Plus size={14} />
-                {t("mcp.add_modal_title")}
-              </Button>
+              {props.onAddMcp ? (
+                <Button variant="outline" onClick={props.onAddMcp}>
+                  <Plus size={14} />
+                  {t("mcp.add_modal_title")}
+                </Button>
+              ) : null}
               {props.onImportFromGithub ? (
                 <Button variant="outline" onClick={props.onImportFromGithub}>
                   <Download size={14} />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -124,7 +124,10 @@ import {
   type WorkspaceList,
   revealDesktopItemInDir,
 } from "@/app/lib/desktop";
-import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
+import {
+  isDesktopProviderBlocked,
+  resolveDesktopExtensionRestrictions,
+} from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction, useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
@@ -1897,6 +1900,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     };
   }, [computerUsePermissions, connectionsSnapshot, extensionStateVersion, providerConnectedIds, userEnvKeys]);
   const builtInExtensionsDisabled = checkDesktopRestriction({ restriction: "allowBuiltInExtensions" });
+  const {
+    skillCreationRestricted: skillCreationDisabled,
+    mcpAddRestricted: mcpAddDisabled,
+  } = resolveDesktopExtensionRestrictions(checkDesktopRestriction);
   const restartExtensionLocalServer = useCallback(async () => {
     if (!isDesktopRuntime()) return false;
     try {
@@ -2376,6 +2383,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 quickConnect={extensionItems.quickConnectEntries}
                 enablementContext={enablementContext}
                 builtInExtensionsDisabled={builtInExtensionsDisabled}
+                skillCreationDisabled={skillCreationDisabled}
+                mcpAddDisabled={mcpAddDisabled}
                 connectMcp={(entry) => {
                   return connectionsStore.connectMcp(entry);
                 }}

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -12,6 +12,7 @@ import {
   CONNECT_STATE_PUSH_RETRY_DELAY_MS,
   deliverConnectState,
   resolveConnectStateToPush,
+  resolveDesktopPolicyStateToPush,
 } from "../src/react-app/domains/cloud/desktop-config-provider";
 
 const originalFetch = globalThis.fetch;
@@ -21,6 +22,22 @@ describe("Den desktop config client", () => {
     expect(resolveConnectStateToPush({})).toBeNull();
     expect(resolveConnectStateToPush({ connectEnabled: false })).toBe(false);
     expect(resolveConnectStateToPush({ connectEnabled: true })).toBe(true);
+  });
+
+  test("resolves effective desktop extension policy state", () => {
+    expect(resolveDesktopPolicyStateToPush({ allowManageExtensions: false })).toEqual({
+      allowCreateSkills: false,
+      allowAddMcpServers: false,
+    });
+    expect(resolveDesktopPolicyStateToPush({ allowCreateSkills: false })).toEqual({
+      allowCreateSkills: false,
+      allowAddMcpServers: true,
+    });
+    expect(resolveDesktopPolicyStateToPush({})).toEqual({
+      allowCreateSkills: true,
+      allowAddMcpServers: true,
+    });
+    expect(resolveDesktopPolicyStateToPush(null)).toBeNull();
   });
 
   test("retries the Connect push until the local server accepts it", async () => {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
     "test": "bun --conditions=development test",
     "test:artifacts": "bun --conditions=development test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build:enterprise-mcp-client": "pnpm --filter @openwork/enterprise-mcp-client build",
-    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts src/opencode-plugins/openwork-desktop-policy-lock.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "pnpm build:enterprise-mcp-client && bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "pnpm build:enterprise-mcp-client && bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "prepare:npm": "pnpm build:bin && node scripts/publish-npm.mjs --prepare-only",

--- a/apps/server/src/desktop-policy-state.test.ts
+++ b/apps/server/src/desktop-policy-state.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { inspectDesktopPolicyState } from "./desktop-policy-state.js";
+import { openworkDesktopPolicyLockPluginPath } from "./openwork-extensions-plugin-path.js";
+import { OpenWorkDesktopPolicyLock } from "./opencode-plugins/openwork-desktop-policy-lock.js";
+import { buildOpenworkRuntimeConfigObject } from "./openwork-runtime-config.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const CLIENT_TOKEN = "owt_desktop_policy_client";
+const HOST_TOKEN = "owt_desktop_policy_host";
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const previousServerUrl = process.env.OPENWORK_SERVER_URL;
+const previousServerToken = process.env.OPENWORK_SERVER_TOKEN;
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  restoreEnv("OPENWORK_RUNTIME_DB", previousRuntimeDb);
+  restoreEnv("OPENWORK_SERVER_URL", previousServerUrl);
+  restoreEnv("OPENWORK_SERVER_TOKEN", previousServerToken);
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function responseRecord(response: Response): Promise<Record<string, unknown>> {
+  const body: unknown = await response.json();
+  if (!isRecord(body)) throw new Error("Response body was not an object");
+  return body;
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object`);
+  return value;
+}
+
+function clientHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${CLIENT_TOKEN}`, "Content-Type": "application/json" };
+}
+
+function hostHeaders(): Record<string, string> {
+  return { "X-OpenWork-Host-Token": HOST_TOKEN, "Content-Type": "application/json" };
+}
+
+function startMockOpencode() {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/global/health") return Response.json({ healthy: true, version: "1.18.15" });
+      if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/mcp") return Response.json({});
+      return Response.json({ code: "not_found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop(true));
+  return server;
+}
+
+async function startOpenwork() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-desktop-policy-"));
+  roots.push(root);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const opencode = startMockOpencode();
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_1",
+      name: "Workspace",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: `http://127.0.0.1:${opencode.port}`,
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, config, root };
+}
+
+async function putPolicy(base: string, state: {
+  allowCreateSkills: boolean;
+  allowAddMcpServers: boolean;
+}): Promise<Response> {
+  return fetch(`${base}/experimental/desktop-policy/state`, {
+    method: "PUT",
+    headers: hostHeaders(),
+    body: JSON.stringify(state),
+  });
+}
+
+describe("desktop policy state", () => {
+  test("persists strict host updates and serves them to clients", async () => {
+    const openwork = await startOpenwork();
+    const putResponse = await putPolicy(openwork.base, {
+      allowCreateSkills: false,
+      allowAddMcpServers: true,
+    });
+    expect(putResponse.status).toBe(200);
+    const putBody = await responseRecord(putResponse);
+    expect(putBody).toMatchObject({
+      ok: true,
+      schemaVersion: 1,
+      state: {
+        allowCreateSkills: false,
+        allowAddMcpServers: true,
+        updatedAt: expect.any(Number),
+      },
+    });
+
+    const persisted: unknown = JSON.parse(await readFile(join(openwork.root, "desktop-policy-state.json"), "utf8"));
+    expect(persisted).toEqual(putBody.state);
+
+    const getResponse = await fetch(`${openwork.base}/experimental/desktop-policy/state`, {
+      headers: clientHeaders(),
+    });
+    expect(getResponse.status).toBe(200);
+    expect(await responseRecord(getResponse)).toEqual(putBody);
+
+    for (const invalid of [
+      { allowCreateSkills: false, allowAddMcpServers: true, extra: true },
+      { allowCreateSkills: "false", allowAddMcpServers: true },
+      { allowCreateSkills: true },
+      null,
+    ]) {
+      const response = await fetch(`${openwork.base}/experimental/desktop-policy/state`, {
+        method: "PUT",
+        headers: hostHeaders(),
+        body: JSON.stringify(invalid),
+      });
+      expect(response.status).toBe(400);
+      expect((await responseRecord(response)).code).toBe("invalid_payload");
+    }
+  });
+
+  test("blocks restricted skill and MCP writes and flips both capability routes", async () => {
+    const openwork = await startOpenwork();
+    expect((await putPolicy(openwork.base, {
+      allowCreateSkills: false,
+      allowAddMcpServers: false,
+    })).status).toBe(200);
+
+    const skillResponse = await fetch(`${openwork.base}/workspace/ws_1/skills`, {
+      method: "POST",
+      headers: clientHeaders(),
+      body: JSON.stringify({ name: "locked-skill", description: "Locked", content: "Instructions" }),
+    });
+    expect(skillResponse.status).toBe(403);
+    expect(await responseRecord(skillResponse)).toMatchObject({
+      code: "policy_restricted",
+      details: { policy: "allowCreateSkills" },
+    });
+
+    const mcpResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+      method: "POST",
+      headers: clientHeaders(),
+      body: JSON.stringify({
+        name: "locked-mcp",
+        config: { type: "remote", url: "https://example.com/mcp", enabled: true },
+      }),
+    });
+    expect(mcpResponse.status).toBe(403);
+    expect(await responseRecord(mcpResponse)).toMatchObject({
+      code: "policy_restricted",
+      details: { policy: "allowAddMcpServers" },
+    });
+
+    for (const path of ["/capabilities", "/w/ws_1/capabilities"]) {
+      const capabilities = await responseRecord(await fetch(`${openwork.base}${path}`, {
+        headers: clientHeaders(),
+      }));
+      expect(requireRecord(capabilities.skills, "skills").write).toBe(false);
+      expect(requireRecord(capabilities.mcp, "mcp").write).toBe(false);
+    }
+  });
+
+  test("fails open when state is missing or invalid", async () => {
+    const openwork = await startOpenwork();
+    expect(await inspectDesktopPolicyState(openwork.config)).toEqual({
+      status: "missing",
+      state: { allowCreateSkills: true, allowAddMcpServers: true, updatedAt: 0 },
+    });
+
+    const capabilities = await responseRecord(await fetch(`${openwork.base}/capabilities`, {
+      headers: clientHeaders(),
+    }));
+    expect(requireRecord(capabilities.skills, "skills").write).toBe(true);
+    expect(requireRecord(capabilities.mcp, "mcp").write).toBe(true);
+
+    const skillResponse = await fetch(`${openwork.base}/workspace/ws_1/skills`, {
+      method: "POST",
+      headers: clientHeaders(),
+      body: JSON.stringify({ name: "default-skill", description: "Default", content: "Instructions" }),
+    });
+    expect(skillResponse.status).toBe(200);
+
+    const mcpResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+      method: "POST",
+      headers: clientHeaders(),
+      body: JSON.stringify({
+        name: "default-mcp",
+        config: { type: "remote", url: "https://example.com/mcp", enabled: true },
+      }),
+    });
+    expect(mcpResponse.status).toBe(200);
+
+    await writeFile(join(openwork.root, "desktop-policy-state.json"), "{not json", "utf8");
+    expect(await inspectDesktopPolicyState(openwork.config)).toEqual({
+      status: "invalid",
+      state: { allowCreateSkills: true, allowAddMcpServers: true, updatedAt: 0 },
+    });
+  });
+
+  test("registers the engine lock and blocks restricted file tools and permissions", async () => {
+    const openwork = await startOpenwork();
+    expect((await putPolicy(openwork.base, {
+      allowCreateSkills: false,
+      allowAddMcpServers: false,
+    })).status).toBe(200);
+    process.env.OPENWORK_SERVER_URL = openwork.base;
+    process.env.OPENWORK_SERVER_TOKEN = CLIENT_TOKEN;
+
+    const hooks = await OpenWorkDesktopPolicyLock();
+    await expect(hooks["tool.execute.before"](
+      { tool: "write" },
+      { args: { filePath: join(openwork.root, ".opencode", "skills", "demo", "SKILL.md") } },
+    )).rejects.toThrow("disabled creating skills");
+    await expect(hooks["tool.execute.before"](
+      { tool: "multi_edit" },
+      { args: { filePath: join(openwork.root, "opencode.jsonc") } },
+    )).rejects.toThrow("file is managed");
+
+    const permission: { status: "ask" | "deny" | "allow" } = { status: "ask" };
+    await hooks["permission.ask"](
+      { pattern: [join(openwork.root, ".opencode", "openwork.json")] },
+      permission,
+    );
+    expect(permission.status).toBe("deny");
+
+    const runtime = await buildOpenworkRuntimeConfigObject();
+    if (!Array.isArray(runtime.plugin)) throw new Error("Runtime plugin list was missing");
+    expect(runtime.plugin).toContain(openworkDesktopPolicyLockPluginPath());
+    const packageJson: unknown = JSON.parse(await readFile(join(import.meta.dir, "..", "package.json"), "utf8"));
+    const build = requireRecord(requireRecord(packageJson, "packageJson").scripts, "scripts").build;
+    if (typeof build !== "string") throw new Error("Package build script was missing");
+    expect(build).toContain("openwork-desktop-policy-lock.ts");
+  });
+});

--- a/apps/server/src/desktop-policy-state.ts
+++ b/apps/server/src/desktop-policy-state.ts
@@ -1,0 +1,106 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { readBoundedRegularTextFile } from "./jsonc.js";
+import { runtimeStorageDir } from "./runtime-db.js";
+import type { ServerConfig } from "./types.js";
+import { ensureDir } from "./utils.js";
+
+const DESKTOP_POLICY_STATE_FILE = "desktop-policy-state.json";
+const DESKTOP_POLICY_STATE_MAX_BYTES = 16 * 1024;
+
+export type DesktopPolicyState = {
+  allowCreateSkills: boolean;
+  allowAddMcpServers: boolean;
+  updatedAt: number;
+};
+
+export type DesktopPolicyStateInspectionStatus = "available" | "missing" | "invalid" | "unreadable";
+
+export type DesktopPolicyStateInspection = {
+  status: DesktopPolicyStateInspectionStatus;
+  state: DesktopPolicyState;
+};
+
+export type DesktopPolicyStateInspectionOptions = {
+  maxBytes?: number;
+  signal?: AbortSignal;
+};
+
+const DEFAULT_DESKTOP_POLICY_STATE: DesktopPolicyState = {
+  allowCreateSkills: true,
+  allowAddMcpServers: true,
+  updatedAt: 0,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function desktopPolicyStatePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), DESKTOP_POLICY_STATE_FILE);
+}
+
+export async function readDesktopPolicyState(config: ServerConfig): Promise<DesktopPolicyState> {
+  return (await inspectDesktopPolicyState(config)).state;
+}
+
+export async function inspectDesktopPolicyState(
+  config: ServerConfig,
+  options?: DesktopPolicyStateInspectionOptions,
+): Promise<DesktopPolicyStateInspection> {
+  try {
+    const raw = await readBoundedRegularTextFile(desktopPolicyStatePath(config), {
+      maxBytes: options?.maxBytes ?? DESKTOP_POLICY_STATE_MAX_BYTES,
+      signal: options?.signal,
+    });
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !isRecord(parsed)
+      || typeof parsed.allowCreateSkills !== "boolean"
+      || typeof parsed.allowAddMcpServers !== "boolean"
+    ) {
+      return { status: "invalid", state: DEFAULT_DESKTOP_POLICY_STATE };
+    }
+    return {
+      status: "available",
+      state: {
+        allowCreateSkills: parsed.allowCreateSkills,
+        allowAddMcpServers: parsed.allowAddMcpServers,
+        updatedAt: typeof parsed.updatedAt === "number" && Number.isFinite(parsed.updatedAt)
+          ? parsed.updatedAt
+          : 0,
+      },
+    };
+  } catch (error) {
+    options?.signal?.throwIfAborted();
+    if (isRecord(error) && error.code === "ENOENT") {
+      return { status: "missing", state: DEFAULT_DESKTOP_POLICY_STATE };
+    }
+    if (error instanceof SyntaxError) {
+      return { status: "invalid", state: DEFAULT_DESKTOP_POLICY_STATE };
+    }
+    return { status: "unreadable", state: DEFAULT_DESKTOP_POLICY_STATE };
+  }
+}
+
+async function persistDesktopPolicyState(
+  config: ServerConfig,
+  state: DesktopPolicyState,
+): Promise<DesktopPolicyState> {
+  await ensureDir(runtimeStorageDir(config));
+  await writeFile(desktopPolicyStatePath(config), `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  return state;
+}
+
+export async function writeDesktopPolicyState(
+  config: ServerConfig,
+  state: Pick<DesktopPolicyState, "allowCreateSkills" | "allowAddMcpServers">,
+): Promise<DesktopPolicyState> {
+  const current = await readDesktopPolicyState(config);
+  return persistDesktopPolicyState(config, {
+    ...current,
+    ...state,
+    updatedAt: Date.now(),
+  });
+}

--- a/apps/server/src/opencode-plugins/openwork-desktop-policy-lock.ts
+++ b/apps/server/src/opencode-plugins/openwork-desktop-policy-lock.ts
@@ -1,0 +1,118 @@
+type DesktopPolicyState = {
+  allowCreateSkills: boolean;
+  allowAddMcpServers: boolean;
+};
+
+type ToolExecuteInput = {
+  tool: string;
+};
+
+type ToolExecuteOutput = {
+  args: unknown;
+};
+
+type PermissionInput = {
+  pattern?: string | string[];
+};
+
+type PermissionOutput = {
+  status: "ask" | "deny" | "allow";
+};
+
+const POLICY_CACHE_MS = 15_000;
+const DEFAULT_POLICY_STATE: DesktopPolicyState = {
+  allowCreateSkills: true,
+  allowAddMcpServers: true,
+};
+const FILE_WRITE_TOOLS = new Set(["write", "edit", "multi_edit", "multiedit"]);
+const SKILL_LOCK_MESSAGE =
+  "Your organization administrator has disabled creating skills on this device.";
+const MCP_LOCK_MESSAGE =
+  "Your organization administrator has disabled adding MCP servers on this device. MCP/connection changes are disabled by your organization, and this file is managed.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsePolicyState(value: unknown): DesktopPolicyState | null {
+  if (!isRecord(value) || !isRecord(value.state)) return null;
+  if (
+    typeof value.state.allowCreateSkills !== "boolean"
+    || typeof value.state.allowAddMcpServers !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    allowCreateSkills: value.state.allowCreateSkills,
+    allowAddMcpServers: value.state.allowAddMcpServers,
+  };
+}
+
+function normalizedPath(value: string): string {
+  return `/${value.trim().replace(/\\/g, "/").replace(/^\/+/, "")}`;
+}
+
+function restrictionMessage(path: string, state: DesktopPolicyState): string | null {
+  const normalized = normalizedPath(path).toLowerCase();
+  if (!state.allowCreateSkills && normalized.includes("/.opencode/skills/")) {
+    return SKILL_LOCK_MESSAGE;
+  }
+  const basename = normalized.split("/").filter(Boolean).at(-1);
+  if (
+    !state.allowAddMcpServers
+    && (
+      basename === "opencode.json"
+      || basename === "opencode.jsonc"
+      || normalized.endsWith("/.opencode/openwork.json")
+    )
+  ) {
+    return MCP_LOCK_MESSAGE;
+  }
+  return null;
+}
+
+function filePathFromArgs(args: unknown): string | null {
+  if (!isRecord(args)) return null;
+  return typeof args.filePath === "string" ? args.filePath : null;
+}
+
+export const OpenWorkDesktopPolicyLock = async (_factoryInput?: unknown) => {
+  let cachedState: DesktopPolicyState | null = null;
+  let cachedAt = 0;
+
+  async function readPolicyState(): Promise<DesktopPolicyState> {
+    if (cachedState && Date.now() - cachedAt < POLICY_CACHE_MS) return cachedState;
+    const url = String(process.env.OPENWORK_SERVER_URL || "").replace(/\/$/, "");
+    const token = String(process.env.OPENWORK_SERVER_TOKEN || "");
+    try {
+      const response = await fetch(`${url}/experimental/desktop-policy/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) throw new Error(`Desktop policy request failed with HTTP ${response.status}`);
+      const parsed = parsePolicyState(await response.json());
+      cachedState = parsed ?? DEFAULT_POLICY_STATE;
+    } catch {
+      cachedState = cachedState ?? DEFAULT_POLICY_STATE;
+    }
+    cachedAt = Date.now();
+    return cachedState;
+  }
+
+  return {
+    "tool.execute.before": async (input: ToolExecuteInput, output: ToolExecuteOutput) => {
+      if (!FILE_WRITE_TOOLS.has(input.tool)) return;
+      const filePath = filePathFromArgs(output.args);
+      if (!filePath) return;
+      const message = restrictionMessage(filePath, await readPolicyState());
+      if (message) throw new Error(message);
+    },
+    "permission.ask": async (input: PermissionInput, output: PermissionOutput) => {
+      const patterns = typeof input.pattern === "string" ? [input.pattern] : input.pattern;
+      if (!patterns?.length) return;
+      const state = await readPolicyState();
+      if (patterns.some((pattern) => restrictionMessage(pattern, state) !== null)) {
+        output.status = "deny";
+      }
+    },
+  };
+};

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -36,3 +36,4 @@ export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath(
 export const openworkAnthropicAdaptiveThinkingPluginPath = () => openworkPluginPath("openwork-anthropic-adaptive-thinking");
 export const openworkAnthropicToolSchemaPluginPath = () => openworkPluginPath("openwork-anthropic-tool-schema");
 export const openworkOfficeAttachmentsPluginPath = () => openworkPluginPath("openwork-office-attachments");
+export const openworkDesktopPolicyLockPluginPath = () => openworkPluginPath("openwork-desktop-policy-lock");

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -21,6 +21,7 @@ import {
   openworkAnthropicAdaptiveThinkingPluginPath,
   openworkAnthropicToolSchemaPluginPath,
   openworkOfficeAttachmentsPluginPath,
+  openworkDesktopPolicyLockPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import { runtimeStorageDir } from "./runtime-db.js";
@@ -124,6 +125,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
     },
     plugin: [
       "opencode-chrome-devtools",
+      openworkDesktopPolicyLockPluginPath(),
       openworkExtensionsPreviewPluginPath(),
       openworkCapabilitiesKnowledgePluginPath(),
       openworkOfficeAttachmentsPluginPath(),

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -10,6 +10,7 @@ import {
 import type { CloudMcpLiveStatusObserver } from "../cloud-mcp-health.js";
 import { readOpenWorkConnectSkillCatalog, renderOpenWorkConnectSkillInstruction } from "../connect-skill-catalog.js";
 import { readOpenWorkAutomationCatalog, renderOpenWorkAutomationInstruction } from "../connect-automation-catalog.js";
+import { readDesktopPolicyState, writeDesktopPolicyState, type DesktopPolicyState } from "../desktop-policy-state.js";
 import { EnvStoreReadError, InvalidEnvKeyError, isValidEnvKey, type EnvService } from "../env-file.js";
 import { syncManagedProviderAuth } from "../managed-provider-auth.js";
 import { ApiError } from "../errors.js";
@@ -44,7 +45,7 @@ interface RegisterCoreRoutesOptions {
   readOptionalJsonBody: ReadJsonBody;
   parseOptionalBoolean: ParseOptionalBoolean;
   ensureWritable: (config: ServerConfig) => void;
-  buildCapabilities: (config: ServerConfig) => Capabilities;
+  buildCapabilities: (config: ServerConfig, desktopPolicyState?: DesktopPolicyState) => Capabilities;
   fetchRuntimeControl: FetchRuntimeControl;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
   resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
@@ -211,7 +212,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
   });
 
   addRoute(routes, "GET", "/w/:id/capabilities", "client", async () => {
-    return jsonResponse(buildCapabilities(config));
+    return jsonResponse(buildCapabilities(config, await readDesktopPolicyState(config)));
   });
 
   addRoute(routes, "GET", "/w/:id/workspaces", "client", async (ctx) => {
@@ -272,7 +273,37 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
   });
 
   addRoute(routes, "GET", "/capabilities", "client", async () => {
-    return jsonResponse(buildCapabilities(config));
+    return jsonResponse(buildCapabilities(config, await readDesktopPolicyState(config)));
+  });
+
+  addRoute(routes, "GET", "/experimental/desktop-policy/state", "client", async () => {
+    return jsonResponse({
+      ok: true,
+      schemaVersion: 1,
+      state: await readDesktopPolicyState(config),
+    });
+  });
+
+  addRoute(routes, "PUT", "/experimental/desktop-policy/state", "host", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    if (
+      !isRecord(body)
+      || typeof body.allowCreateSkills !== "boolean"
+      || typeof body.allowAddMcpServers !== "boolean"
+      || Object.keys(body).some((key) => key !== "allowCreateSkills" && key !== "allowAddMcpServers")
+    ) {
+      throw new ApiError(
+        400,
+        "invalid_payload",
+        "allowCreateSkills and allowAddMcpServers must be booleans",
+      );
+    }
+    const state = await writeDesktopPolicyState(config, {
+      allowCreateSkills: body.allowCreateSkills,
+      allowAddMcpServers: body.allowAddMcpServers,
+    });
+    return jsonResponse({ ok: true, schemaVersion: 1, state });
   });
 
   addRoute(routes, "GET", "/experimental/connect/state", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -137,6 +137,7 @@ import {
 } from "./openwork-workspace-config-store.js";
 import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { readLegacyConfigSweepState } from "./legacy-config-sweep.js";
+import { readDesktopPolicyState, type DesktopPolicyState } from "./desktop-policy-state.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { CloudProviderSync, parseCloudProviderDenSession } from "./cloud-provider-sync.js";
 import pkg from "../package.json" with { type: "json" };
@@ -1753,7 +1754,7 @@ async function requireHost(request: Request, config: ServerConfig, tokens: Token
   return { type: "remote", clientId, tokenHash: hashToken(bearer), scope };
 }
 
-function buildCapabilities(config: ServerConfig): Capabilities {
+function buildCapabilities(config: ServerConfig, desktopPolicyState?: DesktopPolicyState): Capabilities {
   const writeEnabled = !config.readOnly;
   const schemaVersion = 1;
   const sandboxBackend = resolveSandboxBackend();
@@ -1768,9 +1769,9 @@ function buildCapabilities(config: ServerConfig): Capabilities {
     serverVersion: SERVER_VERSION,
     opencodeVersion: OPENCODE_VERSION,
     providerSync: true,
-    skills: { read: true, write: writeEnabled, source: "openwork" },
+    skills: { read: true, write: writeEnabled && desktopPolicyState?.allowCreateSkills !== false, source: "openwork" },
     plugins: { read: true, write: writeEnabled },
-    mcp: { read: true, write: writeEnabled },
+    mcp: { read: true, write: writeEnabled && desktopPolicyState?.allowAddMcpServers !== false },
     commands: { read: true, write: writeEnabled },
     config: { read: true, write: writeEnabled },
     engine: { rollover: config.engineRollover === true },
@@ -1792,6 +1793,23 @@ function buildCapabilities(config: ServerConfig): Capabilities {
       },
     },
   };
+}
+
+type RestrictedDesktopPolicy = "allowCreateSkills" | "allowAddMcpServers";
+
+const desktopPolicyRestrictionNotices: Record<RestrictedDesktopPolicy, string> = {
+  allowCreateSkills: "Your organization administrator has disabled creating skills on this device.",
+  allowAddMcpServers: "Your organization administrator has disabled adding MCP servers on this device.",
+};
+
+async function ensureDesktopPolicyAllows(
+  config: ServerConfig,
+  policy: RestrictedDesktopPolicy,
+): Promise<void> {
+  const state = await readDesktopPolicyState(config);
+  if (state[policy] === false) {
+    throw new ApiError(403, "policy_restricted", desktopPolicyRestrictionNotices[policy], { policy });
+  }
 }
 
 function resolveSandboxBackend(): Capabilities["sandbox"]["backend"] {
@@ -2960,6 +2978,7 @@ function createRoutes(
   addRoute(routes, "POST", "/workspace/:id/skills", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowCreateSkills");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
@@ -2993,6 +3012,7 @@ function createRoutes(
   addRoute(routes, "DELETE", "/workspace/:id/skills/:name", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowCreateSkills");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = String(ctx.params.name ?? "").trim();
     if (!name) {
@@ -3126,6 +3146,7 @@ function createRoutes(
   addRoute(routes, "POST", "/workspace/:id/mcp/managed", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowAddMcpServers");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "").trim();
@@ -3263,6 +3284,7 @@ function createRoutes(
   addRoute(routes, "POST", "/workspace/:id/mcp", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowAddMcpServers");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
@@ -3308,6 +3330,7 @@ function createRoutes(
   addRoute(routes, "DELETE", "/workspace/:id/mcp/:name", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowAddMcpServers");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     await requireApproval(ctx, {
@@ -3345,6 +3368,7 @@ function createRoutes(
   addRoute(routes, "POST", "/workspace/:id/mcp/:name/enabled", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
+    await ensureDesktopPolicyAllows(config, "allowAddMcpServers");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     const body = await readJsonBody(ctx.request);

--- a/evals/specs/desktop-policy-lockdown.e2e.test.ts
+++ b/evals/specs/desktop-policy-lockdown.e2e.test.ts
@@ -1,0 +1,256 @@
+import { expect } from "vitest";
+import { denFetch, evalIn, go, waitForText } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { app, eventually, needs, server, test } from "@openwork/testkit";
+
+const SKILL_NOTICE = "Your organization administrator has disabled creating skills on this device.";
+const MCP_NOTICE = "Your organization administrator has disabled adding MCP servers on this device.";
+const REQUEST_TIMEOUT_MS = 20_000;
+
+interface ApiResult {
+  status: number;
+  body: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function stringField(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value) throw new Error(`${label} was not a non-empty string.`);
+  return value;
+}
+
+function auth(session: DenSession, orgId?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${session.token}`,
+    ...(orgId ? { "x-openwork-org-id": orgId } : {}),
+  };
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = record(result.body, "organization response");
+  const organization = records(body.orgs)[0];
+  const id = organization ? stringField(organization.id, "organization id") : "";
+  if (!result.response.ok || !id) throw new Error(`Finding the isolated organization failed with HTTP ${result.response.status}.`);
+  return id;
+}
+
+async function configureLockdown(admin: DenSession, orgId: string): Promise<Record<string, unknown>> {
+  const listed = await denFetch(admin, "/v1/desktop-policies", {
+    headers: auth(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const listBody = record(listed.body, "desktop policy list");
+  const policy = records(listBody.desktopPolicies).find((entry) => entry.isDefault === true);
+  if (!listed.response.ok || !policy) throw new Error(`Finding the default desktop policy failed with HTTP ${listed.response.status}.`);
+  const policyId = stringField(policy.id, "default desktop policy id");
+  const existingPolicy = record(policy.policy, "default desktop policy document");
+  const assignments = records(policy.assignments);
+  const patched = await denFetch(admin, `/v1/desktop-policies/${encodeURIComponent(policyId)}`, {
+    method: "PATCH",
+    headers: { ...auth(admin, orgId), "content-type": "application/json" },
+    body: JSON.stringify({
+      policyName: stringField(policy.policyName, "default desktop policy name"),
+      policy: {
+        ...existingPolicy,
+        allowCreateSkills: false,
+        allowAddMcpServers: false,
+      },
+      priority: typeof policy.priority === "number" ? policy.priority : 0,
+      isEnabled: policy.isEnabled === true,
+      memberIds: assignments.flatMap((entry) => typeof entry.orgMemberId === "string" ? [entry.orgMemberId] : []),
+      teamIds: assignments.flatMap((entry) => typeof entry.teamId === "string" ? [entry.teamId] : []),
+      roles: Array.isArray(policy.roles) ? policy.roles : [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const patchedBody = record(patched.body, "patched desktop policy response");
+  const updated = record(patchedBody.desktopPolicy, "patched desktop policy");
+  const updatedPolicy = record(updated.policy, "patched desktop policy document");
+  const preserved = Object.entries(existingPolicy)
+    .filter(([key]) => key !== "allowCreateSkills" && key !== "allowAddMcpServers")
+    .every(([key, value]) => JSON.stringify(updatedPolicy[key]) === JSON.stringify(value));
+  if (patched.response.status !== 200 || !preserved) {
+    throw new Error(`Patching the default desktop policy failed or replaced existing values: HTTP ${patched.response.status}.`);
+  }
+  return updatedPolicy;
+}
+
+async function readMemberDesktopConfig(member: DenSession, orgId: string): Promise<Record<string, unknown>> {
+  const result = await denFetch(member, "/v1/me/desktop-config", {
+    headers: auth(member, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!result.response.ok) throw new Error(`Reading member desktop config failed with HTTP ${result.response.status}.`);
+  return record(result.body, "member desktop config");
+}
+
+async function localRequest(
+  desktop: Parameters<typeof evalIn>[0],
+  path: string,
+  input: { method?: string; body?: Record<string, unknown> } = {},
+): Promise<ApiResult> {
+  const raw = await evalIn(desktop, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? info?.connectUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+    if (!baseUrl || !token) return JSON.stringify({ status: 0, body: { code: "local_server_unavailable" } });
+    const response = await fetch(baseUrl + ${JSON.stringify(path)}, {
+      method: ${JSON.stringify(input.method ?? "GET")},
+      headers: {
+        authorization: "Bearer " + token,
+        "content-type": "application/json",
+      },
+      body: ${input.body ? JSON.stringify(JSON.stringify(input.body)) : "undefined"},
+    });
+    const text = await response.text();
+    let body = null;
+    try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+    return JSON.stringify({ status: response.status, body });
+  })()`, { awaitPromise: true, timeoutMs: REQUEST_TIMEOUT_MS });
+  const parsed: unknown = JSON.parse(String(raw));
+  const result = record(parsed, `local ${input.method ?? "GET"} ${path} response`);
+  if (typeof result.status !== "number") throw new Error(`Local response had no numeric status: ${JSON.stringify(result)}`);
+  return { status: result.status, body: result.body };
+}
+
+function policyState(body: unknown): Record<string, unknown> {
+  return record(record(body, "desktop policy state response").state, "desktop policy state");
+}
+
+function hasLockdown(state: Record<string, unknown>): boolean {
+  return state.allowCreateSkills === false && state.allowAddMcpServers === false;
+}
+
+async function exactButtonVisible(desktop: Parameters<typeof evalIn>[0], label: string): Promise<boolean> {
+  return (await evalIn(desktop, `[...document.querySelectorAll("button")]
+    .some((button) => (button.textContent ?? "").trim() === ${JSON.stringify(label)})`)) === true;
+}
+
+async function textVisible(desktop: Parameters<typeof evalIn>[0], text: string): Promise<boolean> {
+  return (await evalIn(desktop, `(document.body?.innerText ?? "").includes(${JSON.stringify(text)})`)) === true;
+}
+
+test("Den desktop policy locks down signed-in desktop skill and MCP writes", async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using den = await server({
+    place,
+    org: {
+      name: `Desktop Policy Lockdown ${Date.now()}`,
+      admin: { name: "Policy Admin" },
+      members: { member: { name: "Policy Member" } },
+    },
+  });
+  const member = den.members.member;
+  if (!member) throw new Error("The testkit did not provision the ordinary organization member.");
+  const orgId = await organizationId(den.admin);
+  const patchedPolicy = await configureLockdown(den.admin, orgId);
+  const desktopConfig = await readMemberDesktopConfig(member, orgId);
+  const denLocked = hasLockdown(desktopConfig);
+  evidence.recordAssertionEvidence(
+    "Den resolves both default desktop policy restrictions for the ordinary member",
+    `Patched policy: ${JSON.stringify(patchedPolicy)}; member desktop config: ${JSON.stringify(desktopConfig)}`,
+    denLocked,
+  );
+  expect(desktopConfig.allowCreateSkills).toBe(false);
+  expect(desktopConfig.allowAddMcpServers).toBe(false);
+
+  await using desktop = await app({ den, as: "member", place });
+  const localStateResult = await eventually(
+    () => localRequest(desktop, "/experimental/desktop-policy/state"),
+    {
+      within: 120_000,
+      intervalMs: 2_000,
+      label: "embedded server receives Den desktop policy",
+      until: (value) => value.status === 200 && hasLockdown(policyState(value.body)),
+    },
+  );
+  const localState = policyState(localStateResult.body);
+  evidence.recordAssertionEvidence(
+    "The signed-in desktop pushes both restrictions into its embedded local server",
+    `Local state response: ${JSON.stringify(localStateResult)}`,
+    localStateResult.status === 200 && hasLockdown(localState),
+  );
+  expect(hasLockdown(localState)).toBe(true);
+
+  const capabilitiesResult = await localRequest(desktop, "/capabilities");
+  const capabilities = record(capabilitiesResult.body, "capabilities response");
+  const skillCapabilities = record(capabilities.skills, "skill capabilities");
+  const mcpCapabilities = record(capabilities.mcp, "MCP capabilities");
+  const writesDisabled = capabilitiesResult.status === 200
+    && skillCapabilities.write === false
+    && mcpCapabilities.write === false;
+  evidence.recordAssertionEvidence(
+    "Embedded server capabilities disable skill and MCP writes",
+    `Capabilities response: ${JSON.stringify(capabilitiesResult)}`,
+    writesDisabled,
+  );
+  expect(skillCapabilities.write).toBe(false);
+  expect(mcpCapabilities.write).toBe(false);
+
+  const workspaceId = desktop.workspaceId;
+  const deniedSkill = await localRequest(desktop, `/workspace/${encodeURIComponent(workspaceId)}/skills`, {
+    method: "POST",
+    body: { name: "blocked-skill", content: "# Blocked skill" },
+  });
+  const deniedSkillBody = record(deniedSkill.body, "denied skill write response");
+  const deniedSkillDetails = record(deniedSkillBody.details, "denied skill write details");
+  const skillDenied = deniedSkill.status === 403
+    && deniedSkillBody.code === "policy_restricted"
+    && deniedSkillDetails.policy === "allowCreateSkills";
+  evidence.recordAssertionEvidence(
+    "Embedded server rejects skill creation under the Den policy",
+    `Denied skill response: ${JSON.stringify(deniedSkill)}`,
+    skillDenied,
+  );
+  expect(skillDenied).toBe(true);
+
+  const deniedMcp = await localRequest(desktop, `/workspace/${encodeURIComponent(workspaceId)}/mcp`, {
+    method: "POST",
+    body: { name: "blocked-mcp", config: { type: "remote", url: "https://blocked.invalid/mcp" } },
+  });
+  const deniedMcpBody = record(deniedMcp.body, "denied MCP write response");
+  const deniedMcpDetails = record(deniedMcpBody.details, "denied MCP write details");
+  const mcpDenied = deniedMcp.status === 403
+    && deniedMcpBody.code === "policy_restricted"
+    && deniedMcpDetails.policy === "allowAddMcpServers";
+  evidence.recordAssertionEvidence(
+    "Embedded server rejects MCP creation under the Den policy",
+    `Denied MCP response: ${JSON.stringify(deniedMcp)}`,
+    mcpDenied,
+  );
+  expect(mcpDenied).toBe(true);
+
+  await go(desktop, `/workspace/${workspaceId}/extensions/skills`);
+  await waitForText(desktop, SKILL_NOTICE, { timeoutMs: 60_000 });
+  const skillNoticeVisible = await textVisible(desktop, SKILL_NOTICE);
+  const addSkillVisible = await exactButtonVisible(desktop, "Add skill");
+  expect(skillNoticeVisible).toBe(true);
+  expect(addSkillVisible).toBe(false);
+  await go(desktop, `/workspace/${workspaceId}/extensions/mcps`);
+  await waitForText(desktop, MCP_NOTICE, { timeoutMs: 60_000 });
+  const mcpNoticeVisible = await textVisible(desktop, MCP_NOTICE);
+  const addMcpVisible = await exactButtonVisible(desktop, "Add MCP");
+  const uiLocked = skillNoticeVisible && mcpNoticeVisible && !addSkillVisible && !addMcpVisible;
+  evidence.recordAssertionEvidence(
+    "Desktop extension routes explain the policy and hide exact add actions",
+    `Saw exact notices ${JSON.stringify([SKILL_NOTICE, MCP_NOTICE])}; Add skill visible: ${addSkillVisible}; Add MCP visible: ${addMcpVisible}.`,
+    uiLocked,
+  );
+  expect(mcpNoticeVisible).toBe(true);
+  expect(addMcpVisible).toBe(false);
+});

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -66,6 +66,24 @@ export const desktopPolicyDefinitions = [
     defaultValue: true,
   },
   {
+    id: "allowCreateSkills",
+    name: "Create skills",
+    description:
+      "Allow users to create or edit skills on this device. When disabled, only skills assigned by the organization are available.",
+    userNotice:
+      "Your organization administrator has disabled creating skills on this device.",
+    defaultValue: true,
+  },
+  {
+    id: "allowAddMcpServers",
+    name: "Add MCP servers",
+    description:
+      "Allow users to add MCP servers or connections on this device. When disabled, only organization-assigned connections are available.",
+    userNotice:
+      "Your organization administrator has disabled adding MCP servers on this device.",
+    defaultValue: true,
+  },
+  {
     id: "allowBuiltInExtensions",
     name: "Built-in Extensions",
     description:


### PR DESCRIPTION
## Summary

Adds a "fully locked" managed-desktop capability for org admins: two new desktop policy keys, `allowCreateSkills` and `allowAddMcpServers` (the existing `allowManageExtensions` acts as the umbrella — `false` locks both). An admin creates a policy in the Den dashboard with these set to `false` and assigns it to the `member` role; members can then only use skills and connections assigned by the organization.

Enforcement is layered so agents cannot bypass the UI:

1. **UI** (`apps/app`) — skill/MCP kinds filtered out of the Library add control; Add MCP button, modal, and Claude plugin import hidden; amber policy notice with the catalog `userNotice` copy.
2. **Local server** (`apps/server`) — the renderer computes effective locks from the Den desktop config and pushes them to the local openwork-server (`PUT /experimental/desktop-policy/state`, mirroring the `connectEnabled` push). The server persists `desktop-policy-state.json` (fail-open on missing/corrupt), returns 403 `policy_restricted` on all skill/MCP write routes, and flips `capabilities.skills.write` / `capabilities.mcp.write` (which the existing `saveSkill` guard already respects).
3. **Engine** — new `openwork-desktop-policy-lock` opencode plugin (registered in the runtime config plugin list and packaged build) denies agent file writes to `.opencode/skills/**` and `opencode.json*` / `.opencode/openwork.json` via `tool.execute.before` and `permission.ask`, reading live state from the local server with a 15s cache.

Den-side needs zero changes: the policy editor checkboxes, API schemas, and storage all derive from the shared catalog in `packages/types/src/den/desktop-policies.ts`.

## Verification

Lane: local (bun), not Daytona.

- `pnpm --filter openwork-server test src/desktop-policy-state.test.ts src/connect-state.test.ts` — **5 pass, 0 fail** (strict PUT validation, persistence, GET, 403 `policy_restricted` on skill/MCP routes, capabilities flip on both `/capabilities` routes, fail-open defaults, engine plugin deny behavior against a live server, plugin registration + packaged-build inclusion)
- `pnpm --filter @openwork/app exec bun test --isolate tests/den-desktop-config.test.ts` — **10 pass, 0 fail** (effective policy mapping incl. `allowManageExtensions` umbrella, push retry loop)
- `pnpm --filter openwork-server typecheck` — clean
- `pnpm --filter @openwork/app typecheck` — clean

## Verdict: Passed

The full Den → signed-in desktop → embedded local-server path is proven by `evals/specs/desktop-policy-lockdown.e2e.test.ts` on PR head `410a519bf`. The published testkit evidence contains 6 passing assertion witnesses and no failures, pending validations, or skips. The PR remains draft as requested.

## Known limitations (by design, documented)

- `bash` output redirection can still write files; the plugin blocks the structured file tools (`write`/`edit`/`multi_edit`) and permission patterns. Fully airtight file-level control would need bash-command inspection or FS-level enforcement.
- Trust model matches `connectEnabled`: lock state is pushed with the host token, so running raw opencode outside the managed app bypasses it (accepted escape hatch for this feature).