### PR TITLE
fix(ci): pin Bun for eval specs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -113,6 +113,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Get pnpm store path
         id: pnpm-store


### PR DESCRIPTION
## Summary
- pin the OpenWork Tests workflow to Bun 1.3.14
- match the Bun toolchain declared by bundled OpenCode v1.18.18
- prevent new Bun releases from silently changing TLS diagnostic expectations

## Verification
- `PATH=<bun-1.3.14>:$PATH pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/egress-tls12-only.test.ts`
- Passed: 1 file, 2 tests; 0 failed, 0 skipped