### PR TITLE
feat(automations): publish deployment availability contract

### DIFF
--- a/ee/apps/den-api/scripts/generate-openapi-snapshot.ts
+++ b/ee/apps/den-api/scripts/generate-openapi-snapshot.ts
@@ -22,6 +22,7 @@ function seedSnapshotEnv() {
   setEnvDefault("DEN_DB_ENCRYPTION_KEY", "local-dev-db-encryption-key-please-change-1234567890")
   setEnvDefault("BETTER_AUTH_SECRET", "local-dev-secret-not-for-production-use!!")
   setEnvDefault("BETTER_AUTH_URL", "http://den.local")
+  setEnvDefault("DEN_AUTOMATIONS_ENABLED", "true")
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -102,6 +102,7 @@ const EnvSchema = z.object({
   PROVISIONER_MODE: z.enum(["stub", "render", "daytona"]).optional(),
   WORKER_URL_TEMPLATE: z.string().optional(),
   WORKER_ACTIVITY_BASE_URL: z.string().optional(),
+  DEN_AUTOMATIONS_ENABLED: z.string().optional(),
   DEN_AUTOMATIONS_POLL_INTERVAL_MS: z.string().optional(),
   DEN_AUTOMATIONS_BATCH_SIZE: z.string().optional(),
   DEN_AUTOMATIONS_MAX_CONCURRENCY: z.string().optional(),
@@ -461,6 +462,11 @@ const generatedArtifactViewsEnabled =
 const remoteMcpAppsEnabled =
   (parsed.DEN_REMOTE_MCP_APPS_ENABLED ?? "false").trim().toLowerCase() === "true"
 
+// Automations are deployment-sensitive and must be explicitly enabled. This
+// keeps direct and packaged self-hosted deployments fail-closed when the flag
+// is omitted; hosted OpenWork sets the same flag to true in its environment.
+const automationsEnabled = parseBooleanFlag(parsed.DEN_AUTOMATIONS_ENABLED ?? "false")
+
 const devMode = (parsed.OPENWORK_DEV_MODE ?? "0").trim() === "1"
 const botIdProtectionEnabled = (parsed.DEN_BOTID_PROTECTION_ENABLED ?? "0").trim() === "1"
 const diagnosticsOrigin = normalizeDiagnosticsOrigin(parsed.DEN_DIAGNOSTICS_ORIGIN, devMode)
@@ -660,6 +666,7 @@ export const env = {
     optionalString(parsed.WORKER_ACTIVITY_BASE_URL) ??
     parsed.BETTER_AUTH_URL.trim().replace(/\/+$/, ""),
   automations: {
+    enabled: automationsEnabled,
     pollIntervalMs: automationTuning(parsed.DEN_AUTOMATIONS_POLL_INTERVAL_MS, 15_000),
     batchSize: automationTuning(parsed.DEN_AUTOMATIONS_BATCH_SIZE, 25),
     maxConcurrency: automationTuning(parsed.DEN_AUTOMATIONS_MAX_CONCURRENCY, 4),

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -376,6 +376,7 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
 
       return c.json({
         ...desktopPolicy,
+        automationsEnabled: env.automations.enabled,
         connectEnabled: memberFacingMcpConnectionsEnabled(organization.metadata, {
           gatingEnabled: env.mcpConnectionsGatingEnabled,
         }),

--- a/ee/apps/den-api/test/automation-rollout.test.ts
+++ b/ee/apps/den-api/test/automation-rollout.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const denApiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function probeAutomations(value?: string) {
+  return spawnSync(process.execPath, ["--conditions", "development", "--eval", `
+    const { env } = await import("./src/env.ts")
+    console.log(JSON.stringify(env.automations.enabled))
+  `], {
+    cwd: denApiRoot,
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      TMPDIR: process.env.TMPDIR ?? "",
+      DATABASE_URL: "mysql://root:password@127.0.0.1:3306/openwork_test",
+      DB_MODE: "mysql",
+      DEN_DB_ENCRYPTION_KEY: "x".repeat(32),
+      BETTER_AUTH_SECRET: "y".repeat(32),
+      BETTER_AUTH_URL: "https://den.openwork.test",
+      OPENWORK_DEV_MODE: "0",
+      PROVISIONER_MODE: "stub",
+      ...(value === undefined ? {} : { DEN_AUTOMATIONS_ENABLED: value }),
+    },
+  })
+}
+
+test("Automations fail closed unless the deployment explicitly enables them", () => {
+  const unset = probeAutomations()
+  const disabled = probeAutomations("false")
+  const enabled = probeAutomations("true")
+
+  expect(unset.status, unset.stderr).toBe(0)
+  expect(unset.stdout.trim()).toBe("false")
+  expect(disabled.status, disabled.stderr).toBe(0)
+  expect(disabled.stdout.trim()).toBe("false")
+  expect(enabled.status, enabled.stderr).toBe(0)
+  expect(enabled.stdout.trim()).toBe("true")
+})
+
+test("the availability contract ships without changing Automation execution", () => {
+  const app = readFileSync(path.join(denApiRoot, "src/app.ts"), "utf8")
+  const meRoutes = readFileSync(path.join(denApiRoot, "src/routes/me/index.ts"), "utf8")
+  const routes = readFileSync(path.join(denApiRoot, "src/routes/automations/index.ts"), "utf8")
+  const server = readFileSync(path.join(denApiRoot, "src/server.ts"), "utf8")
+
+  expect(meRoutes).toContain("automationsEnabled: env.automations.enabled")
+  expect(app).toContain("registerAutomationRoutes(app)")
+  expect(routes).not.toContain("automationsDisabledResponse")
+  expect(server).toContain("startAutomationSchedulerLoop()")
+})

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -301,6 +301,7 @@ function expectConnectEnabled(body: Record<string, unknown>, metadata: Record<st
 
 test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", async () => {
   const flatBody = await requestDesktopConfig(organizationId)
+  expect(flatBody.automationsEnabled).toBe(false)
   expectConnectEnabled(flatBody, flatConnectMetadata)
   expect(flatBody.brandAppName).toBe(flatConnectMetadata.brandAppName)
   expect(flatBody.brandLogoUrl).toBe(flatConnectMetadata.brandLogoUrl)

--- a/evals/specs/automation-deployment-gate.e2e.test.ts
+++ b/evals/specs/automation-deployment-gate.e2e.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "vitest"
+import { denFetch } from "@openwork/behaviors"
+import { needs, server, test } from "@openwork/testkit"
+
+const requirements = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS", "OPENWORK_EVAL_AUTOMATION_DEPLOYMENT_GATE_E2E_TEST"],
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+test("Den publishes the Automation availability contract before enforcing it", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs(requirements)
+  await using den = await server({
+    place,
+    env: { DEN_AUTOMATIONS_ENABLED: "false" },
+  })
+
+  const config = await denFetch(den.admin, "/v1/me/desktop-config", {
+    headers: { authorization: `Bearer ${den.admin.token}` },
+  })
+  expect(config.response.status, config.text).toBe(200)
+  expect(isRecord(config.body) ? config.body.automationsEnabled : undefined).toBe(false)
+
+  const list = await denFetch(den.admin, "/v1/automations", {
+    headers: { authorization: `Bearer ${den.admin.token}` },
+  })
+  expect(list.response.status, list.text).toBe(200)
+  expect(isRecord(list.body) && Array.isArray(list.body.items)).toBe(true)
+
+  expect(await den.apiLog()).toContain("Automation scheduler enabled")
+  evidence.recordAssertionEvidence(
+    "Automation availability contract",
+    "Den advertised automationsEnabled=false through desktop config while preserving the published Automation API and scheduler behavior for the staged Desktop rollout.",
+    true,
+  )
+})

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -201,6 +201,7 @@ export const desktopConfigSchema = desktopPolicyValueSchema
     brandLogoUrl: z.string().url().max(2048).optional(),
     brandIconUrl: z.string().url().max(2048).optional(),
     brandAccentColor: z.enum(brandAccentColorValues).optional(),
+    automationsEnabled: z.boolean().optional(),
     connectEnabled: z.boolean().optional(),
     onboardingPrompts: onboardingPromptsSchema.optional(),
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
@@ -550,6 +551,10 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
   const brandLogoUrl = normalizeBrandUrl(raw?.brandLogoUrl);
   const brandIconUrl = normalizeBrandUrl(raw?.brandIconUrl);
   const brandAccentColor = normalizeBrandAccentColor(raw?.brandAccentColor);
+  const automationsEnabled =
+    typeof raw?.automationsEnabled === "boolean"
+      ? raw.automationsEnabled
+      : undefined;
   const connectEnabled =
     typeof raw?.connectEnabled === "boolean" ? raw.connectEnabled : undefined;
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(raw);
@@ -561,6 +566,7 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
     ...(brandLogoUrl !== undefined ? { brandLogoUrl } : {}),
     ...(brandIconUrl !== undefined ? { brandIconUrl } : {}),
     ...(brandAccentColor !== undefined ? { brandAccentColor } : {}),
+    ...(automationsEnabled !== undefined ? { automationsEnabled } : {}),
     ...(connectEnabled !== undefined ? { connectEnabled } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -104,6 +104,45 @@ helm template openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 helm upgrade --install openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 ```
 
+### Automations rollout
+
+The Helm chart advertises Automations as unavailable by default for self-hosted
+and customer-managed deployments. Set availability explicitly when the
+deployment is ready:
+
+```yaml
+config:
+  public:
+    automationsEnabled: "true"
+```
+
+This renders `DEN_AUTOMATIONS_ENABLED=true` for Den. Missing configuration is
+treated as unavailable in every deployment; hosted OpenWork Cloud sets the
+variable explicitly to `true`.
+
+The flag is delivered in compatibility-safe phases. This release adds the Den
+configuration contract and publishes its effective value through
+`/v1/me/desktop-config`; it deliberately leaves the existing Automation API,
+scheduler, and published Desktop behavior unchanged. A follow-up Desktop
+release consumes the contract before a later Den release enforces disabled
+execution. This ordering avoids breaking independently released Desktop and
+Den versions.
+
+For an existing deployment, stage the upgrade so independently released Den
+and Desktop versions never observe an unintended flag state:
+
+1. Set `config.public.automationsEnabled: "true"` before upgrading the chart.
+2. Upgrade Den and verify `/v1/me/desktop-config` reports
+   `automationsEnabled: true`.
+3. Roll out the config-aware Desktop follow-up release.
+4. Roll out the Den enforcement follow-up release.
+5. Leave the value `true` to keep Automations, or change it to `"false"` only
+   after both follow-ups are deployed to disable them.
+
+New installations that intend to keep Automations off can keep the chart's
+default `"false"`. Until the enforcement follow-up is deployed, that value is
+an advertised availability contract rather than a runtime kill switch.
+
 Provider-specific starter guides:
 
 - AWS EKS:

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -34,6 +34,7 @@ data:
   DEN_WEB_APP_HOSTS: {{ .Values.config.public.webAppHosts | quote }}
   DEN_BOOTSTRAP_ADMIN_EMAILS: {{ .Values.config.public.bootstrapAdminEmails | quote }}
   DEN_INSTALL_LINKS_GATING_ENABLED: {{ .Values.config.public.installLinksGatingEnabled | quote }}
+  DEN_AUTOMATIONS_ENABLED: {{ .Values.config.public.automationsEnabled | quote }}
   DEN_GENERATED_ARTIFACT_VIEWS_ENABLED: {{ .Values.config.public.generatedArtifactViewsEnabled | quote }}
   DEN_REMOTE_MCP_APPS_ENABLED: {{ .Values.config.public.remoteMcpAppsEnabled | quote }}
   DEN_CONNECT_LINK_MODE: {{ .Values.config.public.connectLinkMode | quote }}

--- a/packaging/helm/openwork-ee/tests/automations-enabled.sh
+++ b/packaging/helm/openwork-ee/tests/automations-enabled.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+default_rendered="$tmp_dir/default.yaml"
+helm template openwork-ee "$chart_dir" > "$default_rendered"
+assert_contains "$default_rendered" 'DEN_AUTOMATIONS_ENABLED: "false"'
+
+enabled_values="$tmp_dir/enabled-values.yaml"
+enabled_rendered="$tmp_dir/enabled.yaml"
+printf '%s\n' 'config:' '  public:' '    automationsEnabled: "true"' > "$enabled_values"
+helm template openwork-ee "$chart_dir" -f "$enabled_values" > "$enabled_rendered"
+assert_contains "$enabled_rendered" 'DEN_AUTOMATIONS_ENABLED: "true"'
+
+printf 'automations-enabled chart checks passed\n'

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -39,6 +39,8 @@ config:
     webAppHosts: openwork.example.com
     bootstrapAdminEmails: ""
     installLinksGatingEnabled: "false"
+    # Self-hosted Automations are opt-in. Hosted OpenWork Cloud enables them.
+    automationsEnabled: "false"
     # Enable only after compatible Desktop MCP Apps hosts are deployed.
     generatedArtifactViewsEnabled: "false"
     # Master opt-in for native and imported MCP Apps. Each organization must


### PR DESCRIPTION
## Summary

- add the deployment-level `DEN_AUTOMATIONS_ENABLED` availability contract, with missing or invalid values treated as false
- expose the effective value as `automationsEnabled` through `/v1/me/desktop-config`
- render the self-hosted Helm value as `config.public.automationsEnabled: "false"` by default with an explicit true override
- deliberately preserve existing Automation routes, scheduler behavior, and current Desktop behavior in this phase
- add no database migration and preserve all existing Automation records

## Ordered rollout

This is phase 1 of the compatibility sequence requested by Warden.

1. Merge and deploy this Den/config contract.
2. Verify `/v1/me/desktop-config` returns the intended value.
3. Ship the config-aware Desktop follow-up.
4. Only after that Desktop is distributed, ship the Den enforcement follow-up.

Hosted OpenWork Cloud is explicitly pinned to `DEN_AUTOMATIONS_ENABLED=true` by [environment workflow run 32401072180](https://github.com/different-ai/openwork/actions/runs/32401072180). Existing self-hosted deployments should also pin true before upgrading. The Helm default remains false for new/customer-managed deployments, but this first phase only advertises availability; it does not yet stop execution.

## Verification

- `pnpm --filter @openwork-ee/den-api exec bun test test/automation-rollout.test.ts test/me-desktop-config.test.ts` — 5 passed, 0 failed
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm --dir apps/app typecheck`
- `bash packaging/helm/openwork-ee/tests/automations-enabled.sh`
- `pnpm evals:e2e automation-deployment-gate --local` — 1 passed, 0 failed, 0 skipped

The required exact-head testkit evidence is published on this PR.