### PR TITLE
feat(automations): honor deployment availability in Desktop

### DIFF
--- a/apps/app/src/components/tools/openwork-automation-proposal.tsx
+++ b/apps/app/src/components/tools/openwork-automation-proposal.tsx
@@ -13,6 +13,7 @@ import { createDenClient, readDenSettings } from "@/app/lib/den"
 import { Button } from "@/components/ui/button"
 import { Tool } from "@/components/ui/tool"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability"
 import { formatAutomationSchedule } from "@/react-app/domains/automations/automation-format"
 import {
   automationModelOptions,
@@ -55,6 +56,7 @@ export function isAutomationProposalToolPart(part: DynamicToolUIPart): boolean {
 export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPart }) {
   const navigate = useNavigate()
   const denAuth = useDenAuth()
+  const automationsEnabled = useAutomationDeploymentEnabled()
   const [created, setCreated] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
@@ -66,7 +68,7 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
   const providersQuery = useQuery({
     queryKey: ["den", "automations", organizationId, "models"],
     queryFn: () => createDenClient({ baseUrl: settings.baseUrl, token }).listOrgLlmProviders(organizationId),
-    enabled: signedIn && !created,
+    enabled: automationsEnabled && signedIn && !created,
   })
   const providers = providersQuery.data ?? []
   const resolved = providersQuery.isError || providersQuery.data === undefined || !proposal
@@ -80,11 +82,14 @@ export function OpenWorkAutomationProposalTool({ part }: { part: DynamicToolUIPa
     return <Tool toolPart={part} title="Proposed an Automation" />
   }
 
-  const blocker = !signedIn
-    ? "Sign in to OpenWork Cloud to create this Automation."
-    : null
+  const blocker = !automationsEnabled
+    ? "Automations are disabled for this deployment."
+    : !signedIn
+      ? "Sign in to OpenWork Cloud to create this Automation."
+      : null
 
   const create = async () => {
+    if (!automationsEnabled) return
     setBusy(true)
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token })

--- a/apps/app/src/react-app/domains/automations/automation-availability.ts
+++ b/apps/app/src/react-app/domains/automations/automation-availability.ts
@@ -1,0 +1,12 @@
+import { useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider"
+
+/**
+ * Deployment-level Automation availability advertised by Den.
+ *
+ * Older Den versions and stale cached configs omit the field. Treat both as
+ * disabled so self-deployed installations and startup stay fail-closed.
+ */
+export function useAutomationDeploymentEnabled() {
+  const { config, loading } = useDesktopConfig()
+  return !loading && config.automationsEnabled === true
+}

--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -6,6 +6,7 @@ import { createDenClient, DenApiError, readDenSettings } from "@/app/lib/den"
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events"
 import { isDesktopRuntime } from "@/app/utils"
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { useAutomationDeploymentEnabled } from "./automation-availability"
 import { createAutomationRunnerConnectCoordinator } from "./automation-runner-connect-coordinator"
 
 const RUNNER_TOKEN_REFRESH_MS = 30 * 60_000
@@ -24,9 +25,10 @@ function resetDesktopRunnerId() {
   return desktopRunnerId()
 }
 
-/** Keeps this signed-in, preview-enabled desktop registered as the owner's Automation runner. */
-export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
+/** Keeps this signed-in desktop registered as the owner's Automation runner when Den allows it. */
+export function AutomationRunnerBridge() {
   const { status } = useDenAuth()
+  const deploymentEnabled = useAutomationDeploymentEnabled()
 
   useEffect(() => {
     if (!isDesktopRuntime() || !window.__OPENWORK_ELECTRON__?.invokeDesktop) return
@@ -36,7 +38,7 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
     const coordinator = createAutomationRunnerConnectCoordinator({
       refreshMs: RUNNER_TOKEN_REFRESH_MS,
       connect: async (isCurrent) => {
-        if (!enabled || status !== "signed_in") {
+        if (!deploymentEnabled || status !== "signed_in") {
           await disconnect()
           return
         }
@@ -110,7 +112,7 @@ export function AutomationRunnerBridge({ enabled }: { enabled: boolean }) {
       window.removeEventListener("online", handleSettingsChanged)
       void disconnect()
     }
-  }, [enabled, status])
+  }, [deploymentEnabled, status])
 
   return null
 }

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -70,6 +70,7 @@ const DESKTOP_CONFIG_ITEMS = [
   "brandLogoUrl",
   "brandIconUrl",
   "brandAccentColor",
+  "automationsEnabled",
   "connectEnabled",
   "onboardingPrompts",
   "onboardingPromptDescriptions",

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -61,7 +61,7 @@ function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
           <BrandThemeProvider>
             <RestrictionNoticeProvider>
               <LocalProvider>
-                <AutomationRunnerBridge enabled={isDesktopRuntime()} />
+                <AutomationRunnerBridge />
                 <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
                 <Toaster />
               </LocalProvider>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -93,6 +93,7 @@ import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
+import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability";
 import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
 import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
@@ -473,7 +474,8 @@ export function SessionRoute() {
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
   const local = useLocal();
-  const automationsEnabled = isDesktopRuntime();
+  const automationDeploymentEnabled = useAutomationDeploymentEnabled();
+  const automationsEnabled = isDesktopRuntime() && automationDeploymentEnabled;
   const automationsRouteActive = automationsEnabled && automationsRouteRequested;
   const denSettings = readDenSettings();
   const [automationsSupported, setAutomationsSupported] = useState(false);

--- a/apps/app/tests/automation-availability.test.ts
+++ b/apps/app/tests/automation-availability.test.ts
@@ -6,11 +6,10 @@ const read = (relative: string) =>
   readFileSync(join(import.meta.dir, "..", relative), "utf8")
 
 /**
- * Automations shipped out of preview: there is no per-device feature flag any
- * more. The surface is available on every desktop, gated only by the runtime
- * (desktop-only) and the live Den availability probe. These checks pin that
- * contract so a refactor cannot silently reintroduce an opt-in gate or expose
- * the surface on web.
+ * Automations shipped out of preview, so there is no per-device preference.
+ * Den now advertises deployment-level availability through desktop config;
+ * Desktop must honor it across the route, runner, and proposal surface while
+ * requiring every deployment to opt in explicitly.
  */
 describe("Automations availability", () => {
   test("no preview feature flag remains in the local preferences", () => {
@@ -21,23 +20,29 @@ describe("Automations availability", () => {
     expect(flags).not.toContain("automations")
   })
 
-  test("the shell gates route, Den probe, and navigation on desktop runtime only", () => {
+  test("the deployment gate stays off unless desktop config explicitly opts in", () => {
+    const availability = read("src/react-app/domains/automations/automation-availability.ts")
+    expect(availability).toContain("!loading && config.automationsEnabled === true")
+  })
+
+  test("the shell gates route, Den probe, and navigation on runtime and deployment availability", () => {
     const source = read("src/react-app/shell/session-route.tsx")
-    expect(source).toContain("const automationsEnabled = isDesktopRuntime()")
+    expect(source).toContain("const automationDeploymentEnabled = useAutomationDeploymentEnabled()")
+    expect(source).toContain("const automationsEnabled = isDesktopRuntime() && automationDeploymentEnabled")
     expect(source).not.toContain("featureFlags?.automations")
     expect(source).toContain("automationsEnabled && automationsRouteRequested")
     expect(source).toContain("!automationsEnabled || !denAuth.isSignedIn")
     expect(source).toContain("automationsEnabled && automationsSupported")
   })
 
-  test("the runner bridge registers on desktop without an opt-in", () => {
+  test("the runner bridge registers only when the deployment contract allows it", () => {
     const providers = read("src/react-app/shell/providers.tsx")
-    expect(providers).toContain("<AutomationRunnerBridge enabled={isDesktopRuntime()} />")
+    expect(providers).toContain("<AutomationRunnerBridge />")
     expect(providers).not.toContain("featureFlags")
 
     const bridge = read("src/react-app/domains/automations/automation-runner-bridge.tsx")
-    expect(bridge).toContain("!enabled || status !== \"signed_in\"")
-    expect(bridge).toContain("[enabled, status]")
+    expect(bridge).toContain("!deploymentEnabled || status !== \"signed_in\"")
+    expect(bridge).toContain("[deploymentEnabled, status]")
     expect(bridge).toContain('automationRunnerConfigure", null')
     expect(bridge).toContain("onCredentialRejected?.(() => coordinator.credentialRejected())")
   })
@@ -51,9 +56,11 @@ describe("Automations availability", () => {
     expect(preload).toContain("ipcRenderer.on(AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT, handler)")
   })
 
-  test("the in-chat proposal tool only blocks on sign-in", () => {
+  test("the in-chat proposal tool blocks creation when the deployment disables Automations", () => {
     const proposal = read("src/components/tools/openwork-automation-proposal.tsx")
-    expect(proposal).not.toContain("automationsEnabled")
+    expect(proposal).toContain("useAutomationDeploymentEnabled()")
+    expect(proposal).toContain("Automations are disabled for this deployment.")
+    expect(proposal).toContain("if (!automationsEnabled) return")
     expect(proposal).toContain("Sign in to OpenWork Cloud")
     expect(proposal).toContain("resolveProposalModel")
     expect(proposal).toContain("data-automation-model-resolution")

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -149,6 +149,13 @@ describe("Den desktop config client", () => {
     }).allowAlphaUpdates).toBeUndefined();
   });
 
+  test("normalizes only explicit Automation deployment availability", () => {
+    expect(normalizeDenDesktopConfig({ automationsEnabled: false }).automationsEnabled).toBe(false);
+    expect(normalizeDenDesktopConfig({ automationsEnabled: true }).automationsEnabled).toBe(true);
+    expect(normalizeDenDesktopConfig({ automationsEnabled: "false" }).automationsEnabled).toBeUndefined();
+    expect(normalizeDenDesktopConfig({}).automationsEnabled).toBeUndefined();
+  });
+
   test("selects targeted onboarding prompts by priority before default fallback", () => {
     const defaultPrompts = ["Default task one", "Default task two"];
 

--- a/evals/packages/testkit/src/server.ts
+++ b/evals/packages/testkit/src/server.ts
@@ -690,6 +690,9 @@ export async function server(options: ServerOptions): Promise<Den> {
       DEN_ORG_MODE: "multi_org",
       DEN_REQUIRE_EMAIL_VERIFICATION: "false",
       DEN_PASSWORD_BREACH_SCREENING_ENABLED: "false",
+      // Existing Automation journeys explicitly exercise the enabled
+      // deployment path. Rollout specs override this to prove disabled UI.
+      DEN_AUTOMATIONS_ENABLED: "true",
       DEN_GENERATED_ARTIFACT_VIEWS_ENABLED:
         process.env.OPENWORK_EVAL_GENERATED_ARTIFACT_VIEWS_E2E_TEST === "1" ? "true" : "false",
       OPENWORK_DEV_MODE: "1",

--- a/evals/specs/automation-deployment-gate.e2e.test.ts
+++ b/evals/specs/automation-deployment-gate.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest"
-import { denFetch } from "@openwork/behaviors"
-import { needs, server, test } from "@openwork/testkit"
+import { denFetch, evalIn, go } from "@openwork/behaviors"
+import { app, needs, server, test } from "@openwork/testkit"
 
 const requirements = {
   optIn: ["OPENWORK_EVAL_E2E_TESTS", "OPENWORK_EVAL_AUTOMATION_DEPLOYMENT_GATE_E2E_TEST"],
@@ -10,7 +10,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-test("Den publishes the Automation availability contract before enforcing it", { timeout: 300_000 }, async ({ evidence, place }) => {
+test("Desktop honors the published Automation availability contract", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs(requirements)
   await using den = await server({
     place,
@@ -29,10 +29,21 @@ test("Den publishes the Automation availability contract before enforcing it", {
   expect(list.response.status, list.text).toBe(200)
   expect(isRecord(list.body) && Array.isArray(list.body.items)).toBe(true)
 
+  const runnerTokenCallsBeforeDesktop = (await den.apiLog()).split("/v1/automation-runners/token").length - 1
+  await using desktop = await app({ den, as: "admin", place })
+  await go(desktop, "/automations")
+  await expect.poll(
+    () => evalIn(desktop, "!/^#\\/automations(?:\\?|$)/.test(location.hash)"),
+    { timeout: 60_000 },
+  ).toBe(true)
+
+  const logAfterDesktopBoot = await den.apiLog()
+  expect(logAfterDesktopBoot.split("/v1/automation-runners/token").length - 1)
+    .toBe(runnerTokenCallsBeforeDesktop)
   expect(await den.apiLog()).toContain("Automation scheduler enabled")
   evidence.recordAssertionEvidence(
-    "Automation availability contract",
-    "Den advertised automationsEnabled=false through desktop config while preserving the published Automation API and scheduler behavior for the staged Desktop rollout.",
+    "Desktop Automation availability",
+    "Desktop redirected the disabled Automation route and did not register its runner while Den preserved existing API and scheduler behavior for published older clients.",
     true,
   )
 })

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -61,11 +61,11 @@ test("desktop Automation runner retires rejected credentials without changing tr
   const bridgeOutput = `${bridge.stdout}${bridge.stderr}`;
   expect(bridge.error, bridgeOutput).toBeUndefined();
   expect(bridge.status, bridgeOutput).toBe(0);
-  expect(bridgeOutput).toContain("11 pass");
+  expect(bridgeOutput).toContain("12 pass");
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 41 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
+    "The runner and bridge suites passed 42 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
     true,
   );
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -120,13 +120,12 @@ This renders `DEN_AUTOMATIONS_ENABLED=true` for Den. Missing configuration is
 treated as unavailable in every deployment; hosted OpenWork Cloud sets the
 variable explicitly to `true`.
 
-The flag is delivered in compatibility-safe phases. This release adds the Den
-configuration contract and publishes its effective value through
-`/v1/me/desktop-config`; it deliberately leaves the existing Automation API,
-scheduler, and published Desktop behavior unchanged. A follow-up Desktop
-release consumes the contract before a later Den release enforces disabled
-execution. This ordering avoids breaking independently released Desktop and
-Den versions.
+The flag is delivered in compatibility-safe phases. Den first publishes its
+effective value through `/v1/me/desktop-config`. The config-aware Desktop then
+hides the Automation surface and does not register its runner when the value is
+not explicitly true, while Den deliberately preserves the existing Automation
+API and scheduler behavior for older published Desktop clients. A later Den
+release enforces disabled execution after this Desktop has been distributed.
 
 For an existing deployment, stage the upgrade so independently released Den
 and Desktop versions never observe an unintended flag state:


### PR DESCRIPTION
## Summary

- consume the `automationsEnabled` contract introduced by #3974
- require an explicit true value before showing Automation navigation or accepting deep links
- avoid Desktop runner registration and Automation proposal creation when unavailable
- fail closed while config is loading or when an older Den omits the field
- deliberately leave Den Automation routes and scheduler behavior unchanged for older published Desktop clients

## Rollout order

This is phase 2 of the Warden-required compatibility rollout. #3974 must be deployed before distributing a Desktop built from this change. Den-side execution enforcement remains a separate phase after this tolerant Desktop has been released.

## Verification

- `pnpm --dir apps/app exec bun test --isolate tests/automation-availability.test.ts tests/den-desktop-config.test.ts tests/automation-runner-presence-client.test.ts tests/automation-runner-connect-coordinator.test.ts tests/automation-runner-visibility.test.ts` — 28 passed, 0 failed
- `pnpm --dir apps/app typecheck`
- `pnpm evals:e2e automation-deployment-gate --local` — 1 passed, 0 failed, 0 skipped on exact head `4c48f3fca`

The E2E starts Den with `DEN_AUTOMATIONS_ENABLED=false`, proves Desktop redirects the Automation route and does not register a runner, and separately proves Den retains its existing API and scheduler behavior for older clients.