### PR TITLE
fix(landing): refresh published desktop releases

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1043,6 +1043,51 @@ jobs:
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
           fi
 
+  refresh-landing-release:
+    name: Refresh public download metadata
+    needs: [resolve-release, publish-release]
+    if: |
+      needs.publish-release.result == 'success' &&
+      needs.resolve-release.outputs.benchmark_only != 'true' &&
+      needs.resolve-release.outputs.prerelease != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Delete cached stable release metadata
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN is required to refresh the public download metadata." >&2
+            exit 1
+          fi
+
+          for attempt in 1 2 3; do
+            if npx --yes vercel@59.3.0 cache dangerously-delete \
+              --project openwork-landing \
+              --scope prologe \
+              --tag openwork-latest-release \
+              --token "$VERCEL_TOKEN" \
+              --yes; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to refresh the public download metadata after 3 attempts." >&2
+              exit 1
+            fi
+
+            sleep "$((attempt * 5))"
+          done
+
   prepare-npm:
     name: Prepare openwork-server npm package
     needs: [resolve-release, verify-release]

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -16,6 +16,7 @@ type Repo = {
 };
 
 const FALLBACK_RELEASE = "https://github.com/different-ai/openwork/releases";
+export const LATEST_RELEASE_CACHE_TAG = "openwork-latest-release";
 // Keep published installers fresh without exceeding GitHub's unauthenticated
 // API budget: 40 latest-release + 6 fallback-list + 1 repo request per hour.
 const GITHUB_REVALIDATE_SECONDS = {
@@ -62,14 +63,15 @@ const selectAsset = (
 
 const fetchJson = async <T,>(
   url: string,
-  revalidateSeconds: number
+  revalidateSeconds: number,
+  tags: string[] = []
 ): Promise<T | null> => {
   try {
     const response = await fetch(url, {
       headers: {
         Accept: "application/vnd.github+json"
       },
-      next: { revalidate: revalidateSeconds }
+      next: { revalidate: revalidateSeconds, tags }
     });
 
     if (!response.ok) return null;
@@ -91,11 +93,13 @@ export const getGithubData = async () => {
     ),
     fetchJson<Release>(
       "https://api.github.com/repos/different-ai/openwork/releases/latest",
-      GITHUB_REVALIDATE_SECONDS.latestRelease
+      GITHUB_REVALIDATE_SECONDS.latestRelease,
+      [LATEST_RELEASE_CACHE_TAG]
     ),
     fetchJson<Release[]>(
       "https://api.github.com/repos/different-ai/openwork/releases?per_page=50",
-      GITHUB_REVALIDATE_SECONDS.releaseList
+      GITHUB_REVALIDATE_SECONDS.releaseList,
+      [LATEST_RELEASE_CACHE_TAG]
     )
   ]);
 

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -16,6 +16,13 @@ type Repo = {
 };
 
 const FALLBACK_RELEASE = "https://github.com/different-ai/openwork/releases";
+// Keep published installers fresh without exceeding GitHub's unauthenticated
+// API budget: 40 latest-release + 6 fallback-list + 1 repo request per hour.
+const GITHUB_REVALIDATE_SECONDS = {
+  repo: 60 * 60,
+  latestRelease: 90,
+  releaseList: 10 * 60
+} as const;
 
 const formatCompact = (value: number) => {
   try {
@@ -53,13 +60,16 @@ const selectAsset = (
   );
 };
 
-const fetchJson = async <T,>(url: string): Promise<T | null> => {
+const fetchJson = async <T,>(
+  url: string,
+  revalidateSeconds: number
+): Promise<T | null> => {
   try {
     const response = await fetch(url, {
       headers: {
         Accept: "application/vnd.github+json"
       },
-      next: { revalidate: 60 * 60 }
+      next: { revalidate: revalidateSeconds }
     });
 
     if (!response.ok) return null;
@@ -75,12 +85,17 @@ export const getGithubData = async () => {
   // the paginated list being flooded by alpha tags pushing stable releases out
   // of the per_page window.
   const [repo, latestRelease, releases] = await Promise.all([
-    fetchJson<Repo>("https://api.github.com/repos/different-ai/openwork"),
+    fetchJson<Repo>(
+      "https://api.github.com/repos/different-ai/openwork",
+      GITHUB_REVALIDATE_SECONDS.repo
+    ),
     fetchJson<Release>(
-      "https://api.github.com/repos/different-ai/openwork/releases/latest"
+      "https://api.github.com/repos/different-ai/openwork/releases/latest",
+      GITHUB_REVALIDATE_SECONDS.latestRelease
     ),
     fetchJson<Release[]>(
-      "https://api.github.com/repos/different-ai/openwork/releases?per_page=50"
+      "https://api.github.com/repos/different-ai/openwork/releases?per_page=50",
+      GITHUB_REVALIDATE_SECONDS.releaseList
     )
   ]);
 

--- a/ee/apps/landing/test/github.test.ts
+++ b/ee/apps/landing/test/github.test.ts
@@ -22,6 +22,11 @@ type GithubFetchFixtures = {
 const repoUrl = "https://api.github.com/repos/different-ai/openwork";
 const latestReleaseUrl = "https://api.github.com/repos/different-ai/openwork/releases/latest";
 const releasesUrl = "https://api.github.com/repos/different-ai/openwork/releases?per_page=50";
+const expectedRevalidateSeconds: Record<string, number> = {
+  [repoUrl]: 60 * 60,
+  [latestReleaseUrl]: 90,
+  [releasesUrl]: 10 * 60
+};
 const fallbackReleaseUrl = "https://github.com/different-ai/openwork/releases";
 const releaseTag = "v0.17.38";
 const releasePageUrl = `${fallbackReleaseUrl}/tag/${releaseTag}`;
@@ -34,6 +39,7 @@ const asset = (name: string): GithubFixtureAsset => ({
 });
 
 const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) => {
+  const requests: Array<{ url: string; revalidate?: number }> = [];
   const fixtures: Record<string, unknown> = {
     [repoUrl]: { stargazers_count: 12345 },
     [latestReleaseUrl]: latestRelease,
@@ -41,10 +47,16 @@ const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) =>
   };
 
   const fetchStub = Object.assign(
-    async (input: Parameters<typeof fetch>[0]) => {
+    async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ) => {
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       const fixture = fixtures[url];
+      const next = (init as { next?: { revalidate?: number } } | undefined)?.next;
+
+      requests.push({ url, revalidate: next?.revalidate });
 
       if (fixture === undefined) {
         return new Response("Not found", { status: 404 });
@@ -59,6 +71,7 @@ const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) =>
   ) satisfies typeof fetch;
 
   globalThis.fetch = fetchStub;
+  return requests;
 };
 
 const releaseWithAssets = (assets: GithubFixtureAsset[]): GithubFixtureRelease => ({
@@ -79,6 +92,19 @@ afterEach(() => {
 });
 
 describe("getGithubData", () => {
+  test("refreshes the latest published release without exhausting the public GitHub API budget", async () => {
+    const release = releaseWithAssets([
+      asset("openwork-mac-arm64-0.17.38.dmg")
+    ]);
+    const requests = installGithubFetch({ latestRelease: release, releases: [release] });
+
+    await getGithubData();
+
+    expect(Object.fromEntries(requests.map(({ url, revalidate }) => [url, revalidate]))).toEqual(
+      expectedRevalidateSeconds
+    );
+  });
+
   test("selects only public desktop assets when installer assets are listed first", async () => {
     const macArm64 = asset("openwork-mac-arm64-0.17.38.dmg");
     const macX64 = asset("openwork-mac-x64-0.17.38.dmg");

--- a/ee/apps/landing/test/github.test.ts
+++ b/ee/apps/landing/test/github.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { getGithubData } from "../lib/github";
+import { getGithubData, LATEST_RELEASE_CACHE_TAG } from "../lib/github";
 
 type GithubFixtureAsset = {
   name: string;
@@ -39,7 +39,7 @@ const asset = (name: string): GithubFixtureAsset => ({
 });
 
 const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) => {
-  const requests: Array<{ url: string; revalidate?: number }> = [];
+  const requests: Array<{ url: string; revalidate?: number; tags?: string[] }> = [];
   const fixtures: Record<string, unknown> = {
     [repoUrl]: { stargazers_count: 12345 },
     [latestReleaseUrl]: latestRelease,
@@ -54,9 +54,11 @@ const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) =>
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       const fixture = fixtures[url];
-      const next = (init as { next?: { revalidate?: number } } | undefined)?.next;
+      const next = (init as {
+        next?: { revalidate?: number; tags?: string[] };
+      } | undefined)?.next;
 
-      requests.push({ url, revalidate: next?.revalidate });
+      requests.push({ url, revalidate: next?.revalidate, tags: next?.tags });
 
       if (fixture === undefined) {
         return new Response("Not found", { status: 404 });
@@ -103,6 +105,13 @@ describe("getGithubData", () => {
     expect(Object.fromEntries(requests.map(({ url, revalidate }) => [url, revalidate]))).toEqual(
       expectedRevalidateSeconds
     );
+    expect(requests.find(({ url }) => url === repoUrl)?.tags).toEqual([]);
+    expect(requests.find(({ url }) => url === latestReleaseUrl)?.tags).toEqual([
+      LATEST_RELEASE_CACHE_TAG
+    ]);
+    expect(requests.find(({ url }) => url === releasesUrl)?.tags).toEqual([
+      LATEST_RELEASE_CACHE_TAG
+    ]);
   });
 
   test("selects only public desktop assets when installer assets are listed first", async () => {

--- a/evals/specs/landing-release-freshness.test.ts
+++ b/evals/specs/landing-release-freshness.test.ts
@@ -1,0 +1,76 @@
+import { expect, onTestFinished } from "vitest";
+import { test } from "@openwork/testkit";
+import { getGithubData } from "../../ee/apps/landing/lib/github";
+
+const repoUrl = "https://api.github.com/repos/different-ai/openwork";
+const latestReleaseUrl = "https://api.github.com/repos/different-ai/openwork/releases/latest";
+const releasesUrl = "https://api.github.com/repos/different-ai/openwork/releases?per_page=50";
+const releaseTag = "v9.9.9";
+const downloadUrl = `https://github.com/different-ai/openwork/releases/download/${releaseTag}/openwork-mac-arm64-9.9.9.dmg`;
+
+test("the public download page refreshes a newly published stable release", async ({ evidence }) => {
+  const originalFetch = globalThis.fetch;
+  const revalidateByUrl = new Map<string, number | undefined>();
+  const release = {
+    draft: false,
+    prerelease: false,
+    html_url: `https://github.com/different-ai/openwork/releases/tag/${releaseTag}`,
+    tag_name: releaseTag,
+    assets: [{
+      name: "openwork-mac-arm64-9.9.9.dmg",
+      browser_download_url: downloadUrl,
+    }],
+  };
+  const fixtures: Record<string, unknown> = {
+    [repoUrl]: { stargazers_count: 22_800 },
+    [latestReleaseUrl]: release,
+    [releasesUrl]: [release],
+  };
+  const fetchStub = Object.assign(
+    async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+      const next = (init as { next?: { revalidate?: number } } | undefined)?.next;
+      revalidateByUrl.set(url, next?.revalidate);
+      const fixture = fixtures[url];
+      return fixture === undefined
+        ? new Response("Not found", { status: 404 })
+        : Response.json(fixture);
+    },
+    { preconnect: originalFetch.preconnect },
+  ) satisfies typeof fetch;
+  globalThis.fetch = fetchStub;
+  onTestFinished(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const result = await getGithubData();
+
+  expect(result.releaseTag).toBe(releaseTag);
+  expect(result.installers.macos.appleSilicon).toBe(downloadUrl);
+  expect(revalidateByUrl.get(latestReleaseUrl)).toBe(90);
+  evidence.recordAssertionEvidence(
+    "A newly published stable release replaces stale public download metadata",
+    "The landing resolver selected the new stable tag and installer while limiting the latest-release cache to 90 seconds instead of one hour.",
+    true,
+  );
+
+  expect(revalidateByUrl.get(repoUrl)).toBe(60 * 60);
+  expect(revalidateByUrl.get(releasesUrl)).toBe(10 * 60);
+  const maximumRequestsPerHour = (60 * 60) / (60 * 60)
+    + (60 * 60) / 90
+    + (60 * 60) / (10 * 60);
+  expect(maximumRequestsPerHour).toBe(47);
+  expect(maximumRequestsPerHour).toBeLessThan(60);
+  evidence.recordAssertionEvidence(
+    "Release freshness stays within the unauthenticated GitHub API budget",
+    "The repo, latest-release, and fallback-list cache intervals cap one deployment at 47 GitHub API requests per hour rather than exhausting the 60-request public allowance.",
+    true,
+  );
+});

--- a/evals/specs/landing-release-freshness.test.ts
+++ b/evals/specs/landing-release-freshness.test.ts
@@ -1,6 +1,10 @@
 import { expect, onTestFinished } from "vitest";
 import { test } from "@openwork/testkit";
-import { getGithubData } from "../../ee/apps/landing/lib/github";
+import { readFile } from "node:fs/promises";
+import {
+  getGithubData,
+  LATEST_RELEASE_CACHE_TAG,
+} from "../../ee/apps/landing/lib/github";
 
 const repoUrl = "https://api.github.com/repos/different-ai/openwork";
 const latestReleaseUrl = "https://api.github.com/repos/different-ai/openwork/releases/latest";
@@ -11,6 +15,7 @@ const downloadUrl = `https://github.com/different-ai/openwork/releases/download/
 test("the public download page refreshes a newly published stable release", async ({ evidence }) => {
   const originalFetch = globalThis.fetch;
   const revalidateByUrl = new Map<string, number | undefined>();
+  const tagsByUrl = new Map<string, string[] | undefined>();
   const release = {
     draft: false,
     prerelease: false,
@@ -36,8 +41,11 @@ test("the public download page refreshes a newly published stable release", asyn
         : input instanceof URL
           ? input.href
           : input.url;
-      const next = (init as { next?: { revalidate?: number } } | undefined)?.next;
+      const next = (init as {
+        next?: { revalidate?: number; tags?: string[] };
+      } | undefined)?.next;
       revalidateByUrl.set(url, next?.revalidate);
+      tagsByUrl.set(url, next?.tags);
       const fixture = fixtures[url];
       return fixture === undefined
         ? new Response("Not found", { status: 404 })
@@ -55,9 +63,21 @@ test("the public download page refreshes a newly published stable release", asyn
   expect(result.releaseTag).toBe(releaseTag);
   expect(result.installers.macos.appleSilicon).toBe(downloadUrl);
   expect(revalidateByUrl.get(latestReleaseUrl)).toBe(90);
+  expect(tagsByUrl.get(latestReleaseUrl)).toEqual([LATEST_RELEASE_CACHE_TAG]);
+  expect(tagsByUrl.get(releasesUrl)).toEqual([LATEST_RELEASE_CACHE_TAG]);
+
+  const releaseWorkflow = await readFile(
+    new URL("../../.github/workflows/release-macos-aarch64.yml", import.meta.url),
+    "utf8",
+  );
+  expect(releaseWorkflow).toContain("needs: [resolve-release, publish-release]");
+  expect(releaseWorkflow).toContain("needs.publish-release.result == 'success'");
+  expect(releaseWorkflow).toContain("needs.resolve-release.outputs.prerelease != 'true'");
+  expect(releaseWorkflow).toContain("cache dangerously-delete");
+  expect(releaseWorkflow).toContain(`--tag ${LATEST_RELEASE_CACHE_TAG}`);
   evidence.recordAssertionEvidence(
-    "A newly published stable release replaces stale public download metadata",
-    "The landing resolver selected the new stable tag and installer while limiting the latest-release cache to 90 seconds instead of one hour.",
+    "A stable release publication deletes the exact landing cache entry",
+    "The landing resolver tags both stable-release lookups, and the successful non-prerelease workflow deletes that Vercel cache tag so the next download request blocks on fresh GitHub metadata.",
     true,
   );
 


### PR DESCRIPTION
## Summary

- tag the stable GitHub release lookups with a dedicated Vercel cache key
- delete that exact cache entry after the release workflow successfully publishes a stable GitHub release, making the next download request block on fresh metadata
- retry the targeted invalidation three times and fail the refresh job visibly if Vercel cannot be reached
- retain a 90-second time-based refresh as a fallback while keeping the unauthenticated GitHub API budget at 47 requests per hour
- add focused unit and `@openwork/testkit` regression coverage for both the cache tag and the post-publish workflow wiring

## Root cause

The landing site's Next.js Data Cache persists across deployments, while publishing a GitHub release did not notify Vercel. A website deployment or ordinary request could therefore reuse the prior release response and render the download page one version behind. This PR connects the publication event to targeted cache deletion instead of relying only on a shorter polling interval.

## Verification

- `pnpm --filter @openwork-ee/landing test` — 5 passed, 0 failed
- `pnpm --filter @openwork-ee/landing exec tsc --noEmit --incremental false` — passed
- `pnpm evals:pr specs/landing-release-freshness.test.ts` — 1 passed, 0 failed, 0 skipped
- release workflow YAML parses and `yaml-lint` passes
- `vercel@59.3.0 cache dangerously-delete --help` confirms the pinned CLI supports the project, scope, tag, token, and non-interactive flags used by CI

## Existing dev issue

`pnpm --filter @openwork-ee/landing build` reaches the repository Connect parity guard and fails at `Cloud onboarding must copy the public /mcp/agent endpoint`. The identical guard failure reproduces from clean `origin/dev@13504969e`; this PR does not touch those files.