### PR TITLE
fix(app): keep workspace switches coherent under load

### DIFF
--- a/apps/app/src/react-app/shell/desktop-local-openwork.ts
+++ b/apps/app/src/react-app/shell/desktop-local-openwork.ts
@@ -5,7 +5,11 @@ import {
   type EngineInfo,
   type OpenworkServerInfo,
 } from "../../app/lib/desktop";
-import { readOpenworkServerSettings, writeOpenworkServerSettings } from "../../app/lib/openwork-server";
+import {
+  readOpenworkServerSettings,
+  writeOpenworkServerSettings,
+  type OpenworkServerSettings,
+} from "../../app/lib/openwork-server";
 import { safeStringify } from "../../app/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
 import type { BootPhaseId } from "./boot-state";
@@ -46,6 +50,17 @@ export function isReadyLocalOpenworkServerInfo(
 
 export const LOCAL_OPENWORK_READINESS_MAX_ATTEMPTS = 20;
 export const LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS = 500;
+
+export function openworkServerSettingsChanged(
+  previous: OpenworkServerSettings,
+  next: OpenworkServerSettings,
+): boolean {
+  return previous.urlOverride !== next.urlOverride
+    || previous.portOverride !== next.portOverride
+    || previous.token !== next.token
+    || previous.hostToken !== next.hostToken
+    || (previous.remoteAccessEnabled === true) !== (next.remoteAccessEnabled === true);
+}
 
 /**
  * Poll the local server bridge until it reports a ready server. A restart
@@ -141,12 +156,14 @@ export async function ensureDesktopLocalOpenworkConnection(
 
   try {
     const engine = await engineInfo().catch(() => null) as EngineInfo | null;
+    let startedEngine = false;
     if (!engine?.running || !engine.baseUrl) {
       await engineStart(workspaceRoot, {
         runtime: "direct",
         workspacePaths,
         openworkRemoteAccess: readOpenworkServerSettings().remoteAccessEnabled === true,
       });
+      startedEngine = true;
     }
 
     // The server publishes its base URL and tokens asynchronously after a
@@ -157,14 +174,17 @@ export async function ensureDesktopLocalOpenworkConnection(
       throw new Error("OpenWork server did not become ready after activation.");
     }
 
-    writeOpenworkServerSettings({
+    const previousSettings = readOpenworkServerSettings();
+    const nextSettings = writeOpenworkServerSettings({
       urlOverride: info.baseUrl,
       token: info.ownerToken?.trim() || info.clientToken?.trim() || undefined,
       hostToken: info.hostToken?.trim() || undefined,
       portOverride: info.port ?? undefined,
       remoteAccessEnabled: info.remoteAccessEnabled === true,
     });
-    emitOpenworkSettingsChanged();
+    if (startedEngine || openworkServerSettingsChanged(previousSettings, nextSettings)) {
+      emitOpenworkSettingsChanged();
+    }
 
     recordInspectorEvent("route.local_openwork.ensure.success", {
       route: options.route,

--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -29,6 +29,67 @@ export type RouteRefreshLifecycle = {
   isInFlight(): boolean;
 };
 
+export type LatestWorkspaceCommitter = {
+  /** Queue the route's newest workspace. Intermediate requests are discarded. */
+  request(workspaceId: string): void;
+  /** Resolve after the current commit and any newer queued commit finish. */
+  settled(): Promise<void>;
+};
+
+/**
+ * Serialize workspace-selection side effects while retaining only the newest
+ * request. Desktop persistence and server activation cannot safely race: an
+ * older, slower request must finish before the final route is committed.
+ */
+export function createLatestWorkspaceCommitter(
+  commit: (workspaceId: string) => Promise<void>,
+): LatestWorkspaceCommitter {
+  let pendingWorkspaceId: string | null = null;
+  let running: Promise<void> | null = null;
+
+  const drain = async () => {
+    while (pendingWorkspaceId !== null) {
+      const workspaceId = pendingWorkspaceId;
+      pendingWorkspaceId = null;
+      await commit(workspaceId).catch(() => undefined);
+      // A duplicate request received while this commit was running is already
+      // satisfied. A different id remains queued and runs next.
+      if (pendingWorkspaceId === workspaceId) pendingWorkspaceId = null;
+    }
+  };
+
+  const start = () => {
+    if (running) return;
+    running = drain().finally(() => {
+      running = null;
+      if (pendingWorkspaceId !== null) start();
+    });
+  };
+
+  return {
+    request(workspaceId) {
+      const id = workspaceId.trim();
+      if (!id) return;
+      pendingWorkspaceId = id;
+      start();
+    },
+    async settled() {
+      while (running) await running;
+    },
+  };
+}
+
+/** Only the routed workspace needs an OpenCode session index immediately. */
+export function planRouteWorkspaceLoads(
+  workspaceIds: string[],
+  selectedWorkspaceId: string,
+  loadedWorkspaceIds: ReadonlySet<string>,
+): string[] {
+  const selectedId = selectedWorkspaceId.trim();
+  if (!selectedId || loadedWorkspaceIds.has(selectedId) || !workspaceIds.includes(selectedId)) return [];
+  return [selectedId];
+}
+
 export function createRouteRefreshLifecycle(): RouteRefreshLifecycle {
   let latestGeneration = 0;
   let inFlightGeneration = 0;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -575,7 +575,6 @@ export function SessionRoute() {
     routeNotFoundMessage,
     endpointForWorkspace,
     refreshRouteState,
-    loadWorkspaceSessionsInBackground,
     rememberPendingCreatedSession,
     handleRuntimeSessionCreated,
     handleRuntimeSessionUpdated,
@@ -2413,9 +2412,12 @@ export function SessionRoute() {
       await refreshRouteState();
       if (targetWorkspaceId) {
         const workspacePath = targetWorkspace?.path?.trim() || folder;
-        // Best-effort first task creation (mirrors the old welcome flow) — a
-        // failure here must not surface as a failed workspace creation.
-        const session = createdOnServer && sessionBaseUrl && sessionToken
+        const firstTaskPrompt = options?.firstTaskPrompt?.trim() ?? "";
+        const firstTaskAttachments = options?.firstTaskAttachments ?? [];
+        // A workspace registry mutation must not eagerly instantiate an
+        // OpenCode directory. Chat-first creation still needs a session for
+        // its supplied prompt; ordinary creation lands on the New task state.
+        const session = createdOnServer && sessionBaseUrl && sessionToken && (firstTaskPrompt || firstTaskAttachments.length > 0)
           ? await createClient(
               `${(buildOpenworkWorkspaceBaseUrl(sessionBaseUrl, targetWorkspaceId) ?? sessionBaseUrl).replace(/\/+$/, "")}/opencode`,
               workspacePath || undefined,
@@ -2434,9 +2436,7 @@ export function SessionRoute() {
         captureAnalyticsEvent("workspace_created", { workspace_type: "local" });
         if (session?.id) {
           captureAnalyticsEvent("task_created", { source: "workspace_created", workspace_type: "local" });
-          const firstTaskPrompt = options?.firstTaskPrompt?.trim();
           if (firstTaskPrompt) {
-            const firstTaskAttachments = options?.firstTaskAttachments ?? [];
             // Attachment chips only survive in-memory (File objects), so the
             // persisted fallback draft drops their tokens.
             saveSessionDraft(targetWorkspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
@@ -2704,30 +2704,9 @@ export function SessionRoute() {
           if (workspaceId === selectedWorkspaceId) return true;
           setLegacySelectedWorkspaceId(workspaceId);
           writeActiveWorkspaceId(workspaceId || null);
-          const workspace = workspaces.find((item) => item.id === workspaceId);
-          if (client && workspace && !sessionsByWorkspaceId[workspaceId]?.length) {
-            setRetryingWorkspaceIds((current) => Array.from(new Set([...current, workspaceId])));
-            void loadWorkspaceSessionsInBackground([workspace]);
-          }
-          // Fire Tauri updates but don't await them — they're bookkeeping and
-          // awaiting 2 IPC roundtrips on every click used to stall rapid
-          // workspace switches behind a queue.
-          if (isDesktopRuntime()) {
-            void workspaceSetSelected(workspaceId).catch(() => undefined);
-            void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
-          }
-          // Tell the OpenWork server this workspace is now active so it can
-          // emit a config reload event that the OpenCode engine picks up.
-          // Without this, the permissions from opencode.jsonc are never
-          // applied on the workspace the user is already on at launch. See
-          // issue #870.
-          if (workspaceId) {
-            const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
-            const endpoint = endpointForWorkspace(workspace);
-            if (endpoint) {
-              void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
-            }
-          }
+          // Route adoption owns desktop persistence and server activation.
+          // Centralizing those effects lets rapid navigation coalesce to the
+          // last route instead of racing stale IPC and engine reloads.
           // If we remember what the user last opened here and that session
           // still exists in our local list, navigate. Otherwise stay put.
           const remembered = readLastSessionFor(workspaceId);

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -17,6 +17,8 @@ import {
 import {
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
+  workspaceSetRuntimeActive,
+  workspaceSetSelected,
   type OpenworkServerInfo,
   type WorkspaceList,
 } from "@/app/lib/desktop";
@@ -45,7 +47,12 @@ import {
   shouldAttemptDesktopLocalReconnect,
 } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
-import { createRouteRefreshLifecycle, planRouteConnectionGap } from "./route-refresh-control";
+import {
+  createLatestWorkspaceCommitter,
+  createRouteRefreshLifecycle,
+  planRouteConnectionGap,
+  planRouteWorkspaceLoads,
+} from "./route-refresh-control";
 import {
   classifyRouteSessionReadError,
   describeRouteError,
@@ -89,6 +96,7 @@ type ModernRouteSessionResolution =
  * bridge or unresponsive server otherwise leaves `loading` true forever,
  * which the session pane renders as an indefinite loading state. */
 const ROUTE_REFRESH_STEP_TIMEOUT_MS = 15_000;
+const ROUTE_WORKSPACE_ACTIVATION_SETTLE_MS = 750;
 
 function withRouteRefreshTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -126,6 +134,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       .replace(/^\/+|\/+$/g, "")
     : "";
   const workspaceInferenceSessionId = sessionIdForLegacyWorkspaceInference(routeWorkspaceId, selectedSessionId);
+  const legacyWorkspaceInferenceKey = routeWorkspaceId ? "" : workspaceInferenceSessionId;
+  const routeWorkspaceIdRef = useRef(routeWorkspaceId);
+  routeWorkspaceIdRef.current = routeWorkspaceId;
+  const workspaceInferenceSessionIdRef = useRef(workspaceInferenceSessionId);
+  workspaceInferenceSessionIdRef.current = workspaceInferenceSessionId;
   const navigateToWorkspaceSession = useCallback((workspaceId: string, sessionId?: string | null, options?: { replace?: boolean }) => {
     const id = workspaceId.trim();
     if (!id) {
@@ -209,9 +222,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const hydratedRouteSessionIdsRef = useRef<Record<string, string>>({});
   const startupRetryTimerRef = useRef<number | null>(null);
   const [retryingWorkspaceIds, setRetryingWorkspaceIds] = useState<string[]>([]);
-  const launchActivatedWorkspaceIdsRef = useRef(new Set<string>());
   const reconnectAttemptedWorkspaceIdRef = useRef("");
   const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
+  const loadedWorkspaceIdsRef = useRef(new Set<string>());
+  const serverActiveWorkspaceIdRef = useRef("");
+  const workspaceSelectionCommitTimerRef = useRef<number | null>(null);
   const rememberPendingCreatedSession = useCallback((workspaceId: string, sessionId: string) => {
     const id = sessionId.trim();
     if (!workspaceId || !id) return;
@@ -319,6 +334,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
             sessionsByWorkspaceIdRef.current = next;
             return next;
           });
+          loadedWorkspaceIdsRef.current.add(workspace.id);
           setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: null }));
           setWorkspaceConnectionOverrides((current) => {
             if (isRemoteOpenworkWorkspace) {
@@ -397,6 +413,25 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     },
     [endpointForWorkspace, mergeFetchedSessionsWithPending],
   );
+  const workspaceSelectionCommitRef = useRef<(workspaceId: string) => Promise<void>>(async () => undefined);
+  workspaceSelectionCommitRef.current = async (workspaceId) => {
+    if (isDesktopRuntime()) {
+      await workspaceSetSelected(workspaceId).catch(() => undefined);
+      await workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
+    }
+    const workspace = workspacesRef.current.find((item) => item.id === workspaceId) ?? null;
+    const endpoint = endpointForWorkspace(workspace);
+    if (!endpoint) return;
+    if (workspace?.workspaceType === "local" && serverActiveWorkspaceIdRef.current === workspaceId) return;
+    await endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true });
+    if (workspace?.workspaceType === "local") serverActiveWorkspaceIdRef.current = workspaceId;
+  };
+  const workspaceSelectionCommitterRef = useRef<ReturnType<typeof createLatestWorkspaceCommitter> | null>(null);
+  if (!workspaceSelectionCommitterRef.current) {
+    workspaceSelectionCommitterRef.current = createLatestWorkspaceCommitter(
+      (workspaceId) => workspaceSelectionCommitRef.current(workspaceId),
+    );
+  }
 
   const refreshRouteState = useCallback(async (options?: { supersede?: boolean }) => {
     // Dedupe: if a refresh is already running, skip this call. Fast workspace
@@ -486,11 +521,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // workspace-scoped requests below. `endpointForWorkspace` reads from
       // this resolver synchronously; the render that mirrors `[baseUrl,
       // token]` into the resolver doesn't run until after the next React commit,
-      // which is too late for the `activateWorkspace` and
-      // `loadWorkspaceSessionsInBackground` calls that fire later in this
-      // function. Stale ref => `resolveWorkspaceEndpoint` returns null for
+      // which is too late for the `loadWorkspaceSessionsInBackground` call
+      // later in this function. Stale ref => `resolveWorkspaceEndpoint` returns null for
       // local workspaces => sidebar gets stuck in "loading" forever.
-      const routeWorkspaceServerClientResolver = updateLocalServer({ baseUrl: normalizedBaseUrl, token: resolvedToken });
+      updateLocalServer({ baseUrl: normalizedBaseUrl, token: resolvedToken });
 
       const openworkClient = createOpenworkServerClient({
         baseUrl: normalizedBaseUrl,
@@ -518,10 +552,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setRouteError(message);
       }
       const nextWorkspaces = workspaceListState.workspaces;
+      serverActiveWorkspaceIdRef.current = workspaceListState.activeId ?? "";
 
       // Preserve any sessions we already have cached so switching routes
       // doesn't erase the sidebar while we refetch.
-      const alreadyLoadedWorkspaceIds = new Set(Object.keys(sessionsByWorkspaceIdRef.current));
+      const alreadyLoadedWorkspaceIds = new Set(loadedWorkspaceIdsRef.current);
       const cachedEntries = nextWorkspaces.map((workspace) => ({
         workspaceId: workspace.id,
         sessions: sessionsByWorkspaceIdRef.current[workspace.id] ?? [],
@@ -531,8 +566,8 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // activeId, the server's activeId, then the first known workspace.
       const persistedActiveId = readActiveWorkspaceId();
       let nextWorkspaceId =
-        (routeWorkspaceId && nextWorkspaces.some((w) => w.id === routeWorkspaceId)
-          ? routeWorkspaceId
+        (routeWorkspaceIdRef.current && nextWorkspaces.some((w) => w.id === routeWorkspaceIdRef.current)
+          ? routeWorkspaceIdRef.current
           : "") ||
         (persistedActiveId && nextWorkspaces.some((w) => w.id === persistedActiveId)
           ? persistedActiveId
@@ -541,12 +576,17 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         workspaceListState.activeId ||
         nextWorkspaces[0]?.id ||
         "";
-      if (workspaceInferenceSessionId) {
+      if (workspaceInferenceSessionIdRef.current) {
         const match = cachedEntries.find((entry) =>
-          entry.sessions.some((session) => session?.id === workspaceInferenceSessionId),
+          entry.sessions.some((session) => session?.id === workspaceInferenceSessionIdRef.current),
         );
         if (match?.workspaceId) nextWorkspaceId = match.workspaceId;
       }
+      const backgroundWorkspaceIds = planRouteWorkspaceLoads(
+        nextWorkspaces.map((workspace) => workspace.id),
+        nextWorkspaceId,
+        alreadyLoadedWorkspaceIds,
+      );
 
       updateLocalServer({ baseUrl: normalizedBaseUrl, token: resolvedToken });
 
@@ -565,28 +605,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         }
         return next;
       });
-      setRetryingWorkspaceIds(
-        cachedEntries.flatMap((entry) =>
-          entry.sessions.length === 0 &&
-          (entry.workspaceId === nextWorkspaceId || !alreadyLoadedWorkspaceIds.has(entry.workspaceId))
-            ? [entry.workspaceId]
-            : [],
-        ),
-      );
+      setRetryingWorkspaceIds(backgroundWorkspaceIds);
       setLegacySelectedWorkspaceId(nextWorkspaceId);
       writeActiveWorkspaceId(nextWorkspaceId || null);
-      // Mark the chosen workspace as active on the server so that the
-      // OpenCode engine bound to it re-reads opencode.jsonc and applies
-      // permissions. Fire-and-forget; the route is idempotent and any
-      // transport failure is non-fatal. See issue #870.
-      if (nextWorkspaceId && workspaceListState.activeId !== nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
-        launchActivatedWorkspaceIdsRef.current.add(nextWorkspaceId);
-        const nextWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId) ?? null;
-        const nextEndpoint = routeWorkspaceServerClientResolver(nextWorkspace);
-        if (nextEndpoint) {
-          void nextEndpoint.client.activateWorkspace(nextEndpoint.workspaceId).catch(() => undefined);
-        }
-      }
       recordInspectorEvent("route.refresh.complete", {
         workspaces: nextWorkspaces.length,
         selectedWorkspaceId: nextWorkspaceId,
@@ -597,15 +618,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // boot. Kick it off in the background instead of blocking the route
       // so the UI is interactive immediately; the sidebar shows a
       // loading state per-workspace until the list arrives.
-      const selectedWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId);
-      const backgroundWorkspaces = nextWorkspaces.filter(
-        (workspace) => workspace.id === nextWorkspaceId || !alreadyLoadedWorkspaceIds.has(workspace.id),
-      );
+      const backgroundWorkspaces = nextWorkspaces.filter((workspace) => backgroundWorkspaceIds.includes(workspace.id));
       if (backgroundWorkspaces.length > 0) {
-        const orderedWorkspaces = selectedWorkspace
-          ? [selectedWorkspace, ...backgroundWorkspaces.filter((workspace) => workspace.id !== selectedWorkspace.id)]
-          : backgroundWorkspaces;
-        void loadWorkspaceSessionsInBackground(orderedWorkspaces);
+        void loadWorkspaceSessionsInBackground(backgroundWorkspaces);
       }
     } catch (error) {
       if (!attempt.isCurrent()) return;
@@ -640,7 +655,44 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         }
       }
     }
-  }, [loadWorkspaceSessionsInBackground, markBootRouteReady, routeWorkspaceId, updateLocalServer, workspaceInferenceSessionId]);
+  }, [legacyWorkspaceInferenceKey, loadWorkspaceSessionsInBackground, markBootRouteReady, updateLocalServer]);
+
+  const routeWorkspaceKnown = Boolean(
+    routeWorkspaceId && workspaces.some((workspace) => workspace.id === routeWorkspaceId),
+  );
+  useEffect(() => {
+    if (workspaceSelectionCommitTimerRef.current !== null) {
+      window.clearTimeout(workspaceSelectionCommitTimerRef.current);
+      workspaceSelectionCommitTimerRef.current = null;
+    }
+    if (!routeWorkspaceId) return;
+
+    // The URL is the user's newest selection. Persist it synchronously so a
+    // slow refresh or activation can never leave storage on an older route.
+    setLegacySelectedWorkspaceId(routeWorkspaceId);
+    writeActiveWorkspaceId(routeWorkspaceId);
+    if (!routeWorkspaceKnown) return;
+
+    workspaceSelectionCommitTimerRef.current = window.setTimeout(() => {
+      workspaceSelectionCommitTimerRef.current = null;
+      workspaceSelectionCommitterRef.current?.request(routeWorkspaceId);
+    }, ROUTE_WORKSPACE_ACTIVATION_SETTLE_MS);
+    const workspaceIdsToLoad = planRouteWorkspaceLoads(
+      workspacesRef.current.map((workspace) => workspace.id),
+      routeWorkspaceId,
+      loadedWorkspaceIdsRef.current,
+    );
+    const workspace = workspacesRef.current.find((item) => item.id === workspaceIdsToLoad[0]);
+    if (workspace) {
+      setRetryingWorkspaceIds((current) => Array.from(new Set([...current, workspace.id])));
+      void loadWorkspaceSessionsInBackground([workspace]);
+    }
+    return () => {
+      if (workspaceSelectionCommitTimerRef.current === null) return;
+      window.clearTimeout(workspaceSelectionCommitTimerRef.current);
+      workspaceSelectionCommitTimerRef.current = null;
+    };
+  }, [loadWorkspaceSessionsInBackground, routeWorkspaceId, routeWorkspaceKnown]);
   const handleRuntimeSessionUpdated = useCallback((update: { sessionId: string; info: Record<string, unknown> }) => {
     if (!selectedWorkspaceId) return;
     setSessionsByWorkspaceId((current) => {

--- a/apps/app/tests/desktop-local-openwork.test.ts
+++ b/apps/app/tests/desktop-local-openwork.test.ts
@@ -4,10 +4,26 @@ import type { OpenworkServerInfo } from "../src/app/lib/desktop";
 import {
   isReadyLocalOpenworkServerInfo,
   LOCAL_OPENWORK_READINESS_RETRY_DELAY_MS,
+  openworkServerSettingsChanged,
   shouldAttemptDesktopLocalReconnect,
   waitForReadyLocalOpenworkServerInfo,
   type DesktopLocalReconnectInput,
 } from "../src/react-app/shell/desktop-local-openwork";
+
+describe("openworkServerSettingsChanged", () => {
+  test("does not refresh the renderer for an unchanged healthy server", () => {
+    const settings = {
+      urlOverride: "http://127.0.0.1:4187",
+      portOverride: 4187,
+      token: "owner",
+      hostToken: "host",
+      remoteAccessEnabled: false,
+    };
+
+    expect(openworkServerSettingsChanged(settings, { ...settings })).toBe(false);
+    expect(openworkServerSettingsChanged(settings, { ...settings, token: "new-owner" })).toBe(true);
+  });
+});
 
 function serverInfo(overrides: Partial<OpenworkServerInfo> = {}): OpenworkServerInfo {
   return {

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -1,9 +1,68 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  createLatestWorkspaceCommitter,
   createRouteRefreshLifecycle,
   planRouteConnectionGap,
+  planRouteWorkspaceLoads,
 } from "../src/react-app/shell/route-refresh-control";
+
+describe("createLatestWorkspaceCommitter", () => {
+  test("coalesces an in-flight switching burst to the last route", async () => {
+    const committed: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const committer = createLatestWorkspaceCommitter(async (workspaceId) => {
+      committed.push(workspaceId);
+      if (workspaceId === "ws_1") await firstBlocked;
+    });
+
+    committer.request("ws_1");
+    committer.request("ws_2");
+    committer.request("ws_3");
+    expect(committed).toEqual(["ws_1"]);
+
+    releaseFirst();
+    await committer.settled();
+    expect(committed).toEqual(["ws_1", "ws_3"]);
+  });
+
+  test("does not repeat the active commit when the final route returns to it", async () => {
+    const committed: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const committer = createLatestWorkspaceCommitter(async (workspaceId) => {
+      committed.push(workspaceId);
+      if (committed.length === 1) await firstBlocked;
+    });
+
+    committer.request("ws_1");
+    committer.request("ws_2");
+    committer.request("ws_1");
+    releaseFirst();
+    await committer.settled();
+
+    expect(committed).toEqual(["ws_1"]);
+  });
+});
+
+describe("planRouteWorkspaceLoads", () => {
+  test("loads only the selected workspace instead of every unseen workspace", () => {
+    expect(planRouteWorkspaceLoads(
+      ["ws_1", "ws_2", "ws_3", "ws_4"],
+      "ws_3",
+      new Set(["ws_1"]),
+    )).toEqual(["ws_3"]);
+  });
+
+  test("skips a selected workspace whose session index is already loaded", () => {
+    expect(planRouteWorkspaceLoads(["ws_1", "ws_2"], "ws_2", new Set(["ws_2"]))).toEqual([]);
+  });
+});
 
 describe("createRouteRefreshLifecycle", () => {
   test("dedupes refreshes while one is in flight", () => {

--- a/evals/specs/workspace-storm-auth-coherence.e2e.test.ts
+++ b/evals/specs/workspace-storm-auth-coherence.e2e.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Repro attempts for the field report "failed authorization / asks me to
+ * reconnect even though the tools/MCPs are connected": a member with many
+ * workspaces (one per customer) who switches quickly between sessions across
+ * those workspaces starts seeing auth failures and reconnect prompts.
+ *
+ * Three attempts, from broad to narrow:
+ *  1. Considerable scale — ~20 workspaces, round-robin switching storms.
+ *  2. Marten-scale (6 workspaces) switching while Den is overloaded
+ *     (latency + 429 bursts) and while Den briefly answers 401.
+ *  3. A two-workspace rapid-toggle race with zero dwell time.
+ *
+ * Every attempt asserts the same coherence contract and its negative half:
+ * the Den session token must never disappear, the active organization must
+ * not change, Connect must stay (or recover to) available, no workspace may
+ * be lost, and the wire log must show no non-injected 401/403 from Den.
+ */
+import { expect } from "vitest";
+import { control, evalIn, go, waitFor } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/test-evidence";
+import {
+  app,
+  eventually,
+  faultProxy,
+  localMysqlIsRunning,
+  needs,
+  readCloudMcpHealth,
+  readConnectState,
+  readDenClientState,
+  server,
+  sleep,
+  test,
+} from "@openwork/testkit";
+import type { App, DenClientState, FaultProxy, FaultRequest } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localMysqlRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const runnable = e2eTestsEnabled && (!localMysqlRequired || mysqlOpen);
+
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localMysqlRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : "";
+
+/** Total workspace count for the scale attempt; the report names ~20. */
+const STORM_WORKSPACE_TOTAL = (() => {
+  const raw = Number(process.env.OPENWORK_EVAL_WORKSPACE_STORM_COUNT ?? "20");
+  return Number.isInteger(raw) && raw >= 2 ? raw : 20;
+})();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface WorkspaceListing {
+  ids: string[];
+  activeId: string | null;
+}
+
+/** The local server's own workspace registry, read the way the app reads it. */
+async function listWorkspaces(desktopApp: App): Promise<WorkspaceListing> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/workspaces", {
+      headers: { authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+    });
+    if (!response.ok) return { error: "workspaces_http_" + response.status };
+    const body = await response.json();
+    const items = Array.isArray(body?.items) ? body.items : [];
+    return {
+      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+      activeId: typeof body?.activeId === "string" ? body.activeId : null,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  if (!isRecord(value) || !Array.isArray(value.ids)) {
+    throw new Error(`Listing workspaces failed: ${JSON.stringify(value)}`);
+  }
+  return {
+    ids: value.ids.filter((id): id is string => typeof id === "string"),
+    activeId: typeof value.activeId === "string" ? value.activeId : null,
+  };
+}
+
+/** Create one workspace through the product's own control action and return its id. */
+async function createWorkspace(desktopApp: App, label: string, index: number): Promise<string> {
+  const before = await listWorkspaces(desktopApp);
+  const path = `/tmp/openwork-${label}-${Date.now()}-${index}`;
+  await control(desktopApp, "workspace.create", { path }, { timeoutMs: 90_000 });
+  const after = await eventually(() => listWorkspaces(desktopApp), {
+    within: 90_000,
+    intervalMs: 500,
+    label: `workspace ${label}-${index} registered`,
+    until: (listing) => listing.ids.length === before.ids.length + 1,
+  });
+  const created = after.ids.find((candidate) => !before.ids.includes(candidate));
+  if (!created) throw new Error(`workspace.create produced no new workspace id (before=${before.ids.length}, after=${after.ids.length}).`);
+  return created;
+}
+
+/** Switch the UI to a workspace's session surface the way route navigation does. */
+async function switchToWorkspace(desktopApp: App, workspaceId: string, dwellMs: number): Promise<void> {
+  await go(desktopApp, `/workspace/${workspaceId}/session`);
+  if (dwellMs > 0) await sleep(dwellMs);
+}
+
+/** Ask the real Den auth provider to re-read its session; exercises injected identity failures. */
+async function refreshDenSession(desktopApp: App, times: number): Promise<void> {
+  await evalIn(desktopApp, `(async () => {
+    for (let index = 0; index < ${times}; index += 1) {
+      window.dispatchEvent(new Event("openwork-den-session-updated"));
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    }
+  })()`, { awaitPromise: true, timeoutMs: 10_000 });
+}
+
+/** Wait until the app itself has adopted the workspace as active. */
+async function waitForAdoptedWorkspace(desktopApp: App, workspaceId: string): Promise<void> {
+  await waitFor(desktopApp, `(localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)}
+    && window.location.hash.includes(${JSON.stringify(`/workspace/${workspaceId}`)})`, {
+    timeoutMs: 60_000,
+    label: `workspace ${workspaceId} adopted as active`,
+  });
+}
+
+function unauthorizedDenResponses(log: FaultRequest[], fromIndex: number): FaultRequest[] {
+  return log
+    .slice(fromIndex)
+    .filter((request) => !request.faulted && (request.status === 401 || request.status === 403));
+}
+
+function formatRequests(requests: FaultRequest[]): string {
+  return JSON.stringify(requests.map((request) => `${request.method} ${request.path} -> ${request.status}`));
+}
+
+async function healthyBaseline(desktopApp: App): Promise<{ den: DenClientState; orgId: string }> {
+  const den = await eventually(() => readDenClientState(desktopApp), {
+    within: 60_000,
+    label: "signed-in Den client state",
+    until: (state) => state.authTokenPresent && Boolean(state.activeOrgId),
+  });
+  await eventually(() => readConnectState(desktopApp), {
+    within: 120_000,
+    label: "Connect available before the storm",
+    until: (state) => state.ok && state.connectEnabled === true,
+  });
+  const orgId = den.activeOrgId;
+  if (!orgId) throw new Error("The baseline Den client state has no active organization.");
+  return { den, orgId };
+}
+
+interface StormOutcome {
+  switches: number;
+  authDropSamples: string[];
+  orgChangeSamples: string[];
+}
+
+/**
+ * Drive the switching storm: visit every workspace in the given order for the
+ * given number of passes, sampling the Den client state as a person's session
+ * would observe it mid-storm. Sampling never waits for the app to settle —
+ * quick switching is the reported trigger.
+ */
+async function runSwitchStorm(
+  desktopApp: App,
+  workspaceIds: string[],
+  input: { passes: number; dwellMs: number; sampleEvery: number; expectedOrgId: string },
+): Promise<StormOutcome> {
+  const outcome: StormOutcome = { switches: 0, authDropSamples: [], orgChangeSamples: [] };
+  for (let pass = 0; pass < input.passes; pass += 1) {
+    // Alternate direction so consecutive passes revisit the most recently
+    // abandoned workspace first — the tightest A→B→A shape the report names.
+    const order = pass % 2 === 0 ? workspaceIds : [...workspaceIds].reverse();
+    for (const workspaceId of order) {
+      await switchToWorkspace(desktopApp, workspaceId, input.dwellMs);
+      outcome.switches += 1;
+      if (outcome.switches % input.sampleEvery !== 0) continue;
+      const state = await readDenClientState(desktopApp);
+      if (!state.authTokenPresent) {
+        outcome.authDropSamples.push(`switch ${outcome.switches} (workspace ${workspaceId}): auth token missing`);
+      }
+      if (state.activeOrgId !== input.expectedOrgId) {
+        outcome.orgChangeSamples.push(`switch ${outcome.switches} (workspace ${workspaceId}): activeOrgId=${String(state.activeOrgId)}`);
+      }
+    }
+  }
+  return outcome;
+}
+
+async function assertPostStormCoherence(input: {
+  desktopApp: App;
+  proxy: FaultProxy;
+  stormStartIndex: number;
+  expectedOrgId: string;
+  expectedWorkspaceIds: string[];
+  finalWorkspaceId: string;
+  evidence: { recordAssertionEvidence(claim: string, witness: string, passed: boolean): void };
+  attempt: string;
+}): Promise<void> {
+  const { desktopApp, proxy, evidence, attempt } = input;
+
+  await waitForAdoptedWorkspace(desktopApp, input.finalWorkspaceId);
+
+  const finalDen = await readDenClientState(desktopApp);
+  const authCoherent = finalDen.authTokenPresent && finalDen.activeOrgId === input.expectedOrgId;
+  evidence.recordAssertionEvidence(
+    `${attempt}: the Den session survives the storm`,
+    `Final Den client state: authTokenPresent=${finalDen.authTokenPresent}, activeOrgId=${String(finalDen.activeOrgId)} (expected ${input.expectedOrgId}).`,
+    authCoherent,
+  );
+  expect(finalDen.authTokenPresent).toBe(true);
+  expect(finalDen.activeOrgId).toBe(input.expectedOrgId);
+
+  const finalConnect = await eventually(() => readConnectState(desktopApp), {
+    within: 120_000,
+    label: `${attempt}: Connect state after the storm`,
+    until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+  });
+  evidence.recordAssertionEvidence(
+    `${attempt}: Connect stays (or recovers to) available without a reconnect`,
+    `Connect after the storm: ok=${finalConnect.ok}, status=${String(finalConnect.status)}, connectEnabled=${String(finalConnect.connectEnabled)}.`,
+    finalConnect.ok && finalConnect.status === "available" && finalConnect.connectEnabled === true,
+  );
+
+  const listing = await eventually(() => listWorkspaces(desktopApp), {
+    within: 60_000,
+    intervalMs: 500,
+    label: `${attempt}: local server adopts the final workspace`,
+    until: (state) => state.activeId === input.finalWorkspaceId,
+  });
+  evidence.recordAssertionEvidence(
+    `${attempt}: server activation is last-route-wins`,
+    `The local server activeId is ${String(listing.activeId)} (expected ${input.finalWorkspaceId}).`,
+    listing.activeId === input.finalWorkspaceId,
+  );
+  expect(listing.activeId).toBe(input.finalWorkspaceId);
+  const missing = input.expectedWorkspaceIds.filter((id) => !listing.ids.includes(id));
+  evidence.recordAssertionEvidence(
+    `${attempt}: no workspace is lost by the storm`,
+    `The local server lists ${listing.ids.length} workspaces; missing after the storm: ${JSON.stringify(missing)}.`,
+    missing.length === 0,
+  );
+  expect(missing).toEqual([]);
+
+  const log = await proxy.requestLog();
+  const unauthorized = unauthorizedDenResponses(log, input.stormStartIndex);
+  evidence.recordAssertionEvidence(
+    `${attempt}: Den never answered the storm with a real authorization failure`,
+    unauthorized.length === 0
+      ? `The wire log recorded ${log.length - input.stormStartIndex} requests during the storm with zero non-injected 401/403 responses.`
+      : `Non-injected unauthorized responses during the storm: ${formatRequests(unauthorized)}.`,
+    unauthorized.length === 0,
+  );
+  expect(unauthorized, formatRequests(unauthorized)).toEqual([]);
+
+  const shot = await screenshot(desktopApp);
+  const seen = await validate(shot, [
+    "The desktop shows a workspace session surface, not a sign-in or reconnect screen",
+    "No error banner asks the user to reconnect or re-authenticate",
+  ]);
+  evidence.recordAssertionEvidence(
+    `${attempt}: no reconnect or sign-in prompt is visible after the storm`,
+    seen.ok ? "The post-storm screenshot shows a normal session surface." : `Visual validation failed: ${seen.why}`,
+    seen.ok,
+  );
+  expect(seen.ok, seen.why).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Attempt 1 — considerable scale: ~20 workspaces, round-robin switching storm.
+// ---------------------------------------------------------------------------
+test.skipIf(!runnable)(
+  `${STORM_WORKSPACE_TOTAL} workspaces with rapid round-robin switching keep one coherent Cloud session${skipSuffix}`,
+  { timeout: 30 * 60_000 },
+  async ({ evidence, place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    await using den = await server({
+      place,
+      org: {
+        name: "Workspace Storm Scale",
+        admin: { name: "Storm Admin" },
+        members: { member: { name: "Storm Member" } },
+      },
+    });
+    await using proxy = await faultProxy(den.ref, {
+      place,
+      sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
+    });
+    await using desktopApp = await app({ den: { ...den, ref: proxy.ref }, as: "member", place });
+
+    const baseline = await healthyBaseline(desktopApp);
+    const workspaceIds = [desktopApp.workspaceId];
+    for (let index = workspaceIds.length; index < STORM_WORKSPACE_TOTAL; index += 1) {
+      workspaceIds.push(await createWorkspace(desktopApp, "storm-scale", index));
+    }
+    evidence.recordAssertionEvidence(
+      "Attempt 1: the member reached the reported scale through the product itself",
+      `${workspaceIds.length} workspaces exist, all created via the app's own workspace.create action.`,
+      workspaceIds.length === STORM_WORKSPACE_TOTAL,
+    );
+
+    const stormStartIndex = (await proxy.requestLog()).length;
+    const outcome = await runSwitchStorm(desktopApp, workspaceIds, {
+      passes: 2,
+      dwellMs: 400,
+      sampleEvery: 5,
+      expectedOrgId: baseline.orgId,
+    });
+    evidence.recordAssertionEvidence(
+      "Attempt 1: mid-storm samples never observed a dropped session",
+      `${outcome.switches} switches across ${workspaceIds.length} workspaces; auth drops: ${JSON.stringify(outcome.authDropSamples)}; org changes: ${JSON.stringify(outcome.orgChangeSamples)}.`,
+      outcome.authDropSamples.length === 0 && outcome.orgChangeSamples.length === 0,
+    );
+    expect(outcome.authDropSamples).toEqual([]);
+    expect(outcome.orgChangeSamples).toEqual([]);
+
+    const finalWorkspaceId = workspaceIds[0];
+    await switchToWorkspace(desktopApp, finalWorkspaceId, 0);
+    await assertPostStormCoherence({
+      desktopApp,
+      proxy,
+      stormStartIndex,
+      expectedOrgId: baseline.orgId,
+      expectedWorkspaceIds: workspaceIds,
+      finalWorkspaceId,
+      evidence,
+      attempt: "Attempt 1",
+    });
+
+    // The reported symptom is Cloud tools claiming to need a reconnect while
+    // connected: the settled workspace's openwork-cloud MCP must still be
+    // usable with its capability tools present.
+    const health = await eventually(
+      () => readCloudMcpHealth(desktopApp, finalWorkspaceId, { probe: true, timeoutMs: 30_000 }),
+      {
+        within: 180_000,
+        intervalMs: 5_000,
+        label: "openwork-cloud MCP usable after the scale storm",
+        until: (state) => state.ok && state.usable === true,
+      },
+    );
+    evidence.recordAssertionEvidence(
+      "Attempt 1: the Cloud MCP stays usable after the storm instead of demanding a reconnect",
+      `Health for workspace ${finalWorkspaceId}: phase=${String(health.phase)}, usable=${String(health.usable)}, engine=${String(health.engineStatus)}, missing tools=${JSON.stringify(health.tools.missing)}.`,
+      health.ok && health.usable === true,
+    );
+    expect(health.usable).toBe(true);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Attempt 2 — Marten-scale: 6 workspaces, switching while Den is overloaded
+// (latency + 429 bursts) and while Den briefly answers 401 on identity reads.
+// ---------------------------------------------------------------------------
+test.skipIf(!runnable)(
+  `six workspaces switched under Den overload and a transient 401 burst recover without a reconnect${skipSuffix}`,
+  { timeout: 25 * 60_000 },
+  async ({ evidence, place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    await using den = await server({
+      place,
+      org: {
+        name: "Workspace Storm Overload",
+        admin: { name: "Overload Admin" },
+        members: { member: { name: "Overload Member" } },
+      },
+    });
+    await using proxy = await faultProxy(den.ref, {
+      place,
+      sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
+    });
+    await using desktopApp = await app({ den: { ...den, ref: proxy.ref }, as: "member", place });
+
+    const baseline = await healthyBaseline(desktopApp);
+    const workspaceIds = [desktopApp.workspaceId];
+    for (let index = workspaceIds.length; index < 6; index += 1) {
+      workspaceIds.push(await createWorkspace(desktopApp, "storm-overload", index));
+    }
+
+    const stormStartIndex = (await proxy.requestLog()).length;
+
+    // Wave A — the reported "unusually high demand": every Den response is
+    // slow for a while and desktop-config intermittently rate-limits.
+    await proxy.faults.latency("/api/den", 1_200, { times: 40 });
+    await proxy.faults.status("/api/den/v1/me/desktop-config", 429, { times: 6 });
+    const waveA = await runSwitchStorm(desktopApp, workspaceIds, {
+      passes: 2,
+      dwellMs: 500,
+      sampleEvery: 3,
+      expectedOrgId: baseline.orgId,
+    });
+    evidence.recordAssertionEvidence(
+      "Attempt 2, wave A: overload (latency + 429) never dropped the session mid-storm",
+      `${waveA.switches} switches under injected latency/429; auth drops: ${JSON.stringify(waveA.authDropSamples)}; org changes: ${JSON.stringify(waveA.orgChangeSamples)}.`,
+      waveA.authDropSamples.length === 0 && waveA.orgChangeSamples.length === 0,
+    );
+    expect(waveA.authDropSamples).toEqual([]);
+    expect(waveA.orgChangeSamples).toEqual([]);
+
+    // Wave B — Den itself briefly answers identity reads with 401, the shape
+    // members reported as "failed authorization" while still connected. A
+    // bounded burst must not sign the desktop out or flip Connect off for good.
+    await proxy.faults.clear();
+    await proxy.faults.status("/api/den", 401, { times: 6 });
+    await refreshDenSession(desktopApp, 6);
+    const waveB = await runSwitchStorm(desktopApp, workspaceIds, {
+      passes: 2,
+      dwellMs: 500,
+      sampleEvery: 3,
+      expectedOrgId: baseline.orgId,
+    });
+    evidence.recordAssertionEvidence(
+      "Attempt 2, wave B: a transient 401 burst never removed the persisted session",
+      `${waveB.switches} switches during the 401 burst; auth drops: ${JSON.stringify(waveB.authDropSamples)}; org changes: ${JSON.stringify(waveB.orgChangeSamples)}.`,
+      waveB.authDropSamples.length === 0 && waveB.orgChangeSamples.length === 0,
+    );
+    expect(waveB.authDropSamples).toEqual([]);
+    expect(waveB.orgChangeSamples).toEqual([]);
+
+    // The injected faults were actually exercised — otherwise this attempt
+    // proved nothing about overload behavior.
+    const log = await proxy.requestLog();
+    const injected = log.slice(stormStartIndex).filter((request) => request.faulted);
+    const injected401 = injected.filter((request) => request.status === 401);
+    evidence.recordAssertionEvidence(
+      "Attempt 2: the overload and 401 conditions were real on the wire",
+      `Injected fault responses during the storm: ${injected.length} total, ${injected401.length} with status 401.`,
+      injected.length > 0 && injected401.length > 0,
+    );
+    expect(injected.length).toBeGreaterThan(0);
+    expect(injected401.length).toBeGreaterThan(0);
+
+    await proxy.faults.clear();
+    const finalWorkspaceId = workspaceIds[workspaceIds.length - 1];
+    await switchToWorkspace(desktopApp, finalWorkspaceId, 0);
+    await assertPostStormCoherence({
+      desktopApp,
+      proxy,
+      stormStartIndex,
+      expectedOrgId: baseline.orgId,
+      expectedWorkspaceIds: workspaceIds,
+      finalWorkspaceId,
+      evidence,
+      attempt: "Attempt 2",
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Attempt 3 — the tightest race: two workspaces toggled with zero dwell time.
+// ---------------------------------------------------------------------------
+test.skipIf(!runnable)(
+  `forty zero-dwell toggles between two workspaces settle on one coherent active workspace${skipSuffix}`,
+  { timeout: 20 * 60_000 },
+  async ({ evidence, place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    await using den = await server({
+      place,
+      org: {
+        name: "Workspace Storm Race",
+        admin: { name: "Race Admin" },
+        members: { member: { name: "Race Member" } },
+      },
+    });
+    await using proxy = await faultProxy(den.ref, {
+      place,
+      sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
+    });
+    await using desktopApp = await app({ den: { ...den, ref: proxy.ref }, as: "member", place });
+
+    const baseline = await healthyBaseline(desktopApp);
+    const first = desktopApp.workspaceId;
+    const second = await createWorkspace(desktopApp, "storm-race", 1);
+
+    const stormStartIndex = (await proxy.requestLog()).length;
+    const toggles = 40;
+    for (let index = 0; index < toggles; index += 1) {
+      await switchToWorkspace(desktopApp, index % 2 === 0 ? first : second, 0);
+    }
+    const finalWorkspaceId = toggles % 2 === 0 ? second : first;
+    evidence.recordAssertionEvidence(
+      "Attempt 3: the race condition was actually driven",
+      `${toggles} zero-dwell toggles between workspaces ${first} and ${second}; the last requested workspace is ${finalWorkspaceId}.`,
+      true,
+    );
+
+    // The lost-update shape: after the burst the app must converge on the
+    // LAST requested workspace, not an intermediate one.
+    await assertPostStormCoherence({
+      desktopApp,
+      proxy,
+      stormStartIndex,
+      expectedOrgId: baseline.orgId,
+      expectedWorkspaceIds: [first, second],
+      finalWorkspaceId,
+      evidence,
+      attempt: "Attempt 3",
+    });
+
+    const adopted = await evalIn(desktopApp, `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`);
+    evidence.recordAssertionEvidence(
+      "Attempt 3: no lost update — the adopted workspace is the last one requested",
+      `openwork.react.activeWorkspace=${JSON.stringify(adopted)} after ${toggles} toggles (expected ${finalWorkspaceId}).`,
+      adopted === finalWorkspaceId,
+    );
+    expect(adopted).toBe(finalWorkspaceId);
+  },
+);


### PR DESCRIPTION
## Summary
- make route-driven workspace selection last-route-wins and serialize desktop/server activation
- stop eagerly loading every unseen workspace session index or creating an OpenCode session for ordinary workspace creation
- avoid redundant renderer settings refreshes for an unchanged healthy local server
- add a testkit stress spec covering 20 workspaces, Den latency/429/401 faults, and rapid zero-dwell switches

## Validation
- `pnpm --filter @openwork/app exec bun test tests/route-refresh-control.test.ts tests/desktop-local-openwork.test.ts` — 19 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `OPENWORK_EVAL_REF=fix/workspace-switch-auth-coherence pnpm evals:e2e workspace-storm-auth-coherence --daytona` (via Infisical) — Daytona, 3 passed, 0 failed, 0 skipped

## Testkit claims
- 20 workspaces can be created and switched round-robin without IPC starvation or Cloud MCP reconnect prompts
- six workspaces survive Den latency, rate limits, and transient unauthorized responses without losing auth, org, Connect, or workspace state
- forty zero-dwell switches converge both renderer persistence and server activation on the last route