### PR TITLE
Fixed Command output not visible in aggregated tool rows #3706

### DIFF
--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -9,6 +9,7 @@ import {
   getAggregateNowLabel,
   getAggregateRowFile,
   getAggregateRowLabel,
+  getAggregateRowOutput,
   getAggregateSummary,
   type AnyToolPart,
 } from "@/lib/tool-aggregate"
@@ -21,6 +22,8 @@ const ROW_CAP = 8
 /** Expansion persists per group while the session stays mounted (Paper rule). */
 const expandedByGroupKey = new Map<string, boolean>()
 const showAllByGroupKey = new Map<string, boolean>()
+/** Per-row output expansion (command rows only), keyed by toolCallId. */
+const expandedRowOutputs = new Set<string>()
 
 type ToolAggregateGroupProps = {
   parts: AnyToolPart[]
@@ -49,6 +52,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
   const groupKey = parts[0]?.toolCallId ?? "aggregate"
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
   const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
+  const [, forceRowRerender] = useState(0)
 
   const setExpanded = (value: boolean) => {
     expandedByGroupKey.set(groupKey, value)
@@ -57,6 +61,14 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
   const setShowAll = (value: boolean) => {
     showAllByGroupKey.set(groupKey, value)
     setShowAllState(value)
+  }
+  const toggleRowOutput = (toolCallId: string) => {
+    if (expandedRowOutputs.has(toolCallId)) {
+      expandedRowOutputs.delete(toolCallId)
+    } else {
+      expandedRowOutputs.add(toolCallId)
+    }
+    forceRowRerender((n) => n + 1)
   }
 
   const anyRunning = parts.some((part) => isToolPartInFlight(part))
@@ -107,38 +119,69 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
           {visibleParts.map((part, index) => {
             const status = rowStatus(part)
             const reason = failureReason(part)
+            const output = getAggregateRowOutput(part)
+            const rowExpanded = output !== null && expandedRowOutputs.has(part.toolCallId)
+            const file = getAggregateRowFile(part)
+
+            const rowLabel = file ? (
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="shrink-0">{file.verb}</span>
+                <FileChip path={file.path} className="min-w-0" />
+              </span>
+            ) : (
+              <span className="min-w-0 truncate font-mono text-[11px]">
+                {getAggregateRowLabel(part)}
+              </span>
+            )
+
+            const rowInner = (
+              <>
+                {output !== null ? (
+                  <ChevronRight
+                    aria-hidden="true"
+                    className={cn(
+                      "size-3 shrink-0 text-muted-foreground/70 transition-transform duration-150",
+                      rowExpanded && "rotate-90",
+                    )}
+                  />
+                ) : null}
+                {status === "running" ? (
+                  <span className="flex size-3.5 shrink-0 items-center justify-center">
+                    <DotMatrixLoader label="Running" className="size-3 text-muted-foreground" />
+                  </span>
+                ) : null}
+                {rowLabel}
+                {durations[index] ? (
+                  <span className="shrink-0 tabular-nums text-muted-foreground/70">
+                    {durations[index]}
+                  </span>
+                ) : null}
+              </>
+            )
+
             return (
               <div key={part.toolCallId} className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  {status === "running" ? (
-                    <span className="flex size-3.5 shrink-0 items-center justify-center">
-                      <DotMatrixLoader label="Running" className="size-3 text-muted-foreground" />
-                    </span>
-                  ) : null}
-                  {(() => {
-                    const file = getAggregateRowFile(part)
-                    if (!file) {
-                      return (
-                        <span className="min-w-0 truncate font-mono text-[11px]">
-                          {getAggregateRowLabel(part)}
-                        </span>
-                      )
-                    }
-                    return (
-                      <span className="flex min-w-0 items-center gap-1.5">
-                        <span className="shrink-0">{file.verb}</span>
-                        <FileChip path={file.path} className="min-w-0" />
-                      </span>
-                    )
-                  })()}
-                  {durations[index] ? (
-                    <span className="shrink-0 tabular-nums text-muted-foreground/70">
-                      {durations[index]}
-                    </span>
-                  ) : null}
-                </div>
+                {output !== null ? (
+                  <button
+                    type="button"
+                    onClick={() => toggleRowOutput(part.toolCallId)}
+                    aria-expanded={rowExpanded}
+                    className="flex min-w-0 cursor-pointer items-center gap-2 text-start text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    {rowInner}
+                  </button>
+                ) : (
+                  <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                    {rowInner}
+                  </div>
+                )}
                 {reason ? (
                   <div className="text-[11px] text-muted-foreground">failed — {reason}</div>
+                ) : null}
+                {rowExpanded && output !== null ? (
+                  <pre className="ms-5 mt-0.5 overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-muted p-2 text-[11px] text-muted-foreground opacity-80">
+                    {output}
+                  </pre>
                 ) : null}
               </div>
             )

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -121,6 +121,14 @@ export function getAggregateRowLabel(part: AnyToolPart): string {
   return getToolActivityLabel(part)
 }
 
+/** Raw output for an expandable aggregate row. other families keep their current one-line behavior. **/
+export function getAggregateRowOutput(part: AnyToolPart): string | null {
+  if (!isBashToolPart(part)) return null
+  if (part.state !== "output-available") return null
+  const output = part.output
+  return typeof output === "string" && output.length > 0 ? output : null
+}
+
 /** Label for the single latest in-flight call — the self-replacing "Now:" line. */
 export function getAggregateNowLabel(parts: AnyToolPart[]): string | null {
   for (let index = parts.length - 1; index >= 0; index -= 1) {


### PR DESCRIPTION
## Summary
- Command rows inside aggregated tool groups (`ToolAggregateGroup`) are now expandable to reveal that call's output.

## Why
- Consecutive bash/edit/read/search calls collapse into one aggregate group, and expanding it only ever showed the command text + duration never the actual output. Standalone `BashTool` calls already show output; this brings the aggregated path to parity.

## Issue
- Closes #3706

## Scope
- `apps/app/src/lib/tool-aggregate.ts`: added `getAggregateRowOutput()`, which returns a bash row's `part.output` when the call is `output-available`, else `null`.
- `apps/app/src/components/chat/tool-aggregate-group.tsx`: command rows with output become a clickable row (chevron + click-to-expand) that reveals a `<pre>` block styled like the standalone `BashTool` collapsible. Row expansion state persists per `toolCallId` while the session stays mounted, matching the existing group/show all expansion pattern in this file.

## Out of scope
- Edit/read/search rows are unchanged and are still one line, not expandable, following the issue's proposal.
- No changes to `BashTool` itself or to how output is captured/streamed from the engine as the data was already present in `part.output`.

## Testing
### Ran
- `pnpm --filter @openwork/app typecheck`
- Manual verification via `pnpm dev:headless-web`, agent session, real bash tool calls

### Result
- pass/fail: **pass**
- if fail, exact files/errors: N/A

## CI status
- pass: will report once CI runs on the PR
- code-related failures: none locally
- external/env/auth blockers: none, resolved by installing the `opencode` CLI locally 

## Manual verification
1. Ran `pnpm dev:headless-web` and started an agent session.
2. Prompted the agent to list repo files, check git status, and show the current branch this produced a real aggregate group ("Ran 1 command, read 1 file").
3. Confirmed the read row (`Read openwork`) stayed one line, not expandable as expected.
4. Confirmed the command row (`git branch --show-current`) is clickable, expands to show its actual output (`fix/3706-aggregate-command-output`) in a `<pre>` block styled like the standalone `BashTool`, and collapses again on a second click.

## Evidence
- Screenshot attached showing the expanded command row with real output (see attached image).
<img width="1440" height="780" alt="Issue3706 Openwork" src="https://github.com/user-attachments/assets/9d6dcfe1-ff75-4cb6-8d68-a6851b3338d7" />


## Risk
- Low. No major changes to data fetching, tool execution, or engine behavior. `getAggregateRowOutput` returns `null` for any non-bash or non-completed part, so non-command rows fall through to their existing rendering path unchanged.

## Rollback
- Revert this PR; no migrations, schema, or config changes involved.