### PR TITLE
docs: add v0.18.31-v0.18.35 release notes

### DIFF
--- a/changelog/release-tracker-2026-08-19.md
+++ b/changelog/release-tracker-2026-08-19.md
@@ -1,0 +1,166 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.31
+
+#### Commit
+`a9c304f3`
+
+#### Released at
+`2026-08-19T00:32:39Z`
+
+#### Title
+Enterprise identity records stay valid
+
+#### One-line summary
+Keeps linked SSO and SCIM account IDs valid while making release validation faster and easier to diagnose.
+
+#### Main changes
+- Fixed linked enterprise identity accounts so their IDs always use the required TypeID format.
+- Strengthened SSO-before-SCIM lifecycle validation.
+- Made release checks faster and improved alerts when extended tests fail.
+
+#### Lines of code changed since previous release
+1294 lines changed since `v0.18.30` (937 insertions, 357 deletions).
+
+#### Release importance
+Minor release: hardens enterprise identity records and improves release validation.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+1
+
+#### Major improvement details
+- Made release validation faster and improved extended-test failure alerts.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+1
+
+#### Major bug fix details
+- Enforced valid TypeIDs for linked SSO and SCIM accounts.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.32
+
+#### Commit
+`ab878c31`
+
+#### Released at
+`2026-08-19T07:18:19Z`
+
+#### Title
+Workspace imports and SAML replay protection get safer
+
+#### One-line summary
+Bounds workspace archive expansion and keeps SAML replay reservations compatible with stored identity records.
+
+#### Main changes
+- Workspace imports now reject archives that expand beyond safe file-count or size limits.
+- Fixed SAML replay reservations so their identifiers remain compatible with the identity database.
+- Clarified how to validate a live Okta SCIM setup.
+
+#### Lines of code changed since previous release
+258 lines changed since `v0.18.31` (161 insertions, 97 deletions).
+
+#### Release importance
+Minor release: closes focused safety and enterprise identity reliability gaps.
+
+#### Major improvements
+False
+
+#### Number of major improvements
+0
+
+#### Major improvement details
+None.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+2
+
+#### Major bug fix details
+- Bounded workspace archive decompression by file count and expanded size.
+- Made SAML replay reservation IDs compatible with the identity database.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.33
+
+#### Commit
+`86e727e8`
+
+#### Released at
+`2026-08-19T13:48:15Z`
+
+#### Title
+Library setup gets clearer and background connections recover cleanly
+
+#### One-line summary
+Adds a clearer Library item picker, makes Desktop automations recover from credential failures, and bounds background cloud requests.
+
+#### Main changes
+- The Library Add flow now presents clear item-type choices before setup begins.
+- Desktop automations recover rejected credentials and back off repeated reconnect failures.
+- Cloud MCP health probes and GitHub token requests now have strict request budgets.
+- Added a Google Cloud deployment prompt and stronger OpenCode MCP OAuth validation.
+- Repaired npm publishing so releases can complete reliably.
+
+#### Lines of code changed since previous release
+10820 lines changed since `v0.18.32` (7023 insertions, 3797 deletions).
+
+#### Release importance
+Major release: improves Library setup, automation recovery, cloud request resilience, and release reliability.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+2
+
+#### Major improvement details
+- Added a clear item-type picker to the Library Add flow.
+- Added a Google Cloud deployment prompt and stronger OpenCode MCP OAuth validation.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+4
+
+#### Major bug fix details
+- Recovered Desktop automations after rejected credentials.
+- Added backoff for repeated Desktop automation reconnect failures.
+- Bounded cloud MCP health probes and GitHub token requests.
+- Repaired npm publishing for stable and recovery releases.
+
+#### Deprecated features
+True
+
+#### Number of deprecated features
+1
+
+#### Deprecated details
+- Standardized end-to-end test and evidence terminology and retired legacy names.

--- a/changelog/release-tracker-2026-08-20.md
+++ b/changelog/release-tracker-2026-08-20.md
@@ -1,0 +1,115 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.34
+
+#### Commit
+`03507e5d`
+
+#### Released at
+`2026-08-20T19:28:27Z`
+
+#### Title
+MCP Apps guide connection setup and Desktop automations recover cleanly
+
+#### One-line summary
+Adds first-party MCP App cards for connection flows, strengthens Desktop automation recovery, and renames Programs to Workflows.
+
+#### Main changes
+- Added first-party MCP App cards that guide connection, plugin, and skill-created flows directly in chat.
+- Desktop automations now report outcomes, open their execution threads, and recover missed runs and credential failures.
+- Renamed Programs to Workflows and retired legacy MCP App surfaces and selection tools.
+- Hardened MCP recovery, OAuth grant liveness, server credentials, and connection error handling.
+- Added current product screenshots, enterprise desktop deployment guidance, and an Automation deployment kill switch.
+
+#### Lines of code changed since previous release
+63338 lines changed since `v0.18.33` (58371 insertions, 4967 deletions).
+
+#### Release importance
+Major release: expands interactive MCP Apps, makes Desktop automations recoverable, and simplifies Workflows across the product.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+4
+
+#### Major improvement details
+- Added first-party MCP App cards for connection, plugin, and skill-created flows.
+- Added Desktop automation outcome reporting and direct execution-thread access.
+- Renamed Programs to Workflows and removed obsolete selection surfaces.
+- Added current product documentation and an Automation deployment kill switch.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+3
+
+#### Major bug fix details
+- Recovered missed Desktop automation occurrences and rejected credentials.
+- Kept Desktop server credentials coherent during managed MCP recovery.
+- Hardened MCP connection failures, protocol compatibility, OAuth liveness, and reconnect bursts.
+
+#### Deprecated features
+True
+
+#### Number of deprecated features
+2
+
+#### Deprecated details
+- Retired legacy MCP App surfaces.
+- Removed obsolete Program selection tools in favor of Workflows.
+
+## v0.18.35
+
+#### Commit
+`13504969`
+
+#### Released at
+`2026-08-20T20:14:28Z`
+
+#### Title
+Desktop respects Automation deployment controls
+
+#### One-line summary
+Keeps Automation routes, proposals, and Desktop runners off unless the connected deployment explicitly enables them.
+
+#### Main changes
+- Desktop now reads Automation availability from the connected deployment.
+- Automation navigation, proposals, and runner registration stay disabled unless the deployment explicitly opts in.
+- Older or self-hosted deployments that do not advertise availability fail closed.
+
+#### Lines of code changed since previous release
+123 lines changed since `v0.18.34` (86 insertions, 37 deletions).
+
+#### Release importance
+Minor release: completes the Automation deployment control by enforcing it throughout Desktop.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+1
+
+#### Major improvement details
+- Enforced deployment-level Automation availability across Desktop routes, proposals, and runner registration.
+
+#### Major bugs resolved
+False
+
+#### Number of major bugs resolved
+0
+
+#### Major bug fix details
+None.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,23 @@
 ---
 title: "Changelog"
 ---
+<Update label="August 20th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
+
+  ## [v0.18.35](https://github.com/different-ai/openwork/compare/v0.18.34...v0.18.35): Desktop respects Automation deployment controls
+
+  - Desktop now shows Automation navigation and proposals and registers a runner only when the connected deployment explicitly enables Automations.
+  - Older and self-hosted deployments that do not advertise Automation availability remain safely disabled.
+
+  ## [v0.18.34](https://github.com/different-ai/openwork/compare/v0.18.33...v0.18.34): MCP Apps guide connection setup and Desktop automations recover cleanly
+
+  - First-party MCP App cards now guide connection, plugin, and skill-created flows directly in chat, including useful recovery cards when a connection fails.
+  - Desktop automations report outcomes, open their execution threads, and recover missed runs and credential failures more reliably.
+  - Programs are now called Workflows, with obsolete selection tools and legacy MCP App surfaces removed.
+  - MCP connections are more resilient to server recovery, protocol changes, OAuth refresh bursts, and stale credentials.
+  - Added current product screenshots, enterprise desktop deployment guidance, and a deployment-level Automation control.
+
+</Update>
+
 <Update label="August 19th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.18.33](https://github.com/different-ai/openwork/compare/v0.18.32...v0.18.33): Library setup gets clearer and background connections recover cleanly

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,28 @@
 ---
 title: "Changelog"
 ---
+<Update label="August 19th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
+
+  ## [v0.18.33](https://github.com/different-ai/openwork/compare/v0.18.32...v0.18.33): Library setup gets clearer and background connections recover cleanly
+
+  - The Library Add flow now starts with clear choices for skills, MCP connections, plugins, and repositories.
+  - Desktop automations recover rejected credentials and slow down repeated reconnect attempts instead of getting stuck.
+  - Cloud MCP health checks and GitHub token requests are bounded, preventing background connection work from running away.
+  - Added a Google Cloud deployment prompt, stronger MCP OAuth validation, and more reliable release publishing.
+
+  ## [v0.18.32](https://github.com/different-ai/openwork/compare/v0.18.31...v0.18.32): Workspace imports and SAML replay protection get safer
+
+  - Workspace imports now reject archives that expand beyond safe file-count or size limits.
+  - Fixed SAML replay protection so its reservation IDs remain compatible with stored identity records.
+  - Clarified how administrators can validate a live Okta SCIM setup.
+
+  ## [v0.18.31](https://github.com/different-ai/openwork/compare/v0.18.30...v0.18.31): Enterprise identity records stay valid
+
+  - Linked SSO and SCIM accounts now always use valid identity IDs, preventing malformed enterprise account records.
+  - Release validation is faster and extended-test failures produce clearer alerts.
+
+</Update>
+
 <Update label="August 18th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.18.30](https://github.com/different-ai/openwork/compare/v0.18.29...v0.18.30): Queue follow-ups and simplify the session workspace


### PR DESCRIPTION
## Summary
- backfill stable release notes for v0.18.31 through v0.18.35
- add matching release facts to the August 19 and August 20 trackers
- preserve release ordering and exact tagged compare links

## Validation
- `node scripts/check-changelog-output.mjs` passed for v0.18.31 through v0.18.35
- `mintlify validate` under Node 24: build validation passed
- `git diff --check`