### PR TITLE
fix(server): preserve live agent runs across workspace switches

### DIFF
--- a/apps/app/src/react-app/kernel/global-sdk-provider.tsx
+++ b/apps/app/src/react-app/kernel/global-sdk-provider.tsx
@@ -75,6 +75,43 @@ type GlobalSDKProviderProps = {
   children: ReactNode;
 };
 
+type GlobalEventSubscriptionRunnerInput = {
+  signal: AbortSignal;
+  subscribe: (signal: AbortSignal) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>;
+  onEvent: (event: unknown) => void | Promise<void>;
+  waitForRetry?: (signal: AbortSignal) => Promise<void>;
+};
+
+function waitForGlobalEventRetry(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, 1_000);
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
+export async function runGlobalEventSubscription(input: GlobalEventSubscriptionRunnerInput): Promise<void> {
+  while (!input.signal.aborted) {
+    try {
+      const stream = await input.subscribe(input.signal);
+      for await (const event of stream) {
+        if (input.signal.aborted) return;
+        await input.onEvent(event);
+      }
+    } catch {
+      if (input.signal.aborted) return;
+    }
+    if (!input.signal.aborted) {
+      await (input.waitForRetry ?? waitForGlobalEventRetry)(input.signal);
+    }
+  }
+}
+
 export function GlobalSDKProvider({ children }: GlobalSDKProviderProps) {
   const server = useServer();
   const platform = usePlatform();
@@ -164,16 +201,17 @@ export function GlobalSDKProvider({ children }: GlobalSDKProviderProps) {
       timer = setTimeout(flush, Math.max(0, 16 - elapsed));
     };
 
-    void (async () => {
-      const subscription = await eventClient.event.subscribe(undefined, {
-        signal: abort.signal,
-      });
-      let yielded = Date.now();
-
-      for await (const event of subscription.stream as AsyncIterable<unknown>) {
+    let yielded = Date.now();
+    void runGlobalEventSubscription({
+      signal: abort.signal,
+      subscribe: async (signal) => {
+        const subscription = await eventClient.event.subscribe(undefined, { signal });
+        return subscription.stream as AsyncIterable<unknown>;
+      },
+      onEvent: async (event) => {
         const record = event as Event & { directory?: string; payload?: Event };
         const payload = record.payload ?? record;
-        if (!payload?.type) continue;
+        if (!payload?.type) return;
         const directory =
           typeof record.directory === "string" ? record.directory : "global";
         const key = keyForEvent(directory, payload);
@@ -185,11 +223,11 @@ export function GlobalSDKProvider({ children }: GlobalSDKProviderProps) {
         queue.push({ directory, payload });
         schedule();
 
-        if (Date.now() - yielded < 8) continue;
+        if (Date.now() - yielded < 8) return;
         yielded = Date.now();
         await Promise.resolve();
-      }
-    })()
+      },
+    })
       .finally(flush)
       .catch(() => undefined);
 

--- a/apps/app/tests/global-sdk-provider.test.ts
+++ b/apps/app/tests/global-sdk-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { runGlobalEventSubscription } from "../src/react-app/kernel/global-sdk-provider";
+
+describe("global SDK event subscription", () => {
+  test("reconnects after an engine generation closes the current stream", async () => {
+    const controller = new AbortController();
+    const events: string[] = [];
+    let subscriptions = 0;
+
+    await runGlobalEventSubscription({
+      signal: controller.signal,
+      subscribe: async function* () {
+        subscriptions += 1;
+        yield `event-${subscriptions}`;
+      },
+      onEvent(event) {
+        if (typeof event !== "string") throw new Error("expected a string event");
+        events.push(event);
+        if (events.length === 2) controller.abort();
+      },
+      waitForRetry: async () => undefined,
+    });
+
+    expect(subscriptions).toBe(2);
+    expect(events).toEqual(["event-1", "event-2"]);
+  });
+});

--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -58,10 +58,13 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "const logPath = process.env.OPENWORK_POOL_LOG;",
     "const statePath = process.env.OPENWORK_POOL_STATE;",
     "const append = (line) => { if (logPath) appendFileSync(logPath, `${line}\\n`); };",
-    "const busySessions = (port) => {",
+    "const busySessions = (port, directory) => {",
     "  try {",
     "    const state = JSON.parse(readFileSync(statePath, 'utf8'));",
-    "    return state[String(port)] ?? [];",
+    "    const value = state[String(port)];",
+    "    if (Array.isArray(value)) return value;",
+    "    if (!value || typeof value !== 'object') return [];",
+    "    return value[directory ?? ''] ?? [];",
     "  } catch { return []; }",
     "};",
     "const server = Bun.serve({",
@@ -71,17 +74,27 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "    const url = new URL(request.url);",
     "    append(`${server.port} ${request.method} ${url.pathname}`);",
     "    if (url.pathname === '/session/status') {",
-    "      const entries = busySessions(server.port).map((id) => [id, { type: 'busy' }]);",
+    "      const entries = busySessions(server.port, url.searchParams.get('directory')).map((id) => [id, { type: 'busy' }]);",
     "      return Response.json(Object.fromEntries(entries));",
     "    }",
     "    if (url.pathname === '/permission') {",
-    "      const sessionID = busySessions(server.port)[0] ?? `ses_${server.port}`;",
-    "      return Response.json([{ id: `req_${server.port}`, sessionID }]);",
+    "      const owner = Number(url.searchParams.get('owner') ?? 0);",
+    "      if (owner && owner !== server.port) return Response.json([]);",
+    "      const sessionID = url.searchParams.get('session') ?? busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
+    "      return Response.json([{ id: url.searchParams.get('request') ?? `req_${server.port}`, sessionID }]);",
     "    }",
     "    if (url.pathname === '/event') {",
-    "      const sessionID = busySessions(server.port)[0] ?? `ses_${server.port}`;",
+    "      const sessionID = busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
     "      const payload = { type: 'session.updated', properties: { sessionID } };",
+    "      if (url.searchParams.has('hold')) {",
+    "        const body = new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(payload)}\\n\\n`)); } });",
+    "        return new Response(body, { headers: { 'content-type': 'text/event-stream' } });",
+    "      }",
     "      return new Response(`data: ${JSON.stringify(payload)}\\n\\n`, { headers: { 'content-type': 'text/event-stream' } });",
+    "    }",
+    "    if (url.pathname.endsWith('/reply')) {",
+    "      const owner = Number(url.searchParams.get('owner') ?? 0);",
+    "      if (owner && owner !== server.port) return Response.json({ ok: false }, { status: 404 });",
     "    }",
     "    return Response.json({ ok: true, port: server.port, path: url.pathname });",
     "  },",
@@ -115,6 +128,7 @@ type Fixture = {
   hookCalls: { reloadInPlace: number; postRefreshSync: number };
   hooks: EnginePoolHooks;
   setBusy: (port: number, sessionIds: string[]) => Promise<void>;
+  setBusyForDirectory: (port: number, directory: string, sessionIds: string[]) => Promise<void>;
   logLines: () => Promise<string[]>;
   setRuntimeConfig: (content: string) => Promise<void>;
   spawnPrimary: () => Promise<ManagedOpencodeServer>;
@@ -197,9 +211,20 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
   };
 
   const setBusy = async (port: number, sessionIds: string[]): Promise<void> => {
-    const state = JSON.parse(await readFile(statePath, "utf8").catch(() => "{}")) as Record<string, string[]>;
+    const state = JSON.parse(await readFile(statePath, "utf8").catch(() => "{}")) as Record<string, string[] | Record<string, string[]>>;
     if (sessionIds.length === 0) delete state[String(port)];
     else state[String(port)] = sessionIds;
+    await writeFile(statePath, JSON.stringify(state));
+  };
+
+  const setBusyForDirectory = async (port: number, directory: string, sessionIds: string[]): Promise<void> => {
+    const state = JSON.parse(await readFile(statePath, "utf8").catch(() => "{}")) as Record<string, string[] | Record<string, string[]>>;
+    const current = state[String(port)];
+    const byDirectory = current !== undefined && !Array.isArray(current) ? current : {};
+    if (sessionIds.length === 0) delete byDirectory[directory];
+    else byDirectory[directory] = sessionIds;
+    if (Object.keys(byDirectory).length === 0) delete state[String(port)];
+    else state[String(port)] = byDirectory;
     await writeFile(statePath, JSON.stringify(state));
   };
 
@@ -219,6 +244,7 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
     hookCalls,
     hooks,
     setBusy,
+    setBusyForDirectory,
     logLines: async () => (await readFile(logPath, "utf8").catch(() => "")).split("\n").filter(Boolean),
     setRuntimeConfig: (content: string) => writeFile(runtimeConfigPath, content),
     spawnPrimary,
@@ -443,6 +469,36 @@ describe("engine pool", () => {
     expect(await fixture.logLines()).toContain(`${oldPort} SIGTERM`);
   });
 
+  test("keeps a live session from another workspace on the draining generation", async () => {
+    const fixture = await createFixture();
+    const secondWorkspace: WorkspaceInfo = {
+      ...fixture.workspace,
+      id: "ws_pool_second",
+      name: "Second pool workspace",
+      path: join(fixture.root, "second"),
+    };
+    fixture.config.workspaces.push(secondWorkspace);
+    const { pool, primary } = await createPool(fixture);
+    const oldPort = portOf(primary.url);
+    await fixture.setBusyForDirectory(oldPort, fixture.workspace.path, ["ses_first_workspace"]);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+
+    const outcome = await pool.requestRollover({
+      reason: "second_workspace_sync",
+      workspace: secondWorkspace,
+      forceStandby: true,
+    });
+
+    expect(outcome.action).toBe("rolled_over");
+    if (outcome.action !== "rolled_over") throw new Error("expected a rollover");
+    expect(outcome.drainingSessions).toBe(1);
+    expect(primary.isAlive()).toBe(true);
+    expect(pool.routeRequest("GET", "/session/ses_first_workspace/message")?.target.baseUrl).toBe(primary.url);
+
+    await fixture.setBusyForDirectory(oldPort, fixture.workspace.path, []);
+    expect(await waitUntil(() => !primary.isAlive(), 5_000)).toBe(true);
+  });
+
   test("keeps live session and prompt traffic on the draining generation", async () => {
     const fixture = await createFixture();
     const { pool, primary } = await createPool(fixture);
@@ -516,6 +572,31 @@ describe("engine pool", () => {
     const reply = await (await proxy(`/permission/req_${oldPort}/reply`, "POST")).json() as { port: number };
     expect(reply.port).toBe(oldPort);
 
+    const lateUrl = new URL(`http://127.0.0.1/opencode/permission?request=req_late&owner=${newPort}&session=ses_live`);
+    const latePending = await proxyOpencodeRequest({
+      config: fixture.config,
+      request: new Request(lateUrl),
+      url: lateUrl,
+      workspace: fixture.workspace,
+      proxyPath: "/permission",
+    });
+    expect(await latePending.json()).toEqual([{ id: "req_late", sessionID: "ses_live" }]);
+    const lateReply = await (await proxy("/permission/req_late/reply", "POST")).json() as { port: number };
+    expect(lateReply.port).toBe(oldPort);
+
+    const currentGeneration = pool.connections().find((connection) => connection.role === "primary");
+    if (!currentGeneration) throw new Error("expected a current generation");
+    pool.observePendingRequests(currentGeneration.generationId, [{ id: "req_stale", sessionID: "ses_new" }]);
+    const staleUrl = new URL(`http://127.0.0.1/opencode/permission/req_stale/reply?owner=${oldPort}`);
+    const staleReply = await proxyOpencodeRequest({
+      config: fixture.config,
+      request: new Request(staleUrl, { method: "POST" }),
+      url: staleUrl,
+      workspace: fixture.workspace,
+      proxyPath: "/permission/req_stale/reply",
+    });
+    expect(await staleReply.json()).toMatchObject({ port: oldPort });
+
     const events = await (await proxy("/event")).text();
     expect(events).toContain('"sessionID":"ses_live"');
     expect(events).toContain(`"sessionID":"ses_${newPort}"`);
@@ -585,6 +666,32 @@ describe("engine pool", () => {
       .toBe("rolled_over");
     expect(lease.signal.aborted).toBe(true);
     lease.release();
+  });
+
+  test("closes an existing event response when a generation flips", async () => {
+    const fixture = await createFixture();
+    const { pool, primary } = await createPool(fixture);
+    await fixture.setBusy(portOf(primary.url), ["ses_live"]);
+    const url = new URL("http://127.0.0.1/opencode/event?hold=1");
+    const response = await proxyOpencodeRequest({
+      config: fixture.config,
+      request: new Request(url),
+      url,
+      workspace: fixture.workspace,
+      proxyPath: "/event",
+    });
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("expected an event response body");
+    expect((await reader.read()).done).toBe(false);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+
+    expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
+      .toBe("rolled_over");
+    const closed = await Promise.race([
+      reader.read().then((result) => result.done),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 2_000)),
+    ]);
+    expect(closed).toBe(true);
   });
 
   test("aborts the remaining sessions once the drain grace period expires", async () => {

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -405,7 +405,15 @@ export class EnginePool {
     const requestId = requestIdFromPath(proxyPath);
     if (requestId) {
       const owner = this.generationForId(this.pinnedRequests.get(requestId));
-      if (owner) return { target: this.connectionFor(owner), fallback: null };
+      if (owner) {
+        const alternate = isLegacyPromptReply(proxyPath)
+          ? this.generations.find((entry) => isRoutableGeneration(entry) && entry.id !== owner.id) ?? null
+          : null;
+        return {
+          target: this.connectionFor(owner),
+          fallback: alternate && isRoutableGeneration(alternate) ? this.connectionFor(alternate) : null,
+        };
+      }
     }
 
     const draining = this.generations.find(
@@ -450,6 +458,23 @@ export class EnginePool {
       const owner = this.pinnedRequests.get(id);
       return owner !== undefined && owner !== generation.id;
     });
+  }
+
+  observePendingRequests(generationId: string, payload: unknown): string[] {
+    const generation = this.generationForId(generationId);
+    if (!generation) return [];
+    const requestIds: string[] = [];
+    for (const record of requestRecords(payload)) {
+      const sessionId = firstString(record, ["sessionID", "sessionId", "session_id"]);
+      const owner = this.generationForId(sessionId ? this.sessionOwnership.get(sessionId) : undefined) ?? generation;
+      const requestId = firstString(record, ["id", "requestID", "requestId", "permissionID", "questionID"]);
+      if (requestId) {
+        this.pinnedRequests.set(requestId, owner.id);
+        requestIds.push(requestId);
+      }
+      if (sessionId && !this.sessionOwnership.has(sessionId)) this.sessionOwnership.set(sessionId, generation.id);
+    }
+    return requestIds;
   }
 
   snapshot(): EnginePoolSnapshot {
@@ -1004,46 +1029,61 @@ export class EnginePool {
 
   private async nonIdleSessionIds(generation: Generation | null): Promise<string[]> {
     if (!generation || generation.status === "dead" || !generation.handle.isAlive()) return [];
-    try {
-      const response = await loopbackFetch(new URL("/session/status", generation.handle.url).toString(), {
-        headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
-        signal: AbortSignal.timeout(5_000),
-      });
-      if (!response.ok) return [];
-      const payload: unknown = await response.json();
-      if (!isRecord(payload)) return [];
-      return Object.entries(payload)
-        .filter(([, status]) => isRecord(status) && status.type !== "idle")
-        .map(([sessionId]) => sessionId);
-    } catch {
-      // Unknown activity never keeps a drain open forever; the grace timeout
-      // still bounds it, and an unreachable engine has nothing left to drain.
-      return [];
-    }
+    const sessionIds = new Set<string>();
+    await Promise.all(this.engineProbeDirectories().map(async (directory) => {
+      try {
+        const url = new URL("/session/status", generation.handle.url);
+        if (directory !== null) url.searchParams.set("directory", directory);
+        const response = await loopbackFetch(url.toString(), {
+          headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
+          signal: AbortSignal.timeout(5_000),
+        });
+        if (!response.ok) return;
+        const payload: unknown = await response.json();
+        if (!isRecord(payload)) return;
+        for (const [sessionId, status] of Object.entries(payload)) {
+          if (isRecord(status) && status.type !== "idle") sessionIds.add(sessionId);
+        }
+      } catch {
+        // Unknown activity never keeps a drain open forever; the grace timeout
+        // still bounds it, and an unreachable engine has nothing left to drain.
+      }
+    }));
+    return [...sessionIds];
+  }
+
+  private engineProbeDirectories(): Array<string | null> {
+    const directories = new Set(
+      this.config.workspaces
+        .filter((workspace) => workspace.workspaceType !== "remote")
+        .map((workspace) => workspace.path),
+    );
+    return directories.size > 0 ? [...directories] : [null];
   }
 
   private async pendingRequestIds(generation: Generation | null): Promise<string[]> {
     if (!generation || generation.status === "dead" || !generation.handle.isAlive()) return [];
     const requestIds = new Set<string>();
-    for (const path of ["/permission", "/question", "/api/permission/request", "/api/question/request"]) {
-      try {
-        const response = await loopbackFetch(new URL(path, generation.handle.url).toString(), {
-          headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
-          signal: AbortSignal.timeout(2_000),
-        });
-        if (!response.ok) continue;
-        const payload: unknown = await response.json();
-        for (const record of requestRecords(payload)) {
-          const requestId = firstString(record, ["id", "requestID", "requestId", "permissionID", "questionID"]);
-          if (requestId) requestIds.add(requestId);
-          const sessionId = firstString(record, ["sessionID", "sessionId", "session_id"]);
-          if (sessionId) this.sessionOwnership.set(sessionId, generation.id);
+    await Promise.all(this.engineProbeDirectories().flatMap((directory) =>
+      ["/permission", "/question", "/api/permission/request", "/api/question/request"].map(async (path) => {
+        try {
+          const url = new URL(path, generation.handle.url);
+          if (directory !== null) url.searchParams.set("directory", directory);
+          const response = await loopbackFetch(url.toString(), {
+            headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
+            signal: AbortSignal.timeout(2_000),
+          });
+          if (!response.ok) return;
+          const payload: unknown = await response.json();
+          for (const requestId of this.observePendingRequests(generation.id, payload)) {
+            requestIds.add(requestId);
+          }
+        } catch {
+          // The legacy and v2 surfaces vary by bundled engine version. A missing
+          // list never blocks the rollover; path routing still handles scoped ids.
         }
-      } catch {
-        // The legacy and v2 surfaces vary by bundled engine version. A missing
-        // list never blocks the rollover; path routing still handles scoped ids.
-      }
-    }
+      }),
+    ));
     return [...requestIds];
   }
 

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { ApiError } from "../errors.js";
 import { buildSession, buildSessionList, buildSessionMessages, buildSessionSnapshot } from "../session-read-model.js";
@@ -36,6 +37,7 @@ interface RegisterSessionRoutesOptions {
   requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
   resolveWorkspaceWithoutBootstrap: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
+  resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
   createWorkspaceOpencodeClient: (
     config: ServerConfig,
     workspace: WorkspaceInfo,
@@ -61,10 +63,26 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     requireClientScope,
     resolveWorkspace,
     resolveWorkspaceWithoutBootstrap,
+    resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
     unwrapOpencodeResult,
   } = options;
   const sessionGroupEvents = new SessionGroupEventStore();
+
+  async function requireWorkspaceSession(workspace: WorkspaceInfo, value: Parameters<typeof buildSession>[0]) {
+    const session = buildSession(value);
+    const directory = resolveOpencodeDirectory(workspace);
+    const [expectedDirectory, sessionDirectory] = workspace.workspaceType === "local" && directory && session.directory
+      ? await Promise.all([
+          realpath(directory).catch(() => directory),
+          realpath(session.directory).catch(() => session.directory),
+        ])
+      : [directory, session.directory];
+    if (expectedDirectory && sessionDirectory !== expectedDirectory) {
+      throw new ApiError(404, "session_not_found", "Session not found");
+    }
+    return session;
+  }
 
   function remapSessionReadError(error: unknown): never {
     if (error instanceof ApiError && error.code === "opencode_request_failed") {
@@ -140,7 +158,8 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
   async function readWorkspaceSession(workspace: WorkspaceInfo, sessionId: string) {
     try {
       const opencode = createWorkspaceOpencodeClient(config, workspace);
-      return buildSession(
+      return await requireWorkspaceSession(
+        workspace,
         unwrapOpencodeResult(
           await opencode.session.get({ sessionID: sessionId }),
           `/session/${encodeURIComponent(sessionId)}`,
@@ -158,12 +177,16 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
   ) {
     try {
       const opencode = createWorkspaceOpencodeClient(config, workspace);
-      return buildSessionMessages(
-        unwrapOpencodeResult(
-          await opencode.session.messages({ sessionID: sessionId, limit: input.limit }),
-          `/session/${encodeURIComponent(sessionId)}/message`,
-        ),
-      );
+      const [session, messages] = await Promise.all([
+        opencode.session
+          .get({ sessionID: sessionId })
+          .then((result) => unwrapOpencodeResult(result, `/session/${encodeURIComponent(sessionId)}`)),
+        opencode.session
+          .messages({ sessionID: sessionId, limit: input.limit })
+          .then((result) => unwrapOpencodeResult(result, `/session/${encodeURIComponent(sessionId)}/message`)),
+      ]);
+      await requireWorkspaceSession(workspace, session);
+      return buildSessionMessages(messages);
     } catch (error) {
       remapSessionReadError(error);
     }
@@ -188,6 +211,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
           .then((result) => unwrapOpencodeResult(result, `/session/${encodeURIComponent(sessionId)}/todo`)),
         opencode.session.status().then((result) => unwrapOpencodeResult(result, "/session/status")),
       ]);
+      await requireWorkspaceSession(workspace, session);
       return buildSessionSnapshot({ session, messages, todos, statuses });
     } catch (error) {
       remapSessionReadError(error);
@@ -252,6 +276,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const sessionId = ctx.params.sessionId?.trim();
     if (!sessionId) throw new ApiError(400, "invalid_payload", "sessionId is required");
+    await readWorkspaceSession(workspace, sessionId);
     console.info("[openwork-server] abort", {
       phase: "start",
       source: "workspace.sessions.abort_route",
@@ -473,6 +498,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
       throw new ApiError(400, "invalid_payload", "sessionId is required");
     }
 
+    await readWorkspaceSession(workspace, sessionId);
     const opencode = createWorkspaceOpencodeClient(config, workspace);
     unwrapOpencodeResult(
       await opencode.session.delete({ sessionID: sessionId }),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1392,6 +1392,7 @@ export async function proxyOpencodeRequest(input: {
   }
   if (pool && method === "GET" && engineAggregateKind(proxyPath)) {
     return proxyEngineAggregateRead({
+      pool,
       connections: pool.connections(),
       proxyPath,
       search: input.url.search,
@@ -1490,6 +1491,7 @@ function pendingItemIdentity(value: unknown): string {
 }
 
 async function proxyEngineAggregateRead(input: {
+  pool: EnginePool;
   connections: EnginePoolConnection[];
   proxyPath: string;
   search: string;
@@ -1521,6 +1523,9 @@ async function proxyEngineAggregateRead(input: {
     return jsonResponse(merged);
   }
 
+  for (const result of results) {
+    input.pool.observePendingRequests(result.connection.generationId, result.payload);
+  }
   const seen = new Set<string>();
   const items: unknown[] = [];
   let containerKey: string | null = null;
@@ -1567,13 +1572,24 @@ function mergedEventBody(input: {
     start(controller) {
       let active = readers.length;
       let closed = false;
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        if (pingTimer) clearInterval(pingTimer);
+        input.lease.signal.removeEventListener("abort", abort);
+        input.lease.release();
+        controller.close();
+      };
+      const abort = () => {
+        if (closed || cancelled) return;
+        cancelled = true;
+        for (const entry of readers) void entry.reader.cancel(input.lease.signal.reason).catch(() => undefined);
+        close();
+      };
       const finish = () => {
         active -= 1;
         if (active > 0 || closed || cancelled) return;
-        closed = true;
-        if (pingTimer) clearInterval(pingTimer);
-        input.lease.release();
-        controller.close();
+        close();
       };
       const pump = async (entry: typeof readers[number]) => {
         const decoder = new TextDecoder();
@@ -1605,6 +1621,8 @@ function mergedEventBody(input: {
         if (!closed && !cancelled) controller.enqueue(encoder.encode(": ping\n\n"));
       }, 30_000);
       pingTimer.unref?.();
+      input.lease.signal.addEventListener("abort", abort, { once: true });
+      if (input.lease.signal.aborted) abort();
     },
     async cancel(reason) {
       cancelled = true;
@@ -2075,6 +2093,7 @@ function createRoutes(
     requireClientScope,
     resolveWorkspace,
     resolveWorkspaceWithoutBootstrap,
+    resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
     unwrapOpencodeResult,
   });

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer } from "./server.js";
-import type { ServerConfig } from "./types.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 type Served = {
   port: number;
@@ -35,7 +35,7 @@ function auth(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
-function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promise<void> }) {
+function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promise<void>; sessionDirectory?: string }) {
   const requests: Array<{ pathname: string; search: string; directory: string | null; method: string; body?: unknown }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -60,7 +60,7 @@ function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promis
             id: "ses_created",
             title: typeof title === "string" ? title : "New session",
             slug: "created-session",
-            directory: request.headers.get("x-opencode-directory"),
+            directory: input?.sessionDirectory ?? request.headers.get("x-opencode-directory"),
             time: { created: 300, updated: 300 },
           });
         }
@@ -87,7 +87,7 @@ function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promis
           id: "ses_1",
           title: "Hostname Check",
           slug: "hostname-check",
-          directory: request.headers.get("x-opencode-directory"),
+          directory: input?.sessionDirectory ?? request.headers.get("x-opencode-directory"),
           time: { created: 100, updated: 200 },
         });
       }
@@ -140,7 +140,30 @@ function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promis
   return { server, requests };
 }
 
-async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl?: string; readOnly?: boolean }) {
+async function startOpenworkServer(input: {
+  workspaceRoot: string;
+  secondWorkspaceRoot?: string;
+  opencodeBaseUrl?: string;
+  readOnly?: boolean;
+}) {
+  const workspaces: WorkspaceInfo[] = [{
+    id: "ws_1",
+    name: "Workspace",
+    path: input.workspaceRoot,
+    preset: "starter",
+    workspaceType: "local",
+    ...(input.opencodeBaseUrl ? { baseUrl: input.opencodeBaseUrl } : {}),
+  }];
+  if (input.secondWorkspaceRoot) {
+    workspaces.push({
+      id: "ws_2",
+      name: "Other workspace",
+      path: input.secondWorkspaceRoot,
+      preset: "starter",
+      workspaceType: "local",
+      ...(input.opencodeBaseUrl ? { baseUrl: input.opencodeBaseUrl } : {}),
+    });
+  }
   const config: ServerConfig = {
     host: "127.0.0.1",
     port: 0,
@@ -148,17 +171,8 @@ async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseU
     hostToken: "owt_host_token",
     approval: { mode: "auto", timeoutMs: 1000 },
     corsOrigins: ["*"],
-    workspaces: [
-      {
-        id: "ws_1",
-        name: "Workspace",
-        path: input.workspaceRoot,
-        preset: "starter",
-        workspaceType: "local",
-        ...(input.opencodeBaseUrl ? { baseUrl: input.opencodeBaseUrl } : {}),
-      },
-    ],
-    authorizedRoots: [input.workspaceRoot],
+    workspaces,
+    authorizedRoots: [input.workspaceRoot, ...(input.secondWorkspaceRoot ? [input.secondWorkspaceRoot] : [])],
     readOnly: input.readOnly ?? true,
     startedAt: Date.now(),
     tokenSource: "cli",
@@ -355,6 +369,25 @@ describe("workspace session read APIs", () => {
       message: "Session not found",
     });
 
+  });
+
+  test("returns 404 when a session belongs to another workspace", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const secondWorkspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode({ sessionDirectory: workspaceRoot });
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      secondWorkspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await fetch(
+      `http://127.0.0.1:${openwork.server.port}/workspace/ws_2/sessions/ses_1/snapshot`,
+      { headers: auth(openwork.token) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ code: "session_not_found" });
   });
 
   test("acknowledges proxied session commands before upstream completion", async () => {

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -22,6 +22,28 @@ export interface MockToolCall {
   at: string;
 }
 
+export interface MockAgentToolStep {
+  tool: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface MockAgentWorkload {
+  promptMarker: string;
+  finalReply: string;
+  steps: MockAgentToolStep[];
+}
+
+export interface MockAgentRequest {
+  model: string;
+  promptMarker: string | null;
+  matchedMarkers: string[];
+  completedTools: number;
+  kind: "utility" | "tool" | "final" | "error";
+  toolName: string | null;
+  arguments: Record<string, unknown>;
+  at: string;
+}
+
 export interface MockMcpHandle {
   url: string;
   mcpUrl: string;
@@ -37,6 +59,7 @@ export interface MockMcpHandle {
    * calls and returns before this run's calls ever arrive.
    */
   toolCalls(opts?: { name?: string; timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockToolCall[]>;
+  agentRequests(opts?: { promptMarker?: string; timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockAgentRequest[]>;
   handshakes(opts?: { timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockAuthorizeRequest[]>;
   configureOAuthRedirectUris(redirectUris: readonly string[]): Promise<void>;
   resetOAuth(): Promise<void>;
@@ -55,6 +78,8 @@ export interface StartMockMcpOptions {
   allowUnauthenticatedMcp?: boolean;
   /** Serve this many additional synthetic mock_tool_<i> tools for scale specs. */
   extraToolCount?: number;
+  /** Script deterministic OpenAI-compatible agent turns through this mock. */
+  agentWorkloads?: MockAgentWorkload[];
 }
 
 export type EnterpriseMcpProfileId =
@@ -230,6 +255,10 @@ async function startEnterpriseProfileMock(options: StartMockMcpOptions): Promise
       if ((opts.atLeast ?? 0) > 0) await sleep(opts.timeoutMs ?? 120_000);
       return [];
     },
+    async agentRequests(opts = {}) {
+      if ((opts.atLeast ?? 0) > 0) await sleep(opts.timeoutMs ?? 120_000);
+      return [];
+    },
     async handshakes(opts = {}) {
       if ((opts.atLeast ?? 0) > 0) await sleep(opts.timeoutMs ?? 120_000);
       return [];
@@ -284,6 +313,18 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
 
   await waitForHealth(url, () => output, child);
 
+  if (options.agentWorkloads) {
+    const response = await fetch(`${url}/admin/agent-workloads`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ workloads: options.agentWorkloads }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Mock agent workload configuration failed: HTTP ${response.status} ${(await response.text()).slice(0, 500)}`);
+    }
+  }
+
   const requests = async (): Promise<MockAuthorizeRequest[]> => {
     const response = await fetch(`${url}/requests`, { signal: AbortSignal.timeout(15_000) });
     const body: unknown = await response.json().catch(() => null);
@@ -323,6 +364,34 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     return calls;
   };
 
+  const readAgentRequests = async (promptMarker?: string, sinceIso?: string): Promise<MockAgentRequest[]> => {
+    const completions: MockAgentRequest[] = [];
+    for (const entry of await rawEntries()) {
+      if (!isRecord(entry.agentCompletion)) continue;
+      const completion = entry.agentCompletion;
+      const at = typeof entry.at === "string" ? entry.at : "";
+      if (sinceIso && at < sinceIso) continue;
+      const kind = completion.kind;
+      if (kind !== "utility" && kind !== "tool" && kind !== "final" && kind !== "error") continue;
+      const marker = typeof completion.promptMarker === "string" ? completion.promptMarker : null;
+      if (promptMarker && marker !== promptMarker) continue;
+      if (typeof completion.model !== "string"
+        || !Array.isArray(completion.matchedMarkers)
+        || typeof completion.completedTools !== "number") continue;
+      completions.push({
+        model: completion.model,
+        promptMarker: marker,
+        matchedMarkers: completion.matchedMarkers.filter((value): value is string => typeof value === "string"),
+        completedTools: completion.completedTools,
+        kind,
+        toolName: typeof completion.toolName === "string" ? completion.toolName : null,
+        arguments: isRecord(completion.arguments) ? completion.arguments : {},
+        at,
+      });
+    }
+    return completions;
+  };
+
   const readHandshakes = async (sinceIso?: string): Promise<MockAuthorizeRequest[]> => {
     const handshakes: MockAuthorizeRequest[] = [];
     for (const entry of await rawEntries()) {
@@ -352,6 +421,17 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         calls = await readToolCalls(opts.name, opts.sinceIso).catch(() => calls);
       }
       return calls;
+    },
+    async agentRequests(opts = {}) {
+      const wanted = opts.atLeast ?? 0;
+      if (wanted <= 0) return readAgentRequests(opts.promptMarker, opts.sinceIso);
+      const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
+      let completions = await readAgentRequests(opts.promptMarker, opts.sinceIso);
+      while (completions.length < wanted && Date.now() < deadline) {
+        await sleep(500);
+        completions = await readAgentRequests(opts.promptMarker, opts.sinceIso).catch(() => completions);
+      }
+      return completions;
     },
     async handshakes(opts = {}) {
       const wanted = opts.atLeast ?? 0;

--- a/evals/packages/labs/test/mock-mcp.test.ts
+++ b/evals/packages/labs/test/mock-mcp.test.ts
@@ -29,3 +29,67 @@ test("records an unauthenticated initialize attempt as a handshake", async () =>
   assert.equal(handshakes[0]?.method, "POST");
   assert.equal(handshakes[0]?.path, "/mcp");
 });
+
+function completionBody(marker: string, completedTools: number): Record<string, unknown> {
+  return {
+    model: "mock-agent-workload-model",
+    stream: true,
+    tools: [
+      { type: "function", function: { name: "write", parameters: { type: "object" } } },
+      { type: "function", function: { name: "read", parameters: { type: "object" } } },
+    ],
+    messages: [
+      { role: "user", content: `run ${marker}` },
+      ...Array.from({ length: completedTools }, (_, index) => ({
+        role: "tool",
+        tool_call_id: `call-${index}`,
+        content: `tool result ${index}`,
+      })),
+    ],
+  };
+}
+
+test("scripts and records deterministic OpenAI-compatible agent tool rounds", async () => {
+  const marker = "agent-workload-unit-marker";
+  await using mock = await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: [{
+      promptMarker: marker,
+      finalReply: "unit workload complete",
+      steps: [
+        { tool: "write", arguments: { filePath: "/tmp/unit.txt", content: marker } },
+        { tool: "read", arguments: { filePath: "/tmp/unit.txt" } },
+      ],
+    }],
+  });
+  const startedAt = new Date().toISOString();
+
+  const first = await fetch(`${mock.url}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(completionBody(marker, 0)),
+  });
+  const firstText = await first.text();
+  assert.equal(first.status, 200);
+  assert.match(firstText, /"name":"write"/);
+  assert.match(firstText, /unit\.txt/);
+
+  const second = await fetch(`${mock.url}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(completionBody(marker, 1)),
+  });
+  assert.match(await second.text(), /"name":"read"/);
+
+  const final = await fetch(`${mock.url}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(completionBody(marker, 2)),
+  });
+  assert.match(await final.text(), /unit workload complete/);
+
+  const requests = await mock.agentRequests({ promptMarker: marker, sinceIso: startedAt, atLeast: 3, timeoutMs: 5_000 });
+  assert.deepEqual(requests.map((request) => request.kind), ["tool", "tool", "final"]);
+  assert.deepEqual(requests.map((request) => request.completedTools), [0, 1, 2]);
+  assert.deepEqual(requests.map((request) => request.matchedMarkers), [[marker], [marker], [marker]]);
+});

--- a/evals/specs/active-session-workspace-storm.e2e.test.ts
+++ b/evals/specs/active-session-workspace-storm.e2e.test.ts
@@ -5,8 +5,8 @@ import {
   evalIn,
   go,
   selectModel,
-  sendComposerMessage,
   waitFor,
+  writeComposerText,
 } from "@openwork/behaviors";
 import { screenshot } from "@openwork/test-evidence";
 import {
@@ -667,9 +667,21 @@ test.skipIf(!runnable)(
         title: `Active storm workspace ${plan.index}`,
       }, { timeoutMs: 30_000 });
       await openExactSessionRoute(desktopApp, plan);
-      await sendComposerMessage(
-        desktopApp,
-        `Run the deterministic active-session workload identified by ${plan.marker}. You may run its shell commands and create, append, and read its workspace file. Keep working through every step and report only when complete.`,
+      const prompt = `Run the deterministic active-session workload identified by ${plan.marker}. You may run its shell commands and create, append, and read its workspace file. Keep working through every step and report only when complete.`;
+      await writeComposerText(desktopApp, prompt);
+      await control(desktopApp, "composer.send", undefined, { timeoutMs: 120_000 });
+      // Under a remote Daytona renderer the message list can lag behind the
+      // composer transition even though the turn is already admitted (the UI
+      // visibly says Thinking). Use the workspace-scoped server snapshot as
+      // the authoritative admission witness instead of waiting for a DOM row.
+      await eventually(
+        () => readSessionFacts(desktopApp, plan.workspaceId, plan.sessionId),
+        {
+          within: 60_000,
+          intervalMs: 500,
+          label: `workspace ${plan.index} prompt admitted to its session`,
+          until: (facts) => facts.text.includes(plan.marker),
+        },
       );
       const running = await waitForSlowTool(desktopApp, plan);
       expect(running.ok).toBe(true);

--- a/evals/specs/active-session-workspace-storm.e2e.test.ts
+++ b/evals/specs/active-session-workspace-storm.e2e.test.ts
@@ -1,0 +1,873 @@
+import { readFile } from "node:fs/promises";
+import { expect } from "vitest";
+import {
+  control,
+  evalIn,
+  go,
+  selectModel,
+  sendComposerMessage,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot } from "@openwork/test-evidence";
+import {
+  app,
+  eventually,
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  mcpMock,
+  needs,
+  readCloudMcpHealth,
+  readConnectState,
+  readDenClientState,
+  server,
+  sleep,
+  test,
+} from "@openwork/testkit";
+import type { App } from "@openwork/testkit";
+
+const providerId = "active-session-storm-mock";
+const modelId = "mock-agent-workload-model";
+const modelName = "Active session storm model";
+const workspaceCount = 3;
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localServicesRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const redisOpen = await localRedisIsRunning();
+const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localServicesRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : localServicesRequired && !redisOpen
+      ? " skipped — needs Redis on 127.0.0.1:6379"
+      : "";
+
+function workloadMinutes(): number {
+  const value = Number(process.env.OPENWORK_EVAL_ACTIVE_SESSION_STORM_MINUTES ?? "2");
+  if (!Number.isFinite(value) || value < 1 || value > 5) {
+    throw new Error("OPENWORK_EVAL_ACTIVE_SESSION_STORM_MINUTES must be a number from 1 through 5.");
+  }
+  return value;
+}
+
+const configuredMinutes = workloadMinutes();
+const slowToolMs = Math.round(configuredMinutes * 60_000);
+// At the default two-minute workload, prove a full minute in which all three
+// slow tools overlap. A one-minute override remains useful for quick iteration
+// and gets a 35-second switching window so startup skew cannot make it flaky.
+const routeStormMs = Math.min(60_000, Math.max(35_000, slowToolMs - 25_000));
+const diagnosticProfileDir = process.env.OPENWORK_EVAL_ACTIVE_SESSION_STORM_PROFILE_DIR?.trim();
+
+interface WorkspacePlan {
+  index: number;
+  path: string;
+  filePath: string;
+  marker: string;
+  slowMarker: string;
+  easyMarker: string;
+  finalReply: string;
+  workspaceId: string;
+  sessionId: string;
+}
+
+interface WorkspaceListing {
+  ids: string[];
+  activeId: string | null;
+}
+
+interface ToolFact {
+  tool: string;
+  status: string;
+  input: Record<string, unknown>;
+  output: string;
+}
+
+interface SessionFacts {
+  ok: boolean;
+  status: number;
+  sessionId: string;
+  text: string;
+  tools: ToolFact[];
+}
+
+interface SurfaceFacts {
+  route: string;
+  sessionId: string;
+  authActions: string[];
+  crash: boolean;
+  bodyHasMarker: boolean;
+  bodyHasToolActivity: boolean;
+}
+
+interface EngineGenerationFact {
+  role: string;
+  pid: number | null;
+  port: number | null;
+}
+
+interface EngineRuntimeFacts {
+  lifecycleState: string;
+  enginePid: number | null;
+  engineRollover: boolean;
+  generations: EngineGenerationFact[];
+}
+
+interface WorkspaceFileFacts {
+  status: number;
+  content: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function parseSessionFacts(value: unknown): SessionFacts {
+  if (!isRecord(value) || typeof value.ok !== "boolean" || typeof value.status !== "number") {
+    throw new Error(`Invalid session facts: ${JSON.stringify(value)}`);
+  }
+  const tools: ToolFact[] = [];
+  if (Array.isArray(value.tools)) {
+    for (const candidate of value.tools) {
+      if (!isRecord(candidate) || typeof candidate.tool !== "string" || typeof candidate.status !== "string") continue;
+      tools.push({
+        tool: candidate.tool,
+        status: candidate.status,
+        input: isRecord(candidate.input) ? candidate.input : {},
+        output: typeof candidate.output === "string" ? candidate.output : "",
+      });
+    }
+  }
+  return {
+    ok: value.ok,
+    status: value.status,
+    sessionId: typeof value.sessionId === "string" ? value.sessionId : "",
+    text: typeof value.text === "string" ? value.text : "",
+    tools,
+  };
+}
+
+function parseSurfaceFacts(value: unknown): SurfaceFacts {
+  if (!isRecord(value)) throw new Error(`Invalid session surface facts: ${JSON.stringify(value)}`);
+  return {
+    route: typeof value.route === "string" ? value.route : "",
+    sessionId: typeof value.sessionId === "string" ? value.sessionId : "",
+    authActions: stringArray(value.authActions),
+    crash: value.crash === true,
+    bodyHasMarker: value.bodyHasMarker === true,
+    bodyHasToolActivity: value.bodyHasToolActivity === true,
+  };
+}
+
+function parseEngineRuntimeFacts(value: unknown): EngineRuntimeFacts {
+  const root = isRecord(value) ? value : {};
+  const engine = isRecord(root.engine) ? root.engine : {};
+  const openworkServer = isRecord(root.openworkServer) ? root.openworkServer : {};
+  const pool = isRecord(root.enginePool) ? root.enginePool : {};
+  const generations: EngineGenerationFact[] = [];
+  if (Array.isArray(pool.generations)) {
+    for (const generation of pool.generations) {
+      if (!isRecord(generation) || typeof generation.role !== "string") continue;
+      generations.push({
+        role: generation.role,
+        pid: typeof generation.pid === "number" ? generation.pid : null,
+        port: typeof generation.port === "number" ? generation.port : null,
+      });
+    }
+  }
+  return {
+    lifecycleState: typeof root.lifecycleState === "string" ? root.lifecycleState : "",
+    enginePid: typeof engine.pid === "number" ? engine.pid : null,
+    engineRollover: openworkServer.engineRollover === true,
+    generations,
+  };
+}
+
+function shellValue(value: string): string {
+  if (!/^[A-Za-z0-9._/-]+$/.test(value)) throw new Error(`Unsafe workload shell value: ${value}`);
+  return value;
+}
+
+function buildPlans(runId: string): WorkspacePlan[] {
+  return Array.from({ length: workspaceCount }, (_, offset) => {
+    const index = offset + 1;
+    const path = `/tmp/openwork-active-session-storm-${runId}-w${index}`;
+    const marker = `STORM-W${index}-${runId}`;
+    return {
+      index,
+      path,
+      filePath: `${path}/storm-output-w${index}.txt`,
+      marker,
+      slowMarker: `SLOW-${marker}`,
+      easyMarker: `EASY-${marker}`,
+      finalReply: `COMPLETE-${marker}`,
+      workspaceId: "",
+      sessionId: "",
+    };
+  });
+}
+
+function agentWorkloads(plans: WorkspacePlan[]) {
+  return plans.map((plan) => ({
+    promptMarker: plan.marker,
+    finalReply: plan.finalReply,
+    steps: [
+      {
+        tool: "bash",
+        arguments: {
+          command: `printf '%s\\n' 'INITIAL-${shellValue(plan.marker)}' > '${shellValue(plan.filePath)}'`,
+          timeout: 30_000,
+          workdir: plan.path,
+          description: `Create the unique output for workspace ${plan.index}`,
+        },
+      },
+      {
+        tool: "bash",
+        arguments: {
+          command: `cat '${shellValue(plan.filePath)}'`,
+          timeout: 30_000,
+          workdir: plan.path,
+          description: `Check the initial output for workspace ${plan.index}`,
+        },
+      },
+      {
+        tool: "bash",
+        arguments: {
+          command: `sleep ${Math.ceil(slowToolMs / 1_000)} && printf '%s\\n' '${shellValue(plan.slowMarker)}' >> '${shellValue(plan.filePath)}'`,
+          timeout: slowToolMs + 30_000,
+          workdir: plan.path,
+          description: `Hold workspace ${plan.index} live, then append its slow marker`,
+        },
+      },
+      {
+        tool: "bash",
+        arguments: {
+          command: `cat '${shellValue(plan.filePath)}'`,
+          timeout: 30_000,
+          workdir: plan.path,
+          description: `Check the slow output for workspace ${plan.index}`,
+        },
+      },
+      {
+        tool: "bash",
+        arguments: {
+          command: `printf '%s\\n' '${shellValue(plan.easyMarker)}' >> '${shellValue(plan.filePath)}'`,
+          timeout: 30_000,
+          workdir: plan.path,
+          description: `Append the easy marker for workspace ${plan.index}`,
+        },
+      },
+      {
+        tool: "bash",
+        arguments: {
+          command: `cat '${shellValue(plan.filePath)}'`,
+          timeout: 30_000,
+          workdir: plan.path,
+          description: `Read the completed output for workspace ${plan.index}`,
+        },
+      },
+    ],
+  }));
+}
+
+async function listWorkspaces(desktopApp: App): Promise<WorkspaceListing> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/workspaces", {
+      headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+      signal: AbortSignal.timeout(15000),
+    });
+    const body = await response.json();
+    const items = Array.isArray(body?.items) ? body.items : [];
+    return {
+      ok: response.ok,
+      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+      activeId: typeof body?.activeId === "string" ? body.activeId : null,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  if (!isRecord(value) || value.ok !== true || !Array.isArray(value.ids)) {
+    throw new Error(`Listing workspaces failed: ${JSON.stringify(value)}`);
+  }
+  return {
+    ids: value.ids.filter((id): id is string => typeof id === "string"),
+    activeId: typeof value.activeId === "string" ? value.activeId : null,
+  };
+}
+
+async function createWorkspace(desktopApp: App, path: string): Promise<string> {
+  const before = await listWorkspaces(desktopApp);
+  await control(desktopApp, "workspace.create", { path }, { timeoutMs: 90_000 });
+  const after = await eventually(() => listWorkspaces(desktopApp), {
+    within: 90_000,
+    intervalMs: 500,
+    label: `workspace ${path} registered`,
+    until: (listing) => listing.ids.length === before.ids.length + 1,
+  });
+  const created = after.ids.find((id) => !before.ids.includes(id));
+  if (!created) throw new Error(`workspace.create produced no new id for ${path}.`);
+  return created;
+}
+
+async function configureWorkspaces(desktopApp: App, plans: WorkspacePlan[], baseUrl: string): Promise<void> {
+  const result = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
+    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const headers = {
+      Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
+      "Content-Type": "application/json",
+    };
+    const outcomes = [];
+    for (const workspaceId of ${JSON.stringify(plans.map((plan) => plan.workspaceId))}) {
+      const config = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          opencode: {
+            permission: { edit: "allow", write: "allow", read: "allow", bash: "allow" },
+            provider: {
+              [${JSON.stringify(providerId)}]: {
+                npm: "@ai-sdk/openai-compatible",
+                name: "Active session storm mock",
+                options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-active-session-storm" },
+                models: {
+                  [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
+                },
+              },
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!config.ok) {
+        outcomes.push({ workspaceId, stage: "config", status: config.status, text: (await config.text()).slice(0, 300) });
+        continue;
+      }
+      const reload = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", {
+        method: "POST",
+        headers,
+        signal: AbortSignal.timeout(60000),
+      });
+      outcomes.push({ workspaceId, stage: "reload", status: reload.status, text: reload.ok ? "ok" : (await reload.text()).slice(0, 300) });
+    }
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    return { outcomes };
+  })()`, { awaitPromise: true, timeoutMs: 240_000 });
+  if (!isRecord(result) || !Array.isArray(result.outcomes)) {
+    throw new Error(`Workspace provider configuration failed: ${JSON.stringify(result)}`);
+  }
+  const failures = result.outcomes.filter((outcome) => !isRecord(outcome) || outcome.status !== 200);
+  if (failures.length > 0) throw new Error(`Workspace provider configuration failures: ${JSON.stringify(failures)}`);
+}
+
+async function openExactSessionRoute(desktopApp: App, plan: WorkspacePlan): Promise<void> {
+  const route = `/workspace/${plan.workspaceId}/session/${plan.sessionId}`;
+  await go(desktopApp, route, { timeoutMs: 60_000 });
+  await waitFor(desktopApp, `(() => {
+    const current = window.__openworkControl?.snapshot().route.split("?")[0].replace(/\\/+$/, "") ?? "";
+    return current === ${JSON.stringify(route)}
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(plan.workspaceId)}
+      && document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") === ${JSON.stringify(plan.sessionId)};
+  })()`, { timeoutMs: 60_000, label: `exact route ${route}` });
+}
+
+async function readSessionFacts(desktopApp: App, workspaceId: string, sessionId: string): Promise<SessionFacts> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { ok: false, status: 0, error: "local_server_unavailable" };
+    const response = await fetch(
+      String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)})
+        + "/sessions/" + encodeURIComponent(${JSON.stringify(sessionId)}) + "/snapshot",
+      {
+        headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+        signal: AbortSignal.timeout(15000),
+      },
+    );
+    const status = response.status;
+    if (!response.ok) return { ok: false, status, sessionId: ${JSON.stringify(sessionId)}, text: "", tools: [] };
+    const payload = await response.json();
+    const item = payload?.item ?? {};
+    const messages = Array.isArray(item?.messages) ? item.messages : [];
+    const text = messages.flatMap((message) => Array.isArray(message?.parts) ? message.parts : [])
+      .flatMap((part) => typeof part?.text === "string" ? [part.text] : []).join("\\n");
+    const tools = messages.flatMap((message) => Array.isArray(message?.parts) ? message.parts : [])
+      .flatMap((part) => {
+        if (!part || typeof part.tool !== "string") return [];
+        const state = part.state && typeof part.state === "object" ? part.state : {};
+        const output = typeof state.output === "string"
+          ? state.output
+          : typeof state.metadata?.output === "string"
+            ? state.metadata.output
+            : "";
+        return [{
+          tool: part.tool,
+          status: typeof state.status === "string" ? state.status : "",
+          input: state.input && typeof state.input === "object" && !Array.isArray(state.input) ? state.input : {},
+          output,
+        }];
+      });
+    return {
+      ok: true,
+      status,
+      sessionId: typeof item?.session?.id === "string" ? item.session.id : "",
+      text,
+      tools,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  return parseSessionFacts(value);
+}
+
+async function readSurfaceFacts(desktopApp: App, marker: string): Promise<SurfaceFacts> {
+  const value = await evalIn(desktopApp, `(() => {
+    const body = document.body.innerText ?? "";
+    const authActions = [...document.querySelectorAll("button, a")]
+      .map((element) => (element.textContent ?? "").trim())
+      .filter((text) => /^(sign in|reconnect|connect again|log in)$/i.test(text));
+    return {
+      route: window.__openworkControl?.snapshot().route ?? window.location.hash,
+      sessionId: document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "",
+      authActions,
+      crash: /aw, snap|renderer process gone|application error|uncaught exception/i.test(body),
+      bodyHasMarker: body.includes(${JSON.stringify(marker)}),
+      bodyHasToolActivity: body.includes("Hold workspace") || body.includes("sleep "),
+    };
+  })()`);
+  return parseSurfaceFacts(value);
+}
+
+async function readEngineRuntimeFacts(desktopApp: App): Promise<EngineRuntimeFacts> {
+  return parseEngineRuntimeFacts(await evalIn(
+    desktopApp,
+    `window.__OPENWORK_ELECTRON__.invokeDesktop("runtimeStatus")`,
+    { awaitPromise: true, timeoutMs: 15_000 },
+  ));
+}
+
+async function readWorkspaceFileFacts(desktopApp: App, plan: WorkspacePlan): Promise<WorkspaceFileFacts> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { status: 0, content: "" };
+    const response = await fetch(
+      String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(${JSON.stringify(plan.workspaceId)})
+        + "/files/content?path=" + encodeURIComponent(${JSON.stringify(plan.filePath.split("/").pop() ?? "")}),
+      {
+        headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    const body = await response.json().catch(() => ({}));
+    return { status: response.status, content: typeof body?.content === "string" ? body.content : "" };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.status !== "number") {
+    throw new Error(`Invalid workspace file facts: ${JSON.stringify(value)}`);
+  }
+  return {
+    status: value.status,
+    content: typeof value.content === "string" ? value.content : "",
+  };
+}
+
+async function readEngineLogSignals(desktopApp: App): Promise<string[]> {
+  if (desktopApp.handle.hostKind !== "local") return [];
+  const logPath = desktopApp.handle.meta?.log;
+  if (!logPath) return [];
+  const text = await readFile(logPath, "utf8").catch(() => "");
+  return text.split("\n")
+    .filter((line) => /engine|dispose|drain|reload|activate|session/i.test(line))
+    .slice(-80)
+    .map((line) => line.slice(0, 500));
+}
+
+function slowToolRunning(facts: SessionFacts): boolean {
+  return facts.tools.some((tool) => tool.tool.endsWith("bash")
+    && (tool.status === "running" || tool.status === "pending")
+    && typeof tool.input.command === "string"
+    && tool.input.command.includes("sleep "));
+}
+
+function sessionCorpus(facts: SessionFacts): string {
+  return `${facts.text}\n${JSON.stringify(facts.tools)}`;
+}
+
+async function allowVisibleToolPermission(desktopApp: App): Promise<boolean> {
+  const clicked = await evalIn(desktopApp, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((candidate) => (candidate.textContent ?? "").trim() === "Allow for session" && !candidate.disabled);
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  if (clicked === true) await sleep(250);
+  return clicked === true;
+}
+
+async function approvePendingToolPermissions(desktopApp: App, plan: WorkspacePlan): Promise<number> {
+  const result = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
+    const root = String(info.baseUrl).replace(/\\/+$/, "")
+      + "/workspace/" + encodeURIComponent(${JSON.stringify(plan.workspaceId)}) + "/opencode";
+    const headers = {
+      Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
+      "Content-Type": "application/json",
+    };
+    const sessionId = ${JSON.stringify(plan.sessionId)};
+    const candidates = [];
+    const v2 = await fetch(root + "/api/session/" + encodeURIComponent(sessionId) + "/permission", {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (v2.ok) {
+      const requests = await v2.json();
+      for (const request of Array.isArray(requests) ? requests : []) {
+        if (typeof request?.id === "string") candidates.push({ id: request.id, protocol: "v2" });
+      }
+    }
+    if (candidates.length === 0) {
+      const legacy = await fetch(root + "/permission", { headers, signal: AbortSignal.timeout(10000) });
+      if (legacy.ok) {
+        const requests = await legacy.json();
+        for (const request of Array.isArray(requests) ? requests : []) {
+          if (typeof request?.id === "string" && request?.sessionID === sessionId) {
+            candidates.push({ id: request.id, protocol: "legacy" });
+          }
+        }
+      }
+    }
+    const replies = [];
+    for (const candidate of candidates) {
+      const path = candidate.protocol === "v2"
+        ? "/api/session/" + encodeURIComponent(sessionId) + "/permission/" + encodeURIComponent(candidate.id) + "/reply"
+        : "/permission/" + encodeURIComponent(candidate.id) + "/reply";
+      const response = await fetch(root + path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ reply: "once" }),
+        signal: AbortSignal.timeout(10000),
+      });
+      replies.push({ id: candidate.id, protocol: candidate.protocol, status: response.status });
+    }
+    return { replies };
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  if (!isRecord(result) || !Array.isArray(result.replies)) {
+    throw new Error(`Permission approval failed for ${plan.sessionId}: ${JSON.stringify(result)}`);
+  }
+  const failures = result.replies.filter((reply) => !isRecord(reply) || typeof reply.status !== "number" || reply.status < 200 || reply.status >= 300);
+  if (failures.length > 0) throw new Error(`Permission replies failed for ${plan.sessionId}: ${JSON.stringify(failures)}`);
+  return result.replies.length;
+}
+
+async function waitForSlowTool(desktopApp: App, plan: WorkspacePlan): Promise<SessionFacts> {
+  const deadline = Date.now() + 90_000;
+  let latest: SessionFacts | null = null;
+  while (Date.now() < deadline) {
+    const clicked = await allowVisibleToolPermission(desktopApp);
+    const approved = clicked ? 0 : await approvePendingToolPermissions(desktopApp, plan);
+    latest = await readSessionFacts(desktopApp, plan.workspaceId, plan.sessionId);
+    // A tool part is already labelled running while it waits for permission.
+    // Require one clean poll with no request left to approve before treating
+    // the slow command as an actually in-flight workload.
+    if (slowToolRunning(latest) && approved === 0 && !clicked) return latest;
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for workspace ${plan.index} slow tool to start after permission approval; latest=${JSON.stringify(latest)}`);
+}
+
+test.skipIf(!runnable)(
+  `three workspaces keep independent live tool runs through exact-route switching${skipSuffix}`,
+  { timeout: 25 * 60_000 },
+  async ({ evidence, place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    const runId = `${Date.now().toString(36)}-${process.pid}`;
+    const plans = buildPlans(runId);
+    await using den = await server({
+      place,
+      mocks: { agent: mcpMock({ agentWorkloads: agentWorkloads(plans) }) },
+      org: {
+        name: "Active Session Workspace Storm",
+        admin: { name: "Storm Admin" },
+        members: { member: { name: "Storm Member" } },
+      },
+    });
+    await using desktopApp = await app({
+      den,
+      as: "member",
+      place,
+      ...(diagnosticProfileDir ? { profileDir: diagnosticProfileDir } : {}),
+    });
+
+    const initialDen = await eventually(() => readDenClientState(desktopApp), {
+      within: 60_000,
+      label: "initial authenticated organization",
+      until: (state) => state.authTokenPresent && Boolean(state.activeOrgId),
+    });
+    const initialConnect = await eventually(() => readConnectState(desktopApp), {
+      within: 120_000,
+      intervalMs: 1_000,
+      label: "initial Connect availability",
+      until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+    });
+    const orgId = initialDen.activeOrgId;
+    if (!orgId) throw new Error("The signed-in baseline has no active organization.");
+    evidence.recordAssertionEvidence(
+      "The workload begins with coherent Den auth, organization, and Connect state",
+      `authTokenPresent=${initialDen.authTokenPresent}; activeOrgId=${orgId}; Connect=${initialConnect.status}/${initialConnect.connectEnabled}.`,
+      initialDen.authTokenPresent && initialConnect.ok && initialConnect.status === "available" && initialConnect.connectEnabled === true,
+    );
+
+    for (const plan of plans) plan.workspaceId = await createWorkspace(desktopApp, plan.path);
+    expect(new Set(plans.map((plan) => plan.workspaceId)).size).toBe(workspaceCount);
+    await configureWorkspaces(desktopApp, plans, den.mocks.agent.url);
+    // The already-mounted model store predates these workspace configs. Reload
+    // once, before any session exists, so every workspace sees the same mock
+    // provider without perturbing an in-flight engine event subscription.
+    await evalIn(desktopApp, "location.reload(); true");
+    await waitFor(desktopApp, "Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "desktop reloaded with the storm model preference",
+    });
+    await eventually(() => readDenClientState(desktopApp), {
+      within: 60_000,
+      label: "Den session restored after provider setup reload",
+      until: (state) => state.authTokenPresent && state.activeOrgId === orgId,
+    });
+
+    const workloadStartedAt = new Date().toISOString();
+    for (const plan of plans) {
+      await go(desktopApp, `/workspace/${plan.workspaceId}/session`);
+      await waitFor(desktopApp, `(localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(plan.workspaceId)}`, {
+        timeoutMs: 60_000,
+        label: `workspace ${plan.index} active before task creation`,
+      });
+      const selected = await selectModel(desktopApp, modelId);
+      expect(selected.id).toBe(modelId);
+      const created = await control(desktopApp, "session.create_task", undefined, { timeoutMs: 60_000 });
+      if (typeof created !== "string" || !created.startsWith("ses_")) {
+        throw new Error(`Workspace ${plan.index} did not create a session: ${JSON.stringify(created)}`);
+      }
+      plan.sessionId = created;
+      await control(desktopApp, "session.rename", {
+        sessionId: plan.sessionId,
+        title: `Active storm workspace ${plan.index}`,
+      }, { timeoutMs: 30_000 });
+      await openExactSessionRoute(desktopApp, plan);
+      await sendComposerMessage(
+        desktopApp,
+        `Run the deterministic active-session workload identified by ${plan.marker}. You may run its shell commands and create, append, and read its workspace file. Keep working through every step and report only when complete.`,
+      );
+      const running = await waitForSlowTool(desktopApp, plan);
+      expect(running.ok).toBe(true);
+      expect(running.sessionId).toBe(plan.sessionId);
+    }
+
+    evidence.recordAssertionEvidence(
+      "All three originating workspaces reached a live slow tool concurrently",
+      `${plans.map((plan) => `${plan.workspaceId}/${plan.sessionId}`).join(", ")} each exposed a pending or running bash sleep before route switching began; configured slow duration=${slowToolMs}ms.`,
+      plans.length === workspaceCount && plans.every((plan) => Boolean(plan.workspaceId && plan.sessionId)),
+    );
+    const engineBeforeStorm = await readEngineRuntimeFacts(desktopApp);
+
+    await openExactSessionRoute(desktopApp, plans[0]);
+    const liveSurface = await readSurfaceFacts(desktopApp, plans[0].marker);
+    expect(liveSurface.bodyHasMarker).toBe(true);
+    expect(liveSurface.bodyHasToolActivity).toBe(true);
+    expect(liveSurface.sessionId).toBe(plans[0].sessionId);
+    expect(liveSurface.authActions).toEqual([]);
+    await screenshot(desktopApp);
+
+    const authDrops: string[] = [];
+    const orgChanges: string[] = [];
+    const connectFailures: string[] = [];
+    const reconnectSurfaces: string[] = [];
+    const nonLiveSamples: string[] = [];
+    const liveSamples = new Map(plans.map((plan) => [plan.sessionId, 0]));
+    const stormStartedAt = Date.now();
+    let switches = 0;
+    while (Date.now() - stormStartedAt < routeStormMs) {
+      for (const plan of plans) {
+        await openExactSessionRoute(desktopApp, plan);
+        switches += 1;
+        const [facts, denState, surface] = await Promise.all([
+          readSessionFacts(desktopApp, plan.workspaceId, plan.sessionId),
+          readDenClientState(desktopApp),
+          readSurfaceFacts(desktopApp, plan.marker),
+        ]);
+        if (slowToolRunning(facts)) {
+          liveSamples.set(plan.sessionId, (liveSamples.get(plan.sessionId) ?? 0) + 1);
+        } else {
+          nonLiveSamples.push(`switch ${switches}: ${plan.sessionId} tools=${JSON.stringify(facts.tools)}`);
+        }
+        if (!denState.authTokenPresent) authDrops.push(`switch ${switches}: ${plan.sessionId}`);
+        if (denState.activeOrgId !== orgId) orgChanges.push(`switch ${switches}: ${String(denState.activeOrgId)}`);
+        if (surface.authActions.length > 0 || surface.crash || !surface.bodyHasMarker) {
+          reconnectSurfaces.push(`switch ${switches}: ${JSON.stringify(surface)}`);
+        }
+        await sleep(250);
+      }
+      const connect = await readConnectState(desktopApp);
+      if (!connect.ok || connect.status !== "available" || connect.connectEnabled !== true) {
+        connectFailures.push(`after switch ${switches}: ${JSON.stringify(connect)}`);
+      }
+    }
+
+    expect(switches).toBeGreaterThanOrEqual(9);
+    expect([...liveSamples.values()].every((count) => count >= 3), JSON.stringify([...liveSamples])).toBe(true);
+    expect(nonLiveSamples).toEqual([]);
+    expect(authDrops).toEqual([]);
+    expect(orgChanges).toEqual([]);
+    expect(connectFailures).toEqual([]);
+    expect(reconnectSurfaces).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "Repeated exact-session-route switching preserves every in-flight turn and Cloud identity",
+      `${switches} exact route switches over ${Date.now() - stormStartedAt}ms; live samples=${JSON.stringify([...liveSamples])}; non-live=${JSON.stringify(nonLiveSamples)}; auth drops=${JSON.stringify(authDrops)}; org changes=${JSON.stringify(orgChanges)}; Connect failures=${JSON.stringify(connectFailures)}; reconnect/crash surfaces=${JSON.stringify(reconnectSurfaces)}.`,
+      switches >= 9
+        && [...liveSamples.values()].every((count) => count >= 3)
+        && nonLiveSamples.length === 0
+        && authDrops.length === 0
+        && orgChanges.length === 0
+        && connectFailures.length === 0
+        && reconnectSurfaces.length === 0,
+    );
+    const engineAfterStorm = await readEngineRuntimeFacts(desktopApp);
+    evidence.recordAssertionEvidence(
+      "The route storm records the managed engine generation topology",
+      `Before=${JSON.stringify(engineBeforeStorm)}; after=${JSON.stringify(engineAfterStorm)}.`,
+      engineBeforeStorm.enginePid !== null && engineAfterStorm.enginePid !== null,
+    );
+
+    const expectedTools = ["bash", "bash", "bash", "bash", "bash", "bash"];
+    for (const plan of plans) {
+      await openExactSessionRoute(desktopApp, plan);
+      const complete = await eventually(
+        async () => {
+          const facts = await readSessionFacts(desktopApp, plan.workspaceId, plan.sessionId);
+          if (!facts.text.includes(plan.finalReply)) {
+            const clicked = await allowVisibleToolPermission(desktopApp);
+            if (!clicked) await approvePendingToolPermissions(desktopApp, plan);
+          }
+          return facts;
+        },
+        {
+          within: slowToolMs + 60_000,
+          intervalMs: 1_000,
+          label: `workspace ${plan.index} independent completion`,
+          until: (facts) => facts.text.includes(plan.finalReply)
+            && facts.tools.length === expectedTools.length
+            && facts.tools.every((tool) => tool.status === "completed"),
+        },
+      ).catch(async (error: unknown) => {
+        const [stuck, file, engine, logSignals] = await Promise.all([
+          readSessionFacts(desktopApp, plan.workspaceId, plan.sessionId),
+          readWorkspaceFileFacts(desktopApp, plan),
+          readEngineRuntimeFacts(desktopApp),
+          readEngineLogSignals(desktopApp),
+        ]);
+        evidence.recordAssertionEvidence(
+          `Workspace ${plan.index} independently completes after route switching`,
+          `Completion exceeded its strict bound; origin=${plan.workspaceId}/${plan.sessionId}; last snapshot=${JSON.stringify(stuck)}; file=${JSON.stringify(file)}; engine=${JSON.stringify(engine)}; engine log signals=${JSON.stringify(logSignals)}.`,
+          false,
+        );
+        throw error;
+      });
+      const corpus = sessionCorpus(complete);
+      expect(complete.sessionId).toBe(plan.sessionId);
+      expect(complete.tools.map((tool) => tool.tool)).toEqual(expectedTools);
+      expect(corpus).toContain(plan.filePath);
+      expect(corpus).toContain(`INITIAL-${plan.marker}`);
+      expect(corpus).toContain(plan.slowMarker);
+      expect(corpus).toContain(plan.easyMarker);
+      expect(corpus).toContain(plan.finalReply);
+      for (const other of plans.filter((candidate) => candidate.index !== plan.index)) {
+        expect(corpus).not.toContain(other.marker);
+        expect(corpus).not.toContain(other.filePath);
+      }
+
+      const providerRequests = await den.mocks.agent.agentRequests({
+        promptMarker: plan.marker,
+        sinceIso: workloadStartedAt,
+      });
+      const mainRequests = providerRequests.filter((request) => request.kind !== "utility");
+      expect(mainRequests.map((request) => request.kind)).toEqual([
+        "tool", "tool", "tool", "tool", "tool", "tool", "final",
+      ]);
+      expect(mainRequests.filter((request) => request.kind === "tool").map((request) => request.toolName)).toEqual(expectedTools);
+      expect(mainRequests.every((request) => request.matchedMarkers.length === 1
+        && request.matchedMarkers[0] === plan.marker)).toBe(true);
+      expect(mainRequests.filter((request) => request.kind === "tool")
+        .every((request) => JSON.stringify(request.arguments).includes(plan.filePath))).toBe(true);
+
+      const wrongWorkspaceStatuses: number[] = [];
+      for (const other of plans.filter((candidate) => candidate.index !== plan.index)) {
+        wrongWorkspaceStatuses.push((await readSessionFacts(desktopApp, other.workspaceId, plan.sessionId)).status);
+      }
+      expect(wrongWorkspaceStatuses.every((status) => status === 404)).toBe(true);
+
+      const finalSurface = await readSurfaceFacts(desktopApp, plan.marker);
+      expect(finalSurface.sessionId).toBe(plan.sessionId);
+      expect(finalSurface.bodyHasMarker).toBe(true);
+      expect(finalSurface.authActions).toEqual([]);
+      expect(finalSurface.crash).toBe(false);
+      await screenshot(desktopApp);
+      evidence.recordAssertionEvidence(
+        `Workspace ${plan.index} completed only its own six-step workload in its originating session`,
+        `Origin=${plan.workspaceId}/${plan.sessionId}; tools=${JSON.stringify(complete.tools)}; provider=${JSON.stringify(mainRequests)}; wrong-workspace snapshot statuses=${JSON.stringify(wrongWorkspaceStatuses)}; transcript=${JSON.stringify(complete.text)}.`,
+        complete.text.includes(plan.finalReply)
+          && complete.tools.map((tool) => tool.tool).join(",") === expectedTools.join(",")
+          && plans.filter((candidate) => candidate.index !== plan.index).every((other) => !corpus.includes(other.marker))
+          && wrongWorkspaceStatuses.every((status) => status === 404),
+      );
+    }
+
+    const finalDen = await readDenClientState(desktopApp);
+    const finalConnect = await eventually(() => readConnectState(desktopApp), {
+      within: 120_000,
+      intervalMs: 1_000,
+      label: "Connect available after all active sessions complete",
+      until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+    });
+    expect(finalDen.authTokenPresent).toBe(true);
+    expect(finalDen.activeOrgId).toBe(orgId);
+    expect(finalConnect.status).toBe("available");
+    expect(finalConnect.connectEnabled).toBe(true);
+
+    const healthSummaries = [];
+    for (const plan of plans) {
+      healthSummaries.push(await eventually(
+        () => readCloudMcpHealth(desktopApp, plan.workspaceId, { probe: true, timeoutMs: 30_000 }),
+        {
+          within: 180_000,
+          intervalMs: 3_000,
+          label: `workspace ${plan.index} Cloud MCP usable after completion`,
+          until: (health) => health.ok && health.usable === true,
+        },
+      ));
+    }
+    expect(healthSummaries.every((health) => health.ok && health.usable === true)).toBe(true);
+    evidence.recordAssertionEvidence(
+      "Den auth, organization selection, and Connect remain coherent after every session completes",
+      `Final authTokenPresent=${finalDen.authTokenPresent}; activeOrgId=${String(finalDen.activeOrgId)}; Connect=${finalConnect.status}/${finalConnect.connectEnabled}; per-workspace Cloud MCP health=${JSON.stringify(healthSummaries)}.`,
+      finalDen.authTokenPresent
+        && finalDen.activeOrgId === orgId
+        && finalConnect.ok
+        && finalConnect.status === "available"
+        && finalConnect.connectEnabled === true
+        && healthSummaries.every((health) => health.ok && health.usable === true),
+    );
+  },
+);

--- a/evals/specs/active-session-workspace-storm.e2e.test.ts
+++ b/evals/specs/active-session-workspace-storm.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   waitFor,
   writeComposerText,
 } from "@openwork/behaviors";
-import { screenshot } from "@openwork/test-evidence";
+import { screenshot, validate } from "@openwork/test-evidence";
 import {
   app,
   eventually,
@@ -701,7 +701,13 @@ test.skipIf(!runnable)(
     expect(liveSurface.bodyHasToolActivity).toBe(true);
     expect(liveSurface.sessionId).toBe(plans[0].sessionId);
     expect(liveSurface.authActions).toEqual([]);
-    await screenshot(desktopApp);
+    const liveShot = await screenshot(desktopApp);
+    const liveValidation = await validate(liveShot, [
+      "The active workspace session visibly shows its deterministic workload prompt or marker",
+      "The session visibly shows live agent activity such as Thinking, a running tool, or a bash command",
+      "No sign-in, reconnect, or application crash screen is visible",
+    ]);
+    expect(liveValidation.ok, liveValidation.why).toBe(true);
 
     const authDrops: string[] = [];
     const orgChanges: string[] = [];
@@ -835,7 +841,13 @@ test.skipIf(!runnable)(
       expect(finalSurface.bodyHasMarker).toBe(true);
       expect(finalSurface.authActions).toEqual([]);
       expect(finalSurface.crash).toBe(false);
-      await screenshot(desktopApp);
+      const completeShot = await screenshot(desktopApp);
+      const completeValidation = await validate(completeShot, [
+        `The session visibly shows the completed workload for workspace ${plan.index}`,
+        "The session transcript visibly contains agent or tool activity rather than an empty New session screen",
+        "No sign-in, reconnect, or application crash screen is visible",
+      ]);
+      expect(completeValidation.ok, completeValidation.why).toBe(true);
       evidence.recordAssertionEvidence(
         `Workspace ${plan.index} completed only its own six-step workload in its originating session`,
         `Origin=${plan.workspaceId}/${plan.sessionId}; tools=${JSON.stringify(complete.tools)}; provider=${JSON.stringify(mainRequests)}; wrong-workspace snapshot statuses=${JSON.stringify(wrongWorkspaceStatuses)}; transcript=${JSON.stringify(complete.text)}.`,

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -47,6 +47,7 @@ const tokens = new Set();
 const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
+let agentWorkloads = [];
 
 const gmailThreadId = "thread-q3-launch";
 
@@ -153,6 +154,149 @@ function readBody(req) {
     req.on("end", () => resolve(raw));
     req.on("error", reject);
   });
+}
+
+function agentContentText(value) {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(agentContentText).filter(Boolean).join("\n");
+  if (!value || typeof value !== "object") return "";
+  if (typeof value.text === "string") return value.text;
+  return agentContentText(value.content);
+}
+
+function validateAgentWorkloads(value) {
+  if (!Array.isArray(value)) throw new Error("agent workloads must be an array");
+  const markers = new Set();
+  return value.map((workload) => {
+    if (!workload || typeof workload !== "object") throw new Error("agent workload must be an object");
+    const promptMarker = typeof workload.promptMarker === "string" ? workload.promptMarker.trim() : "";
+    const finalReply = typeof workload.finalReply === "string" ? workload.finalReply : "";
+    if (!promptMarker || !finalReply || !Array.isArray(workload.steps) || workload.steps.length === 0) {
+      throw new Error("agent workload needs promptMarker, finalReply, and at least one step");
+    }
+    if (markers.has(promptMarker)) throw new Error(`duplicate agent workload marker: ${promptMarker}`);
+    markers.add(promptMarker);
+    const steps = workload.steps.map((step) => {
+      if (!step || typeof step !== "object" || typeof step.tool !== "string" || !step.tool.trim()) {
+        throw new Error(`agent workload ${promptMarker} has an invalid tool step`);
+      }
+      if (!step.arguments || typeof step.arguments !== "object" || Array.isArray(step.arguments)) {
+        throw new Error(`agent workload ${promptMarker} tool ${step.tool} needs object arguments`);
+      }
+      return { tool: step.tool.trim(), arguments: structuredClone(step.arguments) };
+    });
+    return { promptMarker, finalReply, steps };
+  });
+}
+
+function offeredAgentTool(body, wanted) {
+  if (!Array.isArray(body?.tools)) return null;
+  const names = body.tools.flatMap((tool) => (
+    tool && typeof tool === "object" && typeof tool.function?.name === "string"
+      ? [tool.function.name]
+      : []
+  ));
+  return names.find((name) => name === wanted)
+    ?? names.find((name) => name.endsWith(`_${wanted}`))
+    ?? null;
+}
+
+function agentStream(res, model, chunks) {
+  res.writeHead(200, {
+    "access-control-allow-origin": "*",
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  let delayMs = 150;
+  for (const chunk of chunks) {
+    setTimeout(() => {
+      if (!res.writableEnded) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    }, delayMs);
+    delayMs += 150;
+  }
+  setTimeout(() => {
+    if (!res.writableEnded) res.end("data: [DONE]\n\n");
+  }, delayMs);
+}
+
+function agentChunk(model, delta, finishReason = null) {
+  return {
+    id: `chatcmpl-mock-agent-${randomUUID()}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+async function handleAgentCompletion(req, res, entry) {
+  const body = await readJson(req);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    json(res, 400, { error: { message: "completion body must be an object" } });
+    return;
+  }
+  const model = typeof body.model === "string" ? body.model : "mock-agent-workload-model";
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const conversationText = messages.map(agentContentText).join("\n");
+  const matchedMarkers = agentWorkloads
+    .filter((workload) => conversationText.includes(workload.promptMarker))
+    .map((workload) => workload.promptMarker);
+  const completedTools = messages.filter((message) => message && typeof message === "object" && message.role === "tool").length;
+  const baseRequest = { model, matchedMarkers, completedTools };
+
+  if (!Array.isArray(body.tools) || body.tools.length === 0) {
+    entry.agentCompletion = { ...baseRequest, kind: "utility", promptMarker: matchedMarkers[0] ?? null, toolName: null, arguments: {} };
+    agentStream(res, model, [
+      agentChunk(model, { role: "assistant" }),
+      agentChunk(model, { content: "Active session workload" }),
+      agentChunk(model, {}, "stop"),
+    ]);
+    return;
+  }
+  if (matchedMarkers.length !== 1) {
+    entry.agentCompletion = { ...baseRequest, kind: "error", promptMarker: null, toolName: null, arguments: {} };
+    json(res, 400, { error: { message: `expected one workload marker, found ${matchedMarkers.length}` } });
+    return;
+  }
+  const workload = agentWorkloads.find((candidate) => candidate.promptMarker === matchedMarkers[0]);
+  if (!workload) throw new Error("matched agent workload disappeared");
+  if (completedTools >= workload.steps.length) {
+    entry.agentCompletion = { ...baseRequest, kind: "final", promptMarker: workload.promptMarker, toolName: null, arguments: {} };
+    agentStream(res, model, [
+      agentChunk(model, { role: "assistant" }),
+      agentChunk(model, { content: workload.finalReply }),
+      agentChunk(model, {}, "stop"),
+    ]);
+    return;
+  }
+  const step = workload.steps[completedTools];
+  const toolName = offeredAgentTool(body, step.tool);
+  if (!toolName) {
+    entry.agentCompletion = { ...baseRequest, kind: "error", promptMarker: workload.promptMarker, toolName: step.tool, arguments: step.arguments };
+    json(res, 400, { error: { message: `tool ${step.tool} was not offered to the mock agent` } });
+    return;
+  }
+  const callId = `call_${workload.promptMarker.replace(/[^a-zA-Z0-9_-]/g, "_")}_${completedTools + 1}`;
+  entry.agentCompletion = {
+    ...baseRequest,
+    kind: "tool",
+    promptMarker: workload.promptMarker,
+    toolName,
+    arguments: step.arguments,
+  };
+  agentStream(res, model, [
+    agentChunk(model, { role: "assistant" }),
+    agentChunk(model, {
+      tool_calls: [{
+        index: 0,
+        id: callId,
+        type: "function",
+        function: { name: toolName, arguments: JSON.stringify(step.arguments) },
+      }],
+    }),
+    agentChunk(model, {}, "tool_calls"),
+  ]);
 }
 
 async function readJson(req) {
@@ -654,6 +798,29 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/requests") {
       json(res, 200, { requests });
+      return;
+    }
+
+    if (url.pathname === "/admin/agent-workloads" && req.method === "POST") {
+      const body = await readJson(req);
+      agentWorkloads = validateAgentWorkloads(body?.workloads);
+      json(res, 200, { configured: agentWorkloads.length });
+      return;
+    }
+
+    if (url.pathname === "/v1/models" && req.method === "GET") {
+      json(res, 200, {
+        object: "list",
+        data: [{ id: "mock-agent-workload-model", object: "model", owned_by: "openwork-testkit" }],
+      });
+      return;
+    }
+
+    if (
+      req.method === "POST"
+      && (url.pathname === "/v1/chat/completions" || url.pathname === "/chat/completions")
+    ) {
+      await handleAgentCompletion(req, res, entry);
       return;
     }
 


### PR DESCRIPTION
## Summary
- preserve busy sessions from every local workspace when an engine generation rolls over instead of probing only the currently active directory
- keep permission/question replies pinned to their owning generation and reconnect global event subscriptions after generation changes
- enforce workspace/session directory isolation for reads, aborts, and deletes
- add a deterministic OpenAI-compatible workload witness that scripts mixed fast and slow tool rounds
- add a testkit E2E that runs three independent six-tool agent turns for two minutes while repeatedly switching their exact session routes

## Root cause
Workspace activation can trigger an engine rollover. Drain detection previously queried session status only without each workspace directory, so a busy session in a non-active workspace was invisible and its generation could be retired while a long tool call was still running. Event streams also ended on generation changes without reconnecting.

## Validation
- `pnpm --filter openwork-server exec bun test src/engine-pool.test.ts src/session-read-model.e2e.test.ts` — 29 passed
- `pnpm --filter @openwork/app exec bun test tests/global-sdk-provider.test.ts` — 1 passed
- `node --test evals/packages/labs/test/mock-mcp.test.ts` — 2 passed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `OPENWORK_EVAL_REF=active-session-workspace-storm pnpm evals:e2e active-session-workspace-storm --daytona` (via Infisical) — 1 passed, 0 failed, 0 skipped on `e5834ea44903`

## E2E workload
Three workspaces each run six sequential bash tools: fast write/read steps, a configurable 1–5 minute sleep/write step (2 minutes by default), and final verification steps. While all three slow tools are live, the spec repeatedly switches exact session routes and checks every turn remains running, Den auth/org and Connect remain coherent, no reconnect surface appears, each transcript/file/provider sequence contains only its own marker, wrong-workspace session reads return 404, and every turn completes.