### PR TITLE
fix(app): forward local MCP environment through the hot-add connect call

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -936,6 +936,18 @@ export function createConnectionsStore(options: {
                 type: "local" as const,
                 command: (mcpEntryConfig["command"] as string[]) ?? entry.command!,
                 enabled: true,
+                // Forward `environment` here the same way the remote branch
+                // above forwards `headers`/`oauth`. resolveLocalMcpEnvironment
+                // has already resolved it into mcpEntryConfig and it is written
+                // to opencode.json, but this hot-add call is what actually
+                // spawns the process on first connect. Omitting it starts the
+                // server with none of its configured environment, so a local
+                // server that resolves required state from an env var fails
+                // immediately with "Connection closed" even though the on-disk
+                // config is correct.
+                ...(mcpEntryConfig["environment"]
+                  ? { environment: mcpEntryConfig["environment"] as Record<string, string> }
+                  : {}),
               };
 
         const status = unwrap(


### PR DESCRIPTION
## Summary

When connecting a local (stdio) MCP server from the Connections UI, the config
passed to the live `client.mcp.add()` call omits `environment`. Any local MCP
server that needs environment variables to start therefore fails on its first
connect, even though the environment was resolved correctly and written into the
project's `opencode.json`.

## Why

`apps/app/src/react-app/domains/connections/store.ts` already calls
`resolveLocalMcpEnvironment(entry)` and persists the result into the project
config. But the `mcpAddConfig` object built a few lines later for the local
branch is `{ type, command, enabled }` — `environment` is dropped. The remote
branch directly above it does forward its own config (`headers`, `oauth`); the
local branch is the asymmetric one.

That hot-add call is what actually spawns the server process on first connect.
The on-disk `opencode.json` is only consulted on a later server start. So the
first "Connect" click spawns the process with no environment, the server exits
during initialization, and the UI reports:

```
MCP error -32000: Connection closed
```

The config on disk is correct the whole time, which is why this survives review
and passes typechecking. Restarting the opencode server afterwards makes the
same server connect fine, which makes the failure look intermittent when it is
actually deterministic on first connect.

## Scope

- `apps/app/src/react-app/domains/connections/store.ts`: conditionally spread
  `environment` into the local branch of `mcpAddConfig` when
  `resolveLocalMcpEnvironment` produced one.

Out of scope: the remote branch of `mcpAddConfig` (unaffected), and any refactor
of `createConnectionsStore` (see Testing).

## Testing

Reproduced both request shapes directly against a running `opencode serve`,
using a local stdio MCP server that refuses to start unless one required
environment variable is set.

Request body exactly as the app builds it today
(`{ type: "local", command: [...], enabled: true }`):

```json
{"<server>":{"status":"failed","error":"MCP error -32000: Connection closed"}}
```

The same request body with `environment` included:

```json
{"<server>":{"status":"connected"}}
```

The `environment` key is the only difference between the two calls.

No unit test is included. `mcpAddConfig` is constructed inline inside the
`createConnectionsStore` closure, and there is no exported seam to test it
through — a focused test would need either an extraction of the config-building
block into a small exported helper, or a fully mocked store with a stubbed
`activeClient.mcp.add`. I did not want to bundle a refactor with a behavioural
fix this small, but I am happy to add either if you have a preference.

## Risk

Low. The change is additive and conditional: `environment` is forwarded only
when `resolveLocalMcpEnvironment` returned one, so entries without an
environment produce a byte-identical request to today's. Remote entries are
untouched. Rollback is a straight revert.

## Note on CI

`warden.yml` skips fork PRs by design (`head.repo.full_name == github.repository`),
so Warden analysis and clearance will not run here. Not code-related — flagging
it so nobody chases an unfulfilled check.
