### PR TITLE
fix(library): keep Add skill discoverable after sign-in

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/library-add-control.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/library-add-control.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useState } from "react";
-import { Plus } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { t } from "../../../../i18n";
@@ -27,6 +27,7 @@ export function libraryAddKindLabel(kind: LibraryAddKind) {
 export function LibraryAddControl(props: {
   kinds: LibraryAddKind[];
   onSelect: (kind: LibraryAddKind) => void;
+  pending?: boolean;
   size?: "xs" | "sm" | "default";
   variant?: "default" | "outline";
 }) {
@@ -35,12 +36,22 @@ export function LibraryAddControl(props: {
   if (kinds.length === 0) return null;
   const size = props.size ?? "default";
   const variant = props.variant ?? "default";
+  const pendingLabel = t("den.checking_session");
 
   const onlyKind = kinds[0];
   if (kinds.length === 1 && onlyKind) {
     return (
-      <Button variant={variant} size={size} className="shrink-0 rounded-lg" onClick={() => props.onSelect(onlyKind)}>
-        <Plus size={16} />
+      <Button
+        variant={variant}
+        size={size}
+        className="shrink-0 rounded-lg"
+        disabled={props.pending}
+        aria-busy={props.pending}
+        aria-label={props.pending ? `${libraryAddKindLabel(onlyKind)} — ${pendingLabel}` : undefined}
+        title={props.pending ? pendingLabel : undefined}
+        onClick={() => props.onSelect(onlyKind)}
+      >
+        {props.pending ? <Loader2 size={16} className="animate-spin" /> : <Plus size={16} />}
         {libraryAddKindLabel(onlyKind)}
       </Button>
     );

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -94,6 +94,7 @@ import {
   type McpViewLocalState,
 } from "./mcp-view-state";
 import { useCloudSession } from "../cloud/cloud-session-provider";
+import { useDenAuth } from "../../cloud/den-auth-provider";
 import {
   libraryAddAction,
   libraryAddKindsForFilter,
@@ -430,6 +431,7 @@ function resolveExtensionDetailTarget(
 
 export function McpView(props: McpViewProps) {
   const cloudSession = useCloudSession();
+  const denAuth = useDenAuth();
   const denBaseUrl = readDenSettings().baseUrl;
   const skillCount = props.installedSkills?.length ?? 0;
   const useRoutedDetail = typeof props.onDetailIdChange === "function";
@@ -540,12 +542,19 @@ export function McpView(props: McpViewProps) {
     setFilter(nextFilter);
     props.onFilterChange?.(nextFilter);
   };
+  const libraryCloudSignedIn = cloudSession.isSignedIn
+    || (Boolean(cloudSession.authToken.trim()) && denAuth.isSignedIn);
   const libraryAddOptions = {
-    cloudSignedIn: cloudSession.isSignedIn,
+    cloudSignedIn: libraryCloudSignedIn,
   };
   const libraryAddKinds = libraryAddKindsForFilter(filter).filter((kind) => (
     libraryAddAction(kind, libraryAddOptions) !== null
   ));
+  const skillAddPending = filter === "skill"
+    && !libraryCloudSignedIn
+    && denAuth.status === "checking"
+    && Boolean(cloudSession.authToken.trim())
+    && Boolean(cloudSession.activeOrganization?.id.trim());
   const handleAddKind = (kind: LibraryAddKind) => {
     const action = libraryAddAction(kind, libraryAddOptions);
     if (!action) return;
@@ -1280,9 +1289,13 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
-      {libraryAddKinds.length > 0 ? (
+      {libraryAddKinds.length > 0 || skillAddPending ? (
         <div className="mb-5 flex justify-end">
-          <LibraryAddControl kinds={libraryAddKinds} onSelect={handleAddKind} />
+          <LibraryAddControl
+            kinds={skillAddPending ? ["skill"] : libraryAddKinds}
+            pending={skillAddPending}
+            onSelect={handleAddKind}
+          />
         </div>
       ) : null}
 

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 
-import { useEffect, useMemo, useSyncExternalStore, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router";
 
 import { captureAnalyticsEvent, initAnalytics } from "../../app/lib/analytics";
@@ -78,6 +78,8 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   const denAuth = useDenAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const locationRef = useRef(location);
+  locationRef.current = location;
   const bootstrap = useSyncExternalStore(
     subscribeToDenBootstrap,
     readDenBootstrapSnapshot,
@@ -147,8 +149,15 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   useEffect(() => {
     const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
       if (event.detail?.status !== "success") return;
+      const signInLocation = locationRef.current;
       let attempts = 0;
       const check = () => {
+        const currentLocation = locationRef.current;
+        if (
+          currentLocation.pathname !== signInLocation.pathname
+          || currentLocation.search !== signInLocation.search
+          || currentLocation.hash !== signInLocation.hash
+        ) return;
         attempts++;
         const settings = readDenSettings();
         if (settings.authToken?.trim() && readOrgSelectionPending().pending) {

--- a/evals/specs/library-add-session-restore.e2e.test.ts
+++ b/evals/specs/library-add-session-restore.e2e.test.ts
@@ -1,0 +1,184 @@
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { desktop } from "@openwork/hosts";
+import {
+  faultProxy,
+  needs,
+  server,
+  signInDesktopAs,
+  test,
+  unmetNeeds,
+} from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `Library Add session restore skipped — needs: ${missingRequirements.join(", ")}`
+  : "Library Add stays on the requested route and exposes bounded Cloud session restoration";
+
+const addSkillButton = `[...document.querySelectorAll("button")]
+  .find((button) => (button.textContent ?? "").trim() === "Add skill")`;
+const pendingAddSkill = `(() => {
+  const button = ${addSkillButton};
+  return button instanceof HTMLButtonElement
+    && button.disabled
+    && button.getAttribute("aria-busy") === "true"
+    && button.getAttribute("aria-label") === "Add skill — Checking session"
+    && button.title === "Checking session";
+})()`;
+const enabledAddSkill = `(() => {
+  const button = ${addSkillButton};
+  return button instanceof HTMLButtonElement
+    && !button.disabled
+    && button.getAttribute("aria-busy") !== "true";
+})()`;
+
+async function reloadCommitted(surface: Surface, label: string): Promise<number> {
+  const previousTimeOrigin = await evalIn(surface, "performance.timeOrigin");
+  expect(typeof previousTimeOrigin).toBe("number");
+  await evalIn(surface, "location.reload(); true").catch(() => undefined);
+  await waitFor(surface, `performance.timeOrigin !== ${JSON.stringify(previousTimeOrigin)}`, {
+    timeoutMs: 10_000,
+    label,
+  });
+  return Date.now();
+}
+
+test(title, { timeout: 600_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  const stamp = Date.now();
+  await using den = await server({
+    place,
+    org: {
+      name: `Library session restore ${stamp}`,
+      admin: {
+        email: `library-session-restore-${stamp}@openwork.test`,
+        name: "Library Session Restore Admin",
+        password: "OpenWorkEval123!",
+      },
+    },
+  });
+  await using proxy = await faultProxy(den.ref, {
+    place,
+    sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
+  });
+  await using surface = await desktop({
+    name: "library-add-session-restore",
+    host: place.host(),
+    bootstrap: {
+      baseUrl: proxy.ref.webUrl,
+      apiBaseUrl: proxy.ref.webUrl,
+      requireSignin: false,
+    },
+  });
+
+  const selected = await createAndSelectWorkspace(surface, {
+    path: `/tmp/openwork-library-session-restore-${stamp}`,
+  });
+  const skillsRoute = `/workspace/${selected.workspaceId}/extensions/skills`;
+  const sessionRoute = `/workspace/${selected.workspaceId}/session`;
+
+  await go(surface, skillsRoute);
+  await waitFor(surface, `location.hash.endsWith(${JSON.stringify(skillsRoute)})
+    && Boolean(document.querySelector('input[placeholder="Search your library"]'))`, {
+    timeoutMs: 30_000,
+    label: "signed-out Skills Library",
+  });
+  const signedOutAddVisible = await evalIn(surface, `Boolean(${addSkillButton})`);
+  expect(signedOutAddVisible).toBe(false);
+  evidence.recordAssertionEvidence(
+    "A truly signed-out Skills Library hides Add skill",
+    "The fresh raw desktop rendered the Skills Library without an Add skill button before any Cloud credential was stored.",
+    signedOutAddVisible === false,
+  );
+
+  await go(surface, sessionRoute);
+  await waitFor(surface, `location.hash.endsWith(${JSON.stringify(sessionRoute)})`, {
+    timeoutMs: 10_000,
+    label: "pre-sign-in session route",
+  });
+  const navigationInstalled = await evalIn(surface, `(() => {
+    window.addEventListener("openwork-den-session-updated", (event) => {
+      if (event.detail?.status === "success") {
+        window.location.hash = ${JSON.stringify(`#${skillsRoute}`)};
+      }
+    }, { once: true });
+    return true;
+  })()`);
+  expect(navigationInstalled).toBe(true);
+  await signInDesktopAs(surface, proxy.ref, den.admin);
+  await waitFor(surface, `location.hash.endsWith(${JSON.stringify(skillsRoute)})`, {
+    timeoutMs: 5_000,
+    label: "immediate post-sign-in Skills route",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  const postSignInRoute = await evalIn(surface, "location.hash");
+  expect(postSignInRoute).toBe(`#${skillsRoute}`);
+  evidence.recordAssertionEvidence(
+    "The delayed sign-in redirect preserves newer navigation",
+    `The route remained ${postSignInRoute} one second after the successful sign-in event instead of reverting to /session.`,
+    postSignInRoute === `#${skillsRoute}`,
+  );
+
+  await proxy.faults.latency("/api/den/v1/me", 10_000, { times: 100 });
+  const healthyCommittedAt = await reloadCommitted(surface, "slow healthy session reload");
+  await waitFor(surface, pendingAddSkill, {
+    timeoutMs: 1_000,
+    label: "pending Add skill during slow healthy session check",
+  });
+  const healthyPendingElapsedMs = Date.now() - healthyCommittedAt;
+  expect(healthyPendingElapsedMs).toBeLessThanOrEqual(1_000);
+  evidence.recordAssertionEvidence(
+    "A persisted session exposes pending Add skill immediately",
+    `The disabled, busy Add skill button with the accessible “Checking session” label appeared ${healthyPendingElapsedMs}ms after reload.`,
+    healthyPendingElapsedMs <= 1_000,
+  );
+
+  const healthyBoundMs = 12_750;
+  await waitFor(surface, enabledAddSkill, {
+    timeoutMs: Math.max(1, healthyBoundMs - (Date.now() - healthyCommittedAt)),
+    label: "enabled Add skill after slow healthy session check",
+  });
+  const healthyEnabledElapsedMs = Date.now() - healthyCommittedAt;
+  expect(healthyEnabledElapsedMs).toBeLessThanOrEqual(healthyBoundMs);
+  expect(await evalIn(surface, `location.hash.endsWith(${JSON.stringify(skillsRoute)})`)).toBe(true);
+  const healthyFaults = (await proxy.requestLog()).filter((request) =>
+    request.faulted && request.path.startsWith("/api/den/v1/me")
+  );
+  expect(healthyFaults.length).toBeGreaterThan(0);
+  evidence.recordAssertionEvidence(
+    "Slow healthy Cloud confirmation enables Add skill within one timeout plus render margin",
+    `A real 10,000ms /v1/me latency was observed and Add skill enabled after ${healthyEnabledElapsedMs}ms without leaving /extensions/skills.`,
+    healthyEnabledElapsedMs <= healthyBoundMs && healthyFaults.length > 0,
+  );
+
+  await proxy.faults.clear();
+  await proxy.faults.latency("/api/den/v1/me", 20_000, { times: 100 });
+  const stalledCommittedAt = await reloadCommitted(surface, "stalled session reload");
+  await waitFor(surface, pendingAddSkill, {
+    timeoutMs: 1_000,
+    label: "pending Add skill during stalled session check",
+  });
+  const stalledPendingElapsedMs = Date.now() - stalledCommittedAt;
+  expect(stalledPendingElapsedMs).toBeLessThanOrEqual(1_000);
+
+  const stalledBoundMs = 13_500;
+  await waitFor(surface, `${enabledAddSkill}
+    && document.body.innerText.includes("OpenWork Cloud is temporarily unavailable.")`, {
+    timeoutMs: Math.max(1, stalledBoundMs - (Date.now() - stalledCommittedAt)),
+    label: "enabled Add skill after stalled session timeout",
+  });
+  const stalledEnabledElapsedMs = Date.now() - stalledCommittedAt;
+  expect(stalledEnabledElapsedMs).toBeGreaterThanOrEqual(11_500);
+  expect(stalledEnabledElapsedMs).toBeLessThanOrEqual(stalledBoundMs);
+  expect(await evalIn(surface, `location.hash.endsWith(${JSON.stringify(skillsRoute)})`)).toBe(true);
+  evidence.recordAssertionEvidence(
+    "A stalled Cloud check retains and enables the persisted session after timeout",
+    `With /v1/me delayed 20,000ms, Add skill changed from pending at ${stalledPendingElapsedMs}ms to enabled with the unavailable notice at ${stalledEnabledElapsedMs}ms.`,
+    stalledPendingElapsedMs <= 1_000
+      && stalledEnabledElapsedMs >= 11_500
+      && stalledEnabledElapsedMs <= stalledBoundMs,
+  );
+});


### PR DESCRIPTION
Closes #3981

## Findings
`libraryAddAction` is gated only by settings-local Cloud session confirmation, not capability inventory or engine readiness. That confirmation is bounded by the 12-second `/v1/me` timeout. The observed >120-second absence came from a separate race: a delayed post-sign-in `/session` redirect overwrote immediate Library navigation. Findings were posted on the issue before coding.

## Fix
- do not let the delayed sign-in redirect overwrite navigation made after the success event
- show a disabled, busy `Add skill` control while a persisted credential/org is being confirmed
- enable it after successful confirmation or retained-unavailable timeout
- keep Add hidden for truly signed-out users

## Verification
- Lane: local fallback (Daytona credentials unavailable).
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `env -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL -u OPENWORK_EVAL_DAYTONA OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/library-add-session-restore.e2e.test.ts` — exit 0; 1 passed, 0 failed, 0 skipped.
- Proof covers signed-out absence, immediate route stability, pending Add within 1s, 10s healthy confirmation within 12.75s, and a 20s stall enabling through the 12s timeout within 13.5s.

Evidence will be published to this PR.