### PR TITLE
feat(connectors): add Xquik OAuth MCP preset

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -77,6 +77,13 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     authType: "oauth",
   },
   {
+    presetId: "xquik",
+    displayName: "Xquik",
+    description: "Search tweets, inspect profiles, export followers, and automate X workflows.",
+    url: "https://xquik.com/mcp",
+    authType: "oauth",
+  },
+  {
     presetId: "slack",
     displayName: "Slack",
     description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",

--- a/ee/apps/den-api/test/external-mcp-resolve.test.ts
+++ b/ee/apps/den-api/test/external-mcp-resolve.test.ts
@@ -87,11 +87,13 @@ describe("matchPresetForQuery", () => {
     expect(matchPresetForQuery("notion", EXTERNAL_MCP_PRESETS)?.presetId).toBe("notion")
     expect(matchPresetForQuery("  Linear ", EXTERNAL_MCP_PRESETS)?.presetId).toBe("linear")
     expect(matchPresetForQuery("CONTEXT7", EXTERNAL_MCP_PRESETS)?.presetId).toBe("context7")
+    expect(matchPresetForQuery("Xquik", EXTERNAL_MCP_PRESETS)?.presetId).toBe("xquik")
   })
 
   test("matches by preset URL host for URL and domain queries", () => {
     expect(matchPresetForQuery("https://mcp.notion.com/mcp", EXTERNAL_MCP_PRESETS)?.presetId).toBe("notion")
     expect(matchPresetForQuery("mcp.stripe.com", EXTERNAL_MCP_PRESETS)?.presetId).toBe("stripe")
+    expect(matchPresetForQuery("https://xquik.com/mcp", EXTERNAL_MCP_PRESETS)?.presetId).toBe("xquik")
   })
 
   test("returns null for unknown names", () => {

--- a/evals/specs/connectors-quick-add.e2e.test.ts
+++ b/evals/specs/connectors-quick-add.e2e.test.ts
@@ -81,11 +81,11 @@ test(title, async ({ evidence, place }) => {
       && Boolean(document.querySelector('[data-testid="connector-quick-add-grid"]'))
       && groupHeaders.includes("From your workspace suite")
       && groupHeaders.includes("MCP servers")
-      && document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 10
+      && document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 11
       && (document.querySelector('[data-testid="quick-add-preset-slack"]')?.textContent ?? "").includes("OAuth app required")
       && (document.querySelector('[data-testid="quick-add-preset-exa"]')?.textContent ?? "").includes("API key")
       && (document.querySelector('[data-testid="quick-add-preset-context7"]')?.textContent ?? "").includes("Instant")
-      && (document.querySelector('[data-testid="quick-add-preset-notion"]')?.textContent ?? "").includes("One-click");
+      && (document.querySelector('[data-testid="quick-add-preset-xquik"]')?.textContent ?? "").includes("One-click");
   })()`, {
     timeoutMs: 60_000,
     label: "full connectors quick-add bar, groups, and preset effort badges",
@@ -107,12 +107,12 @@ test(title, async ({ evidence, place }) => {
     const headers = [...document.querySelectorAll("h4")].map((entry) => (entry.textContent ?? "").trim());
     return headers.includes("From your workspace suite") && headers.includes("MCP servers");
   })()`);
-  expect(fullPresetCount).toBe(10);
+  expect(fullPresetCount).toBe(11);
   expect(bothGroupHeaders).toBe(true);
   evidence.recordAssertionEvidence(
-    "Quick add separates the workspace suite from all ten MCP server presets",
+    "Quick add separates the workspace suite from all eleven MCP server presets",
     `Both group headers present: ${String(bothGroupHeaders)}; MCP preset tiles: ${String(fullPresetCount)}.`,
-    bothGroupHeaders === true && fullPresetCount === 10,
+    bothGroupHeaders === true && fullPresetCount === 11,
   );
 
   const effortBadgesMatch = await evalIn(browser, `(() => {
@@ -120,12 +120,12 @@ test(title, async ({ evidence, place }) => {
     return text("quick-add-preset-slack").includes("OAuth app required")
       && text("quick-add-preset-exa").includes("API key")
       && text("quick-add-preset-context7").includes("Instant")
-      && text("quick-add-preset-notion").includes("One-click");
+      && text("quick-add-preset-xquik").includes("One-click");
   })()`);
   expect(effortBadgesMatch).toBe(true);
   evidence.recordAssertionEvidence(
     "Preset tiles disclose OAuth-app, API-key, instant, and one-click setup effort",
-    "Slack showed OAuth app required; Exa showed API key; Context7 showed Instant; Notion showed One-click.",
+    "Slack showed OAuth app required; Exa showed API key; Context7 showed Instant; Xquik showed One-click.",
     effortBadgesMatch === true,
   );
   // Context7's Instant mechanism is covered without clicking it here: doing so
@@ -165,7 +165,7 @@ test(title, async ({ evidence, place }) => {
   );
 
   await replaceSmartBarText(browser, "");
-  await waitFor(browser, `document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 10`, {
+  await waitFor(browser, `document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 11`, {
     timeoutMs: 20_000,
     label: "full preset grid after clearing the smart bar",
   });
@@ -226,10 +226,10 @@ test(title, async ({ evidence, place }) => {
     const notice = [...document.querySelectorAll('[role="status"]')]
       .find((entry) => (entry.textContent ?? "").includes("added for everyone"));
     return Boolean(row && notice)
-      && document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 10;
+      && document.querySelectorAll('[data-testid^="quick-add-preset-"]').length === 11;
   })()`, {
     timeoutMs: 60_000,
-    label: "created mock connection row, success notice, and restored ten-preset grid",
+    label: "created mock connection row, success notice, and restored eleven-preset grid",
   });
 
   const createdRowTestId = await evalIn(browser, `([...document.querySelectorAll('[data-testid^="mcp-connection-row-"]')]
@@ -238,16 +238,16 @@ test(title, async ({ evidence, place }) => {
   const restoredPresetCount = await evalIn(browser, `document.querySelectorAll('[data-testid^="quick-add-preset-"]').length`);
   expect(typeof createdRowTestId).toBe("string");
   expect(createdRowTestId).toMatch(/^mcp-connection-row-/);
-  expect(restoredPresetCount).toBe(10);
+  expect(restoredPresetCount).toBe(11);
   // This mock connection uses a custom URL, so no curated tile should flip to
   // Added. The Added/Manage tile mechanism has focused Bun coverage; this app
-  // spec scopes frame 6 to the real row plus the unaffected ten-preset grid.
+  // spec scopes frame 6 to the real row plus the unaffected eleven-preset grid.
   evidence.recordAssertionEvidence(
     "Add connection creates a row in Your connectors without disturbing the preset grid",
     `Created row test id: ${String(createdRowTestId)}; remaining preset tiles: ${String(restoredPresetCount)}.`,
     typeof createdRowTestId === "string"
       && createdRowTestId.startsWith("mcp-connection-row-")
-      && restoredPresetCount === 10,
+      && restoredPresetCount === 11,
   );
 
   const handshakes = await connector.handshakes({

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sharing MCP connections with your team"
-description: "Share Notion, Linear, Stripe, Exa, or any MCP server in OpenWork Cloud with Individual accounts by default, or One org account when everyone should act as the same account"
+description: "Share managed MCP servers through OpenWork Cloud. Use individual accounts by default, or one organization account for a shared identity."
 ---
 
 Use `Connectors` when you want the organization to manage an MCP integration once
@@ -20,8 +20,7 @@ Two ways to handle whose account the AI uses, chosen per connection:
 
 1. Open `Connectors` in the OpenWork Cloud dashboard.
 2. Click `Add connection`.
-3. Pick a preset (Notion, Linear, Stripe, Sentry, Exa, Context7) or enter any
-   MCP server URL.
+3. Pick a preset or enter any MCP server URL.
 4. Choose the account mode: `Individual accounts` or `One org account`.
 5. Choose who can use it: the whole workspace, specific teams, or specific
    people.


### PR DESCRIPTION
## Problem and outcome

OpenWork demonstrates Twitter reply exports, but its managed catalog has no dedicated X data connector. Admins must already know and paste a custom endpoint even though the verified preset path exists for this setup.

- **Outcome:** Connectors shows Xquik as a one-click OAuth preset and resolves it by name or URL.
- **Invariant:** Authentication, access grants, discovery, and tool policy remain owned by the existing external MCP connection path.
- **Scope boundary:** This does not add credentials, provider-specific OAuth code, direct tool execution, or a local desktop fallback entry.

## Review guidance

- **Feedback requested:** Confirm that the hosted server meets the bar for a managed OAuth preset and that the proof covers the visible catalog change.
- **Start here:** `ee/apps/den-api/src/capability-sources/external-mcp-presets.ts:79`; this is the only runtime catalog change.
- **Review order:** Preset data, resolver assertions, connector browser spec, then the documentation cleanup.
- **Lower-attention areas:** The browser spec changes only the preset count and Xquik tile assertion. The docs change removes a stale provider enumeration.
- **Known risk or uncertainty:** The remote connector depends on Xquik availability, like every hosted preset.

## Solution

Add `https://xquik.com/mcp` as a standard OAuth preset. OpenWork's existing discovery client handles its protected-resource metadata, client metadata documents, dynamic registration, PKCE, and authorization-response issuer validation. The resolver tests bind the curated name and host to that endpoint. The existing browser spec proves the new tile without contacting the provider or executing a tool.

The shared-connections guide previously listed only 6 of the 10 existing presets. It now describes the stable action instead of maintaining another incomplete catalog copy.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | An admin enters the Xquik URL through advanced custom setup. | An admin selects Xquik from Quick add and uses the normal one-click OAuth flow. |
| **Failure behavior** | Custom discovery reports existing connector errors and OAuth requirements. | The preset uses the same discovery, diagnostics, grants, and policy enforcement. |

### User flow

```mermaid
flowchart LR
  A[Admin opens Connectors] --> B[Select Xquik]
  B --> C[Publish access grants]
  C --> D[Member completes OAuth]
  D --> E[OpenWork searches and executes approved capabilities]
```

## Validation

- `pnpm --dir ee/apps/den-api exec bun test test/external-mcp-resolve.test.ts test/external-mcp-preset-oauth-defaults.test.ts`; 23 passed; proves preset resolution and response-schema compatibility.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit`; passed; proves Den API type safety.
- `pnpm --filter @openwork-ee/den-web typecheck`; passed; proves the connector UI remains type-safe.
- `pnpm --dir ee/apps/den-web exec bun test tests/connector-quick-add-v2.test.ts`; 2 passed; proves the quick-add surface contract.
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/connectors-quick-add.e2e.test.ts`; spec compiled and registered, then skipped because `OPENWORK_EVAL_E2E_TESTS` was unset.
- Live `discoverConnectionRequirements` through `@openwork/enterprise-mcp-client` returned `ready`, OAuth issuer `https://xquik.com`, required scope `mcp:tools`, client metadata and dynamic registration support, and zero warnings.
- **Not verified:** The full browser OAuth journey requires the opt-in E2E stack and a user authorization. No credential was created or stored during this change.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing connections and custom URL setup do not change. | The patch adds one preset and reuses the current route. |
| Security / permissions / data | No secret or new authorization path is introduced. Existing per-member OAuth, grants, and tool policy remain authoritative. | Live discovery plus the unchanged external MCP client path. |
| Rollout / rollback | The preset is additive. Remove its catalog entry and assertions to roll back. | `external-mcp-presets.ts` and focused tests. |
| Documentation / communication | The guide no longer duplicates an incomplete provider list. | `shared-mcp-connections.mdx`. |

## Links

- Closes #3995

