### PR TITLE
fix(chat): keep live thinking still when the user scrolls it

### DIFF
--- a/apps/app/src/components/chat/live-step-scroll.ts
+++ b/apps/app/src/components/chat/live-step-scroll.ts
@@ -1,0 +1,28 @@
+export const LIVE_STEP_BOTTOM_GAP_PX = 16
+
+export type LiveStepScrollBox = {
+  scrollHeight: number
+  scrollTop: number
+  clientHeight: number
+}
+
+export function isLiveStepAtBottom(box: LiveStepScrollBox, gapPx = LIVE_STEP_BOTTOM_GAP_PX) {
+  return box.scrollHeight - (box.scrollTop + box.clientHeight) <= gapPx
+}
+
+export function shouldFollowLiveStepGrowth(input: { isLive: boolean; pinned: boolean }) {
+  return input.isLive && input.pinned
+}
+
+export function pinnedAfterUserScroll(atBottom: boolean) {
+  return atBottom
+}
+
+export function pinnedAfterWheel(input: {
+  deltaY: number
+  pinned: boolean
+  atBottom: boolean
+}) {
+  if (input.deltaY < 0) return false
+  return input.pinned && input.atBottom
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -82,6 +82,12 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import {
+  isLiveStepAtBottom,
+  pinnedAfterUserScroll,
+  pinnedAfterWheel,
+  shouldFollowLiveStepGrowth,
+} from "@/components/chat/live-step-scroll"
 import { hasPreservedMcpAppResult, McpAppFrame } from "@/components/chat/mcp-app-frame"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { SubagentRunLine } from "@/components/chat/subagent-run-line"
@@ -960,13 +966,42 @@ function MessageGroup({
   const lastRealItem = items.findLast((item) => !isSessionErrorMessage(item.message))
   const isLiveGroup = isStreaming && lastItem !== undefined && lastItem.index === messages.length - 1
   const stepsRef = React.useRef<HTMLDivElement>(null)
+  const stepsPinnedRef = React.useRef(true)
+  const stepsProgrammaticRef = React.useRef(false)
 
-  // Keep the capped step run pinned to the latest step while streaming.
-  React.useEffect(() => {
+  const handleStepsScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const atBottom = isLiveStepAtBottom(event.currentTarget)
+    if (stepsProgrammaticRef.current && atBottom) return
+    stepsProgrammaticRef.current = false
+    stepsPinnedRef.current = pinnedAfterUserScroll(atBottom)
+  }, [])
+
+  const handleStepsWheel = React.useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    const nextPinned = pinnedAfterWheel({
+      deltaY: event.deltaY,
+      pinned: stepsPinnedRef.current,
+      atBottom: isLiveStepAtBottom(event.currentTarget),
+    })
+    stepsPinnedRef.current = nextPinned
+    if (!nextPinned) stepsProgrammaticRef.current = false
+  }, [])
+
+  // Follow the latest live step only while the user is still at the tail.
+  // Wheel-up unpins immediately so streaming re-renders cannot yank the list
+  // back to the bottom while they browse earlier thinking.
+  React.useLayoutEffect(() => {
     const node = stepsRef.current
-    if (node && isLiveGroup) {
-      node.scrollTop = node.scrollHeight
+    if (!node) return
+    if (!shouldFollowLiveStepGrowth({ isLive: isLiveGroup, pinned: stepsPinnedRef.current })) {
+      node.style.overflowAnchor = "auto"
+      return
     }
+    node.style.overflowAnchor = "none"
+    stepsProgrammaticRef.current = true
+    node.scrollTop = node.scrollHeight
+    window.requestAnimationFrame(() => {
+      stepsProgrammaticRef.current = false
+    })
   })
 
   if (!lastItem || isMessageEmptyGroup(items)) {
@@ -1106,13 +1141,20 @@ function MessageGroup({
       {stepItems.length > 0 ? (
         collapseSteps ? (
           <CompletedStepRun label={stepRunLabel}>
-            <div className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
+            <div data-scrollable="" className="flex max-h-[520px] flex-col gap-2 overflow-y-auto overscroll-y-contain">
               {renderItems(stepItems, 0)}
               {foldedReasoning}
             </div>
           </CompletedStepRun>
         ) : (
-          <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
+          <div
+            ref={stepsRef}
+            data-scrollable=""
+            data-live-steps=""
+            onScroll={handleStepsScroll}
+            onWheel={handleStepsWheel}
+            className="flex max-h-[520px] flex-col gap-2 overflow-y-auto overscroll-y-contain"
+          >
             {renderItems(stepItems, 0)}
           </div>
         )

--- a/apps/app/tests/live-step-scroll.test.ts
+++ b/apps/app/tests/live-step-scroll.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isLiveStepAtBottom,
+  pinnedAfterUserScroll,
+  pinnedAfterWheel,
+  shouldFollowLiveStepGrowth,
+} from "../src/components/chat/live-step-scroll";
+
+describe("live step scroll", () => {
+  test("follows streaming growth only while the user is pinned to the tail", () => {
+    expect(shouldFollowLiveStepGrowth({ isLive: true, pinned: true })).toBe(true);
+    expect(shouldFollowLiveStepGrowth({ isLive: true, pinned: false })).toBe(false);
+    expect(shouldFollowLiveStepGrowth({ isLive: false, pinned: true })).toBe(false);
+  });
+
+  test("a wheel-up gesture unpins even when the list is still at the bottom", () => {
+    expect(pinnedAfterWheel({ deltaY: -12, pinned: true, atBottom: true })).toBe(false);
+    expect(pinnedAfterUserScroll(false)).toBe(false);
+    expect(pinnedAfterUserScroll(true)).toBe(true);
+  });
+
+  test("treats a small tail gap as still at the bottom", () => {
+    expect(isLiveStepAtBottom({ scrollHeight: 800, scrollTop: 284, clientHeight: 520 })).toBe(true);
+    expect(isLiveStepAtBottom({ scrollHeight: 800, scrollTop: 100, clientHeight: 520 })).toBe(false);
+  });
+});

--- a/evals/specs/live-step-scroll.test.ts
+++ b/evals/specs/live-step-scroll.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  isLiveStepAtBottom,
+  pinnedAfterUserScroll,
+  pinnedAfterWheel,
+  shouldFollowLiveStepGrowth,
+} from "../../apps/app/src/components/chat/live-step-scroll";
+
+const messageListPath = fileURLToPath(
+  new URL("../../apps/app/src/components/chat/message-list.tsx", import.meta.url),
+);
+
+test("live thinking stays put when the user scrolls the step list", ({ evidence }) => {
+  const overflowingBottom = { scrollHeight: 2_000, scrollTop: 1_480, clientHeight: 520 };
+  const nearBottom = { scrollHeight: 2_000, scrollTop: 1_470, clientHeight: 520 };
+  const browsing = { scrollHeight: 2_000, scrollTop: 240, clientHeight: 520 };
+
+  expect(isLiveStepAtBottom(overflowingBottom)).toBe(true);
+  expect(isLiveStepAtBottom(nearBottom)).toBe(true);
+  expect(isLiveStepAtBottom(browsing)).toBe(false);
+
+  expect(shouldFollowLiveStepGrowth({ isLive: true, pinned: true })).toBe(true);
+  expect(shouldFollowLiveStepGrowth({ isLive: true, pinned: false })).toBe(false);
+  expect(shouldFollowLiveStepGrowth({ isLive: false, pinned: true })).toBe(false);
+
+  expect(pinnedAfterWheel({ deltaY: -40, pinned: true, atBottom: true })).toBe(false);
+  expect(pinnedAfterWheel({ deltaY: 40, pinned: true, atBottom: true })).toBe(true);
+  expect(pinnedAfterWheel({ deltaY: 40, pinned: false, atBottom: false })).toBe(false);
+  expect(pinnedAfterUserScroll(false)).toBe(false);
+  expect(pinnedAfterUserScroll(true)).toBe(true);
+
+  const source = readFileSync(messageListPath, "utf8");
+  expect(source).toContain("shouldFollowLiveStepGrowth");
+  expect(source).toContain("pinnedAfterWheel");
+  expect(source).toContain('data-live-steps=""');
+  expect(source).toContain('data-scrollable=""');
+  expect(source).not.toContain("if (node && isLiveGroup)");
+
+  evidence.recordAssertionEvidence(
+    "Scrolling live thinking leaves earlier steps on screen",
+    "Wheel-up unpins the height-capped step list, so streaming growth no longer forces scrollTop back to the latest step. Returning to the tail re-pins; finished turns still fold as before.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- The live thinking / tool-step list was forcing `scrollTop` to the bottom on every streaming render, so scrolling earlier steps was immediately undone.
- Follow the tail only while the user is still there. A wheel-up unpins immediately; returning to the bottom re-pins. Nested step lists are marked as their own scroll surface so they do not steal the session's stick-to-bottom gesture.

## Test plan
- [ ] Start a long streaming turn with many thinking/tool rows
- [ ] Scroll up through the ongoing thinking list and confirm earlier rows stay on screen as new steps arrive
- [ ] Scroll back to the latest step and confirm the list follows new work again
- [ ] Confirm a finished long turn still folds behind `Worked for…`

Proof on `19ae3b4ec` (local, Daytona credentials unavailable):
- `pnpm --filter @openwork/app exec bun test --isolate tests/live-step-scroll.test.ts tests/message-list-step-fold.test.tsx tests/message-list-loading.test.tsx` — 9 passed
- `pnpm evals:pr specs/live-step-scroll.test.ts` — 1 passed, 0 skipped


Made with [Cursor](https://cursor.com)