### PR TITLE
fix(server): refresh Connect MCP App catalog on cache miss

### DIFF
--- a/apps/server/src/connect-mcp-server-catalog.test.ts
+++ b/apps/server/src/connect-mcp-server-catalog.test.ts
@@ -12,6 +12,9 @@ import {
   readOpenWorkConnectMcpAppHostCatalog,
   readOpenWorkConnectMcpServerIndex,
   reconcileOpenWorkConnectMcpServers,
+  refreshOpenWorkConnectMcpAppHostCatalog,
+  writeOpenWorkConnectMcpAppHostAuthorization,
+  writeOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
 import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
@@ -142,6 +145,63 @@ describe("OpenWork Connect MCP server catalog", () => {
         url: `https://api.openworklabs.com/mcp/agent/connections/${connectionId}`,
       }],
     });
+  });
+
+  test("opportunistically refreshes a stale private catalog from the runtime Cloud endpoint", async () => {
+    const config = await fixtureConfig();
+    const connectionId = "emc_01k28e8q8pf8r9sff9mhyqxved";
+    const requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
+    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+      mcp: {
+        "openwork-cloud": { type: "remote", url: "https://api.openworklabs.com/mcp/agent" },
+      },
+    }));
+    await writeOpenWorkConnectMcpAppHostAuthorization(
+      config,
+      "ws_1",
+      "Bearer private-app-host-token",
+      "https://api.openworklabs.com/mcp/agent",
+    );
+
+    const result = await refreshOpenWorkConnectMcpAppHostCatalog(config, "ws_1", indexFetcher(requests));
+
+    expect(result).toEqual({ status: "synced", appHostNames: [connectMcpAppHostName(connectionId)] });
+    expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers[0]?.connectionId).toBe(connectionId);
+    expect(requests.every((request) => request.headers.get("authorization") === "Bearer private-app-host-token")).toBe(true);
+  });
+
+  test("preserves the last known-good catalog when an opportunistic refresh is unavailable", async () => {
+    const config = await fixtureConfig();
+    const connectionId = "emc_01lastknowngood";
+    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+      mcp: {
+        "openwork-cloud": { type: "remote", url: "https://api.openworklabs.com/mcp/agent" },
+      },
+    }));
+    await writeOpenWorkConnectMcpAppHostAuthorization(
+      config,
+      "ws_1",
+      "Bearer private-app-host-token",
+      "https://api.openworklabs.com/mcp/agent",
+    );
+    await writeOpenWorkConnectMcpAppHostCatalog(config, "ws_1", {
+      schemaVersion: "openwork.connect/mcp-servers/1",
+      servers: [{
+        connectionId,
+        name: "Last known good",
+        description: null,
+        url: `https://api.openworklabs.com/mcp/agent/connections/${connectionId}`,
+      }],
+    });
+
+    const result = await refreshOpenWorkConnectMcpAppHostCatalog(
+      config,
+      "ws_1",
+      async () => new Response(null, { status: 503 }),
+    );
+
+    expect(result).toEqual({ status: "unavailable", appHostNames: [] });
+    expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers[0]?.connectionId).toBe(connectionId);
   });
 
   test("fails closed and purges prior runtime entries when Cloud has no index", async () => {

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 
 import { readMcpResourceText, type McpFetch } from "./connect-mcp-transport.js";
 import { readActivatedEnterpriseDenOrigin } from "./enterprise-den-origin.js";
-import { runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  readRuntimeMcpConfig,
+  runtimeMcpMap,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { createWorkspaceKvStore } from "./workspace-kv-store.js";
@@ -196,6 +200,37 @@ export async function readOpenWorkConnectMcpServerIndex(
   const cloudOrigin = endpointOrigin(cloudMcp.url);
   if (!cloudOrigin || parsed.data.servers.some((server) => endpointOrigin(server.url) !== cloudOrigin)) return null;
   return parsed.data;
+}
+
+/**
+ * Refreshes the private App-host catalog when a gateway launch proves the
+ * cached catalog may be stale. Unlike startup reconciliation, an unavailable
+ * opportunistic refresh preserves the last known-good catalog.
+ */
+export async function refreshOpenWorkConnectMcpAppHostCatalog(
+  config: ServerConfig,
+  workspaceId: string,
+  fetcher?: McpFetch,
+): Promise<{ status: "synced" | "unavailable"; appHostNames: string[] }> {
+  const cloudMcp = await readRuntimeMcpConfig(config, workspaceId, "openwork-cloud");
+  if (!cloudMcp || !await trustedAppHostCloudEndpoint(cloudMcp)) {
+    return { status: "unavailable", appHostNames: [] };
+  }
+  const appHostAuthorization = await readOpenWorkConnectMcpAppHostAuthorization(
+    config,
+    workspaceId,
+    String(cloudMcp.url),
+  );
+  if (!appHostAuthorization) return { status: "unavailable", appHostNames: [] };
+
+  const index = await readOpenWorkConnectMcpServerIndex(cloudMcp, appHostAuthorization, fetcher).catch(() => null);
+  if (!index) return { status: "unavailable", appHostNames: [] };
+
+  await writeOpenWorkConnectMcpAppHostCatalog(config, workspaceId, index);
+  return {
+    status: "synced",
+    appHostNames: index.servers.map((server) => connectMcpAppHostName(server.connectionId)).sort(),
+  };
 }
 
 /**

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -12,7 +12,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { addMcp } from "./mcp.js";
 import {
+  CONNECT_MCP_SERVER_INDEX_URI,
   connectMcpAppHostName,
+  readOpenWorkConnectMcpAppHostCatalog,
   writeOpenWorkConnectMcpAppHostAuthorization,
   writeOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
@@ -58,8 +60,12 @@ function serverConfig(root: string): ServerConfig {
   };
 }
 
-async function startFixtureMcp(resourceContent: { text?: string; blob?: string } = { text: RESOURCE_HTML }) {
+async function startFixtureMcp(
+  resourceContent: { text?: string; blob?: string } = { text: RESOURCE_HTML },
+  connectionId?: string,
+) {
   let activeResourceUri = RESOURCE_URI;
+  let catalogReads = 0;
   const mcp = new Server(
     { name: "mcp-app-fixture", version: "1.0.0" },
     {
@@ -146,11 +152,51 @@ async function startFixtureMcp(resourceContent: { text?: string; blob?: string }
   }));
 
   let transport: WebStandardStreamableHTTPServerTransport;
+  let serverOrigin = "";
   const http = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch: (request) => transport.handleRequest(request),
+    fetch: async (request): Promise<Response> => {
+      if (new URL(request.url).pathname !== "/catalog" || !connectionId) {
+        return await transport.handleRequest(request);
+      }
+      const body: unknown = await request.json();
+      const method = body && typeof body === "object" ? Reflect.get(body, "method") : null;
+      const id = body && typeof body === "object" ? Reflect.get(body, "id") : null;
+      if (method === "initialize") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id,
+          result: { protocolVersion: "2025-06-18", capabilities: { resources: {} } },
+        });
+      }
+      if (method === "notifications/initialized") return new Response(null, { status: 202 });
+      if (method === "resources/read") {
+        catalogReads += 1;
+        return Response.json({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            contents: [{
+              uri: CONNECT_MCP_SERVER_INDEX_URI,
+              mimeType: "application/json",
+              text: JSON.stringify({
+                schemaVersion: "openwork.connect/mcp-servers/1",
+                servers: [{
+                  connectionId,
+                  name: "Fixture provider",
+                  description: null,
+                  url: `${serverOrigin}/provider`,
+                }],
+              }),
+            }],
+          },
+        });
+      }
+      return new Response(null, { status: 404 });
+    },
   });
+  serverOrigin = `http://127.0.0.1:${http.port}`;
   const reconnect = async () => {
     await mcp.close();
     transport = new WebStandardStreamableHTTPServerTransport({
@@ -167,7 +213,9 @@ async function startFixtureMcp(resourceContent: { text?: string; blob?: string }
     http.stop(true);
   });
   return {
-    url: `http://127.0.0.1:${http.port}`,
+    url: `${serverOrigin}/provider`,
+    catalogUrl: `${serverOrigin}/catalog`,
+    catalogReads: () => catalogReads,
     activateUpdatedResource: async () => {
       activeResourceUri = UPDATED_RESOURCE_URI;
       // A stateful SDK server transport owns one initialized MCP session. The
@@ -183,7 +231,12 @@ async function configuredFixture(
   resourceContent?: { text?: string; blob?: string },
   mcpName = "fixture",
   connectionId?: string,
-): Promise<{ config: ServerConfig; root: string; activateUpdatedResource: () => Promise<void> }> {
+): Promise<{
+  config: ServerConfig;
+  root: string;
+  activateUpdatedResource: () => Promise<void>;
+  catalogReads: () => number;
+}> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
   const previousDevMode = process.env.OPENWORK_DEV_MODE;
@@ -198,7 +251,7 @@ async function configuredFixture(
   });
   await mkdir(join(root, ".git"), { recursive: true });
   const config = serverConfig(root);
-  const fixture = await startFixtureMcp(resourceContent);
+  const fixture = await startFixtureMcp(resourceContent, connectionId);
   const mcpConfig = {
     type: "remote",
     url: fixture.url,
@@ -210,18 +263,32 @@ async function configuredFixture(
       ...current,
       mcp: {
         ...runtimeMcpMap(current),
-        "openwork-cloud": { ...mcpConfig, headers: { Authorization: "Bearer member-token" } },
+        "openwork-cloud": {
+          ...mcpConfig,
+          url: fixture.catalogUrl,
+          headers: { Authorization: "Bearer member-token" },
+        },
       },
     }));
     await writeOpenWorkConnectMcpAppHostCatalog(config, WORKSPACE_ID, {
       schemaVersion: "openwork.connect/mcp-servers/1",
       servers: [{ connectionId, name: "Fixture provider", description: null, url: fixture.url }],
     });
-    await writeOpenWorkConnectMcpAppHostAuthorization(config, WORKSPACE_ID, "Bearer app-host-token", fixture.url);
+    await writeOpenWorkConnectMcpAppHostAuthorization(
+      config,
+      WORKSPACE_ID,
+      "Bearer app-host-token",
+      fixture.catalogUrl,
+    );
   } else {
     await addMcp(config, WORKSPACE_ID, mcpName, mcpConfig);
   }
-  return { config, root, activateUpdatedResource: fixture.activateUpdatedResource };
+  return {
+    config,
+    root,
+    activateUpdatedResource: fixture.activateUpdatedResource,
+    catalogReads: fixture.catalogReads,
+  };
 }
 
 describe("MCP Apps host transport", () => {
@@ -253,7 +320,7 @@ describe("MCP Apps host transport", () => {
   test("resolves a capability gateway launch through its exact native Connect tool", async () => {
     const connectionId = "emc_01mcpappgatewayfixture";
     const serverName = connectMcpAppHostName(connectionId);
-    const { config, root } = await configuredFixture(
+    const { config, root, catalogReads } = await configuredFixture(
       "openwork-mcp-app-host-gateway-",
       undefined,
       serverName,
@@ -278,6 +345,42 @@ describe("MCP Apps host transport", () => {
       html: RESOURCE_HTML,
     });
     expect(Object.keys(runtimeMcpMap(await readRuntimeOpencodeConfig(config, WORKSPACE_ID)))).toEqual(["openwork-cloud"]);
+    expect(catalogReads()).toBe(0);
+  });
+
+  test("refreshes a missing private catalog entry when a capability gateway launch arrives", async () => {
+    const connectionId = "emc_01mcpappgatewayrefresh";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root, catalogReads } = await configuredFixture(
+      "openwork-mcp-app-host-gateway-refresh-",
+      undefined,
+      serverName,
+      connectionId,
+    );
+    await writeOpenWorkConnectMcpAppHostCatalog(config, WORKSPACE_ID, {
+      schemaVersion: "openwork.connect/mcp-servers/1",
+      servers: [],
+    });
+
+    const app = await resolveConnectMcpAppResource({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      launch: {
+        connectionId,
+        toolName: "render_fixture",
+        resourceUri: RESOURCE_URI,
+      },
+    });
+
+    expect(app).toMatchObject({
+      serverName,
+      toolName: "render_fixture",
+      resourceUri: RESOURCE_URI,
+      html: RESOURCE_HTML,
+    });
+    expect((await readOpenWorkConnectMcpAppHostCatalog(config, WORKSPACE_ID)).servers[0]?.connectionId).toBe(connectionId);
+    expect(catalogReads()).toBe(1);
   });
 
   test("rejects a stale private catalog endpoint outside the credential's trusted origin", async () => {

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -8,6 +8,7 @@ import {
   connectMcpAppHostName,
   findOpenWorkConnectMcpAppHostServer,
   readOpenWorkConnectMcpAppHostAuthorization,
+  refreshOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
 import type { ServerConfig } from "./types.js";
 import {
@@ -260,11 +261,21 @@ async function privateConnectMcpConfig(input: {
   connectionId?: string;
   serverName?: string;
 }): Promise<{ serverName: string; config: Record<string, unknown> } | null> {
-  const descriptor = await findOpenWorkConnectMcpAppHostServer(
+  let descriptor = await findOpenWorkConnectMcpAppHostServer(
     input.serverConfig,
     input.workspaceId,
     { connectionId: input.connectionId, serverName: input.serverName },
   );
+  if (!descriptor) {
+    const refreshed = await refreshOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
+    if (refreshed.status === "synced") {
+      descriptor = await findOpenWorkConnectMcpAppHostServer(
+        input.serverConfig,
+        input.workspaceId,
+        { connectionId: input.connectionId, serverName: input.serverName },
+      );
+    }
+  }
   if (!descriptor) return null;
   const appHostAuthorization = await readOpenWorkConnectMcpAppHostAuthorization(
     input.serverConfig,

--- a/evals/specs/remote-mcp-apps.e2e.test.ts
+++ b/evals/specs/remote-mcp-apps.e2e.test.ts
@@ -17,7 +17,7 @@ const title = !e2eTestsEnabled
     ? "Remote MCP Apps skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
     : !mysqlOpen
       ? "Remote MCP Apps skipped — needs MySQL on 127.0.0.1:3306"
-      : "standard MCP Apps stay behind capability search while standalone URL Apps remain unavailable";
+      : "standard MCP Apps refresh after connection changes while standalone URL Apps remain unavailable";
 const providerId = "remote-mcp-apps-provider";
 const modelId = "remote-mcp-apps-model";
 const desktopClosingReply = "Project Atlas is open through its standard MCP server.";
@@ -872,6 +872,30 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     return "ok";
   })()`, { awaitPromise: true, timeoutMs: 60_000 });
   expect(configured).toBe("ok");
+
+  const lateConnection = await createOrgConnection(den.admin, {
+    name: "Atlas added after Desktop reconcile",
+    url: `${fixtureUrl}/mcp`,
+    authType: "none",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  gatewayCapabilityName = `mcp:${lateConnection.id}:open_project_atlas`;
+  const refreshedIndexRead = await agentRpc(
+    den.ref.apiUrl,
+    appHostMcpToken,
+    "resources/read",
+    { uri: "openwork://connect/mcp-servers/index.json" },
+    "/mcp/agent",
+    appHostCapabilityHeaders,
+  );
+  const refreshedIndex = requireRecord(
+    JSON.parse(String(contentsFrom(refreshedIndexRead)[0]?.text ?? "{}")),
+    "refreshed Connect MCP server index",
+  );
+  const refreshedServers = Array.isArray(refreshedIndex.servers) ? refreshedIndex.servers.filter(isRecord) : [];
+  expect(refreshedServers).toContainEqual(expect.objectContaining({ connectionId: lateConnection.id }));
+
   await evalIn(desktopApp, "location.reload(); true");
   await waitFor(desktopApp, "Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "desktop control after reload" });
   const engineReady = await evalIn(desktopApp, `(async () => {
@@ -975,7 +999,7 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(persistedMcpResult._meta).toEqual({
     source: "project-atlas-standard-mcp",
     "openwork/mcpApp": {
-      connectionId: connection.id,
+      connectionId: lateConnection.id,
       toolName: "open_project_atlas",
       resourceUri: connectedResourceUri,
       arguments: {},
@@ -1054,8 +1078,8 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(standardMcpCalls).toBe(4);
 
   evidence.recordAssertionEvidence(
-    "Native MCP Apps stay bounded while standalone URL Apps remain unavailable",
-    `Kept every model-visible provider operation behind search_capabilities and execute_capability; exposed only the regular connected Project Atlas App binding on connection ${connection.id} to the App host; blocked direct provider access; proved the URL import tool, REST calls, Library button/form, capability matches, ui:// library resources, and standalone launch tools absent; completed the native MCP App handshake; then disabled the organization rollout, published an empty provider index, and preserved ordinary search/execute without MCP App launch metadata.`,
+    "Native MCP Apps refresh on a justified catalog miss while standalone URL Apps remain unavailable",
+    `Reconciled Desktop before adding connection ${lateConnection.id}, then rendered that newly added standard MCP App through search_capabilities and execute_capability without leaking provider tools into the model runtime. Kept direct provider access and standalone URL Apps unavailable; completed the native MCP App handshake; then disabled the organization rollout, published an empty provider index, and preserved ordinary search/execute without MCP App launch metadata.`,
     standardMcpCalls === 4 && mountedProjectAtlas,
   );
 });


### PR DESCRIPTION
## Summary

- refresh the private Connect MCP App catalog when a valid gateway launch references a connection missing from Desktop cache
- preserve the cached catalog when the opportunistic refresh is unavailable and retain trusted-origin plus scoped App-host credential checks
- retry the descriptor lookup once, while leaving already-cached launches on the zero-refresh fast path
- extend the Remote MCP Apps exact-head journey with a connection added after Desktop reconciliation

## Why

Desktop health repair can leave the private App-host catalog stale when a new standard MCP connection is added after the initial Cloud MCP reconcile. The capability gateway can execute the tool, but the thread renderer then reports `MCP_APP_RESOURCE_RESOLUTION_FAILED` / `server_unavailable` because the native provider descriptor is absent locally.

## Verification

- `pnpm --filter openwork-server exec bun --conditions=development test src/connect-mcp-server-catalog.test.ts src/mcp-app-host.test.ts` — 28 passed, 0 failed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm evals:e2e remote-mcp-apps --local` — Passed on `a4e8e4c5c7482d750b12bf1ba8ef01308c238f2e`; 1 passed, 0 failed, 0 skipped; local lane because this existing spec requires local placement