### PR TITLE
fix(desktop): keep updater channel selection stable

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -153,6 +153,8 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   });
   const { appVersion, updateEnv } = envState;
   const autoCheckKeyRef = useRef<string | null>(null);
+  const checkRequestRef = useRef(0);
+  const releaseChannelRequestRef = useRef(0);
   const availableReleaseChannelRef = useRef<ReleaseChannel | null>(null);
   const downloadedReleaseChannelRef = useRef<ReleaseChannel | null>(null);
   const desktopConfigRef = useRef(desktopConfig);
@@ -239,6 +241,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   }, [onReleaseChannelChange, policyReleaseChannel]);
 
   const downloadUpdate = useCallback(async (channelOverride?: ReleaseChannel) => {
+    const releaseChannelRequestId = releaseChannelRequestRef.current;
+    const isCurrentReleaseChannel = () =>
+      releaseChannelRequestRef.current === releaseChannelRequestId;
     const bridge = electronUpdaterBridge();
     if (!bridge?.download) {
       const message = "Electron updater downloads are available only in the Electron desktop app.";
@@ -254,17 +259,20 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     const releaseChannelResolution = await resolvePolicyReleaseChannel(
       requestedReleaseChannel,
     ).catch((error: unknown) => {
-      setUpdateStatus({
-        state: "error",
-        message: describeError(error),
-        failedAction: "download",
-      });
+      if (isCurrentReleaseChannel()) {
+        setUpdateStatus({
+          state: "error",
+          message: describeError(error),
+          failedAction: "download",
+        });
+      }
       return null;
     });
-    if (!releaseChannelResolution) return;
+    if (!releaseChannelResolution || !isCurrentReleaseChannel()) return;
     if (releaseChannelResolution.channel !== requestedReleaseChannel) {
       onReleaseChannelChange(releaseChannelResolution.channel);
       await bridge.setChannel?.(releaseChannelResolution.channel);
+      if (!isCurrentReleaseChannel()) return;
       availableReleaseChannelRef.current = null;
       downloadedReleaseChannelRef.current = null;
       setUpdateStatus(null);
@@ -276,6 +284,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     let unsubProgress: (() => void) | null = null;
     if (bridge.onDownloadProgress) {
       unsubProgress = bridge.onDownloadProgress((data) => {
+        if (!isCurrentReleaseChannel()) return;
         setUpdateStatus((current) => ({
           ...(current ?? {}),
           state: "downloading",
@@ -285,6 +294,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       });
     }
 
+    if (!isCurrentReleaseChannel()) return;
     setUpdateStatus((current) => ({
       ...(current ?? {}),
       state: "downloading",
@@ -293,6 +303,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     }));
     try {
       const result = await bridge.download();
+      if (!isCurrentReleaseChannel()) return;
       if (!result?.ok) {
         setUpdateStatus({
           state: "error",
@@ -319,6 +330,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         state: "ready",
       }));
     } catch (error) {
+      if (!isCurrentReleaseChannel()) return;
       setUpdateStatus({
         state: "error",
         message: describeError(error),
@@ -339,6 +351,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     manual = false,
   ) => {
     if (!isElectronRuntime()) return;
+    const requestId = checkRequestRef.current + 1;
+    checkRequestRef.current = requestId;
+    const isCurrentRequest = () => checkRequestRef.current === requestId;
     const requestedReleaseChannel = channelOverride ?? releaseChannel;
     const bridge = electronUpdaterBridge();
     if (!bridge?.check) {
@@ -354,14 +369,17 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       const releaseChannelResolution = await resolvePolicyReleaseChannel(
         requestedReleaseChannel,
       );
+      if (!isCurrentRequest()) return;
       const activeReleaseChannel = releaseChannelResolution.channel;
       const freshDesktopConfig = releaseChannelResolution.desktopConfig;
       if (activeReleaseChannel !== requestedReleaseChannel) {
         onReleaseChannelChange(activeReleaseChannel);
         await bridge.setChannel?.(activeReleaseChannel);
+        if (!isCurrentRequest()) return;
       }
       if (manual && activeReleaseChannel === "stable") {
         const channelState = await bridge.getChannel?.();
+        if (!isCurrentRequest()) return;
         const currentVersion = channelState?.currentVersion ?? appVersion;
         if (!currentVersion) {
           throw new Error("Could not determine the installed OpenWork version.");
@@ -371,6 +389,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           currentVersion,
           refreshDesktopConfig,
         });
+        if (!isCurrentRequest()) return;
         if (!selection) {
           throw new Error("Den returned an invalid desktop release inventory.");
         }
@@ -397,10 +416,8 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       }
 
       let result = await bridge.check(activeReleaseChannel, targetVersion);
+      if (!isCurrentRequest()) return;
       dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
-      if (result.channel && result.channel !== releaseChannel) {
-        onReleaseChannelChange(result.channel);
-      }
       let checkedReleaseChannel = result.channel ?? activeReleaseChannel;
       if (
         !result.reason &&
@@ -419,13 +436,12 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
               desktopConfig: freshDesktopConfig,
             })
           : null;
+        if (!isCurrentRequest()) return;
         if (fallbackTargetVersion) {
           targetVersion = fallbackTargetVersion;
           result = await bridge.check(checkedReleaseChannel, targetVersion);
+          if (!isCurrentRequest()) return;
           dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
-          if (result.channel && result.channel !== releaseChannel) {
-            onReleaseChannelChange(result.channel);
-          }
           checkedReleaseChannel = result.channel ?? checkedReleaseChannel;
         }
       }
@@ -454,6 +470,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
             ? await isAlphaUpdateAllowed(result.latestVersion, latestDesktopConfig)
             : await isUpdateAllowed(result.latestVersion, latestDesktopConfig)
         : result.available;
+      if (!isCurrentRequest()) return;
       const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
         ? {
             state: "available",
@@ -478,6 +495,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         await downloadUpdate(checkedReleaseChannel);
       }
     } catch (error) {
+      if (!isCurrentRequest()) return;
       setUpdateStatus({
         state: "error",
         message: describeError(error),
@@ -512,6 +530,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   }, [checkForUpdates, updateCheckRequestedAt, updateEnv?.supported]);
 
   const installUpdateAndRestart = useCallback(async () => {
+    const releaseChannelRequestId = releaseChannelRequestRef.current;
+    const isCurrentReleaseChannel = () =>
+      releaseChannelRequestRef.current === releaseChannelRequestId;
     const bridge = electronUpdaterBridge();
     if (!bridge?.installAndRestart) {
       const message = "Electron update install is available only in the Electron desktop app.";
@@ -522,15 +543,18 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     try {
       if (downloadedReleaseChannelRef.current === "alpha") {
         const releaseChannelResolution = await resolvePolicyReleaseChannel("alpha");
+        if (!isCurrentReleaseChannel()) return;
         if (releaseChannelResolution.channel !== "alpha") {
           onReleaseChannelChange(releaseChannelResolution.channel);
           await bridge.setChannel?.(releaseChannelResolution.channel);
+          if (!isCurrentReleaseChannel()) return;
           downloadedReleaseChannelRef.current = null;
           setUpdateStatus(null);
           return;
         }
       }
       const result = await bridge.installAndRestart();
+      if (!isCurrentReleaseChannel()) return;
       if (!result?.ok) {
         if (result?.reason === "update-not-downloaded") {
           // The main-side staged download was invalidated; re-check so the UI
@@ -547,6 +571,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         });
       }
     } catch (error) {
+      if (!isCurrentReleaseChannel()) return;
       setUpdateStatus({
         state: "error",
         message: describeError(error),
@@ -557,19 +582,25 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
 
   const setReleaseChannel = useCallback(
     async (next: ReleaseChannel) => {
+      const requestId = releaseChannelRequestRef.current + 1;
+      releaseChannelRequestRef.current = requestId;
+      checkRequestRef.current += 1;
       const bridge = electronUpdaterBridge();
       try {
         const releaseChannelResolution = await resolvePolicyReleaseChannel(next);
+        if (releaseChannelRequestRef.current !== requestId) return;
         const allowedReleaseChannel = releaseChannelResolution.channel;
         onReleaseChannelChange(allowedReleaseChannel);
         if (!bridge?.setChannel) return;
         const state = await bridge.setChannel(allowedReleaseChannel);
+        if (releaseChannelRequestRef.current !== requestId) return;
         dispatchEnvState({ type: "app-version", appVersion: state.currentVersion ?? null });
         if (state.channel && state.channel !== allowedReleaseChannel) {
           onReleaseChannelChange(state.channel);
         }
         await checkForUpdates(state.channel ?? allowedReleaseChannel);
       } catch (error) {
+        if (releaseChannelRequestRef.current !== requestId) return;
         setUpdateStatus({
           state: "error",
           message: describeError(error),

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -120,6 +120,7 @@ import {
   workspaceSetRuntimeActive,
   workspaceSetSelected,
   desktopBridge,
+  readDesktopDistributionInfo,
   type WorkspaceInfo,
   type WorkspaceList,
   revealDesktopItemInDir,
@@ -2539,6 +2540,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             alphaChannelSupported={
               isElectronRuntime() &&
               isMacPlatform() &&
+              readDesktopDistributionInfo().flavor === "public" &&
               desktopConfig.config.allowAlphaUpdates !== false
             }
           />

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -191,8 +191,17 @@ function updaterChannelState(app, channel, targetVersion = null, manifestChannel
   };
 }
 
-async function applyElectronUpdaterFeed(app, updater, targetVersion = null, manifestChannel = "latest", allowOlder = false) {
-  const channel = await readElectronUpdaterChannel(app, manifestChannel);
+async function applyElectronUpdaterFeed(
+  app,
+  updater,
+  targetVersion = null,
+  manifestChannel = "latest",
+  allowOlder = false,
+  channelOverride,
+) {
+  const channel = channelOverride === undefined
+    ? await readElectronUpdaterChannel(app, manifestChannel)
+    : normalizeElectronUpdaterChannel(channelOverride, manifestChannel);
   if (targetVersion && channel !== "stable") {
     throw new Error("Version-specific update feeds are supported only on the stable channel.");
   }
@@ -296,12 +305,20 @@ export function registerUpdaterIpc({
   env = process.env,
 }) {
   let autoUpdaterInstance = null;
-  let autoUpdaterLoaded = false;
+  let autoUpdaterLoadPromise = null;
   let checkedUpdateVersion = null;
   let checkedUpdateTargetVersion = null;
+  let checkedUpdateChannel = null;
   let updateDownloaded = false;
   let recoveryReleases = [];
   const recoveryWitness = { installRequests: [], openedArtifactUrls: [], quitRequested: false };
+  let updaterOperationQueue = Promise.resolve();
+
+  function queueUpdaterOperation(operation) {
+    const result = updaterOperationQueue.then(operation, operation);
+    updaterOperationQueue = result.then(() => undefined, () => undefined);
+    return result;
+  }
 
   function sendToRenderer(channel, data) {
     try {
@@ -316,50 +333,53 @@ export function registerUpdaterIpc({
 
   async function ensureAutoUpdater() {
     if (!app.isPackaged) return null;
-    if (autoUpdaterLoaded) return autoUpdaterInstance;
-    autoUpdaterLoaded = true;
-    try {
-      const mod = await loadAutoUpdater();
-      autoUpdaterInstance = mod.autoUpdater ?? mod.default?.autoUpdater ?? null;
-      if (autoUpdaterInstance) {
-        autoUpdaterInstance.autoDownload = false;
-        autoUpdaterInstance.autoInstallOnAppQuit = true;
-        // Differential (blockmap) downloads reconstruct the update zip from the
-        // installed app + a diff. On macOS that reconstructed bundle is what
-        // feeds Squirrel's fragile move-based install, and is a common trigger
-        // for the "Failed to copy bundle … no such file" abort. Download the
-        // full zip instead — alpha builds are swapped wholesale anyway.
-        autoUpdaterInstance.disableDifferentialDownload = true;
-        // Make Squirrel.Mac write contents in place rather than moving whole
-        // bundles (see enableSquirrelDirectContentsWrite for why).
-        await enableSquirrelDirectContentsWrite(shipItDefaultsDomain);
-        autoUpdaterInstance.on("error", (err) => {
-          // Do not invalidate a staged download on arbitrary updater errors.
-          // A later transient check failure does not delete the downloaded
-          // update; quitAndInstall reports a descriptive failure if it is gone.
-          console.warn("[updater] error", err);
-        });
-        autoUpdaterInstance.on("update-downloaded", () => {
-          updateDownloaded = true;
-        });
-        // Forward download progress to the renderer so the UI can show
-        // incremental bytes instead of staying stuck at 0.
-        autoUpdaterInstance.on("download-progress", (info) => {
-          sendToRenderer("openwork:updater:download-progress", {
-            bytesPerSecond: info.bytesPerSecond ?? 0,
-            percent: info.percent ?? 0,
-            transferred: info.transferred ?? 0,
-            total: info.total ?? 0,
-            delta: info.delta ?? 0,
-          });
-        });
-        await applyElectronUpdaterFeed(app, autoUpdaterInstance, null, manifestChannel);
-      }
-    } catch (error) {
-      console.warn("[updater] electron-updater not available", error);
-      autoUpdaterInstance = null;
+    if (!autoUpdaterLoadPromise) {
+      autoUpdaterLoadPromise = (async () => {
+        try {
+          const mod = await loadAutoUpdater();
+          autoUpdaterInstance = mod.autoUpdater ?? mod.default?.autoUpdater ?? null;
+          if (autoUpdaterInstance) {
+            autoUpdaterInstance.autoDownload = false;
+            autoUpdaterInstance.autoInstallOnAppQuit = true;
+            // Differential (blockmap) downloads reconstruct the update zip from the
+            // installed app + a diff. On macOS that reconstructed bundle is what
+            // feeds Squirrel's fragile move-based install, and is a common trigger
+            // for the "Failed to copy bundle … no such file" abort. Download the
+            // full zip instead — alpha builds are swapped wholesale anyway.
+            autoUpdaterInstance.disableDifferentialDownload = true;
+            // Make Squirrel.Mac write contents in place rather than moving whole
+            // bundles (see enableSquirrelDirectContentsWrite for why).
+            await enableSquirrelDirectContentsWrite(shipItDefaultsDomain);
+            autoUpdaterInstance.on("error", (err) => {
+              // Do not invalidate a staged download on arbitrary updater errors.
+              // A later transient check failure does not delete the downloaded
+              // update; quitAndInstall reports a descriptive failure if it is gone.
+              console.warn("[updater] error", err);
+            });
+            autoUpdaterInstance.on("update-downloaded", () => {
+              updateDownloaded = true;
+            });
+            // Forward download progress to the renderer so the UI can show
+            // incremental bytes instead of staying stuck at 0.
+            autoUpdaterInstance.on("download-progress", (info) => {
+              sendToRenderer("openwork:updater:download-progress", {
+                bytesPerSecond: info.bytesPerSecond ?? 0,
+                percent: info.percent ?? 0,
+                transferred: info.transferred ?? 0,
+                total: info.total ?? 0,
+                delta: info.delta ?? 0,
+              });
+            });
+            await applyElectronUpdaterFeed(app, autoUpdaterInstance, null, manifestChannel);
+          }
+        } catch (error) {
+          console.warn("[updater] electron-updater not available", error);
+          autoUpdaterInstance = null;
+        }
+        return autoUpdaterInstance;
+      })();
     }
-    return autoUpdaterInstance;
+    return autoUpdaterLoadPromise;
   }
 
   async function resolveRecoveryArtifact(version) {
@@ -560,10 +580,13 @@ export function registerUpdaterIpc({
     }
   }
 
-  ipcMain.handle("openwork:recovery:use", async (_event, id) => useRecoveryRelease(id));
+  ipcMain.handle("openwork:recovery:use", async (_event, id) =>
+    queueUpdaterOperation(() => useRecoveryRelease(id)));
   ipcMain.handle("openwork:recovery:restorePrevious", async () => {
-    const previous = recoveryReleases.find((release) => release.marking === "previous");
-    return previous ? useRecoveryRelease(previous.id) : { ok: false, reason: "No verified previous version is available." };
+    return queueUpdaterOperation(() => {
+      const previous = recoveryReleases.find((release) => release.marking === "previous");
+      return previous ? useRecoveryRelease(previous.id) : { ok: false, reason: "No verified previous version is available." };
+    });
   });
   ipcMain.handle("openwork:recovery:evalSnapshot", async () => ({
     candidates: recoveryReleases,
@@ -571,15 +594,16 @@ export function registerUpdaterIpc({
     ...recoveryWitness,
   }));
 
-  ipcMain.handle("openwork:updater:getChannel", async () => {
+  ipcMain.handle("openwork:updater:getChannel", async () => queueUpdaterOperation(async () => {
     const channel = await readElectronUpdaterChannel(app, manifestChannel);
     return updaterChannelState(app, channel, null, manifestChannel);
-  });
+  }));
 
-  ipcMain.handle("openwork:updater:setChannel", async (_event, rawChannel) => {
+  ipcMain.handle("openwork:updater:setChannel", async (_event, rawChannel) => queueUpdaterOperation(async () => {
     const channel = await writeElectronUpdaterChannel(app, rawChannel, manifestChannel);
     checkedUpdateVersion = null;
     checkedUpdateTargetVersion = null;
+    checkedUpdateChannel = null;
     updateDownloaded = false;
     const updater = await ensureAutoUpdater();
     if (updater) {
@@ -587,15 +611,17 @@ export function registerUpdaterIpc({
       // also prevents an Alpha build from installing automatically on quit
       // after an organization policy moves the desktop back to Stable.
       preventPendingUpdaterInstall(updater);
-      return applyElectronUpdaterFeed(app, updater, null, manifestChannel);
+      return applyElectronUpdaterFeed(app, updater, null, manifestChannel, false, channel);
     }
     return updaterChannelState(app, channel, null, manifestChannel);
-  });
+  }));
 
-  ipcMain.handle("openwork:updater:check", async (_event, rawChannel, rawTargetVersion) => {
-    if (rawChannel !== undefined) {
-      await writeElectronUpdaterChannel(app, rawChannel, manifestChannel);
-    }
+  ipcMain.handle("openwork:updater:check", async (_event, rawChannel, rawTargetVersion) => queueUpdaterOperation(async () => {
+    // A check selects a feed for this operation only. The persisted preference
+    // belongs exclusively to setChannel so a stale check cannot undo a choice.
+    const channel = rawChannel === undefined
+      ? await readElectronUpdaterChannel(app, manifestChannel)
+      : normalizeElectronUpdaterChannel(rawChannel, manifestChannel);
     const updater = await ensureAutoUpdater();
     try {
       const targetVersion = rawTargetVersion === undefined
@@ -605,13 +631,8 @@ export function registerUpdaterIpc({
         throw new Error("Target update version must use the stable x.y.z format.");
       }
       const channelState = updater
-        ? await applyElectronUpdaterFeed(app, updater, targetVersion, manifestChannel)
-        : updaterChannelState(
-            app,
-            await readElectronUpdaterChannel(app, manifestChannel),
-            targetVersion,
-            manifestChannel,
-          );
+        ? await applyElectronUpdaterFeed(app, updater, targetVersion, manifestChannel, false, channel)
+        : updaterChannelState(app, channel, targetVersion, manifestChannel);
       if (!updater) return { available: false, reason: "unavailable", ...channelState };
 
       const result = await updater.checkForUpdates();
@@ -623,6 +644,7 @@ export function registerUpdaterIpc({
       const available = Boolean(info?.version && isVersionNewer(info.version, currentVersion));
       checkedUpdateVersion = available ? info.version : null;
       checkedUpdateTargetVersion = available ? targetVersion : null;
+      checkedUpdateChannel = available ? channelState.channel : null;
       if (!available) updateDownloaded = false;
       return {
         available,
@@ -635,21 +657,22 @@ export function registerUpdaterIpc({
     } catch (error) {
       checkedUpdateVersion = null;
       checkedUpdateTargetVersion = null;
+      checkedUpdateChannel = null;
       // A transient failed check must not invalidate an already-downloaded update.
       return {
         available: false,
         reason: String(error?.message ?? error),
         ...updaterChannelState(
           app,
-          await readElectronUpdaterChannel(app, manifestChannel),
+          channel,
           null,
           manifestChannel,
         ),
       };
     }
-  });
+  }));
 
-  ipcMain.handle("openwork:updater:download", async () => {
+  ipcMain.handle("openwork:updater:download", async () => queueUpdaterOperation(async () => {
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
@@ -658,6 +681,8 @@ export function registerUpdaterIpc({
         updater,
         checkedUpdateTargetVersion,
         manifestChannel,
+        false,
+        checkedUpdateChannel ?? undefined,
       );
       const currentVersion = resolveAppVersion(app);
       if (!checkedUpdateVersion || !isVersionNewer(checkedUpdateVersion, currentVersion)) {
@@ -690,9 +715,9 @@ export function registerUpdaterIpc({
       updateDownloaded = false;
       return { ok: false, reason: String(error?.message ?? error) };
     }
-  });
+  }));
 
-  ipcMain.handle("openwork:updater:installAndRestart", async () => {
+  ipcMain.handle("openwork:updater:installAndRestart", async () => queueUpdaterOperation(async () => {
     if (!updateDownloaded) return { ok: false, reason: "update-not-downloaded" };
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
@@ -705,7 +730,7 @@ export function registerUpdaterIpc({
     } catch (error) {
       return { ok: false, reason: String(error?.message ?? error) };
     }
-  });
+  }));
 
   return { ensureAutoUpdater };
 }

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -37,6 +37,8 @@ let isolatedUpdaterImportId = 0;
 function fakeUpdaterHarness({ version }) {
   const listeners = new Map();
   const calls = [];
+  const feeds = [];
+  const downloadFeeds = [];
   const updater = {
     autoDownload: true,
     autoInstallOnAppQuit: false,
@@ -44,16 +46,17 @@ function fakeUpdaterHarness({ version }) {
     allowPrerelease: false,
     allowDowngrade: false,
     on: (name, fn) => listeners.set(name, fn),
-    setFeedURL: () => {},
+    setFeedURL: (feed) => feeds.push(feed),
     checkForUpdates: async () => ({ updateInfo: { version } }),
     downloadUpdate: async () => {
       calls.push("download");
+      downloadFeeds.push(feeds.at(-1));
     },
     quitAndInstall: () => {
       calls.push("quitAndInstall");
     },
   };
-  return { updater, listeners, calls };
+  return { updater, listeners, calls, feeds, downloadFeeds };
 }
 
 async function registerFakeUpdaterIpc({ version }) {
@@ -614,6 +617,91 @@ describe("release channel changes", () => {
       });
     } finally {
       await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let a check overwrite the selected channel", {
+    skip: process.platform !== "darwin",
+  }, async () => {
+    const { tempDir, handlers } = await registerFakeUpdaterIpc({
+      version: "0.18.0",
+    });
+    try {
+      const check = handlers.get("openwork:updater:check");
+      const setChannel = handlers.get("openwork:updater:setChannel");
+      const getChannel = handlers.get("openwork:updater:getChannel");
+
+      assert.equal((await setChannel(null, "alpha")).channel, "alpha");
+      assert.equal((await check(null, "stable")).channel, "stable");
+      assert.equal((await getChannel()).channel, "alpha");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("downloads from the channel used by the successful check", {
+    skip: process.platform !== "darwin",
+  }, async () => {
+    const { tempDir, handlers, downloadFeeds } = await registerFakeUpdaterIpc({
+      version: "0.18.0-alpha.1",
+    });
+    try {
+      const check = handlers.get("openwork:updater:check");
+      const download = handlers.get("openwork:updater:download");
+
+      assert.equal((await check(null, "alpha")).channel, "alpha");
+      assert.deepEqual(await download(), { ok: true });
+      assert.equal(
+        downloadFeeds.at(-1)?.url,
+        "https://github.com/different-ai/openwork/releases/download/alpha-macos-latest",
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Alpha selected when a Stable check is already in flight", {
+    skip: process.platform !== "darwin",
+  }, async () => {
+    const { tempDir, handlers, updater, feeds } = await registerFakeUpdaterIpc({
+      version: "0.18.0",
+    });
+    let finishStableCheck;
+    const stableCheckStarted = new Promise((resolve) => {
+      updater.checkForUpdates = () => new Promise((finish) => {
+        finishStableCheck = () => finish({ updateInfo: { version: "0.18.0" } });
+        resolve();
+        updater.checkForUpdates = async () => ({ updateInfo: { version: "0.18.0-alpha.1" } });
+      });
+    });
+    try {
+      const check = handlers.get("openwork:updater:check");
+      const setChannel = handlers.get("openwork:updater:setChannel");
+      const getChannel = handlers.get("openwork:updater:getChannel");
+
+      const stableCheck = check(null, "stable");
+      await stableCheckStarted;
+      const alphaSelection = setChannel(null, "alpha");
+      const alphaCheck = check(null, "alpha");
+      finishStableCheck();
+
+      assert.equal((await stableCheck).channel, "stable");
+      assert.equal((await alphaSelection).channel, "alpha");
+      assert.equal((await alphaCheck).channel, "alpha");
+      assert.equal((await getChannel()).channel, "alpha");
+      assert.equal(
+        JSON.parse(await readFile(
+          path.join(tempDir, "userData", "electron-updater-channel.v1.json"),
+          "utf8",
+        )).channel,
+        "alpha",
+      );
+      assert.equal(
+        feeds.at(-1)?.url,
+        "https://github.com/different-ai/openwork/releases/download/alpha-macos-latest",
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -666,10 +666,11 @@ describe("release channel changes", () => {
     const { tempDir, handlers, updater, feeds } = await registerFakeUpdaterIpc({
       version: "0.18.0",
     });
-    let finishStableCheck;
+    /** @type {{ finish: null | (() => void) }} */
+    const stableCheckControl = { finish: null };
     const stableCheckStarted = new Promise((resolve) => {
       updater.checkForUpdates = () => new Promise((finish) => {
-        finishStableCheck = () => finish({ updateInfo: { version: "0.18.0" } });
+        stableCheckControl.finish = () => finish({ updateInfo: { version: "0.18.0" } });
         resolve();
         updater.checkForUpdates = async () => ({ updateInfo: { version: "0.18.0-alpha.1" } });
       });
@@ -683,6 +684,7 @@ describe("release channel changes", () => {
       await stableCheckStarted;
       const alphaSelection = setChannel(null, "alpha");
       const alphaCheck = check(null, "alpha");
+      const finishStableCheck = stableCheckControl.finish;
       if (!finishStableCheck) throw new Error("Stable update check did not start.");
       finishStableCheck();
 

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -683,6 +683,7 @@ describe("release channel changes", () => {
       await stableCheckStarted;
       const alphaSelection = setChannel(null, "alpha");
       const alphaCheck = check(null, "alpha");
+      if (!finishStableCheck) throw new Error("Stable update check did not start.");
       finishStableCheck();
 
       assert.equal((await stableCheck).channel, "stable");

--- a/evals/specs/updater-channel-selection.e2e.test.ts
+++ b/evals/specs/updater-channel-selection.e2e.test.ts
@@ -1,0 +1,300 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import { allocateFreePort } from "@openwork/cdp";
+import { desktop, localHost } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const onMac = process.platform === "darwin";
+const enabled = e2eTestsEnabled && onMac;
+const title = enabled
+  ? "the macOS updater keeps an Alpha selection through a stale check and relaunch"
+  : e2eTestsEnabled
+    ? `updater channel selection skipped — needs: run on macOS (Alpha is unavailable on ${process.platform})`
+    : "updater channel selection skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+type UpdaterSnapshot = {
+  checks: string[];
+  setChannels: string[];
+  nativeChannel: string | null;
+  preferenceChannel: string | null;
+  pickerText: string;
+  pageText: string;
+};
+
+function updaterSnapshot(value: unknown, label: string): UpdaterSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} returned no updater snapshot: ${JSON.stringify(value)}`);
+  }
+  const snapshot = value as Record<string, unknown>;
+  if (
+    !Array.isArray(snapshot.checks) ||
+    !snapshot.checks.every((entry) => typeof entry === "string") ||
+    !Array.isArray(snapshot.setChannels) ||
+    !snapshot.setChannels.every((entry) => typeof entry === "string") ||
+    !(snapshot.nativeChannel === null || typeof snapshot.nativeChannel === "string") ||
+    !(snapshot.preferenceChannel === null || typeof snapshot.preferenceChannel === "string") ||
+    typeof snapshot.pickerText !== "string" ||
+    typeof snapshot.pageText !== "string"
+  ) {
+    throw new Error(`${label} returned an unexpected updater snapshot: ${JSON.stringify(value)}`);
+  }
+  return snapshot as UpdaterSnapshot;
+}
+
+async function installControlledUpdaterBridge(
+  app: Parameters<typeof evalIn>[0],
+  options: { delayStable: boolean },
+): Promise<void> {
+  const installed = await evalIn(app, `(() => {
+    const nativeUpdater = window.__OPENWORK_ELECTRON__?.updater;
+    if (!nativeUpdater?.getChannel || !nativeUpdater.setChannel) return false;
+    const state = {
+      checks: [],
+      setChannels: [],
+      stableStarted: false,
+      stableResolved: false,
+      finishStable: null,
+    };
+    window.__openworkUpdaterEvalState = state;
+    window.__openworkApplyDesktopConfig?.({ allowAlphaUpdates: true });
+    window.__openworkSetDesktopConfigRefreshResult?.({ allowAlphaUpdates: true });
+    window.__openworkUpdaterEvalBridge = {
+      getChannel: () => nativeUpdater.getChannel(),
+      setChannel: async (channel) => {
+        state.setChannels.push(channel);
+        return nativeUpdater.setChannel(channel);
+      },
+      check: async (channel) => {
+        state.checks.push(channel);
+        if (${JSON.stringify(options.delayStable)} && channel === "stable") {
+          state.stableStarted = true;
+          return new Promise((resolve) => {
+            state.finishStable = () => {
+              state.stableResolved = true;
+              resolve({
+                available: true,
+                channel: "stable",
+                currentVersion: "0.18.0",
+                latestVersion: "9.9.9",
+              });
+            };
+          });
+        }
+        return {
+          available: false,
+          channel,
+          currentVersion: "0.18.0",
+          latestVersion: channel === "alpha" ? "0.18.0-alpha.1" : "0.18.0",
+        };
+      },
+      download: async () => ({ ok: false, reason: "unused by this updater-channel proof" }),
+      installAndRestart: async () => ({ ok: false, reason: "unused by this updater-channel proof" }),
+      onDownloadProgress: () => () => {},
+    };
+    return true;
+  })()`);
+  expect(installed).toBe(true);
+}
+
+async function openUpdates(app: Parameters<typeof evalIn>[0], workspaceId: string): Promise<void> {
+  await go(app, `/workspace/${workspaceId}/settings/updates`);
+  await waitFor(
+    app,
+    `window.location.hash.includes("/settings/updates")
+      && Boolean(document.querySelector('[aria-label="Release channel"]'))`,
+    { timeoutMs: 60_000, label: "public macOS Updates page with release channel picker" },
+  );
+}
+
+async function selectAlpha(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  const triggerPoint = await evalIn(app, `(() => {
+    const trigger = document.querySelector('[aria-label="Release channel"]');
+    if (!(trigger instanceof HTMLElement)) return null;
+    const rect = trigger.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (
+    !triggerPoint ||
+    typeof triggerPoint !== "object" ||
+    !("x" in triggerPoint) ||
+    !("y" in triggerPoint) ||
+    typeof triggerPoint.x !== "number" ||
+    typeof triggerPoint.y !== "number"
+  ) {
+    throw new Error(`Could not resolve the release channel trigger: ${JSON.stringify(triggerPoint)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", ...triggerPoint });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...triggerPoint, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...triggerPoint, button: "left", clickCount: 1 });
+  await waitFor(
+    app,
+    `[...document.querySelectorAll('[data-slot="select-item"]')]
+      .some((item) => item.textContent?.trim() === "Alpha")`,
+    { timeoutMs: 15_000, label: "Alpha release channel option" },
+  );
+  const optionPoint = await evalIn(app, `(() => {
+    const option = [...document.querySelectorAll('[data-slot="select-item"]')]
+      .find((item) => item.textContent?.trim() === "Alpha");
+    if (!(option instanceof HTMLElement)) return null;
+    const rect = option.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (
+    !optionPoint ||
+    typeof optionPoint !== "object" ||
+    !("x" in optionPoint) ||
+    !("y" in optionPoint) ||
+    typeof optionPoint.x !== "number" ||
+    typeof optionPoint.y !== "number"
+  ) {
+    throw new Error(`Could not resolve the Alpha release channel option: ${JSON.stringify(optionPoint)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", ...optionPoint });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...optionPoint, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...optionPoint, button: "left", clickCount: 1 });
+}
+
+async function readUpdaterSnapshot(app: Parameters<typeof evalIn>[0], label: string): Promise<UpdaterSnapshot> {
+  const value = await evalIn(app, `(async () => {
+    const state = window.__openworkUpdaterEvalState;
+    const nativeState = await window.__OPENWORK_ELECTRON__?.updater?.getChannel?.();
+    let preferences = null;
+    try {
+      preferences = JSON.parse(localStorage.getItem("openwork.preferences") || "null");
+    } catch {}
+    return {
+      checks: Array.isArray(state?.checks) ? [...state.checks] : [],
+      setChannels: Array.isArray(state?.setChannels) ? [...state.setChannels] : [],
+      nativeChannel: typeof nativeState?.channel === "string" ? nativeState.channel : null,
+      preferenceChannel: typeof preferences?.releaseChannel === "string" ? preferences.releaseChannel : null,
+      pickerText: document.querySelector('[aria-label="Release channel"]')?.textContent?.trim() ?? "",
+      pageText: document.body.innerText,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  return updaterSnapshot(value, label);
+}
+
+async function quitDesktopGracefully(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  // Ask Chromium to close at the browser level rather than terminating the
+  // host process. This gives the shared profile a clean storage shutdown.
+  await app.client.send("Browser.close").catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/CDP websocket (?:failed|closed)/i.test(message)) throw error;
+  });
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${app.handle.cdpUrl.replace(/\/$/, "")}/json/version`, {
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (!response.ok) return;
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("Electron did not exit after the browser-level close request.");
+}
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  // Alpha is deliberately macOS-only. Daytona Electron surfaces are Linux, so
+  // this journey uses the local Mac host instead of producing a vacuous remote
+  // pass in a platform where the picker cannot exist.
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-updater-channel-eval-"));
+  const workspacePath = join(profileDir, "workspace");
+  // Local storage is scoped to the dev-server origin. Pin both launches to the
+  // same Vite port so this is a genuine relaunch of one renderer origin, just
+  // like a packaged desktop, rather than two unrelated development origins.
+  const desktopEnv = { PORT: String(await allocateFreePort()) };
+  await using host = localHost();
+  let workspaceId = "";
+
+  try {
+    const firstApp = await desktop({ name: "updater-channel-selection", host, profileDir, env: desktopEnv });
+    try {
+      ({ workspaceId } = await createAndSelectWorkspace(firstApp, { path: workspacePath }));
+      await installControlledUpdaterBridge(firstApp, { delayStable: true });
+      await openUpdates(firstApp, workspaceId);
+      await waitFor(firstApp, `window.__openworkUpdaterEvalState?.stableStarted === true`, {
+        timeoutMs: 30_000,
+        label: "initial Stable update check in flight",
+      });
+
+      await selectAlpha(firstApp);
+      await waitFor(firstApp, `(() => {
+        const state = window.__openworkUpdaterEvalState;
+        let preferences = null;
+        try { preferences = JSON.parse(localStorage.getItem("openwork.preferences") || "null"); } catch {}
+        return state?.checks?.includes("alpha")
+          && state?.setChannels?.includes("alpha")
+          && preferences?.releaseChannel === "alpha"
+          && document.querySelector('[aria-label="Release channel"]')?.textContent?.includes("Alpha");
+      })()`, { timeoutMs: 30_000, label: "Alpha selected and checked" });
+
+      const finishedStable = await evalIn(firstApp, `(() => {
+        const finish = window.__openworkUpdaterEvalState?.finishStable;
+        if (typeof finish !== "function") return false;
+        finish();
+        return true;
+      })()`);
+      expect(finishedStable).toBe(true);
+      await evalIn(firstApp, `new Promise((resolve) => setTimeout(resolve, 300))`, {
+        awaitPromise: true,
+        timeoutMs: 2_000,
+      });
+
+      const afterRace = await readUpdaterSnapshot(firstApp, "post-race updater state");
+      expect(afterRace.checks[0]).toBe("stable");
+      expect(afterRace.checks).toContain("alpha");
+      expect(afterRace.checks.at(-1)).toBe("alpha");
+      expect(afterRace.setChannels).toContain("alpha");
+      expect(afterRace.nativeChannel).toBe("alpha");
+      expect(afterRace.preferenceChannel).toBe("alpha");
+      expect(afterRace.pickerText).toContain("Alpha");
+      expect(afterRace.pageText).toContain("You're up to date");
+      expect(afterRace.pageText).not.toContain("9.9.9");
+      evidence.recordAssertionEvidence(
+        "A stale Stable response cannot overwrite a newer Alpha choice",
+        `The controlled renderer observed checks ${JSON.stringify(afterRace.checks)}; after the delayed Stable result reported v9.9.9, the picker, local preference, and native Electron channel all remained Alpha and the page did not render v9.9.9.`,
+        true,
+      );
+      await quitDesktopGracefully(firstApp);
+    } finally {
+      await firstApp.stop();
+    }
+
+    const relaunchedApp = await desktop({ name: "updater-channel-selection", host, profileDir, env: desktopEnv });
+    try {
+      await go(relaunchedApp, "/session");
+      await installControlledUpdaterBridge(relaunchedApp, { delayStable: false });
+      await openUpdates(relaunchedApp, workspaceId);
+      await waitFor(relaunchedApp, `window.__openworkUpdaterEvalState?.checks?.includes("alpha")`, {
+        timeoutMs: 30_000,
+        label: "Alpha check after relaunch",
+      });
+
+      const afterRelaunch = await readUpdaterSnapshot(relaunchedApp, "relaunched updater state");
+      expect(afterRelaunch.checks).toContain("alpha");
+      expect(afterRelaunch.checks).not.toContain("stable");
+      expect(afterRelaunch.nativeChannel).toBe("alpha");
+      expect(afterRelaunch.preferenceChannel).toBe("alpha");
+      expect(afterRelaunch.pickerText).toContain("Alpha");
+      evidence.recordAssertionEvidence(
+        "The selected updater channel survives a desktop relaunch",
+        `The relaunched app reused the same profile, issued an Alpha check, and exposed Alpha in the picker, local preference, and actual Electron updater channel: ${JSON.stringify(afterRelaunch)}.`,
+        true,
+      );
+    } finally {
+      await relaunchedApp.stop();
+    }
+  } finally {
+    await rm(profileDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- stop stale update checks from overwriting the persisted Stable/Alpha selection
- serialize stateful Electron updater operations and preserve the checked feed through download
- ignore stale renderer responses after a newer channel choice or check
- hide Alpha for non-public desktop distributions and add updater regression coverage

## Checks
- `git diff --check origin/dev...HEAD`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --dir apps/desktop exec node --test electron/updater.test.mjs` (28 passed, 1 expected platform skip)
- `pnpm evals:pr` (49 passed, 2 expected opt-in skips)
- `pnpm evals:e2e updater-channel-selection --local` (1 passed; 2 assertion-evidence claims)

All focused checks passed on exact head `501f561f1f0fcc3fad336f7b9c25d72a5b2230fe` after rebasing onto `dev` at `404c9de75720158bf6bc502c5ee61722a804c873`.

## Runtime proof
The focused testkit journey runs on a local Mac because Alpha is macOS-only and Daytona Electron surfaces are Linux. It uses the actual Electron updater `getChannel`/`setChannel` bridge while controlling update-check responses so no live release feed or installer is touched.

The passing tape proves:
1. selecting Alpha while a Stable check is in flight persists Alpha in the picker, local preferences, and native Electron updater state; the delayed Stable result cannot surface its stale version
2. a clean desktop relaunch with the same profile and renderer origin starts and remains on Alpha

The exact-head tape is published in the PR's test-evidence comment.

## Risk / gaps
- updater operation sequencing changed across checks, downloads, installs, and recovery actions
- the proof does not download or install an actual release; feed selection and the checked-feed download handoff are covered by the focused Electron regression suite

Same-repository replacement for #3999.
