### PR TITLE
Render hosted MCP Apps through the credential-bound Den gateway

### DIFF
--- a/apps/server/src/connect-mcp-server-catalog.test.ts
+++ b/apps/server/src/connect-mcp-server-catalog.test.ts
@@ -104,6 +104,17 @@ describe("OpenWork Connect MCP server catalog", () => {
       === CONNECT_MCP_APP_HOST_CAPABILITY)).toBe(true);
   });
 
+  test("keeps hosted api-origin provider proxies on the credential-bound app gateway origin", async () => {
+    const index = await readOpenWorkConnectMcpServerIndex({
+      type: "remote",
+      url: "https://app.openworklabs.com/api/den/mcp/agent",
+    }, "Bearer private-app-host-token", indexFetcher([]));
+
+    expect(index?.servers[0]?.url).toBe(
+      "https://app.openworklabs.com/api/den/mcp/agent/connections/emc_01k28e8q8pf8r9sff9mhyqxved",
+    );
+  });
+
   test("reconciles only OpenWork-owned proxy entries and preserves user MCPs", async () => {
     const config = await fixtureConfig();
     await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
@@ -290,6 +301,25 @@ describe("OpenWork Connect MCP server catalog", () => {
         name: "Untrusted endpoint",
         description: null,
         url: "https://attacker.example/mcp/agent/connections/emc_01crossorigin",
+      }]),
+    });
+
+    expect(result).toEqual({ status: "unavailable", appHostNames: [], removedNames: [] });
+    expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers).toEqual([]);
+  });
+
+  test("rejects a hosted api-origin descriptor that is not the exact connection proxy", async () => {
+    const config = await fixtureConfig();
+    const result = await reconcileOpenWorkConnectMcpServers({
+      config,
+      workspace: config.workspaces[0]!,
+      cloudMcp: { type: "remote", url: "https://app.openworklabs.com/api/den/mcp/agent" },
+      appHostAuthorization: "Bearer private-app-host-token",
+      fetcher: indexFetcher([], [{
+        connectionId: "emc_01crossorigin",
+        name: "Wrong proxy path",
+        description: null,
+        url: "https://api.openworklabs.com/mcp/agent/connections/another-connection",
       }]),
     });
 

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -26,6 +26,11 @@ const BUILTIN_APP_HOST_CLOUD_ORIGINS = new Set([
   "https://app.openwork.software",
 ]);
 
+const BUILTIN_APP_HOST_GATEWAY_PROXY_ORIGINS = new Map([
+  ["https://app.openworklabs.com", "https://api.openworklabs.com"],
+  ["https://app.openwork.software", "https://api.openwork.software"],
+]);
+
 const indexSchema = z.object({
   schemaVersion: z.literal(CONNECT_MCP_SERVER_INDEX_SCHEMA_VERSION),
   servers: z.array(z.object({
@@ -92,6 +97,37 @@ function endpointOrigin(value: unknown): string | null {
   } catch {
     return null;
   }
+}
+
+function normalizeAppHostProxyUrl(
+  cloudMcpUrl: unknown,
+  server: OpenWorkConnectMcpServerIndex["servers"][number],
+): string | null {
+  if (typeof cloudMcpUrl !== "string") return null;
+  let cloudEndpoint: URL;
+  let serverEndpoint: URL;
+  try {
+    cloudEndpoint = new URL(cloudMcpUrl);
+    serverEndpoint = new URL(server.url);
+  } catch {
+    return null;
+  }
+  if (cloudEndpoint.username || cloudEndpoint.password || serverEndpoint.username || serverEndpoint.password) return null;
+  if (serverEndpoint.search || serverEndpoint.hash) return null;
+  if (serverEndpoint.origin === cloudEndpoint.origin) return serverEndpoint.toString();
+
+  // Hosted Desktop talks to Den through the app-origin gateway, while Den's
+  // authenticated member index names its canonical api-origin proxy. Keep the
+  // credential on the configured app origin by translating only this exact,
+  // built-in proxy pair and exact per-connection path. Arbitrary cross-origin
+  // descriptors still fail closed.
+  if (BUILTIN_APP_HOST_GATEWAY_PROXY_ORIGINS.get(cloudEndpoint.origin) !== serverEndpoint.origin) return null;
+  const cloudTerminalPath = "/mcp/agent";
+  if (!cloudEndpoint.pathname.endsWith(cloudTerminalPath) || cloudEndpoint.search || cloudEndpoint.hash) return null;
+  const expectedServerPath = `/mcp/agent/connections/${encodeURIComponent(server.connectionId)}`;
+  if (serverEndpoint.pathname !== expectedServerPath) return null;
+  const gatewayPrefix = cloudEndpoint.pathname.slice(0, -cloudTerminalPath.length);
+  return new URL(`${gatewayPrefix}${serverEndpoint.pathname}`, cloudEndpoint.origin).toString();
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -197,9 +233,13 @@ export async function readOpenWorkConnectMcpServerIndex(
   if (text === null) return null;
   const parsed = indexSchema.safeParse(JSON.parse(text));
   if (!parsed.success) return null;
-  const cloudOrigin = endpointOrigin(cloudMcp.url);
-  if (!cloudOrigin || parsed.data.servers.some((server) => endpointOrigin(server.url) !== cloudOrigin)) return null;
-  return parsed.data;
+  const servers: OpenWorkConnectMcpServerIndex["servers"] = [];
+  for (const server of parsed.data.servers) {
+    const url = normalizeAppHostProxyUrl(cloudMcp.url, server);
+    if (!url) return null;
+    servers.push({ ...server, url });
+  }
+  return { ...parsed.data, servers };
 }
 
 /**

--- a/docs/features/remote-mcp-apps/demo-runbook.md
+++ b/docs/features/remote-mcp-apps/demo-runbook.md
@@ -1,0 +1,116 @@
+# Native MCP Apps local demo
+
+This runbook proves the native MCP Apps path with a deterministic local fixture.
+It does not depend on a hosted gallery, production rollout flags, customer
+connectors, or personal credentials.
+
+The required fixture is Project Atlas from
+`evals/specs/remote-mcp-apps.e2e.test.ts`. It runs as a local Streamable HTTP MCP
+server, exposes `ui://project-atlas/view.html`, and has a same-server
+`search_projects` operation. The tape starts real local Den API and Web
+processes, a real Electron Desktop/local-server process, MySQL, Redis, and a
+synthetic model server.
+
+## Prerequisites
+
+- Node.js 24 and pnpm 11.4.0 (the versions declared by the repository)
+- Bun, Docker, and an available local MySQL port (`3306`)
+- no real model/provider credentials in the shell
+
+From a clean checkout of the exact branch under test:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --dir evals install --frozen-lockfile
+pnpm --filter @openwork/types build
+pnpm --filter @openwork-ee/den-db build
+pnpm --filter @openwork/email build
+pnpm dev:den:mysql
+```
+
+## Run the exact-head demo tape
+
+```bash
+OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e remote-mcp-apps
+```
+
+A valid required proof ends with one passing test, zero failed tests, zero
+skips, and `"verdict":"passed"`. Keep the JSON report path printed by the
+runner with the local verification record.
+
+The tape performs this demo sequence:
+
+1. Starts an isolated Den organization, synthetic member, local Project Atlas
+   MCP server, and Desktop profile.
+2. Enables the deployment gate only for the local Den process and enables the
+   organization capability through the local admin API.
+3. Adds Project Atlas as an organization Connect MCP server and waits for it to
+   become ready.
+4. Confirms the model-visible surface contains only the central
+   `search_capabilities` and `execute_capability` tools.
+5. Confirms stale per-connection compatibility exposes only that same bounded
+   pair, no resources/templates/App metadata, and no direct provider tools.
+6. Confirms the private App host receives only the originating server's
+   app-visible tools and exact `ui://project-atlas/view.html` resource.
+7. Searches and executes `search_projects` through the originating server's
+   App-host capability pair and observes the synthetic Atlas migration result.
+8. Prompts the synthetic model to return the bound tool result, renders the App
+   in Desktop, reloads it, and confirms it renders again.
+9. Disables the organization gate, refreshes the private catalog, and confirms
+   the App closes while the normal text result and ordinary Connect execution
+   remain available.
+10. Restores the gate and confirms the App renders again.
+11. Restarts Desktop with the same isolated profile, revisits the session, and
+    confirms the App recovers.
+
+The deployment gate is `DEN_REMOTE_MCP_APPS_ENABLED=true`; the organization
+gate is the `remoteMcpApps` capability. Both default off. Never change a
+production flag for this demo.
+
+## Focused security and compatibility checks
+
+```bash
+cd apps/server
+bun --conditions=development test \
+  src/connect-mcp-server-catalog.test.ts \
+  src/mcp-app-host.test.ts \
+  src/mcp-app-sandbox.test.ts \
+  src/cloud-mcp-reconcile.e2e.test.ts
+
+cd ../app
+bun test \
+  tests/den-mcp-url.test.ts \
+  tests/mcp-app-frame.test.ts \
+  tests/session-mcp-maintenance.test.ts \
+  tests/cloud-mcp-maintenance-gate.test.ts
+
+cd ../../ee/apps/den-api
+bun test \
+  test/remote-mcp-app-rollout.test.ts \
+  test/external-connection-proxy.test.ts \
+  test/admin-organization-capabilities.test.ts \
+  test/organization-capabilities.test.ts
+```
+
+These checks cover exact trusted-origin matching, cross-origin rejection,
+origin-bound App-host credentials, App-host credential privacy, sandbox/CSP
+enforcement, same-server binding, rollout defaults, older responses without an
+App-host credential, bounded stale-client compatibility, and preservation of
+ordinary Connect when Apps are disabled.
+
+## Expected failure categories
+
+- A skipped tape is incomplete proof. Check the consent environment variable,
+  local placement, and MySQL availability.
+- `missing local server credentials` is a Desktop startup/readiness problem.
+- A resource error names the exact URI, MIME, size, or CSP validation failure.
+- An origin error indicates that the Den/App-host endpoint pair is not an exact
+  trusted-origin match.
+- A tool denial indicates wrong-server routing, app visibility, workspace
+  policy, provider authorization, or required mutation confirmation.
+- With either gate off, an empty App index and a preserved normal tool result
+  are expected, not a resource-loading failure.
+
+The hosted SOL gallery may be checked separately as an external observation,
+but its reachability is not OpenWork compatibility proof and it is not part of
+this required demo.

--- a/evals/specs/remote-mcp-apps.e2e.test.ts
+++ b/evals/specs/remote-mcp-apps.e2e.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { rm } from "node:fs/promises";
 import { expect, onTestFinished } from "vitest";
 import { clickButton, createAndSelectWorkspace, createOrgConnection, denFetch, evalIn, waitFor } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
@@ -326,6 +327,39 @@ async function agentRpc(
   const message = requireRecord(payload, `${method} response`);
   if (message.error) throw new Error(`MCP ${method} returned ${JSON.stringify(message.error)}`);
   return requireRecord(message.result, `${method} result`);
+}
+
+async function reconcileDesktopCatalog(input: {
+  app: Awaited<ReturnType<typeof desktop>>;
+  workspaceId: string;
+  denApiUrl: string;
+  mcpToken: string;
+  appHostMcpToken: string;
+}) {
+  return evalIn(input.app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(input.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
+      method: "POST",
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        config: {
+          type: "remote",
+          url: ${JSON.stringify(`${input.denApiUrl}/mcp/agent`)},
+          enabled: true,
+          headers: { Authorization: ${JSON.stringify(`Bearer ${input.mcpToken}`)} },
+          oauth: false,
+        },
+        appHostAuthorization: ${JSON.stringify(`Bearer ${input.appHostMcpToken}`)},
+        provider: ${JSON.stringify(providerId)},
+        model: ${JSON.stringify(modelId)},
+        trigger: "exact-head-tape-refresh",
+      }),
+    });
+    const text = await response.text();
+    return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
 }
 
 function toolsFrom(result: Record<string, unknown>) {
@@ -781,9 +815,11 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(JSON.stringify(providerAppRun.structuredContent)).toContain("Atlas migration");
   expect(standardMcpCalls).toBe(2);
 
-  await using desktopApp = await desktop({
+  const desktopProfileDir = `/tmp/openwork-remote-mcp-apps-profile-${Date.now()}`;
+  let desktopApp = await desktop({
     name: "remote-mcp-apps",
     mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+    profileDir: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? undefined : desktopProfileDir,
     env: {
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
@@ -792,6 +828,10 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
       OPENWORK_API_KEY: "",
       OPENWORK_INFERENCE_BASE_URL: "",
     },
+  });
+  onTestFinished(async () => {
+    await desktopApp.stop().catch(() => undefined);
+    await rm(desktopProfileDir, { recursive: true, force: true });
   });
   const workspace = await createAndSelectWorkspace(desktopApp, {
     path: `/tmp/openwork-remote-mcp-apps-${Date.now()}`,
@@ -1009,11 +1049,16 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
     timeoutMs: 60_000,
     label: "connected standard MCP App sandboxed iframe",
   });
-  const mountedProjectAtlas = await waitForMountedProjectAtlas(desktopApp, undefined, 15_000);
+  const mountedProjectAtlas = await waitForMountedProjectAtlas(desktopApp, undefined, 30_000);
   const desktopTranscript = await evalIn(desktopApp, "document.body?.innerText ?? ''");
   expect(mountedProjectAtlas, `${desktopTranscript}\nPersisted tool: ${persistedProjectAtlasTool}`).toBe(true);
   expect(desktopTranscript).not.toContain("MCP_APP_INITIALIZE_TIMEOUT");
   expect(desktopTranscript).not.toContain("Interactive view unavailable");
+  expect(standardMcpCalls).toBe(3);
+
+  await evalIn(desktopApp, "location.reload(); true");
+  await waitFor(desktopApp, "Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "desktop control after App reload" });
+  expect(await waitForMountedProjectAtlas(desktopApp, undefined, 30_000)).toBe(true);
   expect(standardMcpCalls).toBe(3);
   const desktopShot = await screenshot(desktopApp);
   const desktopExpectations = [
@@ -1077,9 +1122,97 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, { timeout:
   expect(flagOffIndex.servers).toEqual([]);
   expect(standardMcpCalls).toBe(4);
 
+  expect(await reconcileDesktopCatalog({
+    app: desktopApp,
+    workspaceId: workspace.workspaceId,
+    denApiUrl: den.ref.apiUrl,
+    mcpToken,
+    appHostMcpToken,
+  })).toBe("ok");
+  await evalIn(desktopApp, "location.reload(); true");
+  await waitFor(desktopApp, `document.body.innerText.includes("Interactive view unavailable")`, {
+    timeoutMs: 30_000,
+    label: "normal result fallback after native MCP App access is disabled",
+  });
+  const disabledTranscript = await evalIn(desktopApp, "document.body?.innerText ?? ''");
+  expect(String(disabledTranscript)).toContain(desktopClosingReply);
+  expect(String(disabledTranscript)).toContain("The normal tool result is still available");
+
+  const restored = await denFetch(den.admin, `/v1/admin/organizations/${organizationId}/capabilities`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({ capabilities: { remoteMcpApps: true } }),
+  });
+  expect(restored.response.ok, restored.text).toBe(true);
+  expect(await reconcileDesktopCatalog({
+    app: desktopApp,
+    workspaceId: workspace.workspaceId,
+    denApiUrl: den.ref.apiUrl,
+    mcpToken,
+    appHostMcpToken,
+  })).toBe("ok");
+  await evalIn(desktopApp, "location.reload(); true");
+  expect(await waitForMountedProjectAtlas(desktopApp, undefined, 30_000)).toBe(true);
+
+  if (!process.env.OPENWORK_EVAL_CDP_URL?.trim()) {
+    const persistedSessionHash = String(await evalIn(desktopApp, "location.hash"));
+    expect(persistedSessionHash).toContain("/session/");
+    await desktopApp.stop();
+    desktopApp = await desktop({
+      name: "remote-mcp-apps-restarted",
+      profileDir: desktopProfileDir,
+      env: {
+        ANTHROPIC_API_KEY: "",
+        OPENAI_API_KEY: "",
+        OPENROUTER_API_KEY: "",
+        GOOGLE_GENERATIVE_AI_API_KEY: "",
+        OPENWORK_API_KEY: "",
+        OPENWORK_INFERENCE_BASE_URL: "",
+      },
+    });
+    await waitFor(desktopApp, "Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "restarted Desktop control" });
+    await waitFor(desktopApp, `Boolean(localStorage.getItem("openwork.server.port") && localStorage.getItem("openwork.server.token"))`, {
+      timeoutMs: 60_000,
+      label: "restarted Desktop local server credentials",
+    });
+    await evalIn(desktopApp, `location.hash = ${JSON.stringify(persistedSessionHash)}; true`);
+    const restartResolution = await evalIn(desktopApp, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      if (!port || !token) return { error: "missing local server credentials" };
+      const headers = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+      const base = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)});
+      const [resolved, listed] = await Promise.all([
+        fetch(base + "/mcp-apps/resolve", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            projectedToolName: "openwork-cloud_execute_capability",
+            launch: {
+              connectionId: ${JSON.stringify(connection.id)},
+              toolName: "open_project_atlas",
+              resourceUri: ${JSON.stringify(connectedResourceUri)},
+              arguments: {},
+            },
+          }),
+        }),
+        fetch(base + "/mcp", { headers }),
+      ]);
+      return {
+        hash: location.hash,
+        resolvedStatus: resolved.status,
+        resolved: await resolved.text(),
+        listedStatus: listed.status,
+        listed: await listed.text(),
+      };
+    })()`, { awaitPromise: true, timeoutMs: 60_000 });
+    expect(await waitForMountedProjectAtlas(desktopApp, undefined, 60_000), JSON.stringify(restartResolution)).toBe(true);
+    expect(standardMcpCalls).toBe(4);
+  }
+
   evidence.recordAssertionEvidence(
-    "Native MCP Apps refresh on a justified catalog miss while standalone URL Apps remain unavailable",
-    `Reconciled Desktop before adding connection ${lateConnection.id}, then rendered that newly added standard MCP App through search_capabilities and execute_capability without leaking provider tools into the model runtime. Kept direct provider access and standalone URL Apps unavailable; completed the native MCP App handshake; then disabled the organization rollout, published an empty provider index, and preserved ordinary search/execute without MCP App launch metadata.`,
+    "Native MCP Apps recover from catalog changes and restart while standalone URL Apps remain unavailable",
+    `Reconciled Desktop before adding connection ${lateConnection.id}, then rendered that newly added standard MCP App through search_capabilities and execute_capability without leaking provider tools into the model runtime. Exposed only the regular connected Project Atlas App binding on connection ${connection.id} to the App host; blocked direct provider access; proved the URL import tool, REST calls, Library button/form, capability matches, ui:// library resources, and standalone launch tools absent; completed the native MCP App handshake and same-server Search projects action; reloaded the App; disabled the organization rollout and preserved ordinary search/execute without MCP App launch metadata while publishing an empty provider index; restored access; and recovered after a Desktop restart on the same isolated profile.`,
     standardMcpCalls === 4 && mountedProjectAtlas,
   );
 });


### PR DESCRIPTION
## Problem

Desktop connects to hosted Den through `https://app.openworklabs.com/api/den/mcp/agent`, while the authenticated MCP App server index names canonical per-connection proxies under `https://api.openworklabs.com/mcp/agent/connections/{connectionId}`. Desktop required every descriptor to have the exact same origin as the configured Cloud endpoint, rejected this valid OpenWork gateway topology, and cleared the private App-host catalog. Users then received `MCP_APP_RESOURCE_RESOLUTION_FAILED` with cause `server_unavailable`, even though capability search and execution succeeded.

## Demo and user impact

Eligible hosted MCP Apps could be discovered and invoked, but their exact `ui://` resources could not be resolved by the private Desktop App host. The normal text fallback remained visible, making the failure look like an App rendering or hosted-gallery problem.

## Root cause

The private catalog validator treated the OpenWork app-origin Den gateway and canonical api-origin connection proxy as unrelated origins. The production gateway topology was not normalized before exact origin-bound credential validation.

## Fix

- Recognize only the explicit built-in OpenWork app/API gateway pairs.
- Require the exact canonical `/mcp/agent/connections/{connectionId}` path and matching connection ID.
- Translate the authenticated descriptor through the already credential-bound app-origin gateway before persisting it in the private catalog.
- Add deterministic regression coverage for the valid hosted topology and a mismatched proxy path.
- Harden the native MCP Apps testkit journey and document the repeatable demo flow.

## Security and compatibility boundaries preserved

- Arbitrary cross-origin descriptors remain rejected.
- Credential-bearing, query-bearing, and fragment-bearing proxy URLs are rejected.
- App-host credentials are never sent to raw third-party MCP origins.
- Provider descriptors and credentials remain private to Desktop.
- Provider tools are not projected into OpenCode or the model-visible catalog.
- Same-server tool and resource binding remains enforced.
- User-authored MCPs and ordinary OpenWork Connect behavior are unchanged.
- Enterprise deployments retain exact-origin behavior.

## Exact-head verification

Head: `9fd67c1a779b92e463ae7b90e38835bad09b702b`

Passed:

- `pnpm --filter openwork-server test -- src/connect-mcp-server-catalog.test.ts src/mcp-app-host.test.ts src/cloud-mcp-reconcile.e2e.test.ts` — 55 passed, 0 failed.
- `pnpm --filter openwork-server typecheck` — passed.
- `git diff --check origin/dev...HEAD` — passed.

Failed:

- None in focused automated verification.

Skipped:

- None in focused automated verification.

Deferred / incomplete:

- The currently published `v0.18.36-alpha.2469+e27b872` predates this fix and still reproduces the failure.
- A rebuilt Desktop at this exact head must rerun the hosted Budget Allocator journey.
- The required exact-head `@openwork/testkit` runtime tape must be published before this PR is ready for review or the MCP Apps demo is declared passed.

## Known remaining gaps

This PR is intentionally draft because live rebuilt-Desktop proof and the exact-head testkit tape are incomplete. No production rollout flags or deployments were changed.