### PR TITLE
fix(release): restore exec bit on openwork-server before npm publish

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1170,6 +1170,16 @@ jobs:
           name: openwork-server-npm-${{ env.RELEASE_VERSION }}
           path: ${{ runner.temp }}/openwork-server-npm
 
+      - name: Restore exec bit lost in the artifact round-trip
+        run: |
+          set -euo pipefail
+          # upload-artifact does not preserve file permissions, so the compiled
+          # server binary arrives 0644 and npm ships that mode in the tarball.
+          # The bin shim then spawns a non-executable binary and every global
+          # install fails with EACCES (issue #4001). npm reads modes from the
+          # filesystem at pack time, so restoring them here is enough.
+          find "$RUNNER_TEMP/openwork-server-npm/dist/bin" -type f -exec chmod 0755 {} +
+
       - name: Publish openwork-server
         run: npm publish "$RUNNER_TEMP/openwork-server-npm" --access public --provenance
 


### PR DESCRIPTION
Fixes #4001

## Root cause

The npm package is assembled in the `prepare-npm` job and published from a *different* job:

1. `prepare-npm` builds the compiled binary (`bun build --compile`, mode 0755) and uploads `apps/server/dist/npm` via `actions/upload-artifact@v4`
2. `publish-npm` downloads it with `actions/download-artifact@v4` and runs `npm publish`

`upload-artifact` does not preserve file permissions across the round-trip. The binary lands 0644 in `$RUNNER_TEMP`, and since `npm pack` records modes from the filesystem at publish time, the shipped tarball carries `-rw-r--r-- dist/bin/openwork-server`.

Verified against the actually-published artifact:

```
$ tar -tvzf openwork-server-0.18.4.tgz
-rw-r--r--  ... package/dist/bin/openwork-server      <- not executable
-rwxr-xr-x  ... package/bin/openwork-server.mjs       <- shim is fine
```

The bin shim then spawns the non-executable binary and every `npm i -g openwork-server@0.18.4` install EACCESes on launch, crash-looping under Docker restart policies, exactly as reported.

## Change

One step in the `publish-npm` job, between download and publish: restore 0755 on everything under `dist/bin`. npm reads modes at pack time, so this alone fixes the shipped tarball.

```yaml
- name: Restore exec bit lost in the artifact round-trip
  run: |
    set -euo pipefail
    find "$RUNNER_TEMP/openwork-server-npm/dist/bin" -type f -exec chmod 0755 {} +
```

If the artifact is ever malformed and the directory is missing, the job now fails loudly before publishing instead of shipping another broken package.

## Notes for reviewers

- No repo source changes; the local `pnpm publish:npm` path was never affected because bun's compile output is already 0755 there.
- Future multi-platform binaries under `dist/bin` are covered by the same find (chmod on a Windows PE inside a Linux-built tarball is a no-op).

---
This change was prepared with AI assistance under human direction and review.
