### PR TITLE
fix(app): force engine restart when applying environment changes

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2088,6 +2088,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       runtime: "direct",
       workspacePaths,
       openworkRemoteAccess: openworkServerSnapshot.openworkServerSettings.remoteAccessEnabled === true,
+      // Environment variables are only read at process spawn. Without this,
+      // engineStart's healthy-engine short-circuit keeps the existing engine
+      // process alive and a newly added variable never reaches it, silently
+      // breaking the "Apply changes" button's promise. Do not remove this as
+      // a supposedly redundant flag.
+      forceRestart: true,
     });
     const reconnected = await openworkServerStore.reconnectOpenworkServer();
     if (!reconnected) {


### PR DESCRIPTION
## The bug

Settings → Environment → **Apply changes** reports success but does not respawn the engine, so a newly added environment variable never reaches it. Any config value written as an `{env:VAR}` reference then resolves to nothing.

The button's own copy promises the opposite.

## Why it happens

`handleApplyEnvironmentChanges` calls `engineStart` without `forceRestart`:

```js
await engineStart(selectedWorkspaceRoot, {
  preferSidecar: true,
  runtime: "direct",
  workspacePaths,
  openworkRemoteAccess: ...,
});
```

`engineStart` short-circuits (`apps/desktop/electron/runtime.mjs:2091-2103`):

```js
if (
  options.forceRestart !== true &&
  openworkServerState.inProcess &&
  lifecycleState === "healthy" &&
  normalizeWorkspaceKey(engineState.projectDir, ...) === normalizeWorkspaceKey(safeProjectDir, ...) &&
  openworkServerState.remoteAccessEnabled === requestedRemoteAccess &&
  openworkServerState.engineRollover === requestedEngineRollover
) {
  ... return snapshotEngineState(engineState);   // returns without respawning
}
```

Every condition holds on a healthy desktop applying environment changes. `preferSidecar`, `runtime` and `workspacePaths` are not part of the guard, so passing them does not defeat it. The call returns the existing snapshot, `reconnectOpenworkServer()` reconnects to the same server, the mutation resolves, the pending flag clears, and the UI reports success — with the original engine process, and therefore the original process environment, still in place.

Environment variables are only read at spawn. An in-place config *reload* cannot substitute, and the codebase already says so — `engine-pool.ts:495-499`: *"Idle engines reload in place; busy ones roll over to a standby."* A reload keeps the process, so it keeps the stale environment.

## The fix

Pass `forceRestart: true`, with a comment so it is not later removed as redundant.

Safety, checked rather than assumed:

- The guard is literally `options.forceRestart !== true && …`, so the flag bypasses it and changes nothing else.
- `engineRestart` in the same file already passes `forceRestart: true` — this is an established pattern, not a new mechanism.
- `handleApplyEnvironmentChanges` already throws when `activeReloadBlockingSessions.length > 0`, so it cannot interrupt a running session.

The behavioural change is that applying environment changes now genuinely respawns the local stack instead of sometimes no-opping. That is what the button claims to do.

## How it was found, and verification

Found by an end-to-end spec while building custom model endpoints on a downstream branch: a credential stored as `{env:...}` never reached the engine, and the upstream gateway answered `No api key passed in.` rather than rejecting a bad key — the request carried no auth header at all, because substitution had resolved to nothing.

- `pnpm typecheck` in `apps/app`: clean, against current `dev`.
- `apps/app` test suite: unchanged from baseline, no new failures.
- The end-to-end spec that exposed this goes from failing to passing with this change, and every step after the restart (model selection, a real chat turn, wire-level assertions on the gateway) then executes.

One caveat worth stating plainly: that spec lives in the larger custom-model-endpoints branch, so it is not included here. This PR is the six-line fix on its own. Happy to add a focused regression test if you would prefer one before merging — the difficulty is that the failure is only observable across a real engine respawn.
