### PR TITLE
fix(chat): ignore stale tool activity

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -111,10 +111,8 @@ import {
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
 import { formatToolCallDuration } from "@/lib/tool-call-duration"
-import {
-  collectToolParts,
-  getActiveToolLabel,
-} from "@/lib/tool-activity"
+import { collectLatestAssistantToolParts } from "@/lib/latest-assistant-tool-parts"
+import { getActiveToolLabel } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { cn } from "@/lib/utils"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
@@ -1227,7 +1225,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
   const liveActionLabel = isStreaming
-    ? getActiveToolLabel(collectToolParts(messages))
+    ? getActiveToolLabel(collectLatestAssistantToolParts(messages))
     : null
 
   return (

--- a/apps/app/src/lib/latest-assistant-tool-parts.ts
+++ b/apps/app/src/lib/latest-assistant-tool-parts.ts
@@ -1,0 +1,21 @@
+import type { DynamicToolUIPart, UIMessage } from "ai";
+
+export function collectLatestAssistantToolParts(messages: UIMessage[]): DynamicToolUIPart[] {
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      latestUserIndex = index;
+      break;
+    }
+  }
+
+  for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    return message.parts.filter(
+      (part): part is DynamicToolUIPart => part.type === "dynamic-tool",
+    );
+  }
+
+  return [];
+}

--- a/apps/app/src/lib/tool-activity.ts
+++ b/apps/app/src/lib/tool-activity.ts
@@ -1,4 +1,4 @@
-import type { DynamicToolUIPart, ToolUIPart, UIMessage } from "ai"
+import type { DynamicToolUIPart, ToolUIPart } from "ai"
 import {
   isApplyPatchToolPart,
   isBashToolPart,
@@ -22,14 +22,6 @@ type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
 export function isToolPartInFlight(part: AnyToolPart): boolean {
   return part.state === "input-streaming" || part.state === "input-available"
-}
-
-export function collectToolParts(messages: UIMessage[]): DynamicToolUIPart[] {
-  return messages.flatMap((message) =>
-    message.parts.filter(
-      (part): part is DynamicToolUIPart => part.type === "dynamic-tool"
-    )
-  )
 }
 
 function hostnameOf(url: string | undefined): string | undefined {
@@ -119,4 +111,3 @@ export function getActiveToolLabel(parts: DynamicToolUIPart[]): string | null {
   }
   return null
 }
-

--- a/evals/specs/current-turn-tool-activity.test.ts
+++ b/evals/specs/current-turn-tool-activity.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { collectLatestAssistantToolParts } from "../../apps/app/src/lib/latest-assistant-tool-parts";
+
+type MessageHistory = Parameters<typeof collectLatestAssistantToolParts>[0];
+
+const staleHistory: MessageHistory = [
+  {
+    id: "user-old",
+    role: "user",
+    parts: [{ type: "text", text: "Run the old action" }],
+  },
+  {
+    id: "assistant-old",
+    role: "assistant",
+    parts: [{
+      type: "dynamic-tool",
+      toolName: "openwork_execute",
+      toolCallId: "old-call",
+      state: "input-streaming",
+      input: {},
+    }],
+  },
+  {
+    id: "assistant-replacement",
+    role: "assistant",
+    parts: [{ type: "text", text: "The replacement run is responding" }],
+  },
+];
+
+const newTurnWithoutAssistant: MessageHistory = [
+  ...staleHistory.slice(0, 2),
+  {
+    id: "user-current",
+    role: "user",
+    parts: [{ type: "text", text: "Start a new turn" }],
+  },
+];
+
+test("live activity ignores unfinished tools from earlier turns", ({ evidence }) => {
+  expect(collectLatestAssistantToolParts(staleHistory)).toEqual([]);
+  expect(collectLatestAssistantToolParts(newTurnWithoutAssistant)).toEqual([]);
+
+  const currentHistory: MessageHistory = [
+    ...newTurnWithoutAssistant,
+    {
+      id: "assistant-current",
+      role: "assistant",
+      parts: [{
+        type: "dynamic-tool",
+        toolName: "read",
+        toolCallId: "current-call",
+        state: "input-streaming",
+        input: { filePath: "/workspace/current.txt" },
+      }],
+    },
+  ];
+
+  expect(collectLatestAssistantToolParts(currentHistory).map((part) => part.toolCallId)).toEqual(["current-call"]);
+
+  evidence.recordAssertionEvidence(
+    "A live turn never reports stale tool activity",
+    "A pending openwork_execute was excluded after both a replacement assistant response and a newer user message, while the newest assistant response retained its current tool.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- keep OpenCode session status as the sole live/idle authority
- derive the live tool label only from the latest assistant response in the current user turn
- add a deterministic `@openwork/testkit` regression for stale `openwork_execute` parts across replacement and new turns

## Verification
- `pnpm evals:pr specs/current-turn-tool-activity.test.ts` (local fallback: 1 passed, 0 failed, 0 skipped)
- `pnpm --filter @openwork/app typecheck` (passed)

Daytona was unavailable because the CLI/API credential prerequisite was not available in this environment; the app-less PR-lane spec ran locally.