### PR TITLE
feat(windows): OfficeCLI auto-MCP and cursor-acp runtime config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# exFAT volumes (e.g. E:) cannot create pnpm symlinks; hoisted layout required on this machine.
+node-linker=hoisted
+symlink=false
+package-import-method=copy

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,7 @@
+# SDD Progress: OfficeCLI Windows auto-MCP
+
+Branch: `feat/officecli-windows-auto-mcp`
+Plan: `docs/superpowers/plans/2026-08-22-officecli-windows.md`
+
+Task 1-6: implementation complete (pending test verification on NTFS)
+Task 7: blocked on exFAT pnpm install — build on C: worktree

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -569,6 +569,13 @@ function pathHelperEntries() {
   return match?.[1]?.split(path.delimiter).filter(Boolean) ?? [];
 }
 
+export function windowsOfficeCliPathCandidates(env = process.env) {
+  if (process.platform !== "win32") return [];
+  const localAppData = String(env.LOCALAPPDATA ?? "").trim();
+  if (!localAppData) return [];
+  return [path.join(localAppData, "OfficeCLI")];
+}
+
 function extraPathEntries() {
   const home = os.homedir();
   const candidates = [];
@@ -610,6 +617,7 @@ function extraPathEntries() {
 
   if (process.platform === "win32") {
     candidates.push(
+      ...windowsOfficeCliPathCandidates(process.env),
       path.join(home, ".volta", "bin"),
       path.join(home, ".bun", "bin"),
       path.join(home, ".cargo", "bin"),

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -20,6 +20,7 @@ import {
   selectStickyOpenworkPortWorkspace,
   snapshotEngineState,
   snapshotOpenworkServerState,
+  windowsOfficeCliPathCandidates,
 } from "./runtime.mjs";
 
 describe("workspace root preparation", () => {
@@ -396,5 +397,20 @@ describe("resetRuntimeStatesAfterFailedServerStart", () => {
     assert.equal(serverState.inProcess, false);
     assert.equal(engineState.baseUrl, "http://127.0.0.1:4097");
     assert.equal(engineState.projectDir, "/workspace/current");
+  });
+});
+
+describe("windowsOfficeCliPathCandidates", () => {
+  it("includes LOCALAPPDATA OfficeCLI on win32", () => {
+    const candidates = windowsOfficeCliPathCandidates({
+      LOCALAPPDATA: "C:\\Users\\Example\\AppData\\Local",
+    });
+    assert.ok(
+      candidates.includes("C:\\Users\\Example\\AppData\\Local\\OfficeCLI"),
+    );
+  });
+
+  it("returns empty list when LOCALAPPDATA is missing", () => {
+    assert.deepEqual(windowsOfficeCliPathCandidates({}), []);
   });
 });

--- a/apps/server/src/cursor-acp-env.test.ts
+++ b/apps/server/src/cursor-acp-env.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EnvService } from "./env-file.js";
+import { resolveCursorApiKey } from "./cursor-acp-env.js";
+
+const roots: string[] = [];
+const cleanups: Array<() => void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) cleanups.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+function isolateProcessKey() {
+  const previous = process.env.CURSOR_API_KEY;
+  cleanups.push(() => {
+    if (previous === undefined) delete process.env.CURSOR_API_KEY;
+    else process.env.CURSOR_API_KEY = previous;
+  });
+  delete process.env.CURSOR_API_KEY;
+}
+
+describe("resolveCursorApiKey", () => {
+  test("returns the env-store key when process.env.CURSOR_API_KEY is unset", async () => {
+    isolateProcessKey();
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    await env.upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("returns process.env.CURSOR_API_KEY when the store has no key", async () => {
+    isolateProcessKey();
+    process.env.CURSOR_API_KEY = "cur_test_key";
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("prefers the env-store key over process.env", async () => {
+    isolateProcessKey();
+    process.env.CURSOR_API_KEY = "cur_process_key";
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    await env.upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("returns empty string when neither source has a key", async () => {
+    isolateProcessKey();
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    expect(await resolveCursorApiKey(env)).toBe("");
+  });
+});

--- a/apps/server/src/cursor-acp-env.ts
+++ b/apps/server/src/cursor-acp-env.ts
@@ -1,0 +1,13 @@
+import { EnvService } from "./env-file.js";
+
+export async function resolveCursorApiKey(envService?: EnvService): Promise<string> {
+  try {
+    const stored = (await (envService ?? new EnvService()).list())
+      .find((entry) => entry.key === "CURSOR_API_KEY")
+      ?.value.trim() ?? "";
+    if (stored) return stored;
+  } catch {
+    // Missing or unreadable env store is not a Cursor-key signal.
+  }
+  return process.env.CURSOR_API_KEY?.trim() ?? "";
+}

--- a/apps/server/src/cursor-acp-plugin-path.test.ts
+++ b/apps/server/src/cursor-acp-plugin-path.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLocalCursorAcpPluginPath } from "./cursor-acp-plugin-path.js";
+
+const roots: string[] = [];
+const cleanups: Array<() => void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) cleanups.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+function isolateConfigDir(dir: string) {
+  const previous = process.env.OPENCODE_CONFIG_DIR;
+  cleanups.push(() => {
+    if (previous === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = previous;
+  });
+  process.env.OPENCODE_CONFIG_DIR = dir;
+}
+
+describe("resolveLocalCursorAcpPluginPath", () => {
+  test("returns the absolute plugin path when plugin/cursor-acp.js exists under OPENCODE_CONFIG_DIR", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cursor-acp-plugin-"));
+    roots.push(dir);
+    isolateConfigDir(dir);
+    const pluginPath = join(dir, "plugin", "cursor-acp.js");
+    await mkdir(join(dir, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+    expect(resolveLocalCursorAcpPluginPath()).toBe(pluginPath);
+  });
+
+  test("returns null when OPENCODE_CONFIG_DIR has no plugin/cursor-acp.js", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cursor-acp-plugin-"));
+    roots.push(dir);
+    isolateConfigDir(dir);
+    expect(resolveLocalCursorAcpPluginPath()).toBeNull();
+  });
+});

--- a/apps/server/src/cursor-acp-plugin-path.ts
+++ b/apps/server/src/cursor-acp-plugin-path.ts
@@ -1,0 +1,11 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { resolveGlobalOpencodeConfigPath } from "@openwork/paths";
+
+export const CURSOR_ACP_PLUGIN_FILENAME = "cursor-acp.js";
+
+export function resolveLocalCursorAcpPluginPath(): string | null {
+  const pluginPath = join(dirname(resolveGlobalOpencodeConfigPath()), "plugin", CURSOR_ACP_PLUGIN_FILENAME);
+  return existsSync(pluginPath) ? pluginPath : null;
+}

--- a/apps/server/src/officecli-mcp.test.ts
+++ b/apps/server/src/officecli-mcp.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+import {
+  OFFICECLI_MCP_NAME,
+  markOfficeCliManagedMcpRemoved,
+  readOfficeCliProvisionState,
+  reconcileOfficeCliMcp,
+  reconcileOfficeCliMcpForAllWorkspaces,
+  resolveOfficeCliBinary,
+  writeOfficeCliProvisionState,
+} from "./officecli-mcp.js";
+
+const previousPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: previousPlatform });
+});
+
+function testServerConfig(workspaceRoot: string, workspaceId: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(workspaceRoot, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: workspaceId, name: "Test", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+describe("resolveOfficeCliBinary", () => {
+  test("returns OPENWORK_OFFICECLI_PATH when the file exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "officecli-resolve-"));
+    const binary = join(root, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      const resolved = resolveOfficeCliBinary({
+        OPENWORK_OFFICECLI_PATH: binary,
+        LOCALAPPDATA: join(root, "unused"),
+        PATH: "",
+      });
+      expect(resolved).toBe(binary);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns default LOCALAPPDATA install path on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const root = await mkdtemp(join(tmpdir(), "officecli-localappdata-"));
+    const officeCliDir = join(root, "OfficeCLI");
+    const binary = join(officeCliDir, "officecli.exe");
+    await mkdir(officeCliDir, { recursive: true });
+    await writeFile(binary, "");
+    try {
+      const resolved = resolveOfficeCliBinary({
+        LOCALAPPDATA: root,
+        PATH: "",
+      });
+      expect(resolved).toBe(binary);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null on non-windows when override is unset", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveOfficeCliBinary({ LOCALAPPDATA: "/tmp", PATH: "/usr/bin" })).toBeNull();
+  });
+
+  test("returns null when no candidate exists", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveOfficeCliBinary({ LOCALAPPDATA: "C:\\missing", PATH: "" })).toBeNull();
+  });
+});
+
+describe("officecli provision state", () => {
+  test("reads and writes managed state in openwork workspace config", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-provision-"));
+    const workspaceId = "ws_officecli";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    try {
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBeNull();
+      await writeOfficeCliProvisionState(config, workspaceId, "managed");
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("managed");
+      await writeOfficeCliProvisionState(config, workspaceId, "removed");
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("removed");
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("reconcileOfficeCliMcp", () => {
+  test("adds managed local MCP when absent", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-add-"));
+    const workspaceId = "ws_add";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("added");
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]).toEqual({
+        type: "local",
+        enabled: true,
+        command: [binary, "mcp"],
+        openworkManaged: true,
+      });
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("skips when provision state is removed", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-removed-"));
+    const workspaceId = "ws_removed";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      await writeOfficeCliProvisionState(config, workspaceId, "removed");
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("skipped");
+      expect(await readRuntimeOpencodeConfig(config, workspaceId)).toEqual({});
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not modify user-owned MCP entry", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-user-"));
+    const workspaceId = "ws_user";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    const userBinary = join(workspaceRoot, "custom-officecli.exe");
+    await writeFile(binary, "");
+    await writeFile(userBinary, "");
+    try {
+      await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
+        ...current,
+        mcp: {
+          [OFFICECLI_MCP_NAME]: {
+            type: "local",
+            enabled: true,
+            command: [userBinary, "mcp"],
+          },
+        },
+      }));
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("skipped");
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]?.command).toEqual([userBinary, "mcp"]);
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("reconcileOfficeCliMcpForAllWorkspaces", () => {
+  test("provisions officecli MCP for every workspace when binary exists", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-all-"));
+    const workspaceId = "ws_all";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    try {
+      process.env.OPENWORK_OFFICECLI_PATH = binary;
+      await reconcileOfficeCliMcpForAllWorkspaces(config);
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]?.command).toEqual([binary, "mcp"]);
+    } finally {
+      delete process.env.OPENWORK_OFFICECLI_PATH;
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("officecli managed delete opt-out", () => {
+  test("marks provision removed when managed officecli MCP is deleted", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-delete-"));
+    const workspaceId = "ws_delete";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      await reconcileOfficeCliMcp(config, workspaceId, binary);
+      await markOfficeCliManagedMcpRemoved(config, workspaceId);
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("removed");
+      const retry = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(retry).toBe("skipped");
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/officecli-mcp.test.ts
+++ b/apps/server/src/officecli-mcp.test.ts
@@ -21,6 +21,15 @@ afterEach(() => {
   Object.defineProperty(process, "platform", { value: previousPlatform });
 });
 
+async function removeWorkspaceRoot(workspaceRoot: string) {
+  try {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "EBUSY") return;
+    throw error;
+  }
+}
+
 function testServerConfig(workspaceRoot: string, workspaceId: string): ServerConfig {
   return {
     host: "127.0.0.1",
@@ -54,7 +63,7 @@ describe("resolveOfficeCliBinary", () => {
       });
       expect(resolved).toBe(binary);
     } finally {
-      await rm(root, { recursive: true, force: true });
+      await removeWorkspaceRoot(root);
     }
   });
 
@@ -72,7 +81,7 @@ describe("resolveOfficeCliBinary", () => {
       });
       expect(resolved).toBe(binary);
     } finally {
-      await rm(root, { recursive: true, force: true });
+      await removeWorkspaceRoot(root);
     }
   });
 
@@ -102,7 +111,7 @@ describe("officecli provision state", () => {
       expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("removed");
     } finally {
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 });
@@ -128,7 +137,7 @@ describe("reconcileOfficeCliMcp", () => {
       });
     } finally {
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 
@@ -147,7 +156,7 @@ describe("reconcileOfficeCliMcp", () => {
       expect(await readRuntimeOpencodeConfig(config, workspaceId)).toEqual({});
     } finally {
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 
@@ -178,7 +187,7 @@ describe("reconcileOfficeCliMcp", () => {
       expect(runtime.mcp?.[OFFICECLI_MCP_NAME]?.command).toEqual([userBinary, "mcp"]);
     } finally {
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 });
@@ -201,7 +210,7 @@ describe("reconcileOfficeCliMcpForAllWorkspaces", () => {
     } finally {
       delete process.env.OPENWORK_OFFICECLI_PATH;
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 });
@@ -223,7 +232,7 @@ describe("officecli managed delete opt-out", () => {
       expect(retry).toBe("skipped");
     } finally {
       process.env.OPENWORK_RUNTIME_DB = previousDb;
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await removeWorkspaceRoot(workspaceRoot);
     }
   });
 });

--- a/apps/server/src/officecli-mcp.ts
+++ b/apps/server/src/officecli-mcp.ts
@@ -1,0 +1,138 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  readOpenworkWorkspaceConfig,
+  writeOpenworkWorkspaceConfig,
+} from "./openwork-workspace-config-store.js";
+import {
+  readRuntimeOpencodeConfig,
+  runtimeMcpMap,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+export const OFFICECLI_MCP_NAME = "officecli" as const;
+
+export type OfficeCliProvisionState = "managed" | "removed";
+
+const OFFICECLI_EXE = "officecli.exe";
+const PROVISION_KEY = "officecliProvision";
+
+function normalizedOverride(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.OPENWORK_OFFICECLI_PATH?.trim();
+  if (!raw) return null;
+  return existsSync(raw) ? raw : null;
+}
+
+function defaultWindowsInstallPath(env: NodeJS.ProcessEnv): string | null {
+  const localAppData = env.LOCALAPPDATA?.trim();
+  if (!localAppData) return null;
+  const candidate = join(localAppData, "OfficeCLI", OFFICECLI_EXE);
+  return existsSync(candidate) ? candidate : null;
+}
+
+function pathScan(env: NodeJS.ProcessEnv): string | null {
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  for (const entry of (env.PATH ?? "").split(delimiter).filter(Boolean)) {
+    const candidate = join(entry, OFFICECLI_EXE);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function resolveOfficeCliBinary(env: NodeJS.ProcessEnv = process.env): string | null {
+  const override = normalizedOverride(env);
+  if (override) return override;
+  if (process.platform !== "win32") return null;
+  return defaultWindowsInstallPath(env) ?? pathScan(env);
+}
+
+function parseProvisionState(value: unknown): OfficeCliProvisionState | null {
+  return value === "managed" || value === "removed" ? value : null;
+}
+
+export async function readOfficeCliProvisionState(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<OfficeCliProvisionState | null> {
+  const workspaceConfig = await readOpenworkWorkspaceConfig(config, workspaceId);
+  return parseProvisionState(workspaceConfig[PROVISION_KEY]);
+}
+
+export async function writeOfficeCliProvisionState(
+  config: ServerConfig,
+  workspaceId: string,
+  state: OfficeCliProvisionState,
+): Promise<void> {
+  await writeOpenworkWorkspaceConfig(config, workspaceId, (current) => ({
+    ...current,
+    [PROVISION_KEY]: state,
+  }));
+}
+
+function managedOfficeCliEntry(binaryPath: string, enabled: boolean): Record<string, unknown> {
+  return {
+    type: "local",
+    enabled,
+    command: [binaryPath, "mcp"],
+    openworkManaged: true,
+  };
+}
+
+export async function reconcileOfficeCliMcp(
+  config: ServerConfig,
+  workspaceId: string,
+  binaryPath: string,
+): Promise<"added" | "updated" | "skipped"> {
+  if (await readOfficeCliProvisionState(config, workspaceId) === "removed") {
+    return "skipped";
+  }
+
+  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspaceId);
+  const mcpMap = runtimeMcpMap(runtimeConfig);
+  const current = mcpMap[OFFICECLI_MCP_NAME];
+
+  if (current && current.openworkManaged !== true) {
+    return "skipped";
+  }
+
+  const enabled = current?.enabled !== false;
+  const nextEntry = managedOfficeCliEntry(binaryPath, enabled);
+  const currentCommand = Array.isArray(current?.command) ? current.command : [];
+  const action = current ? "updated" : "added";
+
+  if (
+    current
+    && currentCommand[0] === binaryPath
+    && current.enabled === enabled
+    && current.openworkManaged === true
+  ) {
+    return "skipped";
+  }
+
+  await writeRuntimeOpencodeConfig(config, workspaceId, (value) => ({
+    ...value,
+    mcp: { ...runtimeMcpMap(value), [OFFICECLI_MCP_NAME]: nextEntry },
+  }));
+  await writeOfficeCliProvisionState(config, workspaceId, "managed");
+  return action;
+}
+
+export async function reconcileOfficeCliMcpForAllWorkspaces(config: ServerConfig): Promise<void> {
+  const binaryPath = resolveOfficeCliBinary();
+  if (!binaryPath) return;
+  for (const workspace of config.workspaces) {
+    await reconcileOfficeCliMcp(config, workspace.id, binaryPath);
+  }
+}
+
+export async function markOfficeCliManagedMcpRemoved(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<void> {
+  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspaceId);
+  const current = runtimeMcpMap(runtimeConfig)[OFFICECLI_MCP_NAME];
+  if (current?.openworkManaged === true) {
+    await writeOfficeCliProvisionState(config, workspaceId, "removed");
+  }
+}

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,6 +11,7 @@ import {
 } from "./openwork-runtime-config.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
+import { closeWorkspaceKvStoreDatabasesForTests } from "./workspace-kv-store.js";
 
 const roots: string[] = [];
 const cleanups: Array<() => void> = [];
@@ -18,6 +19,7 @@ let previousDb: string | undefined;
 
 afterEach(async () => {
   while (cleanups.length) cleanups.pop()?.();
+  await closeWorkspaceKvStoreDatabasesForTests();
   while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
   if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
   else process.env.OPENWORK_RUNTIME_DB = previousDb;
@@ -186,5 +188,111 @@ describe("openwork runtime config file", () => {
     const second = await buildOpenworkRuntimeConfig(config, "ws_1");
 
     expect(second).toBe(first);
+  });
+});
+
+describe("cursor-acp provider injection", () => {
+  const GLOBAL_CONFIG_WITH_CURSOR_ACP = JSON.stringify({
+    plugin: ["cursor-acp"],
+    provider: {
+      "cursor-acp": {
+        name: "Cursor",
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "http://127.0.0.1:32124/v1" },
+        models: { auto: { name: "Auto" } },
+      },
+    },
+  });
+
+  type BuiltProvider = Record<string, {
+    name?: string;
+    npm?: string;
+    options?: { baseURL?: string };
+    models?: Record<string, { name?: string }>;
+  }>;
+
+  async function setupCursorAcp(options: { cursorApiKey?: string; globalConfig?: string }) {
+    const { config } = await setup();
+    const globalDir = await mkdtemp(join(tmpdir(), "openwork-cursor-acp-global-"));
+    roots.push(globalDir);
+    if (options.globalConfig !== undefined) {
+      await writeFile(join(globalDir, "opencode.json"), options.globalConfig, "utf8");
+    }
+    const previousKey = process.env.CURSOR_API_KEY;
+    const previousDir = process.env.OPENCODE_CONFIG_DIR;
+    cleanups.push(() => {
+      if (previousKey === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = previousKey;
+      if (previousDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+      else process.env.OPENCODE_CONFIG_DIR = previousDir;
+    });
+    if (options.cursorApiKey === undefined) delete process.env.CURSOR_API_KEY;
+    else process.env.CURSOR_API_KEY = options.cursorApiKey;
+    process.env.OPENCODE_CONFIG_DIR = globalDir;
+    return { config };
+  }
+
+  async function buildParsed(config: ServerConfig): Promise<Record<string, unknown>> {
+    return JSON.parse(await buildOpenworkRuntimeConfig(config, "ws_1")) as Record<string, unknown>;
+  }
+
+  test("adds cursor-acp plugin and provider from the global config when CURSOR_API_KEY is set", async () => {
+    const { config } = await setupCursorAcp({
+      cursorApiKey: "cur_test_key",
+      globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP,
+    });
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain("cursor-acp");
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.name).toBe("Cursor");
+    expect(provider["cursor-acp"]?.npm).toBe("@ai-sdk/openai-compatible");
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+    expect(provider["cursor-acp"]?.models?.auto?.name).toBe("Auto");
+  });
+
+  test("leaves cursor-acp out when CURSOR_API_KEY is not set", async () => {
+    const { config } = await setupCursorAcp({ globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP });
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).not.toContain("cursor-acp");
+    const provider = (parsed.provider ?? {}) as Record<string, unknown>;
+    expect(provider["cursor-acp"]).toBeUndefined();
+  });
+
+  test("leaves cursor-acp out when the global config has no cursor-acp provider", async () => {
+    const { config } = await setupCursorAcp({ cursorApiKey: "cur_test_key", globalConfig: "{}" });
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).not.toContain("cursor-acp");
+    const provider = (parsed.provider ?? {}) as Record<string, unknown>;
+    expect(provider["cursor-acp"]).toBeUndefined();
+  });
+
+  test("leaves cursor-acp out when no global config file exists", async () => {
+    const { config } = await setupCursorAcp({ cursorApiKey: "cur_test_key" });
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).not.toContain("cursor-acp");
+    const provider = (parsed.provider ?? {}) as Record<string, unknown>;
+    expect(provider["cursor-acp"]).toBeUndefined();
+  });
+
+  test("runtime-DB cursor-acp provider wins over the global config and the plugin is not duplicated", async () => {
+    const { config } = await setupCursorAcp({
+      cursorApiKey: "cur_test_key",
+      globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP,
+    });
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      plugin: ["cursor-acp"],
+      provider: { "cursor-acp": { name: "Runtime Cursor" } },
+    }));
+
+    const parsed = await buildParsed(config);
+    const plugins = (parsed.plugin as string[]).filter((name) => name === "cursor-acp");
+    expect(plugins).toHaveLength(1);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.name).toBe("Runtime Cursor");
   });
 });

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +12,7 @@ import {
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 import { closeWorkspaceKvStoreDatabasesForTests } from "./workspace-kv-store.js";
+import { EnvService } from "./env-file.js";
 
 const roots: string[] = [];
 const cleanups: Array<() => void> = [];
@@ -218,17 +219,22 @@ describe("cursor-acp provider injection", () => {
     if (options.globalConfig !== undefined) {
       await writeFile(join(globalDir, "opencode.json"), options.globalConfig, "utf8");
     }
+    const envPath = join(globalDir, "env.json");
     const previousKey = process.env.CURSOR_API_KEY;
     const previousDir = process.env.OPENCODE_CONFIG_DIR;
+    const previousStore = process.env.OPENWORK_ENV_STORE;
     cleanups.push(() => {
       if (previousKey === undefined) delete process.env.CURSOR_API_KEY;
       else process.env.CURSOR_API_KEY = previousKey;
       if (previousDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
       else process.env.OPENCODE_CONFIG_DIR = previousDir;
+      if (previousStore === undefined) delete process.env.OPENWORK_ENV_STORE;
+      else process.env.OPENWORK_ENV_STORE = previousStore;
     });
     if (options.cursorApiKey === undefined) delete process.env.CURSOR_API_KEY;
     else process.env.CURSOR_API_KEY = options.cursorApiKey;
     process.env.OPENCODE_CONFIG_DIR = globalDir;
+    process.env.OPENWORK_ENV_STORE = envPath;
     return { config };
   }
 
@@ -276,6 +282,51 @@ describe("cursor-acp provider injection", () => {
     expect(parsed.plugin).not.toContain("cursor-acp");
     const provider = (parsed.provider ?? {}) as Record<string, unknown>;
     expect(provider["cursor-acp"]).toBeUndefined();
+  });
+
+  test("adds cursor-acp from the env store when process.env.CURSOR_API_KEY is unset", async () => {
+    const { config } = await setupCursorAcp({ globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP });
+    const envPath = join(roots[roots.length - 1]!, "env.json");
+    const previousStore = process.env.OPENWORK_ENV_STORE;
+    cleanups.push(() => {
+      if (previousStore === undefined) delete process.env.OPENWORK_ENV_STORE;
+      else process.env.OPENWORK_ENV_STORE = previousStore;
+    });
+    process.env.OPENWORK_ENV_STORE = envPath;
+    await new EnvService({ path: envPath }).upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain("cursor-acp");
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+  });
+
+  test("injects the absolute local plugin path when plugin/cursor-acp.js exists", async () => {
+    const { config } = await setupCursorAcp({
+      cursorApiKey: "cur_test_key",
+      globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP,
+    });
+    const pluginPath = join(process.env.OPENCODE_CONFIG_DIR!, "plugin", "cursor-acp.js");
+    await mkdir(join(process.env.OPENCODE_CONFIG_DIR!, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain(pluginPath);
+    expect((parsed.plugin as string[]).filter((name) => name === "cursor-acp")).toEqual([]);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+  });
+
+  test("injects cursor-acp from a local plugin file even when CURSOR_API_KEY is unset", async () => {
+    const { config } = await setupCursorAcp({ globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP });
+    const pluginPath = join(process.env.OPENCODE_CONFIG_DIR!, "plugin", "cursor-acp.js");
+    await mkdir(join(process.env.OPENCODE_CONFIG_DIR!, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain(pluginPath);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.name).toBe("Cursor");
   });
 
   test("runtime-DB cursor-acp provider wins over the global config and the plugin is not duplicated", async () => {

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -329,6 +329,24 @@ describe("cursor-acp provider injection", () => {
     expect(provider["cursor-acp"]?.name).toBe("Cursor");
   });
 
+  test("reads cursor-acp from opencode.json when opencode.jsonc has no block", async () => {
+    const { config } = await setupCursorAcp({
+      cursorApiKey: "cur_test_key",
+      globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP,
+    });
+    await writeFile(
+      join(process.env.OPENCODE_CONFIG_DIR!, "opencode.jsonc"),
+      JSON.stringify({ $schema: "https://opencode.ai/config.json" }),
+      "utf8",
+    );
+
+    const parsed = await buildParsed(config);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+    const plugins = parsed.plugin as string[];
+    expect(plugins.includes("cursor-acp") || plugins.some((name) => name.endsWith("cursor-acp.js"))).toBe(true);
+  });
+
   test("runtime-DB cursor-acp provider wins over the global config and the plugin is not duplicated", async () => {
     const { config } = await setupCursorAcp({
       cursorApiKey: "cur_test_key",

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -37,6 +37,8 @@ import {
   type RuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
 import { CONNECT_MCP_SERVER_NAME_PREFIX } from "./connect-mcp-server-catalog.js";
+import { resolveCursorApiKey } from "./cursor-acp-env.js";
+import { resolveLocalCursorAcpPluginPath } from "./cursor-acp-plugin-path.js";
 
 const OPENWORK_AGENT_PROMPT = `You are OpenWork.
 
@@ -110,13 +112,19 @@ async function readGlobalCursorAcpProvider(): Promise<Record<string, unknown> | 
 }
 
 async function withCursorAcpProvider(runtimeConfig: RuntimeOpencodeConfig): Promise<RuntimeOpencodeConfig> {
-  if (!process.env.CURSOR_API_KEY?.trim()) return runtimeConfig;
   const providers = runtimeProviderMap(runtimeConfig);
+  const localPluginPath = resolveLocalCursorAcpPluginPath();
+  const hasKey = Boolean(await resolveCursorApiKey());
+  if (!hasKey && !localPluginPath && !providers[CURSOR_ACP_PROVIDER_ID]) return runtimeConfig;
   const block = providers[CURSOR_ACP_PROVIDER_ID] ?? (await readGlobalCursorAcpProvider());
   if (!block) return runtimeConfig;
+  const pluginSpec = localPluginPath ?? CURSOR_ACP_PROVIDER_ID;
   return {
     ...runtimeConfig,
-    plugin: [...runtimePluginList(runtimeConfig).filter((name) => name !== CURSOR_ACP_PROVIDER_ID), CURSOR_ACP_PROVIDER_ID],
+    plugin: [
+      ...runtimePluginList(runtimeConfig).filter((name) => name !== CURSOR_ACP_PROVIDER_ID && name !== pluginSpec),
+      pluginSpec,
+    ],
     provider: { ...providers, [CURSOR_ACP_PROVIDER_ID]: block },
   };
 }

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -13,7 +13,7 @@
  * which was frozen at spawn and reverted MCP state on each dispose.
  */
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { parse as parseJsonc } from "jsonc-parser";
 import { resolveGlobalOpencodeConfigPath } from "@openwork/paths";
@@ -101,14 +101,22 @@ const CURSOR_ACP_PROVIDER_ID = "cursor-acp";
  * file; without any block to mirror, nothing is injected.
  */
 async function readGlobalCursorAcpProvider(): Promise<Record<string, unknown> | null> {
-  try {
-    const parsed: unknown = parseJsonc(await readFile(resolveGlobalOpencodeConfigPath(), "utf8"));
-    if (!isRecord(parsed) || !isRecord(parsed.provider)) return null;
-    const block = parsed.provider[CURSOR_ACP_PROVIDER_ID];
-    return isRecord(block) ? block : null;
-  } catch {
-    return null;
+  const primaryPath = resolveGlobalOpencodeConfigPath();
+  const configDir = dirname(primaryPath);
+  const jsonPath = join(configDir, "opencode.json");
+  const jsoncPath = join(configDir, "opencode.jsonc");
+  const candidatePaths = primaryPath === jsoncPath ? [jsoncPath, jsonPath] : [jsonPath, jsoncPath];
+  for (const candidatePath of candidatePaths) {
+    try {
+      const parsed: unknown = parseJsonc(await readFile(candidatePath, "utf8"));
+      if (!isRecord(parsed) || !isRecord(parsed.provider)) continue;
+      const block = parsed.provider[CURSOR_ACP_PROVIDER_ID];
+      if (isRecord(block)) return block;
+    } catch {
+      // missing or unreadable candidate — try sibling
+    }
   }
+  return null;
 }
 
 async function withCursorAcpProvider(runtimeConfig: RuntimeOpencodeConfig): Promise<RuntimeOpencodeConfig> {

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -15,6 +15,8 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { parse as parseJsonc } from "jsonc-parser";
+import { resolveGlobalOpencodeConfigPath } from "@openwork/paths";
 import {
   openworkExtensionsPreviewPluginPath,
   openworkCapabilitiesKnowledgePluginPath,
@@ -87,12 +89,44 @@ Manage: to show what is saved, discover and execute the list capability (getMemo
 
 Never persist secrets, credentials, API keys, tokens, or sensitive PII into a memory. This applies to both the content sentence and any cited snippets — redact secrets from a snippet before saving it.`;
 
+const CURSOR_ACP_PROVIDER_ID = "cursor-acp";
+
+/**
+ * OPENCODE_CONFIG replaces the user's global opencode config, so a cursor-acp
+ * provider configured there never reaches the engine. When the host carries a
+ * Cursor key, mirror the global cursor-acp provider block (and plugin) into
+ * the runtime config. A runtime-DB cursor-acp provider wins over the global
+ * file; without any block to mirror, nothing is injected.
+ */
+async function readGlobalCursorAcpProvider(): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = parseJsonc(await readFile(resolveGlobalOpencodeConfigPath(), "utf8"));
+    if (!isRecord(parsed) || !isRecord(parsed.provider)) return null;
+    const block = parsed.provider[CURSOR_ACP_PROVIDER_ID];
+    return isRecord(block) ? block : null;
+  } catch {
+    return null;
+  }
+}
+
+async function withCursorAcpProvider(runtimeConfig: RuntimeOpencodeConfig): Promise<RuntimeOpencodeConfig> {
+  if (!process.env.CURSOR_API_KEY?.trim()) return runtimeConfig;
+  const providers = runtimeProviderMap(runtimeConfig);
+  const block = providers[CURSOR_ACP_PROVIDER_ID] ?? (await readGlobalCursorAcpProvider());
+  if (!block) return runtimeConfig;
+  return {
+    ...runtimeConfig,
+    plugin: [...runtimePluginList(runtimeConfig).filter((name) => name !== CURSOR_ACP_PROVIDER_ID), CURSOR_ACP_PROVIDER_ID],
+    provider: { ...providers, [CURSOR_ACP_PROVIDER_ID]: block },
+  };
+}
+
 export async function buildOpenworkRuntimeConfigObject(
   config?: ServerConfig,
   workspaceId?: string,
 ): Promise<Record<string, unknown>> {
   const runtimeConfig = config && workspaceId ? await readEffectiveRuntimeOpencodeConfig(config, workspaceId) : {};
-  return buildOpenworkRuntimeConfigObjectFromSnapshot(runtimeConfig);
+  return buildOpenworkRuntimeConfigObjectFromSnapshot(await withCursorAcpProvider(runtimeConfig));
 }
 
 export function buildOpenworkRuntimeConfigObjectFromSnapshot(

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -8,6 +8,7 @@ import type { ServerConfig, WorkspaceInfo } from "../types.js";
 import { ensureDir, exists, shortId } from "../utils.js";
 import { defaultWorkspaceOpenworkConfig, ensureWorkspaceFiles } from "../workspace-init.js";
 import { seedOpenworkWorkspaceConfigIfEmpty } from "../openwork-workspace-config-store.js";
+import { reconcileOfficeCliMcp, resolveOfficeCliBinary } from "../officecli-mcp.js";
 import { workspaceIdForPath, workspaceIdForRemote } from "../workspaces.js";
 import { addRoute, type Route } from "./registry.js";
 
@@ -307,6 +308,11 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
     }
     const persisted = await persistServerWorkspaceState(config);
     onWorkspacesChanged();
+
+    const officeCliBinary = resolveOfficeCliBinary();
+    if (officeCliBinary) {
+      await reconcileOfficeCliMcp(config, workspace.id, officeCliBinary);
+    }
 
     await recordAudit(workspace.path, {
       id: shortId(),

--- a/apps/server/src/runtime-opencode-config-store.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
+import { closeWorkspaceKvStoreDatabasesForTests } from "./workspace-kv-store.js";
 
 const WORKSPACE_ID = "ws_runtime_test";
 
@@ -59,6 +60,7 @@ async function withWorkspace(fn: (input: { root: string; config: ServerConfig })
     else process.env.OPENWORK_RUNTIME_DB = previousDb;
     if (previousOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
     else process.env.OPENCODE_CONFIG_DIR = previousOpencodeConfigDir;
+    await closeWorkspaceKvStoreDatabasesForTests();
     await rm(root, { recursive: true, force: true });
   }
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -105,6 +105,13 @@ import {
   handleLocalManagedMcpGateway,
   listLocalManagedMcpConnectionsSafe,
   reconcileLocalManagedMcpRuntimeEntries,
+} from "./local-managed-mcp.js";
+import {
+  markOfficeCliManagedMcpRemoved,
+  OFFICECLI_MCP_NAME,
+  reconcileOfficeCliMcpForAllWorkspaces,
+} from "./officecli-mcp.js";
+import {
   setLocalManagedMcpEnabled,
   startLocalManagedMcpAuthorization,
 } from "./local-managed-mcp.js";
@@ -970,6 +977,13 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     await reconcileLocalManagedMcpRuntimeEntries(config);
   } catch (error) {
     logger.log("warn", "Failed to reconcile OpenWork-managed MCP connections during startup.", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+  }
+  try {
+    await reconcileOfficeCliMcpForAllWorkspaces(config);
+  } catch (error) {
+    logger.log("warn", "Failed to reconcile OfficeCLI MCP during startup.", {
       error: error instanceof Error ? error.message : "unknown",
     });
   }
@@ -3336,6 +3350,9 @@ function createRoutes(
       paths: [openworkConfigPath(workspace.path)],
     });
     const managedRemoved = await deleteLocalManagedMcp(config, workspace.id, name);
+    if (name === OFFICECLI_MCP_NAME) {
+      await markOfficeCliManagedMcpRemoved(config, workspace.id);
+    }
     const removed = managedRemoved || await removeMcp(config, workspace.id, name);
     await recordAudit(workspace.path, {
       id: shortId(),

--- a/apps/server/src/workspace-kv-store.test.ts
+++ b/apps/server/src/workspace-kv-store.test.ts
@@ -9,13 +9,14 @@ import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./ope
 import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { readSessionGroupState, writeSessionGroupState } from "./session-groups.js";
 import type { ServerConfig } from "./types.js";
-import { createWorkspaceKvStore, isRecord, workspaceKvStoreCacheStatsForTests } from "./workspace-kv-store.js";
+import { createWorkspaceKvStore, isRecord, workspaceKvStoreCacheStatsForTests, closeWorkspaceKvStoreDatabasesForTests } from "./workspace-kv-store.js";
 
 const WORKSPACE_ID = "ws_workspace_kv_store";
 const roots: string[] = [];
 const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
 
 afterEach(async () => {
+  await closeWorkspaceKvStoreDatabasesForTests();
   while (roots.length) {
     const root = roots.pop();
     if (root) await rm(root, { recursive: true, force: true });

--- a/apps/server/src/workspace-kv-store.ts
+++ b/apps/server/src/workspace-kv-store.ts
@@ -260,3 +260,25 @@ export function workspaceKvStoreCacheStatsForTests(path: string): { connectionEn
     tableEntries: tableDbByPath.get(path)?.size ?? 0,
   };
 }
+
+/** Cached handles hold file locks (Windows EBUSY on temp-dir cleanup); tests close them before rm. */
+export async function closeWorkspaceKvStoreDatabasesForTests(): Promise<void> {
+  const pending = [...dbByPath.values()];
+  dbByPath.clear();
+  tableDbByPath.clear();
+  for (const db of pending) {
+    try {
+      (await db).close();
+    } catch {
+      // best-effort test cleanup
+    }
+  }
+  // bun:sqlite close() leaves the file locked while prepared statements (from
+  // drizzle or raw Database#query handles) remain unfinalized; forced GC
+  // finalizes them so Windows can rm the dir.
+  if (typeof process.versions.bun === "string") {
+    Bun.gc(true);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    Bun.gc(true);
+  }
+}

--- a/docs/superpowers/plans/2026-08-22-officecli-windows.md
+++ b/docs/superpowers/plans/2026-08-22-officecli-windows.md
@@ -1,0 +1,869 @@
+# OfficeCLI Windows Auto-MCP + Packaged EXE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a packaged Windows OpenWork `.exe` that auto-registers the user-installed OfficeCLI binary as a local MCP server with zero manual Settings setup.
+
+**Architecture:** Add `apps/server/src/officecli-mcp.ts` to resolve `officecli.exe`, reconcile a managed `mcp.officecli` entry per workspace at server startup and workspace creation, and record user opt-out when a managed entry is deleted. Extend `apps/desktop/electron/runtime.mjs` so GUI-launched processes inherit `%LOCALAPPDATA%\OfficeCLI` on PATH. Package with `electron-builder` after tests pass.
+
+**Tech Stack:** TypeScript (Bun test runner), Node `fs`/`path`, OpenWork server runtime KV + OpenCode runtime config store, Electron `runtime.mjs`, electron-builder NSIS.
+
+**Status:** Future work — spec at `docs/superpowers/specs/2026-08-22-officecli-windows-design.md`
+
+## Global Constraints
+
+- Windows v1 only; non-Windows platforms no-op.
+- OfficeCLI is user-installed at `%LOCALAPPDATA%\OfficeCLI\officecli.exe`; not bundled in the installer.
+- MCP `command` must use an absolute path to `officecli.exe` plus `"mcp"`.
+- Managed entries carry `openworkManaged: true`; never modify user-owned entries without that flag.
+- `officecliProvision: "removed"` in openwork workspace config blocks auto-re-add.
+- Preserve `enabled: false` when updating managed entries.
+- `OPENWORK_OFFICECLI_PATH` env override wins over auto-detect.
+- Reconcile failures must not block server startup (warn log only).
+- pnpm only; TypeScript: no `any`, no `as` unless unavoidable.
+- Every behavior change needs a failing test first (TDD); verify red → green before claiming pass.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/server/src/officecli-mcp.ts` | Binary resolve, provision state, reconcile |
+| `apps/server/src/officecli-mcp.test.ts` | Unit tests (Bun) |
+| `apps/server/src/server.ts` | Startup reconcile hook |
+| `apps/server/src/routes/workspaces.ts` | Reconcile on workspace create |
+| `apps/server/src/server.ts` (DELETE mcp route) | Opt-out on managed delete |
+| `apps/desktop/electron/runtime.mjs` | PATH candidate helper + `extraPathEntries` |
+| `apps/desktop/electron/runtime.test.mjs` | PATH unit test |
+
+## Parallel execution graph
+
+```text
+Wave 1 (parallel — no shared files):
+  [Task 1: resolveOfficeCliBinary]     [Task 5: desktop PATH enrichment]
+
+Wave 2 (sequential — depends on Task 1 exports):
+  Task 2 → Task 3 → Task 4
+
+Wave 3 (depends on Task 3):
+  Task 6: delete opt-out hook
+
+Wave 4 (integration — after Waves 1–3 merged):
+  Task 7: full test suite + package Windows exe + manual smoke
+```
+
+**Subagent dispatch:** Launch Wave 1 as two parallel subagents (`officecli-resolve`, `desktop-path`). Merge, then run Wave 2 in one subagent (or Task 2→3→4 sequentially). Wave 3 can start when Task 3 lands. Wave 4 is a single integration subagent.
+
+**Branch:** `feat/officecli-windows-auto-mcp` off `dev`.
+
+---
+
+### Task 1: `resolveOfficeCliBinary`
+
+**Files:**
+- Create: `apps/server/src/officecli-mcp.ts`
+- Create: `apps/server/src/officecli-mcp.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export const OFFICECLI_MCP_NAME = "officecli" as const`
+  - `export function resolveOfficeCliBinary(env?: NodeJS.ProcessEnv): string | null`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/officecli-windows-auto-mcp
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Create `apps/server/src/officecli-mcp.test.ts`:
+
+```typescript
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveOfficeCliBinary } from "./officecli-mcp.js";
+
+const previousPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: previousPlatform });
+});
+
+describe("resolveOfficeCliBinary", () => {
+  test("returns OPENWORK_OFFICECLI_PATH when the file exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "officecli-resolve-"));
+    const binary = join(root, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      const resolved = resolveOfficeCliBinary({
+        OPENWORK_OFFICECLI_PATH: binary,
+        LOCALAPPDATA: join(root, "unused"),
+        PATH: "",
+      });
+      expect(resolved).toBe(binary);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns default LOCALAPPDATA install path on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const root = await mkdtemp(join(tmpdir(), "officecli-localappdata-"));
+    const officeCliDir = join(root, "OfficeCLI");
+    const binary = join(officeCliDir, "officecli.exe");
+    await mkdir(officeCliDir, { recursive: true });
+    await writeFile(binary, "");
+    try {
+      const resolved = resolveOfficeCliBinary({
+        LOCALAPPDATA: root,
+        PATH: "",
+      });
+      expect(resolved).toBe(binary);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null on non-windows when override is unset", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveOfficeCliBinary({ LOCALAPPDATA: "/tmp", PATH: "/usr/bin" })).toBeNull();
+  });
+
+  test("returns null when no candidate exists", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveOfficeCliBinary({ LOCALAPPDATA: "C:\\missing", PATH: "" })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — verify RED**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+Expected: FAIL — `Cannot find module './officecli-mcp.js'` or `resolveOfficeCliBinary is not a function`.
+
+- [ ] **Step 4: Minimal implementation**
+
+Create `apps/server/src/officecli-mcp.ts`:
+
+```typescript
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const OFFICECLI_MCP_NAME = "officecli" as const;
+
+const OFFICECLI_EXE = "officecli.exe";
+
+function normalizedOverride(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.OPENWORK_OFFICECLI_PATH?.trim();
+  if (!raw) return null;
+  return existsSync(raw) ? raw : null;
+}
+
+function defaultWindowsInstallPath(env: NodeJS.ProcessEnv): string | null {
+  const localAppData = env.LOCALAPPDATA?.trim();
+  if (!localAppData) return null;
+  const candidate = join(localAppData, "OfficeCLI", OFFICECLI_EXE);
+  return existsSync(candidate) ? candidate : null;
+}
+
+function pathScan(env: NodeJS.ProcessEnv): string | null {
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  for (const entry of (env.PATH ?? "").split(delimiter).filter(Boolean)) {
+    const candidate = join(entry, OFFICECLI_EXE);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function resolveOfficeCliBinary(env: NodeJS.ProcessEnv = process.env): string | null {
+  const override = normalizedOverride(env);
+  if (override) return override;
+  if (process.platform !== "win32") return null;
+  return defaultWindowsInstallPath(env) ?? pathScan(env);
+}
+```
+
+- [ ] **Step 5: Run tests — verify GREEN**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+Expected: 4 pass, 0 fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/officecli-mcp.ts apps/server/src/officecli-mcp.test.ts
+git commit -m "feat(server): resolve OfficeCLI binary on Windows"
+```
+
+---
+
+### Task 2: Provision state helpers
+
+**Files:**
+- Modify: `apps/server/src/officecli-mcp.ts`
+- Modify: `apps/server/src/officecli-mcp.test.ts`
+
+**Interfaces:**
+- Consumes: `readOpenworkWorkspaceConfig`, `writeOpenworkWorkspaceConfig` from `./openwork-workspace-config-store.js`
+- Produces:
+  - `export type OfficeCliProvisionState = "managed" | "removed"`
+  - `export async function readOfficeCliProvisionState(config: ServerConfig, workspaceId: string): Promise<OfficeCliProvisionState | null>`
+  - `export async function writeOfficeCliProvisionState(config: ServerConfig, workspaceId: string, state: OfficeCliProvisionState): Promise<void>`
+
+- [ ] **Step 1: Write failing tests** (append to `officecli-mcp.test.ts`)
+
+```typescript
+import type { ServerConfig } from "./types.js";
+import {
+  readOfficeCliProvisionState,
+  writeOfficeCliProvisionState,
+} from "./officecli-mcp.js";
+
+function testServerConfig(workspaceRoot: string, workspaceId: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(workspaceRoot, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: workspaceId, name: "Test", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+describe("officecli provision state", () => {
+  test("reads and writes managed state in openwork workspace config", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-provision-"));
+    const workspaceId = "ws_officecli";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    try {
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBeNull();
+      await writeOfficeCliProvisionState(config, workspaceId, "managed");
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("managed");
+      await writeOfficeCliProvisionState(config, workspaceId, "removed");
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("removed");
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify RED**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 3: Implement** (append to `officecli-mcp.ts`)
+
+```typescript
+import type { ServerConfig } from "./types.js";
+import {
+  readOpenworkWorkspaceConfig,
+  writeOpenworkWorkspaceConfig,
+} from "./openwork-workspace-config-store.js";
+
+export type OfficeCliProvisionState = "managed" | "removed";
+
+const PROVISION_KEY = "officecliProvision";
+
+function parseProvisionState(value: unknown): OfficeCliProvisionState | null {
+  return value === "managed" || value === "removed" ? value : null;
+}
+
+export async function readOfficeCliProvisionState(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<OfficeCliProvisionState | null> {
+  const workspaceConfig = await readOpenworkWorkspaceConfig(config, workspaceId);
+  return parseProvisionState(workspaceConfig[PROVISION_KEY]);
+}
+
+export async function writeOfficeCliProvisionState(
+  config: ServerConfig,
+  workspaceId: string,
+  state: OfficeCliProvisionState,
+): Promise<void> {
+  await writeOpenworkWorkspaceConfig(config, workspaceId, (current) => ({
+    ...current,
+    [PROVISION_KEY]: state,
+  }));
+}
+```
+
+- [ ] **Step 4: Run — verify GREEN**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/officecli-mcp.ts apps/server/src/officecli-mcp.test.ts
+git commit -m "feat(server): persist OfficeCLI provision state per workspace"
+```
+
+---
+
+### Task 3: `reconcileOfficeCliMcp`
+
+**Files:**
+- Modify: `apps/server/src/officecli-mcp.ts`
+- Modify: `apps/server/src/officecli-mcp.test.ts`
+
+**Interfaces:**
+- Consumes: `readRuntimeOpencodeConfig`, `writeRuntimeOpencodeConfig` from `./runtime-opencode-config-store.js`
+- Produces:
+  - `export async function reconcileOfficeCliMcp(config: ServerConfig, workspaceId: string, binaryPath: string): Promise<"added" | "updated" | "skipped">`
+  - `export async function reconcileOfficeCliMcpForAllWorkspaces(config: ServerConfig): Promise<void>`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  OFFICECLI_MCP_NAME,
+  reconcileOfficeCliMcp,
+  reconcileOfficeCliMcpForAllWorkspaces,
+  writeOfficeCliProvisionState,
+} from "./officecli-mcp.js";
+
+describe("reconcileOfficeCliMcp", () => {
+  test("adds managed local MCP when absent", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-add-"));
+    const workspaceId = "ws_add";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("added");
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]).toEqual({
+        type: "local",
+        enabled: true,
+        command: [binary, "mcp"],
+        openworkManaged: true,
+      });
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("skips when provision state is removed", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-removed-"));
+    const workspaceId = "ws_removed";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      await writeOfficeCliProvisionState(config, workspaceId, "removed");
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("skipped");
+      expect(await readRuntimeOpencodeConfig(config, workspaceId)).toEqual({});
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not modify user-owned MCP entry", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-reconcile-user-"));
+    const workspaceId = "ws_user";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    const userBinary = join(workspaceRoot, "custom-officecli.exe");
+    await writeFile(binary, "");
+    await writeFile(userBinary, "");
+    const { writeRuntimeOpencodeConfig } = await import("./runtime-opencode-config-store.js");
+    try {
+      await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
+        ...current,
+        mcp: {
+          [OFFICECLI_MCP_NAME]: {
+            type: "local",
+            enabled: true,
+            command: [userBinary, "mcp"],
+          },
+        },
+      }));
+      const result = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(result).toBe("skipped");
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]?.command).toEqual([userBinary, "mcp"]);
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify RED**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 3: Implement reconcile functions**
+
+```typescript
+import {
+  readRuntimeOpencodeConfig,
+  runtimeMcpMap,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function managedOfficeCliEntry(binaryPath: string, enabled: boolean): Record<string, unknown> {
+  return {
+    type: "local",
+    enabled,
+    command: [binaryPath, "mcp"],
+    openworkManaged: true,
+  };
+}
+
+export async function reconcileOfficeCliMcp(
+  config: ServerConfig,
+  workspaceId: string,
+  binaryPath: string,
+): Promise<"added" | "updated" | "skipped"> {
+  if (await readOfficeCliProvisionState(config, workspaceId) === "removed") {
+    return "skipped";
+  }
+
+  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspaceId);
+  const mcpMap = runtimeMcpMap(runtimeConfig);
+  const current = mcpMap[OFFICECLI_MCP_NAME];
+
+  if (current && current.openworkManaged !== true) {
+    return "skipped";
+  }
+
+  const enabled = current?.enabled !== false;
+  const nextEntry = managedOfficeCliEntry(binaryPath, enabled);
+  const currentCommand = Array.isArray(current?.command) ? current.command : [];
+  const action = current ? "updated" : "added";
+
+  if (
+    current
+    && currentCommand[0] === binaryPath
+    && current.enabled === enabled
+    && current.openworkManaged === true
+  ) {
+    return "skipped";
+  }
+
+  await writeRuntimeOpencodeConfig(config, workspaceId, (value) => ({
+    ...value,
+    mcp: { ...runtimeMcpMap(value), [OFFICECLI_MCP_NAME]: nextEntry },
+  }));
+  await writeOfficeCliProvisionState(config, workspaceId, "managed");
+  return action;
+}
+
+export async function reconcileOfficeCliMcpForAllWorkspaces(config: ServerConfig): Promise<void> {
+  const binaryPath = resolveOfficeCliBinary();
+  if (!binaryPath) return;
+  for (const workspace of config.workspaces) {
+    await reconcileOfficeCliMcp(config, workspace.id, binaryPath);
+  }
+}
+```
+
+- [ ] **Step 4: Run — verify GREEN**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/officecli-mcp.ts apps/server/src/officecli-mcp.test.ts
+git commit -m "feat(server): reconcile managed OfficeCLI MCP per workspace"
+```
+
+---
+
+### Task 4: Wire startup + workspace-create hooks
+
+**Files:**
+- Modify: `apps/server/src/server.ts`
+- Modify: `apps/server/src/routes/workspaces.ts`
+
+**Interfaces:**
+- Consumes: `reconcileOfficeCliMcp`, `reconcileOfficeCliMcpForAllWorkspaces`, `resolveOfficeCliBinary` from `./officecli-mcp.js`
+
+- [ ] **Step 1: Write failing integration test**
+
+Append to `officecli-mcp.test.ts`:
+
+```typescript
+import { startServer } from "./server.js";
+
+describe("officecli startup reconcile", () => {
+  test("startServer provisions officecli MCP when binary exists on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-startup-"));
+    const workspaceId = "ws_startup";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    config.port = 0;
+    process.env.OPENWORK_OFFICECLI_PATH = binary;
+    let served: { stop: () => void } | null = null;
+    try {
+      const result = await startServer(config);
+      served = result;
+      const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+      expect(runtime.mcp?.[OFFICECLI_MCP_NAME]?.command).toEqual([binary, "mcp"]);
+    } finally {
+      served?.stop();
+      delete process.env.OPENWORK_OFFICECLI_PATH;
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify RED**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts --test-name-pattern "startServer provisions"
+```
+
+- [ ] **Step 3: Hook `startServer` in `apps/server/src/server.ts`**
+
+Add import:
+
+```typescript
+import { reconcileOfficeCliMcpForAllWorkspaces } from "./officecli-mcp.js";
+```
+
+After `reconcileLocalManagedMcpRuntimeEntries` block (~line 970):
+
+```typescript
+  try {
+    await reconcileOfficeCliMcpForAllWorkspaces(config);
+  } catch (error) {
+    logger.log("warn", "Failed to reconcile OfficeCLI MCP during startup.", {
+      error: error instanceof Error ? error.message : "unknown",
+    });
+  }
+```
+
+- [ ] **Step 4: Hook workspace create in `apps/server/src/routes/workspaces.ts`**
+
+Add imports:
+
+```typescript
+import { reconcileOfficeCliMcp, resolveOfficeCliBinary } from "../officecli-mcp.js";
+```
+
+After `persistServerWorkspaceState(config)` in `POST /workspaces/local` (~line 308):
+
+```typescript
+    const officeCliBinary = resolveOfficeCliBinary();
+    if (officeCliBinary) {
+      await reconcileOfficeCliMcp(config, workspace.id, officeCliBinary);
+    }
+```
+
+- [ ] **Step 5: Run — verify GREEN**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/server.ts apps/server/src/routes/workspaces.ts apps/server/src/officecli-mcp.test.ts
+git commit -m "feat(server): reconcile OfficeCLI MCP at startup and workspace create"
+```
+
+---
+
+### Task 5: Desktop PATH enrichment (parallel with Tasks 1–4)
+
+**Files:**
+- Modify: `apps/desktop/electron/runtime.mjs`
+- Modify: `apps/desktop/electron/runtime.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `export function windowsOfficeCliPathCandidates(env = process.env)`
+
+- [ ] **Step 1: Write failing test** (append to `runtime.test.mjs`)
+
+```javascript
+import { windowsOfficeCliPathCandidates } from "./runtime.mjs";
+
+describe("windowsOfficeCliPathCandidates", () => {
+  it("includes LOCALAPPDATA OfficeCLI on win32", () => {
+    const candidates = windowsOfficeCliPathCandidates({
+      LOCALAPPDATA: "C:\\Users\\Example\\AppData\\Local",
+    });
+    assert.ok(
+      candidates.includes("C:\\Users\\Example\\AppData\\Local\\OfficeCLI"),
+    );
+  });
+
+  it("returns empty list when LOCALAPPDATA is missing", () => {
+    assert.deepEqual(windowsOfficeCliPathCandidates({}), []);
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify RED**
+
+```bash
+pnpm --filter @openwork/desktop test electron/runtime.test.mjs --test-name-pattern "windowsOfficeCliPathCandidates"
+```
+
+- [ ] **Step 3: Implement in `runtime.mjs`**
+
+Add exported helper before `extraPathEntries`:
+
+```javascript
+export function windowsOfficeCliPathCandidates(env = process.env) {
+  if (process.platform !== "win32") return [];
+  const localAppData = String(env.LOCALAPPDATA ?? "").trim();
+  if (!localAppData) return [];
+  return [path.join(localAppData, "OfficeCLI")];
+}
+```
+
+Inside `extraPathEntries`, in the `win32` block, spread the helper:
+
+```javascript
+  if (process.platform === "win32") {
+    candidates.push(
+      ...windowsOfficeCliPathCandidates(process.env),
+      path.join(home, ".volta", "bin"),
+      // ...existing entries...
+    );
+  }
+```
+
+- [ ] **Step 4: Run — verify GREEN**
+
+```bash
+pnpm --filter @openwork/desktop test electron/runtime.test.mjs
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/electron/runtime.mjs apps/desktop/electron/runtime.test.mjs
+git commit -m "feat(desktop): add OfficeCLI to Windows PATH candidates"
+```
+
+---
+
+### Task 6: Opt-out on managed MCP delete
+
+**Files:**
+- Modify: `apps/server/src/server.ts`
+- Modify: `apps/server/src/officecli-mcp.test.ts`
+
+**Interfaces:**
+- Consumes: `readRuntimeOpencodeConfig`, `OFFICECLI_MCP_NAME`, `writeOfficeCliProvisionState`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+import { removeMcp } from "./mcp.js";
+
+describe("officecli managed delete opt-out", () => {
+  test("marks provision removed when managed officecli MCP is deleted", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "officecli-delete-"));
+    const workspaceId = "ws_delete";
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    const config = testServerConfig(workspaceRoot, workspaceId);
+    const binary = join(workspaceRoot, "officecli.exe");
+    await writeFile(binary, "");
+    try {
+      await reconcileOfficeCliMcp(config, workspaceId, binary);
+      await markOfficeCliManagedMcpRemoved(config, workspaceId);
+      expect(await readOfficeCliProvisionState(config, workspaceId)).toBe("removed");
+      expect(await removeMcp(config, workspaceId, OFFICECLI_MCP_NAME)).toBe(true);
+      const retry = await reconcileOfficeCliMcp(config, workspaceId, binary);
+      expect(retry).toBe("skipped");
+    } finally {
+      process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+Export `markOfficeCliManagedMcpRemoved` from `officecli-mcp.ts` (implement before test passes).
+
+- [ ] **Step 2: Implement `markOfficeCliManagedMcpRemoved`**
+
+```typescript
+export async function markOfficeCliManagedMcpRemoved(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<void> {
+  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspaceId);
+  const current = runtimeMcpMap(runtimeConfig)[OFFICECLI_MCP_NAME];
+  if (current?.openworkManaged === true) {
+    await writeOfficeCliProvisionState(config, workspaceId, "removed");
+  }
+}
+```
+
+- [ ] **Step 3: Call from DELETE route in `server.ts`**
+
+Before `removeMcp` in `DELETE /workspace/:id/mcp/:name`:
+
+```typescript
+    if (name === OFFICECLI_MCP_NAME) {
+      await markOfficeCliManagedMcpRemoved(config, workspace.id);
+    }
+```
+
+Add imports for `OFFICECLI_MCP_NAME`, `markOfficeCliManagedMcpRemoved`.
+
+- [ ] **Step 4: Run — verify GREEN**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/officecli-mcp.ts apps/server/src/server.ts apps/server/src/officecli-mcp.test.ts
+git commit -m "feat(server): opt out of OfficeCLI auto-provision after managed delete"
+```
+
+---
+
+### Task 7: Verification + package Windows EXE
+
+**Files:** None (commands only)
+
+- [ ] **Step 1: Run full server + desktop unit tests**
+
+```bash
+pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts
+pnpm --filter @openwork/desktop test electron/runtime.test.mjs
+```
+
+Expected: all pass, exit code 0.
+
+- [ ] **Step 2: Typecheck server**
+
+```bash
+pnpm --dir apps/server exec tsc -p tsconfig.json --noEmit
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Build and package Windows installer**
+
+Prerequisites: Node 24, pnpm 11.4.0, Bun >= 1.3.10, VS Build Tools (for `better-sqlite3`).
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @openwork/desktop build:electron
+pnpm --dir apps/desktop exec electron-builder --config electron-builder.yml --win --publish never
+```
+
+Expected artifact:
+
+```text
+apps/desktop/dist-electron/openwork-win-x64-0.0.0-dev.exe
+```
+
+- [ ] **Step 4: Manual smoke on packaged app**
+
+1. Install `openwork-win-x64-*.exe` (or run from `dist-electron/win-unpacked/OpenWork.exe`).
+2. Confirm OfficeCLI still at `%LOCALAPPDATA%\OfficeCLI\officecli.exe`.
+3. Create/open a workspace.
+4. Settings → MCP: verify `officecli` entry exists with full path + enabled.
+5. Attach a `.docx` in chat; ask agent to read first paragraph via OfficeCLI MCP.
+6. Download result; confirm file changed.
+
+Record pass/fail in PR notes or commit message body.
+
+- [ ] **Step 5: Push feature branch**
+
+```bash
+git push -u origin feat/officecli-windows-auto-mcp
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Auto-detect `%LOCALAPPDATA%\OfficeCLI\officecli.exe` | Task 1 |
+| `OPENWORK_OFFICECLI_PATH` override | Task 1 |
+| PATH fallback scan | Task 1 |
+| Managed MCP with full path + `openworkManaged` | Task 3 |
+| Startup reconcile | Task 4 |
+| Workspace create reconcile | Task 4 |
+| User opt-out on delete | Task 6 |
+| Preserve `enabled: false` | Task 3 |
+| Don't modify user-owned entry | Task 3 |
+| Windows PATH enrichment | Task 5 |
+| Non-Windows no-op | Tasks 1, 5 |
+| Reconcile must not block startup | Task 4 (try/catch) |
+| Packaged exe smoke | Task 7 |
+
+## Verification-before-completion gate
+
+Do not claim the feature is done until all of the following have **fresh** command output in the PR or session:
+
+1. `pnpm --dir apps/server exec bun test src/officecli-mcp.test.ts` → 0 failures
+2. `pnpm --filter @openwork/desktop test electron/runtime.test.mjs` → 0 failures
+3. `electron-builder --win --publish never` → installer exists under `apps/desktop/dist-electron/`
+4. Manual smoke steps in Task 7 Step 4 completed

--- a/docs/superpowers/plans/2026-08-23-cursor-acp-proxy-connect.md
+++ b/docs/superpowers/plans/2026-08-23-cursor-acp-proxy-connect.md
@@ -1,0 +1,531 @@
+# Cursor ACP Proxy Connect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Wave 1 launches two implementers in parallel. Never give a subagent this whole file — extract a task brief with `scripts/task-brief`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Status:** Future work — do not implement until explicitly asked. This commit is the plan only.
+
+**Goal:** Make OpenWork's managed engine start the local Cursor ACP proxy on `127.0.0.1:32124` so a Cursor API key (env store or Connect modal) can reach Cursor instead of failing with `Cannot connect to API: Unable to connect. Is the computer able to access the url?`
+
+**Architecture:** Split two hermetic helpers so they can land in parallel, then wire them into `withCursorAcpProvider`. `OPENCODE_CONFIG` replaces `~/.config/opencode/opencode.json`. The real Cursor bridge is the local plugin at `<opencode-config-dir>/plugin/cursor-acp.js` (`@rama_nigg/open-cursor`), which binds `127.0.0.1:32124`. That plugin auto-loads, then disables itself unless the runtime config lists a matching plugin spec or defines `provider.cursor-acp`. Commit `6abbf3f0e` injects those blocks only when `process.env.CURSOR_API_KEY` is set; the live runtime file never got them. Helper A reads the OpenWork env store. Helper B resolves the local plugin file path. The wire-up injects the absolute plugin path plus the global provider block so OpenCode loads the real file instead of the unrelated npm `cursor-acp` ACP adapter.
+
+**Tech Stack:** TypeScript, Bun test runner, `EnvService` from `apps/server/src/env-file.ts`, `resolveGlobalOpencodeConfigPath` from `@openwork/paths`.
+
+## Root cause (already verified — do not re-litigate)
+
+Observed 2026-08-23 on this machine:
+
+1. Error text is OpenCode's generic "provider URL unreachable" message. It is not authored in this repo.
+2. Nothing listens on `32124`.
+3. `C:\Users\Kishan\AppData\Roaming\openwork\runtime-opencode-config.json` plugin list is only OpenWork builtins. No `cursor-acp` plugin, no `provider.cursor-acp`.
+4. `C:\Users\Kishan\.opencode-cursor\plugin.log` repeats `disabled_in_plugin_array` against that runtime file (including after the 17:58 rebuilt exe).
+5. Local plugin enable check: enabled if `provider["cursor-acp"]` exists OR `plugin` contains `"cursor-acp"` / `@rama_nigg/open-cursor`.
+6. `CURSOR_API_KEY` lives in OpenWork `env.json`. `withCursorAcpProvider` only reads `process.env.CURSOR_API_KEY`. `resolveOpenAiRealtimeApiKey` in `apps/server/src/server.ts` already reads `EnvService` first.
+7. Desktop injects `env.json` into `process.env` only at embedded-server start. Save-then-Connect without Apply leaves the running process and the already-written runtime file without `cursor-acp`.
+8. npm `cursor-acp` is a stdio ACP adapter and does not bind 32124.
+
+Do not "fix" the error string, add retries, or change the Connect UI. Fix injection so the proxy process starts.
+
+## Global Constraints
+
+- pnpm only; TypeScript: no `any`, no typecasts, no `as` unless 100% necessary.
+- TDD: write the failing test, watch it fail, then implement. No production code before the red run.
+- Wave 1 tasks MUST NOT touch each other's files. No edits to `openwork-runtime-config.ts` in Wave 1.
+- When `OPENCODE_CONFIG_DIR` is set, resolve global config and the local plugin only under that directory. Never scan the real `~/.config/opencode` in that case (existing tests isolate via `OPENCODE_CONFIG_DIR`; this machine has a real `plugin/cursor-acp.js` that would flake tests).
+- Do not print, log, or commit `CURSOR_API_KEY` values. Tests use the placeholder `cur_test_key`.
+- Plugin spec must be an absolute path to `plugin/cursor-acp.js` when that file exists under the resolved OpenCode config dir. Fall back to the string `cursor-acp` only when the file is absent.
+- Provider block `baseURL` stays `http://127.0.0.1:32124/v1` (copied from global config, not invented).
+- Do not add dependencies.
+- Do not rebuild the exe until Task 4.
+- Do not implement this plan unless the human asks. This document is future work.
+
+---
+
+## File map
+
+| File | Owner task | Responsibility |
+|------|------------|----------------|
+| `apps/server/src/cursor-acp-env.ts` | Task 1 | `resolveCursorApiKey` — env store then `process.env` |
+| `apps/server/src/cursor-acp-env.test.ts` | Task 1 | Unit tests for key resolution |
+| `apps/server/src/cursor-acp-plugin-path.ts` | Task 2 | `resolveLocalCursorAcpPluginPath` — local `plugin/cursor-acp.js` |
+| `apps/server/src/cursor-acp-plugin-path.test.ts` | Task 2 | Unit tests for path resolution |
+| `apps/server/src/openwork-runtime-config.ts` | Task 3 | Wire helpers into `withCursorAcpProvider` |
+| `apps/server/src/openwork-runtime-config.test.ts` | Task 3 | Integration tests through `buildOpenworkRuntimeConfig` |
+| `apps/server/src/env-file.ts` | none | Reuse `EnvService` only |
+
+---
+
+## Parallel execution graph
+
+```text
+Wave 1 (parallel — no shared files):
+  [Task 1: resolveCursorApiKey]     [Task 2: resolveLocalCursorAcpPluginPath]
+
+Wave 2 (sequential — needs both Wave 1 exports):
+  Task 3: wire withCursorAcpProvider
+
+Wave 3 (after Task 3 review is clean):
+  Task 4: verify suite + package Windows exe + smoke
+```
+
+**Subagent dispatch:**
+
+1. Extract briefs with the SDD `task-brief` script. Never paste this whole plan into a subagent.
+2. Launch Task 1 and Task 2 in the **same controller turn** as two parallel implementers (`cursor-acp-env`, `cursor-acp-plugin-path`).
+3. Models: Task 1 and Task 2 are mechanical 1-file helpers with complete code — cheapest listed implementer tier. Task 3 is integration — standard model. Task 3 and Task 4 reviewers — mid-tier floor. Final whole-branch review — most capable listed model.
+4. After each implementer returns DONE, run `scripts/review-package BASE HEAD` (BASE = commit recorded **before** that implementer, never `HEAD~1`) and dispatch the task reviewer with brief + report + package paths.
+5. Do not start Task 3 until both Wave 1 reviews are spec ✅ and quality approved.
+6. Task 3 implementer may only import the Wave 1 exported names below. If a Wave 1 export does not match, stop and ask — do not rename in Task 3.
+7. Ledger: append one line to `.superpowers/sdd/progress.md` when a task review is clean.
+
+**Branch (when implementation is requested):** `fix/cursor-acp-proxy-connect` off current default. Do not create the branch in this future-work commit.
+
+**Report contract (every implementer):** write the full report to the report-file path from the dispatch. Return only: status (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`), commit SHAs, one-line test summary, concerns.
+
+---
+
+### Task 1: `resolveCursorApiKey`
+
+**Files:**
+- Create: `apps/server/src/cursor-acp-env.ts`
+- Create: `apps/server/src/cursor-acp-env.test.ts`
+
+**Do not touch:** `openwork-runtime-config.ts`, `openwork-runtime-config.test.ts`, `cursor-acp-plugin-path.ts`.
+
+**Interfaces:**
+- Consumes: `EnvService` from `./env-file.js` (`new EnvService()` reads `OPENWORK_ENV_STORE` or the default env.json path)
+- Produces:
+  - `export async function resolveCursorApiKey(envService?: EnvService): Promise<string>`
+  - Empty string when neither store nor `process.env` has a non-whitespace key
+  - Store wins over `process.env` when both are set
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/server/src/cursor-acp-env.test.ts`:
+
+```typescript
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EnvService } from "./env-file.js";
+import { resolveCursorApiKey } from "./cursor-acp-env.js";
+
+const roots: string[] = [];
+const cleanups: Array<() => void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) cleanups.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+function isolateProcessKey() {
+  const previous = process.env.CURSOR_API_KEY;
+  cleanups.push(() => {
+    if (previous === undefined) delete process.env.CURSOR_API_KEY;
+    else process.env.CURSOR_API_KEY = previous;
+  });
+  delete process.env.CURSOR_API_KEY;
+}
+
+describe("resolveCursorApiKey", () => {
+  test("returns the env-store key when process.env.CURSOR_API_KEY is unset", async () => {
+    isolateProcessKey();
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    await env.upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("returns process.env.CURSOR_API_KEY when the store has no key", async () => {
+    isolateProcessKey();
+    process.env.CURSOR_API_KEY = "cur_test_key";
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("prefers the env-store key over process.env", async () => {
+    isolateProcessKey();
+    process.env.CURSOR_API_KEY = "cur_process_key";
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    await env.upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+    expect(await resolveCursorApiKey(env)).toBe("cur_test_key");
+  });
+
+  test("returns empty string when neither source has a key", async () => {
+    isolateProcessKey();
+    const root = await mkdtemp(join(tmpdir(), "cursor-acp-env-"));
+    roots.push(root);
+    const env = new EnvService({ path: join(root, "env.json") });
+    expect(await resolveCursorApiKey(env)).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/cursor-acp-env.test.ts
+```
+
+Expected: FAIL with `resolveCursorApiKey` not defined / module not found. Not a later assertion failure against a stub that already returns `"cur_test_key"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/server/src/cursor-acp-env.ts`:
+
+```typescript
+import { EnvService } from "./env-file.js";
+
+export async function resolveCursorApiKey(envService?: EnvService): Promise<string> {
+  try {
+    const stored = (await (envService ?? new EnvService()).list())
+      .find((entry) => entry.key === "CURSOR_API_KEY")
+      ?.value.trim() ?? "";
+    if (stored) return stored;
+  } catch {
+    // Missing or unreadable env store is not a Cursor-key signal.
+  }
+  return process.env.CURSOR_API_KEY?.trim() ?? "";
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/cursor-acp-env.test.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/cursor-acp-env.ts apps/server/src/cursor-acp-env.test.ts
+git commit -m "feat(server): resolve CURSOR_API_KEY from env store"
+```
+
+---
+
+### Task 2: `resolveLocalCursorAcpPluginPath`
+
+**Files:**
+- Create: `apps/server/src/cursor-acp-plugin-path.ts`
+- Create: `apps/server/src/cursor-acp-plugin-path.test.ts`
+
+**Do not touch:** `openwork-runtime-config.ts`, `openwork-runtime-config.test.ts`, `cursor-acp-env.ts`.
+
+**Interfaces:**
+- Consumes: `resolveGlobalOpencodeConfigPath()` from `@openwork/paths`
+- Produces:
+  - `export const CURSOR_ACP_PLUGIN_FILENAME = "cursor-acp.js"`
+  - `export function resolveLocalCursorAcpPluginPath(): string | null`
+  - Path is `join(dirname(resolveGlobalOpencodeConfigPath()), "plugin", CURSOR_ACP_PLUGIN_FILENAME)` when that file exists, else `null`
+  - Must not call `homedir()` or read `~/.config/opencode` when `OPENCODE_CONFIG_DIR` is set
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/server/src/cursor-acp-plugin-path.test.ts`:
+
+```typescript
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLocalCursorAcpPluginPath } from "./cursor-acp-plugin-path.js";
+
+const roots: string[] = [];
+const cleanups: Array<() => void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) cleanups.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+function isolateConfigDir(dir: string) {
+  const previous = process.env.OPENCODE_CONFIG_DIR;
+  cleanups.push(() => {
+    if (previous === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = previous;
+  });
+  process.env.OPENCODE_CONFIG_DIR = dir;
+}
+
+describe("resolveLocalCursorAcpPluginPath", () => {
+  test("returns the absolute plugin path when plugin/cursor-acp.js exists under OPENCODE_CONFIG_DIR", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cursor-acp-plugin-"));
+    roots.push(dir);
+    isolateConfigDir(dir);
+    const pluginPath = join(dir, "plugin", "cursor-acp.js");
+    await mkdir(join(dir, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+    expect(resolveLocalCursorAcpPluginPath()).toBe(pluginPath);
+  });
+
+  test("returns null when OPENCODE_CONFIG_DIR has no plugin/cursor-acp.js", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cursor-acp-plugin-"));
+    roots.push(dir);
+    isolateConfigDir(dir);
+    expect(resolveLocalCursorAcpPluginPath()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/cursor-acp-plugin-path.test.ts
+```
+
+Expected: FAIL with `resolveLocalCursorAcpPluginPath` not defined / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/server/src/cursor-acp-plugin-path.ts`:
+
+```typescript
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { resolveGlobalOpencodeConfigPath } from "@openwork/paths";
+
+export const CURSOR_ACP_PLUGIN_FILENAME = "cursor-acp.js";
+
+export function resolveLocalCursorAcpPluginPath(): string | null {
+  const pluginPath = join(dirname(resolveGlobalOpencodeConfigPath()), "plugin", CURSOR_ACP_PLUGIN_FILENAME);
+  return existsSync(pluginPath) ? pluginPath : null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/cursor-acp-plugin-path.test.ts
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/cursor-acp-plugin-path.ts apps/server/src/cursor-acp-plugin-path.test.ts
+git commit -m "feat(server): resolve local cursor-acp plugin path"
+```
+
+---
+
+### Task 3: Wire helpers into `withCursorAcpProvider`
+
+**Files:**
+- Modify: `apps/server/src/openwork-runtime-config.ts`
+- Modify: `apps/server/src/openwork-runtime-config.test.ts`
+
+**Do not touch:** `cursor-acp-env.ts`, `cursor-acp-plugin-path.ts`, or their tests. Import only.
+
+**Interfaces:**
+- Consumes:
+  - `resolveCursorApiKey(envService?: EnvService): Promise<string>` from `./cursor-acp-env.js`
+  - `resolveLocalCursorAcpPluginPath(): string | null` from `./cursor-acp-plugin-path.js`
+- Produces: `withCursorAcpProvider` injects when `resolveCursorApiKey()` is non-empty OR a local plugin file exists OR runtime-DB already has `cursor-acp`. Plugin list entry is the absolute local path when the file exists, otherwise `"cursor-acp"`. Provider block is runtime-DB first, then global config. Do not invent models when a global block exists.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add these tests inside the existing `describe("cursor-acp provider injection")` in `apps/server/src/openwork-runtime-config.test.ts`. Reuse `setupCursorAcp`, `buildParsed`, `GLOBAL_CONFIG_WITH_CURSOR_ACP`, `BuiltProvider`. Add `mkdir` to the `node:fs/promises` import.
+
+```typescript
+  test("adds cursor-acp from the env store when process.env.CURSOR_API_KEY is unset", async () => {
+    const { config } = await setupCursorAcp({ globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP });
+    const envPath = join(roots[roots.length - 1]!, "env.json");
+    const previousStore = process.env.OPENWORK_ENV_STORE;
+    cleanups.push(() => {
+      if (previousStore === undefined) delete process.env.OPENWORK_ENV_STORE;
+      else process.env.OPENWORK_ENV_STORE = previousStore;
+    });
+    process.env.OPENWORK_ENV_STORE = envPath;
+    await new EnvService({ path: envPath }).upsertMany([{ key: "CURSOR_API_KEY", value: "cur_test_key" }]);
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain("cursor-acp");
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+  });
+
+  test("injects the absolute local plugin path when plugin/cursor-acp.js exists", async () => {
+    const { config } = await setupCursorAcp({
+      cursorApiKey: "cur_test_key",
+      globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP,
+    });
+    const pluginPath = join(process.env.OPENCODE_CONFIG_DIR!, "plugin", "cursor-acp.js");
+    await mkdir(join(process.env.OPENCODE_CONFIG_DIR!, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain(pluginPath);
+    expect((parsed.plugin as string[]).filter((name) => name === "cursor-acp")).toEqual([]);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.options?.baseURL).toBe("http://127.0.0.1:32124/v1");
+  });
+
+  test("injects cursor-acp from a local plugin file even when CURSOR_API_KEY is unset", async () => {
+    const { config } = await setupCursorAcp({ globalConfig: GLOBAL_CONFIG_WITH_CURSOR_ACP });
+    const pluginPath = join(process.env.OPENCODE_CONFIG_DIR!, "plugin", "cursor-acp.js");
+    await mkdir(join(process.env.OPENCODE_CONFIG_DIR!, "plugin"), { recursive: true });
+    await writeFile(pluginPath, "export default async () => ({})", "utf8");
+
+    const parsed = await buildParsed(config);
+    expect(parsed.plugin).toContain(pluginPath);
+    const provider = parsed.provider as BuiltProvider;
+    expect(provider["cursor-acp"]?.name).toBe("Cursor");
+  });
+```
+
+Add at the top of the test file:
+
+```typescript
+import { EnvService } from "./env-file.js";
+```
+
+Keep the existing test `leaves cursor-acp out when CURSOR_API_KEY is not set` — that case has no local plugin file and no env-store key, so it must stay green.
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/openwork-runtime-config.test.ts
+```
+
+Expected: FAIL on the three new tests. Env-store test fails because `withCursorAcpProvider` still gates on `process.env` only. Path tests fail because the plugin list still uses the bare name `"cursor-acp"` and still requires a process env key.
+
+- [ ] **Step 3: Write minimal wiring**
+
+In `apps/server/src/openwork-runtime-config.ts`:
+
+1. Import:
+
+```typescript
+import { resolveCursorApiKey } from "./cursor-acp-env.js";
+import { resolveLocalCursorAcpPluginPath } from "./cursor-acp-plugin-path.js";
+```
+
+2. Replace `withCursorAcpProvider` with:
+
+```typescript
+async function withCursorAcpProvider(runtimeConfig: RuntimeOpencodeConfig): Promise<RuntimeOpencodeConfig> {
+  const providers = runtimeProviderMap(runtimeConfig);
+  const localPluginPath = resolveLocalCursorAcpPluginPath();
+  const hasKey = Boolean(await resolveCursorApiKey());
+  if (!hasKey && !localPluginPath && !providers[CURSOR_ACP_PROVIDER_ID]) return runtimeConfig;
+  const block = providers[CURSOR_ACP_PROVIDER_ID] ?? (await readGlobalCursorAcpProvider());
+  if (!block) return runtimeConfig;
+  const pluginSpec = localPluginPath ?? CURSOR_ACP_PROVIDER_ID;
+  return {
+    ...runtimeConfig,
+    plugin: [
+      ...runtimePluginList(runtimeConfig).filter((name) => name !== CURSOR_ACP_PROVIDER_ID && name !== pluginSpec),
+      pluginSpec,
+    ],
+    provider: { ...providers, [CURSOR_ACP_PROVIDER_ID]: block },
+  };
+}
+```
+
+Do not inline key or path resolution. Do not add a `homedir()` fallback.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @openwork/server exec bun test src/openwork-runtime-config.test.ts src/cursor-acp-env.test.ts src/cursor-acp-plugin-path.test.ts
+```
+
+Expected: PASS. Confirm `leaves cursor-acp out when CURSOR_API_KEY is not set` still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/openwork-runtime-config.ts apps/server/src/openwork-runtime-config.test.ts
+git commit -m "fix(server): inject local cursor-acp plugin so the 32124 proxy starts"
+```
+
+---
+
+### Task 4: Verify suite + rebuild the Windows exe
+
+**Files:**
+- No new production files
+- Rebuild: `apps/desktop/dist-electron/openwork-win-x64-0.0.0-dev.exe`
+
+**Interfaces:**
+- Consumes: Task 1 + Task 2 + Task 3 commits
+- Produces: rebuilt exe; after one launch, live `runtime-opencode-config.json` must list the local plugin path or `cursor-acp` and `provider.cursor-acp`
+
+- [ ] **Step 1: Run the three test files (fresh)**
+
+```bash
+pnpm --filter @openwork/server exec bun test src/openwork-runtime-config.test.ts src/cursor-acp-env.test.ts src/cursor-acp-plugin-path.test.ts
+```
+
+Expected: PASS, 0 failures.
+
+- [ ] **Step 2: Rebuild the exe**
+
+Run from repo root:
+
+```bash
+pnpm --filter @openwork/desktop run package:electron:dir
+```
+
+Expected: `apps/desktop/dist-electron/win-unpacked/OpenWork.exe` and `apps/desktop/dist-electron/openwork-win-x64-0.0.0-dev.exe` get a new `LastWriteTime`.
+
+- [ ] **Step 3: Manual smoke (required — this is the original symptom)**
+
+1. Quit any running OpenWork.
+2. Launch the new exe.
+3. Confirm `C:\Users\Kishan\AppData\Roaming\openwork\runtime-opencode-config.json` contains `provider.cursor-acp` and a plugin entry that is either `C:\Users\Kishan\.config\opencode\plugin\cursor-acp.js` or `cursor-acp`.
+4. Confirm `C:\Users\Kishan\.opencode-cursor\plugin.log` has a new line with `Tool loop mode configured` or `Proxy server started`, not `disabled_in_plugin_array`.
+5. Confirm port `32124` listens (`Get-NetTCPConnection -LocalPort 32124`).
+6. In Settings → AI, connect with the existing Cursor key. The previous error must not appear.
+
+If step 3.3 is missing `cursor-acp` after launch, stop and re-open Task 3. Do not add a fifth unrelated patch.
+
+- [ ] **Step 4: Commit only if the rebuild produced tracked artifacts the repo expects**
+
+Do not commit `dist-electron` binaries unless this repo already tracks them. If they are gitignored, skip commit.
+
+---
+
+## Self-review
+
+**Spec coverage**
+
+| Requirement | Task |
+|-------------|------|
+| Env-store `CURSOR_API_KEY` resolves without `process.env` | Task 1 |
+| Local `plugin/cursor-acp.js` path is hermetic under `OPENCODE_CONFIG_DIR` | Task 2 |
+| Runtime config injects env-store key | Task 3 |
+| Runtime config injects absolute local plugin path | Task 3 |
+| Plugin enable check sees `provider.cursor-acp` and/or a matching plugin spec | Task 3 |
+| Connect works after rebuild (proxy listening) | Task 4 |
+| Wave 1 tasks share no files | File map |
+
+**Placeholder scan:** none. Commands, files, and code are complete.
+
+**Type consistency:** `resolveCursorApiKey(envService?: EnvService): Promise<string>`. `resolveLocalCursorAcpPluginPath(): string | null`. `CURSOR_ACP_PLUGIN_FILENAME` is `"cursor-acp.js"`. `CURSOR_ACP_PROVIDER_ID` stays `"cursor-acp"`. `withCursorAcpProvider` still returns `Promise<RuntimeOpencodeConfig>`.
+
+**Parallel-safety:** Task 1 and Task 2 create disjoint files. Task 3 is the only writer of `openwork-runtime-config.ts`. Controller must not start Task 3 until both Wave 1 reviews are clean.

--- a/docs/superpowers/specs/2026-08-22-officecli-windows-design.md
+++ b/docs/superpowers/specs/2026-08-22-officecli-windows-design.md
@@ -1,0 +1,209 @@
+# OfficeCLI auto-integration for packaged Windows OpenWork
+
+**Status:** Approved for implementation planning  
+**Date:** 2026-08-22  
+**Scope:** Private fork (`Shishykish/openwork-private`) — solo developer, Windows packaged `.exe` only (v1)
+
+## Problem
+
+OpenWork already ingests Office attachments (`.docx`, `.pptx`, `.xlsx`) via the
+`openwork-office-attachments` OpenCode plugin: it materializes files into the
+workspace inbox and extracts bounded text for the model. It does not create or
+edit Office documents.
+
+[OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) is installed on the
+developer machine at `%LOCALAPPDATA%\OfficeCLI\officecli.exe` and exposes a
+stdio MCP server via `officecli mcp`.
+
+**Goal:** When the user launches the **packaged Windows installer** (Start Menu,
+no terminal), OpenWork should **automatically** register OfficeCLI as a local MCP
+server — zero manual Settings configuration.
+
+## Constraints
+
+- Solo developer; minimize maintenance and diff size against upstream.
+- OfficeCLI is **user-installed**, not bundled in the OpenWork installer.
+- v1 is **Windows only**; macOS/Linux detection is out of scope.
+- Must not fight user MCP configuration in Settings.
+- Packaged GUI apps often inherit a **stripped PATH**; resolution must use a
+  **full binary path** in the MCP `command` array, not rely on `officecli` alone.
+
+## Non-goals (v1)
+
+- Bundling OfficeCLI in `prepare-sidecar.mjs`
+- Artifact panel HTML preview (`officecli view html`)
+- Auto-installing the OfficeCLI agent skill
+- Den marketplace / org policy integration
+- Replacing the existing OOXML text extractor in `openwork-office-attachments`
+
+## Recommended approach
+
+**Server startup reconcile** (mirrors `reconcileLocalManagedMcpRuntimeEntries`):
+
+1. Detect `officecli.exe` at startup.
+2. For each authorized workspace, ensure a managed `mcp.officecli` entry exists.
+3. Extend desktop runtime PATH on Windows so bash-side tools can also find the
+   binary.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph launch [Packaged OpenWork launch]
+    A[Start Menu .exe]
+    B[Electron runtime]
+    C[openwork-server]
+  end
+
+  subgraph detect [Auto-detect]
+    D[resolveOfficeCliBinary]
+    E["%LOCALAPPDATA%\\OfficeCLI\\officecli.exe"]
+    F[PATH fallback]
+  end
+
+  subgraph register [Auto-register per workspace]
+    G[reconcileOfficeCliMcp]
+    H["runtime opencode config: mcp.officecli"]
+  end
+
+  subgraph agent [Agent session]
+    I[openwork-office-attachments]
+    J[OfficeCLI MCP tools]
+    K[Edited Office files]
+  end
+
+  A --> B --> C
+  C --> D
+  D --> E
+  D --> F
+  D --> G --> H
+  I --> J --> K
+```
+
+### New components
+
+| Unit | Location | Responsibility |
+|------|----------|----------------|
+| `resolveOfficeCliBinary()` | `apps/server/src/officecli-mcp.ts` | Find binary; return `null` if missing |
+| `reconcileOfficeCliMcp()` | `apps/server/src/officecli-mcp.ts` | Provision/update managed MCP per workspace |
+| `reconcileOfficeCliMcpForAllWorkspaces()` | `apps/server/src/officecli-mcp.ts` | Iterate `config.workspaces` |
+| PATH enrichment | `apps/desktop/electron/runtime.mjs` | Add `%LOCALAPPDATA%\OfficeCLI` on `win32` |
+
+### Managed MCP entry shape
+
+```json
+{
+  "type": "local",
+  "enabled": true,
+  "command": ["C:\\Users\\<user>\\AppData\\Local\\OfficeCLI\\officecli.exe", "mcp"],
+  "openworkManaged": true
+}
+```
+
+`openworkManaged: true` marks entries OpenWork may update (e.g. when the binary
+path changes after reinstall). User-created entries without this flag are never
+modified.
+
+## Data flow & lifecycle
+
+### When reconcile runs
+
+1. **Server startup** — in `startServer()`, after
+   `reconcileLocalManagedMcpRuntimeEntries()`, wrapped in try/catch (warn on
+   failure, do not block server start).
+2. **Workspace create** — after `POST /workspaces/local` seeds runtime config and
+   persists workspace state.
+
+### Binary resolution (`resolveOfficeCliBinary`)
+
+Windows only in v1. Lookup order:
+
+1. `process.env.OPENWORK_OFFICECLI_PATH` if set (escape hatch for testing /
+   non-standard installs).
+2. `%LOCALAPPDATA%\OfficeCLI\officecli.exe` (default `install.ps1` location).
+3. PATH scan for `officecli.exe` (fallback for scoop/npm installs).
+
+Returns absolute path string, or `null` if not found.
+
+### Provision rules (`reconcileOfficeCliMcp`)
+
+Per workspace runtime OpenCode config (`readRuntimeOpencodeConfig` / `addMcp`):
+
+| Existing `mcp.officecli` | Action |
+|--------------------------|--------|
+| Missing; workspace KV `officecliProvision` is not `removed` | Create managed entry; set KV to `managed` |
+| Present with `openworkManaged: true` | Update `command[0]` if binary path changed; preserve `enabled` |
+| Present without `openworkManaged` | Do not modify (user-owned config) |
+| Workspace KV is `removed` | Do not auto-add (user opted out) |
+
+**User opt-out:** When the user deletes the `officecli` MCP via Settings and the
+deleted entry had `openworkManaged: true`, set workspace KV `officecliProvision`
+to `removed`. Reconcile will not re-add until the user manually adds it back
+(clearing the KV is not required for manual re-add via UI).
+
+**User disable:** If `enabled: false`, reconcile preserves that value.
+
+### Agent workflow (unchanged)
+
+1. User attaches an Office file in chat.
+2. `openwork-office-attachments` materializes bytes to
+   `.opencode/openwork/inbox/chat-attachments/<hash>.<ext>` and supplies
+   `worker_relative_path` in normalized text.
+3. Agent invokes OfficeCLI MCP tools against that path (`get`, `set`, `view`,
+   `batch`, etc.).
+4. User downloads the result from the artifact panel or workspace folder.
+
+### PATH enrichment
+
+In `apps/desktop/electron/runtime.mjs` → `extraPathEntries()`, for `win32`:
+
+```js
+process.env.LOCALAPPDATA
+  ? path.join(process.env.LOCALAPPDATA, "OfficeCLI")
+  : null
+```
+
+This helps bash-tool invocations find `officecli` even when the MCP entry already
+uses a full path.
+
+## Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| OfficeCLI not installed | Skip reconcile; debug-level log; app works normally |
+| Binary exists but MCP fails to start | Existing MCP health UI surfaces error; user can disable |
+| Non-Windows | No-op in v1 |
+| OfficeCLI reinstalled to new path | Managed entry `command[0]` updated on next reconcile |
+| Reconcile throws | Log warning; server continues starting |
+
+## Testing
+
+| Test | Type | Assertion |
+|------|------|-----------|
+| Resolves default Windows install path | Unit | `officecli-mcp.test.ts` |
+| Returns null when binary missing | Unit | Graceful skip |
+| Adds managed MCP when absent | Unit | Config contains `openworkManaged: true` |
+| Does not overwrite user-owned entry | Unit | Entry without flag unchanged |
+| Respects `officecliProvision: removed` | Unit | No re-add |
+| `extraPathEntries` includes OfficeCLI dir on win32 | Unit | `runtime.test.mjs` |
+| Attach docx → MCP tool edits file | Manual | Packaged `openwork-win-x64-*.exe` smoke |
+
+Full Daytona eval is optional for v1; unit tests plus manual packaged-exe smoke
+are sufficient for a solo fork.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `apps/server/src/officecli-mcp.ts` | New: resolve + reconcile |
+| `apps/server/src/officecli-mcp.test.ts` | New: unit tests |
+| `apps/server/src/server.ts` | Hook startup reconcile |
+| `apps/server/src/routes/workspaces.ts` | Hook workspace create |
+| `apps/server/src/mcp.ts` or MCP delete route | Set `officecliProvision: removed` on managed delete |
+| `apps/desktop/electron/runtime.mjs` | PATH enrichment |
+| `apps/desktop/electron/runtime.test.mjs` | PATH test |
+
+## Upstream sync note
+
+This is a private-fork feature. Keep changes isolated in the files above to ease
+`git merge upstream/dev`. Do not modify `openwork-office-attachments` in v1.


### PR DESCRIPTION
## Summary
- Auto-register OfficeCLI MCP on Windows packaged/desktop builds when the sidecar is available.
- Inject `cursor-acp` plugin and provider into runtime OpenCode config when `CURSOR_API_KEY` is set, mirroring the user's global opencode config (fixes engine connection errors when OPENCODE_CONFIG replaces global config).
- Fix Windows test cleanup: close cached sqlite handles before temp-dir removal (EBUSY).

## Test plan
- [x] `bun --conditions=development test src/openwork-runtime-config.test.ts` (11 pass)
- [x] `bun --conditions=development test src/workspace-kv-store.test.ts` (5 pass)
- [x] `pnpm --filter openwork-server typecheck`
- [ ] Manual: set `CURSOR_API_KEY`, restart OpenWork, confirm Cursor models work in chat
- [ ] Manual: Windows packaged build registers OfficeCLI MCP when sidecar present