### PR TITLE
fix(den-web): omit cookies on direct API calls

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -39,6 +39,24 @@ export function denApiEndpointForWebOrigin(path: string, webOrigin: string): str
   return `${origin}${normalizedPath}`;
 }
 
+export function denApiCredentialsForEndpoint(endpoint: string, webOrigin: string): RequestCredentials {
+  try {
+    const endpointOrigin = new URL(endpoint).origin;
+    const currentOrigin = new URL(webOrigin).origin;
+    return endpointOrigin === currentOrigin ? "include" : "omit";
+  } catch {
+    return "include";
+  }
+}
+
+export function denApiCredentials(endpoint: string): RequestCredentials {
+  if (typeof window === "undefined") {
+    return "include";
+  }
+
+  return denApiCredentialsForEndpoint(endpoint, window.location.origin);
+}
+
 export function denApiEndpoint(path: string): string {
   if (/^https?:\/\//i.test(path)) {
     return path;

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -1,5 +1,5 @@
 import { DEN_WORKER_POLL_INTERVAL_MS } from "./CONSTS";
-import { denApiEndpoint } from "./den-api-origin";
+import { denApiCredentials, denApiEndpoint } from "./den-api-origin";
 import { ORG_SCOPE_HEADER, getRequestOrgScope, shouldPinOrgScopePath } from "./org-scope";
 
 export type AuthMode = "sign-in" | "sign-up";
@@ -1172,7 +1172,7 @@ export async function requestJson(path: string, init: RequestInit = {}, timeoutM
     response = await fetch(endpoint, {
       ...init,
       headers,
-      credentials: "include",
+      credentials: init.credentials ?? denApiCredentials(endpoint),
       signal: init.signal ?? timeoutController?.signal
     });
   } catch (error) {

--- a/ee/apps/den-web/app/mcp/consent/page.tsx
+++ b/ee/apps/den-web/app/mcp/consent/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { denApiEndpoint } from "../../(den)/_lib/den-api-origin";
+import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 
 function getErrorMessage(payload: unknown, fallback: string) {
   if (payload && typeof payload === "object" && "message" in payload && typeof payload.message === "string") return payload.message;
@@ -10,9 +10,10 @@ function getErrorMessage(payload: unknown, fallback: string) {
 }
 
 async function submitConsent(accept: boolean, oauthQuery: string, scope: string) {
-  const response = await fetch(denApiEndpoint("/api/auth/oauth2/consent"), {
+  const endpoint = denApiEndpoint("/api/auth/oauth2/consent");
+  const response = await fetch(endpoint, {
     method: "POST",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ accept, scope, oauth_query: oauthQuery }),
   });

--- a/ee/apps/den-web/app/mcp/select-organization/page.tsx
+++ b/ee/apps/den-web/app/mcp/select-organization/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { denApiEndpoint } from "../../(den)/_lib/den-api-origin";
+import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 import { useOrgListWindow } from "../../(den)/_lib/use-org-list-window";
 
 type Organization = {
@@ -41,8 +41,9 @@ function getErrorMessage(payload: unknown, fallback: string) {
 }
 
 async function requestJson(path: string, init?: RequestInit) {
-  const response = await fetch(denApiEndpoint(path), {
-    credentials: "include",
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
+    credentials: denApiCredentials(endpoint),
     headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
     ...init,
   });

--- a/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
+++ b/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { denApiEndpoint } from "../../(den)/_lib/den-api-origin";
+import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 import { getSocialCallbackUrl } from "../../(den)/_lib/den-flow";
 
 export default function OrganizationSsoSignInPage() {
@@ -19,13 +19,14 @@ export default function OrganizationSsoSignInPage() {
 
     void (async () => {
       try {
-        const response = await fetch(denApiEndpoint("/api/auth/sign-in/sso"), {
+        const endpoint = denApiEndpoint("/api/auth/sign-in/sso");
+        const response = await fetch(endpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
           },
-          credentials: "include",
+          credentials: denApiCredentials(endpoint),
           body: JSON.stringify({
             organizationSlug: orgSlug,
             callbackURL,

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Copy, Pencil, Trash2 } from "lucide-react";
-import { denApiEndpoint } from "../app/(den)/_lib/den-api-origin";
+import { denApiCredentials, denApiEndpoint } from "../app/(den)/_lib/den-api-origin";
 
 type AccessState = "loading" | "ready" | "signed-out" | "forbidden" | "error";
 type ViewMode = "users" | "companies" | "organizations";
@@ -977,9 +977,10 @@ async function requestJson(path: string, signal?: AbortSignal) {
     return { response: new Response(JSON.stringify(fixturePayload), { status: 200 }), payload: fixturePayload };
   }
 
-  const response = await fetch(denApiEndpoint(path), {
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
     method: "GET",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     signal,
     headers: withStoredBearer({
       Accept: "application/json"
@@ -1005,9 +1006,10 @@ function isAbortError(error: unknown): boolean {
 }
 
 async function patchJson(path: string, body: unknown) {
-  const response = await fetch(denApiEndpoint(path), {
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
     method: "PATCH",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
@@ -1030,9 +1032,10 @@ async function patchJson(path: string, body: unknown) {
 }
 
 async function postJson(path: string, body: unknown) {
-  const response = await fetch(denApiEndpoint(path), {
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
     method: "POST",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
@@ -1053,9 +1056,10 @@ async function postJson(path: string, body: unknown) {
 }
 
 async function putJson(path: string, body: unknown) {
-  const response = await fetch(denApiEndpoint(path), {
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
     method: "PUT",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     headers: withStoredBearer({
       Accept: "application/json",
       "Content-Type": "application/json"
@@ -1078,9 +1082,10 @@ async function putJson(path: string, body: unknown) {
 }
 
 async function deleteJson(path: string) {
-  const response = await fetch(denApiEndpoint(path), {
+  const endpoint = denApiEndpoint(path);
+  const response = await fetch(endpoint, {
     method: "DELETE",
-    credentials: "include",
+    credentials: denApiCredentials(endpoint),
     headers: withStoredBearer({
       Accept: "application/json"
     })

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { denApiEndpointForWebOrigin, denApiOriginForWebOrigin } from "../app/(den)/_lib/den-api-origin";
+import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin } from "../app/(den)/_lib/den-api-origin";
 
 describe("Den API browser origin", () => {
   test("prefixes the hosted app origin with the api subdomain", () => {
@@ -20,5 +20,10 @@ describe("Den API browser origin", () => {
     expect(denApiEndpointForWebOrigin("/api/auth/sign-in/email", "https://app.openworklabs.com")).toBe(
       "https://api.app.openworklabs.com/api/auth/sign-in/email",
     );
+  });
+
+  test("omits cookies for direct API-origin browser requests", () => {
+    expect(denApiCredentialsForEndpoint("https://api.app.openworklabs.com/v1/me", "https://app.openworklabs.com")).toBe("omit");
+    expect(denApiCredentialsForEndpoint("/api/runtime-config", "https://app.openworklabs.com")).toBe("include");
   });
 });


### PR DESCRIPTION
## Summary
- omit browser cookies when den-web calls the cross-origin api.* endpoint directly
- keep same-origin credentials behavior for local relative endpoints
- add coverage for credential selection on direct API URLs

## Context
Cloudflare blocks direct api.app.openworklabs.com requests when browser client-hint headers are combined with the parent-domain PostHog cookie. Direct API calls do not need that cookie, and authenticated calls already attach bearer tokens from localStorage.

## Validation
- curl with browser headers and no cookie to https://api.app.openworklabs.com/v1/orgs/sso/resolve returns 200
- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/den-api-origin.test.ts app/api/_lib/den-api-redirect.test.mjs tests/mcp-tool-error-attribution.test.ts
- pnpm --filter @openwork-ee/den-web typecheck
- pnpm --filter @openwork-ee/den-web test