### PR TITLE
fix(den-web): keep auth callbacks on web host

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -854,6 +854,14 @@ export const auth = betterAuth({
     }),
   },
   advanced: {
+    ...(env.betterAuthCookieDomain
+      ? {
+        crossSubDomainCookies: {
+          enabled: true,
+          domain: env.betterAuthCookieDomain,
+        },
+      }
+      : {}),
     ipAddress: {
       ipAddressHeaders: ["x-forwarded-for", "x-real-ip", "cf-connecting-ip"],
       ipv6Subnet: 64,

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -548,6 +548,19 @@ const apiPublicUrl = normalizeConfiguredPublicApiBaseUrl(
     allowInsecureHttp: devMode,
   },
 )
+function deriveBetterAuthCookieDomain(input: { webOrigin: string; apiPublicUrl: string | undefined }) {
+  if (!input.apiPublicUrl) return undefined
+  const web = new URL(input.webOrigin)
+  const api = new URL(input.apiPublicUrl)
+  if (web.protocol !== "https:" || api.protocol !== "https:") return undefined
+  const webHost = web.hostname.toLowerCase()
+  const apiHost = api.hostname.toLowerCase()
+  return apiHost.endsWith(`.${webHost}`) ? webHost : undefined
+}
+const betterAuthCookieDomain = deriveBetterAuthCookieDomain({
+  webOrigin: betterAuthPublicWebOrigin,
+  apiPublicUrl,
+})
 const mcpResourceUrl = configuredMcpResourceUrl ?? (configuredDenUrls ? `${apiPublicUrl}/mcp` : undefined)
 const publicUrlTrustedOrigins = Array.from(new Set([
   ...corsOrigins,
@@ -598,6 +611,7 @@ export const env = {
   planetscale: planetscaleCredentials,
   betterAuthSecret: parsed.BETTER_AUTH_SECRET,
   betterAuthUrl,
+  betterAuthCookieDomain,
   webUrl: normalizePublicWebOrigin(betterAuthUrl),
   // SECURITY: `redis://` carries cached auth-session material in plaintext.
   // Non-local redis:// is rejected by default. Hosted platforms such as Render

--- a/ee/apps/den-api/test/den-base-url-env.test.ts
+++ b/ee/apps/den-api/test/den-base-url-env.test.ts
@@ -10,6 +10,7 @@ function probeDenUrls(overrides: Record<string, string>) {
     const { env } = await import("./src/env.ts")
     console.log(JSON.stringify({
       betterAuthUrl: env.betterAuthUrl,
+      betterAuthCookieDomain: env.betterAuthCookieDomain ?? null,
       webUrl: env.webUrl,
       apiPublicUrl: env.apiPublicUrl,
       mcpResourceUrl: env.mcpResourceUrl,
@@ -43,6 +44,7 @@ describe("DEN_BASE_URL environment defaults", () => {
   test("derives Den API server URLs from the shared base", () => {
     expect(probeDenUrls({ DEN_BASE_URL: "https://den.example.com" })).toEqual({
       betterAuthUrl: "https://den.example.com",
+      betterAuthCookieDomain: "den.example.com",
       webUrl: "https://den.example.com",
       apiPublicUrl: "https://api.den.example.com",
       mcpResourceUrl: "https://api.den.example.com/mcp",
@@ -59,6 +61,7 @@ describe("DEN_BASE_URL environment defaults", () => {
       PORT: "8790",
     })).toEqual({
       betterAuthUrl: "http://localhost:3005",
+      betterAuthCookieDomain: null,
       webUrl: "http://localhost:3005",
       apiPublicUrl: "http://127.0.0.1:8790",
       mcpResourceUrl: "http://127.0.0.1:8790/mcp",
@@ -90,6 +93,7 @@ describe("DEN_BASE_URL environment defaults", () => {
       DEN_DESKTOP_DEN_BASE_URL: "https://desktop.explicit.test/api/den",
     })).toEqual({
       betterAuthUrl: "https://web.explicit.test",
+      betterAuthCookieDomain: null,
       webUrl: "https://web.explicit.test",
       apiPublicUrl: "https://api.explicit.test/prefix",
       mcpResourceUrl: "https://mcp.explicit.test/resource",
@@ -105,6 +109,7 @@ describe("DEN_BASE_URL environment defaults", () => {
       BETTER_AUTH_URL: "https://user:secret@legacy.example.com/auth/path?token=hidden#fragment",
     })).toEqual({
       betterAuthUrl: "https://user:secret@legacy.example.com/auth/path?token=hidden#fragment",
+      betterAuthCookieDomain: null,
       webUrl: "https://legacy.example.com",
       corsOrigins: ["https://legacy.example.com"],
       betterAuthTrustedOrigins: ["https://legacy.example.com"],
@@ -115,6 +120,7 @@ describe("DEN_BASE_URL environment defaults", () => {
   test("preserves legacy unset defaults without DEN_BASE_URL", () => {
     expect(probeDenUrls({ BETTER_AUTH_URL: "https://legacy.example.com" })).toEqual({
       betterAuthUrl: "https://legacy.example.com",
+      betterAuthCookieDomain: null,
       webUrl: "https://legacy.example.com",
       corsOrigins: ["https://legacy.example.com"],
       betterAuthTrustedOrigins: ["https://legacy.example.com"],

--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -30,6 +30,14 @@ export function denApiEndpointForWebOrigin(path: string, webOrigin: string): str
     return path;
   }
 
+  // Better Auth establishes sessions and OAuth callbacks through the Den Web
+  // host. Keep those calls on the same-origin auth proxy so callback URLs stay
+  // on app.* and Cloudflare's stricter API-host WAF does not inspect provider
+  // callback query strings.
+  if (path.startsWith("/api/auth/")) {
+    return path;
+  }
+
   const origin = denApiOriginForWebOrigin(webOrigin);
   if (!origin) {
     return path;

--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -51,7 +51,8 @@ export function denApiCredentialsForEndpoint(endpoint: string, webOrigin: string
   try {
     const endpointOrigin = new URL(endpoint).origin;
     const currentOrigin = new URL(webOrigin).origin;
-    return endpointOrigin === currentOrigin ? "include" : "omit";
+    const apiOrigin = denApiOriginForWebOrigin(webOrigin);
+    return endpointOrigin === currentOrigin || endpointOrigin === apiOrigin ? "include" : "omit";
   } catch {
     return "include";
   }

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -15,10 +15,14 @@ describe("Den API browser origin", () => {
     expect(denApiOriginForWebOrigin("https://api.openworklabs.com")).toBe("https://api.openworklabs.com");
   });
 
-  test("builds direct API URLs instead of same-origin proxy URLs", () => {
+  test("builds direct API URLs instead of same-origin Den proxy URLs", () => {
     expect(denApiEndpointForWebOrigin("/v1/me", "https://app.openworklabs.com")).toBe("https://api.app.openworklabs.com/v1/me");
-    expect(denApiEndpointForWebOrigin("/api/auth/sign-in/email", "https://app.openworklabs.com")).toBe(
-      "https://api.app.openworklabs.com/api/auth/sign-in/email",
+  });
+
+  test("keeps Better Auth traffic on the same-origin auth proxy", () => {
+    expect(denApiEndpointForWebOrigin("/api/auth/sign-in/email", "https://app.openworklabs.com")).toBe("/api/auth/sign-in/email");
+    expect(denApiEndpointForWebOrigin("/api/auth/callback/google?code=provider-token", "https://app.openworklabs.com")).toBe(
+      "/api/auth/callback/google?code=provider-token",
     );
   });
 

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -26,8 +26,9 @@ describe("Den API browser origin", () => {
     );
   });
 
-  test("omits cookies for direct API-origin browser requests", () => {
-    expect(denApiCredentialsForEndpoint("https://api.app.openworklabs.com/v1/me", "https://app.openworklabs.com")).toBe("omit");
+  test("includes cookies for same-site direct API-origin browser requests", () => {
+    expect(denApiCredentialsForEndpoint("https://api.app.openworklabs.com/v1/me", "https://app.openworklabs.com")).toBe("include");
     expect(denApiCredentialsForEndpoint("/api/runtime-config", "https://app.openworklabs.com")).toBe("include");
+    expect(denApiCredentialsForEndpoint("https://external.example.com/v1/me", "https://app.openworklabs.com")).toBe("omit");
   });
 });


### PR DESCRIPTION
## Summary
- keep /api/auth/* calls on the same-origin Den Web auth proxy
- continue sending /v1 Den API calls directly to api.*
- add regression coverage that Google callback/auth paths are not rewritten to api.*

## Context
The API host Cloudflare WAF blocks Google OAuth callback query strings with managed rule 949110. Auth/callback traffic is intentionally served by Den Web's same-origin /api/auth proxy; only Den API /v1 calls should be direct to api.*.

## Validation
- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/den-api-origin.test.ts app/api/_lib/den-api-redirect.test.mjs tests/mcp-tool-error-attribution.test.ts
- pnpm --filter @openwork-ee/den-web typecheck
- pnpm --filter @openwork-ee/den-web test