### PR TITLE
fix(den-web): omit cookies for public SSO resolve

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -47,23 +47,33 @@ export function denApiEndpointForWebOrigin(path: string, webOrigin: string): str
   return `${origin}${normalizedPath}`;
 }
 
-export function denApiCredentialsForEndpoint(endpoint: string, webOrigin: string): RequestCredentials {
+const PUBLIC_DEN_API_PATH_PREFIXES = ["/v1/orgs/sso/resolve"];
+
+function isPublicDenApiPath(path: string): boolean {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return PUBLIC_DEN_API_PATH_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
+}
+
+export function denApiCredentialsForEndpoint(endpoint: string, webOrigin: string, path = endpoint): RequestCredentials {
   try {
     const endpointOrigin = new URL(endpoint).origin;
     const currentOrigin = new URL(webOrigin).origin;
     const apiOrigin = denApiOriginForWebOrigin(webOrigin);
+    if (endpointOrigin === apiOrigin && isPublicDenApiPath(path)) {
+      return "omit";
+    }
     return endpointOrigin === currentOrigin || endpointOrigin === apiOrigin ? "include" : "omit";
   } catch {
     return "include";
   }
 }
 
-export function denApiCredentials(endpoint: string): RequestCredentials {
+export function denApiCredentials(endpoint: string, path = endpoint): RequestCredentials {
   if (typeof window === "undefined") {
     return "include";
   }
 
-  return denApiCredentialsForEndpoint(endpoint, window.location.origin);
+  return denApiCredentialsForEndpoint(endpoint, window.location.origin, path);
 }
 
 export function denApiEndpoint(path: string): string {

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -1172,7 +1172,7 @@ export async function requestJson(path: string, init: RequestInit = {}, timeoutM
     response = await fetch(endpoint, {
       ...init,
       headers,
-      credentials: init.credentials ?? denApiCredentials(endpoint),
+      credentials: init.credentials ?? denApiCredentials(endpoint, path),
       signal: init.signal ?? timeoutController?.signal
     });
   } catch (error) {

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -31,4 +31,12 @@ describe("Den API browser origin", () => {
     expect(denApiCredentialsForEndpoint("/api/runtime-config", "https://app.openworklabs.com")).toBe("include");
     expect(denApiCredentialsForEndpoint("https://external.example.com/v1/me", "https://app.openworklabs.com")).toBe("omit");
   });
+
+  test("omits cookies for public direct API endpoints", () => {
+    expect(denApiCredentialsForEndpoint(
+      "https://api.app.openworklabs.com/v1/orgs/sso/resolve?email=omar%40openworklabs.com",
+      "https://app.openworklabs.com",
+      "/v1/orgs/sso/resolve?email=omar%40openworklabs.com",
+    )).toBe("omit");
+  });
 });


### PR DESCRIPTION
## Summary
- keep cross-subdomain cookies for session-backed direct API calls like /v1/me
- omit credentials for the public /v1/orgs/sso/resolve endpoint so broad parent-domain cookies are not sent to the API host
- add regression coverage for credential selection

## Context
After enabling option A, public SSO resolution requests started sending browser cookies (including parent-domain analytics cookies) to api.app.openworklabs.com again, which triggers Cloudflare WAF. The endpoint is public and does not need cookies; OAuth-created session reads still include credentials for /v1/me.

## Validation
- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/den-api-origin.test.ts app/api/_lib/den-api-redirect.test.mjs tests/mcp-tool-error-attribution.test.ts
- pnpm --filter @openwork-ee/den-web typecheck
- pnpm --filter @openwork-ee/den-web test