### PR TITLE
fix(den-web): rewrite auth cookie domains

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -68,6 +68,19 @@ describe("Den upstream proxy", () => {
           });
         }
 
+        if (url.pathname === "/api/auth/callback/google") {
+          const headers = new Headers({ "content-type": "text/plain" });
+          headers.append(
+            "set-cookie",
+            "__Secure-better-auth.session_token=abc; Path=/; Domain=api.app.example.com; Secure; HttpOnly; SameSite=Lax",
+          );
+          headers.append(
+            "set-cookie",
+            "better-auth.session_data=def; Path=/; Secure; HttpOnly; SameSite=Lax",
+          );
+          return new Response("signed in", { headers });
+        }
+
         return new Response("proxied", {
           status: 207,
           headers: {
@@ -195,6 +208,40 @@ describe("Den upstream proxy", () => {
     await proxyUpstream(request, [], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
 
     expect(observed.cookie).toBe("better-auth.state=oauth-state; __Secure-better-auth.session_token=session");
+  });
+
+  test("rewrites auth Set-Cookie domains to the browser origin", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const originalFetch = globalThis.fetch;
+    process.env.DEN_API_BASE = "https://api.app.example.com";
+    globalThis.fetch = async () => {
+      const headers = new Headers({ "content-type": "text/plain" });
+      headers.append(
+        "set-cookie",
+        "__Secure-better-auth.session_token=abc; Path=/; Domain=api.app.example.com; Secure; HttpOnly; SameSite=Lax",
+      );
+      headers.append(
+        "set-cookie",
+        "better-auth.session_data=def; Path=/; Secure; HttpOnly; SameSite=Lax",
+      );
+      return new Response("signed in", { headers });
+    };
+    const request = new NextRequest("https://app.example.com/api/auth/callback/google", {
+      method: "GET",
+    });
+
+    let response;
+    try {
+      response = await proxyUpstream(request, ["callback", "google"], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.DEN_API_BASE = `http://127.0.0.1:${server.port}`;
+    }
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "__Secure-better-auth.session_token=abc; Path=/; Domain=app.example.com; Secure; HttpOnly; SameSite=Lax",
+      "better-auth.session_data=def; Path=/; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
+    ]);
   });
 
   test("rejects http and lookalike hostnames", async () => {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -251,9 +251,45 @@ async function cloneRequestHeaders(
   return headers;
 }
 
-function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers): void {
+function isDomainCookieHostEligible(origin: URL): boolean {
+  const hostname = origin.hostname.toLowerCase();
+  return origin.protocol === "https:" && hostname.includes(".") && hostname !== "localhost";
+}
+
+function rewriteAuthSetCookieHeader(cookie: string, request: NextRequest, apiBase: string, options: ProxyOptions): string {
+  if (options.routePrefix !== "/api/auth") return cookie;
+
+  let apiOrigin: URL;
+  try {
+    apiOrigin = new URL(apiBase);
+  } catch {
+    return cookie;
+  }
+
+  const publicOrigin = requestPublicOrigin(request);
+  if (!isDomainCookieHostEligible(publicOrigin)) return cookie;
+  const publicHostname = publicOrigin.hostname.toLowerCase();
+  const apiHostname = apiOrigin.hostname.toLowerCase();
+  const canShareWithApiSubdomain = apiHostname.endsWith(`.${publicHostname}`);
+  let hasDomain = false;
+
+  const rewritten = cookie
+    .split(";")
+    .map((part, index) => {
+      const trimmed = part.trim();
+      if (!/^domain=/iu.test(trimmed)) return index === 0 ? trimmed : ` ${trimmed}`;
+      hasDomain = true;
+      return ` Domain=${publicHostname}`;
+    })
+    .join(";");
+
+  if (hasDomain || !canShareWithApiSubdomain || /^__Host-/u.test(cookie)) return rewritten;
+  return `${rewritten}; Domain=${publicHostname}`;
+}
+
+function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers, request: NextRequest, apiBase: string, options: ProxyOptions): void {
   for (const cookie of upstreamHeaders.getSetCookie()) {
-    if (cookie) responseHeaders.append("set-cookie", cookie);
+    if (cookie) responseHeaders.append("set-cookie", rewriteAuthSetCookieHeader(cookie, request, apiBase, options));
   }
 }
 
@@ -326,7 +362,7 @@ function cloneResponseHeaders(request: NextRequest, upstream: Response, options:
     }
     headers.append(name, value);
   });
-  copySetCookieHeaders(upstream.headers, headers);
+  copySetCookieHeaders(upstream.headers, headers, request, apiBase, options);
   sanitizeExposeHeaders(headers);
   return headers;
 }


### PR DESCRIPTION
## Summary\n- rewrite auth proxy Set-Cookie Domain attributes from the API host to the browser-facing web host\n- add a Domain attribute for Better Auth cookies without one when the API is a web subdomain\n- cover OAuth callback cookie rewriting in the upstream proxy tests\n\n## Tests\n- pnpm --filter @openwork-ee/den-web exec bun test --conditions development app/api/_lib/upstream-proxy.test.mjs tests/den-api-origin.test.ts\n- pnpm --filter @openwork-ee/den-web typecheck