### PR TITLE
feat(evals): prove and complete the kind world substrate

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -146,12 +146,22 @@ snapshot remains available for listing, rebuilding, or removal with
 
 World v1 has deliberate limits:
 
-- Every app signs in.
 - Apps join the first (primary) organization only.
 - Witnesses are MCP mocks only.
-- `onKind()` exists, but `den.substrate: "kind"` is validation-only and
-  `startWorld()` throws `den.substrate "kind" is not wired yet`.
-- There is no session seeding yet.
+- `onKind()` runs a real Helm Den on the shared `openwork-kube-lab` kind cluster.
+  Kind worlds can boot local Electron apps signed in as the seeded Acme admin;
+  they do not yet accept witnesses, extra organizations, seed overrides, custom
+  port-forwards, or non-local placement.
+
+Run the opt-in proof on a machine with local Docker, kind, kubectl, and Helm:
+
+```bash
+OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_KIND_E2E=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/world-kind-den.e2e.test.ts
+```
+
+Daytona cannot host this substrate: its sandbox has no Docker binary or daemon,
+reports `CapEff: 0000000000000000`, and blocks `unshare -Urm`, so no container
+runtime can start kind there.
 
 ### Reproducing a failure
 

--- a/evals/fixtures/kube/values/multi-org.yaml
+++ b/evals/fixtures/kube/values/multi-org.yaml
@@ -1,5 +1,5 @@
 config:
-  openworkDevMode: "1"
+  openworkDevMode: "0"
   denApiNodeOptions: --use-openssl-ca
   tenancy:
     mode: multi_org

--- a/evals/fixtures/kube/values/single-org.yaml
+++ b/evals/fixtures/kube/values/single-org.yaml
@@ -1,5 +1,5 @@
 config:
-  openworkDevMode: "1"
+  openworkDevMode: "0"
   denApiNodeOptions: --use-openssl-ca
   tenancy:
     mode: single_org

--- a/evals/packages/env/src/index.ts
+++ b/evals/packages/env/src/index.ts
@@ -6,5 +6,6 @@ export * from "./desktop-app.ts";
 export * from "./topology.ts";
 export * from "./presets.ts";
 export * from "./world.ts";
+export * from "./kind-stack.ts";
 export * from "./faults.ts";
 export * from "./litellm.ts";

--- a/evals/packages/env/src/kind-stack.ts
+++ b/evals/packages/env/src/kind-stack.ts
@@ -322,20 +322,48 @@ async function httpOk(url: string, timeoutMs = 2_500): Promise<boolean> {
   }
 }
 
-async function signInDemoOwner(): Promise<{ token: string; email: string } | null> {
+async function demoOwnerTokenIsValid(token: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${DEN_API_URL}/v1/me`, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(2_500),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function signInDemoOwner(runtime: KubeRuntime): Promise<{ token: string; email: string }> {
+  const existingToken = await mysqlQuery(
+    runtime,
+    `SELECT s.token FROM \`session\` s JOIN \`user\` u ON u.id=s.user_id WHERE u.email='${DEMO_EMAIL.toLowerCase()}' AND s.expires_at > UTC_TIMESTAMP(3) ORDER BY s.expires_at DESC LIMIT 1;`,
+  );
+  if (existingToken && await demoOwnerTokenIsValid(existingToken)) {
+    runtime.log(`Reusing a valid demo-owner session (${DEMO_EMAIL})`);
+    return { token: existingToken, email: DEMO_EMAIL };
+  }
+
   try {
     const response = await fetch(`${DEN_API_URL}/api/auth/sign-in/email`, {
       method: "POST",
-      headers: { "content-type": "application/json", origin: DEN_BASE_URL },
+      headers: {
+        "content-type": "application/json",
+        origin: DEN_BASE_URL,
+        "x-forwarded-for": "127.0.0.1",
+      },
       body: JSON.stringify({ email: DEMO_EMAIL, password: DEMO_PASSWORD }),
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${(await response.text()).slice(0, 500)}`);
+    }
     const payload: unknown = await response.json();
-    return isRecord(payload) && typeof payload.token === "string" && payload.token
-      ? { token: payload.token, email: DEMO_EMAIL }
-      : null;
-  } catch {
-    return null;
+    if (!isRecord(payload) || typeof payload.token !== "string" || !payload.token) {
+      throw new Error("the response did not contain a session token");
+    }
+    return { token: payload.token, email: DEMO_EMAIL };
+  } catch (error) {
+    throw new Error(`Could not obtain a demo-owner session from the kube Den API: ${errorText(error)}`);
   }
 }
 
@@ -822,6 +850,8 @@ export async function ensureSeed(options: KubeLayerOptions = {}): Promise<void> 
 export async function ensureKindDenReady(options: KubeLayerOptions = {}): Promise<void> {
   const runtime = createRuntime(options);
   await phase(runtime, "existing-stack", () => requireKindStack(runtime));
+  await phase(runtime, "den-api-rollout", () => ensureRollout(runtime, `${KUBE_RELEASE_NAME}-den-api`, "60s"));
+  await phase(runtime, "den-web-rollout", () => ensureRollout(runtime, `${KUBE_RELEASE_NAME}-den-web`, "60s"));
   await phase(runtime, "schema", () => ensureSchema(options));
   await phase(runtime, "seed", () => ensureSeed(options));
 }
@@ -879,16 +909,31 @@ async function ensurePortForward(runtime: KubeRuntime, kind: "api" | "web", serv
     }
     await runtime.sleep(1_000);
   }
+  await stopProcess(runtime, pid, `${kind} port-forward`);
+  await rm(pidStatePath(runtime, stateName), { force: true });
   throw new Error(`${kind} port-forward did not become healthy on :${localPort} within 60s.`);
+}
+
+async function stopEndpointForward(runtime: KubeRuntime, kind: "api" | "web", pid: number): Promise<void> {
+  await stopProcess(runtime, pid, `${kind} port-forward`);
+  await rm(pidStatePath(runtime, `${kind}-port-forward.pid`), { force: true });
 }
 
 export async function exposeEndpointHandles(profile: KubeProfileConfig, options: KubeLayerOptions = {}): Promise<KindEndpoints> {
   const runtime = createRuntime(options);
   await mkdir(runtime.stateDir, { recursive: true });
-  const apiPid = await ensurePortForward(runtime, "api", DEN_API_SERVICE, DEN_API_PORT, 8788);
-  const webPid = await ensurePortForward(runtime, "web", DEN_WEB_SERVICE, DEN_WEB_PORT, 3005);
-  const owner = await signInDemoOwner();
-  if (!owner) throw new Error("Could not obtain a demo-owner session token from the kube Den API.");
+  let apiPid: number | undefined;
+  let webPid: number | undefined;
+  let owner: { token: string; email: string };
+  try {
+    apiPid = await ensurePortForward(runtime, "api", DEN_API_SERVICE, DEN_API_PORT, 8788);
+    webPid = await ensurePortForward(runtime, "web", DEN_WEB_SERVICE, DEN_WEB_PORT, 3005);
+    owner = await signInDemoOwner(runtime);
+  } catch (error) {
+    if (webPid !== undefined) await stopEndpointForward(runtime, "web", webPid);
+    if (apiPid !== undefined) await stopEndpointForward(runtime, "api", apiPid);
+    throw error;
+  }
   let stopped = false;
   return {
     apiUrl: DEN_API_URL,
@@ -898,10 +943,8 @@ export async function exposeEndpointHandles(profile: KubeProfileConfig, options:
     async stop(): Promise<void> {
       if (stopped) return;
       stopped = true;
-      await stopProcess(runtime, apiPid, "api port-forward");
-      await rm(pidStatePath(runtime, "api-port-forward.pid"), { force: true });
-      await stopProcess(runtime, webPid, "web port-forward");
-      await rm(pidStatePath(runtime, "web-port-forward.pid"), { force: true });
+      await stopEndpointForward(runtime, "api", apiPid);
+      await stopEndpointForward(runtime, "web", webPid);
     },
   };
 }

--- a/evals/packages/env/src/needs.ts
+++ b/evals/packages/env/src/needs.ts
@@ -23,6 +23,12 @@ function present(env: NodeJS.ProcessEnv, name: string): boolean {
   return Boolean(env[name]?.trim());
 }
 
+function commandProbeArgs(command: string): string[] {
+  if (command === "kubectl") return ["version", "--client"];
+  if (command === "helm" || command === "kind" || command === "docker") return ["version"];
+  return ["--version"];
+}
+
 export function unmetNeeds(requirements: TestNeeds, env: NodeJS.ProcessEnv): string[] {
   const missing: string[] = [];
   for (const name of requirements.env ?? []) {
@@ -32,7 +38,7 @@ export function unmetNeeds(requirements: TestNeeds, env: NodeJS.ProcessEnv): str
     if (env[name]?.trim() !== "1") missing.push(`set ${name}=1`);
   }
   for (const command of requirements.commands ?? []) {
-    const result = spawnSync(command, ["--version"], { stdio: "ignore", timeout: 10_000 });
+    const result = spawnSync(command, commandProbeArgs(command), { stdio: "ignore", timeout: 10_000 });
     if (result.error || result.status !== 0) missing.push(`install ${command}`);
   }
   if (requirements.model === "tool-capable") {

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -247,10 +247,6 @@ function validateReferences(topology: WorldTopology): void {
   }
 
   if (topology.den.substrate === "kind") {
-    const appKeys = Object.keys(topology.apps ?? {});
-    if (appKeys.length > 0) {
-      throw new Error('den.substrate "kind" cannot define apps: v1 limitation: kind worlds expose only the seeded Den.');
-    }
     const witnessKeys = Object.keys(topology.witnesses ?? {});
     if (witnessKeys.length > 0) {
       throw new Error('den.substrate "kind" cannot define witnesses: v1 limitation: the shared kind Den cannot inject world witnesses.');
@@ -280,6 +276,13 @@ function validateReferences(topology: WorldTopology): void {
     }
     if (seededOrg.admin?.password !== undefined && seededOrg.admin.password !== "OpenWorkDemo123!") {
       throw new Error('den.substrate "kind" admin.password must match the seeded demo admin password.');
+    }
+    for (const [appName, app] of Object.entries(topology.apps ?? {})) {
+      if (app.signedInTo?.as !== "admin") {
+        throw new Error(
+          `World app ${JSON.stringify(appName)} on den.substrate "kind" must sign in as "admin": only the seeded admin session has been proved on the shared kind Den.`,
+        );
+      }
     }
   }
 

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -574,7 +574,12 @@ async function kindDen(): Promise<Den> {
   const endpoints = await exposeEndpointHandles(kubeProfileConfig("single-org"));
   const ref: DenRef = { apiUrl: endpoints.apiUrl, webUrl: endpoints.webUrl };
   try {
-    const admin = await signIn(ref, { email: endpoints.adminEmail, password: DEMO_PASSWORD });
+    const admin: DenSession = {
+      ...ref,
+      token: endpoints.token,
+      email: endpoints.adminEmail,
+      password: DEMO_PASSWORD,
+    };
     let disposed = false;
     return {
       ref,
@@ -791,6 +796,9 @@ export async function startWorld(
 ): Promise<World> {
   const topology = worldTopology(definition);
   const place = options.place ?? resolvePlace(process.env);
+  if (topology.den.substrate === "kind" && place.kind !== "local") {
+    throw new Error('den.substrate "kind" requires local placement because the kind cluster and its port-forwards run on the local Docker host.');
+  }
   const name = options.name ?? `world-${Date.now().toString(36)}-${process.pid.toString(36)}`;
   const [primaryOrgName, primaryOrg] = primaryOrganization(topology);
   const scope = await Effect.runPromise(Scope.make("sequential"));

--- a/evals/packages/env/test/kind-stack.test.ts
+++ b/evals/packages/env/test/kind-stack.test.ts
@@ -226,6 +226,52 @@ test("endpoint handles return credentials and stop only their recorded port-forw
   }
 });
 
+test("endpoint acquisition failure stops both newly started port-forwards", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openwork-kind-endpoints-failure-test-"));
+  const killed: number[] = [];
+  const pids = [987_661, 987_662];
+  let spawned = 0;
+  const spawnDetached: KubeSpawnDetached = () => {
+    const pid = pids[spawned];
+    spawned += 1;
+    if (pid === undefined) throw new Error("Unexpected extra detached process.");
+    return pid;
+  };
+  const { exec } = createExec((call) => call.command === "lsof"
+    ? { stdout: "", stderr: "", code: 1 }
+    : success());
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+    return new Response(url.endsWith("/api/auth/sign-in/email") ? "no" : "ok", {
+      status: url.endsWith("/api/auth/sign-in/email") ? 401 : 200,
+    });
+  };
+  try {
+    await assert.rejects(
+      () => exposeEndpointHandles(kubeProfileConfig("single-org"), {
+        stateDir,
+        exec,
+        spawnDetached,
+        sleep: async () => undefined,
+        killProcess: (pid) => killed.push(pid),
+      }),
+      /Could not obtain a demo-owner session.*HTTP 401/,
+    );
+
+    assert.deepEqual(killed, [-987_662, 987_662, -987_661, 987_661]);
+    await assert.rejects(() => readFile(join(stateDir, "api-port-forward.pid"), "utf8"), /ENOENT/);
+    await assert.rejects(() => readFile(join(stateDir, "web-port-forward.pid"), "utf8"), /ENOENT/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("ensureKindDenReady fails fast when the shared kind cluster is absent", async () => {
   const { exec, calls } = createExec(() => success(""));
 
@@ -234,6 +280,28 @@ test("ensureKindDenReady fails fast when the shared kind cluster is absent", asy
     /ensureKubeStack\(\{ cdpCandidates: \[\], skipApp: true \}\)/,
   );
   assert.deepEqual(calls.map((call) => `${call.command} ${call.args.join(" ")}`), ["kind get clusters"]);
+});
+
+test("ensureKindDenReady verifies both Den rollouts before reading shared state", async () => {
+  const { exec, calls } = createExec((call) => {
+    const text = `${call.command} ${call.args.join(" ")}`;
+    if (text === "kind get clusters") return success("openwork-kube-lab\n");
+    if (text.includes("SHOW TABLES LIKE")) {
+      return success("organization\ndesktop_connect_grant\nscim_group\ngroup_mapping_mode\n");
+    }
+    if (text.includes("SELECT id FROM `user`")) return success("seeded-owner-id\n");
+    return success();
+  });
+
+  await ensureKindDenReady({ exec });
+
+  const commands = calls.map((call) => `${call.command} ${call.args.join(" ")}`);
+  const apiRollout = commands.findIndex((command) => command.includes("rollout status deployment/openwork-ee-den-api"));
+  const webRollout = commands.findIndex((command) => command.includes("rollout status deployment/openwork-ee-den-web"));
+  const schemaQuery = commands.findIndex((command) => command.includes("SHOW TABLES LIKE"));
+  assert(apiRollout >= 0);
+  assert(webRollout > apiRollout);
+  assert(schemaQuery > webRollout);
 });
 
 test("kubeStackDown stops port-forwards before uninstalling the release", async () => {

--- a/evals/packages/env/test/topology.test.ts
+++ b/evals/packages/env/test/topology.test.ts
@@ -26,13 +26,15 @@ test("onKind selects the kind Den substrate", () => {
   assert.equal(kind.topology.den.substrate, "kind");
 });
 
-test("kind substrate rejects apps, witnesses, multiple organizations, and local-lane options", () => {
+test("kind substrate accepts seeded-admin apps and rejects unsupported shared-stack options", () => {
+  const withApp = kindSeedWorld().with({
+    den: { substrate: "kind" },
+    apps: { main: { signedInTo: { org: "Acme Robotics", as: "admin" } } },
+  });
+  assert.equal(withApp.topology.apps?.main?.signedInTo?.as, "admin");
   assert.throws(
-    () => kindSeedWorld().with({
-      den: { substrate: "kind" },
-      apps: { main: { signedInTo: { org: "Acme Robotics", as: "admin" } } },
-    }),
-    /den\.substrate "kind" cannot define apps: v1 limitation/,
+    () => kindSeedWorld().with({ den: { substrate: "kind" }, apps: { main: {} } }),
+    /must sign in as "admin": only the seeded admin session has been proved/,
   );
   assert.throws(
     () => kindSeedWorld().with({

--- a/evals/specs/world-kind-den.e2e.test.ts
+++ b/evals/specs/world-kind-den.e2e.test.ts
@@ -1,0 +1,138 @@
+import { execFile } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import {
+  defineWorld,
+  ensureKubeStack,
+  eventually,
+  KUBE_CLUSTER_NAME,
+  KUBE_CONTEXT,
+  needs,
+  onKind,
+  readDenClientState,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+
+const execFileAsync = promisify(execFile);
+const stateDir = fileURLToPath(new URL("../results/.kube-stack/", import.meta.url));
+const apiPidPath = fileURLToPath(new URL("../results/.kube-stack/api-port-forward.pid", import.meta.url));
+const webPidPath = fileURLToPath(new URL("../results/.kube-stack/web-port-forward.pid", import.meta.url));
+
+function auth(token: string): Record<string, string> {
+  return { authorization: `Bearer ${token}` };
+}
+
+async function portCanBind(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(false));
+    probe.listen(port, "127.0.0.1", () => probe.close(() => resolve(true)));
+  });
+}
+
+function endpointPort(url: string): number {
+  const port = Number(new URL(url).port);
+  if (!Number.isInteger(port) || port < 1) throw new Error(`Kind endpoint has no explicit port: ${url}`);
+  return port;
+}
+
+test("a kind world serves its seeded admin and disposes only its port-forwards", { timeout: 900_000 }, async ({ evidence }) => {
+  needs({
+    optIn: ["OPENWORK_EVAL_KIND_E2E"],
+    commands: ["kind", "kubectl", "helm", "docker"],
+  });
+
+  await ensureKubeStack({
+    cdpCandidates: [],
+    skipApp: true,
+    images: "published",
+    stateDir,
+    log: (message) => console.error(`[openwork/testkit] ${message}`),
+  });
+
+  const definition = onKind(defineWorld({
+    den: {
+      orgs: {
+        "Acme Robotics": {
+          admin: {
+            email: "alex@acme.test",
+            name: "Alex Chen",
+            password: "OpenWorkDemo123!",
+          },
+        },
+      },
+    },
+    apps: {
+      main: { signedInTo: { org: "Acme Robotics", as: "admin" } },
+    },
+  }));
+
+  const world = await startWorld(definition, { name: `kind-den-${Date.now().toString(36)}` });
+  const apiPort = endpointPort(world.den.ref.apiUrl);
+  const webPort = endpointPort(world.den.ref.webUrl);
+  try {
+    const health = await fetch(`${world.den.ref.apiUrl}/health`);
+    expect(health.status).toBe(200);
+
+    const organizations = await denFetch(world.den.admin, "/v1/me/orgs", {
+      headers: auth(world.den.admin.token),
+    });
+    expect(organizations.response.status).toBe(200);
+    expect(organizations.body).toMatchObject({
+      orgs: [{ name: "Acme Robotics", role: "owner" }],
+    });
+    evidence.recordAssertionEvidence(
+      "The kind Den answers health and an authenticated seeded-admin route",
+      `GET /health returned ${health.status}; GET /v1/me/orgs returned ${organizations.response.status} for ${world.den.admin.email}.`,
+      true,
+    );
+
+    const clientState = await eventually(() => readDenClientState(world.app("main")), {
+      within: 30_000,
+      label: "Electron app signed in to the kind Den",
+      until: (state) => state.authTokenPresent && state.activeOrgName === "Acme Robotics",
+    });
+    expect(clientState).toMatchObject({ authTokenPresent: true, activeOrgName: "Acme Robotics" });
+    evidence.recordAssertionEvidence(
+      "A local Electron app signs in to the port-forwarded kind Den",
+      `The desktop stored an auth token and selected ${clientState.activeOrgName}.`,
+      true,
+    );
+
+    const snapshot: unknown = JSON.parse(await readFile(world.snapshotPath, "utf8"));
+    expect(snapshot).toMatchObject({
+      topology: { den: { substrate: "kind" } },
+      resolved: { den: { substrate: "kind" } },
+    });
+    evidence.recordAssertionEvidence(
+      "The world snapshot records the kind substrate",
+      "Both topology.den.substrate and resolved.den.substrate equal kind.",
+      true,
+    );
+
+    expect(Number(await readFile(apiPidPath, "utf8"))).toBeGreaterThan(0);
+    expect(Number(await readFile(webPidPath, "utf8"))).toBeGreaterThan(0);
+  } finally {
+    await world[Symbol.asyncDispose]();
+  }
+
+  await expect(access(apiPidPath)).rejects.toMatchObject({ code: "ENOENT" });
+  await expect(access(webPidPath)).rejects.toMatchObject({ code: "ENOENT" });
+  expect(await portCanBind(apiPort)).toBe(true);
+  expect(await portCanBind(webPort)).toBe(true);
+
+  const namespaces = await execFileAsync("kubectl", ["--context", KUBE_CONTEXT, "get", "namespaces", "-o", "name"]);
+  expect(namespaces.stdout).toContain("namespace/default");
+  const clusters = await execFileAsync("kind", ["get", "clusters"]);
+  expect(clusters.stdout.split(/\r?\n/)).toContain(KUBE_CLUSTER_NAME);
+  evidence.recordAssertionEvidence(
+    "Disposal stops the world port-forwards but leaves the kind cluster running",
+    `Both pid files were removed, ports ${apiPort}/${webPort} can bind, and kubectl still listed namespace/default in ${KUBE_CONTEXT}.`,
+    true,
+  );
+});


### PR DESCRIPTION
## What this proves

PR #4016 introduced `den.substrate: "kind"`, but no cluster had executed the runtime. This follow-up boots `startWorld(onKind(...))` against a real local kind cluster, authenticates as the seeded Acme owner, boots a local Electron app against the port-forwarded Den, records `resolved.den.substrate: "kind"`, and proves disposal stops only the port-forwards while the cluster survives.

## Defects fixed

- Helm eval values set `OPENWORK_DEV_MODE=1`, making packaged Den images re-exec TypeScript source and crash on an extensionless source import. The chart now runs packaged images in production mode; seed execution still opts into dev mode only for its command.
- Kind readiness checked only cluster/release existence. It now verifies both Den rollouts before schema/seed preflight.
- Endpoint setup performed duplicate owner sign-ins and hit the shared Better Auth 5-per-5-minute rate bucket. It now reuses and validates a live seeded-owner session, and the world consumes that session directly.
- Endpoint acquisition failures leaked tracked port-forwards. Startup timeout/auth failures and world disposal now remove only their pid files/processes, never the Helm release or cluster.
- `needs({ commands })` falsely rejected installed Helm and kubectl because those CLIs do not support `--version`; their real version probes are used.
- Kind worlds now reject non-local placement explicitly.

## Restrictions re-evaluated

**Lifted:** local Electron apps signed in as the seeded Acme admin. The E2E proof observes the desktop auth token and active `Acme Robotics` organization.

**Kept:** witnesses (no proved host-mock routing/injection into the shared cluster), extra organizations and members (the proved profile is single-org with a fixed seeded roster), seed overrides (the shared stack owns the demo seed), custom ports (the shared stack owns fixed tracked port-forwards), and unsigned/member apps. No unexecuted restriction was lifted.

## Images and verification lane

Final proof uses the published `ghcr.io/different-ai/openwork-den-api:latest` and `openwork-den-web:latest` multi-arch images. The first published attempt exposed the dev-mode chart defect; a diagnostic local-image fallback reproduced it. After correcting the chart values, all final stack and E2E runs used published images.

Lane: **LOCAL**. Daytona is impossible for kind: a fresh sandbox had no Docker binary, no daemon, `CapEff: 0000000000000000`, and blocked `unshare -Urm`; with zero Linux capabilities and no usable container runtime it cannot start kind.

## Verification

| Command | Result |
| --- | --- |
| `pnpm evals:typecheck` | Expected inherited baseline: exit 2, exactly 35 errors |
| `pnpm evals:test` | Exit 0, 212/212 passed |
| `pnpm --dir evals run lint:layers` | Exit 0, clean |
| `pnpm evals:pr` | Exit 0, 51 passed / 2 expected skips |
| `OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_KIND_E2E=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/world-kind-den.e2e.test.ts` | Exit 0, 1/1 passed against live kind |
| `pnpm evals:e2e testkit-app-boot` | Exit 0, 1/1 passed |
| `kind get clusters` after disposal | Exit 0, `openwork-kube-lab` still listed |

## Stack follow-up

PR #4016 merged while this follow-up was being proved. This PR intentionally retains the requested stacked base `feat/evals-env-worlds`; before merging it must be rebased/re-targeted to `dev`, all checks rerun on the resulting head, and head-bound evidence republished per `prove-a-pr`.