### PR TITLE
fix(den-web): preserve combined auth cookies

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -244,6 +244,37 @@ describe("Den upstream proxy", () => {
     ]);
   });
 
+  test("copies auth Set-Cookie from runtimes that only expose the combined header", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const originalFetch = globalThis.fetch;
+    process.env.DEN_API_BASE = "https://api.app.example.com";
+    globalThis.fetch = async () => {
+      const response = new Response("signed in", {
+        headers: {
+          "set-cookie": "better-auth.session_token=abc; Path=/; Secure; HttpOnly; SameSite=Lax, better-auth.session_data=def; Path=/; Expires=Tue, 25 Aug 2026 23:54:00 GMT; Secure; HttpOnly; SameSite=Lax",
+        },
+      });
+      Object.defineProperty(response.headers, "getSetCookie", { value: () => [] });
+      return response;
+    };
+    const request = new NextRequest("https://app.example.com/api/auth/callback/google", {
+      method: "GET",
+    });
+
+    let response;
+    try {
+      response = await proxyUpstream(request, ["callback", "google"], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.DEN_API_BASE = `http://127.0.0.1:${server.port}`;
+    }
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "better-auth.session_token=abc; Path=/; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
+      "better-auth.session_data=def; Path=/; Expires=Tue, 25 Aug 2026 23:54:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
+    ]);
+  });
+
   test("rejects http and lookalike hostnames", async () => {
     const { proxyUpstream } = await import("./upstream-proxy.ts");
     for (const origin of ["http://8787-x.daytonaproxy01.net", "https://daytonaproxy01.net.evil.com"]) {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -287,8 +287,42 @@ function rewriteAuthSetCookieHeader(cookie: string, request: NextRequest, apiBas
   return `${rewritten}; Domain=${publicHostname}`;
 }
 
+function splitCombinedSetCookieHeader(value: string): string[] {
+  const cookies: string[] = [];
+  let start = 0;
+  let inExpires = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === ";") {
+      inExpires = false;
+      continue;
+    }
+    if (!inExpires && value.slice(index, index + 8).toLowerCase() === "expires=") {
+      inExpires = true;
+      index += 7;
+      continue;
+    }
+    if (char === "," && !inExpires) {
+      const candidate = value.slice(start, index).trim();
+      if (candidate) cookies.push(candidate);
+      start = index + 1;
+    }
+  }
+
+  const finalCookie = value.slice(start).trim();
+  if (finalCookie) cookies.push(finalCookie);
+  return cookies;
+}
+
+function readSetCookieHeaders(upstreamHeaders: Headers): string[] {
+  const cookies = upstreamHeaders.getSetCookie();
+  if (cookies.length > 0) return cookies;
+  const combined = upstreamHeaders.get("set-cookie");
+  return combined ? splitCombinedSetCookieHeader(combined) : [];
+}
+
 function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers, request: NextRequest, apiBase: string, options: ProxyOptions): void {
-  for (const cookie of upstreamHeaders.getSetCookie()) {
+  for (const cookie of readSetCookieHeaders(upstreamHeaders)) {
     if (cookie) responseHeaders.append("set-cookie", rewriteAuthSetCookieHeader(cookie, request, apiBase, options));
   }
 }


### PR DESCRIPTION
## Summary\n- fall back to the combined Set-Cookie header when the runtime returns an empty getSetCookie() list\n- split combined cookies without breaking Expires commas\n- keep auth cookie domain rewriting on the fallback path\n\n## HAR finding\nThe provided login HAR shows the Google callback at /api/auth/callback/google returns 302 to / but no Set-Cookie headers/cookies are visible, so the browser never has a session cookie to store or send to https://api.app.openworklabs.com/v1/me.\n\n## Tests\n- pnpm --filter @openwork-ee/den-web exec bun test --conditions development app/api/_lib/upstream-proxy.test.mjs tests/den-api-origin.test.ts\n- pnpm --filter @openwork-ee/den-web typecheck