### PR TITLE
fix(den-api): derive public API URL from auth origin

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -345,6 +345,16 @@ function denBaseUrlIsLoopback(denBaseUrl: string | undefined) {
   }
 }
 
+function deriveApiPublicUrlFromWebOrigin(input: { devMode: boolean; port: number; webOrigin: string }) {
+  const web = new URL(input.webOrigin)
+  if (input.devMode && isLoopbackHostname(web.hostname)) {
+    return `http://127.0.0.1:${input.port}`
+  }
+  const api = new URL(web.toString())
+  api.hostname = `api.${web.hostname}`
+  return api.origin
+}
+
 function isLocalRedisHost(hostname: string) {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1"
 }
@@ -541,7 +551,7 @@ if (diagnosticsBearerToken && diagnosticsBearerToken.length < 24) {
 }
 const derivedDenApiPublicUrl = configuredDenUrls && devMode && denBaseUrlIsLoopback(configuredDenUrls.web)
   ? `http://127.0.0.1:${port}`
-  : configuredDenUrls?.api
+  : configuredDenUrls?.api ?? deriveApiPublicUrlFromWebOrigin({ devMode, port, webOrigin: betterAuthPublicWebOrigin })
 const apiPublicUrl = normalizeConfiguredPublicApiBaseUrl(
   optionalString(parsed.DEN_API_PUBLIC_URL) ?? derivedDenApiPublicUrl,
   {

--- a/ee/apps/den-api/test/den-base-url-env.test.ts
+++ b/ee/apps/den-api/test/den-base-url-env.test.ts
@@ -109,22 +109,40 @@ describe("DEN_BASE_URL environment defaults", () => {
       BETTER_AUTH_URL: "https://user:secret@legacy.example.com/auth/path?token=hidden#fragment",
     })).toEqual({
       betterAuthUrl: "https://user:secret@legacy.example.com/auth/path?token=hidden#fragment",
-      betterAuthCookieDomain: null,
+      betterAuthCookieDomain: "legacy.example.com",
       webUrl: "https://legacy.example.com",
+      apiPublicUrl: "https://api.legacy.example.com",
       corsOrigins: ["https://legacy.example.com"],
       betterAuthTrustedOrigins: ["https://legacy.example.com"],
       webAppHosts: ["legacy.example.com"],
     })
   })
 
-  test("preserves legacy unset defaults without DEN_BASE_URL", () => {
+  test("derives the public API URL from BETTER_AUTH_URL without DEN_BASE_URL", () => {
     expect(probeDenUrls({ BETTER_AUTH_URL: "https://legacy.example.com" })).toEqual({
       betterAuthUrl: "https://legacy.example.com",
-      betterAuthCookieDomain: null,
+      betterAuthCookieDomain: "legacy.example.com",
       webUrl: "https://legacy.example.com",
+      apiPublicUrl: "https://api.legacy.example.com",
       corsOrigins: ["https://legacy.example.com"],
       betterAuthTrustedOrigins: ["https://legacy.example.com"],
       webAppHosts: ["legacy.example.com"],
+    })
+  })
+
+  test("derives local API URL from BETTER_AUTH_URL and PORT without DEN_BASE_URL", () => {
+    expect(probeDenUrls({
+      BETTER_AUTH_URL: "http://localhost:3005",
+      OPENWORK_DEV_MODE: "1",
+      PORT: "8790",
+    })).toMatchObject({
+      betterAuthUrl: "http://localhost:3005",
+      betterAuthCookieDomain: null,
+      webUrl: "http://localhost:3005",
+      apiPublicUrl: "http://127.0.0.1:8790",
+      corsOrigins: ["http://localhost:3005"],
+      betterAuthTrustedOrigins: ["http://localhost:3005"],
+      webAppHosts: ["localhost"],
     })
   })
 })


### PR DESCRIPTION
## Summary\n- derive env.apiPublicUrl from BETTER_AUTH_URL when DEN_API_PUBLIC_URL and DEN_BASE_URL are unset\n- preserve local dev behavior by deriving http://127.0.0.1:<PORT> for loopback auth origins\n- cover hosted and local fallback derivation in env tests\n\n## Why\nExternal MCP connection responses call externalMcpCallbackUrl(), which requires env.apiPublicUrl. Production logs showed DEN_API_PUBLIC_URL missing; this fallback lets deployments that already define the web/auth origin infer the matching api.<web-host> origin instead of throwing.\n\n## Tests\n- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/den-base-url-env.test.ts\n- pnpm --filter @openwork-ee/den-api build