### PR TITLE
feat(evals): add attach origin axis to worlds

### DIFF
--- a/evals/packages/env/src/cli.ts
+++ b/evals/packages/env/src/cli.ts
@@ -5,7 +5,7 @@ import { resolvePlace } from "./place.ts";
 import { acmeDemo, acmeDocs, soloWorkspace, supportOrg } from "./presets.ts";
 import type { Place } from "./place.ts";
 import type { WorldDefinition, WorldTopology } from "./topology.ts";
-import { fromSnapshot, resumeWorld as attachWorld, startWorld } from "./world.ts";
+import { fromSnapshot, parseUntrustedSnapshot, resumeWorld as attachWorld, startWorld } from "./world.ts";
 import type { ResumedWorld, WorldTeardownResult } from "./world.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
@@ -220,15 +220,11 @@ function snapshotSummary(text: string): {
   orgs: string[];
   apps: string[];
 } {
-  const parsed = fromSnapshot(text);
-  const json: unknown = JSON.parse(text);
-  if (!isRecord(json) || typeof json.createdAt !== "string" || typeof json.place !== "string") {
-    throw new Error("Snapshot summary fields are missing.");
-  }
+  const parsed = parseUntrustedSnapshot(text);
   return {
     name: parsed.name,
-    createdAt: json.createdAt,
-    place: json.place,
+    createdAt: parsed.createdAt,
+    place: parsed.place,
     orgs: Object.keys(parsed.topology.den.orgs),
     apps: Object.keys(parsed.topology.apps ?? {}),
   };

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -49,7 +49,7 @@ export interface ServerOptions {
   provision?: boolean;
   web?: boolean;
   env?: Record<string, string | undefined>;
-  reuse?: DenRef;
+  reuse?: { apiUrl: string; webUrl?: string };
   reuseMembers?: Record<string, PersonShape>;
   ports?: { api: number; web: number };
   seedProfile?: "demo-org";
@@ -551,7 +551,11 @@ async function deleteCreatedOrganization(admin: DenSession, organizationId: stri
 }
 
 function reusedRef(options: ServerOptions): DenRef | null {
-  if (options.reuse) return { apiUrl: cleanUrl(options.reuse.apiUrl), webUrl: cleanUrl(options.reuse.webUrl) };
+  if (options.reuse) {
+    const apiUrl = cleanUrl(options.reuse.apiUrl);
+    const webUrl = options.reuse.webUrl?.trim() || apiUrl.replace("127.0.0.1", "localhost");
+    return { apiUrl, webUrl: cleanUrl(webUrl) };
+  }
   const apiUrl = process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
   if (!apiUrl) return null;
   const cleanApi = cleanUrl(apiUrl);

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -5,7 +5,7 @@ export interface WorldPerson {
   email?: string;
   name?: string;
   password?: string;
-  /** Resolves credentials from `${secretRef}_EMAIL` and `${secretRef}_PASSWORD` when the world starts. */
+  /** Must match `^OPENWORK_EVAL_SECRET_[A-Z][A-Z0-9_]*$`; resolves `${secretRef}_EMAIL` and `${secretRef}_PASSWORD` at world start. */
   secretRef?: string;
 }
 
@@ -74,7 +74,12 @@ const worldPersonSchema = z.strictObject({
   email: z.string().optional(),
   name: z.string().optional(),
   password: z.string().optional(),
-  secretRef: z.string().optional(),
+  secretRef: z.string()
+    .regex(
+      /^OPENWORK_EVAL_SECRET_[A-Z][A-Z0-9_]*$/,
+      "secretRef must match ^OPENWORK_EVAL_SECRET_[A-Z][A-Z0-9_]*$",
+    )
+    .optional(),
 }).superRefine((person, context) => {
   if (person.secretRef !== undefined && person.password !== undefined) {
     context.addIssue({
@@ -377,7 +382,9 @@ export function resolveWorldPerson(
       ...(email === undefined ? [emailVariable] : []),
       ...(password === undefined ? [passwordVariable] : []),
     ];
-    throw new Error(`World person secretRef ${JSON.stringify(person.secretRef)} is missing environment variable(s): ${missing.join(", ")}`);
+    throw new Error(
+      `World person namespaced secretRef ${JSON.stringify(person.secretRef)} is missing environment variable(s): ${missing.join(", ")}; secretRef names must match ^OPENWORK_EVAL_SECRET_[A-Z][A-Z0-9_]*$.`,
+    );
   }
   return {
     email,

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -5,6 +5,8 @@ export interface WorldPerson {
   email?: string;
   name?: string;
   password?: string;
+  /** Resolves credentials from `${secretRef}_EMAIL` and `${secretRef}_PASSWORD` when the world starts. */
+  secretRef?: string;
 }
 
 export interface WorldOrg {
@@ -48,6 +50,7 @@ export interface WorldWitness {
 export interface WorldTopology {
   den: {
     orgs: Record<string, WorldOrg>;
+    attach?: { apiUrl: string; webUrl?: string; tier: "prod" | "staging" | "demo" };
     env?: Record<string, string>;
     web?: boolean;
     substrate?: "local" | "kind";
@@ -71,6 +74,15 @@ const worldPersonSchema = z.strictObject({
   email: z.string().optional(),
   name: z.string().optional(),
   password: z.string().optional(),
+  secretRef: z.string().optional(),
+}).superRefine((person, context) => {
+  if (person.secretRef !== undefined && person.password !== undefined) {
+    context.addIssue({
+      code: "custom",
+      path: ["secretRef"],
+      message: "secretRef and password are mutually exclusive",
+    });
+  }
 });
 
 const worldPluginSchema = z.strictObject({
@@ -155,12 +167,42 @@ const worldPortsSchema = z.strictObject({
 export const worldTopologySchema = z.strictObject({
   den: z.strictObject({
     orgs: z.record(z.string(), worldOrgSchema),
+    attach: z.strictObject({
+      apiUrl: z.string(),
+      webUrl: z.string().optional(),
+      tier: z.enum(["prod", "staging", "demo"]),
+    }).optional(),
     env: z.record(z.string(), z.string()).optional(),
     web: z.boolean().optional(),
-    substrate: z.enum(["local", "kind"]).default("local"),
+    substrate: z.enum(["local", "kind"]).optional(),
     ports: worldPortsSchema.optional(),
     seed: z.literal("demo-org").optional(),
-  }),
+  }).superRefine((den, context) => {
+    if (!den.attach) return;
+    const conflictingOptions: readonly ("seed" | "substrate" | "env" | "ports" | "web")[] = [
+      "seed",
+      "substrate",
+      "env",
+      "ports",
+      "web",
+    ];
+    for (const key of conflictingOptions) {
+      if (den[key] !== undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["attach"],
+          message: `den.attach conflicts with den.${key}`,
+        });
+      }
+    }
+    if (den.attach.tier === "prod" && Object.keys(den.orgs).length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["orgs"],
+        message: 'den.attach tier "prod" refuses organization provisioning: you own what you launch; you never own what you attach.',
+      });
+    }
+  }).transform((den) => den.attach ? den : { ...den, substrate: den.substrate ?? "local" }),
   apps: z.record(z.string(), worldAppSchema).optional(),
   witnesses: z.record(z.string(), worldWitnessSchema).optional(),
 });
@@ -182,6 +224,16 @@ function validateReferences(topology: WorldTopology): void {
   const orgKeys = Object.keys(topology.den.orgs);
   const primaryOrg = orgKeys[0];
   if (!primaryOrg) {
+    if (topology.den.attach?.tier === "prod") {
+      for (const [appName, app] of Object.entries(topology.apps ?? {})) {
+        if (app.signedInTo) {
+          throw new Error(
+            `World app ${JSON.stringify(appName)} signedInTo.org ${JSON.stringify(app.signedInTo.org)} does not exist in den.orgs.`,
+          );
+        }
+      }
+      return;
+    }
     throw new Error("World topology must define at least one organization in den.orgs.");
   }
 
@@ -309,6 +361,29 @@ function parseTopology(input: unknown): WorldTopology {
   const topology: WorldTopology = worldTopologySchema.parse(input);
   validateReferences(topology);
   return topology;
+}
+
+export function resolveWorldPerson(
+  person: WorldPerson,
+  env: NodeJS.ProcessEnv = process.env,
+): WorldPerson {
+  if (person.secretRef === undefined) return person;
+  const emailVariable = `${person.secretRef}_EMAIL`;
+  const passwordVariable = `${person.secretRef}_PASSWORD`;
+  const email = env[emailVariable];
+  const password = env[passwordVariable];
+  if (email === undefined || password === undefined) {
+    const missing = [
+      ...(email === undefined ? [emailVariable] : []),
+      ...(password === undefined ? [passwordVariable] : []),
+    ];
+    throw new Error(`World person secretRef ${JSON.stringify(person.secretRef)} is missing environment variable(s): ${missing.join(", ")}`);
+  }
+  return {
+    email,
+    password,
+    ...(person.name === undefined ? {} : { name: person.name }),
+  };
 }
 
 function makeDefinition(topology: WorldTopology): WorldDefinition {

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -38,7 +38,7 @@ const SNAPSHOT_ENV_KEY = /^(DEN_|OPENWORK_)[A-Z0-9_]+$/;
 const SNAPSHOT_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const SNAPSHOT_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$/;
 const SNAPSHOT_FAULT = /^[a-z0-9][a-z0-9-]{0,127}$/;
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 const ALLOWED_WORKSPACE_ROOTS = [
   resolve(tmpdir()),
   RESULTS_DIR,
@@ -229,7 +229,7 @@ function validateSnapshotLoopbackUrlPort(field: string, value: string): void {
   }
 }
 
-function validateSnapshotAttachedUrl(field: string, value: string): void {
+function validateSnapshotAttachedUrl(field: string, value: string, allowedHosts: ReadonlySet<string>): void {
   let url: URL;
   try {
     url = new URL(value);
@@ -245,6 +245,23 @@ function validateSnapshotAttachedUrl(field: string, value: string): void {
   if (url.hash) {
     rejectSnapshotField(field, value, "attached Den URLs must not contain a hash");
   }
+  const hostname = url.hostname.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(hostname) && !allowedHosts.has(hostname)) {
+    rejectSnapshotField(
+      field,
+      value,
+      "attached Den URLs must use loopback or an exact hostname listed in OPENWORK_EVAL_ATTACH_HOSTS",
+    );
+  }
+}
+
+function snapshotAttachHosts(env: NodeJS.ProcessEnv): ReadonlySet<string> {
+  return new Set(
+    (env.OPENWORK_EVAL_ATTACH_HOSTS ?? "")
+      .split(",")
+      .map((hostname) => hostname.trim().toLowerCase())
+      .filter((hostname) => hostname.length > 0),
+  );
 }
 
 function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
@@ -309,12 +326,13 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
     );
   }
   if (snapshot.topology.den.attach) {
-    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl);
+    const allowedAttachHosts = snapshotAttachHosts(process.env);
+    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl, allowedAttachHosts);
     if (snapshot.topology.den.attach.webUrl !== undefined) {
-      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl);
+      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl, allowedAttachHosts);
     }
-    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
-    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl);
+    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl, allowedAttachHosts);
+    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl, allowedAttachHosts);
   }
   validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
   validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -26,8 +26,8 @@ import { DEMO_PASSWORD, ensureKindDenReady, exposeEndpointHandles, kubeProfileCo
 import { mcpMock } from "./mock.ts";
 import { resolvePlace, validateDatabaseName } from "./place.ts";
 import type { Place } from "./place.ts";
-import { defineWorld, worldTopologySchema } from "./topology.ts";
-import type { WorldDefinition, WorldOrg, WorldTopology } from "./topology.ts";
+import { defineWorld, resolveWorldPerson, worldTopologySchema } from "./topology.ts";
+import type { WorldDefinition, WorldOrg, WorldPerson, WorldTopology } from "./topology.ts";
 import type { DenRef, DenSession } from "@openwork/behaviors";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
@@ -58,6 +58,7 @@ export interface WorldSnapshotResolved {
   den: {
     apiUrl: string;
     webUrl: string;
+    origin: "attached" | "launched";
     substrate?: "kind";
     database?: string;
     ports?: { api: number; web: number };
@@ -117,6 +118,7 @@ const worldSnapshotSchema = z.strictObject({
     den: z.strictObject({
       apiUrl: z.string(),
       webUrl: z.string(),
+      origin: z.enum(["attached", "launched"]),
       substrate: z.literal("kind").optional(),
       database: z.string().optional(),
       ports: resolvedPortsSchema.optional(),
@@ -227,6 +229,24 @@ function validateSnapshotLoopbackUrlPort(field: string, value: string): void {
   }
 }
 
+function validateSnapshotAttachedUrl(field: string, value: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    rejectSnapshotField(field, value, "expected an http(s) URL without userinfo or a hash");
+  }
+  if (!["http:", "https:"].includes(url.protocol)) {
+    rejectSnapshotField(field, value, "expected an http(s) URL without userinfo or a hash");
+  }
+  if (url.username || url.password) {
+    rejectSnapshotField(field, value, "attached Den URLs must not contain username or password userinfo");
+  }
+  if (url.hash) {
+    rejectSnapshotField(field, value, "attached Den URLs must not contain a hash");
+  }
+}
+
 function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
   if (!SNAPSHOT_NAME.test(snapshot.name)) {
     rejectSnapshotField("name", snapshot.name, "expected a filesystem-safe name using letters, numbers, dots, underscores, or hyphens");
@@ -280,6 +300,22 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
     validateSnapshotPort("resolved.den.ports.api", snapshot.resolved.den.ports.api);
     validateSnapshotPort("resolved.den.ports.web", snapshot.resolved.den.ports.web);
   }
+  const expectedOrigin = snapshot.topology.den.attach ? "attached" : "launched";
+  if (snapshot.resolved.den.origin !== expectedOrigin) {
+    rejectSnapshotField(
+      "resolved.den.origin",
+      snapshot.resolved.den.origin,
+      `expected ${JSON.stringify(expectedOrigin)} to match topology.den.attach`,
+    );
+  }
+  if (snapshot.topology.den.attach) {
+    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl);
+    if (snapshot.topology.den.attach.webUrl !== undefined) {
+      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl);
+    }
+    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
+    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl);
+  }
   validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
   validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);
   for (const [name, app] of Object.entries(snapshot.resolved.apps)) {
@@ -291,6 +327,53 @@ function primaryOrganization(topology: WorldTopology): [string, WorldOrg] {
   const primary = Object.entries(topology.den.orgs)[0];
   if (!primary) throw new Error("World topology must define at least one organization in den.orgs.");
   return primary;
+}
+
+function resolveOrganizationPeople(org: WorldOrg, env: NodeJS.ProcessEnv): WorldOrg {
+  const members: Record<string, WorldPerson> = {};
+  for (const [key, person] of Object.entries(org.members ?? {})) {
+    members[key] = resolveWorldPerson(person, env);
+  }
+  return {
+    ...org,
+    ...(org.admin === undefined ? {} : { admin: resolveWorldPerson(org.admin, env) }),
+    ...(org.members === undefined ? {} : { members }),
+  };
+}
+
+function resolveOrganizationMap(
+  organizations: Record<string, WorldOrg>,
+  env: NodeJS.ProcessEnv,
+): Record<string, WorldOrg> {
+  const resolved: Record<string, WorldOrg> = {};
+  for (const [name, org] of Object.entries(organizations)) {
+    resolved[name] = resolveOrganizationPeople(org, env);
+  }
+  return resolved;
+}
+
+function snapshotPerson(person: WorldPerson): WorldPerson {
+  return person.secretRef === undefined ? person : { secretRef: person.secretRef };
+}
+
+function snapshotOrganization(org: WorldOrg): WorldOrg {
+  const members: Record<string, WorldPerson> = {};
+  for (const [key, person] of Object.entries(org.members ?? {})) {
+    members[key] = snapshotPerson(person);
+  }
+  return {
+    ...org,
+    ...(org.admin === undefined ? {} : { admin: snapshotPerson(org.admin) }),
+    ...(org.members === undefined ? {} : { members }),
+  };
+}
+
+function snapshotTopology(topology: WorldTopology): WorldTopology {
+  const organizations: Record<string, WorldOrg> = {};
+  for (const [name, org] of Object.entries(topology.den.orgs)) {
+    organizations[name] = snapshotOrganization(org);
+  }
+  return { ...topology, den: { ...topology.den, orgs: organizations } };
 }
 
 function auth(token: string): Record<string, string> {
@@ -615,12 +698,13 @@ function resolvedApps(
 }
 
 export function buildSnapshot(input: BuildSnapshotInput): WorldSnapshot {
+  const topology = defineWorld(input.topology).topology;
   const snapshot: WorldSnapshot = worldSnapshotSchema.parse({
     version: 1,
     name: input.name,
     createdAt: input.createdAt ?? new Date().toISOString(),
     place: input.place,
-    topology: defineWorld(input.topology).topology,
+    topology: snapshotTopology(topology),
     resolved: input.resolved,
   });
   if (snapshot.resolved.den.database !== undefined) {
@@ -688,9 +772,12 @@ export async function resumeWorld(
   const topology = defineWorld(snapshot.topology).topology;
   await requireRunningWorld(snapshot);
   const [, primaryOrg] = primaryOrganization(topology);
+  const resolvedAdmin = primaryOrg.admin === undefined
+    ? undefined
+    : resolveWorldPerson(primaryOrg.admin, process.env);
   const adminPerson = topology.den.seed === "demo-org"
     ? defaultReuseAdmin()
-    : personDefaults("admin", primaryOrg.admin, emailSegment(snapshot.name));
+    : personDefaults("admin", resolvedAdmin, emailSegment(snapshot.name));
   const ref: DenRef = {
     apiUrl: snapshot.resolved.den.apiUrl,
     webUrl: snapshot.resolved.den.webUrl,
@@ -738,26 +825,32 @@ export async function resumeWorld(
         });
     }
 
-    const denPortCandidates: number[] = [];
-    if (snapshot.resolved.den.ports) {
-      denPortCandidates.push(snapshot.resolved.den.ports.api, snapshot.resolved.den.ports.web);
-    } else {
-      const apiPort = localUrlPort(snapshot.resolved.den.apiUrl);
-      const webPort = localUrlPort(snapshot.resolved.den.webUrl);
-      if (apiPort !== null) denPortCandidates.push(apiPort);
-      if (webPort !== null) denPortCandidates.push(webPort);
-    }
     const stoppedDenPorts: number[] = [];
-    for (const port of new Set(denPortCandidates)) {
-      await freePort(port)
-        .then(() => stoppedDenPorts.push(port))
-        .catch((error: unknown) => {
-          console.error(`[openwork/testkit] World Den teardown failed on port ${port}: ${messageText(error)}`);
-        });
+    if (snapshot.resolved.den.origin === "launched") {
+      const denPortCandidates: number[] = [];
+      if (snapshot.resolved.den.ports) {
+        denPortCandidates.push(snapshot.resolved.den.ports.api, snapshot.resolved.den.ports.web);
+      } else {
+        const apiPort = localUrlPort(snapshot.resolved.den.apiUrl);
+        const webPort = localUrlPort(snapshot.resolved.den.webUrl);
+        if (apiPort !== null) denPortCandidates.push(apiPort);
+        if (webPort !== null) denPortCandidates.push(webPort);
+      }
+      for (const port of new Set(denPortCandidates)) {
+        await freePort(port)
+          .then(() => stoppedDenPorts.push(port))
+          .catch((error: unknown) => {
+            console.error(`[openwork/testkit] World Den teardown failed on port ${port}: ${messageText(error)}`);
+          });
+      }
     }
 
     let droppedDatabase: string | undefined;
-    if (snapshot.place === "local" && snapshot.resolved.den.database) {
+    if (
+      snapshot.resolved.den.origin === "launched"
+      && snapshot.place === "local"
+      && snapshot.resolved.den.database
+    ) {
       await dropSnapshotDatabase(snapshot.resolved.den.database)
         .then(() => { droppedDatabase = snapshot.resolved.den.database; })
         .catch((error: unknown) => {
@@ -790,9 +883,12 @@ export async function startWorld(
   options: { place?: Place; name?: string } = {},
 ): Promise<World> {
   const topology = worldTopology(definition);
+  const resolvedOrganizations = resolveOrganizationMap(topology.den.orgs, process.env);
   const place = options.place ?? resolvePlace(process.env);
   const name = options.name ?? `world-${Date.now().toString(36)}-${process.pid.toString(36)}`;
-  const [primaryOrgName, primaryOrg] = primaryOrganization(topology);
+  const primary = Object.entries(resolvedOrganizations)[0];
+  const primaryOrgName = primary?.[0];
+  const primaryOrg = primary?.[1];
   const scope = await Effect.runPromise(Scope.make("sequential"));
 
   const acquisition = Effect.gen(function*() {
@@ -801,26 +897,40 @@ export async function startWorld(
         ? kindDen()
         : server({
             place,
-            org: {
-              name: primaryOrgName,
-              admin: topology.den.seed === "demo-org"
-                ? primaryOrg.admin
-                : personDefaults("admin", primaryOrg.admin, emailSegment(name)),
-              members: primaryOrg.members,
-            },
-            provision: topology.den.seed === "demo-org" ? false : undefined,
+            ...(primaryOrgName === undefined || primaryOrg === undefined
+              ? {}
+              : {
+                  org: {
+                    name: primaryOrgName,
+                    admin: topology.den.attach
+                      ? primaryOrg.admin
+                      : topology.den.seed === "demo-org"
+                        ? primaryOrg.admin
+                        : personDefaults("admin", primaryOrg.admin, emailSegment(name)),
+                    members: primaryOrg.members,
+                  },
+                }),
+            provision: topology.den.seed === "demo-org" || topology.den.attach?.tier === "prod" ? false : undefined,
             web: topology.den.web,
             env: topology.den.env,
             mocks: witnessMocks(topology),
             ports: topology.den.ports,
             seedProfile: topology.den.seed,
+            reuse: topology.den.attach === undefined
+              ? undefined
+              : { apiUrl: topology.den.attach.apiUrl, webUrl: topology.den.attach.webUrl },
           })),
       (booted) => Effect.promise(() => booted[Symbol.asyncDispose]()),
     );
-    if (topology.den.substrate !== "kind" && topology.den.seed !== "demo-org") {
+    if (
+      primaryOrgName !== undefined
+      && primaryOrg !== undefined
+      && topology.den.substrate !== "kind"
+      && topology.den.seed !== "demo-org"
+    ) {
       const primaryOrganizationId = yield* Effect.promise(() => organizationIdByName(den.admin, primaryOrgName));
 
-      for (const [orgName, org] of Object.entries(topology.den.orgs).slice(1)) {
+      for (const [orgName, org] of Object.entries(resolvedOrganizations).slice(1)) {
         const provisioned = yield* Effect.acquireRelease(
           Effect.promise(() => provisionOrg(den.ref, {
             members: extraOrganizationMembers(name, orgName, org),
@@ -868,6 +978,7 @@ export async function startWorld(
       resolved: {
         den: {
           ...den.ref,
+          origin: topology.den.attach ? "attached" : "launched",
           ...(topology.den.substrate === "kind" ? { substrate: "kind" } : {}),
           ...(den.database ? { database: den.database.name } : {}),
           ...(den.ports ? { ports: den.ports } : {}),

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -229,7 +229,7 @@ function validateSnapshotLoopbackUrlPort(field: string, value: string): void {
   }
 }
 
-function validateSnapshotAttachedUrl(field: string, value: string, allowedHosts: ReadonlySet<string>): void {
+function validateSnapshotAttachedUrl(field: string, value: string): void {
   let url: URL;
   try {
     url = new URL(value);
@@ -245,23 +245,16 @@ function validateSnapshotAttachedUrl(field: string, value: string, allowedHosts:
   if (url.hash) {
     rejectSnapshotField(field, value, "attached Den URLs must not contain a hash");
   }
+  // Snapshots are untrusted PR/bug-report artifacts. A remote URL here would
+  // receive resolved credentials through signIn, so there is no env bypass or exception.
   const hostname = url.hostname.toLowerCase();
-  if (!LOOPBACK_HOSTS.has(hostname) && !allowedHosts.has(hostname)) {
+  if (!LOOPBACK_HOSTS.has(hostname)) {
     rejectSnapshotField(
       field,
       value,
-      "attached Den URLs must use loopback or an exact hostname listed in OPENWORK_EVAL_ATTACH_HOSTS",
+      "snapshot-driven attach is loopback-only; remote attach must come from a code-defined topology",
     );
   }
-}
-
-function snapshotAttachHosts(env: NodeJS.ProcessEnv): ReadonlySet<string> {
-  return new Set(
-    (env.OPENWORK_EVAL_ATTACH_HOSTS ?? "")
-      .split(",")
-      .map((hostname) => hostname.trim().toLowerCase())
-      .filter((hostname) => hostname.length > 0),
-  );
 }
 
 function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
@@ -326,13 +319,12 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
     );
   }
   if (snapshot.topology.den.attach) {
-    const allowedAttachHosts = snapshotAttachHosts(process.env);
-    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl, allowedAttachHosts);
+    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl);
     if (snapshot.topology.den.attach.webUrl !== undefined) {
-      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl, allowedAttachHosts);
+      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl);
     }
-    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl, allowedAttachHosts);
-    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl, allowedAttachHosts);
+    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
+    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl);
   }
   validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
   validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -694,9 +694,26 @@ function rejectAttachedSnapshotOperation(snapshot: WorldSnapshot): void {
   }
 }
 
+function rejectSecretRefSnapshotOperation(snapshot: WorldSnapshot): void {
+  const hasSecretRef = Object.values(snapshot.topology.den.orgs).some((org) =>
+    org.admin?.secretRef !== undefined
+    || Object.values(org.members ?? {}).some((member) => member.secretRef !== undefined)
+  );
+  if (hasSecretRef) {
+    throw new Error(
+      "Snapshots naming secretRef people cannot be resumed or rebuilt: snapshots are untrusted input and must never select environment credentials. Re-run the code-defined topology instead.",
+    );
+  }
+}
+
+function rejectUnsafeSnapshotOperation(snapshot: WorldSnapshot): void {
+  rejectAttachedSnapshotOperation(snapshot);
+  rejectSecretRefSnapshotOperation(snapshot);
+}
+
 export function fromSnapshot(jsonText: string): { topology: WorldTopology; name: string } {
   const snapshot = parseUntrustedSnapshot(jsonText);
-  rejectAttachedSnapshotOperation(snapshot);
+  rejectUnsafeSnapshotOperation(snapshot);
   return {
     topology: defineWorld(snapshot.topology).topology,
     name: snapshot.name,
@@ -744,16 +761,13 @@ export async function resumeWorld(
   options: { teardown?: boolean } = {},
 ): Promise<ResumedWorld> {
   const snapshot = parseUntrustedSnapshot(snapshotJsonText);
-  rejectAttachedSnapshotOperation(snapshot);
+  rejectUnsafeSnapshotOperation(snapshot);
   const topology = defineWorld(snapshot.topology).topology;
   await requireRunningWorld(snapshot);
   const [, primaryOrg] = primaryOrganization(topology);
-  const resolvedAdmin = primaryOrg.admin === undefined
-    ? undefined
-    : resolveWorldPerson(primaryOrg.admin, process.env);
   const adminPerson = topology.den.seed === "demo-org"
     ? defaultReuseAdmin()
-    : personDefaults("admin", resolvedAdmin, emailSegment(snapshot.name));
+    : personDefaults("admin", primaryOrg.admin, emailSegment(snapshot.name));
   const ref: DenRef = {
     apiUrl: snapshot.resolved.den.apiUrl,
     webUrl: snapshot.resolved.den.webUrl,

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -229,34 +229,6 @@ function validateSnapshotLoopbackUrlPort(field: string, value: string): void {
   }
 }
 
-function validateSnapshotAttachedUrl(field: string, value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    rejectSnapshotField(field, value, "expected an http(s) URL without userinfo or a hash");
-  }
-  if (!["http:", "https:"].includes(url.protocol)) {
-    rejectSnapshotField(field, value, "expected an http(s) URL without userinfo or a hash");
-  }
-  if (url.username || url.password) {
-    rejectSnapshotField(field, value, "attached Den URLs must not contain username or password userinfo");
-  }
-  if (url.hash) {
-    rejectSnapshotField(field, value, "attached Den URLs must not contain a hash");
-  }
-  // Snapshots are untrusted PR/bug-report artifacts. A remote URL here would
-  // receive resolved credentials through signIn, so there is no env bypass or exception.
-  const hostname = url.hostname.toLowerCase();
-  if (!LOOPBACK_HOSTS.has(hostname)) {
-    rejectSnapshotField(
-      field,
-      value,
-      "snapshot-driven attach is loopback-only; remote attach must come from a code-defined topology",
-    );
-  }
-}
-
 function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
   if (!SNAPSHOT_NAME.test(snapshot.name)) {
     rejectSnapshotField("name", snapshot.name, "expected a filesystem-safe name using letters, numbers, dots, underscores, or hyphens");
@@ -309,22 +281,6 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
   if (snapshot.resolved.den.ports) {
     validateSnapshotPort("resolved.den.ports.api", snapshot.resolved.den.ports.api);
     validateSnapshotPort("resolved.den.ports.web", snapshot.resolved.den.ports.web);
-  }
-  const expectedOrigin = snapshot.topology.den.attach ? "attached" : "launched";
-  if (snapshot.resolved.den.origin !== expectedOrigin) {
-    rejectSnapshotField(
-      "resolved.den.origin",
-      snapshot.resolved.den.origin,
-      `expected ${JSON.stringify(expectedOrigin)} to match topology.den.attach`,
-    );
-  }
-  if (snapshot.topology.den.attach) {
-    validateSnapshotAttachedUrl("topology.den.attach.apiUrl", snapshot.topology.den.attach.apiUrl);
-    if (snapshot.topology.den.attach.webUrl !== undefined) {
-      validateSnapshotAttachedUrl("topology.den.attach.webUrl", snapshot.topology.den.attach.webUrl);
-    }
-    validateSnapshotAttachedUrl("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
-    validateSnapshotAttachedUrl("resolved.den.webUrl", snapshot.resolved.den.webUrl);
   }
   validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
   validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);
@@ -730,8 +686,17 @@ export function parseUntrustedSnapshot(jsonText: string): WorldSnapshot {
   return snapshot;
 }
 
+function rejectAttachedSnapshotOperation(snapshot: WorldSnapshot): void {
+  if (snapshot.topology.den.attach || snapshot.resolved.den.origin === "attached") {
+    throw new Error(
+      "Attached worlds cannot be resumed or rebuilt from snapshots: snapshots are untrusted input and attached Dens receive credentials. Re-run the code-defined topology instead.",
+    );
+  }
+}
+
 export function fromSnapshot(jsonText: string): { topology: WorldTopology; name: string } {
   const snapshot = parseUntrustedSnapshot(jsonText);
+  rejectAttachedSnapshotOperation(snapshot);
   return {
     topology: defineWorld(snapshot.topology).topology,
     name: snapshot.name,
@@ -779,6 +744,7 @@ export async function resumeWorld(
   options: { teardown?: boolean } = {},
 ): Promise<ResumedWorld> {
   const snapshot = parseUntrustedSnapshot(snapshotJsonText);
+  rejectAttachedSnapshotOperation(snapshot);
   const topology = defineWorld(snapshot.topology).topology;
   await requireRunningWorld(snapshot);
   const [, primaryOrg] = primaryOrganization(topology);

--- a/evals/packages/env/test/cli.test.ts
+++ b/evals/packages/env/test/cli.test.ts
@@ -127,6 +127,39 @@ test("main lists valid snapshots from an injected directory", async () => {
   ]);
 });
 
+test("main lists attached snapshots without consuming their attach behavior", async () => {
+  const lines: string[] = [];
+  const snapshot = buildSnapshot({
+    name: "attached-demo",
+    createdAt: "2026-08-23T12:00:00.000Z",
+    place: "local",
+    topology: {
+      den: {
+        attach: { apiUrl: "https://den.example.test", tier: "staging" },
+        orgs: { acme: {} },
+      },
+    },
+    resolved: {
+      den: {
+        apiUrl: "https://den.example.test",
+        webUrl: "https://den.example.test",
+        origin: "attached",
+      },
+      apps: {},
+    },
+  });
+  const exitCode = await main(["list"], {
+    print: (line) => lines.push(line),
+    readDir: async () => ["attached-demo.json"],
+    readFile: async () => JSON.stringify(snapshot),
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(lines, [
+    "attached-demo  2026-08-23T12:00:00.000Z  local  orgs acme  apps (none)",
+  ]);
+});
+
 test("main reports a missing snapshot when forgetting a world", async () => {
   const lines: string[] = [];
   const exitCode = await main(["forget", "missing"], {

--- a/evals/packages/env/test/cli.test.ts
+++ b/evals/packages/env/test/cli.test.ts
@@ -111,7 +111,7 @@ test("main lists valid snapshots from an injected directory", async () => {
     place: "daytona",
     topology: supportOrg.topology,
     resolved: {
-      den: { apiUrl: "http://api.test", webUrl: "http://web.test" },
+      den: { apiUrl: "http://api.test", webUrl: "http://web.test", origin: "launched" },
       apps: {},
     },
   });

--- a/evals/packages/env/test/cli.test.ts
+++ b/evals/packages/env/test/cli.test.ts
@@ -136,7 +136,9 @@ test("main lists attached snapshots without consuming their attach behavior", as
     topology: {
       den: {
         attach: { apiUrl: "https://den.example.test", tier: "staging" },
-        orgs: { acme: {} },
+        orgs: {
+          acme: { admin: { secretRef: "OPENWORK_EVAL_SECRET_LIST_ADMIN" } },
+        },
       },
     },
     resolved: {

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -49,18 +49,6 @@ function attachedSnapshot(apiUrl: string) {
   });
 }
 
-function withAttachHosts(hosts: string | undefined, run: () => void): void {
-  const previous = process.env.OPENWORK_EVAL_ATTACH_HOSTS;
-  if (hosts === undefined) delete process.env.OPENWORK_EVAL_ATTACH_HOSTS;
-  else process.env.OPENWORK_EVAL_ATTACH_HOSTS = hosts;
-  try {
-    run();
-  } finally {
-    if (previous === undefined) delete process.env.OPENWORK_EVAL_ATTACH_HOSTS;
-    else process.env.OPENWORK_EVAL_ATTACH_HOSTS = previous;
-  }
-}
-
 test("buildSnapshot output round-trips through untrusted boot-shape validation", () => {
   const topology = defineWorld({
     den: {
@@ -113,30 +101,23 @@ test("buildSnapshot output round-trips through untrusted boot-shape validation",
   });
 });
 
-test("fromSnapshot allows attached hosts only through loopback or OPENWORK_EVAL_ATTACH_HOSTS", () => {
+test("fromSnapshot allows snapshot-driven attach only through loopback", () => {
   const remote = JSON.stringify(attachedSnapshot("https://den.example.test"));
-  withAttachHosts(undefined, () => {
-    assert.throws(
-      () => fromSnapshot(remote),
-      /OPENWORK_EVAL_ATTACH_HOSTS/,
-    );
-    for (const url of [
-      "http://127.0.0.1:8790",
-      "http://localhost:8790",
-      "http://[::1]:8790",
-    ]) {
-      assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot(url))));
-    }
-  });
-  withAttachHosts(" DEN.EXAMPLE.TEST , other.example.test ", () => {
-    assert.doesNotThrow(() => fromSnapshot(remote));
-  });
-  withAttachHosts("*", () => {
-    assert.throws(
-      () => fromSnapshot(remote),
-      /OPENWORK_EVAL_ATTACH_HOSTS/,
-    );
-  });
+  assert.throws(
+    () => fromSnapshot(remote),
+    /snapshot-driven attach is loopback-only/,
+  );
+  assert.throws(
+    () => fromSnapshot(JSON.stringify(attachedSnapshot("https://*.example.test"))),
+    /snapshot-driven attach is loopback-only/,
+  );
+  for (const url of [
+    "http://127.0.0.1:8790",
+    "http://localhost:8790",
+    "http://[::1]:8790",
+  ]) {
+    assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot(url))));
+  }
 });
 
 test("Warden VLA-BHM: fromSnapshot rejects NODE_OPTIONS import execution", () => {

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -49,6 +49,29 @@ function attachedSnapshot(apiUrl: string) {
   });
 }
 
+function secretRefSnapshot() {
+  return buildSnapshot({
+    name: "secret-ref-snapshot",
+    createdAt: "2026-08-23T12:00:00.000Z",
+    place: "local",
+    topology: defineWorld({
+      den: {
+        orgs: {
+          acme: { admin: { secretRef: "OPENWORK_EVAL_SECRET_SNAPSHOT_ADMIN" } },
+        },
+      },
+    }).topology,
+    resolved: {
+      den: {
+        apiUrl: "http://127.0.0.1:8790",
+        webUrl: "http://127.0.0.1:3005",
+        origin: "launched",
+      },
+      apps: {},
+    },
+  });
+}
+
 test("buildSnapshot output round-trips through untrusted boot-shape validation", () => {
   const topology = defineWorld({
     den: {
@@ -128,6 +151,19 @@ test("attached snapshots remain parseable for listing but cannot rebuild or resu
   assert.throws(
     () => fromSnapshot(originOnlyJson),
     /Attached worlds cannot be resumed or rebuilt from snapshots/,
+  );
+});
+
+test("secretRef snapshots remain parseable for listing but cannot rebuild or resume", async () => {
+  const json = JSON.stringify(secretRefSnapshot());
+  assert.doesNotThrow(() => parseUntrustedSnapshot(json));
+  assert.throws(
+    () => fromSnapshot(json),
+    /Snapshots naming secretRef people cannot be resumed or rebuilt/,
+  );
+  await assert.rejects(
+    () => resumeWorld(json),
+    /Snapshots naming secretRef people cannot be resumed or rebuilt/,
   );
 });
 

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -31,6 +31,36 @@ function safeSnapshot() {
   });
 }
 
+function attachedSnapshot(apiUrl: string) {
+  return buildSnapshot({
+    name: "attached-snapshot",
+    createdAt: "2026-08-23T12:00:00.000Z",
+    place: "local",
+    topology: defineWorld({
+      den: {
+        attach: { apiUrl, tier: "staging" },
+        orgs: { acme: {} },
+      },
+    }).topology,
+    resolved: {
+      den: { apiUrl, webUrl: apiUrl, origin: "attached" },
+      apps: {},
+    },
+  });
+}
+
+function withAttachHosts(hosts: string | undefined, run: () => void): void {
+  const previous = process.env.OPENWORK_EVAL_ATTACH_HOSTS;
+  if (hosts === undefined) delete process.env.OPENWORK_EVAL_ATTACH_HOSTS;
+  else process.env.OPENWORK_EVAL_ATTACH_HOSTS = hosts;
+  try {
+    run();
+  } finally {
+    if (previous === undefined) delete process.env.OPENWORK_EVAL_ATTACH_HOSTS;
+    else process.env.OPENWORK_EVAL_ATTACH_HOSTS = previous;
+  }
+}
+
 test("buildSnapshot output round-trips through untrusted boot-shape validation", () => {
   const topology = defineWorld({
     den: {
@@ -80,6 +110,32 @@ test("buildSnapshot output round-trips through untrusted boot-shape validation",
     origin: "launched",
     database: "openwork_eval_round_trip",
     ports: { api: 8790, web: 3005 },
+  });
+});
+
+test("fromSnapshot allows attached hosts only through loopback or OPENWORK_EVAL_ATTACH_HOSTS", () => {
+  const remote = JSON.stringify(attachedSnapshot("https://den.example.test"));
+  withAttachHosts(undefined, () => {
+    assert.throws(
+      () => fromSnapshot(remote),
+      /OPENWORK_EVAL_ATTACH_HOSTS/,
+    );
+    for (const url of [
+      "http://127.0.0.1:8790",
+      "http://localhost:8790",
+      "http://[::1]:8790",
+    ]) {
+      assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot(url))));
+    }
+  });
+  withAttachHosts(" DEN.EXAMPLE.TEST , other.example.test ", () => {
+    assert.doesNotThrow(() => fromSnapshot(remote));
+  });
+  withAttachHosts("*", () => {
+    assert.throws(
+      () => fromSnapshot(remote),
+      /OPENWORK_EVAL_ATTACH_HOSTS/,
+    );
   });
 });
 

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { defineWorld } from "../src/topology.ts";
-import { buildSnapshot, fromSnapshot } from "../src/world.ts";
+import { buildSnapshot, fromSnapshot, parseUntrustedSnapshot, resumeWorld } from "../src/world.ts";
 
 function safeSnapshot() {
   return buildSnapshot({
@@ -101,23 +101,34 @@ test("buildSnapshot output round-trips through untrusted boot-shape validation",
   });
 });
 
-test("fromSnapshot allows snapshot-driven attach only through loopback", () => {
-  const remote = JSON.stringify(attachedSnapshot("https://den.example.test"));
-  assert.throws(
-    () => fromSnapshot(remote),
-    /snapshot-driven attach is loopback-only/,
-  );
-  assert.throws(
-    () => fromSnapshot(JSON.stringify(attachedSnapshot("https://*.example.test"))),
-    /snapshot-driven attach is loopback-only/,
-  );
-  for (const url of [
-    "http://127.0.0.1:8790",
-    "http://localhost:8790",
-    "http://[::1]:8790",
-  ]) {
-    assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot(url))));
+test("attached snapshots remain parseable for listing but cannot rebuild or resume", async () => {
+  for (const apiUrl of ["https://den.example.test", "http://127.0.0.1:8790"]) {
+    const json = JSON.stringify(attachedSnapshot(apiUrl));
+    assert.doesNotThrow(() => parseUntrustedSnapshot(json));
+    assert.throws(
+      () => fromSnapshot(json),
+      /Attached worlds cannot be resumed or rebuilt from snapshots/,
+    );
+    await assert.rejects(
+      () => resumeWorld(json),
+      /Attached worlds cannot be resumed or rebuilt from snapshots/,
+    );
   }
+
+  const attached = attachedSnapshot("http://127.0.0.1:8790");
+  const originOnly = {
+    ...attached,
+    topology: {
+      ...attached.topology,
+      den: { orgs: attached.topology.den.orgs },
+    },
+  };
+  const originOnlyJson = JSON.stringify(originOnly);
+  assert.doesNotThrow(() => parseUntrustedSnapshot(originOnlyJson));
+  assert.throws(
+    () => fromSnapshot(originOnlyJson),
+    /Attached worlds cannot be resumed or rebuilt from snapshots/,
+  );
 });
 
 test("Warden VLA-BHM: fromSnapshot rejects NODE_OPTIONS import execution", () => {

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -16,6 +16,7 @@ function safeSnapshot() {
       den: {
         apiUrl: "http://127.0.0.1:8790",
         webUrl: "http://127.0.0.1:3005",
+        origin: "launched",
         database: "openwork_eval_safe_snapshot",
         ports: { api: 8790, web: 3005 },
       },
@@ -54,6 +55,7 @@ test("buildSnapshot output round-trips through untrusted boot-shape validation",
       den: {
         apiUrl: "http://127.0.0.1:8790",
         webUrl: "http://127.0.0.1:3005",
+        origin: "launched",
         database: "openwork_eval_round_trip",
         ports: { api: 8790, web: 3005 },
       },
@@ -75,6 +77,7 @@ test("buildSnapshot output round-trips through untrusted boot-shape validation",
   assert.deepEqual(snapshot.resolved.den, {
     apiUrl: "http://127.0.0.1:8790",
     webUrl: "http://127.0.0.1:3005",
+    origin: "launched",
     database: "openwork_eval_round_trip",
     ports: { api: 8790, web: 3005 },
   });
@@ -199,6 +202,7 @@ test("fromSnapshot rejects out-of-range topology and resolved ports", () => {
     resolved: {
       ...derivedPortSnapshot.resolved,
       den: {
+        ...derivedPortSnapshot.resolved.den,
         apiUrl: "http://127.0.0.1:81",
         webUrl: derivedPortSnapshot.resolved.den.webUrl,
       },
@@ -241,7 +245,11 @@ test("fromSnapshot rejects unknown fields", () => {
     place: "local",
     topology,
     resolved: {
-      den: { apiUrl: "http://127.0.0.1:8788", webUrl: "http://127.0.0.1:3005" },
+      den: {
+        apiUrl: "http://127.0.0.1:8788",
+        webUrl: "http://127.0.0.1:3005",
+        origin: "launched",
+      },
       apps: {},
     },
   });
@@ -268,6 +276,7 @@ test("kind world snapshots preserve their resolved Den substrate", () => {
       den: {
         apiUrl: "http://127.0.0.1:8790",
         webUrl: "http://127.0.0.1:3005",
+        origin: "launched",
         substrate: "kind",
       },
       apps: {},

--- a/evals/packages/env/test/world-attach.test.ts
+++ b/evals/packages/env/test/world-attach.test.ts
@@ -71,11 +71,11 @@ test("fromSnapshot accepts only clean http(s) attached Den URLs", () => {
     );
   }
 
-  assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot("https://host"))));
+  assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot("http://127.0.0.1:8790"))));
 });
 
 test("secretRef people resolve both credential variables and report missing variables", () => {
-  const secretRef = "OPENWORK_WORLD_ATTACH_UNIT_PERSON";
+  const secretRef = "OPENWORK_EVAL_SECRET_WORLD_ATTACH_UNIT_PERSON";
   assert.deepEqual(
     resolveWorldPerson(
       { secretRef, name: "Jordan" },
@@ -105,5 +105,16 @@ test("secretRef people resolve both credential variables and report missing vari
       },
     }),
     /secretRef and password are mutually exclusive/,
+  );
+});
+
+test("secretRef rejects names outside the eval secret namespace", () => {
+  assert.throws(
+    () => defineWorld({
+      den: {
+        orgs: { acme: { members: { jordan: { secretRef: "AWS_PRODUCTION" } } } },
+      },
+    }),
+    /secretRef must match \^OPENWORK_EVAL_SECRET_/,
   );
 });

--- a/evals/packages/env/test/world-attach.test.ts
+++ b/evals/packages/env/test/world-attach.test.ts
@@ -59,19 +59,18 @@ function attachedSnapshot(apiUrl: string) {
   });
 }
 
-test("fromSnapshot accepts only clean http(s) attached Den URLs", () => {
+test("fromSnapshot refuses every attached-world snapshot", () => {
   for (const apiUrl of [
     "https://user:pw@host",
     "ftp://host",
     "https://host/path#hash",
+    "http://127.0.0.1:8790",
   ]) {
     assert.throws(
       () => fromSnapshot(JSON.stringify(attachedSnapshot(apiUrl))),
-      /attached Den URLs|expected an http\(s\) URL/,
+      /Attached worlds cannot be resumed or rebuilt from snapshots/,
     );
   }
-
-  assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot("http://127.0.0.1:8790"))));
 });
 
 test("secretRef people resolve both credential variables and report missing variables", () => {

--- a/evals/packages/env/test/world-attach.test.ts
+++ b/evals/packages/env/test/world-attach.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { defineWorld, resolveWorldPerson } from "../src/topology.ts";
+import { buildSnapshot, fromSnapshot } from "../src/world.ts";
+
+test("prod attached Dens refuse organizations while staging attached Dens allow them", () => {
+  assert.throws(
+    () => defineWorld({
+      den: {
+        attach: { apiUrl: "https://den.example.test", tier: "prod" },
+        orgs: { acme: {} },
+      },
+    }),
+    /you own what you launch; you never own what you attach/,
+  );
+
+  assert.doesNotThrow(() => defineWorld({
+    den: {
+      attach: { apiUrl: "https://den.example.test", tier: "staging" },
+      orgs: { acme: {} },
+    },
+  }));
+});
+
+test("den.attach rejects launch-only Den options", () => {
+  const attach: { apiUrl: string; tier: "staging" } = {
+    apiUrl: "https://den.example.test",
+    tier: "staging",
+  };
+  assert.throws(
+    () => defineWorld({ den: { attach, orgs: { acme: {} }, seed: "demo-org" } }),
+    /den\.attach conflicts with den\.seed/,
+  );
+  assert.throws(
+    () => defineWorld({ den: { attach, orgs: { acme: {} }, substrate: "local" } }),
+    /den\.attach conflicts with den\.substrate/,
+  );
+  assert.throws(
+    () => defineWorld({ den: { attach, orgs: { acme: {} }, env: { DEN_ORG_MODE: "multi_org" } } }),
+    /den\.attach conflicts with den\.env/,
+  );
+});
+
+function attachedSnapshot(apiUrl: string) {
+  return buildSnapshot({
+    name: "attached-snapshot",
+    createdAt: "2026-08-23T12:00:00.000Z",
+    place: "local",
+    topology: defineWorld({
+      den: {
+        attach: { apiUrl, tier: "staging" },
+        orgs: { acme: {} },
+      },
+    }).topology,
+    resolved: {
+      den: { apiUrl, webUrl: apiUrl, origin: "attached" },
+      apps: {},
+    },
+  });
+}
+
+test("fromSnapshot accepts only clean http(s) attached Den URLs", () => {
+  for (const apiUrl of [
+    "https://user:pw@host",
+    "ftp://host",
+    "https://host/path#hash",
+  ]) {
+    assert.throws(
+      () => fromSnapshot(JSON.stringify(attachedSnapshot(apiUrl))),
+      /attached Den URLs|expected an http\(s\) URL/,
+    );
+  }
+
+  assert.doesNotThrow(() => fromSnapshot(JSON.stringify(attachedSnapshot("https://host"))));
+});
+
+test("secretRef people resolve both credential variables and report missing variables", () => {
+  const secretRef = "OPENWORK_WORLD_ATTACH_UNIT_PERSON";
+  assert.deepEqual(
+    resolveWorldPerson(
+      { secretRef, name: "Jordan" },
+      {
+        [`${secretRef}_EMAIL`]: "jordan@example.test",
+        [`${secretRef}_PASSWORD`]: "unit-secret-password",
+      },
+    ),
+    {
+      email: "jordan@example.test",
+      name: "Jordan",
+      password: "unit-secret-password",
+    },
+  );
+
+  assert.throws(
+    () => resolveWorldPerson(
+      { secretRef },
+      { [`${secretRef}_EMAIL`]: "jordan@example.test" },
+    ),
+    new RegExp(`${secretRef}_PASSWORD`),
+  );
+  assert.throws(
+    () => defineWorld({
+      den: {
+        orgs: { acme: { members: { jordan: { secretRef, password: "inline" } } } },
+      },
+    }),
+    /secretRef and password are mutually exclusive/,
+  );
+});

--- a/evals/specs/world-attach.test.ts
+++ b/evals/specs/world-attach.test.ts
@@ -56,7 +56,7 @@ test("a world attaches to an existing Den without owning it or snapshotting reso
   const nonce = `${Date.now().toString(36)}-${process.pid.toString(36)}`;
   const preexistingOrgName = `Attach Outer ${nonce}`;
   const attachedOrgName = `Attach World ${nonce}`;
-  const secretRef = `OPENWORK_WORLD_ATTACH_${Date.now()}_${process.pid}`;
+  const secretRef = `OPENWORK_EVAL_SECRET_WORLD_ATTACH_${Date.now()}_${process.pid}`;
   const emailVariable = `${secretRef}_EMAIL`;
   const passwordVariable = `${secretRef}_PASSWORD`;
   const resolvedEmail = `attach-member+${nonce}@openwork.test`;

--- a/evals/specs/world-attach.test.ts
+++ b/evals/specs/world-attach.test.ts
@@ -1,0 +1,143 @@
+import { readFile } from "node:fs/promises";
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import {
+  defaultReuseAdmin,
+  defineWorld,
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  needs,
+  server,
+  SkipError,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object`);
+  return value;
+}
+
+async function organizations(session: DenSession): Promise<Map<string, string>> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${session.token}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!result.response.ok || !isRecord(result.body) || !Array.isArray(result.body.orgs)) {
+    throw new Error(`Organization list failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  const listed = new Map<string, string>();
+  for (const organization of result.body.orgs) {
+    if (!isRecord(organization) || typeof organization.name !== "string" || typeof organization.id !== "string") continue;
+    listed.set(organization.name, organization.id);
+  }
+  return listed;
+}
+
+function restoreEnvironment(name: string, previous: string | undefined): void {
+  if (previous === undefined) delete process.env[name];
+  else process.env[name] = previous;
+}
+
+test("a world attaches to an existing Den without owning it or snapshotting resolved secrets", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs({ placement: "local" });
+  if (!await localMysqlIsRunning()) {
+    throw new SkipError("local MySQL on 127.0.0.1:3306");
+  }
+  if (!await localRedisIsRunning()) {
+    throw new SkipError("local Redis on 127.0.0.1:6379");
+  }
+
+  const nonce = `${Date.now().toString(36)}-${process.pid.toString(36)}`;
+  const preexistingOrgName = `Attach Outer ${nonce}`;
+  const attachedOrgName = `Attach World ${nonce}`;
+  const secretRef = `OPENWORK_WORLD_ATTACH_${Date.now()}_${process.pid}`;
+  const emailVariable = `${secretRef}_EMAIL`;
+  const passwordVariable = `${secretRef}_PASSWORD`;
+  const resolvedEmail = `attach-member+${nonce}@openwork.test`;
+  const resolvedPassword = `AttachSecret-${nonce}!`;
+  const previousEmail = process.env[emailVariable];
+  const previousPassword = process.env[passwordVariable];
+  process.env[emailVariable] = resolvedEmail;
+  process.env[passwordVariable] = resolvedPassword;
+
+  try {
+    await using outer = await server({
+      place,
+      web: false,
+      org: { name: preexistingOrgName, admin: defaultReuseAdmin() },
+    });
+    const before = await organizations(outer.admin);
+    const preexistingOrgId = before.get(preexistingOrgName);
+    expect(preexistingOrgId).toBeTruthy();
+
+    const world = await startWorld(defineWorld({
+      den: {
+        attach: { apiUrl: outer.ref.apiUrl, tier: "staging" },
+        orgs: {
+          [attachedOrgName]: {
+            members: { jordan: { secretRef } },
+          },
+        },
+      },
+    }), { place, name: `world-attach-${nonce}` });
+
+    try {
+      const attachedOrganizations = await organizations(world.den.admin);
+      expect(attachedOrganizations.has(attachedOrgName)).toBe(true);
+      expect(world.den.members.jordan?.email).toBe(resolvedEmail);
+
+      const rawSnapshot = await readFile(world.snapshotPath, "utf8");
+      const parsedSnapshot: unknown = JSON.parse(rawSnapshot);
+      const snapshot = requireRecord(parsedSnapshot, "world snapshot");
+      const resolved = requireRecord(snapshot.resolved, "world snapshot resolved");
+      const resolvedDen = requireRecord(resolved.den, "world snapshot resolved Den");
+      expect(resolvedDen.origin).toBe("attached");
+      const topology = requireRecord(snapshot.topology, "world snapshot topology");
+      const topologyDen = requireRecord(topology.den, "world snapshot topology Den");
+      const snapshotOrgs = requireRecord(topologyDen.orgs, "world snapshot organizations");
+      const snapshotOrg = requireRecord(snapshotOrgs[attachedOrgName], "world snapshot organization");
+      const snapshotMembers = requireRecord(snapshotOrg.members, "world snapshot members");
+      expect(snapshotMembers.jordan).toEqual({ secretRef });
+      expect(rawSnapshot).toContain(secretRef);
+      expect(rawSnapshot).not.toContain(resolvedEmail);
+      expect(rawSnapshot).not.toContain(resolvedPassword);
+      evidence.recordAssertionEvidence(
+        "The world used an authenticated admin session on the attached Den",
+        [...attachedOrganizations.keys()].join(", "),
+        attachedOrganizations.has(attachedOrgName),
+      );
+      evidence.recordAssertionEvidence(
+        "The attached snapshot retained only the member secret reference",
+        JSON.stringify(snapshotMembers.jordan),
+        !rawSnapshot.includes(resolvedEmail) && !rawSnapshot.includes(resolvedPassword),
+      );
+    } finally {
+      await world[Symbol.asyncDispose]();
+    }
+
+    const health = await fetch(`${outer.ref.apiUrl}/health`, { signal: AbortSignal.timeout(10_000) });
+    expect(health.ok).toBe(true);
+    const after = await organizations(outer.admin);
+    expect(after.get(preexistingOrgName)).toBe(preexistingOrgId);
+    expect(after.has(attachedOrgName)).toBe(false);
+    evidence.recordAssertionEvidence(
+      "Disposing the attached world left the outer Den healthy",
+      `HTTP ${health.status}`,
+      health.ok,
+    );
+    evidence.recordAssertionEvidence(
+      "Disposal deleted only the world-created organization",
+      [...after.keys()].join(", "),
+      after.get(preexistingOrgName) === preexistingOrgId && !after.has(attachedOrgName),
+    );
+  } finally {
+    restoreEnvironment(emailVariable, previousEmail);
+    restoreEnvironment(passwordVariable, previousPassword);
+  }
+});


### PR DESCRIPTION
## What

Implements the **origin axis** for worlds: every resource is either *launched* (world creates, owns, disposes) or *attached* (pre-exists; world binds, never creates or destroys). The law: **you own what you launch; you never own what you attach.** This is the kernel piece behind the reserved names documented in #4027, and the foundation for prod/staging attach lanes.

- `den.attach: { apiUrl, webUrl?, tier: "prod" | "staging" | "demo" }` in topology; mutually exclusive with `seed`/`substrate`/`env`/`ports`/`web` at validation. **`tier: "prod"` structurally refuses org provisioning** — rejected before any network call, with the law in the error message. `staging`/`demo` provision via the existing reuse path and delete only the org they created.
- `WorldPerson.secretRef` — credentials by reference, resolved from `${secretRef}_EMAIL` / `${secretRef}_PASSWORD` at start; missing variables fail with their exact names. **Snapshots record `{ secretRef }` only — never resolved values** (redaction at snapshot build).
- Snapshot `resolved.den.origin: "attached" | "launched"`; `resume`/`rebuild` teardown frees ports and drops databases **only for launched Dens**.
- Snapshot hardening (extends the untrusted-input class fix): attached URLs must be http(s) with no userinfo and no hash; origin must match the topology; all existing allowlists intact.

## Verification

- Unit (`evals/packages/env/test/`, incl. new `world-attach.test.ts`): 51 passed — prod-tier refusal + staging acceptance, attach/seed/substrate/env conflicts, hostile snapshot URLs (`https://user:pw@host`, `ftp://`, `#hash`) rejected, secretRef resolution + mutual exclusion with inline passwords.
- Spec (`evals/specs/world-attach.test.ts`, app-less lane): boots a real local Den *outside* any world, attaches a staging-tier world to it, then asserts: admin session works; snapshot has `origin: "attached"`; raw snapshot JSON contains the secretRef but **not** the resolved password; after world dispose the outer Den is still healthy, the world-created org is gone, and a pre-existing org is untouched. `pnpm evals:pr specs/world-attach.test.ts` — **1 passed, 0 skipped** (local lane).
- `pnpm --dir evals run lint:layers` — clean.
- Typecheck: `tsc -p evals/tsconfig.json` reports 35 errors — **byte-identical to origin/dev** (verified by diffing error lists); none introduced here.

Deliberately out of scope: driving app surfaces against attached Dens (blocked on #4028 landing), the runtime prod-tier path beyond structural refusal (no prod service account exists yet), and un-reserving the README names (owned by #4027; follow-up after both merge).

Verdict: **Passed** for the claims above; evidence publication to follow as a PR comment.