### PR TITLE
feat(evals): add live lane with prod Den signup+invite spec

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -29,6 +29,7 @@ Demo-driven features start from a preset or world plus a spec in `evals/specs`.
 | fault | Declared misbehavior used to reproduce a failure condition. |
 | surface | A drivable UI: Electron, or Chrome on Den Web. |
 | origin | Whether a resource is launched or attached. See below. |
+| live | A spec attached to a live shared substrate; red is an incident signal about the service, not a verdict on the diff. |
 
 ### Origin: launch vs attach
 
@@ -90,10 +91,31 @@ placement environment.
 
 See `run-tests` for environment requirements and the cold-boot verdict check.
 
+### Live lane
+
+Surface and substrate are independent axes:
+
+| Surface | Launched substrate (world-owned, hermetic) | Attached live substrate |
+| --- | --- | --- |
+| App-less | `<slug>.test.ts` | `<slug>.live.test.ts` |
+| App-driving | `<slug>.e2e.test.ts` | Not yet paved |
+
+Run a live spec only by exact name and with explicit consent and endpoint values:
+
+```bash
+OPENWORK_EVAL_LIVE=1 OPENWORK_EVAL_LIVE_DEN_API_URL=https://api.openworklabs.com OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL=<mailbox> pnpm evals:pr specs/prod-den-signup-invites.live.test.ts
+```
+
+The live Den is attached and never deleted. Timestamped plus-addressed identities,
+organizations, and invitations launched onto it are owned by the spec; cleanup is
+asserted even on failure, and any residue (including an account without a
+self-service deletion endpoint) must be documented with exact identities.
+
 ## Authoring contract
 
 - Import `test` from `@openwork/testkit`.
 - Name app-driving files `<slug>.e2e.test.ts`; app-less tests use `<slug>.test.ts`.
+- Live specs use `<slug>.live.test.ts`, never run in PR/E2E suites, and require a consent environment variable.
 - Acquire resources in dependency order with `needs()` → `server()` → `app()`.
 - Drive user-visible behavior and assert observable outcomes. Backend, file,
   and process checks may witness side effects but do not replace the journey.

--- a/evals/specs/prod-den-signup-invites.live.test.ts
+++ b/evals/specs/prod-den-signup-invites.live.test.ts
@@ -1,0 +1,265 @@
+import { denFetch, signIn } from "@openwork/behaviors";
+import type { DenFetchResult, DenRef, DenSession } from "@openwork/behaviors";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+// Live lane: the production Den is attached and never owned by this spec. The
+// timestamped user, organization, and invitations are launched onto it, so the
+// spec owns their cleanup. den-api does not enable Better Auth's self-service
+// account deletion endpoint, so the retained account is reported as residue.
+
+interface LiveIdentity {
+  owner: string;
+  invitees: [string, string];
+  neverInvited: string;
+  timestamp: string;
+}
+
+interface OrganizationSummary {
+  id: string;
+  name: string;
+}
+
+interface OrganizationList {
+  activeOrgId: string | null;
+  activeOrgSlug: string | null;
+  orgs: OrganizationSummary[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return typeof field === "string" ? field : null;
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return isRecord(field) ? field : null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Unreachable after needs(): ${name} is missing.`);
+  return value;
+}
+
+function liveIdentity(mailbox: string): LiveIdentity {
+  const at = mailbox.lastIndexOf("@");
+  if (at < 1 || at === mailbox.length - 1) {
+    throw new Error("OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL must be a complete email address.");
+  }
+  const local = mailbox.slice(0, at);
+  const domain = mailbox.slice(at + 1);
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
+  const prefix = `${local}+prod-${timestamp}`;
+  return {
+    owner: `${prefix}@${domain}`,
+    invitees: [`${prefix}-m1@${domain}`, `${prefix}-m2@${domain}`],
+    neverInvited: `${prefix}-never-invited@${domain}`,
+    timestamp,
+  };
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+function responseFailure(label: string, result: DenFetchResult): Error {
+  return new Error(`${label}: HTTP ${result.response.status} ${result.text.slice(0, 1_000)}`);
+}
+
+function parseOrganizationList(result: DenFetchResult, label: string): OrganizationList {
+  if (result.response.status !== 200 || !isRecord(result.body) || !Array.isArray(result.body.orgs)) {
+    throw responseFailure(label, result);
+  }
+
+  const orgs: OrganizationSummary[] = [];
+  for (const value of result.body.orgs) {
+    const id = stringField(value, "id");
+    const name = stringField(value, "name");
+    if (!id || !name) throw new Error(`${label}: malformed organization ${JSON.stringify(value).slice(0, 500)}`);
+    orgs.push({ id, name });
+  }
+
+  const activeOrgId = result.body.activeOrgId;
+  const activeOrgSlug = result.body.activeOrgSlug;
+  if (activeOrgId !== null && typeof activeOrgId !== "string") {
+    throw new Error(`${label}: activeOrgId was neither a string nor null.`);
+  }
+  if (activeOrgSlug !== null && typeof activeOrgSlug !== "string") {
+    throw new Error(`${label}: activeOrgSlug was neither a string nor null.`);
+  }
+
+  return {
+    activeOrgId,
+    activeOrgSlug,
+    orgs: orgs.sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+async function listOrganizations(session: DenSession, label: string): Promise<OrganizationList> {
+  const result = await denFetch(session, "/v1/me/orgs", { headers: auth(session) });
+  return parseOrganizationList(result, label);
+}
+
+async function createOrganization(session: DenSession, name: string): Promise<string> {
+  const result = await denFetch(session, "/v1/org", {
+    method: "POST",
+    headers: auth(session),
+    body: JSON.stringify({ name }),
+  });
+  const id = stringField(recordField(result.body, "organization"), "id");
+  if (result.response.status !== 201 || !id) throw responseFailure("Organization creation failed", result);
+  return id;
+}
+
+async function invite(session: DenSession, email: string): Promise<void> {
+  const result = await denFetch(session, "/v1/invitations", {
+    method: "POST",
+    headers: auth(session),
+    body: JSON.stringify({ email, role: "member" }),
+  });
+  if (!result.response.ok) throw responseFailure(`Invitation failed for ${email}`, result);
+}
+
+function listedEmails(body: unknown, key: "invitations" | "members"): string[] {
+  if (!isRecord(body) || !Array.isArray(body[key])) {
+    throw new Error(`Organization listing had no ${key} array: ${JSON.stringify(body).slice(0, 500)}`);
+  }
+  const emails: string[] = [];
+  for (const value of body[key]) {
+    const email = key === "invitations"
+      ? stringField(value, "email")
+      : stringField(recordField(value, "user"), "email");
+    if (!email) throw new Error(`Organization ${key} entry had no email: ${JSON.stringify(value).slice(0, 500)}`);
+    emails.push(email);
+  }
+  return emails.sort();
+}
+
+async function organizationEmails(session: DenSession): Promise<{ invitations: string[]; members: string[] }> {
+  const result = await denFetch(session, "/v1/org", { headers: auth(session) });
+  if (result.response.status !== 200) throw responseFailure("Organization invite/member listing failed", result);
+  return {
+    invitations: listedEmails(result.body, "invitations"),
+    members: listedEmails(result.body, "members"),
+  };
+}
+
+async function deleteCreatedOrganization(session: DenSession, organizationId: string): Promise<void> {
+  const active = await signIn(session, { email: session.email, password: session.password });
+  const selected = await denFetch(active, "/v1/me/active-organization", {
+    method: "POST",
+    headers: auth(active),
+    body: JSON.stringify({ organizationId }),
+  });
+  if (selected.response.status === 404) return;
+  if (!selected.response.ok) throw responseFailure("Organization cleanup selection failed", selected);
+
+  const deleted = await denFetch(active, "/v1/org", { method: "DELETE", headers: auth(active) });
+  if (!deleted.response.ok && deleted.response.status !== 404) {
+    throw responseFailure("Organization cleanup failed", deleted);
+  }
+}
+
+test("production Den supports fresh signup, organization invitations, and owned cleanup", async ({ evidence }) => {
+  needs({
+    optIn: ["OPENWORK_EVAL_LIVE"],
+    env: ["OPENWORK_EVAL_LIVE_DEN_API_URL", "OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL"],
+  });
+
+  const apiUrl = requiredEnv("OPENWORK_EVAL_LIVE_DEN_API_URL").replace(/\/+$/, "");
+  const webUrl = apiUrl === "https://api.openworklabs.com" ? "https://app.openworklabs.com" : apiUrl;
+  const den: DenRef = { apiUrl, webUrl };
+  const identity = liveIdentity(requiredEnv("OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL"));
+  const password = `ProdLive-${identity.timestamp}!`;
+  const organizationName = `Prod Live ${identity.timestamp}`;
+  let session: DenSession | null = null;
+  let organizationId: string | null = null;
+  let organizationDeleted = false;
+  let scenarioError: unknown = null;
+  let cleanupError: unknown = null;
+
+  try {
+    const signUp = await denFetch(den, "/api/auth/sign-up/email", {
+      method: "POST",
+      body: JSON.stringify({ email: identity.owner, name: `Prod Live ${identity.timestamp}`, password }),
+    });
+    expect(signUp.response.ok, `Sign-up failed: HTTP ${signUp.response.status} ${signUp.text.slice(0, 1_000)}`).toBe(true);
+
+    session = await signIn(den, { email: identity.owner, password });
+    const baseline = await listOrganizations(session, "Authenticated baseline organization list failed");
+    const wrongPassword = await denFetch(den, "/api/auth/sign-in/email", {
+      method: "POST",
+      body: JSON.stringify({ email: identity.owner, password: `${password}-wrong` }),
+    });
+    expect(wrongPassword.response.ok, `Wrong password unexpectedly returned HTTP ${wrongPassword.response.status}`).toBe(false);
+    expect(wrongPassword.response.status).toBeGreaterThanOrEqual(400);
+    evidence.recordAssertionEvidence(
+      "C1: fresh production signup authenticates while a wrong password is rejected",
+      `${identity.owner} signed up and GET /v1/me/orgs returned 200; the wrong-password sign-in returned HTTP ${wrongPassword.response.status}.`,
+      true,
+    );
+
+    organizationId = await createOrganization(session, organizationName);
+    await invite(session, identity.invitees[0]);
+    await invite(session, identity.invitees[1]);
+
+    const organizationList = await listOrganizations(session, "Post-creation organization list failed");
+    expect(organizationList.orgs).toEqual([{ id: organizationId, name: organizationName }]);
+    const emails = await organizationEmails(session);
+    expect(emails.invitations).toEqual([...identity.invitees].sort());
+    expect(emails.members).toEqual([identity.owner, ...identity.invitees].sort());
+    expect(emails.invitations).not.toContain(identity.neverInvited);
+    expect(emails.members).not.toContain(identity.neverInvited);
+    evidence.recordAssertionEvidence(
+      "C2: the new organization contains exactly both invitations and excludes a never-invited address",
+      `${organizationName} is the user's only organization; its invitation and member listings contain ${identity.invitees.join(" and ")} and omit ${identity.neverInvited}.`,
+      true,
+    );
+
+    await deleteCreatedOrganization(session, organizationId);
+    organizationDeleted = true;
+    session = await signIn(den, { email: identity.owner, password });
+    const afterCleanup = await listOrganizations(session, "Post-cleanup organization list failed");
+    expect(afterCleanup).toEqual(baseline);
+    organizationId = null;
+    evidence.recordAssertionEvidence(
+      "C3: owned production organization data is deleted",
+      `DELETE /v1/org removed ${organizationName}; the normalized organization list returned to its exact pre-creation baseline. den-api does not enable its self-service account deletion endpoint.`,
+      true,
+    );
+  } catch (error) {
+    scenarioError = error;
+  } finally {
+    if (organizationId && session) {
+      try {
+        await deleteCreatedOrganization(session, organizationId);
+        organizationDeleted = true;
+        organizationId = null;
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+    console.info(
+      `[live-lane] owner=${identity.owner} invitees=${identity.invitees.join(",")} neverInvited=${identity.neverInvited} org=${organizationName} orgDeleted=${String(organizationDeleted)} accountDeletion=self-service-disabled`,
+    );
+  }
+
+  if (scenarioError) {
+    if (cleanupError) {
+      throw new Error(`${errorMessage(scenarioError)}; cleanup also failed: ${errorMessage(cleanupError)}`);
+    }
+    throw scenarioError;
+  }
+  if (cleanupError) throw cleanupError;
+});

--- a/evals/specs/prod-den-signup-invites.live.test.ts
+++ b/evals/specs/prod-den-signup-invites.live.test.ts
@@ -12,7 +12,7 @@ import { expect } from "vitest";
 // infisical run -- pnpm evals:pr specs/prod-den-signup-invites.live.test.ts
 
 const AGENTMAIL_API_URL = "https://api.agentmail.to/v0";
-const MAX_AGENTMAIL_INBOXES = 3;
+const MAX_AGENTMAIL_INBOXES = 2;
 const requirements: TestNeeds = {
   optIn: ["OPENWORK_EVAL_LIVE"],
   env: ["OPENWORK_EVAL_LIVE_DEN_API_URL", "AGENTMAIL_API_KEY"],
@@ -194,12 +194,15 @@ async function waitForAgentMailMessage(
   inbox: AgentMailInbox,
   after: string,
   label: string,
-  subjectMatches: (subject: string) => boolean,
+  messageMatches: (message: AgentMailMessage) => boolean,
 ): Promise<AgentMailMessage> {
   const message = await eventually(async () => {
     const messages = await listAgentMailMessages(apiKey, inbox, after);
-    const summary = messages.find((candidate) => subjectMatches(candidate.subject));
-    return summary ? getAgentMailMessage(apiKey, inbox, summary) : null;
+    for (const summary of messages) {
+      const candidate = await getAgentMailMessage(apiKey, inbox, summary);
+      if (messageMatches(candidate)) return candidate;
+    }
+    return null;
   }, {
     within: 60_000,
     intervalMs: 2_000,
@@ -215,6 +218,12 @@ function verificationCode(message: AgentMailMessage): string {
   const code = match?.[1];
   if (!code) throw new Error(`Verification email ${message.messageId} contained no six-digit code.`);
   return code;
+}
+
+function plusAddress(email: string, tag: string): string {
+  const at = email.lastIndexOf("@");
+  if (at < 1 || at === email.length - 1) throw new Error(`Cannot plus-address invalid email ${email}.`);
+  return `${email.slice(0, at)}+${tag}@${email.slice(at + 1)}`;
 }
 
 function auth(session: DenSession): Record<string, string> {
@@ -353,14 +362,13 @@ test(title, { timeout: 240_000 }, async ({ evidence }) => {
   try {
     const ownerInbox = await provisionAgentMailInbox("owner");
     const inviteeM1Inbox = await provisionAgentMailInbox("m1");
-    const inviteeM2Inbox = await provisionAgentMailInbox("m2");
     const at = ownerInbox.email.lastIndexOf("@");
     if (at < 1 || at === ownerInbox.email.length - 1) {
       throw new Error(`AgentMail created an invalid owner address: ${ownerInbox.email}`);
     }
     const createdIdentity: LiveIdentity = {
       owner: ownerInbox.email,
-      invitees: [inviteeM1Inbox.email, inviteeM2Inbox.email],
+      invitees: [inviteeM1Inbox.email, plusAddress(inviteeM1Inbox.email, "m2")],
       neverInvited: `${runPrefix}-never-invited@${ownerInbox.email.slice(at + 1)}`,
     };
     identity = createdIdentity;
@@ -377,7 +385,7 @@ test(title, { timeout: 240_000 }, async ({ evidence }) => {
       ownerInbox,
       runStartedAt,
       `OpenWork verification email in ${ownerInbox.email}`,
-      (subject) => subject.toLowerCase().includes("openwork verification code"),
+      (message) => message.subject.toLowerCase().includes("openwork verification code"),
     );
     const verified = await denFetch(den, "/api/auth/email-otp/verify-email", {
       method: "POST",
@@ -410,7 +418,9 @@ test(title, { timeout: 240_000 }, async ({ evidence }) => {
       inviteeM1Inbox,
       runStartedAt,
       `OpenWork organization invitation in ${inviteeM1Inbox.email}`,
-      (subject) => subject.includes(organizationName) && subject.toLowerCase().includes("invited"),
+      (message) => message.subject.includes(organizationName)
+        && message.subject.toLowerCase().includes("invited")
+        && message.to.some((recipient) => recipient.toLowerCase().includes(createdIdentity.invitees[0].toLowerCase())),
     );
     expect(invitationMessage.subject).toContain(organizationName);
     expect(

--- a/evals/specs/prod-den-signup-invites.live.test.ts
+++ b/evals/specs/prod-den-signup-invites.live.test.ts
@@ -1,18 +1,47 @@
 import { denFetch, signIn } from "@openwork/behaviors";
 import type { DenFetchResult, DenRef, DenSession } from "@openwork/behaviors";
-import { needs, test } from "@openwork/testkit";
+import { eventually, needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
 import { expect } from "vitest";
 
 // Live lane: the production Den is attached and never owned by this spec. The
 // timestamped user, organization, and invitations are launched onto it, so the
 // spec owns their cleanup. den-api does not enable Better Auth's self-service
 // account deletion endpoint, so the retained account is reported as residue.
+// AGENTMAIL_API_KEY lives in Infisical. Invoke this spec with:
+// infisical run -- pnpm evals:pr specs/prod-den-signup-invites.live.test.ts
+
+const AGENTMAIL_API_URL = "https://api.agentmail.to/v0";
+const MAX_AGENTMAIL_INBOXES = 3;
+const requirements: TestNeeds = {
+  optIn: ["OPENWORK_EVAL_LIVE"],
+  env: ["OPENWORK_EVAL_LIVE_DEN_API_URL", "AGENTMAIL_API_KEY"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `production Den signup and invitations skipped — needs: ${missingRequirements.join(", ")}`
+  : "production Den supports verified signup, delivered organization invitations, and owned cleanup";
 
 interface LiveIdentity {
   owner: string;
   invitees: [string, string];
   neverInvited: string;
-  timestamp: string;
+}
+
+interface AgentMailInbox {
+  inboxId: string;
+  email: string;
+}
+
+interface AgentMailMessageSummary {
+  messageId: string;
+  subject: string;
+}
+
+interface AgentMailMessage extends AgentMailMessageSummary {
+  to: string[];
+  text: string;
+  html: string;
 }
 
 interface OrganizationSummary {
@@ -42,6 +71,16 @@ function recordField(value: unknown, key: string): Record<string, unknown> | nul
   return isRecord(field) ? field : null;
 }
 
+function stringArrayField(value: unknown, key: string): string[] | null {
+  if (!isRecord(value) || !Array.isArray(value[key])) return null;
+  const fields: string[] = [];
+  for (const field of value[key]) {
+    if (typeof field !== "string") return null;
+    fields.push(field);
+  }
+  return fields;
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -52,21 +91,130 @@ function requiredEnv(name: string): string {
   return value;
 }
 
-function liveIdentity(mailbox: string): LiveIdentity {
-  const at = mailbox.lastIndexOf("@");
-  if (at < 1 || at === mailbox.length - 1) {
-    throw new Error("OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL must be a complete email address.");
+async function agentMailFetch(apiKey: string, path: string, init: RequestInit = {}): Promise<DenFetchResult> {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${apiKey}`);
+  if (init.body && !headers.has("content-type")) headers.set("content-type", "application/json");
+  const response = await fetch(`${AGENTMAIL_API_URL}${path}`, {
+    ...init,
+    headers,
+    signal: init.signal ?? AbortSignal.timeout(30_000),
+  });
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = text.trim() ? JSON.parse(text) : null;
+  } catch {
+    body = text;
   }
-  const local = mailbox.slice(0, at);
-  const domain = mailbox.slice(at + 1);
-  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
-  const prefix = `${local}+prod-${timestamp}`;
+  return { response, body, text };
+}
+
+async function createAgentMailInbox(apiKey: string, username: string): Promise<AgentMailInbox> {
+  const result = await agentMailFetch(apiKey, "/inboxes", {
+    method: "POST",
+    body: JSON.stringify({
+      username,
+      display_name: username,
+      client_id: username,
+    }),
+  });
+  const inboxId = stringField(result.body, "inbox_id");
+  const email = stringField(result.body, "email");
+  if (result.response.status !== 200 || !inboxId || !email) {
+    throw responseFailure(`AgentMail inbox creation failed for ${username}`, result);
+  }
+  if (!email.toLowerCase().startsWith(`${username.toLowerCase()}@`)) {
+    throw new Error(`AgentMail created ${email} instead of the requested timestamped username ${username}.`);
+  }
+  return { inboxId, email };
+}
+
+async function deleteAgentMailInbox(apiKey: string, inbox: AgentMailInbox): Promise<void> {
+  const result = await agentMailFetch(apiKey, `/inboxes/${encodeURIComponent(inbox.inboxId)}`, { method: "DELETE" });
+  if (!result.response.ok && result.response.status !== 404) {
+    throw responseFailure(`AgentMail inbox cleanup failed for ${inbox.email}`, result);
+  }
+}
+
+async function listAgentMailMessages(
+  apiKey: string,
+  inbox: AgentMailInbox,
+  after: string,
+): Promise<AgentMailMessageSummary[]> {
+  const query = new URLSearchParams({
+    limit: "20",
+    after,
+    include_unauthenticated: "true",
+  });
+  const result = await agentMailFetch(
+    apiKey,
+    `/inboxes/${encodeURIComponent(inbox.inboxId)}/messages?${query.toString()}`,
+  );
+  if (!result.response.ok || !isRecord(result.body) || !Array.isArray(result.body.messages)) {
+    throw responseFailure(`AgentMail message listing failed for ${inbox.email}`, result);
+  }
+
+  const messages: AgentMailMessageSummary[] = [];
+  for (const value of result.body.messages) {
+    const messageId = stringField(value, "message_id");
+    if (!messageId) {
+      throw new Error(`AgentMail returned a message without message_id: ${JSON.stringify(value).slice(0, 500)}`);
+    }
+    messages.push({ messageId, subject: stringField(value, "subject") ?? "" });
+  }
+  return messages;
+}
+
+async function getAgentMailMessage(
+  apiKey: string,
+  inbox: AgentMailInbox,
+  summary: AgentMailMessageSummary,
+): Promise<AgentMailMessage> {
+  const result = await agentMailFetch(
+    apiKey,
+    `/inboxes/${encodeURIComponent(inbox.inboxId)}/messages/${encodeURIComponent(summary.messageId)}`,
+  );
+  const messageId = stringField(result.body, "message_id");
+  const to = stringArrayField(result.body, "to");
+  if (!result.response.ok || !messageId || !to) {
+    throw responseFailure(`AgentMail message retrieval failed for ${summary.messageId}`, result);
+  }
   return {
-    owner: `${prefix}@${domain}`,
-    invitees: [`${prefix}-m1@${domain}`, `${prefix}-m2@${domain}`],
-    neverInvited: `${prefix}-never-invited@${domain}`,
-    timestamp,
+    messageId,
+    subject: stringField(result.body, "subject") ?? summary.subject,
+    to,
+    text: stringField(result.body, "text") ?? "",
+    html: stringField(result.body, "html") ?? "",
   };
+}
+
+async function waitForAgentMailMessage(
+  apiKey: string,
+  inbox: AgentMailInbox,
+  after: string,
+  label: string,
+  subjectMatches: (subject: string) => boolean,
+): Promise<AgentMailMessage> {
+  const message = await eventually(async () => {
+    const messages = await listAgentMailMessages(apiKey, inbox, after);
+    const summary = messages.find((candidate) => subjectMatches(candidate.subject));
+    return summary ? getAgentMailMessage(apiKey, inbox, summary) : null;
+  }, {
+    within: 60_000,
+    intervalMs: 2_000,
+    label,
+    until: (candidate) => candidate !== null,
+  });
+  if (!message) throw new Error(`Unreachable after eventually(): ${label} was not delivered.`);
+  return message;
+}
+
+function verificationCode(message: AgentMailMessage): string {
+  const match = `${message.subject}\n${message.text}\n${message.html}`.match(/\b(\d{6})\b/);
+  const code = match?.[1];
+  if (!code) throw new Error(`Verification email ${message.messageId} contained no six-digit code.`);
+  return code;
 }
 
 function auth(session: DenSession): Record<string, string> {
@@ -171,65 +319,120 @@ async function deleteCreatedOrganization(session: DenSession, organizationId: st
   }
 }
 
-test("production Den supports fresh signup, organization invitations, and owned cleanup", async ({ evidence }) => {
-  needs({
-    optIn: ["OPENWORK_EVAL_LIVE"],
-    env: ["OPENWORK_EVAL_LIVE_DEN_API_URL", "OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL"],
-  });
-
+test(title, { timeout: 240_000 }, async ({ evidence }) => {
+  needs(requirements);
   const apiUrl = requiredEnv("OPENWORK_EVAL_LIVE_DEN_API_URL").replace(/\/+$/, "");
+  const agentMailApiKey = requiredEnv("AGENTMAIL_API_KEY");
   const webUrl = apiUrl === "https://api.openworklabs.com" ? "https://app.openworklabs.com" : apiUrl;
   const den: DenRef = { apiUrl, webUrl };
-  const identity = liveIdentity(requiredEnv("OPENWORK_EVAL_SECRET_LIVE_MAILBOX_EMAIL"));
-  const password = `ProdLive-${identity.timestamp}!`;
-  const organizationName = `Prod Live ${identity.timestamp}`;
+  const runStartedAt = new Date().toISOString();
+  const timestamp = runStartedAt.replace(/\D/g, "");
+  const runPrefix = `openwork-live-${timestamp}`;
+  const password = `ProdLive-${timestamp}!`;
+  const organizationName = `Prod Live ${timestamp}`;
+  const agentMailInboxes: AgentMailInbox[] = [];
+  const agentMailDeleted: string[] = [];
+  const agentMailResidue: string[] = [];
+  let identity: LiveIdentity | null = null;
   let session: DenSession | null = null;
   let organizationId: string | null = null;
   let organizationDeleted = false;
+  let accountCreated = false;
   let scenarioError: unknown = null;
   let cleanupError: unknown = null;
 
+  async function provisionAgentMailInbox(role: string): Promise<AgentMailInbox> {
+    if (agentMailInboxes.length >= MAX_AGENTMAIL_INBOXES) {
+      throw new Error(`AgentMail inbox cap of ${MAX_AGENTMAIL_INBOXES} reached for this live run.`);
+    }
+    const inbox = await createAgentMailInbox(agentMailApiKey, `${runPrefix}-${role}`);
+    agentMailInboxes.push(inbox);
+    return inbox;
+  }
+
   try {
+    const ownerInbox = await provisionAgentMailInbox("owner");
+    const inviteeM1Inbox = await provisionAgentMailInbox("m1");
+    const inviteeM2Inbox = await provisionAgentMailInbox("m2");
+    const at = ownerInbox.email.lastIndexOf("@");
+    if (at < 1 || at === ownerInbox.email.length - 1) {
+      throw new Error(`AgentMail created an invalid owner address: ${ownerInbox.email}`);
+    }
+    const createdIdentity: LiveIdentity = {
+      owner: ownerInbox.email,
+      invitees: [inviteeM1Inbox.email, inviteeM2Inbox.email],
+      neverInvited: `${runPrefix}-never-invited@${ownerInbox.email.slice(at + 1)}`,
+    };
+    identity = createdIdentity;
+
     const signUp = await denFetch(den, "/api/auth/sign-up/email", {
       method: "POST",
-      body: JSON.stringify({ email: identity.owner, name: `Prod Live ${identity.timestamp}`, password }),
+      body: JSON.stringify({ email: createdIdentity.owner, name: `Prod Live ${timestamp}`, password }),
     });
     expect(signUp.response.ok, `Sign-up failed: HTTP ${signUp.response.status} ${signUp.text.slice(0, 1_000)}`).toBe(true);
+    accountCreated = true;
 
-    session = await signIn(den, { email: identity.owner, password });
+    const verificationMessage = await waitForAgentMailMessage(
+      agentMailApiKey,
+      ownerInbox,
+      runStartedAt,
+      `OpenWork verification email in ${ownerInbox.email}`,
+      (subject) => subject.toLowerCase().includes("openwork verification code"),
+    );
+    const verified = await denFetch(den, "/api/auth/email-otp/verify-email", {
+      method: "POST",
+      body: JSON.stringify({ email: createdIdentity.owner, otp: verificationCode(verificationMessage) }),
+    });
+    expect(
+      verified.response.ok,
+      `Email verification failed: HTTP ${verified.response.status} ${verified.text.slice(0, 1_000)}`,
+    ).toBe(true);
+
+    session = await signIn(den, { email: createdIdentity.owner, password });
     const baseline = await listOrganizations(session, "Authenticated baseline organization list failed");
     const wrongPassword = await denFetch(den, "/api/auth/sign-in/email", {
       method: "POST",
-      body: JSON.stringify({ email: identity.owner, password: `${password}-wrong` }),
+      body: JSON.stringify({ email: createdIdentity.owner, password: `${password}-wrong` }),
     });
     expect(wrongPassword.response.ok, `Wrong password unexpectedly returned HTTP ${wrongPassword.response.status}`).toBe(false);
     expect(wrongPassword.response.status).toBeGreaterThanOrEqual(400);
     evidence.recordAssertionEvidence(
-      "C1: fresh production signup authenticates while a wrong password is rejected",
-      `${identity.owner} signed up and GET /v1/me/orgs returned 200; the wrong-password sign-in returned HTTP ${wrongPassword.response.status}.`,
+      "C1: fresh production signup receives verification, verifies, and authenticates while a wrong password is rejected",
+      `${createdIdentity.owner} received AgentMail message ${verificationMessage.messageId}; OTP verification and GET /v1/me/orgs succeeded, while the wrong-password sign-in returned HTTP ${wrongPassword.response.status}.`,
       true,
     );
 
     organizationId = await createOrganization(session, organizationName);
-    await invite(session, identity.invitees[0]);
-    await invite(session, identity.invitees[1]);
+    await invite(session, createdIdentity.invitees[0]);
+    await invite(session, createdIdentity.invitees[1]);
+    const invitationMessage = await waitForAgentMailMessage(
+      agentMailApiKey,
+      inviteeM1Inbox,
+      runStartedAt,
+      `OpenWork organization invitation in ${inviteeM1Inbox.email}`,
+      (subject) => subject.includes(organizationName) && subject.toLowerCase().includes("invited"),
+    );
+    expect(invitationMessage.subject).toContain(organizationName);
+    expect(
+      invitationMessage.to.some((recipient) => recipient.toLowerCase().includes(createdIdentity.invitees[0].toLowerCase())),
+    ).toBe(true);
 
     const organizationList = await listOrganizations(session, "Post-creation organization list failed");
     expect(organizationList.orgs).toEqual([{ id: organizationId, name: organizationName }]);
     const emails = await organizationEmails(session);
-    expect(emails.invitations).toEqual([...identity.invitees].sort());
-    expect(emails.members).toEqual([identity.owner, ...identity.invitees].sort());
-    expect(emails.invitations).not.toContain(identity.neverInvited);
-    expect(emails.members).not.toContain(identity.neverInvited);
+    expect(emails.invitations).toEqual([...createdIdentity.invitees].sort());
+    expect(emails.members).toEqual([createdIdentity.owner, ...createdIdentity.invitees].sort());
+    expect(emails.invitations).not.toContain(createdIdentity.neverInvited);
+    expect(emails.members).not.toContain(createdIdentity.neverInvited);
     evidence.recordAssertionEvidence(
-      "C2: the new organization contains exactly both invitations and excludes a never-invited address",
-      `${organizationName} is the user's only organization; its invitation and member listings contain ${identity.invitees.join(" and ")} and omit ${identity.neverInvited}.`,
+      "C2: the first invitation is delivered and the new organization contains exactly both invitations while excluding a never-invited address",
+      `AgentMail delivered message ${invitationMessage.messageId} to ${createdIdentity.invitees[0]}; ${organizationName}'s invitation and member listings contain ${createdIdentity.invitees.join(" and ")} and omit ${createdIdentity.neverInvited}.`,
       true,
     );
 
     await deleteCreatedOrganization(session, organizationId);
     organizationDeleted = true;
-    session = await signIn(den, { email: identity.owner, password });
+    session = await signIn(den, { email: createdIdentity.owner, password });
     const afterCleanup = await listOrganizations(session, "Post-cleanup organization list failed");
     expect(afterCleanup).toEqual(baseline);
     organizationId = null;
@@ -250,8 +453,16 @@ test("production Den supports fresh signup, organization invitations, and owned 
         cleanupError = error;
       }
     }
+    for (const inbox of [...agentMailInboxes].reverse()) {
+      try {
+        await deleteAgentMailInbox(agentMailApiKey, inbox);
+        agentMailDeleted.push(`${inbox.email}(${inbox.inboxId})`);
+      } catch (error) {
+        agentMailResidue.push(`${inbox.email}(${inbox.inboxId}): ${errorMessage(error)}`);
+      }
+    }
     console.info(
-      `[live-lane] owner=${identity.owner} invitees=${identity.invitees.join(",")} neverInvited=${identity.neverInvited} org=${organizationName} orgDeleted=${String(organizationDeleted)} accountDeletion=self-service-disabled`,
+      `[live-lane] owner=${identity?.owner ?? "not-created"} invitees=${identity?.invitees.join(",") ?? "not-created"} neverInvited=${identity?.neverInvited ?? "not-created"} org=${organizationName} orgDeleted=${String(organizationDeleted)} accountCreated=${String(accountCreated)} accountDeletion=self-service-disabled agentMailCreated=${agentMailInboxes.map((inbox) => `${inbox.email}(${inbox.inboxId})`).join(",") || "none"} agentMailDeleted=${agentMailDeleted.join(",") || "none"} agentMailResidue=${agentMailResidue.join(" | ") || "none"}`,
     );
   }
 

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -10,6 +10,7 @@ const prepareSuite = shouldPrepareSuite(process.argv);
 const attachedDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
 const managedStack = prepareSuite && !attachedDen;
 const e2eWorkers = managedStack ? suiteWorkerCount(process.argv, process.env) : 1;
+const namedLiveSpec = process.argv.some((argument) => argument.endsWith(".live.test.ts"));
 
 export default defineConfig({
   test: {
@@ -21,9 +22,9 @@ export default defineConfig({
         test: {
           ...common,
           name: "pr",
-          // Naming convention: *.e2e.test.ts drives the app/Den; every other test must be app-less.
+          // Live specs are attached-system incident signals: exclude them unless explicitly named.
           include: ["specs/**/*.test.ts"],
-          exclude: ["**/*.e2e.test.ts"],
+          exclude: ["**/*.e2e.test.ts", ...(namedLiveSpec ? [] : ["**/*.live.test.ts"])],
         },
       },
       {


### PR DESCRIPTION
## What

Introduces the **live lane**: specs that run against an *attached live substrate* (production/staging Den) instead of a launched, world-owned one.

- Naming: `*.live.test.ts`. Two axes classify specs: **surface** (`.e2e` = app-driving) × **substrate** (`live` = attached shared system). Red in this lane means *the service is wrong* (incident signal), never *your diff is wrong* — so live specs are excluded from the default PR and E2E suites (`evals/vitest.config.ts`) and run only by explicit name with consent env (`OPENWORK_EVAL_LIVE=1`).
- First spec: `prod-den-signup-invites.live.test.ts` — the complete real-user journey against `api.openworklabs.com`, with the email round-trip done through AgentMail inboxes created per run (`AGENTMAIL_API_KEY` from Infisical; missing key ⇒ named skip).
- Ownership law: the prod Den is attached (never owned); the user, org, invites, and mail inboxes are launched onto it (owned → deleted in `finally`; residue documented).
- README: `live` glossary entry, lane rules, run command, residue policy.

## Verdict: **Passed** — all claims asserted in-run against production

- **C1** — fresh sign-up with a run-scoped AgentMail address; verification email delivered; OTP completed; sign-in succeeds; wrong password rejected (401).
- **C2** — org created; two members invited; **invitation email delivery asserted** by receipt in the invitee's AgentMail inbox; roster is exactly the two invitees; a never-invited address is absent; the account's org list contains only the run's org.
- **C3** — org deleted on dispose; org list restored to pre-run baseline; AgentMail inboxes deleted.

Run: `2026-08-24T12-34-17-789Z-…` at head `0ac76bc72`. Evidence: sticky comment below.

Invocation:
```
infisical run -- sh -c 'OPENWORK_EVAL_LIVE=1 OPENWORK_EVAL_LIVE_DEN_API_URL=https://api.openworklabs.com pnpm evals:pr specs/prod-den-signup-invites.live.test.ts'
```

## Facts about prod this lane surfaced on the way

1. Better Auth password length ceiling (400 `password_too_long`).
2. Auth routes enforce origin headers (403 `INVALID_ORIGIN`).
3. Email verification is required before a session works (`EMAIL_NOT_VERIFIED`) — the wall this spec now crosses legitimately.
4. den-api does not enable Better Auth self-service account deletion — so each green run retains one inert, timestamped prod account (this run: `openwork-live-20260824123417808-owner@agentmail.to`; zero orgs/invites). Enabling scoped self-deletion would let this lane run residue-free — noted as a follow-up.
5. AgentMail org inbox limits exist; the spec now uses two inboxes + an alias for m2.

## Non-live verification

lint:layers clean · tsc baseline unchanged (35 pre-existing) · lane exclusion proven both directions (default suites don't collect `*.live.test.ts`; named invocation runs it; missing env ⇒ named skip).