### PR TITLE
fix(den-api): clear stale login session cookie

### DIFF
--- a/ee/apps/den-api/src/auth-login-options.ts
+++ b/ee/apps/den-api/src/auth-login-options.ts
@@ -5,6 +5,14 @@ export type LoginOptionAccount = {
   hasPassword: boolean
 }
 
+const BETTER_AUTH_SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token"
+
+export function buildLoginOptionsSessionCookieClearHeaders(cookieDomain?: string) {
+  const expiredCookie = `${BETTER_AUTH_SECURE_SESSION_COOKIE}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`
+  const normalizedDomain = cookieDomain?.trim().toLowerCase()
+  return normalizedDomain ? [`${expiredCookie}; Domain=${normalizedDomain}`, expiredCookie] : [expiredCookie]
+}
+
 export function normalizeLoginEmail(email: string) {
   return email.trim().toLowerCase()
 }

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -7,7 +7,7 @@ import type { Context } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth, DEN_MCP_OAUTH_RESOURCE, normalizeMcpOAuthResource } from "../../auth.js"
-import { normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
+import { buildLoginOptionsSessionCookieClearHeaders, normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
 import { verifyBotProtection } from "../../bot-protection.js"
 import {
   EMAIL_PASSWORD_SIGN_UP_PATH,
@@ -815,6 +815,9 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
     queryValidator(loginOptionsQuerySchema),
     async (c) => {
       const { email, invite } = c.req.valid("query")
+      for (const cookie of buildLoginOptionsSessionCookieClearHeaders(env.betterAuthCookieDomain)) {
+        c.header("Set-Cookie", cookie, { append: true })
+      }
       const botProtection = await verifyBotProtection()
       if (!botProtection.ok) {
         return c.json({

--- a/ee/apps/den-api/test/auth-login-options.test.ts
+++ b/ee/apps/den-api/test/auth-login-options.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "bun:test"
-import { normalizeLoginEmail, resolveLoginOptionKind } from "../src/auth-login-options.js"
+import { buildLoginOptionsSessionCookieClearHeaders, normalizeLoginEmail, resolveLoginOptionKind } from "../src/auth-login-options.js"
+
+test("login option response clears stale secure Better Auth session cookies", () => {
+  expect(buildLoginOptionsSessionCookieClearHeaders("app.example.com")).toEqual([
+    "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
+    "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
+  ])
+})
 
 test("login option resolution normalizes email input", () => {
   expect(normalizeLoginEmail(" User@Example.COM ")).toBe("user@example.com")

--- a/ee/apps/den-api/test/sso-resolve-route.test.ts
+++ b/ee/apps/den-api/test/sso-resolve-route.test.ts
@@ -154,6 +154,7 @@ test("login-options also requires BotID before deterministic auth-method routing
     error: "bot_verification_failed",
     message: "Request verification failed.",
   })
+  expect(response.headers.getSetCookie()).toContain("__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax")
 })
 
 test("login-options returns SSO as the first step for verified SSO domains", async () => {


### PR DESCRIPTION
## Summary\n- expire stale __Secure-better-auth.session_token cookies on the login-options response\n- clear both domain-scoped and host-only variants before deterministic login routing\n- add focused coverage for the cookie cleanup helper and login-options route\n\n## Tests\n- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/auth-login-options.test.ts test/sso-resolve-route.test.ts\n- git diff --check