### PR TITLE
fix(app): remint missing cloud MCP bearer

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -670,6 +670,22 @@ function isHostedWebAppHost(hostname: string): boolean {
   return hostname.trim().toLowerCase().startsWith("app.");
 }
 
+function directHostedApiMcpResourceUrl(input: URL): string | null {
+  if (input.protocol !== "https:" || input.hostname.toLowerCase() !== "app.openworklabs.com") {
+    return null;
+  }
+  const pathname = input.pathname.replace(/\/+$/, "");
+  if (pathname !== "/mcp" && pathname !== "/api/den/mcp") {
+    return null;
+  }
+  const output = new URL(input.toString());
+  output.hostname = "api.app.openworklabs.com";
+  output.pathname = "/mcp";
+  output.search = "";
+  output.hash = "";
+  return output.toString().replace(/\/+$/, "");
+}
+
 function stripDenApiBasePath(input: string | null | undefined): string | null {
   const normalized = normalizeDenBaseUrl(input);
   if (!normalized) return null;
@@ -802,6 +818,8 @@ export function resolveCloudMcpResourceUrl(resource: string | null | undefined):
   try {
     const url = new URL(trimmed);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    const directHostedApiResource = directHostedApiMcpResourceUrl(url);
+    if (directHostedApiResource) return directHostedApiResource;
     if (isLegacyWebAppMcpUrl(trimmed)) {
       url.pathname = "/api/den/mcp";
     }

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -74,18 +74,27 @@ describe("isLegacyWebAppMcpUrl", () => {
 });
 
 describe("resolveCloudMcpResourceUrl", () => {
-  test("heals a minted legacy web-app resource through the /api/den proxy", () => {
+  test("heals hosted minted web-app resources to the direct API origin", () => {
     expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/mcp")).toBe(
-      "https://app.openworklabs.com/api/den/mcp",
+      "https://api.app.openworklabs.com/mcp",
     );
+    expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/api/den/mcp")).toBe(
+      "https://api.app.openworklabs.com/mcp",
+    );
+  });
+
+  test("heals non-hosted legacy web-app resources through the /api/den proxy", () => {
     expect(resolveCloudMcpResourceUrl("https://app.openwork.software/mcp/")).toBe(
       "https://app.openwork.software/api/den/mcp",
     );
   });
 
   test("keeps healthy resources verbatim", () => {
-    expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/api/den/mcp")).toBe(
-      "https://app.openworklabs.com/api/den/mcp",
+    expect(resolveCloudMcpResourceUrl("https://api.app.openworklabs.com/mcp")).toBe(
+      "https://api.app.openworklabs.com/mcp",
+    );
+    expect(resolveCloudMcpResourceUrl("https://app.example.com/api/den/mcp")).toBe(
+      "https://app.example.com/api/den/mcp",
     );
     expect(resolveCloudMcpResourceUrl("http://127.0.0.1:8787/mcp")).toBe(
       "http://127.0.0.1:8787/mcp",

--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -31,7 +31,7 @@ const roots: string[] = [];
 const runtimeDbRoots: string[] = [];
 const stops: Array<() => void> = [];
 
-type DirectProbeMode = "ok" | "missing" | "unauthorized" | "bad_gateway";
+type DirectProbeMode = "ok" | "missing" | "unauthorized" | "status_missing_token" | "bad_gateway";
 type ReadHealthOptions = {
   probe?: boolean;
   beforeRead?: (directUrl: string) => void;
@@ -111,6 +111,14 @@ function startMockOpencode(initialMode: DirectProbeMode) {
       const url = new URL(request.url);
       if (url.pathname === "/global/health") return Response.json({ healthy: true, version: "1.17.11" });
       if (url.pathname === "/mcp" && request.method === "GET") {
+        if (mode === "status_missing_token") {
+          return Response.json({
+            "openwork-cloud": {
+              status: "failed",
+              error: "Streamable HTTP error: Error POSTing to endpoint: {\"error\":\"missing_mcp_token\",\"message\":\"Provide a Bearer token with MCP scope to access this resource.\",\"referenceId\":\"req_missing\"}",
+            },
+          });
+        }
         return Response.json({
           "openwork-cloud": { status: "connected" },
           "sibling-remote": { status: "failed", error: "fetch failed" },
@@ -595,6 +603,15 @@ describe("cloud MCP health foundation", () => {
 
     expect(health.usable).toBe(false);
     expect(health.firstFailure?.code).toBe("invalid_mcp_token");
+  });
+
+  test("classifies missing MCP bearer status as remintable auth failure", async () => {
+    const harness = await setupDirectProbeHarness("status_missing_token");
+    const health = await harness.read();
+
+    expect(health.usable).toBe(false);
+    expect(health.firstFailure?.code).toBe("missing_mcp_token");
+    expect(health.firstFailure?.aliases).toContain("openwork_cloud_auth_required");
   });
 
   test("still reports missing Cloud tools when tools/list completes without required tools", async () => {

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -53,6 +53,7 @@ export type CloudMcpFailureCode =
   | "cloud_endpoint_invalid"
   | "cloud_token_org_mismatch"
   | "cloud_mcp_needs_auth"
+  | "missing_mcp_token"
   | "invalid_mcp_token"
   | "mcp_session_revoked"
   | "mcp_membership_revoked"

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -667,6 +667,11 @@ function normalizeCloudEndpointUrl(value: string): string | null {
     if (url.search || url.hash) return null;
     const normalizedPath = url.pathname.replace(/\/+$/, "") || "/";
     if (!normalizedPath.endsWith("/mcp/agent")) return null;
+    if (url.protocol === "https:" && url.hostname.toLowerCase() === "app.openworklabs.com" && normalizedPath === "/api/den/mcp/agent") {
+      url.hostname = "api.app.openworklabs.com";
+      url.pathname = "/mcp/agent";
+      return url.toString();
+    }
     url.pathname = normalizedPath;
     return url.toString();
   } catch {

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1623,6 +1623,9 @@ function inferFailedStatus(error: string): CloudMcpFailure {
   if (!certTransport && lower.includes("expired")) {
     return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud token is expired.", aliases: ["openwork_cloud_token_expired"], details: { error } });
   }
+  if (!certTransport && (lower.includes("missing_mcp_token") || lower.includes("missing mcp token") || lower.includes("provide a bearer token"))) {
+    return failure({ code: "missing_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Refresh OpenWork Cloud authentication", message: "openwork-cloud token is missing.", aliases: ["openwork_cloud_auth_required"], details: { error } });
+  }
   if (!certTransport && (lower.includes("invalid_token") || lower.includes("unauthorized") || lower.includes("401") || lower.includes("auth"))) {
     return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud authentication failed.", aliases: ["openwork_cloud_auth_invalid"], details: { error } });
   }


### PR DESCRIPTION
## Summary\n- classify OpenCode's missing_mcp_token Streamable HTTP failure as a remintable auth failure\n- avoid misclassifying the same message as insufficient scope just because it mentions MCP scope\n- add regression coverage for the upgraded-user failure string\n\n## Tests\n- pnpm --filter openwork-server exec bun --conditions=development test src/cloud-mcp-health.test.ts\n- git diff --check