### PR TITLE
fix(den): clear stale auth cookies before signin

### DIFF
--- a/ee/apps/den-api/src/auth-login-options.ts
+++ b/ee/apps/den-api/src/auth-login-options.ts
@@ -9,6 +9,61 @@ export function normalizeLoginEmail(email: string) {
   return email.trim().toLowerCase()
 }
 
+export const BETTER_AUTH_SESSION_COOKIE_NAMES = [
+  "__Secure-better-auth.session_token",
+  "better-auth.session_token",
+  "better-auth-session_token",
+] as const
+
+const EXPIRED_COOKIE_DATE = "Thu, 01 Jan 1970 00:00:00 GMT"
+
+function normalizeCookieDomain(domain: string | null | undefined) {
+  const normalized = domain?.trim().toLowerCase().replace(/^\.+/, "") ?? ""
+  return normalized || null
+}
+
+function expiredCookieHeader(name: string, domain: string | null) {
+  const attributes = [
+    `${name}=`,
+    "Path=/",
+    `Expires=${EXPIRED_COOKIE_DATE}`,
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ]
+
+  if (domain) {
+    attributes.push(`Domain=${domain}`)
+  }
+
+  return attributes.join("; ")
+}
+
+export function buildStaleBetterAuthSessionCookieClearHeaders(input: {
+  cookieDomain?: string | null
+  requestHost?: string | null
+}) {
+  const domains = new Set<string | null>([null])
+  const cookieDomain = normalizeCookieDomain(input.cookieDomain)
+  if (cookieDomain) {
+    domains.add(cookieDomain)
+  }
+
+  const requestHost = normalizeCookieDomain(input.requestHost?.split(":", 1)[0])
+  if (requestHost && requestHost !== cookieDomain) {
+    domains.add(requestHost)
+  }
+
+  const headers: string[] = []
+  for (const name of BETTER_AUTH_SESSION_COOKIE_NAMES) {
+    for (const domain of domains) {
+      headers.push(expiredCookieHeader(name, domain))
+    }
+  }
+  return headers
+}
+
 function normalizeProviderId(providerId: string) {
   return providerId.trim().toLowerCase()
 }

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -7,7 +7,7 @@ import type { Context } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth, DEN_MCP_OAUTH_RESOURCE, normalizeMcpOAuthResource } from "../../auth.js"
-import { normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
+import { buildStaleBetterAuthSessionCookieClearHeaders, normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
 import { verifyBotProtection } from "../../bot-protection.js"
 import {
   EMAIL_PASSWORD_SIGN_UP_PATH,
@@ -855,6 +855,12 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
       const allowPublicSignup = env.orgMode !== "single_org" || env.singleOrg.allowPublicSignup
       const allowInvitationSignup = !requirement && await hasPendingInvitationForEmail(invite, email)
       const nextStep = resolveLoginOptionKind({ requireSso: Boolean(requirement), accounts, allowNewAccount: allowPublicSignup || allowInvitationSignup })
+      for (const cookie of buildStaleBetterAuthSessionCookieClearHeaders({
+        cookieDomain: env.betterAuthCookieDomain,
+        requestHost: c.req.raw.headers.get("host"),
+      })) {
+        c.header("Set-Cookie", cookie, { append: true })
+      }
 
       if (nextStep === "sso" && requirement) {
         return c.json({

--- a/ee/apps/den-api/test/auth-login-options.test.ts
+++ b/ee/apps/den-api/test/auth-login-options.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { normalizeLoginEmail, resolveLoginOptionKind } from "../src/auth-login-options.js"
+import { buildStaleBetterAuthSessionCookieClearHeaders, normalizeLoginEmail, resolveLoginOptionKind } from "../src/auth-login-options.js"
 
 test("login option resolution normalizes email input", () => {
   expect(normalizeLoginEmail(" User@Example.COM ")).toBe("user@example.com")
@@ -48,4 +48,17 @@ test("login option resolution keeps private single-org unknown users in sign-in"
     accounts: [],
     allowNewAccount: false,
   })).toBe("password")
+})
+
+test("login option cookie cleanup expires secure, legacy, domain, and host-only session cookies", () => {
+  const headers = buildStaleBetterAuthSessionCookieClearHeaders({
+    cookieDomain: ".app.openworklabs.com",
+    requestHost: "api.app.openworklabs.com",
+  })
+
+  expect(headers).toContain("__Secure-better-auth.session_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax")
+  expect(headers).toContain("__Secure-better-auth.session_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax; Domain=app.openworklabs.com")
+  expect(headers).toContain("__Secure-better-auth.session_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax; Domain=api.app.openworklabs.com")
+  expect(headers.some((header) => header.startsWith("better-auth.session_token="))).toBe(true)
+  expect(headers.some((header) => header.startsWith("better-auth-session_token="))).toBe(true)
 })

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -222,6 +222,7 @@ declare global {
 }
 
 export const LAST_WORKER_STORAGE_KEY = "openwork:web:last-worker";
+export const PENDING_SOCIAL_AUTH_STORAGE_KEY = "openwork:web:pending-social-auth";
 export const PENDING_SOCIAL_SIGNUP_STORAGE_KEY = "openwork:web:pending-social-signup";
 export const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
 export const ONBOARDING_INTENT_STORAGE_KEY = "openwork:web:onboarding-intent";
@@ -346,6 +347,28 @@ export function getSocialCallbackUrl(authCallbackBaseUrl = ""): string {
       }
     }
     return typeof window !== "undefined" ? `${window.location.origin}/` : "/";
+  }
+}
+
+export function shouldDelaySessionHydrationForAuthRedirect(input: {
+  pathname: string;
+  search: string;
+  pendingSocialAuth: string | null;
+}): boolean {
+  return input.pathname === "/" && input.search === "" && (input.pendingSocialAuth === "github" || input.pendingSocialAuth === "google");
+}
+
+export function waitForAuthRedirectCookieSettlement(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, 350);
+  });
+}
+
+export async function clearStaleAuthCookiesBeforeSignIn(): Promise<void> {
+  try {
+    await requestJson("/api/auth/clear-stale-cookies", { method: "POST", credentials: "include" }, 3000);
+  } catch {
+    // Cookie cleanup is best-effort. The sign-in attempt should still proceed.
   }
 }
 

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_AUTH_NAME,
   DEFAULT_WORKER_NAME,
   LAST_WORKER_STORAGE_KEY,
+  PENDING_SOCIAL_AUTH_STORAGE_KEY,
   ONBOARDING_INTENT_STORAGE_KEY,
   PENDING_SOCIAL_SIGNUP_STORAGE_KEY,
   WORKER_STATUS_POLL_MS,
@@ -25,6 +26,7 @@ import {
   type WorkerStatusBucket,
   buildOpenworkAppConnectUrl,
   buildOpenworkDeepLink,
+  clearStaleAuthCookiesBeforeSignIn,
   deriveOnboardingWorkerName,
   getAuthInfoForMode,
   getBillingSummary,
@@ -53,7 +55,9 @@ import {
   requestJson,
   resetPosthogUser,
   resolveOpenworkWorkspaceUrl,
-  trackPosthogEvent
+  shouldDelaySessionHydrationForAuthRedirect,
+  trackPosthogEvent,
+  waitForAuthRedirectCookieSettlement
 } from "../_lib/den-flow";
 import { EMPTY_RUNTIME_CONFIG, getRuntimeConfig, type DenWebRuntimeConfig } from "../_lib/runtime-config";
 import {
@@ -1196,6 +1200,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       if (trimmedEmail && await redirectToRequiredSso(trimmedEmail)) {
         return null;
       }
+      await clearStaleAuthCookiesBeforeSignIn();
       const endpoint = submitMode === "sign-up" && pendingInvitationId
         ? `/api/auth/sign-up/email?invite=${encodeURIComponent(pendingInvitationId)}`
         : submitMode === "sign-up"
@@ -1272,6 +1277,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     const shouldTrackSocialSignup = authMode === "sign-up";
+    window.sessionStorage.setItem(PENDING_SOCIAL_AUTH_STORAGE_KEY, provider);
     if (shouldTrackSocialSignup) {
       window.sessionStorage.setItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY, provider);
     }
@@ -1288,11 +1294,13 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     try {
       const trimmedEmail = email.trim();
       if (trimmedEmail && await redirectToRequiredSso(trimmedEmail)) {
+        window.sessionStorage.removeItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
         if (shouldTrackSocialSignup) {
           window.sessionStorage.removeItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY);
         }
         return;
       }
+      await clearStaleAuthCookiesBeforeSignIn();
       const latestRuntimeConfig = await getRuntimeConfig();
       setRuntimeConfig(latestRuntimeConfig);
       const callbackURL = getSocialCallbackUrl(latestRuntimeConfig.openworkAuthCallbackUrl);
@@ -1306,6 +1314,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       });
 
       if (!response.ok) {
+        window.sessionStorage.removeItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
         if (shouldTrackSocialSignup) {
           window.sessionStorage.removeItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY);
         }
@@ -1321,6 +1330,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       const redirectUrl = payloadUrl || headerUrl;
 
       if (!redirectUrl) {
+        window.sessionStorage.removeItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
         if (shouldTrackSocialSignup) {
           window.sessionStorage.removeItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY);
         }
@@ -1332,6 +1342,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
       window.location.assign(redirectUrl);
     } catch (error) {
+      window.sessionStorage.removeItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
       if (shouldTrackSocialSignup) {
         window.sessionStorage.removeItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY);
       }
@@ -1938,8 +1949,21 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     const hydrateSession = async () => {
       try {
+        const pendingSocialAuth = typeof window === "undefined"
+          ? null
+          : window.sessionStorage.getItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
+        if (typeof window !== "undefined" && shouldDelaySessionHydrationForAuthRedirect({
+          pathname: window.location.pathname,
+          search: window.location.search,
+          pendingSocialAuth,
+        })) {
+          await waitForAuthRedirectCookieSettlement();
+        }
         await refreshSession(true);
       } finally {
+        if (typeof window !== "undefined") {
+          window.sessionStorage.removeItem(PENDING_SOCIAL_AUTH_STORAGE_KEY);
+        }
         if (!cancelled) {
           setSessionHydrated(true);
         }

--- a/ee/apps/den-web/app/api/auth/clear-stale-cookies/route.ts
+++ b/ee/apps/den-web/app/api/auth/clear-stale-cookies/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { readPublicWebOrigin } from "../../../_lib/public-web-origin";
+
+export const dynamic = "force-dynamic";
+
+const BETTER_AUTH_SESSION_COOKIE_NAMES = [
+  "__Secure-better-auth.session_token",
+  "better-auth.session_token",
+  "better-auth-session_token",
+] as const;
+const POSTHOG_COOKIE_PREFIX = "ph_phc_";
+const EXPIRED_COOKIE_DATE = "Thu, 01 Jan 1970 00:00:00 GMT";
+
+function normalizeCookieDomain(domain: string | null | undefined): string | null {
+  const normalized = domain?.trim().toLowerCase().replace(/^\.+/, "") ?? "";
+  return normalized || null;
+}
+
+function requestPublicHostname(request: NextRequest): string | null {
+  const configuredOrigin = readPublicWebOrigin();
+  if (configuredOrigin) {
+    try {
+      return normalizeCookieDomain(new URL(configuredOrigin).hostname);
+    } catch {}
+  }
+
+  return normalizeCookieDomain(new URL(request.url).hostname);
+}
+
+function expiredCookieHeader(name: string, domain: string | null): string {
+  const attributes = [
+    `${name}=`,
+    "Path=/",
+    `Expires=${EXPIRED_COOKIE_DATE}`,
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ];
+  if (domain) attributes.push(`Domain=${domain}`);
+  return attributes.join("; ");
+}
+
+function staleCookieNames(request: NextRequest): string[] {
+  const names = new Set<string>(BETTER_AUTH_SESSION_COOKIE_NAMES);
+  for (const cookie of request.cookies.getAll()) {
+    if (cookie.name.startsWith(POSTHOG_COOKIE_PREFIX)) {
+      names.add(cookie.name);
+    }
+  }
+  return [...names];
+}
+
+export async function POST(request: NextRequest) {
+  const response = NextResponse.json({ ok: true });
+  const domains = new Set<string | null>([null]);
+  const hostname = requestPublicHostname(request);
+  if (hostname) domains.add(hostname);
+
+  for (const name of staleCookieNames(request)) {
+    for (const domain of domains) {
+      response.headers.append("Set-Cookie", expiredCookieHeader(name, domain));
+    }
+  }
+
+  return response;
+}

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin } from "../app/(den)/_lib/den-api-origin";
+import { shouldDelaySessionHydrationForAuthRedirect } from "../app/(den)/_lib/den-flow";
 
 describe("Den API browser origin", () => {
   test("prefixes the hosted app origin with the api subdomain", () => {
@@ -38,5 +39,28 @@ describe("Den API browser origin", () => {
       "https://app.openworklabs.com",
       "/v1/orgs/sso/resolve?email=omar%40openworklabs.com",
     )).toBe("omit");
+  });
+
+  test("delays the root session check only while returning from social auth", () => {
+    expect(shouldDelaySessionHydrationForAuthRedirect({
+      pathname: "/",
+      search: "",
+      pendingSocialAuth: "google",
+    })).toBe(true);
+    expect(shouldDelaySessionHydrationForAuthRedirect({
+      pathname: "/dashboard",
+      search: "",
+      pendingSocialAuth: "google",
+    })).toBe(false);
+    expect(shouldDelaySessionHydrationForAuthRedirect({
+      pathname: "/",
+      search: "?desktopAuth=1",
+      pendingSocialAuth: "google",
+    })).toBe(false);
+    expect(shouldDelaySessionHydrationForAuthRedirect({
+      pathname: "/",
+      search: "",
+      pendingSocialAuth: null,
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- clear stale Better Auth session cookies across host-only/domain and legacy cookie names before sign-in
- add a same-origin Den Web cleanup endpoint that also expires stale ph_phc PostHog cookies present during sign-in
- delay the root / session hydration check briefly after social auth redirects so callback cookies can settle before /v1/me

## Tests
- pnpm --filter @openwork-ee/den-api exec bun test test/auth-login-options.test.ts
- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/den-api-origin.test.ts
- pnpm --filter @openwork-ee/den-web typecheck
- pnpm --filter @openwork-ee/den-api run build:mcp-apps && pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false