### PR TITLE
fix(den-api): preserve legacy MCP callback URLs

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -32,7 +32,7 @@ import {
   externalMcpIdentityBinding,
   type ExternalMcpConnectionRow,
 } from "./external-mcp-connections.js"
-import { externalMcpCallbackUrl } from "./external-mcp-oauth-contract.js"
+import { externalMcpCallbackUrl, externalMcpCompatibleCallbackUrl } from "./external-mcp-oauth-contract.js"
 import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
 
 const MAX_PENDING_AUTHORIZATIONS = 8
@@ -232,12 +232,15 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
       const registeredRedirectUri = typeof extra?.registeredRedirectUri === "string"
         ? extra.registeredRedirectUri
         : undefined
-      const currentRedirectUri = externalMcpCallbackUrl({
+      const currentRedirectUri = externalMcpCompatibleCallbackUrl({
         connectionId: this.connection.id,
         callbackMode: this.connection.oauthConfiguration?.callbackMode ?? "legacy-v1",
+        createdAt: this.connection.createdAt,
+        registeredRedirectUri,
       })
       if (
         extra?.enterpriseMcpRegistrationSource === "pre-registered"
+        && registeredRedirectUri !== undefined
         && registeredRedirectUri !== currentRedirectUri
       ) {
         throw new EnterpriseMcpOAuthContractError(

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -32,7 +32,7 @@ import {
   externalMcpIdentityBinding,
   type ExternalMcpConnectionRow,
 } from "./external-mcp-connections.js"
-import { externalMcpCallbackUrl, externalMcpCompatibleCallbackUrl } from "./external-mcp-oauth-contract.js"
+import { externalMcpCompatibleCallbackUrl } from "./external-mcp-oauth-contract.js"
 import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
 
 const MAX_PENDING_AUTHORIZATIONS = 8
@@ -264,6 +264,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
     save: async (input: {
       context: EnterpriseMcpPersistenceContext
       clientInformation: OAuthClientInformationMixed
+      redirectUri: string
       expiresAt?: number
       source: "client-metadata" | "dynamic"
     }): Promise<EnterpriseMcpOAuthClientRegistration> => {
@@ -300,10 +301,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
             clientInformation: safeClientInformation(input.clientInformation),
             enterpriseMcpRegistrationSource: input.source,
             registrationContractVersion: 2,
-            registeredRedirectUri: externalMcpCallbackUrl({
-              connectionId: this.connection.id,
-              callbackMode: this.connection.oauthConfiguration?.callbackMode ?? "legacy-v1",
-            }),
+            registeredRedirectUri: input.redirectUri,
             authorizationServerIssuer: this.connection.oauthConfiguration?.authorizationServerIssuer ?? undefined,
           },
           createdByOrgMembershipId: this.connection.createdByOrgMembershipId,

--- a/ee/apps/den-api/src/capability-sources/external-mcp-oauth-contract.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-oauth-contract.ts
@@ -1,6 +1,8 @@
 import type { ExternalMcpOAuthCallbackMode } from "@openwork-ee/den-db/schema"
 import { env } from "../env.js"
 
+export const HOSTED_MCP_CALLBACK_MIGRATION_CUTOFF = new Date("2026-08-24T00:01:00.000Z")
+
 function configuredPublicApiBaseUrl(): string {
   if (!env.apiPublicUrl) {
     throw new Error("DEN_API_PUBLIC_URL must be configured before external MCP OAuth can start.")
@@ -20,6 +22,60 @@ export function externalMcpSharedCallbackUrl(): string {
 
 export function externalMcpLegacyCallbackUrl(connectionId: string): string {
   return publicApiUrl(`/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/callback`)
+}
+
+function hostedWebProxyUrl(pathname: string): string {
+  const url = new URL(`/api/den${pathname}`, env.betterAuthUrl)
+  return url.toString()
+}
+
+function usesHostedDirectApiMigration(): boolean {
+  if (!env.apiPublicUrl) return false
+  const web = new URL(env.betterAuthUrl)
+  const api = new URL(env.apiPublicUrl)
+  return web.protocol === "https:"
+    && api.protocol === "https:"
+    && web.hostname === "app.openworklabs.com"
+    && (api.hostname === "api.app.openworklabs.com" || api.hostname === "api.openworklabs.com")
+}
+
+export function externalMcpHostedWebProxyCallbackUrl(input: {
+  connectionId: string
+  callbackMode: ExternalMcpOAuthCallbackMode
+}): string {
+  return input.callbackMode === "shared-v1"
+    ? hostedWebProxyUrl("/v1/mcp-connections/oauth/callback")
+    : hostedWebProxyUrl(`/v1/mcp-connections/${encodeURIComponent(input.connectionId)}/connect/callback`)
+}
+
+function validAbsoluteUrl(value: string | null | undefined): string | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+export function externalMcpCompatibleCallbackUrl(input: {
+  connectionId: string
+  callbackMode: ExternalMcpOAuthCallbackMode
+  createdAt: Date
+  registeredRedirectUri?: string | null
+}): string {
+  // The provider's OAuth app registration is authoritative for reconnects: if
+  // Den recorded the redirect URI used when the client was registered, keep
+  // sending that exact URI through authorize and token exchange.
+  const registered = validAbsoluteUrl(input.registeredRedirectUri)
+  if (registered) return registered
+  // Rows created before the hosted Den API split may not have a recorded client
+  // redirect. Keep those on the old app/proxy callback so existing provider
+  // allowlists continue to work, while new rows use the direct API callback.
+  if (input.createdAt.getTime() < HOSTED_MCP_CALLBACK_MIGRATION_CUTOFF.getTime() && usesHostedDirectApiMigration()) {
+    return externalMcpHostedWebProxyCallbackUrl(input)
+  }
+  return externalMcpCallbackUrl(input)
 }
 
 export function externalMcpCallbackUrl(input: {

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -77,6 +77,7 @@ import { getConnectedAccount, getOrgOAuthClient, upsertOrgOAuthClient } from "..
 import { assertPublicUrl, createGuardedFetch, createRealmSafeFetch } from "../../capability-sources/url-guard.js"
 import {
   externalMcpCallbackUrl,
+  externalMcpCompatibleCallbackUrl,
   externalMcpClientMetadataUrl,
   externalMcpSharedCallbackUrl,
 } from "../../capability-sources/external-mcp-oauth-contract.js"
@@ -542,7 +543,7 @@ function memberConnectLinks(connection: ExternalMcpConnectionRow) {
     yourConnections: yourConnections.toString(),
     oauthCallback: connection.kind === "native_provider" && connection.nativeProviderKey
       ? nativeProviderCallbackUrl(connection.nativeProviderKey)
-      : callbackRedirectUri(connection),
+      : callbackRedirectUriWithClient(connection, null),
   }
 }
 
@@ -961,6 +962,31 @@ function oauthRegistrationSourceForClient(
   return oauthClient ? "pre-registered" : null
 }
 
+function registeredRedirectUriForClient(oauthClient: Awaited<ReturnType<typeof getOrgOAuthClient>>): string | null {
+  const registeredRedirectUri = oauthClient?.extra?.registeredRedirectUri
+  return typeof registeredRedirectUri === "string" ? registeredRedirectUri : null
+}
+
+function callbackRedirectUriWithClient(
+  connection: ExternalMcpConnectionRow,
+  oauthClient: Awaited<ReturnType<typeof getOrgOAuthClient>>,
+) {
+  if (connection.authType !== "oauth") return "http://127.0.0.1/unused-mcp-oauth-callback"
+  return externalMcpCompatibleCallbackUrl({
+    connectionId: connection.id,
+    callbackMode: connection.oauthConfiguration?.callbackMode ?? "legacy-v1",
+    createdAt: connection.createdAt,
+    registeredRedirectUri: registeredRedirectUriForClient(oauthClient),
+  })
+}
+
+async function callbackRedirectUri(connection: ExternalMcpConnectionRow) {
+  const oauthClient = connection.authType === "oauth"
+    ? await getOrgOAuthClient(connection.organizationId, connection.id)
+    : null
+  return callbackRedirectUriWithClient(connection, oauthClient)
+}
+
 async function toConnectionResponse(
   row: ExternalMcpConnectionRow,
   options: {
@@ -1081,7 +1107,7 @@ async function toConnectionResponse(
       oauthCallbackUrl: row.authType === "oauth"
         ? row.kind === "native_provider" && row.nativeProviderKey
           ? nativeProviderCallbackUrl(row.nativeProviderKey)
-          : externalMcpCallbackUrl({ connectionId: row.id, callbackMode: callbackMode ?? "legacy-v1" })
+          : callbackRedirectUriWithClient(row, oauthClient)
         : null,
       oauthSharedCallbackUrl: row.kind === "external_mcp" && row.authType === "oauth" ? externalMcpSharedCallbackUrl() : null,
       oauthClientMetadataUrl: row.kind === "external_mcp" && row.authType === "oauth" ? externalMcpClientMetadataUrl() : null,
@@ -1144,14 +1170,6 @@ export async function listMemberUsableConnectionFacts(input: {
     teamIds,
   })
   return [...nativeEntries, ...connections]
-}
-
-function callbackRedirectUri(connection: ExternalMcpConnectionRow) {
-  if (connection.authType !== "oauth") return "http://127.0.0.1/unused-mcp-oauth-callback"
-  return externalMcpCallbackUrl({
-    connectionId: connection.id,
-    callbackMode: connection.oauthConfiguration?.callbackMode ?? "legacy-v1",
-  })
 }
 
 function invalidMcpOAuthCallback(message: string): Response {
@@ -1348,7 +1366,7 @@ async function handleExternalMcpOAuthCallback(input: {
     await completeAuthorization(
       connection,
       code,
-      externalMcpCallbackUrl({ connectionId: connection.id, callbackMode }),
+      await callbackRedirectUri(connection),
       member,
       input.requestId,
       state,
@@ -1811,7 +1829,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       try {
         const tools = await listExternalMcpTools(
           connection,
-          callbackRedirectUri(connection),
+          await callbackRedirectUri(connection),
           credential.member,
           c.get("requestId"),
         )
@@ -1928,7 +1946,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       try {
         const inspected = await inspectExternalMcpToolCall({
           connection,
-          redirectUri: callbackRedirectUri(connection),
+          redirectUri: await callbackRedirectUri(connection),
           toolName,
           args: toolArguments,
           member: credential.member,
@@ -2117,7 +2135,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       if (body.authType !== "oauth") {
         // No OAuth dance needed — validate the server is real and reachable now.
         try {
-          await connectExternalMcp(created, callbackRedirectUri(created), undefined, undefined, c.get("requestId"))
+          await connectExternalMcp(created, await callbackRedirectUri(created), undefined, undefined, c.get("requestId"))
           // OAuth records a successful connection while persisting tokens.
           // A no-auth server has no token write, so retain the successful
           // initialize probe explicitly for readiness and catalog discovery.
@@ -2329,7 +2347,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         try {
           await connectExternalMcp(
             proposedConnection,
-            callbackRedirectUri(proposedConnection),
+            await callbackRedirectUri(proposedConnection),
             undefined,
             undefined,
             c.get("requestId"),
@@ -2708,7 +2726,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           })
           const result = await connectExternalMcp(
             target,
-            callbackRedirectUri(target),
+            await callbackRedirectUri(target),
             signedState,
             member,
             c.get("requestId"),
@@ -2829,7 +2847,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           return c.json({
             error: "mcp_oauth_configuration_required",
             message: "This authorization server requires a pre-registered OAuth client before OpenWork can connect.",
-            callbackUrl: callbackRedirectUri(connection),
+            callbackUrl: await callbackRedirectUri(connection),
             clientMetadataUrl: externalMcpClientMetadataUrl(),
             manualRequirements: [
               "Create an OAuth application in the external provider.",

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -356,6 +356,7 @@ test("callback isolation replaces SDK registration state and exposes the scoped 
 test("connect start keeps the shared callback for a pre-registered confidential client without response issuer support", async () => {
   let origin = ""
   let expectedCodeChallenge = ""
+  let expectedRedirectUri = ""
   let initializeRequests = 0
   let toolsListRequests = 0
   const server = Bun.serve({
@@ -387,6 +388,7 @@ test("connect start keeps the shared callback for a pre-registered confidential 
         expect(form.get("client_secret")).toBe("confidential-secret")
         expect(form.get("grant_type")).toBe("authorization_code")
         expect(form.get("code")).toBe("shared-authorization-code")
+        expect(form.get("redirect_uri")).toBe(expectedRedirectUri)
         expect(form.get("resource")).toBe(`${origin}/mcp`)
         const verifier = form.get("code_verifier")
         expect(verifier?.length).toBeGreaterThanOrEqual(43)
@@ -453,10 +455,8 @@ test("connect start keeps the shared callback for a pre-registered confidential 
       createdByOrgMembershipId: memberId,
       access: { orgWide: true, memberIds: [], teamIds: [] },
     })
-    const sharedCallback = new URL(
-      "/v1/mcp-connections/oauth/callback",
-      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
-    ).toString()
+    const sharedCallback = "https://app.openworklabs.com/api/den/v1/mcp-connections/oauth/callback"
+    expectedRedirectUri = sharedCallback
     await upsertOrgOAuthClient({
       organizationId,
       providerId: connection.id,
@@ -506,7 +506,13 @@ test("connect start keeps the shared callback for a pre-registered confidential 
       ? pendingAuthorizations.transactions
       : []).toHaveLength(1)
 
-    const callbackUrl = new URL(sharedCallback)
+    // The provider redirects to the legacy app/proxy callback. Den Web forwards
+    // that browser request to this direct API route, but token exchange must
+    // still send the original registered redirect_uri.
+    const callbackUrl = new URL(
+      "/v1/mcp-connections/oauth/callback",
+      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
+    )
     callbackUrl.searchParams.set("code", "shared-authorization-code")
     callbackUrl.searchParams.set("state", signedState)
     const callbackResponse = await app.fetch(new Request(callbackUrl))

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -505,6 +505,7 @@ test("connect start keeps the shared callback for a pre-registered confidential 
     expect(isRecord(pendingAuthorizations) && Array.isArray(pendingAuthorizations.transactions)
       ? pendingAuthorizations.transactions
       : []).toHaveLength(1)
+    expect((await getOrgOAuthClient(organizationId, connection.id))?.extra?.registeredRedirectUri).toBe(sharedCallback)
 
     // The provider redirects to the legacy app/proxy callback. Den Web forwards
     // that browser request to this direct API route, but token exchange must

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
 
+import { redirectToDenApi } from "../app/api/_lib/den-api-redirect";
 import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin } from "../app/(den)/_lib/den-api-origin";
 
 describe("Den API browser origin", () => {
@@ -17,6 +19,17 @@ describe("Den API browser origin", () => {
 
   test("builds direct API URLs instead of same-origin Den proxy URLs", () => {
     expect(denApiEndpointForWebOrigin("/v1/me", "https://app.openworklabs.com")).toBe("https://api.app.openworklabs.com/v1/me");
+  });
+
+  test("redirects legacy app/proxy MCP callbacks to the direct API callback path", () => {
+    const request = new NextRequest(
+      "https://app.openworklabs.com/api/den/v1/mcp-connections/oauth/callback?code=abc&state=opaque",
+    );
+    const response = redirectToDenApi(request, "/api/den");
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://api.app.openworklabs.com/v1/mcp-connections/oauth/callback?code=abc&state=opaque",
+    );
   });
 
   test("keeps Better Auth traffic on the same-origin auth proxy", () => {

--- a/packages/enterprise-mcp-client/src/contracts.ts
+++ b/packages/enterprise-mcp-client/src/contracts.ts
@@ -46,6 +46,8 @@ export interface EnterpriseMcpOAuthClientRegistrationPort {
   save(input: {
     context: EnterpriseMcpPersistenceContext
     clientInformation: OAuthClientInformationMixed
+    /** The redirect URI used for this client registration attempt. */
+    redirectUri: string
     expiresAt?: EnterpriseMcpEpochMs
     source: "client-metadata" | "dynamic"
   }): Promise<EnterpriseMcpOAuthClientRegistration>

--- a/packages/enterprise-mcp-client/src/oauth-provider.ts
+++ b/packages/enterprise-mcp-client/src/oauth-provider.ts
@@ -226,6 +226,7 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     const saved = await this.persistence.clientRegistrations.save({
       context: this.context(),
       clientInformation: validated,
+      redirectUri: this.redirectUri,
       expiresAt: clientExpiration(validated),
       source,
     })


### PR DESCRIPTION
## Summary
- Prefer each MCP OAuth client's stored registered redirect URI when reconnecting
- Fall back old hosted MCP connections created before 2026-08-24T00:01Z to the app/proxy callback URL
- Keep token exchange using the same callback URL and cover legacy app/proxy callback forwarding in Den Web tests

## Tests
- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/den-api-origin.test.ts
- pnpm --filter @openwork-ee/den-api build

Note: targeted Den API test could not run locally because the MySQL test database openwork_test_pr7 is not present in this environment.