### PR TITLE
feat(connect): support stateless MCP 2026

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "test": "node --test electron/after-pack-paths.test.mjs electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/blank-slate-profile.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-darwin.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/sentry.test.mjs electron/server-dependency-mirror.test.mjs electron/secure-vault-key.test.mjs electron/stdio-errors.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-archive.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.15",
     "@openwork/enterprise-mcp-client": "workspace:*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,6 +49,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.15",
     "@openwork/enterprise-mcp-client": "workspace:*",

--- a/apps/server/src/local-managed-mcp.e2e.test.ts
+++ b/apps/server/src/local-managed-mcp.e2e.test.ts
@@ -98,7 +98,7 @@ async function startOAuthProvider(port: number): Promise<string> {
   return baseUrl;
 }
 
-type HandshakeFailure = "oauth-client-registration" | "mcp-initialize" | "unexpected-sdk-failure";
+type HandshakeFailure = "oauth-client-registration" | "mcp-discovery" | "mcp-initialize" | "unexpected-sdk-failure";
 
 function startHandshakeFailureProvider(failure: HandshakeFailure): string {
   const nestedSecret = `${failure}-nested-secret`;
@@ -182,6 +182,12 @@ function startHandshakeFailureProvider(failure: HandshakeFailure): string {
         const body: unknown = await request.json().catch(() => null);
         const method = typeof body === "object" && body !== null && "method" in body ? body.method : null;
         const id = typeof body === "object" && body !== null && "id" in body ? body.id : null;
+        if (method === "server/discover" && failure === "mcp-discovery") {
+          return Response.json({
+            error: "provider_discovery_failed",
+            cause: { client_secret: nestedSecret },
+          }, { status: 503 });
+        }
         if (method === "initialize") {
           if (failure === "mcp-initialize") {
             return Response.json({
@@ -325,7 +331,7 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
     }
   });
 
-  test("returns safe connection errors for DCR reconnect and callback initialize failures", async () => {
+  test("returns safe connection errors for DCR and protocol negotiation failures", async () => {
     const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
     const previousDevMode = process.env.OPENWORK_DEV_MODE;
     const previousTelemetry = globalThis.__openworkDesktopTelemetry;
@@ -419,6 +425,43 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
         lastError: expectedMessage,
         hasCredential: false,
       });
+
+      const discoveryProvider = startHandshakeFailureProvider("mcp-discovery");
+      await createLocalManagedMcpConnection(config, {
+        workspaceId: "ws_managed",
+        name: "discovery-failure",
+        serverUrl: `${discoveryProvider}/mcp`,
+        oauth: { applicationType: "native", requestedScopes: ["mcp:read"] },
+      });
+      const discoveryStarted = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/discovery-failure/managed/connect`,
+        { method: "POST", headers: clientHeaders(config.token) },
+      );
+      expect(discoveryStarted.status).toBe(200);
+      const discoveryStartedBody: unknown = await discoveryStarted.json();
+      if (typeof discoveryStartedBody !== "object" || discoveryStartedBody === null
+        || !("authorizeUrl" in discoveryStartedBody) || typeof discoveryStartedBody.authorizeUrl !== "string") {
+        throw new Error("Expected an OAuth authorization URL.");
+      }
+      const discoveryAuthorization = await fetch(discoveryStartedBody.authorizeUrl, { redirect: "manual" });
+      expect(discoveryAuthorization.status).toBe(302);
+      const discoveryCallback = await fetch(discoveryAuthorization.headers.get("location")!);
+      expect(discoveryCallback.status).toBe(502);
+      const discoveryCallbackBody = await discoveryCallback.json();
+      expect(discoveryCallbackBody).toEqual({
+        code: "managed_mcp_connection_failed",
+        message: expectedMessage,
+      });
+      expect(JSON.stringify(discoveryCallbackBody)).not.toContain("mcp-discovery-nested-secret");
+      const discoveryStatus = await fetch(
+        `${openworkBaseUrl}/workspace/ws_managed/mcp/discovery-failure/managed`,
+        { headers: clientHeaders(config.token) },
+      );
+      expect(await discoveryStatus.json()).toMatchObject({
+        status: "reconnect_required",
+        lastError: expectedMessage,
+        hasCredential: false,
+      });
       expect(captured).toEqual([]);
 
       const internalProvider = startHandshakeFailureProvider("unexpected-sdk-failure");
@@ -442,7 +485,7 @@ describe("OpenWork-managed local MCP OAuth gateway", () => {
       expect(captured[0]).not.toBeInstanceOf(ApiError);
       expect(captured[0]).toMatchObject({
         code: "MCP_CONNECTION_HANDSHAKE_FAILED",
-        requestPhase: "mcp-initialize",
+        requestPhase: "mcp-discovery",
       });
     } finally {
       globalThis.__openworkDesktopTelemetry = previousTelemetry;

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -1022,7 +1022,9 @@ function errorCauseChain(error: unknown): unknown[] {
   for (let depth = 0; depth < 6 && current !== undefined && current !== null && !seen.has(current); depth += 1) {
     chain.push(current);
     seen.add(current);
-    current = isRecord(current) ? current.cause : undefined;
+    current = isRecord(current)
+      ? current.cause ?? (isRecord(current.data) ? current.data.cause : undefined)
+      : undefined;
   }
   return chain;
 }

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -9,10 +9,13 @@ import {
 } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import {
+  OAuthError,
+  RegistrationRejectedError,
+  SdkHttpError,
+} from "@modelcontextprotocol/client";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { OAuthError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { OAuthClientInformationMixed } from "@modelcontextprotocol/sdk/shared/auth.js";
 import {
@@ -164,6 +167,7 @@ const MANAGED_MCP_CONNECTION_FAILED_MESSAGE =
   "OpenWork could not connect to this MCP server. Check its OAuth settings and availability, then try again.";
 const EXTERNAL_HANDSHAKE_REQUEST_PHASES = new Set<EnterpriseMcpRequestPhase>([
   "oauth-client-registration",
+  "mcp-discovery",
   "mcp-initialize",
 ]);
 const vaultQueueByPath = new Map<string, Promise<void>>();
@@ -1028,7 +1032,9 @@ function hasConcreteRequestCause(error: EnterpriseMcpClientError, diagnostic: Co
   if (diagnostic.httpStatus !== undefined) {
     return diagnostic.httpStatus >= 400
       && diagnostic.httpStatus <= 599
-      && chain.some((cause) => cause instanceof OAuthError || cause instanceof StreamableHTTPError);
+      && chain.some((cause) => cause instanceof OAuthError
+        || cause instanceof RegistrationRejectedError
+        || cause instanceof SdkHttpError);
   }
   return chain.some((cause) => cause instanceof LocalManagedMcpPrivateUrlError
     || (cause instanceof TypeError && cause.message === "fetch failed")

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -37,6 +37,7 @@
     "@hono/standard-validator": "^0.2.2",
     "@hono/swagger-ui": "^0.6.1",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.220.0",
@@ -89,6 +90,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@sentry/cli": "3.6.0",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^20.11.30",

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -5,6 +5,8 @@ import {
   type EnterpriseMcpOAuthClientRegistration,
   type EnterpriseMcpOAuthPersistence,
   type EnterpriseMcpPersistenceContext,
+  type StoredOAuthClientInformation,
+  type StoredOAuthTokens,
 } from "@openwork/enterprise-mcp-client"
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
 import { and, eq } from "@openwork-ee/den-db/drizzle"
@@ -22,8 +24,6 @@ import {
   OAuthMetadataSchema,
   OAuthProtectedResourceMetadataSchema,
   OpenIdProviderMetadataSchema,
-  type OAuthClientInformationMixed,
-  type OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { z } from "zod"
 import { db } from "../db.js"
@@ -54,11 +54,48 @@ function invalidCredentialHealth(
   return credentialHealth("reconnect_required", "authorization_rejected")
 }
 
+function oauthIssuer(configuration: ExternalMcpOAuthConfiguration | null | undefined): string | undefined {
+  const discovery = configuration?.discovery
+  const metadata = discovery?.authorizationServerMetadata
+  const metadataIssuer = metadata
+    && typeof metadata === "object"
+    && "issuer" in metadata
+    && typeof metadata.issuer === "string"
+    ? metadata.issuer
+    : undefined
+  const authorizationServerUrl = typeof discovery?.authorizationServerUrl === "string"
+    ? discovery.authorizationServerUrl
+    : undefined
+  return configuration?.authorizationServerIssuer
+    ?? metadataIssuer
+    ?? authorizationServerUrl
+    ?? undefined
+}
+
+function oauthConfigurationWithIssuer(
+  configuration: ExternalMcpOAuthConfiguration | null | undefined,
+  issuer: string,
+): ExternalMcpOAuthConfiguration {
+  return {
+    ...(configuration ?? {
+      version: 1,
+      authorizationServerIssuer: null,
+      requestedScopes: [],
+      callbackMode: "legacy-v1",
+    }),
+    authorizationServerIssuer: issuer,
+  }
+}
+
 const oauthDiscoveryStateSchema = z.object({
   authorizationServerUrl: z.string().url(),
   authorizationServerMetadata: OAuthMetadataSchema.or(OpenIdProviderMetadataSchema).optional(),
   resourceMetadata: OAuthProtectedResourceMetadataSchema.optional(),
   resourceMetadataUrl: z.string().url().optional(),
+  openworkMetadataVerification: z.object({
+    version: z.literal(1),
+    issuer: z.string().url(),
+  }).optional(),
 })
 
 const pendingAuthorizationSchema = z.object({
@@ -122,13 +159,13 @@ function clientRevision(input: {
     .digest("hex")
 }
 
-function clientExpiration(clientInformation: OAuthClientInformationMixed): number | undefined {
+function clientExpiration(clientInformation: StoredOAuthClientInformation): number | undefined {
   const parsed = OAuthClientInformationFullSchema.safeParse(clientInformation)
   const seconds = parsed.success ? parsed.data.client_secret_expires_at : undefined
   return seconds && seconds > 0 ? seconds * 1_000 : undefined
 }
 
-function safeClientInformation(clientInformation: OAuthClientInformationMixed): Record<string, unknown> {
+function safeClientInformation(clientInformation: StoredOAuthClientInformation): Record<string, unknown> {
   return Object.fromEntries(Object.entries(clientInformation).filter(([key]) => (
     key !== "client_secret" && key !== "registration_access_token"
   )))
@@ -138,8 +175,16 @@ function restoredClientInformation(input: {
   clientId: string
   clientSecret: string | null
   extra: Record<string, unknown> | null
-}): OAuthClientInformationMixed {
+}): StoredOAuthClientInformation {
   const candidate = input.extra?.clientInformation
+  const candidateIssuer = typeof candidate === "object"
+    && candidate !== null
+    && "issuer" in candidate
+    && typeof candidate.issuer === "string"
+    ? candidate.issuer
+    : undefined
+  const issuer = candidateIssuer
+    ?? (typeof input.extra?.authorizationServerIssuer === "string" ? input.extra.authorizationServerIssuer : undefined)
   const tokenEndpointAuthMethod = input.extra?.tokenEndpointAuthMethod
   const registeredRedirectUri = input.extra?.registeredRedirectUri
   const full = OAuthClientInformationFullSchema.safeParse({
@@ -153,11 +198,12 @@ function restoredClientInformation(input: {
         }
       : {}),
   })
-  if (full.success) return full.data
-  return OAuthClientInformationSchema.parse({
+  if (full.success) return { ...full.data, ...(issuer ? { issuer } : {}) }
+  const clientInformation = OAuthClientInformationSchema.parse({
     client_id: input.clientId,
     client_secret: input.clientSecret ?? undefined,
   })
+  return { ...clientInformation, ...(issuer ? { issuer } : {}) }
 }
 
 export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersistence {
@@ -263,7 +309,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
 
     save: async (input: {
       context: EnterpriseMcpPersistenceContext
-      clientInformation: OAuthClientInformationMixed
+      clientInformation: StoredOAuthClientInformation
       redirectUri: string
       expiresAt?: number
       source: "client-metadata" | "dynamic"
@@ -281,6 +327,17 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         if (!connections[0]) throw new Error("The enterprise MCP connection no longer exists.")
         this.assertCurrentIdentity(connections[0])
         assertCommitActive(input.context)
+        const selectedIssuer = oauthIssuer(connections[0].oauthConfiguration)
+        if (
+          input.clientInformation.issuer
+          && selectedIssuer
+          && input.clientInformation.issuer !== selectedIssuer
+        ) {
+          throw new EnterpriseMcpOAuthContractError(
+            "MCP_OAUTH_ISSUER_MISMATCH",
+            "The OAuth client registration does not match the selected authorization server issuer.",
+          )
+        }
         const existing = await tx
           .select()
           .from(OrgOAuthClientTable)
@@ -555,6 +612,9 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
             token_type: account.tokenType ?? "Bearer",
             refresh_token: account.refreshToken ?? undefined,
             scope: account.scopes?.join(" ") ?? undefined,
+            ...(oauthIssuer(this.connection.oauthConfiguration)
+              ? { issuer: oauthIssuer(this.connection.oauthConfiguration) }
+              : {}),
           },
           expiresAt: account.expiresAt?.getTime(),
           revision: `${account.id}:${account.updatedAt.getTime()}`,
@@ -567,6 +627,9 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           token_type: this.connection.tokenType ?? "Bearer",
           refresh_token: this.connection.refreshToken ?? undefined,
           scope: this.connection.scope ?? undefined,
+          ...(oauthIssuer(this.connection.oauthConfiguration)
+            ? { issuer: oauthIssuer(this.connection.oauthConfiguration) }
+            : {}),
         },
         expiresAt: this.connection.expiresAt?.getTime(),
         revision: `${this.connection.id}:${this.connection.updatedAt.getTime()}`,
@@ -575,7 +638,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
 
     save: async (input: {
       context: EnterpriseMcpPersistenceContext
-      tokens: OAuthTokens
+      tokens: StoredOAuthTokens
       expiresAt?: number
       source: "authorization-code" | "refresh"
       authorization?: EnterpriseMcpOAuthAuthorizationHandle
@@ -596,6 +659,16 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         if (!connection) throw new Error("The enterprise MCP connection no longer exists.")
         this.assertCurrentIdentity(connection)
         assertCommitActive(input.context)
+        const selectedIssuer = oauthIssuer(connection.oauthConfiguration)
+        if (input.tokens.issuer && selectedIssuer && input.tokens.issuer !== selectedIssuer) {
+          throw new EnterpriseMcpOAuthContractError(
+            "MCP_OAUTH_ISSUER_MISMATCH",
+            "The OAuth credential does not match the selected authorization server issuer.",
+          )
+        }
+        const issuerConfiguration = input.tokens.issuer && !selectedIssuer
+          ? oauthConfigurationWithIssuer(connection.oauthConfiguration, input.tokens.issuer)
+          : undefined
         const account = this.member
           ? (await tx
               .select()
@@ -661,6 +734,12 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           ? new Date(Math.max(Date.now(), account.connectedAt.getTime() + 1))
           : new Date()
         if (this.isPerMember && this.member) {
+          if (issuerConfiguration) {
+            await tx
+              .update(ExternalMcpConnectionTable)
+              .set({ oauthConfiguration: issuerConfiguration })
+              .where(eq(ExternalMcpConnectionTable.id, connection.id))
+          }
           if (account) {
             await tx
               .update(ConnectedAccountTable)
@@ -704,6 +783,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
               credentialHealth: credentialHealth("ready", null),
               updatedAt,
               connectedAt: new Date(),
+              ...(issuerConfiguration ? { oauthConfiguration: issuerConfiguration } : {}),
             })
             .where(eq(ExternalMcpConnectionTable.id, connection.id))
         }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -1629,8 +1629,12 @@ export class ExternalMcpDiagnosticTracker {
         inferredClassification = classifyError(this.backgroundFailure.error, this.backgroundFailure.phase)
       }
     }
+    const sourceCode = errorCode(source.error)
+    const sourceIsApplicationOwnedOAuthFailure = sourceCode?.startsWith("MCP_OAUTH_") === true
+      || sourceCode === "MCP_LIFECYCLE_DEADLINE"
     const classified = this.forcedClassification
       && !TYPED_OAUTH_ERROR_NAMES.has(errorName(source.error))
+      && !sourceIsApplicationOwnedOAuthFailure
       && inferredClassification.phase !== "MCP_VERSION"
       ? this.forcedClassification
       : inferredClassification

--- a/ee/apps/den-api/src/mcp/agent-http.ts
+++ b/ee/apps/den-api/src/mcp/agent-http.ts
@@ -1,0 +1,19 @@
+import {
+  createMcpHandler,
+  type McpHttpHandler,
+  type McpServer,
+} from "@modelcontextprotocol/server"
+
+/** The dual-era, sessionless HTTP entry used by the public agent MCP route. */
+export function createAgentMcpHttpHandler(
+  serverForRequest: (request: Request) => McpServer,
+  onerror?: (error: Error) => void,
+): McpHttpHandler {
+  return createMcpHandler(({ requestInfo }) => {
+    if (!requestInfo) throw new Error("Agent MCP HTTP transport requires request context.")
+    return serverForRequest(requestInfo)
+  }, {
+    legacy: "stateless",
+    onerror,
+  })
+}

--- a/ee/apps/den-api/src/mcp/agent-http.ts
+++ b/ee/apps/den-api/src/mcp/agent-http.ts
@@ -1,7 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks"
 import {
   createMcpHandler,
   type McpHttpHandler,
   type McpServer,
+  type ServerEvent,
+  type ServerEventBus,
 } from "@modelcontextprotocol/server"
 
 /** The dual-era, sessionless HTTP entry used by the public agent MCP route. */
@@ -16,4 +19,99 @@ export function createAgentMcpHttpHandler(
     legacy: "stateless",
     onerror,
   })
+}
+
+export type ScopedAgentMcpHttpHandlers = {
+  /** Serve one request inside a stable, authenticated catalog audience. */
+  fetch: (scopeKey: string, request: Request, server: McpServer) => Promise<Response>
+  /** Publish only to subscription streams in the matching audience. */
+  notify: {
+    toolsChanged: (scopeKey: string) => void
+    resourcesChanged: (scopeKey: string) => void
+  }
+  close: () => Promise<void>
+}
+
+class ScopedAgentMcpEventBus implements ServerEventBus {
+  private readonly scope = new AsyncLocalStorage<string>()
+  private readonly listeners = new Map<(event: ServerEvent) => void, string>()
+
+  constructor(private readonly onerror?: (error: Error) => void) {}
+
+  run<T>(scopeKey: string, callback: () => T): T {
+    return this.scope.run(scopeKey, callback)
+  }
+
+  publish(event: ServerEvent): void {
+    const scopeKey = this.scope.getStore()
+    if (!scopeKey) return
+    for (const [listener, listenerScope] of this.listeners) {
+      if (listenerScope !== scopeKey) continue
+      try {
+        listener(event)
+      } catch (error) {
+        this.reportError(error)
+      }
+    }
+  }
+
+  subscribe(listener: (event: ServerEvent) => void): () => void {
+    const scopeKey = this.scope.getStore()
+    if (!scopeKey) throw new Error("Agent MCP subscriptions require an authenticated catalog audience.")
+    this.listeners.set(listener, scopeKey)
+    let live = true
+    return () => {
+      if (!live) return
+      live = false
+      this.listeners.delete(listener)
+    }
+  }
+
+  private reportError(error: unknown) {
+    try {
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)))
+    } catch {
+      // Error reporting must never alter subscription delivery.
+    }
+  }
+}
+
+/**
+ * Keep the SDK's subscription bus isolated by authenticated catalog audience.
+ *
+ * One handler retains the SDK's global subscription bound and shutdown
+ * semantics. Its event bus captures the authenticated audience when a listen
+ * stream subscribes, then delivers a published catalog event only to listeners
+ * captured in that same audience. Async-local scoping remains correct when
+ * requests for different members execute concurrently.
+ */
+export function createScopedAgentMcpHttpHandlers(
+  onerror?: (error: Error) => void,
+): ScopedAgentMcpHttpHandlers {
+  const bus = new ScopedAgentMcpEventBus(onerror)
+  const requestServer = new AsyncLocalStorage<McpServer>()
+  const handler = createMcpHandler(() => {
+    const server = requestServer.getStore()
+    if (!server) throw new Error("Agent MCP request server was not prepared.")
+    return server
+  }, {
+    legacy: "stateless",
+    onerror,
+    bus,
+  })
+
+  return {
+    fetch(scopeKey, request, server) {
+      return bus.run(scopeKey, () => requestServer.run(server, () => handler.fetch(request)))
+    },
+    notify: {
+      toolsChanged(scopeKey) {
+        bus.run(scopeKey, () => handler.notify.toolsChanged())
+      },
+      resourcesChanged(scopeKey) {
+        bus.run(scopeKey, () => handler.notify.resourcesChanged())
+      },
+    },
+    close: handler.close,
+  }
 }

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -1,6 +1,11 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { ErrorCode, McpError, type ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
-import { StreamableHTTPTransport } from "@hono/mcp"
+import {
+  McpServer,
+  ProtocolError,
+  ProtocolErrorCode,
+  SdkError,
+  SdkErrorCode,
+  type ToolAnnotations,
+} from "@modelcontextprotocol/server"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
@@ -16,9 +21,9 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { DEN_MCP_APP_HOST_SCOPE, DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
+import { createAgentMcpHttpHandler } from "./agent-http.js"
 import { rejectStandaloneSseResponse } from "./standalone-sse.js"
 import { appLogger } from "../observability/logger.js"
-import { normalizeMcpProtocolVersionHeader } from "./protocol-version.js"
 import {
   compareCapabilityMatches,
   EXECUTE_CAPABILITY_TOOL_NAME,
@@ -91,7 +96,7 @@ import {
   PluginArchRouteFailure,
 } from "../routes/org/plugin-system/store.js"
 
-const protocolVersionLogger = appLogger.child({ component: "mcp_protocol_version" })
+const agentMcpLogger = appLogger.child({ component: "agent_mcp" })
 
 export { externalToolContent } from "./tool-content.js"
 export { externalCapabilityErrorToolResult, externalCapabilitySuccessToolResult }
@@ -251,7 +256,7 @@ function capabilityTimeoutResult(capability: string): ExecuteCapabilityToolResul
 }
 
 function isTimeoutError(error: unknown): boolean {
-  if (error instanceof McpError && error.code === ErrorCode.RequestTimeout) {
+  if (error instanceof SdkError && error.code === SdkErrorCode.RequestTimeout) {
     return true
   }
   if (error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError")) {
@@ -334,7 +339,9 @@ export function registerAgentSkillResources(input: {
         ?? (marketplaceResult?.ok && marketplaceResult.result.kind === "skill"
           ? marketplaceResult.result.content
           : null)
-      if (typeof source !== "string") throw new McpError(ErrorCode.InvalidRequest, "Skill is no longer available")
+      if (typeof source !== "string") {
+        throw new ProtocolError(ProtocolErrorCode.InvalidRequest, "Skill is no longer available")
+      }
       return {
         contents: [{
           uri: skill.location,
@@ -366,6 +373,13 @@ export function registerAgentSkillResources(input: {
  * operations are not individually callable on this endpoint.
  */
 export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(app: Hono<T>) {
+  const serverByRequest = new WeakMap<Request, McpServer>()
+  const handler = createAgentMcpHttpHandler((request) => {
+    const server = serverByRequest.get(request)
+    if (!server) throw new Error("Agent MCP request server was not prepared.")
+    return server
+  }, (error) => agentMcpLogger.warn("Agent MCP transport error", { error }))
+
   app.get("/.well-known/oauth-protected-resource/mcp/agent", publicRoute, (c) =>
     c.json(protectedResourceMetadata(c.req.raw, "agent")))
   app.get("/mcp/agent/.well-known/oauth-protected-resource", publicRoute, (c) =>
@@ -390,10 +404,6 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
     if (preflightResponse) {
       return preflightResponse
     }
-
-    normalizeMcpProtocolVersionHeader(c.req.raw.headers, "agent", requestId, (message, fields) => {
-      protocolVersionLogger.warn(message, fields)
-    })
 
     const catalog = await getCatalog(app as unknown as Hono, c.env)
     // External MCP connections are scoped to the calling MEMBER (grants +
@@ -440,7 +450,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
     const { externalMcpConnectionsEnabled } = capabilityContext
     let remoteSkills: RemoteSkillDescriptor[] = []
     let libraryContext: PluginArchActorContext | null = null
-    const appCatalogMethod = method === "initialize"
+    const appCatalogMethod = method === "server/discover"
+      || method === "initialize"
       || method === "tools/list"
       || method === "tools/call"
       || method === "resources/list"
@@ -462,7 +473,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       }
     }
     const artifactContext = codemodeEnabled ? libraryContext : null
-    if (method === "initialize" || method === "resources/list" || method === "resources/read") {
+    if (method === "server/discover" || method === "initialize" || method === "resources/list" || method === "resources/read") {
       remoteSkills = [
         ...listBuiltinSkillDescriptors(),
         ...(await listAccessibleMarketplaceSkillDescriptors({
@@ -474,7 +485,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         .sort((a, b) => a.name.localeCompare(b.name) || a.capability.localeCompare(b.capability))
     }
     const server = createAgentMcpServer()
-    if (method === "initialize" || method === "resources/list" || method === "resources/read") {
+    if (method === "server/discover" || method === "initialize" || method === "resources/list" || method === "resources/read") {
       if (memberIdentity) {
         registerConnectMcpServerIndex({
           server,
@@ -859,6 +870,10 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           save: (request) => saveArtifactViewRevision({ context: artifactContext, ...request }),
           activate: (request) => activateArtifactViewRevision({ context: artifactContext, ...request }),
           retire: (request) => retireArtifactView({ context: artifactContext, ...request }),
+          notifyCatalogChanged: () => {
+            handler.notify.toolsChanged()
+            handler.notify.resourcesChanged()
+          },
         })
 
         const exactResource = requestInfo.resourceUri ? parseArtifactViewResourceUri(requestInfo.resourceUri) : null
@@ -934,9 +949,11 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       )
     }
 
-    const transport = new StreamableHTTPTransport()
-    await server.connect(transport)
-    const response = await transport.handleRequest(c)
-    return response ?? new Response(null, { status: 204 })
+    serverByRequest.set(c.req.raw, server)
+    try {
+      return await handler.fetch(c.req.raw)
+    } finally {
+      serverByRequest.delete(c.req.raw)
+    }
   })
 }

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -21,7 +21,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { DEN_MCP_APP_HOST_SCOPE, DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
-import { createAgentMcpHttpHandler } from "./agent-http.js"
+import { createScopedAgentMcpHttpHandlers } from "./agent-http.js"
 import { rejectStandaloneSseResponse } from "./standalone-sse.js"
 import { appLogger } from "../observability/logger.js"
 import {
@@ -373,12 +373,9 @@ export function registerAgentSkillResources(input: {
  * operations are not individually callable on this endpoint.
  */
 export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables & Record<string, unknown> }>(app: Hono<T>) {
-  const serverByRequest = new WeakMap<Request, McpServer>()
-  const handler = createAgentMcpHttpHandler((request) => {
-    const server = serverByRequest.get(request)
-    if (!server) throw new Error("Agent MCP request server was not prepared.")
-    return server
-  }, (error) => agentMcpLogger.warn("Agent MCP transport error", { error }))
+  const handlers = createScopedAgentMcpHttpHandlers(
+    (error) => agentMcpLogger.warn("Agent MCP transport error", { error }),
+  )
 
   app.get("/.well-known/oauth-protected-resource/mcp/agent", publicRoute, (c) =>
     c.json(protectedResourceMetadata(c.req.raw, "agent")))
@@ -413,6 +410,7 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       userId: principal.userId,
       organizationId: principal.organizationId,
     })
+    const notificationScope = `${principal.organizationId}\0${principal.userId}`
     const organizationId = normalizeDenTypeId("organization", principal.organizationId)
     const organizationRows = await db
       .select({ metadata: OrganizationTable.metadata })
@@ -871,8 +869,8 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
           activate: (request) => activateArtifactViewRevision({ context: artifactContext, ...request }),
           retire: (request) => retireArtifactView({ context: artifactContext, ...request }),
           notifyCatalogChanged: () => {
-            handler.notify.toolsChanged()
-            handler.notify.resourcesChanged()
+            handlers.notify.toolsChanged(notificationScope)
+            handlers.notify.resourcesChanged(notificationScope)
           },
         })
 
@@ -949,11 +947,6 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
       )
     }
 
-    serverByRequest.set(c.req.raw, server)
-    try {
-      return await handler.fetch(c.req.raw)
-    } finally {
-      serverByRequest.delete(c.req.raw)
-    }
+    return await handlers.fetch(notificationScope, c.req.raw, server)
   })
 }

--- a/ee/apps/den-api/src/mcp/automation-index.ts
+++ b/ee/apps/den-api/src/mcp/automation-index.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import type { AutomationList } from "@openwork/types/automations"
 
 export const AGENT_AUTOMATION_INDEX_URI = "automation://index.json"

--- a/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
+++ b/ee/apps/den-api/src/mcp/connect-mcp-server-index.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import type { ExternalMcpConnectionRow } from "../capability-sources/external-mcp-connections.js"
 
 export const CONNECT_MCP_SERVER_INDEX_URI = "openwork://connect/mcp-servers/index.json"

--- a/ee/apps/den-api/src/mcp/connection-action-app.ts
+++ b/ee/apps/den-api/src/mcp/connection-action-app.ts
@@ -2,9 +2,9 @@ import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server"
+} from "./mcp-app-v2.js"
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import { connectionActionAppHtml } from "@openwork/mcp-apps/connection-action"
 import {
   connectionActionAppResourceUri,

--- a/ee/apps/den-api/src/mcp/external-mcp-tool-arguments.ts
+++ b/ee/apps/den-api/src/mcp/external-mcp-tool-arguments.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto"
-import type { Tool } from "@modelcontextprotocol/sdk/types.js"
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/server/validators/ajv"
 
 export type ExternalMcpArgumentIssue = {
   path: string
@@ -38,12 +37,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-export function externalMcpToolSchemaDigest(schema: Tool["inputSchema"]): string {
+export function externalMcpToolSchemaDigest(schema: Record<string, unknown>): string {
   return `sha256:${createHash("sha256").update(canonicalJson(schema)).digest("hex")}`
 }
 
 export function validateExternalMcpToolArguments(
-  schema: Tool["inputSchema"],
+  schema: Record<string, unknown>,
   value: unknown,
 ): ExternalMcpArgumentValidation {
   if (!isRecord(value)) {

--- a/ee/apps/den-api/src/mcp/generated-artifact-views.ts
+++ b/ee/apps/den-api/src/mcp/generated-artifact-views.ts
@@ -3,9 +3,9 @@ import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server"
+} from "./mcp-app-v2.js"
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
-import type { McpServer, RegisteredResource, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer, RegisteredResource, RegisteredTool } from "@modelcontextprotocol/server"
 import {
   workflowArtifactPayloadSchema,
   generatedArtifactViewSchema,
@@ -47,13 +47,6 @@ function resourceMeta(csp: GeneratedArtifactViewCsp, digest: string): { ui: McpU
 
 function digest(value: string): string {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`
-}
-
-async function sendCatalogChanged(extra: {
-  sendNotification: (notification: { method: "notifications/tools/list_changed" | "notifications/resources/list_changed" }) => Promise<void>
-}) {
-  await extra.sendNotification({ method: "notifications/tools/list_changed" })
-  await extra.sendNotification({ method: "notifications/resources/list_changed" })
 }
 
 export function registerGeneratedArtifactResource(input: {
@@ -167,6 +160,7 @@ export function registerAgentGeneratedArtifactViews(input: {
   }) => Promise<GeneratedArtifactView>
   activate: (request: { artifactViewId: string; revisionId: string }) => Promise<GeneratedArtifactView>
   retire: (request: { artifactViewId: string }) => Promise<GeneratedArtifactView>
+  notifyCatalogChanged: () => void
 }) {
   const registeredResources = new Map<string, RegisteredResource>()
   const registeredTools = new Map<string, { revisionId: string; registration: RegisteredTool }>()
@@ -233,7 +227,7 @@ export function registerAgentGeneratedArtifactViews(input: {
       }),
       outputSchema: saveOutputSchema,
     },
-    async (request, extra) => {
+    async (request) => {
       let view: GeneratedArtifactView
       try {
         view = await input.save(request)
@@ -259,7 +253,7 @@ export function registerAgentGeneratedArtifactViews(input: {
         )
       }
       syncView(view)
-      await sendCatalogChanged(extra)
+      input.notifyCatalogChanged()
       const displayInstruction = `Call ${view.status === "active" && view.activeRevisionId === revision.id
         ? `render_artifact_${view.id}`
         : `preview_artifact_${view.id}`} to display that revision.`
@@ -279,10 +273,10 @@ export function registerAgentGeneratedArtifactViews(input: {
       inputSchema: z.object({ artifactViewId: idSchema, revisionId: idSchema }),
       outputSchema: saveOutputSchema,
     },
-    async (request, extra) => {
+    async (request) => {
       const view = await input.activate(request)
       syncView(view)
-      await sendCatalogChanged(extra)
+      input.notifyCatalogChanged()
       return {
         content: [{
           type: "text" as const,
@@ -302,10 +296,10 @@ export function registerAgentGeneratedArtifactViews(input: {
       inputSchema: z.object({ artifactViewId: idSchema }),
       outputSchema: saveOutputSchema,
     },
-    async (request, extra) => {
+    async (request) => {
       const view = await input.retire(request)
       syncView(view)
-      await sendCatalogChanged(extra)
+      input.notifyCatalogChanged()
       return {
         content: [{ type: "text" as const, text: `Retired Artifact view ${request.artifactViewId}. Its revision resources remain immutable.` }],
         structuredContent: { view },

--- a/ee/apps/den-api/src/mcp/mcp-app-v2.ts
+++ b/ee/apps/den-api/src/mcp/mcp-app-v2.ts
@@ -50,8 +50,8 @@ export function registerAppTool<
 
   return server.registerTool(
     name,
-    { ...config, _meta: normalizedMeta } as never,
-    callback as never,
+    { ...config, _meta: normalizedMeta },
+    callback,
   )
 }
 

--- a/ee/apps/den-api/src/mcp/mcp-app-v2.ts
+++ b/ee/apps/den-api/src/mcp/mcp-app-v2.ts
@@ -1,0 +1,73 @@
+import type { McpUiResourceMeta, McpUiToolMeta } from "@modelcontextprotocol/ext-apps"
+import type {
+  McpServer,
+  ReadResourceCallback,
+  RegisteredResource,
+  RegisteredTool,
+  ResourceMetadata,
+  ToolAnnotations,
+  ToolCallback,
+} from "@modelcontextprotocol/server"
+import type { ZodType } from "zod"
+
+export const EXTENSION_ID = "io.modelcontextprotocol/ui"
+export const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app"
+const RESOURCE_URI_META_KEY = "ui/resourceUri"
+
+type AppToolConfig<InputArgs extends ZodType | undefined, OutputArgs extends ZodType> = {
+  title?: string
+  description?: string
+  inputSchema?: InputArgs
+  outputSchema?: OutputArgs
+  annotations?: ToolAnnotations
+  _meta: Record<string, unknown> & {
+    ui?: McpUiToolMeta
+    [RESOURCE_URI_META_KEY]?: string
+  }
+}
+
+/**
+ * MCP Apps' published helper is still typed against SDK v1. This v2 adapter
+ * preserves its metadata normalization while registering directly on the v2
+ * server. Remove it once ext-apps publishes a v2-compatible server helper.
+ */
+export function registerAppTool<
+  InputArgs extends ZodType | undefined = undefined,
+  OutputArgs extends ZodType = ZodType,
+>(
+  server: McpServer,
+  name: string,
+  config: AppToolConfig<InputArgs, OutputArgs>,
+  callback: ToolCallback<InputArgs>,
+): RegisteredTool {
+  const ui = config._meta.ui
+  const legacyResourceUri = config._meta[RESOURCE_URI_META_KEY]
+  const normalizedMeta = ui?.resourceUri && !legacyResourceUri
+    ? { ...config._meta, [RESOURCE_URI_META_KEY]: ui.resourceUri }
+    : legacyResourceUri && !ui?.resourceUri
+      ? { ...config._meta, ui: { ...ui, resourceUri: legacyResourceUri } }
+      : config._meta
+
+  return server.registerTool(
+    name,
+    { ...config, _meta: normalizedMeta } as never,
+    callback as never,
+  )
+}
+
+type AppResourceConfig = ResourceMetadata & {
+  _meta?: Record<string, unknown> & { ui?: McpUiResourceMeta }
+}
+
+export function registerAppResource(
+  server: McpServer,
+  name: string,
+  uri: string,
+  config: AppResourceConfig,
+  callback: ReadResourceCallback,
+): RegisteredResource {
+  return server.registerResource(name, uri, {
+    mimeType: RESOURCE_MIME_TYPE,
+    ...config,
+  }, callback)
+}

--- a/ee/apps/den-api/src/mcp/plugin-flow-app.ts
+++ b/ee/apps/den-api/src/mcp/plugin-flow-app.ts
@@ -2,9 +2,9 @@ import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server"
+} from "./mcp-app-v2.js"
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import { pluginFlowAppHtml } from "@openwork/mcp-apps/plugin-flow"
 import {
   pluginFlowAppSchemaVersion,

--- a/ee/apps/den-api/src/mcp/skill-created-app.ts
+++ b/ee/apps/den-api/src/mcp/skill-created-app.ts
@@ -2,9 +2,9 @@ import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server"
+} from "./mcp-app-v2.js"
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import { skillCreatedAppHtml } from "@openwork/mcp-apps/skill-created"
 import {
   skillCreatedAppSchemaVersion,

--- a/ee/apps/den-api/src/mcp/workflow-artifact-app.ts
+++ b/ee/apps/den-api/src/mcp/workflow-artifact-app.ts
@@ -3,9 +3,9 @@ import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server"
+} from "./mcp-app-v2.js"
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps"
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { McpServer } from "@modelcontextprotocol/server"
 import {
   workflowArtifactPayloadSchema,
   workflowArtifactSchemaVersion,

--- a/ee/apps/den-api/test/agent-codemode-script.test.ts
+++ b/ee/apps/den-api/test/agent-codemode-script.test.ts
@@ -110,6 +110,11 @@ function resultRecord(payload: Record<string, unknown>) {
   return payload.result
 }
 
+function errorRecord(payload: Record<string, unknown>) {
+  if (!isRecord(payload.error)) throw new Error("Expected JSON-RPC error")
+  return payload.error
+}
+
 function listedToolNames(payload: Record<string, unknown>): string[] {
   const tools = resultRecord(payload).tools
   if (!Array.isArray(tools)) throw new Error("Expected MCP tools list")
@@ -163,8 +168,7 @@ test("rejects guessed generated-view tool calls while keeping Workflows enabled"
   organizationMetadata = { capabilities: { workflows: true } }
   for (const name of ["save_artifact_view", "activate_artifact_view_revision", "retire_artifact_view"]) {
     const payload = await rpc(buildApp(), "tools/call", { name, arguments: {} })
-    expect(resultRecord(payload).isError).toBe(true)
-    expect(JSON.stringify(payload)).toContain("not found")
+    expect(errorRecord(payload)).toMatchObject({ code: -32602, message: expect.stringContaining("not found") })
   }
 })
 

--- a/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
+++ b/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
@@ -256,10 +256,12 @@ describe("Den enterprise MCP OAuth persistence adapter", () => {
         client_secret: "encrypted-client-secret",
         registration_access_token: "must-not-enter-json",
         token_endpoint_auth_method: "client_secret_post",
+        issuer: "https://login.example.test",
       },
       source: "dynamic",
     })
     expect(saved.clientInformation.client_id).toBe("registered-client")
+    expect(saved.clientInformation.issuer).toBe("https://login.example.test")
     const rows = await db
       .select()
       .from(schema.OrgOAuthClientTable)
@@ -318,6 +320,7 @@ describe("Den enterprise MCP OAuth persistence adapter", () => {
         refresh_token: "callback-refresh-token",
         token_type: "Bearer",
         expires_in: 3_600,
+        issuer: "https://login.example.test",
       },
       expiresAt: Date.now() + 3_600_000,
       source: "authorization-code",
@@ -326,6 +329,21 @@ describe("Den enterprise MCP OAuth persistence adapter", () => {
     })
     expect(await persistence.authorizations.load({ context: context(), id: "signed-state-a" })).toBeUndefined()
     expect(await persistence.authorizations.load({ context: context(), id: "signed-state-b" })).toBeDefined()
+    expect((await persistence.credentials.load(context()))?.tokens).toMatchObject({
+      access_token: "callback-access-token",
+      issuer: "https://login.example.test",
+    })
+    const currentCredential = await persistence.credentials.load(context())
+    await expect(persistence.credentials.save({
+      context: context(),
+      tokens: {
+        access_token: "wrong-issuer-token",
+        token_type: "Bearer",
+        issuer: "https://attacker.example.test",
+      },
+      source: "refresh",
+      expectedCredentialRevision: currentCredential?.revision,
+    })).rejects.toMatchObject({ code: "MCP_OAUTH_ISSUER_MISMATCH" })
     expect((await persistence.credentials.load(context()))?.tokens.access_token).toBe("callback-access-token")
 
     await expect(persistence.credentials.save({

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -1124,6 +1124,32 @@ describe("external MCP diagnostics", () => {
     })
   })
 
+  test("preserves an application-owned OAuth issuer mismatch over a captured HTTP 401", async () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_issuer_mismatch")
+    const diagnosticFetch = createExternalMcpDiagnosticFetch({
+      endpoint: "https://mcp.example.invalid/mcp",
+      tracker,
+      fetch: async () => new Response(null, { status: 401 }),
+    })
+    await diagnosticFetch("https://mcp.example.invalid/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    })
+    const oauthError = Object.assign(new Error("Authorization server metadata issuer mismatch."), {
+      code: "MCP_OAUTH_ISSUER_MISMATCH",
+    })
+
+    expect(tracker.error(oauthError).diagnostic).toMatchObject({
+      phase: "AUTH_ISSUER_DISCOVERY",
+      category: "oauth_issuer_mismatch",
+      code: "MCP_OAUTH_ISSUER_MISMATCH",
+      retryable: false,
+      actionOwner: "organization_admin",
+      httpStatus: 401,
+    })
+  })
+
   test("maps bounded SDK protocol incompatibility errors to MCP_VERSION", () => {
     const tracker = new ExternalMcpDiagnosticTracker("req_version")
     tracker.passed("MCP_TRANSPORT", "reachable")

--- a/ee/apps/den-api/test/mcp-agent-stateless.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-stateless.test.ts
@@ -1,0 +1,192 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  Client,
+  PROTOCOL_VERSION_META_KEY,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
+import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport as LegacyStreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { expect, test } from "bun:test"
+import { z } from "zod"
+import { createAgentMcpHttpHandler } from "../src/mcp/agent-http.js"
+
+type ObservedExchange = {
+  body: Record<string, unknown>
+  requestHeaders: Headers
+  responseHeaders: Headers
+}
+
+function textFromToolResult(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content[0]
+  if (!content || content.type !== "text") throw new Error("Expected text tool content.")
+  return content.text
+}
+
+test("serves the 2026 stateless wire with fresh per-request servers", async () => {
+  let serverInstances = 0
+  const exchanges: ObservedExchange[] = []
+  const handler = createAgentMcpHttpHandler(() => {
+    const instance = ++serverInstances
+    const server = new McpServer({ name: "openwork-agent-stateless-test", version: "1.0.0" })
+    server.registerTool("stateless_instance", {
+      description: "Return the per-request server instance ordinal.",
+      inputSchema: z.object({}),
+    }, async () => ({
+      content: [{ type: "text", text: String(instance) }],
+    }))
+    return server
+  })
+  const transport = new StreamableHTTPClientTransport(new URL("https://openwork.example.test/mcp/agent"), {
+    fetch: async (url, init) => {
+      const request = new Request(url, init)
+      const body = await request.clone().json() as Record<string, unknown>
+      const response = await handler.fetch(request)
+      exchanges.push({
+        body,
+        requestHeaders: request.headers,
+        responseHeaders: response.headers,
+      })
+      return response
+    },
+  })
+  const client = new Client(
+    { name: "stateless-wire-test", version: "1.0.0" },
+    { capabilities: {}, versionNegotiation: { mode: "auto" } },
+  )
+
+  try {
+    await client.connect(transport)
+    expect(client.getProtocolEra()).toBe("modern")
+    expect(client.getNegotiatedProtocolVersion()).toBe("2026-07-28")
+    expect((await client.listTools()).tools.some((tool) => tool.name === "stateless_instance")).toBe(true)
+
+    const first = textFromToolResult(await client.callTool({ name: "stateless_instance", arguments: {} }))
+    const second = textFromToolResult(await client.callTool({ name: "stateless_instance", arguments: {} }))
+    expect(first).not.toBe(second)
+
+    const methods = exchanges.map((exchange) => exchange.body.method)
+    expect(methods[0]).toBe("server/discover")
+    expect(methods).not.toContain("initialize")
+    expect(methods).not.toContain("notifications/initialized")
+    for (const exchange of exchanges) {
+      const params = exchange.body.params as { _meta?: Record<string, unknown> } | undefined
+      expect(params?._meta?.[PROTOCOL_VERSION_META_KEY]).toBe("2026-07-28")
+      expect(params?._meta?.[CLIENT_INFO_META_KEY]).toEqual({ name: "stateless-wire-test", version: "1.0.0" })
+      expect(params?._meta?.[CLIENT_CAPABILITIES_META_KEY]).toEqual({})
+      expect(exchange.requestHeaders.get("mcp-protocol-version")).toBe("2026-07-28")
+      expect(exchange.requestHeaders.get("mcp-method")).toBe(exchange.body.method)
+      expect(exchange.requestHeaders.has("mcp-session-id")).toBe(false)
+      expect(exchange.responseHeaders.has("mcp-session-id")).toBe(false)
+    }
+    const calls = exchanges.filter((exchange) => exchange.body.method === "tools/call")
+    expect(calls).toHaveLength(2)
+    expect(calls.every((exchange) => exchange.requestHeaders.get("mcp-name") === "stateless_instance")).toBe(true)
+    expect(serverInstances).toBe(exchanges.length)
+  } finally {
+    await client.close()
+    await handler.close()
+  }
+})
+
+test("rejects a modern protocol header/body mismatch instead of normalizing it", async () => {
+  const handler = createAgentMcpHttpHandler(() => new McpServer({
+    name: "openwork-agent-stateless-test",
+    version: "1.0.0",
+  }))
+  try {
+    const response = await handler.fetch(new Request("https://openwork.example.test/mcp/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "mcp-method": "tools/list",
+        "mcp-protocol-version": "2027-01-01",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "mismatched-version",
+        method: "tools/list",
+        params: {
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: "2026-07-28",
+            [CLIENT_INFO_META_KEY]: { name: "stateless-wire-test", version: "1.0.0" },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
+        },
+      }),
+    }))
+    const body = await response.json() as { error?: { code?: number; message?: string } }
+    expect(response.status).toBe(400)
+    expect(body.error?.code).toBe(-32_020)
+    expect(body.error?.message).toContain("headers and body disagree")
+    expect(response.headers.has("mcp-session-id")).toBe(false)
+  } finally {
+    await handler.close()
+  }
+})
+
+test("keeps the 2025 stateless fallback for existing clients", async () => {
+  const methods: string[] = []
+  const handler = createAgentMcpHttpHandler(() => {
+    const server = new McpServer({ name: "openwork-agent-legacy-test", version: "1.0.0" })
+    server.registerTool("legacy_compatible", { inputSchema: z.object({}) }, async () => ({
+      content: [{ type: "text", text: "compatible" }],
+    }))
+    return server
+  })
+  const transport = new LegacyStreamableHTTPClientTransport(new URL("https://openwork.example.test/mcp/agent"), {
+    fetch: async (url, init) => {
+      const request = new Request(url, init)
+      const body = await request.clone().json() as { method?: string }
+      if (body.method) methods.push(body.method)
+      expect(request.headers.has("mcp-session-id")).toBe(false)
+      const response = await handler.fetch(request)
+      expect(response.headers.has("mcp-session-id")).toBe(false)
+      return response
+    },
+  })
+  const client = new LegacyClient({ name: "legacy-stateless-test", version: "1.0.0" })
+
+  try {
+    await client.connect(transport)
+    expect((await client.listTools()).tools.some((tool) => tool.name === "legacy_compatible")).toBe(true)
+    expect(methods).toContain("initialize")
+    expect(methods).toContain("notifications/initialized")
+    expect(methods).toContain("tools/list")
+  } finally {
+    await client.close()
+    await handler.close()
+  }
+})
+
+test("delivers modern list changes through subscriptions/listen", async () => {
+  const handler = createAgentMcpHttpHandler(() => new McpServer(
+    { name: "openwork-agent-subscription-test", version: "1.0.0" },
+    { capabilities: { tools: { listChanged: true } } },
+  ))
+  const transport = new StreamableHTTPClientTransport(new URL("https://openwork.example.test/mcp/agent"), {
+    fetch: async (url, init) => handler.fetch(new Request(url, init)),
+  })
+  const client = new Client(
+    { name: "stateless-subscription-test", version: "1.0.0" },
+    { capabilities: {}, versionNegotiation: { mode: "auto" } },
+  )
+  let toolChanges = 0
+  client.setNotificationHandler("notifications/tools/list_changed", () => {
+    toolChanges += 1
+  })
+
+  try {
+    await client.connect(transport)
+    const subscription = await client.listen({ toolsListChanged: true })
+    expect(subscription.honoredFilter).toEqual({ toolsListChanged: true })
+    handler.notify.toolsChanged()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(toolChanges).toBe(1)
+    await subscription.close()
+  } finally {
+    await client.close()
+    await handler.close()
+  }
+})

--- a/ee/apps/den-api/test/mcp-agent-stateless.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-stateless.test.ts
@@ -10,7 +10,10 @@ import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.j
 import { StreamableHTTPClientTransport as LegacyStreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { expect, test } from "bun:test"
 import { z } from "zod"
-import { createAgentMcpHttpHandler } from "../src/mcp/agent-http.js"
+import {
+  createAgentMcpHttpHandler,
+  createScopedAgentMcpHttpHandlers,
+} from "../src/mcp/agent-http.js"
 
 type ObservedExchange = {
   body: Record<string, unknown>
@@ -160,6 +163,32 @@ test("keeps the 2025 stateless fallback for existing clients", async () => {
   }
 })
 
+test("keeps a prepared request-local server bound through legacy request cloning", async () => {
+  const handlers = createScopedAgentMcpHttpHandlers()
+  let serverInstances = 0
+  const transport = new LegacyStreamableHTTPClientTransport(new URL("https://openwork.example.test/mcp/agent"), {
+    fetch: async (url, init) => {
+      const instance = ++serverInstances
+      const server = new McpServer({ name: "openwork-agent-legacy-binding-test", version: "1.0.0" })
+      server.registerTool("legacy_request_instance", { inputSchema: z.object({}) }, async () => ({
+        content: [{ type: "text", text: String(instance) }],
+      }))
+      return handlers.fetch("org-a\0user-a", new Request(url, init), server)
+    },
+  })
+  const client = new LegacyClient({ name: "legacy-request-binding-test", version: "1.0.0" })
+
+  try {
+    await client.connect(transport)
+    const result = await client.callTool({ name: "legacy_request_instance", arguments: {} })
+    expect(result.content[0]).toMatchObject({ type: "text", text: expect.any(String) })
+    expect(serverInstances).toBeGreaterThan(1)
+  } finally {
+    await client.close()
+    await handlers.close()
+  }
+})
+
 test("delivers modern list changes through subscriptions/listen", async () => {
   const handler = createAgentMcpHttpHandler(() => new McpServer(
     { name: "openwork-agent-subscription-test", version: "1.0.0" },
@@ -188,5 +217,80 @@ test("delivers modern list changes through subscriptions/listen", async () => {
   } finally {
     await client.close()
     await handler.close()
+  }
+})
+
+test("isolates list-change subscriptions by authenticated catalog audience", async () => {
+  const handlers = createScopedAgentMcpHttpHandlers()
+  const requestServer = (toolName: string) => {
+    const server = new McpServer(
+      { name: "openwork-agent-scoped-subscription-test", version: "1.0.0" },
+      { capabilities: { tools: { listChanged: true }, resources: { listChanged: true } } },
+    )
+    server.registerTool(toolName, { inputSchema: z.object({}) }, async () => ({
+      content: [{ type: "text", text: toolName }],
+    }))
+    return server
+  }
+  const clientFor = (scopeKey: string, toolName: string) => {
+    const transport = new StreamableHTTPClientTransport(new URL("https://openwork.example.test/mcp/agent"), {
+      fetch: async (url, init) => handlers.fetch(scopeKey, new Request(url, init), requestServer(toolName)),
+    })
+    const client = new Client(
+      { name: `stateless-scoped-subscription-${scopeKey}`, version: "1.0.0" },
+      { capabilities: {}, versionNegotiation: { mode: "auto" } },
+    )
+    return { client, transport }
+  }
+  const first = clientFor("org-a\0user-a", "scope_a_tool")
+  const second = clientFor("org-b\0user-b", "scope_b_tool")
+  const firstChanges = { tools: 0, resources: 0 }
+  const secondChanges = { tools: 0, resources: 0 }
+  first.client.setNotificationHandler("notifications/tools/list_changed", () => {
+    firstChanges.tools += 1
+  })
+  first.client.setNotificationHandler("notifications/resources/list_changed", () => {
+    firstChanges.resources += 1
+  })
+  second.client.setNotificationHandler("notifications/tools/list_changed", () => {
+    secondChanges.tools += 1
+  })
+  second.client.setNotificationHandler("notifications/resources/list_changed", () => {
+    secondChanges.resources += 1
+  })
+
+  try {
+    await Promise.all([
+      first.client.connect(first.transport),
+      second.client.connect(second.transport),
+    ])
+    const [firstTools, secondTools] = await Promise.all([
+      first.client.listTools(),
+      second.client.listTools(),
+    ])
+    expect(firstTools.tools.map((tool) => tool.name)).toEqual(["scope_a_tool"])
+    expect(secondTools.tools.map((tool) => tool.name)).toEqual(["scope_b_tool"])
+    const [firstSubscription, secondSubscription] = await Promise.all([
+      first.client.listen({ toolsListChanged: true, resourcesListChanged: true }),
+      second.client.listen({ toolsListChanged: true, resourcesListChanged: true }),
+    ])
+    try {
+      handlers.notify.toolsChanged("org-a\0user-a")
+      handlers.notify.resourcesChanged("org-a\0user-a")
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(firstChanges).toEqual({ tools: 1, resources: 1 })
+      expect(secondChanges).toEqual({ tools: 0, resources: 0 })
+
+      handlers.notify.toolsChanged("org-b\0user-b")
+      handlers.notify.resourcesChanged("org-b\0user-b")
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(firstChanges).toEqual({ tools: 1, resources: 1 })
+      expect(secondChanges).toEqual({ tools: 1, resources: 1 })
+    } finally {
+      await Promise.all([firstSubscription.close(), secondSubscription.close()])
+    }
+  } finally {
+    await Promise.all([first.client.close(), second.client.close()])
+    await handlers.close()
   }
 })

--- a/ee/apps/den-api/test/mcp-connection-action-app.test.ts
+++ b/ee/apps/den-api/test/mcp-connection-action-app.test.ts
@@ -1,6 +1,5 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
 import { expect, test } from "bun:test"
 import {
   CONNECTION_ACTION_APP_HTML,

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -542,6 +542,19 @@ test("connect start repairs a verified stale resource issuer alias before author
     port: 0,
     async fetch(incoming) {
       const url = new URL(incoming.url)
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: authorizationOrigin,
+          authorization_endpoint: `${authorizationOrigin}/authorize`,
+          token_endpoint: `${authorizationOrigin}/token`,
+          registration_endpoint: `${authorizationOrigin}/register`,
+          authorization_response_iss_parameter_supported: true,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["none"],
+        })
+      }
       if (url.pathname === "/register") {
         const metadata: unknown = await incoming.json()
         const redirectUris = isRecord(metadata) && isStringArray(metadata.redirect_uris)
@@ -623,9 +636,9 @@ test("connect start repairs a verified stale resource issuer alias before author
             authorizationServerUrl: resourceOrigin,
             authorizationServerMetadata: {
               issuer: authorizationOrigin,
-              authorization_endpoint: `${authorizationOrigin}/authorize`,
-              token_endpoint: `${authorizationOrigin}/token`,
-              registration_endpoint: `${authorizationOrigin}/register`,
+              authorization_endpoint: "http://127.0.0.1:1/authorize",
+              token_endpoint: "http://127.0.0.1:1/token",
+              registration_endpoint: "http://127.0.0.1:1/register",
               authorization_response_iss_parameter_supported: true,
               code_challenge_methods_supported: ["S256"],
             },
@@ -654,6 +667,9 @@ test("connect start repairs a verified stale resource issuer alias before author
       .limit(1)
     expect(repaired?.oauthConfiguration?.authorizationServerIssuer).toBe(authorizationOrigin)
     expect(repaired?.oauthIssuerReviewRequiredAt).toBeNull()
+    expect(repaired?.oauthConfiguration?.discovery?.authorizationServerUrl).toBe(authorizationOrigin)
+    expect(repaired?.oauthConfiguration?.discovery?.authorizationServerMetadata?.authorization_endpoint).toBe(`${authorizationOrigin}/authorize`)
+    expect(repaired?.oauthConfiguration?.discovery?.authorizationServerMetadata?.token_endpoint).toBe(`${authorizationOrigin}/token`)
 
     if (!repaired?.oauthConfiguration?.discovery) throw new Error("Expected repaired discovery state.")
     await db
@@ -665,6 +681,18 @@ test("connect start repairs a verified stale resource issuer alias before author
         },
       })
       .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+    const [staleAgain] = await db
+      .select()
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+      .limit(1)
+    expect(staleAgain?.oauthConfiguration?.authorizationServerIssuer).toBe(resourceOrigin)
+    expect(staleAgain?.oauthConfiguration?.discovery?.authorizationServerUrl).toBe(authorizationOrigin)
+    expect(staleAgain?.oauthConfiguration?.discovery?.authorizationServerMetadata).toMatchObject({
+      issuer: authorizationOrigin,
+      authorization_endpoint: `${authorizationOrigin}/authorize`,
+      token_endpoint: `${authorizationOrigin}/token`,
+    })
     const memberResponse = await principalRequest(
       regularUserId,
       `/v1/mcp-connections/${connection.id}/connect/start`,

--- a/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
+++ b/ee/apps/den-api/test/mcp-dynamic-artifact-app.test.ts
@@ -1,6 +1,5 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
 import { expect, test } from "bun:test"
 import {
   LEGACY_WORKFLOW_ARTIFACT_TOOL_NAME,

--- a/ee/apps/den-api/test/mcp-generated-artifact-views.test.ts
+++ b/ee/apps/den-api/test/mcp-generated-artifact-views.test.ts
@@ -1,7 +1,5 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { ResourceListChangedNotificationSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
 import { expect, test } from "bun:test"
 import { createHash } from "node:crypto"
 import type { GeneratedArtifactView, WorkflowArtifactPayload } from "@openwork/types/workflows"
@@ -93,6 +91,10 @@ async function withClient<T>(
     save: overrides.save ?? (async () => view),
     activate: overrides.activate ?? (async ({ revisionId }) => ({ ...view, activeRevisionId: revisionId })),
     retire: overrides.retire ?? (async () => ({ ...view, status: "retired", activeRevisionId: null })),
+    notifyCatalogChanged: () => {
+      server.sendToolListChanged()
+      server.sendResourceListChanged()
+    },
   })
   const client = new Client({ name: "host", version: "1.0.0" }, { capabilities: {} })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -162,8 +164,8 @@ test("activation and rollback refresh the render tool to each exact immutable UR
   await withClient(async (client) => {
     let changed = 0
     let resourcesChanged = 0
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => { changed += 1 })
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => { resourcesChanged += 1 })
+    client.setNotificationHandler("notifications/tools/list_changed", () => { changed += 1 })
+    client.setNotificationHandler("notifications/resources/list_changed", () => { resourcesChanged += 1 })
     await client.callTool({
       name: "activate_artifact_view_revision",
       arguments: { artifactViewId: viewId, revisionId: draftRevisionId },
@@ -194,8 +196,8 @@ test("save and retirement refresh the same session's resources and tools", async
   await withClient(async (client) => {
     let changed = 0
     let resourcesChanged = 0
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => { changed += 1 })
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => { resourcesChanged += 1 })
+    client.setNotificationHandler("notifications/tools/list_changed", () => { changed += 1 })
+    client.setNotificationHandler("notifications/resources/list_changed", () => { resourcesChanged += 1 })
     const saved = await client.callTool({
       name: "save_artifact_view",
       arguments: {

--- a/ee/apps/den-api/test/mcp-plugin-flow-app.test.ts
+++ b/ee/apps/den-api/test/mcp-plugin-flow-app.test.ts
@@ -1,6 +1,5 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
 import { expect, test } from "bun:test"
 import {
   attachPluginFlowCard,

--- a/ee/apps/den-api/test/mcp-skill-created-app.test.ts
+++ b/ee/apps/den-api/test/mcp-skill-created-app.test.ts
@@ -1,6 +1,5 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client"
+import { McpServer } from "@modelcontextprotocol/server"
 import { expect, test } from "bun:test"
 import {
   CREATE_SKILL_TOOL_NAME,

--- a/evals/specs/managed-mcp-handshake-boundaries.test.ts
+++ b/evals/specs/managed-mcp-handshake-boundaries.test.ts
@@ -4,7 +4,7 @@ import { expect } from "vitest";
 import { test } from "@openwork/testkit";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
-const witnessName = "returns safe connection errors for DCR reconnect and callback initialize failures";
+const witnessName = "returns safe connection errors for DCR and protocol negotiation failures";
 
 test("managed MCP handshake boundaries separate provider failures from internal defects", ({ evidence }) => {
   const result = spawnSync("pnpm", [
@@ -26,21 +26,21 @@ test("managed MCP handshake boundaries separate provider failures from internal 
   expect(result.status, output).toBe(0);
   expect(output).toContain("1 pass");
   expect(output).toContain("0 fail");
-  expect(output).toContain("18 expect() calls");
+  expect(output).toContain("24 expect() calls");
 
   evidence.recordAssertionEvidence(
-    "Provider DCR and initialize failures cross a safe reconnect boundary",
-    "The focused HTTP witness requires both deterministic provider failures to return exactly managed_mcp_connection_failed/502, omit nested provider secrets, and persist reconnect_required with no credential.",
+    "Provider DCR and protocol negotiation failures cross a safe reconnect boundary",
+    "The focused HTTP witness requires DCR rejection plus modern discovery and legacy initialize failures to return exactly managed_mcp_connection_failed/502, omit nested provider secrets, and persist reconnect_required with no credential.",
     true,
   );
   evidence.recordAssertionEvidence(
     "Recognized provider handshake failures stay out of telemetry",
-    "The same witness requires the telemetry capture list to remain empty after the DCR and callback-initialize failures.",
+    "The same witness requires the telemetry capture list to remain empty after DCR rejection plus modern discovery and legacy initialize failures.",
     true,
   );
   evidence.recordAssertionEvidence(
     "Malformed SDK data remains an actionable internal defect",
-    "The malformed registration witness must return the generic internal 500 while capturing exactly one non-ApiError EnterpriseMcpClientError with MCP_CONNECTION_HANDSHAKE_FAILED at mcp-initialize.",
+    "The malformed registration witness must return the generic internal 500 while capturing exactly one non-ApiError EnterpriseMcpClientError with MCP_CONNECTION_HANDSHAKE_FAILED at mcp-discovery.",
     true,
   );
 });

--- a/evals/specs/managed-mcp-handshake-boundaries.test.ts
+++ b/evals/specs/managed-mcp-handshake-boundaries.test.ts
@@ -4,7 +4,7 @@ import { expect } from "vitest";
 import { test } from "@openwork/testkit";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
-const witnessName = "returns safe connection errors for DCR and protocol negotiation failures";
+const witnessName = "rolls back a new managed connection when the initial OAuth handshake fails|returns safe connection errors for DCR and protocol negotiation failures";
 
 test("managed MCP handshake boundaries separate provider failures from internal defects", ({ evidence }) => {
   const result = spawnSync("pnpm", [
@@ -24,13 +24,13 @@ test("managed MCP handshake boundaries separate provider failures from internal 
 
   expect(result.error, output).toBeUndefined();
   expect(result.status, output).toBe(0);
-  expect(output).toContain("1 pass");
+  expect(output).toContain("2 pass");
   expect(output).toContain("0 fail");
-  expect(output).toContain("24 expect() calls");
+  expect(output).toContain("28 expect() calls");
 
   evidence.recordAssertionEvidence(
     "Provider DCR and protocol negotiation failures cross a safe reconnect boundary",
-    "The focused HTTP witness requires DCR rejection plus modern discovery and legacy initialize failures to return exactly managed_mcp_connection_failed/502, omit nested provider secrets, and persist reconnect_required with no credential.",
+    "The focused HTTP witness requires an unreachable endpoint plus DCR rejection and modern discovery or legacy initialize failures to return exactly managed_mcp_connection_failed/502, omit provider details, and leave no usable credential.",
     true,
   );
   evidence.recordAssertionEvidence(

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process"
+import { resolve } from "node:path"
+import { expect } from "vitest"
+import { test } from "@openwork/testkit"
+
+const repoRoot = resolve(import.meta.dirname, "../..")
+
+function run(command: string, args: string[]) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 180_000,
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  return {
+    error: result.error,
+    output: `${result.stdout}${result.stderr}`,
+    status: result.status,
+  }
+}
+
+test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ evidence }) => {
+  const connect = run("pnpm", ["--filter", "@openwork/enterprise-mcp-client", "test"])
+  expect(connect.error, connect.output).toBeUndefined()
+  expect(connect.status, connect.output).toBe(0)
+  expect(connect.output).toContain("discovers a 2026 stateless server without an initialize handshake")
+  expect(connect.output).toContain("negotiates the stateless protocol without initialize or a session id")
+  expect(connect.output).toContain("does not downgrade the discovery probe after HTTP 401")
+  expect(connect.output).toContain("keeps an administrator's selected scopes narrower than a scope-less provider advertisement")
+  expect(connect.output).toContain("tests 77")
+  expect(connect.output).toContain("fail 0")
+
+  const agent = run("pnpm", [
+    "--filter",
+    "@openwork-ee/den-api",
+    "exec",
+    "bun",
+    "test",
+    "test/mcp-agent-stateless.test.ts",
+  ])
+  expect(agent.error, agent.output).toBeUndefined()
+  expect(agent.status, agent.output).toBe(0)
+  expect(agent.output).toContain("serves the 2026 stateless wire with fresh per-request servers")
+  expect(agent.output).toContain("rejects a modern protocol header/body mismatch instead of normalizing it")
+  expect(agent.output).toContain("keeps the 2025 stateless fallback for existing clients")
+  expect(agent.output).toContain("delivers modern list changes through subscriptions/listen")
+  expect(agent.output).toContain("4 pass")
+  expect(agent.output).toContain("0 fail")
+
+  evidence.recordAssertionEvidence(
+    "OpenWork Connect negotiates the current stateless protocol",
+    "The outbound client uses automatic SDK negotiation, reaches a 2026-07-28 server through server/discover without initialize or Mcp-Session-Id, and does not misclassify authorization or server failures as legacy-protocol signals.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "The public agent MCP is stateless on the modern wire",
+    "The HTTP witness observes a fresh server for every server/discover, tools/list, and tools/call request; 2026 protocol, method, name, client, and capability metadata; and no request or response session identifier.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "Compatibility and notification behavior remain explicit",
+    "A 2025 SDK client completes initialize and tools/list without a session identifier, while a modern listener receives catalog changes through subscriptions/listen.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "Protocol and authorization boundaries fail closed",
+    "The server rejects a protocol header/body mismatch with JSON-RPC error -32020, and OAuth keeps an administrator-selected read scope narrower than a provider's broader advertisement.",
+    true,
+  )
+})

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -44,13 +44,15 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
     "tsx",
     "--test",
     "--test-name-pattern",
-    "keeps an administrator's selected scopes narrower",
+    "prefers protected-resource scopes|keeps an administrator's selected scopes narrower|rejects selected scopes",
     "test/enterprise-mcp-client.test.ts",
   ])
   expect(scopes.error, scopes.output).toBeUndefined()
   expect(scopes.status, scopes.output).toBe(0)
+  expect(scopes.output).toContain("prefers protected-resource scopes over unrelated authorization-server scopes")
   expect(scopes.output).toContain("keeps an administrator's selected scopes narrower than a scope-less provider advertisement")
-  expect(scopes.output).toContain("tests 1")
+  expect(scopes.output).toContain("rejects selected scopes that neither the resource nor authorization server advertises")
+  expect(scopes.output).toContain("tests 3")
   expect(scopes.output).toContain("fail 0")
 
   const agent = run("pnpm", [
@@ -66,8 +68,10 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   expect(agent.output).toContain("serves the 2026 stateless wire with fresh per-request servers")
   expect(agent.output).toContain("rejects a modern protocol header/body mismatch instead of normalizing it")
   expect(agent.output).toContain("keeps the 2025 stateless fallback for existing clients")
+  expect(agent.output).toContain("keeps a prepared request-local server bound through legacy request cloning")
   expect(agent.output).toContain("delivers modern list changes through subscriptions/listen")
-  expect(agent.output).toContain("4 pass")
+  expect(agent.output).toContain("isolates list-change subscriptions by authenticated catalog audience")
+  expect(agent.output).toContain("6 pass")
   expect(agent.output).toContain("0 fail")
 
   const managedGateway = run("pnpm", [
@@ -96,12 +100,12 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   )
   evidence.recordAssertionEvidence(
     "Compatibility and notification behavior remain explicit",
-    "A 2025 SDK client completes initialize and tools/list without a session identifier, while a modern listener receives catalog changes through subscriptions/listen.",
+    "A 2025 SDK client completes initialize and tools/list without a session identifier even when the SDK clones its Request, while modern listeners receive catalog changes through subscriptions/listen only for their authenticated organization and user audience.",
     true,
   )
   evidence.recordAssertionEvidence(
     "Protocol and authorization boundaries fail closed",
-    "The server rejects a protocol header/body mismatch with JSON-RPC error -32020, and OAuth keeps an administrator-selected read scope narrower than a provider's broader advertisement.",
+    "The server rejects a protocol header/body mismatch with JSON-RPC error -32020. OAuth prefers resource-specific scopes over unrelated authorization-server scopes, preserves a narrower administrator selection, and rejects selections advertised by neither party before registration.",
     true,
   )
   evidence.recordAssertionEvidence(

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -47,6 +47,20 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   expect(agent.output).toContain("4 pass")
   expect(agent.output).toContain("0 fail")
 
+  const managedGateway = run("pnpm", [
+    "--filter",
+    "openwork-server",
+    "test",
+    "src/local-managed-mcp.e2e.test.ts",
+    "--test-name-pattern",
+    "returns safe connection errors for DCR and protocol negotiation failures",
+  ])
+  expect(managedGateway.error, managedGateway.output).toBeUndefined()
+  expect(managedGateway.status, managedGateway.output).toBe(0)
+  expect(managedGateway.output).toContain("1 pass")
+  expect(managedGateway.output).toContain("0 fail")
+  expect(managedGateway.output).toContain("24 expect() calls")
+
   evidence.recordAssertionEvidence(
     "OpenWork Connect negotiates the current stateless protocol",
     "The outbound client uses automatic SDK negotiation, reaches a 2026-07-28 server through server/discover without initialize or Mcp-Session-Id, and does not misclassify authorization or server failures as legacy-protocol signals.",
@@ -65,6 +79,11 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   evidence.recordAssertionEvidence(
     "Protocol and authorization boundaries fail closed",
     "The server rejects a protocol header/body mismatch with JSON-RPC error -32020, and OAuth keeps an administrator-selected read scope narrower than a provider's broader advertisement.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "Managed Connect failures preserve safe API boundaries",
+    "DCR rejection plus modern discovery and legacy initialize failures return the bounded managed-MCP 502 without provider secrets or telemetry noise, while malformed internal SDK data remains a captured generic 500.",
     true,
   )
 })

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -20,15 +20,38 @@ function run(command: string, args: string[]) {
 }
 
 test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ evidence }) => {
-  const connect = run("pnpm", ["--filter", "@openwork/enterprise-mcp-client", "test"])
+  const connect = run("pnpm", [
+    "--filter",
+    "@openwork/enterprise-mcp-client",
+    "exec",
+    "tsx",
+    "--test",
+    "test/requirements-discovery.test.ts",
+    "test/slack-mcp-compat.test.ts",
+  ])
   expect(connect.error, connect.output).toBeUndefined()
   expect(connect.status, connect.output).toBe(0)
   expect(connect.output).toContain("discovers a 2026 stateless server without an initialize handshake")
   expect(connect.output).toContain("negotiates the stateless protocol without initialize or a session id")
   expect(connect.output).toContain("does not downgrade the discovery probe after HTTP 401")
-  expect(connect.output).toContain("keeps an administrator's selected scopes narrower than a scope-less provider advertisement")
-  expect(connect.output).toContain("tests 77")
+  expect(connect.output).toContain("tests 16")
   expect(connect.output).toContain("fail 0")
+
+  const scopes = run("pnpm", [
+    "--filter",
+    "@openwork/enterprise-mcp-client",
+    "exec",
+    "tsx",
+    "--test",
+    "--test-name-pattern",
+    "keeps an administrator's selected scopes narrower",
+    "test/enterprise-mcp-client.test.ts",
+  ])
+  expect(scopes.error, scopes.output).toBeUndefined()
+  expect(scopes.status, scopes.output).toBe(0)
+  expect(scopes.output).toContain("keeps an administrator's selected scopes narrower than a scope-less provider advertisement")
+  expect(scopes.output).toContain("tests 1")
+  expect(scopes.output).toContain("fail 0")
 
   const agent = run("pnpm", [
     "--filter",

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -114,6 +114,7 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
     "@openwork-ee/den-api",
     "exec",
     "bun",
+    "--conditions=development",
     "test",
     "--test-name-pattern",
     "preserves an application-owned OAuth issuer mismatch over a captured HTTP 401",

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -34,8 +34,29 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   expect(connect.output).toContain("discovers a 2026 stateless server without an initialize handshake")
   expect(connect.output).toContain("negotiates the stateless protocol without initialize or a session id")
   expect(connect.output).toContain("does not downgrade the discovery probe after HTTP 401")
-  expect(connect.output).toContain("tests 16")
+  expect(connect.output).toContain("tests 18")
   expect(connect.output).toContain("fail 0")
+
+  const oauthMetadataBinding = run("pnpm", [
+    "--filter",
+    "@openwork/enterprise-mcp-client",
+    "exec",
+    "tsx",
+    "--test",
+    "--test-name-pattern",
+    "ignores endpoints from a resource alias|rejects a resource alias when the claimed canonical issuer does not verify|replaces resource-alias endpoints with strictly discovered canonical metadata|preserves a cached issuer mismatch through the modern discovery probe|rejects stored OAuth clients and tokens stamped for another issuer",
+    "test/requirements-discovery.test.ts",
+    "test/enterprise-mcp-client.test.ts",
+  ])
+  expect(oauthMetadataBinding.error, oauthMetadataBinding.output).toBeUndefined()
+  expect(oauthMetadataBinding.status, oauthMetadataBinding.output).toBe(0)
+  expect(oauthMetadataBinding.output).toContain("ignores endpoints from a resource alias and uses strictly bound canonical metadata")
+  expect(oauthMetadataBinding.output).toContain("rejects a resource alias when the claimed canonical issuer does not verify")
+  expect(oauthMetadataBinding.output).toContain("replaces resource-alias endpoints with strictly discovered canonical metadata")
+  expect(oauthMetadataBinding.output).toContain("preserves a cached issuer mismatch through the modern discovery probe")
+  expect(oauthMetadataBinding.output).toContain("rejects stored OAuth clients and tokens stamped for another issuer")
+  expect(oauthMetadataBinding.output).toContain("tests 5")
+  expect(oauthMetadataBinding.output).toContain("fail 0")
 
   const scopes = run("pnpm", [
     "--filter",
@@ -88,6 +109,21 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   expect(managedGateway.output).toContain("0 fail")
   expect(managedGateway.output).toContain("28 expect() calls")
 
+  const diagnosticPrecedence = run("pnpm", [
+    "--filter",
+    "@openwork-ee/den-api",
+    "exec",
+    "bun",
+    "test",
+    "--test-name-pattern",
+    "preserves an application-owned OAuth issuer mismatch over a captured HTTP 401",
+    "test/external-mcp-diagnostics.test.ts",
+  ])
+  expect(diagnosticPrecedence.error, diagnosticPrecedence.output).toBeUndefined()
+  expect(diagnosticPrecedence.status, diagnosticPrecedence.output).toBe(0)
+  expect(diagnosticPrecedence.output).toContain("1 pass")
+  expect(diagnosticPrecedence.output).toContain("0 fail")
+
   evidence.recordAssertionEvidence(
     "OpenWork Connect negotiates the current stateless protocol",
     "The outbound client uses automatic SDK negotiation, reaches a 2026-07-28 server through server/discover without initialize or Mcp-Session-Id, and does not misclassify authorization or server failures as legacy-protocol signals.",
@@ -105,7 +141,7 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   )
   evidence.recordAssertionEvidence(
     "Protocol and authorization boundaries fail closed",
-    "The server rejects a protocol header/body mismatch with JSON-RPC error -32020. OAuth prefers resource-specific scopes over unrelated authorization-server scopes, preserves a narrower administrator selection, and rejects selections advertised by neither party before registration.",
+    "The server rejects a protocol header/body mismatch with JSON-RPC error -32020. OAuth prefers resource-specific scopes, rejects unadvertised selections, independently verifies a canonical issuer behind a resource discovery alias, discards alias-supplied endpoints, binds persisted client and token records to their issuer, and preserves issuer-mismatch diagnostics over a captured HTTP 401.",
     true,
   )
   evidence.recordAssertionEvidence(

--- a/evals/specs/mcp-stateless-2026-transport.test.ts
+++ b/evals/specs/mcp-stateless-2026-transport.test.ts
@@ -76,13 +76,13 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
     "test",
     "src/local-managed-mcp.e2e.test.ts",
     "--test-name-pattern",
-    "returns safe connection errors for DCR and protocol negotiation failures",
+    "rolls back a new managed connection when the initial OAuth handshake fails|returns safe connection errors for DCR and protocol negotiation failures",
   ])
   expect(managedGateway.error, managedGateway.output).toBeUndefined()
   expect(managedGateway.status, managedGateway.output).toBe(0)
-  expect(managedGateway.output).toContain("1 pass")
+  expect(managedGateway.output).toContain("2 pass")
   expect(managedGateway.output).toContain("0 fail")
-  expect(managedGateway.output).toContain("24 expect() calls")
+  expect(managedGateway.output).toContain("28 expect() calls")
 
   evidence.recordAssertionEvidence(
     "OpenWork Connect negotiates the current stateless protocol",
@@ -106,7 +106,7 @@ test("OpenWork Connect and the agent endpoint implement stateless MCP 2026", ({ 
   )
   evidence.recordAssertionEvidence(
     "Managed Connect failures preserve safe API boundaries",
-    "DCR rejection plus modern discovery and legacy initialize failures return the bounded managed-MCP 502 without provider secrets or telemetry noise, while malformed internal SDK data remains a captured generic 500.",
+    "An unreachable server plus DCR rejection and modern discovery or legacy initialize failures return the bounded managed-MCP 502 without provider secrets or telemetry noise, while malformed internal SDK data remains a captured generic 500.",
     true,
   )
 })

--- a/packages/enterprise-mcp-client/package.json
+++ b/packages/enterprise-mcp-client/package.json
@@ -21,7 +21,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/core": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/enterprise-mcp-client/src/contracts.ts
+++ b/packages/enterprise-mcp-client/src/contracts.ts
@@ -1,7 +1,12 @@
-import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
-import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import type { Implementation, ServerCapabilities, Tool } from "@modelcontextprotocol/sdk/types.js"
+import type {
+  Client,
+  Implementation,
+  OAuthClientInformationMixed,
+  OAuthDiscoveryState,
+  OAuthTokens,
+  ServerCapabilities,
+  Tool,
+} from "@modelcontextprotocol/client"
 
 /** Epoch milliseconds. The package never reads a database or environment clock. */
 export type EnterpriseMcpEpochMs = number
@@ -155,6 +160,7 @@ export type EnterpriseMcpRequestPhase =
   | "oauth-client-registration"
   | "oauth-token-exchange"
   | "oauth-token-refresh"
+  | "mcp-discovery"
   | "mcp-initialize"
   | "mcp-tool-discovery"
   | "mcp-tool-execution"
@@ -184,7 +190,8 @@ export type EnterpriseMcpDiagnosticEvent =
     durationMs?: number
     httpStatus?: number
     responseBodyExcerpt?: string
-    protocolVersionFallback?: string
+    protocolEra?: "modern" | "legacy"
+    protocolVersion?: string
   }
   | {
     kind: "credential-invalidation"
@@ -266,6 +273,10 @@ export type EnterpriseMcpListResourceTemplatesInput = {
 }
 
 export type EnterpriseMcpToolResult = Awaited<ReturnType<Client["callTool"]>>
+export type EnterpriseMcpTool = Omit<Tool, "inputSchema" | "outputSchema"> & {
+  inputSchema: Record<string, unknown>
+  outputSchema?: Record<string, unknown>
+}
 export type EnterpriseMcpResourceList = Awaited<ReturnType<Client["listResources"]>>["resources"]
 export type EnterpriseMcpResourceTemplateList = Awaited<ReturnType<Client["listResourceTemplates"]>>["resourceTemplates"]
 export type EnterpriseMcpResourceResult = Awaited<ReturnType<Client["readResource"]>>
@@ -304,7 +315,9 @@ export type EnterpriseMcpConnectionRequirements = {
   status: "ready" | "manual_action_required" | "unsupported" | "unreachable"
   server: {
     url: string
+    protocolEra?: "modern" | "legacy"
     protocolVersion?: string
+    /** Protocol-negotiation status; the field name is retained for API compatibility. */
     initialize: "succeeded" | "authentication_required" | "failed"
   }
   authentication: {
@@ -361,7 +374,7 @@ export interface EnterpriseMcpClient {
   connect(input: EnterpriseMcpConnectInput): Promise<EnterpriseMcpConnectResult>
   completeAuthorization(input: EnterpriseMcpCompleteAuthorizationInput): Promise<void>
   abandonAuthorization(input: EnterpriseMcpAbandonAuthorizationInput): Promise<void>
-  listTools(input: EnterpriseMcpListToolsInput): Promise<Tool[]>
+  listTools(input: EnterpriseMcpListToolsInput): Promise<EnterpriseMcpTool[]>
   callTool(input: EnterpriseMcpCallToolInput): Promise<EnterpriseMcpToolResult>
   callToolRaw(input: EnterpriseMcpCallToolInput): Promise<EnterpriseMcpToolResult>
   listResources(input: EnterpriseMcpListResourcesInput): Promise<EnterpriseMcpResourceList>

--- a/packages/enterprise-mcp-client/src/contracts.ts
+++ b/packages/enterprise-mcp-client/src/contracts.ts
@@ -1,12 +1,14 @@
 import type {
   Client,
   Implementation,
-  OAuthClientInformationMixed,
   OAuthDiscoveryState,
-  OAuthTokens,
   ServerCapabilities,
+  StoredOAuthClientInformation,
+  StoredOAuthTokens,
   Tool,
 } from "@modelcontextprotocol/client"
+
+export type { StoredOAuthClientInformation, StoredOAuthTokens } from "@modelcontextprotocol/client"
 
 /** Epoch milliseconds. The package never reads a database or environment clock. */
 export type EnterpriseMcpEpochMs = number
@@ -34,7 +36,7 @@ export type EnterpriseMcpPersistenceContext = {
 }
 
 export type EnterpriseMcpOAuthClientRegistration = {
-  clientInformation: OAuthClientInformationMixed
+  clientInformation: StoredOAuthClientInformation
   /** Opaque adapter-owned compare-and-swap revision. */
   revision: string
   /** Absolute client/client-secret expiration, when the provider declares one. */
@@ -50,7 +52,7 @@ export interface EnterpriseMcpOAuthClientRegistrationPort {
    */
   save(input: {
     context: EnterpriseMcpPersistenceContext
-    clientInformation: OAuthClientInformationMixed
+    clientInformation: StoredOAuthClientInformation
     /** The redirect URI used for this client registration attempt. */
     redirectUri: string
     expiresAt?: EnterpriseMcpEpochMs
@@ -75,7 +77,7 @@ export interface EnterpriseMcpOAuthDiscoveryPort {
 }
 
 export type EnterpriseMcpOAuthCredential = {
-  tokens: OAuthTokens
+  tokens: StoredOAuthTokens
   /** Absolute access-token expiration, computed when tokens are committed. */
   expiresAt?: EnterpriseMcpEpochMs
   /** Opaque adapter-owned compare-and-swap revision. */
@@ -124,7 +126,7 @@ export interface EnterpriseMcpOAuthCredentialPort {
    */
   save(input: {
     context: EnterpriseMcpPersistenceContext
-    tokens: OAuthTokens
+    tokens: StoredOAuthTokens
     expiresAt?: EnterpriseMcpEpochMs
     source: "authorization-code" | "refresh"
     authorization?: EnterpriseMcpOAuthAuthorizationHandle

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -280,6 +280,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           },
           authorizationTransactionTtlMs,
           expirationSkewMs,
+          fetch: observer.fetch,
           oauthConfiguration,
         })
       : undefined

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -1,7 +1,10 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { auth, UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
-import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
+import {
+  auth,
+  Client,
+  StreamableHTTPClientTransport,
+  UnauthorizedError,
+} from "@modelcontextprotocol/client"
+import type { RequestOptions } from "@modelcontextprotocol/client"
 import { z } from "zod"
 import type {
   EnterpriseMcpAuthorization,
@@ -64,7 +67,6 @@ const DEFAULT_OPERATION_TIMEOUT_MS = 30_000
 const DEFAULT_CLOSE_TIMEOUT_MS = 5_000
 const DEFAULT_AUTHORIZATION_TRANSACTION_TTL_MS = 10 * 60_000
 const DEFAULT_EXPIRATION_SKEW_MS = 30_000
-export const ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK = "2025-06-18"
 const MCP_APP_EXTENSION = "io.modelcontextprotocol/ui"
 const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app"
 
@@ -86,7 +88,6 @@ type Session = {
   controller: AbortController
   requestOptions: RequestOptions
   lifecycle: EnterpriseMcpLifecycle
-  createTransport: () => StreamableHTTPClientTransport
 }
 
 function requestInit(authorization: EnterpriseMcpAuthorization): RequestInit | undefined {
@@ -182,7 +183,8 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
   }
 
   function isMcpResourceRequest(phase: EnterpriseMcpRequestPhase): boolean {
-    return phase === "mcp-initialize"
+    return phase === "mcp-discovery"
+      || phase === "mcp-initialize"
       || phase === "mcp-tool-discovery"
       || phase === "mcp-tool-execution"
       || phase === "mcp-resource-discovery"
@@ -281,18 +283,23 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           oauthConfiguration,
         })
       : undefined
-    const createTransport = () => new StreamableHTTPClientTransport(serverUrl, {
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
       authProvider: oauthProvider,
       fetch: observer.fetch,
       requestInit: requestInit(input.connection.authorization),
     })
-    const transport = createTransport()
     const capabilities = {
       extensions: {
         [MCP_APP_EXTENSION]: { mimeTypes: [MCP_APP_MIME_TYPE] },
       },
     }
-    const client = new Client({ name: clientName, version: clientVersion }, { capabilities })
+    const client = new Client(
+      { name: clientName, version: clientVersion },
+      {
+        capabilities,
+        versionNegotiation: { mode: "auto" },
+      },
+    )
     const requestOptions: RequestOptions = {
       signal: requestSignal,
       timeout: requestTimeoutMs,
@@ -309,59 +316,24 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
       controller,
       requestOptions,
       lifecycle: { expiresAt: configuredExpiresAt, signal: requestSignal },
-      createTransport,
     }
   }
 
-  function hasInitializeHttp400(error: unknown): boolean {
-    let current: unknown = error
-    const seen = new Set<unknown>()
-    for (let depth = 0; depth < 5 && current && !seen.has(current); depth += 1) {
-      seen.add(current)
-      if (current instanceof StreamableHTTPError && current.code === 400) return true
-      current = typeof current === "object" && current !== null && "cause" in current
-        ? current.cause
-        : undefined
-    }
-    return false
-  }
-
-  async function connectWithProtocolVersionFallback(input: {
+  async function connectWithProtocolNegotiation(input: {
     session: Session
     connectionId: string
     operationPhase: EnterpriseMcpOperationPhase
   }): Promise<void> {
-    try {
-      await input.session.client.connect(input.session.transport, input.session.requestOptions)
-      return
-    } catch (error) {
-      if (
-        input.session.observer.lastFailedRequestPhase() !== "mcp-initialize"
-        || !hasInitializeHttp400(error)
-      ) throw error
-    }
-
+    await input.session.client.connect(input.session.transport, input.session.requestOptions)
     emitDiagnostic({
-      kind: "request",
+      kind: "operation",
       connectionId: input.connectionId,
       operationPhase: input.operationPhase,
-      requestPhase: "mcp-initialize",
-      outcome: "started",
-      protocolVersionFallback: ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK,
+      requestPhase: input.session.observer.lastRequestPhase(),
+      outcome: "succeeded",
+      protocolEra: input.session.client.getProtocolEra(),
+      protocolVersion: input.session.client.getNegotiatedProtocolVersion(),
     })
-    input.session.client = new Client(
-      { name: clientName, version: clientVersion },
-      {
-        capabilities: {
-          extensions: {
-            [MCP_APP_EXTENSION]: { mimeTypes: [MCP_APP_MIME_TYPE] },
-          },
-        },
-        protocolVersion: ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK,
-      },
-    )
-    input.session.transport = input.session.createTransport()
-    await input.session.client.connect(input.session.transport, input.session.requestOptions)
   }
 
   async function runOperation<T>(input: {
@@ -434,17 +406,10 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
       flow: { kind: "runtime" },
       operation: async (session) => {
         try {
-          await connectWithProtocolVersionFallback({
+          await connectWithProtocolNegotiation({
             session,
             connectionId: input.connection.id,
             operationPhase: input.operationPhase,
-          })
-          emitDiagnostic({
-            kind: "operation",
-            connectionId: input.connection.id,
-            operationPhase: input.operationPhase,
-            requestPhase: "mcp-initialize",
-            outcome: "succeeded",
           })
           let operationFailed = false
           try {
@@ -498,19 +463,12 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             const hadOAuthCredential = session.oauthProvider
               ? Boolean(await session.oauthProvider.tokens())
               : false
-            await connectWithProtocolVersionFallback({
+            await connectWithProtocolNegotiation({
               session,
               connectionId: input.connection.id,
               operationPhase: "connection-handshake",
             })
-            emitDiagnostic({
-              kind: "operation",
-              connectionId: input.connection.id,
-              operationPhase: "connection-handshake",
-              requestPhase: "mcp-initialize",
-              outcome: "succeeded",
-            })
-            // Some providers allow initialize before challenging on tools/list.
+            // Some providers allow protocol negotiation before challenging on tools/list.
             // Probe only when the server advertised the tools capability: MCP
             // servers are allowed to expose resources and/or prompts without
             // implementing tools/list at all.
@@ -518,7 +476,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
               await session.client.listTools(undefined, session.requestOptions)
             }
             // OAuth connections must not be treated as member-connected merely
-            // because a provider exposes initialize and tools/list publicly.
+            // because a provider exposes protocol negotiation and tools/list publicly.
             // When no member credential exists, proactively run OAuth discovery
             // so providers such as BigQuery can return an authorization URL
             // without first issuing an MCP-level 401 challenge.
@@ -583,17 +541,10 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           try {
             await session.transport.finishAuth(code)
             exchangedTokens = true
-            await connectWithProtocolVersionFallback({
+            await connectWithProtocolNegotiation({
               session,
               connectionId: input.connection.id,
               operationPhase: "authorization-callback",
-            })
-            emitDiagnostic({
-              kind: "operation",
-              connectionId: input.connection.id,
-              operationPhase: "authorization-callback",
-              requestPhase: "mcp-initialize",
-              outcome: "succeeded",
             })
             if (session.client.getServerCapabilities()?.tools) {
               await session.client.listTools(undefined, session.requestOptions)
@@ -690,7 +641,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           const result = await session.client.callTool({
             name: toolName,
             arguments: input.arguments,
-          }, undefined, session.requestOptions)
+          }, session.requestOptions)
           return result
         },
       })
@@ -707,7 +658,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           const result = await session.client.callTool({
             name: toolName,
             arguments: input.arguments,
-          }, undefined, session.requestOptions)
+          }, session.requestOptions)
           if ("isError" in result && result.isError) throw new EnterpriseMcpToolResultError(result)
           return result
         },

--- a/packages/enterprise-mcp-client/src/errors.ts
+++ b/packages/enterprise-mcp-client/src/errors.ts
@@ -1,5 +1,4 @@
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
-
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client"
 import type { EnterpriseMcpOperationPhase, EnterpriseMcpRequestPhase } from "./contracts.js"
 
 export type EnterpriseMcpErrorCode =
@@ -32,7 +31,7 @@ const phaseLabel: Record<EnterpriseMcpOperationPhase, string> = {
   "requirements-discovery": "MCP connection requirements discovery",
   "connection-handshake": "MCP connection handshake",
   "authorization-callback": "OAuth authorization callback",
-  "protocol-initialize": "MCP protocol initialization",
+  "protocol-initialize": "MCP protocol negotiation",
   "tool-discovery": "MCP tool discovery",
   "tool-execution": "MCP tool execution",
   "resource-discovery": "MCP resource discovery",
@@ -47,6 +46,7 @@ const requestPhaseLabel: Record<EnterpriseMcpRequestPhase, string> = {
   "oauth-client-registration": "OAuth client registration",
   "oauth-token-exchange": "OAuth token exchange",
   "oauth-token-refresh": "OAuth token refresh",
+  "mcp-discovery": "the MCP server/discover request",
   "mcp-initialize": "the MCP initialize request",
   "mcp-tool-discovery": "the MCP tools/list request",
   "mcp-tool-execution": "the MCP tools/call request",
@@ -76,17 +76,17 @@ export class EnterpriseMcpClientError extends Error {
 
 /**
  * Marks a lifecycle abort as ours on the `data` of an MCP error. The SDK
- * rethrows an `McpError` untouched but collapses any other abort reason into
+ * rethrows an `SdkError` untouched but collapses any other abort reason into
  * `String(reason)` on a RequestTimeout, leaving downstream diagnostics unable
  * to tell an OpenWork deadline apart from a provider-declared failure.
  */
 export const ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY = "enterpriseMcpLifecycleDeadline"
 
-export class EnterpriseMcpLifecycleDeadlineError extends McpError {
+export class EnterpriseMcpLifecycleDeadlineError extends SdkError {
   readonly operationPhase: EnterpriseMcpOperationPhase
 
   constructor(operationPhase: EnterpriseMcpOperationPhase) {
-    super(ErrorCode.RequestTimeout, `Enterprise MCP ${operationPhase} exceeded its lifecycle deadline.`, {
+    super(SdkErrorCode.RequestTimeout, `Enterprise MCP ${operationPhase} exceeded its lifecycle deadline.`, {
       [ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY]: true,
       operationPhase,
     })

--- a/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
+++ b/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
@@ -1,4 +1,4 @@
-import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/client"
 import { isEquivalentOAuthDiscoveryAlias } from "./oauth-resource-alias.js"
 
 type OAuthDiscoveryBindingState = Pick<OAuthDiscoveryState, "authorizationServerUrl"> & {

--- a/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
+++ b/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
@@ -14,6 +14,16 @@ function isResourceScopedDiscoveryAlias(state: OAuthDiscoveryBindingState, expec
     && advertisedIssuers?.some((issuer) => isEquivalentOAuthDiscoveryAlias(issuer, state.authorizationServerUrl)) === true
 }
 
+function advertisesExpectedIssuerOrResourceAlias(
+  state: OAuthDiscoveryBindingState,
+  expectedIssuer: string,
+): boolean {
+  const advertisedIssuers = state.resourceMetadata?.authorization_servers
+  if (advertisedIssuers === undefined) return true
+  return advertisedIssuers.some((issuer) => isEquivalentOAuthDiscoveryAlias(issuer, expectedIssuer))
+    || advertisedIssuers.some((issuer) => isEquivalentOAuthDiscoveryAlias(issuer, state.resourceMetadata?.resource))
+}
+
 /**
  * Bind OAuth metadata to either its advertised issuer or the constrained
  * resource-scoped discovery alias advertised by the protected resource.
@@ -23,10 +33,8 @@ export function isAuthorizationServerDiscoveryBound(
   state: OAuthDiscoveryBindingState,
   expectedIssuer: string,
 ): boolean {
-  const advertisedIssuers = state.resourceMetadata?.authorization_servers
   const directBinding = isEquivalentOAuthDiscoveryAlias(state.authorizationServerUrl, expectedIssuer)
-    && (advertisedIssuers === undefined
-      || advertisedIssuers.some((issuer) => isEquivalentOAuthDiscoveryAlias(issuer, expectedIssuer)))
+    && advertisesExpectedIssuerOrResourceAlias(state, expectedIssuer)
   const discoveryBinding = directBinding || isResourceScopedDiscoveryAlias(state, expectedIssuer)
   return discoveryBinding
     && (state.authorizationServerMetadata?.issuer === undefined

--- a/packages/enterprise-mcp-client/src/oauth-provider.ts
+++ b/packages/enterprise-mcp-client/src/oauth-provider.ts
@@ -1,11 +1,10 @@
-import type { OAuthClientProvider, OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
-import {
-  OAuthClientInformationFullSchema,
-  OAuthClientInformationSchema,
-  OAuthTokensSchema,
-  type OAuthClientInformationMixed,
-  type OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js"
+import { OAuthClientInformationFullSchema, OAuthClientInformationSchema, OAuthTokensSchema } from "@modelcontextprotocol/core"
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientProvider,
+  OAuthDiscoveryState,
+  OAuthTokens,
+} from "@modelcontextprotocol/client"
 import type {
   EnterpriseMcpClock,
   EnterpriseMcpLifecycle,

--- a/packages/enterprise-mcp-client/src/oauth-provider.ts
+++ b/packages/enterprise-mcp-client/src/oauth-provider.ts
@@ -1,9 +1,12 @@
 import { OAuthClientInformationFullSchema, OAuthClientInformationSchema, OAuthTokensSchema } from "@modelcontextprotocol/core"
+import { discoverAuthorizationServerMetadata, IssuerMismatchError } from "@modelcontextprotocol/client"
 import type {
-  OAuthClientInformationMixed,
+  AuthorizationServerMetadata,
+  OAuthClientInformationContext,
   OAuthClientProvider,
   OAuthDiscoveryState,
-  OAuthTokens,
+  StoredOAuthClientInformation,
+  StoredOAuthTokens,
 } from "@modelcontextprotocol/client"
 import type {
   EnterpriseMcpClock,
@@ -12,6 +15,7 @@ import type {
   EnterpriseMcpOAuthClientRegistration,
   EnterpriseMcpOAuthCredential,
   EnterpriseMcpOAuthConfiguration,
+  EnterpriseMcpFetch,
   EnterpriseMcpOAuthPersistence,
   EnterpriseMcpPersistenceContext,
 } from "./contracts.js"
@@ -22,6 +26,13 @@ type OAuthFlowContext =
   | { kind: "connect"; authorizationId?: string }
   | { kind: "callback"; authorizationId: string }
   | { kind: "runtime" }
+
+type VerifiedOAuthDiscoveryState = OAuthDiscoveryState & {
+  openworkMetadataVerification?: {
+    version: 1
+    issuer: string
+  }
+}
 
 const oauthClientInformationMixedSchema = OAuthClientInformationFullSchema.or(OAuthClientInformationSchema)
 
@@ -35,14 +46,14 @@ function assertFiniteEpoch(value: number, field: string): number {
   return value
 }
 
-function clientExpiration(clientInformation: OAuthClientInformationMixed): number | undefined {
+function clientExpiration(clientInformation: StoredOAuthClientInformation): number | undefined {
   const parsed = OAuthClientInformationFullSchema.safeParse(clientInformation)
   const seconds = parsed.success ? parsed.data.client_secret_expires_at : undefined
   if (seconds === undefined || seconds === 0) return undefined
   return assertFiniteEpoch(seconds * 1_000, "client expiration")
 }
 
-function tokenExpiration(tokens: OAuthTokens, now: number): number | undefined {
+function tokenExpiration(tokens: StoredOAuthTokens, now: number): number | undefined {
   if (tokens.expires_in === undefined) return undefined
   if (!Number.isFinite(tokens.expires_in) || tokens.expires_in < 0) {
     throw new EnterpriseMcpOAuthContractError(
@@ -66,10 +77,12 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
   private readonly applicationType: EnterpriseMcpOAuthConfiguration["applicationType"]
   private readonly authorizationServerIssuer: string | undefined
   private readonly requestedScopes: string[]
+  private readonly fetch: EnterpriseMcpFetch
   readonly clientMetadataUrl: string | undefined
   private loadedClient: EnterpriseMcpOAuthClientRegistration | undefined
   private loadedCredential: EnterpriseMcpOAuthCredential | undefined
   private loadedDiscovery: OAuthDiscoveryState | undefined
+  private verifiedAuthorizationServerMetadata: AuthorizationServerMetadata | undefined
   private authorizationHandle: EnterpriseMcpOAuthAuthorizationHandle | undefined
   authorizeUrl: string | null = null
 
@@ -83,6 +96,7 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     lifecycle: EnterpriseMcpLifecycle
     authorizationTransactionTtlMs: number
     expirationSkewMs: number
+    fetch: EnterpriseMcpFetch
     oauthConfiguration?: EnterpriseMcpOAuthConfiguration
   }) {
     this.redirectUri = input.redirectUri
@@ -98,6 +112,7 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     this.clientMetadataUrl = input.oauthConfiguration?.clientMetadataUrl
     this.authorizationServerIssuer = input.oauthConfiguration?.authorizationServerIssuer
     this.requestedScopes = [...new Set(input.oauthConfiguration?.requestedScopes ?? [])]
+    this.fetch = input.fetch
   }
 
   private context(): EnterpriseMcpPersistenceContext {
@@ -161,18 +176,132 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     }
   }
 
-  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
-    const state = await this.persistence.discovery?.load(this.context())
+  private expectedCredentialIssuer(context?: OAuthClientInformationContext): string | undefined {
+    const boundIssuer = this.authorizationServerIssuer
+      ?? this.loadedDiscovery?.authorizationServerMetadata?.issuer
+      ?? this.loadedDiscovery?.authorizationServerUrl
+    if (context?.issuer && boundIssuer && context.issuer !== boundIssuer) {
+      throw new EnterpriseMcpOAuthContractError(
+        "MCP_OAUTH_ISSUER_MISMATCH",
+        "The OAuth credential context does not match the selected authorization server issuer.",
+      )
+    }
+    return boundIssuer ?? context?.issuer
+  }
+
+  private assertStoredIssuer(issuer: string | undefined, expectedIssuer: string | undefined): void {
+    if (issuer === undefined || expectedIssuer === undefined || issuer === expectedIssuer) return
+    throw new EnterpriseMcpOAuthContractError(
+      "MCP_OAUTH_ISSUER_MISMATCH",
+      "The stored OAuth credential does not match the selected authorization server issuer.",
+    )
+  }
+
+  private storedClientInformation(
+    clientInformation: StoredOAuthClientInformation,
+    context?: OAuthClientInformationContext,
+  ): StoredOAuthClientInformation {
+    const expectedIssuer = this.expectedCredentialIssuer(context)
+    this.assertStoredIssuer(clientInformation.issuer, expectedIssuer)
+    const validated = oauthClientInformationMixedSchema.parse(clientInformation)
+    const issuer = clientInformation.issuer ?? expectedIssuer
+    return { ...validated, ...(issuer ? { issuer } : {}) }
+  }
+
+  private storedTokens(tokens: StoredOAuthTokens, context?: OAuthClientInformationContext): StoredOAuthTokens {
+    const expectedIssuer = this.expectedCredentialIssuer(context)
+    this.assertStoredIssuer(tokens.issuer, expectedIssuer)
+    const validated = OAuthTokensSchema.parse(tokens)
+    const issuer = tokens.issuer ?? expectedIssuer
+    return { ...validated, ...(issuer ? { issuer } : {}) }
+  }
+
+  private async canonicalAuthorizationServerMetadata(): Promise<AuthorizationServerMetadata | undefined> {
+    const selectedIssuer = this.authorizationServerIssuer
+    if (!selectedIssuer) return undefined
+    if (this.verifiedAuthorizationServerMetadata?.issuer === selectedIssuer) {
+      return this.verifiedAuthorizationServerMetadata
+    }
+
+    let metadata: AuthorizationServerMetadata | undefined
+    try {
+      metadata = await discoverAuthorizationServerMetadata(selectedIssuer, { fetchFn: this.fetch })
+    } catch (error) {
+      if (error instanceof IssuerMismatchError) {
+        throw new EnterpriseMcpOAuthContractError(
+          "MCP_OAUTH_ISSUER_MISMATCH",
+          "The selected OAuth issuer could not be verified against its canonical metadata.",
+        )
+      }
+      throw error
+    }
+    if (!metadata) {
+      throw new Error(`No OAuth metadata was found for the selected issuer ${selectedIssuer}.`)
+    }
+    this.verifiedAuthorizationServerMetadata = metadata
+    return metadata
+  }
+
+  private hasCurrentMetadataVerification(state: OAuthDiscoveryState, selectedIssuer: string): boolean {
+    const verifiedState = state as VerifiedOAuthDiscoveryState
+    return verifiedState.openworkMetadataVerification?.version === 1
+      && verifiedState.openworkMetadataVerification.issuer === selectedIssuer
+      && state.authorizationServerUrl === selectedIssuer
+      && state.authorizationServerMetadata?.issuer === selectedIssuer
+  }
+
+  private async normalizeDiscoveryState(state: OAuthDiscoveryState | undefined): Promise<VerifiedOAuthDiscoveryState | undefined> {
+    const selectedIssuer = this.authorizationServerIssuer
+    if (!selectedIssuer) return state
     if (state) {
       this.assertDiscoveryBinding(state)
+      if (this.hasCurrentMetadataVerification(state, selectedIssuer)) {
+        this.verifiedAuthorizationServerMetadata = state.authorizationServerMetadata
+        return state
+      }
+    }
+    const metadata = await this.canonicalAuthorizationServerMetadata()
+    if (!metadata) return state
+
+    const normalized: VerifiedOAuthDiscoveryState = {
+      ...state,
+      authorizationServerUrl: selectedIssuer,
+      authorizationServerMetadata: metadata,
+      openworkMetadataVerification: {
+        version: 1,
+        issuer: selectedIssuer,
+      },
+    }
+    this.assertDiscoveryBinding(normalized)
+    return normalized
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    const persistedState = await this.persistence.discovery?.load(this.context())
+    const state = await this.normalizeDiscoveryState(persistedState)
+    if (state) {
+      this.assertDiscoveryBinding(state)
+      if (
+        persistedState
+        && (
+          persistedState.authorizationServerUrl !== state.authorizationServerUrl
+          || JSON.stringify(persistedState.authorizationServerMetadata) !== JSON.stringify(state.authorizationServerMetadata)
+          || !(persistedState as VerifiedOAuthDiscoveryState).openworkMetadataVerification
+        )
+      ) {
+        await this.persistence.discovery?.save({ context: this.context(), state })
+      }
       this.loadedDiscovery = state
     }
     return state
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    let normalizedState: OAuthDiscoveryState | undefined
     try {
-      this.assertDiscoveryBinding(state)
+      normalizedState = await this.normalizeDiscoveryState(state)
+      if (!normalizedState) throw new Error("OAuth discovery state was unavailable.")
+      this.assertDiscoveryBinding(normalizedState)
     } catch (error) {
       await this.persistence.discovery?.invalidate({
         context: this.context(),
@@ -180,11 +309,11 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
       })
       throw error
     }
-    await this.persistence.discovery?.save({ context: this.context(), state })
-    this.loadedDiscovery = state
+    await this.persistence.discovery?.save({ context: this.context(), state: normalizedState })
+    this.loadedDiscovery = normalizedState
   }
 
-  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+  async clientInformation(context?: OAuthClientInformationContext): Promise<StoredOAuthClientInformation | undefined> {
     const record = await this.persistence.clientRegistrations.load(this.context())
     if (!record) {
       this.loadedClient = undefined
@@ -198,7 +327,7 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
       }
       return undefined
     }
-    oauthClientInformationMixedSchema.parse(record.clientInformation)
+    const clientInformation = this.storedClientInformation(record.clientInformation, context)
     if (!record.revision.trim()) {
       throw new EnterpriseMcpOAuthContractError(
         "MCP_OAUTH_PERSISTENCE_INVALID",
@@ -216,11 +345,14 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
       }
     }
     this.loadedClient = record
-    return record.clientInformation
+    return clientInformation
   }
 
-  async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
-    const validated = oauthClientInformationMixedSchema.parse(clientInformation)
+  async saveClientInformation(
+    clientInformation: StoredOAuthClientInformation,
+    context?: OAuthClientInformationContext,
+  ): Promise<void> {
+    const validated = this.storedClientInformation(clientInformation, context)
     const source = this.clientMetadataUrl === validated.client_id ? "client-metadata" : "dynamic"
     const saved = await this.persistence.clientRegistrations.save({
       context: this.context(),
@@ -238,13 +370,13 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     this.loadedClient = saved
   }
 
-  async tokens(): Promise<OAuthTokens | undefined> {
+  async tokens(context?: OAuthClientInformationContext): Promise<StoredOAuthTokens | undefined> {
     const record = await this.persistence.credentials.load(this.context())
     if (!record) {
       this.loadedCredential = undefined
       return undefined
     }
-    const tokens = OAuthTokensSchema.parse(record.tokens)
+    const tokens = this.storedTokens(record.tokens, context)
     if (!record.revision.trim()) {
       throw new EnterpriseMcpOAuthContractError(
         "MCP_OAUTH_PERSISTENCE_INVALID",
@@ -265,8 +397,8 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
     return tokens
   }
 
-  async saveTokens(tokens: OAuthTokens): Promise<void> {
-    const validated = OAuthTokensSchema.parse(tokens)
+  async saveTokens(tokens: StoredOAuthTokens, context?: OAuthClientInformationContext): Promise<void> {
+    const validated = this.storedTokens(tokens, context)
     const source = this.authorizationHandle ? "authorization-code" : "refresh"
     const existing = source === "refresh"
       ? (this.loadedCredential ?? await this.persistence.credentials.load(this.context()))

--- a/packages/enterprise-mcp-client/src/request-observer.ts
+++ b/packages/enterprise-mcp-client/src/request-observer.ts
@@ -36,6 +36,7 @@ function bodyRequestPhase(body: BodyInit | null | undefined): EnterpriseMcpReque
       }
       return null
     }
+    if (request.data.method === "server/discover") return "mcp-discovery"
     if (request.data.method === "initialize") return "mcp-initialize"
     if (request.data.method === "tools/list") return "mcp-tool-discovery"
     if (request.data.method === "tools/call") return "mcp-tool-execution"
@@ -50,6 +51,7 @@ function bodyRequestPhase(body: BodyInit | null | undefined): EnterpriseMcpReque
 
 function isMcpRequestPhase(phase: EnterpriseMcpRequestPhase): boolean {
   return phase === "endpoint-request"
+    || phase === "mcp-discovery"
     || phase === "mcp-initialize"
     || phase === "mcp-tool-discovery"
     || phase === "mcp-tool-execution"

--- a/packages/enterprise-mcp-client/src/requirements-discovery.ts
+++ b/packages/enterprise-mcp-client/src/requirements-discovery.ts
@@ -1,11 +1,11 @@
 import {
+  Client,
   discoverAuthorizationServerMetadata,
   discoverOAuthProtectedResourceMetadata,
   extractWWWAuthenticateParams,
-} from "@modelcontextprotocol/sdk/client/auth.js"
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
-import type { AuthorizationServerMetadata } from "@modelcontextprotocol/sdk/shared/auth.js"
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client"
+import type { AuthorizationServerMetadata } from "@modelcontextprotocol/client"
 import type {
   DiscoverEnterpriseMcpConnectionRequirementsInput,
   EnterpriseMcpAuthorizationServerRequirement,
@@ -198,13 +198,20 @@ export async function discoverConnectionRequirements(
   const warnings: EnterpriseMcpConnectionRequirements["warnings"] = []
   const tools: NonNullable<EnterpriseMcpConnectionRequirements["tools"]["items"]> = []
   let initialize: EnterpriseMcpConnectionRequirements["server"]["initialize"] = "failed"
+  let protocolEra: EnterpriseMcpConnectionRequirements["server"]["protocolEra"]
+  let protocolVersion: string | undefined
   let authenticationRequired = false
   let client: Client | undefined
   try {
-    client = new Client({ name: "OpenWork requirements discovery", version: "1.0.0" }, { capabilities: {} })
+    client = new Client(
+      { name: "OpenWork requirements discovery", version: "1.0.0" },
+      { capabilities: {}, versionNegotiation: { mode: "auto" } },
+    )
     const transport = new StreamableHTTPClientTransport(serverUrl, { fetch })
     await client.connect(transport, { signal: controller.signal })
     initialize = "succeeded"
+    protocolEra = client.getProtocolEra()
+    protocolVersion = client.getNegotiatedProtocolVersion()
     let cursor: string | undefined
     const maxTools = input.maxTools ?? DEFAULT_MAX_TOOLS
     for (let page = 0; page < MAX_TOOL_PAGES && tools.length < maxTools; page += 1) {
@@ -259,7 +266,15 @@ export async function discoverConnectionRequirements(
   const authorizationServers: EnterpriseMcpAuthorizationServerRequirement[] = []
   for (const issuer of advertisedIssuers) {
     try {
-      const metadata = await discoverAuthorizationServerMetadata(issuer, { fetchFn: fetch })
+      // Some providers advertise the protected resource itself as their OAuth
+      // discovery alias. The SDK's strict issuer echo check cannot recognize
+      // that shape, so defer the comparison to metadataRequirement below,
+      // which accepts only an exact issuer, a root-slash alias, or this
+      // protected resource's own discovery alias.
+      const metadata = await discoverAuthorizationServerMetadata(issuer, {
+        fetchFn: fetch,
+        skipIssuerValidation: true,
+      })
       if (!metadata) {
         warnings.push({ code: "oauth_server_metadata_unavailable", message: `No OAuth metadata was found for issuer ${issuer}.` })
         continue
@@ -312,7 +327,12 @@ export async function discoverConnectionRequirements(
   try {
     return {
       status,
-      server: { url: serverUrl.toString(), initialize },
+      server: {
+        url: serverUrl.toString(),
+        initialize,
+        ...(protocolEra ? { protocolEra } : {}),
+        ...(protocolVersion ? { protocolVersion } : {}),
+      },
       authentication: {
         kind: initialize === "succeeded" ? "none" : oauthDetected ? "oauth" : authenticationRequired ? "manual_bearer" : "unknown",
         resource: resourceMetadata?.resource,

--- a/packages/enterprise-mcp-client/src/requirements-discovery.ts
+++ b/packages/enterprise-mcp-client/src/requirements-discovery.ts
@@ -3,6 +3,7 @@ import {
   discoverAuthorizationServerMetadata,
   discoverOAuthProtectedResourceMetadata,
   extractWWWAuthenticateParams,
+  IssuerMismatchError,
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client"
 import type { AuthorizationServerMetadata } from "@modelcontextprotocol/client"
@@ -95,20 +96,7 @@ function scopedFetch(input: {
   }
 }
 
-function metadataRequirement(
-  advertisedIssuer: string,
-  metadata: AuthorizationServerMetadata,
-  resource: string | undefined,
-): EnterpriseMcpAuthorizationServerRequirement | null {
-  // Some providers advertise the protected resource itself as a scoped
-  // metadata discovery alias. Accept that alias, including the equivalent
-  // trailing root slash form, while retaining the metadata issuer as the
-  // canonical issuer used by the OAuth flow.
-  if (
-    metadata.issuer !== advertisedIssuer
-    && !isEquivalentOAuthDiscoveryAlias(advertisedIssuer, metadata.issuer)
-    && !isEquivalentOAuthDiscoveryAlias(advertisedIssuer, resource)
-  ) return null
+function metadataRequirement(metadata: AuthorizationServerMetadata): EnterpriseMcpAuthorizationServerRequirement {
   return {
     issuer: metadata.issuer,
     authorizationEndpoint: metadata.authorization_endpoint,
@@ -120,6 +108,33 @@ function metadataRequirement(
     codeChallengeMethodsSupported: metadata.code_challenge_methods_supported,
     tokenEndpointAuthMethodsSupported: metadata.token_endpoint_auth_methods_supported,
   }
+}
+
+async function discoverBoundAuthorizationServerMetadata(input: {
+  advertisedIssuer: string
+  resource: string | undefined
+  fetch: EnterpriseMcpFetch
+}): Promise<AuthorizationServerMetadata | null> {
+  let canonicalIssuer: string
+  try {
+    return await discoverAuthorizationServerMetadata(input.advertisedIssuer, { fetchFn: input.fetch }) ?? null
+  } catch (error) {
+    if (
+      !(error instanceof IssuerMismatchError)
+      || !isEquivalentOAuthDiscoveryAlias(input.advertisedIssuer, input.resource)
+      || typeof error.received !== "string"
+      || !error.received
+    ) throw error
+    canonicalIssuer = error.received
+  }
+
+  // A few providers advertise the protected resource as a discovery alias.
+  // The strict SDK mismatch exposes only the parsed issuer identifier. Treat
+  // that value as a pointer, independently rediscover it with RFC 8414 issuer
+  // validation enabled, and never consume endpoints from the alias document.
+  return await discoverAuthorizationServerMetadata(canonicalIssuer, {
+    fetchFn: input.fetch,
+  }) ?? null
 }
 
 function uniqueScopes(value: string | undefined): string[] {
@@ -266,28 +281,19 @@ export async function discoverConnectionRequirements(
   const authorizationServers: EnterpriseMcpAuthorizationServerRequirement[] = []
   for (const issuer of advertisedIssuers) {
     try {
-      // Some providers advertise the protected resource itself as their OAuth
-      // discovery alias. The SDK's strict issuer echo check cannot recognize
-      // that shape, so defer the comparison to metadataRequirement below,
-      // which accepts only an exact issuer, a root-slash alias, or this
-      // protected resource's own discovery alias.
-      const metadata = await discoverAuthorizationServerMetadata(issuer, {
-        fetchFn: fetch,
-        skipIssuerValidation: true,
+      const metadata = await discoverBoundAuthorizationServerMetadata({
+        advertisedIssuer: issuer,
+        resource: resourceMetadata?.resource,
+        fetch,
       })
       if (!metadata) {
         warnings.push({ code: "oauth_server_metadata_unavailable", message: `No OAuth metadata was found for issuer ${issuer}.` })
         continue
       }
-      const requirement = metadataRequirement(issuer, metadata, resourceMetadata?.resource)
-      if (!requirement) {
-        warnings.push({ code: "oauth_issuer_mismatch", message: `OAuth metadata did not return the advertised issuer ${issuer}.` })
-        continue
-      }
-      authorizationServers.push(requirement)
+      authorizationServers.push(metadataRequirement(metadata))
     } catch (error) {
       warnings.push({
-        code: "oauth_server_metadata_unavailable",
+        code: error instanceof IssuerMismatchError ? "oauth_issuer_mismatch" : "oauth_server_metadata_unavailable",
         message: error instanceof Error ? error.message : `OAuth metadata could not be loaded for issuer ${issuer}.`,
       })
     }

--- a/packages/enterprise-mcp-client/src/resource-catalog.ts
+++ b/packages/enterprise-mcp-client/src/resource-catalog.ts
@@ -1,6 +1,5 @@
 import { Buffer } from "node:buffer"
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
+import type { Client, RequestOptions } from "@modelcontextprotocol/client"
 import { EnterpriseMcpCatalogError } from "./errors.js"
 
 export const ENTERPRISE_MCP_RESOURCE_PAGE_LIMIT = 20

--- a/packages/enterprise-mcp-client/src/tool-catalog.ts
+++ b/packages/enterprise-mcp-client/src/tool-catalog.ts
@@ -1,7 +1,6 @@
 import { Buffer } from "node:buffer"
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
-import type { Tool } from "@modelcontextprotocol/sdk/types.js"
+import type { RequestOptions } from "@modelcontextprotocol/client"
+import type { EnterpriseMcpTool } from "./contracts.js"
 import { EnterpriseMcpCatalogError, type EnterpriseMcpCatalogErrorCode } from "./errors.js"
 
 export const ENTERPRISE_MCP_TOOL_PAGE_LIMIT = 20
@@ -14,7 +13,10 @@ export const ENTERPRISE_MCP_TOOL_SCHEMA_DEPTH_LIMIT = 64
 export const ENTERPRISE_MCP_CURSOR_LIMIT_BYTES = 16 * 1024
 export const ENTERPRISE_MCP_CATALOG_LIMIT_BYTES = 8 * 1024 * 1024
 
-type ToolPage = Awaited<ReturnType<Client["listTools"]>>
+type ToolPage = {
+  tools: EnterpriseMcpTool[]
+  nextCursor?: string
+}
 
 function serializedBytes(value: unknown): number {
   const serialized = JSON.stringify(value)
@@ -65,7 +67,7 @@ function assertSchema(schema: unknown): void {
   }
 }
 
-function assertTool(tool: Tool): void {
+function assertTool(tool: EnterpriseMcpTool): void {
   assertStringLimit(tool.name, ENTERPRISE_MCP_TOOL_NAME_LIMIT_BYTES, "MCP_CATALOG_TOOL_NAME_LIMIT")
   assertStringLimit(tool.title, ENTERPRISE_MCP_TOOL_TITLE_LIMIT_BYTES, "MCP_CATALOG_TOOL_TITLE_LIMIT")
   assertStringLimit(tool.description, ENTERPRISE_MCP_TOOL_DESCRIPTION_LIMIT_BYTES, "MCP_CATALOG_TOOL_DESCRIPTION_LIMIT")
@@ -76,8 +78,8 @@ function assertTool(tool: Tool): void {
 export async function collectEnterpriseMcpTools(input: {
   listPage: (cursor: string | undefined, options: RequestOptions) => Promise<ToolPage>
   requestOptions: RequestOptions
-}): Promise<Tool[]> {
-  const tools: Tool[] = []
+}): Promise<EnterpriseMcpTool[]> {
+  const tools: EnterpriseMcpTool[] = []
   const names = new Set<string>()
   const cursors = new Set<string>()
   let cursor: string | undefined

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -25,8 +25,8 @@ import {
   assertEnterpriseMcpResourceResult,
   collectEnterpriseMcpResources,
 } from "../src/resource-catalog.js"
-import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
-import { selectClientAuthMethod, type OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+import { selectClientAuthMethod } from "@modelcontextprotocol/client"
+import type { OAuthClientInformationMixed, OAuthDiscoveryState, OAuthTokens } from "@modelcontextprotocol/client"
 
 const rpcRequestSchema = z.object({
   id: z.union([z.string(), z.number()]).optional(),
@@ -208,6 +208,7 @@ async function startOAuthMcpServer(options: {
   rejectAuthenticatedToolsList?: boolean
   clientMetadataSupported?: boolean
   scopeLessChallenge?: boolean
+  advertisedScopes?: string[]
 } = {}) {
   let origin = ""
   let capturedRegistration: Record<string, unknown> | null = null
@@ -218,7 +219,7 @@ async function startOAuthMcpServer(options: {
         sendJson(response, 200, {
           resource: `${origin}/mcp`,
           authorization_servers: [origin],
-          scopes_supported: ["tools.read"],
+          scopes_supported: options.advertisedScopes ?? ["tools.read"],
           bearer_methods_supported: ["header"],
         })
         return
@@ -233,7 +234,7 @@ async function startOAuthMcpServer(options: {
           grant_types_supported: ["authorization_code", "refresh_token"],
           token_endpoint_auth_methods_supported: ["none"],
           code_challenge_methods_supported: ["S256"],
-          scopes_supported: ["tools.read"],
+          scopes_supported: options.advertisedScopes ?? ["tools.read"],
           ...(options.clientMetadataSupported ? { client_id_metadata_document_supported: true } : {}),
         })
         return
@@ -552,7 +553,7 @@ describe("enterprise MCP client", () => {
         assert.ok(error instanceof EnterpriseMcpClientError)
         assert.equal(error.code, "MCP_CONNECTION_HANDSHAKE_FAILED")
         assert.equal(error.operationPhase, "connection-handshake")
-        assert.equal(error.requestPhase, "mcp-initialize")
+        assert.equal(error.requestPhase, "mcp-discovery")
         assert.match(error.message, /MCP connection handshake/)
         return true
       },
@@ -1452,6 +1453,36 @@ describe("enterprise MCP OAuth persistence contract", () => {
         connection,
         redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
         authorizationId: "signed-fallback-state",
+      })
+      assert.equal(started.status, "needs_auth")
+      if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
+      assert.equal(new URL(started.authorizeUrl).searchParams.get("scope"), "tools.read")
+      assert.equal(server.registration()?.scope, "tools.read")
+    } finally {
+      await server.close()
+    }
+  })
+
+  it("keeps an administrator's selected scopes narrower than a scope-less provider advertisement", async () => {
+    const server = await startOAuthMcpServer({
+      scopeLessChallenge: true,
+      advertisedScopes: ["tools.read", "tools.write"],
+    })
+    try {
+      const client = createEnterpriseMcpClient({ fetch })
+      const connection: EnterpriseMcpConnection = {
+        id: "oauth-selected-scope",
+        serverUrl: `${server.origin}/mcp`,
+        authorization: {
+          type: "oauth",
+          persistence: new MemoryOAuthPersistence(),
+          configuration: { applicationType: "web", requestedScopes: ["tools.read"] },
+        },
+      }
+      const started = await client.connect({
+        connection,
+        redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+        authorizationId: "signed-selected-scope-state",
       })
       assert.equal(started.status, "needs_auth")
       if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -209,6 +209,8 @@ async function startOAuthMcpServer(options: {
   clientMetadataSupported?: boolean
   scopeLessChallenge?: boolean
   advertisedScopes?: string[]
+  resourceAdvertisedScopes?: string[]
+  authorizationAdvertisedScopes?: string[]
 } = {}) {
   let origin = ""
   let capturedRegistration: Record<string, unknown> | null = null
@@ -219,7 +221,7 @@ async function startOAuthMcpServer(options: {
         sendJson(response, 200, {
           resource: `${origin}/mcp`,
           authorization_servers: [origin],
-          scopes_supported: options.advertisedScopes ?? ["tools.read"],
+          scopes_supported: options.resourceAdvertisedScopes ?? options.advertisedScopes ?? ["tools.read"],
           bearer_methods_supported: ["header"],
         })
         return
@@ -234,7 +236,7 @@ async function startOAuthMcpServer(options: {
           grant_types_supported: ["authorization_code", "refresh_token"],
           token_endpoint_auth_methods_supported: ["none"],
           code_challenge_methods_supported: ["S256"],
-          scopes_supported: options.advertisedScopes ?? ["tools.read"],
+          scopes_supported: options.authorizationAdvertisedScopes ?? options.advertisedScopes ?? ["tools.read"],
           ...(options.clientMetadataSupported ? { client_id_metadata_document_supported: true } : {}),
         })
         return
@@ -1463,10 +1465,42 @@ describe("enterprise MCP OAuth persistence contract", () => {
     }
   })
 
+  it("prefers protected-resource scopes over unrelated authorization-server scopes", async () => {
+    const server = await startOAuthMcpServer({
+      scopeLessChallenge: true,
+      resourceAdvertisedScopes: ["tools.read"],
+      authorizationAdvertisedScopes: ["openid", "profile"],
+    })
+    try {
+      const client = createEnterpriseMcpClient({ fetch })
+      const connection: EnterpriseMcpConnection = {
+        id: "oauth-resource-scope-fallback",
+        serverUrl: `${server.origin}/mcp`,
+        authorization: {
+          type: "oauth",
+          persistence: new MemoryOAuthPersistence(),
+          configuration: { applicationType: "web", requestedScopes: [] },
+        },
+      }
+      const started = await client.connect({
+        connection,
+        redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+        authorizationId: "signed-resource-scope-state",
+      })
+      assert.equal(started.status, "needs_auth")
+      if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
+      assert.equal(new URL(started.authorizeUrl).searchParams.get("scope"), "tools.read")
+      assert.equal(server.registration()?.scope, "tools.read")
+    } finally {
+      await server.close()
+    }
+  })
+
   it("keeps an administrator's selected scopes narrower than a scope-less provider advertisement", async () => {
     const server = await startOAuthMcpServer({
       scopeLessChallenge: true,
-      advertisedScopes: ["tools.read", "tools.write"],
+      resourceAdvertisedScopes: ["tools.read", "tools.write"],
+      authorizationAdvertisedScopes: ["openid", "profile"],
     })
     try {
       const client = createEnterpriseMcpClient({ fetch })
@@ -1488,6 +1522,36 @@ describe("enterprise MCP OAuth persistence contract", () => {
       if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
       assert.equal(new URL(started.authorizeUrl).searchParams.get("scope"), "tools.read")
       assert.equal(server.registration()?.scope, "tools.read")
+    } finally {
+      await server.close()
+    }
+  })
+
+  it("rejects selected scopes that neither the resource nor authorization server advertises", async () => {
+    const server = await startOAuthMcpServer({
+      scopeLessChallenge: true,
+      resourceAdvertisedScopes: ["tools.read"],
+      authorizationAdvertisedScopes: ["openid", "profile"],
+    })
+    try {
+      const client = createEnterpriseMcpClient({ fetch })
+      const connection: EnterpriseMcpConnection = {
+        id: "oauth-unsupported-selected-scope",
+        serverUrl: `${server.origin}/mcp`,
+        authorization: {
+          type: "oauth",
+          persistence: new MemoryOAuthPersistence(),
+          configuration: { applicationType: "web", requestedScopes: ["admin.write"] },
+        },
+      }
+      await assert.rejects(client.connect({
+        connection,
+        redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+        authorizationId: "signed-unsupported-scope-state",
+      }), (error: unknown) => error instanceof EnterpriseMcpClientError
+        && error.cause instanceof Error
+        && error.cause.message.includes("selected OAuth scope is not advertised"))
+      assert.equal(server.registration(), null)
     } finally {
       await server.close()
     }

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -17,6 +17,8 @@ import {
   type EnterpriseMcpOAuthClientRegistration,
   type EnterpriseMcpOAuthCredential,
   type EnterpriseMcpOAuthPersistence,
+  type StoredOAuthClientInformation,
+  type StoredOAuthTokens,
 } from "../src/index.js"
 import { EnterpriseMcpOAuthProvider } from "../src/oauth-provider.js"
 import { createEnterpriseMcpRequestObserver } from "../src/request-observer.js"
@@ -26,7 +28,7 @@ import {
   collectEnterpriseMcpResources,
 } from "../src/resource-catalog.js"
 import { selectClientAuthMethod } from "@modelcontextprotocol/client"
-import type { OAuthClientInformationMixed, OAuthDiscoveryState, OAuthTokens } from "@modelcontextprotocol/client"
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/client"
 
 const rpcRequestSchema = z.object({
   id: z.union([z.string(), z.number()]).optional(),
@@ -773,7 +775,7 @@ class MemoryOAuthPersistence implements EnterpriseMcpOAuthPersistence {
     load: async () => this.registration,
     save: async (input: {
       context: { commitExpiresAt: number; signal: AbortSignal }
-      clientInformation: OAuthClientInformationMixed
+      clientInformation: StoredOAuthClientInformation
       expiresAt?: number
       source: "client-metadata" | "dynamic"
     }) => {
@@ -832,7 +834,7 @@ class MemoryOAuthPersistence implements EnterpriseMcpOAuthPersistence {
     load: async () => this.credential,
     save: async (input: {
       context: { commitExpiresAt: number; signal: AbortSignal }
-      tokens: OAuthTokens
+      tokens: StoredOAuthTokens
       expiresAt?: number
       source: "authorization-code" | "refresh"
       authorization?: EnterpriseMcpOAuthAuthorizationHandle
@@ -869,7 +871,7 @@ class MemoryOAuthPersistence implements EnterpriseMcpOAuthPersistence {
     },
   }
 
-  seedRegistration(clientInformation: OAuthClientInformationMixed, expiresAt?: number): void {
+  seedRegistration(clientInformation: StoredOAuthClientInformation, expiresAt?: number): void {
     this.registration = {
       clientInformation,
       revision: this.nextRevision(),
@@ -878,8 +880,30 @@ class MemoryOAuthPersistence implements EnterpriseMcpOAuthPersistence {
     }
   }
 
-  seedCredential(tokens: OAuthTokens, expiresAt?: number): void {
+  seedCredential(tokens: StoredOAuthTokens, expiresAt?: number): void {
     this.credential = { tokens, expiresAt, revision: this.nextRevision() }
+  }
+}
+
+function oauthMetadataFetch(issuer: string): EnterpriseMcpFetch {
+  const canonical = new URL(issuer)
+  return async (url) => {
+    const target = new URL(url)
+    if (
+      target.origin === canonical.origin
+      && (
+        target.pathname.startsWith("/.well-known/oauth-authorization-server")
+        || target.pathname.startsWith("/.well-known/openid-configuration")
+      )
+    ) {
+      return Response.json({
+        issuer,
+        authorization_endpoint: `${canonical.origin}/authorize`,
+        token_endpoint: `${canonical.origin}/token`,
+        response_types_supported: ["code"],
+      })
+    }
+    return new Response(null, { status: 404 })
   }
 }
 
@@ -902,6 +926,7 @@ function oauthProvider(input: {
     lifecycle: { expiresAt: now() + 30_000, signal: controller.signal },
     authorizationTransactionTtlMs: input.authorizationTransactionTtlMs ?? 600_000,
     expirationSkewMs: input.expirationSkewMs ?? 0,
+    fetch: async () => new Response(null, { status: 404 }),
   })
 }
 
@@ -1075,15 +1100,15 @@ describe("enterprise MCP OAuth persistence contract", () => {
       && error.code === "MCP_OAUTH_ISSUER_MISMATCH")
   })
 
-  it("binds a resource-scoped discovery alias to its canonical callback issuer", async () => {
+  it("replaces resource-alias endpoints with strictly discovered canonical metadata", async () => {
     const alias = "https://api.salesforce.example:443/platform/mcp/v1/platform/sobject-all"
     const canonicalIssuer = "https://login.salesforce.example"
     const discoveryState: OAuthDiscoveryState = {
       authorizationServerUrl: alias,
       authorizationServerMetadata: {
         issuer: canonicalIssuer,
-        authorization_endpoint: `${canonicalIssuer}/services/oauth2/authorize`,
-        token_endpoint: `${canonicalIssuer}/services/oauth2/token`,
+        authorization_endpoint: "https://attacker.example.test/authorize",
+        token_endpoint: "https://attacker.example.test/token",
         response_types_supported: ["code"],
       },
       resourceMetadata: {
@@ -1102,6 +1127,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: oauthMetadataFetch(canonicalIssuer),
       oauthConfiguration: {
         applicationType: "web",
         authorizationServerIssuer: canonicalIssuer,
@@ -1109,6 +1135,28 @@ describe("enterprise MCP OAuth persistence contract", () => {
     })
 
     await assert.doesNotReject(provider.saveDiscoveryState(discoveryState))
+    assert.equal(persistence.discoveryState?.authorizationServerUrl, canonicalIssuer)
+    assert.equal(persistence.discoveryState?.authorizationServerMetadata?.authorization_endpoint, `${canonicalIssuer}/authorize`)
+    assert.equal(persistence.discoveryState?.authorizationServerMetadata?.token_endpoint, `${canonicalIssuer}/token`)
+    const reloadedProvider = new EnterpriseMcpOAuthProvider({
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      connectionId: "connection-1",
+      persistence,
+      flow: { kind: "runtime" },
+      clientName: "OpenWork",
+      clock: { now: () => Date.now() },
+      lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
+      authorizationTransactionTtlMs: 600_000,
+      expirationSkewMs: 0,
+      fetch: async () => {
+        throw new Error("verified cached metadata must not be rediscovered")
+      },
+      oauthConfiguration: {
+        applicationType: "web",
+        authorizationServerIssuer: canonicalIssuer,
+      },
+    })
+    assert.equal((await reloadedProvider.discoveryState())?.authorizationServerUrl, canonicalIssuer)
     assert.doesNotThrow(() => validateMcpAuthorizationResponseIssuer({
       expectedIssuer: canonicalIssuer,
       discoveryState,
@@ -1142,6 +1190,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: oauthMetadataFetch(canonicalIssuer),
       oauthConfiguration: {
         applicationType: "web",
         authorizationServerIssuer: canonicalIssuer,
@@ -1188,6 +1237,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: oauthMetadataFetch(canonicalIssuer),
       oauthConfiguration: {
         applicationType: "web",
         authorizationServerIssuer: canonicalIssuer,
@@ -1221,6 +1271,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: oauthMetadataFetch(canonicalIssuer),
       oauthConfiguration: {
         applicationType: "web",
         authorizationServerIssuer: canonicalIssuer,
@@ -1283,6 +1334,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: async () => new Response(null, { status: 404 }),
       oauthConfiguration: {
         applicationType: "web",
         clientMetadataUrl: "https://den.example.test/oauth/client-metadata.json",
@@ -1309,6 +1361,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: oauthMetadataFetch("https://identity.example.test/tenant-a"),
       oauthConfiguration: {
         applicationType: "web",
         authorizationServerIssuer: "https://identity.example.test/tenant-a",
@@ -1333,6 +1386,52 @@ describe("enterprise MCP OAuth persistence contract", () => {
         && error.code === "MCP_OAUTH_ISSUER_MISMATCH",
     )
     assert.equal(persistence.discoveryState, undefined)
+  })
+
+  it("preserves a cached issuer mismatch through the modern discovery probe", async () => {
+    const selectedIssuer = "https://mcp.example.test"
+    const canonicalIssuer = "https://identity.example.test"
+    const persistence = new MemoryOAuthPersistence()
+    persistence.discoveryState = {
+      authorizationServerUrl: canonicalIssuer,
+      authorizationServerMetadata: {
+        issuer: canonicalIssuer,
+        authorization_endpoint: `${canonicalIssuer}/authorize`,
+        token_endpoint: `${canonicalIssuer}/token`,
+        response_types_supported: ["code"],
+      },
+      resourceMetadata: {
+        resource: selectedIssuer,
+        authorization_servers: [selectedIssuer],
+      },
+    }
+    const client = createEnterpriseMcpClient({
+      fetch: async () => new Response(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer resource_metadata="${selectedIssuer}/.well-known/oauth-protected-resource"`,
+        },
+      }),
+    })
+
+    await assert.rejects(client.connect({
+      connection: {
+        id: "issuer-mismatch-probe",
+        serverUrl: selectedIssuer,
+        authorization: {
+          type: "oauth",
+          persistence,
+          configuration: {
+            applicationType: "web",
+            authorizationServerIssuer: selectedIssuer,
+          },
+        },
+      },
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      authorizationId: "signed-state",
+    }), (error: unknown) => error instanceof EnterpriseMcpClientError
+      && error.cause instanceof EnterpriseMcpOAuthContractError
+      && error.cause.code === "MCP_OAUTH_ISSUER_MISMATCH")
   })
 
   it("returns a typed configuration requirement when neither CIMD nor DCR is advertised", async () => {
@@ -1372,6 +1471,7 @@ describe("enterprise MCP OAuth persistence contract", () => {
       lifecycle: { expiresAt: Date.now() + 30_000, signal: controller.signal },
       authorizationTransactionTtlMs: 600_000,
       expirationSkewMs: 0,
+      fetch: async () => new Response(null, { status: 404 }),
     })
 
     assert.equal(provider.state(), "signed-state")
@@ -1413,7 +1513,9 @@ describe("enterprise MCP OAuth persistence contract", () => {
         code: "approved-code",
         authorizationId: "signed-den-state",
       })
+      assert.equal(persistence.registration?.clientInformation.issuer, server.origin)
       assert.equal(persistence.credential?.tokens.access_token, "enterprise-access-token")
+      assert.equal(persistence.credential?.tokens.issuer, server.origin)
       assert.equal(persistence.authorizationRecords.size, 0)
       assert.deepEqual(await client.connect({
         connection,
@@ -1435,6 +1537,45 @@ describe("enterprise MCP OAuth persistence contract", () => {
     } finally {
       await server.close()
     }
+  })
+
+  it("rejects stored OAuth clients and tokens stamped for another issuer", async () => {
+    const selectedIssuer = "https://identity.example.test"
+    const persistence = new MemoryOAuthPersistence()
+    persistence.seedRegistration({
+      client_id: "wrong-issuer-client",
+      issuer: "https://attacker.example.test",
+    })
+    persistence.seedCredential({
+      access_token: "wrong-issuer-token",
+      token_type: "Bearer",
+      issuer: "https://attacker.example.test",
+    })
+    const provider = new EnterpriseMcpOAuthProvider({
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      connectionId: "connection-1",
+      persistence,
+      flow: { kind: "runtime" },
+      clientName: "OpenWork",
+      clock: { now: () => Date.now() },
+      lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
+      authorizationTransactionTtlMs: 600_000,
+      expirationSkewMs: 0,
+      fetch: oauthMetadataFetch(selectedIssuer),
+      oauthConfiguration: {
+        applicationType: "web",
+        authorizationServerIssuer: selectedIssuer,
+      },
+    })
+
+    await assert.rejects(provider.clientInformation({ issuer: selectedIssuer }), (error: unknown) => (
+      error instanceof EnterpriseMcpOAuthContractError
+      && error.code === "MCP_OAUTH_ISSUER_MISMATCH"
+    ))
+    await assert.rejects(provider.tokens({ issuer: selectedIssuer }), (error: unknown) => (
+      error instanceof EnterpriseMcpOAuthContractError
+      && error.code === "MCP_OAUTH_ISSUER_MISMATCH"
+    ))
   })
 
   it("falls back to advertised scopes when the challenge and requested scopes are empty", async () => {

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -589,12 +589,12 @@ describe("enterprise MCP client", () => {
   })
 
   it("honors an injected lifecycle longer than the per-request timeout while progress streams", async () => {
-    const server = await startProgressMcpServer({ resultDelayMs: 70, progressIntervalMs: 10 })
+    const server = await startProgressMcpServer({ resultDelayMs: 500, progressIntervalMs: 40 })
     try {
       const client = createEnterpriseMcpClient({
         fetch,
-        operationTimeoutMs: 25,
-        lifecycle: { expiresAt: Date.now() + 120, signal: new AbortController().signal },
+        operationTimeoutMs: 150,
+        lifecycle: { expiresAt: Date.now() + 1_200, signal: new AbortController().signal },
       })
       const result = await client.callTool({
         connection: {
@@ -614,12 +614,12 @@ describe("enterprise MCP client", () => {
   })
 
   it("still stops a progressing provider at the injected absolute lifecycle", async () => {
-    const server = await startProgressMcpServer({ resultDelayMs: 160, progressIntervalMs: 10 })
+    const server = await startProgressMcpServer({ resultDelayMs: 1_500, progressIntervalMs: 40 })
     try {
       const client = createEnterpriseMcpClient({
         fetch,
-        operationTimeoutMs: 25,
-        lifecycle: { expiresAt: Date.now() + 80, signal: new AbortController().signal },
+        operationTimeoutMs: 150,
+        lifecycle: { expiresAt: Date.now() + 700, signal: new AbortController().signal },
       })
       const startedAt = Date.now()
       await assert.rejects(
@@ -637,8 +637,8 @@ describe("enterprise MCP client", () => {
           && error.operationPhase === "tool-execution",
       )
       const elapsedMs = Date.now() - startedAt
-      assert.ok(elapsedMs >= 60, `expected lifecycle timeout to outlast per-request timeout, got ${elapsedMs}ms`)
-      assert.ok(elapsedMs < 500, `expected lifecycle timeout before the provider result, got ${elapsedMs}ms`)
+      assert.ok(elapsedMs >= 500, `expected lifecycle timeout to outlast per-request timeout, got ${elapsedMs}ms`)
+      assert.ok(elapsedMs < 2_000, `expected lifecycle timeout before the provider result, got ${elapsedMs}ms`)
     } finally {
       await server.close()
     }

--- a/packages/enterprise-mcp-client/test/lifecycle-deadline-error.test.ts
+++ b/packages/enterprise-mcp-client/test/lifecycle-deadline-error.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client"
 import {
   EnterpriseMcpClientError,
   EnterpriseMcpLifecycleDeadlineError,
@@ -8,20 +8,20 @@ import {
 } from "../src/index.js"
 
 describe("lifecycle deadline error", () => {
-  it("aborts with an McpError so the SDK rethrows it instead of stringifying the reason", () => {
+  it("aborts with an SdkError so the SDK rethrows it instead of stringifying the reason", () => {
     const error = new EnterpriseMcpLifecycleDeadlineError("tool-execution")
 
     // The SDK only passes an abort reason through untouched when it is already
-    // an McpError; anything else becomes String(reason) on a new RequestTimeout.
-    assert.ok(error instanceof McpError)
-    assert.equal(error.code, ErrorCode.RequestTimeout)
+    // an SdkError; anything else becomes String(reason) on a new RequestTimeout.
+    assert.ok(error instanceof SdkError)
+    assert.equal(error.code, SdkErrorCode.RequestTimeout)
     assert.equal(error.operationPhase, "tool-execution")
     assert.match(error.message, /exceeded its lifecycle deadline/)
   })
 
   it("carries a marker that survives an SDK round trip", () => {
     const reason = new EnterpriseMcpLifecycleDeadlineError("tool-execution")
-    const rethrown = reason instanceof McpError ? reason : new McpError(ErrorCode.RequestTimeout, String(reason))
+    const rethrown = reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason))
 
     assert.ok(isEnterpriseMcpLifecycleDeadline(rethrown))
   })
@@ -37,7 +37,7 @@ describe("lifecycle deadline error", () => {
   })
 
   it("does not claim a provider's own RequestTimeout as ours", () => {
-    const providerError = new McpError(ErrorCode.RequestTimeout, "upstream is busy", { provider_detail: "busy" })
+    const providerError = new SdkError(SdkErrorCode.RequestTimeout, "upstream is busy", { provider_detail: "busy" })
 
     assert.equal(isEnterpriseMcpLifecycleDeadline(providerError), false)
     assert.equal(isEnterpriseMcpLifecycleDeadline(new Error("unrelated")), false)

--- a/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
+++ b/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
@@ -47,6 +47,65 @@ function unauthenticatedMcpFetch(): EnterpriseMcpFetch {
 }
 
 describe("enterprise MCP requirements discovery", () => {
+  it("discovers a 2026 stateless server without an initialize handshake", async () => {
+    const methods: string[] = []
+    const fetch: EnterpriseMcpFetch = async (_url, init) => {
+      assert.equal(typeof init?.body, "string")
+      const request = rpcRequestSchema.parse(JSON.parse(init?.body as string))
+      methods.push(request.method)
+      assert.equal(new Headers(init?.headers).get("mcp-protocol-version"), "2026-07-28")
+      assert.equal(new Headers(init?.headers).has("mcp-session-id"), false)
+      if (request.method === "server/discover") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            supportedVersions: ["2026-07-28"],
+            capabilities: { tools: {} },
+            resultType: "complete",
+            ttlMs: 0,
+            cacheScope: "private",
+            _meta: {
+              "io.modelcontextprotocol/serverInfo": { name: "requirements-modern-test", version: "1.0.0" },
+            },
+          },
+        })
+      }
+      if (request.method === "tools/list") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            resultType: "complete",
+            ttlMs: 0,
+            cacheScope: "private",
+            tools: [{
+              name: "read-modern-record",
+              inputSchema: { type: "object" },
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            }],
+            _meta: {
+              "io.modelcontextprotocol/serverInfo": { name: "requirements-modern-test", version: "1.0.0" },
+            },
+          },
+        })
+      }
+      return new Response(null, { status: 404 })
+    }
+
+    const result = await discoverConnectionRequirements({
+      serverUrl: "https://mcp.example.test/mcp",
+      fetch,
+    })
+
+    assert.deepEqual(methods, ["server/discover", "tools/list"])
+    assert.equal(result.status, "ready")
+    assert.equal(result.server.initialize, "succeeded")
+    assert.equal(result.server.protocolEra, "modern")
+    assert.equal(result.server.protocolVersion, "2026-07-28")
+    assert.equal(result.tools.items?.[0]?.name, "read-modern-record")
+  })
+
   it("initializes and lists tools without creating registration state", async () => {
     const result = await discoverConnectionRequirements({
       serverUrl: "https://mcp.example.test/mcp",

--- a/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
+++ b/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
@@ -229,6 +229,18 @@ describe("enterprise MCP requirements discovery", () => {
           scopes_supported: ["mcp_api", "refresh_token"],
         })
       }
+      if (target.origin === "https://login.salesforce.example" && target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: "https://login.salesforce.example",
+          authorization_endpoint: "https://login.salesforce.example/services/oauth2/authorize",
+          token_endpoint: "https://login.salesforce.example/services/oauth2/token",
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+          code_challenge_methods_supported: ["S256"],
+          scopes_supported: ["mcp_api", "refresh_token"],
+        })
+      }
       return new Response(null, { status: 401 })
     }
 
@@ -269,6 +281,18 @@ describe("enterprise MCP requirements discovery", () => {
           code_challenge_methods_supported: ["S256"],
         })
       }
+      if (target.origin === "https://vercel.example" && target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: "https://vercel.example",
+          authorization_endpoint: "https://vercel.example/oauth/authorize",
+          token_endpoint: "https://vercel.example/oauth/token",
+          registration_endpoint: "https://vercel.example/oauth/register",
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+        })
+      }
       return new Response(null, {
         status: 401,
         headers: {
@@ -293,6 +317,82 @@ describe("enterprise MCP requirements discovery", () => {
       selectedIssuer: "https://unrelated.example",
       requirements: result,
     }), undefined)
+  })
+
+  it("ignores endpoints from a resource alias and uses strictly bound canonical metadata", async () => {
+    const resource = "https://mcp.example.test/mcp"
+    const issuer = "https://identity.example.test"
+    const fetch: EnterpriseMcpFetch = async (url) => {
+      const target = new URL(url)
+      if (target.origin === "https://mcp.example.test" && target.pathname === "/.well-known/oauth-protected-resource/mcp") {
+        return Response.json({ resource, authorization_servers: [resource] })
+      }
+      if (target.origin === "https://mcp.example.test" && target.pathname === "/.well-known/oauth-authorization-server/mcp") {
+        return Response.json({
+          issuer,
+          authorization_endpoint: "https://attacker.example.test/authorize",
+          token_endpoint: "https://attacker.example.test/token",
+          registration_endpoint: "https://attacker.example.test/register",
+          response_types_supported: ["code"],
+        })
+      }
+      if (target.origin === "https://identity.example.test" && target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer,
+          authorization_endpoint: `${issuer}/authorize`,
+          token_endpoint: `${issuer}/token`,
+          response_types_supported: ["code"],
+        })
+      }
+      return new Response(null, {
+        status: 401,
+        headers: { "www-authenticate": "Bearer resource_metadata=\"https://mcp.example.test/.well-known/oauth-protected-resource/mcp\"" },
+      })
+    }
+
+    const result = await discoverConnectionRequirements({ serverUrl: resource, fetch })
+
+    assert.equal(result.authentication.authorizationServers[0]?.issuer, issuer)
+    assert.equal(result.authentication.authorizationServers[0]?.authorizationEndpoint, `${issuer}/authorize`)
+    assert.equal(result.authentication.authorizationServers[0]?.tokenEndpoint, `${issuer}/token`)
+    assert.equal(result.authentication.authorizationServers[0]?.registrationEndpoint, undefined)
+  })
+
+  it("rejects a resource alias when the claimed canonical issuer does not verify", async () => {
+    const resource = "https://mcp.example.test/mcp"
+    const fetch: EnterpriseMcpFetch = async (url) => {
+      const target = new URL(url)
+      if (target.origin === "https://mcp.example.test" && target.pathname === "/.well-known/oauth-protected-resource/mcp") {
+        return Response.json({ resource, authorization_servers: [resource] })
+      }
+      if (target.origin === "https://mcp.example.test" && target.pathname === "/.well-known/oauth-authorization-server/mcp") {
+        return Response.json({
+          issuer: "https://identity.example.test",
+          authorization_endpoint: "https://attacker.example.test/authorize",
+          token_endpoint: "https://attacker.example.test/token",
+          response_types_supported: ["code"],
+        })
+      }
+      if (target.origin === "https://identity.example.test" && target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: "https://different.example.test",
+          authorization_endpoint: "https://attacker.example.test/authorize",
+          token_endpoint: "https://attacker.example.test/token",
+          response_types_supported: ["code"],
+        })
+      }
+      return new Response(null, {
+        status: 401,
+        headers: { "www-authenticate": "Bearer resource_metadata=\"https://mcp.example.test/.well-known/oauth-protected-resource/mcp\"" },
+      })
+    }
+
+    const result = await discoverConnectionRequirements({ serverUrl: resource, fetch })
+
+    assert.equal(result.authentication.authorizationServers.length, 0)
+    assert.equal(result.authentication.authorizationServers.some((server) => server.tokenEndpoint?.includes("attacker.example.test")), false)
+    assert.equal(result.warnings.some((warning) => warning.code === "oauth_issuer_mismatch"), true)
+    assert.equal(result.status, "manual_action_required")
   })
 
   it("accepts an authorization-server root issuer with an equivalent trailing slash", async () => {

--- a/packages/enterprise-mcp-client/test/slack-mcp-compat.test.ts
+++ b/packages/enterprise-mcp-client/test/slack-mcp-compat.test.ts
@@ -1,12 +1,10 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import { exchangeAuthorization } from "@modelcontextprotocol/sdk/client/auth.js"
-import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js"
+import { exchangeAuthorization, OAuthError, OAuthErrorCode } from "@modelcontextprotocol/client"
 import { z } from "zod"
 import {
   createEnterpriseMcpClient,
   createEnterpriseMcpTokenResponseCompat,
-  ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK,
   SLACK_STYLE_OAUTH_ERROR_MAPPING,
   type EnterpriseMcpConnection,
   type EnterpriseMcpDiagnosticEvent,
@@ -28,10 +26,10 @@ const tokenResponseSchema = z.object({
   token_type: z.string(),
 }).passthrough()
 
-const initializeRequestSchema = z.object({
+const discoverRequestSchema = z.object({
   id: z.union([z.string(), z.number()]),
-  method: z.literal("initialize"),
-  params: z.object({ protocolVersion: z.string() }).passthrough(),
+  method: z.literal("server/discover"),
+  params: z.object({ _meta: z.record(z.string(), z.unknown()) }).passthrough(),
 }).passthrough()
 
 function tokenRequestInit(): RequestInit {
@@ -94,7 +92,8 @@ describe("Slack-style MCP compatibility", () => {
         fetchFn: sdkFetch,
       }),
       (error: unknown) => {
-        assert.ok(error instanceof InvalidGrantError)
+        assert.ok(error instanceof OAuthError)
+        assert.equal(error.code, OAuthErrorCode.InvalidGrant)
         assert.match(error.message, /Slack-style provider error: invalid_code/)
         return true
       },
@@ -135,28 +134,28 @@ describe("Slack-style MCP compatibility", () => {
     )
   })
 
-  it("retries initialize exactly once with the fallback protocol version", async () => {
-    const protocolVersions: string[] = []
+  it("negotiates the stateless protocol without initialize or a session id", async () => {
+    const methods: string[] = []
+    const headers: Headers[] = []
     const events: EnterpriseMcpDiagnosticEvent[] = []
     const client = createEnterpriseMcpClient({
       diagnosticSink: (event) => events.push(event),
       fetch: async (_url, init) => {
-        if (typeof init?.body !== "string") return new Response(null, { status: 202 })
-        const parsed: unknown = JSON.parse(init.body)
-        const initialized = z.object({ method: z.literal("notifications/initialized") }).safeParse(parsed)
-        if (initialized.success) return new Response(null, { status: 202 })
-        const request = initializeRequestSchema.parse(parsed)
-        protocolVersions.push(request.params.protocolVersion)
-        if (protocolVersions.length === 1) {
-          return Response.json({ error: "unsupported_protocol_version" }, { status: 400 })
-        }
+        headers.push(new Headers(init?.headers))
+        const body = init?.body
+        assert.equal(typeof body, "string")
+        const parsed: unknown = JSON.parse(body as string)
+        const request = discoverRequestSchema.parse(parsed)
+        methods.push(request.method)
         return Response.json({
-          jsonrpc: "2.0",
+          jsonrpc: "2.0" as const,
           id: request.id,
           result: {
-            protocolVersion: ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK,
+            supportedVersions: ["2026-07-28"],
             capabilities: {},
-            serverInfo: { name: "fallback-test", version: "1.0.0" },
+            _meta: {
+              "io.modelcontextprotocol/serverInfo": { name: "stateless-test", version: "1.0.0" },
+            },
           },
         })
       },
@@ -166,18 +165,21 @@ describe("Slack-style MCP compatibility", () => {
       connection: noAuthConnection(),
       redirectUri: "https://den.example.test/callback",
     }), { status: "connected" })
-    assert.equal(protocolVersions.length, 2)
-    assert.equal(protocolVersions[1], ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK)
+    assert.deepEqual(methods, ["server/discover"])
+    assert.equal(headers[0]?.get("mcp-protocol-version"), "2026-07-28")
+    assert.equal(headers[0]?.get("mcp-method"), "server/discover")
+    assert.equal(headers[0]?.has("mcp-session-id"), false)
     assert.equal(events.filter((event) => event.kind !== "credential-invalidation"
-      && event.protocolVersionFallback === ENTERPRISE_MCP_PROTOCOL_VERSION_FALLBACK).length, 1)
+      && event.protocolEra === "modern"
+      && event.protocolVersion === "2026-07-28").length, 1)
   })
 
   for (const status of [401, 500]) {
-    it(`does not retry initialize after HTTP ${status}`, async () => {
-      let initializeRequests = 0
+    it(`does not downgrade the discovery probe after HTTP ${status}`, async () => {
+      let protocolRequests = 0
       const client = createEnterpriseMcpClient({
         fetch: async (_url, init) => {
-          if (typeof init?.body === "string") initializeRequests += 1
+          if (typeof init?.body === "string") protocolRequests += 1
           return Response.json({ error: "provider_rejected" }, { status })
         },
       })
@@ -186,7 +188,7 @@ describe("Slack-style MCP compatibility", () => {
         connection: noAuthConnection(),
         redirectUri: "https://den.example.test/callback",
       }))
-      assert.equal(initializeRequests, 1)
+      assert.equal(protocolRequests, 1)
     })
   }
 

--- a/packages/enterprise-mcp-client/test/terminal-401-guard.demo.ts
+++ b/packages/enterprise-mcp-client/test/terminal-401-guard.demo.ts
@@ -24,8 +24,7 @@ import {
   type EnterpriseMcpOAuthCredential,
   type EnterpriseMcpOAuthPersistence,
 } from "../src/index.js"
-import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
-import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+import type { OAuthClientInformationMixed, OAuthDiscoveryState, OAuthTokens } from "@modelcontextprotocol/client"
 
 const rpcRequestSchema = z.object({
   id: z.union([z.string(), z.number()]).nullish(),

--- a/patches/@modelcontextprotocol__client@2.0.0.patch
+++ b/patches/@modelcontextprotocol__client@2.0.0.patch
@@ -2,37 +2,39 @@ diff --git a/dist/index.cjs b/dist/index.cjs
 index 635f1c0134274c89e7efbcae2adf3d9ecba575ee..700143e48595a767266869b6be9da5dead1d7ee8 100644
 --- a/dist/index.cjs
 +++ b/dist/index.cjs
-@@ -635,3 +635,11 @@ function determineScope(options) {
+@@ -635,3 +635,12 @@ function determineScope(options) {
 -	let effectiveScope = requestedScope || resourceMetadata?.scopes_supported?.join(" ") || clientMetadata.scope;
 -	if (effectiveScope && authServerMetadata?.scopes_supported?.includes("offline_access") && !effectiveScope.split(" ").includes("offline_access") && clientMetadata.grant_types?.includes("refresh_token")) effectiveScope = `${effectiveScope} offline_access`;
 -	return effectiveScope;
 +	const requiredScopes = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
 +	const selectedScopes = clientMetadata.scope?.split(/\s+/).filter(Boolean) ?? [];
-+	const advertisedScopes = authServerMetadata?.scopes_supported ?? resourceMetadata?.scopes_supported;
-+	if (advertisedScopes) {
++	const authorizationServerScopes = authServerMetadata?.scopes_supported;
++	const resourceScopes = resourceMetadata?.scopes_supported;
++	const advertisedScopes = [...new Set([...(authorizationServerScopes ?? []), ...(resourceScopes ?? [])])];
++	if (advertisedScopes.length > 0) {
 +		const unsupportedScope = selectedScopes.find((selectedScope) => !advertisedScopes.includes(selectedScope));
 +		if (unsupportedScope) throw new Error(`The selected OAuth scope is not advertised by the authorization server or protected resource: ${unsupportedScope}`);
 +	}
 +	const effectiveScopes = [...new Set([...requiredScopes, ...selectedScopes])];
-+	if (effectiveScopes.length === 0 && advertisedScopes) effectiveScopes.push(...new Set(advertisedScopes));
-+	if (effectiveScopes.includes("offline_access") && !requiredScopes.includes("offline_access") && (!advertisedScopes?.includes("offline_access") || !authServerMetadata?.grant_types_supported?.includes("refresh_token"))) effectiveScopes.splice(effectiveScopes.indexOf("offline_access"), 1);
++	if (effectiveScopes.length === 0) effectiveScopes.push(...new Set(resourceScopes ?? authorizationServerScopes ?? []));
 +	return effectiveScopes.length > 0 ? effectiveScopes.join(" ") : void 0;
 diff --git a/dist/index.mjs b/dist/index.mjs
 index f02ce3ca394e826fc27c9848dbe9a214bf6ba7a9..cc0b4f30a209297213e1897fc9ff34680066c59b 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -632,3 +632,11 @@ function determineScope(options) {
+@@ -632,3 +632,12 @@ function determineScope(options) {
 -	let effectiveScope = requestedScope || resourceMetadata?.scopes_supported?.join(" ") || clientMetadata.scope;
 -	if (effectiveScope && authServerMetadata?.scopes_supported?.includes("offline_access") && !effectiveScope.split(" ").includes("offline_access") && clientMetadata.grant_types?.includes("refresh_token")) effectiveScope = `${effectiveScope} offline_access`;
 -	return effectiveScope;
 +	const requiredScopes = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
 +	const selectedScopes = clientMetadata.scope?.split(/\s+/).filter(Boolean) ?? [];
-+	const advertisedScopes = authServerMetadata?.scopes_supported ?? resourceMetadata?.scopes_supported;
-+	if (advertisedScopes) {
++	const authorizationServerScopes = authServerMetadata?.scopes_supported;
++	const resourceScopes = resourceMetadata?.scopes_supported;
++	const advertisedScopes = [...new Set([...(authorizationServerScopes ?? []), ...(resourceScopes ?? [])])];
++	if (advertisedScopes.length > 0) {
 +		const unsupportedScope = selectedScopes.find((selectedScope) => !advertisedScopes.includes(selectedScope));
 +		if (unsupportedScope) throw new Error(`The selected OAuth scope is not advertised by the authorization server or protected resource: ${unsupportedScope}`);
 +	}
 +	const effectiveScopes = [...new Set([...requiredScopes, ...selectedScopes])];
-+	if (effectiveScopes.length === 0 && advertisedScopes) effectiveScopes.push(...new Set(advertisedScopes));
-+	if (effectiveScopes.includes("offline_access") && !requiredScopes.includes("offline_access") && (!advertisedScopes?.includes("offline_access") || !authServerMetadata?.grant_types_supported?.includes("refresh_token"))) effectiveScopes.splice(effectiveScopes.indexOf("offline_access"), 1);
++	if (effectiveScopes.length === 0) effectiveScopes.push(...new Set(resourceScopes ?? authorizationServerScopes ?? []));
 +	return effectiveScopes.length > 0 ? effectiveScopes.join(" ") : void 0;

--- a/patches/@modelcontextprotocol__client@2.0.0.patch
+++ b/patches/@modelcontextprotocol__client@2.0.0.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 635f1c0134274c89e7efbcae2adf3d9ecba575ee..700143e48595a767266869b6be9da5dead1d7ee8 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -635,3 +635,11 @@ function determineScope(options) {
+-	let effectiveScope = requestedScope || resourceMetadata?.scopes_supported?.join(" ") || clientMetadata.scope;
+-	if (effectiveScope && authServerMetadata?.scopes_supported?.includes("offline_access") && !effectiveScope.split(" ").includes("offline_access") && clientMetadata.grant_types?.includes("refresh_token")) effectiveScope = `${effectiveScope} offline_access`;
+-	return effectiveScope;
++	const requiredScopes = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
++	const selectedScopes = clientMetadata.scope?.split(/\s+/).filter(Boolean) ?? [];
++	const advertisedScopes = authServerMetadata?.scopes_supported ?? resourceMetadata?.scopes_supported;
++	if (advertisedScopes) {
++		const unsupportedScope = selectedScopes.find((selectedScope) => !advertisedScopes.includes(selectedScope));
++		if (unsupportedScope) throw new Error(`The selected OAuth scope is not advertised by the authorization server or protected resource: ${unsupportedScope}`);
++	}
++	const effectiveScopes = [...new Set([...requiredScopes, ...selectedScopes])];
++	if (effectiveScopes.length === 0 && advertisedScopes) effectiveScopes.push(...new Set(advertisedScopes));
++	if (effectiveScopes.includes("offline_access") && !requiredScopes.includes("offline_access") && (!advertisedScopes?.includes("offline_access") || !authServerMetadata?.grant_types_supported?.includes("refresh_token"))) effectiveScopes.splice(effectiveScopes.indexOf("offline_access"), 1);
++	return effectiveScopes.length > 0 ? effectiveScopes.join(" ") : void 0;
+diff --git a/dist/index.mjs b/dist/index.mjs
+index f02ce3ca394e826fc27c9848dbe9a214bf6ba7a9..cc0b4f30a209297213e1897fc9ff34680066c59b 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -632,3 +632,11 @@ function determineScope(options) {
+-	let effectiveScope = requestedScope || resourceMetadata?.scopes_supported?.join(" ") || clientMetadata.scope;
+-	if (effectiveScope && authServerMetadata?.scopes_supported?.includes("offline_access") && !effectiveScope.split(" ").includes("offline_access") && clientMetadata.grant_types?.includes("refresh_token")) effectiveScope = `${effectiveScope} offline_access`;
+-	return effectiveScope;
++	const requiredScopes = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
++	const selectedScopes = clientMetadata.scope?.split(/\s+/).filter(Boolean) ?? [];
++	const advertisedScopes = authServerMetadata?.scopes_supported ?? resourceMetadata?.scopes_supported;
++	if (advertisedScopes) {
++		const unsupportedScope = selectedScopes.find((selectedScope) => !advertisedScopes.includes(selectedScope));
++		if (unsupportedScope) throw new Error(`The selected OAuth scope is not advertised by the authorization server or protected resource: ${unsupportedScope}`);
++	}
++	const effectiveScopes = [...new Set([...requiredScopes, ...selectedScopes])];
++	if (effectiveScopes.length === 0 && advertisedScopes) effectiveScopes.push(...new Set(advertisedScopes));
++	if (effectiveScopes.includes("offline_access") && !requiredScopes.includes("offline_access") && (!advertisedScopes?.includes("offline_access") || !authServerMetadata?.grant_types_supported?.includes("refresh_token"))) effectiveScopes.splice(effectiveScopes.indexOf("offline_access"), 1);
++	return effectiveScopes.length > 0 ? effectiveScopes.join(" ") : void 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,7 @@ overrides:
 
 patchedDependencies:
   '@better-auth/drizzle-adapter@1.7.0-beta.10': cd64da0c48130585986f4c25fac25093e761675db1885d837df7dc31c358f7f8
+  '@modelcontextprotocol/client@2.0.0': 04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000
   '@modelcontextprotocol/sdk': b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10
 
 importers:
@@ -495,6 +496,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -643,6 +647,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
       '@sentry/cli':
         specifier: 3.6.0
         version: 3.6.0
@@ -1142,9 +1149,12 @@ importers:
 
   packages/enterprise-mcp-client:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
+      '@modelcontextprotocol/core':
+        specifier: ^2.0.0
+        version: 2.0.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2700,6 +2710,14 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/ext-apps@1.7.5':
     resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
     engines: {node: '>=20'}
@@ -2723,6 +2741,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -10662,6 +10684,20 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
+  '@modelcontextprotocol/client@2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      jose: 6.2.8
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.3.6
+
   '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
@@ -10714,6 +10750,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.3.6
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ overrides:
 
 patchedDependencies:
   '@better-auth/drizzle-adapter@1.7.0-beta.10': cd64da0c48130585986f4c25fac25093e761675db1885d837df7dc31c358f7f8
-  '@modelcontextprotocol/client@2.0.0': 04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000
+  '@modelcontextprotocol/client@2.0.0': 8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb
   '@modelcontextprotocol/sdk': b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10
 
 importers:
@@ -306,7 +306,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
-        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
+        version: 2.0.0(patch_hash=8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
@@ -379,7 +379,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
-        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
+        version: 2.0.0(patch_hash=8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)
@@ -655,7 +655,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
-        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
+        version: 2.0.0(patch_hash=8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb)
       '@sentry/cli':
         specifier: 3.6.0
         version: 3.6.0
@@ -1157,7 +1157,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
-        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
+        version: 2.0.0(patch_hash=8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb)
       '@modelcontextprotocol/core':
         specifier: ^2.0.0
         version: 2.0.0
@@ -10690,7 +10690,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@modelcontextprotocol/client@2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)':
+  '@modelcontextprotocol/client@2.0.0(patch_hash=8edb220e8e6e532f49f835f9d6fbc3bc808a4324f417cd4a91c4fc7722356ffb)':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
       cross-spawn: 7.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0(patch_hash=04f6fc6886d1ec78bc1b163d09d9e1e19377b1747baba25373ed21bb54537000)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(patch_hash=b9b29e6a319e94ea968476aa440eb8586b5da9db6b8011ce749c384d186f8a10)(zod@4.3.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,4 +118,5 @@ allowBuilds:
   sharp: true
 patchedDependencies:
   '@better-auth/drizzle-adapter@1.7.0-beta.10': patches/@better-auth__drizzle-adapter@1.7.0-beta.10.patch
+  '@modelcontextprotocol/client@2.0.0': patches/@modelcontextprotocol__client@2.0.0.patch
   '@modelcontextprotocol/sdk': patches/@modelcontextprotocol__sdk.patch


### PR DESCRIPTION
## Summary

- upgrade OpenWork Connect to the official MCP TypeScript v2 client with automatic 2026-07-28 negotiation and an explicit 2025 stateless fallback
- serve the public `/mcp/agent` endpoint through the official v2 stateless HTTP handler with a fresh server per request, strict protocol validation, and `subscriptions/listen`
- preserve MCP App metadata while the remaining internal legacy endpoints stay on SDK v1
- classify v2 DCR, negotiation, OAuth, and structured network failures at the managed Desktop gateway without leaking provider details or hiding internal defects
- mirror the v2 client into the packaged Desktop runtime and add focused modern-wire, legacy-compatibility, OAuth-boundary, managed-gateway, and repository testkit coverage

## Safety hardening

- bind each prepared server through request-local async context so SDK request cloning on the legacy path cannot detach it from the authenticated request
- scope list-change subscriptions by organization and user, preventing one catalog mutation from notifying another authenticated audience
- retain one handler and its global subscription binding rather than multiplying listener capacity per tenant
- prefer protected-resource OAuth scopes over unrelated authorization-server scopes, preserve explicit narrow selections, and reject selections advertised by neither party before dynamic registration
- validate OAuth discovery aliases as a strict two-hop binding: an advertised resource alias may point to a canonical issuer, but OpenWork independently rediscovers that issuer and discards all endpoints supplied by the alias
- bind cached OAuth metadata, client registrations, access tokens, refresh tokens, and callback state to the verified issuer; migrate legacy resource-alias records only after strict rediscovery
- preserve application-owned issuer mismatch diagnostics over generic HTTP status evidence so an OAuth boundary failure cannot be hidden by a captured 401
- keep the proof lane independent of generated workspace build output by resolving source packages through the repository's development export condition
- stabilize lifecycle tests around the additional negotiation round trip so deadline coverage remains meaningful under concurrent CI load

## Preserved Connect optimizations

- keep the model-facing `/mcp/agent` surface compact: ordinary provider tools remain behind bounded `search_capabilities` and `execute_capability` instead of being projected into the client context
- keep provider discovery server-side, grant- and policy-filtered, top-K bounded, deadline-limited, and cached; `server/discover` advertises protocol capabilities only and does not include the provider tool catalog
- expose only App-visible provider tools and their bound resources to the private Connect App-host audience; ordinary clients, legacy clients, and forged audience headers cannot unlock that surface
- preserve the selected provider result as an opaque `openwork/mcpApp` launch reference, then re-list and revalidate the exact connection, tool visibility, and live `ui://` binding before the unchanged Desktop sandbox renderer loads it

## Verification

- focused compact-catalog and Connect MCP App rendering regression matrix — 83/83 passed across the Den proxy/App registrations, live search/execute fixture, local App host, result-preservation mapper, and iframe policy
- `pnpm evals:pr specs/mcp-stateless-2026-transport.test.ts` — passed at `8cbda049a3275950782132d59525c829ad769084`: 5/5 evidence assertions, 0 failed, 0 pending, 0 skipped
- the same exact eval passed in a clean detached worktree with a frozen offline install and no enterprise-client `dist` output present
- `pnpm --filter @openwork/enterprise-mcp-client test` — 83/83 passed
- `pnpm --filter openwork-server exec bun test src/local-managed-mcp.e2e.test.ts` — 8/8 passed, 147 assertions
- focused Den OAuth persistence, connect-start, and diagnostics suites — 112/112 passed, 418 assertions
- `pnpm --filter @openwork/desktop test` — 259 passed, 0 failed, 1 expected platform skip
- enterprise client, embedded server, Den API, and app typechecks — passed
- Den API production build, frozen-lockfile install, and patch application — passed
- full app suite — 893 passed; seven pre-existing `window.matchMedia` suite-order failures remain. The same seven failures were reproduced on untouched `origin/dev`, while all 43 affected tests pass together in isolation. This PR changes no `apps/app` source.
- local macOS Electron smoke on the rebased runtime tree — clean fresh launch; workspace, Library, MCP filter, and expanded Advanced MCP settings rendered; Electron/control bridges were present; workspace, MCP, config, agent, command, and event requests returned 200; no UI alerts or fetch errors remained after refresh
- production dependency audit — no newly introduced advisory; the only high finding is the same transitive `sharp@0.34.5` advisory already present on `dev`

## Scaling note

Request handling is stateless across replicas. Subscription notifications use an in-process, authenticated-audience-scoped event bus; this matches the current one-replica Den API deployment default. A future multi-replica Den API topology will need a shared event bus for cross-replica notification fan-out.
