### PR TITLE
fix(den-web): keep PostHog cookie off API host

### DIFF
--- a/ee/apps/den-web/app/layout.tsx
+++ b/ee/apps/den-web/app/layout.tsx
@@ -71,9 +71,11 @@ const posthogKey = process.env.DEN_WEB_POSTHOG_KEY?.trim() || "";
 const posthogHost = (process.env.DEN_WEB_POSTHOG_HOST ?? defaultPosthogProxyPath).trim();
 
 const posthogBootstrap = posthogKey
-  ? `!function(t,e){var o,n,p,r;e.__SV||(window.posthog&&window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture identify alias reset register unregister setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])})}(document,window.posthog||[]);
+  ? `!function(){for(var c=document.cookie.split(";"),i=0;i<c.length;i++){var n=c[i].split("=")[0].trim();n.startsWith("ph_")&&n.endsWith("_posthog")&&(document.cookie=n+"=; Max-Age=0; Path=/; Domain=openworklabs.com; Secure; SameSite=Lax")}}();
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog&&window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture identify alias reset register unregister setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])})}(document,window.posthog||[]);
 posthog.init(${JSON.stringify(posthogKey)}, {
   api_host: ${JSON.stringify(posthogHost)},
+  cross_subdomain_cookie: false,
   defaults: '2025-11-30',
   person_profiles: 'identified_only'
 });`


### PR DESCRIPTION
## Incident

A legacy `ph_*_posthog` analytics cookie scoped to `.openworklabs.com` is sent with credentialed Den Web requests to `api.app.*`. For affected Google/Better Auth sessions, that request can be rejected before `/v1/me` or organization selection completes, leaving an already-signed-in user stuck.

## Tiny targeted fix

This PR changes only `ee/apps/den-web/app/layout.tsx`:

- synchronously expire matching legacy PostHog cookies at `Domain=openworklabs.com` before hydration;
- set `cross_subdomain_cookie: false` so PostHog recreates its persistence cookie on the app host only.

The authentication path is deliberately untouched: Better Auth cookies, `credentials: include`, Google callbacks, organization selection, and API proxy behavior remain as-is.

Affected users recover on their next page load. Analytics continues through the existing PostHog proxy, but its persistence cookie is no longer sent to the API subdomain.

## Diff

- 1 file
- 3 additions
- 1 deletion
- 1 signed commit

## Proof

Exact head: `1f85e9475d2d5ac32307d57dc7b82a14630329c8`

- focused direct-API/auth-proxy tests: 26 passed, 0 failed
- `pnpm typecheck`: passed
- `pnpm build`: passed
- exact-head `@openwork/testkit` browser tape: 1 passed, 0 failed, 0 skipped
- GitHub CodeQL, Linux/macOS suites, Warden/security review, and Den artifact build: passed

The browser tape seeded an isolated parent-domain PostHog cookie, confirmed it was eligible for `api.app.*`, ran the exact cleanup statement from this head, and verified the cookie was removed while a host-only replacement was excluded from `api.app.*`.

## Scope

This targets the parent-domain PostHog/WAF regression only. It does not redesign auth, add fallback states, or alter session semantics.
