### PR TITLE
fix(den): source API URL from runtime config

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -707,6 +707,25 @@ function ensureDenApiBasePath(input: string | null | undefined): string | null {
   }
 }
 
+function denApiOriginForDenBaseUrl(input: string | null | undefined): string | null {
+  const normalized = normalizeDenBaseUrl(input);
+  if (!normalized) return null;
+
+  try {
+    const url = new URL(normalized);
+    const hostname = url.hostname.toLowerCase();
+    if (hostname !== "api" && !hostname.startsWith("api.")) {
+      url.hostname = `api.${hostname}`;
+    }
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
 export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?: string | null } | string | null | undefined): DenBaseUrls {
   const rawBaseUrl = typeof input === "string" ? input : input?.baseUrl;
   const normalizedBaseUrl = normalizeDenBaseUrl(rawBaseUrl);
@@ -733,9 +752,7 @@ export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?
   // Build-time API pin (headless/dev web): route API calls through the
   // configured proxy regardless of which web base the caller resolved.
   const buildDenApiBaseUrl = normalizedApiBaseUrl ? null : normalizeDenBaseUrl(readBuildDenApiBaseUrl());
-  const hostedDefaultApiBaseUrl = denOriginComparisonKey(baseUrl) === denOriginComparisonKey(HOSTED_DEFAULT_DEN_BASE_URL)
-    ? HOSTED_DEFAULT_DEN_API_BASE_URL
-    : null;
+  const deterministicApiBaseUrl = denApiOriginForDenBaseUrl(baseUrl);
 
   return {
     baseUrl,
@@ -743,9 +760,7 @@ export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?
       ? normalizedApiBaseUrl
       : buildDenApiBaseUrl
         ? ensureDenApiBasePath(buildDenApiBaseUrl) ?? buildDenApiBaseUrl
-        : hostedDefaultApiBaseUrl
-          ? hostedDefaultApiBaseUrl
-          : ensureDenApiBasePath(baseUrl) ?? baseUrl,
+        : deterministicApiBaseUrl ?? ensureDenApiBasePath(baseUrl) ?? baseUrl,
   };
 }
 
@@ -845,6 +860,72 @@ function resolveDenBootstrapConfig(
   };
 }
 
+function denRuntimeConfigUrl(baseUrl: string): string | null {
+  const normalized = normalizeDenBaseUrl(baseUrl);
+  if (!normalized) return null;
+
+  try {
+    const url = new URL(normalized);
+    url.pathname = "/api/runtime-config";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function readRuntimeConfigDenApiUrl(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  const denApiUrl = typeof payload.denApiUrl === "string" ? payload.denApiUrl.trim() : "";
+  return normalizeDenBaseUrl(denApiUrl);
+}
+
+async function fetchRuntimeConfigDenApiUrl(baseUrl: string): Promise<string | null> {
+  const url = denRuntimeConfigUrl(baseUrl);
+  if (!url) return null;
+
+  try {
+    const response = await fetchWithTimeout(
+      resolveFetch(url),
+      url,
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        credentials: "omit",
+        cache: "no-store",
+      },
+      2_000,
+    );
+    if (!response.ok) return null;
+    return readRuntimeConfigDenApiUrl(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+async function resolveDenBootstrapConfigWithRuntimeApi(
+  input: Parameters<typeof resolveDenBootstrapConfig>[0],
+): Promise<DenBootstrapConfig> {
+  const resolved = resolveDenBootstrapConfig(input);
+  if (!isDesktopRuntime()) {
+    return resolved;
+  }
+
+  const runtimeApiBaseUrl = await fetchRuntimeConfigDenApiUrl(resolved.baseUrl);
+  if (!runtimeApiBaseUrl) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    apiBaseUrl: resolveDenBaseUrls({
+      baseUrl: resolved.baseUrl,
+      apiBaseUrl: runtimeApiBaseUrl,
+    }).apiBaseUrl,
+  };
+}
+
 function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null {
   if (next.baseUrl === undefined && next.apiBaseUrl === undefined) {
     return null;
@@ -919,7 +1000,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
 
   const initialBootstrap = readInitialDesktopBootstrapConfig();
   if (initialBootstrap) {
-    applyDesktopBootstrapConfig(resolveDenBootstrapConfig(initialBootstrap));
+    applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(initialBootstrap));
     return desktopBootstrapConfig;
   }
 
@@ -931,7 +1012,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   for (let attempt = 1; attempt <= SHELL_BOOTSTRAP_ATTEMPTS; attempt += 1) {
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+      applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
       return desktopBootstrapConfig;
     } catch (error) {
       console.error("[den-bootstrap] shell read failed", attempt, error);
@@ -958,7 +1039,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
       await new Promise((resolve) => setTimeout(resolve, 2_000));
       try {
         const bootstrap = await getDesktopBootstrapConfigFromShell();
-        applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+        applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
         dispatchDenSettingsChanged({ settings: readDenSettings() });
         return;
       } catch {
@@ -980,7 +1061,7 @@ export async function refreshDenBootstrapConfigFromShell(): Promise<DenBootstrap
   if (isDesktopRuntime()) {
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+      applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
       dispatchDenSettingsChanged({ settings: readDenSettings() });
     } catch {
       // Bridge hiccup — keep the current cached snapshot.
@@ -994,7 +1075,7 @@ export async function setDenBootstrapConfig(
   options?: { dispatchSettingsChanged?: boolean },
 ): Promise<DenBootstrapConfig> {
   const previous = readDenBootstrapConfig();
-  const normalized = resolveDenBootstrapConfig({
+  const normalized = await resolveDenBootstrapConfigWithRuntimeApi({
     ...next,
     enterpriseActivation: next.enterpriseActivation ?? previous.enterpriseActivation,
   });
@@ -1015,7 +1096,7 @@ export async function setDenBootstrapConfig(
       ...(normalized.enterpriseActivation ? { enterpriseActivation: normalized.enterpriseActivation } : {}),
     });
     
-    applyDesktopBootstrapConfig(resolveDenBootstrapConfig({ ...persisted, source: "file" }));
+    applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi({ ...persisted, source: "file" }));
   } else {
     applyDesktopBootstrapConfig(normalized);
   }

--- a/apps/app/tests/den-desktop-bootstrap-settings.test.ts
+++ b/apps/app/tests/den-desktop-bootstrap-settings.test.ts
@@ -101,7 +101,7 @@ describe("desktop Den bootstrap settings", () => {
 
     const settings = readDenSettings();
     expect(settings.baseUrl).toBe("https://bootstrap.example.com");
-    expect(settings.apiBaseUrl).toBe("https://bootstrap.example.com/api/den");
+    expect(settings.apiBaseUrl).toBe("https://api.bootstrap.example.com");
   });
 
   test("keeps the prepared workspace and claim action in the shared bootstrap snapshot", async () => {
@@ -164,6 +164,50 @@ describe("desktop Den bootstrap settings", () => {
     expect(readDenBootstrapConfig().baseUrl).toBe("https://preload.example.com");
     expect(readDenBootstrapConfig().source).toBe("file");
     expect(ipcReads).toBe(0);
+  });
+
+  test("uses Den Web runtime-config API URL as the desktop source of truth", async () => {
+    const fetches: string[] = [];
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: () => true,
+        __OPENWORK_ELECTRON__: {
+          invokeDesktop: async (command: string, url?: string) => {
+            if (command === "getDesktopBootstrapConfig") {
+              return {
+                baseUrl: "https://app.runtime.example.com",
+                requireSignin: false,
+              };
+            }
+            if (command === "__fetch" && typeof url === "string") {
+              fetches.push(url);
+              return {
+                status: 200,
+                statusText: "OK",
+                headers: [["content-type", "application/json"]],
+                body: JSON.stringify({ denApiUrl: "https://api.override.example.com" }),
+              };
+            }
+            throw new Error(`Unexpected desktop command: ${command}`);
+          },
+        },
+      },
+    });
+
+    await initializeDenBootstrapConfig();
+
+    expect(fetches).toEqual(["https://app.runtime.example.com/api/runtime-config"]);
+    expect(readDenBootstrapConfig().baseUrl).toBe("https://app.runtime.example.com");
+    expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://api.override.example.com");
+  });
+
+  test("falls back to deterministic API subdomain when runtime-config is unavailable", async () => {
+    await initializeDenBootstrapConfig();
+
+    expect(readDenBootstrapConfig().baseUrl).toBe("https://bootstrap.example.com");
+    expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://api.bootstrap.example.com");
   });
 
   test("saves base URL changes to bootstrap and clears legacy endpoint storage", async () => {

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -35,10 +35,10 @@ describe("resolveDenBaseUrls", () => {
     expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:8787");
   });
 
-  test("derives the /api/den proxy from a web-app baseUrl when no apiBaseUrl is set", () => {
+  test("derives the api subdomain from a web-app baseUrl when no apiBaseUrl is set", () => {
     const resolved = resolveDenBaseUrls({ baseUrl: "https://den.self-hosted.example.com" });
     expect(resolved.baseUrl).toBe("https://den.self-hosted.example.com");
-    expect(resolved.apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
+    expect(resolved.apiBaseUrl).toBe("https://api.den.self-hosted.example.com");
   });
 
   test("uses the nested hosted API origin for the hosted web default", () => {

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -452,7 +452,7 @@ describe("non-gateway connection modes", () => {
     storage.setItem("openwork.den.baseUrl", "https://den.self-hosted.example.com");
 
     expect(readDenSettings().baseUrl).toBe("https://den.self-hosted.example.com");
-    expect(readDenSettings().apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
+    expect(readDenSettings().apiBaseUrl).toBe("https://api.den.self-hosted.example.com");
   });
 
   test("VITE_DEN_API_BASE_URL pins Den API calls to the proxy while sign-in stays on the web base", () => {

--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -1,3 +1,24 @@
+let denApiOriginOverride: string | null = null;
+
+function normalizeOrigin(input: string | null | undefined): string | null {
+  const trimmed = input?.trim() ?? "";
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+export function setDenApiOriginOverride(input: string | null | undefined) {
+  denApiOriginOverride = normalizeOrigin(input);
+}
+
 export function denApiOriginForWebOrigin(webOrigin: string): string | null {
   let url: URL;
   try {
@@ -18,11 +39,15 @@ export function denApiOriginForWebOrigin(webOrigin: string): string | null {
   return url.toString().replace(/\/$/, "");
 }
 
+function currentDenApiOriginForWebOrigin(webOrigin: string): string | null {
+  return denApiOriginOverride ?? denApiOriginForWebOrigin(webOrigin);
+}
+
 export function currentDenApiOrigin(): string | null {
   if (typeof window === "undefined") {
     return null;
   }
-  return denApiOriginForWebOrigin(window.location.origin);
+  return currentDenApiOriginForWebOrigin(window.location.origin);
 }
 
 export function denApiEndpointForWebOrigin(path: string, webOrigin: string): string {
@@ -38,7 +63,7 @@ export function denApiEndpointForWebOrigin(path: string, webOrigin: string): str
     return path;
   }
 
-  const origin = denApiOriginForWebOrigin(webOrigin);
+  const origin = currentDenApiOriginForWebOrigin(webOrigin);
   if (!origin) {
     return path;
   }
@@ -58,7 +83,7 @@ export function denApiCredentialsForEndpoint(endpoint: string, webOrigin: string
   try {
     const endpointOrigin = new URL(endpoint).origin;
     const currentOrigin = new URL(webOrigin).origin;
-    const apiOrigin = denApiOriginForWebOrigin(webOrigin);
+    const apiOrigin = currentDenApiOriginForWebOrigin(webOrigin);
     if (endpointOrigin === apiOrigin && isPublicDenApiPath(path)) {
       return "omit";
     }

--- a/ee/apps/den-web/app/(den)/_lib/runtime-config.ts
+++ b/ee/apps/den-web/app/(den)/_lib/runtime-config.ts
@@ -1,6 +1,9 @@
+import { setDenApiOriginOverride } from "./den-api-origin";
+
 export type DenOrgMode = "single_org" | "multi_org";
 
 export type DenWebRuntimeConfig = {
+  denApiUrl: string;
   openworkAppConnectUrl: string;
   openworkWebUrl: string;
   openworkAuthCallbackUrl: string;
@@ -14,6 +17,7 @@ export type DenWebRuntimeConfig = {
 export const DEFAULT_OPENWORK_WEB_URL = "https://web.openworklabs.com";
 
 export const EMPTY_RUNTIME_CONFIG: DenWebRuntimeConfig = {
+  denApiUrl: "",
   openworkAppConnectUrl: "",
   openworkWebUrl: DEFAULT_OPENWORK_WEB_URL,
   openworkAuthCallbackUrl: "",
@@ -47,6 +51,7 @@ function normalizeRuntimeConfig(value: unknown): DenWebRuntimeConfig {
   const singleOrgName = readStringProperty(value, "singleOrgName");
   const singleOrgSlug = readStringProperty(value, "singleOrgSlug");
   return {
+    denApiUrl: readStringProperty(value, "denApiUrl"),
     openworkAppConnectUrl: readStringProperty(value, "openworkAppConnectUrl"),
     openworkWebUrl: readStringProperty(value, "openworkWebUrl") || DEFAULT_OPENWORK_WEB_URL,
     openworkAuthCallbackUrl: readStringProperty(value, "openworkAuthCallbackUrl"),
@@ -67,7 +72,9 @@ export function getRuntimeConfig(): Promise<DenWebRuntimeConfig> {
           return EMPTY_RUNTIME_CONFIG;
         }
 
-        return normalizeRuntimeConfig(await response.json());
+        const config = normalizeRuntimeConfig(await response.json());
+        setDenApiOriginOverride(config.denApiUrl);
+        return config;
       })
       .catch(() => {
         runtimeConfigPromise = null;

--- a/ee/apps/den-web/app/api/ready/route.ts
+++ b/ee/apps/den-web/app/api/ready/route.ts
@@ -48,18 +48,20 @@ async function checkUpstream(apiBase: string): Promise<CheckStatus> {
   }
 }
 
+function readDenApiBase() {
+  const urls = denUrls(process.env);
+  return readBaseUrlEnv(process.env, "DEN_API_BASE") ?? urls.api;
+}
+
 export async function GET() {
-  const apiBase = readBaseUrlEnv(process.env, "DEN_API_BASE");
+  let apiBase: string | null = null;
   let hasPublicWebOrigin = true;
   try {
-    denUrls(process.env);
+    apiBase = readDenApiBase();
   } catch {
     hasPublicWebOrigin = false;
   }
   const missing: string[] = [];
-  if (!apiBase) {
-    missing.push("DEN_API_BASE");
-  }
   if (!hasPublicWebOrigin) {
     missing.push("DEN_BASE_URL");
   }

--- a/ee/apps/den-web/app/api/runtime-config/route.ts
+++ b/ee/apps/den-web/app/api/runtime-config/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { joinBaseUrl, readBaseUrlEnv } from "@openwork/types/url";
+import { denUrls } from "@openwork-ee/utils";
 import { DEFAULT_OPENWORK_WEB_URL } from "../../(den)/_lib/runtime-config";
 
 export const dynamic = "force-dynamic";
@@ -10,6 +11,10 @@ function readPublicRuntimeEnv(name: string) {
 
 function readOrgMode() {
   return readPublicRuntimeEnv("DEN_ORG_MODE") === "multi_org" ? "multi_org" : "single_org";
+}
+
+function readDenApiUrl() {
+  return readBaseUrlEnv(process.env, "DEN_API_BASE") ?? denUrls(process.env).api;
 }
 
 function readBooleanEnv(name: string, defaultValue: boolean) {
@@ -69,6 +74,7 @@ export async function GET() {
 
   return NextResponse.json(
     {
+      denApiUrl: readDenApiUrl(),
       openworkAppConnectUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_APP_CONNECT_URL"),
       openworkWebUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_WEB_URL") || DEFAULT_OPENWORK_WEB_URL,
       openworkAuthCallbackUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_AUTH_CALLBACK_URL"),

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin } from "../app/(den)/_lib/den-api-origin";
+import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin, setDenApiOriginOverride } from "../app/(den)/_lib/den-api-origin";
+
+afterEach(() => {
+  setDenApiOriginOverride(null);
+});
 
 describe("Den API browser origin", () => {
   test("prefixes the hosted app origin with the api subdomain", () => {
@@ -17,6 +21,13 @@ describe("Den API browser origin", () => {
 
   test("builds direct API URLs instead of same-origin Den proxy URLs", () => {
     expect(denApiEndpointForWebOrigin("/v1/me", "https://app.openworklabs.com")).toBe("https://api.app.openworklabs.com/v1/me");
+  });
+
+  test("uses the runtime-config API origin override when present", () => {
+    setDenApiOriginOverride("https://api.override.example.test/v1/ignored");
+
+    expect(denApiEndpointForWebOrigin("/v1/me", "https://app.openworklabs.com")).toBe("https://api.override.example.test/v1/me");
+    expect(denApiCredentialsForEndpoint("https://api.override.example.test/v1/me", "https://app.openworklabs.com")).toBe("include");
   });
 
   test("keeps Better Auth traffic on the same-origin auth proxy", () => {

--- a/ee/apps/den-web/tests/den-public-origin.test.ts
+++ b/ee/apps/den-web/tests/den-public-origin.test.ts
@@ -56,6 +56,6 @@ describe("Den public web origin", () => {
     const configuredBaseResponse = await GET();
     const configuredBasePayload = await configuredBaseResponse.json();
 
-    expect(configuredBasePayload.missing).toEqual(["DEN_API_BASE"]);
+    expect(configuredBasePayload.missing).toBeUndefined();
   });
 });

--- a/ee/apps/den-web/tests/single-org-signup-ui.test.ts
+++ b/ee/apps/den-web/tests/single-org-signup-ui.test.ts
@@ -5,6 +5,7 @@ import { GET } from "../app/api/runtime-config/route";
 
 const originalEnv = {
   DEN_API_BASE: process.env.DEN_API_BASE,
+  DEN_BASE_URL: process.env.DEN_BASE_URL,
   DEN_ORG_MODE: process.env.DEN_ORG_MODE,
   DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP,
 };
@@ -28,6 +29,7 @@ function readBooleanProperty(value: unknown, key: string) {
 
 afterEach(() => {
   restoreEnvValue("DEN_API_BASE");
+  restoreEnvValue("DEN_BASE_URL");
   restoreEnvValue("DEN_ORG_MODE");
   restoreEnvValue("DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP");
 });
@@ -35,6 +37,7 @@ afterEach(() => {
 describe("single-org public signup UI policy", () => {
   test("runtime config exposes private public-signup default for single-org deployments", async () => {
     delete process.env.DEN_API_BASE;
+    process.env.DEN_BASE_URL = "https://app.openworklabs.com";
     process.env.DEN_ORG_MODE = "single_org";
     delete process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP;
 
@@ -45,6 +48,7 @@ describe("single-org public signup UI policy", () => {
 
   test("runtime config parses Helm string public-signup values", async () => {
     delete process.env.DEN_API_BASE;
+    process.env.DEN_BASE_URL = "https://app.openworklabs.com";
     process.env.DEN_ORG_MODE = "single_org";
     process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP = "true";
 

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -8,6 +8,7 @@ import { GET } from "../app/api/runtime-config/route";
 
 const originalEnv = {
   DEN_API_BASE: process.env.DEN_API_BASE,
+  DEN_BASE_URL: process.env.DEN_BASE_URL,
   DEN_WEB_OPENWORK_WEB_URL: process.env.DEN_WEB_OPENWORK_WEB_URL,
 };
 
@@ -31,6 +32,7 @@ function readStringProperty(value: unknown, key: string) {
 
 afterEach(() => {
   restoreEnvValue("DEN_API_BASE");
+  restoreEnvValue("DEN_BASE_URL");
   restoreEnvValue("DEN_WEB_OPENWORK_WEB_URL");
 });
 
@@ -64,6 +66,7 @@ describe("Web dashboard page", () => {
 
   test("runtime config exposes the default Web URL and deployment override", async () => {
     delete process.env.DEN_API_BASE;
+    process.env.DEN_BASE_URL = "https://app.openworklabs.com";
     delete process.env.DEN_WEB_OPENWORK_WEB_URL;
 
     const defaultPayload: unknown = await (await GET()).json();
@@ -72,5 +75,17 @@ describe("Web dashboard page", () => {
     process.env.DEN_WEB_OPENWORK_WEB_URL = "https://self-hosted.example.test";
     const overridePayload: unknown = await (await GET()).json();
     expect(readStringProperty(overridePayload, "openworkWebUrl")).toBe("https://self-hosted.example.test");
+  });
+
+  test("runtime config exposes the Den API URL with DEN_API_BASE override precedence", async () => {
+    delete process.env.DEN_API_BASE;
+    process.env.DEN_BASE_URL = "https://den.example.test";
+
+    const derivedPayload: unknown = await (await GET()).json();
+    expect(readStringProperty(derivedPayload, "denApiUrl")).toBe("https://api.den.example.test");
+
+    process.env.DEN_API_BASE = "https://api.override.example.test";
+    const overridePayload: unknown = await (await GET()).json();
+    expect(readStringProperty(overridePayload, "denApiUrl")).toBe("https://api.override.example.test");
   });
 });


### PR DESCRIPTION
## Summary\n- expose denApiUrl from Den Web /api/runtime-config using DEN_API_BASE when set, otherwise api.<DEN_BASE_URL>\n- use the runtime-config API URL as the desktop bootstrap source of truth, with deterministic fallback when unavailable\n- teach Den Web browser API calls to honor the runtime-config API origin override\n\n## Validation\n- pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/web-page.test.ts tests/single-org-signup-ui.test.ts tests/den-public-origin.test.ts tests/den-api-origin.test.ts\n- pnpm --filter @openwork/app exec bun test --isolate tests/den-mcp-url.test.ts tests/den-desktop-bootstrap-settings.test.ts tests/gateway-runtime.test.ts\n- pnpm --filter @openwork-ee/den-web typecheck\n- pnpm --filter @openwork/app typecheck\n