### PR TITLE
fix(den-api): allow explicit auth cookie domain

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -24,6 +24,7 @@ const EnvSchema = z.object({
   DATABASE_REDIS_ALLOW_INSECURE_INTERNAL: z.string().optional(),
   DEN_MCP_RESOURCE_URL: z.string().optional(),
   DEN_MCP_ADDITIONAL_RESOURCES: z.string().optional(),
+  DEN_BETTER_AUTH_COOKIE_DOMAIN: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
   DEN_WEB_APP_HOSTS: z.string().optional(),
   GITHUB_CLIENT_ID: z.string().optional(),
@@ -567,7 +568,29 @@ function deriveBetterAuthCookieDomain(input: { webOrigin: string; apiPublicUrl: 
   const apiHost = api.hostname.toLowerCase()
   return apiHost.endsWith(`.${webHost}`) ? webHost : undefined
 }
-const betterAuthCookieDomain = deriveBetterAuthCookieDomain({
+function normalizeBetterAuthCookieDomain(value: string | undefined) {
+  const configured = optionalString(value)
+  if (!configured) return undefined
+
+  const domain = configured.replace(/^\.+/, "").trim().toLowerCase()
+  if (!domain) {
+    throw new Error("DEN_BETTER_AUTH_COOKIE_DOMAIN must be a domain name, not an empty value.")
+  }
+
+  let parsedDomain: URL
+  try {
+    parsedDomain = new URL(`https://${domain}`)
+  } catch {
+    throw new Error("DEN_BETTER_AUTH_COOKIE_DOMAIN must be a valid domain name without protocol, path, query, or fragment.")
+  }
+
+  if (parsedDomain.hostname !== domain || parsedDomain.port || parsedDomain.username || parsedDomain.password || parsedDomain.pathname !== "/" || parsedDomain.search || parsedDomain.hash) {
+    throw new Error("DEN_BETTER_AUTH_COOKIE_DOMAIN must be a valid domain name without protocol, path, query, or fragment.")
+  }
+
+  return domain
+}
+const betterAuthCookieDomain = normalizeBetterAuthCookieDomain(parsed.DEN_BETTER_AUTH_COOKIE_DOMAIN) ?? deriveBetterAuthCookieDomain({
   webOrigin: betterAuthPublicWebOrigin,
   apiPublicUrl,
 })

--- a/ee/apps/den-api/test/den-base-url-env.test.ts
+++ b/ee/apps/den-api/test/den-base-url-env.test.ts
@@ -104,6 +104,23 @@ describe("DEN_BASE_URL environment defaults", () => {
     })
   })
 
+  test("supports explicit shared cookie domains for sibling web and API hosts", () => {
+    expect(probeDenUrls({
+      BETTER_AUTH_URL: "https://app.openworklabs.com",
+      DEN_API_PUBLIC_URL: "https://api.openworklabs.com",
+      DEN_BETTER_AUTH_COOKIE_DOMAIN: "openworklabs.com",
+      CORS_ORIGINS: "https://app.openworklabs.com,https://api.openworklabs.com,https://api.app.openworklabs.com",
+    })).toMatchObject({
+      betterAuthUrl: "https://app.openworklabs.com",
+      betterAuthCookieDomain: "openworklabs.com",
+      webUrl: "https://app.openworklabs.com",
+      apiPublicUrl: "https://api.openworklabs.com",
+      corsOrigins: ["https://app.openworklabs.com", "https://api.openworklabs.com", "https://api.app.openworklabs.com"],
+      betterAuthTrustedOrigins: ["https://app.openworklabs.com"],
+      webAppHosts: ["app.openworklabs.com"],
+    })
+  })
+
   test("exposes only the public web origin when BETTER_AUTH_URL includes URL components", () => {
     expect(probeDenUrls({
       BETTER_AUTH_URL: "https://user:secret@legacy.example.com/auth/path?token=hidden#fragment",

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -39,6 +39,9 @@ data:
   {{ if .Values.config.public.betterAuthTrustedOrigins }}
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: {{ .Values.config.public.betterAuthTrustedOrigins | quote }}
   {{ end }}
+  {{ if .Values.config.public.betterAuthCookieDomain }}
+  DEN_BETTER_AUTH_COOKIE_DOMAIN: {{ .Values.config.public.betterAuthCookieDomain | quote }}
+  {{ end }}
   {{ if .Values.config.public.webAppHosts }}
   DEN_WEB_APP_HOSTS: {{ .Values.config.public.webAppHosts | quote }}
   {{ end }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -39,6 +39,7 @@ config:
     mcpClaimNamespace: ""
     desktopDenBaseUrl: ""
     corsOrigins: ""
+    betterAuthCookieDomain: ""
     betterAuthTrustedOrigins: ""
     webAppHosts: ""
     bootstrapAdminEmails: ""


### PR DESCRIPTION
## Summary\n- add DEN_BETTER_AUTH_COOKIE_DOMAIN to override the derived Better Auth cookie domain\n- support sibling app/API hosts such as app.openworklabs.com and api.openworklabs.com sharing openworklabs.com cookies\n- pass the new setting through the Helm chart\n\n## Tests\n- bun test ee/apps/den-api/test/den-base-url-env.test.ts ee/apps/den-api/test/auth-login-options.test.ts