### PR TITLE
MCP Apps dashboard: per-user grid with add-from-Connect picker

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -421,6 +421,24 @@ export type OpenworkMcpAppLaunchReference = {
   arguments: Record<string, unknown>;
 };
 
+export type OpenworkMcpAppCatalogApp = {
+  serverName: string;
+  toolName: string;
+  projectedToolName: string;
+  resourceUri: string;
+  title: string | null;
+  description: string | null;
+  /** True when the launch tool declares required input, so a host cannot start it with empty arguments. */
+  requiresInput: boolean;
+};
+
+export type OpenworkMcpAppCatalogServer = {
+  serverName: string;
+  reachable: boolean;
+  error?: string;
+  apps: OpenworkMcpAppCatalogApp[];
+};
+
 export type OpenworkMcpAppToolResult = {
   content: Array<Record<string, unknown>>;
   structuredContent?: Record<string, unknown>;
@@ -1934,6 +1952,12 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${workspaceId}/mcp`,
         { token, hostToken },
+      ),
+    listMcpApps: (workspaceId: string) =>
+      requestJson<{ servers: OpenworkMcpAppCatalogServer[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/mcp-apps/list`,
+        { token, hostToken, timeoutMs: timeouts.binary },
       ),
     resolveMcpApp: (
       workspaceId: string,

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -432,6 +432,8 @@ export type OpenworkMcpAppCatalogApp = {
   description: string | null;
   /** True when the launch tool declares required input, so a host cannot start it with empty arguments. */
   requiresInput: boolean;
+  /** True when calling the launch tool needs user approval (not explicitly read-only, or destructive). */
+  requiresApproval: boolean;
 };
 
 export type OpenworkMcpAppCatalogServer = {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -423,6 +423,8 @@ export type OpenworkMcpAppLaunchReference = {
 
 export type OpenworkMcpAppCatalogApp = {
   serverName: string;
+  /** Present for Connect app-host apps: launch them through this connection reference. */
+  connectionId?: string;
   toolName: string;
   projectedToolName: string;
   resourceUri: string;
@@ -434,6 +436,9 @@ export type OpenworkMcpAppCatalogApp = {
 
 export type OpenworkMcpAppCatalogServer = {
   serverName: string;
+  /** Human-readable provider name for Connect app-host servers. */
+  displayName?: string;
+  connectionId?: string;
   reachable: boolean;
   error?: string;
   apps: OpenworkMcpAppCatalogApp[];

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -48,7 +48,7 @@ const ACTIONABLE_MCP_APP_RESOLUTION_CODES = new Set([
   "unsupported_resource_permissions",
 ])
 
-type PreservedMcpAppResult = {
+export type PreservedMcpAppResult = {
   content: Array<Record<string, unknown>>
   structuredContent?: Record<string, unknown>
   _meta?: Record<string, unknown>
@@ -196,62 +196,64 @@ export function isActionableMcpAppResolutionError(cause: unknown): boolean {
   return cause instanceof OpenworkServerError && ACTIONABLE_MCP_APP_RESOLUTION_CODES.has(cause.code)
 }
 
-export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
+const CHAT_MCP_APP_UNAVAILABLE_NOTICE = "Interactive view unavailable. The normal tool result is still available."
+
+export function McpAppDiagnosticNotice({ error, notice }: { error: McpAppDiagnostic; notice: string }) {
+  const [detailsCopied, setDetailsCopied] = useState(false)
+  const details = formatMcpAppDiagnostic(error)
+  return (
+    <div className="mt-2 text-xs text-muted-foreground" role="status">
+      <p>{notice} {error.message}</p>
+      <details className="mt-1">
+        <summary className="cursor-pointer select-none">Technical details ({error.code})</summary>
+        <p className="mt-1">Copy these details when reporting the rendering problem.</p>
+        <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-2 font-mono text-[11px] text-foreground">{details}</pre>
+        <button
+          type="button"
+          className="mt-1 underline underline-offset-2"
+          onClick={() => {
+            if (!navigator.clipboard) return
+            void navigator.clipboard.writeText(details)
+              .then(() => setDetailsCopied(true))
+              .catch(() => setDetailsCopied(false))
+          }}
+        >
+          {detailsCopied ? "Copied" : "Copy details"}
+        </button>
+      </details>
+    </div>
+  )
+}
+
+export type McpAppSandboxViewProps = {
+  app: OpenworkMcpAppResource
+  /** Tool name used for host diagnostics and the iframe title. */
+  toolName: string
+  /** Arguments the host reports to the app as its launch input. */
+  inputArguments: Record<string, unknown>
+  /** Tool result delivered to the app once it initializes. */
+  result: PreservedMcpAppResult
+  /** Notice prefix shown when the sandboxed view cannot render. */
+  unavailableNotice: string
+  onRequestTeardown?: () => void
+}
+
+/**
+ * Chat-independent MCP App renderer: sandboxes one resolved app resource and
+ * bridges it to the workspace MCP App host. Chat messages and dashboard tiles
+ * share this exact pipeline so rendering and diagnostics stay identical.
+ */
+export function McpAppSandboxView({ app, toolName, inputArguments, result, unavailableNotice, onRequestTeardown }: McpAppSandboxViewProps) {
   const { openworkServerClient, workspaceId } = useWorkspace()
-  const nextResult = preservedResult(part)
-  const nextResultSignature = JSON.stringify(nextResult)
-  const resultCache = useRef<{ signature: string; value: PreservedMcpAppResult | null }>({
-    signature: nextResultSignature,
-    value: nextResult,
-  })
-  if (resultCache.current.signature !== nextResultSignature) {
-    resultCache.current = { signature: nextResultSignature, value: nextResult }
-  }
-  const result = resultCache.current.value
-  const launch = useMemo(() => gatewayMcpAppLaunch(result?._meta), [result])
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
   const [height, setHeight] = useState(DEFAULT_HEIGHT)
   const [error, setError] = useState<McpAppDiagnostic | null>(null)
-  const [detailsCopied, setDetailsCopied] = useState(false)
-
-  useEffect(() => {
-    let cancelled = false
-    setApp(null)
-    setError(null)
-    setDetailsCopied(false)
-    if (!result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
-    const startedAt = performance.now()
-    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined)
-      .then(({ app: resolved }) => {
-        if (cancelled) return
-        // A preserved MCP result is neutral transport data. A null resolution
-        // means the current tool definition does not advertise an MCP App, so
-        // ordinary tools such as save_artifact_view render only their normal
-        // result without claiming an unavailable interactive view.
-        setApp(resolved)
-      })
-      .catch((cause) => {
-        if (!cancelled && isActionableMcpAppResolutionError(cause)) {
-          const diagnostic: McpAppDiagnostic = {
-            code: "MCP_APP_RESOURCE_RESOLUTION_FAILED",
-            ...(cause instanceof OpenworkServerError ? { causeCode: cause.code } : {}),
-            stage: "resource-resolution",
-            message: safeMcpAppDiagnosticMessage(cause, "The interactive view resource could not be resolved."),
-            toolName: part.toolName,
-            elapsedMs: Math.round(performance.now() - startedAt),
-            checkpoints: ["resolve-started"],
-          }
-          console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
-          setError(diagnostic)
-        }
-      })
-    return () => { cancelled = true }
-  }, [launch, openworkServerClient, part.toolName, result, workspaceId])
+  const teardownRef = useRef(onRequestTeardown)
+  teardownRef.current = onRequestTeardown
 
   useEffect(() => {
     const iframe = iframeRef.current
-    if (!app || !result || !iframe || !iframe.contentWindow || !openworkServerClient || !workspaceId) return
+    if (!iframe || !iframe.contentWindow || !openworkServerClient || !workspaceId) return
     let disposed = false
     let lastSizeEventAt = 0
     const startedAt = performance.now()
@@ -272,7 +274,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         code,
         stage,
         message: safeMcpAppDiagnosticMessage(cause, fallback),
-        toolName: part.toolName,
+        toolName,
         resourceUri: app.resourceUri,
         ...(sandboxOrigin ? { sandboxOrigin } : {}),
         elapsedMs: Math.round(performance.now() - startedAt),
@@ -312,7 +314,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         return {}
       } catch (cause) {
         console.error("[OpenWork MCP App] MCP_APP_OPEN_LINK_BLOCKED", {
-          toolName: part.toolName,
+          toolName,
           message: safeMcpAppDiagnosticMessage(cause, "The link could not be opened."),
         })
         return { isError: true }
@@ -355,7 +357,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       }, SIZE_EVENT_INTERVAL_MS)
     }
     bridge.onrequestteardown = () => {
-      setApp(null)
+      teardownRef.current?.()
     }
     bridge.oncalltool = async ({ name, arguments: args }) => {
       const request = { serverName: app.serverName, name, resourceUri: app.resourceUri, arguments: args }
@@ -374,7 +376,7 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       if (resourceDeliveryTimer !== undefined) window.clearTimeout(resourceDeliveryTimer)
       if (initializeTimer !== undefined) window.clearTimeout(initializeTimer)
       void bridge.sendToolInput({
-        arguments: launch?.arguments ?? (isRecord(part.input) ? part.input : {}),
+        arguments: inputArguments,
       }).then(() => bridge.sendToolResult({
         content: result.content as CallToolResult["content"],
         ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
@@ -518,51 +520,93 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
         new Promise<void>((resolve) => window.setTimeout(resolve, 500)),
       ]).catch(() => undefined).finally(() => bridge.close().catch(() => undefined))
     }
-  }, [app, launch, openworkServerClient, part.input, result, workspaceId])
+  }, [app, inputArguments, openworkServerClient, result, toolName, workspaceId])
 
-  if (!result || (!app && !error)) return null
-  if (error) {
-    const details = formatMcpAppDiagnostic(error)
-    return (
-      <div className="mt-2 text-xs text-muted-foreground" role="status">
-        <p>Interactive view unavailable. The normal tool result is still available. {error.message}</p>
-        <details className="mt-1">
-          <summary className="cursor-pointer select-none">Technical details ({error.code})</summary>
-          <p className="mt-1">Copy these details when reporting the rendering problem.</p>
-          <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-2 font-mono text-[11px] text-foreground">{details}</pre>
-          <button
-            type="button"
-            className="mt-1 underline underline-offset-2"
-            onClick={() => {
-              if (!navigator.clipboard) return
-              void navigator.clipboard.writeText(details)
-                .then(() => setDetailsCopied(true))
-                .catch(() => setDetailsCopied(false))
-            }}
-          >
-            {detailsCopied ? "Copied" : "Copy details"}
-          </button>
-        </details>
-      </div>
-    )
-  }
-
+  if (error) return <McpAppDiagnosticNotice error={error} notice={unavailableNotice} />
   return (
     <div
       className={cn(
         "mt-3 overflow-hidden rounded-xl bg-background",
-        app?.prefersBorder && "border border-border",
+        app.prefersBorder && "border border-border",
       )}
-      data-mcp-app-resource={app?.resourceUri}
+      data-mcp-app-resource={app.resourceUri}
     >
       <iframe
         ref={iframeRef}
-        title={`${part.toolName} interactive view`}
+        title={`${toolName} interactive view`}
         sandbox="allow-scripts allow-same-origin"
         referrerPolicy="no-referrer"
         className="block w-full border-0 bg-transparent"
         style={{ height }}
       />
     </div>
+  )
+}
+
+export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
+  const { openworkServerClient, workspaceId } = useWorkspace()
+  const nextResult = preservedResult(part)
+  const nextResultSignature = JSON.stringify(nextResult)
+  const resultCache = useRef<{ signature: string; value: PreservedMcpAppResult | null }>({
+    signature: nextResultSignature,
+    value: nextResult,
+  })
+  if (resultCache.current.signature !== nextResultSignature) {
+    resultCache.current = { signature: nextResultSignature, value: nextResult }
+  }
+  const result = resultCache.current.value
+  const launch = useMemo(() => gatewayMcpAppLaunch(result?._meta), [result])
+  const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
+  const [error, setError] = useState<McpAppDiagnostic | null>(null)
+  const inputArguments = useMemo(
+    () => launch?.arguments ?? (isRecord(part.input) ? part.input : {}),
+    [launch, part.input],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    setApp(null)
+    setError(null)
+    if (!result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
+    const startedAt = performance.now()
+    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined)
+      .then(({ app: resolved }) => {
+        if (cancelled) return
+        // A preserved MCP result is neutral transport data. A null resolution
+        // means the current tool definition does not advertise an MCP App, so
+        // ordinary tools such as save_artifact_view render only their normal
+        // result without claiming an unavailable interactive view.
+        setApp(resolved)
+      })
+      .catch((cause) => {
+        if (!cancelled && isActionableMcpAppResolutionError(cause)) {
+          const diagnostic: McpAppDiagnostic = {
+            code: "MCP_APP_RESOURCE_RESOLUTION_FAILED",
+            ...(cause instanceof OpenworkServerError ? { causeCode: cause.code } : {}),
+            stage: "resource-resolution",
+            message: safeMcpAppDiagnosticMessage(cause, "The interactive view resource could not be resolved."),
+            toolName: part.toolName,
+            elapsedMs: Math.round(performance.now() - startedAt),
+            checkpoints: ["resolve-started"],
+          }
+          console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
+          setError(diagnostic)
+        }
+      })
+    return () => { cancelled = true }
+  }, [launch, openworkServerClient, part.toolName, result, workspaceId])
+
+  if (!result || (!app && !error)) return null
+  if (error) return <McpAppDiagnosticNotice error={error} notice={CHAT_MCP_APP_UNAVAILABLE_NOTICE} />
+  if (!app) return null
+  return (
+    <McpAppSandboxView
+      app={app}
+      toolName={part.toolName}
+      inputArguments={inputArguments}
+      result={result}
+      unavailableNotice={CHAT_MCP_APP_UNAVAILABLE_NOTICE}
+      onRequestTeardown={() => setApp(null)}
+    />
   )
 }

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -236,6 +236,10 @@ export type McpAppSandboxViewProps = {
   /** Notice prefix shown when the sandboxed view cannot render. */
   unavailableNotice: string
   onRequestTeardown?: () => void
+  /** Starting iframe height, letting a host restore the last measured size across remounts. */
+  initialHeight?: number
+  /** Reports app-requested size changes so a host can persist them past this view's lifetime. */
+  onHeightChange?: (height: number) => void
 }
 
 /**
@@ -243,13 +247,19 @@ export type McpAppSandboxViewProps = {
  * bridges it to the workspace MCP App host. Chat messages and dashboard tiles
  * share this exact pipeline so rendering and diagnostics stay identical.
  */
-export function McpAppSandboxView({ app, toolName, inputArguments, result, unavailableNotice, onRequestTeardown }: McpAppSandboxViewProps) {
+export function McpAppSandboxView({ app, toolName, inputArguments, result, unavailableNotice, onRequestTeardown, initialHeight, onHeightChange }: McpAppSandboxViewProps) {
   const { openworkServerClient, workspaceId } = useWorkspace()
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const [height, setHeight] = useState(DEFAULT_HEIGHT)
+  const [height, setHeightState] = useState(initialHeight ?? DEFAULT_HEIGHT)
   const [error, setError] = useState<McpAppDiagnostic | null>(null)
   const teardownRef = useRef(onRequestTeardown)
   teardownRef.current = onRequestTeardown
+  const onHeightChangeRef = useRef(onHeightChange)
+  onHeightChangeRef.current = onHeightChange
+  const setHeight = (next: number) => {
+    setHeightState(next)
+    onHeightChangeRef.current?.(next)
+  }
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -558,6 +568,9 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const launch = useMemo(() => gatewayMcpAppLaunch(result?._meta), [result])
   const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
   const [error, setError] = useState<McpAppDiagnostic | null>(null)
+  // The sandbox view unmounts on every preserved-result change; keep the last
+  // measured height here so the rebuilt iframe does not snap back to default.
+  const heightRef = useRef(DEFAULT_HEIGHT)
   const inputArguments = useMemo(
     () => launch?.arguments ?? (isRecord(part.input) ? part.input : {}),
     [launch, part.input],
@@ -607,6 +620,8 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
       result={result}
       unavailableNotice={CHAT_MCP_APP_UNAVAILABLE_NOTICE}
       onRequestTeardown={() => setApp(null)}
+      initialHeight={heightRef.current}
+      onHeightChange={(next) => { heightRef.current = next }}
     />
   )
 }

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -111,8 +111,9 @@ function CatalogAppRow({ app, added, onAdd }: {
   const [argsText, setArgsText] = useState("");
   const [argsError, setArgsError] = useState<string | null>(null);
   const entry = mcpEntryFromCatalogApp(app);
-  // Input capture and write-consent both happen once, at add time.
-  const needsDetails = app.requiresInput || app.requiresApproval;
+  // Every add goes through the details panel: it names what adding consents
+  // to (automatic launches, data modification, stored input) so no tool runs
+  // later on a server-controlled hint the user never saw.
   const buildEntry = (launchArguments?: Record<string, unknown>): DashboardMcpAppEntry => ({
     ...entry,
     ...(launchArguments ? { launchArguments } : {}),
@@ -161,7 +162,7 @@ function CatalogAppRow({ app, added, onAdd }: {
           <Button variant="ghost" size="sm" disabled>
             <Check className="size-4" /> Added
           </Button>
-        ) : needsDetails ? (
+        ) : (
           <Button
             variant="outline"
             size="sm"
@@ -170,10 +171,6 @@ function CatalogAppRow({ app, added, onAdd }: {
             onClick={() => setDetailsOpen((value) => !value)}
           >
             <Plus className="size-4" /> Add…
-          </Button>
-        ) : (
-          <Button variant="outline" size="sm" aria-label={`Add ${entry.title}`} onClick={() => onAdd(entry)}>
-            <Plus className="size-4" /> Add
           </Button>
         )}
       </div>
@@ -201,12 +198,18 @@ function CatalogAppRow({ app, added, onAdd }: {
               {entry.serverName}). Adding it allows that call, and the tile only
               runs when you press Run — never automatically.
             </p>
-          ) : null}
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Adding this app ({entry.toolName} on {entry.serverName}) lets its
+              tile launch automatically whenever you open the dashboard.
+            </p>
+          )}
           {argsError ? <p className="text-xs text-destructive" role="alert">{argsError}</p> : null}
           <div className="flex justify-end gap-2">
             <Button variant="ghost" size="sm" onClick={() => setDetailsOpen(false)}>Cancel</Button>
             <Button variant="outline" size="sm" onClick={addFromDetails}>
-              <Plus className="size-4" /> {app.requiresApproval ? "Add and allow" : "Add with input"}
+              <Plus className="size-4" />
+              {app.requiresApproval ? "Add and allow" : app.requiresInput ? "Add with input" : "Add"}
             </Button>
           </div>
         </div>

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useQuery } from "@tanstack/react-query";
-import { AlertTriangle, Check, Plus } from "lucide-react";
+import { AlertTriangle, Check, Plus, RefreshCw } from "lucide-react";
 
 import type { OpenworkMcpAppCatalogApp, OpenworkMcpAppCatalogServer } from "@/app/lib/openwork-server";
 import { Badge } from "@/components/ui/badge";
@@ -21,6 +21,7 @@ export function mcpEntryFromCatalogApp(app: OpenworkMcpAppCatalogApp): Dashboard
     kind: "mcp",
     id: `mcp:${app.serverName}:${app.toolName}`,
     serverName: app.serverName,
+    ...(app.connectionId ? { connectionId: app.connectionId } : {}),
     toolName: app.toolName,
     projectedToolName: app.projectedToolName,
     resourceUri: app.resourceUri,
@@ -63,7 +64,9 @@ function ServerSection({ server, existingIds, onAdd }: {
   return (
     <section className="space-y-1">
       <div className="flex items-center gap-2">
-        <span className="truncate text-xs font-medium text-muted-foreground">{server.serverName}</span>
+        <span className="truncate text-xs font-medium text-muted-foreground">
+          {server.displayName ?? server.serverName}
+        </span>
         {server.reachable ? (
           <Badge variant="secondary">Connected</Badge>
         ) : (
@@ -108,13 +111,14 @@ function ServerSection({ server, existingIds, onAdd }: {
 
 export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppDialogProps) {
   const { openworkServerClient, workspaceId } = useWorkspace();
+  const workspaceReady = Boolean(openworkServerClient) && Boolean(workspaceId);
   const catalog = useQuery({
     queryKey: ["mcp-app-catalog", workspaceId],
     queryFn: () => {
       if (!openworkServerClient || !workspaceId) throw new Error("No connected workspace is available.");
       return openworkServerClient.listMcpApps(workspaceId);
     },
-    enabled: open && Boolean(openworkServerClient) && Boolean(workspaceId),
+    enabled: open && workspaceReady,
     staleTime: 30_000,
   });
   const hello = builtinHelloEntry();
@@ -130,6 +134,27 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="flex-1 text-xs font-medium text-muted-foreground">
+              {!workspaceReady
+                ? "Waiting for a connected workspace…"
+                : catalog.isFetching
+                  ? "Checking your MCP servers…"
+                  : catalog.data
+                    ? `Checked ${catalog.data.servers.length} MCP source${catalog.data.servers.length === 1 ? "" : "s"}.`
+                    : null}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!workspaceReady || catalog.isFetching}
+              onClick={() => {
+                void catalog.refetch();
+              }}
+            >
+              <RefreshCw className="size-4" /> Refresh
+            </Button>
+          </div>
           <section className="space-y-1">
             <span className="text-xs font-medium text-muted-foreground">Built-in</span>
             <div className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
@@ -144,22 +169,28 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
               />
             </div>
           </section>
-          {catalog.isPending && catalog.isFetching ? (
+          {!workspaceReady ? (
+            <p className="text-xs text-muted-foreground" role="status">
+              MCP apps cannot be listed until a workspace connection is ready.
+              Open a session in this workspace first, then try again.
+            </p>
+          ) : null}
+          {workspaceReady && catalog.isFetching ? (
             <div className="space-y-2" role="status" aria-label="Loading MCP apps">
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />
             </div>
           ) : null}
-          {catalog.isError ? (
+          {catalog.isError && !catalog.isFetching ? (
             <p className="text-xs text-muted-foreground" role="status">
               MCP apps could not be listed: {catalog.error instanceof Error ? catalog.error.message : "unknown error"}
             </p>
           ) : null}
-          {catalog.data ? (
+          {catalog.data && !catalog.isFetching ? (
             catalog.data.servers.length === 0 ? (
               <p className="text-xs text-muted-foreground">
-                No MCP servers are configured for this workspace yet. Connect one
-                in Settings to see its apps here.
+                No MCP app sources were found. Connect an MCP server in Settings,
+                or sign in to OpenWork Connect, then refresh.
               </p>
             ) : (
               catalog.data.servers.map((server) => (

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -32,9 +32,6 @@ export function mcpEntryFromCatalogApp(app: OpenworkMcpAppCatalogApp): Dashboard
     projectedToolName: app.projectedToolName,
     resourceUri: app.resourceUri,
     title: app.title ?? app.toolName,
-    // Adding through the picker is the user's consent to automatic launches;
-    // write-tools stay run-on-request regardless.
-    ...(app.requiresApproval ? {} : { autoLaunch: true }),
   };
 }
 
@@ -200,8 +197,9 @@ function CatalogAppRow({ app, added, onAdd }: {
             </p>
           ) : (
             <p className="text-xs text-muted-foreground">
-              Adding this app ({entry.toolName} on {entry.serverName}) lets its
-              tile launch automatically whenever you open the dashboard.
+              This app runs {entry.toolName} on {entry.serverName}. Its tile
+              waits for you to run it once; after that first run it launches
+              automatically whenever you open the dashboard.
             </p>
           )}
           {argsError ? <p className="text-xs text-destructive" role="alert">{argsError}</p> : null}
@@ -239,9 +237,9 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           <DialogTitle>Add app</DialogTitle>
           <DialogDescription>
             MCP apps available via OpenWork Connect and this workspace&apos;s MCP
-            servers. Added apps launch automatically when the dashboard opens;
-            apps that modify data only run on request. Apps that need input ask
-            for JSON launch arguments when you add them.
+            servers. New tiles wait for a first manual run before launching
+            automatically; apps that modify data always run on request. Apps
+            that need input ask for JSON launch arguments when you add them.
           </DialogDescription>
         </DialogHeader>
         <div className="min-w-0 space-y-4">

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -171,8 +171,8 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           </section>
           {!workspaceReady ? (
             <p className="text-xs text-muted-foreground" role="status">
-              MCP apps cannot be listed until a workspace connection is ready.
-              Open a session in this workspace first, then try again.
+              MCP apps launch through a workspace&apos;s MCP runtime and none is
+              available yet. Create or open a workspace, then refresh.
             </p>
           ) : null}
           {workspaceReady && catalog.isFetching ? (

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -32,6 +32,9 @@ export function mcpEntryFromCatalogApp(app: OpenworkMcpAppCatalogApp): Dashboard
     projectedToolName: app.projectedToolName,
     resourceUri: app.resourceUri,
     title: app.title ?? app.toolName,
+    // Adding through the picker is the user's consent to automatic launches;
+    // write-tools stay run-on-request regardless.
+    ...(app.requiresApproval ? {} : { autoLaunch: true }),
   };
 }
 
@@ -233,8 +236,9 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           <DialogTitle>Add app</DialogTitle>
           <DialogDescription>
             MCP apps available via OpenWork Connect and this workspace&apos;s MCP
-            servers. Apps that need input ask for JSON launch arguments when you
-            add them.
+            servers. Added apps launch automatically when the dashboard opens;
+            apps that modify data only run on request. Apps that need input ask
+            for JSON launch arguments when you add them.
           </DialogDescription>
         </DialogHeader>
         <div className="min-w-0 space-y-4">

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource react */
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, Check, Plus, RefreshCw } from "lucide-react";
 
@@ -13,8 +14,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { builtinHelloEntry, type DashboardEntry, type DashboardMcpAppEntry } from "./dashboard-store";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 export function mcpEntryFromCatalogApp(app: OpenworkMcpAppCatalogApp): DashboardMcpAppEntry {
   return {
@@ -80,32 +86,102 @@ function ServerSection({ server, existingIds, onAdd }: {
       ) : server.apps.length === 0 ? (
         <p className="text-xs text-muted-foreground">This MCP server does not advertise any apps.</p>
       ) : (
-        server.apps.map((app) => {
-          const entry = mcpEntryFromCatalogApp(app);
-          return (
-            <div key={entry.id} className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{entry.title}</p>
-                {app.description ? (
-                  <p className="truncate text-xs text-muted-foreground">{app.description}</p>
-                ) : null}
-              </div>
-              {app.requiresInput ? (
-                <Badge variant="outline" title="This app needs launch input, which dashboard tiles do not provide.">
-                  <AlertTriangle className="size-3" /> Requires input
-                </Badge>
-              ) : null}
-              <AddButton
-                added={existingIds.has(entry.id)}
-                disabled={app.requiresInput}
-                label={entry.title}
-                onAdd={() => onAdd(entry)}
-              />
-            </div>
-          );
-        })
+        server.apps.map((app) => (
+          <CatalogAppRow
+            key={`${app.serverName}:${app.toolName}`}
+            app={app}
+            added={existingIds.has(mcpEntryFromCatalogApp(app).id)}
+            onAdd={onAdd}
+          />
+        ))
       )}
     </section>
+  );
+}
+
+function CatalogAppRow({ app, added, onAdd }: {
+  app: OpenworkMcpAppCatalogApp;
+  added: boolean;
+  onAdd: (entry: DashboardEntry) => void;
+}) {
+  const [inputOpen, setInputOpen] = useState(false);
+  const [argsText, setArgsText] = useState("");
+  const [argsError, setArgsError] = useState<string | null>(null);
+  const entry = mcpEntryFromCatalogApp(app);
+  const addWithInput = () => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(argsText);
+    } catch {
+      setArgsError("This is not valid JSON.");
+      return;
+    }
+    if (!isRecord(parsed)) {
+      setArgsError("Launch input must be a JSON object, for example {\"query\": \"…\"}.");
+      return;
+    }
+    setArgsError(null);
+    setInputOpen(false);
+    onAdd({ ...entry, launchArguments: parsed });
+  };
+  return (
+    <div className="min-w-0 space-y-2 rounded-lg border border-border px-3 py-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{entry.title}</p>
+          {app.description ? (
+            <p className="line-clamp-2 text-xs break-words text-muted-foreground">{app.description}</p>
+          ) : null}
+        </div>
+        {app.requiresInput ? (
+          <Badge variant="outline" title="This app needs launch input; you provide it once when adding.">
+            <AlertTriangle className="size-3" /> Requires input
+          </Badge>
+        ) : null}
+        {added ? (
+          <Button variant="ghost" size="sm" disabled>
+            <Check className="size-4" /> Added
+          </Button>
+        ) : app.requiresInput ? (
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label={`Add ${entry.title} with input`}
+            aria-expanded={inputOpen}
+            onClick={() => setInputOpen((value) => !value)}
+          >
+            <Plus className="size-4" /> Add…
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" aria-label={`Add ${entry.title}`} onClick={() => onAdd(entry)}>
+            <Plus className="size-4" /> Add
+          </Button>
+        )}
+      </div>
+      {inputOpen && !added ? (
+        <div className="space-y-1">
+          <Textarea
+            value={argsText}
+            onChange={(event) => setArgsText(event.target.value)}
+            placeholder='{"key": "value"}'
+            rows={3}
+            className="font-mono text-xs"
+            aria-label={`Launch input for ${entry.title}`}
+          />
+          <p className="text-xs text-muted-foreground">
+            Paste the launch arguments as a JSON object. The tile reuses them on
+            every launch and refresh.
+          </p>
+          {argsError ? <p className="text-xs text-destructive" role="alert">{argsError}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setInputOpen(false)}>Cancel</Button>
+            <Button variant="outline" size="sm" onClick={addWithInput}>
+              <Plus className="size-4" /> Add with input
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -130,10 +206,11 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           <DialogTitle>Add app</DialogTitle>
           <DialogDescription>
             MCP apps available via OpenWork Connect and this workspace&apos;s MCP
-            servers. Only apps that can start without input can be added.
+            servers. Apps that need input ask for JSON launch arguments when you
+            add them.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
+        <div className="min-w-0 space-y-4">
           <div className="flex items-center gap-2">
             <span className="flex-1 text-xs font-medium text-muted-foreground">
               {!workspaceReady
@@ -157,10 +234,10 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
           </div>
           <section className="space-y-1">
             <span className="text-xs font-medium text-muted-foreground">Built-in</span>
-            <div className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
+            <div className="flex min-w-0 items-center gap-2 rounded-lg border border-border px-3 py-2">
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium">{hello.title}</p>
-                <p className="truncate text-xs text-muted-foreground">A static local tile that ships with OpenWork.</p>
+                <p className="line-clamp-2 text-xs text-muted-foreground">A static local tile that ships with OpenWork.</p>
               </div>
               <AddButton
                 added={existingIds.has(hello.id)}

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { AlertTriangle, Check, Plus, RefreshCw } from "lucide-react";
+import { AlertTriangle, Check, Plus, RefreshCw, SquarePen } from "lucide-react";
 
 import type { OpenworkMcpAppCatalogApp, OpenworkMcpAppCatalogServer } from "@/app/lib/openwork-server";
 import { Badge } from "@/components/ui/badge";
@@ -104,25 +104,36 @@ function CatalogAppRow({ app, added, onAdd }: {
   added: boolean;
   onAdd: (entry: DashboardEntry) => void;
 }) {
-  const [inputOpen, setInputOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [argsText, setArgsText] = useState("");
   const [argsError, setArgsError] = useState<string | null>(null);
   const entry = mcpEntryFromCatalogApp(app);
-  const addWithInput = () => {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(argsText);
-    } catch {
-      setArgsError("This is not valid JSON.");
-      return;
-    }
-    if (!isRecord(parsed)) {
-      setArgsError("Launch input must be a JSON object, for example {\"query\": \"…\"}.");
-      return;
+  // Input capture and write-consent both happen once, at add time.
+  const needsDetails = app.requiresInput || app.requiresApproval;
+  const buildEntry = (launchArguments?: Record<string, unknown>): DashboardMcpAppEntry => ({
+    ...entry,
+    ...(launchArguments ? { launchArguments } : {}),
+    ...(app.requiresApproval ? { requiresApproval: true, launchApproved: true } : {}),
+  });
+  const addFromDetails = () => {
+    let launchArguments: Record<string, unknown> | undefined;
+    if (app.requiresInput) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(argsText);
+      } catch {
+        setArgsError("This is not valid JSON.");
+        return;
+      }
+      if (!isRecord(parsed)) {
+        setArgsError("Launch input must be a JSON object, for example {\"query\": \"…\"}.");
+        return;
+      }
+      launchArguments = parsed;
     }
     setArgsError(null);
-    setInputOpen(false);
-    onAdd({ ...entry, launchArguments: parsed });
+    setDetailsOpen(false);
+    onAdd(buildEntry(launchArguments));
   };
   return (
     <div className="min-w-0 space-y-2 rounded-lg border border-border px-3 py-2">
@@ -138,17 +149,22 @@ function CatalogAppRow({ app, added, onAdd }: {
             <AlertTriangle className="size-3" /> Requires input
           </Badge>
         ) : null}
+        {app.requiresApproval ? (
+          <Badge variant="outline" title="This app modifies data when it runs; its tile only runs on request.">
+            <SquarePen className="size-3" /> Modifies data
+          </Badge>
+        ) : null}
         {added ? (
           <Button variant="ghost" size="sm" disabled>
             <Check className="size-4" /> Added
           </Button>
-        ) : app.requiresInput ? (
+        ) : needsDetails ? (
           <Button
             variant="outline"
             size="sm"
-            aria-label={`Add ${entry.title} with input`}
-            aria-expanded={inputOpen}
-            onClick={() => setInputOpen((value) => !value)}
+            aria-label={`Add ${entry.title}`}
+            aria-expanded={detailsOpen}
+            onClick={() => setDetailsOpen((value) => !value)}
           >
             <Plus className="size-4" /> Add…
           </Button>
@@ -158,25 +174,36 @@ function CatalogAppRow({ app, added, onAdd }: {
           </Button>
         )}
       </div>
-      {inputOpen && !added ? (
+      {detailsOpen && !added ? (
         <div className="space-y-1">
-          <Textarea
-            value={argsText}
-            onChange={(event) => setArgsText(event.target.value)}
-            placeholder='{"key": "value"}'
-            rows={3}
-            className="font-mono text-xs"
-            aria-label={`Launch input for ${entry.title}`}
-          />
-          <p className="text-xs text-muted-foreground">
-            Paste the launch arguments as a JSON object. The tile reuses them on
-            every launch and refresh.
-          </p>
+          {app.requiresInput ? (
+            <>
+              <Textarea
+                value={argsText}
+                onChange={(event) => setArgsText(event.target.value)}
+                placeholder='{"key": "value"}'
+                rows={3}
+                className="font-mono text-xs"
+                aria-label={`Launch input for ${entry.title}`}
+              />
+              <p className="text-xs text-muted-foreground">
+                Paste the launch arguments as a JSON object. The tile reuses them
+                on every launch and refresh.
+              </p>
+            </>
+          ) : null}
+          {app.requiresApproval ? (
+            <p className="text-xs text-muted-foreground">
+              This app modifies data when it runs ({entry.toolName} on{" "}
+              {entry.serverName}). Adding it allows that call, and the tile only
+              runs when you press Run — never automatically.
+            </p>
+          ) : null}
           {argsError ? <p className="text-xs text-destructive" role="alert">{argsError}</p> : null}
           <div className="flex justify-end gap-2">
-            <Button variant="ghost" size="sm" onClick={() => setInputOpen(false)}>Cancel</Button>
-            <Button variant="outline" size="sm" onClick={addWithInput}>
-              <Plus className="size-4" /> Add with input
+            <Button variant="ghost" size="sm" onClick={() => setDetailsOpen(false)}>Cancel</Button>
+            <Button variant="outline" size="sm" onClick={addFromDetails}>
+              <Plus className="size-4" /> {app.requiresApproval ? "Add and allow" : "Add with input"}
             </Button>
           </div>
         </div>

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource react */
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Check, Plus } from "lucide-react";
+
+import type { OpenworkMcpAppCatalogApp, OpenworkMcpAppCatalogServer } from "@/app/lib/openwork-server";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useWorkspace } from "@/react-app/shell/workspace-provider";
+import { builtinHelloEntry, type DashboardEntry, type DashboardMcpAppEntry } from "./dashboard-store";
+
+export function mcpEntryFromCatalogApp(app: OpenworkMcpAppCatalogApp): DashboardMcpAppEntry {
+  return {
+    kind: "mcp",
+    id: `mcp:${app.serverName}:${app.toolName}`,
+    serverName: app.serverName,
+    toolName: app.toolName,
+    projectedToolName: app.projectedToolName,
+    resourceUri: app.resourceUri,
+    title: app.title ?? app.toolName,
+  };
+}
+
+type AddAppDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingIds: ReadonlySet<string>;
+  onAdd: (entry: DashboardEntry) => void;
+};
+
+function AddButton({ added, disabled, onAdd, label }: {
+  added: boolean;
+  disabled?: boolean;
+  onAdd: () => void;
+  label: string;
+}) {
+  if (added) {
+    return (
+      <Button variant="ghost" size="sm" disabled>
+        <Check className="size-4" /> Added
+      </Button>
+    );
+  }
+  return (
+    <Button variant="outline" size="sm" disabled={disabled} aria-label={`Add ${label}`} onClick={onAdd}>
+      <Plus className="size-4" /> Add
+    </Button>
+  );
+}
+
+function ServerSection({ server, existingIds, onAdd }: {
+  server: OpenworkMcpAppCatalogServer;
+  existingIds: ReadonlySet<string>;
+  onAdd: (entry: DashboardEntry) => void;
+}) {
+  return (
+    <section className="space-y-1">
+      <div className="flex items-center gap-2">
+        <span className="truncate text-xs font-medium text-muted-foreground">{server.serverName}</span>
+        {server.reachable ? (
+          <Badge variant="secondary">Connected</Badge>
+        ) : (
+          <Badge variant="destructive" title={server.error}>Not connected</Badge>
+        )}
+      </div>
+      {!server.reachable ? (
+        <p className="text-xs text-muted-foreground">
+          This MCP server is not reachable right now, so its apps cannot be listed.
+        </p>
+      ) : server.apps.length === 0 ? (
+        <p className="text-xs text-muted-foreground">This MCP server does not advertise any apps.</p>
+      ) : (
+        server.apps.map((app) => {
+          const entry = mcpEntryFromCatalogApp(app);
+          return (
+            <div key={entry.id} className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{entry.title}</p>
+                {app.description ? (
+                  <p className="truncate text-xs text-muted-foreground">{app.description}</p>
+                ) : null}
+              </div>
+              {app.requiresInput ? (
+                <Badge variant="outline" title="This app needs launch input, which dashboard tiles do not provide.">
+                  <AlertTriangle className="size-3" /> Requires input
+                </Badge>
+              ) : null}
+              <AddButton
+                added={existingIds.has(entry.id)}
+                disabled={app.requiresInput}
+                label={entry.title}
+                onAdd={() => onAdd(entry)}
+              />
+            </div>
+          );
+        })
+      )}
+    </section>
+  );
+}
+
+export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppDialogProps) {
+  const { openworkServerClient, workspaceId } = useWorkspace();
+  const catalog = useQuery({
+    queryKey: ["mcp-app-catalog", workspaceId],
+    queryFn: () => {
+      if (!openworkServerClient || !workspaceId) throw new Error("No connected workspace is available.");
+      return openworkServerClient.listMcpApps(workspaceId);
+    },
+    enabled: open && Boolean(openworkServerClient) && Boolean(workspaceId),
+    staleTime: 30_000,
+  });
+  const hello = builtinHelloEntry();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add app</DialogTitle>
+          <DialogDescription>
+            MCP apps available via OpenWork Connect and this workspace&apos;s MCP
+            servers. Only apps that can start without input can be added.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <section className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">Built-in</span>
+            <div className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{hello.title}</p>
+                <p className="truncate text-xs text-muted-foreground">A static local tile that ships with OpenWork.</p>
+              </div>
+              <AddButton
+                added={existingIds.has(hello.id)}
+                label={hello.title}
+                onAdd={() => onAdd(hello)}
+              />
+            </div>
+          </section>
+          {catalog.isPending && catalog.isFetching ? (
+            <div className="space-y-2" role="status" aria-label="Loading MCP apps">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : null}
+          {catalog.isError ? (
+            <p className="text-xs text-muted-foreground" role="status">
+              MCP apps could not be listed: {catalog.error instanceof Error ? catalog.error.message : "unknown error"}
+            </p>
+          ) : null}
+          {catalog.data ? (
+            catalog.data.servers.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No MCP servers are configured for this workspace yet. Connect one
+                in Settings to see its apps here.
+              </p>
+            ) : (
+              catalog.data.servers.map((server) => (
+                <ServerSection
+                  key={server.serverName}
+                  server={server}
+                  existingIds={existingIds}
+                  onAdd={onAdd}
+                />
+              ))
+            )
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
+++ b/apps/app/src/react-app/domains/dashboard/add-app-dialog.tsx
@@ -279,18 +279,20 @@ export function AddAppDialog({ open, onOpenChange, existingIds, onAdd }: AddAppD
               available yet. Create or open a workspace, then refresh.
             </p>
           ) : null}
-          {workspaceReady && catalog.isFetching ? (
+          {workspaceReady && catalog.isFetching && !catalog.data ? (
             <div className="space-y-2" role="status" aria-label="Loading MCP apps">
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />
             </div>
           ) : null}
-          {catalog.isError && !catalog.isFetching ? (
+          {catalog.isError && !catalog.data && !catalog.isFetching ? (
             <p className="text-xs text-muted-foreground" role="status">
               MCP apps could not be listed: {catalog.error instanceof Error ? catalog.error.message : "unknown error"}
             </p>
           ) : null}
-          {catalog.data && !catalog.isFetching ? (
+          {/* Keep rows mounted through background refetches: unmounting would
+              destroy in-progress launch-input text in an open row. */}
+          {catalog.data ? (
             catalog.data.servers.length === 0 ? (
               <p className="text-xs text-muted-foreground">
                 No MCP app sources were found. Connect an MCP server in Settings,

--- a/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
@@ -1,0 +1,11 @@
+export const MCP_APPS_DASHBOARD_FLAG_KEY = "openwork.mcpAppsDashboard";
+
+/**
+ * Local opt-in flag for the MCP Apps dashboard. The dashboard, its sidebar
+ * entry, and its route stay hidden unless this flag is explicitly enabled,
+ * mirroring the `openwork.developerMode` local-flag pattern.
+ */
+export function isMcpAppsDashboardEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(MCP_APPS_DASHBOARD_FLAG_KEY) === "1";
+}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
@@ -9,3 +9,9 @@ export function isMcpAppsDashboardEnabled(): boolean {
   if (typeof window === "undefined") return false;
   return window.localStorage.getItem(MCP_APPS_DASHBOARD_FLAG_KEY) === "1";
 }
+
+export function setMcpAppsDashboardEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  if (enabled) window.localStorage.setItem(MCP_APPS_DASHBOARD_FLAG_KEY, "1");
+  else window.localStorage.removeItem(MCP_APPS_DASHBOARD_FLAG_KEY);
+}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -82,6 +82,9 @@ function DashboardBoard({ scopeKey, fallbackEndpoints }: {
   const markLaunchApproved = (id: string) => updateEntries(entries.map((entry) => (
     entry.kind === "mcp" && entry.id === id ? { ...entry, launchApproved: true } : entry
   )));
+  const markAutoLaunchUnlocked = (id: string) => updateEntries(entries.map((entry) => (
+    entry.kind === "mcp" && entry.id === id ? { ...entry, autoLaunch: true } : entry
+  )));
 
   return (
     <div className="mx-auto w-full max-w-6xl px-6 py-6" data-dashboard-page>
@@ -119,6 +122,7 @@ function DashboardBoard({ scopeKey, fallbackEndpoints }: {
                 entry={entry}
                 onRemove={() => removeEntry(entry.id)}
                 onApprovedLaunch={() => markLaunchApproved(entry.id)}
+                onFirstRunCompleted={() => markAutoLaunchUnlocked(entry.id)}
                 fallbackEndpoints={fallbackEndpoints}
               />
             )

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -46,6 +46,9 @@ export function DashboardPage() {
     writeDashboardEntries(scopeKey, next);
   };
   const removeEntry = (id: string) => updateEntries(entries.filter((entry) => entry.id !== id));
+  const markLaunchApproved = (id: string) => updateEntries(entries.map((entry) => (
+    entry.kind === "mcp" && entry.id === id ? { ...entry, launchApproved: true } : entry
+  )));
 
   return (
     <div className="mx-auto w-full max-w-6xl px-6 py-6" data-dashboard-page>
@@ -78,7 +81,12 @@ export function DashboardPage() {
             entry.kind === "builtin-hello" ? (
               <HelloWorldTile key={entry.id} onRemove={() => removeEntry(entry.id)} />
             ) : (
-              <McpAppTile key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />
+              <McpAppTile
+                key={entry.id}
+                entry={entry}
+                onRemove={() => removeEntry(entry.id)}
+                onApprovedLaunch={() => markLaunchApproved(entry.id)}
+              />
             )
           ))}
         </div>

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -1,0 +1,96 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import { LayoutDashboard, Plus } from "lucide-react";
+
+import { readDenSettings } from "@/app/lib/den";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { AddAppDialog } from "./add-app-dialog";
+import {
+  dashboardScopeKey,
+  readDashboardEntries,
+  writeDashboardEntries,
+  type DashboardEntry,
+} from "./dashboard-store";
+import { HelloWorldTile } from "./hello-world-tile";
+import { McpAppTile } from "./mcp-app-tile";
+
+/**
+ * The per-user MCP Apps dashboard: a session-independent grid of app tiles.
+ * Entries persist locally per signed-in user and organization, so switching
+ * sessions or workspaces never changes the board.
+ */
+export function DashboardPage() {
+  const denAuth = useDenAuth();
+  const scopeKey = useMemo(() => {
+    const settings = readDenSettings();
+    return dashboardScopeKey(denAuth.user?.id ?? null, settings.activeOrgId ?? null);
+  }, [denAuth.user?.id]);
+  const [entries, setEntries] = useState<DashboardEntry[]>(() => readDashboardEntries(scopeKey));
+  useEffect(() => {
+    setEntries(readDashboardEntries(scopeKey));
+  }, [scopeKey]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const existingIds = useMemo(() => new Set(entries.map((entry) => entry.id)), [entries]);
+
+  const updateEntries = (next: DashboardEntry[]) => {
+    setEntries(next);
+    writeDashboardEntries(scopeKey, next);
+  };
+  const removeEntry = (id: string) => updateEntries(entries.filter((entry) => entry.id !== id));
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-6 py-6" data-dashboard-page>
+      <header className="mb-4 flex items-center gap-2">
+        <p className="flex-1 text-sm text-muted-foreground">
+          Your MCP apps, one click away in every session.
+        </p>
+        <Button onClick={() => setPickerOpen(true)}>
+          <Plus className="size-4" /> Add app
+        </Button>
+      </header>
+      {entries.length === 0 ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon"><LayoutDashboard /></EmptyMedia>
+            <EmptyTitle>No apps yet</EmptyTitle>
+            <EmptyDescription>
+              Add MCP apps available via OpenWork Connect to keep them one click away.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button onClick={() => setPickerOpen(true)}>
+              <Plus className="size-4" /> Add app
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+          {entries.map((entry) => (
+            entry.kind === "builtin-hello" ? (
+              <HelloWorldTile key={entry.id} onRemove={() => removeEntry(entry.id)} />
+            ) : (
+              <McpAppTile key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />
+            )
+          ))}
+        </div>
+      )}
+      <AddAppDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        existingIds={existingIds}
+        onAdd={(entry) => {
+          if (!existingIds.has(entry.id)) updateEntries([...entries, entry]);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -5,6 +5,7 @@ import { Blocks, Plus } from "lucide-react";
 import { readDenSettings } from "@/app/lib/den";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Empty,
   EmptyContent,
@@ -46,6 +47,26 @@ export function DashboardPage({ fallbackEndpoints }: {
     () => dashboardScopeKey(denAuth.user?.id ?? null, activeOrgId),
     [activeOrgId, denAuth.user?.id],
   );
+  // While Den auth is restoring, the board would read the shared signed-out
+  // scope and auto-launch its entries against the account about to be
+  // restored. Hold the board (and every launch) until the scope is final.
+  if (denAuth.status === "checking") {
+    return (
+      <div className="mx-auto w-full max-w-6xl px-6 py-6" data-dashboard-page>
+        <div className="space-y-2 pt-3" role="status" aria-label="Loading dashboard">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      </div>
+    );
+  }
+  return <DashboardBoard key={scopeKey} scopeKey={scopeKey} fallbackEndpoints={fallbackEndpoints} />;
+}
+
+function DashboardBoard({ scopeKey, fallbackEndpoints }: {
+  scopeKey: string;
+  fallbackEndpoints?: DashboardLaunchEndpoint[];
+}) {
   const [entries, setEntries] = useState<DashboardEntry[]>(() => readDashboardEntries(scopeKey));
   useEffect(() => {
     setEntries(readDashboardEntries(scopeKey));

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useState } from "react";
-import { LayoutDashboard, Plus } from "lucide-react";
+import { Blocks, Plus } from "lucide-react";
 
 import { readDenSettings } from "@/app/lib/den";
 import { Button } from "@/components/ui/button";
@@ -60,7 +60,7 @@ export function DashboardPage() {
       {entries.length === 0 ? (
         <Empty>
           <EmptyHeader>
-            <EmptyMedia variant="icon"><LayoutDashboard /></EmptyMedia>
+            <EmptyMedia variant="icon"><Blocks /></EmptyMedia>
             <EmptyTitle>No apps yet</EmptyTitle>
             <EmptyDescription>
               Add MCP apps available via OpenWork Connect to keep them one click away.

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Blocks, Plus } from "lucide-react";
 
 import { readDenSettings } from "@/app/lib/den";
+import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -30,10 +31,18 @@ import { McpAppTile } from "./mcp-app-tile";
  */
 export function DashboardPage() {
   const denAuth = useDenAuth();
-  const scopeKey = useMemo(() => {
-    const settings = readDenSettings();
-    return dashboardScopeKey(denAuth.user?.id ?? null, settings.activeOrgId ?? null);
-  }, [denAuth.user?.id]);
+  // The active org lives in den settings, which change outside React; track it
+  // through the settings-changed event so an org switch swaps the board scope.
+  const [activeOrgId, setActiveOrgId] = useState<string | null>(() => readDenSettings().activeOrgId ?? null);
+  useEffect(() => {
+    const sync = () => setActiveOrgId(readDenSettings().activeOrgId ?? null);
+    window.addEventListener(denSettingsChangedEvent, sync);
+    return () => window.removeEventListener(denSettingsChangedEvent, sync);
+  }, []);
+  const scopeKey = useMemo(
+    () => dashboardScopeKey(denAuth.user?.id ?? null, activeOrgId),
+    [activeOrgId, denAuth.user?.id],
+  );
   const [entries, setEntries] = useState<DashboardEntry[]>(() => readDashboardEntries(scopeKey));
   useEffect(() => {
     setEntries(readDashboardEntries(scopeKey));

--- a/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-page.tsx
@@ -22,14 +22,17 @@ import {
   type DashboardEntry,
 } from "./dashboard-store";
 import { HelloWorldTile } from "./hello-world-tile";
-import { McpAppTile } from "./mcp-app-tile";
+import { McpAppTile, type DashboardLaunchEndpoint } from "./mcp-app-tile";
 
 /**
  * The per-user MCP Apps dashboard: a session-independent grid of app tiles.
  * Entries persist locally per signed-in user and organization, so switching
  * sessions or workspaces never changes the board.
  */
-export function DashboardPage() {
+export function DashboardPage({ fallbackEndpoints }: {
+  /** Other workspace MCP runtimes tiles may launch through when the primary one lacks their server. */
+  fallbackEndpoints?: DashboardLaunchEndpoint[];
+} = {}) {
   const denAuth = useDenAuth();
   // The active org lives in den settings, which change outside React; track it
   // through the settings-changed event so an org switch swaps the board scope.
@@ -95,6 +98,7 @@ export function DashboardPage() {
                 entry={entry}
                 onRemove={() => removeEntry(entry.id)}
                 onApprovedLaunch={() => markLaunchApproved(entry.id)}
+                fallbackEndpoints={fallbackEndpoints}
               />
             )
           ))}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -4,6 +4,8 @@ export type DashboardMcpAppEntry = {
   kind: "mcp";
   id: string;
   serverName: string;
+  /** Present for Connect app-host apps: launch them through this connection reference. */
+  connectionId?: string;
   toolName: string;
   projectedToolName: string;
   resourceUri: string;
@@ -53,6 +55,7 @@ function parseEntry(value: unknown): DashboardEntry | null {
     kind: "mcp",
     id: value.id,
     serverName: value.serverName,
+    ...(typeof value.connectionId === "string" ? { connectionId: value.connectionId } : {}),
     toolName: value.toolName,
     projectedToolName: value.projectedToolName,
     resourceUri: value.resourceUri,

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -1,0 +1,89 @@
+/** Per-user, thread-independent MCP Apps dashboard entries persisted locally. */
+
+export type DashboardMcpAppEntry = {
+  kind: "mcp";
+  id: string;
+  serverName: string;
+  toolName: string;
+  projectedToolName: string;
+  resourceUri: string;
+  title: string;
+};
+
+export type DashboardBuiltinEntry = {
+  kind: "builtin-hello";
+  id: string;
+  title: string;
+};
+
+export type DashboardEntry = DashboardMcpAppEntry | DashboardBuiltinEntry;
+
+export const BUILTIN_HELLO_ENTRY_ID = "builtin:hello";
+
+const STORAGE_PREFIX = "openwork.react.dashboardApps.v1";
+
+/**
+ * The dashboard is scoped to the signed-in Den user and organization so
+ * switching accounts or orgs swaps the whole board. Signed-out desktops share
+ * one local scope.
+ */
+export function dashboardScopeKey(userId: string | null, organizationId: string | null): string {
+  return `${STORAGE_PREFIX}.${userId?.trim() || "local"}.${organizationId?.trim() || "none"}`;
+}
+
+export function builtinHelloEntry(): DashboardBuiltinEntry {
+  return { kind: "builtin-hello", id: BUILTIN_HELLO_ENTRY_ID, title: "Hello World" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseEntry(value: unknown): DashboardEntry | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.title !== "string") return null;
+  if (value.kind === "builtin-hello") return { kind: "builtin-hello", id: value.id, title: value.title };
+  if (value.kind !== "mcp") return null;
+  if (
+    typeof value.serverName !== "string"
+    || typeof value.toolName !== "string"
+    || typeof value.projectedToolName !== "string"
+    || typeof value.resourceUri !== "string"
+  ) return null;
+  return {
+    kind: "mcp",
+    id: value.id,
+    serverName: value.serverName,
+    toolName: value.toolName,
+    projectedToolName: value.projectedToolName,
+    resourceUri: value.resourceUri,
+    title: value.title,
+  };
+}
+
+/** First open seeds the built-in tile so the dashboard is never empty. */
+export function readDashboardEntries(scopeKey: string): DashboardEntry[] {
+  if (typeof window === "undefined") return [builtinHelloEntry()];
+  const raw = window.localStorage.getItem(scopeKey);
+  if (raw === null) return [builtinHelloEntry()];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [builtinHelloEntry()];
+    const entries: DashboardEntry[] = [];
+    for (const value of parsed) {
+      const entry = parseEntry(value);
+      if (entry && !entries.some((existing) => existing.id === entry.id)) entries.push(entry);
+    }
+    return entries;
+  } catch {
+    return [builtinHelloEntry()];
+  }
+}
+
+export function writeDashboardEntries(scopeKey: string, entries: DashboardEntry[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(scopeKey, JSON.stringify(entries));
+  } catch {
+    // Persistence is best-effort; the in-memory dashboard still works.
+  }
+}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -10,6 +10,8 @@ export type DashboardMcpAppEntry = {
   projectedToolName: string;
   resourceUri: string;
   title: string;
+  /** Optional launch arguments captured when the app was added; every (re)launch reuses them. */
+  launchArguments?: Record<string, unknown>;
 };
 
 export type DashboardBuiltinEntry = {
@@ -60,6 +62,7 @@ function parseEntry(value: unknown): DashboardEntry | null {
     projectedToolName: value.projectedToolName,
     resourceUri: value.resourceUri,
     title: value.title,
+    ...(isRecord(value.launchArguments) ? { launchArguments: value.launchArguments } : {}),
   };
 }
 

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -12,6 +12,8 @@ export type DashboardMcpAppEntry = {
   title: string;
   /** Optional launch arguments captured when the app was added; every (re)launch reuses them. */
   launchArguments?: Record<string, unknown>;
+  /** True once the user approved this tile's write-tool launch; removing the tile revokes it. */
+  launchApproved?: boolean;
 };
 
 export type DashboardBuiltinEntry = {
@@ -63,6 +65,7 @@ function parseEntry(value: unknown): DashboardEntry | null {
     resourceUri: value.resourceUri,
     title: value.title,
     ...(isRecord(value.launchArguments) ? { launchArguments: value.launchArguments } : {}),
+    ...(value.launchApproved === true ? { launchApproved: true } : {}),
   };
 }
 

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -12,6 +12,12 @@ export type DashboardMcpAppEntry = {
   title: string;
   /** Optional launch arguments captured when the app was added; every (re)launch reuses them. */
   launchArguments?: Record<string, unknown>;
+  /**
+   * True only when the user added this app through the picker, consenting to
+   * automatic launches. Entries without it (tampered or imported storage)
+   * stay run-on-request.
+   */
+  autoLaunch?: boolean;
   /** True when the launch tool modifies data: the tile only runs on request, never on mount. */
   requiresApproval?: boolean;
   /** True once the user approved this tile's write-tool launch; removing the tile revokes it. */
@@ -67,6 +73,7 @@ function parseEntry(value: unknown): DashboardEntry | null {
     resourceUri: value.resourceUri,
     title: value.title,
     ...(isRecord(value.launchArguments) ? { launchArguments: value.launchArguments } : {}),
+    ...(value.autoLaunch === true ? { autoLaunch: true } : {}),
     ...(value.requiresApproval === true ? { requiresApproval: true } : {}),
     ...(value.launchApproved === true ? { launchApproved: true } : {}),
   };

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -13,9 +13,9 @@ export type DashboardMcpAppEntry = {
   /** Optional launch arguments captured when the app was added; every (re)launch reuses them. */
   launchArguments?: Record<string, unknown>;
   /**
-   * True only when the user added this app through the picker, consenting to
-   * automatic launches. Entries without it (tampered or imported storage)
-   * stay run-on-request.
+   * True once the user has launched this tile manually and seen what it does;
+   * only then do later dashboard opens launch it automatically. Never granted
+   * at add time or by storage alone, and write-tools stay run-on-request.
    */
   autoLaunch?: boolean;
   /** True when the launch tool modifies data: the tile only runs on request, never on mount. */

--- a/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-store.ts
@@ -12,6 +12,8 @@ export type DashboardMcpAppEntry = {
   title: string;
   /** Optional launch arguments captured when the app was added; every (re)launch reuses them. */
   launchArguments?: Record<string, unknown>;
+  /** True when the launch tool modifies data: the tile only runs on request, never on mount. */
+  requiresApproval?: boolean;
   /** True once the user approved this tile's write-tool launch; removing the tile revokes it. */
   launchApproved?: boolean;
 };
@@ -65,6 +67,7 @@ function parseEntry(value: unknown): DashboardEntry | null {
     resourceUri: value.resourceUri,
     title: value.title,
     ...(isRecord(value.launchArguments) ? { launchArguments: value.launchArguments } : {}),
+    ...(value.requiresApproval === true ? { requiresApproval: true } : {}),
     ...(value.launchApproved === true ? { launchApproved: true } : {}),
   };
 }

--- a/apps/app/src/react-app/domains/dashboard/dashboard-tile-shell.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-tile-shell.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource react */
+import type { ReactNode } from "react";
+import { RefreshCw, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type DashboardTileShellProps = {
+  title: string;
+  subtitle?: string;
+  badge?: ReactNode;
+  onRefresh?: () => void;
+  onRemove: () => void;
+  children: ReactNode;
+};
+
+export function DashboardTileShell({ title, subtitle, badge, onRefresh, onRemove, children }: DashboardTileShellProps) {
+  return (
+    <section className="flex min-h-64 flex-col overflow-hidden rounded-xl border border-border bg-background">
+      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+          <span className="truncate text-sm font-medium">{title}</span>
+          {subtitle ? <span className="truncate text-xs text-muted-foreground">{subtitle}</span> : null}
+        </div>
+        {badge}
+        {onRefresh ? (
+          <Button variant="ghost" size="icon" aria-label={`Refresh ${title}`} title="Refresh" onClick={onRefresh}>
+            <RefreshCw className="size-4" />
+          </Button>
+        ) : null}
+        <Button variant="ghost" size="icon" aria-label={`Remove ${title}`} title="Remove" onClick={onRemove}>
+          <X className="size-4" />
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-3 pb-3">{children}</div>
+    </section>
+  );
+}

--- a/apps/app/src/react-app/domains/dashboard/hello-world-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/hello-world-tile.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource react */
+import { Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { DashboardTileShell } from "./dashboard-tile-shell";
+
+/**
+ * Minimal built-in tile so the dashboard is never empty on first open. It is
+ * a static local component, deliberately marked built-in: no MCP server, no
+ * network, no launch capability.
+ */
+export function HelloWorldTile({ onRemove }: { onRemove: () => void }) {
+  return (
+    <DashboardTileShell
+      title="Hello World"
+      badge={<Badge variant="secondary">Built-in</Badge>}
+      onRemove={onRemove}
+    >
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center">
+        <Sparkles className="size-8 text-muted-foreground" aria-hidden />
+        <p className="text-sm font-medium">Hello from your dashboard</p>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          This is your permanent home for MCP apps. Use Add app to pin
+          interactive apps from your connected MCP servers.
+        </p>
+      </div>
+    </DashboardTileShell>
+  );
+}

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource react */
 import { useEffect, useRef, useState } from "react";
+import { Play } from "lucide-react";
 
 import {
   OpenworkServerError,
   type OpenworkMcpAppResource,
 } from "@/app/lib/openwork-server";
 import { McpAppSandboxView, type PreservedMcpAppResult } from "@/components/chat/mcp-app-frame";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { DashboardTileShell } from "./dashboard-tile-shell";
@@ -18,16 +20,34 @@ import type { DashboardMcpAppEntry } from "./dashboard-store";
 const EMPTY_ARGUMENTS: Record<string, unknown> = {};
 
 type TileState =
+  | { phase: "idle" }
   | { phase: "loading" }
   | { phase: "ready"; app: OpenworkMcpAppResource; result: PreservedMcpAppResult }
   | { phase: "closed" }
   | { phase: "error"; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function firstTextContent(content: Array<Record<string, unknown>>): string | null {
   for (const item of content) {
     if (item.type === "text" && typeof item.text === "string" && item.text.trim()) return item.text;
   }
   return null;
+}
+
+/** Providers often return machine-shaped JSON errors; surface their message text. */
+function launchFailureMessage(content: Array<Record<string, unknown>>): string | null {
+  const text = firstTextContent(content);
+  if (!text) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (isRecord(parsed) && typeof parsed.message === "string" && parsed.message.trim()) return parsed.message;
+  } catch {
+    // Plain-text errors pass through unchanged.
+  }
+  return text;
 }
 
 export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
@@ -37,8 +57,12 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
   onApprovedLaunch?: () => void;
 }) {
   const { openworkServerClient, workspaceId } = useWorkspace();
+  // Write-tools only run on request: mount shows an idle card with a Run
+  // button, so a dashboard visit can never repeat a data-modifying call.
+  const manualLaunch = entry.requiresApproval === true;
+  const [started, setStarted] = useState(!manualLaunch);
   const [nonce, setNonce] = useState(0);
-  const [state, setState] = useState<TileState>({ phase: "loading" });
+  const [state, setState] = useState<TileState>({ phase: manualLaunch ? "idle" : "loading" });
   const launchArguments = entry.launchArguments ?? EMPTY_ARGUMENTS;
   // Read consent through refs so persisting it after the first approval does
   // not re-run the launch effect and duplicate a write-tool call.
@@ -49,6 +73,10 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
 
   useEffect(() => {
     let cancelled = false;
+    if (!started) {
+      setState({ phase: "idle" });
+      return;
+    }
     setState({ phase: "loading" });
     if (!openworkServerClient || !workspaceId) {
       setState({ phase: "error", message: "No connected workspace is available to launch this app." });
@@ -92,7 +120,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
       if (result.isError) {
         return {
           phase: "error",
-          message: firstTextContent(result.content)
+          message: launchFailureMessage(result.content)
             ?? (entry.launchArguments
               ? "This app could not start with the saved launch input. Remove the tile and add it again with corrected input."
               : "This app could not start without input, which this tile does not provide."),
@@ -121,15 +149,31 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
     return () => {
       cancelled = true;
     };
-  }, [entry.connectionId, entry.launchArguments, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, nonce, openworkServerClient, workspaceId]);
+  }, [entry.connectionId, entry.launchArguments, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, nonce, openworkServerClient, started, workspaceId]);
+
+  const run = () => {
+    setStarted(true);
+    setNonce((value) => value + 1);
+  };
 
   return (
     <DashboardTileShell
       title={entry.title}
       subtitle={entry.serverName}
-      onRefresh={() => setNonce((value) => value + 1)}
+      onRefresh={run}
       onRemove={onRemove}
     >
+      {state.phase === "idle" ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center">
+          <Play className="size-6 text-muted-foreground" aria-hidden />
+          <p className="max-w-xs text-xs text-muted-foreground">
+            This app modifies data when it runs, so it only runs when you ask.
+          </p>
+          <Button variant="outline" size="sm" onClick={run} aria-label={`Run ${entry.title}`}>
+            <Play className="size-4" /> Run
+          </Button>
+        </div>
+      ) : null}
       {state.phase === "loading" ? (
         <div className="space-y-2 pt-3" role="status" aria-label={`Loading ${entry.title}`}>
           <Skeleton className="h-4 w-2/3" />

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -70,6 +70,10 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
   launchApprovedRef.current = entry.launchApproved === true;
   const onApprovedLaunchRef = useRef(onApprovedLaunch);
   onApprovedLaunchRef.current = onApprovedLaunch;
+  // A write-tool launch must map 1:1 to a Run/refresh press. The effect also
+  // re-runs when the client or workspace identity changes; this ref keeps such
+  // re-runs from repeating an already-executed data-modifying call.
+  const executedRunRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -77,12 +81,15 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
       setState({ phase: "idle" });
       return;
     }
+    if (manualLaunch && executedRunRef.current === nonce) return;
+    executedRunRef.current = nonce;
     setState({ phase: "loading" });
     if (!openworkServerClient || !workspaceId) {
       setState({ phase: "error", message: "No connected workspace is available to launch this app." });
       return;
     }
     const client = openworkServerClient;
+    const userInitiated = nonce > 0;
     void (async (): Promise<TileState> => {
       // Connect app-host apps resolve through their connection reference; the
       // host revalidates the live UI binding before returning the resource.
@@ -108,6 +115,10 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
         result = await client.callMcpAppTool(workspaceId, request);
       } catch (cause) {
         if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
+        // A stored entry can go stale: a tool that was read-only at add time
+        // may need approval now. Never pop a consent prompt from an automatic
+        // mount launch — fall back to the idle Run card and ask on request.
+        if (!userInitiated) return { phase: "idle" };
         const approved = window.confirm(
           `Allow this MCP App to call ${app.toolName} on ${app.serverName}? `
           + "OpenWork remembers your choice for this tile until you remove it.",
@@ -149,7 +160,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
     return () => {
       cancelled = true;
     };
-  }, [entry.connectionId, entry.launchArguments, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, nonce, openworkServerClient, started, workspaceId]);
+  }, [entry.connectionId, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, manualLaunch, nonce, openworkServerClient, started, workspaceId]);
 
   const run = () => {
     setStarted(true);

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   OpenworkServerError,
@@ -30,11 +30,22 @@ function firstTextContent(content: Array<Record<string, unknown>>): string | nul
   return null;
 }
 
-export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; onRemove: () => void }) {
+export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
+  entry: DashboardMcpAppEntry;
+  onRemove: () => void;
+  /** Persists the user's one-time launch approval on the stored entry. */
+  onApprovedLaunch?: () => void;
+}) {
   const { openworkServerClient, workspaceId } = useWorkspace();
   const [nonce, setNonce] = useState(0);
   const [state, setState] = useState<TileState>({ phase: "loading" });
   const launchArguments = entry.launchArguments ?? EMPTY_ARGUMENTS;
+  // Read consent through refs so persisting it after the first approval does
+  // not re-run the launch effect and duplicate a write-tool call.
+  const launchApprovedRef = useRef(entry.launchApproved === true);
+  launchApprovedRef.current = entry.launchApproved === true;
+  const onApprovedLaunchRef = useRef(onApprovedLaunch);
+  onApprovedLaunchRef.current = onApprovedLaunch;
 
   useEffect(() => {
     let cancelled = false;
@@ -62,15 +73,21 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
         name: app.toolName,
         resourceUri: app.resourceUri,
         arguments: launchArguments,
+        ...(launchApprovedRef.current ? { approved: true } : {}),
       };
       let result;
       try {
         result = await client.callMcpAppTool(workspaceId, request);
       } catch (cause) {
         if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
-        const approved = window.confirm(`Allow this MCP App to call ${app.toolName} on ${app.serverName}?`);
+        const approved = window.confirm(
+          `Allow this MCP App to call ${app.toolName} on ${app.serverName}? `
+          + "OpenWork remembers your choice for this tile until you remove it.",
+        );
         if (!approved) return { phase: "error", message: "The app launch was declined." };
         result = await client.callMcpAppTool(workspaceId, { ...request, approved: true });
+        launchApprovedRef.current = true;
+        onApprovedLaunchRef.current?.();
       }
       if (result.isError) {
         return {

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -12,8 +12,8 @@ import { DashboardTileShell } from "./dashboard-tile-shell";
 import type { DashboardMcpAppEntry } from "./dashboard-store";
 
 /**
- * Dashboard tiles only host zero-config launches: the stored reference has no
- * argument payload and every (re)launch calls the tool with empty arguments.
+ * Tiles launch with the arguments captured when the app was added (empty for
+ * zero-config apps). Every launch and refresh reuses that exact stored input.
  */
 const EMPTY_ARGUMENTS: Record<string, unknown> = {};
 
@@ -34,6 +34,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
   const { openworkServerClient, workspaceId } = useWorkspace();
   const [nonce, setNonce] = useState(0);
   const [state, setState] = useState<TileState>({ phase: "loading" });
+  const launchArguments = entry.launchArguments ?? EMPTY_ARGUMENTS;
 
   useEffect(() => {
     let cancelled = false;
@@ -51,7 +52,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
             connectionId: entry.connectionId,
             toolName: entry.toolName,
             resourceUri: entry.resourceUri,
-            arguments: EMPTY_ARGUMENTS,
+            arguments: launchArguments,
           }
         : undefined;
       const { app } = await client.resolveMcpApp(workspaceId, entry.projectedToolName, launch);
@@ -60,7 +61,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
         serverName: app.serverName,
         name: app.toolName,
         resourceUri: app.resourceUri,
-        arguments: EMPTY_ARGUMENTS,
+        arguments: launchArguments,
       };
       let result;
       try {
@@ -75,7 +76,9 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
         return {
           phase: "error",
           message: firstTextContent(result.content)
-            ?? "This app could not start without input, which the dashboard does not provide.",
+            ?? (entry.launchArguments
+              ? "This app could not start with the saved launch input. Remove the tile and add it again with corrected input."
+              : "This app could not start without input, which this tile does not provide."),
         };
       }
       return {
@@ -101,7 +104,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
     return () => {
       cancelled = true;
     };
-  }, [entry.connectionId, entry.projectedToolName, entry.resourceUri, entry.toolName, nonce, openworkServerClient, workspaceId]);
+  }, [entry.connectionId, entry.launchArguments, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, nonce, openworkServerClient, workspaceId]);
 
   return (
     <DashboardTileShell
@@ -129,7 +132,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
           key={nonce}
           app={state.app}
           toolName={entry.projectedToolName}
-          inputArguments={EMPTY_ARGUMENTS}
+          inputArguments={launchArguments}
           result={state.result}
           unavailableNotice="This app view is unavailable."
           onRequestTeardown={() => setState({ phase: "closed" })}

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -5,13 +5,20 @@ import { Play } from "lucide-react";
 import {
   OpenworkServerError,
   type OpenworkMcpAppResource,
+  type OpenworkServerClient,
 } from "@/app/lib/openwork-server";
 import { McpAppSandboxView, type PreservedMcpAppResult } from "@/components/chat/mcp-app-frame";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useWorkspace } from "@/react-app/shell/workspace-provider";
+import { useWorkspace, WorkspaceProvider } from "@/react-app/shell/workspace-provider";
 import { DashboardTileShell } from "./dashboard-tile-shell";
 import type { DashboardMcpAppEntry } from "./dashboard-store";
+
+/** A workspace MCP runtime a tile may launch through. */
+export type DashboardLaunchEndpoint = {
+  client: OpenworkServerClient;
+  workspaceId: string;
+};
 
 /**
  * Tiles launch with the arguments captured when the app was added (empty for
@@ -22,7 +29,7 @@ const EMPTY_ARGUMENTS: Record<string, unknown> = {};
 type TileState =
   | { phase: "idle" }
   | { phase: "loading" }
-  | { phase: "ready"; app: OpenworkMcpAppResource; result: PreservedMcpAppResult }
+  | { phase: "ready"; app: OpenworkMcpAppResource; result: PreservedMcpAppResult; endpoint: DashboardLaunchEndpoint }
   | { phase: "closed" }
   | { phase: "error"; message: string };
 
@@ -50,16 +57,21 @@ function launchFailureMessage(content: Array<Record<string, unknown>>): string |
   return text;
 }
 
-export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
+export function McpAppTile({ entry, onRemove, onApprovedLaunch, fallbackEndpoints }: {
   entry: DashboardMcpAppEntry;
   onRemove: () => void;
   /** Persists the user's one-time launch approval on the stored entry. */
   onApprovedLaunch?: () => void;
+  /** Other workspace runtimes to try when the primary one cannot resolve the app. */
+  fallbackEndpoints?: DashboardLaunchEndpoint[];
 }) {
-  const { openworkServerClient, workspaceId } = useWorkspace();
+  const workspace = useWorkspace();
+  const { openworkServerClient, workspaceId } = workspace;
   // Write-tools only run on request: mount shows an idle card with a Run
   // button, so a dashboard visit can never repeat a data-modifying call.
-  const manualLaunch = entry.requiresApproval === true;
+  // Entries without the picker's add-time auto-launch consent (tampered or
+  // imported storage) are also run-on-request.
+  const manualLaunch = entry.requiresApproval === true || entry.autoLaunch !== true;
   const [started, setStarted] = useState(!manualLaunch);
   const [nonce, setNonce] = useState(0);
   const [state, setState] = useState<TileState>({ phase: manualLaunch ? "idle" : "loading" });
@@ -84,11 +96,17 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
     if (manualLaunch && executedRunRef.current === nonce) return;
     executedRunRef.current = nonce;
     setState({ phase: "loading" });
-    if (!openworkServerClient || !workspaceId) {
+    // Tiles are user-scoped while MCP servers are workspace-scoped: prefer the
+    // selected workspace's runtime, then any other available one that can
+    // still resolve this app.
+    const candidates: DashboardLaunchEndpoint[] = [
+      ...(openworkServerClient && workspaceId ? [{ client: openworkServerClient, workspaceId }] : []),
+      ...(fallbackEndpoints ?? []),
+    ].filter((endpoint, index, all) => all.findIndex((other) => other.workspaceId === endpoint.workspaceId) === index);
+    if (candidates.length === 0) {
       setState({ phase: "error", message: "No connected workspace is available to launch this app." });
       return;
     }
-    const client = openworkServerClient;
     const userInitiated = nonce > 0;
     void (async (): Promise<TileState> => {
       // Connect app-host apps resolve through their connection reference; the
@@ -101,8 +119,24 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
             arguments: launchArguments,
           }
         : undefined;
-      const { app } = await client.resolveMcpApp(workspaceId, entry.projectedToolName, launch);
-      if (!app) return { phase: "error", message: "This tool no longer advertises an interactive app." };
+      let resolved: { endpoint: DashboardLaunchEndpoint; app: OpenworkMcpAppResource } | null = null;
+      let resolveFailure: unknown = null;
+      for (const endpoint of candidates) {
+        try {
+          const { app } = await endpoint.client.resolveMcpApp(endpoint.workspaceId, entry.projectedToolName, launch);
+          if (app) {
+            resolved = { endpoint, app };
+            break;
+          }
+        } catch (cause) {
+          resolveFailure ??= cause;
+        }
+      }
+      if (!resolved) {
+        if (resolveFailure) throw resolveFailure;
+        return { phase: "error", message: "This tool no longer advertises an interactive app." };
+      }
+      const { endpoint, app } = resolved;
       const request = {
         serverName: app.serverName,
         name: app.toolName,
@@ -112,7 +146,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
       };
       let result;
       try {
-        result = await client.callMcpAppTool(workspaceId, request);
+        result = await endpoint.client.callMcpAppTool(endpoint.workspaceId, request);
       } catch (cause) {
         if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
         // A stored entry can go stale: a tool that was read-only at add time
@@ -124,7 +158,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
           + "OpenWork remembers your choice for this tile until you remove it.",
         );
         if (!approved) return { phase: "error", message: "The app launch was declined." };
-        result = await client.callMcpAppTool(workspaceId, { ...request, approved: true });
+        result = await endpoint.client.callMcpAppTool(endpoint.workspaceId, { ...request, approved: true });
         launchApprovedRef.current = true;
         onApprovedLaunchRef.current?.();
       }
@@ -140,6 +174,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
       return {
         phase: "ready",
         app,
+        endpoint,
         result: {
           content: result.content,
           ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
@@ -160,7 +195,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
     return () => {
       cancelled = true;
     };
-  }, [entry.connectionId, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, manualLaunch, nonce, openworkServerClient, started, workspaceId]);
+  }, [entry.connectionId, entry.projectedToolName, entry.resourceUri, entry.toolName, fallbackEndpoints, launchArguments, manualLaunch, nonce, openworkServerClient, started, workspaceId]);
 
   const run = () => {
     setStarted(true);
@@ -178,7 +213,9 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
         <div className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center">
           <Play className="size-6 text-muted-foreground" aria-hidden />
           <p className="max-w-xs text-xs text-muted-foreground">
-            This app modifies data when it runs, so it only runs when you ask.
+            {entry.requiresApproval === true
+              ? "This app modifies data when it runs, so it only runs when you ask."
+              : "This app only runs when you ask."}
           </p>
           <Button variant="outline" size="sm" onClick={run} aria-label={`Run ${entry.title}`}>
             <Play className="size-4" /> Run
@@ -200,15 +237,25 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch }: {
         </p>
       ) : null}
       {state.phase === "ready" ? (
-        <McpAppSandboxView
-          key={nonce}
-          app={state.app}
-          toolName={entry.projectedToolName}
-          inputArguments={launchArguments}
-          result={state.result}
-          unavailableNotice="This app view is unavailable."
-          onRequestTeardown={() => setState({ phase: "closed" })}
-        />
+        // The sandbox bridge calls tools through the workspace context, so the
+        // view must run under the endpoint that actually resolved the app.
+        <WorkspaceProvider
+          client={workspace.client}
+          opencodeBaseUrl={workspace.opencodeBaseUrl}
+          openworkServerClient={state.endpoint.client}
+          workspaceId={state.endpoint.workspaceId}
+          selectedWorkspaceRoot={workspace.selectedWorkspaceRoot}
+        >
+          <McpAppSandboxView
+            key={nonce}
+            app={state.app}
+            toolName={entry.projectedToolName}
+            inputArguments={launchArguments}
+            result={state.result}
+            unavailableNotice="This app view is unavailable."
+            onRequestTeardown={() => setState({ phase: "closed" })}
+          />
+        </WorkspaceProvider>
       ) : null}
     </DashboardTileShell>
   );

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -57,20 +57,22 @@ function launchFailureMessage(content: Array<Record<string, unknown>>): string |
   return text;
 }
 
-export function McpAppTile({ entry, onRemove, onApprovedLaunch, fallbackEndpoints }: {
+export function McpAppTile({ entry, onRemove, onApprovedLaunch, onFirstRunCompleted, fallbackEndpoints }: {
   entry: DashboardMcpAppEntry;
   onRemove: () => void;
   /** Persists the user's one-time launch approval on the stored entry. */
   onApprovedLaunch?: () => void;
+  /** Persists that the user has run this tile once, unlocking automatic launches. */
+  onFirstRunCompleted?: () => void;
   /** Other workspace runtimes to try when the primary one cannot resolve the app. */
   fallbackEndpoints?: DashboardLaunchEndpoint[];
 }) {
   const workspace = useWorkspace();
   const { openworkServerClient, workspaceId } = workspace;
-  // Write-tools only run on request: mount shows an idle card with a Run
-  // button, so a dashboard visit can never repeat a data-modifying call.
-  // Entries without the picker's add-time auto-launch consent (tampered or
-  // imported storage) are also run-on-request.
+  // Automatic launches are earned, not granted: a tile runs on dashboard open
+  // only after the user has run it manually once and seen what it does.
+  // Write-tools stay run-on-request forever, so a dashboard visit can never
+  // repeat a data-modifying call.
   const manualLaunch = entry.requiresApproval === true || entry.autoLaunch !== true;
   const [started, setStarted] = useState(!manualLaunch);
   const [nonce, setNonce] = useState(0);
@@ -82,6 +84,8 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch, fallbackEndpoint
   launchApprovedRef.current = entry.launchApproved === true;
   const onApprovedLaunchRef = useRef(onApprovedLaunch);
   onApprovedLaunchRef.current = onApprovedLaunch;
+  const onFirstRunCompletedRef = useRef(onFirstRunCompleted);
+  onFirstRunCompletedRef.current = onFirstRunCompleted;
   // A write-tool launch must map 1:1 to a Run/refresh press. The effect also
   // re-runs when the client or workspace identity changes; this ref keeps such
   // re-runs from repeating an already-executed data-modifying call.
@@ -171,6 +175,9 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch, fallbackEndpoint
               : "This app could not start without input, which this tile does not provide."),
         };
       }
+      if (userInitiated && entry.requiresApproval !== true && entry.autoLaunch !== true) {
+        onFirstRunCompletedRef.current?.();
+      }
       return {
         phase: "ready",
         app,
@@ -215,7 +222,7 @@ export function McpAppTile({ entry, onRemove, onApprovedLaunch, fallbackEndpoint
           <p className="max-w-xs text-xs text-muted-foreground">
             {entry.requiresApproval === true
               ? "This app modifies data when it runs, so it only runs when you ask."
-              : "This app only runs when you ask."}
+              : "Run this app once; after that it launches automatically when the dashboard opens."}
           </p>
           <Button variant="outline" size="sm" onClick={run} aria-label={`Run ${entry.title}`}>
             <Play className="size-4" /> Run

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -44,7 +44,17 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
     }
     const client = openworkServerClient;
     void (async (): Promise<TileState> => {
-      const { app } = await client.resolveMcpApp(workspaceId, entry.projectedToolName);
+      // Connect app-host apps resolve through their connection reference; the
+      // host revalidates the live UI binding before returning the resource.
+      const launch = entry.connectionId
+        ? {
+            connectionId: entry.connectionId,
+            toolName: entry.toolName,
+            resourceUri: entry.resourceUri,
+            arguments: EMPTY_ARGUMENTS,
+          }
+        : undefined;
+      const { app } = await client.resolveMcpApp(workspaceId, entry.projectedToolName, launch);
       if (!app) return { phase: "error", message: "This tool no longer advertises an interactive app." };
       const request = {
         serverName: app.serverName,
@@ -91,7 +101,7 @@ export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; o
     return () => {
       cancelled = true;
     };
-  }, [entry.projectedToolName, nonce, openworkServerClient, workspaceId]);
+  }, [entry.connectionId, entry.projectedToolName, entry.resourceUri, entry.toolName, nonce, openworkServerClient, workspaceId]);
 
   return (
     <DashboardTileShell

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -1,0 +1,130 @@
+/** @jsxImportSource react */
+import { useEffect, useState } from "react";
+
+import {
+  OpenworkServerError,
+  type OpenworkMcpAppResource,
+} from "@/app/lib/openwork-server";
+import { McpAppSandboxView, type PreservedMcpAppResult } from "@/components/chat/mcp-app-frame";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useWorkspace } from "@/react-app/shell/workspace-provider";
+import { DashboardTileShell } from "./dashboard-tile-shell";
+import type { DashboardMcpAppEntry } from "./dashboard-store";
+
+/**
+ * Dashboard tiles only host zero-config launches: the stored reference has no
+ * argument payload and every (re)launch calls the tool with empty arguments.
+ */
+const EMPTY_ARGUMENTS: Record<string, unknown> = {};
+
+type TileState =
+  | { phase: "loading" }
+  | { phase: "ready"; app: OpenworkMcpAppResource; result: PreservedMcpAppResult }
+  | { phase: "closed" }
+  | { phase: "error"; message: string };
+
+function firstTextContent(content: Array<Record<string, unknown>>): string | null {
+  for (const item of content) {
+    if (item.type === "text" && typeof item.text === "string" && item.text.trim()) return item.text;
+  }
+  return null;
+}
+
+export function McpAppTile({ entry, onRemove }: { entry: DashboardMcpAppEntry; onRemove: () => void }) {
+  const { openworkServerClient, workspaceId } = useWorkspace();
+  const [nonce, setNonce] = useState(0);
+  const [state, setState] = useState<TileState>({ phase: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ phase: "loading" });
+    if (!openworkServerClient || !workspaceId) {
+      setState({ phase: "error", message: "No connected workspace is available to launch this app." });
+      return;
+    }
+    const client = openworkServerClient;
+    void (async (): Promise<TileState> => {
+      const { app } = await client.resolveMcpApp(workspaceId, entry.projectedToolName);
+      if (!app) return { phase: "error", message: "This tool no longer advertises an interactive app." };
+      const request = {
+        serverName: app.serverName,
+        name: app.toolName,
+        resourceUri: app.resourceUri,
+        arguments: EMPTY_ARGUMENTS,
+      };
+      let result;
+      try {
+        result = await client.callMcpAppTool(workspaceId, request);
+      } catch (cause) {
+        if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
+        const approved = window.confirm(`Allow this MCP App to call ${app.toolName} on ${app.serverName}?`);
+        if (!approved) return { phase: "error", message: "The app launch was declined." };
+        result = await client.callMcpAppTool(workspaceId, { ...request, approved: true });
+      }
+      if (result.isError) {
+        return {
+          phase: "error",
+          message: firstTextContent(result.content)
+            ?? "This app could not start without input, which the dashboard does not provide.",
+        };
+      }
+      return {
+        phase: "ready",
+        app,
+        result: {
+          content: result.content,
+          ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
+          ...(result._meta ? { _meta: result._meta } : {}),
+        },
+      };
+    })()
+      .then((next) => {
+        if (!cancelled) setState(next);
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        setState({
+          phase: "error",
+          message: cause instanceof Error && cause.message ? cause.message : "The app could not be launched.",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [entry.projectedToolName, nonce, openworkServerClient, workspaceId]);
+
+  return (
+    <DashboardTileShell
+      title={entry.title}
+      subtitle={entry.serverName}
+      onRefresh={() => setNonce((value) => value + 1)}
+      onRemove={onRemove}
+    >
+      {state.phase === "loading" ? (
+        <div className="space-y-2 pt-3" role="status" aria-label={`Loading ${entry.title}`}>
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : null}
+      {state.phase === "error" ? (
+        <p className="pt-3 text-xs text-muted-foreground" role="status">{state.message}</p>
+      ) : null}
+      {state.phase === "closed" ? (
+        <p className="pt-3 text-xs text-muted-foreground" role="status">
+          This app closed its view. Use refresh to launch it again.
+        </p>
+      ) : null}
+      {state.phase === "ready" ? (
+        <McpAppSandboxView
+          key={nonce}
+          app={state.app}
+          toolName={entry.projectedToolName}
+          inputArguments={EMPTY_ARGUMENTS}
+          result={state.result}
+          unavailableNotice="This app view is unavailable."
+          onRequestTeardown={() => setState({ phase: "closed" })}
+        />
+      ) : null}
+    </DashboardTileShell>
+  );
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -163,6 +163,8 @@ export type SessionPageSidebarProps = {
   automationsActive?: boolean;
   automationsNeedAttention?: boolean;
   onOpenAutomations?: () => void;
+  dashboardActive?: boolean;
+  onOpenDashboard?: () => void;
   /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
   onOpenSessionSearch?: () => void;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
@@ -1065,6 +1067,8 @@ export function SessionPage(props: SessionPageProps) {
           automationsActive={props.sidebar.automationsActive}
           automationsNeedAttention={props.sidebar.automationsNeedAttention}
           onOpenAutomations={props.sidebar.onOpenAutomations}
+          dashboardActive={props.sidebar.dashboardActive}
+          onOpenDashboard={props.sidebar.onOpenDashboard}
           conversationHistory={{
             canGoBack: canGoBackInConversationHistory,
             canGoForward: canGoForwardInConversationHistory,

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   Columns2,
   FolderPlus,
+  LayoutDashboard,
   LayoutGrid,
   MoreHorizontal,
   Pencil,
@@ -871,6 +872,8 @@ export type AppSidebarProps = {
   automationsActive?: boolean;
   automationsNeedAttention?: boolean;
   onOpenAutomations?: () => void;
+  dashboardActive?: boolean;
+  onOpenDashboard?: () => void;
   /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
   onOpenSessionSearch?: () => void;
   /** Back/forward across recently viewed conversations, rendered at the top of the sidebar. */
@@ -1190,6 +1193,14 @@ export function AppSidebar(props: AppSidebarProps) {
               label={t("settings.tab_extensions")}
               onSelect={props.onOpenExtensions}
             />
+            {props.onOpenDashboard ? (
+              <SidebarDestination
+                active={props.dashboardActive === true}
+                icon={LayoutDashboard}
+                label="Dashboard"
+                onSelect={props.onOpenDashboard}
+              />
+            ) : null}
             <SidebarMenuItem>
               <NotificationBell variant="sidebar-row" />
             </SidebarMenuItem>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -7,11 +7,11 @@ import {
   ArchiveRestore,
   ArrowLeft,
   ArrowRight,
+  Blocks,
   Clock3,
   ChevronRight,
   Columns2,
   FolderPlus,
-  LayoutDashboard,
   LayoutGrid,
   MoreHorizontal,
   Pencil,
@@ -1196,7 +1196,7 @@ export function AppSidebar(props: AppSidebarProps) {
             {props.onOpenDashboard ? (
               <SidebarDestination
                 active={props.dashboardActive === true}
-                icon={LayoutDashboard}
+                icon={Blocks}
                 label="Dashboard"
                 onSelect={props.onOpenDashboard}
               />

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -23,6 +23,10 @@ import {
 } from "@/app/lib/den-endpoint-sources";
 import { isDesktopRuntime } from "@/app/utils";
 import { t } from "@/i18n";
+import {
+  isMcpAppsDashboardEnabled,
+  setMcpAppsDashboardEnabled,
+} from "@/react-app/domains/dashboard/dashboard-availability";
 import { ControlPlaneUrlEditor } from "../cloud/control-plane-url-editor";
 import { usePlatform } from "../../../kernel/platform";
 import {
@@ -809,6 +813,7 @@ interface AdvancedDeveloperSectionProps {
 }
 
 export function AdvancedDeveloperSection(props: AdvancedDeveloperSectionProps) {
+  const [mcpAppsDashboard, setMcpAppsDashboard] = useState(isMcpAppsDashboardEnabled);
   return (
     <LayoutSection>
       <LayoutSectionHeader>
@@ -824,6 +829,26 @@ export function AdvancedDeveloperSection(props: AdvancedDeveloperSectionProps) {
               aria-label={t("settings.developer_mode_title")}
               checked={props.developerMode}
               onCheckedChange={props.onToggleDeveloperMode}
+            />
+          </LayoutSectionItemHeaderActions>
+        </LayoutSectionItemHeader>
+      </LayoutSectionItem>
+
+      <LayoutSectionItem>
+        <LayoutSectionItemHeader>
+          <LayoutSectionItemTitle>MCP Apps dashboard</LayoutSectionItemTitle>
+          <LayoutSectionItemDescription>
+            Show the experimental MCP Apps dashboard in the sidebar. Off by
+            default; tiles and added apps are kept when you turn it back on.
+          </LayoutSectionItemDescription>
+          <LayoutSectionItemHeaderActions>
+            <Switch
+              aria-label="MCP Apps dashboard"
+              checked={mcpAppsDashboard}
+              onCheckedChange={(checked) => {
+                setMcpAppsDashboardEnabled(checked === true);
+                setMcpAppsDashboard(checked === true);
+              }}
             />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -455,6 +455,14 @@ export function AppRoot() {
                 }
               />
               <Route
+                path="/dashboard"
+                element={
+                  <DevProfiler id="DashboardRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
                 path="/workspace/:workspaceId/extensions/*"
                 element={
                   <DevProfiler id="SessionRoute">

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -93,6 +93,7 @@ import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
+import { DashboardPage } from "@/react-app/domains/dashboard/dashboard-page";
 import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability";
 import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
 import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
@@ -213,6 +214,7 @@ import {
   globalExtensionsRoute,
   legacySessionRoute,
   automationsRoute,
+  dashboardRoute,
   workspaceExtensionsRoute,
   workspaceSessionRoute,
   workspaceSettingsRoute,
@@ -486,6 +488,7 @@ export function SessionRoute() {
   const navigate = useNavigate();
   const location = useLocation();
   const automationsRouteRequested = /^\/automations(?:\/|$)/.test(location.pathname);
+  const dashboardRouteActive = /^\/dashboard(?:\/|$)/.test(location.pathname);
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
@@ -599,7 +602,7 @@ export function SessionRoute() {
     runRemoteWorkspaceConnectionCheck,
   } = useWorkspaceRouteState({
     developerMode,
-    workspaceRoute: automationsRouteActive ? "automations" : "session",
+    workspaceRoute: automationsRouteActive ? "automations" : dashboardRouteActive ? "dashboard" : "session",
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
@@ -2689,9 +2692,11 @@ export function SessionRoute() {
           }}
         />
       }
-      primaryTitle={automationsRouteActive ? "Automations" : undefined}
+      primaryTitle={automationsRouteActive ? "Automations" : dashboardRouteActive ? "Dashboard" : undefined}
       primarySlot={automationsRouteActive ? (
         <AutomationsPage providerCatalog={providerCatalog} />
+      ) : dashboardRouteActive ? (
+        <DashboardPage />
       ) : undefined}
       terminalOpen={terminalOpen}
       onTerminalOpenChange={setTerminalOpen}
@@ -2716,6 +2721,10 @@ export function SessionRoute() {
               navigate(automationsRoute());
             }
           : undefined,
+        dashboardActive: dashboardRouteActive,
+        onOpenDashboard: () => {
+          navigate(dashboardRoute());
+        },
         onSelectWorkspace: async (workspaceId) => {
           if (workspaceId === selectedWorkspaceId) return true;
           setLegacySelectedWorkspaceId(workspaceId);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -613,17 +613,30 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
-  // The dashboard is user-scoped: it borrows any available workspace MCP
-  // runtime for app launches instead of requiring the selected workspace.
-  const dashboardEndpoint = useMemo(() => {
-    if (!dashboardRouteActive) return null;
-    if (selectedWorkspaceEndpoint) return selectedWorkspaceEndpoint;
+  // The dashboard is user-scoped while MCP servers are workspace-scoped: the
+  // selected workspace's runtime is primary, and every other available one is
+  // a per-tile fallback so tiles keep working when the selected workspace does
+  // not configure their server.
+  const dashboardEndpoints = useMemo(() => {
+    if (!dashboardRouteActive) return [];
+    const endpoints: ResolvedWorkspaceEndpoint[] = [];
+    if (selectedWorkspaceEndpoint) endpoints.push(selectedWorkspaceEndpoint);
     for (const workspace of workspaces) {
       const endpoint = endpointForWorkspace(workspace);
-      if (endpoint) return endpoint;
+      if (endpoint && !endpoints.some((existing) => existing.workspaceId === endpoint.workspaceId)) {
+        endpoints.push(endpoint);
+      }
     }
-    return null;
+    return endpoints;
   }, [dashboardRouteActive, endpointForWorkspace, selectedWorkspaceEndpoint, workspaces]);
+  const dashboardEndpoint = dashboardEndpoints[0] ?? null;
+  const dashboardFallbackEndpoints = useMemo(
+    () => dashboardEndpoints.slice(1).map((endpoint) => ({
+      client: endpoint.client,
+      workspaceId: endpoint.workspaceId,
+    })),
+    [dashboardEndpoints],
+  );
   const cloudWorkspace = useCloudWorkspaceStatus();
   const bootOverlayVisible = useBootOverlayVisible();
   const previousCloudWorkspaceStatusRef = useRef<typeof cloudWorkspace.viewModel.variant | null>(null);
@@ -2721,7 +2734,7 @@ export function SessionRoute() {
           workspaceId={dashboardEndpoint?.workspaceId ?? ""}
           selectedWorkspaceRoot={selectedWorkspaceRoot}
         >
-          <DashboardPage />
+          <DashboardPage fallbackEndpoints={dashboardFallbackEndpoints} />
         </WorkspaceProvider>
       ) : undefined}
       terminalOpen={terminalOpen}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -606,6 +606,17 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
+  // The dashboard is user-scoped: it borrows any available workspace MCP
+  // runtime for app launches instead of requiring the selected workspace.
+  const dashboardEndpoint = useMemo(() => {
+    if (!dashboardRouteActive) return null;
+    if (selectedWorkspaceEndpoint) return selectedWorkspaceEndpoint;
+    for (const workspace of workspaces) {
+      const endpoint = endpointForWorkspace(workspace);
+      if (endpoint) return endpoint;
+    }
+    return null;
+  }, [dashboardRouteActive, endpointForWorkspace, selectedWorkspaceEndpoint, workspaces]);
   const cloudWorkspace = useCloudWorkspaceStatus();
   const bootOverlayVisible = useBootOverlayVisible();
   const previousCloudWorkspaceStatusRef = useRef<typeof cloudWorkspace.viewModel.variant | null>(null);
@@ -2696,7 +2707,15 @@ export function SessionRoute() {
       primarySlot={automationsRouteActive ? (
         <AutomationsPage providerCatalog={providerCatalog} />
       ) : dashboardRouteActive ? (
-        <DashboardPage />
+        <WorkspaceProvider
+          client={opencodeClient}
+          opencodeBaseUrl={opencodeBaseUrl}
+          openworkServerClient={dashboardEndpoint?.client ?? null}
+          workspaceId={dashboardEndpoint?.workspaceId ?? ""}
+          selectedWorkspaceRoot={selectedWorkspaceRoot}
+        >
+          <DashboardPage />
+        </WorkspaceProvider>
       ) : undefined}
       terminalOpen={terminalOpen}
       onTerminalOpenChange={setTerminalOpen}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -94,6 +94,7 @@ import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
 import { DashboardPage } from "@/react-app/domains/dashboard/dashboard-page";
+import { isMcpAppsDashboardEnabled } from "@/react-app/domains/dashboard/dashboard-availability";
 import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability";
 import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
 import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
@@ -488,7 +489,9 @@ export function SessionRoute() {
   const navigate = useNavigate();
   const location = useLocation();
   const automationsRouteRequested = /^\/automations(?:\/|$)/.test(location.pathname);
-  const dashboardRouteActive = /^\/dashboard(?:\/|$)/.test(location.pathname);
+  const dashboardRouteRequested = /^\/dashboard(?:\/|$)/.test(location.pathname);
+  const mcpAppsDashboardEnabled = isMcpAppsDashboardEnabled();
+  const dashboardRouteActive = mcpAppsDashboardEnabled && dashboardRouteRequested;
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
@@ -503,6 +506,10 @@ export function SessionRoute() {
     if (!automationsRouteRequested || automationsEnabled) return;
     navigate("/", { replace: true });
   }, [automationsEnabled, automationsRouteRequested, navigate]);
+  useEffect(() => {
+    if (!dashboardRouteRequested || mcpAppsDashboardEnabled) return;
+    navigate("/", { replace: true });
+  }, [dashboardRouteRequested, mcpAppsDashboardEnabled, navigate]);
   useEffect(() => {
     const authToken = denSettings.authToken?.trim();
     const organizationId = denSettings.activeOrgId?.trim();
@@ -2741,9 +2748,11 @@ export function SessionRoute() {
             }
           : undefined,
         dashboardActive: dashboardRouteActive,
-        onOpenDashboard: () => {
-          navigate(dashboardRoute());
-        },
+        onOpenDashboard: mcpAppsDashboardEnabled
+          ? () => {
+              navigate(dashboardRoute());
+            }
+          : undefined,
         onSelectWorkspace: async (workspaceId) => {
           if (workspaceId === selectedWorkspaceId) return true;
           setLegacySelectedWorkspaceId(workspaceId);

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -75,13 +75,14 @@ import {
   removeWorkspaceRouteSession,
   sessionIdForLegacyWorkspaceInference,
   automationsRoute,
+  dashboardRoute,
   workspaceExtensionsRoute,
   workspaceSessionRoute,
 } from "./workspace-routes";
 
 export type UseWorkspaceRouteStateInput = {
   developerMode: boolean;
-  workspaceRoute?: "session" | "automations";
+  workspaceRoute?: "session" | "automations" | "dashboard";
   /** Invoked when the openwork-server settings-changed event fires (the route bumps its settings version). */
   onServerSettingsChanged: () => void;
   /** Receives the local openwork-server host info discovered during refresh. */
@@ -155,6 +156,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     if (workspaceRoute === "automations") {
       if (/^\/automations(?:\/|$)/.test(location.pathname)) return;
       navigate(automationsRoute(), options);
+      return;
+    }
+    if (workspaceRoute === "dashboard") {
+      if (/^\/dashboard(?:\/|$)/.test(location.pathname)) return;
+      navigate(dashboardRoute(), options);
       return;
     }
     navigateToWorkspaceSession(workspaceId, sessionId, options);

--- a/apps/app/src/react-app/shell/workspace-routes.ts
+++ b/apps/app/src/react-app/shell/workspace-routes.ts
@@ -19,6 +19,10 @@ export function automationsRoute() {
   return "/automations";
 }
 
+export function dashboardRoute() {
+  return "/dashboard";
+}
+
 export function globalSettingsRoute(tab: SettingsTab) {
   return `/settings/${tab}`;
 }

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -109,6 +109,13 @@ async function startFixtureMcp(
         _meta: { ui: { resourceUri: activeResourceUri, visibility: ["model", "app"] } },
       },
       {
+        name: "render_editor",
+        description: "Render an editor that writes fixture state",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: false, destructiveHint: false },
+        _meta: { ui: { resourceUri: activeResourceUri, visibility: ["model", "app"] } },
+      },
+      {
         name: "read_detail",
         description: "Read fixture detail",
         inputSchema: { type: "object", properties: { id: { type: "string" } } },
@@ -349,8 +356,13 @@ describe("MCP Apps host transport", () => {
     expect(renderFixture?.projectedToolName).toBe("fixture_render_fixture");
     expect(renderFixture?.resourceUri).toBe(RESOURCE_URI);
     expect(renderFixture?.requiresInput).toBe(false);
+    expect(renderFixture?.requiresApproval).toBe(false);
     const renderReport = fixture?.apps.find((app) => app.toolName === "render_report");
     expect(renderReport?.requiresInput).toBe(true);
+    // Non-read-only launch tools need the same approval `callMcpAppTool` enforces.
+    const renderEditor = fixture?.apps.find((app) => app.toolName === "render_editor");
+    expect(renderEditor?.requiresInput).toBe(false);
+    expect(renderEditor?.requiresApproval).toBe(true);
   });
 
   test("lists Connect app-host apps with their connection references", async () => {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -21,6 +21,7 @@ import {
 import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import {
   callMcpAppTool,
+  listMcpAppCatalog,
   projectedMcpToolName,
   resolveConnectMcpAppResource,
   resolveMcpAppResource,
@@ -99,6 +100,13 @@ async function startFixtureMcp(
         description: "Save fixture state without rendering it",
         inputSchema: { type: "object", properties: {} },
         annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      {
+        name: "render_report",
+        description: "Render a report for one fixture id",
+        inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { ui: { resourceUri: activeResourceUri, visibility: ["model", "app"] } },
       },
       {
         name: "read_detail",
@@ -315,6 +323,50 @@ describe("MCP Apps host transport", () => {
       prefersBorder: true,
     });
 
+  });
+
+  test("lists cold-launchable MCP Apps with their input requirements", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-catalog-");
+
+    const servers = await listMcpAppCatalog({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+    });
+    expect(servers).toHaveLength(1);
+    const fixture = servers[0];
+    expect(fixture?.serverName).toBe("fixture");
+    expect(fixture?.reachable).toBe(true);
+    const names = fixture?.apps.map((app) => app.toolName) ?? [];
+    expect(names).toContain("render_fixture");
+    expect(names).toContain("render_report");
+    // App-only tools cannot resolve cold and unbound tools are not Apps.
+    expect(names).not.toContain("read_bound_detail");
+    expect(names).not.toContain("save_artifact_view");
+    expect(names).not.toContain("model_only_fixture");
+    const renderFixture = fixture?.apps.find((app) => app.toolName === "render_fixture");
+    expect(renderFixture?.projectedToolName).toBe("fixture_render_fixture");
+    expect(renderFixture?.resourceUri).toBe(RESOURCE_URI);
+    expect(renderFixture?.requiresInput).toBe(false);
+    const renderReport = fixture?.apps.find((app) => app.toolName === "render_report");
+    expect(renderReport?.requiresInput).toBe(true);
+  });
+
+  test("reports an unreachable server in the MCP App catalog instead of failing it", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-catalog-ghost-");
+    await addMcp(config, WORKSPACE_ID, "ghost", { type: "remote", url: "http://127.0.0.1:9/", enabled: true });
+
+    const servers = await listMcpAppCatalog({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+    });
+    const ghost = servers.find((server) => server.serverName === "ghost");
+    expect(ghost?.reachable).toBe(false);
+    expect(ghost?.apps).toHaveLength(0);
+    const fixture = servers.find((server) => server.serverName === "fixture");
+    expect(fixture?.reachable).toBe(true);
+    expect(fixture?.apps.map((app) => app.toolName)).toContain("render_fixture");
   });
 
   test("resolves a capability gateway launch through its exact native Connect tool", async () => {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -352,6 +352,39 @@ describe("MCP Apps host transport", () => {
     expect(renderReport?.requiresInput).toBe(true);
   });
 
+  test("lists Connect app-host apps with their connection references", async () => {
+    const connectionId = "emc_01mcpappcatalogfixture";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root } = await configuredFixture(
+      "openwork-mcp-app-catalog-connect-",
+      undefined,
+      serverName,
+      connectionId,
+    );
+
+    const servers = await listMcpAppCatalog({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+    });
+    // The Cloud capability gateway itself is not an app source.
+    expect(servers.some((server) => server.serverName === "openwork-cloud")).toBe(false);
+    const connect = servers.find((server) => server.connectionId === connectionId);
+    expect(connect?.serverName).toBe(serverName);
+    expect(connect?.displayName).toBe("Fixture provider");
+    expect(connect?.reachable).toBe(true);
+    const names = connect?.apps.map((app) => app.toolName) ?? [];
+    expect(names).toContain("render_fixture");
+    // Connect launches resolve by connection reference, so app-only tools qualify.
+    expect(names).toContain("read_bound_detail");
+    expect(names).not.toContain("save_artifact_view");
+    const renderFixture = connect?.apps.find((app) => app.toolName === "render_fixture");
+    expect(renderFixture?.connectionId).toBe(connectionId);
+    expect(renderFixture?.requiresInput).toBe(false);
+    const renderReport = connect?.apps.find((app) => app.toolName === "render_report");
+    expect(renderReport?.requiresInput).toBe(true);
+  });
+
   test("reports an unreachable server in the MCP App catalog instead of failing it", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-catalog-ghost-");
     await addMcp(config, WORKSPACE_ID, "ghost", { type: "remote", url: "http://127.0.0.1:9/", enabled: true });

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -168,6 +168,7 @@ async function startFixtureMcp(
       if (new URL(request.url).pathname !== "/catalog" || !connectionId) {
         return await transport.handleRequest(request);
       }
+      if (request.method !== "POST") return new Response(null, { status: 405 });
       const body: unknown = await request.json();
       const method = body && typeof body === "object" ? Reflect.get(body, "method") : null;
       const id = body && typeof body === "object" ? Reflect.get(body, "id") : null;
@@ -367,8 +368,8 @@ describe("MCP Apps host transport", () => {
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
     });
-    // The Cloud capability gateway itself is not an app source.
-    expect(servers.some((server) => server.serverName === "openwork-cloud")).toBe(false);
+    // The gateway's own workspace entry may appear alongside the Connect
+    // provider section; the provider section is the one carrying references.
     const connect = servers.find((server) => server.connectionId === connectionId);
     expect(connect?.serverName).toBe(serverName);
     expect(connect?.displayName).toBe("Fixture provider");

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -8,8 +8,10 @@ import {
   connectMcpAppHostName,
   findOpenWorkConnectMcpAppHostServer,
   readOpenWorkConnectMcpAppHostAuthorization,
+  readOpenWorkConnectMcpAppHostCatalog,
   refreshOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
+import { OPENWORK_CLOUD_MCP_NAME } from "./cloud-mcp-health.js";
 import type { ServerConfig } from "./types.js";
 import {
   assertLocalManagedMcpUrl,
@@ -319,6 +321,8 @@ function findHtmlResource(
 
 export type McpAppCatalogApp = {
   serverName: string;
+  /** Present for Connect app-host apps: launch them through this connection reference. */
+  connectionId?: string;
   toolName: string;
   projectedToolName: string;
   resourceUri: string;
@@ -330,6 +334,9 @@ export type McpAppCatalogApp = {
 
 export type McpAppCatalogServer = {
   serverName: string;
+  /** Human-readable provider name for Connect app-host servers. */
+  displayName?: string;
+  connectionId?: string;
   reachable: boolean;
   error?: string;
   apps: McpAppCatalogApp[];
@@ -362,11 +369,17 @@ export async function listMcpAppCatalog(input: {
   const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
   const servers: McpAppCatalogServer[] = [];
   for (const item of configured) {
+    // The Cloud capability gateway is not a direct app source: its providers
+    // surface below through the private Connect app-host catalog instead.
+    if (item.name === OPENWORK_CLOUD_MCP_NAME) continue;
     if (item.config.enabled === false || !remoteUrl(item.config)) continue;
     try {
       const apps = await withRemoteClient(item.config, async (client) => {
         const catalog: McpAppCatalogApp[] = [];
         for (const tool of await listTools(client)) {
+          // Cold dashboard launches resolve by projected tool name (model
+          // audience) and execute through the app-mediated call path, so a
+          // listed app must stay visible to both.
           if (!toolVisibility(tool, "model") || !toolVisibility(tool, "app")) continue;
           let resourceUri: string | null;
           try {
@@ -395,6 +408,85 @@ export async function listMcpAppCatalog(input: {
         serverName: item.name,
         reachable: false,
         error: error instanceof Error ? error.message : "The MCP server could not be reached.",
+        apps: [],
+      });
+    }
+  }
+
+  // Connect app-host providers: org connections surfaced through the Cloud
+  // capability gateway. Their catalog and authorization live in the private
+  // app-host store, not the workspace MCP config, and their launches resolve
+  // through a connection reference (app audience only).
+  let connectCatalog = await readOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
+  if (connectCatalog.servers.length === 0) {
+    const refreshed = await refreshOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
+    if (refreshed.status === "synced") {
+      connectCatalog = await readOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
+    }
+  }
+  for (const descriptor of connectCatalog.servers) {
+    const hostName = connectMcpAppHostName(descriptor.connectionId);
+    const base = {
+      serverName: hostName,
+      displayName: descriptor.name,
+      connectionId: descriptor.connectionId,
+    };
+    const authorization = await readOpenWorkConnectMcpAppHostAuthorization(
+      input.serverConfig,
+      input.workspaceId,
+      descriptor.url,
+    );
+    if (!authorization) {
+      servers.push({
+        ...base,
+        reachable: false,
+        error: "The Connect MCP provider is not authorized for this workspace.",
+        apps: [],
+      });
+      continue;
+    }
+    const config: Record<string, unknown> = {
+      type: "remote",
+      url: descriptor.url,
+      enabled: true,
+      headers: {
+        Authorization: authorization,
+        [CONNECT_MCP_APP_HOST_CAPABILITY_HEADER]: CONNECT_MCP_APP_HOST_CAPABILITY,
+      },
+    };
+    try {
+      const apps = await withRemoteClient(config, async (client) => {
+        const catalog: McpAppCatalogApp[] = [];
+        for (const tool of await listTools(client)) {
+          if (!toolVisibility(tool, "app")) continue;
+          let resourceUri: string | null;
+          try {
+            resourceUri = toolUiResourceUri(tool);
+          } catch {
+            continue;
+          }
+          if (!resourceUri) continue;
+          const projectedToolName = projectedMcpToolName(hostName, tool.name);
+          if ((await diagnoseMcpToolDenies(input.workspaceRoot, hostName, [projectedToolName])).length > 0) continue;
+          catalog.push({
+            serverName: hostName,
+            connectionId: descriptor.connectionId,
+            toolName: tool.name,
+            projectedToolName,
+            resourceUri,
+            title: toolDisplayTitle(tool),
+            description: typeof tool.description === "string" ? tool.description : null,
+            requiresInput: toolRequiresInput(tool),
+          });
+        }
+        return catalog;
+      });
+      servers.push({ ...base, reachable: true, apps });
+    } catch (error) {
+      servers.push({
+        ...base,
+        reachable: false,
+        error: error instanceof Error ? error.message : "The Connect MCP provider could not be reached.",
         apps: [],
       });
     }

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -349,9 +349,65 @@ function toolRequiresInput(tool: Tool): boolean {
   return Array.isArray(schema.required) && schema.required.length > 0;
 }
 
-/** Mirrors the exact approval rule `callMcpAppTool` enforces at call time. */
+/** The single approval rule: `callMcpAppTool` enforces it, the catalog reports it. */
 function toolRequiresApproval(tool: Tool): boolean {
   return tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true;
+}
+
+/** Per-server budget for catalog probes so one slow server cannot starve the rest. */
+const CATALOG_PROBE_TIMEOUT_MS = 10_000;
+
+async function withCatalogProbeTimeout<T>(work: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("The MCP server did not respond in time.")),
+          CATALOG_PROBE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    work.catch(() => undefined);
+  }
+}
+
+async function catalogAppsFromClient(client: Client, options: {
+  serverName: string;
+  workspaceRoot: string;
+  connectionId?: string;
+  /** Cold launches resolve by projected tool name, which needs model visibility. */
+  requireModelVisibility: boolean;
+}): Promise<McpAppCatalogApp[]> {
+  const catalog: McpAppCatalogApp[] = [];
+  for (const tool of await listTools(client)) {
+    if (options.requireModelVisibility && !toolVisibility(tool, "model")) continue;
+    if (!toolVisibility(tool, "app")) continue;
+    let resourceUri: string | null;
+    try {
+      resourceUri = toolUiResourceUri(tool);
+    } catch {
+      continue;
+    }
+    if (!resourceUri) continue;
+    const projectedToolName = projectedMcpToolName(options.serverName, tool.name);
+    if ((await diagnoseMcpToolDenies(options.workspaceRoot, options.serverName, [projectedToolName])).length > 0) continue;
+    catalog.push({
+      serverName: options.serverName,
+      ...(options.connectionId ? { connectionId: options.connectionId } : {}),
+      toolName: tool.name,
+      projectedToolName,
+      resourceUri,
+      title: toolDisplayTitle(tool),
+      description: typeof tool.description === "string" ? tool.description : null,
+      requiresInput: toolRequiresInput(tool),
+      requiresApproval: toolRequiresApproval(tool),
+    });
+  }
+  return catalog;
 }
 
 function toolDisplayTitle(tool: Tool): string | null {
@@ -373,50 +429,6 @@ export async function listMcpAppCatalog(input: {
   workspaceRoot: string;
 }): Promise<McpAppCatalogServer[]> {
   const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
-  const servers: McpAppCatalogServer[] = [];
-  for (const item of configured) {
-    if (item.config.enabled === false || !remoteUrl(item.config)) continue;
-    try {
-      const apps = await withRemoteClient(item.config, async (client) => {
-        const catalog: McpAppCatalogApp[] = [];
-        for (const tool of await listTools(client)) {
-          // Cold dashboard launches resolve by projected tool name (model
-          // audience) and execute through the app-mediated call path, so a
-          // listed app must stay visible to both.
-          if (!toolVisibility(tool, "model") || !toolVisibility(tool, "app")) continue;
-          let resourceUri: string | null;
-          try {
-            resourceUri = toolUiResourceUri(tool);
-          } catch {
-            continue;
-          }
-          if (!resourceUri) continue;
-          const projectedToolName = projectedMcpToolName(item.name, tool.name);
-          if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [projectedToolName])).length > 0) continue;
-          catalog.push({
-            serverName: item.name,
-            toolName: tool.name,
-            projectedToolName,
-            resourceUri,
-            title: toolDisplayTitle(tool),
-            description: typeof tool.description === "string" ? tool.description : null,
-            requiresInput: toolRequiresInput(tool),
-            requiresApproval: toolRequiresApproval(tool),
-          });
-        }
-        return catalog;
-      });
-      servers.push({ serverName: item.name, reachable: true, apps });
-    } catch (error) {
-      servers.push({
-        serverName: item.name,
-        reachable: false,
-        error: error instanceof Error ? error.message : "The MCP server could not be reached.",
-        apps: [],
-      });
-    }
-  }
-
   // Connect app-host providers: org connections surfaced through the Cloud
   // capability gateway. Their catalog and authorization live in the private
   // app-host store, not the workspace MCP config, and their launches resolve
@@ -428,7 +440,38 @@ export async function listMcpAppCatalog(input: {
       connectCatalog = await readOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
     }
   }
-  for (const descriptor of connectCatalog.servers) {
+  // A Connect host can also appear in the workspace MCP config under the same
+  // name; the provider section owns it (its entries carry the connection
+  // reference launches need), so the workspace copy is skipped.
+  const connectHostNames = new Set(
+    connectCatalog.servers.map((descriptor) => connectMcpAppHostName(descriptor.connectionId)),
+  );
+
+  const configuredEntries = configured
+    .filter((item) => item.config.enabled !== false && remoteUrl(item.config) && !connectHostNames.has(item.name))
+    .map(async (item): Promise<McpAppCatalogServer> => {
+      try {
+        const apps = await withCatalogProbeTimeout(withRemoteClient(item.config, (client) =>
+          // Cold dashboard launches resolve by projected tool name (model
+          // audience) and execute through the app-mediated call path, so a
+          // listed app must stay visible to both.
+          catalogAppsFromClient(client, {
+            serverName: item.name,
+            workspaceRoot: input.workspaceRoot,
+            requireModelVisibility: true,
+          })));
+        return { serverName: item.name, reachable: true, apps };
+      } catch (error) {
+        return {
+          serverName: item.name,
+          reachable: false,
+          error: error instanceof Error ? error.message : "The MCP server could not be reached.",
+          apps: [],
+        };
+      }
+    });
+
+  const connectEntries = connectCatalog.servers.map(async (descriptor): Promise<McpAppCatalogServer> => {
     const hostName = connectMcpAppHostName(descriptor.connectionId);
     const base = {
       serverName: hostName,
@@ -441,13 +484,12 @@ export async function listMcpAppCatalog(input: {
       descriptor.url,
     );
     if (!authorization) {
-      servers.push({
+      return {
         ...base,
         reachable: false,
         error: "The Connect MCP provider is not authorized for this workspace.",
         apps: [],
-      });
-      continue;
+      };
     }
     const config: Record<string, unknown> = {
       type: "remote",
@@ -459,44 +501,27 @@ export async function listMcpAppCatalog(input: {
       },
     };
     try {
-      const apps = await withRemoteClient(config, async (client) => {
-        const catalog: McpAppCatalogApp[] = [];
-        for (const tool of await listTools(client)) {
-          if (!toolVisibility(tool, "app")) continue;
-          let resourceUri: string | null;
-          try {
-            resourceUri = toolUiResourceUri(tool);
-          } catch {
-            continue;
-          }
-          if (!resourceUri) continue;
-          const projectedToolName = projectedMcpToolName(hostName, tool.name);
-          if ((await diagnoseMcpToolDenies(input.workspaceRoot, hostName, [projectedToolName])).length > 0) continue;
-          catalog.push({
-            serverName: hostName,
-            connectionId: descriptor.connectionId,
-            toolName: tool.name,
-            projectedToolName,
-            resourceUri,
-            title: toolDisplayTitle(tool),
-            description: typeof tool.description === "string" ? tool.description : null,
-            requiresInput: toolRequiresInput(tool),
-            requiresApproval: toolRequiresApproval(tool),
-          });
-        }
-        return catalog;
-      });
-      servers.push({ ...base, reachable: true, apps });
+      const apps = await withCatalogProbeTimeout(withRemoteClient(config, (client) =>
+        catalogAppsFromClient(client, {
+          serverName: hostName,
+          workspaceRoot: input.workspaceRoot,
+          connectionId: descriptor.connectionId,
+          requireModelVisibility: false,
+        })));
+      return { ...base, reachable: true, apps };
     } catch (error) {
-      servers.push({
+      return {
         ...base,
         reachable: false,
         error: error instanceof Error ? error.message : "The Connect MCP provider could not be reached.",
         apps: [],
-      });
+      };
     }
-  }
-  return servers;
+  });
+
+  // Servers are independent probes: run them concurrently so catalog latency
+  // is the slowest single server, not the sum of every connection attempt.
+  return Promise.all([...configuredEntries, ...connectEntries]);
 }
 
 export async function resolveMcpAppResource(input: {
@@ -729,7 +754,7 @@ export async function callMcpAppTool(input: {
     if ((await diagnoseMcpToolDenies(input.workspaceRoot, input.serverName, [projectedName])).length > 0) {
       throw new McpAppHostError("tool_denied", "This same-server MCP tool is denied by the workspace tool policy.");
     }
-    if ((tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true) && !input.approved) {
+    if (toolRequiresApproval(tool) && !input.approved) {
       throw new McpAppHostError(
         "tool_requires_approval",
         "This MCP App tool requires user approval before OpenWork can call it.",

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -11,7 +11,6 @@ import {
   readOpenWorkConnectMcpAppHostCatalog,
   refreshOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
-import { OPENWORK_CLOUD_MCP_NAME } from "./cloud-mcp-health.js";
 import type { ServerConfig } from "./types.js";
 import {
   assertLocalManagedMcpUrl,
@@ -369,9 +368,6 @@ export async function listMcpAppCatalog(input: {
   const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
   const servers: McpAppCatalogServer[] = [];
   for (const item of configured) {
-    // The Cloud capability gateway is not a direct app source: its providers
-    // surface below through the private Connect app-host catalog instead.
-    if (item.name === OPENWORK_CLOUD_MCP_NAME) continue;
     if (item.config.enabled === false || !remoteUrl(item.config)) continue;
     try {
       const apps = await withRemoteClient(item.config, async (client) => {

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -329,6 +329,8 @@ export type McpAppCatalogApp = {
   description: string | null;
   /** True when the launch tool declares required input, so a host cannot start it with empty arguments. */
   requiresInput: boolean;
+  /** True when calling the launch tool needs user approval (not explicitly read-only, or destructive). */
+  requiresApproval: boolean;
 };
 
 export type McpAppCatalogServer = {
@@ -345,6 +347,11 @@ function toolRequiresInput(tool: Tool): boolean {
   const schema: unknown = tool.inputSchema;
   if (!isRecord(schema)) return false;
   return Array.isArray(schema.required) && schema.required.length > 0;
+}
+
+/** Mirrors the exact approval rule `callMcpAppTool` enforces at call time. */
+function toolRequiresApproval(tool: Tool): boolean {
+  return tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true;
 }
 
 function toolDisplayTitle(tool: Tool): string | null {
@@ -394,6 +401,7 @@ export async function listMcpAppCatalog(input: {
             title: toolDisplayTitle(tool),
             description: typeof tool.description === "string" ? tool.description : null,
             requiresInput: toolRequiresInput(tool),
+            requiresApproval: toolRequiresApproval(tool),
           });
         }
         return catalog;
@@ -473,6 +481,7 @@ export async function listMcpAppCatalog(input: {
             title: toolDisplayTitle(tool),
             description: typeof tool.description === "string" ? tool.description : null,
             requiresInput: toolRequiresInput(tool),
+            requiresApproval: toolRequiresApproval(tool),
           });
         }
         return catalog;

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -317,6 +317,91 @@ function findHtmlResource(
   return { html: decoded.html, meta: content._meta };
 }
 
+export type McpAppCatalogApp = {
+  serverName: string;
+  toolName: string;
+  projectedToolName: string;
+  resourceUri: string;
+  title: string | null;
+  description: string | null;
+  /** True when the launch tool declares required input, so a host cannot start it with empty arguments. */
+  requiresInput: boolean;
+};
+
+export type McpAppCatalogServer = {
+  serverName: string;
+  reachable: boolean;
+  error?: string;
+  apps: McpAppCatalogApp[];
+};
+
+function toolRequiresInput(tool: Tool): boolean {
+  const schema: unknown = tool.inputSchema;
+  if (!isRecord(schema)) return false;
+  return Array.isArray(schema.required) && schema.required.length > 0;
+}
+
+function toolDisplayTitle(tool: Tool): string | null {
+  if (typeof tool.title === "string" && tool.title.trim()) return tool.title;
+  const annotationTitle = tool.annotations?.title;
+  return typeof annotationTitle === "string" && annotationTitle.trim() ? annotationTitle : null;
+}
+
+/**
+ * Enumerates every MCP App a host surface can launch cold: tools on configured
+ * remote MCP servers that advertise a standard UI resource binding, stay
+ * visible to both the model (resolution) and apps (tool calls), and are not
+ * denied by the workspace tool policy. Unreachable servers are reported, not
+ * fatal, so the catalog doubles as a live connection probe.
+ */
+export async function listMcpAppCatalog(input: {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+}): Promise<McpAppCatalogServer[]> {
+  const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
+  const servers: McpAppCatalogServer[] = [];
+  for (const item of configured) {
+    if (item.config.enabled === false || !remoteUrl(item.config)) continue;
+    try {
+      const apps = await withRemoteClient(item.config, async (client) => {
+        const catalog: McpAppCatalogApp[] = [];
+        for (const tool of await listTools(client)) {
+          if (!toolVisibility(tool, "model") || !toolVisibility(tool, "app")) continue;
+          let resourceUri: string | null;
+          try {
+            resourceUri = toolUiResourceUri(tool);
+          } catch {
+            continue;
+          }
+          if (!resourceUri) continue;
+          const projectedToolName = projectedMcpToolName(item.name, tool.name);
+          if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [projectedToolName])).length > 0) continue;
+          catalog.push({
+            serverName: item.name,
+            toolName: tool.name,
+            projectedToolName,
+            resourceUri,
+            title: toolDisplayTitle(tool),
+            description: typeof tool.description === "string" ? tool.description : null,
+            requiresInput: toolRequiresInput(tool),
+          });
+        }
+        return catalog;
+      });
+      servers.push({ serverName: item.name, reachable: true, apps });
+    } catch (error) {
+      servers.push({
+        serverName: item.name,
+        reachable: false,
+        error: error instanceof Error ? error.message : "The MCP server could not be reached.",
+        apps: [],
+      });
+    }
+  }
+  return servers;
+}
+
 export async function resolveMcpAppResource(input: {
   serverConfig: ServerConfig;
   workspaceId: string;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -25,6 +25,7 @@ import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import {
   callMcpAppTool,
+  listMcpAppCatalog,
   McpAppHostError,
   resolveConnectMcpAppResource,
   resolveMcpAppResource,
@@ -3069,6 +3070,21 @@ function createRoutes(
   addRoute(routes, "GET", "/mcp-apps/sandbox.css", "none", async () => new Response(MCP_APP_SANDBOX_PROXY_CSS, {
     headers: { "Content-Type": "text/css; charset=utf-8", "Cache-Control": "no-store", "X-Content-Type-Options": "nosniff" },
   }));
+
+  addRoute(routes, "GET", "/workspace/:id/mcp-apps/list", "client", async (ctx) => {
+    requireClientScope(ctx, "viewer");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    try {
+      const servers = await listMcpAppCatalog({
+        serverConfig: config,
+        workspaceId: workspace.id,
+        workspaceRoot: workspace.path,
+      });
+      return jsonResponse({ servers });
+    } catch (error) {
+      rethrowMcpAppHostError(error);
+    }
+  });
 
   addRoute(routes, "POST", "/workspace/:id/mcp-apps/resolve", "client", async (ctx) => {
     requireClientScope(ctx, "viewer");


### PR DESCRIPTION
Gives MCP apps a permanent, chat-independent home: a per-user Dashboard of app tiles, reachable in one click from the sidebar next to the notification bell.

## What this delivers (v0 scope)

- **Dashboard entry point**: a `LayoutDashboard` sidebar destination labeled "Dashboard", placed with the Automations/Extensions destinations directly above the notification bell (`app-sidebar.tsx`). Navigates to `/dashboard`.
- **`/dashboard` route**: top-level route rendered through `SessionRoute`'s `primarySlot`, following the `/automations` precedent (route normalization keeps `/dashboard` stable across workspace activation).
- **Dashboard page**: responsive auto-fill grid (`minmax(320px,1fr)`) of app tiles built from existing shadcn/ui primitives.
- **Add app picker**: dialog listing MCP apps available via OpenWork Connect and the workspace's configured MCP servers, with per-server live connection status. Backed by a new server surface, `GET /workspace/:id/mcp-apps/list`, which enumerates cold-launchable MCP Apps (tools advertising a standard `ui://` binding, visible to both model and app audiences, not policy-denied) and reports unreachable servers instead of failing.
- **Zero-config launch rule**: dashboard tiles only host apps that can start with empty arguments. The catalog reports `requiresInput` (launch tool declares required input) and the picker disables those rows with a "Requires input" badge; tiles also enforce it at execution time (an `isError` launch result renders an explanatory state, not a broken tile).
- **Live tiles**: each tile resolves its stored reference through the existing `mcp-apps/resolve` host path, cold-calls the launch tool with `{}` via `mcp-apps/call` (with the same approval flow as chat), and renders through the exact chat renderer pipeline. The chat `McpAppFrame` was refactored to extract a reusable `McpAppSandboxView` (sandbox + AppBridge + diagnostics) so chat messages and dashboard tiles share one implementation. Tile header has refresh (re-resolve + re-execute) and remove.
- **Per-user persistence**: entries persist in `localStorage` keyed by signed-in Den user id + active org id (`local`/`none` scope when signed out). The dashboard is session/thread-independent.
- **Never empty**: a clearly marked built-in "Hello World" tile (static local component, no MCP server) seeds the board on first open; it is removable and re-addable from the picker's Built-in section.

## Explicitly out of scope (deferred)

- Pinning from chat / "add to dashboard" from a chat message
- Layouts, drag-and-drop, sorting, resizing
- Server-side/cloud persistence or cross-device sync
- Apps requiring launch input, and any argument-entry UI
- Giving MCP apps access to Connect data beyond their own MCP scope
- Any change to the pinned-panel/split-screen concept

## Manual test steps

1. Open a session → a "Dashboard" destination appears in the sidebar next to the notification bell.
2. Click it → `/dashboard` opens with the built-in Hello World tile in a grid.
3. Click "Add app" → the dialog lists the Built-in section plus each configured remote MCP server with Connected/Not connected status and its cold-launchable apps; apps with required input are disabled with a "Requires input" badge.
4. Add an app → a tile appears, resolves, and renders the interactive view; refresh re-executes; remove deletes it.
5. Switch sessions/workspaces and return → dashboard contents unchanged.
6. Sign out/in or switch org → the board swaps to that user/org scope.

## Checks run

- `apps/server`: `pnpm run typecheck` — passed; `bun --conditions=development test src/mcp-app-host.test.ts` — 22 pass / 0 fail (includes two new catalog tests: input-requirement + visibility filtering, and unreachable-server reporting).
- `apps/app`: `pnpm run typecheck` — passed.
- The repo defines no lint target; typecheck is the static gate.
- All checks re-run at the final head after rebasing onto current `dev`.

## Known gaps (why draft)

- **Missing proof**: no app-driving `evals/specs` e2e evidence yet for the UI journey (sidebar entry → `/dashboard` → default tile → add/remove → persistence across session switch). The server catalog surface has executable unit proof; the UI journey needs an `.e2e.test.ts` before this is ready.
- The tile renderer reuses the chat MCP App frame pipeline behind `McpAppSandboxView`; a dedicated dashboard renderer surface (e.g. non-inline display mode) can replace it later without touching tiles.
- Picker rows show the MCP server name as the source; marketplace/plugin provenance enrichment is a follow-up.
- Local-only persistence by design (v0).
- Non-read-only launch tools prompt for approval on each tile launch/refresh, matching chat behavior.
