### PR TITLE
fix(den-web): preserve shared auth cookie domain

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -244,6 +244,35 @@ describe("Den upstream proxy", () => {
     ]);
   });
 
+  test("preserves auth Set-Cookie parent domains shared by sibling web and API hosts", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const originalFetch = globalThis.fetch;
+    process.env.DEN_API_BASE = "https://api.openworklabs.com";
+    globalThis.fetch = async () => {
+      const headers = new Headers({ "content-type": "text/plain" });
+      headers.append(
+        "set-cookie",
+        "__Secure-better-auth.session_token=abc; Path=/; Domain=openworklabs.com; Secure; HttpOnly; SameSite=Lax",
+      );
+      return new Response("signed in", { headers });
+    };
+    const request = new NextRequest("https://app.openworklabs.com/api/auth/callback/google", {
+      method: "GET",
+    });
+
+    let response;
+    try {
+      response = await proxyUpstream(request, ["callback", "google"], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.DEN_API_BASE = `http://127.0.0.1:${server.port}`;
+    }
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "__Secure-better-auth.session_token=abc; Path=/; Domain=openworklabs.com; Secure; HttpOnly; SameSite=Lax",
+    ]);
+  });
+
   test("copies auth Set-Cookie from runtimes that only expose the combined header", async () => {
     const { proxyUpstream } = await import("./upstream-proxy.ts");
     const originalFetch = globalThis.fetch;

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -256,6 +256,16 @@ function isDomainCookieHostEligible(origin: URL): boolean {
   return origin.protocol === "https:" && hostname.includes(".") && hostname !== "localhost";
 }
 
+function normalizeCookieDomainAttribute(value: string): string | null {
+  const domain = value.trim().replace(/^\.+/u, "").toLowerCase();
+  if (!domain || domain.includes(":")) return null;
+  return domain;
+}
+
+function cookieDomainAppliesToHost(domain: string, hostname: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
 function rewriteAuthSetCookieHeader(cookie: string, request: NextRequest, apiBase: string, options: ProxyOptions): string {
   if (options.routePrefix !== "/api/auth") return cookie;
 
@@ -279,7 +289,10 @@ function rewriteAuthSetCookieHeader(cookie: string, request: NextRequest, apiBas
       const trimmed = part.trim();
       if (!/^domain=/iu.test(trimmed)) return index === 0 ? trimmed : ` ${trimmed}`;
       hasDomain = true;
-      return ` Domain=${publicHostname}`;
+      const upstreamDomain = normalizeCookieDomainAttribute(trimmed.slice("domain=".length));
+      return upstreamDomain && cookieDomainAppliesToHost(upstreamDomain, publicHostname)
+        ? ` Domain=${upstreamDomain}`
+        : ` Domain=${publicHostname}`;
     })
     .join(";");
 


### PR DESCRIPTION
## Summary\n- preserve upstream Better Auth parent cookie domains when they apply to the browser host\n- keep rewriting invalid upstream API-only cookie domains to the app host\n- add coverage for app.openworklabs.com + api.openworklabs.com sharing Domain=openworklabs.com through the auth proxy\n\n## Tests\n- bun test --conditions development ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs\n- bun test ee/apps/den-api/test/den-base-url-env.test.ts ee/apps/den-api/test/auth-login-options.test.ts\n\nNote: an accidental broad workspace test run also hit an unrelated existing desktop runtime-ca failure; the targeted den-web and den-api checks above pass.