### PR TITLE
feat(server): support private GitHub repos in Claude plugin installs via OPENWORK_GITHUB_TOKEN

### DIFF
--- a/apps/server/src/claude-plugin-bundle.e2e.test.ts
+++ b/apps/server/src/claude-plugin-bundle.e2e.test.ts
@@ -63,10 +63,12 @@ const PLUGIN_FILES: Record<string, string> = {
 
 function startMockGithub(options?: { branch?: string }) {
   const branch = options?.branch ?? "main";
+  const authHeaders: Array<string | null> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
+      authHeaders.push(request.headers.get("authorization"));
       const url = new URL(request.url);
       // API: repo info
       if (url.pathname === "/repos/slackapi/slack-mcp-plugin") {
@@ -92,7 +94,7 @@ function startMockGithub(options?: { branch?: string }) {
     },
   }) as Served;
   stops.push(() => server.stop(true));
-  return server;
+  return { port: server.port, authHeaders };
 }
 
 function startMockOpencode() {
@@ -157,6 +159,7 @@ async function startOpenwork(options?: { branch?: string }) {
     headers: { Authorization: "Bearer owt_test_token", "Content-Type": "application/json" },
     workspaceRoot,
     engine,
+    github,
   };
 }
 
@@ -225,6 +228,34 @@ describe("claude plugin bundles", () => {
     expect(body.preview.warnings.some((warning) => warning.includes("local-helper"))).toBe(true);
     // Nothing installed on dryRun.
     expect(existsSync(join(openwork.workspaceRoot, ".opencode/skills/slack-plugin"))).toBe(false);
+  });
+
+  test("sends OPENWORK_GITHUB_TOKEN as a Bearer header for private repos", async () => {
+    const openwork = await startOpenwork();
+    setEnv("OPENWORK_GITHUB_TOKEN", "ghp_test_private_token");
+
+    const response = await fetch(`${openwork.base}/workspace/ws_1/claude-plugins`, {
+      method: "POST",
+      headers: openwork.headers,
+      body: JSON.stringify({ url: "https://github.com/slackapi/slack-mcp-plugin", dryRun: true }),
+    });
+    expect(response.status).toBe(200);
+    expect(openwork.github.authHeaders.length).toBeGreaterThan(0);
+    expect(openwork.github.authHeaders.every((header) => header === "Bearer ghp_test_private_token")).toBe(true);
+  });
+
+  test("sends no Authorization header when OPENWORK_GITHUB_TOKEN is unset", async () => {
+    const openwork = await startOpenwork();
+    setEnv("OPENWORK_GITHUB_TOKEN", "");
+
+    const response = await fetch(`${openwork.base}/workspace/ws_1/claude-plugins`, {
+      method: "POST",
+      headers: openwork.headers,
+      body: JSON.stringify({ url: "https://github.com/slackapi/slack-mcp-plugin", dryRun: true }),
+    });
+    expect(response.status).toBe(200);
+    expect(openwork.github.authHeaders.length).toBeGreaterThan(0);
+    expect(openwork.github.authHeaders.every((header) => header === null)).toBe(true);
   });
 
   test("resolves branch names containing slashes in /tree/ URLs", async () => {

--- a/apps/server/src/claude-plugin-bundle.ts
+++ b/apps/server/src/claude-plugin-bundle.ts
@@ -57,6 +57,15 @@ function githubRawBase(): string {
   return (process.env.OPENWORK_GITHUB_RAW_BASE?.trim() || "https://raw.githubusercontent.com").replace(/\/+$/, "");
 }
 
+/**
+ * Optional token for private repos. GitHub accepts the same Bearer token on
+ * both api.github.com and raw.githubusercontent.com.
+ */
+function githubAuthHeaders(): Record<string, string> {
+  const token = process.env.OPENWORK_GITHUB_TOKEN?.trim();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -99,7 +108,7 @@ export function parseClaudePluginSource(input: string): ClaudePluginSource {
 
 async function fetchGithubJson(url: string): Promise<unknown> {
   const response = await externalFetch(url, {
-    headers: { Accept: "application/vnd.github+json", "User-Agent": "openwork-server" },
+    headers: { Accept: "application/vnd.github+json", "User-Agent": "openwork-server", ...githubAuthHeaders() },
     signal: AbortSignal.timeout(20_000),
   });
   if (!response.ok) {
@@ -111,7 +120,7 @@ async function fetchGithubJson(url: string): Promise<unknown> {
 
 async function fetchGithubText(url: string): Promise<string> {
   const response = await externalFetch(url, {
-    headers: { Accept: "text/plain", "User-Agent": "openwork-server" },
+    headers: { Accept: "text/plain", "User-Agent": "openwork-server", ...githubAuthHeaders() },
     signal: AbortSignal.timeout(20_000),
   });
   if (!response.ok) {


### PR DESCRIPTION
## Summary

The *From GitHub* plugin installer fetches `api.github.com` and `raw.githubusercontent.com` anonymously, so Claude plugin bundles in **private org repos** cannot be installed (the catalog/tree fetches 404). This adds an optional `OPENWORK_GITHUB_TOKEN` env var, sent as a `Bearer` token on both hosts when set — following the existing `OPENWORK_GITHUB_API_BASE` / `OPENWORK_GITHUB_RAW_BASE` naming. Behavior is byte-identical when the var is unset.

Use case (from #1775): orgs distribute internal skills as a private GitHub repo in Claude plugin-bundle format. Claude Code installs it (it authenticates as the user); OpenWork already understands the format perfectly — this closes the one gap.

Closes #1775

## Changes
- `claude-plugin-bundle.ts`: `githubAuthHeaders()` helper, spread into the two fetch helpers that funnel every GitHub request (repo info, trees API, raw files). +13 lines.
- `claude-plugin-bundle.e2e.test.ts`: mock GitHub now records `Authorization` headers; two new tests assert the token is sent on every request when set, and that no header is sent when unset.

## Verification

```
cd apps/server && bun --conditions=development test src/claude-plugin-bundle.e2e.test.ts
6 pass, 0 fail, 36 expect() calls
```

(4 pre-existing tests + 2 new; run on macOS, bun 1.4.0.)

Notes: GitHub accepts the same token on both api and raw hosts (classic PAT or fine-grained with Contents read). Happy to adjust if you'd prefer a per-install token field over an env var — env var was the smallest diff and matches the existing `OPENWORK_GITHUB_*` overrides.