### PR TITLE
fix(den-web): clear stale auth cookies on session miss

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -1175,6 +1175,12 @@ export async function requestJson(path: string, init: RequestInit = {}, timeoutM
       credentials: init.credentials ?? denApiCredentials(endpoint, path),
       signal: init.signal ?? timeoutController?.signal
     });
+    if (path === "/v1/me" && response.status === 401 && typeof window !== "undefined") {
+      await fetch("/api/auth/clear-session-cookie", {
+        method: "POST",
+        credentials: "include"
+      }).catch(() => null);
+    }
   } catch (error) {
     // Only the deadline created by this helper becomes a timeout. An abort
     // supplied by a caller becomes a distinct cancellation error.

--- a/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.test.mjs
+++ b/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildAuthSessionCookieClearHeaders } from "./session-cookie-clear.ts";
+
+describe("auth session cookie clearing", () => {
+  test("clears host-only, app-host, and parent-domain session cookies", () => {
+    expect(buildAuthSessionCookieClearHeaders("https://app.openworklabs.com/api/auth/clear-session-cookie", "openworklabs.com")).toEqual([
+      "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
+      "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=openworklabs.com",
+      "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.openworklabs.com",
+    ]);
+  });
+
+  test("normalizes a leading-dot configured cookie domain", () => {
+    expect(buildAuthSessionCookieClearHeaders("https://app.example.com/api/auth/clear-session-cookie", ".example.com")).toContain(
+      "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=example.com",
+    );
+  });
+});

--- a/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.ts
+++ b/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.ts
@@ -1,0 +1,43 @@
+const BETTER_AUTH_SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token";
+
+function normalizeCookieDomain(value: string | null | undefined): string | null {
+  const domain = value?.trim().replace(/^\.+/u, "").toLowerCase() ?? "";
+  if (!domain || domain.includes(":")) return null;
+  return domain;
+}
+
+function parentCookieDomain(hostname: string): string | null {
+  const labels = hostname.toLowerCase().split(".").filter(Boolean);
+  if (labels.length < 3) return null;
+  return labels.slice(-2).join(".");
+}
+
+function domainCandidates(requestUrl: string, configuredDomain?: string): string[] {
+  const candidates = new Set<string>();
+  const configured = normalizeCookieDomain(configuredDomain);
+  if (configured) candidates.add(configured);
+
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return Array.from(candidates);
+  }
+
+  const hostname = normalizeCookieDomain(url.hostname);
+  if (hostname) {
+    candidates.add(hostname);
+    const parent = parentCookieDomain(hostname);
+    if (parent) candidates.add(parent);
+  }
+
+  return Array.from(candidates);
+}
+
+export function buildAuthSessionCookieClearHeaders(requestUrl: string, configuredDomain = process.env.DEN_BETTER_AUTH_COOKIE_DOMAIN): string[] {
+  const expiredCookie = `${BETTER_AUTH_SECURE_SESSION_COOKIE}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`;
+  return [
+    expiredCookie,
+    ...domainCandidates(requestUrl, configuredDomain).map((domain) => `${expiredCookie}; Domain=${domain}`),
+  ];
+}

--- a/ee/apps/den-web/app/api/auth/clear-session-cookie/route.ts
+++ b/ee/apps/den-web/app/api/auth/clear-session-cookie/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildAuthSessionCookieClearHeaders } from "../_lib/session-cookie-clear";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const response = NextResponse.json({ ok: true });
+  for (const cookie of buildAuthSessionCookieClearHeaders(request.url)) {
+    response.headers.append("set-cookie", cookie);
+  }
+  return response;
+}

--- a/ee/apps/den-web/tests/den-flow-auth-cookie-clear.test.mjs
+++ b/ee/apps/den-web/tests/den-flow-auth-cookie-clear.test.mjs
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { requestJson } from "../app/(den)/_lib/den-flow.ts";
+import { setDenApiOriginOverride } from "../app/(den)/_lib/den-api-origin.ts";
+
+const previousWindow = globalThis.window;
+const previousFetch = globalThis.fetch;
+
+afterEach(() => {
+  setDenApiOriginOverride(null);
+  globalThis.fetch = previousFetch;
+  if (previousWindow === undefined) {
+    delete globalThis.window;
+  } else {
+    globalThis.window = previousWindow;
+  }
+});
+
+describe("Den flow stale session cleanup", () => {
+  test("clears Better Auth session cookies after /v1/me returns unauthorized", async () => {
+    setDenApiOriginOverride("https://api.openworklabs.com");
+    globalThis.window = {
+      location: { origin: "https://app.openworklabs.com" },
+      localStorage: { getItem: () => null },
+    };
+    const calls = [];
+    globalThis.fetch = async (input, init) => {
+      calls.push({ input: String(input), credentials: init?.credentials, method: init?.method });
+      if (String(input) === "https://api.openworklabs.com/v1/me") {
+        return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const { response } = await requestJson("/v1/me", { method: "GET" }, 12000);
+
+    expect(response.status).toBe(401);
+    expect(calls).toEqual([
+      { input: "https://api.openworklabs.com/v1/me", credentials: "include", method: "GET" },
+      { input: "/api/auth/clear-session-cookie", credentials: "include", method: "POST" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a same-origin Den Web endpoint that expires __Secure-better-auth.session_token cookies across host-only, app-host, configured, and parent-domain variants\n- call the cleanup endpoint when the browser /v1/me session check returns 401\n- cover the cleanup header set and the /v1/me unauthorized client path\n\n## Tests\n- bun test --conditions development ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.test.mjs ee/apps/den-web/tests/den-flow-auth-cookie-clear.test.mjs