### PR TITLE
fix(app): load session lists for all workspaces on launch

### DIFF
--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -79,15 +79,26 @@ export function createLatestWorkspaceCommitter(
   };
 }
 
-/** Only the routed workspace needs an OpenCode session index immediately. */
+/**
+ * Every workspace with an unloaded session index gets a background load, with
+ * the routed workspace first so the visible pane fills fastest. Loading only
+ * the routed workspace left every other workspace's sidebar showing the
+ * "No tasks yet." empty state on launch even when it had sessions, because
+ * nothing else ever fetched their session lists. Session-list loads are
+ * read-only `listSessions` calls, so this does not interact with the
+ * workspace-activation serialization from the switching-coherence fix.
+ */
 export function planRouteWorkspaceLoads(
   workspaceIds: string[],
   selectedWorkspaceId: string,
   loadedWorkspaceIds: ReadonlySet<string>,
 ): string[] {
   const selectedId = selectedWorkspaceId.trim();
-  if (!selectedId || loadedWorkspaceIds.has(selectedId) || !workspaceIds.includes(selectedId)) return [];
-  return [selectedId];
+  const selectedFirst = selectedId && !loadedWorkspaceIds.has(selectedId) && workspaceIds.includes(selectedId)
+    ? [selectedId]
+    : [];
+  const remaining = workspaceIds.filter((id) => id !== selectedId && !loadedWorkspaceIds.has(id));
+  return [...selectedFirst, ...remaining];
 }
 
 export function createRouteRefreshLifecycle(): RouteRefreshLifecycle {

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -677,12 +677,16 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       workspaceSelectionCommitTimerRef.current = null;
       workspaceSelectionCommitterRef.current?.request(routeWorkspaceId);
     }, ROUTE_WORKSPACE_ACTIVATION_SETTLE_MS);
+    // On navigation only the routed workspace needs a load: boot already
+    // scheduled background loads for every other unloaded workspace.
     const workspaceIdsToLoad = planRouteWorkspaceLoads(
       workspacesRef.current.map((workspace) => workspace.id),
       routeWorkspaceId,
       loadedWorkspaceIdsRef.current,
     );
-    const workspace = workspacesRef.current.find((item) => item.id === workspaceIdsToLoad[0]);
+    const workspace = workspaceIdsToLoad.includes(routeWorkspaceId)
+      ? workspacesRef.current.find((item) => item.id === routeWorkspaceId)
+      : undefined;
     if (workspace) {
       setRetryingWorkspaceIds((current) => Array.from(new Set([...current, workspace.id])));
       void loadWorkspaceSessionsInBackground([workspace]);

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -51,16 +51,24 @@ describe("createLatestWorkspaceCommitter", () => {
 });
 
 describe("planRouteWorkspaceLoads", () => {
-  test("loads only the selected workspace instead of every unseen workspace", () => {
+  test("loads every unloaded workspace with the selected workspace first", () => {
     expect(planRouteWorkspaceLoads(
       ["ws_1", "ws_2", "ws_3", "ws_4"],
       "ws_3",
       new Set(["ws_1"]),
-    )).toEqual(["ws_3"]);
+    )).toEqual(["ws_3", "ws_2", "ws_4"]);
   });
 
-  test("skips a selected workspace whose session index is already loaded", () => {
-    expect(planRouteWorkspaceLoads(["ws_1", "ws_2"], "ws_2", new Set(["ws_2"]))).toEqual([]);
+  test("still loads other unloaded workspaces when the selected one is loaded", () => {
+    expect(planRouteWorkspaceLoads(["ws_1", "ws_2"], "ws_2", new Set(["ws_2"]))).toEqual(["ws_1"]);
+  });
+
+  test("returns nothing when every workspace session index is loaded", () => {
+    expect(planRouteWorkspaceLoads(["ws_1", "ws_2"], "ws_1", new Set(["ws_1", "ws_2"]))).toEqual([]);
+  });
+
+  test("ignores a selected workspace that is not in the list", () => {
+    expect(planRouteWorkspaceLoads(["ws_1"], "ws_missing", new Set())).toEqual(["ws_1"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- On launch, only the routed workspace's session index was fetched (regression from the workspace-switch coherence fix #3977), so every other workspace's sidebar showed the "No tasks yet." empty state even when it had sessions.
- `planRouteWorkspaceLoads` now returns every workspace with an unloaded session index, routed workspace first, so boot schedules background `listSessions` loads for all of them. These are read-only calls and do not touch the serialized workspace-activation path from #3977.
- The navigation effect stays scoped to loading only the routed workspace on switches.

## Repro (before)

Reported on 0.18.36-alpha.2476: workspaces never opened in the current app run show "No tasks yet." in the sidebar despite having sessions.

Verified against the local dev stack via CDP:
- Server ground truth: `ws_b4f5dfaecbc5` had 5 sessions, `ws_e8008925f44c` had 16.
- Dev server log showed boot issued `GET /workspace/<id>/sessions` only for the active workspace.
- Expanding the other workspaces in the sidebar rendered "No tasks yet." and triggered no fetch.

![before: expanded unopened workspaces show "No tasks yet." despite 5 and 16 sessions](https://litter.catbox.moe/hcaky2.png)

## Evidence (after)

- Dev server log on cold launch now shows one `GET /workspace/<id>/sessions` per workspace (3/3) with no extra probes.
- Unopened workspaces list their real sessions when expanded; zero "No tasks yet." occurrences while sessions exist.

![after: boot loads all workspaces, active workspace renders sessions](https://litter.catbox.moe/2xhofr.png)
![after: expanded unopened workspaces show their real session lists](https://litter.catbox.moe/fyebw1.png)

### Build verification
- `pnpm --filter @openwork/app build` — passed

### Test verification
- `bun test tests/route-refresh-control.test.ts` — 12 pass, 0 fail (plan tests updated: selected-first ordering, other unloaded workspaces included, all-loaded returns empty)
- `bun test tests/workspace-routes.test.ts tests/settings-route.test.ts tests/workspace-endpoint.test.ts` — 23 pass, 0 fail

### UI verification
- Verified via CDP against the local Electron dev app (`pnpm dev`, port 9825)
- Console errors: none observed during boot/expand
- Failed network requests: none

## Test instructions

1. Have 3+ local workspaces, each with at least one session.
2. `pnpm dev` and wait for boot to settle.
3. Without opening them, expand the non-active workspaces in the sidebar.
4. Verify each lists its sessions instead of "No tasks yet.".
5. Rapidly switch workspaces to confirm switch coherence is unchanged.