### PR TITLE
fix(desktop): keep bootstrap and retained Den sessions origin-coherent

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -63,6 +63,13 @@ declare global {
 export const STORAGE_BASE_URL = "openwork.den.baseUrl";
 const LEGACY_STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
 const STORAGE_AUTH_TOKEN = "openwork.den.authToken";
+/**
+ * Origin comparison key (see denOriginComparisonKey) of the Den control plane
+ * that issued the retained auth token. Written together with the token so a
+ * later boot can prove the retained session belongs to the resolved bootstrap
+ * origin before any credential-bearing request is made.
+ */
+export const STORAGE_SESSION_ORIGIN = "openwork.den.sessionOrigin";
 const STORAGE_ACTIVE_ORG_ID = "openwork.den.activeOrgId";
 const STORAGE_ACTIVE_ORG_SLUG = "openwork.den.activeOrgSlug";
 const STORAGE_ACTIVE_ORG_NAME = "openwork.den.activeOrgName";
@@ -439,6 +446,28 @@ let desktopBootstrapConfig: DenBootstrapConfig = {
 let gatewayBootstrapConfig: DenBootstrapConfig | null = null;
 let gatewayBootstrapConfigOrigin: string | null = null;
 let gatewayBootstrapConfigSource: DenBootstrapConfig | null = null;
+
+/**
+ * Whether the in-memory bootstrap snapshot came from an authoritative source
+ * (preload snapshot, shell IPC read, or an explicit persist) or is only the
+ * in-memory fallback used while the shell bridge is unavailable. An
+ * `unresolved` bootstrap must never be treated as a real hosted selection:
+ * retained credentials stay quarantined until the origin that owns them is
+ * proven.
+ */
+export type DenBootstrapResolution = "unresolved" | "resolved";
+let desktopBootstrapResolution: DenBootstrapResolution = "unresolved";
+/**
+ * Monotonic startup/refresh generation. Every asynchronous bootstrap
+ * resolution belongs to the generation that started it; a late result from an
+ * obsolete generation must never replace the current snapshot.
+ */
+let desktopBootstrapGeneration = 0;
+let lastCredentialGateLog: string | null = null;
+
+export function getDenBootstrapResolution(): DenBootstrapResolution {
+  return desktopBootstrapResolution;
+}
 
 export type DenAppVersionMetadata = {
   minAppVersion: string;
@@ -968,6 +997,70 @@ function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null
 
 function applyDesktopBootstrapConfig(config: DenBootstrapConfig) {
   desktopBootstrapConfig = config;
+  desktopBootstrapResolution = "resolved";
+}
+
+function readStoredDenSessionOrigin(): string | null {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") return null;
+  return (window.localStorage.getItem(STORAGE_SESSION_ORIGIN) ?? "").trim() || null;
+}
+
+function readStoredDenAuthToken(): string | null {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") return null;
+  return (window.localStorage.getItem(STORAGE_AUTH_TOKEN) ?? "").trim() || null;
+}
+
+/**
+ * Adopts a retained session written by builds that predate the session-origin
+ * tag. Runs only at authoritative boot-time resolution: an untagged token is
+ * bound to the origin the bootstrap actually resolved to, which matches the
+ * origin those builds would have used it against.
+ */
+function adoptUntaggedDenSessionOrigin() {
+  if (!isDesktopRuntime() || desktopBootstrapResolution !== "resolved") return;
+  if (!readStoredDenAuthToken() || readStoredDenSessionOrigin()) return;
+  const origin = denOriginComparisonKey(desktopBootstrapConfig.baseUrl);
+  if (!origin) return;
+  try {
+    window.localStorage.setItem(STORAGE_SESSION_ORIGIN, origin);
+  } catch {
+    // Storage unavailable: the session stays quarantined instead of adopted.
+  }
+}
+
+/**
+ * The single origin-coherence gate. True when the retained token must be
+ * withheld because the enrollment that owns it has not been proven to match
+ * the effective Den origin: either the bootstrap is still unresolved (the
+ * in-memory fallback is not a real selection) or the resolved origin differs
+ * from the origin recorded next to the token.
+ */
+function shouldWithholdDenCredentials(bootstrapBaseUrl: string): boolean {
+  if (!isDesktopRuntime()) return false;
+  if (!readStoredDenAuthToken()) return false;
+
+  const sessionOrigin = readStoredDenSessionOrigin();
+  const configOrigin = denOriginComparisonKey(bootstrapBaseUrl);
+  const withheld = sessionOrigin
+    ? sessionOrigin !== configOrigin
+    : desktopBootstrapResolution !== "resolved";
+
+  const logKey = withheld
+    ? (sessionOrigin ? "origin-mismatch" : "bootstrap-unresolved")
+    : null;
+  if (logKey !== lastCredentialGateLog) {
+    lastCredentialGateLog = logKey;
+    if (logKey === "bootstrap-unresolved") {
+      console.warn(
+        "[den-session] Desktop bootstrap is unresolved; retained Den credentials are quarantined until the control plane origin is proven.",
+      );
+    } else if (logKey === "origin-mismatch") {
+      console.warn(
+        "[den-session] Retained Den session belongs to a different control plane origin than the resolved bootstrap; credentials are quarantined.",
+      );
+    }
+  }
+  return withheld;
 }
 
 export function readDenBootstrapConfig(): DenBootstrapConfig {
@@ -997,6 +1090,8 @@ export function readDenBootstrapConfig(): DenBootstrapConfig {
 }
 
 export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig> {
+  const generation = ++desktopBootstrapGeneration;
+
   if (!isDesktopRuntime()) {
     const gatewayOrigin = getOpenworkGatewayOrigin();
     // Forced env settings (headless/dev runs): stale stored base URLs from
@@ -1013,12 +1108,16 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
       ...(gatewayOrigin ? { apiBaseUrl: gatewayOrigin } : {}),
       requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
     });
+    desktopBootstrapResolution = "resolved";
     return desktopBootstrapConfig;
   }
 
   const initialBootstrap = readInitialDesktopBootstrapConfig();
   if (initialBootstrap) {
-    applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(initialBootstrap));
+    const resolved = await resolveDenBootstrapConfigWithRuntimeApi(initialBootstrap);
+    if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
+    applyDesktopBootstrapConfig(resolved);
+    adoptUntaggedDenSessionOrigin();
     return desktopBootstrapConfig;
   }
 
@@ -1030,34 +1129,51 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   for (let attempt = 1; attempt <= SHELL_BOOTSTRAP_ATTEMPTS; attempt += 1) {
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
+      const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+      if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
+      applyDesktopBootstrapConfig(resolved);
+      adoptUntaggedDenSessionOrigin();
       return desktopBootstrapConfig;
     } catch (error) {
       console.error("[den-bootstrap] shell read failed", attempt, error);
+      if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
       if (attempt < SHELL_BOOTSTRAP_ATTEMPTS) {
         await new Promise((resolve) => setTimeout(resolve, SHELL_BOOTSTRAP_RETRY_DELAY_MS));
       }
     }
   }
 
+  if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
+
   // All quick attempts failed. Keep build defaults in memory only — do NOT
   // sync them to localStorage: previously synced values from a successful
   // boot are more trustworthy than build defaults, and clobbering them
   // silently reverted custom/self-hosted control planes to the production
-  // URL until a manual reload.
+  // URL until a manual reload. The snapshot stays `unresolved`: it is a
+  // recovery placeholder, not a real hosted selection, so retained
+  // credentials remain quarantined until an authoritative read succeeds.
   desktopBootstrapConfig = resolveDenBootstrapConfig({
     baseUrl: HOSTED_DEFAULT_DEN_BASE_URL,
     requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
   });
+  desktopBootstrapResolution = "unresolved";
+  console.warn(
+    "[den-bootstrap] Shell bootstrap is unavailable; using an in-memory placeholder and withholding Den credentials until the real config is read.",
+  );
 
   // Heal in the background without blocking boot: once the bridge comes up,
-  // apply the real shell config and notify listeners.
+  // apply the real shell config and notify listeners. Results from an
+  // obsolete startup generation are discarded.
   void (async () => {
     for (let attempt = 0; attempt < 15; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 2_000));
+      if (generation !== desktopBootstrapGeneration) return;
       try {
         const bootstrap = await getDesktopBootstrapConfigFromShell();
-        applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
+        const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+        if (generation !== desktopBootstrapGeneration) return;
+        applyDesktopBootstrapConfig(resolved);
+        adoptUntaggedDenSessionOrigin();
         dispatchDenSettingsChanged({ settings: readDenSettings() });
         return;
       } catch {
@@ -1077,10 +1193,15 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
  */
 export async function refreshDenBootstrapConfigFromShell(): Promise<DenBootstrapConfig> {
   if (isDesktopRuntime()) {
+    const generation = ++desktopBootstrapGeneration;
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      applyDesktopBootstrapConfig(await resolveDenBootstrapConfigWithRuntimeApi(bootstrap));
-      dispatchDenSettingsChanged({ settings: readDenSettings() });
+      const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+      if (generation === desktopBootstrapGeneration) {
+        applyDesktopBootstrapConfig(resolved);
+        adoptUntaggedDenSessionOrigin();
+        dispatchDenSettingsChanged({ settings: readDenSettings() });
+      }
     } catch {
       // Bridge hiccup — keep the current cached snapshot.
     }
@@ -1099,6 +1220,9 @@ export async function setDenBootstrapConfig(
   });
 
   if (isDesktopRuntime()) {
+    // An explicit persist is a new authoritative bootstrap: retire any
+    // in-flight startup resolution so a late read cannot replace it.
+    desktopBootstrapGeneration += 1;
     const persisted = await setDesktopBootstrapConfigInShell({
       baseUrl: normalized.baseUrl,
       apiBaseUrl: normalized.apiBaseUrl,
@@ -1198,6 +1322,21 @@ export function readDenSettings(): DenSettings {
       ? bootstrapConfig
       : { baseUrl: window.localStorage.getItem(STORAGE_BASE_URL) ?? bootstrapConfig.baseUrl },
   );
+
+  // Origin coherence: the retained token and organization are only usable
+  // together with the origin that issued them. While the bootstrap is
+  // unresolved, or when it resolved to a different control plane, the
+  // retained session stays quarantined in storage — visible to no caller, so
+  // no credential-bearing request can mix origins.
+  if (shouldWithholdDenCredentials(bootstrapConfig.baseUrl)) {
+    return {
+      ...baseUrls,
+      authToken: null,
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    };
+  }
 
   return {
     ...baseUrls,
@@ -1343,6 +1482,15 @@ export function writeDenSettings(
     intentionalActiveOrgClear: options?.intentionalActiveOrgClear,
   });
 
+  // Quarantined credentials are invisible to callers, so a caller writing an
+  // empty session cannot have meant to delete them. Preserve the stored
+  // session untouched; explicit sign-out and server changes go through
+  // clearDenSession(), which deletes storage directly.
+  const preserveQuarantinedSession =
+    !authToken
+    && readStoredDenAuthToken() !== null
+    && shouldWithholdDenCredentials(readDenBootstrapConfig().baseUrl);
+
   if (isDesktopRuntime()) {
     window.localStorage.removeItem(STORAGE_BASE_URL);
   } else {
@@ -1352,28 +1500,39 @@ export function writeDenSettings(
   if (previous.baseUrl !== baseUrl || (previous.authToken ?? "") !== authToken) {
     window.localStorage.removeItem(CLOUD_MCP_SYNC_MARKER_STORAGE_KEY);
   }
-  if (authToken) {
-    window.localStorage.setItem(STORAGE_AUTH_TOKEN, authToken);
-  } else {
-    window.localStorage.removeItem(STORAGE_AUTH_TOKEN);
-  }
+  if (!preserveQuarantinedSession) {
+    if (authToken) {
+      window.localStorage.setItem(STORAGE_AUTH_TOKEN, authToken);
+      // Record which control plane issued this token so later boots can prove
+      // origin coherence before using it.
+      const sessionOrigin = denOriginComparisonKey(baseUrl);
+      if (sessionOrigin) {
+        window.localStorage.setItem(STORAGE_SESSION_ORIGIN, sessionOrigin);
+      } else {
+        window.localStorage.removeItem(STORAGE_SESSION_ORIGIN);
+      }
+    } else {
+      window.localStorage.removeItem(STORAGE_AUTH_TOKEN);
+      window.localStorage.removeItem(STORAGE_SESSION_ORIGIN);
+    }
 
-  if (activeOrgId) {
-    window.localStorage.setItem(STORAGE_ACTIVE_ORG_ID, activeOrgId);
-  } else {
-    window.localStorage.removeItem(STORAGE_ACTIVE_ORG_ID);
-  }
+    if (activeOrgId) {
+      window.localStorage.setItem(STORAGE_ACTIVE_ORG_ID, activeOrgId);
+    } else {
+      window.localStorage.removeItem(STORAGE_ACTIVE_ORG_ID);
+    }
 
-  if (activeOrgSlug) {
-    window.localStorage.setItem(STORAGE_ACTIVE_ORG_SLUG, activeOrgSlug);
-  } else {
-    window.localStorage.removeItem(STORAGE_ACTIVE_ORG_SLUG);
-  }
+    if (activeOrgSlug) {
+      window.localStorage.setItem(STORAGE_ACTIVE_ORG_SLUG, activeOrgSlug);
+    } else {
+      window.localStorage.removeItem(STORAGE_ACTIVE_ORG_SLUG);
+    }
 
-  if (activeOrgName) {
-    window.localStorage.setItem(STORAGE_ACTIVE_ORG_NAME, activeOrgName);
-  } else {
-    window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);
+    if (activeOrgName) {
+      window.localStorage.setItem(STORAGE_ACTIVE_ORG_NAME, activeOrgName);
+    } else {
+      window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);
+    }
   }
 
   if (options?.persistBootstrap !== false && pendingBootstrap) {
@@ -1417,6 +1576,7 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
   }
 
   window.localStorage.removeItem(STORAGE_AUTH_TOKEN);
+  window.localStorage.removeItem(STORAGE_SESSION_ORIGIN);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_ID);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_SLUG);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);

--- a/apps/app/tests/den-bootstrap-origin-coherence.test.ts
+++ b/apps/app/tests/den-bootstrap-origin-coherence.test.ts
@@ -1,0 +1,494 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  clearDenSession,
+  ensureDenActiveOrganization,
+  getDenBootstrapResolution,
+  initializeDenBootstrapConfig,
+  readDenBootstrapConfig,
+  readDenSettings,
+  setDenBootstrapConfig,
+  STORAGE_SESSION_ORIGIN,
+  writeDenSettings,
+} from "../src/app/lib/den";
+
+const RETAINED_TOKEN = "retained-self-hosted-token-8fd1";
+const RETAINED_ORG_ID = "org_selfhosted_1";
+
+type WitnessRequest = {
+  method: string;
+  path: string;
+  authorization: string | null;
+};
+
+type Witness = {
+  url: string;
+  origin: string;
+  requests: WitnessRequest[];
+  credentialed: () => WitnessRequest[];
+  stop: () => void;
+};
+
+/** A deterministic Den control-plane stand-in that records every request it sees. */
+function startWitness(): Witness {
+  const requests: WitnessRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      requests.push({
+        method: request.method,
+        path: url.pathname,
+        authorization: request.headers.get("authorization"),
+      });
+      if (url.pathname === "/api/runtime-config") {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.pathname === "/v1/me/orgs") {
+        return Response.json({
+          orgs: [{ id: RETAINED_ORG_ID, name: "Self Hosted", slug: "self-hosted", role: "admin" }],
+          activeOrgId: RETAINED_ORG_ID,
+        });
+      }
+      if (url.pathname === "/v1/me/active-organization") {
+        return Response.json({ ok: true });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const url = `http://127.0.0.1:${server.port}`;
+  return {
+    url,
+    origin: `http://localhost:${server.port}`,
+    requests,
+    credentialed: () => requests.filter((entry) => entry.authorization !== null),
+    stop: () => server.stop(true),
+  };
+}
+
+type FetchLogEntry = { url: string; authorization: string | null };
+
+type ShellScript = {
+  /** Sequential outcomes for getDesktopBootstrapConfig reads. The last entry repeats. */
+  reads: Array<
+    | { kind: "fail" }
+    | { kind: "config"; config: Record<string, unknown> }
+    | { kind: "defer"; promise: Promise<Record<string, unknown>> }
+  >;
+};
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+const originalWindow = globalThis.window;
+const originalWarn = console.warn;
+const originalError = console.error;
+
+describe("den bootstrap and retained session origin coherence", () => {
+  let fetchLog: FetchLogEntry[];
+  let shellWrites: Array<Record<string, unknown>>;
+  let consoleLines: string[];
+  let witnesses: Witness[];
+
+  function isLoopback(url: URL): boolean {
+    return url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
+  }
+
+  function installWindow(options: {
+    shell: ShellScript;
+    preloadBootstrap?: Record<string, unknown> | null;
+    storage?: Storage;
+  }): Storage {
+    const storage = options.storage ?? memoryStorage();
+    let readIndex = 0;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: storage,
+        dispatchEvent: () => true,
+        __OPENWORK_ELECTRON__: {
+          ...(options.preloadBootstrap !== undefined
+            ? { meta: { desktopBootstrap: options.preloadBootstrap } }
+            : {}),
+          invokeDesktop: async (command: string, ...args: unknown[]) => {
+            if (command === "getDesktopBootstrapConfig") {
+              const step = options.shell.reads[Math.min(readIndex, options.shell.reads.length - 1)];
+              readIndex += 1;
+              if (!step || step.kind === "fail") {
+                throw new Error("shell bridge unavailable");
+              }
+              if (step.kind === "defer") return step.promise;
+              return step.config;
+            }
+            if (command === "setDesktopBootstrapConfig") {
+              const payload = args[0] as Record<string, unknown>;
+              shellWrites.push(payload);
+              return { ...payload, writtenAt: "2026-08-24T00:00:00.000Z" };
+            }
+            if (command === "__fetch") {
+              const url = String(args[0]);
+              const init = (args[1] ?? {}) as {
+                method?: string;
+                headers?: Record<string, string>;
+                body?: string;
+              };
+              const headers = init.headers ?? {};
+              const authorization = headers.Authorization ?? headers.authorization ?? null;
+              fetchLog.push({ url, authorization });
+              const parsed = new URL(url);
+              if (isLoopback(parsed)) {
+                const response = await fetch(url, {
+                  method: init.method ?? "GET",
+                  headers,
+                  body: init.body,
+                });
+                return {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: Array.from(response.headers.entries()),
+                  body: await response.text(),
+                };
+              }
+              // Non-loopback origins (e.g. the hosted default) are recorded but
+              // never reached: the test asserts what would have left the machine.
+              return {
+                status: 503,
+                statusText: "Service Unavailable",
+                headers: [["content-type", "application/json"]],
+                body: "{}",
+              };
+            }
+            throw new Error(`Unexpected desktop command: ${command}`);
+          },
+        },
+      },
+    });
+    return storage;
+  }
+
+  function seedRetainedSession(storage: Storage, sessionOrigin: string | null) {
+    storage.setItem("openwork.den.authToken", RETAINED_TOKEN);
+    storage.setItem("openwork.den.activeOrgId", RETAINED_ORG_ID);
+    storage.setItem("openwork.den.activeOrgSlug", "self-hosted");
+    storage.setItem("openwork.den.activeOrgName", "Self Hosted");
+    if (sessionOrigin) {
+      storage.setItem(STORAGE_SESSION_ORIGIN, sessionOrigin);
+    }
+  }
+
+  function credentialedFetches(): FetchLogEntry[] {
+    return fetchLog.filter((entry) => entry.authorization !== null);
+  }
+
+  beforeEach(() => {
+    fetchLog = [];
+    shellWrites = [];
+    consoleLines = [];
+    witnesses = [];
+    console.warn = (...args: unknown[]) => {
+      consoleLines.push(args.map(String).join(" "));
+    };
+    console.error = (...args: unknown[]) => {
+      consoleLines.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+    for (const witness of witnesses) witness.stop();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("a valid preload bootstrap resolves immediately and the matching session works", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({
+      shell: { reads: [{ kind: "fail" }] },
+      preloadBootstrap: { baseUrl: den.url, apiBaseUrl: den.url, requireSignin: false, fromFile: true },
+    });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("resolved");
+    const settings = readDenSettings();
+    expect(settings.authToken).toBe(RETAINED_TOKEN);
+    expect(settings.activeOrgId).toBe(RETAINED_ORG_ID);
+
+    const org = await ensureDenActiveOrganization();
+    expect(org?.id).toBe(RETAINED_ORG_ID);
+    const credentialed = den.credentialed();
+    expect(credentialed.length).toBeGreaterThan(0);
+    expect(credentialed.every((entry) => entry.authorization === `Bearer ${RETAINED_TOKEN}`)).toBe(true);
+  });
+
+  test("a retained session with an unresolved bootstrap issues zero credential-bearing requests", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({ shell: { reads: [{ kind: "fail" }] } });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("unresolved");
+    const settings = readDenSettings();
+    expect(settings.authToken).toBeNull();
+    expect(settings.activeOrgId).toBeNull();
+
+    // The credential-bearing helper the app uses on boot finds no usable session.
+    expect(await ensureDenActiveOrganization()).toBeNull();
+    expect(credentialedFetches()).toEqual([]);
+    expect(den.credentialed()).toEqual([]);
+
+    // The retained session survives quarantine instead of being destroyed.
+    expect(storage.getItem("openwork.den.authToken")).toBe(RETAINED_TOKEN);
+    expect(storage.getItem("openwork.den.activeOrgId")).toBe(RETAINED_ORG_ID);
+  });
+
+  test("a legacy untagged session is also quarantined while the bootstrap is unresolved", async () => {
+    const storage = installWindow({ shell: { reads: [{ kind: "fail" }] } });
+    seedRetainedSession(storage, null);
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("unresolved");
+    expect(readDenSettings().authToken).toBeNull();
+    expect(await ensureDenActiveOrganization()).toBeNull();
+    expect(credentialedFetches()).toEqual([]);
+  });
+
+  test("the unresolved fallback is never persisted as an authoritative hosted selection", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({ shell: { reads: [{ kind: "fail" }] } });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+    expect(getDenBootstrapResolution()).toBe("unresolved");
+    expect(readDenBootstrapConfig().source).toBe("default");
+
+    // A passive settings mirror of the (gated) state must not delete the
+    // quarantined session and must not persist the fallback hosted URL.
+    const gated = readDenSettings();
+    writeDenSettings({ ...gated, authToken: null, activeOrgId: null, activeOrgSlug: null, activeOrgName: null });
+
+    expect(shellWrites).toEqual([]);
+    expect(storage.getItem("openwork.den.baseUrl")).toBeNull();
+    expect(storage.getItem("openwork.den.authToken")).toBe(RETAINED_TOKEN);
+    expect(storage.getItem("openwork.den.activeOrgId")).toBe(RETAINED_ORG_ID);
+    expect(storage.getItem(STORAGE_SESSION_ORIGIN)).toBe(den.origin);
+  });
+
+  test("delayed resolution of the same self-hosted bootstrap re-enables the matching session", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({
+      shell: {
+        reads: [
+          { kind: "fail" },
+          { kind: "fail" },
+          { kind: "config", config: { baseUrl: den.url, apiBaseUrl: den.url, requireSignin: false, fromFile: true } },
+        ],
+      },
+    });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("resolved");
+    expect(readDenBootstrapConfig().baseUrl).toBe(den.url);
+    const settings = readDenSettings();
+    expect(settings.authToken).toBe(RETAINED_TOKEN);
+    expect(settings.activeOrgId).toBe(RETAINED_ORG_ID);
+
+    const org = await ensureDenActiveOrganization();
+    expect(org?.id).toBe(RETAINED_ORG_ID);
+    expect(den.credentialed().length).toBeGreaterThan(0);
+  }, 10_000);
+
+  test("background healing after the quick attempts also restores the session for the proven origin", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({
+      shell: {
+        reads: [
+          { kind: "fail" },
+          { kind: "fail" },
+          { kind: "fail" },
+          { kind: "config", config: { baseUrl: den.url, apiBaseUrl: den.url, requireSignin: false, fromFile: true } },
+        ],
+      },
+    });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+    expect(getDenBootstrapResolution()).toBe("unresolved");
+    expect(readDenSettings().authToken).toBeNull();
+
+    const deadline = Date.now() + 8_000;
+    while (getDenBootstrapResolution() !== "resolved" && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    expect(getDenBootstrapResolution()).toBe("resolved");
+    expect(readDenBootstrapConfig().baseUrl).toBe(den.url);
+    expect(readDenSettings().authToken).toBe(RETAINED_TOKEN);
+  }, 15_000);
+
+  test("resolution to a different origin quarantines the retained token and organization", async () => {
+    const originalDen = startWitness();
+    const otherDen = startWitness();
+    witnesses.push(originalDen, otherDen);
+    const storage = installWindow({
+      shell: {
+        reads: [
+          { kind: "config", config: { baseUrl: otherDen.url, apiBaseUrl: otherDen.url, requireSignin: false, fromFile: true } },
+        ],
+      },
+    });
+    seedRetainedSession(storage, originalDen.origin);
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("resolved");
+    const settings = readDenSettings();
+    expect(settings.baseUrl).toBe(otherDen.url);
+    expect(settings.authToken).toBeNull();
+    expect(settings.activeOrgId).toBeNull();
+
+    expect(await ensureDenActiveOrganization()).toBeNull();
+    expect(otherDen.credentialed()).toEqual([]);
+    expect(originalDen.credentialed()).toEqual([]);
+    expect(credentialedFetches()).toEqual([]);
+
+    // Quarantined, not destroyed: the session revives if its own origin returns.
+    expect(storage.getItem("openwork.den.authToken")).toBe(RETAINED_TOKEN);
+    expect(storage.getItem(STORAGE_SESSION_ORIGIN)).toBe(originalDen.origin);
+  });
+
+  test("a late bootstrap result from an obsolete startup generation cannot replace the current one", async () => {
+    const staleDen = startWitness();
+    const currentDen = startWitness();
+    witnesses.push(staleDen, currentDen);
+    let releaseStaleRead: (config: Record<string, unknown>) => void = () => {};
+    const staleRead = new Promise<Record<string, unknown>>((resolve) => {
+      releaseStaleRead = resolve;
+    });
+    installWindow({ shell: { reads: [{ kind: "defer", promise: staleRead }] } });
+
+    const staleInitialize = initializeDenBootstrapConfig();
+    await setDenBootstrapConfig({ baseUrl: currentDen.url, apiBaseUrl: currentDen.url, requireSignin: false });
+    expect(readDenBootstrapConfig().baseUrl).toBe(currentDen.url);
+
+    releaseStaleRead({ baseUrl: staleDen.url, apiBaseUrl: staleDen.url, requireSignin: false, fromFile: true });
+    await staleInitialize;
+
+    expect(readDenBootstrapConfig().baseUrl).toBe(currentDen.url);
+    expect(readDenBootstrapConfig().apiBaseUrl).toBe(currentDen.url);
+  });
+
+  test("an explicitly configured hosted session keeps working", async () => {
+    const storage = installWindow({
+      shell: {
+        reads: [{ kind: "config", config: { baseUrl: "https://app.openworklabs.com", requireSignin: false, fromFile: true } }],
+      },
+    });
+    storage.setItem("openwork.den.authToken", "hosted-token-1");
+    storage.setItem("openwork.den.activeOrgId", "org_hosted_1");
+    storage.setItem(STORAGE_SESSION_ORIGIN, "https://app.openworklabs.com");
+
+    await initializeDenBootstrapConfig();
+
+    expect(getDenBootstrapResolution()).toBe("resolved");
+    const settings = readDenSettings();
+    expect(settings.baseUrl).toBe("https://app.openworklabs.com");
+    expect(settings.authToken).toBe("hosted-token-1");
+    expect(settings.activeOrgId).toBe("org_hosted_1");
+  });
+
+  test("a resolved bootstrap adopts a legacy untagged session for its proven origin", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({
+      shell: {
+        reads: [{ kind: "config", config: { baseUrl: den.url, apiBaseUrl: den.url, requireSignin: false, fromFile: true } }],
+      },
+    });
+    seedRetainedSession(storage, null);
+
+    await initializeDenBootstrapConfig();
+
+    expect(storage.getItem(STORAGE_SESSION_ORIGIN)).toBe(den.origin);
+    expect(readDenSettings().authToken).toBe(RETAINED_TOKEN);
+  });
+
+  test("local-only startup stays usable with no retained session and an unresolved bootstrap", async () => {
+    installWindow({ shell: { reads: [{ kind: "fail" }] } });
+
+    const config = await initializeDenBootstrapConfig();
+
+    expect(config.baseUrl.length).toBeGreaterThan(0);
+    expect(getDenBootstrapResolution()).toBe("unresolved");
+    const settings = readDenSettings();
+    expect(settings.authToken).toBeNull();
+    expect(await ensureDenActiveOrganization()).toBeNull();
+    expect(credentialedFetches()).toEqual([]);
+  });
+
+  test("sign-out clears the session origin tag together with the session", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({
+      shell: {
+        reads: [{ kind: "config", config: { baseUrl: den.url, apiBaseUrl: den.url, requireSignin: false, fromFile: true } }],
+      },
+    });
+    seedRetainedSession(storage, den.origin);
+    await initializeDenBootstrapConfig();
+
+    clearDenSession();
+
+    expect(storage.getItem("openwork.den.authToken")).toBeNull();
+    expect(storage.getItem(STORAGE_SESSION_ORIGIN)).toBeNull();
+  });
+
+  test("quarantine diagnostics never contain the retained secret", async () => {
+    const den = startWitness();
+    witnesses.push(den);
+    const storage = installWindow({ shell: { reads: [{ kind: "fail" }] } });
+    seedRetainedSession(storage, den.origin);
+
+    await initializeDenBootstrapConfig();
+    readDenSettings();
+
+    expect(consoleLines.length).toBeGreaterThan(0);
+    for (const line of consoleLines) {
+      expect(line).not.toContain(RETAINED_TOKEN);
+    }
+  });
+});

--- a/evals/specs/den-bootstrap-origin-coherence.test.ts
+++ b/evals/specs/den-bootstrap-origin-coherence.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+/**
+ * Desktop bootstrap and retained Den session must stay origin-coherent.
+ *
+ * The renderer suite this spec runs boots the real Den settings module
+ * against deterministic loopback control-plane witnesses (real HTTP servers
+ * that record every Authorization header they receive) and a scriptable shell
+ * bridge, covering the full matrix:
+ *
+ * 1. a valid preload bootstrap resolves immediately and its matching session
+ *    reaches its own origin with a bearer token;
+ * 2. a retained token with an unresolved bootstrap produces zero
+ *    credential-bearing requests to any origin;
+ * 3. the unresolved fallback is never persisted or treated as an
+ *    authoritative hosted selection, and the quarantined session survives;
+ * 4. delayed resolution of the same self-hosted bootstrap (quick retry and
+ *    background heal) re-enables the matching token and organization;
+ * 5. resolution to a different origin quarantines the retained token and
+ *    organization — neither origin receives a credentialed request;
+ * 6. a late bootstrap result from an obsolete startup generation cannot
+ *    replace the current generation;
+ * 7. an explicitly configured hosted session keeps working;
+ * 8. local-only startup stays usable while Den bootstrap is unresolved;
+ * 9. quarantine diagnostics never contain the retained secret.
+ */
+test("desktop bootstrap and retained Den session stay origin-coherent", ({ evidence }) => {
+  const run = spawnSync("pnpm", [
+    "--dir",
+    "apps/app",
+    "exec",
+    "bun",
+    "test",
+    "--isolate",
+    "tests/den-bootstrap-origin-coherence.test.ts",
+  ], { cwd: repoRoot, encoding: "utf8" });
+  const output = `${run.stdout}${run.stderr}`;
+  expect(run.error, output).toBeUndefined();
+  expect(run.status, output).toBe(0);
+  expect(output).toContain("13 pass");
+  expect(output).toContain("0 fail");
+
+  evidence.recordAssertionEvidence(
+    "One resolved enrollment generation owns every credential-bearing Den request",
+    "With deterministic origin witnesses, the retained token only ever reaches the origin recorded as its issuer, and only after the bootstrap resolved to that same origin.",
+    run.status === 0,
+  );
+  evidence.recordAssertionEvidence(
+    "An unresolved or mismatched bootstrap origin receives no credential-bearing request",
+    "While the shell bootstrap is unavailable, and when it resolves to a different origin, the HTTP witnesses record zero requests carrying an Authorization header and the hosted fallback is never persisted as an authoritative selection.",
+    run.status === 0,
+  );
+  evidence.recordAssertionEvidence(
+    "Quarantine is recoverable and local startup stays usable",
+    "The retained session survives quarantine in storage, delayed resolution of its own origin re-enables it, obsolete startup generations are discarded, and logged-out or local-only startup completes without Den authentication.",
+    run.status === 0,
+  );
+});


### PR DESCRIPTION
## Problem

On Desktop, a user connected to a self-hosted OpenWork server could reopen the app and have it briefly treat their organization server as the hosted default. If the Electron shell's bootstrap bridge was missing, delayed, or failing at first paint, the renderer fell back to `https://app.openworklabs.com` while localStorage still held the bearer token and active organization from the prior self-hosted session. The result was an invalid mixed state: hosted/fallback base URL, self-hosted token, self-hosted organization — and any Den feature that woke up in that window could send the retained credentials to an origin that never issued them.

This is a source-confirmed unsafe state transition: the fallback path in `initializeDenBootstrapConfig()` installed the hosted default as a fully "resolved-looking" bootstrap while `readDenSettings()` independently kept exposing the retained token and organization from storage. No production incident is claimed.

## Root cause

Bootstrap resolution and retained-session hydration were independently authoritative:

- the shell-read fallback produced a config indistinguishable from a genuinely resolved hosted selection, and
- `readDenSettings()` unconditionally attached the stored token/org to whatever base URL the bootstrap snapshot currently held,

with nothing recording which origin issued the retained token and nothing guarding late async bootstrap results from earlier startup attempts.

## Invariant

The Den base URL, bearer token, active organization, and bootstrap generation used for a credential-bearing operation must belong to one coherent, successfully resolved enrollment generation. When origin coherence is unknown, local workspace startup continues, Den-dependent authenticated operations stay unavailable, and retained credentials are sent nowhere.

## Solution

- **Explicit resolution state.** The bootstrap snapshot is now `resolved` (preload snapshot, shell IPC read, or explicit persist) or `unresolved` (in-memory fallback while the bridge is unavailable). The fallback is a recovery placeholder, never an authoritative hosted selection, and is still never persisted.
- **Session origin tag.** `writeDenSettings()` records the issuing control-plane origin (`openwork.den.sessionOrigin`) next to the token; `clearDenSession()` removes it. Legacy untagged sessions are adopted for the origin the bootstrap actually resolves to, at authoritative boot-time resolution only.
- **One credential gate.** `readDenSettings()` — the single choke point every Den credential consumer already uses — withholds the token and organization whenever the bootstrap is unresolved or resolved to a different origin than the one recorded with the token. Quarantine hides credentials without deleting them, and passive writes cannot delete a session they never saw; the session revives when its own origin resolves (including via the delayed background heal, which notifies listeners).
- **Startup generation guard.** A monotonic generation counter ties each async bootstrap resolution (quick retries, background heal, shell refresh) to the startup attempt that began it; explicit persists retire in-flight generations, so a late result from an obsolete boot can never replace the current config.
- **Sanitized diagnostics.** State transitions log fixed strings only — no tokens, cookies, grants, or URLs.

## Preservation

- A valid preload bootstrap remains the immediate fast path.
- Genuinely configured hosted sessions keep working, including while the bridge is briefly down (their recorded origin matches the fallback origin).
- Genuinely configured self-hosted sessions keep working and re-enable automatically once their own bootstrap resolves.
- Local workspace startup is not blocked while Den bootstrap recovery is pending; logged-out and local-only users see no Den authentication.
- Compatible retained state is never discarded: quarantine is storage-preserving and legacy sessions are adopted, not dropped.

## Proof

| Check | Command | Verdict |
| --- | --- | --- |
| Testkit proof (exact head, local lane) | `pnpm --dir evals exec vitest run --config vitest.config.ts specs/den-bootstrap-origin-coherence.test.ts` | Passed |
| Focused matrix suite (13 tests, HTTP witnesses) | `pnpm --dir apps/app exec bun test --isolate tests/den-bootstrap-origin-coherence.test.ts` | Passed |
| App unit suite | `pnpm --filter @openwork/app exec bun test --isolate tests/` | 872 pass; same 7 pre-existing failures also fail on the base commit (verified before this change) |
| App typecheck | `pnpm --filter @openwork/app run typecheck` | Passed |
| Evals PR lane | `pnpm evals:pr` | 40 passed, 2 named skips; `world-attach.test.ts` failed once on a parallel den-db asset-build race (`ENOTEMPTY` in `build-assets.mjs`, unrelated) and passed on isolated rerun |
| Adjacent credential-coherence spec | `pnpm --dir evals exec vitest run --config vitest.config.ts specs/desktop-server-credential-coherence.test.ts` | Passed |

The testkit spec drives the real Den settings module against deterministic loopback control-plane witnesses — real HTTP servers that record every `Authorization` header they receive — plus a scriptable shell bridge and a main-process fetch seam that records what would leave the machine for non-loopback origins.

## Negative proof

With a retained self-hosted token and an unresolved bootstrap, the witnesses record **zero** requests carrying an `Authorization` header to any origin, and the recorded main-process egress shows none addressed to the hosted fallback. When the bootstrap resolves to a *different* origin than the token's issuer, neither origin receives a credential-bearing request, while the quarantined session provably survives in storage.

## Risk and rollback

- Compatibility: pre-existing sessions have no origin tag; they are adopted at the first authoritative bootstrap resolution, matching the origin those builds already used. Until resolution succeeds, a legacy session is quarantined instead of being sent to an unproven origin — that withholding is the intended behavior change.
- Blast radius is one module (`apps/app/src/app/lib/den.ts`); all gating flows through `readDenSettings()`/`writeDenSettings()`. Rolling back this commit restores prior behavior; the extra `openwork.den.sessionOrigin` key is ignored by older builds.

## Scope exclusions

This PR does not redesign cross-server handoff, general desktop-policy convergence, deployment, or release behavior. It only enforces origin coherence between the desktop bootstrap and the retained Den session.
