### PR TITLE
fix(app): validate each conversation's own model for availability

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/model-availability.ts
+++ b/apps/app/src/react-app/domains/session/surface/model-availability.ts
@@ -1,0 +1,107 @@
+// Availability of one provider/model identity against the active workspace's
+// provider catalogs. The route builds a resolver from its catalog state and
+// each composer (an existing conversation or the New Task default) evaluates
+// its OWN effective model through it, so a missing global default can never
+// disable a conversation that remembers a different, valid model — and vice
+// versa. `pending` is explicit: an unsettled catalog (still loading, cloud
+// provider sync incomplete, or superseded by a workspace switch) never
+// produces a definitive "unavailable" verdict.
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import {
+  isDesktopProviderBlocked,
+  type DesktopAppRestrictionChecker,
+} from "@/app/cloud/desktop-app-restrictions";
+import type { ModelRef } from "@/app/types";
+import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
+import { isManagedModelAvailabilityPending } from "@/react-app/domains/connections/provider-auth/managed-models-recovery";
+import { isModelAvailableInConnectedProviders } from "@/react-app/infra/provider-list-query";
+
+export type ModelUnavailableReason =
+  | "provider_blocked"
+  | "provider_not_connected"
+  | "model_missing";
+
+export type ModelAvailability =
+  | { status: "pending" }
+  | { status: "available" }
+  | { status: "unavailable"; reason: ModelUnavailableReason };
+
+export type ModelAvailabilityResolver = (model: ModelRef | null) => ModelAvailability;
+
+export type ModelAvailabilityContext = {
+  /** Workspace + engine client are resolved (route is not still booting). */
+  workspaceReady: boolean;
+  /** Route-level loading flag; nothing is settled while it is true. */
+  loading: boolean;
+  signedIn: boolean;
+  /** Cloud provider sync completed for the CURRENT workspace/org context. */
+  cloudProviderSyncReady: boolean;
+  openWorkModelsSyncing: boolean;
+  /** Org policy restricts members to cloud-managed providers. */
+  restrictToCloud: boolean;
+  checkRestriction: DesktopAppRestrictionChecker;
+  /** Settled cloud-managed catalog for the current context, if any. */
+  cloudProviderList: ProviderListResponse | null;
+  /**
+   * Provider catalog for the current workspace (query keyed by server +
+   * directory). `null`/`undefined` means the catalog has not settled for this
+   * context yet — a stale catalog from a previous workspace never appears
+   * here because the query key changes with the workspace.
+   */
+  providerList: ProviderListResponse | null | undefined;
+};
+
+export function computeModelAvailability(
+  model: ModelRef | null | undefined,
+  context: ModelAvailabilityContext,
+): ModelAvailability {
+  if (!context.workspaceReady || context.loading) return { status: "pending" };
+  if (!model?.providerID?.trim() || !model.modelID?.trim()) {
+    // No selection to validate: never claim a model is unavailable.
+    return { status: "pending" };
+  }
+
+  const providerId = model.providerID.trim();
+  const usesCloudProvider = isCloudManagedProviderKey(providerId);
+  if (
+    isManagedModelAvailabilityPending({
+      signedIn: context.signedIn,
+      selectedModelUsesCloudProvider: usesCloudProvider,
+      cloudProviderSyncReady: context.cloudProviderSyncReady,
+      openWorkModelsSyncing: context.openWorkModelsSyncing,
+    })
+  ) {
+    return { status: "pending" };
+  }
+  if (usesCloudProvider && !context.cloudProviderSyncReady) return { status: "pending" };
+
+  // Desktop policy blocks are definitive regardless of catalog state.
+  if (
+    isDesktopProviderBlocked({
+      providerId,
+      checkRestriction: context.checkRestriction,
+    })
+  ) {
+    return { status: "unavailable", reason: "provider_blocked" };
+  }
+
+  const providerList = usesCloudProvider ? context.cloudProviderList : context.providerList;
+  if (!providerList) {
+    // Catalog not settled for the current context: pending, not unavailable.
+    return { status: "pending" };
+  }
+
+  if (
+    context.restrictToCloud &&
+    !providerList.connected.some((connectedId) => connectedId.trim() === providerId)
+  ) {
+    return { status: "unavailable", reason: "provider_not_connected" };
+  }
+
+  if (!isModelAvailableInConnectedProviders(providerList, model)) {
+    return { status: "unavailable", reason: "model_missing" };
+  }
+
+  return { status: "available" };
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -43,6 +43,7 @@ import type {
 import { ReactSessionComposer } from "./composer/composer";
 import { useSessionModelSelection } from "./session-model-store";
 import type { ProviderCatalog } from "./use-model-behavior";
+import type { ModelAvailability } from "./model-availability";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
@@ -309,6 +310,13 @@ export type SessionSurfaceProps = {
   modelPickerOpen: boolean;
   modelUnavailable?: boolean;
   modelUnavailableMessage?: string | null;
+  /**
+   * Resolves availability for one provider/model identity against the active
+   * workspace's settled catalogs. Each surface validates its OWN effective
+   * session model with it instead of inheriting the route-global default
+   * verdict; `props.modelUnavailable` is only the fallback when absent.
+   */
+  resolveModelAvailability?: (model: ModelRef | null) => ModelAvailability;
   organizationModelsEmpty?: boolean;
   selectedModel: ModelRef;
   /** providerID → modelID → provider model, for per-session variant options. */
@@ -733,6 +741,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleOpenModelPicker = useCallback(() => {
     props.onModelClick(props.sessionId);
   }, [props.onModelClick, props.sessionId]);
+  // Availability is scoped to THIS conversation's effective model. A missing
+  // global default must not disable a conversation that remembers a valid
+  // model, and a pending catalog (loading or superseded by a workspace
+  // switch) never renders "Model no longer available".
+  const sessionModelUnavailable = props.resolveModelAvailability
+    ? props.resolveModelAvailability(sessionModel.selectedModel).status === "unavailable"
+    : Boolean(props.modelUnavailable);
   const [error, setError] = useState<SessionError | null>(null);
   const [restoringRevertedMessages, setRestoringRevertedMessages] = useState(false);
   const [showDelayedLoading, setShowDelayedLoading] = useState(false);
@@ -1234,11 +1249,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     if (model.transitionState !== "idle") return;
     if (chatStreaming) return;
-    if (props.modelUnavailable) return;
+    if (sessionModelUnavailable) return;
     if (!draft.trim()) return;
     if (!consumeComposerAutoSend(props.sessionId)) return;
     void handleSend();
-  }, [chatStreaming, draft, handleSend, model.transitionState, props.modelUnavailable, props.sessionId]);
+  }, [chatStreaming, draft, handleSend, model.transitionState, sessionModelUnavailable, props.sessionId]);
 
   const handleSteer = useCallback(async () => {
     setSteering(true);
@@ -1555,13 +1570,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Send the composer prompt",
     description: "Send the currently visible composer draft to the active session.",
     sideEffect: "mutation",
-    disabled: props.modelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
+    disabled: sessionModelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
     targetRef: composerShellRef,
     execute: async () => {
       await handleSend();
       return true;
     },
-  }), [attachments.length, draft, handleSend, model.transitionState, props.modelUnavailable]);
+  }), [attachments.length, draft, handleSend, model.transitionState, sessionModelUnavailable]);
   useControlAction(props.isControlTarget ? composerSendControlAction : null);
 
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -2165,9 +2180,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
         steering={steering}
         submissionPreparing={preparingCloudTools}
         queuedCount={queuedItems.length}
-        disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
-        modelUnavailable={Boolean(props.modelUnavailable)}
-        modelUnavailableMessage={props.modelUnavailableMessage}
+        disabled={model.transitionState !== "idle" || sessionModelUnavailable}
+        modelUnavailable={sessionModelUnavailable}
+        modelUnavailableMessage={sessionModelUnavailable ? props.modelUnavailableMessage : null}
         organizationModelsEmpty={props.organizationModelsEmpty}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
         modelPickerOpen={modelPickerOpen}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -112,6 +112,7 @@ import { firstLineLocalFileParts, joinWorkspaceRelativePath, toFileUrl } from "@
 import { composerAttachmentsToWorkspaceFileParts } from "@/react-app/domains/session/sync/attachment-file-part";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
+import { computeModelAvailability, type ModelAvailability } from "@/react-app/domains/session/surface/model-availability";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { getSessionModelSelection, useSessionModelStore } from "@/react-app/domains/session/surface/session-model-store";
@@ -227,7 +228,6 @@ import { writeStoredDefaultModel } from "@/react-app/kernel/model-config";
 import {
   ensureProviderListQuery,
   getConnectedProviderItems,
-  isModelAvailableInConnectedProviders,
   refreshProviderListQueries,
   useProviderListQuery,
 } from "@/react-app/infra/provider-list-query";
@@ -1042,9 +1042,6 @@ export function SessionRoute() {
   const selectedModelUsesCloudProvider = Boolean(
     local.prefs.defaultModel && isCloudManagedProviderKey(local.prefs.defaultModel.providerID),
   );
-  const selectedModelProviderList = selectedModelUsesCloudProvider
-    ? cloudProviderList
-    : providerListQuery.data;
   const entitledOrgDefaultModel = useMemo(() => {
     const runtimeOptions = providerListModelEntitlementOptions(
       cloudProviderList ?? providerListQuery.data,
@@ -1074,38 +1071,60 @@ export function SessionRoute() {
     cloudProviderSyncReady,
     openWorkModelsSyncing,
   });
-  const selectedModelUnavailable = Boolean(
-    selectedWorkspaceId &&
-      opencodeClient &&
-      !loading &&
-      !selectedModelAvailabilityPending &&
-      local.prefs.defaultModel &&
-      (!selectedModelUsesCloudProvider || cloudProviderSyncReady) &&
-      (
-        isDesktopProviderBlocked({
-          providerId: local.prefs.defaultModel.providerID,
-          checkRestriction: checkDesktopRestriction,
-        }) ||
-        (
-          selectedModelProviderList &&
-          restrictToCloudProviders &&
-          !selectedModelProviderList.connected.some(
-            (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
-          )
-        ) ||
-        (
-          selectedModelProviderList &&
-          !isModelAvailableInConnectedProviders(selectedModelProviderList, local.prefs.defaultModel)
-        )
-      ),
+  // Availability is resolved per effective model identity: the New Task
+  // composer validates the global default while each conversation validates
+  // its OWN remembered provider/model against the current workspace's
+  // catalogs. The provider-list query is keyed by server + workspace
+  // directory, so a workspace switch supersedes the old catalog (the new key
+  // reads as unsettled → pending) instead of judging the new workspace with
+  // stale data.
+  const resolveModelAvailability = useCallback((model: ModelRef | null): ModelAvailability =>
+    computeModelAvailability(model, {
+      workspaceReady: Boolean(selectedWorkspaceId && opencodeClient),
+      loading,
+      signedIn: denAuth.isSignedIn,
+      cloudProviderSyncReady,
+      openWorkModelsSyncing,
+      restrictToCloud: restrictToCloudProviders,
+      checkRestriction: checkDesktopRestriction,
+      cloudProviderList,
+      providerList: providerListQuery.data,
+    }), [
+    checkDesktopRestriction,
+    cloudProviderList,
+    cloudProviderSyncReady,
+    denAuth.isSignedIn,
+    loading,
+    opencodeClient,
+    openWorkModelsSyncing,
+    providerListQuery.data,
+    restrictToCloudProviders,
+    selectedWorkspaceId,
+  ]);
+  const selectedModelUnavailable =
+    resolveModelAvailability(local.prefs.defaultModel ?? null).status === "unavailable";
+  // The composer the user is looking at: the selected conversation's
+  // remembered model when it has one, otherwise the global default.
+  const selectedSessionModelSelection = useSessionModelStore((state) =>
+    (selectedSessionId ? state.bySessionId[selectedSessionId] ?? null : null),
   );
-  const selectedModelUnavailableKey = selectedModelUnavailable && local.prefs.defaultModel
-    ? `${local.prefs.defaultModel.providerID}:${local.prefs.defaultModel.modelID}`
+  const activeComposerModel = selectedSessionModelSelection?.model ?? local.prefs.defaultModel ?? null;
+  const activeComposerAvailability = resolveModelAvailability(activeComposerModel);
+  const activeComposerTargetsSession = Boolean(selectedSessionModelSelection && selectedSessionId);
+  const selectedModelUnavailableKey = activeComposerAvailability.status === "unavailable" && activeComposerModel
+    ? `${activeComposerTargetsSession ? selectedSessionId : "default"}:${activeComposerModel.providerID}:${activeComposerModel.modelID}`
     : null;
   const autoOpenedUnavailableModelRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!selectedModelUnavailableKey) {
+      // The active composer's model is fine (or pending). If the picker was
+      // auto-opened for a previously broken composer — e.g. the New Task
+      // default — do not let that recovery modal follow the user into a
+      // conversation whose own model is valid.
+      if (autoOpenedUnavailableModelRef.current) {
+        modelPicker.setOpen(false);
+      }
       autoOpenedUnavailableModelRef.current = null;
       return;
     }
@@ -1113,21 +1132,25 @@ export function SessionRoute() {
       selectedModelUnavailableKey,
       signedIn: denAuth.isSignedIn,
       cloudProviderSyncReady,
-      entitledOrgDefaultModel: Boolean(entitledOrgDefaultModel),
+      // Silent default repair only applies when the broken selection IS the
+      // default; a conversation's own unavailable model must surface the
+      // picker for that conversation instead.
+      entitledOrgDefaultModel: activeComposerTargetsSession ? false : Boolean(entitledOrgDefaultModel),
       organizationModelsEmpty,
       autoOpenedUnavailableModelKey: autoOpenedUnavailableModelRef.current,
     })) return;
-    if (entitledOrgDefaultModel) {
+    if (!activeComposerTargetsSession && entitledOrgDefaultModel) {
       writeStoredDefaultModel(entitledOrgDefaultModel);
       return;
     }
 
     autoOpenedUnavailableModelRef.current = selectedModelUnavailableKey;
+    setModelPickerSessionId(activeComposerTargetsSession ? selectedSessionId : null);
     modelPicker.setQuery("");
     modelPicker.setRecentProviderIds(new Set());
     modelPicker.setCompactOpen(false);
     modelPicker.setOpen(true);
-  }, [cloudProviderSyncReady, denAuth.isSignedIn, entitledOrgDefaultModel, modelPicker.setCompactOpen, modelPicker.setOpen, modelPicker.setQuery, modelPicker.setRecentProviderIds, organizationModelsEmpty, selectedModelUnavailableKey]);
+  }, [activeComposerTargetsSession, cloudProviderSyncReady, denAuth.isSignedIn, entitledOrgDefaultModel, modelPicker.setCompactOpen, modelPicker.setOpen, modelPicker.setQuery, modelPicker.setRecentProviderIds, organizationModelsEmpty, selectedModelUnavailableKey, selectedSessionId]);
 
   const hasUsableModel = Boolean(
     local.prefs.defaultModel &&
@@ -1325,8 +1348,11 @@ export function SessionRoute() {
       },
       providerCatalog,
       modelPickerOpen: modelPicker.compactOpen,
+      // Legacy fallback only; each surface resolves availability for its own
+      // effective session model through `resolveModelAvailability`.
       modelUnavailable: selectedModelUnavailable,
       modelUnavailableMessage,
+      resolveModelAvailability,
       organizationModelsEmpty,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       openWorkModelsEntitled,
@@ -1369,7 +1395,11 @@ export function SessionRoute() {
         const sessionModelSelection = getSessionModelSelection(targetSessionId);
         const sendModel = sessionModelSelection?.model ?? local.prefs.defaultModel;
         const sendVariant = sessionModelSelection ? sessionModelSelection.variant : modelVariantValue;
-        if (!sessionModelSelection && selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
+        // Send-time validation targets the exact provider/model identity this
+        // conversation displays and will submit — not the global default.
+        if (resolveModelAvailability(sendModel ?? null).status === "unavailable") {
+          throw new Error("Selected model is unavailable. Choose another model before sending.");
+        }
 
         return submitWithCloudMcpReadiness({
           // Temporarily bypass the pre-send Cloud MCP gate: it blocks every
@@ -1599,6 +1629,7 @@ export function SessionRoute() {
     openWorkModelsSyncing,
     refreshCloudProviderSync,
     refreshOrganizationModelAccess,
+    resolveModelAvailability,
     opencodeBaseUrl,
     opencodeClient,
     providerConnectedIds,
@@ -2007,8 +2038,11 @@ export function SessionRoute() {
   }, [navigateToWorkspaceSession, selectedWorkspaceId]);
 
   const openModelPickerForControl = useCallback(() => {
+    // Opened while a conversation is visible: target that conversation so the
+    // picker's checkmark and the selection it writes match the composer.
+    setModelPickerSessionId(selectedSessionId || null);
     modelPicker.setOpen(true);
-  }, []);
+  }, [selectedSessionId]);
 
   useSessionControlActions({
     workspaces,
@@ -2031,11 +2065,15 @@ export function SessionRoute() {
     return {
       id: "eval.model_not_available.seed",
       label: "Seed an unavailable selected model",
-      description: "Dev-only eval hook that selects a missing model and returns an available model to recover with.",
+      description: "Dev-only eval hook that selects a missing model and returns an available model to recover with. scope=default leaves the open conversation's remembered model untouched.",
       sideEffect: "mutation",
       disabled: !opencodeClient,
-      execute: async () => {
+      args: [{ name: "scope", type: "string", description: "default | both (default: both)" }],
+      execute: async (args) => {
         if (!opencodeClient) return { ok: false, error: "OpenCode client is not connected." };
+        const scope = (args && typeof args === "object" && Reflect.get(args, "scope") === "default")
+          ? "default"
+          : "both";
 
         const providerList = await ensureProviderListQuery(getReactQueryClient(), {
           client: opencodeClient,
@@ -2067,8 +2105,15 @@ export function SessionRoute() {
           defaultModel: unavailableModel,
           modelVariant: null,
         }));
+        // Per-conversation memory is session-scoped: seeding "both" makes the
+        // open conversation's own model unavailable; "default" reproduces the
+        // workspace-switch state where only the global default is missing.
+        if (scope === "both" && selectedSessionId) {
+          useSessionModelStore.getState().setModel(selectedSessionId, unavailableModel, null);
+        }
 
         return {
+          scope,
           unavailableModel,
           availableModel: {
             providerID: availableProvider.id,
@@ -2661,7 +2706,11 @@ export function SessionRoute() {
       environmentClient={client}
       openworkServerToken={selectedWorkspaceServerToken}
       developerMode={developerMode}
-      headerStatus={canCreateTask ? t("status.connected") : (modelUnavailableMessage ?? t("session.loading_detail"))}
+      headerStatus={
+        canCreateTask || (activeComposerTargetsSession && !selectedWorkspaceError && activeComposerAvailability.status === "available")
+          ? t("status.connected")
+          : (modelUnavailableMessage ?? t("session.loading_detail"))
+      }
       busyHint={organizationModelsEmpty ? t("models.organization_models_empty") : effectiveLoading ? t("session.loading_detail") : null}
       startupPhase={effectiveLoading ? "nativeInit" : "ready"}
       providerConnectedIds={providerConnectedIds}
@@ -3013,6 +3062,7 @@ export function SessionRoute() {
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
       onOpenExtensions={() => handleOpenExtensions()}
       onOpenModelPicker={() => {
+        setModelPickerSessionId(selectedSessionId || null);
         modelPicker.setQuery("");
         modelPicker.setRecentProviderIds(new Set());
         window.requestAnimationFrame(() => modelPicker.setOpen(true));
@@ -3058,7 +3108,15 @@ export function SessionRoute() {
 
       query={modelPicker.query}
       setQuery={modelPicker.setQuery}
-      subtitle={selectedModelUnavailable ? MODEL_PICKER_UNAVAILABLE_SUBTITLE : undefined}
+      subtitle={
+        resolveModelAvailability(
+          (modelPickerSessionId ? getSessionModelSelection(modelPickerSessionId)?.model : null)
+            ?? local.prefs.defaultModel
+            ?? null,
+        ).status === "unavailable"
+          ? MODEL_PICKER_UNAVAILABLE_SUBTITLE
+          : undefined
+      }
       target="default"
       current={
         (modelPickerSessionId ? getSessionModelSelection(modelPickerSessionId)?.model : null)
@@ -3122,7 +3180,7 @@ export function SessionRoute() {
         modelPicker.setOpen(false);
         handleOpenSettings("/settings/general");
       }}
-      onClose={() => { modelPicker.setOpen(false); modelPicker.setRecentProviderIds(new Set()); }}
+      onClose={() => { modelPicker.setOpen(false); modelPicker.setRecentProviderIds(new Set()); setModelPickerSessionId(null); }}
       openWorkModelsEntitled={openWorkModelsEntitled}
       openWorkModelsSyncing={openWorkModelsSyncing}
       onRefreshOrganizationModels={refreshOrganizationModelAccess}

--- a/apps/app/tests/model-availability.test.ts
+++ b/apps/app/tests/model-availability.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import type { ProviderListItem } from "../src/app/types";
+import {
+  computeModelAvailability,
+  type ModelAvailabilityContext,
+} from "../src/react-app/domains/session/surface/model-availability";
+
+function provider(id: string, modelIds: string[]): ProviderListItem {
+  return {
+    id,
+    name: id,
+    source: "config",
+    env: [],
+    models: Object.fromEntries(modelIds.map((modelId) => [modelId, { name: modelId }])),
+  } as unknown as ProviderListItem;
+}
+
+function catalog(providers: Array<{ id: string; models: string[] }>): ProviderListResponse {
+  return {
+    all: providers.map((entry) => provider(entry.id, entry.models)),
+    connected: providers.map((entry) => entry.id),
+    default: {},
+  } as unknown as ProviderListResponse;
+}
+
+function context(overrides: Partial<ModelAvailabilityContext> = {}): ModelAvailabilityContext {
+  return {
+    workspaceReady: true,
+    loading: false,
+    signedIn: false,
+    cloudProviderSyncReady: false,
+    openWorkModelsSyncing: false,
+    restrictToCloud: false,
+    checkRestriction: () => false,
+    cloudProviderList: null,
+    providerList: catalog([
+      { id: "anthropic", models: ["claude-fable-5"] },
+      { id: "openai", models: ["gpt-5.5"] },
+    ]),
+    ...overrides,
+  };
+}
+
+const sessionModel = { providerID: "anthropic", modelID: "claude-fable-5" };
+const defaultModel = { providerID: "openai", modelID: "gpt-5.5" };
+
+describe("computeModelAvailability", () => {
+  test("a model present in the settled catalog is available", () => {
+    expect(computeModelAvailability(sessionModel, context())).toEqual({ status: "available" });
+  });
+
+  test("a session model stays available when the global default is missing", () => {
+    const shared = context({
+      providerList: catalog([{ id: "anthropic", models: ["claude-fable-5"] }]),
+    });
+    expect(computeModelAvailability(sessionModel, shared)).toEqual({ status: "available" });
+    expect(computeModelAvailability(defaultModel, shared)).toEqual({
+      status: "unavailable",
+      reason: "model_missing",
+    });
+  });
+
+  test("a genuinely missing session model is unavailable while the default stays available", () => {
+    const shared = context({
+      providerList: catalog([{ id: "openai", models: ["gpt-5.5"] }]),
+    });
+    expect(computeModelAvailability(sessionModel, shared)).toEqual({
+      status: "unavailable",
+      reason: "model_missing",
+    });
+    expect(computeModelAvailability(defaultModel, shared)).toEqual({ status: "available" });
+  });
+
+  test("an unsettled catalog is pending, never unavailable", () => {
+    expect(computeModelAvailability(sessionModel, context({ providerList: undefined }))).toEqual({
+      status: "pending",
+    });
+    expect(computeModelAvailability(sessionModel, context({ providerList: null }))).toEqual({
+      status: "pending",
+    });
+  });
+
+  test("a workspace that is still booting is pending", () => {
+    expect(computeModelAvailability(sessionModel, context({ workspaceReady: false }))).toEqual({
+      status: "pending",
+    });
+    expect(computeModelAvailability(sessionModel, context({ loading: true }))).toEqual({
+      status: "pending",
+    });
+  });
+
+  test("no selection to validate is pending", () => {
+    expect(computeModelAvailability(null, context())).toEqual({ status: "pending" });
+    expect(
+      computeModelAvailability({ providerID: "", modelID: "" }, context()),
+    ).toEqual({ status: "pending" });
+  });
+
+  test("a cloud-managed model is pending until cloud provider sync settles", () => {
+    const cloudModel = { providerID: "lpr_org_provider", modelID: "gpt-5.5" };
+    expect(
+      computeModelAvailability(cloudModel, context({ signedIn: true, cloudProviderSyncReady: false })),
+    ).toEqual({ status: "pending" });
+    expect(
+      computeModelAvailability(
+        cloudModel,
+        context({
+          signedIn: true,
+          cloudProviderSyncReady: true,
+          cloudProviderList: catalog([{ id: "lpr_org_provider", models: ["gpt-5.5"] }]),
+        }),
+      ),
+    ).toEqual({ status: "available" });
+    expect(
+      computeModelAvailability(
+        cloudModel,
+        context({
+          signedIn: true,
+          cloudProviderSyncReady: true,
+          cloudProviderList: catalog([{ id: "lpr_other", models: ["gpt-5.5"] }]),
+        }),
+      ),
+    ).toEqual({ status: "unavailable", reason: "model_missing" });
+  });
+
+  test("cloud sync while OpenWork Models is reconciling stays pending", () => {
+    const cloudModel = { providerID: "openwork", modelID: "gpt-5.5" };
+    expect(
+      computeModelAvailability(
+        cloudModel,
+        context({ signedIn: true, cloudProviderSyncReady: true, openWorkModelsSyncing: true }),
+      ),
+    ).toEqual({ status: "pending" });
+  });
+
+  test("a policy-blocked provider is unavailable even while the catalog loads", () => {
+    expect(
+      computeModelAvailability(
+        { providerID: "opencode", modelID: "grok-code" },
+        context({
+          providerList: undefined,
+          checkRestriction: ({ restriction }) => restriction === "allowZenModel",
+        }),
+      ),
+    ).toEqual({ status: "unavailable", reason: "provider_blocked" });
+  });
+
+  test("restrict-to-cloud marks non-connected custom providers unavailable", () => {
+    expect(
+      computeModelAvailability(
+        sessionModel,
+        context({
+          restrictToCloud: true,
+          providerList: catalog([{ id: "openai", models: ["gpt-5.5"] }]),
+        }),
+      ),
+    ).toEqual({ status: "unavailable", reason: "provider_not_connected" });
+  });
+
+  test("a disconnected provider's model is unavailable in a settled catalog", () => {
+    const list = catalog([
+      { id: "anthropic", models: ["claude-fable-5"] },
+    ]);
+    (list as { connected: string[] }).connected = [];
+    expect(computeModelAvailability(sessionModel, context({ providerList: list }))).toEqual({
+      status: "unavailable",
+      reason: "model_missing",
+    });
+  });
+});

--- a/evals/specs/session-model-availability.e2e.test.ts
+++ b/evals/specs/session-model-availability.e2e.test.ts
@@ -1,0 +1,190 @@
+// A conversation's remembered model must be validated as ITSELF against the
+// active workspace's settled catalog. Regression: after a workspace switch,
+// route-level availability judged every conversation by the global default —
+// a conversation displaying a valid remembered model was disabled with a
+// false "Model no longer available" banner, its picker checkmark sat on the
+// default, and Retry could not recover.
+import { expect, test } from "vitest";
+import type { Surface } from "@openwork/cdp";
+import { createVisualEvidence, screenshot, validate } from "@openwork/test-evidence";
+import { desktop } from "@openwork/hosts";
+import {
+  createAndSelectWorkspace,
+  evalIn,
+  readAvailableModels,
+  readComposerState,
+  selectModel,
+  waitFor,
+  waitForText,
+  writeComposerText,
+} from "@openwork/behaviors";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "a conversation keeps its remembered model when the global default disappears across a workspace switch"
+  : "session model availability skipped: set OPENWORK_EVAL_E2E_TESTS=1 to opt in";
+const warning = "Model no longer available";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function executeControl(app: Surface, action: string, args?: unknown): Promise<unknown> {
+  const value = await evalIn(
+    app,
+    `window.__openworkControl.execute(${JSON.stringify(action)}, ${JSON.stringify(args ?? null)})`,
+    { awaitPromise: true },
+  );
+  if (!isRecord(value) || value.ok !== true) {
+    throw new Error(`Control action ${action} failed: ${JSON.stringify(value)}`);
+  }
+  return value.result;
+}
+
+async function createConversation(app: Surface): Promise<string> {
+  await waitFor(app, `window.__openworkControl?.listActions().some((entry) => entry.id === "session.create_task" && entry.disabled === false)`, {
+    timeoutMs: 90_000,
+    label: "session.create_task enabled",
+  });
+  const sessionId = await executeControl(app, "session.create_task");
+  if (typeof sessionId !== "string" || !sessionId) throw new Error("Task creation did not return a session id.");
+  await waitFor(app, `window.location.hash.includes(${JSON.stringify(sessionId)})`, {
+    timeoutMs: 60_000,
+    label: "created conversation opened",
+  });
+  return sessionId;
+}
+
+async function closeModelPicker(app: Surface): Promise<void> {
+  await evalIn(app, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    if (!dialog) return true;
+    const done = [...dialog.querySelectorAll("button")].find((button) => (button.textContent ?? "").trim() === "Done");
+    if (done) { done.click(); return true; }
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    return true;
+  })()`);
+  await waitFor(app, `!Boolean(document.querySelector('input[placeholder="Search providers and models..."]'))`, {
+    timeoutMs: 30_000,
+    label: "Models dialog closed",
+  });
+}
+
+test.skipIf(!e2eTestsEnabled)(title, async () => {
+  await using app = await desktop({ name: "session-model-availability" });
+  await using visualEvidence = createVisualEvidence("session-model-availability");
+  const stamp = Date.now();
+
+  // Workspace A with a conversation that remembers its own model.
+  const { workspaceId: workspaceA } = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-session-model-a-${stamp}`,
+  });
+  const conversationA = await createConversation(app);
+
+  let models = await readAvailableModels(app);
+  const catalogDeadline = Date.now() + 90_000;
+  while (models.length === 0 && Date.now() < catalogDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    models = await readAvailableModels(app);
+  }
+  const rememberedModel = models.find((candidate) => candidate.selectable);
+  expect(rememberedModel).toBeTruthy();
+  if (!rememberedModel) throw new Error("No selectable model was returned.");
+  const selected = await selectModel(app, rememberedModel.id);
+  expect(selected.id).toBe(rememberedModel.id);
+
+  // Workspace B: switching re-keys the provider catalog context.
+  await executeControl(app, "workspace.create", { path: `/tmp/openwork-session-model-b-${stamp}` });
+  await waitFor(app, `(() => {
+    try {
+      const active = localStorage.getItem("openwork.react.activeWorkspace") ?? "";
+      return active !== "" && active !== ${JSON.stringify(workspaceA)};
+    } catch { return false; }
+  })()`, { timeoutMs: 120_000, label: "workspace B selected" });
+
+  // Break ONLY the global default while workspace B is active; conversation
+  // A's remembered selection is untouched.
+  const seeded = await executeControl(app, "eval.model_not_available.seed", { scope: "default" });
+  if (!isRecord(seeded) || !isRecord(seeded.unavailableModel)) {
+    throw new Error(`Seed returned malformed facts: ${JSON.stringify(seeded)}`);
+  }
+
+  // Switch back into workspace A's conversation.
+  await executeControl(app, "session.open", { sessionId: conversationA });
+  await waitFor(app, `window.location.hash.includes(${JSON.stringify(conversationA)})`, {
+    timeoutMs: 60_000,
+    label: "conversation A reopened",
+  });
+  await writeComposerText(app, "Remembered model survives the workspace switch.");
+
+  // The conversation validates its OWN model: the composer must stay usable
+  // and no false unavailable banner may appear once the catalog settles.
+  await waitFor(app, `(() => {
+    const run = [...document.querySelectorAll("button")].find((button) => (button.textContent ?? "").trim() === "Run task");
+    return Boolean(run && !run.disabled);
+  })()`, { timeoutMs: 60_000, label: "conversation A composer usable" });
+  const settleDeadline = Date.now() + 6_000;
+  while (Date.now() < settleDeadline) {
+    const state = await readComposerState(app);
+    expect(state.modelUnavailable, "conversation A must not report the default model's unavailability").toBe(false);
+    expect(state.runTaskEnabled).toBe(true);
+    expect(state.selectedModelLabel).toContain(selected.name);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The conversation composer is usable with a visible selected model",
+      "No 'Model no longer available' warning is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await visualEvidence.recordScreenshot(shot, seen);
+  }
+
+  // The picker checkmark targets the conversation's model, not the default.
+  const pickerModels = await readAvailableModels(app);
+  const checked = pickerModels.filter((model) => model.selected);
+  expect(checked.map((model) => model.id)).toContain(rememberedModel.id);
+  await closeModelPicker(app);
+
+  // Honesty: when the conversation's OWN model is genuinely missing, the
+  // unavailable state appears for that conversation and recovery targets it.
+  const bothSeed = await executeControl(app, "eval.model_not_available.seed", { scope: "both" });
+  if (!isRecord(bothSeed) || !isRecord(bothSeed.availableModel)) {
+    throw new Error(`Seed returned malformed facts: ${JSON.stringify(bothSeed)}`);
+  }
+  const recoveryModelId = String(
+    isRecord(bothSeed.availableModel) ? bothSeed.availableModel.modelID ?? "" : "",
+  );
+  await waitForText(app, warning, { timeoutMs: 30_000 });
+  {
+    const state = await readComposerState(app);
+    expect(state.modelUnavailable).toBe(true);
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A Model no longer available warning is visible for the conversation",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await visualEvidence.recordScreenshot(shot, seen);
+  }
+
+  // Choosing a replacement recovers this conversation.
+  expect(recoveryModelId).toBeTruthy();
+  await selectModel(app, recoveryModelId);
+  await waitFor(app, `!document.body.innerText.includes(${JSON.stringify(warning)})`, {
+    timeoutMs: 30_000,
+    label: "unavailable warning cleared after recovery",
+  });
+  const recovered = await readComposerState(app);
+  expect(recovered.modelUnavailable).toBe(false);
+  expect(recovered.runTaskEnabled).toBe(true);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The conversation composer is usable again after selecting a replacement model",
+      "No 'Model no longer available' warning is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+    await visualEvidence.recordScreenshot(shot, seen);
+  }
+});


### PR DESCRIPTION
## Problem

After switching workspaces, an existing conversation that remembers a valid model (e.g. `Claude Fable 5`) could show a false **"Model no longer available"** state: the composer displayed the remembered model, the picker listed it under an enabled provider, yet the composer was disabled, the picker checkmark sat on the global default (e.g. `GPT-5.5`), Retry never recovered, and re-selecting the unchanged model "fixed" it.

## Root cause (confirmed in source)

`session-route.tsx` computed a single `selectedModelUnavailable` boolean **from the global default model only** (`local.prefs.defaultModel`) and passed it into every `SessionSurface` as `modelUnavailable`. Each surface resolves and displays its own per-conversation model through `session-model-store`, so a conversation showing valid model X was disabled by a verdict computed for default model Y. Compounding it:

- The composer disable/auto-send/`composer.send` gates in `session-surface.tsx` used the route-global boolean.
- The unavailable-recovery `ModelPickerModal` auto-open never set `modelPickerSessionId`, so its `current` checkmark fell back to the global default while the composer displayed the session model.
- Retry (`onRefreshOrganizationModels`) refreshed provider data correctly, but the recomputation re-ran the same global-default check, so a conversation with a valid model could never recover.
- Re-selecting the model recovered because the picker's `onSelect` writes both the session selection and the default, realigning the two identities.

## Solution

- New `model-availability.ts` module with one shared resolver and an explicit state: `pending | available | unavailable (provider_blocked | provider_not_connected | model_missing)`. `pending` covers a booting workspace, an unsettled provider-list query, and incomplete cloud provider sync — it is never rendered as "Model no longer available". The provider-list query is keyed by server + workspace directory and the cloud sync result is identity-guarded by its context, so a workspace switch supersedes the old catalog and late stale results cannot judge the new workspace.
- `SessionSurface` now validates **its own effective session model** through the resolver; the New Task composer keeps validating the global default independently. The send path validates the exact provider/model identity it submits (session selection, falling back to the default) instead of the default-only guard.
- Picker targeting: auto-open, command palette, and the `session.model_picker.open` control now target the active conversation, so the checkmark, subtitle, and the written selection match the composer. An auto-opened default-recovery picker closes instead of following the user into a conversation whose own model is valid. Silent entitled-default repair still applies only when the broken selection is the default.
- The dev-only `eval.model_not_available.seed` hook gains a `scope` argument (`default | both`) so tests can stage "default broken, conversation intact" separately from "conversation's own model gone".

## Preserved behavior

- Per-conversation model memory is unchanged; two conversations can use different models and validate independently.
- The New Task composer keeps its own default validation and recovery; a missing default no longer disables existing conversations, and a conversation's missing model still shows an honest unavailable state without silently switching to the default.
- Desktop policy blocks (`allowZenModel`), restrict-to-cloud (`allowCustomProviders`), disabled providers, and cloud provider-auth flows are enforced exactly as before (`provider_blocked` remains definitive even while a catalog loads).
- Selecting a model in a conversation still also records it as the last-used default for future sessions (existing documented behavior).

## Verification

Tested commit: `560ad97ad1a7062fa610c80274b0a9a615313868` (this head, rebased onto `dev` @ `fa5e5db5ea6b675445d80ab04bd5d852c53dfd92`).

| Check | Command | Result |
| --- | --- | --- |
| Unit (new) | `bun test tests/model-availability.test.ts` (apps/app) | Passed (11/11) |
| Unit (full app) | `bun test --isolate tests/` (apps/app) | 870 pass / 7 fail — the same 7 failures reproduce on unmodified `dev`, verified by stash-run on the base SHA |
| Typecheck | `pnpm --dir apps/app typecheck` | Passed |
| Build | `pnpm --filter @openwork/app build` | Passed |
| Evals layers lint | `pnpm --dir evals run lint:layers` | Passed |
| E2E regression (new) | `pnpm evals:e2e session-model-availability` | Passed at this exact head |
| E2E regression proof | same spec with the app fix stashed | Failed with the reported symptoms (`modelUnavailable: true`, composer disabled) — the spec catches the defect |
| E2E adjacent | `pnpm evals:e2e models-available` | App-driving test passed; managed-Den test skipped — needs `OPENWORK_EVAL_DEN_API_URL` (pre-existing conditional) |
| E2E adjacent | `pnpm evals:e2e composer-model-picker-no-subscribe-promo` | Passed |
| E2E adjacent | `pnpm evals:e2e model-lands-mid-run` | Failed identically on unmodified `dev` (reload-deferral assertion, unrelated pre-existing) |

Lane: local (Daytona credentials/tooling unavailable in this environment; local fallback per `evals/README.md` / `run-tests`).

The new `evals/specs/session-model-availability.e2e.test.ts` drives the real app: create workspace A with a conversation, select a model for it, create workspace B, break only the global default, switch back into conversation A, and assert the composer stays usable with no unavailable banner over a settle window, the picker checkmark targets the conversation's model, an honestly-missing conversation model still surfaces the unavailable state, and selecting a replacement recovers.

## Risk

- The unavailable-recovery picker now keys off the composer the user is viewing; if a conversation and the default are both broken, recovery targets the conversation first (selecting there also updates the default, so both heal in one step).
- Send-time validation now also rejects a session-selected model that is unavailable (previously only default-selected sends were guarded); this is stricter but matches the composer state.
- Workspace-switch races are bounded by query keying and the cloud-sync context guard; a genuinely slow catalog shows a usable composer (pending) rather than a false error, matching pre-change behavior for the default flow.
