### PR TITLE
fix(desktop): reconcile Connect policy across runtime generations

### DIFF
--- a/apps/app/src/react-app/domains/cloud/connect-policy-reconciler.ts
+++ b/apps/app/src/react-app/domains/cloud/connect-policy-reconciler.ts
@@ -1,0 +1,217 @@
+/**
+ * Desired-state reconciler for the organization Connect policy.
+ *
+ * The Den desktop config carries one desired Connect switch
+ * (`connectEnabled`). The local OpenWork server owns the actual state and is
+ * a moving target: every (re)start is a new *runtime generation*, and a
+ * policy delivered to one generation says nothing about the next one.
+ *
+ * This module reconciles `actual = desired` per target generation instead of
+ * retrying a fixed number of times:
+ *
+ * - The desired value is one normalized tuple: the Connect switch plus the
+ *   revision (active organization) it came from.
+ * - The target identity combines the resolved runtime connection (base URL +
+ *   host token) with the desktop runtime's per-start generation, so it
+ *   changes whenever the runtime restarts or the workspace switches to a
+ *   different local server lifetime.
+ * - Success is recorded as the tuple (target key, desired value, revision).
+ *   A new generation never matches the recorded key, so an unchanged policy
+ *   is reapplied after a restart.
+ * - Every `setDesired` or `notifyTargetChanged` call starts a new epoch.
+ *   In-flight attempts from an older epoch are invalidated: their results are
+ *   discarded and never recorded against the current target.
+ * - Transient failures retry with bounded backoff while the same target
+ *   remains relevant. When the schedule is exhausted the reconciler parks in
+ *   a sanitized `stalled` state; the next desired-state or target-generation
+ *   observation re-arms it. There is no free-running timer loop.
+ *
+ * Applying the policy is idempotent (a PUT of the desired switch), so
+ * re-reconciling an already-converged target performs one cheap target
+ * resolution and no policy request.
+ */
+
+export type ConnectPolicyDesired = {
+  connectEnabled: boolean;
+  /** Identity of the policy source, e.g. the active organization id. */
+  revision: string;
+};
+
+export type ConnectPolicyTarget = {
+  /**
+   * Stable identity of one runtime generation: the resolved connection plus
+   * the desktop runtime's per-start counter. Changes on every restart even
+   * though ports and tokens are sticky.
+   */
+  key: string;
+  apply: (connectEnabled: boolean) => Promise<void>;
+};
+
+export type ConnectPolicySyncState =
+  | { state: "idle" }
+  | { state: "pending"; reason: "runtime_unavailable" | "applying" | "retrying" }
+  | { state: "applied" }
+  | { state: "stalled"; reason: "runtime_unavailable" | "apply_failed" };
+
+export type ConnectPolicyReconcilerDeps = {
+  /** Resolve the current runtime target; null while the runtime is not ready. */
+  resolveTarget: () => Promise<ConnectPolicyTarget | null>;
+  wait: (delayMs: number) => Promise<void>;
+  onStateChange?: (state: ConnectPolicySyncState) => void;
+};
+
+export type ConnectPolicyReconciler = {
+  /** Replace the desired policy. `null` means no explicit organization policy. */
+  setDesired: (desired: ConnectPolicyDesired | null) => void;
+  /** Observe a possible runtime readiness or generation change. */
+  notifyTargetChanged: () => void;
+  getState: () => ConnectPolicySyncState;
+  getLastApplied: () => ConnectPolicyLastApplied | null;
+  dispose: () => void;
+};
+
+export type ConnectPolicyLastApplied = {
+  targetKey: string;
+  connectEnabled: boolean;
+  revision: string;
+};
+
+/** Bounded backoff for one epoch; exhaustion parks the reconciler as stalled. */
+export const CONNECT_POLICY_BACKOFF_SCHEDULE_MS = [
+  1_000, 2_000, 4_000, 8_000, 15_000, 30_000,
+] as const;
+
+function sameDesired(a: ConnectPolicyDesired | null, b: ConnectPolicyDesired | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.connectEnabled === b.connectEnabled && a.revision === b.revision;
+}
+
+export function createConnectPolicyReconciler(
+  deps: ConnectPolicyReconcilerDeps,
+): ConnectPolicyReconciler {
+  let epoch = 0;
+  let disposed = false;
+  let desired: ConnectPolicyDesired | null = null;
+  let lastApplied: ConnectPolicyLastApplied | null = null;
+  let state: ConnectPolicySyncState = { state: "idle" };
+  // Serializes policy requests so a stale attempt can never land on the
+  // server after a newer one: each attempt re-checks its epoch inside the
+  // lock and abandons the request instead of racing it.
+  let applyChain: Promise<void> = Promise.resolve();
+
+  const setState = (next: ConnectPolicySyncState) => {
+    if (state.state === next.state && ("reason" in state ? state.reason : null) === ("reason" in next ? next.reason : null)) return;
+    state = next;
+    deps.onStateChange?.(next);
+  };
+
+  const isStale = (runEpoch: number) => disposed || runEpoch !== epoch;
+
+  const reconcile = async (runEpoch: number): Promise<void> => {
+    for (let failures = 0; ; ) {
+      if (isStale(runEpoch)) return;
+      const currentDesired = desired;
+      if (currentDesired === null) {
+        setState({ state: "idle" });
+        return;
+      }
+
+      let target: ConnectPolicyTarget | null = null;
+      try {
+        target = await deps.resolveTarget();
+      } catch {
+        target = null;
+      }
+      if (isStale(runEpoch)) return;
+
+      if (target === null) {
+        const delayMs = CONNECT_POLICY_BACKOFF_SCHEDULE_MS[failures];
+        failures += 1;
+        if (delayMs === undefined) {
+          // The runtime never became ready within this epoch. Park with a
+          // sanitized reason; the runtime publishing a connection fires
+          // notifyTargetChanged and starts a fresh epoch.
+          setState({ state: "stalled", reason: "runtime_unavailable" });
+          return;
+        }
+        setState({ state: "pending", reason: "runtime_unavailable" });
+        await deps.wait(delayMs);
+        continue;
+      }
+
+      if (
+        lastApplied !== null &&
+        lastApplied.targetKey === target.key &&
+        lastApplied.connectEnabled === currentDesired.connectEnabled &&
+        lastApplied.revision === currentDesired.revision
+      ) {
+        setState({ state: "applied" });
+        return;
+      }
+
+      setState({ state: "pending", reason: "applying" });
+      try {
+        const attempt = applyChain.then(async () => {
+          // Re-check inside the lock: a newer epoch may have applied while
+          // this attempt waited its turn, and a stale request must be
+          // abandoned rather than raced against the newer one.
+          if (isStale(runEpoch)) return;
+          await target.apply(currentDesired.connectEnabled);
+        });
+        applyChain = attempt.catch(() => undefined);
+        await attempt;
+        // A stale attempt must never record success against the current
+        // target: the runtime generation or desired policy moved on while the
+        // request was in flight.
+        if (isStale(runEpoch)) return;
+        lastApplied = {
+          targetKey: target.key,
+          connectEnabled: currentDesired.connectEnabled,
+          revision: currentDesired.revision,
+        };
+        setState({ state: "applied" });
+        return;
+      } catch {
+        if (isStale(runEpoch)) return;
+        const delayMs = CONNECT_POLICY_BACKOFF_SCHEDULE_MS[failures];
+        failures += 1;
+        if (delayMs === undefined) {
+          setState({ state: "stalled", reason: "apply_failed" });
+          return;
+        }
+        setState({ state: "pending", reason: "retrying" });
+        await deps.wait(delayMs);
+      }
+    }
+  };
+
+  const startEpoch = () => {
+    if (disposed) return;
+    epoch += 1;
+    void reconcile(epoch);
+  };
+
+  return {
+    setDesired: (next) => {
+      if (disposed) return;
+      if (sameDesired(desired, next)) {
+        // An unchanged desired value is not a new fact, but it may recover a
+        // parked epoch (e.g. the hourly config refresh after a stall).
+        if (state.state === "stalled") startEpoch();
+        return;
+      }
+      desired = next;
+      startEpoch();
+    },
+    notifyTargetChanged: () => {
+      if (disposed) return;
+      startEpoch();
+    },
+    getState: () => state,
+    getLastApplied: () => lastApplied,
+    dispose: () => {
+      disposed = true;
+      epoch += 1;
+    },
+  };
+}

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -37,6 +37,12 @@ import {
 } from "../../../app/lib/den-session-events";
 import { isDesktopRuntime } from "../../../app/lib/runtime-env";
 import { resolveOpenworkConnection } from "../../shell/openwork-connection";
+import {
+  createConnectPolicyReconciler,
+  type ConnectPolicyReconciler,
+  type ConnectPolicySyncState,
+  type ConnectPolicyTarget,
+} from "./connect-policy-reconciler";
 import { useDenAuth } from "./den-auth-provider";
 import {
   bootstrapBrandingFromDesktopConfig,
@@ -55,6 +61,12 @@ export type DesktopConfigStore = {
    * from non-hook code paths.
    */
   checkRestriction: DesktopAppRestrictionChecker;
+  /**
+   * Sanitized convergence state of the organization Connect policy against
+   * the local runtime. Informational only — nothing gates on it, so local
+   * work continues while reconciliation is pending or stalled.
+   */
+  connectPolicySync: ConnectPolicySyncState;
 };
 
 const DesktopConfigContext = createContext<DesktopConfigStore | undefined>(
@@ -80,32 +92,30 @@ export function resolveConnectStateToPush(config: DenDesktopConfig): boolean | n
   return typeof config.connectEnabled === "boolean" ? config.connectEnabled : null;
 }
 
-export const CONNECT_STATE_PUSH_RETRY_DELAY_MS = 3_000;
-export const CONNECT_STATE_PUSH_MAX_ATTEMPTS = 20;
-
 /**
- * Push the Connect switch to the local server until it is actually accepted.
- * On a fresh install the local server (or its host token) may not be ready
- * when the first push fires; dropping that push would strand the on-disk
- * default (`connectEnabled: false`) forever. Resolves true once delivered.
+ * Resolve the current local-runtime target for the Connect policy. The target
+ * key identifies one runtime lifetime: the desktop bridge reports a monotonic
+ * per-start generation (ports and tokens are sticky across restarts), so
+ * after a restart or a workspace switch the key changes and the policy must
+ * be reapplied to the new generation.
  */
-export async function deliverConnectState(
-  attempt: () => Promise<boolean>,
-  wait: (delayMs: number) => Promise<void>,
-  isCancelled: () => boolean,
-): Promise<boolean> {
-  for (let attemptIndex = 0; attemptIndex < CONNECT_STATE_PUSH_MAX_ATTEMPTS; attemptIndex += 1) {
-    if (isCancelled()) return false;
-    try {
-      if (await attempt()) return true;
-    } catch {
-      // The local server may still be starting; retry below.
-    }
-    if (isCancelled()) return false;
-    await wait(CONNECT_STATE_PUSH_RETRY_DELAY_MS);
-  }
-
-  return false;
+export async function resolveConnectPolicyTarget(): Promise<ConnectPolicyTarget | null> {
+  const connection = await resolveOpenworkConnection();
+  if (!connection.normalizedBaseUrl || !connection.resolvedHostToken) return null;
+  const { normalizedBaseUrl, resolvedToken, resolvedHostToken } = connection;
+  // The desktop runtime reports a monotonic per-start generation; remote or
+  // stored connections identify a lifetime by URL and host token instead.
+  const generation = connection.hostInfo?.generation ?? null;
+  return {
+    key: `${normalizedBaseUrl}\u0000${resolvedHostToken}\u0000${generation ?? ""}`,
+    apply: async (connectEnabled) => {
+      await createOpenworkServerClient({
+        baseUrl: normalizedBaseUrl,
+        token: resolvedToken,
+        hostToken: resolvedHostToken,
+      }).setConnectState(connectEnabled);
+    },
+  };
 }
 
 type DesktopConfigItem = (typeof DESKTOP_CONFIG_ITEMS)[number];
@@ -214,7 +224,8 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   const [settingsVersion, bumpSettingsVersion] = useReducer((value: number) => value + 1, 0);
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
   const refreshRunRef = useRef(0);
-  const lastPushedConnectEnabledRef = useRef<boolean | null>(null);
+  const connectPolicyReconcilerRef = useRef<ConnectPolicyReconciler | null>(null);
+  const [connectPolicySync, setConnectPolicySync] = useState<ConnectPolicySyncState>({ state: "idle" });
   // Safe in-memory copy of the last config we actually applied. State drives
   // rendering, while this ref lets the handler compare without stale closures.
   const currentDesktopConfigRef = useRef<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
@@ -381,6 +392,11 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     const interval = window.setInterval(() => {
       if (!isSignedIn) return;
       void desktopConfigHandler();
+      // Level-based safety net behind the event-driven reconciler: if a
+      // runtime-generation observation was ever missed, the hourly tick
+      // re-checks convergence (one target resolution; no request when the
+      // recorded tuple already matches).
+      connectPolicyReconcilerRef.current?.notifyTargetChanged();
     }, DESKTOP_CONFIG_REFRESH_MS);
 
     return () => {
@@ -392,35 +408,45 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
   const connectEnabled = resolveConnectStateToPush(config);
 
+  // Reconciler lifecycle: created once per mount and rearmed by runtime
+  // observations. Every renderer path that (re)publishes the local server —
+  // boot, engine reload, workspace reconnect, debug restart — dispatches
+  // "openwork-server-settings-changed", which is the runtime-generation
+  // observation channel.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const reconciler = createConnectPolicyReconciler({
+      resolveTarget: resolveConnectPolicyTarget,
+      wait: (delayMs) => new Promise((resolveWait) => window.setTimeout(resolveWait, delayMs)),
+      onStateChange: setConnectPolicySync,
+    });
+    connectPolicyReconcilerRef.current = reconciler;
+    const handleRuntimeChanged = () => reconciler.notifyTargetChanged();
+    window.addEventListener("openwork-server-settings-changed", handleRuntimeChanged);
+    return () => {
+      window.removeEventListener("openwork-server-settings-changed", handleRuntimeChanged);
+      reconciler.dispose();
+      if (connectPolicyReconcilerRef.current === reconciler) {
+        connectPolicyReconcilerRef.current = null;
+      }
+    };
+  }, []);
+
+  // Desired-state feed: reconcile whenever the effective Connect policy or
+  // its source (the active organization) changes. `settingsVersion` ties this
+  // to Den session/settings events so an organization switch re-reconciles
+  // even when both organizations desire the same switch value.
   useEffect(() => {
     if (loading) return;
-    if (connectEnabled === null) return;
-    if (lastPushedConnectEnabledRef.current === connectEnabled) return;
-    let cancelled = false;
-
-    void deliverConnectState(
-      async () => {
-        const connection = await resolveOpenworkConnection();
-        if (!connection.normalizedBaseUrl || !connection.resolvedHostToken) return false;
-        await createOpenworkServerClient({
-          baseUrl: connection.normalizedBaseUrl,
-          token: connection.resolvedToken,
-          hostToken: connection.resolvedHostToken,
-        }).setConnectState(connectEnabled);
-        return true;
-      },
-      (delayMs) => new Promise((resolveWait) => window.setTimeout(resolveWait, delayMs)),
-      () => cancelled,
-    ).then((delivered) => {
-      if (delivered && !cancelled) {
-        lastPushedConnectEnabledRef.current = connectEnabled;
-      }
-    }).catch(() => null);
-
-    return () => {
-      cancelled = true;
-    };
-  }, [connectEnabled, loading]);
+    const reconciler = connectPolicyReconcilerRef.current;
+    if (!reconciler) return;
+    if (connectEnabled === null) {
+      reconciler.setDesired(null);
+      return;
+    }
+    const activeOrgId = readDenSettings().activeOrgId?.trim() ?? "";
+    reconciler.setDesired({ connectEnabled, revision: activeOrgId });
+  }, [connectEnabled, loading, settingsVersion]);
 
   // Dev-only: expose a bridge so evals can inject config directly without
   // requiring a cloud sign-in. This simply applies the config to React state.
@@ -450,8 +476,8 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     // recent org restrictions without having to recompute every render.
     const checkRestriction: DesktopAppRestrictionChecker = ({ restriction }) =>
       checkDesktopAppRestriction({ config, restriction });
-    return { config, loading, refresh, refreshFresh, checkRestriction };
-  }, [config, loading, refresh, refreshFresh]);
+    return { config, loading, refresh, refreshFresh, checkRestriction, connectPolicySync };
+  }, [config, loading, refresh, refreshFresh, connectPolicySync]);
 
   return (
     <DesktopConfigContext.Provider value={value}>

--- a/apps/app/tests/connect-policy-reconciler.test.ts
+++ b/apps/app/tests/connect-policy-reconciler.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONNECT_POLICY_BACKOFF_SCHEDULE_MS,
+  createConnectPolicyReconciler,
+  type ConnectPolicySyncState,
+  type ConnectPolicyTarget,
+} from "../src/react-app/domains/cloud/connect-policy-reconciler";
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+const settle = async (turns = 8) => {
+  for (let index = 0; index < turns; index += 1) await tick();
+};
+
+type PendingWait = { delayMs: number; release: () => void };
+
+function createHarness() {
+  const applyCalls: { key: string; value: boolean }[] = [];
+  const waits: PendingWait[] = [];
+  const states: ConnectPolicySyncState[] = [];
+  let resolveTargetImpl: () => Promise<ConnectPolicyTarget | null> = async () => null;
+
+  const makeTarget = (
+    key: string,
+    options?: { applyGate?: () => Promise<void>; failApply?: () => boolean },
+  ): ConnectPolicyTarget => ({
+    key,
+    apply: async (value) => {
+      await options?.applyGate?.();
+      if (options?.failApply?.()) throw new Error("transient apply failure");
+      applyCalls.push({ key, value });
+    },
+  });
+
+  const reconciler = createConnectPolicyReconciler({
+    resolveTarget: () => resolveTargetImpl(),
+    wait: (delayMs) =>
+      new Promise<void>((resolve) => {
+        waits.push({ delayMs, release: resolve });
+      }),
+    onStateChange: (state) => {
+      states.push(state);
+    },
+  });
+
+  return {
+    reconciler,
+    applyCalls,
+    waits,
+    states,
+    makeTarget,
+    setTarget: (impl: () => Promise<ConnectPolicyTarget | null>) => {
+      resolveTargetImpl = impl;
+    },
+    releaseNextWait: async () => {
+      const next = waits.shift();
+      expect(next).toBeDefined();
+      next?.release();
+      await settle();
+    },
+  };
+}
+
+describe("Connect policy reconciler", () => {
+  test("applies immediately when the runtime is ready before the policy arrives", async () => {
+    const harness = createHarness();
+    const target = harness.makeTarget("gen-a");
+    harness.setTarget(async () => target);
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+
+    expect(harness.applyCalls).toEqual([{ key: "gen-a", value: true }]);
+    expect(harness.waits).toHaveLength(0);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+    expect(harness.reconciler.getLastApplied()).toEqual({
+      targetKey: "gen-a",
+      connectEnabled: true,
+      revision: "org-1",
+    });
+  });
+
+  test("converges when the runtime becomes ready only after the bounded backoff parked it", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => null);
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+
+    // Advance every fake backoff delay: the runtime never becomes ready, so
+    // the epoch exhausts the bounded schedule and parks in a sanitized state
+    // instead of looping forever.
+    const observedDelays: number[] = [];
+    for (let index = 0; index < CONNECT_POLICY_BACKOFF_SCHEDULE_MS.length; index += 1) {
+      const next = harness.waits[0];
+      expect(next).toBeDefined();
+      if (next) observedDelays.push(next.delayMs);
+      await harness.releaseNextWait();
+    }
+    expect(observedDelays).toEqual([...CONNECT_POLICY_BACKOFF_SCHEDULE_MS]);
+    expect(harness.applyCalls).toHaveLength(0);
+    expect(harness.reconciler.getState()).toEqual({ state: "stalled", reason: "runtime_unavailable" });
+    expect(harness.waits).toHaveLength(0);
+
+    // The runtime publishing its connection is observed as a target change
+    // and converges the policy — however late readiness arrived.
+    const target = harness.makeTarget("gen-late");
+    harness.setTarget(async () => target);
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+
+    expect(harness.applyCalls).toEqual([{ key: "gen-late", value: true }]);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("reapplies an unchanged policy to a new runtime generation after a restart", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    expect(harness.applyCalls).toEqual([{ key: "gen-a", value: true }]);
+
+    // Restart: same desired policy, new generation.
+    harness.setTarget(async () => harness.makeTarget("gen-b"));
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+
+    expect(harness.applyCalls).toEqual([
+      { key: "gen-a", value: true },
+      { key: "gen-b", value: true },
+    ]);
+    expect(harness.reconciler.getLastApplied()).toEqual({
+      targetKey: "gen-b",
+      connectEnabled: true,
+      revision: "org-1",
+    });
+  });
+
+  test("converges both policy directions over the previously applied value", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    harness.reconciler.setDesired({ connectEnabled: false, revision: "org-1" });
+    await settle();
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+
+    expect(harness.applyCalls).toEqual([
+      { key: "gen-a", value: true },
+      { key: "gen-a", value: false },
+      { key: "gen-a", value: true },
+    ]);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("reasserts the policy when the organization changes even if the switch value is unchanged", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-2" });
+    await settle();
+
+    expect(harness.applyCalls).toEqual([
+      { key: "gen-a", value: true },
+      { key: "gen-a", value: true },
+    ]);
+    expect(harness.reconciler.getLastApplied()).toEqual({
+      targetKey: "gen-a",
+      connectEnabled: true,
+      revision: "org-2",
+    });
+  });
+
+  test("a late result from an obsolete generation is discarded and never recorded", async () => {
+    const harness = createHarness();
+    let releaseStaleApply: () => void = () => {};
+    const staleGate = new Promise<void>((resolve) => {
+      releaseStaleApply = resolve;
+    });
+    harness.setTarget(async () => harness.makeTarget("gen-old", { applyGate: () => staleGate }));
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    // The apply against gen-old is in flight and blocked.
+    expect(harness.reconciler.getState()).toEqual({ state: "pending", reason: "applying" });
+
+    // Workspace switch / restart: the target moves to a new generation while
+    // the old attempt is still in flight.
+    harness.setTarget(async () => harness.makeTarget("gen-new"));
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+
+    releaseStaleApply();
+    await settle();
+
+    // The stale completion is ignored: the recorded tuple belongs to the new
+    // generation and the final state is converged against it.
+    expect(harness.applyCalls).toEqual([
+      { key: "gen-old", value: true },
+      { key: "gen-new", value: true },
+    ]);
+    expect(harness.reconciler.getLastApplied()).toEqual({
+      targetKey: "gen-new",
+      connectEnabled: true,
+      revision: "org-1",
+    });
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("a stale queued attempt abandons its request instead of racing a newer one", async () => {
+    const harness = createHarness();
+    let releaseFirstApply: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirstApply = resolve;
+    });
+    let gateFirst = true;
+    harness.setTarget(async () =>
+      harness.makeTarget("gen-a", {
+        applyGate: () => {
+          if (gateFirst) {
+            gateFirst = false;
+            return firstGate;
+          }
+          return Promise.resolve();
+        },
+      }),
+    );
+
+    // Epoch 1 applies and blocks while holding the request lock.
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-a" });
+    await settle();
+
+    // Epoch 2 queues behind the lock, then epoch 3 makes it stale before it
+    // ever issues its request.
+    harness.reconciler.setDesired({ connectEnabled: false, revision: "org-b" });
+    await settle();
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-c" });
+    await settle();
+
+    releaseFirstApply();
+    await settle();
+
+    // Three epochs, but only two requests: the stale middle attempt was
+    // abandoned inside the lock, so an obsolete value can never land after
+    // the newest one.
+    expect(harness.applyCalls).toEqual([
+      { key: "gen-a", value: true },
+      { key: "gen-a", value: true },
+    ]);
+    expect(harness.reconciler.getLastApplied()).toEqual({
+      targetKey: "gen-a",
+      connectEnabled: true,
+      revision: "org-c",
+    });
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("retries transient apply failures with bounded backoff and converges", async () => {
+    const harness = createHarness();
+    let remainingFailures = 2;
+    harness.setTarget(async () =>
+      harness.makeTarget("gen-a", {
+        failApply: () => {
+          if (remainingFailures > 0) {
+            remainingFailures -= 1;
+            return true;
+          }
+          return false;
+        },
+      }),
+    );
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+
+    expect(harness.waits.map((wait) => wait.delayMs)).toEqual([CONNECT_POLICY_BACKOFF_SCHEDULE_MS[0]]);
+    await harness.releaseNextWait();
+    expect(harness.waits.map((wait) => wait.delayMs)).toEqual([CONNECT_POLICY_BACKOFF_SCHEDULE_MS[1]]);
+    await harness.releaseNextWait();
+
+    expect(harness.applyCalls).toEqual([{ key: "gen-a", value: true }]);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("permanent failure parks in a sanitized recoverable state and recovers on the next observation", async () => {
+    const harness = createHarness();
+    let healthy = false;
+    let attempts = 0;
+    harness.setTarget(async () =>
+      harness.makeTarget("gen-a", {
+        failApply: () => {
+          if (healthy) return false;
+          attempts += 1;
+          return true;
+        },
+      }),
+    );
+
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    for (let index = 0; index < CONNECT_POLICY_BACKOFF_SCHEDULE_MS.length; index += 1) {
+      await harness.releaseNextWait();
+    }
+
+    expect(attempts).toBe(CONNECT_POLICY_BACKOFF_SCHEDULE_MS.length + 1);
+    // The parked state carries only a sanitized reason — no error text,
+    // URLs, or tokens.
+    expect(harness.reconciler.getState()).toEqual({ state: "stalled", reason: "apply_failed" });
+    expect(harness.waits).toHaveLength(0);
+
+    healthy = true;
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+    expect(harness.applyCalls).toEqual([{ key: "gen-a", value: true }]);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("re-observing a converged target is idempotent and issues no requests", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    expect(harness.applyCalls).toHaveLength(1);
+
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+    harness.reconciler.notifyTargetChanged();
+    await settle();
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+
+    expect(harness.applyCalls).toHaveLength(1);
+    expect(harness.waits).toHaveLength(0);
+    expect(harness.reconciler.getState()).toEqual({ state: "applied" });
+  });
+
+  test("returns to idle when the explicit policy is withdrawn", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    harness.reconciler.setDesired(null);
+    await settle();
+
+    expect(harness.applyCalls).toHaveLength(1);
+    expect(harness.reconciler.getState()).toEqual({ state: "idle" });
+  });
+
+  test("dispose invalidates pending work", async () => {
+    const harness = createHarness();
+    harness.setTarget(async () => null);
+    harness.reconciler.setDesired({ connectEnabled: true, revision: "org-1" });
+    await settle();
+    expect(harness.waits).toHaveLength(1);
+
+    harness.reconciler.dispose();
+    harness.setTarget(async () => harness.makeTarget("gen-a"));
+    const pending = harness.waits.shift();
+    pending?.release();
+    await settle();
+
+    expect(harness.applyCalls).toHaveLength(0);
+    harness.reconciler.notifyTargetChanged();
+    harness.reconciler.setDesired({ connectEnabled: false, revision: "org-2" });
+    await settle();
+    expect(harness.applyCalls).toHaveLength(0);
+  });
+});

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -7,68 +7,15 @@ import {
   selectEffectiveOnboardingPrompts,
 } from "@openwork/types/den/desktop-policies";
 import { createDenClient, normalizeDenDesktopConfig } from "../src/app/lib/den";
-import {
-  CONNECT_STATE_PUSH_MAX_ATTEMPTS,
-  CONNECT_STATE_PUSH_RETRY_DELAY_MS,
-  deliverConnectState,
-  resolveConnectStateToPush,
-} from "../src/react-app/domains/cloud/desktop-config-provider";
+import { resolveConnectStateToPush } from "../src/react-app/domains/cloud/desktop-config-provider";
 
 const originalFetch = globalThis.fetch;
 
 describe("Den desktop config client", () => {
-  test("only pushes an explicit Connect policy", () => {
+  test("only reconciles an explicit Connect policy", () => {
     expect(resolveConnectStateToPush({})).toBeNull();
     expect(resolveConnectStateToPush({ connectEnabled: false })).toBe(false);
     expect(resolveConnectStateToPush({ connectEnabled: true })).toBe(true);
-  });
-
-  test("retries the Connect push until the local server accepts it", async () => {
-    let attempts = 0;
-    const waits: number[] = [];
-
-    const delivered = await deliverConnectState(
-      async () => {
-        attempts += 1;
-        if (attempts === 1) return false;
-        if (attempts === 2) throw new Error("local server starting");
-        return true;
-      },
-      async (delayMs) => {
-        waits.push(delayMs);
-      },
-      () => false,
-    );
-
-    expect(delivered).toBe(true);
-    expect(attempts).toBe(3);
-    expect(waits).toEqual([CONNECT_STATE_PUSH_RETRY_DELAY_MS, CONNECT_STATE_PUSH_RETRY_DELAY_MS]);
-  });
-
-  test("stops the Connect push when cancelled or exhausted", async () => {
-    let cancelledAttempts = 0;
-    const cancelled = await deliverConnectState(
-      async () => {
-        cancelledAttempts += 1;
-        return false;
-      },
-      async () => {},
-      () => cancelledAttempts >= 2,
-    );
-    expect(cancelled).toBe(false);
-    expect(cancelledAttempts).toBe(2);
-
-    let exhaustedAttempts = 0;
-    const exhausted = await deliverConnectState(
-      async () => {
-        exhaustedAttempts += 1;
-        return false;
-      },
-      async () => {},
-      () => false,
-    );
-    expect(exhausted).toBe(false);
-    expect(exhaustedAttempts).toBe(CONNECT_STATE_PUSH_MAX_ATTEMPTS);
   });
 
   afterEach(() => {

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -385,6 +385,10 @@ function createOpenworkServerState() {
     childExited: true,
     inProcess: false,
     engineRollover: false,
+    // Monotonic per-start identity assigned by startOpenworkServerInner.
+    // Sticky ports and persisted tokens make the connection details identical
+    // across restarts, so clients need this to observe a new server lifetime.
+    generation: null,
     remoteAccessEnabled: false,
     host: null,
     port: null,
@@ -409,6 +413,7 @@ export function snapshotOpenworkServerState(state) {
   return {
     running,
     engineRollover: state.engineRollover === true,
+    generation: typeof state.generation === "number" ? state.generation : null,
     remoteAccessEnabled: state.remoteAccessEnabled,
     host: state.host,
     port: state.port,
@@ -1342,6 +1347,10 @@ export function createRuntimeManager({
   let injectedUserEnvKeys = new Set();
   const engineState = createEngineState();
   const openworkServerState = createOpenworkServerState();
+  // Monotonic across this Electron process. Never reset with the server
+  // state: each successful server start must be observable as a new
+  // generation even when ports and tokens are reused.
+  let openworkServerGenerationCounter = 0;
 
   // Serialize engine lifecycle operations. Without this, concurrent renderer
   // invocations of engineStart/engineStop/engineRestart race: each call's
@@ -1954,6 +1963,8 @@ export function createRuntimeManager({
 
     openworkServerState.inProcess = true;
     openworkServerState.engineRollover = options.engineRollover === true;
+    openworkServerGenerationCounter += 1;
+    openworkServerState.generation = openworkServerGenerationCounter;
     openworkServerState.remoteAccessEnabled = options.remoteAccessEnabled;
     openworkServerState.host = host;
     openworkServerState.port = boundPort;

--- a/evals/specs/connect-policy-runtime-restart.e2e.test.ts
+++ b/evals/specs/connect-policy-runtime-restart.e2e.test.ts
@@ -1,0 +1,184 @@
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { evalIn } from "@openwork/behaviors";
+import { electronProfilePaths } from "@openwork/hosts";
+import {
+  app,
+  eventually,
+  inviteMember,
+  localMysqlIsRunning,
+  needs,
+  readConnectState,
+  readConnectStateFile,
+  server,
+  test,
+} from "@openwork/testkit";
+
+type RuntimeGeneration = {
+  running: boolean;
+  baseUrl: string;
+  generation: number | null;
+};
+
+// Reads the live local-server lifetime identity from the desktop bridge.
+// Ports and tokens are sticky across restarts, so the monotonic per-start
+// generation is the observable identity of one server lifetime.
+async function readRuntimeGeneration(surface: Parameters<typeof evalIn>[0]): Promise<RuntimeGeneration> {
+  const value = await evalIn(surface, `(async () => {
+    const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+    if (!invokeDesktop) return { running: false, baseUrl: "", generation: null };
+    try {
+      const info = await invokeDesktop("openworkServerInfo");
+      return {
+        running: Boolean(info && info.running === true),
+        baseUrl: String((info && info.baseUrl) ?? "").trim(),
+        generation: info && typeof info.generation === "number" ? info.generation : null,
+      };
+    } catch {
+      return { running: false, baseUrl: "", generation: null };
+    }
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  const record = value as Partial<RuntimeGeneration> | null;
+  return {
+    running: record?.running === true,
+    baseUrl: typeof record?.baseUrl === "string" ? record.baseUrl : "",
+    generation: typeof record?.generation === "number" ? record.generation : null,
+  };
+}
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !e2eTestsEnabled
+  ? "Connect policy runtime convergence skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : !localPlacement
+    ? "Connect policy runtime convergence skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "Connect policy runtime convergence skipped — needs MySQL on 127.0.0.1:3306"
+      : "Connect policy converges on a slow-starting runtime and is reapplied to the next runtime generation";
+
+test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using den = await server({
+    place,
+    org: {
+      name: "Connect Policy Convergence",
+      admin: {
+        email: `connect-policy-admin-${Date.now()}@openwork.test`,
+        name: "Connect Policy Admin",
+        password: "OpenWorkEval123!",
+      },
+    },
+  });
+  await inviteMember(den, "fresh", {
+    email: `connect-policy-member-${Date.now()}@openwork.test`,
+    name: "Fresh Profile Member",
+    password: "OpenWorkEval123!",
+  });
+
+  // The local server publishes readiness only after a deliberate delay, so the
+  // organization policy is known to the app before the runtime target exists.
+  await using desktopApp = await app({
+    den,
+    as: "fresh",
+    place,
+    localServerDelayMs: 5_000,
+  });
+
+  const initialState = await eventually(() => readConnectState(desktopApp), {
+    within: 90_000,
+    label: "Connect policy convergence on the delayed runtime",
+    until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+  });
+  expect(initialState.status).toBe("available");
+  expect(initialState.connectEnabled).toBe(true);
+  evidence.recordAssertionEvidence(
+    "The organization Connect policy converged on a slow-starting runtime",
+    "Although the local server delayed its readiness past the policy arrival, the state endpoint reported status=available and connectEnabled=true.",
+    true,
+  );
+
+  const firstGeneration = await readRuntimeGeneration(desktopApp);
+  expect(firstGeneration.running).toBe(true);
+  expect(firstGeneration.baseUrl.length).toBeGreaterThan(0);
+  expect(firstGeneration.generation).not.toBeNull();
+
+  if (desktopApp.handle.hostKind !== "local" || !desktopApp.handle.profileDir) {
+    throw new Error("This spec drives the local desktop profile and requires a local app with a profile directory.");
+  }
+  // Remove the persisted Connect state so post-restart convergence cannot be
+  // explained by on-disk persistence: only a reapplication to the new runtime
+  // generation can restore it.
+  const paths = electronProfilePaths(desktopApp.handle.profileDir);
+  const stateFileCandidates = [
+    join(paths.userDataDir, "openwork-dev-data", "xdg", "config", "openwork", "connect-state.json"),
+    join(paths.configHome, "openwork", "connect-state.json"),
+    join(paths.homeDir, ".config", "openwork", "connect-state.json"),
+  ];
+  for (const candidate of stateFileCandidates) {
+    await rm(candidate, { force: true });
+  }
+  const clearedFile = await readConnectStateFile(desktopApp);
+  expect(clearedFile.status).toBe("missing");
+  evidence.recordAssertionEvidence(
+    "The persisted Connect state was cleared before the restart",
+    "connect-state.json reports missing, so any post-restart Connect state must come from a fresh policy application, not persistence.",
+    true,
+  );
+
+  // Restart the local server through the same runtime path every product
+  // restart uses, followed by the runtime-change observation those paths
+  // dispatch after republishing the server connection.
+  const restarted = await evalIn(desktopApp, `(async () => {
+    const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+    if (!invokeDesktop) return false;
+    const info = await invokeDesktop("openworkServerRestart", {});
+    window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
+    return Boolean(info && info.running === true);
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  expect(restarted).toBe(true);
+
+  const secondGeneration = await eventually(() => readRuntimeGeneration(desktopApp), {
+    within: 30_000,
+    label: "new runtime generation after restart",
+    until: (generation) =>
+      generation.running &&
+      generation.baseUrl.length > 0 &&
+      generation.generation !== null &&
+      generation.generation !== firstGeneration.generation,
+  });
+  expect(secondGeneration.generation).not.toBeNull();
+  expect(secondGeneration.generation).not.toBe(firstGeneration.generation);
+  evidence.recordAssertionEvidence(
+    "The restart produced a new runtime generation",
+    `The restarted local server reported per-start generation ${secondGeneration.generation} where the previous lifetime reported ${firstGeneration.generation}.`,
+    true,
+  );
+
+  const reappliedState = await eventually(() => readConnectState(desktopApp), {
+    within: 90_000,
+    label: "Connect policy reapplication on the new runtime generation",
+    until: (state) => state.ok && state.status === "available" && state.connectEnabled === true,
+  });
+  expect(reappliedState.status).toBe("available");
+  expect(reappliedState.connectEnabled).toBe(true);
+  evidence.recordAssertionEvidence(
+    "The unchanged policy was reapplied to the new runtime generation",
+    "With persistence cleared, the restarted server reached status=available and connectEnabled=true again — the desired organization policy was re-delivered to the new generation.",
+    true,
+  );
+
+  const persistedAgain = await eventually(() => readConnectStateFile(desktopApp), {
+    within: 30_000,
+    label: "reapplied Connect state persisted",
+    until: (state) => state.status === "available" && state.connectEnabled === true,
+  });
+  expect(persistedAgain).toEqual({ status: "available", connectEnabled: true });
+  evidence.recordAssertionEvidence(
+    "The reapplied policy persisted to the profile",
+    "connect-state.json reports connectEnabled=true again after the reapplication.",
+    true,
+  );
+});

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -88,6 +88,14 @@ export type DesktopIntegrationResult = {
 export type OpenworkServerInfo = {
   running: boolean;
   engineRollover: boolean;
+  /**
+   * Monotonic per-start identity of the embedded server within this desktop
+   * process. Sticky ports and persisted tokens keep the connection details
+   * identical across restarts, so clients that must re-deliver state to a new
+   * server lifetime (e.g. the Connect policy) key on this value. Null when
+   * the bridge predates the field or no start completed yet.
+   */
+  generation: number | null;
   remoteAccessEnabled: boolean;
   host: string | null;
   port: number | null;


### PR DESCRIPTION
## Problem

Organization desktop policy can require OpenWork Connect to be enabled or disabled in the local workspace runtime, and the policy routinely arrives before that runtime is ready. Delivery used a fixed retry window (20 attempts × 3 s, keyed only on the desired boolean): if the local server became ready after ~60 s, or restarted after a successful delivery, the app still "knew" the desired policy but stopped converging the runtime. Nothing reapplied the policy until an unrelated event changed the boolean or the user restarted/reloaded. This is a source-confirmed convergence gap, not a confirmed production incident.

A second gap made restarts invisible even in principle: the embedded server keeps a sticky port and persisted tokens across restarts, so a new server lifetime published a byte-identical connection and clients had no way to observe that their previously delivered state was gone.

## Root cause

A bounded retry loop is a delivery mechanism, not a desired-state reconciler. It fires on one edge (the boolean changing), forgets which runtime it delivered to, and gives up permanently after its window. Policy is desired state over a moving target: reconciliation must trigger when *either* the desired policy *or* the target runtime generation changes, and success is only meaningful relative to the generation it was applied to.

## Invariant

For every active workspace runtime generation, the actual Connect state eventually equals the latest desired organization policy — whether policy precedes readiness, readiness is slow, the runtime restarts, the workspace or organization switches, or the desired value flips in either direction.

## Solution

- **Runtime generation** (`apps/desktop/electron/runtime.mjs`, `packages/types/src/desktop-ipc.ts`): the desktop runtime now assigns a monotonic per-start `generation` to the embedded server and reports it through `openworkServerInfo`, making each server lifetime observable despite sticky ports and tokens.
- **Reconciler** (`connect-policy-reconciler.ts`): one normalized desired tuple (`connectEnabled` + organization revision), one target identity (resolved base URL + host token + runtime generation), and a record of the last successfully applied tuple `(target key, desired value, revision)`. Reconciliation runs when the desired state changes, when a runtime publish event (`openwork-server-settings-changed`) fires — every boot/restart/workspace-reconnect path already dispatches it — and on the existing hourly config tick as a level-based safety net.
- **Stale-attempt invalidation**: every trigger starts a new epoch; older attempts are abandoned at each await point, never record success, and all policy requests are serialized behind a lock with an in-lock staleness re-check, so an obsolete workspace/organization/generation attempt can neither record success nor land after a newer application.
- **Bounded backoff**: transient failures (runtime not ready, request failure) retry on a capped schedule (1 s → 30 s, 7 attempts per epoch). Exhaustion parks the reconciler in a sanitized `pending/stalled` state (enum reasons only — no URLs, tokens, or error text) exposed on the desktop-config store; the next observation re-arms it. There is no free-running timer loop, and an already-converged target costs one connection resolution and zero requests per observation.
- The superseded finite-retry `deliverConnectState` and its constants are removed.

## Preservation

- Local-only users: no desired policy → reconciler stays idle; nothing is pushed.
- A ready runtime receives policy immediately (no waits when the target resolves first try).
- Idempotent: re-observing a converged target issues no requests; applying an already-applied value is a no-op PUT.
- Workspace switching cannot cross-apply: the target is resolved per attempt and stale epochs are invalidated, so a late previous-workspace attempt cannot mutate or be recorded against the new runtime.
- Organization switching reasserts only the new organization's desired state (revision is part of the desired tuple; equal booleans still reassert once).
- Both enable and disable converge; temporary unavailability parks recoverably instead of failing permanently; runtime configuration unrelated to Connect is untouched (the server PUT writes only `connect-state.json`, unchanged in this PR).
- Nothing gates on the sync state, so unaffected local functionality keeps working while reconciliation is pending.

## Proof

Lane: local (Daytona credentials unavailable on this machine — Infisical CLI not installed). All commands ran on the exact head `429f739bd` after rebasing onto `origin/dev` `c7e378169`.

| # | Claim | Where proven | Command | Verdict |
|---|---|---|---|---|
| 1 | Policy before readiness; runtime ready after the old retry window; still converges | unit: backoff exhaustion + readiness observation re-arms (fake waits); e2e: 5 s delayed local server converges | `bun test tests/connect-policy-reconciler.test.ts` / `vitest … connect-policy-runtime-restart.e2e.test.ts` | Passed |
| 2 | Runtime ready before policy; immediate convergence | unit "applies immediately…"; e2e `connect-state-provenance` | same | Passed |
| 3 | Restart reapplies unchanged policy to the new generation | unit "reapplies an unchanged policy…"; e2e restarts the server with `connect-state.json` cleared and proves reapplication on a new generation | same | Passed |
| 4/5 | false-over-true and true-over-false converge | unit "converges both policy directions" | `bun test tests/connect-policy-reconciler.test.ts` | Passed |
| 6 | Workspace A cannot mutate workspace B after a switch | unit "a late result from an obsolete generation is discarded" (target switch mid-flight; stale result never recorded) | same | Passed |
| 7 | Org A cannot overwrite org B policy after a switch | unit "a stale queued attempt abandons its request" (serialized lock; middle epoch never issues its request) | same | Passed |
| 8 | Late result from obsolete generation ignored | unit, same tests as 6/7 | same | Passed |
| 9 | Transient failure retries with bounded backoff and converges | unit "retries transient apply failures…" (observed delays = schedule) | same | Passed |
| 10 | Permanent failure surfaces a sanitized recoverable state, non-blocking | unit "permanent failure parks…" (state is exactly `{state:"stalled",reason:"apply_failed"}`) | same | Passed |
| 11 | Idempotent; no uncontrolled request loop | unit "re-observing a converged target…" (repeat observations ⇒ 1 request, 0 timers) | same | Passed |
| 12 | Unrelated runtime configuration intact | server Connect PUT path unchanged; `apps/server` connect-state tests + typecheck | `bun test src/connect-state.test.ts src/connect-state.inspect.test.ts`, `tsc --noEmit` | Passed |

Commands and results (exact head):

- `pnpm --dir apps/app typecheck` — Passed
- `apps/app: bun test tests/connect-policy-reconciler.test.ts tests/den-desktop-config.test.ts` — Passed (22 pass, 0 fail)
- `apps/desktop: node --test electron/runtime.test.mjs` — Passed (23 pass, 0 fail)
- `apps/desktop: pnpm typecheck:electron` — Passed
- `apps/server: tsc --noEmit` + connect-state tests — Passed
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/connect-policy-runtime-restart.e2e.test.ts` — Passed
- `… specs/connect-state-provenance.e2e.test.ts` — Passed
- `apps/app: bun test --isolate tests/` — 882 pass / 7 fail; the same 7 failures reproduce identically on the untouched base commit `5c74c2530` (verified in a clean scratch worktree), so they are pre-existing and unrelated
- `… specs/first-signin-fresh-profile.e2e.test.ts` — Failed on this head **and** identically on the untouched base `5c74c2530` (fault-proxy never observes a faulted `/api/den/v1/me/orgs` request; the Connect and organization convergence assertions inside it pass before that witness). Pre-existing red, reported for visibility.

## Negative proof

- Stale attempts: with an apply in flight against generation A, switching the target to generation B discards A's completion — the recorded tuple and final state belong to B (unit-asserted).
- Serialized requests: three rapid desired changes produce exactly two requests; the stale middle attempt is abandoned inside the request lock and never reaches the server (unit-asserted).
- No uncontrolled loop: repeated runtime observations of a converged target issue zero policy requests and schedule zero timers (unit-asserted).
- The restart e2e clears `connect-state.json` before restarting, so post-restart convergence cannot be explained by persistence — only by reapplication to the observed new generation.

## Risk and rollback

- The `generation` field is additive to `OpenworkServerInfo`; bridges that predate it yield `null` and the target identity degrades to base URL + host token (the previous best available signal). No wire or persistence format changes.
- The reconciler is renderer-local, reads the same desktop-config source of truth as before, and introduces no second policy authority. Reverting this commit restores the previous retry behavior wholesale.
- Runtime lifecycle risk is limited to one counter increment inside the existing successful-start commit path in `runtime.mjs`, covered by the existing runtime tests.

## Scope exclusions

This PR does not redesign Desktop enrollment, cross-server handoff, deployment, or release behavior, and does not change the server-side Connect state endpoint or its persistence.
