### PR TITLE
fix(desktop): commit cross-server handoffs atomically

### DIFF
--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -242,11 +242,15 @@ export async function exchangeHandoffAndSignIn(
           ...(carryOriginScopedFields && previousBootstrap.prepared
             ? { prepared: previousBootstrap.prepared }
             : {}),
-          ...(options.bootstrap?.enterpriseActivation
-            ? { enterpriseActivation: options.bootstrap.enterpriseActivation }
+          // The activation stamp is origin-scoped. Cross-origin commits clear
+          // it explicitly: omitting it would let the persist layer retain the
+          // previous origin's stamp and mark the new control plane as already
+          // activated.
+          enterpriseActivation: options.bootstrap?.enterpriseActivation
+            ? options.bootstrap.enterpriseActivation
             : carryOriginScopedFields && previousBootstrap.enterpriseActivation
-              ? { enterpriseActivation: previousBootstrap.enterpriseActivation }
-              : {}),
+              ? previousBootstrap.enterpriseActivation
+              : null,
         });
       } catch (error) {
         // Nothing was activated: the previous enrollment (origin, token, and

--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -1,10 +1,15 @@
 import {
   createDenClient,
+  denOriginComparisonKey,
+  readDenBootstrapConfig,
   readDenSettings,
-  resolveDenBaseUrls,
+  resolveDenBaseUrlsForDestination,
   seedDenDesktopConfigConnectPolicy,
+  setDenBootstrapConfig,
   writeDenSettings,
+  type DenBootstrapConfig,
   type DenDesktopHandoffExchange,
+  type DenEnterpriseActivation,
 } from "./den";
 import { dispatchDenSessionUpdated } from "./den-session-events";
 import {
@@ -15,7 +20,6 @@ import {
   resolveHandoffOrgPlan,
 } from "./den-sign-in-intent";
 
-type DenClient = ReturnType<typeof createDenClient>;
 export const DEN_HANDOFF_AUTO_CONTINUE_KEY = "openwork.den.handoffAutoContinueAt";
 
 export type HandoffActiveOrg = {
@@ -24,13 +28,25 @@ export type HandoffActiveOrg = {
   name?: string | null;
 };
 
+/**
+ * Bootstrap fields the caller wants persisted in the same durable commit as
+ * the handoff enrollment, instead of as a separate follow-up write that could
+ * be lost after the session already switched.
+ */
+export type HandoffBootstrapCommit = {
+  /** Force the persisted bootstrap's requireSignin flag. */
+  requireSignin?: boolean;
+  /** Stamp an enterprise activation into the committed bootstrap. */
+  enterpriseActivation?: DenEnterpriseActivation;
+  /** Strip a consumed one-time bootstrap grant in the same commit. */
+  clearHandoff?: boolean;
+};
+
 export type ExchangeHandoffOptions = {
   /** Den base URL to exchange against (and persist on success). */
   baseUrl: string;
   /** Direct Den API base to exchange against and preserve on success. */
   apiBaseUrl?: string | null;
-  /** Pre-built client to reuse. When omitted, a default client for `baseUrl` is created. */
-  client?: DenClient;
   /** Optional active org to select on sign-in (bootstrap prepares this). */
   activeOrg?: HandoffActiveOrg | null;
   /**
@@ -43,88 +59,271 @@ export type ExchangeHandoffOptions = {
   desktopInitiated?: boolean;
   /** Message used when the exchange fails without a specific Error message. */
   fallbackErrorMessage?: string;
+  /** Extra bootstrap fields to persist atomically with the enrollment. */
+  bootstrap?: HandoffBootstrapCommit;
 };
 
 export type ExchangeHandoffResult =
   | { ok: true; exchange: DenDesktopHandoffExchange; baseUrl: string }
-  | { ok: false; error: string };
+  | {
+      ok: false;
+      error: string;
+      /**
+       * True when the one-time grant was already sent to (and consumed by)
+       * the destination. A consumed grant must not be retried; the user needs
+       * a fresh handoff link instead.
+       */
+      grantConsumed: boolean;
+      /** True when a newer handoff attempt superseded this one. */
+      stale: boolean;
+    };
+
+// Handoff attempts are numbered so a late result from an older attempt can
+// never replace a newer enrollment, and commits are serialized so two
+// in-flight attempts can never interleave their persistence steps.
+let handoffAttemptCounter = 0;
+let commitQueue: Promise<unknown> = Promise.resolve();
+
+function bootstrapRestorePayload(previous: DenBootstrapConfig) {
+  return {
+    baseUrl: previous.baseUrl,
+    apiBaseUrl: previous.apiBaseUrl,
+    requireSignin: previous.requireSignin,
+    ...(typeof previous.requireActivation === "boolean"
+      ? { requireActivation: previous.requireActivation }
+      : {}),
+    ...(previous.brandAppName ? { brandAppName: previous.brandAppName } : {}),
+    ...(previous.brandLogoUrl ? { brandLogoUrl: previous.brandLogoUrl } : {}),
+    ...(previous.brandIconUrl ? { brandIconUrl: previous.brandIconUrl } : {}),
+    ...(previous.claimLinks ? { claimLinks: previous.claimLinks } : {}),
+    ...(previous.handoff ? { handoff: previous.handoff } : {}),
+    ...(previous.prepared ? { prepared: previous.prepared } : {}),
+    ...(previous.enterpriseActivation
+      ? { enterpriseActivation: previous.enterpriseActivation }
+      : {}),
+  };
+}
 
 /**
- * Single source of truth for the desktop handoff sign-in sequence:
- * exchange a one-time grant, persist the resulting session (and optional active
- * org) into Den settings, then broadcast `denSessionUpdated`.
+ * Single source of truth for the desktop handoff sign-in sequence, used by
+ * every handoff entry point (deep link, manual paste, control action, and the
+ * agent-first prepared bootstrap).
  *
- * Used by every handoff entry point (deep link, manual paste, control action,
- * and the agent-first prepared bootstrap) so the exchange/persist/dispatch
- * logic is not re-implemented per call site.
+ * A cross-server handoff is a transaction: the control-plane origin, session
+ * credential, active organization, and enrollment generation become active
+ * together, or none of them do. The phases are:
+ *
+ * 1. Prepare — resolve the expected destination (including the API base the
+ *    destination publishes) and number the attempt.
+ * 2. Validate — exchange the grant with a client constructed from that
+ *    resolved destination, so the credential can only come from the origin
+ *    this transaction would persist.
+ * 3. Durable commit — persist the destination bootstrap (plus any
+ *    caller-requested bootstrap fields) and confirm the committed bootstrap
+ *    is the intended destination before anything becomes active.
+ * 4. Activate — publish origin, token, and organization to the active
+ *    session in one write. The previous organization never carries across
+ *    origins; only a destination-provided organization (or a same-origin
+ *    stored one) is selected.
+ * 5. Publish — only after the durable commit, broadcast success.
+ *
+ * Any failure after preparation leaves the previously active enrollment
+ * untouched (rolling the bootstrap back if it was already switched), and a
+ * stale attempt — one superseded by a newer handoff — never activates or
+ * publishes anything.
  */
 export async function exchangeHandoffAndSignIn(
   grant: string,
   options: ExchangeHandoffOptions,
 ): Promise<ExchangeHandoffResult> {
   const fallback = options.fallbackErrorMessage ?? "Failed to sign in to OpenWork Cloud.";
+  const attempt = ++handoffAttemptCounter;
+
+  const fail = (
+    error: string,
+    input: { grantConsumed: boolean; stale?: boolean; publishError?: boolean },
+  ): ExchangeHandoffResult => {
+    if (input.publishError !== false) {
+      dispatchDenSessionUpdated({ status: "error", message: error });
+    }
+    return { ok: false, error, grantConsumed: input.grantConsumed, stale: input.stale === true };
+  };
+
+  // Phase 1: prepare. Resolve the expected destination once; the exchange
+  // client, the durable bootstrap commit, and the activated session all use
+  // this same resolution, so they cannot diverge.
   const storedSettings = readDenSettings();
-  const apiBaseUrl = options.apiBaseUrl ?? (
-    storedSettings.baseUrl === resolveDenBaseUrls(options.baseUrl).baseUrl
-      ? storedSettings.apiBaseUrl
-      : undefined
-  );
-  const client = options.client ?? createDenClient({
-    baseUrl: options.baseUrl,
-    apiBaseUrl,
+  const sameOrigin =
+    denOriginComparisonKey(storedSettings.baseUrl) === denOriginComparisonKey(options.baseUrl);
+  let destination: Awaited<ReturnType<typeof resolveDenBaseUrlsForDestination>>;
+  try {
+    destination = await resolveDenBaseUrlsForDestination({
+      baseUrl: options.baseUrl,
+      apiBaseUrl: options.apiBaseUrl ?? (sameOrigin ? storedSettings.apiBaseUrl : undefined),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : fallback;
+    return fail(message, { grantConsumed: false });
+  }
+  const destinationKey = denOriginComparisonKey(destination.baseUrl);
+  const apiBaseUrl = destination.apiBaseUrl;
+
+  // Phase 2: exchange with a client constructed from the resolved
+  // destination, so the grant can only be sent to — and the credential can
+  // only come from — the origin this transaction would persist.
+  const client = createDenClient({
+    baseUrl: destination.baseUrl,
+    apiBaseUrl: destination.apiBaseUrl,
   });
 
+  let exchange: DenDesktopHandoffExchange;
   try {
-    const exchange = await client.exchangeDesktopHandoff(grant);
-    if (!exchange.token) {
-      throw new Error(fallback);
+    exchange = await client.exchangeDesktopHandoff(grant);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : fallback;
+    return fail(message, { grantConsumed: false });
+  }
+  if (!exchange.token) {
+    return fail(fallback, { grantConsumed: true });
+  }
+
+  // Phases 3-5 run serialized: one commit at a time, newest attempt wins.
+  const commit = async (): Promise<ExchangeHandoffResult> => {
+    if (attempt !== handoffAttemptCounter) {
+      // A newer handoff attempt owns the enrollment now. Do not activate or
+      // publish anything from this one.
+      return fail("This sign-in was superseded by a newer attempt.", {
+        grantConsumed: true,
+        stale: true,
+        publishError: false,
+      });
     }
 
-    if (typeof window !== "undefined") {
-      try {
-        window.sessionStorage.setItem(DEN_HANDOFF_AUTO_CONTINUE_KEY, String(Date.now()));
-      } catch {}
-    }
     const desktopInitiated = options.desktopInitiated ?? hasActiveDesktopSignInIntent();
-    clearDesktopSignInIntent();
     const plan = resolveHandoffOrgPlan({
       explicitActiveOrg: options.activeOrg ?? null,
       exchangeOrganization: exchange.organization ?? null,
       desktopInitiated,
     });
-    if (plan.kind === "await-user-selection") {
-      // Desktop-initiated sign-in: hold the org choice for the onboarding
-      // step. The exchange-reported org is only the chooser's default;
-      // single-org accounts still auto-select there without a visible stop.
-      markOrgSelectionPending(plan.suggestion);
-      writeDenSettings(
-        {
-          baseUrl: options.baseUrl,
+
+    // Phase 3: durable bootstrap commit before any active-session write. The
+    // current enrollment stays authoritative until the destination bootstrap
+    // is persisted and confirmed.
+    const previousBootstrap = readDenBootstrapConfig();
+    const bootstrapChangesOrigin =
+      denOriginComparisonKey(previousBootstrap.baseUrl) !== destinationKey;
+    const needsBootstrapCommit = bootstrapChangesOrigin || options.bootstrap !== undefined;
+    if (needsBootstrapCommit) {
+      // Branding, claim links, and prepared-workspace state belong to the
+      // origin that wrote them; they carry through same-origin commits only.
+      const carryOriginScopedFields = !bootstrapChangesOrigin;
+      const clearHandoff = options.bootstrap?.clearHandoff === true || bootstrapChangesOrigin;
+      try {
+        await setDenBootstrapConfig({
+          baseUrl: destination.baseUrl,
           ...(apiBaseUrl ? { apiBaseUrl } : {}),
-          authToken: exchange.token,
-          activeOrgId: null,
-          activeOrgSlug: null,
-          activeOrgName: null,
-        },
-        { intentionalActiveOrgClear: true },
-      );
-    } else {
-      // Prefer the caller-provided org (install-link bootstrap), then the org
-      // the server resolved for this session. When neither is known, keep
-      // whatever is already stored: overwriting with null strands fresh
-      // profiles without an organization, which disables Connect and skips
-      // org onboarding.
-      clearOrgSelectionPending();
-      const activeOrg = plan.organization;
-      writeDenSettings({
-        baseUrl: options.baseUrl,
-        ...(apiBaseUrl ? { apiBaseUrl } : {}),
-        authToken: exchange.token,
-        activeOrgId: activeOrg ? activeOrg.id : storedSettings.activeOrgId,
-        activeOrgSlug: activeOrg ? activeOrg.slug ?? null : storedSettings.activeOrgSlug,
-        activeOrgName: activeOrg ? activeOrg.name ?? null : storedSettings.activeOrgName,
-      });
+          requireSignin: options.bootstrap?.requireSignin ?? previousBootstrap.requireSignin,
+          ...(typeof previousBootstrap.requireActivation === "boolean"
+            ? { requireActivation: previousBootstrap.requireActivation }
+            : {}),
+          ...(carryOriginScopedFields && previousBootstrap.brandAppName
+            ? { brandAppName: previousBootstrap.brandAppName }
+            : {}),
+          ...(carryOriginScopedFields && previousBootstrap.brandLogoUrl
+            ? { brandLogoUrl: previousBootstrap.brandLogoUrl }
+            : {}),
+          ...(carryOriginScopedFields && previousBootstrap.brandIconUrl
+            ? { brandIconUrl: previousBootstrap.brandIconUrl }
+            : {}),
+          ...(carryOriginScopedFields && previousBootstrap.claimLinks
+            ? { claimLinks: previousBootstrap.claimLinks }
+            : {}),
+          handoff: clearHandoff ? null : previousBootstrap.handoff ?? null,
+          ...(carryOriginScopedFields && previousBootstrap.prepared
+            ? { prepared: previousBootstrap.prepared }
+            : {}),
+          ...(options.bootstrap?.enterpriseActivation
+            ? { enterpriseActivation: options.bootstrap.enterpriseActivation }
+            : carryOriginScopedFields && previousBootstrap.enterpriseActivation
+              ? { enterpriseActivation: previousBootstrap.enterpriseActivation }
+              : {}),
+        });
+      } catch (error) {
+        // Nothing was activated: the previous enrollment (origin, token, and
+        // organization) is still complete and authoritative.
+        const message = error instanceof Error ? error.message : fallback;
+        return fail(message, { grantConsumed: true });
+      }
+
+      // Confirm the committed bootstrap is the intended destination before
+      // promoting the credential. A divergent read-back means the durable
+      // state is not what this transaction validated.
+      if (denOriginComparisonKey(readDenBootstrapConfig().baseUrl) !== destinationKey) {
+        await setDenBootstrapConfig(bootstrapRestorePayload(previousBootstrap)).catch(() => undefined);
+        return fail(fallback, { grantConsumed: true });
+      }
     }
+
+    // Phase 4: activate. One synchronous write publishes origin, token, and
+    // organization together. Roll the bootstrap back if it cannot complete.
+    try {
+      clearDesktopSignInIntent();
+      if (plan.kind === "await-user-selection") {
+        // Desktop-initiated sign-in: hold the org choice for the onboarding
+        // step. The exchange-reported org is only the chooser's default;
+        // single-org accounts still auto-select there without a visible stop.
+        markOrgSelectionPending(plan.suggestion);
+        writeDenSettings(
+          {
+            baseUrl: destination.baseUrl,
+            ...(apiBaseUrl ? { apiBaseUrl } : {}),
+            authToken: exchange.token,
+            activeOrgId: null,
+            activeOrgSlug: null,
+            activeOrgName: null,
+          },
+          { persistBootstrap: false, intentionalActiveOrgClear: true },
+        );
+      } else {
+        // Prefer the caller-provided org (install-link bootstrap), then the
+        // org the destination resolved for this session. Without either, a
+        // same-origin handoff keeps the stored organization, but an
+        // organization never carries into a different origin: the destination
+        // must prove or return its own.
+        clearOrgSelectionPending();
+        const activeOrg = plan.organization;
+        const inheritStoredOrg = !activeOrg && sameOrigin;
+        writeDenSettings(
+          {
+            baseUrl: destination.baseUrl,
+            ...(apiBaseUrl ? { apiBaseUrl } : {}),
+            authToken: exchange.token,
+            activeOrgId: activeOrg ? activeOrg.id : inheritStoredOrg ? storedSettings.activeOrgId : null,
+            activeOrgSlug: activeOrg
+              ? activeOrg.slug ?? null
+              : inheritStoredOrg
+                ? storedSettings.activeOrgSlug
+                : null,
+            activeOrgName: activeOrg
+              ? activeOrg.name ?? null
+              : inheritStoredOrg
+                ? storedSettings.activeOrgName
+                : null,
+          },
+          {
+            persistBootstrap: false,
+            ...(activeOrg || inheritStoredOrg ? {} : { intentionalActiveOrgClear: true }),
+          },
+        );
+      }
+    } catch (error) {
+      if (needsBootstrapCommit) {
+        await setDenBootstrapConfig(bootstrapRestorePayload(previousBootstrap)).catch(() => undefined);
+      }
+      const message = error instanceof Error ? error.message : fallback;
+      return fail(message, { grantConsumed: true });
+    }
+
     if (exchange.organization) {
       seedDenDesktopConfigConnectPolicy({
         organizationId: exchange.organization.id,
@@ -132,18 +331,24 @@ export async function exchangeHandoffAndSignIn(
       });
     }
 
+    // Phase 5: publish success only after the durable commit and activation.
+    if (typeof window !== "undefined") {
+      try {
+        window.sessionStorage.setItem(DEN_HANDOFF_AUTO_CONTINUE_KEY, String(Date.now()));
+      } catch {}
+    }
     dispatchDenSessionUpdated({
       status: "success",
-      baseUrl: options.baseUrl,
+      baseUrl: destination.baseUrl,
       token: exchange.token,
       user: exchange.user,
       email: exchange.user?.email ?? null,
     });
 
-    return { ok: true, exchange, baseUrl: options.baseUrl };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : fallback;
-    dispatchDenSessionUpdated({ status: "error", message });
-    return { ok: false, error: message };
-  }
+    return { ok: true, exchange, baseUrl: destination.baseUrl };
+  };
+
+  const result = commitQueue.then(commit, commit);
+  commitQueue = result.catch(() => undefined);
+  return result;
 }

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1010,6 +1010,35 @@ async function resolveDenBootstrapConfigWithRuntimeApi(
   };
 }
 
+/**
+ * Resolve a handoff destination's base URLs. On desktop, when the caller does
+ * not already know the destination's API base, prefer the API base the
+ * destination publishes in its runtime config — the same source the durable
+ * bootstrap commit uses — so the exchange and the persisted bootstrap can
+ * never disagree about where the destination's API lives.
+ */
+export async function resolveDenBaseUrlsForDestination(
+  input: { baseUrl: string; apiBaseUrl?: string | null },
+): Promise<DenBaseUrls> {
+  const resolved = resolveDenBaseUrls(input);
+  if (input.apiBaseUrl || !isDesktopRuntime()) {
+    return resolved;
+  }
+
+  const runtimeApiBaseUrl = await fetchRuntimeConfigDenApiUrl(resolved.baseUrl);
+  if (!runtimeApiBaseUrl) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    apiBaseUrl: resolveDenBaseUrls({
+      baseUrl: resolved.baseUrl,
+      apiBaseUrl: runtimeApiBaseUrl,
+    }).apiBaseUrl,
+  };
+}
+
 function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null {
   if (next.baseUrl === undefined && next.apiBaseUrl === undefined) {
     return null;

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1026,7 +1026,7 @@ export async function resolveDenBaseUrlsForDestination(
   }
 
   const runtimeApiBaseUrl = await fetchRuntimeConfigDenApiUrl(resolved.baseUrl);
-  if (!runtimeApiBaseUrl) {
+  if (!runtimeApiBaseUrl || !destinationApiOriginVerified(resolved.baseUrl, runtimeApiBaseUrl)) {
     return resolved;
   }
 
@@ -1037,6 +1037,29 @@ export async function resolveDenBaseUrlsForDestination(
       apiBaseUrl: runtimeApiBaseUrl,
     }).apiBaseUrl,
   };
+}
+
+/**
+ * A destination-published API origin receives the one-time handoff grant and
+ * the bearer credential minted from it, so a syntactically valid URL is not
+ * enough: the published origin must have a relationship to the destination
+ * web origin this client can verify on its own. That is either the same
+ * origin (the destination's own `/api/den` proxy) or the deterministic API
+ * sibling derived for hosted deployments. Every other published value is
+ * ignored and the exchange stays on the destination's same-origin proxy,
+ * which reaches the same control plane without trusting the runtime config
+ * to route credentials.
+ */
+function destinationApiOriginVerified(webBaseUrl: string, candidate: string): boolean {
+  try {
+    const webOrigin = new URL(webBaseUrl).origin;
+    const candidateOrigin = new URL(candidate).origin;
+    if (candidateOrigin === webOrigin) return true;
+    const deterministic = denApiOriginForDenBaseUrl(webBaseUrl);
+    return deterministic !== null && new URL(deterministic).origin === candidateOrigin;
+  } catch {
+    return false;
+  }
 }
 
 function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null {
@@ -1282,7 +1305,13 @@ export async function setDenBootstrapConfig(
   const previous = readDenBootstrapConfig();
   const normalized = await resolveDenBootstrapConfigWithRuntimeApi({
     ...next,
-    enterpriseActivation: next.enterpriseActivation ?? previous.enterpriseActivation,
+    // An omitted stamp retains the previous one; an explicit null clears it.
+    // Cross-origin handoffs rely on the explicit clear: the old control
+    // plane's activation must never mark a new control plane as activated.
+    enterpriseActivation:
+      next.enterpriseActivation !== undefined
+        ? next.enterpriseActivation
+        : previous.enterpriseActivation,
   });
 
   if (isDesktopRuntime()) {

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -433,21 +433,25 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     }
 
     handledGrantsRef.current.add(handoff.grant);
-    const client = createDenClient({
-      baseUrl: handoff.denBaseUrl,
-    });
-
     void exchangeHandoffAndSignIn(handoff.grant, {
       baseUrl: handoff.denBaseUrl,
-      client,
       activeOrg: { id: handoff.orgId, slug: handoff.orgSlug || null, name: handoff.orgName || null },
+      // The consumed grant is stripped from the persisted bootstrap in the
+      // same durable commit that enrolls the session, so a relaunch can
+      // neither re-exchange it nor lose the enrollment it produced.
+      bootstrap: { clearHandoff: true },
     }).then((result) => {
-      if (!result.ok) {
+      if (result.ok) return;
+      if (!result.grantConsumed) {
+        // The grant never reached the destination; a later bootstrap heal may
+        // retry it.
         handledGrantsRef.current.delete(handoff.grant);
         return;
       }
-      // Best-effort cleanup; not part of the auth success/failure path.
-      clearConsumedBootstrapHandoff(bootstrap, handoff.denBaseUrl);
+      // The one-time grant is spent but the enrollment did not commit. Drop
+      // the grant from disk (best effort) so restarts do not retry it forever;
+      // the user needs a fresh handoff link.
+      clearConsumedBootstrapHandoff(bootstrap, bootstrap.baseUrl);
     });
   }, [clearConsumedBootstrapHandoff]);
 
@@ -468,34 +472,25 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     isEnterpriseActivation: boolean,
   ) => {
     handledGrantsRef.current.add(grant);
-    const client = createDenClient({
-      baseUrl: denBaseUrl,
-    });
     void exchangeHandoffAndSignIn(grant, {
       baseUrl: denBaseUrl,
-      client,
-    }).then(async (result) => {
-      if (!result.ok) {
+      // Enterprise activation is part of the same durable commit as the
+      // enrollment: the stamp and the session it locks in land together.
+      ...(isEnterpriseActivation
+        ? {
+            bootstrap: {
+              requireSignin: true,
+              enterpriseActivation: {
+                activatedAt: new Date().toISOString(),
+                denBaseUrl,
+              },
+            },
+          }
+        : {}),
+    }).then((result) => {
+      if (!result.ok && !result.grantConsumed) {
         handledGrantsRef.current.delete(grant);
-        return;
       }
-      if (!isEnterpriseActivation) return;
-
-      const bootstrap = readDenBootstrapConfig();
-      await setDenBootstrapConfig({
-        baseUrl: denBaseUrl,
-        requireSignin: true,
-        requireActivation: bootstrap.requireActivation,
-        ...(bootstrap.brandAppName ? { brandAppName: bootstrap.brandAppName } : {}),
-        ...(bootstrap.brandLogoUrl ? { brandLogoUrl: bootstrap.brandLogoUrl } : {}),
-        ...(bootstrap.brandIconUrl ? { brandIconUrl: bootstrap.brandIconUrl } : {}),
-        ...(bootstrap.claimLinks ? { claimLinks: bootstrap.claimLinks } : {}),
-        ...(bootstrap.prepared ? { prepared: bootstrap.prepared } : {}),
-        enterpriseActivation: {
-          activatedAt: new Date().toISOString(),
-          denBaseUrl,
-        },
-      });
     });
   }, []);
 

--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -4,7 +4,6 @@ import { useState, useSyncExternalStore, type FormEvent, type ReactNode } from "
 
 import {
   buildDenAuthUrl,
-  createDenClient,
   readDenBootstrapConfig,
   setDenBootstrapConfig,
 } from "@/app/lib/den";
@@ -84,30 +83,26 @@ function EnterpriseActivationPage() {
     setServerError(null);
     setStatusMessage("Finishing OpenWork Enterprise sign-in…");
     try {
-      // Persist the confirmed server before exchanging so the session is
-      // scoped to this organization's base URL and survives the provider
-      // remount that follows activation.
-      await setDenBootstrapConfig({ baseUrl, requireSignin: true });
+      // The confirmed server, session, and activation stamp commit in one
+      // handoff transaction, so activation can never leave the bootstrap and
+      // the session pointing at different servers.
       const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl,
-        client: createDenClient({ baseUrl }),
         desktopInitiated: true,
         fallbackErrorMessage: "OpenWork Enterprise did not return a session token.",
+        bootstrap: {
+          requireSignin: true,
+          enterpriseActivation: {
+            activatedAt: new Date().toISOString(),
+            denBaseUrl: baseUrl,
+          },
+        },
       });
       if (!result.ok) {
         setStatusMessage(null);
         setAuthError(result.error);
         return;
       }
-
-      await setDenBootstrapConfig({
-        baseUrl,
-        requireSignin: true,
-        enterpriseActivation: {
-          activatedAt: new Date().toISOString(),
-          denBaseUrl: baseUrl,
-        },
-      });
     } catch (error) {
       setStatusMessage(null);
       setAuthError(

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -5,14 +5,12 @@ import { t } from "../../../i18n";
 import {
   buildDenAuthUrl,
   clearDenSession,
-  createDenClient,
   DEFAULT_DEN_BASE_URL,
   denOriginComparisonKey,
   normalizeDenBaseUrl,
   readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
-  setDenBootstrapConfig,
 } from "../../../app/lib/den";
 import { markDesktopSignInInitiated } from "../../../app/lib/den-sign-in-intent";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
@@ -104,30 +102,28 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     setStatusMessage(t("den.signing_in"));
 
     try {
-      const client = createDenClient({
-        baseUrl: nextBaseUrl,
-      });
-      // The helper exchanges, persists, and dispatches the success/error session events.
+      // The helper exchanges, commits, and dispatches the success/error session
+      // events. An enterprise activation stamp lands in the same durable
+      // commit as the enrollment it locks in.
       const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl: nextBaseUrl,
-        client,
         // Pasted one-time codes are desktop-initiated sign-ins.
         desktopInitiated: true,
         fallbackErrorMessage: t("den.error_no_token"),
+        ...(readDesktopDistributionInfo().flavor === "enterprise"
+          ? {
+              bootstrap: {
+                requireSignin: true,
+                enterpriseActivation: {
+                  activatedAt: new Date().toISOString(),
+                  denBaseUrl: nextBaseUrl,
+                },
+              },
+            }
+          : {}),
       });
       if (!result.ok) {
         return false;
-      }
-
-      if (readDesktopDistributionInfo().flavor === "enterprise") {
-        await setDenBootstrapConfig({
-          baseUrl: nextBaseUrl,
-          requireSignin: true,
-          enterpriseActivation: {
-            activatedAt: new Date().toISOString(),
-            denBaseUrl: nextBaseUrl,
-          },
-        });
       }
 
       if (developerMode) {

--- a/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { installConfigSchema, parseInstallLinkInput } from "@openwork/install-config";
 
-import { clearDenSession, createDenClient, readDenBootstrapConfig, readDenSettings, setDenBootstrapConfig } from "@/app/lib/den";
+import { clearDenSession, readDenBootstrapConfig, readDenSettings, setDenBootstrapConfig } from "@/app/lib/den";
 import { parseManualAuthInput } from "@/app/lib/manual-auth-input";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { desktopFetchViaMain } from "@/app/lib/desktop";
@@ -215,7 +215,6 @@ export function JoinOrganizationDialog({
     setStatus({ phase: "connecting", clientName: t("join_org.openwork_cloud"), host: hostFromUrl(baseUrl) });
     const result = await exchangeHandoffAndSignIn(parsed.grant, {
       baseUrl,
-      client: createDenClient({ baseUrl }),
       // Pasted one-time codes are desktop-initiated sign-ins.
       desktopInitiated: true,
       fallbackErrorMessage: t("den.error_no_token"),

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -243,7 +243,6 @@ function PreparedWorkspacePage({ prepared }: { prepared: PreparedBootstrapSummar
     try {
       const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl: settings.baseUrl,
-        client: createDenClient({ baseUrl: settings.baseUrl }),
         // A pasted one-time code is a desktop-initiated sign-in.
         desktopInitiated: true,
       });

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -5,7 +5,6 @@ import { toast } from "@/components/ui/sonner";
 import {
   buildDenAuthUrl,
   clearDenSession,
-  createDenClient,
   DEFAULT_DEN_BASE_URL,
   DenApiError,
   ensureDenActiveOrganization,
@@ -473,11 +472,9 @@ export function useDenSession({
     setStatusMessage(t("den.signing_in"));
 
     try {
-      const exchangeClient = createDenClient({ baseUrl: nextBaseUrl });
       // The helper exchanges, persists, and dispatches the success/error session events.
       const result = await exchangeHandoffAndSignIn(parsed.grant, {
         baseUrl: nextBaseUrl,
-        client: exchangeClient,
         // Pasted one-time codes are desktop-initiated sign-ins.
         desktopInitiated: true,
         fallbackErrorMessage: t("den.error_no_token"),

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -5,7 +5,6 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router"
 
 import { captureAnalyticsEvent, initAnalytics } from "../../app/lib/analytics";
 import {
-  createDenClient,
   readDenBootstrapConfig,
   readDenSettings,
   setDenBootstrapConfig,
@@ -238,10 +237,8 @@ function DenAuthControlActions() {
       if (!grant?.trim()) return { ok: false, error: "grant is required" };
       const settings = readDenSettings();
       const targetBaseUrl = argBaseUrl?.trim() || settings.baseUrl;
-      const client = createDenClient({ baseUrl: targetBaseUrl });
       const result = await exchangeHandoffAndSignIn(grant.trim(), {
         baseUrl: targetBaseUrl,
-        client,
         // Automation surface: commit the exchange-reported org directly; a
         // UI chooser would strand a headless driver.
         desktopInitiated: false,

--- a/apps/app/tests/den-handoff.test.ts
+++ b/apps/app/tests/den-handoff.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import {
+  initializeDenBootstrapConfig,
+  readDenBootstrapConfig,
+  readDenSettings,
+} from "../src/app/lib/den";
 import { exchangeHandoffAndSignIn } from "../src/app/lib/den-handoff";
 import {
   hasActiveDesktopSignInIntent,
@@ -35,30 +40,83 @@ function memoryStorage(): Storage {
   };
 }
 
-function stubWindow() {
+type SessionEvent = {
+  status?: string;
+  message?: string | null;
+  /** Bootstrap origin observed at the moment the event was published. */
+  bootstrapBaseUrlAtDispatch: string;
+};
+
+type StubbedWindow = {
+  sessionEvents: SessionEvent[];
+};
+
+function stubWindow(extra?: Record<string, unknown>): StubbedWindow {
+  const sessionEvents: SessionEvent[] = [];
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
       localStorage: memoryStorage(),
       sessionStorage: memoryStorage(),
-      dispatchEvent: () => true,
+      dispatchEvent(event: Event) {
+        if (event.type === "openwork-den-session-updated") {
+          const detail = (event as CustomEvent<{ status?: string; message?: string | null }>).detail;
+          sessionEvents.push({
+            status: detail?.status,
+            message: detail?.message ?? null,
+            bootstrapBaseUrlAtDispatch: readDenBootstrapConfig().baseUrl,
+          });
+        }
+        return true;
+      },
+      ...extra,
     },
   });
+  return { sessionEvents };
 }
 
-function stubExchangeResponse(payload: Record<string, unknown>) {
+type RecordedRequest = { url: string; method: string };
+
+function stubFetch(
+  handler: (url: URL) => { status: number; body?: unknown } | Promise<Response>,
+): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
-    value: (async () => new Response(JSON.stringify(payload), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    })) satisfies typeof fetch,
+    value: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      requests.push({ url: raw, method: init?.method ?? "GET" });
+      const outcome = handler(new URL(raw));
+      if (outcome instanceof Promise) return outcome;
+      return new Response(JSON.stringify(outcome.body ?? {}), {
+        status: outcome.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) satisfies typeof fetch,
   });
+  return requests;
+}
+
+function stubExchangeResponse(payload: Record<string, unknown>): RecordedRequest[] {
+  return stubFetch(() => ({ status: 200, body: payload }));
 }
 
 const exchangeUser = { id: "user_invited", email: "invited@example.com", name: "Invited Member" };
 
-afterEach(() => {
+function seedSignedInAt(baseUrl: string, token: string, org?: { id: string; slug: string; name: string }) {
+  window.localStorage.setItem("openwork.den.baseUrl", baseUrl);
+  window.localStorage.setItem("openwork.den.authToken", token);
+  // Dev's origin-coherence invariant stores the issuing origin next to the
+  // token (denOriginComparisonKey form; equal to the origin for these URLs).
+  window.localStorage.setItem("openwork.den.sessionOrigin", baseUrl);
+  if (org) {
+    window.localStorage.setItem("openwork.den.activeOrgId", org.id);
+    window.localStorage.setItem("openwork.den.activeOrgSlug", org.slug);
+    window.localStorage.setItem("openwork.den.activeOrgName", org.name);
+  }
+}
+
+afterEach(async () => {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: originalWindow,
@@ -67,6 +125,8 @@ afterEach(() => {
     configurable: true,
     value: originalFetch,
   });
+  // Reset the module-level bootstrap snapshot mutated by committed handoffs.
+  await initializeDenBootstrapConfig();
 });
 
 describe("exchangeHandoffAndSignIn", () => {
@@ -86,6 +146,7 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_invited");
     expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("invited-org");
     expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Invited Org");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den.test");
     expect(result.exchange.connectEnabled).toBe(false);
     expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_invited"))
       .toBe(JSON.stringify({ connectEnabled: false }));
@@ -109,11 +170,13 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_bootstrap")).toBeNull();
   });
 
-  test("preserves the stored organization when the exchange has none", async () => {
+  test("a same-origin handoff without an exchange org preserves the stored organization", async () => {
     stubWindow();
-    window.localStorage.setItem("openwork.den.activeOrgId", "org_stored");
-    window.localStorage.setItem("openwork.den.activeOrgSlug", "stored-org");
-    window.localStorage.setItem("openwork.den.activeOrgName", "Stored Org");
+    seedSignedInAt("https://den.test", "tok_before", {
+      id: "org_stored",
+      slug: "stored-org",
+      name: "Stored Org",
+    });
     stubExchangeResponse({ token: "tok_handoff", user: exchangeUser });
 
     const result = await exchangeHandoffAndSignIn("grant_test", { baseUrl: "https://den.test" });
@@ -126,6 +189,53 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(result.exchange.connectEnabled).toBeNull();
     expect(window.localStorage.getItem("openwork.den.desktopConfig:https://den.test::org_stored"))
       .toBeNull();
+  });
+
+  test("a cross-origin handoff without a destination org does not inherit the source organization", async () => {
+    stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+    stubExchangeResponse({ token: "tok_b", user: exchangeUser });
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    // Origin, token, and enrollment marker all switched together…
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-b.test");
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_b");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-b.test");
+    // …and A's organization did not leak into B.
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBeNull();
+  });
+
+  test("a cross-origin handoff commits origin, token, and organization together", async () => {
+    stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+    const requests = stubExchangeResponse({
+      token: "tok_b",
+      user: exchangeUser,
+      organization: { id: "org_b", slug: "org-b", name: "Org B" },
+    });
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-b.test");
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_b");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_b");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-b.test");
+    // The grant went to the destination API host only — never to A.
+    expect(requests.length).toBeGreaterThan(0);
+    for (const request of requests) {
+      expect(new URL(request.url).hostname).toBe("api.den-b.test");
+    }
   });
 
   test("a desktop-initiated sign-in defers the org choice to the chooser", async () => {
@@ -207,5 +317,402 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(result.ok).toBe(true);
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_remote");
     expect(readOrgSelectionPending()).toEqual({ pending: false, suggestion: null });
+  });
+
+  test("an exchange failure leaves the previous enrollment untouched and publishes no success", async () => {
+    const { sessionEvents } = stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+    stubFetch(() => ({ status: 500, body: { message: "exchange exploded" } }));
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.grantConsumed).toBe(false);
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-a.test");
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_a");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_a");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-a.test");
+    expect(window.sessionStorage.getItem("openwork.den.handoffAutoContinueAt")).toBeNull();
+    expect(sessionEvents.map((event) => event.status)).toEqual(["error"]);
+  });
+
+  test("the exchange client is constructed from the expected destination, not the caller", async () => {
+    stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+    const requests = stubExchangeResponse({ token: "tok_b", user: exchangeUser });
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test/",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    // Every request of the transaction targeted the normalized destination.
+    expect(requests.length).toBeGreaterThan(0);
+    for (const request of requests) {
+      expect(new URL(request.url).hostname).toBe("api.den-b.test");
+    }
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-b.test");
+  });
+
+  test("a late result from an older handoff attempt cannot replace a newer enrollment", async () => {
+    stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+
+    let resolveOld: ((response: Response) => void) | null = null;
+    stubFetch((url) => {
+      if (url.hostname === "api.den-old.test") {
+        return new Promise<Response>((resolve) => {
+          resolveOld = resolve;
+        });
+      }
+      return {
+        status: 200,
+        body: {
+          token: "tok_new",
+          user: exchangeUser,
+          organization: { id: "org_new", slug: "org-new", name: "Org New" },
+        },
+      };
+    });
+
+    const oldAttempt = exchangeHandoffAndSignIn("grant_old", {
+      baseUrl: "https://den-old.test",
+      desktopInitiated: false,
+    });
+    // The old attempt's exchange must be in flight before the new one starts.
+    while (!resolveOld) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    const newAttempt = await exchangeHandoffAndSignIn("grant_new", {
+      baseUrl: "https://den-new.test",
+      desktopInitiated: false,
+    });
+    expect(newAttempt.ok).toBe(true);
+
+    resolveOld(new Response(
+      JSON.stringify({
+        token: "tok_old",
+        user: exchangeUser,
+        organization: { id: "org_old", slug: "org-old", name: "Org Old" },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    const oldResult = await oldAttempt;
+
+    expect(oldResult.ok).toBe(false);
+    if (oldResult.ok) throw new Error("expected stale failure");
+    expect(oldResult.stale).toBe(true);
+    // The newer enrollment stands, complete and unmixed.
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-new.test");
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_new");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_new");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-new.test");
+  });
+
+  test("concurrent handoffs to two destinations cannot cross origins, tokens, or organizations", async () => {
+    stubWindow();
+    seedSignedInAt("https://den-a.test", "tok_a", { id: "org_a", slug: "org-a", name: "Org A" });
+
+    const resolvers = new Map<string, (response: Response) => void>();
+    stubFetch((url) => new Promise<Response>((resolve) => {
+      resolvers.set(url.hostname, resolve);
+    }));
+
+    const attemptB = exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+    const attemptC = exchangeHandoffAndSignIn("grant_c", {
+      baseUrl: "https://den-c.test",
+      desktopInitiated: false,
+    });
+
+    // Both exchanges must be in flight before either destination responds.
+    while (resolvers.size < 2) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    const respond = (host: string, token: string, org: string) => {
+      resolvers.get(host)?.(new Response(
+        JSON.stringify({
+          token,
+          user: exchangeUser,
+          organization: { id: org, slug: org, name: org },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ));
+    };
+    // B's exchange returns first, then C's — the newest attempt still wins.
+    respond("api.den-b.test", "tok_b", "org_b");
+    respond("api.den-c.test", "tok_c", "org_c");
+
+    const [resultB, resultC] = await Promise.all([attemptB, attemptC]);
+
+    expect(resultC.ok).toBe(true);
+    expect(resultB.ok).toBe(false);
+    if (resultB.ok) throw new Error("expected the superseded attempt to fail");
+    expect(resultB.stale).toBe(true);
+
+    // Every persisted field belongs to C — no mixing with B or A.
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-c.test");
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_c");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_c");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-c.test");
+  });
+});
+
+describe("exchangeHandoffAndSignIn on desktop (durable bootstrap commit)", () => {
+  type BootstrapFile = Record<string, unknown>;
+
+  function stubDesktopWindow(input: {
+    bootstrap: BootstrapFile;
+    failBootstrapWrites?: boolean;
+    exchange: (url: URL) => { status: number; body?: unknown };
+  }) {
+    const state = {
+      bootstrapFile: { ...input.bootstrap },
+      bootstrapWrites: 0,
+      requests: [] as RecordedRequest[],
+      failBootstrapWrites: input.failBootstrapWrites === true,
+    };
+    const stubbed = stubWindow({
+      location: { origin: "http://localhost:5173" },
+      __OPENWORK_ELECTRON__: {
+        meta: { desktopBootstrap: { ...input.bootstrap } },
+        invokeDesktop: async (command: string, ...args: unknown[]) => {
+          if (command === "getDesktopBootstrapConfig") {
+            return { ...state.bootstrapFile };
+          }
+          if (command === "setDesktopBootstrapConfig") {
+            if (state.failBootstrapWrites) {
+              throw new Error("bootstrap write failed: disk unavailable");
+            }
+            state.bootstrapWrites += 1;
+            state.bootstrapFile = { ...(args[0] as BootstrapFile), fromFile: true };
+            return { ...state.bootstrapFile };
+          }
+          if (command === "__fetch") {
+            const url = new URL(args[0] as string);
+            state.requests.push({
+              url: url.toString(),
+              method: ((args[1] as { method?: string } | undefined)?.method) ?? "GET",
+            });
+            if (url.pathname === "/api/runtime-config") {
+              return { status: 404, statusText: "Not Found", headers: {}, body: "" };
+            }
+            const outcome = input.exchange(url);
+            return {
+              status: outcome.status,
+              statusText: "",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(outcome.body ?? {}),
+            };
+          }
+          throw new Error(`unexpected desktop command: ${command}`);
+        },
+      },
+    });
+    return { state, sessionEvents: stubbed.sessionEvents };
+  }
+
+  test("a bootstrap persistence failure leaves the complete previous enrollment active", async () => {
+    const logs: string[] = [];
+    const originalConsole = { log: console.log, warn: console.warn, error: console.error };
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    console.warn = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    console.error = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+
+    try {
+      const { state, sessionEvents } = stubDesktopWindow({
+        bootstrap: { baseUrl: "https://den-a.test", requireSignin: false, fromFile: true },
+        failBootstrapWrites: true,
+        exchange: () => ({
+          status: 200,
+          body: {
+            token: "tok_b_secret",
+            user: exchangeUser,
+            organization: { id: "org_b", slug: "org-b", name: "Org B" },
+          },
+        }),
+      });
+      await initializeDenBootstrapConfig();
+      window.localStorage.setItem("openwork.den.authToken", "tok_a");
+      window.localStorage.setItem("openwork.den.sessionOrigin", "https://den-a.test");
+      window.localStorage.setItem("openwork.den.activeOrgId", "org_a");
+      window.localStorage.setItem("openwork.den.activeOrgSlug", "org-a");
+      window.localStorage.setItem("openwork.den.activeOrgName", "Org A");
+
+      const result = await exchangeHandoffAndSignIn("grant_b_secret", {
+        baseUrl: "https://den-b.test",
+        desktopInitiated: false,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      // The one-time grant is spent; callers must not retry it blindly.
+      expect(result.grantConsumed).toBe(true);
+
+      // The complete A enrollment is still active: origin, token, and org.
+      expect(readDenBootstrapConfig().baseUrl).toBe("https://den-a.test");
+      expect(state.bootstrapFile.baseUrl).toBe("https://den-a.test");
+      const settings = readDenSettings();
+      expect(settings.baseUrl).toBe("https://den-a.test");
+      expect(settings.authToken).toBe("tok_a");
+      expect(settings.activeOrgId).toBe("org_a");
+      // No B credential became visible and no B success state was published.
+      expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_a");
+      expect(window.sessionStorage.getItem("openwork.den.handoffAutoContinueAt")).toBeNull();
+      expect(sessionEvents.map((event) => event.status)).toEqual(["error"]);
+      // The exchange spoke only to B — the failed handoff sent nothing to A.
+      // (Runtime-config probes are credential-free GETs and are excluded.)
+      const exchangeRequests = state.requests.filter(
+        (request) => new URL(request.url).pathname !== "/api/runtime-config",
+      );
+      expect(exchangeRequests.length).toBeGreaterThan(0);
+      for (const request of exchangeRequests) {
+        expect(new URL(request.url).hostname.endsWith("den-b.test")).toBe(true);
+        expect(request.url).toContain("/v1/auth/desktop-handoff/exchange");
+      }
+      // Diagnostics never contain the grant or the tokens.
+      const captured = logs.join("\n");
+      expect(captured).not.toContain("grant_b_secret");
+      expect(captured).not.toContain("tok_b_secret");
+      expect(captured).not.toContain("tok_a");
+    } finally {
+      console.log = originalConsole.log;
+      console.warn = originalConsole.warn;
+      console.error = originalConsole.error;
+    }
+  });
+
+  test("a committed bootstrap that is not the expected destination is rejected and rolled back", async () => {
+    const { state, sessionEvents } = stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-a.test", requireSignin: false, fromFile: true },
+      exchange: () => ({
+        status: 200,
+        body: {
+          token: "tok_b",
+          user: exchangeUser,
+          organization: { id: "org_b", slug: "org-b", name: "Org B" },
+        },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+    window.localStorage.setItem("openwork.den.authToken", "tok_a");
+    window.localStorage.setItem("openwork.den.sessionOrigin", "https://den-a.test");
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_a");
+
+    // The shell "persists" a different origin than the transaction asked for
+    // (a tampered or corrupted write). The first divergent write is detected;
+    // the rollback write is allowed through so the previous state is restored.
+    const bridge = window.__OPENWORK_ELECTRON__ as unknown as {
+      invokeDesktop: (command: string, ...args: unknown[]) => Promise<unknown>;
+    };
+    const originalInvoke = bridge.invokeDesktop;
+    let divergedOnce = false;
+    bridge.invokeDesktop = async (command: string, ...args: unknown[]) => {
+      if (command === "setDesktopBootstrapConfig" && !divergedOnce) {
+        divergedOnce = true;
+        return originalInvoke(command, {
+          ...(args[0] as Record<string, unknown>),
+          baseUrl: "https://den-evil.test",
+        });
+      }
+      return originalInvoke(command, ...args);
+    };
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.grantConsumed).toBe(true);
+    // The rollback restored the previous origin durably…
+    expect(state.bootstrapFile.baseUrl).toBe("https://den-a.test");
+    expect(readDenBootstrapConfig().baseUrl).toBe("https://den-a.test");
+    // …the previous enrollment stayed active, and no B state was published.
+    const settings = readDenSettings();
+    expect(settings.authToken).toBe("tok_a");
+    expect(settings.activeOrgId).toBe("org_a");
+    expect(sessionEvents.map((event) => event.status)).toEqual(["error"]);
+  });
+
+  test("a successful cross-server handoff commits the bootstrap durably before publishing success", async () => {
+    const { state, sessionEvents } = stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-a.test", requireSignin: false, fromFile: true },
+      exchange: () => ({
+        status: 200,
+        body: {
+          token: "tok_b",
+          user: exchangeUser,
+          organization: { id: "org_b", slug: "org-b", name: "Org B" },
+        },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+    window.localStorage.setItem("openwork.den.authToken", "tok_a");
+    window.localStorage.setItem("openwork.den.sessionOrigin", "https://den-a.test");
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_a");
+
+    const result = await exchangeHandoffAndSignIn("grant_b", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    // Durably persisted destination…
+    expect(state.bootstrapWrites).toBe(1);
+    expect(state.bootstrapFile.baseUrl).toBe("https://den-b.test");
+    // …and the success event observed the committed bootstrap, proving the
+    // durable commit happened before publication.
+    expect(sessionEvents.map((event) => event.status)).toEqual(["success"]);
+    expect(sessionEvents[0]?.bootstrapBaseUrlAtDispatch).toBe("https://den-b.test");
+    const settings = readDenSettings();
+    expect(settings.baseUrl).toBe("https://den-b.test");
+    expect(settings.authToken).toBe("tok_b");
+    expect(settings.activeOrgId).toBe("org_b");
+    expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-b.test");
+  });
+
+  test("a session enrolled against another origin is never exposed to the active control plane", async () => {
+    // Simulates a restart after an interrupted commit: the durable bootstrap
+    // points at B while the stored session still belongs to A.
+    stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-b.test", requireSignin: false, fromFile: true },
+      exchange: () => ({ status: 500 }),
+    });
+    await initializeDenBootstrapConfig();
+    window.localStorage.setItem("openwork.den.authToken", "tok_a");
+    window.localStorage.setItem("openwork.den.sessionOrigin", "https://den-a.test");
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_a");
+
+    const settings = readDenSettings();
+    // Never a hybrid: at B, A's credential and organization are absent.
+    expect(settings.baseUrl).toBe("https://den-b.test");
+    expect(settings.authToken).toBeNull();
+    expect(settings.activeOrgId).toBeNull();
+  });
+
+  test("a restart after a committed handoff restores the complete new enrollment", async () => {
+    stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-b.test", requireSignin: false, fromFile: true },
+      exchange: () => ({ status: 500 }),
+    });
+    await initializeDenBootstrapConfig();
+    window.localStorage.setItem("openwork.den.authToken", "tok_b");
+    window.localStorage.setItem("openwork.den.sessionOrigin", "https://den-b.test");
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_b");
+
+    const settings = readDenSettings();
+    expect(settings.baseUrl).toBe("https://den-b.test");
+    expect(settings.authToken).toBe("tok_b");
+    expect(settings.activeOrgId).toBe("org_b");
   });
 });

--- a/apps/app/tests/den-handoff.test.ts
+++ b/apps/app/tests/den-handoff.test.ts
@@ -231,10 +231,12 @@ describe("exchangeHandoffAndSignIn", () => {
     expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_b");
     expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_b");
     expect(window.localStorage.getItem("openwork.den.sessionOrigin")).toBe("https://den-b.test");
-    // The grant went to the destination API host only — never to A.
+    // The grant went to the destination origin only — never to A. A
+    // non-hosted destination has no derivable API sibling, so the exchange
+    // stays on the destination's own same-origin API proxy.
     expect(requests.length).toBeGreaterThan(0);
     for (const request of requests) {
-      expect(new URL(request.url).hostname).toBe("api.den-b.test");
+      expect(new URL(request.url).hostname).toBe("den-b.test");
     }
   });
 
@@ -354,7 +356,7 @@ describe("exchangeHandoffAndSignIn", () => {
     // Every request of the transaction targeted the normalized destination.
     expect(requests.length).toBeGreaterThan(0);
     for (const request of requests) {
-      expect(new URL(request.url).hostname).toBe("api.den-b.test");
+      expect(new URL(request.url).hostname).toBe("den-b.test");
     }
     expect(window.localStorage.getItem("openwork.den.baseUrl")).toBe("https://den-b.test");
   });
@@ -365,7 +367,7 @@ describe("exchangeHandoffAndSignIn", () => {
 
     let resolveOld: ((response: Response) => void) | null = null;
     stubFetch((url) => {
-      if (url.hostname === "api.den-old.test") {
+      if (url.hostname === "den-old.test") {
         return new Promise<Response>((resolve) => {
           resolveOld = resolve;
         });
@@ -448,8 +450,8 @@ describe("exchangeHandoffAndSignIn", () => {
       ));
     };
     // B's exchange returns first, then C's — the newest attempt still wins.
-    respond("api.den-b.test", "tok_b", "org_b");
-    respond("api.den-c.test", "tok_c", "org_c");
+    respond("den-b.test", "tok_b", "org_b");
+    respond("den-c.test", "tok_c", "org_c");
 
     const [resultB, resultC] = await Promise.all([attemptB, attemptC]);
 
@@ -472,6 +474,8 @@ describe("exchangeHandoffAndSignIn on desktop (durable bootstrap commit)", () =>
   function stubDesktopWindow(input: {
     bootstrap: BootstrapFile;
     failBootstrapWrites?: boolean;
+    /** Optional runtime-config payload served by the destination web origin. */
+    runtimeConfig?: Record<string, unknown>;
     exchange: (url: URL) => { status: number; body?: unknown };
   }) {
     const state = {
@@ -503,6 +507,14 @@ describe("exchangeHandoffAndSignIn on desktop (durable bootstrap commit)", () =>
               method: ((args[1] as { method?: string } | undefined)?.method) ?? "GET",
             });
             if (url.pathname === "/api/runtime-config") {
+              if (input.runtimeConfig) {
+                return {
+                  status: 200,
+                  statusText: "",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify(input.runtimeConfig),
+                };
+              }
               return { status: 404, statusText: "Not Found", headers: {}, body: "" };
             }
             const outcome = input.exchange(url);
@@ -714,5 +726,126 @@ describe("exchangeHandoffAndSignIn on desktop (durable bootstrap commit)", () =>
     expect(settings.baseUrl).toBe("https://den-b.test");
     expect(settings.authToken).toBe("tok_b");
     expect(settings.activeOrgId).toBe("org_b");
+  });
+
+  test("a runtime-published API origin with no verified relationship never receives the grant", async () => {
+    const { state } = stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-a.test", requireSignin: false, fromFile: true },
+      // The destination's runtime config points the API at an unrelated host.
+      // A syntactically valid URL is not authority: the one-time grant and
+      // the resulting bearer credential must never be routed there.
+      runtimeConfig: { denApiUrl: "https://collector.attacker.test" },
+      exchange: () => ({
+        status: 200,
+        body: { token: "tok_b_secret", user: exchangeUser, organization: { id: "org_b", slug: "org-b", name: "Org B" } },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+
+    const result = await exchangeHandoffAndSignIn("grant_b_secret", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    // The one-time grant never left the destination's own origin: no request
+    // of any kind reached the unverified published origin during the
+    // handoff transaction.
+    for (const request of state.requests) {
+      expect(new URL(request.url).hostname).not.toBe("collector.attacker.test");
+    }
+    // The exchange stayed on the destination's own same-origin API proxy.
+    const exchangeRequests = state.requests.filter((request) =>
+      request.url.includes("/v1/auth/desktop-handoff/exchange"),
+    );
+    expect(exchangeRequests.length).toBeGreaterThan(0);
+    for (const request of exchangeRequests) {
+      expect(new URL(request.url).hostname).toBe("den-b.test");
+    }
+    expect(readDenSettings().authToken).toBe("tok_b_secret");
+  });
+
+  test("a runtime-published same-origin API base is still adopted", async () => {
+    const { state } = stubDesktopWindow({
+      bootstrap: { baseUrl: "https://den-a.test", requireSignin: false, fromFile: true },
+      runtimeConfig: { denApiUrl: "https://den-b.test" },
+      exchange: () => ({
+        status: 200,
+        body: { token: "tok_b_secret", user: exchangeUser, organization: { id: "org_b", slug: "org-b", name: "Org B" } },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+
+    const result = await exchangeHandoffAndSignIn("grant_b_secret", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    const exchangeRequests = state.requests.filter((request) =>
+      request.url.includes("/v1/auth/desktop-handoff/exchange"),
+    );
+    expect(exchangeRequests.length).toBeGreaterThan(0);
+    for (const request of exchangeRequests) {
+      expect(new URL(request.url).hostname).toBe("den-b.test");
+    }
+  });
+
+  test("a cross-origin handoff clears the previous origin's enterprise activation stamp", async () => {
+    const { state } = stubDesktopWindow({
+      bootstrap: {
+        baseUrl: "https://den-a.test",
+        requireSignin: false,
+        requireActivation: true,
+        enterpriseActivation: { activatedAt: "2026-01-01T00:00:00.000Z", denBaseUrl: "https://den-a.test" },
+        fromFile: true,
+      },
+      exchange: () => ({
+        status: 200,
+        body: { token: "tok_b_secret", user: exchangeUser, organization: { id: "org_b", slug: "org-b", name: "Org B" } },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+
+    const result = await exchangeHandoffAndSignIn("grant_b_secret", {
+      baseUrl: "https://den-b.test",
+      desktopInitiated: false,
+    });
+
+    expect(result.ok).toBe(true);
+    // The committed B bootstrap must not inherit A's activation stamp:
+    // an inherited stamp would mark the new control plane as already
+    // activated and bypass its activation gate.
+    expect(state.bootstrapFile.baseUrl).toBe("https://den-b.test");
+    expect(state.bootstrapFile.enterpriseActivation).toBeUndefined();
+    expect(readDenBootstrapConfig().enterpriseActivation ?? null).toBeNull();
+  });
+
+  test("a same-origin recommit preserves the origin's own enterprise activation stamp", async () => {
+    const stamp = { activatedAt: "2026-01-01T00:00:00.000Z", denBaseUrl: "https://den-a.test" };
+    const { state } = stubDesktopWindow({
+      bootstrap: {
+        baseUrl: "https://den-a.test",
+        requireSignin: false,
+        enterpriseActivation: stamp,
+        fromFile: true,
+      },
+      exchange: () => ({
+        status: 200,
+        body: { token: "tok_a_next", user: exchangeUser, organization: { id: "org_a", slug: "org-a", name: "Org A" } },
+      }),
+    });
+    await initializeDenBootstrapConfig();
+
+    const result = await exchangeHandoffAndSignIn("grant_a_refresh", {
+      baseUrl: "https://den-a.test",
+      desktopInitiated: false,
+      // Force a bootstrap commit on the same origin.
+      bootstrap: { requireSignin: false },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(state.bootstrapFile.baseUrl).toBe("https://den-a.test");
+    expect(state.bootstrapFile.enterpriseActivation).toEqual(stamp);
   });
 });

--- a/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
+++ b/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
@@ -1,0 +1,295 @@
+import { chmod, mkdtemp, readFile, rm } from "node:fs/promises";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import { control, evalIn } from "@openwork/behaviors";
+import { desktop as relaunchDesktop, electronProfilePaths } from "@openwork/hosts";
+import type { DesktopHandle } from "@openwork/hosts";
+import {
+  app,
+  createDesktopHandoffGrant,
+  eventually,
+  localMysqlIsRunning,
+  needs,
+  readDenClientState,
+  server,
+  test,
+} from "@openwork/testkit";
+import type { App } from "@openwork/env";
+import type { Surface } from "@openwork/cdp";
+
+/**
+ * A cross-server handoff is an atomic enrollment transaction: accepting a
+ * sign-in for control plane B while control plane A is active must switch the
+ * durable bootstrap origin, the session credential, and the active
+ * organization together — or leave the complete A enrollment untouched.
+ *
+ * This spec drives the real desktop app between two independent Den servers
+ * with an injected bootstrap-persistence failure (the profile root is made
+ * read-only, so the shell's atomic bootstrap write fails), and asserts both
+ * halves: the failed handoff changes nothing, and the retried handoff with a
+ * fresh grant commits everything together, survives a restart, and keeps
+ * one-time grants single-use. The OS deep-link dispatch is bridged through
+ * the product's own documented control seam (`auth.exchange-grant`), exactly
+ * like every signed-in app boot in this suite.
+ */
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !e2eTestsEnabled
+  ? "cross-server handoff atomic commit skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : !localPlacement
+    ? "cross-server handoff atomic commit skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "cross-server handoff atomic commit skipped — needs MySQL on 127.0.0.1:3306"
+      : "a cross-server handoff commits origin, credential, and organization atomically or not at all";
+
+const ORG_A = "Handoff Atomic A";
+const ORG_B = "Handoff Atomic B";
+
+const EVENT_RECORDER = `(() => {
+  if (!window.__handoffProofEvents) {
+    window.__handoffProofEvents = [];
+    window.addEventListener("openwork-den-session-updated", (event) => {
+      window.__handoffProofEvents.push(String(event?.detail?.status ?? "unknown"));
+    });
+  }
+  return true;
+})()`;
+
+async function readSessionEvents(desktop: Surface): Promise<string[]> {
+  const raw = await evalIn(desktop, "JSON.stringify(window.__handoffProofEvents ?? [])");
+  return JSON.parse(String(raw)) as string[];
+}
+
+async function readEnrollmentOrigin(desktop: Surface): Promise<string | null> {
+  const raw = await evalIn(
+    desktop,
+    "window.localStorage.getItem('openwork.den.sessionOrigin') ?? ''",
+  );
+  return String(raw).trim() || null;
+}
+
+async function readBootstrapFileBaseUrl(profileDir: string): Promise<string> {
+  const { bootstrapPath } = electronProfilePaths(profileDir);
+  const parsed = JSON.parse(await readFile(bootstrapPath, "utf8")) as { baseUrl?: string };
+  return (parsed.baseUrl ?? "").replace(/\/+$/, "");
+}
+
+function normalizedUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/** True while something still accepts connections on the loopback port. */
+function portInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host: "127.0.0.1", port, timeout: 750 }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+/** The stored session origin uses the product's origin comparison key, which
+ * folds loopback aliases (127.0.0.1) into `localhost`. */
+function sessionOriginKey(url: string): string {
+  const parsed = new URL(url);
+  if (["127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(parsed.hostname)) {
+    parsed.hostname = "localhost";
+  }
+  return parsed.origin;
+}
+
+test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(
+  title,
+  { timeout: 15 * 60_000 },
+  async ({ evidence, place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+    await using denA = await server({
+      place,
+      org: {
+        name: ORG_A,
+        admin: {
+          email: "handoff-atomic-admin-a@openwork.test",
+          name: "Handoff Atomic Admin A",
+          password: "OpenWorkEval123!",
+        },
+      },
+    });
+    await using denB = await server({
+      place,
+      org: {
+        name: ORG_B,
+        admin: {
+          email: "handoff-atomic-admin-b@openwork.test",
+          name: "Handoff Atomic Admin B",
+          password: "OpenWorkEval123!",
+        },
+      },
+    });
+
+    const profileDir = await mkdtemp(join(tmpdir(), "openwork-handoff-atomic-"));
+    onTestFinished(async () => {
+      await chmod(profileDir, 0o755).catch(() => undefined);
+      await rm(profileDir, { recursive: true, force: true });
+    });
+
+    let desktop: App | null = await app({ den: denA, as: "admin", place, profileDir });
+    try {
+      // The boot sign-in is itself a same-origin handoff through the same
+      // transaction — its success proves same-origin handoffs still work.
+      const stateA = await readDenClientState(desktop);
+      expect(stateA.authTokenPresent).toBe(true);
+      expect(stateA.activeOrgName).toBe(ORG_A);
+      expect(await readEnrollmentOrigin(desktop)).toBe(sessionOriginKey(denA.ref.webUrl));
+      evidence.recordAssertionEvidence(
+        "Same-origin handoff enrolled control plane A",
+        `The app signed in to ${ORG_A} with the enrollment origin stamped to A.`,
+        true,
+      );
+
+      await evalIn(desktop, EVENT_RECORDER);
+
+      // Injected bootstrap-persistence failure: the shell's atomic
+      // bootstrap.json write (temp file + rename in the profile root) cannot
+      // create its temp file in a read-only directory.
+      await chmod(profileDir, 0o555);
+      const consumedGrant = await createDesktopHandoffGrant(denB.admin);
+      let failedError: string | null = null;
+      try {
+        await control(
+          desktop,
+          "auth.exchange-grant",
+          { grant: consumedGrant, baseUrl: denB.ref.webUrl },
+          { timeoutMs: 60_000 },
+        );
+      } catch (error) {
+        failedError = error instanceof Error ? error.message : String(error);
+      } finally {
+        await chmod(profileDir, 0o755);
+      }
+      expect(failedError).toBeTruthy();
+
+      // The complete A enrollment is still active: durable origin, session
+      // credential, organization, and enrollment marker all remained A's.
+      const stateAfterFailure = await readDenClientState(desktop);
+      expect(stateAfterFailure.authTokenPresent).toBe(true);
+      expect(stateAfterFailure.activeOrgName).toBe(ORG_A);
+      expect(await readEnrollmentOrigin(desktop)).toBe(sessionOriginKey(denA.ref.webUrl));
+      expect(await readBootstrapFileBaseUrl(profileDir)).toBe(normalizedUrl(denA.ref.webUrl));
+      const eventsAfterFailure = await readSessionEvents(desktop);
+      expect(eventsAfterFailure).toContain("error");
+      expect(eventsAfterFailure).not.toContain("success");
+      evidence.recordAssertionEvidence(
+        "Bootstrap persistence failure left the complete A enrollment active",
+        "With bootstrap writes failing, the B handoff was rejected: the bootstrap file, token, organization, and enrollment origin all still belong to A, and no success state was published.",
+        true,
+      );
+
+      // Recovery needs a fresh handoff: the failed attempt consumed its
+      // one-time grant. A new grant commits B's origin, token, and
+      // organization together.
+      const freshGrant = await createDesktopHandoffGrant(denB.admin);
+      await control(
+        desktop,
+        "auth.exchange-grant",
+        { grant: freshGrant, baseUrl: denB.ref.webUrl },
+        { timeoutMs: 60_000 },
+      );
+      const stateB = await eventually(() => readDenClientState(desktop as App), {
+        within: 60_000,
+        label: "committed B enrollment",
+        until: (state) => state.activeOrgName === ORG_B,
+      });
+      expect(stateB.authTokenPresent).toBe(true);
+      expect(stateB.activeOrgName).toBe(ORG_B);
+      expect(await readEnrollmentOrigin(desktop)).toBe(sessionOriginKey(denB.ref.webUrl));
+      expect(await readBootstrapFileBaseUrl(profileDir)).toBe(normalizedUrl(denB.ref.webUrl));
+      const eventsAfterCommit = await readSessionEvents(desktop);
+      expect(eventsAfterCommit).toContain("success");
+      evidence.recordAssertionEvidence(
+        "The retried handoff committed B atomically",
+        `Origin (bootstrap file), credential, organization (${ORG_B}), and enrollment marker switched to B together.`,
+        true,
+      );
+
+      // One-time grants stay single-use: replaying the consumed grant fails
+      // and does not disturb the committed B enrollment.
+      let replayError: string | null = null;
+      try {
+        await control(
+          desktop,
+          "auth.exchange-grant",
+          { grant: consumedGrant, baseUrl: denB.ref.webUrl },
+          { timeoutMs: 60_000 },
+        );
+      } catch (error) {
+        replayError = error instanceof Error ? error.message : String(error);
+      }
+      expect(replayError).toBeTruthy();
+      const stateAfterReplay = await readDenClientState(desktop);
+      expect(stateAfterReplay.activeOrgName).toBe(ORG_B);
+      expect(stateAfterReplay.authTokenPresent).toBe(true);
+      evidence.recordAssertionEvidence(
+        "A consumed one-time grant cannot be replayed",
+        "Re-exchanging the spent grant failed and the committed B enrollment was untouched.",
+        true,
+      );
+
+      // Restart: the committed B enrollment is restored completely. The
+      // renderer port is pinned to the first launch's port because a packaged
+      // app has one fixed renderer origin — the eval harness's per-launch dev
+      // port would otherwise rotate the origin that scopes localStorage.
+      const rendererPort = desktop.handle.meta?.vitePort;
+      if (!rendererPort) throw new Error("The first launch did not record its renderer port.");
+      await desktop.stop();
+      desktop = null;
+      // The dev server auto-increments a busy port instead of failing, which
+      // would silently rotate the renderer origin and hide the stored
+      // session; wait until the first launch's port is actually released.
+      await eventually(async () => !(await portInUse(Number(rendererPort))), {
+        within: 60_000,
+        label: `renderer port ${rendererPort} released before relaunch`,
+      });
+      const restarted: DesktopHandle = await relaunchDesktop({
+        name: "handoff-atomic-restart",
+        profileDir,
+        bootstrap: { baseUrl: denB.ref.webUrl, requireSignin: false },
+        env: { PORT: rendererPort },
+      });
+      try {
+        const restartedOrigin = String(await evalIn(restarted, "window.location.origin"));
+        if (new URL(restartedOrigin).port !== rendererPort) {
+          throw new Error(
+            `The relaunched renderer did not reuse port ${rendererPort} (origin ${restartedOrigin}); the restart cannot observe the persisted session.`,
+          );
+        }
+        const stateAfterRestart = await eventually(() => readDenClientState(restarted), {
+          within: 90_000,
+          label: "restored B enrollment after restart",
+          until: (state) => state.authTokenPresent && state.activeOrgName === ORG_B,
+        });
+        expect(stateAfterRestart.authTokenPresent).toBe(true);
+        expect(stateAfterRestart.activeOrgName).toBe(ORG_B);
+        expect(await readEnrollmentOrigin(restarted)).toBe(sessionOriginKey(denB.ref.webUrl));
+        evidence.recordAssertionEvidence(
+          "Restart restored the complete B enrollment",
+          `After a relaunch, the app came back signed in to ${ORG_B} with the B credential and enrollment origin.`,
+          true,
+        );
+      } finally {
+        await restarted.stop().catch(() => undefined);
+      }
+    } finally {
+      await desktop?.stop().catch(() => undefined);
+    }
+  },
+);


### PR DESCRIPTION
## Problem

A user can accept a Desktop sign-in, organization, install-link, or enterprise handoff for control plane B while control plane A is still active — and end up with a **partially switched Desktop state**. Concretely:

- B's bearer token could become the active credential while A's bootstrap origin stayed persisted on disk.
- An organization selected on A could silently carry into B when B's exchange did not return one.
- The renderer published sign-in success before B's bootstrap was durably committed, so a bootstrap write failure or an app exit right after "success" left a hybrid enrollment.
- A late exchange result from an older handoff attempt could overwrite a newer one, and two concurrent attempts could interleave their persistence steps.

## Root cause

The handoff sequence updated its pieces independently: `exchangeHandoffAndSignIn` wrote the token and organization to session storage synchronously, while the bootstrap origin was persisted by a **fire-and-forget** write (`void setDenBootstrapConfig(...).catch(() => undefined)`) inside `writeDenSettings`, and the `denSessionUpdated` success event fired before either was confirmed. Enterprise activation stamps and consumed-grant cleanup were separate follow-up bootstrap writes after the session had already switched. Nothing versioned attempts, so late or concurrent exchanges raced. The exchange client was supplied redundantly by each caller, so the exchange target and the persisted destination were only coincidentally the same.

## Transaction boundary

`exchangeHandoffAndSignIn` is now a single enrollment transaction with explicit phases:

1. **Preparation** — resolve the expected destination once (`resolveDenBaseUrlsForDestination`, which prefers the API base the destination publishes in its runtime config — the same source the bootstrap commit uses) and number the attempt.
2. **Validation** — exchange the grant with a client constructed from that resolved destination, so the grant can only be sent to, and the credential can only come from, the origin this transaction would persist. The caller-supplied `client` option is removed.
3. **Durable commit** — persist the destination bootstrap (folding in `requireSignin`, enterprise activation stamps, and consumed-grant cleanup that used to be follow-up writes), then **re-read and confirm** the committed bootstrap is the intended destination. On divergence, restore the previous bootstrap.
4. **Activation** — one `writeDenSettings` call publishes origin, token, and organization together (stamping the issuing origin next to the token via the #4050 invariant).
5. **Publication** — only after the durable commit and activation, broadcast `denSessionUpdated: success`.

Commits are serialized through a module-level queue, and each attempt carries a generation number checked at the commit boundary.

## Invariant

A cross-server handoff's origin, credential, organization, and enrollment generation become active **together, or none of them do**. The current enrollment remains authoritative until the candidate has been validated against the expected destination, durably persisted, confirmed as the committed bootstrap, promoted to the active session, and only then published as successful.

## Solution details

- **Single commit point:** the durable bootstrap write happens before any active-session write; the session write is one synchronous batch; success is published last.
- **Rollback:** a persistence failure before activation leaves the complete previous enrollment untouched (nothing was written); a read-back mismatch or activation failure restores the previous bootstrap.
- **No cross-origin organization carry-forward:** a same-origin handoff with no exchange organization keeps the stored one (unchanged behavior); a cross-origin handoff without a destination organization commits none.
- **Stale-attempt protection:** a late result from a superseded attempt returns `stale: true`, activates nothing, and publishes nothing; concurrent A→B / A→C attempts cannot cross fields — the newest attempt wins whole.
- **Consumed one-time grants:** failures after the grant reached the destination return `grantConsumed: true`; the deep-link and prepared-bootstrap entry points stop retrying spent grants (the prepared-bootstrap path strips the spent grant from disk best-effort) — recovery is a fresh handoff link.
- **Crash windows:** the interval between the durable bootstrap commit and the session write is covered by the session-origin coherence gate from #4050 — an interrupted commit resumes as signed-out-at-the-destination, never as a hybrid.

## Preservation

- **Same-origin handoffs** (including every eval boot sign-in) work unchanged; the boot sign-in in the new spec is itself a same-origin handoff.
- **One-time grants** remain single-use — the spec replays a consumed grant and proves it fails without disturbing the committed enrollment.
- **Hosted, self-hosted, install-link, prepared-bootstrap, and enterprise activation** flows all funnel through this one transaction; enterprise activation now commits its stamp atomically with the enrollment instead of after it.
- **Manual control-plane URL changes** (`saveControlPlaneUrl`) keep their existing semantics; the transaction adopts the same persist-then-activate order that path already modeled.
- **Local-only Desktop behavior** is unaffected; web (non-desktop) deployments keep their storage-backed base-URL behavior.

## Proof

Two deterministic Den identities (two independent local Den servers, orgs "Handoff Atomic A"/"Handoff Atomic B") and an injected bootstrap-persistence failure (the Electron profile root is made read-only so the shell's atomic `bootstrap.json` write fails).

| Command | Result |
| --- | --- |
| `pnpm --filter @openwork/app test` (890 tests, incl. 18 handoff transaction tests + the 13 #4050 origin-coherence tests) | Passed for all handoff/den suites; 7 unrelated failures pre-exist on base `dev` in this environment (verified by an A/B run on the clean base: identical set, e.g. missing `window.matchMedia`) |
| `pnpm --filter @openwork/app typecheck` | Passed |
| `pnpm --filter @openwork/app build` | Passed |
| `pnpm evals:e2e cross-server-handoff-atomic-commit --local` at the exact head | Passed (lane: local; the spec requires local placement because the persistence-failure injection needs local filesystem control, matching `first-run-bootstrap-contract`'s gating) |
| `pnpm --dir evals run lint:layers` | Passed |
| `pnpm evals:e2e first-run-bootstrap-contract --local` | Failed **identically on the clean base** in this environment (timeout waiting for the injected 429 to be observed); A/B verified pre-existing, not introduced by this change |

Testkit spec: `evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts` proves, in one journey against the real app: same-origin enrollment to A → injected bootstrap-persistence failure leaves the complete A enrollment (bootstrap file, token, organization, session origin) active with an error and **no success event** → a fresh grant commits B's origin, credential, and organization together (file + storage + session-origin all B) → the consumed grant cannot be replayed → a restart restores the complete B enrollment.

Unit/integration (`apps/app/tests/den-handoff.test.ts`, 18 tests) covers the full matrix: atomic cross-origin commit, no org inheritance, persistence-failure rollback with no success publication and no credential exposure (exchange requests asserted to reach only the destination API host — the negative network half), read-back origin mismatch rejection with durable rollback, stale-attempt rejection, concurrent-attempt isolation, interrupted-commit restart state (never hybrid), committed-commit restart restore, desktop-initiated org deferral, and log capture asserting grants/tokens never appear in diagnostics.

## Negative proof

- With bootstrap persistence failing, the control action returns an error, the bootstrap file on disk still names A, the token/org/session-origin in storage are A's, and the recorded `denSessionUpdated` stream contains `error` and **no** `success` (e2e + unit).
- A stale attempt returns `stale: true` and the persisted state is entirely the newer attempt's — asserted field-by-field (unit).
- In the failure path, every credential-bearing request went to the destination API host only; nothing was sent to A (unit assertion over the recorded request log), and captured console output contains neither the grant nor either token.

## Dependency statement

**Independent.** The bootstrap/session-origin coherence work landed on `dev` as #4050 while this change was in flight; this PR is rebased onto it and **reuses** its `sessionOrigin` invariant for the crash-window guarantee instead of duplicating a second marker (an earlier draft's separate enrollment marker was removed during reconciliation). No stacked base or special merge order is required.

## Risk and rollback

- **Interruption:** a crash between the durable bootstrap commit and the session write resolves via the #4050 quarantine to signed-out-at-the-destination — recoverable, never hybrid; switching the control plane back revives the quarantined previous session.
- **Compatibility:** no storage schema changes beyond what #4050 introduced; legacy untagged sessions keep #4050's adoption behavior. The removed `client` option was only ever passed with the same base URL the callers already supplied.
- **Behavioral deltas to be aware of:** a cross-origin handoff that returns no organization now commits none (previously it silently kept the old org — the leak this fixes), and consumed grants are no longer retried automatically (the user gets an explicit retry-with-a-fresh-link state).
- **Rollback:** revert this single commit; no migrations.

## Scope exclusions

This PR does not redesign general Connect policy reconciliation (see #4052), does not change release or deployment behavior, and does not alter Den-side grant issuance.
