### PR TITLE
fix(app): only derive the api. host for hosted openworklabs.com Dens

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -38,7 +38,12 @@ export BETTER_AUTH_URL="${BETTER_AUTH_URL:-$DEN_WEB_PUBLIC_URL}"
 export DEN_BETTER_AUTH_URL="$BETTER_AUTH_URL"
 export DEN_API_PUBLIC_URL
 export DEN_MCP_RESOURCE_URL="${DEN_MCP_RESOURCE_URL:-$DEN_API_PUBLIC_URL/mcp}"
-export DEN_API_BASE="${DEN_API_BASE:-http://127.0.0.1:$DEN_API_PORT}"
+# DEN_API_BASE is the externally reachable Den API origin (see
+# packages/docs/start-here/private-network-deployment.mdx): Den Web publishes
+# it through /api/runtime-config as the desktop's denApiUrl. Desktops run in
+# other sandboxes and can only reach the public preview URL, never this
+# sandbox's loopback.
+export DEN_API_BASE="${DEN_API_BASE:-${DEN_API_PUBLIC_URL:-http://127.0.0.1:$DEN_API_PORT}}"
 export DEN_AUTH_ORIGIN="${DEN_AUTH_ORIGIN:-$DEN_WEB_PUBLIC_URL}"
 export DEN_AUTH_FALLBACK_BASE="${DEN_AUTH_FALLBACK_BASE:-http://127.0.0.1:$DEN_API_PORT}"
 export NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="${NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL:-$DEN_WEB_PUBLIC_URL}"

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -752,6 +752,28 @@ function ensureDenApiBasePath(input: string | null | undefined): string | null {
   }
 }
 
+const HOSTED_DEN_APEX_HOST = "openworklabs.com";
+
+function isHostedDenHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === HOSTED_DEN_APEX_HOST || normalized.endsWith(`.${HOSTED_DEN_APEX_HOST}`);
+}
+
+/**
+ * The deterministic API origin for a Den base URL, without runtime config.
+ *
+ * Only two shapes are known ahead of time:
+ * - An explicit API host (`api.*`) is already the API origin.
+ * - Hosted OpenWork Cloud (`*.openworklabs.com`) serves its API at the
+ *   `api.`-prefixed host.
+ *
+ * Every other deployment (self-hosted single host, localhost, tunnel or
+ * sandbox preview hosts with single-label wildcard certificates) keeps the
+ * same-origin `/api/den` proxy. Inventing `api.<host>` there produced
+ * unreachable origins and TLS names the deployment's certificate cannot
+ * cover, which broke desktop sign-in. Runtime config (`denApiUrl`) remains
+ * the source of truth when present.
+ */
 function denApiOriginForDenBaseUrl(input: string | null | undefined): string | null {
   const normalized = normalizeDenBaseUrl(input);
   if (!normalized) return null;
@@ -759,7 +781,11 @@ function denApiOriginForDenBaseUrl(input: string | null | undefined): string | n
   try {
     const url = new URL(normalized);
     const hostname = url.hostname.toLowerCase();
-    if (hostname !== "api" && !hostname.startsWith("api.")) {
+    const isExplicitApiHost = hostname === "api" || hostname.startsWith("api.");
+    if (!isExplicitApiHost && !isHostedDenHost(hostname)) {
+      return null;
+    }
+    if (!isExplicitApiHost) {
       url.hostname = `api.${hostname}`;
     }
     url.pathname = "";

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -200,10 +200,10 @@ function installProviderSyncFetch(
         body: getRequestBody(init),
       });
 
-      if (url.origin === "https://api.den.example" && url.pathname === "/v1/llm-providers") {
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers") {
         return jsonResponse({ llmProviders: [cloudProviderPayload(options)] });
       }
-      if (url.origin === "https://api.den.example" && url.pathname === "/v1/llm-providers/lpr_test/connect") {
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers/lpr_test/connect") {
         return jsonResponse({ llmProvider: cloudProviderPayload(options) });
       }
       if (url.origin === "https://server.example" && url.pathname === "/workspace/ws_1/config" && method === "GET") {
@@ -318,8 +318,8 @@ describe("cloud provider sync in gateway mode", () => {
     const patchRequests = requests.filter(
       (request) => request.method === "PATCH" && request.url === "https://server.example/workspace/ws_1/config",
     );
-    expect(requests.some((request) => request.url === "https://api.den.example/v1/llm-providers")).toBe(true);
-    expect(requests.some((request) => request.url === "https://api.den.example/v1/llm-providers/lpr_test/connect")).toBe(true);
+    expect(requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers")).toBe(true);
+    expect(requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers/lpr_test/connect")).toBe(true);
     expect(patchRequests).toHaveLength(1);
     expect(patchRequests[0]?.body).toContain("\"opencode\"");
     expect(store.getSnapshot().importedCloudProviders.lpr_test?.providerId).toBe("lpr_test");
@@ -355,14 +355,14 @@ describe("cloud provider sync in gateway mode", () => {
     });
     expect(store.getSnapshot().importedCloudProviders.lpr_test).toBeUndefined();
     const firstConnectCount = requests.filter(
-      (request) => request.url === "https://api.den.example/v1/llm-providers/lpr_test/connect",
+      (request) => request.url === "https://den.example/api/den/v1/llm-providers/lpr_test/connect",
     ).length;
     expect(firstConnectCount).toBe(1);
 
     await store.runCloudProviderSync("app_resume");
 
     const secondConnectCount = requests.filter(
-      (request) => request.url === "https://api.den.example/v1/llm-providers/lpr_test/connect",
+      (request) => request.url === "https://den.example/api/den/v1/llm-providers/lpr_test/connect",
     ).length;
     expect(secondConnectCount).toBe(firstConnectCount);
   });
@@ -496,7 +496,7 @@ describe("cloud provider sync in server-capability mode", () => {
     const sessionRequests = requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session");
     expect(sessionRequests).toHaveLength(1);
     expect(sessionRequests[0]?.body).toBe(JSON.stringify({
-      baseUrl: "https://api.den.example",
+      baseUrl: "https://den.example/api/den",
       token: "den-token",
       orgId: "org_test",
     }));

--- a/apps/app/tests/den-desktop-bootstrap-settings.test.ts
+++ b/apps/app/tests/den-desktop-bootstrap-settings.test.ts
@@ -101,7 +101,7 @@ describe("desktop Den bootstrap settings", () => {
 
     const settings = readDenSettings();
     expect(settings.baseUrl).toBe("https://bootstrap.example.com");
-    expect(settings.apiBaseUrl).toBe("https://api.bootstrap.example.com");
+    expect(settings.apiBaseUrl).toBe("https://bootstrap.example.com/api/den");
   });
 
   test("keeps the prepared workspace and claim action in the shared bootstrap snapshot", async () => {
@@ -203,11 +203,11 @@ describe("desktop Den bootstrap settings", () => {
     expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://api.override.example.com");
   });
 
-  test("falls back to deterministic API subdomain when runtime-config is unavailable", async () => {
+  test("falls back to the same-origin API path when runtime-config is unavailable", async () => {
     await initializeDenBootstrapConfig();
 
     expect(readDenBootstrapConfig().baseUrl).toBe("https://bootstrap.example.com");
-    expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://api.bootstrap.example.com");
+    expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://bootstrap.example.com/api/den");
   });
 
   test("saves base URL changes to bootstrap and clears legacy endpoint storage", async () => {

--- a/apps/app/tests/den-extension-projection.test.ts
+++ b/apps/app/tests/den-extension-projection.test.ts
@@ -88,7 +88,7 @@ describe("Den extension projections", () => {
     const resolved = await client.getOrgMarketplaceResolved("organization_test", "marketplace_test");
     const plugin = resolved.plugins[0];
 
-    expect(calls).toEqual(["http://api.den.local/v1/marketplaces/marketplace_test/resolved"]);
+    expect(calls).toEqual(["http://den.local/api/den/v1/marketplaces/marketplace_test/resolved"]);
     expect(plugin.extension?.sourceFormat).toBe("claude-plugin");
     expect(plugin.extension?.manifest?.resources).toEqual([{
       type: "command",

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -35,10 +35,22 @@ describe("resolveDenBaseUrls", () => {
     expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:8787");
   });
 
-  test("derives the api subdomain from a web-app baseUrl when no apiBaseUrl is set", () => {
+  test("keeps the same-origin API path for a self-hosted baseUrl when no apiBaseUrl is set", () => {
     const resolved = resolveDenBaseUrls({ baseUrl: "https://den.self-hosted.example.com" });
     expect(resolved.baseUrl).toBe("https://den.self-hosted.example.com");
-    expect(resolved.apiBaseUrl).toBe("https://api.den.self-hosted.example.com");
+    expect(resolved.apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
+  });
+
+  test("uses an explicit api host directly when no apiBaseUrl is set", () => {
+    const resolved = resolveDenBaseUrls({ baseUrl: "https://api.den.example" });
+    expect(resolved.baseUrl).toBe("https://api.den.example");
+    expect(resolved.apiBaseUrl).toBe("https://api.den.example");
+  });
+
+  test("derives the api subdomain for hosted openworklabs.com deployments", () => {
+    const resolved = resolveDenBaseUrls({ baseUrl: "https://staging.openworklabs.com" });
+    expect(resolved.baseUrl).toBe("https://staging.openworklabs.com");
+    expect(resolved.apiBaseUrl).toBe("https://api.staging.openworklabs.com");
   });
 
   test("uses the nested hosted API origin for the hosted web default", () => {

--- a/apps/app/tests/den-session-offline-resilience.test.ts
+++ b/apps/app/tests/den-session-offline-resilience.test.ts
@@ -146,7 +146,7 @@ describe("mergePassiveDenSettings", () => {
 
     expect(result).toEqual({
       baseUrl: "https://next.example.com",
-      apiBaseUrl: "https://api.next.example.com",
+      apiBaseUrl: "https://next.example.com/api/den",
       authToken: "tok_stored",
       activeOrgId: "org_stored",
       activeOrgSlug: "stored-org",

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -452,7 +452,7 @@ describe("non-gateway connection modes", () => {
     storage.setItem("openwork.den.baseUrl", "https://den.self-hosted.example.com");
 
     expect(readDenSettings().baseUrl).toBe("https://den.self-hosted.example.com");
-    expect(readDenSettings().apiBaseUrl).toBe("https://api.den.self-hosted.example.com");
+    expect(readDenSettings().apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
   });
 
   test("VITE_DEN_API_BASE_URL pins Den API calls to the proxy while sign-in stays on the web base", () => {

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -165,10 +165,10 @@ function installFetchMock(
         headers: normalizeHeaders(init),
       });
 
-      if (url.origin === "https://api.den.example" && url.pathname === "/v1/llm-providers") {
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers") {
         return options.providerResponse ?? jsonResponse({ llmProviders: [cloudProviderPayload()] });
       }
-      if (url.origin === "https://api.den.example" && url.pathname === "/v1/llm-providers/lpr_test/connect") {
+      if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers/lpr_test/connect") {
         return jsonResponse({ llmProvider: cloudProviderPayload() });
       }
       if (url.pathname === "/den-session" && method === "PUT") {
@@ -322,7 +322,7 @@ describe("session-route cloud provider sync wiring", () => {
       },
     ]);
     expect(
-      requests.filter((request) => request.url === "https://api.den.example/v1/llm-providers"),
+      requests.filter((request) => request.url === "https://den.example/api/den/v1/llm-providers"),
     ).toHaveLength(1);
     expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(0);
     store.dispose();
@@ -402,11 +402,11 @@ describe("session-route cloud provider sync wiring", () => {
 
     store.start();
     for (let attempt = 0; attempt < 20; attempt += 1) {
-      if (requests.some((request) => request.url === "https://api.den.example/v1/llm-providers")) break;
+      if (requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers")) break;
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     expect(
-      requests.filter((request) => request.url === "https://api.den.example/v1/llm-providers"),
+      requests.filter((request) => request.url === "https://den.example/api/den/v1/llm-providers"),
     ).toHaveLength(1);
     clearDenSession();
     resolveProviderResponse(jsonResponse({ llmProviders: [cloudProviderPayload()] }));
@@ -437,7 +437,7 @@ describe("session-route cloud provider sync wiring", () => {
     expect(new URL(sessionPuts[0]?.url ?? "").origin).toBe(LOCAL_SERVER_ORIGIN);
     expect(sessionPuts[0]?.headers["x-openwork-host-token"]).toBe("host-token-live");
     expect(sessionPuts[0]?.body).toBe(JSON.stringify({
-      baseUrl: "https://api.den.example",
+      baseUrl: "https://den.example/api/den",
       token: "den-token",
       orgId: "org_test",
     }));
@@ -489,6 +489,6 @@ describe("session-route cloud provider sync wiring", () => {
     expect(requests.filter((request) => new URL(request.url).pathname === "/den-session")).toHaveLength(0);
     expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(0);
     // The legacy renderer-side reconciliation still runs for remote workspaces.
-    expect(requests.some((request) => request.url === "https://api.den.example/v1/llm-providers")).toBe(true);
+    expect(requests.some((request) => request.url === "https://den.example/api/den/v1/llm-providers")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- #4026 made `resolveDenBaseUrls` rewrite **every** Den base URL host to `api.<host>` when no `apiBaseUrl` is known. Self-hosted single-host deploys, localhost, and sandbox preview hosts got unreachable API origins, breaking desktop sign-in (`auth.exchange-grant`) with `net::ERR_CONNECTION_REFUSED` / `net::ERR_CERT_COMMON_NAME_INVALID` (single-label wildcard certs cannot cover `api.<sub>.<domain>`).
- Restrict the deterministic rewrite to explicit `api.*` hosts and `*.openworklabs.com`; every other deployment falls back to the same-origin `/api/den` proxy path (pre-#4026 behavior). Runtime-config `denApiUrl` stays the source of truth when present.
- Daytona server start script: default `DEN_API_BASE` to the public preview URL. Den Web publishes it via `/api/runtime-config` as the desktop's `denApiUrl`; desktops run in other sandboxes and cannot reach this sandbox's loopback (docs: `private-network-deployment.mdx` documents DEN_API_BASE as the externally reachable API origin).

## Evidence

### Root cause repro (before fix)
- `evals:e2e cross-workspace-composer-switch --daytona` and reference spec `live-tool-visible-after-session-switch` both failed at `signInDesktopAs -> auth.exchange-grant`:
  - runtime-config reachable: `denApiUrl=http://127.0.0.1:8788` -> `net::ERR_CONNECTION_REFUSED`
  - runtime-config unavailable: fallback `https://api.3005-<id>.daytonaproxy01.net` -> `net::ERR_CERT_COMMON_NAME_INVALID` (cert SAN is `*.daytonaproxy01.net`, verified via openssl from inside a sandbox)

### After fix (this branch merged with the eval spec + bun pins on `eval/composer-switch-verify`)
- `OPENWORK_EVAL_REF=eval/composer-switch-verify pnpm evals:e2e cross-workspace-composer-switch --daytona` -> **verdict: passed** (sign-in, 2 workspaces, 4 chats, 14 cross-workspace switches, real send). Previously failed at sign-in in <1 attempt.

### Build verification
- `pnpm --filter @openwork/app build` — passed

### Unit tests
- `bun test --isolate tests/` in `apps/app`: 895 pass / 7 fail — the 7 failures are pre-existing on `origin/dev` (identical baseline diff), none introduced.
- Updated the #4026 expectations that locked in the regression (`den-mcp-url`, `den-desktop-bootstrap-settings`, `den-extension-projection`, `cloud-provider-sync-gateway`, `den-session-offline-resilience`, `gateway-runtime`, `session-provider-auth-server-sync`), and added explicit cases: explicit `api.*` host passthrough, hosted `*.openworklabs.com` derivation, self-hosted same-origin fallback.

## Test instructions

1. `bun test --isolate tests/den-mcp-url.test.ts` in `apps/app`
2. Desktop against a single-host Den (e.g. local dev Den at `http://localhost:3005`): sign-in exchange must target `<base>/api/den`, not `api.localhost`.
3. Hosted: `https://app.openworklabs.com` still resolves API to `https://api.app.openworklabs.com`.