### PR TITLE
fix(sandboxes): pin bun to 1.3.14 in sandbox and docker images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # pnpm + bun
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN npm install -g bun
+# Pin bun to the CI-proven 1.3 line; unpinned installs picked up bun 1.4.0,
+# which breaks the Den/desktop sandbox stack (sign-in grant exchange fails).
+RUN npm install -g bun@1.3.14
 
 # noVNC index
 RUN ln -sf /usr/share/novnc/vnc.html /usr/share/novnc/index.html

--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -16,7 +16,7 @@ RUN apt-get update \
     git \
     procps \
     sudo \
-  && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun \
+  && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun@1.3.14 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /root/.cache /root/.npm /tmp/*
 

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -9,7 +9,7 @@ WORKDIR /src
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
     python3 make g++ \
-  && npm install -g bun \
+  && npm install -g bun@1.3.14 \
   && corepack enable \
   && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/docker/Dockerfile.microsandbox
+++ b/packaging/docker/Dockerfile.microsandbox
@@ -4,7 +4,7 @@ WORKDIR /src
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
-  && npm install -g bun \
+  && npm install -g bun@1.3.14 \
   && corepack enable \
   && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -52,7 +52,7 @@ services:
         export PATH="$$BUN_INSTALL/bin:$$PATH"
         if ! command -v bun >/dev/null 2>&1; then
           echo "[openwork-server] Installing bun..."
-          curl -fsSL https://bun.sh/install | bash
+          curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
         fi
 
         # --- Enable pnpm via corepack ---
@@ -144,7 +144,7 @@ services:
         export BUN_INSTALL="/root/.bun"
         export PATH="$$BUN_INSTALL/bin:$$PATH"
         if ! command -v bun >/dev/null 2>&1; then
-          curl -fsSL https://bun.sh/install | bash
+          curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
         fi
         corepack enable && corepack prepare pnpm@10.27.0 --activate
 


### PR DESCRIPTION
## Summary

- Sandbox and docker images installed **unpinned** bun (`npm install -g bun`, `curl bun.sh/install`). bun 1.4.0 shipped on npm as `latest`, so freshly built Daytona server sandboxes and dev containers silently jumped a major line while CI pins 1.3.9–1.3.14 (`ci-tests.yml`, `build-electron-desktop.yml`, release workflows).
- Pin `bun@1.3.14` (the newest CI-proven version) in:
  - `.devcontainer/Dockerfile`
  - `.devcontainer/Dockerfile.daytona-server`
  - `packaging/docker/Dockerfile.microsandbox`
  - `ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot`
  - `packaging/docker/docker-compose.dev.yml` (both `bun.sh/install` calls -> `bash -s "bun-v1.3.14"`)

## Evidence

- `npm view bun versions` tail: `1.3.14`, then `1.4.0` published as latest.
- No `openwork-server` Daytona snapshot existed at the time, so every eval server sandbox rebuilt from `Dockerfile.daytona-server` and picked up whatever bun was latest that day — runtime drift with zero repo changes.
- Daytona server sandbox image rebuilt with this pin (`npm install -g pnpm@10.27.0 bun@1.3.14` visible in the build log) as part of the verification run for #4057; Den API/Web booted and the full E2E (`cross-workspace-composer-switch`) passed on the combined branch `eval/composer-switch-verify`.
- No build changes needed: Dockerfiles/compose only.

## Test instructions

1. `docker build -f .devcontainer/Dockerfile.daytona-server .` -> image contains bun 1.3.14 (`bun --version`).
2. CI stays on its own pinned setup-bun versions (unchanged).