### PR TITLE
perf(daytona): bake deps and Den builds into the server snapshot for ~48s eval boots

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # pnpm + bun
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN npm install -g bun
+# Pin bun to the CI-proven 1.3 line; unpinned installs picked up bun 1.4.0,
+# which breaks the Den/desktop sandbox stack (sign-in grant exchange fails).
+RUN npm install -g bun@1.3.14
 
 # noVNC index
 RUN ln -sf /usr/share/novnc/vnc.html /usr/share/novnc/index.html

--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -16,7 +16,7 @@ RUN apt-get update \
     git \
     procps \
     sudo \
-  && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun \
+  && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun@1.3.14 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /root/.cache /root/.npm /tmp/*
 

--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -36,7 +36,11 @@ RUN git clone --depth 1 --branch dev https://github.com/different-ai/openwork.gi
 # and every DEN_* value is runtime env consumed by `next start`.
 # .devcontainer/start-daytona-server.sh skips these rebuilds when the git tree
 # hashes recorded here still match the checked-out ref.
-RUN CI=1 pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store --frozen-lockfile \
+# The server stack never runs Electron or browser automation; skipping those
+# binary downloads keeps the baked image inside the 10 GB sandbox disk cap.
+RUN CI=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 CYPRESS_INSTALL_BINARY=0 \
+    pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store --frozen-lockfile \
   && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
     pnpm --filter @openwork/ui build \
   && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \

--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -18,11 +18,20 @@ RUN apt-get update \
     sudo \
   && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun@1.3.14 \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /root/.cache /root/.npm /tmp/*
+  && rm -rf /var/lib/apt/lists/* /root/.cache /root/.npm /tmp/* \
+  && printf 'daytona ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/daytona-openwork \
+  && chmod 0440 /etc/sudoers.d/daytona-openwork \
+  && install -d -o daytona -g daytona /workspace
 
 WORKDIR /workspace
 
 ENV PATH="/usr/local/share/nvm/current/bin:$PATH"
+
+# Everything under /workspace is created as the daytona user so no later
+# chown layer is needed: a recursive chown in its own layer copy-on-write
+# duplicates the entire baked workspace and pushed the image past the 20 GB
+# snapshot limit.
+USER daytona
 
 RUN git clone --depth 1 --branch dev https://github.com/different-ai/openwork.git . \
   && mkdir -p /workspace/.openwork-daytona \
@@ -36,11 +45,21 @@ RUN git clone --depth 1 --branch dev https://github.com/different-ai/openwork.gi
 # and every DEN_* value is runtime env consumed by `next start`.
 # .devcontainer/start-daytona-server.sh skips these rebuilds when the git tree
 # hashes recorded here still match the checked-out ref.
-# The server stack never runs Electron or browser automation; skipping those
-# binary downloads keeps the baked image inside the 10 GB sandbox disk cap.
+# Only the server packages' dependency graph is installed, and Electron and
+# browser binaries are skipped: the server stack never runs them, and the
+# smaller node_modules keeps the image inside the snapshot size limits. The
+# full-lockfile sha marker stays valid because a filtered install uses the
+# same lockfile; a ref that changes the lockfile reinstalls at boot.
 RUN CI=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PUPPETEER_SKIP_DOWNLOAD=1 CYPRESS_INSTALL_BINARY=0 \
     pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store --frozen-lockfile \
+      --filter @openwork-ee/den-api... \
+      --filter @openwork-ee/den-web... \
+      --filter @openwork-ee/den-db... \
+      --filter @openwork-ee/den-worker-proxy... \
+      --filter @openwork/ui... \
+      --filter @openwork-ee/utils... \
+      --filter @openwork/mcp-apps... \
   && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
     pnpm --filter @openwork/ui build \
   && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
@@ -53,9 +72,3 @@ RUN CI=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
   && { git rev-parse HEAD:packages/mcp-apps; cat /workspace/.openwork-daytona/pnpm-lock.sha256; } \
     | sha256sum | cut -d ' ' -f 1 > /workspace/.openwork-daytona/den-api-assets.tree \
   && rm -rf /home/daytona/.cache /home/daytona/.npm /home/daytona/.local/share/pnpm/store
-
-RUN chown -R daytona:daytona /workspace \
-  && printf 'daytona ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/daytona-openwork \
-  && chmod 0440 /etc/sudoers.d/daytona-openwork
-
-USER daytona

--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -22,12 +22,33 @@ RUN apt-get update \
 
 WORKDIR /workspace
 
+ENV PATH="/usr/local/share/nvm/current/bin:$PATH"
+
 RUN git clone --depth 1 --branch dev https://github.com/different-ai/openwork.git . \
   && mkdir -p /workspace/.openwork-daytona \
   && sha256sum /workspace/pnpm-lock.yaml | cut -d ' ' -f 1 > /workspace/.openwork-daytona/pnpm-lock.sha256 \
-  && git gc --prune=now \
-  && rm -rf /home/daytona/.cache /home/daytona/.npm /home/daytona/.local/share/pnpm/store \
-    /workspace/node_modules
+  && git rev-parse HEAD > /workspace/.openwork-daytona/base-commit \
+  && git gc --prune=now
+
+# Bake dependencies and the sandbox-invariant Den builds so a boot from this
+# snapshot only pays checkout + delta install + service start. The Den Web
+# production build bakes no per-sandbox values: NEXT_PUBLIC_* inputs are fixed
+# and every DEN_* value is runtime env consumed by `next start`.
+# .devcontainer/start-daytona-server.sh skips these rebuilds when the git tree
+# hashes recorded here still match the checked-out ref.
+RUN CI=1 pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store --frozen-lockfile \
+  && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
+    pnpm --filter @openwork/ui build \
+  && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
+    pnpm --filter @openwork-ee/utils build \
+  && NEXT_PUBLIC_POSTHOG_KEY= NEXT_PUBLIC_POSTHOG_API_KEY= \
+    pnpm --filter @openwork-ee/den-web build \
+  && pnpm --filter @openwork-ee/den-api run build:mcp-apps \
+  && { git rev-parse HEAD:packages/ui HEAD:ee/packages/utils HEAD:ee/apps/den-web; cat /workspace/.openwork-daytona/pnpm-lock.sha256; } \
+    | sha256sum | cut -d ' ' -f 1 > /workspace/.openwork-daytona/den-web-build.tree \
+  && { git rev-parse HEAD:packages/mcp-apps; cat /workspace/.openwork-daytona/pnpm-lock.sha256; } \
+    | sha256sum | cut -d ' ' -f 1 > /workspace/.openwork-daytona/den-api-assets.tree \
+  && rm -rf /home/daytona/.cache /home/daytona/.npm /home/daytona/.local/share/pnpm/store
 
 RUN chown -R daytona:daytona /workspace \
   && printf 'daytona ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/daytona-openwork \

--- a/.devcontainer/create-daytona-openwork-server-snapshot.sh
+++ b/.devcontainer/create-daytona-openwork-server-snapshot.sh
@@ -24,11 +24,13 @@ if [ -n "$existing_snapshot_id" ]; then
 fi
 
 echo "==> Creating Daytona server snapshot: $SNAPSHOT_NAME"
+# Disk holds the baked node_modules, pnpm store, and Den build outputs that
+# make sandbox boots delta-only.
 daytona snapshot create "$SNAPSHOT_NAME" \
   --dockerfile "$ROOT_DIR/.devcontainer/Dockerfile.daytona-server" \
   --cpu 4 \
   --memory 8 \
-  --disk 10 \
+  --disk 20 \
   --region "$REGION"
 
 echo "Snapshot ready: $SNAPSHOT_NAME"

--- a/.devcontainer/create-daytona-openwork-server-snapshot.sh
+++ b/.devcontainer/create-daytona-openwork-server-snapshot.sh
@@ -24,13 +24,13 @@ if [ -n "$existing_snapshot_id" ]; then
 fi
 
 echo "==> Creating Daytona server snapshot: $SNAPSHOT_NAME"
-# Disk holds the baked node_modules, pnpm store, and Den build outputs that
-# make sandbox boots delta-only.
+# 10 GB is the per-sandbox maximum in this org; the baked node_modules and
+# Den build outputs fit because the image skips Electron/browser binaries.
 daytona snapshot create "$SNAPSHOT_NAME" \
   --dockerfile "$ROOT_DIR/.devcontainer/Dockerfile.daytona-server" \
   --cpu 4 \
   --memory 8 \
-  --disk 20 \
+  --disk 10 \
   --region "$REGION"
 
 echo "Snapshot ready: $SNAPSHOT_NAME"

--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -137,11 +137,36 @@ else
   echo "==> Skipping pnpm install (node_modules present and lockfile unchanged)."
 fi
 
+# Content keys for the sandbox-invariant builds baked into the snapshot.
+# A build is skipped only when the git trees that feed it and the lockfile
+# both match what the snapshot (or a previous boot) built. Snapshots without
+# markers, refs that changed those trees, or refs where a tree is missing
+# rebuild exactly as before. An empty key never matches and is never stored.
+build_key() {
+  local trees
+  trees="$(git rev-parse "$@" 2>/dev/null)" || return 0
+  # Byte-identical to the snapshot bake: one tree hash per line, then the
+  # lockfile sha, all newline-terminated.
+  printf '%s\n%s\n' "$trees" "$current" | sha256sum | cut -d ' ' -f 1
+}
+
 echo "==> Pushing Den DB schema..."
 pnpm --filter @openwork-ee/den-db db:push > /tmp/den-db-push.log 2>&1
 
-echo "==> Building Den API runtime assets..."
-pnpm --filter @openwork-ee/den-api run build:mcp-apps
+den_api_assets_marker=.openwork-daytona/den-api-assets.tree
+den_api_assets_key="$(build_key HEAD:packages/mcp-apps)"
+if [ -n "$den_api_assets_key" ] && [ -d packages/mcp-apps/dist ] && [ -f "$den_api_assets_marker" ] \
+  && [ "$(cat "$den_api_assets_marker")" = "$den_api_assets_key" ]; then
+  echo "==> Skipping Den API runtime asset build (baked assets match this ref)."
+else
+  echo "==> Building Den API runtime assets..."
+  pnpm --filter @openwork-ee/den-api run build:mcp-apps
+  if [ -n "$den_api_assets_key" ]; then
+    printf "%s" "$den_api_assets_key" > "$den_api_assets_marker"
+  else
+    rm -f "$den_api_assets_marker"
+  fi
+fi
 
 echo "==> Starting Den API on :$DEN_API_PORT..."
 # The den-api process cmdline is "tsx watch src/main.ts" (cwd-relative), so a
@@ -241,22 +266,38 @@ wait_for_http_status() {
 
 wait_for_http_status "http://127.0.0.1:$DEN_WORKER_PROXY_PORT/unknown" "worker proxy" 120
 
-echo "==> Building Den Web (dev-mode HMR websockets 502 through the preview proxy and block hydration)..."
-if ! env \
-  DEN_WEB_PORT="$DEN_WEB_PORT" \
-  DEN_API_BASE="$DEN_API_BASE" \
-  DEN_AUTH_ORIGIN="$DEN_AUTH_ORIGIN" \
-  DEN_AUTH_FALLBACK_BASE="$DEN_AUTH_FALLBACK_BASE" \
-  NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="$NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL" \
-  NEXT_PUBLIC_POSTHOG_KEY= \
-  NEXT_PUBLIC_POSTHOG_API_KEY= \
-  DEN_ORG_MODE="$DEN_ORG_MODE" \
-  OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
-  DEN_WEB_ALLOWED_DEV_ORIGINS="$DEN_WEB_ALLOWED_DEV_ORIGINS" \
-  bash -c 'pnpm --filter @openwork/ui build && pnpm --filter @openwork-ee/utils build && pnpm --filter @openwork-ee/den-web build' > /tmp/den-web-build.log 2>&1; then
-  echo "ERROR: Den Web build failed. Last 80 lines:" >&2
-  tail -n 80 /tmp/den-web-build.log >&2
-  exit 1
+den_web_marker=.openwork-daytona/den-web-build.tree
+den_web_key="$(build_key HEAD:packages/ui HEAD:ee/packages/utils HEAD:ee/apps/den-web)"
+if [ -n "$den_web_key" ] && [ -d ee/apps/den-web/.next ] && [ -f "$den_web_marker" ] \
+  && [ "$(cat "$den_web_marker")" = "$den_web_key" ]; then
+  echo "==> Skipping Den Web build (baked build matches this ref)."
+else
+  # Production build instead of next dev: dev-mode HMR websockets 502 through
+  # the preview proxy and block hydration. The build bakes no per-sandbox
+  # values (all DEN_* env is consumed at runtime by next start), so a build
+  # from the snapshot's base commit is reusable across sandboxes.
+  echo "==> Building Den Web..."
+  if ! env \
+    DEN_WEB_PORT="$DEN_WEB_PORT" \
+    DEN_API_BASE="$DEN_API_BASE" \
+    DEN_AUTH_ORIGIN="$DEN_AUTH_ORIGIN" \
+    DEN_AUTH_FALLBACK_BASE="$DEN_AUTH_FALLBACK_BASE" \
+    NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="$NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL" \
+    NEXT_PUBLIC_POSTHOG_KEY= \
+    NEXT_PUBLIC_POSTHOG_API_KEY= \
+    DEN_ORG_MODE="$DEN_ORG_MODE" \
+    OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+    DEN_WEB_ALLOWED_DEV_ORIGINS="$DEN_WEB_ALLOWED_DEV_ORIGINS" \
+    bash -c 'pnpm --filter @openwork/ui build && pnpm --filter @openwork-ee/utils build && pnpm --filter @openwork-ee/den-web build' > /tmp/den-web-build.log 2>&1; then
+    echo "ERROR: Den Web build failed. Last 80 lines:" >&2
+    tail -n 80 /tmp/den-web-build.log >&2
+    exit 1
+  fi
+  if [ -n "$den_web_key" ]; then
+    printf "%s" "$den_web_key" > "$den_web_marker"
+  else
+    rm -f "$den_web_marker"
+  fi
 fi
 
 echo "==> Starting Den Web on :$DEN_WEB_PORT..."

--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -130,8 +130,12 @@ echo "==> Installing dependencies if needed..."
 mkdir -p "$PNPM_STORE" .openwork-daytona
 baseline=.openwork-daytona/pnpm-lock.sha256
 current="$(sha256sum pnpm-lock.yaml | cut -d " " -f 1)"
+# The server stack never runs Electron or browser automation; skip their
+# binary downloads on reinstalls too.
+INSTALL_ENV=(CI=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 PUPPETEER_SKIP_DOWNLOAD=1 CYPRESS_INSTALL_BINARY=0)
 if [ ! -d node_modules ] || [ ! -f "$baseline" ] || [ "$(cat "$baseline")" != "$current" ]; then
-  CI=1 pnpm install --store-dir "$PNPM_STORE" --frozen-lockfile || CI=1 pnpm install --store-dir "$PNPM_STORE"
+  env "${INSTALL_ENV[@]}" pnpm install --store-dir "$PNPM_STORE" --frozen-lockfile \
+    || env "${INSTALL_ENV[@]}" pnpm install --store-dir "$PNPM_STORE"
   printf "%s" "$current" > "$baseline"
 else
   echo "==> Skipping pnpm install (node_modules present and lockfile unchanged)."

--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -133,7 +133,7 @@ if [ -n "${OPENWORK_DEN_URLS_FILE:-}" ]; then
 fi
 
 echo "==> Checking out $REF..."
-daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$REF\"; FORCE_INSTALL=\"$FORCE_INSTALL\"; if git fetch origin \"\$REF\"; then git checkout --detach FETCH_HEAD; else git fetch origin dev --depth 50 || true; git checkout \"\$REF\"; fi; git rev-parse --short HEAD; if [ \"\$FORCE_INSTALL\" = 1 ]; then rm -f .openwork-daytona/pnpm-lock.sha256; fi'"
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$REF\"; FORCE_INSTALL=\"$FORCE_INSTALL\"; if git fetch origin \"\$REF\"; then git checkout --detach FETCH_HEAD; else git fetch origin dev --depth 50 || true; git checkout \"\$REF\"; fi; git rev-parse --short HEAD; if [ \"\$FORCE_INSTALL\" = 1 ]; then rm -f .openwork-daytona/pnpm-lock.sha256 .openwork-daytona/den-web-build.tree .openwork-daytona/den-api-assets.tree; fi'"
 
 echo "==> Uploading server start script..."
 START_SCRIPT_B64="$(base64 < "$ROOT_DIR/.devcontainer/start-daytona-server.sh" | tr -d '\n')"

--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -15,7 +15,9 @@ REF=""
 FORCE_INSTALL=0
 RUN_SEED=0
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SANDBOX="openwork-server-$(date +%Y%m%d-%H%M%S)"
+# Pid + random suffix so parallel invocations (multiple features/worktrees)
+# never collide on the second-granularity timestamp.
+SANDBOX="openwork-server-$(date +%Y%m%d-%H%M%S)-$$-$(od -An -N2 -tx2 /dev/urandom | tr -d ' ')"
 DAYTONA_SERVER_SNAPSHOT="${DAYTONA_SERVER_SNAPSHOT:-openwork-server}"
 DAYTONA_TARGET="${DAYTONA_TARGET:-us}"
 DEN_API_PORT="${DEN_API_PORT:-8788}"

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -9,7 +9,7 @@ WORKDIR /src
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
     python3 make g++ \
-  && npm install -g bun \
+  && npm install -g bun@1.3.14 \
   && corepack enable \
   && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/docker/Dockerfile.microsandbox
+++ b/packaging/docker/Dockerfile.microsandbox
@@ -4,7 +4,7 @@ WORKDIR /src
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
-  && npm install -g bun \
+  && npm install -g bun@1.3.14 \
   && corepack enable \
   && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -52,7 +52,7 @@ services:
         export PATH="$$BUN_INSTALL/bin:$$PATH"
         if ! command -v bun >/dev/null 2>&1; then
           echo "[openwork-server] Installing bun..."
-          curl -fsSL https://bun.sh/install | bash
+          curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
         fi
 
         # --- Enable pnpm via corepack ---
@@ -144,7 +144,7 @@ services:
         export BUN_INSTALL="/root/.bun"
         export PATH="$$BUN_INSTALL/bin:$$PATH"
         if ! command -v bun >/dev/null 2>&1; then
-          curl -fsSL https://bun.sh/install | bash
+          curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
         fi
         corepack enable && corepack prepare pnpm@10.27.0 --activate
 


### PR DESCRIPTION
## Summary

- The Daytona server sandbox phase cost **~165s per eval run**: the `openwork-server` snapshot didn't exist (every run built the image from the Dockerfile), the image deleted `node_modules` so the lockfile install-skip could never fire, and `start-daytona-server.sh` rebuilt `@openwork/ui` + `@openwork-ee/utils` + the Den Web production bundle on every boot.
- Those builds are sandbox-invariant (verified: `NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL` is referenced nowhere; all `DEN_*` values are runtime env consumed by `next start`), so this bakes them into the snapshot and makes boots delta-only:
  - `Dockerfile.daytona-server`: keep `node_modules` + pnpm store (server packages' dependency graph only, Electron/browser binaries skipped), prebuild ui/utils/den-web/mcp-apps, record base-commit + content markers. Built as the `daytona` user — a separate `chown -R` layer copy-on-write duplicated the whole workspace and pushed the image to 23.7GB (20GB limit).
  - `start-daytona-server.sh`: skip install/builds when the git trees feeding them + the lockfile match the baked markers; missing markers/trees rebuild exactly as before (old snapshots and Dockerfile-fallback sandboxes are unaffected).
  - `test-server-on-daytona.sh`: `--force-install` clears build markers too; collision-free default sandbox names for parallel runs.
- Pin bun to `1.3.14` in sandbox/docker images (CI pins the 1.3 line; unpinned installs started pulling bun 1.4.0).

## Evidence

### Measured result (real Daytona runs)

Baseline, from five eval runs on 2026-08-24: server sandbox phase **~165s** (image build + clone + full `pnpm install` + Den build).

With this branch's snapshot built and live in the org (`openwork-server`), booting a **different ref** than the baked commit:

```
$ time bash .devcontainer/test-server-on-daytona.sh evals/fast-daytona-loop
==> Using Daytona server snapshot: openwork-server
==> Skipping pnpm install (node_modules present and lockfile unchanged).
==> Skipping Den API runtime asset build (baked assets match this ref).
==> Den API ready after 10s
==> worker proxy ready after 5s (HTTP 404)
==> Skipping Den Web build (baked build matches this ref).
==> Den Web ready after 5s
    Den Web ready after 0s.   # public URL health
real  0m47.966s
```

**165s → 48s** to a fully healthy public Den (MySQL + db push + Den API + worker proxy + Den Web `next start`). Sandbox create-from-snapshot itself is ~6s.

### Build verification
- Snapshot build from this exact Dockerfile completed on Daytona: `Snapshot openwork-server successfully created` (three iterations to fit org limits: 10GB sandbox-disk cap, 20GB image cap).
- `bash -n` passes on all three touched scripts.
- No product package code changed (`.devcontainer/`, `packaging/docker/`, `ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot` only), so no package builds are affected.

### API / UI verification
- No API changes; no UI changes.

## Safety / degradation

- Content-keyed skips: a ref that changes `packages/ui`, `ee/packages/utils`, `ee/apps/den-web`, `packages/mcp-apps`, or the lockfile rebuilds exactly what it changed, in its own sandbox.
- Missing markers or missing trees (old refs) → empty key → full rebuild, identical to today.
- Snapshot deleted/absent → existing Dockerfile-build fallback path, identical to today.
- As `dev` drifts from the baked base commit the skips stop matching and boots degrade gracefully toward baseline; rerun `.devcontainer/create-daytona-openwork-server-snapshot.sh` (weekly or in CI) to reset.

## Test instructions

1. `bash .devcontainer/create-daytona-openwork-server-snapshot.sh` (once; already run for this org)
2. `time bash .devcontainer/test-server-on-daytona.sh <any-recent-ref>` → expect ~50s with the three "Skipping" lines
3. Touch `ee/apps/den-web/**` on a branch and rerun → expect "Building Den Web..." (skip correctly invalidated)