### PR TITLE
fix(automations): reject disabled desktop models

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -122,6 +122,16 @@ function assistantFailure(snapshot) {
   return null
 }
 
+function disabledAutomationModelError(model, workspaceId) {
+  const identity = `${model.providerId}/${model.modelId}`
+  const error = new Error(
+    `The selected model ${identity} is not available on this desktop runner because provider ${model.providerId} is disabled. Choose a supported model to resume this Automation.`,
+  )
+  Object.defineProperty(error, "code", { value: "model_access_lost" })
+  Object.defineProperty(error, "workspaceId", { value: workspaceId })
+  return error
+}
+
 /** Runs the assignment as a normal visible local OpenWork thread. */
 export async function executeDesktopAutomation(assignment, options) {
   const local = await options.getLocalRuntime()
@@ -138,6 +148,15 @@ export async function executeDesktopAutomation(assignment, options) {
   const workspace = workspaces.find((item) => item?.id === listed?.activeId) ?? workspaces[0]
   if (!workspace?.id) throw new Error("No local workspace is available")
   const workspaceId = String(workspace.id)
+  const config = await localRequest(
+    `/workspace/${encodeURIComponent(workspaceId)}/opencode/config`,
+  ).catch(() => null)
+  const disabledProviders = Array.isArray(config?.disabled_providers)
+    ? config.disabled_providers.filter((providerId) => typeof providerId === "string")
+    : []
+  if (disabledProviders.includes(assignment.model.providerId)) {
+    throw disabledAutomationModelError(assignment.model, workspaceId)
+  }
   const client = createWorkspaceSessionClient(local, workspaceId, options.fetchImpl ?? fetch)
   const created = await client.createThread({
     title: `Automation: ${assignment.automationName}`.slice(0, 120),

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -1104,7 +1104,10 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
   assert.equal(result.workspaceId, "workspace-1")
   assert.equal(result.resultSummary, "Desktop runner result")
   assert.deepEqual(result.usage, { inputTokens: 12, outputTokens: 7, costMicros: null })
-  const localRequests = requests.filter((request) => request.path !== "/workspaces")
+  const localRequests = requests.filter((request) => ![
+    "/workspaces",
+    "/workspace/workspace-1/opencode/config",
+  ].includes(request.path))
   assert.deepEqual(localRequests.slice(0, 2).map(({ path, method, body }) => ({ path, method, body })), [
     {
       path: sessionPaths.create,
@@ -1167,6 +1170,99 @@ test("desktop Automation execution accepts a completed tool-only assistant turn"
     resultSummary: null,
     usage: { inputTokens: 9, outputTokens: 3, costMicros: null },
   })
+})
+
+test("desktop Automation execution rejects a disabled provider before creating a thread", async () => {
+  const requests = []
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-never-created")
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url)
+    requests.push({ path: parsed.pathname, method: options.method ?? "GET" })
+    if (parsed.pathname === "/workspaces") {
+      return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+    }
+    if (parsed.pathname === "/workspace/workspace-1/opencode/config") {
+      return Response.json({ disabled_providers: ["opencode"] })
+    }
+    throw new Error(`Unexpected request ${parsed.pathname}`)
+  }
+
+  await assert.rejects(
+    executeDesktopAutomation(testAssignment(), {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+      fetchImpl,
+      signal: new AbortController().signal,
+    }),
+    (error) => error instanceof Error
+      && Reflect.get(error, "code") === "model_access_lost"
+      && Reflect.get(error, "workspaceId") === "workspace-1"
+      && Reflect.get(error, "sessionId") === undefined
+      && error.message.includes("opencode/big-pickle")
+      && error.message.includes("provider opencode is disabled"),
+  )
+  assert.equal(requests.some((request) => request.path === sessionPaths.create), false)
+  assert.equal(requests.some((request) => request.path === sessionPaths.prompt), false)
+})
+
+test("disabled-provider preflight reaches a failed Den completion without a local thread", async () => {
+  let offered = false
+  const completions = []
+  const localRequests = []
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-never-created")
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") {
+        localRequests.push(parsed.pathname)
+        if (parsed.pathname === "/workspaces") {
+          return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        }
+        if (parsed.pathname === "/workspace/workspace-1/opencode/config") {
+          return Response.json({ disabled_providers: ["opencode"] })
+        }
+        throw new Error("Unexpected local request " + parsed.pathname)
+      }
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push(JSON.parse(options.body))
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error("Unexpected Den request " + parsed.pathname)
+    },
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await withTimeout(completed, "disabled-provider completion timed out")
+  runner.stop()
+
+  assert.deepEqual(completions, [{
+    status: "failed",
+    sessionId: null,
+    workspaceId: "workspace-1",
+    resultSummary: null,
+    usage: { inputTokens: null, outputTokens: null, costMicros: null },
+    error: {
+      code: "model_access_lost",
+      message: "The selected model opencode/big-pickle is not available on this desktop runner because provider opencode is disabled. Choose a supported model to resume this Automation.",
+      retryable: false,
+    },
+    attempt: 1,
+  }])
+  assert.equal(localRequests.includes(sessionPaths.create), false)
+  assert.equal(localRequests.includes(sessionPaths.prompt), false)
 })
 
 test("failed desktop assignments retain their created local thread in the Den completion", async () => {

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -17,7 +17,7 @@ function requestBudget(delays: number[], windowMs: number): number {
   return attempts;
 }
 
-test("desktop Automation runner retires rejected credentials without changing transient backoff", async ({ evidence }) => {
+test("desktop Automation runner rejects disabled providers and preserves reconnect behavior", async ({ evidence }) => {
   // automation-runner.mjs resolves @openwork/headless-threads through its
   // published "default" export (dist/index.js) when run under plain node,
   // so the package must be built before the unit test can load.
@@ -47,6 +47,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("waking during an active run keeps its lease and starts no second claim loop");
   expect(unit.stdout).toContain("a work poll left hanging by a suspended machine times out and retries");
   expect(unit.stdout).toContain("desktop Automation execution accepts a completed tool-only assistant turn");
+  expect(unit.stdout).toContain("desktop Automation execution rejects a disabled provider before creating a thread");
+  expect(unit.stdout).toContain("disabled-provider preflight reaches a failed Den completion without a local thread");
   expect(unit.stdout).toContain("failed desktop assignments retain their created local thread in the Den completion");
   expect(unit.stdout).toContain("cancellation during execution preserves the local thread and reaches a terminal completion");
   expect(unit.stdout).toContain("an explicit assistant provider failure terminates immediately with its local thread");
@@ -54,8 +56,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("remote-session creation omits nullable prompt and model fields");
   expect(unit.stdout).toContain("a local remote-session failure completes as failed without leaking the response body");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 34\b/);
-  expect(unit.stdout).toMatch(/# pass 34\b/);
+  expect(unit.stdout).toMatch(/# tests 36\b/);
+  expect(unit.stdout).toMatch(/# pass 36\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -77,7 +79,12 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 45 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, remote-session delivery and failure receipts, and work-only polling.",
+    "The runner and bridge suites passed 48 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, remote-session delivery and failure receipts, and work-only polling.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Disabled desktop providers fail before creating a thread",
+    "The runner suite verified both the direct preflight and terminal completion: opencode/big-pickle reports model_access_lost for workspace-1, no OpenCode session is created, and Den receives a failed completion with no session ID.",
     true,
   );
 


### PR DESCRIPTION
## Summary

- read the active workspace's OpenCode config before creating a desktop Automation thread
- return `model_access_lost` with the selected model and workspace when its provider is explicitly disabled
- keep config-read failures fail-open and preserve the shared headless-thread session path

## Why

A desktop Automation pinned to a disabled provider currently creates an empty thread and ends with a generic no-result error. Failing before thread creation makes the configured model problem actionable.

## Issue

- Closes #3993

## Scope

- desktop Automation runner preflight
- direct runner and Den-completion regression coverage
- existing executable runner evidence updated for the new case

## Out of scope

- model catalog changes from #3769
- automatic model fallback
- Automation editor warnings or scheduler behavior

## Testing

### Ran

- `pnpm evals:pr specs/automation-runner-reconnect-backoff.test.ts`
- `node --test apps/desktop/electron/automation-runner.test.mjs`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --dir evals lint:layers`
- `pnpm check:outbound-access`
- `pnpm --filter @openwork/desktop test`
- `git diff --check`

### Result

- focused eval proof: 1 passed, 0 failed
- runner suite: 36 passed, 0 failed
- bridge suites: 12 passed, 0 failed
- Electron typecheck, eval dependency layers, outbound manifest, and diff check: passed
- full desktop suite: 283 passed, 1 skipped, 1 failed in `runtime-ca.test.mjs`; clean current `dev` produced the same certificate failure with 281 passed and 1 skipped

## CI status

- pass: local exact-head checks listed above; Vercel landing preview and Preview Comments
- code-related failures: none identified locally
- external/env/auth blockers: fork Vercel app, Den, and diagnostics previews require Different AI team authorization; GitHub's `verify-and-approve` workflow is skipped for this fork; a frozen install could not fetch the unrelated SheetJS CDN tarball

## Manual verification

1. The disabled-provider fixture returns `model_access_lost` for `opencode/big-pickle`.
2. No local thread is created, and Den receives a failed completion with `sessionId: null`.
3. No live Den/Desktop Automation was dispatched; this is a non-visual runner boundary.

## Evidence

- `@openwork/testkit`: 3 assertions passed, 0 failed or pending; exact-head evidence is in the sticky PR comment

## Risk

- low: one authenticated local config read is added before session creation
- config-read failures remain fail-open; only an explicit provider match blocks the run

## Rollback

Revert the commit to restore the previous create-then-wait behavior.
