### PR TITLE
fix(den): route auth callbacks through API origin

### DIFF
--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -60,16 +60,20 @@ export function getOrganizationSsoSignInPath(organizationSlug: string) {
   return `/sso/${encodeURIComponent(organizationSlug)}`
 }
 
+function authCallbackBaseUrl() {
+  return env.apiPublicUrl ?? env.betterAuthUrl
+}
+
 export function getSsoAcsUrl(providerId: string) {
-  return `${env.betterAuthUrl}/api/auth/sso/saml2/sp/acs/${encodeURIComponent(providerId)}`
+  return `${authCallbackBaseUrl()}/api/auth/sso/saml2/sp/acs/${encodeURIComponent(providerId)}`
 }
 
 export function getSsoMetadataUrl(providerId: string) {
-  return `${env.betterAuthUrl}/api/auth/sso/saml2/sp/metadata?providerId=${encodeURIComponent(providerId)}`
+  return `${authCallbackBaseUrl()}/api/auth/sso/saml2/sp/metadata?providerId=${encodeURIComponent(providerId)}`
 }
 
 export function getSsoOidcRedirectUrl(providerId: string) {
-  return `${env.betterAuthUrl}/api/auth/sso/callback/${encodeURIComponent(providerId)}`
+  return `${authCallbackBaseUrl()}/api/auth/sso/callback/${encodeURIComponent(providerId)}`
 }
 
 function isDevLoopbackIssuer(issuer: string) {

--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -9,8 +9,8 @@ Frontend for `app.openworklabs.com`.
 - Lists and connects existing cloud workers.
 - Sends users to the organization billing page for subscription management.
 - Offers desktop handoff actions so users can open the generated worker directly in OpenWork or copy the connect credentials manually.
-- Calls the Den API directly at the matching `api.*` origin (for example, `app.openworklabs.com` -> `api.app.openworklabs.com`).
-- Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openworklabs.com`.
+- Calls the Den API directly at the matching `api.*` origin (for example, `app.openworklabs.com` -> `api.app.openworklabs.com`), including Better Auth traffic.
+- Keeps a same-origin auth proxy (`/api/auth/*`) only for compatibility with already-registered auth callbacks that still land on the web host.
 
 ## Current hosted user flow
 
@@ -39,8 +39,7 @@ Frontend for `app.openworklabs.com`.
   - The web panel appends `/connect-remote` and injects worker URL/token params automatically.
 - `DEN_WEB_OPENWORK_WEB_URL` (runtime): URL opened by the dashboard Web tab.
   - default: `https://web.openworklabs.com`
-- `DEN_WEB_OPENWORK_AUTH_CALLBACK_URL` (runtime): Canonical URL used for GitHub auth callback redirects.
-  - this host must serve `/api/auth/*`; the included proxy route does that
+- `DEN_WEB_OPENWORK_AUTH_CALLBACK_URL` (runtime): Canonical URL where the app returns after auth completes.
 - `DEN_WEB_POSTHOG_KEY` (server/runtime): PostHog project key used for Den analytics.
 - `DEN_WEB_POSTHOG_HOST` (server/runtime): PostHog ingest host or same-origin proxy path.
   - default: `/ow`
@@ -59,7 +58,7 @@ Direct OTLP shutdown/flush for stock `next start` and Vercel deployments is oper
 
 Sentry wraps the Next config for browser Sentry builds (`NEXT_PUBLIC_DEN_OBSERVABILITY_BACKEND=sentry`) and for explicit source-map upload builds. Source-map uploads are disabled by default; enable them with the build-only `DEN_WEB_UPLOAD_SENTRY_SOURCEMAPS=true` flag and provide `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` as build credentials. Normal Docker/image builds do not need runtime `DEN_OBSERVABILITY_BACKEND` or `SENTRY_DSN` values. Never expose `SENTRY_AUTH_TOKEN` to the browser.
 
-Runtime logs and telemetry scrubbing avoid request bodies, cookies, authorization headers, credentials, and target query strings. The compatibility `/api/den/*` route redirects legacy callers to the direct `api.*` origin; `/api/auth/*` remains an upstream proxy for auth callback compatibility and emits one structured completion/error log per request while forwarding W3C trace context.
+Runtime logs and telemetry scrubbing avoid request bodies, cookies, authorization headers, credentials, and target query strings. The compatibility `/api/den/*` route redirects legacy callers to the direct `api.*` origin; `/api/auth/*` remains an upstream proxy only for legacy auth callback compatibility and emits one structured completion/error log per request while forwarding W3C trace context.
 
 ### Related Den API env vars
 

--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -62,14 +62,6 @@ export function denApiEndpointForWebOrigin(path: string, webOrigin: string): str
     return path;
   }
 
-  // Better Auth establishes sessions and OAuth callbacks through the Den Web
-  // host. Keep those calls on the same-origin auth proxy so callback URLs stay
-  // on app.* and Cloudflare's stricter API-host WAF does not inspect provider
-  // callback query strings.
-  if (path.startsWith("/api/auth/")) {
-    return path;
-  }
-
   const origin = currentDenApiOriginForWebOrigin(webOrigin);
   if (!origin) {
     return path;

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -43,10 +43,12 @@ describe("Den API browser origin", () => {
     );
   });
 
-  test("keeps Better Auth traffic on the same-origin auth proxy", () => {
-    expect(denApiEndpointForWebOrigin("/api/auth/sign-in/email", "https://app.openworklabs.com")).toBe("/api/auth/sign-in/email");
+  test("builds direct API URLs for Better Auth traffic", () => {
+    expect(denApiEndpointForWebOrigin("/api/auth/sign-in/email", "https://app.openworklabs.com")).toBe(
+      "https://api.app.openworklabs.com/api/auth/sign-in/email",
+    );
     expect(denApiEndpointForWebOrigin("/api/auth/callback/google?code=provider-token", "https://app.openworklabs.com")).toBe(
-      "/api/auth/callback/google?code=provider-token",
+      "https://api.app.openworklabs.com/api/auth/callback/google?code=provider-token",
     );
   });
 


### PR DESCRIPTION
## Summary
- route Den Web Better Auth requests to the direct API origin instead of the app-host proxy
- generate SSO ACS, metadata, and OIDC callback URLs from the public API origin when configured
- keep the Den Web auth proxy only as legacy compatibility for already-registered callbacks

## Verification
- pnpm --filter @openwork-ee/den-web test tests/den-api-origin.test.ts
  - 138 pass, 0 fail

## Notes
- A focused den-api route guard check was attempted after building @openwork/mcp-apps, but it is red on clean origin/dev with the same uncovered-route signature, so it is pre-existing and unrelated.