### PR TITLE
fix(den-api): build telemetry package

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -16,6 +16,7 @@
     "build:codemode": "pnpm --filter @openwork/codemode build",
     "build:headless-threads": "pnpm --filter @openwork/headless-threads build",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
+    "build:telemetry": "pnpm --filter @openwork-ee/telemetry build",
     "openapi:snapshot": "tsx scripts/generate-openapi-snapshot.ts",
     "smoke:config-object-payload-boundary": "tsx scripts/smoke-config-object-payload-boundary.ts",
     "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",

--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -119,6 +119,7 @@ function main() {
   run(pnpmCommand, ["run", "build:codemode"])
   run(pnpmCommand, ["run", "build:headless-threads"])
   run(pnpmCommand, ["run", "build:den-db"])
+  run(pnpmCommand, ["run", "build:telemetry"])
   run(pnpmCommand, ["exec", "tsc", "-p", "tsconfig.json"])
   maybeUploadSentrySourcemaps()
 }


### PR DESCRIPTION
## Summary
- build the direct `@openwork-ee/telemetry` workspace dependency during the Den API build
- ensure Render has `telemetry/dist/index.js` when starting the compiled API

## Verification
- `pnpm --filter @openwork-ee/den-api build` (passed)
- `node --input-type=module -e "await import('@openwork-ee/telemetry'); console.log('telemetry runtime import passed')"` from `ee/apps/den-api` (passed)