### PR TITLE
fix(den-api): build telemetry package

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -16,6 +16,7 @@
     "build:codemode": "pnpm --filter @openwork/codemode build",
     "build:headless-threads": "pnpm --filter @openwork/headless-threads build",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
+    "build:telemetry": "pnpm --filter @openwork-ee/telemetry build",
     "openapi:snapshot": "tsx scripts/generate-openapi-snapshot.ts",
     "smoke:config-object-payload-boundary": "tsx scripts/smoke-config-object-payload-boundary.ts",
     "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",

--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -119,6 +119,7 @@ function main() {
   run(pnpmCommand, ["run", "build:codemode"])
   run(pnpmCommand, ["run", "build:headless-threads"])
   run(pnpmCommand, ["run", "build:den-db"])
+  run(pnpmCommand, ["run", "build:telemetry"])
   run(pnpmCommand, ["exec", "tsc", "-p", "tsconfig.json"])
   maybeUploadSentrySourcemaps()
 }


### PR DESCRIPTION
## Summary
- build @openwork-ee/telemetry as part of the den-api build
- ensures Render has telemetry/dist/index.js before den-api starts

## Verification
- pnpm --dir ee/apps/den-api run build
- DEN_DB_ENCRYPTION_KEY=local-dev-db-encryption-key-please-change-1234567890 BETTER_AUTH_SECRET='local-dev-secret-not-for-production-use!!' DEN_BASE_URL=http://localhost:3005 DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den node --input-type=module -e "await import('./ee/apps/den-api/dist/routes/telemetry/index.js'); console.log('telemetry route import ok'); process.exit(0)"