### PR TITLE
fix(den-web): add temporary auth recovery notice

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -8,6 +8,7 @@ import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
 import { useWebGlSupported } from "../_lib/use-webgl-supported";
 import { useDenFlow } from "../_providers/den-flow-provider";
 import { AuthPanel } from "./auth-panel";
+import { TemporaryAuthNotice } from "./temporary-auth-notice";
 
 function SessionStatusPanel({ mode }: { mode: "checking" | "redirecting" }) {
   const status = mode === "checking"
@@ -111,7 +112,10 @@ export function AuthScreen() {
             ) : hasResolvedSession ? (
               <SessionStatusPanel mode="redirecting" />
             ) : (
-              <AuthPanel bare emailFirstFlow />
+              <div className="grid gap-5">
+                <TemporaryAuthNotice />
+                <AuthPanel bare emailFirstFlow />
+              </div>
             )}
           </div>
         </div>

--- a/ee/apps/den-web/app/(den)/_components/temporary-auth-notice.tsx
+++ b/ee/apps/den-web/app/(den)/_components/temporary-auth-notice.tsx
@@ -1,0 +1,25 @@
+import { shouldShowTemporaryAuthNotice } from "../_lib/temporary-auth-notice";
+import { DenNotice } from "./ui/notice";
+
+export function TemporaryAuthNotice() {
+  if (!shouldShowTemporaryAuthNotice()) return null;
+
+  return (
+    <DenNotice
+      tone="warning"
+      className="leading-5"
+      message={(
+        <span className="grid gap-2">
+          <span>
+            <strong className="font-semibold">Trouble signing in?</strong> We recently changed our authentication system. If sign-in or sign-up does not finish, clear saved site data for <strong className="font-semibold">openworklabs.com</strong>, then force-refresh. We&apos;re sorry for the disruption. Clearing site data signs you out.
+          </span>
+          <span className="grid gap-1 text-[13px]">
+            <span><strong className="font-semibold">Chrome or Edge:</strong> Open the site controls beside the address bar, clear cookies and site data, then press Cmd/Ctrl+Shift+R.</span>
+            <span><strong className="font-semibold">Safari:</strong> Safari &gt; Settings &gt; Privacy &gt; Manage Website Data, remove openworklabs.com, then reload.</span>
+            <span><strong className="font-semibold">Firefox or another browser:</strong> Clear cookies and site data for openworklabs.com in site settings, then press Cmd/Ctrl+Shift+R.</span>
+          </span>
+        </span>
+      )}
+    />
+  );
+}

--- a/ee/apps/den-web/app/(den)/_lib/temporary-auth-notice.ts
+++ b/ee/apps/den-web/app/(den)/_lib/temporary-auth-notice.ts
@@ -1,0 +1,5 @@
+export const TEMPORARY_AUTH_NOTICE_EXPIRES_AT = Date.parse("2026-09-01T12:00:00.000Z");
+
+export function shouldShowTemporaryAuthNotice(now = Date.now()) {
+  return now < TEMPORARY_AUTH_NOTICE_EXPIRES_AT;
+}

--- a/evals/specs/temporary-auth-notice.test.ts
+++ b/evals/specs/temporary-auth-notice.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  TEMPORARY_AUTH_NOTICE_EXPIRES_AT,
+  shouldShowTemporaryAuthNotice,
+} from "../../ee/apps/den-web/app/(den)/_lib/temporary-auth-notice";
+
+const authScreenPath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/(den)/_components/auth-screen.tsx", import.meta.url),
+);
+const noticePath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/(den)/_components/temporary-auth-notice.tsx", import.meta.url),
+);
+
+test("sign-in and sign-up temporarily explain how to recover after the authentication change", async ({ evidence }) => {
+  const authScreen = readFileSync(authScreenPath, "utf8");
+  const notice = readFileSync(noticePath, "utf8");
+
+  expect(authScreen).toContain("<TemporaryAuthNotice />");
+  expect(authScreen).toContain("<AuthPanel bare emailFirstFlow />");
+  expect(notice).toContain("We recently changed our authentication system.");
+  expect(notice).toContain("Chrome or Edge:");
+  expect(notice).toContain("Safari:");
+  expect(notice).toContain("Firefox or another browser:");
+  expect(notice).toContain("Clearing site data signs you out.");
+
+  expect(shouldShowTemporaryAuthNotice(TEMPORARY_AUTH_NOTICE_EXPIRES_AT - 1)).toBe(true);
+  expect(shouldShowTemporaryAuthNotice(TEMPORARY_AUTH_NOTICE_EXPIRES_AT)).toBe(false);
+
+  evidence.recordAssertionEvidence(
+    "Hosted sign-in and sign-up show time-bounded authentication recovery guidance",
+    "The shared email-first auth screen includes an apology and site-data recovery steps for Chrome/Edge, Safari, and Firefox/other browsers before the fixed expiry, then removes the notice at expiry.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- show an authentication recovery notice on the shared hosted sign-in/sign-up screen
- provide Chrome/Edge, Safari, and Firefox/other-browser site-data and force-refresh steps
- automatically stop rendering the notice on September 1, 2026 at 12:00 UTC

## Verification
- `pnpm evals:pr specs/temporary-auth-notice.test.ts` (1 passed, 0 failed, 0 skipped)
- `pnpm --filter @openwork-ee/den-web test -- tests/auth-landing-contract.test.ts` (138 passed, 0 failed)
- `pnpm --filter @openwork-ee/den-web typecheck` (passed)