### PR TITLE
fix(den-web): show auth notice in MCP flow

### DIFF
--- a/ee/apps/den-web/app/mcp/consent/page.tsx
+++ b/ee/apps/den-web/app/mcp/consent/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { TemporaryAuthNotice } from "../../(den)/_components/temporary-auth-notice";
 import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 
 function getErrorMessage(payload: unknown, fallback: string) {
@@ -57,6 +58,9 @@ export default function McpConsentPage() {
         <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">OpenWork MCP</p>
         <h1 className="mt-3 text-3xl font-semibold">Authorize MCP access</h1>
         <p className="mt-3 text-sm text-slate-300">`{clientId}` wants to access OpenWork through MCP.</p>
+        <div className="mt-6">
+          <TemporaryAuthNotice />
+        </div>
         <div className="mt-6 rounded-2xl border border-white/10 bg-slate-900/70 p-4">
           <p className="text-sm font-medium text-slate-200">Requested scopes</p>
           <p className="mt-2 break-words font-mono text-xs text-cyan-100">{scope}</p>

--- a/ee/apps/den-web/app/mcp/select-organization/page.tsx
+++ b/ee/apps/den-web/app/mcp/select-organization/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { TemporaryAuthNotice } from "../../(den)/_components/temporary-auth-notice";
 import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 import { useOrgListWindow } from "../../(den)/_lib/use-org-list-window";
 
@@ -286,6 +287,8 @@ export default function McpSelectOrganizationPage() {
               </h2>
               <p className="den-copy">{introCopy}</p>
             </div>
+
+            <TemporaryAuthNotice />
 
             {flowState === "loading" ? (
               <div className="h-2 overflow-hidden rounded-full bg-[var(--dls-hover)]">

--- a/evals/specs/temporary-auth-notice.test.ts
+++ b/evals/specs/temporary-auth-notice.test.ts
@@ -13,13 +13,23 @@ const authScreenPath = fileURLToPath(
 const noticePath = fileURLToPath(
   new URL("../../ee/apps/den-web/app/(den)/_components/temporary-auth-notice.tsx", import.meta.url),
 );
+const mcpSelectOrganizationPath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/mcp/select-organization/page.tsx", import.meta.url),
+);
+const mcpConsentPath = fileURLToPath(
+  new URL("../../ee/apps/den-web/app/mcp/consent/page.tsx", import.meta.url),
+);
 
-test("sign-in and sign-up temporarily explain how to recover after the authentication change", async ({ evidence }) => {
+test("authentication pages temporarily explain how to recover after the authentication change", async ({ evidence }) => {
   const authScreen = readFileSync(authScreenPath, "utf8");
   const notice = readFileSync(noticePath, "utf8");
+  const mcpSelectOrganization = readFileSync(mcpSelectOrganizationPath, "utf8");
+  const mcpConsent = readFileSync(mcpConsentPath, "utf8");
 
   expect(authScreen).toContain("<TemporaryAuthNotice />");
   expect(authScreen).toContain("<AuthPanel bare emailFirstFlow />");
+  expect(mcpSelectOrganization).toContain("<TemporaryAuthNotice />");
+  expect(mcpConsent).toContain("<TemporaryAuthNotice />");
   expect(notice).toContain("We recently changed our authentication system.");
   expect(notice).toContain("Chrome or Edge:");
   expect(notice).toContain("Safari:");
@@ -30,8 +40,8 @@ test("sign-in and sign-up temporarily explain how to recover after the authentic
   expect(shouldShowTemporaryAuthNotice(TEMPORARY_AUTH_NOTICE_EXPIRES_AT)).toBe(false);
 
   evidence.recordAssertionEvidence(
-    "Hosted sign-in and sign-up show time-bounded authentication recovery guidance",
-    "The shared email-first auth screen includes an apology and site-data recovery steps for Chrome/Edge, Safari, and Firefox/other browsers before the fixed expiry, then removes the notice at expiry.",
+    "Hosted sign-in, sign-up, and MCP authorization show time-bounded authentication recovery guidance",
+    "The shared email-first auth screen, MCP workspace selection, and MCP consent page include an apology and site-data recovery steps for Chrome/Edge, Safari, and Firefox/other browsers before the fixed expiry, then remove the notice at expiry.",
     true,
   );
 });


### PR DESCRIPTION
## Summary
- show the temporary authentication recovery notice on MCP workspace selection
- show the same notice on the fallback MCP consent page
- extend proof to cover login, MCP workspace selection, and MCP consent placement

## Verification
- `pnpm evals:pr specs/temporary-auth-notice.test.ts` (1 passed, 0 failed, 0 skipped)
- `pnpm --filter @openwork-ee/den-web test -- tests/auth-landing-contract.test.ts` (138 passed, 0 failed)
- `pnpm --filter @openwork-ee/den-web typecheck` (passed)