### PR TITLE
fix(den-api): rename better auth session cookie

### DIFF
--- a/ee/apps/den-api/src/auth-login-options.ts
+++ b/ee/apps/den-api/src/auth-login-options.ts
@@ -5,12 +5,17 @@ export type LoginOptionAccount = {
   hasPassword: boolean
 }
 
-const BETTER_AUTH_SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token"
+const BETTER_AUTH_SECURE_SESSION_COOKIES = [
+  "__Secure-openwork-den.session_token",
+  "__Secure-better-auth.session_token",
+] as const
 
 export function buildLoginOptionsSessionCookieClearHeaders(cookieDomain?: string) {
-  const expiredCookie = `${BETTER_AUTH_SECURE_SESSION_COOKIE}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`
   const normalizedDomain = cookieDomain?.trim().toLowerCase()
-  return normalizedDomain ? [`${expiredCookie}; Domain=${normalizedDomain}`, expiredCookie] : [expiredCookie]
+  return BETTER_AUTH_SECURE_SESSION_COOKIES.flatMap((cookieName) => {
+    const expiredCookie = `${cookieName}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`
+    return normalizedDomain ? [`${expiredCookie}; Domain=${normalizedDomain}`, expiredCookie] : [expiredCookie]
+  })
 }
 
 export function normalizeLoginEmail(email: string) {

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -854,6 +854,7 @@ export const auth = betterAuth({
     }),
   },
   advanced: {
+    cookiePrefix: "openwork-den",
     ...(env.betterAuthCookieDomain
       ? {
         crossSubDomainCookies: {

--- a/ee/apps/den-api/src/session.ts
+++ b/ee/apps/den-api/src/session.ts
@@ -35,6 +35,8 @@ const INTERNAL_MCP_PRINCIPAL_HEADER = "x-den-internal-mcp-principal"
 const INTERNAL_MCP_PRINCIPAL_TTL_MS = 60_000
 export const INTERNAL_CAPABILITY_CONNECTOR_HEADER = "x-den-internal-capability-connector"
 const BETTER_AUTH_SESSION_COOKIE_NAMES = [
+  "openwork-den.session_token",
+  "__Secure-openwork-den.session_token",
   "better-auth.session_token",
   "__Secure-better-auth.session_token",
   "better-auth-session_token",

--- a/ee/apps/den-api/test/auth-login-options.test.ts
+++ b/ee/apps/den-api/test/auth-login-options.test.ts
@@ -3,6 +3,8 @@ import { buildLoginOptionsSessionCookieClearHeaders, normalizeLoginEmail, resolv
 
 test("login option response clears stale secure Better Auth session cookies", () => {
   expect(buildLoginOptionsSessionCookieClearHeaders("app.example.com")).toEqual([
+    "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
+    "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
     "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.example.com",
     "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
   ])

--- a/ee/apps/den-api/test/bearer-session.test.ts
+++ b/ee/apps/den-api/test/bearer-session.test.ts
@@ -395,7 +395,7 @@ test("desktop bearer session cache misses populate from the database lookup", as
   expect(cached?.session.token).toBe(token)
 })
 
-test("signed Better Auth cookie sessions resolve through the Den cache", async () => {
+test("signed OpenWork Den auth cookie sessions resolve through the Den cache", async () => {
   const now = new Date("2026-07-09T12:00:00.000Z")
   setSystemTime(now)
   stored = makeStoredSession({
@@ -409,14 +409,14 @@ test("signed Better Auth cookie sessions resolve through the Den cache", async (
     return c.json({ id: resolved?.session.id ?? null })
   })
 
-  const cookie = await generateSignedCookie("better-auth.session_token", token, process.env.BETTER_AUTH_SECRET ?? "")
+  const cookie = await generateSignedCookie("openwork-den.session_token", token, process.env.BETTER_AUTH_SECRET ?? "")
   const response = await app.request("/session", { headers: { cookie } })
 
   await expect(response.json()).resolves.toEqual({ id: sessionId })
   expect(selects).toBe(1)
 })
 
-test("unsigned Better Auth cookies are ignored", async () => {
+test("unsigned OpenWork Den auth cookies are ignored", async () => {
   const now = new Date("2026-07-09T12:00:00.000Z")
   setSystemTime(now)
   stored = makeStoredSession({
@@ -430,7 +430,7 @@ test("unsigned Better Auth cookies are ignored", async () => {
     return c.json({ id: resolved?.session.id ?? null })
   })
 
-  const response = await app.request("/session", { headers: { cookie: `better-auth.session_token=${token}` } })
+  const response = await app.request("/session", { headers: { cookie: `openwork-den.session_token=${token}` } })
 
   await expect(response.json()).resolves.toEqual({ id: null })
   expect(selects).toBe(0)


### PR DESCRIPTION
## Summary\n- set Better Auth cookie prefix to openwork-den for Den API\n- accept both new and legacy session cookie names during rollout\n- clear both new and legacy secure session cookies from login option responses\n\n## Tests\n- pnpm --filter @openwork-ee/utils build\n- pnpm --filter @openwork-ee/den-db build\n- bun test test/bearer-session.test.ts test/auth-login-options.test.ts