### PR TITLE
fix(den-web): scope Vercel workspace install

### DIFF
--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -79,9 +79,9 @@ Recommended project settings:
 - Framework preset: Next.js
 - Build command: `cd ../../.. && pnpm --filter @openwork-ee/den-web build`
 - Output directory: `.next`
-- Install command: `cd ../../.. && pnpm install --frozen-lockfile`
+- Install command: use the command committed in `vercel.json`
 
-These commands should be configured in the Vercel dashboard rather than committed in `vercel.json`, so the app still builds from the monorepo root and can resolve shared workspace packages like `@openwork-ee/utils`.
+The filtered install includes Den Web's workspace dependency closure, so shared packages like `@openwork-ee/utils` remain available without installing unrelated native desktop and server dependencies.
 
 Then assign custom domain:
 

--- a/ee/apps/den-web/vercel.json
+++ b/ee/apps/den-web/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "installCommand": "cd ../../.. && pnpm install --frozen-lockfile --filter @openwork-ee/den-web..."
 }

--- a/evals/specs/den-web-vercel-install.test.ts
+++ b/evals/specs/den-web-vercel-install.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { briefTest, claim, testBrief } from "@openwork/testkit";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+briefTest(testBrief({
+  behavior: "The Den Web Vercel deployment installs only its workspace dependency closure.",
+  claims: {
+    scopedInstall: claim("the Vercel install includes Den Web and its workspace dependencies", {
+      never: "install unrelated native desktop or server packages",
+    }),
+  },
+}), async ({ prove }) => {
+  const config = await readFile(join(repoRoot, "ee", "apps", "den-web", "vercel.json"), "utf8");
+
+  expect(config).toContain(
+    '"installCommand": "cd ../../.. && pnpm install --frozen-lockfile --filter @openwork-ee/den-web..."',
+  );
+  expect(config).not.toContain('"installCommand": "cd ../../.. && pnpm install --frozen-lockfile"');
+
+  prove.scopedInstall(
+    true,
+    "Vercel filters installation to @openwork-ee/den-web and its workspace dependency closure",
+  );
+});


### PR DESCRIPTION
## Summary
- scope the Den Web Vercel install to its workspace dependency closure
- avoid building unrelated native desktop/server packages such as better-sqlite3
- document and test the deployment install contract

## Verification
- `pnpm install --frozen-lockfile --filter @openwork-ee/den-web...`
- `pnpm evals:pr specs/den-web-vercel-install.test.ts` (1 passed, 0 failed, 0 skipped)
- `pnpm --filter @openwork-ee/den-web build`

Verdict: Passed (local app-less lane).