### PR TITLE
fix(den-web): forward renamed auth cookies

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -196,18 +196,18 @@ describe("Den upstream proxy", () => {
     expect(observed.cookie).toBe("better-auth.session_token=sess_test");
   });
 
-  test("forwards only Better Auth cookies through the auth proxy", async () => {
+  test("forwards only OpenWork Den and legacy Better Auth cookies through the auth proxy", async () => {
     const { proxyUpstream } = await import("./upstream-proxy.ts");
     const request = new NextRequest("https://app.example.com/api/auth/sign-in/social", {
       method: "POST",
       headers: {
-        cookie: "ph_posthog=analytics; better-auth.state=oauth-state; __Secure-better-auth.session_token=session; other=value",
+        cookie: "ph_posthog=analytics; __Secure-openwork-den.state=oauth-state; openwork-den.session_token=session; better-auth.state=legacy-oauth-state; __Secure-better-auth.session_token=legacy-session; other=value",
       },
     });
 
     await proxyUpstream(request, [], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
 
-    expect(observed.cookie).toBe("better-auth.state=oauth-state; __Secure-better-auth.session_token=session");
+    expect(observed.cookie).toBe("__Secure-openwork-den.state=oauth-state; openwork-den.session_token=session; better-auth.state=legacy-oauth-state; __Secure-better-auth.session_token=legacy-session");
   });
 
   test("rewrites auth Set-Cookie domains to the browser origin", async () => {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -38,7 +38,14 @@ const INTERNAL_RESPONSE_HEADERS = new Set([
   "x-vercel-id",
 ]);
 const SAFE_X_RESPONSE_HEADERS = new Set(["x-content-type-options"]);
-const AUTH_COOKIE_PREFIXES = ["better-auth.", "__Secure-better-auth.", "better-auth-"];
+const AUTH_COOKIE_PREFIXES = [
+  "openwork-den.",
+  "__Secure-openwork-den.",
+  "openwork-den-",
+  "better-auth.",
+  "__Secure-better-auth.",
+  "better-auth-",
+];
 
 /**
  * OpenWork Cloud instances are served from Daytona preview origins that are

--- a/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.test.mjs
+++ b/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.test.mjs
@@ -5,6 +5,9 @@ import { buildAuthSessionCookieClearHeaders } from "./session-cookie-clear.ts";
 describe("auth session cookie clearing", () => {
   test("clears host-only, app-host, and parent-domain session cookies", () => {
     expect(buildAuthSessionCookieClearHeaders("https://app.openworklabs.com/api/auth/clear-session-cookie", "openworklabs.com")).toEqual([
+      "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
+      "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=openworklabs.com",
+      "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.openworklabs.com",
       "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax",
       "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=openworklabs.com",
       "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=app.openworklabs.com",
@@ -13,7 +16,7 @@ describe("auth session cookie clearing", () => {
 
   test("normalizes a leading-dot configured cookie domain", () => {
     expect(buildAuthSessionCookieClearHeaders("https://app.example.com/api/auth/clear-session-cookie", ".example.com")).toContain(
-      "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=example.com",
+      "__Secure-openwork-den.session_token=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax; Domain=example.com",
     );
   });
 });

--- a/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.ts
+++ b/ee/apps/den-web/app/api/auth/_lib/session-cookie-clear.ts
@@ -1,4 +1,7 @@
-const BETTER_AUTH_SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token";
+const BETTER_AUTH_SECURE_SESSION_COOKIES = [
+  "__Secure-openwork-den.session_token",
+  "__Secure-better-auth.session_token",
+];
 
 function normalizeCookieDomain(value: string | null | undefined): string | null {
   const domain = value?.trim().replace(/^\.+/u, "").toLowerCase() ?? "";
@@ -35,9 +38,11 @@ function domainCandidates(requestUrl: string, configuredDomain?: string): string
 }
 
 export function buildAuthSessionCookieClearHeaders(requestUrl: string, configuredDomain = process.env.DEN_BETTER_AUTH_COOKIE_DOMAIN): string[] {
-  const expiredCookie = `${BETTER_AUTH_SECURE_SESSION_COOKIE}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`;
-  return [
-    expiredCookie,
-    ...domainCandidates(requestUrl, configuredDomain).map((domain) => `${expiredCookie}; Domain=${domain}`),
-  ];
+  return BETTER_AUTH_SECURE_SESSION_COOKIES.flatMap((cookieName) => {
+    const expiredCookie = `${cookieName}=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax`;
+    return [
+      expiredCookie,
+      ...domainCandidates(requestUrl, configuredDomain).map((domain) => `${expiredCookie}; Domain=${domain}`),
+    ];
+  });
 }


### PR DESCRIPTION
## Summary
- Forward renamed `openwork-den` Better Auth cookies through the Den Web `/api/auth` proxy
- Keep forwarding legacy `better-auth` cookies for mixed-version compatibility
- Clear both renamed and legacy secure session cookies from Den Web stale-session cleanup

## Verification
- `pnpm --dir ee/apps/den-web exec bun test --conditions development app/api/_lib/upstream-proxy.test.mjs app/api/auth/_lib/session-cookie-clear.test.mjs`
- Result: 21 pass, 0 fail