### PR TITLE
feat(evals): launch dev desktop with live production state

### DIFF
--- a/apps/desktop/electron/runtime-user-env.test.mjs
+++ b/apps/desktop/electron/runtime-user-env.test.mjs
@@ -69,3 +69,20 @@ test("refreshes an injected user env key when its stored value changes", () => {
 
   assert.equal(processEnv.ANTHROPIC_API_KEY, "new-value");
 });
+
+test("dev child env reconciliation preserves an inherited OPENCODE_DB override", () => {
+  const inheritedEnv = {
+    OPENWORK_DEV_MODE: "1",
+    OPENCODE_DB: "/tmp/installed-production/opencode.db",
+  };
+  const processEnv = { ...inheritedEnv };
+
+  reconcileInjectedUserEnv({
+    processEnv,
+    inheritedEnv,
+    userEnv: {},
+    previouslyInjectedKeys: new Set(),
+  });
+
+  assert.equal(processEnv.OPENCODE_DB, "/tmp/installed-production/opencode.db");
+});

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1391,10 +1391,14 @@ export function createRuntimeManager({
   }
 
   function openworkServerTokenStorePath() {
+    const override = process.env.OPENWORK_SERVER_TOKEN_STORE_PATH?.trim();
+    if (override) return path.resolve(override);
     return path.join(userDataDir, "openwork-server-tokens.json");
   }
 
   function openworkServerStatePath() {
+    const override = process.env.OPENWORK_SERVER_STATE_PATH?.trim();
+    if (override) return path.resolve(override);
     return path.join(userDataDir, "openwork-server-state.json");
   }
 
@@ -1522,7 +1526,7 @@ export function createRuntimeManager({
     // User env is layered first so process.env + any caller overrides always
     // win. See apps/server/src/env-file.ts — all loaders must agree on path +
     // reserved-keys policy.
-    const devPaths = process.env.OPENWORK_DEV_MODE === "1"
+    const devPaths = process.env.OPENWORK_DEV_MODE === "1" && process.env.OPENWORK_DEV_SHARED_STATE !== "1"
       ? await ensureDevModePaths()
       : null;
     const userEnvPathEnv = devPaths

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -166,10 +166,14 @@ export function createWorkspaceStore({
   }
 
   function workspaceStatePath() {
+    const override = process.env.OPENWORK_DESKTOP_WORKSPACE_STATE_PATH?.trim();
+    if (override) return path.resolve(override);
     return path.join(app.getPath("userData"), "openwork-workspaces.json");
   }
 
   function openworkServerTokenStorePath() {
+    const override = process.env.OPENWORK_SERVER_TOKEN_STORE_PATH?.trim();
+    if (override) return path.resolve(override);
     return path.join(app.getPath("userData"), "openwork-server-tokens.json");
   }
 

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -102,6 +102,43 @@ test("recovers missing desktop workspace state from token store paths", async ()
   }
 });
 
+test("reads live shared workspace state from the explicit production path", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-shared-"));
+  const isolatedUserData = path.join(root, "isolated-userData");
+  const workspace = path.join(root, "production-workspace");
+  const sharedState = path.join(root, "production-userData", "openwork-workspaces.json");
+  await mkdir(isolatedUserData, { recursive: true });
+  await mkdir(workspace, { recursive: true });
+  await mkdir(path.dirname(sharedState), { recursive: true });
+  await writeFile(sharedState, JSON.stringify({
+    selectedId: "ws_production",
+    watchedId: "ws_production",
+    activeId: "ws_production",
+    workspaces: [{ id: "ws_production", name: "Production", path: workspace, workspaceType: "local" }],
+  }), "utf8");
+
+  const previousStatePath = process.env.OPENWORK_DESKTOP_WORKSPACE_STATE_PATH;
+  const previousRecovery = process.env.OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY;
+  process.env.OPENWORK_DESKTOP_WORKSPACE_STATE_PATH = sharedState;
+  process.env.OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY = "1";
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? isolatedUserData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+    const state = await store.readWorkspaceState();
+    assert.equal(state.selectedId, "ws_production");
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].path, workspace);
+    await assert.rejects(readFile(path.join(isolatedUserData, "openwork-workspaces.json"), "utf8"));
+  } finally {
+    restoreEnv("OPENWORK_DESKTOP_WORKSPACE_STATE_PATH", previousStatePath);
+    restoreEnv("OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY", previousRecovery);
+  }
+});
+
 test("keeps persisted empty desktop workspace state authoritative", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
   const userData = path.join(root, "userData");

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
-import { isAbsolute, join } from "node:path";
-import { opencodeDataDirs as defaultOpencodeDataDirs } from "@openwork/paths";
+import { join } from "node:path";
+import { opencodeDataDirs as defaultOpencodeDataDirs, opencodeDbCandidates } from "@openwork/paths";
 
 // better-sqlite3's N-API binding hard-crashes Bun (panic: "NAPI FATAL ERROR:
 // Error::New napi_get_last_error_info"), and the Daytona worker runtime ships
@@ -54,12 +54,6 @@ const DEFAULT_PROVIDER = "openai";
 const DEFAULT_MODEL = "gpt-5.4";
 const OPENWORK_DEV_DATA_DIRS = ["openwork-dev-data", "opencode-dev"];
 
-function truthy(value: string | undefined): boolean {
-  if (!value) return false;
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
-}
-
 function opencodeOpenworkDataDirs(): string[] {
   const root = process.env.OPENWORK_DATA_DIR?.trim();
   if (!root) return [];
@@ -88,35 +82,12 @@ function opencodeDataDirs(): string[] {
   return Array.from(new Set(dirs));
 }
 
-function preferredDbNames(): string[] {
-  const channel = process.env.OPENCODE_CHANNEL?.trim() || "local";
-  return channel === "latest" || channel === "beta" || truthy(process.env.OPENCODE_DISABLE_CHANNEL_DB)
-    ? ["opencode.db"]
-    : [`opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`, "opencode.db"];
-}
-
 function candidateOpencodeDbPaths(): string[] {
-  const override = process.env.OPENCODE_DB?.trim();
-  if (override) {
-    if (isAbsolute(override)) return [override];
-    const candidates: string[] = [];
-    const dirs = opencodeDataDirs();
-    for (const dir of dirs) {
-      candidates.push(join(dir, override));
-    }
-    const firstDir = dirs[0];
-    if (firstDir) candidates.push(join(firstDir, override));
-    return Array.from(new Set(candidates));
-  }
-
-  const candidates: string[] = [];
-  for (const dir of opencodeDataDirs()) {
-    for (const name of preferredDbNames()) {
-      candidates.push(join(dir, name));
-    }
-  }
-
-  return Array.from(new Set(candidates));
+  return opencodeDbCandidates({
+    env: process.env,
+    dataDirs: opencodeDataDirs(),
+    defaultChannel: "local",
+  });
 }
 
 export function resolveOpencodeDbPath(): string {

--- a/evals/README.md
+++ b/evals/README.md
@@ -173,9 +173,9 @@ deep-patched with `.with()`. The topology has:
   model, sessions, and optional local server delay.
 - `witnesses`: optional named witnesses; v1 accepts MCP mocks only.
 
-The shipped definitions are `soloWorkspace`, `supportOrg`, `acmeDemo`, and
-`acmeDocs`; their CLI names are `solo`, `support-org`, `acme-demo`, and
-`acme-docs`. `startWorld()` boots the Den, organizations, witnesses, and apps in
+The shipped definitions are `soloWorkspace`, `supportOrg`, `acmeDemo`,
+`acmeDocs`, and `desktopProductionLive`; their CLI names are `solo`,
+`support-org`, `acme-demo`, `acme-docs`, and `desktop-prod-live`. `startWorld()` boots the Den, organizations, witnesses, and apps in
 dependency order and disposes them together. `fromSnapshot()` validates
 generated snapshot JSON and returns the name and topology needed to start an
 equivalent fresh world.
@@ -201,6 +201,9 @@ pnpm world resume acme-demo --teardown
 pnpm world rebuild <snapshot>      # rebuild the world a failed run was in
 pnpm world list
 pnpm world forget <name>
+
+# Explicit macOS-only live sharing with the installed production stores.
+pnpm world up desktop-prod-live --allow-shared-state --name prod-live-dev --keep
 ```
 
 `up` also accepts `--name <name>`. Without `--keep`, Ctrl-C tears down the
@@ -208,6 +211,19 @@ resources; with `--keep`, Ctrl-C leaves them detached. `resume` accepts a world
 name or snapshot path and detaches on Ctrl-C unless `--teardown` is present.
 `forget` removes snapshot metadata without stopping detached services. `help`
 prints usage and the available presets.
+
+`desktop-prod-live` is a deliberately dangerous local-only mode. It launches
+source Electron through `pnpm dev` with isolated Electron userData, app
+identifier, Vite/CDP ports, and protocol registration, while resolving the
+installed production `OPENWORK_DATA_DIR` and channel-aware `OPENCODE_DB` only at
+launch time. It never copies or symlinks those stores, does not boot or modify a
+Den, and does not seed a workspace, session, or sign-in. Production may remain
+running, but concurrent writes from production and dev are unsupported and may
+corrupt state. `up` and every `rebuild` require `--allow-shared-state`; `resume`
+only attaches to the already-running isolated dev process. Snapshots retain the
+symbolic `desktopState` source/mode plus CDP/workspace metadata, never resolved
+production paths or tokens. Teardown stops only the dev process and does not
+delete shared stores.
 
 World v1 has deliberate limits:
 

--- a/evals/packages/env/src/cli.ts
+++ b/evals/packages/env/src/cli.ts
@@ -2,11 +2,12 @@ import { readFile, readdir, unlink } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePlace } from "./place.ts";
-import { acmeDemo, acmeDocs, soloWorkspace, supportOrg } from "./presets.ts";
+import { acmeDemo, acmeDocs, desktopProductionLive, soloWorkspace, supportOrg } from "./presets.ts";
 import type { Place } from "./place.ts";
+import { usesLiveSharedProductionState } from "./topology.ts";
 import type { WorldDefinition, WorldTopology } from "./topology.ts";
 import { fromSnapshot, parseUntrustedSnapshot, resumeWorld as attachWorld, startWorld } from "./world.ts";
-import type { ResumedWorld, WorldTeardownResult } from "./world.ts";
+import type { ResumedWorld, StartWorldOptions, WorldTeardownResult } from "./world.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const WORLDS_DIR = join(REPO_ROOT, "evals", "results", ".worlds");
@@ -14,13 +15,14 @@ const WORLDS_DIR = join(REPO_ROOT, "evals", "results", ".worlds");
 export const presetCatalog: Record<string, WorldDefinition> = {
   "acme-demo": acmeDemo,
   "acme-docs": acmeDocs,
+  "desktop-prod-live": desktopProductionLive,
   solo: soloWorkspace,
   "support-org": supportOrg,
 };
 
 export type WorldCommand =
-  | { kind: "up"; preset: string; name?: string; keep?: boolean }
-  | { kind: "rebuild"; snapshotPath: string }
+  | { kind: "up"; preset: string; name?: string; keep?: boolean; allowSharedState?: boolean }
+  | { kind: "rebuild"; snapshotPath: string; allowSharedState?: boolean }
   | { kind: "resume"; nameOrSnapshotPath: string; teardown?: boolean }
   | { kind: "list" }
   | { kind: "forget"; name: string }
@@ -45,7 +47,7 @@ interface WorldIo {
   print?: (line: string) => void;
   startWorld?: (
     definition: WorldDefinition | WorldTopology,
-    options?: { place?: Place; name?: string },
+    options?: StartWorldOptions,
   ) => Promise<StartedWorld>;
   resumeWorld?: (
     snapshotJsonText: string,
@@ -72,10 +74,15 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
     if (!Object.hasOwn(presetCatalog, preset)) return helpError(`Unknown preset ${JSON.stringify(preset)}.`);
     let name: string | undefined;
     let keep = false;
+    let allowSharedState = false;
     for (let index = 0; index < options.length; index += 1) {
       const option = options[index];
       if (option === "--keep" && !keep) {
         keep = true;
+        continue;
+      }
+      if (option === "--allow-shared-state" && !allowSharedState) {
+        allowSharedState = true;
         continue;
       }
       if (option === "--name" && name === undefined) {
@@ -85,19 +92,24 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
         index += 1;
         continue;
       }
-      return helpError("Use --name <name> and/or --keep after the preset.");
+      return helpError("Use --name <name>, --keep, and/or --allow-shared-state after the preset.");
     }
     return {
       kind: "up",
       preset,
       ...(name === undefined ? {} : { name }),
       ...(keep ? { keep: true } : {}),
+      ...(allowSharedState ? { allowSharedState: true } : {}),
     };
   }
   if (command === "rebuild") {
-    return args.length === 1 && args[0]
-      ? { kind: "rebuild", snapshotPath: args[0] }
-      : helpError("The rebuild command needs exactly one snapshot path.");
+    const [snapshotPath, ...options] = args;
+    if (!snapshotPath) return helpError("The rebuild command needs one snapshot path.");
+    if (options.length === 0) return { kind: "rebuild", snapshotPath };
+    if (options.length === 1 && options[0] === "--allow-shared-state") {
+      return { kind: "rebuild", snapshotPath, allowSharedState: true };
+    }
+    return helpError("Use only --allow-shared-state after the rebuild snapshot path.");
   }
   if (command === "resume") {
     const [nameOrSnapshotPath, ...options] = args;
@@ -121,10 +133,11 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
 }
 
 const HELP = `Usage:
-  pnpm world up <preset> [--name <name>] [--keep]
+  pnpm world up <preset> [--name <name>] [--keep] [--allow-shared-state]
       Start a world from a preset. --keep leaves its detached services running after Ctrl-C.
-  pnpm world rebuild <snapshot-path>
-      Start a new world using a saved snapshot.
+      --allow-shared-state explicitly permits a local live-shared production-state desktop.
+  pnpm world rebuild <snapshot-path> [--allow-shared-state]
+      Start a new world using a saved snapshot. Shared state requires the opt-in again.
   pnpm world resume <name-or-snapshot-path> [--teardown]
       Attach to a detached world, or stop its services and database with --teardown.
   pnpm world list
@@ -134,7 +147,10 @@ const HELP = `Usage:
   pnpm world help
       Show this help.
 
-Presets: acme-demo, acme-docs, solo, support-org`;
+Presets: acme-demo, acme-docs, desktop-prod-live, solo, support-org
+
+Live shared production state:
+  pnpm world up desktop-prod-live --allow-shared-state --name prod-live-dev --keep`;
 
 function messageText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -165,9 +181,15 @@ function printStarted(
   lifecycle: string,
   print: (line: string) => void,
 ): void {
-  print(`World ${JSON.stringify(world.name)} is up (${description}, ${placeKind}).`);
-  print(`den web  ${world.den.ref.webUrl}`);
-  print(`den api  ${world.den.ref.apiUrl}`);
+  const sharedProductionState = usesLiveSharedProductionState(world.topology);
+  if (sharedProductionState) {
+    print("LIVE SHARED PRODUCTION STATE — concurrent writes by production and dev are unsupported and may corrupt state.");
+  }
+  print(`World ${JSON.stringify(world.name)} is up (${description}, ${placeKind}${sharedProductionState ? ", LIVE SHARED PRODUCTION STATE" : ""}).`);
+  if (!sharedProductionState) {
+    print(`den web  ${world.den.ref.webUrl}`);
+    print(`den api  ${world.den.ref.apiUrl}`);
+  }
   for (const [name, app] of Object.entries(world.apps)) {
     const signedInTo = world.topology.apps?.[name]?.signedInTo;
     const signIn = signedInTo ? ` (signed in to ${signedInTo.org} as ${signedInTo.as})` : "";
@@ -179,7 +201,7 @@ function printStarted(
 
 async function runWorld(
   definition: WorldDefinition | WorldTopology,
-  options: { place: Place; name?: string; keep?: boolean },
+  options: { place: Place; name?: string; keep?: boolean; allowSharedState?: boolean },
   description: string,
   io: Required<Pick<WorldIo, "print" | "startWorld" | "onExit">>,
 ): Promise<number> {
@@ -219,6 +241,7 @@ function snapshotSummary(text: string): {
   place: string;
   orgs: string[];
   apps: string[];
+  sharedProductionState: boolean;
 } {
   const parsed = parseUntrustedSnapshot(text);
   return {
@@ -227,6 +250,7 @@ function snapshotSummary(text: string): {
     place: parsed.place,
     orgs: Object.keys(parsed.topology.den.orgs),
     apps: Object.keys(parsed.topology.apps ?? {}),
+    sharedProductionState: usesLiveSharedProductionState(parsed.topology),
   };
 }
 
@@ -270,7 +294,12 @@ export async function main(argv = process.argv.slice(2), io: WorldIo = {}): Prom
     const definition = presetCatalog[command.preset];
     if (!definition) throw new Error(`Unknown preset ${JSON.stringify(command.preset)}.`);
     const place = resolvePlace(process.env);
-    return runWorld(definition, { place, name: command.name, keep: command.keep }, `preset ${command.preset}`, {
+    return runWorld(definition, {
+      place,
+      name: command.name,
+      keep: command.keep,
+      allowSharedState: command.allowSharedState,
+    }, `preset ${command.preset}`, {
       print,
       startWorld: boot,
       onExit,
@@ -280,7 +309,11 @@ export async function main(argv = process.argv.slice(2), io: WorldIo = {}): Prom
     try {
       const snapshot = fromSnapshot(await load(command.snapshotPath));
       const place = resolvePlace(process.env);
-      return runWorld(snapshot.topology, { place, name: snapshot.name }, "rebuilt from snapshot", {
+      return runWorld(snapshot.topology, {
+        place,
+        name: snapshot.name,
+        allowSharedState: command.allowSharedState,
+      }, "rebuilt from snapshot", {
         print,
         startWorld: boot,
         onExit,
@@ -343,7 +376,7 @@ export async function main(argv = process.argv.slice(2), io: WorldIo = {}): Prom
       const path = join(WORLDS_DIR, name);
       try {
         const summary = snapshotSummary(await load(path));
-        print(`${summary.name}  ${summary.createdAt}  ${summary.place}  orgs ${joinedKeys(summary.orgs)}  apps ${joinedKeys(summary.apps)}`);
+        print(`${summary.name}  ${summary.createdAt}  ${summary.place}  orgs ${joinedKeys(summary.orgs)}  apps ${joinedKeys(summary.apps)}${summary.sharedProductionState ? "  LIVE SHARED PRODUCTION STATE" : ""}`);
         printed += 1;
       } catch (error) {
         print(`Warning: skipped ${displayPath(path)}: ${messageText(error)}`);

--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -1,7 +1,9 @@
 import { createAndSelectWorkspace, signInDesktopAs } from "@openwork/behaviors";
+import { attachSurface, evaluateOnSurface, isInteractive, probeAppStateOnSurface } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import { desktop } from "@openwork/hosts";
-import type { DesktopHandle, Host } from "@openwork/hosts";
+import { liveSharedProductionStateEnv } from "@openwork/hosts";
+import type { AppReadiness, DesktopHandle, Host, InstalledProductionDesktopState } from "@openwork/hosts";
 import type { Den } from "./den.ts";
 import type { Place } from "./place.ts";
 
@@ -34,6 +36,102 @@ export type AppOptions = SignedInAppOptions | FreshAppOptions;
 /** A desktop; its Electron profile root is available at handle.profileDir. */
 export interface App extends DesktopHandle {
   workspaceId: string;
+  /** Live-state launches may have no selected workspace; snapshots preserve that as null. */
+  snapshotWorkspaceId?: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function serializedPageValue(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new Error("Installed production renderer state could not be serialized.");
+  return serialized.replace(/</g, "\\u003c").replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
+}
+
+async function mirrorInstalledProductionRendererState(target: Surface): Promise<AppReadiness> {
+  const cdpUrl = process.env.OPENWORK_EVAL_INSTALLED_PRODUCTION_CDP_URL?.trim() || "http://127.0.0.1:9223";
+  await using source = await attachSurface({
+    name: "installed-production-source",
+    kind: "electron",
+    hostKind: "local",
+    cdpUrl,
+  });
+  const raw = await evaluateOnSurface(source, `({
+    route: location.hash,
+    entries: Object.entries(localStorage).filter(([key]) => key.startsWith("openwork.")),
+  })`);
+  if (!isRecord(raw) || typeof raw.route !== "string" || !Array.isArray(raw.entries)) {
+    throw new Error(`Installed production desktop at ${cdpUrl} returned invalid renderer state.`);
+  }
+  const entries: [string, string][] = [];
+  for (const entry of raw.entries) {
+    if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== "string" || typeof entry[1] !== "string") {
+      throw new Error(`Installed production desktop at ${cdpUrl} returned an invalid localStorage entry.`);
+    }
+    entries.push([entry[0], entry[1]]);
+  }
+  try {
+    await evaluateOnSurface(target, `(() => {
+      const state = ${serializedPageValue({ route: raw.route, entries })};
+      for (const [key, value] of state.entries) localStorage.setItem(key, value);
+      location.hash = state.route;
+      location.reload();
+      return true;
+    })()`);
+  } catch {
+    // The CDP evaluator includes expression prefixes in timeout errors. Never
+    // propagate the expression because it contains production localStorage.
+    throw new Error("Dev desktop could not adopt installed production renderer state.");
+  }
+
+  const deadline = Date.now() + 60_000;
+  let lastRoute = "";
+  while (Date.now() < deadline) {
+    try {
+      const probe = await probeAppStateOnSurface(target, { timeoutMs: 5_000 });
+      lastRoute = probe.route;
+      if (isInteractive(probe) && probe.surface && !probe.route.endsWith("/signin")) {
+        return { state: probe.surface, workspaceId: probe.workspaceId, route: probe.route };
+      }
+    } catch {
+      // Reload briefly destroys the renderer execution context.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Dev desktop did not adopt installed production renderer state within 60 seconds; last route ${JSON.stringify(lastRoute)}.`);
+}
+
+export async function liveSharedProductionApp(options: {
+  host: Host;
+  name: string;
+  state: InstalledProductionDesktopState;
+}): Promise<App> {
+  const surface = await desktop({
+    name: options.name,
+    host: options.host,
+    devCommand: "dev",
+    prepareSharedResources: false,
+    env: liveSharedProductionStateEnv(options.state),
+  });
+  try {
+    const readiness = await mirrorInstalledProductionRendererState(surface);
+    const selectedWorkspaceId = readiness.workspaceId;
+    return {
+      handle: surface.handle,
+      client: surface.client,
+      readiness,
+      workspaceRoot: surface.workspaceRoot,
+      workspaceId: selectedWorkspaceId === null ? "" : selectedWorkspaceId,
+      snapshotWorkspaceId: selectedWorkspaceId,
+      stop: () => surface.stop(),
+      [Symbol.asyncDispose]: () => surface[Symbol.asyncDispose](),
+    };
+  } catch (error) {
+    await surface[Symbol.asyncDispose]();
+    throw error;
+  }
 }
 
 export async function app(options: AppOptions): Promise<App> {

--- a/evals/packages/env/src/presets.ts
+++ b/evals/packages/env/src/presets.ts
@@ -11,6 +11,15 @@ export const soloWorkspace = defineWorld({
   },
 });
 
+export const desktopProductionLive = defineWorld({
+  den: { orgs: {} },
+  apps: {
+    main: {
+      desktopState: { source: "installed-production", mode: "live-shared" },
+    },
+  },
+});
+
 export const supportOrg = defineWorld({
   den: {
     orgs: {

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -34,6 +34,7 @@ export interface WorldOrg {
 
 export interface WorldApp {
   signedInTo?: { org: string; as: string };
+  desktopState?: { source: "installed-production"; mode: "live-shared" };
   workspacePath?: string;
   model?: string;
   localServerDelayMs?: number;
@@ -133,10 +134,32 @@ const worldAppSchema = z.strictObject({
     org: z.string(),
     as: z.string(),
   }).optional(),
+  desktopState: z.strictObject({
+    source: z.literal("installed-production"),
+    mode: z.literal("live-shared"),
+  }).optional(),
   workspacePath: z.string().optional(),
   model: z.string().optional(),
   localServerDelayMs: z.number().optional(),
   sessions: z.array(z.string().trim().min(1)).max(30).readonly().optional(),
+}).superRefine((app, context) => {
+  if (!app.desktopState) return;
+  const conflictingOptions: readonly ("signedInTo" | "workspacePath" | "model" | "localServerDelayMs" | "sessions")[] = [
+    "signedInTo",
+    "workspacePath",
+    "model",
+    "localServerDelayMs",
+    "sessions",
+  ];
+  for (const key of conflictingOptions) {
+    if (app[key] !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["desktopState"],
+        message: `desktopState live-shared conflicts with ${key}: live shared boot does not seed, sign in, or override production state`,
+      });
+    }
+  }
 });
 
 // Keep these values aligned with EnterpriseMcpProfileId in @openwork/labs.
@@ -228,6 +251,29 @@ function deepMerge(base: unknown, patch: unknown): unknown {
 function validateReferences(topology: WorldTopology): void {
   const orgKeys = Object.keys(topology.den.orgs);
   const primaryOrg = orgKeys[0];
+  const apps = Object.values(topology.apps ?? {});
+  const sharedStateApps = apps.filter((app) => app.desktopState?.mode === "live-shared");
+  if (sharedStateApps.length > 0) {
+    if (sharedStateApps.length !== 1) {
+      throw new Error("Live-shared installed-production desktop worlds require exactly one dev desktop.");
+    }
+    if (sharedStateApps.length !== apps.length) {
+      throw new Error("World topology cannot mix live-shared installed-production desktops with provisioned desktop apps.");
+    }
+    if (
+      orgKeys.length > 0
+      || topology.den.attach !== undefined
+      || topology.den.env !== undefined
+      || topology.den.web !== undefined
+      || topology.den.ports !== undefined
+      || topology.den.seed !== undefined
+      || topology.den.substrate !== "local"
+      || Object.keys(topology.witnesses ?? {}).length > 0
+    ) {
+      throw new Error("Live-shared installed-production desktop worlds must be desktop-only: use empty den.orgs and no Den or witness options.");
+    }
+    return;
+  }
   if (!primaryOrg) {
     if (topology.den.attach?.tier === "prod") {
       for (const [appName, app] of Object.entries(topology.apps ?? {})) {
@@ -363,6 +409,12 @@ function validateReferences(topology: WorldTopology): void {
       );
     }
   }
+}
+
+export function usesLiveSharedProductionState(topology: WorldTopology): boolean {
+  return Object.values(topology.apps ?? {}).some(
+    (app) => app.desktopState?.source === "installed-production" && app.desktopState.mode === "live-shared",
+  );
 }
 
 function parseTopology(input: unknown): WorldTopology {

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -12,13 +12,13 @@ import {
   seedSessions,
   signIn,
 } from "@openwork/behaviors";
-import { desktop, freePort } from "@openwork/hosts";
+import { desktop, freePort, localHost, resolveInstalledProductionDesktopState, stopOwnedElectronSurface } from "@openwork/hosts";
 import { Effect, Exit, Scope } from "effect";
 import { createConnection } from "mysql2/promise";
 import { z } from "zod";
 import type { ProvisionedOrg } from "@openwork/behaviors";
-import type { DesktopHandle } from "@openwork/hosts";
-import { app as bootApp } from "./desktop-app.ts";
+import type { DesktopHandle, InstalledProductionDesktopState } from "@openwork/hosts";
+import { app as bootApp, liveSharedProductionApp } from "./desktop-app.ts";
 import type { App } from "./desktop-app.ts";
 import { defaultReuseAdmin, personDefaults, server } from "./den.ts";
 import type { Den } from "./den.ts";
@@ -26,7 +26,7 @@ import { DEMO_PASSWORD, ensureKindDenReady, exposeEndpointHandles, kubeProfileCo
 import { mcpMock } from "./mock.ts";
 import { resolvePlace, validateDatabaseName } from "./place.ts";
 import type { Place } from "./place.ts";
-import { defineWorld, resolveWorldPerson, worldTopologySchema } from "./topology.ts";
+import { defineWorld, resolveWorldPerson, usesLiveSharedProductionState, worldTopologySchema } from "./topology.ts";
 import type { WorldDefinition, WorldOrg, WorldPerson, WorldTopology } from "./topology.ts";
 import type { DenRef, DenSession } from "@openwork/behaviors";
 
@@ -62,8 +62,13 @@ export interface WorldSnapshotResolved {
     substrate?: "kind";
     database?: string;
     ports?: { api: number; web: number };
-  };
-  apps: Record<string, { cdpUrl: string; workspaceId: string; sessions: string[] }>;
+  } | { origin: "none" };
+  apps: Record<string, {
+    cdpUrl: string;
+    workspaceId: string | null;
+    sessions: string[];
+    owner?: { pid: number; profileDir: string };
+  }>;
 }
 
 export interface WorldTeardownResult {
@@ -99,8 +104,12 @@ export interface BuildSnapshotInput {
 
 const resolvedAppSchema = z.strictObject({
   cdpUrl: z.string(),
-  workspaceId: z.string(),
+  workspaceId: z.string().nullable(),
   sessions: z.array(z.string()),
+  owner: z.strictObject({
+    pid: z.number().int().positive(),
+    profileDir: z.string(),
+  }).optional(),
 });
 
 const resolvedPortsSchema = z.strictObject({
@@ -115,14 +124,17 @@ const worldSnapshotSchema = z.strictObject({
   place: z.enum(["local", "daytona"]),
   topology: worldTopologySchema,
   resolved: z.strictObject({
-    den: z.strictObject({
-      apiUrl: z.string(),
-      webUrl: z.string(),
-      origin: z.enum(["attached", "launched"]),
-      substrate: z.literal("kind").optional(),
-      database: z.string().optional(),
-      ports: resolvedPortsSchema.optional(),
-    }),
+    den: z.union([
+      z.strictObject({
+        apiUrl: z.string(),
+        webUrl: z.string(),
+        origin: z.enum(["attached", "launched"]),
+        substrate: z.literal("kind").optional(),
+        database: z.string().optional(),
+        ports: resolvedPortsSchema.optional(),
+      }),
+      z.strictObject({ origin: z.literal("none") }),
+    ]),
     apps: z.record(z.string(), resolvedAppSchema),
   }),
 });
@@ -233,6 +245,17 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
   if (!SNAPSHOT_NAME.test(snapshot.name)) {
     rejectSnapshotField("name", snapshot.name, "expected a filesystem-safe name using letters, numbers, dots, underscores, or hyphens");
   }
+  const sharedProductionState = usesLiveSharedProductionState(snapshot.topology);
+  if (sharedProductionState && snapshot.place !== "local") {
+    rejectSnapshotField("place", snapshot.place, "live-shared installed-production desktop snapshots must use local placement");
+  }
+  if (sharedProductionState !== (snapshot.resolved.den.origin === "none")) {
+    rejectSnapshotField(
+      "resolved.den.origin",
+      snapshot.resolved.den.origin,
+      "origin none is reserved for live-shared installed-production desktop worlds and is required by them",
+    );
+  }
 
   for (const [key, value] of Object.entries(snapshot.topology.den.env ?? {})) {
     if (!SNAPSHOT_ENV_KEY.test(key)) {
@@ -261,29 +284,44 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
       rejectSnapshotField(`topology.apps.${name}.localServerDelayMs`, app.localServerDelayMs, "expected an integer from 0 to 300000");
     }
   }
+  for (const [name, app] of Object.entries(snapshot.resolved.apps)) {
+    if (sharedProductionState && app.owner === undefined) {
+      rejectSnapshotField(`resolved.apps.${name}.owner`, app.owner, "live-shared app snapshots require an owned dev process receipt");
+    }
+    if (app.owner) {
+      const profileRoot = resolve(RESULTS_DIR, ".surfaces");
+      const candidate = resolve(app.owner.profileDir);
+      const child = relative(profileRoot, candidate);
+      if (!child || child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) {
+        rejectSnapshotField(`resolved.apps.${name}.owner.profileDir`, app.owner.profileDir, "expected an eval-owned profile inside evals/results/.surfaces");
+      }
+    }
+  }
   for (const [name, witness] of Object.entries(snapshot.topology.witnesses ?? {})) {
     if (witness.fault !== undefined && !SNAPSHOT_FAULT.test(witness.fault)) {
       rejectSnapshotField(`topology.witnesses.${name}.fault`, witness.fault, "expected a lowercase fault id containing only letters, numbers, or hyphens");
     }
   }
 
-  const database = snapshot.resolved.den.database;
-  if (database !== undefined) {
-    try {
-      validateDatabaseName(database);
-    } catch {
-      rejectSnapshotField("resolved.den.database", database, "expected a valid ephemeral database name matching ^[a-z][a-z0-9_]{0,62}$");
+  if (snapshot.resolved.den.origin !== "none") {
+    const database = snapshot.resolved.den.database;
+    if (database !== undefined) {
+      try {
+        validateDatabaseName(database);
+      } catch {
+        rejectSnapshotField("resolved.den.database", database, "expected a valid ephemeral database name matching ^[a-z][a-z0-9_]{0,62}$");
+      }
+      if (!database.startsWith("openwork_eval_")) {
+        rejectSnapshotField("resolved.den.database", database, "only generated openwork_eval_* databases may be torn down");
+      }
     }
-    if (!database.startsWith("openwork_eval_")) {
-      rejectSnapshotField("resolved.den.database", database, "only generated openwork_eval_* databases may be torn down");
+    if (snapshot.resolved.den.ports) {
+      validateSnapshotPort("resolved.den.ports.api", snapshot.resolved.den.ports.api);
+      validateSnapshotPort("resolved.den.ports.web", snapshot.resolved.den.ports.web);
     }
+    validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
+    validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);
   }
-  if (snapshot.resolved.den.ports) {
-    validateSnapshotPort("resolved.den.ports.api", snapshot.resolved.den.ports.api);
-    validateSnapshotPort("resolved.den.ports.web", snapshot.resolved.den.ports.web);
-  }
-  validateSnapshotLoopbackUrlPort("resolved.den.apiUrl", snapshot.resolved.den.apiUrl);
-  validateSnapshotLoopbackUrlPort("resolved.den.webUrl", snapshot.resolved.den.webUrl);
   for (const [name, app] of Object.entries(snapshot.resolved.apps)) {
     validateSnapshotCdpUrl(`resolved.apps.${name}.cdpUrl`, app.cdpUrl);
   }
@@ -659,10 +697,16 @@ function resolvedApps(
 ): WorldSnapshotResolved["apps"] {
   const resolved: WorldSnapshotResolved["apps"] = {};
   for (const [name, booted] of Object.entries(apps)) {
+    const workspaceId = booted.snapshotWorkspaceId === undefined
+      ? booted.workspaceId
+      : booted.snapshotWorkspaceId;
     resolved[name] = {
       cdpUrl: booted.handle.cdpUrl,
-      workspaceId: booted.workspaceId,
+      workspaceId,
       sessions: seededTitles[name],
+      ...(booted.handle.pid && booted.handle.profileDir
+        ? { owner: { pid: booted.handle.pid, profileDir: booted.handle.profileDir } }
+        : {}),
     };
   }
   return resolved;
@@ -678,7 +722,7 @@ export function buildSnapshot(input: BuildSnapshotInput): WorldSnapshot {
     topology: snapshotTopology(topology),
     resolved: input.resolved,
   });
-  if (snapshot.resolved.den.database !== undefined) {
+  if (snapshot.resolved.den.origin !== "none" && snapshot.resolved.den.database !== undefined) {
     validateDatabaseName(snapshot.resolved.den.database);
   }
   return snapshot;
@@ -726,6 +770,7 @@ export function fromSnapshot(jsonText: string): { topology: WorldTopology; name:
 }
 
 async function requireRunningWorld(snapshot: WorldSnapshot): Promise<void> {
+  if (snapshot.resolved.den.origin === "none") return;
   const url = `${snapshot.resolved.den.apiUrl.replace(/\/+$/, "")}/health`;
   let last = "not attempted";
   for (let attempt = 0; attempt < 6; attempt += 1) {
@@ -768,16 +813,27 @@ export async function resumeWorld(
   const snapshot = parseUntrustedSnapshot(snapshotJsonText);
   rejectUnsafeSnapshotOperation(snapshot);
   const topology = defineWorld(snapshot.topology).topology;
+  const sharedProductionState = usesLiveSharedProductionState(topology);
   await requireRunningWorld(snapshot);
-  const [, primaryOrg] = primaryOrganization(topology);
-  const adminPerson = topology.den.seed === "demo-org"
-    ? defaultReuseAdmin()
-    : personDefaults("admin", primaryOrg.admin, emailSegment(snapshot.name));
-  const ref: DenRef = {
-    apiUrl: snapshot.resolved.den.apiUrl,
-    webUrl: snapshot.resolved.den.webUrl,
-  };
-  const admin = await signIn(ref, { email: adminPerson.email, password: adminPerson.password });
+  let ref: DenRef;
+  let admin: DenSession;
+  if (sharedProductionState) {
+    ref = { apiUrl: "", webUrl: "" };
+    admin = { ...ref, token: "", email: "", password: "" };
+  } else {
+    if (snapshot.resolved.den.origin === "none") {
+      throw new Error("World snapshot has no Den but its topology is not a live-shared installed-production desktop world.");
+    }
+    const [, primaryOrg] = primaryOrganization(topology);
+    const adminPerson = topology.den.seed === "demo-org"
+      ? defaultReuseAdmin()
+      : personDefaults("admin", primaryOrg.admin, emailSegment(snapshot.name));
+    ref = {
+      apiUrl: snapshot.resolved.den.apiUrl,
+      webUrl: snapshot.resolved.den.webUrl,
+    };
+    admin = await signIn(ref, { email: adminPerson.email, password: adminPerson.password });
+  }
   const apps: Record<string, DesktopHandle> = {};
   if (options.teardown !== true) {
     for (const [name, resolved] of Object.entries(snapshot.resolved.apps)) {
@@ -811,6 +867,14 @@ export async function resumeWorld(
     await detach();
     const stoppedApps: string[] = [];
     for (const [name, resolved] of Object.entries(snapshot.resolved.apps)) {
+      if (sharedProductionState && resolved.owner) {
+        await stopOwnedElectronSurface(resolved.owner.pid, resolved.owner.profileDir)
+          .then(() => stoppedApps.push(name))
+          .catch((error: unknown) => {
+            console.error(`[openwork/testkit] World app ${JSON.stringify(name)} owned teardown failed: ${messageText(error)}`);
+          });
+        continue;
+      }
       const port = localUrlPort(resolved.cdpUrl);
       if (port === null) continue;
       await freePort(port)
@@ -841,15 +905,14 @@ export async function resumeWorld(
     }
 
     let droppedDatabase: string | undefined;
-    if (
-      snapshot.resolved.den.origin === "launched"
-      && snapshot.place === "local"
-      && snapshot.resolved.den.database
-    ) {
-      await dropSnapshotDatabase(snapshot.resolved.den.database)
-        .then(() => { droppedDatabase = snapshot.resolved.den.database; })
+    const database = snapshot.resolved.den.origin === "launched"
+      ? snapshot.resolved.den.database
+      : undefined;
+    if (snapshot.place === "local" && database) {
+      await dropSnapshotDatabase(database)
+        .then(() => { droppedDatabase = database; })
         .catch((error: unknown) => {
-          console.error(`[openwork/testkit] World database ${snapshot.resolved.den.database} teardown failed: ${messageText(error)}`);
+          console.error(`[openwork/testkit] World database ${database} teardown failed: ${messageText(error)}`);
         });
     }
     teardownResult = {
@@ -873,13 +936,41 @@ function worldTopology(definition: WorldDefinition | WorldTopology): WorldTopolo
   return defineWorld("topology" in definition ? definition.topology : definition).topology;
 }
 
+function disabledDen(): Den {
+  const ref: DenRef = { apiUrl: "", webUrl: "" };
+  return {
+    ref,
+    admin: { ...ref, token: "", email: "", password: "" },
+    members: {},
+    mocks: {},
+    async apiLog(): Promise<string> {
+      throw new Error("This desktop-only world does not run a Den.");
+    },
+    async [Symbol.asyncDispose](): Promise<void> {},
+  };
+}
+
+export interface StartWorldOptions {
+  place?: Place;
+  name?: string;
+  allowSharedState?: boolean;
+  resolveInstalledProductionState?: () => Promise<InstalledProductionDesktopState>;
+}
+
 export async function startWorld(
   definition: WorldDefinition | WorldTopology,
-  options: { place?: Place; name?: string } = {},
+  options: StartWorldOptions = {},
 ): Promise<World> {
   const topology = worldTopology(definition);
   const resolvedOrganizations = resolveOrganizationMap(topology.den.orgs, process.env);
   const place = options.place ?? resolvePlace(process.env);
+  const sharedProductionState = usesLiveSharedProductionState(topology);
+  if (sharedProductionState && options.allowSharedState !== true) {
+    throw new Error("Refusing LIVE SHARED PRODUCTION STATE launch without explicit --allow-shared-state opt-in.");
+  }
+  if (sharedProductionState && place.kind !== "local") {
+    throw new Error("LIVE SHARED PRODUCTION STATE requires local placement; remote and Daytona placement are refused.");
+  }
   if (topology.den.substrate === "kind" && place.kind !== "local") {
     throw new Error('den.substrate "kind" requires local placement because the kind cluster and its port-forwards run on the local Docker host.');
   }
@@ -891,7 +982,9 @@ export async function startWorld(
 
   const acquisition = Effect.gen(function*() {
     const den = yield* Effect.acquireRelease(
-      Effect.promise(() => topology.den.substrate === "kind"
+      Effect.promise(() => sharedProductionState
+        ? Promise.resolve(disabledDen())
+        : topology.den.substrate === "kind"
         ? kindDen()
         : server({
             place,
@@ -923,6 +1016,7 @@ export async function startWorld(
     if (
       primaryOrgName !== undefined
       && primaryOrg !== undefined
+      && !sharedProductionState
       && topology.den.substrate !== "kind"
       && topology.den.seed !== "demo-org"
     ) {
@@ -947,18 +1041,31 @@ export async function startWorld(
 
     const apps: Record<string, App> = {};
     const seededTitles: Record<string, string[]> = {};
+    let installedProductionState: InstalledProductionDesktopState | null = null;
     for (const [appName, appDefinition] of Object.entries(topology.apps ?? {})) {
       const booted = yield* Effect.acquireRelease(
-        Effect.promise(() => bootApp({
-          den,
-          place,
-          workspacePath: appDefinition.workspacePath,
-          model: appDefinition.model,
-          localServerDelayMs: appDefinition.localServerDelayMs,
-          ...(appDefinition.signedInTo
-            ? { as: appDefinition.signedInTo.as }
-            : { signIn: false }),
-        })),
+        Effect.promise(async () => {
+          if (appDefinition.desktopState?.mode === "live-shared") {
+            installedProductionState ??= await (
+              options.resolveInstalledProductionState ?? resolveInstalledProductionDesktopState
+            )();
+            return liveSharedProductionApp({
+              host: localHost(),
+              name: `world-${name}-${appName}`,
+              state: installedProductionState,
+            });
+          }
+          return bootApp({
+            den,
+            place,
+            workspacePath: appDefinition.workspacePath,
+            model: appDefinition.model,
+            localServerDelayMs: appDefinition.localServerDelayMs,
+            ...(appDefinition.signedInTo
+              ? { as: appDefinition.signedInTo.as }
+              : { signIn: false }),
+          });
+        }),
         (running) => Effect.promise(() => running[Symbol.asyncDispose]()),
       );
       apps[appName] = booted;
@@ -974,13 +1081,15 @@ export async function startWorld(
       place: place.kind,
       topology,
       resolved: {
-        den: {
-          ...den.ref,
-          origin: topology.den.attach ? "attached" : "launched",
-          ...(topology.den.substrate === "kind" ? { substrate: "kind" } : {}),
-          ...(den.database ? { database: den.database.name } : {}),
-          ...(den.ports ? { ports: den.ports } : {}),
-        },
+        den: sharedProductionState
+          ? { origin: "none" }
+          : {
+              ...den.ref,
+              origin: topology.den.attach ? "attached" : "launched",
+              ...(topology.den.substrate === "kind" ? { substrate: "kind" } : {}),
+              ...(den.database ? { database: den.database.name } : {}),
+              ...(den.ports ? { ports: den.ports } : {}),
+            },
         apps: resolvedApps(apps, seededTitles),
       },
     });

--- a/evals/packages/env/test/cli.test.ts
+++ b/evals/packages/env/test/cli.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { buildSnapshot } from "../src/world.ts";
 import { parseWorldArgs, main } from "../src/cli.ts";
-import { supportOrg } from "../src/presets.ts";
+import { desktopProductionLive, supportOrg } from "../src/presets.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DEMO_SNAPSHOT_PATH = join(REPO_ROOT, "evals", "results", ".worlds", "demo.json");
@@ -29,9 +29,20 @@ test("parseWorldArgs parses every world command", () => {
     name: "demo",
     keep: true,
   });
+  assert.deepEqual(parseWorldArgs(["up", "desktop-prod-live", "--allow-shared-state", "--keep"]), {
+    kind: "up",
+    preset: "desktop-prod-live",
+    keep: true,
+    allowSharedState: true,
+  });
   assert.deepEqual(parseWorldArgs(["rebuild", "saved.json"]), {
     kind: "rebuild",
     snapshotPath: "saved.json",
+  });
+  assert.deepEqual(parseWorldArgs(["rebuild", "saved.json", "--allow-shared-state"]), {
+    kind: "rebuild",
+    snapshotPath: "saved.json",
+    allowSharedState: true,
   });
   assert.deepEqual(parseWorldArgs(["list"]), { kind: "list" });
   assert.deepEqual(parseWorldArgs(["resume", "demo"]), {
@@ -53,6 +64,7 @@ test("parseWorldArgs turns invalid input into help with an error", () => {
     ["up", "unknown"],
     ["up", "solo", "--name"],
     ["up", "solo", "--keep", "--keep"],
+    ["up", "solo", "--allow-shared-state", "--allow-shared-state"],
     ["rebuild"],
     ["rebuild", "one", "two"],
     ["resume"],
@@ -101,6 +113,32 @@ test("main starts, describes, and tears down a world", async () => {
   assert.ok(lines.includes("app alice  CDP http://cdp.test (signed in to acme as admin)"));
   assert.ok(lines.includes("snapshot  evals/results/.worlds/demo.json"));
   assert.equal(lines.at(-1), 'World "demo" torn down.');
+});
+
+test("main forwards shared-state opt-in and labels the dangerous mode", async () => {
+  const lines: string[] = [];
+  let receivedAllowSharedState = false;
+  const exitCode = await main(["up", "desktop-prod-live", "--allow-shared-state"], {
+    print: (line) => lines.push(line),
+    startWorld: async (_definition, options) => {
+      receivedAllowSharedState = options?.allowSharedState === true;
+      return {
+        name: "prod-live",
+        topology: desktopProductionLive.topology,
+        den: { ref: { webUrl: "", apiUrl: "" } },
+        apps: { main: { handle: { cdpUrl: "http://127.0.0.1:31002" } } },
+        snapshotPath: DEMO_SNAPSHOT_PATH,
+        async [Symbol.asyncDispose]() {},
+      };
+    },
+    onExit: async () => {},
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(receivedAllowSharedState, true);
+  assert.ok(lines.includes("LIVE SHARED PRODUCTION STATE — concurrent writes by production and dev are unsupported and may corrupt state."));
+  assert.ok(lines.some((line) => line.includes("LIVE SHARED PRODUCTION STATE")));
+  assert.ok(!lines.some((line) => line.startsWith("den web") || line.startsWith("den api")));
 });
 
 test("main lists valid snapshots from an injected directory", async () => {

--- a/evals/packages/env/test/snapshot.test.ts
+++ b/evals/packages/env/test/snapshot.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { defineWorld } from "../src/topology.ts";
 import { buildSnapshot, fromSnapshot, parseUntrustedSnapshot, resumeWorld } from "../src/world.ts";
 
@@ -281,6 +282,7 @@ test("fromSnapshot rejects out-of-range topology and resolved ports", () => {
   );
 
   const derivedPortSnapshot = safeSnapshot();
+  if (derivedPortSnapshot.resolved.den.origin === "none") throw new Error("safe snapshot unexpectedly had no Den");
   const badDerivedPort = {
     ...derivedPortSnapshot,
     resolved: {
@@ -367,6 +369,39 @@ test("kind world snapshots preserve their resolved Den substrate", () => {
     },
   });
 
+  if (snapshot.resolved.den.origin === "none") throw new Error("kind snapshot unexpectedly had no Den");
   assert.equal(snapshot.resolved.den.substrate, "kind");
   assert.deepEqual(fromSnapshot(JSON.stringify(snapshot)), { topology, name: "kind-world" });
+});
+
+test("live shared production snapshots preserve only symbolic state selection", () => {
+  const profileDir = fileURLToPath(new URL("../../../results/.surfaces/production-live-fixture", import.meta.url));
+  const topology = defineWorld({
+    den: { orgs: {} },
+    apps: {
+      main: { desktopState: { source: "installed-production", mode: "live-shared" } },
+    },
+  }).topology;
+  const snapshot = buildSnapshot({
+    name: "production-live",
+    createdAt: "2026-08-25T12:00:00.000Z",
+    place: "local",
+    topology,
+    resolved: {
+      den: { origin: "none" },
+      apps: {
+        main: {
+          cdpUrl: "http://127.0.0.1:9222",
+          workspaceId: null,
+          sessions: [],
+          owner: { pid: 4242, profileDir },
+        },
+      },
+    },
+  });
+  assert.deepEqual(fromSnapshot(JSON.stringify(snapshot)), { topology, name: "production-live" });
+  assert.throws(
+    () => fromSnapshot(JSON.stringify({ ...snapshot, place: "daytona" })),
+    /live-shared installed-production desktop snapshots must use local placement/,
+  );
 });

--- a/evals/packages/env/test/topology.test.ts
+++ b/evals/packages/env/test/topology.test.ts
@@ -104,6 +104,40 @@ test("defineWorld accepts a fresh app without a sign-in target", () => {
   assert.deepEqual(world.topology.apps, { main: {} });
 });
 
+test("live shared production desktop state is symbolic and desktop-only", () => {
+  const world = defineWorld({
+    den: { orgs: {} },
+    apps: {
+      main: { desktopState: { source: "installed-production", mode: "live-shared" } },
+    },
+  });
+  assert.deepEqual(world.topology.apps?.main?.desktopState, {
+    source: "installed-production",
+    mode: "live-shared",
+  });
+  assert.throws(
+    () => defineWorld({
+      den: { orgs: {} },
+      apps: {
+        main: {
+          desktopState: { source: "installed-production", mode: "live-shared" },
+          sessions: ["must not seed"],
+        },
+      },
+    }),
+    /live shared boot does not seed, sign in, or override production state/,
+  );
+  assert.throws(
+    () => defineWorld({
+      den: { orgs: { acme: {} } },
+      apps: {
+        main: { desktopState: { source: "installed-production", mode: "live-shared" } },
+      },
+    }),
+    /must be desktop-only/,
+  );
+});
+
 test("defineWorld validates fixed Den ports", () => {
   const world = defineWorld({
     den: {

--- a/evals/packages/hosts/package.json
+++ b/evals/packages/hosts/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@openwork/cdp": "workspace:*",
+    "@openwork/paths": "link:../../../packages/paths",
     "@openwork/timeline": "workspace:*"
   }
 }

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -49,6 +49,10 @@ export interface DesktopOptions {
     requireSignin?: boolean;
   };
   env?: Record<string, string>;
+  /** Root package script used for a source Electron launch. */
+  devCommand?: "dev" | "dev:electron";
+  /** Skip host-side sidecar/helper preparation for an explicitly constrained launch. */
+  prepareSharedResources?: boolean;
   /** Exact caller-owned Electron profile root, for restart scenarios. */
   profileDir?: string;
   timeoutMs?: number;
@@ -129,6 +133,8 @@ export async function desktop(opts: DesktopOptions = {}): Promise<DesktopHandle>
       profileDir: opts.profileDir,
       bootstrap: opts.bootstrap,
       env: opts.env,
+      devCommand: opts.devCommand,
+      prepareSharedResources: opts.prepareSharedResources,
     });
   }
 

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -1,9 +1,17 @@
 import { execFile, spawn } from "node:child_process";
 import { constants, existsSync, openSync } from "node:fs";
-import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { allocateFreePort, allocateFreePorts, listTargets, waitForCdp } from "@openwork/cdp";
+import {
+  desktopBootstrapPath,
+  globalOpencodeConfigDir,
+  opencodeDbCandidates,
+  openworkEnvStorePath,
+  openworkServerConfigPath,
+  openworkServerDataDir,
+} from "@openwork/paths";
 import { ensureDenStack } from "./den-stack.ts";
 import type { ChildProcess } from "node:child_process";
 import type { DisposableHost, SurfaceHandle, ElectronSurfaceOptions, ChromeSurfaceOptions, DenServiceOptions, DenServiceHandle, ShareLinks } from "./types.ts";
@@ -30,6 +38,25 @@ export interface ElectronProfilePaths {
   root: string;
   stateHome: string;
   userDataDir: string;
+}
+
+export interface InstalledProductionDesktopState {
+  bootstrapPath: string;
+  dataDir: string;
+  envStorePath: string;
+  homeDir: string;
+  opencodeDb: string;
+  opencodeConfigDir: string;
+  serverConfigPath: string;
+  serverStatePath: string;
+  serverTokenStorePath: string;
+  workspaceStatePath: string;
+}
+
+export interface InstalledProductionDesktopStateOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
 }
 
 interface ElectronSurfaceEnvOptions {
@@ -436,7 +463,11 @@ function hostPnpmHome(): string | null {
   return null;
 }
 
-export function electronSurfaceEnv(paths: ElectronProfilePaths, options: ElectronSurfaceEnvOptions): Record<string, string> {
+export function electronSurfaceEnv(
+  paths: ElectronProfilePaths,
+  options: ElectronSurfaceEnvOptions,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
   const pnpmHome = hostPnpmHome();
   // Give local eval Electron surfaces isolated app data, config, and identity so
   // they cannot affect the user's real desktop app.
@@ -464,6 +495,105 @@ export function electronSurfaceEnv(paths: ElectronProfilePaths, options: Electro
     XDG_CONFIG_HOME: paths.configHome,
     XDG_DATA_HOME: paths.dataHome,
     XDG_STATE_HOME: paths.stateHome,
+    ...overrides,
+  };
+}
+
+export function liveSharedProductionStateEnv(state: InstalledProductionDesktopState): Record<string, string> {
+  return {
+    HOME: state.homeDir,
+    USERPROFILE: state.homeDir,
+    XDG_CONFIG_HOME: join(state.homeDir, ".config"),
+    XDG_DATA_HOME: join(state.homeDir, ".local", "share"),
+    XDG_CACHE_HOME: join(state.homeDir, ".cache"),
+    XDG_STATE_HOME: join(state.homeDir, ".local", "state"),
+    OPENWORK_DATA_DIR: state.dataDir,
+    OPENWORK_DESKTOP_BOOTSTRAP_PATH: state.bootstrapPath,
+    OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY: "0",
+    OPENWORK_DESKTOP_WORKSPACE_STATE_PATH: state.workspaceStatePath,
+    OPENWORK_DEV_SHARED_STATE: "1",
+    OPENWORK_ENV_STORE: state.envStorePath,
+    OPENWORK_SERVER_CONFIG: state.serverConfigPath,
+    OPENWORK_SERVER_STATE_PATH: state.serverStatePath,
+    OPENWORK_SERVER_TOKEN_STORE_PATH: state.serverTokenStorePath,
+    OPENCODE_DB: state.opencodeDb,
+    OPENCODE_CONFIG_DIR: state.opencodeConfigDir,
+  };
+}
+
+async function requireInstalledPath(path: string, kind: "directory" | "file", label: string): Promise<void> {
+  let metadata;
+  try {
+    metadata = await stat(path);
+  } catch {
+    throw new Error(`${label} is unavailable at ${path}. Start the installed production OpenWork desktop once and confirm its local state exists.`);
+  }
+  const matches = kind === "directory" ? metadata.isDirectory() : metadata.isFile();
+  if (!matches) throw new Error(`${label} at ${path} is not a ${kind}.`);
+}
+
+/** Resolve installed production stores without launching, copying, linking, or mutating them. */
+export async function resolveInstalledProductionDesktopState(
+  options: InstalledProductionDesktopStateOptions = {},
+): Promise<InstalledProductionDesktopState> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "darwin") {
+    throw new Error(`Live shared installed-production state is currently supported only on macOS; received ${platform}.`);
+  }
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? homedir();
+  const dataDir = openworkServerDataDir({ env, homeDir, platform });
+  await requireInstalledPath(dataDir, "directory", "Installed production OpenWork data directory");
+  const userDataDir = join(homeDir, "Library", "Application Support", "com.differentai.openwork");
+  const workspaceStatePath = join(userDataDir, "openwork-workspaces.json");
+  const serverTokenStorePath = join(userDataDir, "openwork-server-tokens.json");
+  const serverStatePath = join(userDataDir, "openwork-server-state.json");
+  const serverConfigPath = openworkServerConfigPath({ env, homeDir, platform });
+  const envStorePath = openworkEnvStorePath({ env, homeDir, platform });
+  const bootstrapPath = desktopBootstrapPath({ env, homeDir, platform, userDataDir });
+  const opencodeConfigDir = globalOpencodeConfigDir({ env, homeDir, platform });
+  for (const [path, label] of [
+    [workspaceStatePath, "Installed production workspace state"],
+    [serverTokenStorePath, "Installed production server token store"],
+    [serverStatePath, "Installed production server state"],
+    [serverConfigPath, "Installed production server config"],
+    [envStorePath, "Installed production environment store"],
+    [bootstrapPath, "Installed production desktop bootstrap"],
+  ]) {
+    await requireInstalledPath(path, "file", label);
+  }
+  await requireInstalledPath(opencodeConfigDir, "directory", "Installed production OpenCode config directory");
+
+  const candidates = opencodeDbCandidates({
+    env,
+    homeDir,
+    platform,
+    defaultChannel: "latest",
+  });
+  let opencodeDb: string | undefined;
+  for (const candidate of candidates) {
+    const metadata = await stat(candidate).catch(() => null);
+    if (metadata?.isFile()) {
+      opencodeDb = candidate;
+      break;
+    }
+  }
+  if (!opencodeDb) {
+    throw new Error(
+      `Installed production OpenCode database is unavailable. Checked channel-aware candidates: ${candidates.join(", ")}.`,
+    );
+  }
+  return {
+    bootstrapPath,
+    dataDir,
+    envStorePath,
+    homeDir,
+    opencodeDb,
+    opencodeConfigDir,
+    serverConfigPath,
+    serverStatePath,
+    serverTokenStorePath,
+    workspaceStatePath,
   };
 }
 
@@ -503,6 +633,39 @@ export async function killLocalPid(pid: number, options: KillLocalPidOptions = {
   else if (killedDirect) options.log?.(`Sent SIGKILL to pid ${pid}`);
   await waitUntilGone(pid, 1_000);
   return true;
+}
+
+export function ownedSurfaceFilePaths(handle: SurfaceHandle): string[] {
+  return handle.kind === "electron" && handle.profileDir && handle.meta?.profileOwner !== "caller"
+    ? [handle.profileDir]
+    : [];
+}
+
+export async function removeOwnedSurfaceFiles(handle: SurfaceHandle): Promise<void> {
+  for (const path of ownedSurfaceFilePaths(handle)) {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+/** Stop a detached eval Electron only when its process environment still names its isolated profile. */
+export async function stopOwnedElectronSurface(pid: number, profileDir: string): Promise<void> {
+  if (!Number.isInteger(pid) || pid <= 1 || !profileDir.trim()) {
+    throw new Error("Detached Electron ownership requires a valid pid and profile directory.");
+  }
+  const processDescription = await new Promise<string>((resolveDescription, reject) => {
+    execFile("ps", ["eww", "-p", String(pid)], { encoding: "utf8", timeout: 5_000 }, (error, stdout) => {
+      if (error) {
+        reject(new Error(`Detached Electron process ${pid} is not running.`));
+        return;
+      }
+      resolveDescription(stdout);
+    });
+  });
+  if (!processDescription.includes(`OPENWORK_ELECTRON_USERDATA=${join(profileDir, "electron-userdata")}`)) {
+    throw new Error(`Refusing to stop pid ${pid}: it does not own the expected eval Electron profile.`);
+  }
+  await killLocalPid(pid);
+  await rm(profileDir, { recursive: true, force: true });
 }
 
 function explicitPort(url: string): number | null {
@@ -635,7 +798,9 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
     workspaceRoot: options.repoRoot,
 
     async spawnElectron(name: string, opts: ElectronSurfaceOptions = {}): Promise<SurfaceHandle> {
-      await prepareSharedElectronResources(options.repoRoot, log);
+      if (opts.prepareSharedResources !== false) {
+        await prepareSharedElectronResources(options.repoRoot, log);
+      }
       const spawnEnvForChecks: NodeJS.ProcessEnv = { ...process.env, ...opts.env };
       if (insideContainerSandbox() && (spawnEnvForChecks.DISPLAY ?? "").trim().length === 0) spawnEnvForChecks.DISPLAY = ":99";
       await ensureDisplay(options.repoRoot, spawnEnvForChecks, log);
@@ -652,8 +817,8 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
       if (port === undefined || cdpPort === undefined) throw new Error("Could not allocate Electron Vite/CDP ports.");
       const appName = `OpenWork Eval ${name}`;
       const appIdentifier = `com.differentai.openwork.eval.${sanitizeSlug(name)}`;
-      const isolationEnv = electronSurfaceEnv(paths, { appName, appIdentifier, port, cdpPort });
-      const env: NodeJS.ProcessEnv = { ...process.env, ...isolationEnv, ...opts.env };
+      const isolationEnv = electronSurfaceEnv(paths, { appName, appIdentifier, port, cdpPort }, opts.env);
+      const env: NodeJS.ProcessEnv = { ...process.env, ...isolationEnv };
       const launchArgs = containerLaunchArgs(env.ELECTRON_EXTRA_LAUNCH_ARGS);
       if (launchArgs !== undefined) env.ELECTRON_EXTRA_LAUNCH_ARGS = launchArgs;
       // appendSwitch() in the main process runs too late for the SUID sandbox
@@ -665,7 +830,9 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
       // segfaults instead of opening a window.
       if (insideContainerSandbox() && (env.DISPLAY ?? "").trim().length === 0) env.DISPLAY = ":99";
       const logPath = join(profileRoot, "electron.log");
-      const packagedBinary = process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim();
+      const packagedBinary = opts.devCommand === undefined
+        ? process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim()
+        : undefined;
       let spawned: SpawnedDetached;
       if (packagedBinary) {
         await access(packagedBinary, constants.F_OK).catch(() => {
@@ -675,7 +842,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         spawned = spawnDetached(packagedBinary, [], { cwd: options.repoRoot, env, logPath });
       } else {
         log(`Starting local Electron surface ${name} (Vite :${port}, CDP :${cdpPort})...`);
-        spawned = spawnDetached(pnpmCommand(), ["dev:electron"], { cwd: options.repoRoot, env, logPath });
+        spawned = spawnDetached(pnpmCommand(), [opts.devCommand ?? "dev:electron"], { cwd: options.repoRoot, env, logPath });
       }
       const cdpUrl = `http://127.0.0.1:${cdpPort}`;
       try {
@@ -775,9 +942,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         await killLocalPid(handle.pid, { log });
       }
       await disposeKnownPorts(handle);
-      if (handle.kind === "electron" && handle.profileDir && handle.meta?.profileOwner !== "caller") {
-        await rm(handle.profileDir, { recursive: true, force: true });
-      }
+      await removeOwnedSurfaceFiles(handle);
       spawnedSurfaces.delete(handle);
     },
 

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -12,6 +12,10 @@ export interface ElectronSurfaceOptions {
     requireSignin?: boolean;
   };
   env?: Record<string, string>;
+  /** Root package script used for a source Electron launch. Setting this bypasses OPENWORK_EVAL_ELECTRON_BINARY. */
+  devCommand?: "dev" | "dev:electron";
+  /** Skip host-side sidecar/helper preparation when the caller intentionally uses existing resources. */
+  prepareSharedResources?: boolean;
 }
 
 export interface ChromeSurfaceOptions {

--- a/evals/packages/hosts/test/local-host.test.ts
+++ b/evals/packages/hosts/test/local-host.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { allocateFreePort } from "@openwork/cdp";
-import { electronProfilePaths, electronSurfaceEnv, freePort, resolveChromeBinary } from "../src/local.ts";
+import { electronProfilePaths, electronSurfaceEnv, freePort, resolveChromeBinary, stopOwnedElectronSurface } from "../src/local.ts";
 
 const ENV_KEYS = [
   "APPDATA",
@@ -95,6 +95,22 @@ test("electronSurfaceEnv matches the isolated Electron demo contract", () => {
   assert.equal(env.XDG_CONFIG_HOME, paths.configHome);
   assert.equal(env.XDG_DATA_HOME, paths.dataHome);
   assert.equal(env.XDG_STATE_HOME, paths.stateHome);
+});
+
+test("stopOwnedElectronSurface verifies profile ownership before removing it", async () => {
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-owned-electron-"));
+  const userDataDir = join(profileDir, "electron-userdata");
+  await mkdir(userDataDir, { recursive: true });
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    detached: true,
+    env: { ...process.env, OPENWORK_ELECTRON_USERDATA: userDataDir },
+    stdio: "ignore",
+  });
+  child.unref();
+  if (!child.pid) throw new Error("Owned Electron fixture did not start.");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await stopOwnedElectronSurface(child.pid, profileDir);
+  await assert.rejects(access(profileDir));
 });
 
 test("resolveChromeBinary honors CHROME_BIN before platform defaults", () => {

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { startWorld as startWorldRaw } from "@openwork/env";
-import type { Place, World, WorldDefinition, WorldTopology } from "@openwork/env";
+import type { StartWorldOptions, World, WorldDefinition, WorldTopology } from "@openwork/env";
 import { currentTestEvidence } from "@openwork/test-evidence";
 
 export { createDesktopHandoffGrant, signInDesktopAs } from "@openwork/behaviors";
@@ -15,7 +15,7 @@ export * from "./state.ts";
 
 export async function startWorld(
   definition: WorldDefinition | WorldTopology,
-  options: { place?: Place; name?: string } = {},
+  options: StartWorldOptions = {},
 ): Promise<World> {
   const world = await startWorldRaw(definition, options);
   try {

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@openwork/cdp':
         specifier: workspace:*
         version: link:../cdp
+      '@openwork/paths':
+        specifier: link:../../../packages/paths
+        version: link:../../../packages/paths
       '@openwork/timeline':
         specifier: workspace:*
         version: link:../timeline

--- a/evals/specs/world-live-shared-state.test.ts
+++ b/evals/specs/world-live-shared-state.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  electronProfilePaths,
+  electronSurfaceEnv,
+  liveSharedProductionStateEnv,
+  removeOwnedSurfaceFiles,
+  resolveInstalledProductionDesktopState,
+} from "@openwork/hosts";
+import {
+  buildSnapshot,
+  desktopProductionLive,
+  resolvePlace,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+
+test("live shared production desktop state is explicit, local, symbolic, and cleanup-safe", async () => {
+  await assert.rejects(
+    () => startWorld(desktopProductionLive, {
+      place: resolvePlace({}),
+      name: "shared-state-refused",
+    }),
+    /without explicit --allow-shared-state opt-in/,
+  );
+  await assert.rejects(
+    () => startWorld(desktopProductionLive, {
+      place: resolvePlace({ OPENWORK_EVAL_DAYTONA: "1" }),
+      name: "shared-state-remote-refused",
+      allowSharedState: true,
+    }),
+    /requires local placement/,
+  );
+
+  const fixtureRoot = await mkdtemp(join(tmpdir(), "openwork-prod-live-state-"));
+  try {
+    const homeDir = join(fixtureRoot, "home");
+    const dataDir = join(homeDir, ".openwork", "openwork-server");
+    const configDir = join(homeDir, ".config", "openwork");
+    const opencodeConfigDir = join(homeDir, ".config", "opencode");
+    const userDataDir = join(homeDir, "Library", "Application Support", "com.differentai.openwork");
+    const opencodeDb = join(homeDir, "Library", "Application Support", "opencode", "opencode.db");
+    await mkdir(dataDir, { recursive: true });
+    await mkdir(configDir, { recursive: true });
+    await mkdir(opencodeConfigDir, { recursive: true });
+    await mkdir(userDataDir, { recursive: true });
+    await mkdir(dirname(opencodeDb), { recursive: true });
+    await writeFile(opencodeDb, "fixture", "utf8");
+    for (const path of [
+      join(configDir, "desktop-bootstrap.json"),
+      join(configDir, "env.json"),
+      join(configDir, "server.json"),
+      join(userDataDir, "openwork-server-state.json"),
+      join(userDataDir, "openwork-server-tokens.json"),
+      join(userDataDir, "openwork-workspaces.json"),
+    ]) {
+      await writeFile(path, "{}\n", "utf8");
+    }
+
+    const resolved = await resolveInstalledProductionDesktopState({
+      env: {},
+      homeDir,
+      platform: "darwin",
+    });
+    assert.deepEqual(resolved, {
+      bootstrapPath: join(configDir, "desktop-bootstrap.json"),
+      dataDir,
+      envStorePath: join(configDir, "env.json"),
+      homeDir,
+      opencodeDb,
+      opencodeConfigDir,
+      serverConfigPath: join(configDir, "server.json"),
+      serverStatePath: join(userDataDir, "openwork-server-state.json"),
+      serverTokenStorePath: join(userDataDir, "openwork-server-tokens.json"),
+      workspaceStatePath: join(userDataDir, "openwork-workspaces.json"),
+    });
+
+    const isolatedProfile = join(fixtureRoot, "isolated-eval-profile");
+    const profilePaths = electronProfilePaths(isolatedProfile);
+    await mkdir(profilePaths.userDataDir, { recursive: true });
+    const launchEnv = electronSurfaceEnv(
+      profilePaths,
+      {
+        appName: "OpenWork Eval production-live",
+        appIdentifier: "com.differentai.openwork.eval.production-live",
+        port: 31_001,
+        cdpPort: 31_002,
+      },
+      liveSharedProductionStateEnv(resolved),
+    );
+    assert.equal(launchEnv.OPENWORK_DATA_DIR, dataDir);
+    assert.equal(launchEnv.OPENCODE_DB, opencodeDb);
+    assert.equal(launchEnv.OPENWORK_DESKTOP_WORKSPACE_STATE_PATH, join(userDataDir, "openwork-workspaces.json"));
+    assert.equal(launchEnv.OPENWORK_SERVER_TOKEN_STORE_PATH, join(userDataDir, "openwork-server-tokens.json"));
+    assert.equal(launchEnv.OPENWORK_SERVER_STATE_PATH, join(userDataDir, "openwork-server-state.json"));
+    assert.equal(launchEnv.OPENWORK_ENV_STORE, join(configDir, "env.json"));
+    assert.equal(launchEnv.OPENWORK_SERVER_CONFIG, join(configDir, "server.json"));
+    assert.equal(launchEnv.OPENWORK_DEV_SHARED_STATE, "1");
+    assert.equal(launchEnv.OPENWORK_ELECTRON_USERDATA, profilePaths.userDataDir);
+    assert.notEqual(launchEnv.OPENWORK_ELECTRON_USERDATA, dataDir);
+    assert.equal(launchEnv.OPENWORK_ELECTRON_APP_IDENTIFIER, "com.differentai.openwork.eval.production-live");
+    assert.equal(launchEnv.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT, "31002");
+
+    const snapshot = buildSnapshot({
+      name: "prod-live-fixture",
+      createdAt: "2026-08-25T12:00:00.000Z",
+      place: "local",
+      topology: desktopProductionLive.topology,
+      resolved: {
+        den: { origin: "none" },
+        apps: {
+          main: {
+            cdpUrl: "http://127.0.0.1:31002",
+            workspaceId: null,
+            sessions: [],
+          },
+        },
+      },
+    });
+    const serialized = JSON.stringify(snapshot);
+    assert.match(serialized, /"source":"installed-production"/);
+    assert.match(serialized, /"mode":"live-shared"/);
+    assert.doesNotMatch(serialized, new RegExp(fixtureRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(serialized, /OPENCODE_DB|OPENWORK_DATA_DIR/);
+
+    await removeOwnedSurfaceFiles({
+      name: "production-live",
+      kind: "electron",
+      hostKind: "local",
+      cdpUrl: "http://127.0.0.1:31002",
+      profileDir: isolatedProfile,
+      meta: { profileOwner: "host" },
+    });
+    await assert.rejects(() => access(isolatedProfile));
+    await access(dataDir);
+    await access(opencodeDb);
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/world-live-shared-state.test.ts
+++ b/evals/specs/world-live-shared-state.test.ts
@@ -17,7 +17,7 @@ import {
   test,
 } from "@openwork/testkit";
 
-test("live shared production desktop state is explicit, local, symbolic, and cleanup-safe", async () => {
+test("live shared production desktop state is explicit, local, symbolic, and cleanup-safe", async ({ evidence }) => {
   await assert.rejects(
     () => startWorld(desktopProductionLive, {
       place: resolvePlace({}),
@@ -136,6 +136,27 @@ test("live shared production desktop state is explicit, local, symbolic, and cle
     await assert.rejects(() => access(isolatedProfile));
     await access(dataDir);
     await access(opencodeDb);
+
+    evidence.recordAssertionEvidence(
+      "Live production state requires explicit local opt-in",
+      "Launch was refused without --allow-shared-state and under remote Daytona placement.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Dev Electron points at installed production stores from an isolated profile",
+      "The launch environment selected production OpenWork, OpenCode, workspace, config, and token paths while retaining an isolated Electron userData directory.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "World snapshots do not persist production paths or credentials",
+      "The snapshot retained only the symbolic installed-production/live-shared selector and omitted resolved production paths and environment names.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Cleanup owns only the isolated dev profile",
+      "Cleanup removed the eval profile while the production OpenWork directory and OpenCode database remained present.",
+      true,
+    );
   } finally {
     await rm(fixtureRoot, { recursive: true, force: true });
   }

--- a/packages/paths/index.d.ts
+++ b/packages/paths/index.d.ts
@@ -7,6 +7,13 @@ export interface PathOptions {
   userDataDir?: string;
 }
 
+export interface OpencodeDbPathOptions extends PathOptions {
+  /** Additional OpenCode data roots to search before the platform defaults. */
+  dataDirs?: string[];
+  /** Channel used when OPENCODE_CHANNEL is unset. */
+  defaultChannel?: string;
+}
+
 export declare const MAX_CONFIG_ROOT_LENGTH: 4096;
 
 export declare function normalizeWorkspaceRootPath(value: unknown, opts?: PathOptions): string;
@@ -22,4 +29,5 @@ export declare function legacyDesktopBootstrapPath(opts?: PathOptions): string;
 export declare function expandHomePath(value: string, opts?: PathOptions): string;
 export declare function openworkServerDataDir(opts?: PathOptions): string;
 export declare function opencodeDataDirs(opts?: PathOptions): string[];
+export declare function opencodeDbCandidates(opts?: OpencodeDbPathOptions): string[];
 export declare function opencodeCacheDirs(opts?: PathOptions): string[];

--- a/packages/paths/index.mjs
+++ b/packages/paths/index.mjs
@@ -247,6 +247,30 @@ export function opencodeDataDirs(opts) {
   return Array.from(new Set(dirs));
 }
 
+function truthy(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/** Candidate OpenCode databases in the same override/channel order used by OpenWork. */
+export function opencodeDbCandidates(opts) {
+  const env = optionEnv(opts);
+  const platform = optionPlatform(opts);
+  const paths = pathApi(platform);
+  const dirs = Array.from(new Set([...(opts?.dataDirs ?? []), ...opencodeDataDirs(opts)]));
+  const override = envValue(env, "OPENCODE_DB");
+  if (override) {
+    if (paths.isAbsolute(override)) return [override];
+    return dirs.map((dir) => paths.join(dir, override));
+  }
+
+  const channel = envValue(env, "OPENCODE_CHANNEL") || opts?.defaultChannel || "local";
+  const names = channel === "latest" || channel === "beta" || truthy(envValue(env, "OPENCODE_DISABLE_CHANNEL_DB"))
+    ? ["opencode.db"]
+    : [`opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`, "opencode.db"];
+  return dirs.flatMap((dir) => names.map((name) => paths.join(dir, name)));
+}
+
 export function opencodeCacheDirs(opts) {
   const env = optionEnv(opts);
   const platform = optionPlatform(opts);

--- a/packages/paths/test/paths.test.mjs
+++ b/packages/paths/test/paths.test.mjs
@@ -9,6 +9,7 @@ import {
   legacyDesktopBootstrapPath,
   MAX_CONFIG_ROOT_LENGTH,
   normalizeWorkspaceRootPath,
+  opencodeDbCandidates,
   openworkEnvStorePath,
   openworkServerConfigPath,
   resolveGlobalOpencodeConfigPath,
@@ -77,6 +78,28 @@ describe("workspace root paths", () => {
 
   test("applies Windows validation only when Windows is injected", () => {
     expect(normalizeWorkspaceRootPath("\\\\?\\C:", { platform: "linux" })).toBe("\\\\?\\C:");
+  });
+});
+
+describe("OpenCode database paths", () => {
+  test("uses the production channel name and honors explicit overrides", () => {
+    expect(opencodeDbCandidates({
+      env: {},
+      homeDir: "/Users/ada",
+      platform: "darwin",
+      defaultChannel: "latest",
+    })).toContain("/Users/ada/Library/Application Support/opencode/opencode.db");
+    expect(opencodeDbCandidates({
+      env: { OPENCODE_CHANNEL: "preview" },
+      dataDirs: ["/tmp/opencode"],
+      homeDir: "/Users/ada",
+      platform: "darwin",
+    })[0]).toBe("/tmp/opencode/opencode-preview.db");
+    expect(opencodeDbCandidates({
+      env: { OPENCODE_DB: "/tmp/production.db" },
+      homeDir: "/Users/ada",
+      platform: "darwin",
+    })).toEqual(["/tmp/production.db"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an explicit macOS-only `desktop-prod-live` world preset guarded by `--allow-shared-state`
- launch source Electron through `pnpm dev` while sharing installed OpenWork/OpenCode stores and mirroring production renderer state into an isolated temporary profile
- preserve production process ownership, sanitize token-bearing errors, and require an eval-owned PID/profile receipt for teardown
- document the workflow and add testkit, topology, snapshot, host, desktop, path, and server coverage

## Usage
```bash
pnpm world up desktop-prod-live --allow-shared-state --name prod-live-dev --keep
```

This mode is intentionally labeled dangerous: concurrent production/dev writes remain unsupported.

## Verification
Local lane (the feature targets the installed local macOS desktop):
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/world-live-shared-state.test.ts` — 1 passed
- `pnpm --dir evals exec node --test packages/env/test/snapshot.test.ts packages/env/test/cli.test.ts packages/env/test/topology.test.ts packages/hosts/test/local-host.test.ts` — 41 passed
- `pnpm --filter @openwork/desktop exec node --test electron/workspace-store.test.mjs electron/runtime-user-env.test.mjs` — 26 passed
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --dir packages/paths test` — 22 passed
- `bun test apps/server/src/opencode-db.test.ts` — 5 passed
- `pnpm --filter openwork-server exec tsc -p tsconfig.json --noEmit` — passed

Live local validation also confirmed the dev desktop opened the installed production workspace/session and `world resume ... --teardown` removed only the eval profile while production remained running.