### PR TITLE
fix(evals): avoid parallel build races

### DIFF
--- a/evals/specs/den-api-production-package.test.ts
+++ b/evals/specs/den-api-production-package.test.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,12 +21,21 @@ async function reservePort() {
 }
 
 test("the Den API production package resolves workspace artifacts and starts listening", { timeout: 300_000 }, async ({ evidence }) => {
-  const build = spawnSync(pnpmCommand, ["--filter", "@openwork-ee/den-api", "run", "build"], {
+  const buildOutput: string[] = [];
+  const build = spawn(pnpmCommand, ["--filter", "@openwork-ee/den-api", "run", "build"], {
     cwd: repoRoot,
-    encoding: "utf8",
     env: { ...process.env, DEN_UPLOAD_SENTRY_SOURCEMAPS: "0" },
   });
-  expect(build.status, `Den API build failed\n${build.stdout}\n${build.stderr}`).toBe(0);
+  build.stdout.on("data", (chunk) => buildOutput.push(String(chunk)));
+  build.stderr.on("data", (chunk) => buildOutput.push(String(chunk)));
+  onTestFinished(() => {
+    if (build.exitCode === null) build.kill("SIGTERM");
+  });
+  const buildExitCode = await new Promise<number | null>((resolveBuild, rejectBuild) => {
+    build.once("error", rejectBuild);
+    build.once("close", resolveBuild);
+  });
+  expect(buildExitCode, `Den API build failed\n${buildOutput.join("")}`).toBe(0);
 
   const port = await reservePort();
   const output: string[] = [];

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -10,20 +10,6 @@ const repoRoot = resolve(import.meta.dirname, "../..");
 test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evidence }) => {
   const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-grant-liveness-"));
   try {
-    // The witnesses exercise real den-api modules whose import chains reach
-    // @openwork-ee/utils and @openwork-ee/den-db. Bun resolves those package
-    // exports through dist, which the eval lane does not prebuild.
-    for (const workspacePackage of ["@openwork-ee/utils", "@openwork-ee/den-db"]) {
-      const build = spawnSync("pnpm", ["--filter", workspacePackage, "build"], {
-        cwd: repoRoot,
-        encoding: "utf8",
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: 120_000,
-      });
-      expect(build.error, `${workspacePackage} build`).toBeUndefined();
-      expect(build.status, `${build.stdout}${build.stderr}`).toBe(0);
-    }
-
     const witnesses = [
       { file: "test/mcp-grant-request-liveness.test.ts", tests: 4 },
       { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },
@@ -39,6 +25,8 @@ test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evide
         "exec",
         "bun",
         "test",
+        "--conditions",
+        "development",
         witness.file,
         "--reporter=junit",
         "--reporter-outfile",


### PR DESCRIPTION
## Summary
- keep Vitest worker RPC responsive while the Den API production build runs
- run MCP grant witnesses against development source exports instead of rebuilding shared `dist` directories
- prevent parallel eval specs from racing over workspace build output

## Test plan
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/mcp-grant-scoped-liveness.test.ts specs/den-api-production-package.test.ts` (2 passed)
- Bun 1.3.14: `pnpm --dir evals run test:pr` (45 files passed, 2 skipped; 55 tests passed, 4 skipped)

## Verification
Incomplete only because the local PR lane contains four environment-gated skips requiring MySQL/Redis/Kubernetes/skill-grant infrastructure. Every executed assertion passed with the same Node 24 and Bun 1.3.14 toolchain used by CI.