### PR TITLE
test(evals): resolve grant-liveness witnesses from source exports

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -137,6 +137,12 @@ jobs:
         run: pnpm --dir evals install --frozen-lockfile --prefer-offline
 
       - name: Run eval spec lane
+        # The 3-core macOS runner cannot host three parallel eval workers plus
+        # their build subprocesses: worker RPC misses vitest's deadline and the
+        # lane fails with "Timeout calling onTaskUpdate" after every test
+        # passed. Cap it like other constrained environments.
+        env:
+          OPENWORK_EVAL_MAX_WORKERS: ${{ runner.os == 'macOS' && '2' || '' }}
         run: pnpm --dir evals run test:pr
 
       - name: Run app unit tests

--- a/evals/specs/mcp-grant-scoped-liveness.test.ts
+++ b/evals/specs/mcp-grant-scoped-liveness.test.ts
@@ -10,20 +10,6 @@ const repoRoot = resolve(import.meta.dirname, "../..");
 test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evidence }) => {
   const reportDir = mkdtempSync(join(tmpdir(), "openwork-mcp-grant-liveness-"));
   try {
-    // The witnesses exercise real den-api modules whose import chains reach
-    // @openwork-ee/utils and @openwork-ee/den-db. Bun resolves those package
-    // exports through dist, which the eval lane does not prebuild.
-    for (const workspacePackage of ["@openwork-ee/utils", "@openwork-ee/den-db"]) {
-      const build = spawnSync("pnpm", ["--filter", workspacePackage, "build"], {
-        cwd: repoRoot,
-        encoding: "utf8",
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: 120_000,
-      });
-      expect(build.error, `${workspacePackage} build`).toBeUndefined();
-      expect(build.status, `${build.stdout}${build.stderr}`).toBe(0);
-    }
-
     const witnesses = [
       { file: "test/mcp-grant-request-liveness.test.ts", tests: 4 },
       { file: "test/mcp-oauth-grant-policy.test.ts", tests: 6 },
@@ -38,6 +24,11 @@ test("MCP OAuth grants outlive login sessions and revoke with consent", ({ evide
         "@openwork-ee/den-api",
         "exec",
         "bun",
+        // Resolve @openwork-ee/utils and @openwork-ee/den-db from their source
+        // export condition: shared dist output is rebuilt (and briefly
+        // removed) by concurrently running specs, so the witnesses must not
+        // depend on it.
+        "--conditions=development",
         "test",
         witness.file,
         "--reporter=junit",


### PR DESCRIPTION
## Summary

- fix the `openwork-tests` failure on the `dev` push after #4055 merged: `specs/mcp-grant-scoped-liveness.test.ts` failed with `FileNotFound while resolving package '@openwork-ee/utils/den-urls'` in its final witness
- the witnesses resolved `@openwork-ee/utils` and `@openwork-ee/den-db` through built dist output and prebuilt it at spec start, but other specs in the parallel eval lane (notably #4069's den-api production-package build) rebuild that shared output concurrently, and tsup removes dist before rewriting it — a witness that resolves during that window fails with a missing module
- run the witnesses with `bun --conditions=development` so both packages resolve their sources directly, removing the dependency on generated build output entirely (the same approach `specs/mcp-stateless-2026-transport.test.ts` already uses); drop the now-unnecessary prebuild step

## Verification

- deleted `ee/packages/utils/dist` and `ee/packages/den-db/dist`, then ran `pnpm evals:pr specs/mcp-grant-scoped-liveness.test.ts` — passed 1/1 with all five witnesses green and no dist present, proving the spec no longer depends on shared build output