### PR TITLE
fix(den): link docs to public site

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -65,7 +65,7 @@ import { buildDenFeedbackUrl } from "../../_lib/feedback";
 import { OrgSelectionScreen } from "../_features/org-selection/org-selection-screen";
 import { UserProfileDialog } from "./user-profile-dialog";
 
-const OPENWORK_DOCS_URL = "/docs";
+const OPENWORK_DOCS_URL = "https://openworklabs.com/docs";
 
 type DashboardNavChild = {
   href: string;

--- a/ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts
+++ b/ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts
@@ -35,4 +35,10 @@ describe("OrgDashboardShell layout", () => {
     expect(source).toContain('target.hasAttribute("data-workspace-switcher-root")');
     expect(source).toContain("if (!clickedInsideSwitcher)");
   });
+
+  test("links Docs to the public documentation site", () => {
+    const source = readFileSync(shellPath, "utf8");
+
+    expect(source).toContain('const OPENWORK_DOCS_URL = "https://openworklabs.com/docs";');
+  });
 });


### PR DESCRIPTION
## Summary
- point the Den dashboard Docs link at https://openworklabs.com/docs
- add a regression assertion

## Verification
- bun test --conditions development tests/org-dashboard-shell-layout.test.ts