### PR TITLE
Fix unfinished tool lifecycle status

### DIFF
--- a/apps/app/src/components/chat/current-tool-lifecycle-context.tsx
+++ b/apps/app/src/components/chat/current-tool-lifecycle-context.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import * as React from "react"
+
+import type { SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
+import {
+  resolveCurrentToolLifecycle,
+  type CurrentToolLifecycle,
+} from "@/lib/current-tool-lifecycle"
+
+type CurrentToolLifecycleContextValue = {
+  activityStatus: SessionActivityStatus
+  currentToolCallIds: ReadonlySet<string>
+}
+
+const CurrentToolLifecycleContext = React.createContext<CurrentToolLifecycleContextValue | null>(null)
+
+export function CurrentToolLifecycleProvider({
+  activityStatus,
+  currentToolCallIds,
+  children,
+}: CurrentToolLifecycleContextValue & { children: React.ReactNode }) {
+  const value = React.useMemo(
+    () => ({ activityStatus, currentToolCallIds }),
+    [activityStatus, currentToolCallIds],
+  )
+
+  return (
+    <CurrentToolLifecycleContext.Provider value={value}>
+      {children}
+    </CurrentToolLifecycleContext.Provider>
+  )
+}
+
+export function useCurrentToolLifecycleResolver(): (
+  toolCallId: string,
+  isToolInFlight: boolean,
+) => CurrentToolLifecycle | null {
+  const context = React.useContext(CurrentToolLifecycleContext)
+  return React.useCallback(
+    (toolCallId, isToolInFlight) => {
+      if (!context) return null
+      return resolveCurrentToolLifecycle(
+        context.activityStatus,
+        context.currentToolCallIds.has(toolCallId),
+        isToolInFlight,
+      )
+    },
+    [context],
+  )
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   Check,
   ChevronRight,
+  CirclePause,
   Copy,
   Download,
   FileIcon,
@@ -93,6 +94,10 @@ import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
+  CurrentToolLifecycleProvider,
+  useCurrentToolLifecycleResolver,
+} from "@/components/chat/current-tool-lifecycle-context"
+import {
   isApplyPatchToolPart,
   isBashToolPart,
   isEditToolPart,
@@ -110,9 +115,10 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
+import type { SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
 import { formatToolCallDuration } from "@/lib/tool-call-duration"
 import { collectLatestAssistantToolParts } from "@/lib/latest-assistant-tool-parts"
-import { getActiveToolLabel } from "@/lib/tool-activity"
+import { getActiveToolLabel, isToolPartInFlight } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { cn } from "@/lib/utils"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
@@ -174,6 +180,40 @@ class ToolMessage extends React.Component<ToolMessageProps, { failed: boolean }>
 
 const ToolMessageInner = ({ part }: ToolMessageProps) => {
   const { onMcpReconnect, onMcpReopenAuthorization, onMcpRetry } = useMessageList()
+  const resolveLifecycle = useCurrentToolLifecycleResolver()
+  const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
+
+  if (lifecycle === "waiting") {
+    return (
+      <div
+        className="flex items-start gap-2 rounded-md border border-amber-7 bg-amber-2 px-3 py-2 text-sm text-amber-12"
+        data-tool-lifecycle="waiting"
+        role="status"
+      >
+        <CirclePause aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+        <div>
+          <div className="font-medium">Waiting for your action</div>
+          <div className="text-xs text-amber-11">Choose an option or approve the request to continue.</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (lifecycle === "interrupted") {
+    return (
+      <div
+        className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+        data-tool-lifecycle="interrupted"
+        role="alert"
+      >
+        <AlertTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+        <div>
+          <div className="font-medium">Task interrupted</div>
+          <div className="text-xs text-destructive/80">This step stopped before it finished. Retry to continue.</div>
+        </div>
+      </div>
+    )
+  }
 
   if (isBashToolPart(part)) {
     return <BashTool part={part} />
@@ -1211,6 +1251,7 @@ function MessageGroup({
 interface MessageListProps {
   messages: UIMessage[]
   status: ThreadStatus
+  activityStatus: SessionActivityStatus
   retryStatus?: RetryStatus | null
 }
 
@@ -1218,7 +1259,7 @@ export function shouldShowMessageListLoading(status: ThreadStatus, messageCount:
   return status === "streaming" || (status === "submitted" && messageCount > 0)
 }
 
-export function MessageList({ messages, status, retryStatus }: MessageListProps) {
+export function MessageList({ messages, status, activityStatus, retryStatus }: MessageListProps) {
   const isStreaming = status === "streaming" || status === "retrying"
   const showLoading = shouldShowMessageListLoading(status, messages.length)
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
@@ -1227,12 +1268,20 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
   const liveActionLabel = isStreaming
     ? getActiveToolLabel(collectLatestAssistantToolParts(messages))
     : null
+  const currentToolCallIds = React.useMemo(
+    () => new Set(collectLatestAssistantToolParts(messages).map((part) => part.toolCallId)),
+    [messages],
+  )
 
   return (
-    <div className={cn("flex flex-col gap-2 @container/message-list")}>
-      {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
+    <CurrentToolLifecycleProvider
+      activityStatus={activityStatus}
+      currentToolCallIds={currentToolCallIds}
+    >
+      <div className={cn("flex flex-col gap-2 @container/message-list")}>
+        {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
 
-      {items.map((item) => {
+        {items.map((item) => {
         if (isMessageGroup(item)) {
           return (
             <MessageGroup
@@ -1259,11 +1308,12 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
             <ArtifactList messages={[item.message]} includeTargetFallbacks={false} />
           </div>
         )
-      })}
+        })}
 
-      {showLoading && <LoadingMessage label={liveActionLabel ?? undefined} />}
-      {retryStatus ? <RetryMessage status={retryStatus} /> : null}
-      {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
-    </div>
+        {showLoading && <LoadingMessage label={liveActionLabel ?? undefined} />}
+        {retryStatus ? <RetryMessage status={retryStatus} /> : null}
+        {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
+      </div>
+    </CurrentToolLifecycleProvider>
   )
 }

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import { useState } from "react"
-import { ChevronRight } from "lucide-react"
+import { AlertTriangle, ChevronRight, CirclePause } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
+import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
 import {
   getAggregateNowLabel,
+  getAggregateCountSummary,
   getAggregateRowFile,
   getAggregateRowLabel,
   getAggregateSummary,
@@ -27,7 +29,7 @@ type ToolAggregateGroupProps = {
   className?: string
 }
 
-function rowStatus(part: AnyToolPart): "running" | "failed" | "done" {
+function persistedRowStatus(part: AnyToolPart): "running" | "failed" | "done" {
   if (isToolPartInFlight(part)) return "running"
   if (part.state === "output-error") return "failed"
   return "done"
@@ -50,6 +52,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
   const latestToolCallId = parts.at(-1)?.toolCallId ?? groupKey
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
   const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
+  const resolveLifecycle = useCurrentToolLifecycleResolver()
 
   const setExpanded = (value: boolean) => {
     expandedByGroupKey.set(groupKey, value)
@@ -60,10 +63,23 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
     setShowAllState(value)
   }
 
+  const inFlightPart = parts.find((part) => isToolPartInFlight(part))
+  const currentLifecycle = resolveLifecycle(
+    inFlightPart?.toolCallId ?? "",
+    Boolean(inFlightPart),
+  )
   const anyRunning = parts.some((part) => isToolPartInFlight(part))
+  const visiblyRunning = anyRunning
+    && currentLifecycle !== "waiting"
+    && currentLifecycle !== "interrupted"
   const failedCount = parts.filter((part) => part.state === "output-error").length
-  const summary = getAggregateSummary(parts, anyRunning ? "present" : "past")
-  const nowLabel = anyRunning ? getAggregateNowLabel(parts) : null
+  const countSummary = getAggregateCountSummary(parts)
+  const summary = currentLifecycle === "waiting"
+    ? `Waiting for your action · ${countSummary}`
+    : currentLifecycle === "interrupted"
+      ? `Task interrupted · ${countSummary}`
+      : getAggregateSummary(parts, visiblyRunning ? "present" : "past")
+  const nowLabel = visiblyRunning ? getAggregateNowLabel(parts) : null
 
   // Track durations for every part so each is frozen the moment it completes.
   const durations = parts.map((part) => trackToolCallDuration(part))
@@ -71,7 +87,11 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
   const hiddenCount = parts.length - visibleParts.length
 
   return (
-    <div className={className} data-tool-aggregate={latestToolCallId}>
+    <div
+      className={className}
+      data-tool-aggregate={latestToolCallId}
+      data-tool-lifecycle={currentLifecycle ?? (visiblyRunning ? "running" : "settled")}
+    >
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
@@ -93,6 +113,20 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
         ) : null}
       </button>
 
+      {currentLifecycle === "waiting" ? (
+        <div className="mt-1 flex items-center gap-1.5 ps-5 text-xs text-amber-11" role="status">
+          <CirclePause aria-hidden="true" className="size-3.5 shrink-0" />
+          <span>Choose an option or approve the request to continue.</span>
+        </div>
+      ) : null}
+
+      {currentLifecycle === "interrupted" ? (
+        <div className="mt-1 flex items-center gap-1.5 ps-5 text-xs text-destructive" role="alert">
+          <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" />
+          <span>This step stopped before it finished. Retry to continue.</span>
+        </div>
+      ) : null}
+
       {nowLabel ? (
         <div className="mt-1 flex min-w-0 items-center gap-2 ps-5 text-sm text-muted-foreground">
           <DotMatrixLoader label={nowLabel} className="text-muted-foreground" />
@@ -106,7 +140,8 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
       {expanded ? (
         <div className="mt-1.5 flex flex-col gap-1 ps-5">
           {visibleParts.map((part, index) => {
-            const status = rowStatus(part)
+            const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
+            const status = lifecycle ?? persistedRowStatus(part)
             const reason = failureReason(part)
             return (
               <div key={part.toolCallId} className="flex min-w-0 flex-col gap-0.5">
@@ -115,6 +150,12 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                     <span className="flex size-3.5 shrink-0 items-center justify-center">
                       <DotMatrixLoader label="Running" className="size-3 text-muted-foreground" />
                     </span>
+                  ) : null}
+                  {status === "waiting" ? (
+                    <CirclePause aria-label="Waiting" className="size-3.5 shrink-0 text-amber-11" />
+                  ) : null}
+                  {status === "interrupted" ? (
+                    <AlertTriangle aria-label="Interrupted" className="size-3.5 shrink-0 text-destructive" />
                   ) : null}
                   {(() => {
                     const file = getAggregateRowFile(part)

--- a/apps/app/src/lib/current-tool-lifecycle.ts
+++ b/apps/app/src/lib/current-tool-lifecycle.ts
@@ -1,0 +1,25 @@
+import type { SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
+
+export type CurrentToolLifecycle = "running" | "waiting" | "interrupted"
+
+const ACTIVE_SESSION_STATUSES = new Set<SessionActivityStatus>([
+  "thinking",
+  "responding",
+  "compacting",
+])
+
+/**
+ * Reconcile a current-turn unfinished tool with the task's authoritative
+ * lifecycle. Only active work may keep animating; every other state is made
+ * explicit instead of leaving a stale "Running" step beside a ready task.
+ */
+export function resolveCurrentToolLifecycle(
+  activityStatus: SessionActivityStatus,
+  isCurrentTurnTool: boolean,
+  isToolInFlight: boolean,
+): CurrentToolLifecycle | null {
+  if (!isCurrentTurnTool || !isToolInFlight) return null
+  if (activityStatus === "waiting") return "waiting"
+  if (ACTIVE_SESSION_STATUSES.has(activityStatus)) return "running"
+  return "interrupted"
+}

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -46,6 +46,37 @@ function plural(count: number, singular: string, pluralForm = `${singular}s`): s
   return `${count} ${count === 1 ? singular : pluralForm}`
 }
 
+export function getAggregateCountSummary(parts: AnyToolPart[]): string {
+  const commands = parts.filter((part) => getToolFamily(part) === "command").length
+  const editPaths = new Set<string>()
+  let editCalls = 0
+  const readPaths = new Set<string>()
+  let readCalls = 0
+  let searches = 0
+
+  for (const part of parts) {
+    const family = getToolFamily(part)
+    if (family === "edit") {
+      editCalls += 1
+      const path = filePathOf(part)
+      if (path) editPaths.add(path)
+    } else if (family === "read") {
+      readCalls += 1
+      const path = filePathOf(part)
+      if (path) readPaths.add(path)
+    } else if (family === "search") {
+      searches += 1
+    }
+  }
+
+  const pieces: string[] = []
+  if (editCalls > 0) pieces.push(plural(editPaths.size > 0 ? editPaths.size : editCalls, "file edit"))
+  if (commands > 0) pieces.push(plural(commands, "command"))
+  if (readCalls > 0) pieces.push(plural(readPaths.size > 0 ? readPaths.size : readCalls, "file read"))
+  if (searches > 0) pieces.push(plural(searches, "search", "searches"))
+  return pieces.join(", ")
+}
+
 /**
  * "Editing 3 files, running 8 commands" / "Edited 3 files, ran 8 commands".
  * File counts are unique paths; searches and commands are call counts.

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -295,6 +295,39 @@ function createChatTranscriptEvalMessages(sessionId: string) {
   return { messages };
 }
 
+function createSessionLifecycleEvalMessages(sessionId: string): UIMessage[] {
+  const now = Date.now();
+  return [
+    {
+      id: `${sessionId}:eval-lifecycle-user`,
+      role: "user",
+      parts: [{ type: "text", text: "Inspect the repository state." }],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-lifecycle-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-lifecycle-bash",
+          state: "input-streaming",
+          input: { command: "git status --short --branch", description: "Check repository state" },
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "read",
+          toolCallId: "eval-lifecycle-read",
+          state: "input-streaming",
+          input: { filePath: "/tmp/openwork-eval/brief.md" },
+        },
+      ],
+      metadata: { opencode: { created: now + 1 } },
+    },
+  ];
+}
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   environmentClient?: OpenworkServerClient | null;
@@ -998,6 +1031,48 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId]);
   useControlAction(props.isControlTarget ? seedChatTranscriptControlAction : null);
+  const seedSessionLifecycleControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.session_lifecycle.seed_unfinished_tools",
+      label: "Seed unfinished tool lifecycle proof",
+      description: "Dev-only eval hook that reconciles unfinished current-turn tools with the active task lifecycle.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: (args) => {
+        const lifecycle = typeof args === "object" && args !== null && "lifecycle" in args
+          ? args.lifecycle
+          : "idle";
+        if (lifecycle !== "active" && lifecycle !== "waiting" && lifecycle !== "idle") {
+          throw new Error(`Unsupported lifecycle: ${String(lifecycle)}`);
+        }
+
+        setEvalMarkdownMessages(createSessionLifecycleEvalMessages(props.sessionId));
+        const activity = useSessionActivityStore.getState();
+        activity.replaceWaitingRequests(props.workspaceId, props.sessionId, "permission", []);
+        activity.replaceWaitingRequests(props.workspaceId, props.sessionId, "question", []);
+        activity.clearError(props.workspaceId, props.sessionId);
+        activity.setCompacting(props.workspaceId, props.sessionId, false);
+        activity.setRunStatus(
+          props.workspaceId,
+          props.sessionId,
+          lifecycle === "active" ? { type: "busy" } : { type: "idle" },
+        );
+        if (lifecycle === "waiting") {
+          activity.setWaitingRequest(
+            props.workspaceId,
+            props.sessionId,
+            "question",
+            "eval-session-lifecycle-question",
+            true,
+          );
+        }
+        return { ok: true, lifecycle };
+      },
+    };
+  }, [props.sessionId, props.workspaceId]);
+  useControlAction(props.isControlTarget ? seedSessionLifecycleControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
@@ -2113,6 +2188,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       <MessageList
                         messages={renderedMessages}
                         status={status}
+                        activityStatus={effectiveActivityStatus}
                         retryStatus={liveStatus.type === "retry" ? liveStatus : null}
                       />
                     </MessageListProvider>

--- a/apps/app/tests/current-tool-lifecycle.test.ts
+++ b/apps/app/tests/current-tool-lifecycle.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveCurrentToolLifecycle } from "@/lib/current-tool-lifecycle"
+
+describe("resolveCurrentToolLifecycle", () => {
+  test("only active current-turn tools remain running", () => {
+    expect(resolveCurrentToolLifecycle("thinking", true, true)).toBe("running")
+    expect(resolveCurrentToolLifecycle("responding", true, true)).toBe("running")
+    expect(resolveCurrentToolLifecycle("compacting", true, true)).toBe("running")
+  })
+
+  test("unfinished current-turn tools expose waiting and interrupted outcomes", () => {
+    expect(resolveCurrentToolLifecycle("waiting", true, true)).toBe("waiting")
+    expect(resolveCurrentToolLifecycle("idle", true, true)).toBe("interrupted")
+    expect(resolveCurrentToolLifecycle("error", true, true)).toBe("interrupted")
+  })
+
+  test("does not rewrite completed or historical tool calls", () => {
+    expect(resolveCurrentToolLifecycle("idle", true, false)).toBeNull()
+    expect(resolveCurrentToolLifecycle("responding", false, true)).toBeNull()
+  })
+})

--- a/evals/specs/unfinished-tool-lifecycle.e2e.test.ts
+++ b/evals/specs/unfinished-tool-lifecycle.e2e.test.ts
@@ -1,0 +1,87 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "unfinished current-turn tools expose active, waiting, and interrupted outcomes"
+  : "unfinished tool lifecycle skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+function lifecycleExpression(lifecycle: "running" | "waiting" | "interrupted", text: string): string {
+  return `(() => {
+    const rows = Array.from(document.querySelectorAll('[data-tool-lifecycle="${lifecycle}"]'));
+    return rows.some((row) => (row.textContent || '').includes(${JSON.stringify(text)}));
+  })()`;
+}
+
+test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "unfinished-tool-lifecycle" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-unfinished-tool-lifecycle-${Date.now()}`,
+  });
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "new task control ready" },
+  );
+  let taskCreated = false;
+  let createTaskError: unknown = null;
+  for (let attempt = 0; attempt < 4 && !taskCreated; attempt += 1) {
+    try {
+      await control(app, "session.create_task");
+      taskCreated = true;
+    } catch (error) {
+      createTaskError = error;
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+  if (!taskCreated) throw createTaskError;
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.session_lifecycle.seed_unfinished_tools" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "unfinished tool lifecycle control ready" },
+  );
+
+  await control(app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "active" });
+  await waitFor(app, lifecycleExpression("running", "Running 1 command, reading 1 file"), {
+    timeoutMs: 15_000,
+    label: "active unfinished tools visibly running",
+  });
+  evidence.recordAssertionEvidence(
+    "Active unfinished tools remain visibly in progress",
+    "The current-turn command and file read rendered with data-tool-lifecycle=running and a present-tense summary.",
+    true,
+  );
+
+  await control(app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "waiting" });
+  await waitFor(app, lifecycleExpression("waiting", "Waiting for your action"), {
+    timeoutMs: 15_000,
+    label: "unfinished tools visibly waiting for action",
+  });
+  expect(await evalIn(app, `document.body.innerText.includes("Choose an option or approve the request to continue.")`)).toBe(true);
+  evidence.recordAssertionEvidence(
+    "A blocked unfinished step says what it needs",
+    "The same tool group changed to data-tool-lifecycle=waiting and displayed an explicit instruction to choose or approve; it no longer used the running lifecycle.",
+    true,
+  );
+
+  await control(app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "idle" });
+  await waitFor(app, lifecycleExpression("interrupted", "Task interrupted"), {
+    timeoutMs: 15_000,
+    label: "idle unfinished tools visibly interrupted",
+  });
+  const terminalState = await evalIn(app, `(() => ({
+    interrupted: document.body.innerText.includes("This step stopped before it finished. Retry to continue."),
+    running: Boolean(document.querySelector('[data-tool-lifecycle="running"]')),
+    waiting: Boolean(document.querySelector('[data-tool-lifecycle="waiting"]')),
+  }))()`);
+  expect(terminalState).toEqual({ interrupted: true, running: false, waiting: false });
+  evidence.recordAssertionEvidence(
+    "An idle task never leaves its unfinished current step silently running",
+    "The tool group converged to data-tool-lifecycle=interrupted, showed retry guidance, and exposed neither running nor waiting lifecycle rows.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- reconcile unfinished current-turn tool rows with the task lifecycle
- show an explicit waiting-for-action state for pending approvals or questions
- replace stale running indicators with an interrupted state and retry guidance when the task becomes idle or errors
- leave completed and historical tool calls unchanged

## Verification

- `pnpm --filter @openwork/app typecheck`
- `pnpm --dir apps/app exec bun test --isolate tests/current-tool-lifecycle.test.ts`
- `OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_DAYTONA=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/unfinished-tool-lifecycle.e2e.test.ts` (Daytona, passed at `93f174bcc`)

The desktop scenario verifies active, waiting, and interrupted transitions and confirms that authoritative idle leaves no running or waiting lifecycle rows.