### PR TITLE
fix(updates): keep installed alpha builds eligible

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -161,16 +161,6 @@ function maxAllowedDesktopVersion(desktopConfig: DenDesktopConfig | null | undef
   return maxVersion;
 }
 
-function effectiveMaxDesktopVersion(
-  denLatestAppVersion: string,
-  desktopConfig: DenDesktopConfig | null | undefined,
-): string {
-  const orgMaxVersion = maxAllowedDesktopVersion(desktopConfig);
-  if (!orgMaxVersion) return denLatestAppVersion;
-  const comparison = compareVersions(orgMaxVersion, denLatestAppVersion);
-  return comparison !== null && comparison < 0 ? orgMaxVersion : denLatestAppVersion;
-}
-
 function isWithinOnePatchAhead(updateVersion: string, maxVersion: string): boolean {
   const directComparison = compareVersions(updateVersion, maxVersion);
   if (directComparison !== null && directComparison <= 0) {
@@ -189,6 +179,44 @@ function isWithinOnePatchAhead(updateVersion: string, maxVersion: string): boole
   const maxPatch = maxRelease[2] ?? 0;
 
   return updateMajor === maxMajor && updateMinor === maxMinor && updatePatch <= maxPatch + 1;
+}
+
+function isNewerPrereleaseOnInstalledRelease(
+  updateVersion: string,
+  currentVersion: string | null | undefined,
+): boolean {
+  if (!currentVersion) return false;
+  const update = parseComparableVersion(updateVersion);
+  const current = parseComparableVersion(currentVersion);
+  if (!update?.prerelease.length || !current?.prerelease.length) return false;
+  if (compareVersions(updateVersion, currentVersion) !== 1) return false;
+
+  const count = Math.max(update.release.length, current.release.length);
+  for (let index = 0; index < count; index += 1) {
+    if ((update.release[index] ?? 0) !== (current.release[index] ?? 0)) return false;
+  }
+  return true;
+}
+
+export function isAlphaUpdateAllowedByVersionCeiling(input: {
+  updateVersion: string;
+  currentVersion?: string | null;
+  denLatestAppVersion: string;
+  desktopConfig: DenDesktopConfig | null | undefined;
+}): boolean {
+  if (!isAlphaChannelAllowedByDesktopConfig(input.desktopConfig)) return false;
+
+  const denAllowsUpdate = isWithinOnePatchAhead(
+    input.updateVersion,
+    input.denLatestAppVersion,
+  ) || isNewerPrereleaseOnInstalledRelease(
+    input.updateVersion,
+    input.currentVersion,
+  );
+  if (!denAllowsUpdate) return false;
+
+  const orgMaxVersion = maxAllowedDesktopVersion(input.desktopConfig);
+  return !orgMaxVersion || isWithinOnePatchAhead(input.updateVersion, orgMaxVersion);
 }
 
 async function readDenLatestAppVersion(): Promise<string | null> {
@@ -325,18 +353,25 @@ export async function isUpdateSupportedByDen(updateVersion: string): Promise<boo
 
 /**
  * Alpha channel builds may run one patch ahead of the current Den/org maximum
- * (e.g. Den allows 0.13.3, alpha 0.13.4-alpha.N is allowed). Larger jumps are
- * still blocked so alpha cannot bypass staged rollout ceilings entirely.
+ * (e.g. Den allows 0.13.3, alpha 0.13.4-alpha.N is allowed). An installed
+ * prerelease may also advance within its existing release while Den's global
+ * stable metadata catches up. Explicit organization ceilings still apply, and
+ * larger release jumps stay blocked so alpha cannot bypass staged rollout.
  */
 export async function isAlphaUpdateAllowed(
   updateVersion: string,
   desktopConfig: DenDesktopConfig | null | undefined,
+  currentVersion?: string | null,
 ): Promise<boolean> {
   if (!isAlphaChannelAllowedByDesktopConfig(desktopConfig)) return false;
   const latestAppVersion = await readDenLatestAppVersion();
   if (!latestAppVersion) return false;
-  const effectiveMaxVersion = effectiveMaxDesktopVersion(latestAppVersion, desktopConfig);
-  return isWithinOnePatchAhead(updateVersion, effectiveMaxVersion);
+  return isAlphaUpdateAllowedByVersionCeiling({
+    updateVersion,
+    currentVersion,
+    denLatestAppVersion: latestAppVersion,
+    desktopConfig,
+  });
 }
 
 /**

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1775,6 +1775,7 @@ export default {
   "settings.update_available_version": "Update available: v{version}",
   "settings.update_blocked_version": "Update available: v{version}",
   "settings.update_blocked_org": "OpenWork {version} is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.",
+  "settings.update_blocked_policy": "OpenWork {version} is available, but this installation is not eligible for it yet.",
   "settings.update_check_button": "Check now",
   "settings.update_check_failed": "Couldn't check for updates",
   "settings.update_checking": "Checking for updates…",

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -138,7 +138,11 @@ async function stageOnboardingUpdate(
   if (
     channelState.channel === "alpha" &&
     update.latestVersion &&
-    !(await isAlphaUpdateAllowed(update.latestVersion, desktopConfig))
+    !(await isAlphaUpdateAllowed(
+      update.latestVersion,
+      desktopConfig,
+      channelState.currentVersion,
+    ))
   ) {
     return false;
   }

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.test.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.test.ts
@@ -7,6 +7,7 @@ declare const expect: (value: unknown) => {
 
 import {
   ELECTRON_UPDATER_UNSUPPORTED_REASON,
+  resolveCheckedUpdateState,
   shouldScheduleElectronUpdateAutoCheck,
   unsupportedElectronUpdaterEnvState,
 } from "./electron-updater-state";
@@ -29,5 +30,15 @@ describe("electron updater web unsupported state", () => {
       autoCheckKey: null,
       nextAutoCheckKey: "stable:unknown",
     })).toBe(false);
+  });
+});
+
+describe("electron updater availability state", () => {
+  test("does not report a policy-blocked available update as current", () => {
+    expect(resolveCheckedUpdateState({ available: true, allowed: false })).toBe("blocked");
+  });
+
+  test("reports current only when the feed has no available update", () => {
+    expect(resolveCheckedUpdateState({ available: false, allowed: false })).toBe("idle");
   });
 });

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -73,6 +73,14 @@ export function shouldScheduleElectronUpdateAutoCheck(input: {
     input.autoCheckKey !== input.nextAutoCheckKey;
 }
 
+export function resolveCheckedUpdateState(input: {
+  available: boolean;
+  allowed: boolean;
+}): "idle" | "available" | "blocked" {
+  if (!input.available) return "idle";
+  return input.allowed ? "available" : "blocked";
+}
+
 type ElectronUpdaterEnvAction =
   | { type: "app-version"; appVersion: string | null }
   | { type: "unsupported"; reason: string };
@@ -467,25 +475,32 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         ? targetVersion
           ? result.latestVersion === targetVersion
           : checkedReleaseChannel === "alpha"
-            ? await isAlphaUpdateAllowed(result.latestVersion, latestDesktopConfig)
+            ? await isAlphaUpdateAllowed(
+                result.latestVersion,
+                latestDesktopConfig,
+                result.currentVersion ?? appVersion,
+              )
             : await isUpdateAllowed(result.latestVersion, latestDesktopConfig)
         : result.available;
       if (!isCurrentRequest()) return;
-      const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
-        ? {
-            state: "available",
-            lastCheckedAt: Date.now(),
-            version: result.latestVersion ?? undefined,
-            date: result.releaseDate ?? undefined,
-            notes: releaseNotesToText(result.releaseNotes),
-          }
-        : {
-            state: "idle",
-            lastCheckedAt: Date.now(),
-            version: result.latestVersion ?? undefined,
-            date: result.releaseDate ?? undefined,
-            notes: releaseNotesToText(result.releaseNotes),
-          };
+      const checkedUpdateState = resolveCheckedUpdateState({
+        available: result.available,
+        allowed: Boolean(availableAllowed),
+      });
+      const nextStatus: Exclude<SettingsUpdateStatus, null> = {
+        state: checkedUpdateState,
+        lastCheckedAt: Date.now(),
+        version: result.latestVersion ?? undefined,
+        date: result.releaseDate ?? undefined,
+        notes: releaseNotesToText(result.releaseNotes),
+        ...(checkedUpdateState === "blocked"
+          ? {
+              message: t("settings.update_blocked_policy", undefined, {
+                version: result.latestVersion ?? "",
+              }),
+            }
+          : {}),
+      };
       availableReleaseChannelRef.current = availableAllowed
         ? checkedReleaseChannel
         : null;

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   isAlphaChannelAllowedByDesktopConfig,
   isAlphaUpdateAllowed,
+  isAlphaUpdateAllowedByVersionCeiling,
   resolveAutomaticStableDesktopUpdate,
   resolveDesktopUpdateChannel,
   resolveFreshStableDesktopUpdate,
@@ -33,6 +34,36 @@ describe("alpha desktop update policy", () => {
     await expect(
       isAlphaUpdateAllowed("999.0.0-alpha.1", { allowAlphaUpdates: false }),
     ).resolves.toBe(false);
+  });
+
+  test("lets an installed alpha advance within its release while Den metadata lags", () => {
+    expect(isAlphaUpdateAllowedByVersionCeiling({
+      updateVersion: "0.18.37-alpha.2492+4921a02",
+      currentVersion: "0.18.37-alpha.2491+64d2d37",
+      denLatestAppVersion: "0.18.35",
+      desktopConfig: { allowAlphaUpdates: true },
+    })).toBe(true);
+  });
+
+  test("does not let an installed alpha bypass the ceiling for a newer release", () => {
+    expect(isAlphaUpdateAllowedByVersionCeiling({
+      updateVersion: "0.18.38-alpha.2493+abcdef0",
+      currentVersion: "0.18.37-alpha.2491+64d2d37",
+      denLatestAppVersion: "0.18.35",
+      desktopConfig: { allowAlphaUpdates: true },
+    })).toBe(false);
+  });
+
+  test("keeps an explicit organization ceiling in force", () => {
+    expect(isAlphaUpdateAllowedByVersionCeiling({
+      updateVersion: "0.18.37-alpha.2492+4921a02",
+      currentVersion: "0.18.37-alpha.2491+64d2d37",
+      denLatestAppVersion: "0.18.35",
+      desktopConfig: {
+        allowAlphaUpdates: true,
+        allowedDesktopVersions: ["0.18.35"],
+      },
+    })).toBe(false);
   });
 });
 

--- a/evals/specs/alpha-update-eligibility.e2e.test.ts
+++ b/evals/specs/alpha-update-eligibility.e2e.test.ts
@@ -1,0 +1,190 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import { allocateFreePort } from "@openwork/cdp";
+import { desktop, localHost } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+import { screenshot } from "@openwork/test-evidence";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const onMac = process.platform === "darwin";
+const enabled = e2eTestsEnabled && onMac;
+const title = enabled
+  ? "the macOS updater surfaces eligible and gated Alpha builds accurately"
+  : e2eTestsEnabled
+    ? `alpha update eligibility skipped — needs: run on macOS (Alpha is unavailable on ${process.platform})`
+    : "alpha update eligibility skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+async function installUpdaterBridge(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  const installed = await evalIn(app, `(() => {
+    const nativeUpdater = window.__OPENWORK_ELECTRON__?.updater;
+    if (!nativeUpdater?.getChannel || !nativeUpdater.setChannel) return false;
+    const state = {
+      checks: [],
+      currentVersion: "0.18.37-alpha.2491+64d2d37",
+      latestVersion: "0.18.37-alpha.2492+4921a02",
+    };
+    window.__openworkAlphaUpdateEligibilityEvalState = state;
+    window.localStorage.setItem("openwork.react.settings.update-auto-check", "0");
+    window.__openworkApplyDesktopConfig?.({ allowAlphaUpdates: true });
+    window.__openworkSetDesktopConfigRefreshResult?.({ allowAlphaUpdates: true });
+    window.__openworkReadDesktopVersionMetadataEval = () => ({
+      minAppVersion: "0.17.0",
+      latestAppVersion: "0.18.35",
+      publishedDesktopVersions: ["0.18.35"],
+    });
+    window.__openworkUpdaterEvalBridge = {
+      getChannel: () => nativeUpdater.getChannel(),
+      setChannel: (channel) => nativeUpdater.setChannel(channel),
+      check: async (channel) => {
+        state.checks.push(channel);
+        return channel === "alpha"
+          ? {
+              available: true,
+              channel,
+              currentVersion: state.currentVersion,
+              latestVersion: state.latestVersion,
+            }
+          : {
+              available: false,
+              channel,
+              currentVersion: state.currentVersion,
+              latestVersion: "0.18.35",
+            };
+      },
+      download: async () => ({ ok: false, reason: "unused by this update eligibility proof" }),
+      installAndRestart: async () => ({ ok: false, reason: "unused by this update eligibility proof" }),
+      onDownloadProgress: () => () => {},
+    };
+    return true;
+  })()`);
+  expect(installed).toBe(true);
+}
+
+async function selectAlpha(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  const triggerPoint = await evalIn(app, `(() => {
+    const trigger = document.querySelector('[aria-label="Release channel"]');
+    if (!(trigger instanceof HTMLElement)) return null;
+    const rect = trigger.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (
+    !triggerPoint ||
+    typeof triggerPoint !== "object" ||
+    !("x" in triggerPoint) ||
+    !("y" in triggerPoint) ||
+    typeof triggerPoint.x !== "number" ||
+    typeof triggerPoint.y !== "number"
+  ) {
+    throw new Error(`Could not resolve the release channel trigger: ${JSON.stringify(triggerPoint)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", ...triggerPoint });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...triggerPoint, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...triggerPoint, button: "left", clickCount: 1 });
+  await waitFor(
+    app,
+    `[...document.querySelectorAll('[data-slot="select-item"]')]
+      .some((item) => item.textContent?.trim() === "Alpha")`,
+    { timeoutMs: 15_000, label: "Alpha release channel option" },
+  );
+  const optionPoint = await evalIn(app, `(() => {
+    const option = [...document.querySelectorAll('[data-slot="select-item"]')]
+      .find((item) => item.textContent?.trim() === "Alpha");
+    if (!(option instanceof HTMLElement)) return null;
+    const rect = option.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (
+    !optionPoint ||
+    typeof optionPoint !== "object" ||
+    !("x" in optionPoint) ||
+    !("y" in optionPoint) ||
+    typeof optionPoint.x !== "number" ||
+    typeof optionPoint.y !== "number"
+  ) {
+    throw new Error(`Could not resolve the Alpha release channel option: ${JSON.stringify(optionPoint)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", ...optionPoint });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...optionPoint, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...optionPoint, button: "left", clickCount: 1 });
+}
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-alpha-update-eligibility-eval-"));
+  const workspacePath = join(profileDir, "workspace");
+  const desktopEnv = { PORT: String(await allocateFreePort()) };
+  await using host = localHost();
+
+  try {
+    const app = await desktop({ name: "alpha-update-eligibility", host, profileDir, env: desktopEnv });
+    try {
+      const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
+      await installUpdaterBridge(app);
+      await go(app, `/workspace/${workspaceId}/settings/updates`);
+      await waitFor(
+        app,
+        `window.location.hash.includes("/settings/updates")
+          && Boolean(document.querySelector('[aria-label="Release channel"]'))`,
+        { timeoutMs: 60_000, label: "public macOS Updates page with release channel picker" },
+      );
+      await selectAlpha(app);
+      await waitFor(
+        app,
+        `window.__openworkAlphaUpdateEligibilityEvalState?.checks
+            ?.filter((channel) => channel === "alpha").length === 1
+          && document.body.innerText.includes("Update available: v0.18.37-alpha.2492+4921a02")
+          && [...document.querySelectorAll("button")]
+            .some((button) => button.textContent?.trim() === "Download")`,
+        { timeoutMs: 30_000, label: "eligible same-release Alpha update" },
+      );
+
+      const availableText = await evalIn(app, "document.body.innerText");
+      expect(availableText).toContain("Update available: v0.18.37-alpha.2492+4921a02");
+      expect(availableText).not.toContain("You're up to date");
+      await screenshot(app);
+      evidence.recordAssertionEvidence(
+        "A newer build on the installed Alpha release is offered despite lagging stable metadata",
+        "With 0.18.37-alpha.2491 installed and Den metadata at 0.18.35, the Updates page offered 0.18.37-alpha.2492 with a Download action and did not say the app was up to date.",
+        true,
+      );
+
+      const switchedCandidate = await evalIn(app, `(() => {
+        const state = window.__openworkAlphaUpdateEligibilityEvalState;
+        if (!state) return false;
+        state.latestVersion = "0.18.38-alpha.2493+abcdef0";
+        const checkButton = [...document.querySelectorAll("button")]
+          .find((button) => button.textContent?.trim() === "Check now");
+        if (!(checkButton instanceof HTMLElement)) return false;
+        checkButton.click();
+        return true;
+      })()`);
+      expect(switchedCandidate).toBe(true);
+      await waitFor(
+        app,
+        `document.body.innerText.includes("Update available: v0.18.38-alpha.2493+abcdef0")
+          && document.body.innerText.includes("this installation is not eligible for it yet")
+          && ![...document.querySelectorAll("button")]
+            .some((button) => button.textContent?.trim() === "Download")`,
+        { timeoutMs: 30_000, label: "blocked newer-release Alpha update" },
+      );
+
+      const blockedText = await evalIn(app, "document.body.innerText");
+      expect(blockedText).toContain("Update available: v0.18.38-alpha.2493+abcdef0");
+      expect(blockedText).not.toContain("You're up to date");
+      await screenshot(app);
+      evidence.recordAssertionEvidence(
+        "A gated Alpha release stays blocked without a false current status",
+        "The Updates page identified 0.18.38-alpha.2493 as available but ineligible, withheld the Download action, and did not say the app was up to date.",
+        true,
+      );
+    } finally {
+      await app.stop();
+    }
+  } finally {
+    await rm(profileDir, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/alpha-update-eligibility.test.ts
+++ b/evals/specs/alpha-update-eligibility.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { isAlphaUpdateAllowedByVersionCeiling } from "../../apps/app/src/app/lib/version-gate";
+import { resolveCheckedUpdateState } from "../../apps/app/src/react-app/domains/settings/state/electron-updater-state";
+
+test("an installed alpha can receive its next build without a false up-to-date status", ({ evidence }) => {
+  const currentVersion = "0.18.37-alpha.2491+64d2d37";
+  const updateVersion = "0.18.37-alpha.2492+4921a02";
+  const allowed = isAlphaUpdateAllowedByVersionCeiling({
+    updateVersion,
+    currentVersion,
+    denLatestAppVersion: "0.18.35",
+    desktopConfig: { allowAlphaUpdates: true },
+  });
+
+  expect(allowed).toBe(true);
+  expect(resolveCheckedUpdateState({ available: true, allowed })).toBe("available");
+  evidence.recordAssertionEvidence(
+    "An installed Alpha build remains eligible for newer builds on the same release",
+    `${currentVersion} accepts ${updateVersion} even while Den's stable release metadata is 0.18.35, and the updater state exposes the candidate as available.`,
+    true,
+  );
+
+  const newerReleaseAllowed = isAlphaUpdateAllowedByVersionCeiling({
+    updateVersion: "0.18.38-alpha.2493+abcdef0",
+    currentVersion,
+    denLatestAppVersion: "0.18.35",
+    desktopConfig: { allowAlphaUpdates: true },
+  });
+  expect(newerReleaseAllowed).toBe(false);
+  expect(resolveCheckedUpdateState({ available: true, allowed: newerReleaseAllowed })).toBe("blocked");
+  evidence.recordAssertionEvidence(
+    "The rollout ceiling still blocks a new release line without claiming the app is current",
+    "The same installation rejects 0.18.38-alpha.2493 and maps the available-but-ineligible candidate to blocked rather than idle.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- allow an installed Alpha prerelease to advance within its existing release while global stable metadata catches up
- preserve explicit organization ceilings and block jumps to a newer release line
- show policy-blocked feed candidates as available but ineligible instead of reporting the app as up to date

## Rollout note

Clients already stranded by stale metadata still need either the global metadata ceiling advanced or one manual install. This change prevents subsequent builds on that installed Alpha release from being hidden.

## Verification

- `pnpm --filter @openwork/app exec bun test --isolate tests/version-gate.test.ts`
- `pnpm --filter @openwork/app exec bun test --isolate src/react-app/domains/settings/state/electron-updater-state.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm evals:pr specs/alpha-update-eligibility.test.ts`
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/alpha-update-eligibility.e2e.test.ts`