### PR TITLE
fix(server): isolate artifact catalog test

### DIFF
--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -116,7 +116,11 @@ describe("artifact file routes", () => {
     const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
     expect(xlsxDownload.status).toBe(200);
     expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
+  });
 
+  test("lists code artifacts while excluding heavy directories", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
     const sessionResponse = await fetch(`${base}/workspace/ws_1/files/sessions`, {
       method: "POST",
       headers: auth(token),


### PR DESCRIPTION
## Summary
- keep the raw binary download assertion as the final request in its test
- run workspace catalog assertions against a fresh server instance
- avoid reusing a streamed-response connection for the subsequent session request, which intermittently reset on Linux

## Verification
- targeted artifact route file completed 40/40 assertions across 20 reruns
- full CI will run the server suite on Linux and macOS

Test-only change; no runtime behavior changed.