### PR TITLE
Let admins auto-run managed dashboard apps

### DIFF
--- a/apps/app/src/app/lib/den-types.ts
+++ b/apps/app/src/app/lib/den-types.ts
@@ -24,8 +24,9 @@ export type DenUser = {
 
 /**
  * One MCP App element of an organization-managed dashboard, in the same
- * reference shape as local desktop dashboard entries. Per-user launch consent
- * (auto-launch, write-tool approval) is never part of the wire shape.
+ * reference shape as local desktop dashboard entries. Local member consent is
+ * not part of the wire shape; organizationAutoLaunch is an explicit admin
+ * policy carried by the managed assignment.
  */
 export type DenDashboardElement = {
   serverName: string;
@@ -36,6 +37,7 @@ export type DenDashboardElement = {
   title: string;
   launchArguments?: Record<string, unknown>;
   requiresApproval?: boolean;
+  organizationAutoLaunch?: boolean;
 };
 
 /** An organization-managed dashboard granted to the signed-in member. */

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1802,6 +1802,7 @@ function getDashboardElement(entry: unknown): DenDashboardElement | null {
     title: entry.title,
     ...(isRecord(entry.launchArguments) ? { launchArguments: entry.launchArguments } : {}),
     ...(entry.requiresApproval === true ? { requiresApproval: true } : {}),
+    ...(entry.organizationAutoLaunch === true ? { organizationAutoLaunch: true } : {}),
   };
 }
 

--- a/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
@@ -77,8 +77,17 @@ export function dashboardTileRunsAutomatically(
   requiresApproval: boolean,
   autoLaunchEnabled: boolean,
   launchApproved: boolean,
+  organizationAutoLaunch: boolean,
 ): boolean {
-  return !requiresApproval && autoLaunchEnabled && !launchApproved;
+  return organizationAutoLaunch || (!requiresApproval && autoLaunchEnabled && !launchApproved);
+}
+
+/** Admin policy is an independent server-authored approval for this managed element. */
+export function dashboardTileLaunchIsApproved(
+  organizationAutoLaunch: boolean,
+  memberApproved: boolean,
+): boolean {
+  return organizationAutoLaunch || memberApproved;
 }
 
 export function shouldAutoRefreshDashboardTile(input: {

--- a/apps/app/src/react-app/domains/dashboard/granted-dashboard-store.ts
+++ b/apps/app/src/react-app/domains/dashboard/granted-dashboard-store.ts
@@ -23,6 +23,8 @@ export type DashboardMcpAppEntry = {
   launchArguments?: Record<string, unknown>;
   /** Write-capable apps remain manual-only. */
   requiresApproval?: boolean;
+  /** Server-authored admin policy to run this exact managed element automatically. */
+  organizationAutoLaunch?: boolean;
   /** The member's locally stored approval for this exact managed element. */
   launchApproved?: boolean;
   /** The member enabled automatic launch by successfully running this exact safe element. */
@@ -69,6 +71,7 @@ export function grantedEntryId(dashboardId: string, element: DenDashboardElement
     resourceUri: element.resourceUri,
     launchArguments: element.launchArguments ?? null,
     requiresApproval: element.requiresApproval === true,
+    organizationAutoLaunch: element.organizationAutoLaunch === true,
   });
   return `granted:${dashboardId}:mcp:${encodeURIComponent(material)}`;
 }
@@ -90,6 +93,7 @@ export function grantedDashboardEntry(
     title: element.title,
     ...(element.launchArguments ? { launchArguments: element.launchArguments } : {}),
     ...(element.requiresApproval === true ? { requiresApproval: true } : {}),
+    ...(element.organizationAutoLaunch === true ? { organizationAutoLaunch: true } : {}),
     ...(consent?.launchApproved === true ? { launchApproved: true } : {}),
     ...(element.requiresApproval !== true
       && consent?.autoLaunch === true

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -14,6 +14,7 @@ import { useWorkspace, WorkspaceProvider } from "@/react-app/shell/workspace-pro
 import { DashboardTileShell } from "./dashboard-tile-shell";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
+  dashboardTileLaunchIsApproved,
   dashboardTileRunsAutomatically,
   readDashboardTileCache,
   shouldAutoRefreshDashboardTile,
@@ -112,6 +113,7 @@ export function McpAppTile({
     entry.requiresApproval === true,
     entry.autoLaunch === true,
     entry.launchApproved === true,
+    entry.organizationAutoLaunch === true,
   );
   const manualLaunch = !runsAutomatically;
   const launchEndpoints = useMemo(() => [
@@ -211,7 +213,10 @@ export function McpAppTile({
         name: app.toolName,
         resourceUri: app.resourceUri,
         arguments: launchArguments,
-        ...(launchApprovedRef.current ? { approved: true } : {}),
+        ...(dashboardTileLaunchIsApproved(
+          entry.organizationAutoLaunch === true,
+          launchApprovedRef.current,
+        ) ? { approved: true } : {}),
       };
       let result;
       let approvalWasRequired = false;
@@ -344,10 +349,14 @@ export function McpAppTile({
     if (state.phase === "ready" && refreshState === "refreshing") return "Saved locally · refreshing";
     if (state.phase === "ready" && refreshState === "failed") return "Saved locally · refresh failed";
     if (state.phase === "ready" && refreshState === "approval-required") return "Saved locally · run required";
+    if (state.phase === "ready" && entry.organizationAutoLaunch === true) {
+      return `Organization auto-run · ${freshnessLabel(state.cachedAt)}`;
+    }
     if (state.phase === "ready" && entry.requiresApproval === true) return "Saved locally · run on request";
     if (state.phase === "ready") return freshnessLabel(state.cachedAt);
     if (state.phase === "loading") return "Loading";
     if (state.phase === "error") return "Refresh failed";
+    if (entry.organizationAutoLaunch === true) return "Organization auto-run";
     if (entry.requiresApproval === true) return "Run on request";
     if (manualLaunch) return "Run once to enable";
     return null;

--- a/apps/app/tests/dashboard-tile-cache.test.ts
+++ b/apps/app/tests/dashboard-tile-cache.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
   dashboardTileCacheScopeKey,
+  dashboardTileLaunchIsApproved,
   dashboardTileRunsAutomatically,
   readDashboardTileCache,
   shouldAutoRefreshDashboardTile,
@@ -71,10 +72,18 @@ afterEach(() => {
 
 describe("dashboard tile cache", () => {
   test("automatically runs only opted-in apps that do not require approval", () => {
-    expect(dashboardTileRunsAutomatically(false, false, false)).toBe(false);
-    expect(dashboardTileRunsAutomatically(false, true, false)).toBe(true);
-    expect(dashboardTileRunsAutomatically(true, true, false)).toBe(false);
-    expect(dashboardTileRunsAutomatically(false, true, true)).toBe(false);
+    expect(dashboardTileRunsAutomatically(false, false, false, false)).toBe(false);
+    expect(dashboardTileRunsAutomatically(false, true, false, false)).toBe(true);
+    expect(dashboardTileRunsAutomatically(true, true, false, false)).toBe(false);
+    expect(dashboardTileRunsAutomatically(false, true, true, false)).toBe(false);
+    expect(dashboardTileRunsAutomatically(true, false, false, true)).toBe(true);
+    expect(dashboardTileRunsAutomatically(true, false, true, true)).toBe(true);
+  });
+
+  test("treats organization auto-launch as approval for the exact managed call", () => {
+    expect(dashboardTileLaunchIsApproved(false, false)).toBe(false);
+    expect(dashboardTileLaunchIsApproved(false, true)).toBe(true);
+    expect(dashboardTileLaunchIsApproved(true, false)).toBe(true);
   });
 
   test("keeps last-known-good app data isolated by user and organization with its originating workspace", () => {

--- a/apps/app/tests/granted-dashboard-store.test.ts
+++ b/apps/app/tests/granted-dashboard-store.test.ts
@@ -33,6 +33,7 @@ describe("grantedEntryId", () => {
       { ...element, projectedToolName: "connect_abc_other" },
       { ...element, launchArguments: { region: "us", team: "ops" } },
       { ...element, requiresApproval: true },
+      { ...element, organizationAutoLaunch: true },
       (() => {
         const { launchArguments: _omitted, ...rest } = element;
         return rest;
@@ -73,5 +74,24 @@ describe("grantedEntryId", () => {
       { ...element, requiresApproval: true },
       { autoLaunch: true },
     ).autoLaunch).toBeUndefined();
+  });
+
+  test("applies an organization auto-launch policy independently of local approval metadata", () => {
+    const dashboard: DenGrantedDashboard = {
+      id: "dsb_1",
+      name: "Operations",
+      elements: [element],
+      updatedAt: null,
+    };
+    const managedElement: DenDashboardElement = {
+      ...element,
+      requiresApproval: true,
+      organizationAutoLaunch: true,
+    };
+
+    expect(grantedDashboardEntry(dashboard, managedElement, undefined)).toMatchObject({
+      requiresApproval: true,
+      organizationAutoLaunch: true,
+    });
   });
 });

--- a/ee/apps/den-api/src/routes/org/dashboards.ts
+++ b/ee/apps/den-api/src/routes/org/dashboards.ts
@@ -29,8 +29,8 @@ import { idParamSchema } from "./shared.js"
  * elements that admins assign to members and teams through the same grants
  * mechanism connector assignment uses (`dashboard_access_grant` mirrors
  * `connector_instance_access_grant`). Granted dashboards render on the desktop
- * MCP Apps dashboard as read-only tiles; per-user launch consent stays on the
- * desktop and is never granted here.
+ * MCP Apps dashboard as read-only tiles. Per-user launch consent stays on the
+ * desktop; admins may explicitly authorize automatic launch on an element.
  */
 
 type DashboardId = typeof DashboardTable.$inferSelect.id
@@ -54,6 +54,7 @@ const dashboardElementSchema = z.object({
   title: z.string().trim().min(1).max(255),
   launchArguments: z.record(z.string(), z.unknown()).optional(),
   requiresApproval: z.boolean().optional(),
+  organizationAutoLaunch: z.boolean().optional(),
 }).meta({ ref: "DashboardElement" })
 
 const dashboardCreateSchema = z.object({
@@ -140,6 +141,7 @@ function toStoredElement(value: DashboardElementInput): DashboardElement {
     title: value.title,
     ...(value.launchArguments ? { launchArguments: value.launchArguments } : {}),
     ...(value.requiresApproval === true ? { requiresApproval: true } : {}),
+    ...(value.organizationAutoLaunch === true ? { organizationAutoLaunch: true } : {}),
   }
 }
 

--- a/ee/apps/den-api/test/dashboards.test.ts
+++ b/ee/apps/den-api/test/dashboards.test.ts
@@ -57,6 +57,11 @@ const writeElement = {
   requiresApproval: true,
 }
 
+const organizationAutoLaunchElement = {
+  ...writeElement,
+  organizationAutoLaunch: true,
+}
+
 async function cleanup() {
   await db.delete(DashboardAccessGrantTable).where(inArray(DashboardAccessGrantTable.organizationId, [organizationId, otherOrganizationId]))
   await db.delete(DashboardTable).where(inArray(DashboardTable.organizationId, [organizationId, otherOrganizationId]))
@@ -208,7 +213,7 @@ async function grantAccess(dashboardId: string, body: Record<string, unknown>) {
 }
 
 test("admins create, list, update, and soft-delete dashboards", async () => {
-  const created = await createDashboard("Support board", [readOnlyElement, writeElement])
+  const created = await createDashboard("Support board", [readOnlyElement, organizationAutoLaunchElement])
   expect(created.id.startsWith("dsb_")).toBe(true)
 
   const listResponse = await request("/v1/dashboards")
@@ -216,17 +221,17 @@ test("admins create, list, update, and soft-delete dashboards", async () => {
   const list = await listResponse.json() as { items: Array<{ id: string; name: string; elements: unknown[] }> }
   const listed = list.items.find((item) => item.id === created.id)
   expect(listed?.name).toBe("Support board")
-  expect(listed?.elements).toEqual([readOnlyElement, writeElement])
+  expect(listed?.elements).toEqual([readOnlyElement, organizationAutoLaunchElement])
 
   const updateResponse = await request(`/v1/dashboards/${created.id}`, {
     method: "PATCH",
-    body: JSON.stringify({ name: "Support board v2", elements: [writeElement, readOnlyElement] }),
+    body: JSON.stringify({ name: "Support board v2", elements: [organizationAutoLaunchElement, readOnlyElement] }),
   })
   expect(updateResponse.status).toBe(200)
   const updated = await updateResponse.json() as { item: { name: string; elements: unknown[] } }
   expect(updated.item.name).toBe("Support board v2")
   // Element array order is the tile order.
-  expect(updated.item.elements).toEqual([writeElement, readOnlyElement])
+  expect(updated.item.elements).toEqual([organizationAutoLaunchElement, readOnlyElement])
 
   const deleteResponse = await request(`/v1/dashboards/${created.id}`, { method: "DELETE" })
   expect(deleteResponse.status).toBe(204)

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
@@ -9,6 +9,7 @@ import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
 import { DenSelect } from "../../_components/ui/select";
+import { DenSwitch } from "../../_components/ui/switch";
 import { getManagedDashboardsRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { useMcpConnections } from "./mcp-connections-data";
@@ -108,7 +109,7 @@ export function OrgDashboardDetailScreen({ dashboardId }: { dashboardId: string 
     <DashboardPageTemplate
       icon={LayoutDashboard}
       title={dashboard.name}
-      description="Members with access see this dashboard's apps on their desktop Dashboard. Each person still runs every tile manually once, and apps that modify data only run on request."
+      description="Members with access see this dashboard's apps on their desktop Dashboard. Apps use member consent unless an admin explicitly enables automatic launch."
       colors={["#E0F2FE", "#0C4A6E", "#0EA5E9", "#BAE6FD"]}
     >
       <Link href={getManagedDashboardsRoute(orgSlug)} className="mb-5 inline-flex items-center gap-1 text-[13px] text-gray-500 hover:text-gray-900">
@@ -151,8 +152,24 @@ export function OrgDashboardDetailScreen({ dashboardId }: { dashboardId: string 
                   <p className="truncate text-[13.5px] font-medium text-gray-900">{element.title}</p>
                   <p className="truncate text-[12px] text-gray-400">
                     {element.toolName}
-                    {element.requiresApproval ? " · runs on request" : ""}
+                    {element.organizationAutoLaunch
+                      ? " · runs automatically by organization policy"
+                      : element.requiresApproval ? " · runs on request" : ""}
                   </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2 pr-2">
+                  <span className="text-[11.5px] text-gray-500">Auto-run</span>
+                  <DenSwitch
+                    size="sm"
+                    checked={element.organizationAutoLaunch === true}
+                    disabled={busy}
+                    onChange={(checked) => saveElements(elements.map((current, currentIndex) => (
+                      currentIndex === index
+                        ? { ...current, organizationAutoLaunch: checked || undefined }
+                        : current
+                    )))}
+                    aria-label={`Run ${element.title} automatically, even if it modifies data`}
+                  />
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
                   <button
@@ -320,6 +337,7 @@ function ConnectionAppRow({
 }) {
   const [argumentsText, setArgumentsText] = useState("");
   const [argumentsError, setArgumentsError] = useState<string | null>(null);
+  const [organizationAutoLaunch, setOrganizationAutoLaunch] = useState(false);
 
   function add() {
     let launchArguments: Record<string, unknown> | undefined;
@@ -346,6 +364,7 @@ function ConnectionAppRow({
       title: app.title,
       ...(launchArguments && Object.keys(launchArguments).length > 0 ? { launchArguments } : {}),
       ...(app.requiresApproval ? { requiresApproval: true } : {}),
+      ...(organizationAutoLaunch ? { organizationAutoLaunch: true } : {}),
     });
   }
 
@@ -367,6 +386,22 @@ function ConnectionAppRow({
           <DenButton size="sm" variant="secondary" onClick={add}>Add</DenButton>
         )}
       </div>
+      {!added ? (
+        <div className="mt-3 flex items-start justify-between gap-4 rounded-xl bg-amber-50 px-3 py-2.5">
+          <div>
+            <p className="text-[12px] font-medium text-amber-950">Run automatically</p>
+            <p className="mt-0.5 text-[11.5px] leading-4 text-amber-800">
+              Run on dashboard load and refresh, even if this app modifies data.
+            </p>
+          </div>
+          <DenSwitch
+            size="sm"
+            checked={organizationAutoLaunch}
+            onChange={setOrganizationAutoLaunch}
+            aria-label={`Run ${app.title} automatically, even if it modifies data`}
+          />
+        </div>
+      ) : null}
       {!added && app.requiresInput ? (
         <label className="mt-2 block">
           <span className="mb-1 block text-[11.5px] font-medium text-gray-600">Launch input (JSON, required by this app)</span>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
@@ -16,6 +16,7 @@ export type DashboardElement = {
   title: string;
   launchArguments?: Record<string, unknown>;
   requiresApproval?: boolean;
+  organizationAutoLaunch?: boolean;
 };
 
 export type ManagedDashboard = {
@@ -93,6 +94,7 @@ function parseElement(value: unknown): DashboardElement | null {
     title,
     ...(isRecord(value.launchArguments) ? { launchArguments: value.launchArguments } : {}),
     ...(value.requiresApproval === true ? { requiresApproval: true } : {}),
+    ...(value.organizationAutoLaunch === true ? { organizationAutoLaunch: true } : {}),
   };
 }
 

--- a/ee/packages/den-db/src/schema/dashboards.ts
+++ b/ee/packages/den-db/src/schema/dashboards.ts
@@ -9,8 +9,9 @@ import { TeamTable } from "./teams"
  * One MCP App tile on an organization-managed Dashboard. The shape mirrors the
  * desktop dashboard entry reference (`DashboardMcpAppEntry` in
  * `apps/app/src/react-app/domains/dashboard/dashboard-store.ts`) so granted
- * elements render as ordinary tiles. Per-user consent (auto-launch, write-tool
- * approval) is never stored here: it stays local to each desktop user.
+ * elements render as ordinary tiles. Per-user consent stays local to each
+ * desktop user; an organization admin may separately set an explicit launch
+ * policy on the managed element.
  */
 export type DashboardElement = {
   serverName: string
@@ -24,6 +25,8 @@ export type DashboardElement = {
   launchArguments?: Record<string, unknown>
   /** True when the launch tool modifies data: tiles only run on request, never on mount. */
   requiresApproval?: boolean
+  /** Explicit admin policy: run this exact element automatically, even when it modifies data. */
+  organizationAutoLaunch?: boolean
 }
 
 export const DashboardTable = mysqlTable(

--- a/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
+++ b/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
@@ -30,26 +30,43 @@ async function organizationId(session: DenSession): Promise<string> {
   return id;
 }
 
-async function createDashboard(session: DenSession, name: string): Promise<string> {
+type DashboardElementInput = {
+  serverName: string;
+  connectionId: string;
+  toolName: string;
+  projectedToolName: string;
+  resourceUri: string;
+  title: string;
+  requiresApproval?: boolean;
+  organizationAutoLaunch?: boolean;
+};
+
+const weeklyReportElement: DashboardElementInput = {
+  serverName: "openwork-app-host-connect-0123456789ab",
+  connectionId: "emc_01dashboardfixture0000000000",
+  toolName: "render_report",
+  projectedToolName: "openwork-app-host-connect-0123456789ab_render_report",
+  resourceUri: "ui://fixture/report/view.html",
+  title: "Weekly report",
+};
+
+async function createDashboard(
+  session: DenSession,
+  name: string,
+  elements: DashboardElementInput[] = [weeklyReportElement],
+): Promise<string> {
   const result = await denFetch(session, "/v1/dashboards", {
     method: "POST",
     headers: { authorization: `Bearer ${session.token}` },
     body: JSON.stringify({
       name,
-      elements: [{
-        serverName: "openwork-app-host-connect-0123456789ab",
-        connectionId: "emc_01dashboardfixture0000000000",
-        toolName: "render_report",
-        projectedToolName: "openwork-app-host-connect-0123456789ab_render_report",
-        resourceUri: "ui://fixture/report/view.html",
-        title: "Weekly report",
-      }],
+      elements,
     }),
   });
   const item = isRecord(result.body) && isRecord(result.body.item) ? result.body.item : null;
   const id = item && typeof item.id === "string" ? item.id : "";
-  const elements = item && Array.isArray(item.elements) ? item.elements : [];
-  if (result.response.status !== 201 || !id || elements.length !== 1) {
+  const returnedElements = item && Array.isArray(item.elements) ? item.elements : [];
+  if (result.response.status !== 201 || !id || returnedElements.length !== elements.length) {
     throw new Error(`Creating ${name} failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
   }
   return id;
@@ -68,7 +85,18 @@ test(title, async ({ evidence, place }) => {
   const orgId = await organizationId(den.admin);
   const grantedName = `Operations board ${Date.now()}`;
   const privateName = `Private board ${Date.now()}`;
-  const grantedDashboardId = await createDashboard(den.admin, grantedName);
+  const grantedDashboardId = await createDashboard(den.admin, grantedName, [
+    weeklyReportElement,
+    {
+      ...weeklyReportElement,
+      toolName: "create_ticket",
+      projectedToolName: "openwork-app-host-connect-0123456789ab_create_ticket",
+      resourceUri: "ui://fixture/ticket/view.html",
+      title: "Automatic ticket summary",
+      requiresApproval: true,
+      organizationAutoLaunch: true,
+    },
+  ]);
   await createDashboard(den.admin, privateName);
   const grant = await denFetch(den.admin, `/v1/dashboards/${grantedDashboardId}/access`, {
     method: "POST",
@@ -134,6 +162,45 @@ test(title, async ({ evidence, place }) => {
     addAppVisible: false,
     managedLabelVisible: true,
   });
+  await waitFor(desktop, `(() => {
+    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${grantedDashboardId}"]`)});
+    if (!(section instanceof HTMLElement)) return false;
+    const automaticTile = [...section.querySelectorAll("[data-dashboard-entry]")]
+      .find((tile) => tile.textContent?.includes("Automatic ticket summary"));
+    const cacheState = automaticTile instanceof HTMLElement
+      ? automaticTile.querySelector("[data-dashboard-cache-state]")?.getAttribute("data-dashboard-cache-state")
+      : null;
+    return automaticTile instanceof HTMLElement
+      && (cacheState === "refreshing" || automaticTile.innerText.includes("Refresh failed"))
+      && !automaticTile.querySelector('button[aria-label="Run Automatic ticket summary"]');
+  })()`, {
+    timeoutMs: 90_000,
+    label: "organization-authorized modifying app attempted automatic load",
+  });
+  const organizationPolicyState = await evalIn(desktop, `(() => {
+    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${grantedDashboardId}"]`)});
+    const tile = section instanceof HTMLElement
+      ? [...section.querySelectorAll("[data-dashboard-entry]")]
+        .find((entry) => entry.textContent?.includes("Automatic ticket summary"))
+      : null;
+    const cacheState = tile instanceof HTMLElement
+      ? tile.querySelector("[data-dashboard-cache-state]")?.getAttribute("data-dashboard-cache-state")
+      : null;
+    return {
+      automaticAttemptVisible: tile instanceof HTMLElement
+        && (cacheState === "refreshing" || tile.innerText.includes("Refresh failed")),
+      cacheState,
+      runVisible: Boolean(tile?.querySelector('button[aria-label="Run Automatic ticket summary"]')),
+    };
+  })()`);
+  expect(organizationPolicyState).toMatchObject({ automaticAttemptVisible: true, runVisible: false });
+  evidence.recordAssertionEvidence(
+    "Organization admins can authorize automatic launch even for an app that modifies data",
+    `tile=Automatic ticket summary; state=${JSON.stringify(organizationPolicyState)}`,
+    isRecord(organizationPolicyState)
+      && organizationPolicyState.automaticAttemptVisible === true
+      && organizationPolicyState.runVisible === false,
+  );
   evidence.recordAssertionEvidence(
     "Desktop renders only dashboards granted to the signed-in member",
     `org=${orgId}; granted=${grantedName}; ungranted=${privateName}; state=${JSON.stringify(initialState)}`,
@@ -188,10 +255,11 @@ test(title, async ({ evidence, place }) => {
       .find((tile) => tile.textContent?.includes("Weekly report"));
     return weeklyTile instanceof HTMLElement
       && Boolean(weeklyTile.querySelector("iframe"))
-      && weeklyTile.innerText.includes("Saved locally · refresh failed");
+      && (weeklyTile.innerText.includes("Saved locally · refreshing")
+        || weeklyTile.innerText.includes("Saved locally · refresh failed"));
   })()`, {
     timeoutMs: 90_000,
-    label: "saved dashboard view remained visible after background refresh failed",
+    label: "saved dashboard view remained visible during background refresh",
   });
 
   const cachedState = await evalIn(desktop, `(() => {
@@ -202,22 +270,23 @@ test(title, async ({ evidence, place }) => {
       : null;
     return {
       cachedViewVisible: weeklyTile instanceof HTMLElement && Boolean(weeklyTile.querySelector("iframe")),
-      refreshFailureVisible: weeklyTile instanceof HTMLElement
-        && weeklyTile.innerText.includes("Saved locally · refresh failed"),
+      refreshActive: weeklyTile instanceof HTMLElement
+        && (weeklyTile.innerText.includes("Saved locally · refreshing")
+          || weeklyTile.innerText.includes("Saved locally · refresh failed")),
       readOnlyRunVisible: Boolean(section?.querySelector('button[aria-label="Run Weekly report"]')),
     };
   })()`);
   expect(cachedState).toEqual({
     cachedViewVisible: true,
-    refreshFailureVisible: true,
+    refreshActive: true,
     readOnlyRunVisible: false,
   });
   evidence.recordAssertionEvidence(
-    "Desktop renders saved dashboard data immediately and keeps it visible when refresh fails",
+    "Desktop renders saved dashboard data immediately and keeps it visible during background refresh",
     `tile=Weekly report; state=${JSON.stringify(cachedState)}`,
     isRecord(cachedState)
       && cachedState.cachedViewVisible === true
-      && cachedState.refreshFailureVisible === true
+      && cachedState.refreshActive === true
       && cachedState.readOnlyRunVisible === false,
   );
   evidence.recordAssertionEvidence(


### PR DESCRIPTION
## Summary

- add an assignment-level auto-run policy for organization-managed dashboard apps
- allow admins to enable automatic launch and refresh even when an app modifies data
- keep member consent as the default when the organization policy is disabled
- carry the policy through Den storage, Desktop grants, request approval, cache identity, and status UI

## Safety

The override is authored through the existing organization-admin dashboard routes and applies only to the exact assigned element. Changing it changes the element identity, so stale local consent and cache state are not reused.

## Validation

- 10 focused Desktop unit tests pass
- Den API dashboard tests pass
- Desktop and Den Web typechecks pass
- exact-head managed-dashboard runtime proof passes 5/5 expectations at 34a836301e37d080318dddfc7aa4f299485f94b3

## Dependency

Stacked on #4089 and should merge after it.