### PR TITLE
Stop dashboard App discovery from getting stuck

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-mcp-app-catalog.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-mcp-app-catalog.ts
@@ -1,0 +1,15 @@
+export function connectionCanListMcpApps(connection: {
+  connectedForMe: boolean;
+  credentialHealth?: "unknown" | "ready" | "reconnect_required";
+  needsReconnect?: boolean;
+  setupRequired?: boolean;
+}): boolean {
+  return connection.connectedForMe
+    && connection.needsReconnect !== true
+    && connection.credentialHealth !== "reconnect_required"
+    && connection.setupRequired !== true;
+}
+
+export function mcpAppCatalogIsLoading(appCount: number, hasPendingConnection: boolean): boolean {
+  return appCount === 0 && hasPendingConnection;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
@@ -13,6 +13,7 @@ import { DenSwitch } from "../../_components/ui/switch";
 import { getManagedDashboardsRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { useMcpConnections } from "./mcp-connections-data";
+import { connectionCanListMcpApps } from "./dashboard-mcp-app-catalog";
 import { OrgMemberIdentity } from "./org-member-identity";
 import {
   type ConnectionMcpAppCatalogItem,
@@ -255,7 +256,9 @@ function AddDashboardAppDialog({
 }) {
   const connectionsQuery = useMcpConnections("manageable");
   const connections = useMemo(
-    () => (connectionsQuery.data ?? []).filter((connection) => connection.nativeProviderKey == null),
+    () => (connectionsQuery.data ?? []).filter((connection) => (
+      connection.nativeProviderKey == null && connectionCanListMcpApps(connection)
+    )),
     [connectionsQuery.data],
   );
   const appsQuery = useConnectionMcpAppCatalog(connections);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { mcpAppCatalogIsLoading } from "./dashboard-mcp-app-catalog";
 
 export type DashboardAccessRole = "viewer" | "editor" | "manager";
 
@@ -387,10 +388,16 @@ export function useConnectionMcpAppCatalog(connections: Array<{ id: string; name
         return apps.map(parseConnectionApp).filter((app): app is ConnectionMcpApp => app !== null);
       },
     })),
-    combine: (results) => ({
-      data: flattenConnectionMcpAppCatalog(connections, results.map((result) => result.data ?? [])),
-      isLoading: results.some((result) => result.isPending),
-      error: results.find((result) => result.error)?.error ?? null,
-    }),
+    combine: (results) => {
+      const data = flattenConnectionMcpAppCatalog(connections, results.map((result) => result.data ?? []));
+      const isLoading = mcpAppCatalogIsLoading(data.length, results.some((result) => result.isPending));
+      return {
+        data,
+        isLoading,
+        error: data.length === 0 && !isLoading
+          ? results.find((result) => result.error)?.error ?? null
+          : null,
+      };
+    },
   });
 }

--- a/ee/apps/den-web/tests/dashboard-mcp-app-catalog.test.ts
+++ b/ee/apps/den-web/tests/dashboard-mcp-app-catalog.test.ts
@@ -4,6 +4,10 @@ import {
   flattenConnectionMcpAppCatalog,
   type ConnectionMcpApp,
 } from "../app/(den)/dashboard/_components/org-dashboards-data";
+import {
+  connectionCanListMcpApps,
+  mcpAppCatalogIsLoading,
+} from "../app/(den)/dashboard/_components/dashboard-mcp-app-catalog";
 
 const app: ConnectionMcpApp = {
   serverName: "reports",
@@ -34,5 +38,18 @@ describe("dashboard MCP App catalog", () => {
       ],
       [app],
     )).toEqual([{ id: "connection_reports", name: "Reports" }]);
+  });
+
+  test("discovers Apps only for connections ready for the current admin", () => {
+    expect(connectionCanListMcpApps({ connectedForMe: true })).toBe(true);
+    expect(connectionCanListMcpApps({ connectedForMe: false })).toBe(false);
+    expect(connectionCanListMcpApps({ connectedForMe: true, needsReconnect: true })).toBe(false);
+    expect(connectionCanListMcpApps({ connectedForMe: true, credentialHealth: "reconnect_required" })).toBe(false);
+    expect(connectionCanListMcpApps({ connectedForMe: true, setupRequired: true })).toBe(false);
+  });
+
+  test("shows discovered Apps while another MCP is still loading", () => {
+    expect(mcpAppCatalogIsLoading(0, true)).toBe(true);
+    expect(mcpAppCatalogIsLoading(1, true)).toBe(false);
   });
 });

--- a/evals/specs/dashboard-mcp-app-catalog-loading.test.ts
+++ b/evals/specs/dashboard-mcp-app-catalog-loading.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  connectionCanListMcpApps,
+  mcpAppCatalogIsLoading,
+} from "../../ee/apps/den-web/app/(den)/dashboard/_components/dashboard-mcp-app-catalog";
+
+test("dashboard MCP Apps render progressively without probing unavailable connections", ({ evidence }) => {
+  const availableAppsRenderWhileAnotherMcpLoads = !mcpAppCatalogIsLoading(1, true);
+  const unavailableConnectionsAreSkipped = [
+    connectionCanListMcpApps({ connectedForMe: false }),
+    connectionCanListMcpApps({ connectedForMe: true, needsReconnect: true }),
+    connectionCanListMcpApps({ connectedForMe: true, credentialHealth: "reconnect_required" }),
+    connectionCanListMcpApps({ connectedForMe: true, setupRequired: true }),
+  ].every((value) => value === false);
+
+  expect(availableAppsRenderWhileAnotherMcpLoads).toBe(true);
+  expect(unavailableConnectionsAreSkipped).toBe(true);
+  evidence.recordAssertionEvidence(
+    "Discovered MCP Apps render without waiting for unrelated MCP discovery",
+    "one App is available while another MCP request remains pending",
+    availableAppsRenderWhileAnotherMcpLoads,
+  );
+  evidence.recordAssertionEvidence(
+    "Unavailable MCP connections are not probed for Apps",
+    "disconnected, reconnect-required, unhealthy, and setup-required connections are excluded",
+    unavailableConnectionsAreSkipped,
+  );
+});


### PR DESCRIPTION
## Summary

- render discovered MCP Apps immediately instead of waiting for every connection request to settle
- skip disconnected, reconnect-required, unhealthy, and setup-required MCP connections before App discovery
- prevent unrelated MCP failures from replacing an already available App catalog with a global loading state

## Regression

#4093 queried every manageable MCP in parallel to filter the selector. Connections without a usable credential returned 409 responses, and one pending connection kept the dialog on Loading apps even after Slack Apps had already loaded.

## Validation

- dashboard MCP App catalog tests pass: 3 tests, 9 expectations
- Den Web typecheck passes
- exact-head PR spec passes with 2/2 published assertions at 1587bc404729c1957fdc89c719fd5bff54b61708
