### PR TITLE
Prevent modifying dashboard apps from auto-running

### DIFF
--- a/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
@@ -79,15 +79,7 @@ export function dashboardTileRunsAutomatically(
   launchApproved: boolean,
   organizationAutoLaunch: boolean,
 ): boolean {
-  return organizationAutoLaunch || (!requiresApproval && autoLaunchEnabled && !launchApproved);
-}
-
-/** Admin policy is an independent server-authored approval for this managed element. */
-export function dashboardTileLaunchIsApproved(
-  organizationAutoLaunch: boolean,
-  memberApproved: boolean,
-): boolean {
-  return organizationAutoLaunch || memberApproved;
+  return !requiresApproval && (organizationAutoLaunch || (autoLaunchEnabled && !launchApproved));
 }
 
 export function shouldAutoRefreshDashboardTile(input: {

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -14,7 +14,6 @@ import { useWorkspace, WorkspaceProvider } from "@/react-app/shell/workspace-pro
 import { DashboardTileShell } from "./dashboard-tile-shell";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
-  dashboardTileLaunchIsApproved,
   dashboardTileRunsAutomatically,
   readDashboardTileCache,
   shouldAutoRefreshDashboardTile,
@@ -109,11 +108,12 @@ export function McpAppTile({
   // Provider annotations are not an authorization boundary. A safe-looking
   // tile runs on load only after this user has successfully run this exact
   // element once; approval-gated tools stay run-on-request forever.
+  const organizationAutoRun = entry.organizationAutoLaunch === true && entry.requiresApproval !== true;
   const runsAutomatically = dashboardTileRunsAutomatically(
     entry.requiresApproval === true,
     entry.autoLaunch === true,
     entry.launchApproved === true,
-    entry.organizationAutoLaunch === true,
+    organizationAutoRun,
   );
   const manualLaunch = !runsAutomatically;
   const launchEndpoints = useMemo(() => [
@@ -213,10 +213,9 @@ export function McpAppTile({
         name: app.toolName,
         resourceUri: app.resourceUri,
         arguments: launchArguments,
-        ...(dashboardTileLaunchIsApproved(
-          entry.organizationAutoLaunch === true,
-          launchApprovedRef.current,
-        ) ? { approved: true } : {}),
+        // Organization auto-run starts only read-only tools and never acts as
+        // an approval override if live provider metadata has changed.
+        ...(launchApprovedRef.current ? { approved: true } : {}),
       };
       let result;
       let approvalWasRequired = false;
@@ -349,14 +348,14 @@ export function McpAppTile({
     if (state.phase === "ready" && refreshState === "refreshing") return "Saved locally · refreshing";
     if (state.phase === "ready" && refreshState === "failed") return "Saved locally · refresh failed";
     if (state.phase === "ready" && refreshState === "approval-required") return "Saved locally · run required";
-    if (state.phase === "ready" && entry.organizationAutoLaunch === true) {
+    if (state.phase === "ready" && organizationAutoRun) {
       return `Organization auto-run · ${freshnessLabel(state.cachedAt)}`;
     }
     if (state.phase === "ready" && entry.requiresApproval === true) return "Saved locally · run on request";
     if (state.phase === "ready") return freshnessLabel(state.cachedAt);
     if (state.phase === "loading") return "Loading";
     if (state.phase === "error") return "Refresh failed";
-    if (entry.organizationAutoLaunch === true) return "Organization auto-run";
+    if (organizationAutoRun) return "Organization auto-run";
     if (entry.requiresApproval === true) return "Run on request";
     if (manualLaunch) return "Run once to enable";
     return null;

--- a/apps/app/tests/dashboard-tile-cache.test.ts
+++ b/apps/app/tests/dashboard-tile-cache.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
   dashboardTileCacheScopeKey,
-  dashboardTileLaunchIsApproved,
   dashboardTileRunsAutomatically,
   readDashboardTileCache,
   shouldAutoRefreshDashboardTile,
@@ -76,14 +75,9 @@ describe("dashboard tile cache", () => {
     expect(dashboardTileRunsAutomatically(false, true, false, false)).toBe(true);
     expect(dashboardTileRunsAutomatically(true, true, false, false)).toBe(false);
     expect(dashboardTileRunsAutomatically(false, true, true, false)).toBe(false);
-    expect(dashboardTileRunsAutomatically(true, false, false, true)).toBe(true);
-    expect(dashboardTileRunsAutomatically(true, false, true, true)).toBe(true);
-  });
-
-  test("treats organization auto-launch as approval for the exact managed call", () => {
-    expect(dashboardTileLaunchIsApproved(false, false)).toBe(false);
-    expect(dashboardTileLaunchIsApproved(false, true)).toBe(true);
-    expect(dashboardTileLaunchIsApproved(true, false)).toBe(true);
+    expect(dashboardTileRunsAutomatically(false, false, false, true)).toBe(true);
+    expect(dashboardTileRunsAutomatically(true, false, false, true)).toBe(false);
+    expect(dashboardTileRunsAutomatically(true, false, true, true)).toBe(false);
   });
 
   test("keeps last-known-good app data isolated by user and organization with its originating workspace", () => {

--- a/apps/app/tests/granted-dashboard-store.test.ts
+++ b/apps/app/tests/granted-dashboard-store.test.ts
@@ -76,7 +76,7 @@ describe("grantedEntryId", () => {
     ).autoLaunch).toBeUndefined();
   });
 
-  test("applies an organization auto-launch policy independently of local approval metadata", () => {
+  test("preserves server policy metadata so the runtime can enforce its safety boundary", () => {
     const dashboard: DenGrantedDashboard = {
       id: "dsb_1",
       name: "Operations",

--- a/ee/apps/den-api/src/routes/org/dashboards.ts
+++ b/ee/apps/den-api/src/routes/org/dashboards.ts
@@ -30,7 +30,7 @@ import { idParamSchema } from "./shared.js"
  * mechanism connector assignment uses (`dashboard_access_grant` mirrors
  * `connector_instance_access_grant`). Granted dashboards render on the desktop
  * MCP Apps dashboard as read-only tiles. Per-user launch consent stays on the
- * desktop; admins may explicitly authorize automatic launch on an element.
+ * desktop; admins may request automatic launch only for read-only elements.
  */
 
 type DashboardId = typeof DashboardTable.$inferSelect.id
@@ -141,7 +141,9 @@ function toStoredElement(value: DashboardElementInput): DashboardElement {
     title: value.title,
     ...(value.launchArguments ? { launchArguments: value.launchArguments } : {}),
     ...(value.requiresApproval === true ? { requiresApproval: true } : {}),
-    ...(value.organizationAutoLaunch === true ? { organizationAutoLaunch: true } : {}),
+    ...(value.organizationAutoLaunch === true && value.requiresApproval !== true
+      ? { organizationAutoLaunch: true }
+      : {}),
   }
 }
 

--- a/ee/apps/den-api/test/dashboards.test.ts
+++ b/ee/apps/den-api/test/dashboards.test.ts
@@ -58,6 +58,12 @@ const writeElement = {
 }
 
 const organizationAutoLaunchElement = {
+  ...readOnlyElement,
+  title: "Automatic weekly report",
+  organizationAutoLaunch: true,
+}
+
+const unsafeAutoLaunchElement = {
   ...writeElement,
   organizationAutoLaunch: true,
 }
@@ -237,6 +243,14 @@ test("admins create, list, update, and soft-delete dashboards", async () => {
   expect(deleteResponse.status).toBe(204)
   const getResponse = await request(`/v1/dashboards/${created.id}`)
   expect(getResponse.status).toBe(404)
+})
+
+test("removes organization auto-launch from elements that modify data", async () => {
+  const created = await createDashboard("Safe launch policy", [unsafeAutoLaunchElement])
+  const response = await request(`/v1/dashboards/${created.id}`)
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { item: { elements: unknown[] } }
+  expect(payload.item.elements).toEqual([writeElement])
 })
 
 test("dashboard management requires an admin role", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
@@ -111,7 +111,7 @@ export function OrgDashboardDetailScreen({ dashboardId }: { dashboardId: string 
     <DashboardPageTemplate
       icon={LayoutDashboard}
       title={dashboard.name}
-      description="Members with access see this dashboard's apps on their desktop Dashboard. Apps use member consent unless an admin explicitly enables automatic launch."
+      description="Members with access see this dashboard's apps on their desktop Dashboard. Read-only apps can run automatically; apps that modify data always run on request."
       colors={["#E0F2FE", "#0C4A6E", "#0EA5E9", "#BAE6FD"]}
     >
       <Link href={getManagedDashboardsRoute(orgSlug)} className="mb-5 inline-flex items-center gap-1 text-[13px] text-gray-500 hover:text-gray-900">
@@ -154,25 +154,29 @@ export function OrgDashboardDetailScreen({ dashboardId }: { dashboardId: string 
                   <p className="truncate text-[13.5px] font-medium text-gray-900">{element.title}</p>
                   <p className="truncate text-[12px] text-gray-400">
                     {element.toolName}
-                    {element.organizationAutoLaunch
+                    {element.organizationAutoLaunch && !element.requiresApproval
                       ? " · runs automatically by organization policy"
                       : element.requiresApproval ? " · runs on request" : ""}
                   </p>
                 </div>
-                <div className="flex shrink-0 items-center gap-2 pr-2">
-                  <span className="text-[11.5px] text-gray-500">Auto-run</span>
-                  <DenSwitch
-                    size="sm"
-                    checked={element.organizationAutoLaunch === true}
-                    disabled={busy}
-                    onChange={(checked) => saveElements(elements.map((current, currentIndex) => (
-                      currentIndex === index
-                        ? { ...current, organizationAutoLaunch: checked || undefined }
-                        : current
-                    )))}
-                    aria-label={`Run ${element.title} automatically, even if it modifies data`}
-                  />
-                </div>
+                {element.requiresApproval ? (
+                  <span className="shrink-0 pr-2 text-[11.5px] text-gray-500">Run required</span>
+                ) : (
+                  <div className="flex shrink-0 items-center gap-2 pr-2">
+                    <span className="text-[11.5px] text-gray-500">Auto-run</span>
+                    <DenSwitch
+                      size="sm"
+                      checked={element.organizationAutoLaunch === true}
+                      disabled={busy}
+                      onChange={(checked) => saveElements(elements.map((current, currentIndex) => (
+                        currentIndex === index
+                          ? { ...current, organizationAutoLaunch: checked || undefined }
+                          : current
+                      )))}
+                      aria-label={`Run ${element.title} automatically`}
+                    />
+                  </div>
+                )}
                 <div className="flex shrink-0 items-center gap-1">
                   <button
                     type="button"
@@ -375,7 +379,7 @@ function ConnectionAppRow({
       title: app.title,
       ...(launchArguments && Object.keys(launchArguments).length > 0 ? { launchArguments } : {}),
       ...(app.requiresApproval ? { requiresApproval: true } : {}),
-      ...(organizationAutoLaunch ? { organizationAutoLaunch: true } : {}),
+      ...(organizationAutoLaunch && !app.requiresApproval ? { organizationAutoLaunch: true } : {}),
     });
   }
 
@@ -398,20 +402,28 @@ function ConnectionAppRow({
           <DenButton size="sm" variant="secondary" onClick={add}>Add</DenButton>
         )}
       </div>
-      {!added ? (
+      {!added && !app.requiresApproval ? (
         <div className="mt-3 flex items-start justify-between gap-4 rounded-xl bg-amber-50 px-3 py-2.5">
           <div>
             <p className="text-[12px] font-medium text-amber-950">Run automatically</p>
             <p className="mt-0.5 text-[11.5px] leading-4 text-amber-800">
-              Run on dashboard load and refresh, even if this app modifies data.
+              Run on dashboard load and refresh.
             </p>
           </div>
           <DenSwitch
             size="sm"
             checked={organizationAutoLaunch}
             onChange={setOrganizationAutoLaunch}
-            aria-label={`Run ${app.title} automatically, even if it modifies data`}
+            aria-label={`Run ${app.title} automatically`}
           />
+        </div>
+      ) : null}
+      {!added && app.requiresApproval ? (
+        <div className="mt-3 rounded-xl bg-gray-50 px-3 py-2.5">
+          <p className="text-[12px] font-medium text-gray-900">Run required</p>
+          <p className="mt-0.5 text-[11.5px] leading-4 text-gray-600">
+            This app can modify data, so it never runs automatically.
+          </p>
         </div>
       ) : null}
       {!added && app.requiresInput ? (

--- a/ee/packages/den-db/src/schema/dashboards.ts
+++ b/ee/packages/den-db/src/schema/dashboards.ts
@@ -10,8 +10,8 @@ import { TeamTable } from "./teams"
  * desktop dashboard entry reference (`DashboardMcpAppEntry` in
  * `apps/app/src/react-app/domains/dashboard/dashboard-store.ts`) so granted
  * elements render as ordinary tiles. Per-user consent stays local to each
- * desktop user; an organization admin may separately set an explicit launch
- * policy on the managed element.
+ * desktop user; an organization admin may separately set an automatic launch
+ * policy only on read-only managed elements.
  */
 export type DashboardElement = {
   serverName: string
@@ -25,7 +25,7 @@ export type DashboardElement = {
   launchArguments?: Record<string, unknown>
   /** True when the launch tool modifies data: tiles only run on request, never on mount. */
   requiresApproval?: boolean
-  /** Explicit admin policy: run this exact element automatically, even when it modifies data. */
+  /** Explicit admin policy for read-only elements. Ignored when requiresApproval is true. */
   organizationAutoLaunch?: boolean
 }
 

--- a/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
+++ b/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
@@ -10,7 +10,7 @@ const requirements: TestNeeds = {
 const missingRequirements = unmetNeeds(requirements, process.env);
 const title = missingRequirements.length > 0
   ? `organization-managed Desktop dashboard skipped — needs: ${missingRequirements.join(", ")}`
-  : "Desktop enables managed dashboard caching and automatic refresh after member opt-in";
+  : "Desktop keeps modifying managed Apps manual while safe Apps cache and refresh";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -92,7 +92,7 @@ test(title, async ({ evidence, place }) => {
       toolName: "create_ticket",
       projectedToolName: "openwork-app-host-connect-0123456789ab_create_ticket",
       resourceUri: "ui://fixture/ticket/view.html",
-      title: "Automatic ticket summary",
+      title: "Protected ticket action",
       requiresApproval: true,
       organizationAutoLaunch: true,
     },
@@ -173,23 +173,22 @@ test(title, async ({ evidence, place }) => {
   await waitFor(desktop, `(() => {
     const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${grantedDashboardId}"]`)});
     if (!(section instanceof HTMLElement)) return false;
-    const automaticTile = [...section.querySelectorAll("[data-dashboard-entry]")]
-      .find((tile) => tile.textContent?.includes("Automatic ticket summary"));
-    const cacheState = automaticTile instanceof HTMLElement
-      ? automaticTile.querySelector("[data-dashboard-cache-state]")?.getAttribute("data-dashboard-cache-state")
-      : null;
-    return automaticTile instanceof HTMLElement
-      && (cacheState === "refreshing" || automaticTile.innerText.includes("Refresh failed"))
-      && !automaticTile.querySelector('button[aria-label="Run Automatic ticket summary"]');
+    const protectedTile = [...section.querySelectorAll("[data-dashboard-entry]")]
+      .find((tile) => tile.textContent?.includes("Protected ticket action"));
+    return protectedTile instanceof HTMLElement
+      && protectedTile.innerText.includes("Run on request")
+      && Boolean(protectedTile.querySelector('button[aria-label="Run Protected ticket action"]'))
+      && !protectedTile.innerText.includes("Loading")
+      && !protectedTile.innerText.includes("Refresh failed");
   })()`, {
     timeoutMs: 90_000,
-    label: "organization-authorized modifying app attempted automatic load",
+    label: "modifying app stayed run-on-request despite an unsafe auto-run assignment",
   });
-  const organizationPolicyState = await evalIn(desktop, `(() => {
+  const writeSafetyState = await evalIn(desktop, `(() => {
     const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${grantedDashboardId}"]`)});
     const tile = section instanceof HTMLElement
       ? [...section.querySelectorAll("[data-dashboard-entry]")]
-        .find((entry) => entry.textContent?.includes("Automatic ticket summary"))
+        .find((entry) => entry.textContent?.includes("Protected ticket action"))
       : null;
     const cacheState = tile instanceof HTMLElement
       ? tile.querySelector("[data-dashboard-cache-state]")?.getAttribute("data-dashboard-cache-state")
@@ -198,21 +197,27 @@ test(title, async ({ evidence, place }) => {
       automaticAttemptVisible: tile instanceof HTMLElement
         && (cacheState === "refreshing" || tile.innerText.includes("Refresh failed")),
       cacheState,
-      runVisible: Boolean(tile?.querySelector('button[aria-label="Run Automatic ticket summary"]')),
+      runVisible: Boolean(tile?.querySelector('button[aria-label="Run Protected ticket action"]')),
+      runOnRequestVisible: tile instanceof HTMLElement && tile.innerText.includes("Run on request"),
     };
   })()`);
-  expect(organizationPolicyState).toMatchObject({ automaticAttemptVisible: true, runVisible: false });
+  expect(writeSafetyState).toMatchObject({
+    automaticAttemptVisible: false,
+    runVisible: true,
+    runOnRequestVisible: true,
+  });
   evidence.recordAssertionEvidence(
     "Desktop places Dashboard directly below Search in the left sidebar",
     `state=${JSON.stringify(initialState)}`,
     isRecord(initialState) && initialState.dashboardImmediatelyAfterSearch === true,
   );
   evidence.recordAssertionEvidence(
-    "Organization admins can authorize automatic launch even for an app that modifies data",
-    `tile=Automatic ticket summary; state=${JSON.stringify(organizationPolicyState)}`,
-    isRecord(organizationPolicyState)
-      && organizationPolicyState.automaticAttemptVisible === true
-      && organizationPolicyState.runVisible === false,
+    "Apps that modify data stay run-on-request even when an assignment requests auto-run",
+    `tile=Protected ticket action; state=${JSON.stringify(writeSafetyState)}`,
+    isRecord(writeSafetyState)
+      && writeSafetyState.automaticAttemptVisible === false
+      && writeSafetyState.runVisible === true
+      && writeSafetyState.runOnRequestVisible === true,
   );
   evidence.recordAssertionEvidence(
     "Desktop renders only dashboards granted to the signed-in member",


### PR DESCRIPTION
## Summary

- keep organization auto-run available only for read-only MCP Apps
- strip unsafe auto-run policy from modifying dashboard elements at the API boundary
- never use organization auto-run as a tool approval override
- show modifying Apps as run-required in the admin and Desktop interfaces
- retain defensive Desktop handling for legacy assignments

## Verification

- `bun test apps/app/tests/dashboard-tile-cache.test.ts apps/app/tests/granted-dashboard-store.test.ts`
- `bun test ee/apps/den-api/test/dashboards.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `node evals/bin/evals.mjs org-managed-dashboard-desktop --local` — passed at `9799671539e9c5e31dc7a5e06231b2ffd0ab9bb3`