### PR TITLE
Fix Settings runtime coherence after rapid workspace switching

### DIFF
--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -36,6 +36,15 @@ export type LatestWorkspaceCommitter = {
   settled(): Promise<void>;
 };
 
+export type RouteWorkspaceSelectionCommit = (workspaceId: string) => Promise<void>;
+
+export type RouteWorkspaceSelectionCommitter = {
+  /** Queue the newest route selection, including the route's live commit implementation. */
+  request(workspaceId: string, commit: RouteWorkspaceSelectionCommit): void;
+  /** Resolve after the current commit and any newer queued route selection finish. */
+  settled(): Promise<void>;
+};
+
 /**
  * Serialize workspace-selection side effects while retaining only the newest
  * request. Desktop persistence and server activation cannot safely race: an
@@ -44,17 +53,42 @@ export type LatestWorkspaceCommitter = {
 export function createLatestWorkspaceCommitter(
   commit: (workspaceId: string) => Promise<void>,
 ): LatestWorkspaceCommitter {
-  let pendingWorkspaceId: string | null = null;
+  const committer = createRouteWorkspaceSelectionCommitter();
+
+  return {
+    request(workspaceId) {
+      committer.request(workspaceId, commit);
+    },
+    settled: () => committer.settled(),
+  };
+}
+
+/**
+ * Serialize workspace selection across route lifetimes. A component-local
+ * queue disappears when navigation unmounts the session route, which lets a
+ * pending session selection race the Settings route's first runtime reads.
+ * Each request carries its route's live commit callback so the shared queue
+ * can outlive either component while retaining only the newest destination.
+ */
+export function createRouteWorkspaceSelectionCommitter(): RouteWorkspaceSelectionCommitter {
+  let pending: { workspaceId: string; commit: RouteWorkspaceSelectionCommit } | null = null;
   let running: Promise<void> | null = null;
 
   const drain = async () => {
-    while (pendingWorkspaceId !== null) {
-      const workspaceId = pendingWorkspaceId;
-      pendingWorkspaceId = null;
-      await commit(workspaceId).catch(() => undefined);
-      // A duplicate request received while this commit was running is already
-      // satisfied. A different id remains queued and runs next.
-      if (pendingWorkspaceId === workspaceId) pendingWorkspaceId = null;
+    while (pending !== null) {
+      const request = pending;
+      pending = null;
+      let succeeded = true;
+      try {
+        await request.commit(request.workspaceId);
+      } catch {
+        succeeded = false;
+      }
+      // A newer request for the same workspace is satisfied only when this
+      // commit succeeded. After a failure, retain the newer route's callback
+      // because it may hold a freshly resolved connection.
+      const newerRequest = pending as { workspaceId: string; commit: RouteWorkspaceSelectionCommit } | null;
+      if (succeeded && newerRequest?.workspaceId === request.workspaceId) pending = null;
     }
   };
 
@@ -62,21 +96,46 @@ export function createLatestWorkspaceCommitter(
     if (running) return;
     running = drain().finally(() => {
       running = null;
-      if (pendingWorkspaceId !== null) start();
+      if (pending !== null) start();
     });
   };
 
   return {
-    request(workspaceId) {
+    request(workspaceId, commit) {
       const id = workspaceId.trim();
       if (!id) return;
-      pendingWorkspaceId = id;
+      pending = { workspaceId: id, commit };
       start();
     },
     async settled() {
       while (running) await running;
     },
   };
+}
+
+/** One last-selection-wins queue shared by session, Settings, and extensions routes. */
+export const routeWorkspaceSelectionCommitter = createRouteWorkspaceSelectionCommitter();
+
+/**
+ * Apply the three workspace-selection side effects in a stable order. The
+ * desktop store implements selected and runtime-active as separate read/write
+ * mutations, so issuing them concurrently can make the last writer restore
+ * stale fields from its earlier read.
+ */
+export async function commitRouteWorkspaceSelection(input: {
+  workspaceId: string;
+  desktopRuntime: boolean;
+  setDesktopSelected: (workspaceId: string) => Promise<unknown>;
+  setDesktopRuntimeActive: (workspaceId: string) => Promise<unknown>;
+  activateWorkspace: (workspaceId: string) => Promise<unknown>;
+}): Promise<void> {
+  const workspaceId = input.workspaceId.trim();
+  if (!workspaceId) return;
+  if (input.desktopRuntime) {
+    await input.setDesktopSelected(workspaceId).catch(() => undefined);
+    await input.setDesktopRuntimeActive(workspaceId).catch(() => undefined);
+  }
+  await input.activateWorkspace(workspaceId);
 }
 
 /**

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -102,10 +102,46 @@ export function classifyRouteSessionReadError(error: unknown): "not-found" | "re
     ? error.code
     : "";
   if (code === "session_not_found") return "not-found";
-  if (status === 502 || status === 503 || status === 504 || isTransientStartupError(describeRouteError(error))) {
+  if (
+    code === "opencode_unconfigured" ||
+    code === "opencode_engine_unreachable" ||
+    status === 502 ||
+    status === 503 ||
+    status === 504 ||
+    isTransientStartupError(describeRouteError(error))
+  ) {
     return "retryable";
   }
   return "error";
+}
+
+/**
+ * Runtime-backed session reads can briefly land between the desktop server
+ * accepting requests and the selected workspace engine becoming ready. Keep
+ * that startup gap inside a bounded retry instead of turning it into a route
+ * error. Terminal authorization and workspace errors still fail immediately.
+ */
+export async function readRouteSessionsWithRetry<T>(input: {
+  load: () => Promise<T>;
+  retryDelaysMs?: readonly number[];
+  wait?: (delayMs: number) => Promise<void>;
+}): Promise<T> {
+  const retryDelaysMs = input.retryDelaysMs ?? [];
+  const wait = input.wait ?? ((delayMs: number) => new Promise<void>((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  }));
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await input.load();
+    } catch (error) {
+      const retryDelayMs = retryDelaysMs[attempt];
+      if (retryDelayMs === undefined || classifyRouteSessionReadError(error) !== "retryable") {
+        throw error;
+      }
+      await wait(retryDelayMs);
+    }
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -52,10 +52,16 @@ import {
   mapDesktopWorkspace,
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
+  readRouteSessionsWithRetry,
   toSessionGroups,
   workspaceExportFilename,
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
+import {
+  commitRouteWorkspaceSelection,
+  createRouteRefreshLifecycle,
+  routeWorkspaceSelectionCommitter,
+} from "@/react-app/shell/route-refresh-control";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
 import { cleanupOpenworkCloudMcpAfterSignOut } from "@/react-app/domains/connections/cloud-mcp-reconciler";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
@@ -424,6 +430,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const location = useLocation();
   const params = useParams<{ workspaceId?: string }>();
   const routeWorkspaceId = props.workspaceId?.trim() || params.workspaceId?.trim() || "";
+  const routeWorkspaceIdRef = useRef(routeWorkspaceId);
+  routeWorkspaceIdRef.current = routeWorkspaceId;
   const local = useLocal();
   const {
     continuousEngineEnabled,
@@ -482,7 +490,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [busyLabel, setBusyLabel] = useState<string | null>(null);
   const [continuousEngineBusy, setContinuousEngineBusy] = useState(false);
   const workspacesRef = useRef<RouteWorkspace[]>([]);
-  const refreshInFlightRef = useRef(false);
+  const lastRequestedRouteWorkspaceIdRef = useRef("");
+  const refreshLifecycleRef = useRef(createRouteRefreshLifecycle());
+  const serverActiveWorkspaceIdRef = useRef("");
   const reconnectAttemptedWorkspaceIdRef = useRef("");
   const refreshMcpServersRef = useRef<(() => void | Promise<void>) | null>(null);
   const notifyMcpReloadingRef = useRef<(() => void) | null>(null);
@@ -530,7 +540,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [voiceStatus, setVoiceStatus] = useState<string | null>(null);
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const [userEnvKeys, setUserEnvKeys] = useState<string[]>([]);
-  const [cloudMcpHealth, setCloudMcpHealth] = useState<OpenworkCloudMcpHealth | null>(null);
+  const [cloudMcpHealthResult, setCloudMcpHealthResult] = useState<{
+    workspaceId: string;
+    health: OpenworkCloudMcpHealth;
+  } | null>(null);
   const emptyWorkspaceDisplay = useMemo<WorkspaceDisplay>(
     () => ({
       id: "",
@@ -599,6 +612,23 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () => createWorkspaceServerClientResolver({ baseUrl, token }),
     [baseUrl, token],
   );
+  const workspaceSelectionCommitRef = useRef<(workspaceId: string) => Promise<void>>(async () => undefined);
+  workspaceSelectionCommitRef.current = async (workspaceId) => {
+    await commitRouteWorkspaceSelection({
+      workspaceId,
+      desktopRuntime: isDesktopRuntime(),
+      setDesktopSelected: workspaceSetSelected,
+      setDesktopRuntimeActive: workspaceSetRuntimeActive,
+      activateWorkspace: async (selectedId) => {
+        const workspace = workspacesRef.current.find((item) => item.id === selectedId) ?? null;
+        const endpoint = workspaceServerClientResolver(workspace);
+        if (!endpoint) throw new Error(`Workspace endpoint unavailable for ${selectedId}.`);
+        if (workspace?.workspaceType === "local" && serverActiveWorkspaceIdRef.current === selectedId) return;
+        await endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true });
+        if (workspace?.workspaceType === "local") serverActiveWorkspaceIdRef.current = selectedId;
+      },
+    });
+  };
   const selectedWorkspaceEndpoint = useWorkspaceServerClient(selectedWorkspace, { baseUrl, token });
   const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
 
@@ -806,7 +836,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       opencodeClient: routeStateRef.current.activeClient,
       directory: routeStateRef.current.selectedWorkspaceRoot,
     });
-    setCloudMcpHealth(null);
+    setCloudMcpHealthResult(null);
     await refreshMcpServersRef.current?.();
   }, []);
   const denSession = useDenSession({
@@ -1000,6 +1030,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
   routeStateRef.current.selectedWorkspaceOpenworkClient = selectedWorkspaceEndpoint?.client ?? openworkClient;
+  const cloudMcpHealth = cloudMcpHealthResult?.workspaceId === runtimeWorkspaceId
+    ? cloudMcpHealthResult.health
+    : null;
+  const handleCloudMcpHealthChange = useCallback((health: OpenworkCloudMcpHealth | null) => {
+    const workspaceId = runtimeWorkspaceId?.trim() ?? "";
+    if ((routeStateRef.current.runtimeWorkspaceId?.trim() ?? "") !== workspaceId) return;
+    setCloudMcpHealthResult(health && workspaceId ? { workspaceId, health } : null);
+  }, [runtimeWorkspaceId]);
 
   const opencodeClient = useMemo(() => {
     if (!selectedWorkspaceEndpoint || !selectedWorkspaceEndpoint.token) return null;
@@ -1067,13 +1105,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     const client = selectedWorkspaceEndpoint?.client ?? openworkClient;
     const workspaceId = runtimeWorkspaceId?.trim() ?? "";
     if (!client || !workspaceId) {
-      setCloudMcpHealth(null);
+      setCloudMcpHealthResult(null);
       return null;
     }
     // probe: the Advanced page refresh should verify the Cloud endpoint
     // directly (outside the engine), not just report the engine's cached state.
     const health = await client.getOpenworkCloudMcpHealth(workspaceId, currentCloudMcpModel ?? undefined, { probe: true });
-    setCloudMcpHealth(health);
+    if (routeStateRef.current.runtimeWorkspaceId?.trim() !== workspaceId) return null;
+    setCloudMcpHealthResult({ workspaceId, health });
     return health;
   }, [currentCloudMcpModel, openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
   const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut(!props.embedded);
@@ -1327,9 +1366,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     phase: bootPhase,
     routeReady: bootRouteReady,
   } = useBootState();
-  const refreshRouteState = useMemo(() => async () => {
-    if (refreshInFlightRef.current) return;
-    refreshInFlightRef.current = true;
+  const refreshRouteState = useMemo(() => async (options?: { supersede?: boolean }) => {
+    const attempt = refreshLifecycleRef.current.begin(options);
+    if (!attempt) return;
     setLoading(true);
     let desktopList: WorkspaceList | null = null;
     let desktopWorkspaces = workspacesRef.current;
@@ -1349,7 +1388,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           desktopWorkspaces = workspacesRef.current;
         }
       }
+      if (!attempt.isCurrent()) return;
+
       const { normalizedBaseUrl, resolvedToken, resolvedHostToken } = await resolveOpenworkConnection();
+      if (!attempt.isCurrent()) return;
 
       if (!normalizedBaseUrl || !resolvedToken) {
         setOpenworkClient(null);
@@ -1372,12 +1414,42 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         hostToken: resolvedHostToken || undefined,
       });
       const list = await client.listWorkspaces();
+      if (!attempt.isCurrent()) return;
+      serverActiveWorkspaceIdRef.current = list.activeId ?? "";
       const serverWorkspaceIds = new Set(list.items.map((workspace) => workspace.id));
       const nextWorkspaces = mergeRouteWorkspaces(list.items, desktopWorkspaces);
       const routeWorkspaceServerClientResolver = createWorkspaceServerClientResolver({
         baseUrl: normalizedBaseUrl,
         token: resolvedToken,
       });
+      const routedWorkspaceId = routeWorkspaceIdRef.current;
+      if (routedWorkspaceId && nextWorkspaces.some((workspace) => workspace.id === routedWorkspaceId)) {
+        // Opening Settings unmounts the session route. Join its shared
+        // selection queue and commit the routed workspace before Settings
+        // performs any runtime-backed reads, so an older session switch
+        // cannot retake the desktop/runtime/server state underneath them.
+        setLegacySelectedWorkspaceId(routedWorkspaceId);
+        writeActiveWorkspaceId(routedWorkspaceId);
+        lastRequestedRouteWorkspaceIdRef.current = routedWorkspaceId;
+        routeWorkspaceSelectionCommitter.request(routedWorkspaceId, async (workspaceId) => {
+          await commitRouteWorkspaceSelection({
+            workspaceId,
+            desktopRuntime: isDesktopRuntime(),
+            setDesktopSelected: workspaceSetSelected,
+            setDesktopRuntimeActive: workspaceSetRuntimeActive,
+            activateWorkspace: async (selectedId) => {
+              const workspace = nextWorkspaces.find((item) => item.id === selectedId) ?? null;
+              const endpoint = routeWorkspaceServerClientResolver(workspace);
+              if (!endpoint) throw new Error(`Workspace endpoint unavailable for ${selectedId}.`);
+              if (workspace?.workspaceType === "local" && serverActiveWorkspaceIdRef.current === selectedId) return;
+              await endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true });
+              if (workspace?.workspaceType === "local") serverActiveWorkspaceIdRef.current = selectedId;
+            },
+          });
+        });
+        await routeWorkspaceSelectionCommitter.settled();
+        if (!attempt.isCurrent()) return;
+      }
       const sessionEntries = await Promise.all(
         nextWorkspaces.map(async (workspace) => {
           const endpoint = routeWorkspaceServerClientResolver(workspace);
@@ -1388,7 +1460,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             return { workspaceId: workspace.id, sessions: [], error: null as string | null };
           }
           try {
-            const response = await endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 });
+            const response = await readRouteSessionsWithRetry({
+              load: () => endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 }),
+              retryDelaysMs: [250, 750, 1_500],
+            });
             const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
             const items = workspaceRoot && !endpoint.isRemote
               ? (response.items ?? []).filter((session) =>
@@ -1421,6 +1496,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           }
         }),
       );
+      if (!attempt.isCurrent()) return;
 
       setOpenworkClient(client);
       setBaseUrl(normalizedBaseUrl);
@@ -1441,12 +1517,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       });
       setLegacySelectedWorkspaceId((current) => {
         const sessionWorkspaceId = findSessionWorkspaceId(navigationSessionId, sessionEntries);
-        const preferred = routeWorkspaceId || sessionWorkspaceId || navigationWorkspaceId || current || readActiveWorkspaceId() || "";
+        const preferred = routeWorkspaceIdRef.current || sessionWorkspaceId || navigationWorkspaceId || current || readActiveWorkspaceId() || "";
         const next = reconcileSelectedWorkspaceId(preferred, list, desktopList, nextWorkspaces);
         writeActiveWorkspaceId(next || null);
         return next;
       });
     } catch (error) {
+      if (!attempt.isCurrent()) return;
       const message = describeRouteError(error);
       console.error("[settings-route] refreshRouteState failed", error);
       recordInspectorEvent("route.refresh.error", {
@@ -1470,12 +1547,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         });
       }
     } finally {
-      setLoading(false);
-      refreshInFlightRef.current = false;
-      // Settings can be the first route a user lands on (direct link, deep
-      // link, or after reload). Let the boot overlay dismiss once we've
-      // completed our first data load.
-      markBootRouteReady();
+      attempt.finish();
+      if (attempt.isCurrent()) {
+        setLoading(false);
+        // Settings can be the first route a user lands on (direct link, deep
+        // link, or after reload). Let the boot overlay dismiss once we've
+        // completed our first data load.
+        markBootRouteReady();
+      }
     }
   }, [markBootRouteReady, navigationSessionId, navigationWorkspaceId, routeWorkspaceId]);
 
@@ -1558,6 +1637,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   useEffect(() => {
     workspacesRef.current = workspaces;
   }, [workspaces]);
+
+  useEffect(() => {
+    if (!routeWorkspaceId || lastRequestedRouteWorkspaceIdRef.current === routeWorkspaceId) return;
+    if (!workspaces.some((workspace) => workspace.id === routeWorkspaceId)) return;
+    setLegacySelectedWorkspaceId(routeWorkspaceId);
+    writeActiveWorkspaceId(routeWorkspaceId);
+    lastRequestedRouteWorkspaceIdRef.current = routeWorkspaceId;
+    routeWorkspaceSelectionCommitter.request(
+      routeWorkspaceId,
+      (workspaceId) => workspaceSelectionCommitRef.current(workspaceId),
+    );
+  }, [routeWorkspaceId, workspaces]);
 
   useEffect(() => {
     const activeWorkspaceIds = new Set(workspaces.map((workspace) => workspace.id));
@@ -1694,9 +1785,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [bootPhase, bootRouteReady, loading, openworkClient, selectedWorkspace, workspaces]);
 
   useEffect(() => {
-    void refreshRouteState();
+    // A workspace-route change must invalidate the previous refresh even if
+    // it is still waiting on that workspace's runtime. The superseded attempt
+    // can finish its network calls, but it can no longer write Settings state.
+    void refreshRouteState({ supersede: true });
     const handleSettingsChange = () => {
-      void refreshRouteState();
+      void refreshRouteState({ supersede: true });
     };
     window.addEventListener("openwork-server-settings-changed", handleSettingsChange);
     return () => {
@@ -2101,22 +2195,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     if (workspaceId === selectedWorkspaceId) return;
     setLegacySelectedWorkspaceId(workspaceId);
     writeActiveWorkspaceId(workspaceId);
-    const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
-    const endpoint = workspaceServerClientResolver(workspace);
-    if (endpoint) {
-      void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
-    }
-    if (isDesktopRuntime()) {
-      void workspaceSetSelected(workspaceId).catch(() => undefined);
-      void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
-    }
+    lastRequestedRouteWorkspaceIdRef.current = workspaceId;
+    routeWorkspaceSelectionCommitter.request(
+      workspaceId,
+      (selectedId) => workspaceSelectionCommitRef.current(selectedId),
+    );
     navigate(
       props.standaloneExtensions
         ? workspaceExtensionsRoute(workspaceId, extensionsPathForRoute(route))
         : workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)),
       { state: location.state },
     );
-  }, [location, navigate, props.standaloneExtensions, route, selectedWorkspaceId, workspaceServerClientResolver, workspaces]);
+  }, [location, navigate, props.standaloneExtensions, route, selectedWorkspaceId]);
 
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -2471,6 +2561,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       case "advanced":
         return (
           <AdvancedView
+            key={runtimeWorkspaceId ?? selectedWorkspaceId}
             busy={busy}
             clientConnected={Boolean(opencodeClient)}
             opencodeConnectStatus={null}
@@ -2579,12 +2670,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       case "debug":
         return (
           <DebugView
+            key={runtimeWorkspaceId ?? selectedWorkspaceId}
             {...debugViewProps}
             agentAccess={{
               client: selectedWorkspaceEndpoint?.client ?? openworkClient,
               workspaceId: runtimeWorkspaceId,
               currentModel: currentCloudMcpModel,
-              onHealthChange: setCloudMcpHealth,
+              onHealthChange: handleCloudMcpHealthChange,
             }}
             agentContextDiagnostics={{
               scopeKey: diagnosticsScopeKey,

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -48,10 +48,11 @@ import {
 } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import {
-  createLatestWorkspaceCommitter,
+  commitRouteWorkspaceSelection,
   createRouteRefreshLifecycle,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
+  routeWorkspaceSelectionCommitter,
 } from "./route-refresh-control";
 import {
   classifyRouteSessionReadError,
@@ -421,23 +422,21 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   );
   const workspaceSelectionCommitRef = useRef<(workspaceId: string) => Promise<void>>(async () => undefined);
   workspaceSelectionCommitRef.current = async (workspaceId) => {
-    if (isDesktopRuntime()) {
-      await workspaceSetSelected(workspaceId).catch(() => undefined);
-      await workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
-    }
-    const workspace = workspacesRef.current.find((item) => item.id === workspaceId) ?? null;
-    const endpoint = endpointForWorkspace(workspace);
-    if (!endpoint) return;
-    if (workspace?.workspaceType === "local" && serverActiveWorkspaceIdRef.current === workspaceId) return;
-    await endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true });
-    if (workspace?.workspaceType === "local") serverActiveWorkspaceIdRef.current = workspaceId;
+    await commitRouteWorkspaceSelection({
+      workspaceId,
+      desktopRuntime: isDesktopRuntime(),
+      setDesktopSelected: workspaceSetSelected,
+      setDesktopRuntimeActive: workspaceSetRuntimeActive,
+      activateWorkspace: async (selectedId) => {
+        const workspace = workspacesRef.current.find((item) => item.id === selectedId) ?? null;
+        const endpoint = endpointForWorkspace(workspace);
+        if (!endpoint) throw new Error(`Workspace endpoint unavailable for ${selectedId}.`);
+        if (workspace?.workspaceType === "local" && serverActiveWorkspaceIdRef.current === selectedId) return;
+        await endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true });
+        if (workspace?.workspaceType === "local") serverActiveWorkspaceIdRef.current = selectedId;
+      },
+    });
   };
-  const workspaceSelectionCommitterRef = useRef<ReturnType<typeof createLatestWorkspaceCommitter> | null>(null);
-  if (!workspaceSelectionCommitterRef.current) {
-    workspaceSelectionCommitterRef.current = createLatestWorkspaceCommitter(
-      (workspaceId) => workspaceSelectionCommitRef.current(workspaceId),
-    );
-  }
 
   const refreshRouteState = useCallback(async (options?: { supersede?: boolean }) => {
     // Dedupe: if a refresh is already running, skip this call. Fast workspace
@@ -681,7 +680,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
 
     workspaceSelectionCommitTimerRef.current = window.setTimeout(() => {
       workspaceSelectionCommitTimerRef.current = null;
-      workspaceSelectionCommitterRef.current?.request(routeWorkspaceId);
+      routeWorkspaceSelectionCommitter.request(
+        routeWorkspaceId,
+        (workspaceId) => workspaceSelectionCommitRef.current(workspaceId),
+      );
     }, ROUTE_WORKSPACE_ACTIVATION_SETTLE_MS);
     // On navigation only the routed workspace needs a load: boot already
     // scheduled background loads for every other unloaded workspace.

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  commitRouteWorkspaceSelection,
   createLatestWorkspaceCommitter,
+  createRouteWorkspaceSelectionCommitter,
   createRouteRefreshLifecycle,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
@@ -47,6 +49,87 @@ describe("createLatestWorkspaceCommitter", () => {
     await committer.settled();
 
     expect(committed).toEqual(["ws_1"]);
+  });
+});
+
+describe("route workspace selection handoff", () => {
+  test("keeps the Settings destination behind an in-flight session commit", async () => {
+    const committed: string[] = [];
+    let releaseSessionCommit: () => void = () => undefined;
+    const sessionCommitBlocked = new Promise<void>((resolve) => {
+      releaseSessionCommit = resolve;
+    });
+    const committer = createRouteWorkspaceSelectionCommitter();
+
+    committer.request("ws_1", async (workspaceId) => {
+      committed.push(`session:${workspaceId}:start`);
+      await sessionCommitBlocked;
+      committed.push(`session:${workspaceId}:end`);
+    });
+    committer.request("ws_2", async (workspaceId) => {
+      committed.push(`session:${workspaceId}`);
+    });
+    committer.request("ws_2", async (workspaceId) => {
+      committed.push(`settings:${workspaceId}`);
+    });
+
+    expect(committed).toEqual(["session:ws_1:start"]);
+    releaseSessionCommit();
+    await committer.settled();
+
+    expect(committed).toEqual([
+      "session:ws_1:start",
+      "session:ws_1:end",
+      "settings:ws_2",
+    ]);
+  });
+
+  test("retries the same destination with the newer route callback after a failed commit", async () => {
+    const committed: string[] = [];
+    let releaseFailedCommit: () => void = () => undefined;
+    const failedCommitBlocked = new Promise<void>((resolve) => {
+      releaseFailedCommit = resolve;
+    });
+    const committer = createRouteWorkspaceSelectionCommitter();
+
+    committer.request("ws_2", async () => {
+      committed.push("session:ws_2");
+      await failedCommitBlocked;
+      throw new Error("stale connection");
+    });
+    committer.request("ws_2", async () => {
+      committed.push("settings:ws_2");
+    });
+
+    releaseFailedCommit();
+    await committer.settled();
+    expect(committed).toEqual(["session:ws_2", "settings:ws_2"]);
+  });
+});
+
+describe("commitRouteWorkspaceSelection", () => {
+  test("serializes desktop mutations before server activation", async () => {
+    const calls: string[] = [];
+    await commitRouteWorkspaceSelection({
+      workspaceId: " ws_2 ",
+      desktopRuntime: true,
+      setDesktopSelected: async (workspaceId) => { calls.push(`selected:${workspaceId}`); },
+      setDesktopRuntimeActive: async (workspaceId) => { calls.push(`runtime:${workspaceId}`); },
+      activateWorkspace: async (workspaceId) => { calls.push(`server:${workspaceId}`); },
+    });
+    expect(calls).toEqual(["selected:ws_2", "runtime:ws_2", "server:ws_2"]);
+  });
+
+  test("continues after a desktop persistence failure", async () => {
+    const calls: string[] = [];
+    await commitRouteWorkspaceSelection({
+      workspaceId: "ws_2",
+      desktopRuntime: true,
+      setDesktopSelected: async () => { throw new Error("write failed"); },
+      setDesktopRuntimeActive: async (workspaceId) => { calls.push(`runtime:${workspaceId}`); },
+      activateWorkspace: async (workspaceId) => { calls.push(`server:${workspaceId}`); },
+    });
+    expect(calls).toEqual(["runtime:ws_2", "server:ws_2"]);
   });
 });
 

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   classifyRouteSessionReadError,
   mergeRouteWorkspaces,
+  readRouteSessionsWithRetry,
   refreshRouteWorkspaceListState,
 } from "../src/react-app/shell/route-workspaces";
 import {
@@ -85,8 +86,45 @@ describe("workspace route session read errors", () => {
     expect(classifyRouteSessionReadError(Object.assign(new Error("missing"), { status: 404, code: "session_not_found" }))).toBe("not-found");
     expect(classifyRouteSessionReadError(Object.assign(new Error("workspace missing"), { status: 404, code: "workspace_not_found" }))).toBe("error");
     expect(classifyRouteSessionReadError(Object.assign(new Error("upstream"), { status: 502 }))).toBe("retryable");
+    expect(classifyRouteSessionReadError(Object.assign(new Error("engine starting"), { status: 400, code: "opencode_unconfigured" }))).toBe("retryable");
     expect(classifyRouteSessionReadError(new Error("request timed out"))).toBe("retryable");
     expect(classifyRouteSessionReadError(Object.assign(new Error("forbidden"), { status: 403 }))).toBe("error");
+  });
+
+  test("retries a bounded runtime startup gap and returns the recovered sessions", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+    const sessions = await readRouteSessionsWithRetry({
+      load: async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw Object.assign(new Error("engine starting"), {
+            status: 400,
+            code: "opencode_unconfigured",
+          });
+        }
+        return ["session-1"];
+      },
+      retryDelaysMs: [250, 750, 1_500],
+      wait: async (delayMs) => { waits.push(delayMs); },
+    });
+
+    expect(sessions).toEqual(["session-1"]);
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([250, 750]);
+  });
+
+  test("does not retry a terminal authorization failure", async () => {
+    let attempts = 0;
+    await expect(readRouteSessionsWithRetry({
+      load: async () => {
+        attempts += 1;
+        throw Object.assign(new Error("forbidden"), { status: 403 });
+      },
+      retryDelaysMs: [250, 750],
+      wait: async () => undefined,
+    })).rejects.toMatchObject({ status: 403 });
+    expect(attempts).toBe(1);
   });
 });
 

--- a/evals/specs/session-switch-settings-runtime.e2e.test.ts
+++ b/evals/specs/session-switch-settings-runtime.e2e.test.ts
@@ -1,0 +1,275 @@
+import { expect } from "vitest";
+import {
+  control,
+  createAndSelectWorkspace,
+  evalIn,
+  go,
+  waitFor,
+} from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import {
+  eventually,
+  needs,
+  sleep,
+  test,
+} from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "rapid workspace switching through session routes opens Settings on one coherent runtime"
+  : "session switching followed by Settings skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test.skipIf(!e2eTestsEnabled)(title, { timeout: 12 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using desktopApp = await desktop({
+    name: "session-switch-settings-runtime",
+    host: place.host(),
+  });
+  const stamp = Date.now();
+
+  const { workspaceId: firstWorkspaceId } = await createAndSelectWorkspace(desktopApp, {
+    path: `/tmp/openwork-session-settings-a-${stamp}`,
+  });
+
+  await control(desktopApp, "workspace.create", {
+    path: `/tmp/openwork-session-settings-b-${stamp}`,
+  }, { timeoutMs: 90_000 });
+  await waitFor(desktopApp, `(() => {
+    const active = localStorage.getItem("openwork.react.activeWorkspace") ?? "";
+    return active !== "" && active !== ${JSON.stringify(firstWorkspaceId)};
+  })()`, { timeoutMs: 120_000, label: "second workspace selected" });
+  const secondWorkspaceId = await evalIn(
+    desktopApp,
+    `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`,
+  );
+  if (typeof secondWorkspaceId !== "string" || !secondWorkspaceId) {
+    throw new Error(`workspace.create did not select a second workspace: ${JSON.stringify(secondWorkspaceId)}`);
+  }
+
+  await evalIn(desktopApp, `(() => {
+    window.__sessionSettingsRuntimeErrors = [];
+    window.addEventListener("error", (event) => {
+      window.__sessionSettingsRuntimeErrors.push(String(event.error?.message ?? event.message ?? "window error"));
+    });
+    window.addEventListener("unhandledrejection", (event) => {
+      window.__sessionSettingsRuntimeErrors.push(String(event.reason?.message ?? event.reason ?? "unhandled rejection"));
+    });
+    return true;
+  })()`);
+
+  const firstRoute = `/workspace/${encodeURIComponent(firstWorkspaceId)}/session`;
+  const secondRoute = `/workspace/${encodeURIComponent(secondWorkspaceId)}/session`;
+  const switches = 24;
+  for (let index = 0; index < switches; index += 1) {
+    await go(desktopApp, index % 2 === 0 ? firstRoute : secondRoute);
+  }
+
+  // Hold the first Settings workspace-list response so the route can change
+  // while that refresh is still in flight. The next request is allowed
+  // through: the final workspace must become coherent before the stale
+  // response is released.
+  await evalIn(desktopApp, `(() => {
+    const originalFetch = window.fetch.bind(window);
+    let releaseGate = () => {};
+    const gate = new Promise((resolve) => { releaseGate = resolve; });
+    const state = {
+      entered: false,
+      released: false,
+      firstCompleted: false,
+      release: () => {
+        if (state.released) return;
+        state.released = true;
+        window.fetch = originalFetch;
+        releaseGate();
+      },
+    };
+    window.__sessionSettingsRefreshGate = state;
+    window.fetch = async (input, init) => {
+      const rawUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      const method = String(init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+      let pathname = "";
+      try { pathname = new URL(rawUrl, window.location.href).pathname; } catch {}
+      if (!state.entered && method === "GET" && pathname === "/workspaces") {
+        state.entered = true;
+        await gate;
+        const response = await originalFetch(input, init);
+        state.firstCompleted = true;
+        return response;
+      }
+      return originalFetch(input, init);
+    };
+    return true;
+  })()`);
+
+  await go(desktopApp, `/workspace/${encodeURIComponent(firstWorkspaceId)}/settings/general`);
+  await waitFor(desktopApp, "window.__sessionSettingsRefreshGate?.entered === true", {
+    timeoutMs: 30_000,
+    label: "first Settings refresh held in flight",
+  });
+  await go(desktopApp, `/workspace/${encodeURIComponent(secondWorkspaceId)}/settings/general`);
+
+  await waitFor(desktopApp, `window.location.hash.includes(${JSON.stringify(`/workspace/${encodeURIComponent(secondWorkspaceId)}/settings/general`)})
+    && document.body.innerText.includes("Overview of all settings")`, {
+    timeoutMs: 90_000,
+    label: "routed Settings surface",
+  });
+
+  const finalRuntimeBeforeRelease = await eventually(
+    () => evalIn(desktopApp, `(async () => {
+      const workspaceId = ${JSON.stringify(secondWorkspaceId)};
+      const desktopState = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("workspaceBootstrap");
+      const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+      const response = await fetch(baseUrl + "/workspaces", {
+        headers: { authorization: "Bearer " + token },
+      });
+      const body = await response.json().catch(() => null);
+      return {
+        storedActiveId: localStorage.getItem("openwork.react.activeWorkspace") ?? "",
+        selectedId: String(desktopState?.selectedId ?? ""),
+        watchedId: String(desktopState?.watchedId ?? ""),
+        desktopActiveId: String(desktopState?.activeId ?? ""),
+        serverActiveId: String(body?.activeId ?? ""),
+      };
+    })()`, { awaitPromise: true, timeoutMs: 20_000 }),
+    {
+      within: 90_000,
+      intervalMs: 500,
+      label: "final Settings runtime coherent before stale response release",
+      until: (value) => isRecord(value)
+        && value.storedActiveId === secondWorkspaceId
+        && value.selectedId === secondWorkspaceId
+        && value.watchedId === secondWorkspaceId
+        && value.desktopActiveId === secondWorkspaceId
+        && value.serverActiveId === secondWorkspaceId,
+    },
+  );
+  evidence.recordAssertionEvidence(
+    "The final Settings route becomes coherent while the previous refresh is still blocked",
+    `Final runtime before releasing the stale response: ${JSON.stringify(finalRuntimeBeforeRelease)}.`,
+    true,
+  );
+
+  await evalIn(desktopApp, "window.__sessionSettingsRefreshGate?.release(); true");
+  await waitFor(desktopApp, "window.__sessionSettingsRefreshGate?.firstCompleted === true", {
+    timeoutMs: 30_000,
+    label: "stale Settings response completed",
+  });
+  await sleep(2_000);
+
+  const facts = await evalIn(desktopApp, `(async () => {
+    const workspaceId = ${JSON.stringify(secondWorkspaceId)};
+    const firstWorkspaceId = ${JSON.stringify(firstWorkspaceId)};
+    const desktopState = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("workspaceBootstrap");
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken ?? info?.clientToken ?? "");
+    const headers = { authorization: "Bearer " + token };
+    const readJson = async (path) => {
+      const response = await fetch(baseUrl + path, { headers });
+      return { status: response.status, body: await response.json().catch(() => null) };
+    };
+    const [workspaces, firstSessions, secondSessions, config] = await Promise.all([
+      readJson("/workspaces"),
+      readJson("/workspace/" + encodeURIComponent(firstWorkspaceId) + "/sessions?limit=200"),
+      readJson("/workspace/" + encodeURIComponent(workspaceId) + "/sessions?limit=200"),
+      readJson("/workspace/" + encodeURIComponent(workspaceId) + "/config"),
+    ]);
+    const workspaceItems = Array.isArray(workspaces?.body?.items) ? workspaces.body.items : [];
+    const selectedWorkspace = workspaceItems.find((item) => String(item?.id ?? "") === workspaceId);
+    return {
+      hash: window.location.hash,
+      storedActiveId: localStorage.getItem("openwork.react.activeWorkspace") ?? "",
+      selectedId: String(desktopState?.selectedId ?? ""),
+      watchedId: String(desktopState?.watchedId ?? ""),
+      desktopActiveId: String(desktopState?.activeId ?? ""),
+      serverActiveId: String(workspaces?.body?.activeId ?? ""),
+      statuses: {
+        workspaces: workspaces.status,
+        firstSessions: firstSessions.status,
+        secondSessions: secondSessions.status,
+        config: config.status,
+      },
+      selectedOpencodeBaseUrl: String(selectedWorkspace?.opencode?.baseUrl ?? selectedWorkspace?.baseUrl ?? ""),
+      responseCodes: [firstSessions, secondSessions, config]
+        .map((entry) => String(entry?.body?.code ?? ""))
+        .filter(Boolean),
+      staleRefreshReleased: window.__sessionSettingsRefreshGate?.firstCompleted === true,
+      runtimeErrors: Array.isArray(window.__sessionSettingsRuntimeErrors)
+        ? [...window.__sessionSettingsRuntimeErrors]
+        : [],
+      visibleError: [
+        "Failed to fetch",
+        "OpenCode base URL is missing",
+        "Workspace configuration failed",
+        "Runtime error",
+      ].find((message) => document.body.innerText.includes(message)) ?? null,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+
+  if (!isRecord(facts) || !isRecord(facts.statuses)) {
+    throw new Error(`Settings coherence probe returned malformed facts: ${JSON.stringify(facts)}`);
+  }
+  const expectedIds = {
+    storedActiveId: secondWorkspaceId,
+    selectedId: secondWorkspaceId,
+    watchedId: secondWorkspaceId,
+    desktopActiveId: secondWorkspaceId,
+    serverActiveId: secondWorkspaceId,
+  };
+  const actualIds = {
+    storedActiveId: facts.storedActiveId,
+    selectedId: facts.selectedId,
+    watchedId: facts.watchedId,
+    desktopActiveId: facts.desktopActiveId,
+    serverActiveId: facts.serverActiveId,
+  };
+  evidence.recordAssertionEvidence(
+    "Opening Settings after the switching burst keeps every active-workspace record on the final route",
+    `${switches} zero-dwell session switches ended on ${secondWorkspaceId}; active ids: ${JSON.stringify(actualIds)}.`,
+    JSON.stringify(actualIds) === JSON.stringify(expectedIds),
+  );
+  expect(actualIds).toEqual(expectedIds);
+
+  evidence.recordAssertionEvidence(
+    "Settings and both session indexes remain readable with a configured OpenCode runtime",
+    `Request statuses: ${JSON.stringify(facts.statuses)}; selected OpenCode base URL present=${String(Boolean(facts.selectedOpencodeBaseUrl))}; response codes=${JSON.stringify(facts.responseCodes)}.`,
+    Object.values(facts.statuses).every((status) => status === 200)
+      && facts.selectedOpencodeBaseUrl !== ""
+      && Array.isArray(facts.responseCodes)
+      && !facts.responseCodes.includes("opencode_unconfigured"),
+  );
+  expect(facts.statuses).toEqual({
+    workspaces: 200,
+    firstSessions: 200,
+    secondSessions: 200,
+    config: 200,
+  });
+  expect(facts.selectedOpencodeBaseUrl).not.toBe("");
+  expect(facts.responseCodes).not.toContain("opencode_unconfigured");
+  expect(facts.staleRefreshReleased).toBe(true);
+  expect(facts.runtimeErrors).toEqual([]);
+  expect(facts.visibleError).toBeNull();
+
+});
+
+declare global {
+  interface Window {
+    __sessionSettingsRuntimeErrors?: string[];
+    __sessionSettingsRefreshGate?: {
+      entered: boolean;
+      released: boolean;
+      firstCompleted: boolean;
+      release: () => void;
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- serialize workspace activation across session and Settings route lifetimes so the last routed workspace wins
- supersede stale Settings refreshes and scope runtime health results to the workspace that produced them
- retry bounded transient OpenCode startup gaps while preserving immediate terminal error handling
- add focused unit coverage and a deterministic desktop regression spec that releases an old Settings response after the final workspace has converged

## Why

Rapid session/workspace switching could leave Settings reading state from an older workspace while desktop and server activation were still settling. In that window, workspace-scoped OpenCode reads could fail with `opencode_unconfigured`, and an older refresh or diagnostic response could overwrite the final route's state.

## Verification

Passed on exact head `7541f14e8fdf67286330d3342616bf6e92d533cd`.

- `OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/session-switch-settings-runtime pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/session-switch-settings-runtime.e2e.test.ts` — 1 passed, 0 failed, 0 skipped
- `bun test apps/app/tests/route-refresh-control.test.ts apps/app/tests/workspace-routes.test.ts apps/server/src/opencode-connection.test.ts` — 33 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — exit 0

The desktop spec holds the first Settings refresh in flight, switches to the final workspace, verifies storage/desktop/runtime/server convergence before releasing the stale response, and then confirms both session indexes and runtime config remain readable with a configured OpenCode base URL and no `opencode_unconfigured` response.
