### PR TITLE
fix(app): stop timer-driven desktop render churn

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -522,10 +522,137 @@ select:disabled {
   background-color: rgb(var(--dls-secondary-rgb) / 0.22);
 }
 
+/* The running-work mark used to advance these frames with a React interval,
+   causing every mounted loader to commit about five times per second. Opacity
+   animation keeps the same four frames on the compositor instead. */
+.ow-dot-matrix-dot {
+  animation-duration: 720ms;
+  animation-iteration-count: infinite;
+  animation-timing-function: step-end;
+}
+
+.ow-dot-matrix-on {
+  opacity: 0.9;
+}
+
+.ow-dot-matrix-off {
+  opacity: 0.25;
+}
+
+@keyframes ow-dot-matrix-a {
+  0%,
+  75%,
+  100% {
+    opacity: 0.9;
+  }
+  25%,
+  50% {
+    opacity: 0.25;
+  }
+}
+
+@keyframes ow-dot-matrix-b {
+  0%,
+  50% {
+    opacity: 0.25;
+  }
+  25%,
+  75%,
+  100% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes ow-dot-matrix-c {
+  0%,
+  25%,
+  75%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes ow-dot-matrix-d {
+  0%,
+  25%,
+  100% {
+    opacity: 0.9;
+  }
+  50%,
+  75% {
+    opacity: 0.25;
+  }
+}
+
+@keyframes ow-dot-matrix-e {
+  0%,
+  50%,
+  75%,
+  100% {
+    opacity: 0.9;
+  }
+  25% {
+    opacity: 0.25;
+  }
+}
+
+@keyframes ow-dot-matrix-f {
+  0%,
+  75%,
+  100% {
+    opacity: 0.25;
+  }
+  25%,
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes ow-dot-matrix-g {
+  0%,
+  25%,
+  75%,
+  100% {
+    opacity: 0.9;
+  }
+  50% {
+    opacity: 0.25;
+  }
+}
+
+.ow-dot-matrix-frame-a {
+  animation-name: ow-dot-matrix-a;
+}
+.ow-dot-matrix-frame-b {
+  animation-name: ow-dot-matrix-b;
+}
+.ow-dot-matrix-frame-c {
+  animation-name: ow-dot-matrix-c;
+}
+.ow-dot-matrix-frame-d {
+  animation-name: ow-dot-matrix-d;
+}
+.ow-dot-matrix-frame-e {
+  animation-name: ow-dot-matrix-e;
+}
+.ow-dot-matrix-frame-f {
+  animation-name: ow-dot-matrix-f;
+}
+.ow-dot-matrix-frame-g {
+  animation-name: ow-dot-matrix-g;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ow-dot-ticker {
     animation: none;
     background-color: rgb(var(--dls-accent-rgb) / 0.6);
+  }
+
+  .ow-dot-matrix-dot {
+    animation: none;
   }
 }
 

--- a/apps/app/src/components/ui/dot-matrix-loader.tsx
+++ b/apps/app/src/components/ui/dot-matrix-loader.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
@@ -11,40 +9,24 @@ type DotMatrixLoaderProps = React.ComponentPropsWithoutRef<"span"> & {
 
 /**
  * Paper rendering rules: 3×3 dot-matrix is the only "living mark" for
- * running work (sidebar rows, transcript tool lines). Frames shuffle;
- * under prefers-reduced-motion a single static frame is shown. Dots use
- * currentColor at two opacities so the lit/dim contrast holds in both
- * light and dark themes.
+ * running work (sidebar rows, transcript tool lines). CSS shuffles the frames
+ * without publishing React state on every animation step. Under
+ * prefers-reduced-motion the first frame remains static.
  */
-const FRAMES: ReadonlyArray<ReadonlyArray<number>> = [
-  [1, 0, 0, 1, 1, 0, 1, 0, 1],
-  [0, 1, 0, 1, 0, 1, 0, 1, 1],
-  [0, 0, 1, 0, 1, 1, 1, 1, 0],
-  [1, 1, 0, 0, 1, 0, 1, 0, 1],
+const FIRST_FRAME: readonly number[] = [1, 0, 0, 1, 1, 0, 1, 0, 1]
+const DOT_ANIMATION_CLASSES = [
+  "ow-dot-matrix-frame-a",
+  "ow-dot-matrix-frame-b",
+  "ow-dot-matrix-frame-c",
+  "ow-dot-matrix-frame-d",
+  "ow-dot-matrix-frame-e",
+  "ow-dot-matrix-frame-f",
+  "ow-dot-matrix-frame-e",
+  "ow-dot-matrix-frame-f",
+  "ow-dot-matrix-frame-g",
 ]
 
 export function DotMatrixLoader({ className, label, ...rest }: DotMatrixLoaderProps) {
-  const [frame, setFrame] = React.useState(0)
-  const [reduceMotion, setReduceMotion] = React.useState(false)
-
-  React.useEffect(() => {
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
-    const sync = () => setReduceMotion(media.matches)
-    sync()
-    media.addEventListener("change", sync)
-    return () => media.removeEventListener("change", sync)
-  }, [])
-
-  React.useEffect(() => {
-    if (reduceMotion) return
-    const id = window.setInterval(() => {
-      setFrame((current) => (current + 1) % FRAMES.length)
-    }, 180)
-    return () => window.clearInterval(id)
-  }, [reduceMotion])
-
-  const pattern = FRAMES[frame] ?? FRAMES[0]
-
   return (
     <span
       {...rest}
@@ -53,11 +35,15 @@ export function DotMatrixLoader({ className, label, ...rest }: DotMatrixLoaderPr
       title={label}
       className={cn("inline-grid size-3.5 shrink-0 grid-cols-3 grid-rows-3 gap-px", className)}
     >
-      {pattern.map((lit, index) => (
+      {FIRST_FRAME.map((lit, index) => (
         <span
           key={index}
           aria-hidden="true"
-          className={cn("size-full rounded-full bg-current", lit ? "opacity-90" : "opacity-25")}
+          className={cn(
+            "ow-dot-matrix-dot size-full rounded-full bg-current",
+            lit ? "ow-dot-matrix-on" : "ow-dot-matrix-off",
+            DOT_ANIMATION_CLASSES[index],
+          )}
         />
       ))}
     </span>

--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -95,6 +95,36 @@ type MutableState = {
 const applyStateAction = <T,>(current: T, next: SetStateAction<T>) =>
   typeof next === "function" ? (next as (value: T) => T)(current) : next;
 
+function sameOpenworkServerSnapshot(
+  current: OpenworkServerStoreSnapshot,
+  next: OpenworkServerStoreSnapshot,
+): boolean {
+  return (
+    current.openworkServerSettings === next.openworkServerSettings &&
+    current.shareRemoteAccessBusy === next.shareRemoteAccessBusy &&
+    current.shareRemoteAccessError === next.shareRemoteAccessError &&
+    current.openworkServerUrl === next.openworkServerUrl &&
+    current.openworkServerBaseUrl === next.openworkServerBaseUrl &&
+    current.openworkServerAuth.token === next.openworkServerAuth.token &&
+    current.openworkServerAuth.hostToken === next.openworkServerAuth.hostToken &&
+    current.openworkServerClient === next.openworkServerClient &&
+    current.openworkServerStatus === next.openworkServerStatus &&
+    current.openworkServerCapabilities === next.openworkServerCapabilities &&
+    current.openworkServerReady === next.openworkServerReady &&
+    current.openworkServerWorkspaceReady === next.openworkServerWorkspaceReady &&
+    current.resolvedOpenworkCapabilities === next.resolvedOpenworkCapabilities &&
+    current.openworkServerCanWriteSkills === next.openworkServerCanWriteSkills &&
+    current.openworkServerCanWritePlugins === next.openworkServerCanWritePlugins &&
+    current.openworkServerHostInfo === next.openworkServerHostInfo &&
+    current.openworkServerDiagnostics === next.openworkServerDiagnostics &&
+    current.openworkReconnectBusy === next.openworkReconnectBusy &&
+    current.openworkAuditEntries === next.openworkAuditEntries &&
+    current.openworkAuditStatus === next.openworkAuditStatus &&
+    current.openworkAuditError === next.openworkAuditError &&
+    current.devtoolsWorkspaceId === next.devtoolsWorkspaceId
+  );
+}
+
 export function createOpenworkServerStore(options: CreateOpenworkServerStoreOptions) {
   const bootStartedAt = Date.now();
   const listeners = new Set<() => void>();
@@ -109,7 +139,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   let healthDelayMs = 10_000;
   let consecutiveHealthFailures = 0;
   let visibilityChangeHandler: (() => void) | null = null;
-  let snapshot: OpenworkServerStoreSnapshot;
+  let snapshot: OpenworkServerStoreSnapshot | undefined;
 
   let state: MutableState = {
     openworkServerSettings: readOpenworkServerSettings(),
@@ -209,7 +239,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     return clientCacheValue;
   };
 
-  const refreshSnapshot = () => {
+  const refreshSnapshot = (): boolean => {
     const openworkServerBaseUrl = getBaseUrl().trim();
     const openworkServerAuth = getAuth();
     const openworkServerClient = getClient();
@@ -227,7 +257,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     if (pref === "server") openworkServerUrl = settingsUrl;
     state.openworkServerUrl = openworkServerUrl;
 
-    snapshot = {
+    const nextSnapshot: OpenworkServerStoreSnapshot = {
       openworkServerSettings: state.openworkServerSettings,
       shareRemoteAccessBusy: state.shareRemoteAccessBusy,
       shareRemoteAccessError: state.shareRemoteAccessError,
@@ -254,12 +284,14 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
       openworkAuditError: state.openworkAuditError,
       devtoolsWorkspaceId: state.devtoolsWorkspaceId,
     };
+    if (snapshot && sameOpenworkServerSnapshot(snapshot, nextSnapshot)) return false;
+    snapshot = nextSnapshot;
+    return true;
   };
 
   const mutateState = (updater: (current: MutableState) => MutableState) => {
     state = updater(state);
-    refreshSnapshot();
-    emitChange();
+    if (refreshSnapshot()) emitChange();
   };
 
   const setStateField = <K extends keyof MutableState>(key: K, value: MutableState[K]) => {
@@ -430,8 +462,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   };
 
   const syncFromOptions = () => {
-    refreshSnapshot();
-    emitChange();
+    if (refreshSnapshot()) emitChange();
 
     if (!isDesktopRuntime()) return;
     const port = state.openworkServerHostInfo?.port;
@@ -814,7 +845,10 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     };
   };
 
-  const getSnapshot = () => snapshot;
+  const getSnapshot = () => {
+    if (!snapshot) throw new Error("OpenWork server snapshot was not initialized.");
+    return snapshot;
+  };
 
   return {
     subscribe,

--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal-state.ts
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal-state.ts
@@ -35,6 +35,14 @@ export function createInitialWorkspaceLocalState(): CreateWorkspaceLocalState {
   };
 }
 
+export function shouldTickWorkspaceElapsedClock(input: {
+  open: boolean;
+  submitting: boolean;
+  startedAt: number | null | undefined;
+}): boolean {
+  return input.open && input.submitting && typeof input.startedAt === "number";
+}
+
 export function createWorkspaceLocalReducer(
   state: CreateWorkspaceLocalState,
   action: CreateWorkspaceLocalAction,

--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
@@ -24,6 +24,7 @@ import { CreateWorkspaceLocalPanel } from "./create-workspace-local-panel";
 import {
   createInitialWorkspaceLocalState,
   createWorkspaceLocalReducer,
+  shouldTickWorkspaceElapsedClock,
   type CreateWorkspaceLocalState,
 } from "./create-workspace-modal-state";
 import {
@@ -126,15 +127,22 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
     dispatchLocal({ type: "reset" });
   }, [props.open]);
 
-  // Tick the "elapsed" clock while submitting.
+  // The modal remains mounted when closed. Only publish elapsed-time updates
+  // while its progress UI is both visible and backed by a real start time.
   useEffect(() => {
     if (!submitting) {
       setShowProgressDetails(false);
-      return;
     }
-    const id = window.setInterval(() => setNow(Date.now()), 500);
+    if (!shouldTickWorkspaceElapsedClock({
+      open: props.open,
+      submitting,
+      startedAt: progress?.startedAt,
+    })) return;
+
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), 1_000);
     return () => window.clearInterval(id);
-  }, [submitting]);
+  }, [progress?.startedAt, props.open, submitting]);
 
   // Focus the URL field when the remote screen opens.
   useEffect(() => {

--- a/apps/app/src/react-app/kernel/server-provider-state.ts
+++ b/apps/app/src/react-app/kernel/server-provider-state.ts
@@ -17,19 +17,29 @@ export const initialServerState: ServerState = {
   healthy: undefined,
 };
 
+function sameServerList(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 export function serverReducer(state: ServerState, action: ServerAction): ServerState {
   switch (action.type) {
-    case "ready":
+    case "ready": {
+      if (state.active === action.active && sameServerList(state.list, action.list)) return state;
       return { ...state, list: action.list, active: action.active };
+    }
     case "active":
+      if (state.active === action.active) return state;
       return { ...state, active: action.active };
-    case "add":
+    case "add": {
+      if (state.active === action.url && state.list.includes(action.url)) return state;
       return {
         ...state,
         list: state.list.includes(action.url) ? state.list : [...state.list, action.url],
         active: action.url,
       };
+    }
     case "remove": {
+      if (!state.list.includes(action.url)) return state;
       const list = state.list.filter((item) => item !== action.url);
       return {
         ...state,
@@ -38,6 +48,7 @@ export function serverReducer(state: ServerState, action: ServerAction): ServerS
       };
     }
     case "healthy":
+      if (Object.is(state.healthy, action.healthy)) return state;
       return { ...state, healthy: action.healthy };
   }
 }

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -171,6 +171,30 @@ describe("gateway runtime mode", () => {
     });
   });
 
+  test("keeps the OpenWork server snapshot stable when options have not changed", () => {
+    installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+    const store = createTestOpenworkServerStore();
+    const initialSnapshot = store.getSnapshot();
+    let notifications = 0;
+    const unsubscribe = store.subscribe(() => {
+      notifications += 1;
+    });
+
+    store.syncFromOptions();
+
+    expect(store.getSnapshot()).toBe(initialSnapshot);
+    expect(notifications).toBe(0);
+
+    store.updateOpenworkServerSettings({
+      urlOverride: "https://instance.example.com",
+      token: "instance-token",
+    });
+
+    expect(store.getSnapshot()).not.toBe(initialSnapshot);
+    expect(notifications).toBe(1);
+    unsubscribe();
+  });
+
   test("keeps Den web on the configured origin and Den API calls on the gateway origin", () => {
     const storage = installWindow({ origin: "https://gw.example", gateway: true });
     storage.setItem("openwork.den.baseUrl", "https://app.openworklabs.com");

--- a/apps/app/tests/render-cycle-state.test.tsx
+++ b/apps/app/tests/render-cycle-state.test.tsx
@@ -1,0 +1,41 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DotMatrixLoader } from "../src/components/ui/dot-matrix-loader";
+import { shouldTickWorkspaceElapsedClock } from "../src/react-app/domains/workspace/create-workspace-modal-state";
+
+describe("render cycle state", () => {
+  test("only advances the workspace elapsed clock for visible progress", () => {
+    expect(shouldTickWorkspaceElapsedClock({
+      open: true,
+      submitting: true,
+      startedAt: 100,
+    })).toBe(true);
+    expect(shouldTickWorkspaceElapsedClock({
+      open: false,
+      submitting: true,
+      startedAt: 100,
+    })).toBe(false);
+    expect(shouldTickWorkspaceElapsedClock({
+      open: true,
+      submitting: true,
+      startedAt: null,
+    })).toBe(false);
+    expect(shouldTickWorkspaceElapsedClock({
+      open: true,
+      submitting: false,
+      startedAt: 100,
+    })).toBe(false);
+  });
+
+  test("renders the task activity mark as nine CSS-animated dots", () => {
+    const html = renderToStaticMarkup(<DotMatrixLoader label="Running" />);
+
+    expect(html.match(/ow-dot-matrix-dot/g)).toHaveLength(9);
+    expect(html).toContain("ow-dot-matrix-frame-a");
+    expect(html).toContain("ow-dot-matrix-frame-g");
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-label="Running"');
+  });
+});

--- a/apps/app/tests/server-provider-state.test.ts
+++ b/apps/app/tests/server-provider-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { initialServerState, serverReducer } from "../src/react-app/kernel/server-provider-state";
+
+describe("server provider state", () => {
+  test("preserves state identity for repeated polling results", () => {
+    const ready = serverReducer(initialServerState, {
+      type: "ready",
+      list: ["http://127.0.0.1:4096/opencode"],
+      active: "http://127.0.0.1:4096/opencode",
+    });
+    const healthy = serverReducer(ready, { type: "healthy", healthy: true });
+
+    expect(serverReducer(healthy, { type: "healthy", healthy: true })).toBe(healthy);
+    expect(serverReducer(healthy, {
+      type: "ready",
+      list: ["http://127.0.0.1:4096/opencode"],
+      active: "http://127.0.0.1:4096/opencode",
+    })).toBe(healthy);
+    expect(serverReducer(healthy, {
+      type: "add",
+      url: "http://127.0.0.1:4096/opencode",
+    })).toBe(healthy);
+    expect(serverReducer(healthy, {
+      type: "remove",
+      url: "http://127.0.0.1:9999/opencode",
+    })).toBe(healthy);
+  });
+
+  test("publishes meaningful health and active-server changes", () => {
+    const healthy = serverReducer(initialServerState, { type: "healthy", healthy: true });
+    const active = serverReducer(healthy, {
+      type: "active",
+      active: "http://127.0.0.1:4096/opencode",
+    });
+
+    expect(healthy).not.toBe(initialServerState);
+    expect(active).not.toBe(healthy);
+    expect(active.healthy).toBe(true);
+    expect(active.active).toBe("http://127.0.0.1:4096/opencode");
+  });
+});

--- a/evals/specs/desktop-render-cycle-stability.e2e.test.ts
+++ b/evals/specs/desktop-render-cycle-stability.e2e.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import type { Surface } from "@openwork/cdp";
+import { clickButton, evalIn, fill, waitFor, waitForText } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `desktop render-cycle stability skipped — needs: ${missingRequirements.join(", ")}`
+  : "workspace onboarding settles without timer-driven React commits";
+
+interface WelcomeRenderFacts {
+  commitCount: number;
+  longestHalfSecondRun: number;
+  recentCommitCount: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNumber(value: Record<string, unknown>, key: string): number {
+  const field = Reflect.get(value, key);
+  if (typeof field !== "number") throw new Error(`Render facts omitted numeric ${key}.`);
+  return field;
+}
+
+async function readWelcomeRenderFacts(app: Surface): Promise<WelcomeRenderFacts> {
+  const value = await evalIn(app, `(() => {
+    const profiler = window.__openwork.snapshot().profiler;
+    const zone = profiler.zones.find((entry) => entry.id === "WelcomeRoute");
+    const commits = profiler.recent
+      .filter((entry) => entry.id === "WelcomeRoute")
+      .map((entry) => entry.commitAt);
+    let longestHalfSecondRun = 0;
+    let currentRun = 0;
+    for (let index = 1; index < commits.length; index += 1) {
+      const gap = commits[index] - commits[index - 1];
+      currentRun = gap >= 400 && gap <= 600 ? currentRun + 1 : 0;
+      longestHalfSecondRun = Math.max(longestHalfSecondRun, currentRun);
+    }
+    return {
+      commitCount: zone?.commitCount ?? 0,
+      longestHalfSecondRun,
+      recentCommitCount: commits.length,
+    };
+  })()`);
+  if (!isRecord(value)) throw new Error("Welcome render facts were not an object.");
+  return {
+    commitCount: readNumber(value, "commitCount"),
+    longestHalfSecondRun: readNumber(value, "longestHalfSecondRun"),
+    recentCommitCount: readNumber(value, "recentCommitCount"),
+  };
+}
+
+test(title, async ({ evidence }) => {
+  needs(requirements);
+
+  await using app = await desktop({
+    name: "desktop-render-cycle-stability",
+    env: { VITE_OPENWORK_PROFILER: "1" },
+  });
+  let workspacePath = "";
+  onTestFinished(async () => {
+    if (workspacePath) await rm(workspacePath, { recursive: true, force: true });
+  });
+
+  expect(app.readiness.route).toContain("/welcome");
+  await waitForText(app, "Welcome to OpenWork");
+  await evalIn(app, `(() => {
+    localStorage.setItem("openwork.debug.profilerOverlay", "1");
+    location.reload();
+    return true;
+  })()`);
+  await waitForText(app, "Welcome to OpenWork", { timeoutMs: 30_000 });
+
+  await clickButton(app, "Use Without Cloud");
+  await waitFor(app, 'Boolean(document.querySelector(\'input[placeholder="/workspace/my-project"]\'))', {
+    timeoutMs: 15_000,
+    label: "local workspace folder input",
+  });
+  workspacePath = await mkdtemp(join(tmpdir(), "openwork-render-cycle-"));
+  await fill(app, 'input[placeholder="/workspace/my-project"]', workspacePath);
+  await clickButton(app, "Use this folder");
+  await waitForText(app, "Skip and use the free model", { timeoutMs: 90_000 });
+
+  const completed = await readWelcomeRenderFacts(app);
+  expect(completed.recentCommitCount).toBeGreaterThan(0);
+  expect(completed.longestHalfSecondRun).toBeLessThan(2);
+
+  await new Promise((resolve) => setTimeout(resolve, 2_500));
+  const settled = await readWelcomeRenderFacts(app);
+  expect(settled.commitCount - completed.commitCount).toBeLessThanOrEqual(1);
+
+  evidence.recordAssertionEvidence(
+    "Workspace creation does not drive an invisible half-second render loop",
+    `recentWelcomeCommits=${completed.recentCommitCount}; longestHalfSecondRun=${completed.longestHalfSecondRun}; settledCommitDelta=${settled.commitCount - completed.commitCount}`,
+    completed.longestHalfSecondRun < 2 && settled.commitCount - completed.commitCount <= 1,
+  );
+});


### PR DESCRIPTION
## Summary

- stop the workspace creation clock unless visible progress actually needs elapsed time
- move the running-task dot matrix from React state updates to a reduced-motion-safe CSS animation
- preserve provider/store state identity when recurring health and sync checks produce no user-visible change
- add focused state tests and a cold-profile render-cycle regression spec

## Why

A fresh desktop profile showed the welcome tree committing every 500 ms during local workspace creation even though that flow had no progress timestamp to display. Running-task indicators also advanced their animation by publishing React state every 180 ms per mounted loader. Repeated identical polling results could create additional provider or external-store work.

The updated paths keep necessary visual feedback while removing those avoidable React commits.

## Verification

- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build
- pnpm --filter @openwork/app exec bun test --isolate tests/render-cycle-state.test.tsx tests/server-provider-state.test.ts tests/gateway-runtime.test.ts — 30 passed
- pnpm --dir evals run lint:layers
- OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/desktop-render-cycle-stability.e2e.test.ts — 1 passed, 0 skipped
- full app suite: 935 passed, 7 existing order-dependent failures; the same seven failures reproduce on clean origin/dev (930 passed, 7 failed), and the first failing file passes in isolation on both trees
