### PR TITLE
fix(app): isolate streaming chat render work

### DIFF
--- a/apps/app/src/components/chat/current-tool-lifecycle-context.tsx
+++ b/apps/app/src/components/chat/current-tool-lifecycle-context.tsx
@@ -15,14 +15,20 @@ type CurrentToolLifecycleContextValue = {
 
 const CurrentToolLifecycleContext = React.createContext<CurrentToolLifecycleContextValue | null>(null)
 
+export function toolCallIdsKey(toolCallIds: ReadonlySet<string>): string {
+  return JSON.stringify([...toolCallIds].sort())
+}
+
 export function CurrentToolLifecycleProvider({
   activityStatus,
   currentToolCallIds,
   children,
 }: CurrentToolLifecycleContextValue & { children: React.ReactNode }) {
+  const idsKey = toolCallIdsKey(currentToolCallIds)
+  const stableToolCallIds = React.useMemo(() => currentToolCallIds, [idsKey])
   const value = React.useMemo(
-    () => ({ activityStatus, currentToolCallIds }),
-    [activityStatus, currentToolCallIds],
+    () => ({ activityStatus, currentToolCallIds: stableToolCallIds }),
+    [activityStatus, stableToolCallIds],
   )
 
   return (

--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -81,6 +81,57 @@ export function MessageListProvider({
   onMcpReopenAuthorization,
   onMcpRetry,
 }: MessageListProviderProps) {
+  const handlersRef = React.useRef({
+    dispatchAction,
+    setPrompt,
+    onRevertToUserMessage,
+    onForkAtMessage,
+    onEditUserMessage,
+    onOpenSubagentSession,
+    onMcpReconnect,
+    onMcpReopenAuthorization,
+    onMcpRetry,
+  })
+  React.useEffect(() => {
+    handlersRef.current = {
+      dispatchAction,
+      setPrompt,
+      onRevertToUserMessage,
+      onForkAtMessage,
+      onEditUserMessage,
+      onOpenSubagentSession,
+      onMcpReconnect,
+      onMcpReopenAuthorization,
+      onMcpRetry,
+    }
+  }, [
+    dispatchAction,
+    setPrompt,
+    onRevertToUserMessage,
+    onForkAtMessage,
+    onEditUserMessage,
+    onOpenSubagentSession,
+    onMcpReconnect,
+    onMcpReopenAuthorization,
+    onMcpRetry,
+  ])
+  const stableHandlers = React.useMemo(() => ({
+    dispatchAction: (action: DispatchAction) => handlersRef.current.dispatchAction(action),
+    setPrompt: (prompt: string) => handlersRef.current.setPrompt(prompt),
+    onRevertToUserMessage: (messageId: string) => handlersRef.current.onRevertToUserMessage(messageId),
+    onForkAtMessage: (messageId: string) => handlersRef.current.onForkAtMessage(messageId),
+    onEditUserMessage: (messageId: string, text: string) => handlersRef.current.onEditUserMessage(messageId, text),
+    onOpenSubagentSession: (sessionId: string) => handlersRef.current.onOpenSubagentSession?.(sessionId),
+    onMcpReconnect: (
+      action: ChatToolReconnectAction,
+      onProgress: (progress: ChatToolReconnectProgress) => void,
+    ) => handlersRef.current.onMcpReconnect(action, onProgress),
+    onMcpReopenAuthorization: (action: ChatToolReconnectAction, authorizeUrl: string) => (
+      handlersRef.current.onMcpReopenAuthorization(action, authorizeUrl)
+    ),
+    onMcpRetry: (action: ChatToolReconnectAction) => handlersRef.current.onMcpRetry(action),
+  }), [])
+  const canOpenSubagentSession = Boolean(onOpenSubagentSession)
   const value = React.useMemo(
     () => ({
       workspaceId,
@@ -90,15 +141,10 @@ export function MessageListProvider({
       developerMode,
       displaySuggestions,
       providerConnectedCount,
-      dispatchAction,
-      setPrompt,
-      onRevertToUserMessage,
-      onForkAtMessage,
-      onEditUserMessage,
-      onOpenSubagentSession,
-      onMcpReconnect,
-      onMcpReopenAuthorization,
-      onMcpRetry,
+      ...stableHandlers,
+      onOpenSubagentSession: canOpenSubagentSession
+        ? stableHandlers.onOpenSubagentSession
+        : undefined,
     }),
     [
       workspaceId,
@@ -108,15 +154,8 @@ export function MessageListProvider({
       developerMode,
       displaySuggestions,
       providerConnectedCount,
-      dispatchAction,
-      setPrompt,
-      onRevertToUserMessage,
-      onForkAtMessage,
-      onEditUserMessage,
-      onOpenSubagentSession,
-      onMcpReconnect,
-      onMcpReopenAuthorization,
-      onMcpRetry,
+      stableHandlers,
+      canOpenSubagentSession,
     ],
   )
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -115,6 +115,7 @@ import { isToolPartInFlight } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { useOpenArtifactPath } from "@/lib/artifacts"
 import { cn } from "@/lib/utils"
+import { DevProfiler } from "@/react-app/shell/dev-profiler"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
 import type { AnyToolPart } from "@/lib/tool-aggregate"
 
@@ -877,10 +878,16 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
   const [seconds, setSeconds] = React.useState(() => retryDelaySeconds(status))
 
   React.useEffect(() => {
-    const update = () => setSeconds(retryDelaySeconds(status))
+    let timer: number | null = null
+    const update = () => {
+      const nextSeconds = retryDelaySeconds(status)
+      setSeconds((current) => current === nextSeconds ? current : nextSeconds)
+      if (nextSeconds > 0) timer = window.setTimeout(update, 1000)
+    }
     update()
-    const timer = window.setInterval(update, 1000)
-    return () => window.clearInterval(timer)
+    return () => {
+      if (timer !== null) window.clearTimeout(timer)
+    }
   }, [status])
 
   const info = seconds > 0
@@ -967,7 +974,7 @@ function CompletedStepRun({ label, children }: { label: string; children: React.
 
 interface AssistantMessageGroupProps {
   items: UIMessageWithIndex[]
-  messages: UIMessage[]
+  isLastGroup: boolean
   isStreaming: boolean
 }
 
@@ -990,7 +997,7 @@ function collectMcpAppParts(items: UIMessageWithIndex[]): DynamicToolUIPart[] {
 
 function MessageGroup({
   items,
-  messages,
+  isLastGroup,
   isStreaming,
 }: AssistantMessageGroupProps) {
   const { onRevertToUserMessage, onForkAtMessage, showThinking } = useMessageList()
@@ -999,7 +1006,7 @@ function MessageGroup({
   // client-side messages (e.g. session errors) don't exist on the server and
   // silently corrupt fork/revert boundaries.
   const lastRealItem = items.findLast((item) => !isSessionErrorMessage(item.message))
-  const isLiveGroup = isStreaming && lastItem !== undefined && lastItem.index === messages.length - 1
+  const isLiveGroup = isStreaming && isLastGroup
 
   if (!lastItem || isMessageEmptyGroup(items)) {
     return null;
@@ -1081,7 +1088,7 @@ function MessageGroup({
     : []
 
   const renderItem = (item: UIMessageWithIndex, groupIndex: number, hideReasoning?: boolean) => {
-    const isLastMessage = item.index === messages.length - 1
+    const isLastMessage = isLastGroup && item.index === lastItem.index
 
     return (
       <div key={item.message.id}>
@@ -1131,6 +1138,7 @@ function MessageGroup({
   }
 
   return (
+    <DevProfiler id={`MessageGroup:${lastItem.message.id}`}>
       <div className="flex flex-col gap-2 group/message-group">
       {/* The scroll area keeps the same 8px rhythm the parts inside a single
           message use, so a step row is spaced identically whether or not a
@@ -1197,8 +1205,37 @@ function MessageGroup({
         </div>
       )}
       </div>
+    </DevProfiler>
   )
 }
+
+function sameMessageGroupProps(left: AssistantMessageGroupProps, right: AssistantMessageGroupProps): boolean {
+  return left.isLastGroup === right.isLastGroup
+    && left.isStreaming === right.isStreaming
+    && left.items.length === right.items.length
+    && left.items.every((item, index) => (
+      item.index === right.items[index]?.index
+      && item.message === right.items[index]?.message
+    ))
+}
+
+const MemoizedMessageGroup = React.memo(MessageGroup, sameMessageGroupProps)
+
+type StandaloneMessageProps = {
+  message: UIMessage
+  isLastMessage: boolean
+  isStreaming: boolean
+  isLastStep: boolean
+}
+
+const StandaloneMessage = React.memo(function StandaloneMessage(props: StandaloneMessageProps) {
+  return (
+    <div>
+      <MessageComponent {...props} />
+      <ArtifactList messages={[props.message]} includeTargetFallbacks={false} />
+    </div>
+  )
+})
 
 interface MessageListProps {
   messages: UIMessage[]
@@ -1261,11 +1298,11 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
         {items.map((item) => {
         if (isMessageGroup(item)) {
           return (
-            <MessageGroup
+            <MemoizedMessageGroup
               key={item.messages[0]?.message.id ?? "empty-assistant-group"}
               items={item.messages}
-              messages={messages}
-              isStreaming={isStreaming}
+              isLastGroup={item.messages.at(-1)?.index === messages.length - 1}
+              isStreaming={isStreaming && item.messages.at(-1)?.index === messages.length - 1}
             />
           )
         }
@@ -1275,15 +1312,13 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
           !messages[item.index + 1] || messages[item.index + 1].role !== item.message.role
 
         return (
-          <div key={item.message.id}>
-            <MessageComponent
-              message={item.message}
-              isLastMessage={isLastMessage}
-              isStreaming={isLastMessage && isStreaming}
-              isLastStep={isLastStep}
-            />
-            <ArtifactList messages={[item.message]} includeTargetFallbacks={false} />
-          </div>
+          <StandaloneMessage
+            key={item.message.id}
+            message={item.message}
+            isLastMessage={isLastMessage}
+            isStreaming={isLastMessage && isStreaming}
+            isLastStep={isLastStep}
+          />
         )
         })}
 

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -28,6 +28,23 @@ export type OpenTarget = {
   updatedAt?: number;
 };
 
+export function sameOpenTargets(left: OpenTarget[], right: OpenTarget[]): boolean {
+  return left.length === right.length && left.every((target, index) => {
+    const other = right[index];
+    return other !== undefined
+      && target.id === other.id
+      && target.kind === other.kind
+      && target.value === other.value
+      && target.name === other.name
+      && target.preview === other.preview
+      && target.confidence === other.confidence
+      && target.reason === other.reason
+      && target.exists === other.exists
+      && target.size === other.size
+      && target.updatedAt === other.updatedAt;
+  });
+}
+
 const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
 const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
 

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -85,6 +85,22 @@ type SessionManagementStore = SessionManagementState & SessionManagementActions;
 
 const EMPTY_GROUP_STATE: WorkspaceGroupState = { groups: [], assignments: {} };
 
+function sameStrings(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameGroupDefinitions(left: SessionGroupDefinition[], right: SessionGroupDefinition[]): boolean {
+  return left.length === right.length && left.every((group, index) => (
+    group.id === right[index]?.id && group.label === right[index]?.label
+  ));
+}
+
+function sameAssignments(left: Record<string, string>, right: Record<string, string>): boolean {
+  const entries = Object.entries(left);
+  return entries.length === Object.keys(right).length
+    && entries.every(([sessionId, groupId]) => right[sessionId] === groupId);
+}
+
 let sessionGroupSyncHandler: SessionGroupSyncHandler | null = null;
 const sessionGroupSyncStatusByWorkspace: Record<string, SessionGroupSyncStatus> = {};
 
@@ -205,16 +221,20 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
         )),
 
       reorderSessions: (workspaceId, sessionIds) =>
-        set((state) => ({
-          orderByWorkspace: { ...state.orderByWorkspace, [workspaceId]: sessionIds },
-        })),
+        set((state) => (
+          sameStrings(state.orderByWorkspace[workspaceId] ?? [], sessionIds)
+            ? state
+            : { orderByWorkspace: { ...state.orderByWorkspace, [workspaceId]: sessionIds } }
+        )),
 
       assignGroup: (workspaceId, sessionId, groupId) => {
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
+          const nextGroupId = groupId && ws.groups.some((group) => group.id === groupId) ? groupId : null;
+          if ((ws.assignments[sessionId] ?? null) === nextGroupId) return state;
           const assignments = { ...ws.assignments };
-          if (groupId && ws.groups.some((g) => g.id === groupId)) {
-            assignments[sessionId] = groupId;
+          if (nextGroupId) {
+            assignments[sessionId] = nextGroupId;
           } else {
             delete assignments[sessionId];
           }
@@ -249,6 +269,8 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
       renameGroup: (workspaceId, groupId, label) => {
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
+          const target = ws.groups.find((group) => group.id === groupId);
+          if (!target || target.label === label) return state;
           return {
             groupsByWorkspace: {
               ...state.groupsByWorkspace,
@@ -277,6 +299,7 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           for (const group of ws.groups) {
             if (!used.has(group.id)) groups.push(group);
           }
+          if (sameGroupDefinitions(ws.groups, groups)) return state;
           return {
             groupsByWorkspace: {
               ...state.groupsByWorkspace,
@@ -311,6 +334,11 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           const collapsedGroupIds = (ws.collapsedGroupIds ?? []).filter(
             (id) => id === "__openwork_ungrouped" || knownGroupIds.has(id),
           );
+          if (
+            sameGroupDefinitions(ws.groups, serverState.groups)
+            && sameAssignments(ws.assignments, serverState.assignments)
+            && sameStrings(ws.collapsedGroupIds ?? [], collapsedGroupIds)
+          ) return state;
           return {
             groupsByWorkspace: {
               ...state.groupsByWorkspace,
@@ -362,6 +390,7 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
 
       forgetWorkspace: (workspaceId) =>
         set((state) => {
+          if (!(workspaceId in state.orderByWorkspace) && !(workspaceId in state.groupsByWorkspace)) return state;
           const { [workspaceId]: _o, ...orderRest } = state.orderByWorkspace;
           const { [workspaceId]: _g, ...groupsRest } = state.groupsByWorkspace;
           return { orderByWorkspace: orderRest, groupsByWorkspace: groupsRest };

--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -109,6 +109,36 @@ function updateWorkspaceStatus(
   };
 }
 
+function sameStrings(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameMessageRoles(
+  left: Record<string, SessionMessageRole>,
+  right: Record<string, SessionMessageRole>,
+): boolean {
+  const leftEntries = Object.entries(left);
+  return leftEntries.length === Object.keys(right).length
+    && leftEntries.every(([messageId, role]) => right[messageId] === role);
+}
+
+function sameActivityRecord(
+  current: SessionActivityRecord,
+  next: SessionActivityRecord,
+  status: SessionActivityStatus,
+): boolean {
+  return current.status === status
+    && current.runActive === next.runActive
+    && current.runStatusAt === next.runStatusAt
+    && current.assistantOutput === next.assistantOutput
+    && current.errorActive === next.errorActive
+    && current.errorMessage === next.errorMessage
+    && current.compacting === next.compacting
+    && sameStrings(current.waitingPermissionIds, next.waitingPermissionIds)
+    && sameStrings(current.waitingQuestionIds, next.waitingQuestionIds)
+    && sameMessageRoles(current.messageRoles, next.messageRoles);
+}
+
 function updateRecord(
   state: Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId">,
   workspaceId: string,
@@ -116,8 +146,10 @@ function updateRecord(
   updater: (record: SessionActivityRecord) => SessionActivityRecord,
 ) {
   const workspaceRecords = state.recordsByWorkspaceId[workspaceId] ?? {};
-  const nextRecord = updater(workspaceRecords[sessionId] ?? createRecord());
+  const currentRecord = workspaceRecords[sessionId];
+  const nextRecord = updater(currentRecord ?? createRecord());
   const status = statusForRecord(nextRecord);
+  if (currentRecord && sameActivityRecord(currentRecord, nextRecord, status)) return state;
   const recordWithStatus = { ...nextRecord, status, updatedAt: Date.now() };
   return {
     recordsByWorkspaceId: {

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 import { AppWindowMac, ArrowUp, Check, ChevronDown, ChevronRight, FileText, LoaderCircle, Paperclip, Plus, RefreshCw, Settings, Square, Terminal, X, Zap } from "lucide-react";
@@ -33,6 +33,7 @@ import {
   composerConnectionSignIn,
   mergeComposerConnectionInventory,
 } from "./composer-connections";
+import { DevProfiler } from "@/react-app/shell/dev-profiler";
 
 type MentionItem = {
   id: string;
@@ -223,7 +224,7 @@ function pluginSlashCommandName(file: CloudImportedPluginFile) {
   return null;
 }
 
-export function ReactSessionComposer(props: ComposerProps) {
+export const ReactSessionComposer = memo(function ReactSessionComposer(props: ComposerProps) {
   let fileInput: HTMLInputElement | undefined;
   const orgMcp = useOrgMcpConnections();
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -1241,6 +1242,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   };
 
   return (
+    <DevProfiler id="SessionComposer">
     <div
       ref={rootRef}
       className={props.flush ? `relative ${toolMenuOpen ? "z-50" : "z-20"}` : `sticky bottom-0 ${toolMenuOpen ? "z-50" : "z-20"} bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 pb-[max(0.5rem,calc(env(safe-area-inset-bottom)+var(--keyboard-inset,0px)))] max-lg:px-3 lg:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-1"}`}
@@ -1817,5 +1819,6 @@ export function ReactSessionComposer(props: ComposerProps) {
 
       </div>
     </div>
+    </DevProfiler>
   );
-}
+});

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -5,6 +5,16 @@ import { mergeSnapshotAndLiveMessages } from "../sync/message-merge";
 import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
+const snapshotMessageCache = new WeakMap<OpenworkSessionSnapshot, UIMessage[]>();
+
+function getSnapshotMessages(snapshot: OpenworkSessionSnapshot) {
+  const cached = snapshotMessageCache.get(snapshot);
+  if (cached) return cached;
+  const messages = snapshotToUIMessages(snapshot);
+  snapshotMessageCache.set(snapshot, messages);
+  return messages;
+}
+
 export function resolveRenderedSessionSnapshot(input: {
   sessionId: string;
   currentSnapshot: OpenworkSessionSnapshot | null | undefined;
@@ -30,7 +40,7 @@ export function deriveRenderedSessionMessages(input: {
   const liveMessages = input.transcriptState ?? [];
 
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
-    ? snapshotToUIMessages(input.snapshot)
+    ? getSnapshotMessages(input.snapshot)
     : [];
 
   // Render the server snapshot as the history floor and layer live stream

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -66,7 +66,7 @@ import { getSessionActivityStatusLabel, useSessionActivityStore, type SessionAct
 import { PermissionApprovalPanel } from "@/react-app/domains/session/chat/permission-approval-modal";
 import { QuestionPanel } from "@/react-app/domains/session/modals/question-modal";
 import { QueuedMessagesPanel } from "@/react-app/domains/session/modals/queued-messages-panel";
-import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
+import { deriveOpenTargets, sameOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
   markSessionSnapshotFetchStart,
@@ -971,6 +971,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
     return [...baseRenderedMessages, ...evalMarkdownMessages];
   }, [baseRenderedMessages, evalMarkdownMessages]);
+  const renderedMessagesRef = useRef(renderedMessages);
+  useEffect(() => {
+    renderedMessagesRef.current = renderedMessages;
+  }, [renderedMessages]);
   const seedMarkdownPrimitiveControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
 
@@ -1121,6 +1125,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     let cancelled = false;
+    const updateVerifiedOpenTargets = (targets: OpenTarget[]) => {
+      setVerifiedOpenTargets((current) => sameOpenTargets(current, targets) ? current : targets);
+    };
     function initializeAutoOpenState(targets: OpenTarget[]) {
       if (initializedAutoOpenSessionRef.current === props.sessionId) return;
       initializedAutoOpenSessionRef.current = props.sessionId;
@@ -1130,7 +1137,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     async function verifyTargets() {
       if (!openTargets.length) {
         initializeAutoOpenState([]);
-        setVerifiedOpenTargets([]);
+        updateVerifiedOpenTargets([]);
         return;
       }
       try {
@@ -1138,13 +1145,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
         if (!cancelled) {
           const nextTargets = response.items as OpenTarget[];
           initializeAutoOpenState(nextTargets);
-          setVerifiedOpenTargets(nextTargets);
+          updateVerifiedOpenTargets(nextTargets);
         }
       } catch {
         if (!cancelled) {
           const nextTargets = openTargets.map((target) => ({ ...target, exists: target.kind === "url" }));
           initializeAutoOpenState(nextTargets);
-          setVerifiedOpenTargets(nextTargets);
+          updateVerifiedOpenTargets(nextTargets);
         }
       }
     }
@@ -1500,7 +1507,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     props.onDraftChange(buildDraft(draft, attachments));
   }, [attachments, buildDraft, draft, props.onDraftChange]);
 
-  const handleAttachFiles = (files: File[]) => {
+  const handleAttachFiles = useCallback((files: File[]) => {
     if (!props.attachmentsEnabled) {
       toast.warning(props.attachmentsDisabledReason ?? "Attachments are unavailable.");
       return;
@@ -1530,18 +1537,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
       props.sessionId,
       `${draft}${next.map((attachment) => `[attachment ${attachment.id}]`).join("")}`,
     );
-  };
+  }, [
+    attachments,
+    draft,
+    props.attachmentsDisabledReason,
+    props.attachmentsEnabled,
+    props.sessionId,
+    setComposerAttachments,
+    setComposerDraft,
+  ]);
 
-  const handleRemoveAttachment = (id: string) => {
+  const handleRemoveAttachment = useCallback((id: string) => {
     const target = attachments.find((item) => item.id === id);
     if (target?.previewUrl) {
       URL.revokeObjectURL(target.previewUrl);
     }
     setComposerAttachments(props.sessionId, attachments.filter((item) => item.id !== id));
     setComposerDraft(props.sessionId, draft.replaceAll(`[attachment ${id}]`, ""));
-  };
+  }, [attachments, draft, props.sessionId, setComposerAttachments, setComposerDraft]);
 
-  const handleInsertMention = (kind: ComposerMentionKind, value: string) => {
+  const handleInsertMention = useCallback((kind: ComposerMentionKind, value: string) => {
     // @agent mentions switch the session agent instead of inserting an agent
     // part. Agent parts are treated as *subagent* (task tool) calls by the
     // engine, which silently fails for primary agents and left every reply
@@ -1574,32 +1589,32 @@ export function SessionSurface(props: SessionSurfaceProps) {
         }
       })();
     }
-  };
+  }, [draft, mentions, props.onSelectAgent, props.sessionId, setComposerDraft, setComposerMentions]);
 
-  const handlePasteText = (text: string) => {
+  const handlePasteText = useCallback((text: string) => {
     const pasted = createPastedTextChip(text);
     setComposerPasteParts(props.sessionId, [...pasteParts, pasted]);
     setComposerDraft(props.sessionId, `${draft}[pasted text ${pasted.label}]`);
-  };
+  }, [draft, pasteParts, props.sessionId, setComposerDraft, setComposerPasteParts]);
 
-  const handleExpandPastedText = (id: string) => {
+  const handleExpandPastedText = useCallback((id: string) => {
     const part = pasteParts.find((item) => item.id === id);
     if (!part) return;
     setComposerDraft(props.sessionId, draft.replace(`[pasted text ${part.label}]`, part.text));
     setComposerPasteParts(props.sessionId, pasteParts.filter((item) => item.id !== id));
-  };
+  }, [draft, pasteParts, props.sessionId, setComposerDraft, setComposerPasteParts]);
 
-  const handleRemovePastedText = (id: string) => {
+  const handleRemovePastedText = useCallback((id: string) => {
     const target = pasteParts.find((item) => item.id === id);
     if (!target) return;
     setComposerDraft(props.sessionId, draft.replace(`[pasted text ${target.label}]`, ""));
     setComposerPasteParts(props.sessionId, pasteParts.filter((item) => item.id !== id));
-  };
+  }, [draft, pasteParts, props.sessionId, setComposerDraft, setComposerPasteParts]);
 
-  const handleUnsupportedFileLinks = (links: string[]) => {
+  const handleUnsupportedFileLinks = useCallback((links: string[]) => {
     if (!links.length) return;
     setComposerDraft(props.sessionId, `${draft}${draft && !draft.endsWith("\n") ? "\n" : ""}${links.join("\n")}`);
-  };
+  }, [draft, props.sessionId, setComposerDraft]);
 
   const typeComposerText = useCallback(async (text: string, revertMessageId?: string | null) => {
     window.dispatchEvent(new Event("openwork:focusPrompt"));
@@ -1673,7 +1688,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }), [chatStreaming, handleAbort]);
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
-  const listSkills = async (): Promise<SkillCard[]> => {
+  const listSkills = useCallback(async (): Promise<SkillCard[]> => {
     const pushId = ++skillsConnectPushRef.current;
     // Paint cached Connect inventory instantly; the fresh fan-out lands live.
     const scope = readCloudInventoryScope();
@@ -1695,9 +1710,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const next = [...localSkills, ...cachedConnect.skills];
     setToolSkills(next);
     return next;
-  };
+  }, [props.client, props.workspaceId]);
 
-  const listMcp = async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
+  const listMcp = useCallback(async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
     const pushId = ++mcpConnectPushRef.current;
     const scope = readCloudInventoryScope();
     const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
@@ -1761,9 +1776,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setToolMcpStatus(status);
 
     return { servers, statuses, status };
-  };
+  }, [opencodeClient, props.client, props.workspaceId, props.workspaceRoot]);
 
-  const listImportedPlugins = async (): Promise<CloudImportedPlugin[]> => {
+  const listImportedPlugins = useCallback(async (): Promise<CloudImportedPlugin[]> => {
     const pushId = ++pluginConnectPushRef.current;
     const scope = readCloudInventoryScope();
     const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
@@ -1775,9 +1790,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const plugins = connectPluginsForComposer(cachedConnect.plugins);
     setToolImportedPlugins(plugins);
     return plugins;
-  };
+  }, []);
 
-  const handleUploadInboxFiles = async (files: File[]) => {
+  const handleUploadInboxFiles = useCallback(async (files: File[]) => {
     const input = files.filter(Boolean);
     if (!input.length) return;
     try {
@@ -1787,7 +1802,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       toast.warning(nextError instanceof Error ? nextError.message : "Shared folder upload failed");
       throw nextError;
     }
-  };
+  }, [props.client, props.workspaceId]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -1980,8 +1995,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleForkAtMessage = useCallback((messageId: string) => {
     // OpenCode's fork copies messages strictly before the given id, so pass
     // the next real message to make the branch include the clicked message.
-    props.onForkAtMessage?.(resolveForkBoundaryId(renderedMessages, messageId), props.sessionId);
-  }, [props.onForkAtMessage, props.sessionId, renderedMessages]);
+    props.onForkAtMessage?.(resolveForkBoundaryId(renderedMessagesRef.current, messageId), props.sessionId);
+  }, [props.onForkAtMessage, props.sessionId]);
 
   const handleEditUserMessage = useCallback((messageId: string, text: string) => {
     // Preserve the boundary with the draft; the destructive revert is deferred
@@ -2228,7 +2243,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
             <span className="text-amber-11/70">Add a provider to run tasks.</span>
           </button>
         ) : null}
-        <DevProfiler id="SessionComposer">
         {props.cloudMcpSubmissionState.status === "failed" ? (
           <div
             className="mx-3 mb-2 flex items-center gap-3 rounded-xl border border-red-7/40 bg-red-2/40 px-3 py-2 text-xs text-red-11"
@@ -2350,7 +2364,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
             ) : null
           }
         />
-        </DevProfiler>
       </div>
       {/* Error display moved inline into the session conversation area */}
       {props.developerMode ? <SessionDebugPanel model={model} snapshot={snapshot} /> : null}

--- a/apps/app/src/react-app/domains/session/sync/message-merge.ts
+++ b/apps/app/src/react-app/domains/session/sync/message-merge.ts
@@ -1,5 +1,16 @@
 import type { UIMessage } from "ai";
 
+const mergedMessageCache = new WeakMap<UIMessage, WeakMap<UIMessage, UIMessage>>();
+const messageSignatureCache = new WeakMap<UIMessage, string>();
+
+function messageSignature(message: UIMessage) {
+  const cached = messageSignatureCache.get(message);
+  if (cached) return cached;
+  const signature = JSON.stringify(message);
+  messageSignatureCache.set(message, signature);
+  return signature;
+}
+
 function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage) {
   const parts = snapshotMessage.parts.map((part, index) => {
     const cachedPart = cachedMessage.parts[index];
@@ -24,13 +35,25 @@ function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage)
 }
 
 function mergeSnapshotMessageWithCached(snapshotMessage: UIMessage, cachedMessage: UIMessage): UIMessage {
-  const metadata = snapshotMessage.metadata ?? cachedMessage.metadata;
+  const cachedMerges = mergedMessageCache.get(snapshotMessage);
+  const cachedMerge = cachedMerges?.get(cachedMessage);
+  if (cachedMerge) return cachedMerge;
 
-  return {
+  const metadata = snapshotMessage.metadata ?? cachedMessage.metadata;
+  const merged: UIMessage = {
     ...snapshotMessage,
     ...(metadata === undefined ? {} : { metadata }),
     parts: mergeMessageParts(snapshotMessage, cachedMessage),
   };
+  const result = messageSignature(merged) === messageSignature(cachedMessage)
+    ? cachedMessage
+    : merged;
+  if (cachedMerges) {
+    cachedMerges.set(cachedMessage, result);
+  } else {
+    mergedMessageCache.set(snapshotMessage, new WeakMap([[cachedMessage, result]]));
+  }
+  return result;
 }
 
 function messageCreated(message: UIMessage) {

--- a/apps/app/src/react-app/shell/dev-profiler.tsx
+++ b/apps/app/src/react-app/shell/dev-profiler.tsx
@@ -42,6 +42,7 @@ type CommitRecord = {
 type ZoneStats = {
   id: string;
   commitCount: number;
+  renderCount: number;
   totalActualMs: number;
   totalBaseMs: number;
   lastActualMs: number;
@@ -140,6 +141,7 @@ function recordCommit(record: CommitRecord) {
     state.zonesById.set(record.id, {
       id: record.id,
       commitCount: 1,
+      renderCount: 0,
       totalActualMs: record.actualMs,
       totalBaseMs: record.baseMs,
       lastActualMs: record.actualMs,
@@ -166,6 +168,30 @@ function recordCommit(record: CommitRecord) {
   }
   // Notify overlay subscribers. We throttle via rAF so a burst of commits
   // during a stream doesn't flood setState.
+  scheduleEmit();
+}
+
+function recordRender(id: string) {
+  if (subscribers.size === 0) return;
+
+  const prev = state.zonesById.get(id);
+  if (prev) {
+    prev.renderCount += 1;
+  } else {
+    state.zonesById.set(id, {
+      id,
+      commitCount: 0,
+      renderCount: 1,
+      totalActualMs: 0,
+      totalBaseMs: 0,
+      lastActualMs: 0,
+      lastBaseMs: 0,
+      lastCommitAt: 0,
+      lastPhase: "mount",
+      mountCount: 0,
+      updateCount: 0,
+    });
+  }
   scheduleEmit();
 }
 
@@ -207,6 +233,16 @@ export function DevProfiler({
   children,
 }: PropsWithChildren<{ id: string }>): ReactNode {
   if (!PROFILER_ENABLED) return children as ReactNode;
+  return <EnabledDevProfiler id={id}>{children}</EnabledDevProfiler>;
+}
+
+function EnabledDevProfiler({
+  id,
+  children,
+}: PropsWithChildren<{ id: string }>) {
+  useEffect(() => {
+    recordRender(id);
+  });
   return (
     <Profiler id={id} onRender={onRender}>
       {children}

--- a/apps/app/tests/attachment-artifacts.test.ts
+++ b/apps/app/tests/attachment-artifacts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
 
 import { canOpenArtifact, getArtifactsFromMessages } from "../src/lib/artifacts";
-import { deriveOpenTargets, filePathFromFileUrl, type OpenTarget } from "../src/react-app/domains/session/artifacts/open-target";
+import { deriveOpenTargets, filePathFromFileUrl, sameOpenTargets, type OpenTarget } from "../src/react-app/domains/session/artifacts/open-target";
 
 const ATTACHMENT_URL = "file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_1/nonce-pge_natural_gas_billing_billing_data_service%202_2_2025-02-20_to_2025-12-05.csv";
 const ATTACHMENT_PATH = "/workspaces/Worker Root/.opencode/openwork/inbox/chat-attachments/ses_1/nonce-pge_natural_gas_billing_billing_data_service 2_2_2025-02-20_to_2025-12-05.csv";
@@ -24,6 +24,24 @@ function userMessageWithAttachment(): UIMessage {
 }
 
 describe("attachment artifacts", () => {
+  test("recognizes equivalent resolved target snapshots", () => {
+    const target: OpenTarget = {
+      id: "file:report.csv",
+      kind: "file",
+      value: "report.csv",
+      name: "report.csv",
+      preview: "sheet",
+      confidence: 100,
+      reason: "workspace tree",
+      exists: true,
+      size: 42,
+      updatedAt: 100,
+    };
+
+    expect(sameOpenTargets([target], [{ ...target }])).toBe(true);
+    expect(sameOpenTargets([target], [{ ...target, size: 43 }])).toBe(false);
+  });
+
   test("filePathFromFileUrl decodes workspace file URLs and rejects other schemes", () => {
     expect(filePathFromFileUrl(ATTACHMENT_URL)).toBe(ATTACHMENT_PATH);
     expect(filePathFromFileUrl("file:///C:/Users/Ada/%E5%B7%A5%E4%BD%9C/scan.pdf")).toBe("C:/Users/Ada/工作/scan.pdf");

--- a/apps/app/tests/current-tool-lifecycle-context.test.ts
+++ b/apps/app/tests/current-tool-lifecycle-context.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { toolCallIdsKey } from "../src/components/chat/current-tool-lifecycle-context";
+
+describe("current tool lifecycle context", () => {
+  test("gives reordered tool identifiers the same context key", () => {
+    expect(toolCallIdsKey(new Set(["tool-a", "tool-b"]))).toBe(toolCallIdsKey(new Set(["tool-b", "tool-a"])));
+  });
+
+  test("changes the context key when membership changes", () => {
+    expect(toolCallIdsKey(new Set(["tool-a"]))).not.toBe(toolCallIdsKey(new Set(["tool-b"])));
+  });
+});

--- a/apps/app/tests/session-management-store.test.ts
+++ b/apps/app/tests/session-management-store.test.ts
@@ -55,4 +55,21 @@ describe("session group management", () => {
       "session-3": "group-b",
     });
   });
+
+  test("does not publish an equivalent server group snapshot", () => {
+    const before = useSessionManagementStore.getState().groupsByWorkspace[workspaceId];
+    let notifications = 0;
+    const unsubscribe = useSessionManagementStore.subscribe(() => {
+      notifications += 1;
+    });
+
+    useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, {
+      groups: before.groups.map((group) => ({ ...group })),
+      assignments: { ...before.assignments },
+    });
+
+    unsubscribe();
+    expect(useSessionManagementStore.getState().groupsByWorkspace[workspaceId]).toBe(before);
+    expect(notifications).toBe(0);
+  });
 });

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+
+function snapshotWithHistory(): OpenworkSessionSnapshot {
+  const sessionId = "session-render-cycle";
+  return {
+    session: {
+      id: sessionId,
+      title: "Render-cycle history",
+      time: { created: 1, updated: 2 },
+      version: "0",
+    },
+    messages: [
+      { id: "historical-user", role: "user", text: "First prompt" },
+      { id: "historical-assistant", role: "assistant", text: "First answer" },
+    ].map((message, index) => ({
+      info: {
+        id: message.id,
+        role: message.role,
+        sessionID: sessionId,
+        time: { created: index + 1 },
+      },
+      parts: [{
+        id: `part-${message.id}`,
+        type: "text",
+        text: message.text,
+        sessionID: sessionId,
+        messageID: message.id,
+      }],
+    })),
+    todos: [],
+    status: { type: "idle" },
+  } as unknown as OpenworkSessionSnapshot;
+}
+
+function message(id: string, role: "user" | "assistant", text: string, created: number): UIMessage {
+  return {
+    id,
+    role,
+    metadata: { opencode: { created } },
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+describe("session render state", () => {
+  test("preserves completed message references while the active answer advances", () => {
+    const snapshot = snapshotWithHistory();
+    const historicalUser = message("historical-user", "user", "First prompt", 1);
+    const historicalAssistant = message("historical-assistant", "assistant", "First answer", 2);
+    const activeUser = message("active-user", "user", "Second prompt", 3);
+    const first = deriveRenderedSessionMessages({
+      snapshot,
+      transcriptState: [
+        historicalUser,
+        historicalAssistant,
+        activeUser,
+        message("active-assistant", "assistant", "chunk-1 ", 4),
+      ],
+    });
+    const second = deriveRenderedSessionMessages({
+      snapshot: snapshotWithHistory(),
+      transcriptState: [
+        ...first.slice(0, 3),
+        message("active-assistant", "assistant", "chunk-1 chunk-2 ", 4),
+      ],
+    });
+
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(second[2]).toBe(first[2]);
+    expect(second[3]).not.toBe(first[3]);
+    expect(second[3]?.parts).toEqual([{ type: "text", text: "chunk-1 chunk-2 ", state: "done" }]);
+  });
+});

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -113,6 +113,27 @@ afterEach(() => {
 });
 
 describe("session run status ordering", () => {
+  test("does not publish duplicate activity observations", () => {
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
+    useSessionActivityStore.getState().markMessageRole(workspaceId, sessionId, "assistant-1", "assistant");
+    useSessionActivityStore.getState().markAssistantOutput(workspaceId, sessionId, "assistant-1");
+    const before = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+    let notifications = 0;
+    const unsubscribe = useSessionActivityStore.subscribe(() => {
+      notifications += 1;
+    });
+
+    useSessionActivityStore.getState().markMessageRole(workspaceId, sessionId, "assistant-1", "assistant");
+    useSessionActivityStore.getState().markAssistantOutput(workspaceId, sessionId, "assistant-1");
+    useSessionActivityStore.getState().replaceWaitingRequests(workspaceId, sessionId, "permission", []);
+    useSessionActivityStore.getState().clearError(workspaceId, sessionId);
+    useSessionActivityStore.getState().setCompacting(workspaceId, sessionId, false);
+
+    unsubscribe();
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBe(before);
+    expect(notifications).toBe(0);
+  });
+
   test("invalidates the durable snapshot when a tracked run becomes idle", () => {
     const { input, cleanup, releaseSession } = createTestSync();
     const queryClient = getReactQueryClient();

--- a/evals/specs/chat-render-cycle-stability.e2e.test.ts
+++ b/evals/specs/chat-render-cycle-stability.e2e.test.ts
@@ -1,0 +1,270 @@
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import type { Surface } from "@openwork/cdp";
+import { control, createAndSelectWorkspace, evalIn, waitFor, waitForText } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `chat render-cycle stability skipped — needs: ${missingRequirements.join(", ")}`
+  : "streaming chat keeps unrelated render work bounded";
+
+const providerId = "chat-render-cycle-mock";
+const modelId = "chat-render-cycle-model";
+const firstReply = "Historical response is complete.";
+const firstPrompt = `Reply with exactly: ${firstReply}`;
+const streamMarker = "STREAM_RENDER_CYCLE";
+const streamChunks = Array.from({ length: 48 }, (_, index) => `chunk-${index + 1} `);
+const streamedReply = streamChunks.join("").trim();
+
+type ProfilerFact = {
+  commitCount: number;
+  renderCount: number;
+};
+
+type ProfilerFacts = Record<string, ProfilerFact>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readProfilerFacts(app: Surface): Promise<ProfilerFacts> {
+  const value = await evalIn(app, `(() => {
+    const zones = window.__openwork.snapshot().profiler.zones;
+    return Object.fromEntries(zones.map((zone) => [zone.id, {
+      commitCount: zone.commitCount,
+      renderCount: zone.renderCount,
+    }]));
+  })()`);
+  if (!isRecord(value)) throw new Error("Profiler facts were not an object.");
+  const facts: ProfilerFacts = {};
+  for (const [key, fact] of Object.entries(value)) {
+    if (
+      isRecord(fact)
+      && typeof fact.commitCount === "number"
+      && typeof fact.renderCount === "number"
+    ) {
+      facts[key] = {
+        commitCount: fact.commitCount,
+        renderCount: fact.renderCount,
+      };
+    }
+  }
+  return facts;
+}
+
+function commitsBetween(before: ProfilerFacts, after: ProfilerFacts, zone: string): number {
+  return (after[zone]?.commitCount ?? 0) - (before[zone]?.commitCount ?? 0);
+}
+
+function rendersBetween(before: ProfilerFacts, after: ProfilerFacts, zone: string): number {
+  return (after[zone]?.renderCount ?? 0) - (before[zone]?.renderCount ?? 0);
+}
+
+async function createSession(app: Surface): Promise<string> {
+  const deadline = Date.now() + 60_000;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const sessionId = await control(app, "session.create_task", undefined, { timeoutMs: 8_000 });
+      if (typeof sessionId === "string" && sessionId.trim()) return sessionId;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Session creation did not settle within 60 seconds: ${String(lastError)}`);
+}
+
+function completionChunk(responseId: string, content: string, finishReason: string | null) {
+  return {
+    id: responseId,
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta: content ? { content } : {}, finish_reason: finishReason }],
+  };
+}
+
+test(title, { timeout: 300_000 }, async ({ evidence }) => {
+  needs(requirements);
+
+  const mockRequests: string[] = [];
+  let completionIndex = 0;
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    mockRequests.push(`${request.method ?? "UNKNOWN"} ${url}`);
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+    if (request.method !== "POST" || (url !== "/v1/chat/completions" && url !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "not found" } }));
+      return;
+    }
+
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => { body += chunk; });
+    request.on("end", () => {
+      const streaming = body.includes(streamMarker);
+      mockRequests.push(`body streaming=${streaming} length=${body.length}`);
+      const chunks = streaming ? streamChunks : [firstReply];
+      completionIndex += 1;
+      const responseId = `chatcmpl-render-cycle-${completionIndex}`;
+      const startDelayMs = streaming ? 0 : body.includes("Reply with exactly") ? 1_000 : 0;
+      setTimeout(() => {
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        response.write(`data: ${JSON.stringify({
+          id: responseId,
+          object: "chat.completion.chunk",
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        })}\n\n`);
+        let index = 0;
+        const writeNext = () => {
+          const chunk = chunks[index];
+          if (chunk !== undefined) {
+            response.write(`data: ${JSON.stringify(completionChunk(responseId, chunk, null))}\n\n`);
+            index += 1;
+            setTimeout(writeNext, streaming ? 35 : 0);
+            return;
+          }
+          response.write(`data: ${JSON.stringify(completionChunk(responseId, "", "stop"))}\n\n`);
+          response.write("data: [DONE]\n\n");
+          response.end();
+        };
+        writeNext();
+      }, startDelayMs);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  await using app = await desktop({
+    name: "chat-render-cycle-stability",
+    env: { VITE_OPENWORK_PROFILER: "1" },
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-chat-render-cycle-${Date.now()}`,
+  });
+
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Chat render-cycle mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-chat-render-cycle" },
+              models: { [${JSON.stringify(modelId)}]: { name: "Chat render-cycle model" } },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  await evalIn(app, `(() => {
+    localStorage.setItem("openwork.debug.profiler", "1");
+    localStorage.setItem("openwork.debug.profilerOverlay", "1");
+    location.reload();
+    return true;
+  })()`);
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+    timeoutMs: 60_000,
+    label: "session controls restored with profiler enabled",
+  });
+
+  await createSession(app);
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer text control ready for historical turn",
+  });
+  await control(app, "composer.set_text", { text: firstPrompt });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer send control ready for historical turn",
+  });
+  await control(app, "composer.send");
+  try {
+    await waitForText(app, firstReply, { timeoutMs: 30_000 });
+  } catch (error) {
+    throw new Error(`${String(error)} Mock requests: ${mockRequests.join("; ")}`);
+  }
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.stop" && action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "historical turn completed",
+  });
+
+  await control(app, "composer.set_text", { text: `${streamMarker}: stream the response.` });
+  const before = await readProfilerFacts(app);
+  await control(app, "composer.send");
+  await waitForText(app, streamedReply, { timeoutMs: 60_000 });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.stop" && action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "streaming turn completed",
+  });
+  const after = await readProfilerFacts(app);
+
+  const messageListCommits = commitsBetween(before, after, "MessageList");
+  const composerCommits = commitsBetween(before, after, "SessionComposer");
+  const historicalGroupZones = Object.keys(before).filter((zone) => zone.startsWith("MessageGroup:"));
+  const historicalGroupRenders = historicalGroupZones.reduce(
+    (total, zone) => total + rendersBetween(before, after, zone),
+    0,
+  );
+  expect(messageListCommits).toBeGreaterThan(8);
+  expect(composerCommits, `messageListCommits=${messageListCommits}`).toBeLessThanOrEqual(10);
+  expect(historicalGroupZones.length).toBeGreaterThan(0);
+  expect(historicalGroupRenders).toBeLessThanOrEqual(2);
+  evidence.recordAssertionEvidence(
+    "Streaming advances the active transcript without repeatedly rendering the composer or completed turns",
+    `messageListCommits=${messageListCommits}; composerCommits=${composerCommits}; historicalGroupRenders=${historicalGroupRenders}; streamedChunks=${streamChunks.length}`,
+    messageListCommits > 8 && composerCommits <= 10 && historicalGroupRenders <= 2,
+  );
+});


### PR DESCRIPTION
## Summary

- preserve completed transcript message identity across live deltas and equivalent snapshot refreshes
- memoize completed message groups and the composer while stabilizing event handlers, tool lifecycle context, and verified target snapshots
- suppress duplicate activity and session-group store publications, and stop retry countdown wakeups after zero
- extend the development profiler with actual render counts for repeatable regression evidence

## Verification

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app exec bun test --isolate tests/session-render-state.test.ts tests/current-tool-lifecycle-context.test.ts tests/session-management-store.test.ts tests/session-sync-run-status.test.ts tests/session-sync-permissions.test.ts tests/attachment-artifacts.test.ts tests/message-list-loading.test.tsx tests/message-list-step-fold.test.tsx tests/session-error-resilience.test.tsx` — 46 passed
- `pnpm --filter @openwork/app build`
- `pnpm evals:e2e chat-render-cycle-stability --local` — 1 passed; 48 streamed chunks, 109 active message-list commits, 10 composer commits, and 1 completed-group render
- `pnpm --filter @openwork/app test` — 969 passed / 5 failed; a clean `origin/dev` control reproduced the same five failures with 963 passed / 5 failed

The desktop proof uses the local lane because the deterministic streaming provider is intentionally co-located on loopback with the app.