### PR TITLE
feat(app): keep workspace sidebar order stable

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1385,6 +1385,7 @@ function WorkspaceReorderItem({
       as="div"
       value={group.workspace.id}
       id={group.workspace.id}
+      data-sidebar-workspace-id={group.workspace.id}
       layout="position"
       dragElastic={0}
       dragListener={false}
@@ -1451,6 +1452,7 @@ function WorkspaceHeader({
         )}
       </SidebarGlyphSlot>
       <div
+        data-sidebar-workspace-drag-handle
         className="min-w-0 flex-1 cursor-grab touch-none active:cursor-grabbing pr-8 group-hover/workspace-header:pr-20 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-20 group-has-data-popup-open/workspace-header:pr-20"
         onPointerDown={onTitlePointerDown}
       >

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -324,6 +324,39 @@ export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: str
   return ordered;
 }
 
+/**
+ * Capture the first visible workspace order and extend it without letting the
+ * server's active-workspace-first list reshuffle existing sidebar entries.
+ * IDs that are temporarily absent stay in the preference so a transient
+ * discovery gap cannot move them when they return.
+ */
+export function stabilizeRouteWorkspaceOrder(
+  workspaces: RouteWorkspace[],
+  orderIds: string[],
+): { orderIds: string[]; workspaces: RouteWorkspace[] } {
+  const stableOrderIds: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const value of orderIds) {
+    const id = value.trim();
+    if (!id || seenIds.has(id)) continue;
+    stableOrderIds.push(id);
+    seenIds.add(id);
+  }
+
+  for (const workspace of workspaces) {
+    const id = workspace.id.trim();
+    if (!id || seenIds.has(id)) continue;
+    stableOrderIds.push(id);
+    seenIds.add(id);
+  }
+
+  return {
+    orderIds: stableOrderIds,
+    workspaces: orderRouteWorkspaces(workspaces, stableOrderIds),
+  };
+}
+
 export function toSessionGroups(
   workspaces: RouteWorkspace[],
   sessionsByWorkspaceId: Record<string, RouteSession[]>,

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -59,8 +59,8 @@ import {
   describeRouteError,
   isTransientStartupError,
   mapDesktopWorkspace,
-  orderRouteWorkspaces,
   refreshRouteWorkspaceListState,
+  stabilizeRouteWorkspaceOrder,
   type RouteSession,
   type RouteWorkspace,
 } from "./route-workspaces";
@@ -68,6 +68,7 @@ import {
   readActiveWorkspaceId,
   readWorkspaceOrderIds,
   writeActiveWorkspaceId,
+  writeWorkspaceOrderIds,
 } from "./session-memory";
 import {
   legacySessionRoute,
@@ -234,6 +235,20 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const loadedWorkspaceIdsRef = useRef(new Set<string>());
   const serverActiveWorkspaceIdRef = useRef("");
   const workspaceSelectionCommitTimerRef = useRef<number | null>(null);
+  const commitStableWorkspaceOrder = useCallback((nextWorkspaces: RouteWorkspace[]) => {
+    const currentOrderIds = workspaceOrderIdsRef.current;
+    const stable = stabilizeRouteWorkspaceOrder(nextWorkspaces, currentOrderIds);
+    const orderChanged = stable.orderIds.length !== currentOrderIds.length
+      || stable.orderIds.some((id, index) => id !== currentOrderIds[index]);
+
+    if (orderChanged) {
+      workspaceOrderIdsRef.current = stable.orderIds;
+      setWorkspaceOrderIds(stable.orderIds);
+      writeWorkspaceOrderIds(stable.orderIds);
+    }
+
+    return stable.workspaces;
+  }, []);
   const rememberPendingCreatedSession = useCallback((workspaceId: string, sessionId: string) => {
     const id = sessionId.trim();
     if (!workspaceId || !id) return;
@@ -496,7 +511,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           setBaseUrl("");
           setToken("");
           if (workspacesRef.current.length === 0 && desktopWorkspaces.length > 0) {
-            const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
+            const orderedDesktopWorkspaces = commitStableWorkspaceOrder(desktopWorkspaces);
             setWorkspaces(orderedDesktopWorkspaces);
             setLegacySelectedWorkspaceId(
               (current) => current || resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "",
@@ -512,7 +527,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setClient(null);
         setBaseUrl("");
         setToken("");
-        const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
+        const orderedDesktopWorkspaces = commitStableWorkspaceOrder(desktopWorkspaces);
         setWorkspaces(orderedDesktopWorkspaces);
         sessionsByWorkspaceIdRef.current = {};
         setSessionsByWorkspaceId({});
@@ -556,7 +571,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         });
         setRouteError(message);
       }
-      const nextWorkspaces = workspaceListState.workspaces;
+      const nextWorkspaces = commitStableWorkspaceOrder(workspaceListState.workspaces);
       serverActiveWorkspaceIdRef.current = workspaceListState.activeId ?? "";
 
       // Preserve any sessions we already have cached so switching routes
@@ -638,7 +653,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       });
       setRouteError(message);
       if (desktopWorkspaces.length > 0) {
-        const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
+        const orderedDesktopWorkspaces = commitStableWorkspaceOrder(desktopWorkspaces);
         setWorkspaces(orderedDesktopWorkspaces);
         setLegacySelectedWorkspaceId((current) =>
           current || resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "",
@@ -660,7 +675,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         }
       }
     }
-  }, [legacyWorkspaceInferenceKey, loadWorkspaceSessionsInBackground, markBootRouteReady, updateLocalServer]);
+  }, [commitStableWorkspaceOrder, legacyWorkspaceInferenceKey, loadWorkspaceSessionsInBackground, markBootRouteReady, updateLocalServer]);
 
   const routeWorkspaceKnown = Boolean(
     routeWorkspaceId && workspaces.some((workspace) => workspace.id === routeWorkspaceId),

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -5,6 +5,7 @@ import {
   mergeRouteWorkspaces,
   readRouteSessionsWithRetry,
   refreshRouteWorkspaceListState,
+  stabilizeRouteWorkspaceOrder,
 } from "../src/react-app/shell/route-workspaces";
 import {
   mergeWorkspaceRouteSession,
@@ -214,6 +215,50 @@ describe("workspace route list merging", () => {
     expect(result.workspaces.map((workspace) => workspace.id)).toEqual([
       "workspace-known",
       "workspace-desktop",
+    ]);
+  });
+
+  test("captures the first visible order so active-workspace refreshes cannot reshuffle the sidebar", () => {
+    const alpha = { ...previouslyKnownWorkspaces[0], id: "workspace-alpha" };
+    const beta = { ...desktopWorkspaces[0], id: "workspace-beta" };
+    const initial = stabilizeRouteWorkspaceOrder([alpha, beta], []);
+    const afterBetaActivation = stabilizeRouteWorkspaceOrder([beta, alpha], initial.orderIds);
+
+    expect(initial.orderIds).toEqual(["workspace-alpha", "workspace-beta"]);
+    expect(afterBetaActivation.workspaces.map((workspace) => workspace.id)).toEqual([
+      "workspace-alpha",
+      "workspace-beta",
+    ]);
+  });
+
+  test("appends newly discovered workspaces without displacing the saved order", () => {
+    const alpha = { ...previouslyKnownWorkspaces[0], id: "workspace-alpha" };
+    const beta = { ...desktopWorkspaces[0], id: "workspace-beta" };
+    const gamma = { ...desktopWorkspaces[0], id: "workspace-gamma" };
+    const stable = stabilizeRouteWorkspaceOrder(
+      [beta, gamma, alpha],
+      ["workspace-alpha", "workspace-beta"],
+    );
+
+    expect(stable.orderIds).toEqual([
+      "workspace-alpha",
+      "workspace-beta",
+      "workspace-gamma",
+    ]);
+    expect(stable.workspaces.map((workspace) => workspace.id)).toEqual(stable.orderIds);
+  });
+
+  test("keeps temporarily absent workspace positions for the next successful refresh", () => {
+    const alpha = { ...previouslyKnownWorkspaces[0], id: "workspace-alpha" };
+    const beta = { ...desktopWorkspaces[0], id: "workspace-beta" };
+    const duringGap = stabilizeRouteWorkspaceOrder([beta], ["workspace-alpha", "workspace-beta"]);
+    const recovered = stabilizeRouteWorkspaceOrder([beta, alpha], duringGap.orderIds);
+
+    expect(duringGap.orderIds).toEqual(["workspace-alpha", "workspace-beta"]);
+    expect(duringGap.workspaces.map((workspace) => workspace.id)).toEqual(["workspace-beta"]);
+    expect(recovered.workspaces.map((workspace) => workspace.id)).toEqual([
+      "workspace-alpha",
+      "workspace-beta",
     ]);
   });
 });

--- a/evals/specs/workspace-sidebar-order.e2e.test.ts
+++ b/evals/specs/workspace-sidebar-order.e2e.test.ts
@@ -1,0 +1,291 @@
+import { rm } from "node:fs/promises";
+import { expect } from "vitest";
+import { control, evalIn, go } from "@openwork/behaviors";
+import {
+  checkedExec,
+  daytonaSandbox,
+  defaultDaytonaExec,
+  deleteSandboxes,
+  desktop,
+  localHost,
+  provisionDesktopSandbox,
+} from "@openwork/hosts";
+import type { DesktopHandle } from "@openwork/hosts";
+import { eventually, needs, sleep, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const title = e2eTestsEnabled
+  ? "workspace sidebar order stays stable, remains draggable, and appends new workspaces"
+  : "workspace sidebar order skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function seedWorkspaces(desktopApp: DesktopHandle, profileDir: string): Promise<string[]> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const plans = ${JSON.stringify(["Alpha", "Beta", "Gamma"])};
+    let state = null;
+    for (const label of plans) {
+      state = await window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
+        folderPath: ${JSON.stringify(profileDir)} + "/" + label.toLowerCase(),
+        name: label,
+      });
+    }
+    return (state?.workspaces ?? []).map((workspace) => workspace.id);
+  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+
+  if (!Array.isArray(value) || value.some((id) => typeof id !== "string")) {
+    throw new Error(`Workspace seeding returned an invalid list: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+async function sidebarOrder(desktopApp: DesktopHandle): Promise<string[]> {
+  const value = await evalIn(
+    desktopApp,
+    `Array.from(document.querySelectorAll("[data-sidebar-workspace-id]"))
+      .map((element) => element.getAttribute("data-sidebar-workspace-id"))
+      .filter(Boolean)`,
+  );
+  if (!Array.isArray(value) || value.some((id) => typeof id !== "string")) {
+    throw new Error(`Sidebar returned an invalid workspace order: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+async function storedOrder(desktopApp: DesktopHandle): Promise<string[]> {
+  const value = await evalIn(desktopApp, `(() => {
+    try {
+      const parsed = JSON.parse(localStorage.getItem("openwork.react.workspaceOrder") ?? "[]");
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  })()`);
+  if (!Array.isArray(value) || value.some((id) => typeof id !== "string")) {
+    throw new Error(`Stored workspace order is invalid: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+async function listServerWorkspaces(desktopApp: DesktopHandle): Promise<{ activeId: string | null; ids: string[] }> {
+  const value = await evalIn(desktopApp, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/workspaces", {
+      headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+      signal: AbortSignal.timeout(15_000),
+    });
+    const body = await response.json();
+    const items = Array.isArray(body?.items) ? body.items : [];
+    return {
+      ok: response.ok,
+      activeId: typeof body?.activeId === "string" ? body.activeId : null,
+      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+    };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+
+  if (!isRecord(value) || value.ok !== true || !Array.isArray(value.ids)) {
+    throw new Error(`Listing server workspaces failed: ${JSON.stringify(value)}`);
+  }
+  return {
+    activeId: typeof value.activeId === "string" ? value.activeId : null,
+    ids: value.ids.filter((id): id is string => typeof id === "string"),
+  };
+}
+
+async function reloadAndReadSidebar(desktopApp: DesktopHandle, expectedCount: number): Promise<string[]> {
+  await evalIn(desktopApp, "window.location.reload(); true");
+  return eventually(() => sidebarOrder(desktopApp), {
+    within: 90_000,
+    intervalMs: 250,
+    label: `sidebar with ${expectedCount} workspaces after reload`,
+    until: (order) => order.length === expectedCount,
+  });
+}
+
+async function dragWorkspaceAfter(desktopApp: DesktopHandle, sourceId: string, targetId: string): Promise<void> {
+  const value = await evalIn(desktopApp, `(() => {
+    const items = Array.from(document.querySelectorAll("[data-sidebar-workspace-id]"));
+    const source = items.find((item) => item.getAttribute("data-sidebar-workspace-id") === ${JSON.stringify(sourceId)});
+    const target = items.find((item) => item.getAttribute("data-sidebar-workspace-id") === ${JSON.stringify(targetId)});
+    const handle = source?.querySelector("[data-sidebar-workspace-drag-handle]");
+    if (!handle || !target) return null;
+    const from = handle.getBoundingClientRect();
+    const to = target.getBoundingClientRect();
+    return {
+      fromX: from.left + from.width / 2,
+      fromY: from.top + from.height / 2,
+      toX: to.left + to.width / 2,
+      toY: to.bottom - 2,
+    };
+  })()`);
+
+  if (!isRecord(value)) throw new Error("Workspace drag handles were not available.");
+  const fromX = value.fromX;
+  const fromY = value.fromY;
+  const toX = value.toX;
+  const toY = value.toY;
+  if (
+    typeof fromX !== "number"
+    || typeof fromY !== "number"
+    || typeof toX !== "number"
+    || typeof toY !== "number"
+  ) {
+    throw new Error(`Workspace drag coordinates were invalid: ${JSON.stringify(value)}`);
+  }
+
+  await desktopApp.client.send("Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x: fromX,
+    y: fromY,
+  });
+  await desktopApp.client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: fromX,
+    y: fromY,
+    button: "left",
+    buttons: 1,
+    clickCount: 1,
+  });
+  for (let step = 1; step <= 16; step += 1) {
+    const progress = step / 16;
+    await desktopApp.client.send("Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: fromX + (toX - fromX) * progress,
+      y: fromY + (toY - fromY) * progress,
+      button: "left",
+      buttons: 1,
+    });
+    await sleep(16);
+  }
+  await desktopApp.client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: toX,
+    y: toY,
+    button: "left",
+    buttons: 0,
+    clickCount: 1,
+  });
+}
+
+async function createWorkspace(desktopApp: DesktopHandle, path: string): Promise<string> {
+  const before = await listServerWorkspaces(desktopApp);
+  await control(desktopApp, "workspace.create", { path }, { timeoutMs: 90_000 });
+  const after = await eventually(() => listServerWorkspaces(desktopApp), {
+    within: 90_000,
+    intervalMs: 500,
+    label: "new workspace registered",
+    until: (listing) => listing.ids.length === before.ids.length + 1,
+  });
+  const createdId = after.ids.find((id) => !before.ids.includes(id));
+  if (!createdId) throw new Error("Workspace creation produced no new workspace id.");
+  return createdId;
+}
+
+test.skipIf(!e2eTestsEnabled)(title, { timeout: 20 * 60_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const profileDir = `/tmp/openwork-workspace-sidebar-order-${process.pid}-${Date.now()}`;
+  const provisioned = daytonaEnabled
+    ? await provisionDesktopSandbox({
+        ref: process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev",
+        name: "workspace-sidebar-order",
+        reuse: process.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim(),
+        log: (line) => console.error(`[openwork/testkit] ${line}`),
+      })
+    : null;
+  const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
+
+  try {
+    let seededWorkspaceIds: string[] = [];
+    {
+      await using seededApp = await desktop({ name: "workspace-order-seed", host, profileDir });
+      seededWorkspaceIds = await seedWorkspaces(seededApp, profileDir);
+    }
+
+    await using desktopApp = await desktop({ name: "workspace-sidebar-order", host, profileDir });
+    const initialOrder = await eventually(() => sidebarOrder(desktopApp), {
+      within: 90_000,
+      intervalMs: 250,
+      label: "seeded workspace sidebar",
+      until: (order) => order.length === seededWorkspaceIds.length,
+    });
+    expect(new Set(initialOrder)).toEqual(new Set(seededWorkspaceIds));
+    expect(await storedOrder(desktopApp)).toEqual(initialOrder);
+
+    const initialServerOrder = await listServerWorkspaces(desktopApp);
+    const activatedWorkspaceId = initialOrder.find((id) => id !== initialServerOrder.activeId)
+      ?? initialOrder[0];
+    await go(desktopApp, `/workspace/${encodeURIComponent(activatedWorkspaceId)}/session`);
+    const activeServerOrder = await eventually(() => listServerWorkspaces(desktopApp), {
+      within: 90_000,
+      intervalMs: 250,
+      label: "server active workspace order",
+      until: (listing) => listing.activeId === activatedWorkspaceId && listing.ids[0] === activatedWorkspaceId,
+    });
+    expect(activeServerOrder.ids[0]).toBe(activatedWorkspaceId);
+
+    const afterActivationReload = await reloadAndReadSidebar(desktopApp, initialOrder.length);
+    expect(afterActivationReload).toEqual(initialOrder);
+    evidence.recordAssertionEvidence(
+      "Selecting a workspace does not reshuffle the sidebar",
+      `The server returned the active workspace first, while the sidebar retained ${JSON.stringify(initialOrder)} across reload.`,
+      true,
+    );
+
+    const draggedWorkspaceId = afterActivationReload[0];
+    const dragTargetId = afterActivationReload[afterActivationReload.length - 1];
+    await dragWorkspaceAfter(desktopApp, draggedWorkspaceId, dragTargetId);
+    const draggedOrder = await eventually(() => sidebarOrder(desktopApp), {
+      within: 30_000,
+      intervalMs: 100,
+      label: "workspace drag reorder",
+      until: (order) => order.length === afterActivationReload.length
+        && order[order.length - 1] === draggedWorkspaceId,
+    });
+    expect(draggedOrder).not.toEqual(afterActivationReload);
+    expect(await storedOrder(desktopApp)).toEqual(draggedOrder);
+    expect(await reloadAndReadSidebar(desktopApp, draggedOrder.length)).toEqual(draggedOrder);
+    evidence.recordAssertionEvidence(
+      "Dragging a workspace changes and persists its position",
+      `The drag changed the sidebar to ${JSON.stringify(draggedOrder)}, local storage matched it, and reload preserved it.`,
+      true,
+    );
+
+    const newWorkspaceId = await createWorkspace(desktopApp, `${profileDir}/delta`);
+    const withNewWorkspace = await eventually(() => sidebarOrder(desktopApp), {
+      within: 90_000,
+      intervalMs: 250,
+      label: "new workspace appended to saved order",
+      until: (order) => order.length === draggedOrder.length + 1 && order.includes(newWorkspaceId),
+    });
+    expect(withNewWorkspace.slice(0, -1)).toEqual(draggedOrder);
+    expect(withNewWorkspace[withNewWorkspace.length - 1]).toBe(newWorkspaceId);
+    evidence.recordAssertionEvidence(
+      "A newly discovered workspace is appended without disturbing the saved order",
+      `The existing order stayed ${JSON.stringify(draggedOrder)} and the new workspace was appended.`,
+      true,
+    );
+  } finally {
+    try {
+      await host[Symbol.asyncDispose]();
+    } finally {
+      if (provisioned) {
+        try {
+          await checkedExec(
+            defaultDaytonaExec,
+            ["exec", provisioned.sandbox, "--", "rm", "-rf", profileDir],
+            `remove caller-owned workspace-order profile ${profileDir}`,
+            { timeoutMs: 30_000 },
+          );
+        } finally {
+          if (provisioned.created) await deleteSandboxes([provisioned.sandbox]);
+        }
+      } else {
+        await rm(profileDir, { recursive: true, force: true });
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- capture the first visible workspace order before active-workspace refreshes can reshuffle it
- preserve drag ordering across reloads and temporary discovery gaps
- append newly discovered workspaces without disturbing the saved arrangement
- cover selection, reload, pointer drag, persistence, and workspace creation in one desktop journey

## Why

The workspace server intentionally returns the active workspace first. The sidebar previously persisted its independent order only after a drag, so selecting a workspace could change the visible list before the user had ever arranged it.

## Verification

- focused workspace route tests: 17 passed, 0 failed
- app typecheck: passed
- workspace sidebar order desktop journey: 1 passed, 0 failed, 0 skipped at the PR head

The repository-wide eval typecheck remains red on the unchanged dev baseline, beginning at ee/packages/den-db/src/schema/auth.ts with the existing NodeNext import-extension error.