### PR TITLE
Preserve composer focus during same-task refreshes

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1079,6 +1079,35 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId, props.workspaceId]);
   useControlAction(props.isControlTarget ? seedSessionLifecycleControlAction : null);
+  const refreshCurrentSessionControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.composer_focus.refresh_current_session",
+      label: "Refresh current session while composing",
+      description: "Dev-only eval hook that exercises a same-session snapshot refresh without changing tasks.",
+      sideEffect: "none",
+      disabled: !props.sessionId,
+      execute: async () => {
+        const editor = composerShellRef.current?.querySelector<HTMLElement>(
+          '[contenteditable="true"][data-lexical-editor="true"]',
+        );
+        const wasFocused = editor === document.activeElement;
+        const result = await snapshotQuery.refetch();
+        await new Promise<void>((resolve) => {
+          window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+        });
+
+        return {
+          ok: result.status === "success",
+          wasFocused,
+          remainsFocused: editor === document.activeElement,
+          editable: editor?.getAttribute("contenteditable") === "true",
+        };
+      },
+    };
+  }, [props.sessionId, snapshotQuery.refetch]);
+  useControlAction(props.isControlTarget ? refreshCurrentSessionControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),

--- a/apps/app/src/react-app/domains/session/sync/transition-controller.ts
+++ b/apps/app/src/react-app/domains/session/sync/transition-controller.ts
@@ -55,7 +55,11 @@ export function deriveSessionRenderModel(input: {
   return {
     intendedSessionId: input.intendedSessionId,
     renderedSessionId: input.renderedSessionId,
-    transitionState: input.isFetching ? "switching" : "idle",
+    // A background refresh of the session already on screen is not a session
+    // switch. Keeping it idle prevents the composer from becoming temporarily
+    // non-editable (and losing focus) when a tool call or final message causes
+    // the current snapshot to refetch.
+    transitionState: "idle",
     renderSource: "live",
   };
 }

--- a/apps/app/tests/session-transition-controller.test.ts
+++ b/apps/app/tests/session-transition-controller.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveSessionRenderModel } from "../src/react-app/domains/session/sync/transition-controller";
+
+describe("session render transitions", () => {
+  test("keeps an already-rendered current session interactive during background refresh", () => {
+    expect(deriveSessionRenderModel({
+      intendedSessionId: "session-current",
+      renderedSessionId: "session-current",
+      hasSnapshot: true,
+      isFetching: true,
+      isError: false,
+    })).toEqual({
+      intendedSessionId: "session-current",
+      renderedSessionId: "session-current",
+      transitionState: "idle",
+      renderSource: "live",
+    });
+  });
+
+  test("still reports switching while the intended session has no rendered snapshot", () => {
+    expect(deriveSessionRenderModel({
+      intendedSessionId: "session-next",
+      renderedSessionId: null,
+      hasSnapshot: false,
+      isFetching: true,
+      isError: false,
+    }).transitionState).toBe("switching");
+  });
+
+  test("still reports switching when a different session remains rendered", () => {
+    expect(deriveSessionRenderModel({
+      intendedSessionId: "session-next",
+      renderedSessionId: "session-previous",
+      hasSnapshot: true,
+      isFetching: true,
+      isError: false,
+    }).transitionState).toBe("switching");
+  });
+});

--- a/evals/specs/composer-focus-continuity.e2e.test.ts
+++ b/evals/specs/composer-focus-continuity.e2e.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "same-session refresh preserves composer focus and uninterrupted typing"
+  : "composer focus continuity skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "composer-focus-continuity" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-composer-focus-continuity-${Date.now()}`,
+  });
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "new task control ready" },
+  );
+  await control(app, "session.create_task");
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.composer_focus.refresh_current_session" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "composer refresh proof control ready" },
+  );
+  await waitFor(
+    app,
+    `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`,
+    { timeoutMs: 30_000, label: "composer editor ready" },
+  );
+
+  const firstDraft = "Keep this draft while the task finishes";
+  const suffix = " and let me keep typing.";
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return document.activeElement === editor;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text: firstDraft });
+  await waitFor(
+    app,
+    `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(firstDraft)}`,
+    { timeoutMs: 10_000, label: "initial composer draft" },
+  );
+
+  const refresh = await control(app, "eval.composer_focus.refresh_current_session");
+  expect(refresh).toMatchObject({
+    ok: true,
+    wasFocused: true,
+    remainsFocused: true,
+    editable: true,
+  });
+
+  const stateAfterRefresh = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return {
+      focused: editor instanceof HTMLElement && document.activeElement === editor,
+      editable: editor?.getAttribute('contenteditable') === 'true',
+      text: editor instanceof HTMLElement ? editor.innerText.trim() : '',
+    };
+  })()`);
+  expect(stateAfterRefresh).toEqual({
+    focused: true,
+    editable: true,
+    text: firstDraft,
+  });
+  evidence.recordAssertionEvidence(
+    "A same-session completion refresh preserves composer focus and editability",
+    "The active Lexical editor remained focused and contenteditable after its session snapshot refreshed.",
+    true,
+  );
+
+  await app.client.send("Input.insertText", { text: suffix });
+  await waitFor(
+    app,
+    `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(firstDraft + suffix)}`,
+    { timeoutMs: 10_000, label: "continued composer draft" },
+  );
+  evidence.recordAssertionEvidence(
+    "The existing draft remains intact and typing continues without another click",
+    `The composer preserved “${firstDraft}” and accepted the suffix immediately after refresh.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- keep an already-rendered current task interactive while its snapshot refreshes in the background
- preserve the existing switching state for initial loads and actual task changes
- add transition-level regression coverage plus a desktop scenario that continues typing without refocusing

## Root cause

Every snapshot refetch was classified as a task switch, including completion updates for the task already on screen. That temporarily made the composer non-editable, blurred the editor, and then restored editability without restoring focus.

## Verification

- `bun test --isolate tests/session-transition-controller.test.ts` — 3 passed
- app TypeScript check — passed
- exact-head desktop E2E at `19fecb38428ce5f3383bf076e9f21d291b779070` — 1 passed, 0 failed, 0 skipped; 2 assertion claims passed