### PR TITLE
Replace running task spinner with a quiet shimmer

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -498,6 +498,14 @@ select:disabled {
   animation: ow-text-shimmer 2.4s linear infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .ow-text-shimmer {
+    background-image: none;
+    color: rgb(var(--dls-secondary-rgb) / 0.7);
+    animation: none;
+  }
+}
+
 /* Quiet, small dot ticker (`:: :: ::`). Each dot pulses briefly in sequence,
    illuminating left-to-right like a subtle running light. Used for boot,
    "awaiting first token", and any idle-but-alive hint. */

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { ArrowUpRight, LoaderCircle } from "lucide-react"
+import { ArrowUpRight } from "lucide-react"
 
 import {
   Collapsible,
@@ -28,7 +28,7 @@ function agentName(slug: string): string {
 }
 
 /**
- * Sub-agent task cards use the standard tool-call spinner while running.
+ * Running sub-agent task cards use a quiet text shimmer for activity.
  * Line 1 = task title + agent name; line 2 = live status verb or
  * "Completed". The card is the doorway into the sub-agent's own session:
  * when the engine reports the child session id, clicking it opens that
@@ -63,12 +63,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   const lines = (
     <>
       <span className="flex min-w-0 items-center gap-2">
-        {inFlight ? (
-          <span className="flex size-3.5 shrink-0 items-center justify-center">
-            <LoaderCircle aria-hidden="true" className="size-3.5 animate-spin text-muted-foreground" />
-          </span>
-        ) : null}
-        <span className="min-w-0 truncate">
+        <span className={cn("min-w-0 truncate", inFlight && "ow-text-shimmer")}>
           {title}
           <span className="text-muted-foreground/70"> · {agent} agent</span>
         </span>
@@ -79,7 +74,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
           />
         ) : null}
       </span>
-      <span className={cn("min-w-0 truncate text-xs text-muted-foreground/70", inFlight && "ps-5.5")}>
+      <span className="min-w-0 truncate text-xs text-muted-foreground/70">
         {isFailed ? `Failed — ${status}` : status}
         {!inFlight && !isFailed && duration ? ` · ${duration}` : ""}
       </span>
@@ -88,7 +83,12 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
 
   if (childSessionId && onOpenSubagentSession) {
     return (
-      <div data-subagent-run={part.toolCallId} data-subagent-session-id={childSessionId} className={className}>
+      <div
+        data-subagent-run={part.toolCallId}
+        data-subagent-session-id={childSessionId}
+        data-subagent-activity={inFlight ? "shimmer" : isFailed ? "failed" : "completed"}
+        className={className}
+      >
         <button
           type="button"
           className="group flex min-w-0 max-w-full cursor-pointer flex-col gap-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -102,7 +102,13 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   }
 
   return (
-    <Collapsible data-subagent-run={part.toolCallId} open={open} onOpenChange={setOpen} className={className}>
+    <Collapsible
+      data-subagent-run={part.toolCallId}
+      data-subagent-activity={inFlight ? "shimmer" : isFailed ? "failed" : "completed"}
+      open={open}
+      onOpenChange={setOpen}
+      className={className}
+    >
       <CollapsibleTrigger
         className="group flex min-w-0 max-w-full cursor-pointer flex-col gap-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
         aria-label={open ? `${title}. Hide details` : `${title}. Show details`}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -355,6 +355,36 @@ function createSessionLifecycleEvalMessages(sessionId: string): UIMessage[] {
   ];
 }
 
+function createSubagentActivityEvalMessages(sessionId: string): UIMessage[] {
+  const now = Date.now();
+  return [
+    {
+      id: `${sessionId}:eval-subagent-user`,
+      role: "user",
+      parts: [{ type: "text", text: "Build an isolated Azure reproduction." }],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-subagent-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "task",
+          toolCallId: "eval-subagent-activity",
+          state: "input-streaming",
+          input: {
+            description: "Build isolated Azure repro",
+            prompt: "Reproduce the Azure failure in isolation.",
+            subagent_type: "executor-deep",
+          },
+        },
+      ],
+      metadata: { opencode: { created: now + 1 } },
+    },
+  ];
+}
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   environmentClient?: OpenworkServerClient | null;
@@ -1159,6 +1189,27 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId, snapshotQuery.refetch]);
   useControlAction(props.isControlTarget ? refreshCurrentSessionControlAction : null);
+  const seedSubagentActivityControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.task_activity.seed",
+      label: "Seed running delegated-task activity proof",
+      description: "Dev-only eval hook that renders a deterministic running delegated-task row.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        setEvalMarkdownMessages(createSubagentActivityEvalMessages(props.sessionId));
+        useSessionActivityStore.getState().setRunStatus(
+          props.workspaceId,
+          props.sessionId,
+          { type: "busy" },
+        );
+        return { ok: true };
+      },
+    };
+  }, [props.sessionId, props.workspaceId]);
+  useControlAction(props.isControlTarget ? seedSubagentActivityControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),

--- a/apps/app/tests/subagent-run-line.test.tsx
+++ b/apps/app/tests/subagent-run-line.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MessageListProvider } from "../src/components/chat/message-list-provider";
+import { SubagentRunLine } from "../src/components/chat/subagent-run-line";
+import type { TaskToolPart } from "../src/lib/build-in-tools";
+
+const noop = () => {};
+
+function taskPart(state: "input-streaming" | "output-available"): TaskToolPart {
+  const input = {
+    description: "Build isolated Azure repro",
+    prompt: "Reproduce the Azure failure in isolation.",
+    subagent_type: "executor-deep",
+  };
+
+  return state === "output-available"
+    ? {
+        type: "dynamic-tool",
+        toolName: "task",
+        toolCallId: "call-subagent",
+        state,
+        input,
+        output: "Completed the reproduction.",
+      }
+    : {
+        type: "dynamic-tool",
+        toolName: "task",
+        toolCallId: "call-subagent",
+        state,
+        input,
+      };
+}
+
+function render(part: TaskToolPart): string {
+  return renderToStaticMarkup(
+    <MessageListProvider
+      workspaceId="workspace-a"
+      sessionId="session-origin"
+      showThinking={false}
+      developerMode={false}
+      displaySuggestions={false}
+      providerConnectedCount={1}
+      dispatchAction={noop}
+      setPrompt={noop}
+      onRevertToUserMessage={noop}
+      onForkAtMessage={noop}
+      onEditUserMessage={noop}
+      onMcpReconnect={async () => "connected"}
+      onMcpReopenAuthorization={async () => {}}
+      onMcpRetry={noop}
+    >
+      <SubagentRunLine part={part} />
+    </MessageListProvider>,
+  );
+}
+
+describe("SubagentRunLine", () => {
+  test("uses a text shimmer instead of a spinner while the subagent is running", () => {
+    const html = render(taskPart("input-streaming"));
+
+    expect(html).toContain('data-subagent-activity="shimmer"');
+    expect(html).toContain("ow-text-shimmer");
+    expect(html).toContain("Build isolated Azure repro");
+    expect(html).toContain("Working 0s");
+    expect(html).not.toContain("animate-spin");
+  });
+
+  test("settles to a static completed treatment", () => {
+    const html = render(taskPart("output-available"));
+
+    expect(html).toContain('data-subagent-activity="completed"');
+    expect(html).toContain("Completed");
+    expect(html).not.toContain("ow-text-shimmer");
+    expect(html).not.toContain("animate-spin");
+  });
+});

--- a/evals/specs/task-activity-shimmer.e2e.test.ts
+++ b/evals/specs/task-activity-shimmer.e2e.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "running delegated-task activity uses a quiet shimmer without a spinner"
+  : "task activity shimmer skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "task-activity-shimmer" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-task-activity-shimmer-${Date.now()}`,
+  });
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "new task control ready" },
+  );
+  await control(app, "session.create_task");
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.task_activity.seed" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "subagent activity proof control ready" },
+  );
+  await control(app, "eval.task_activity.seed");
+
+  await waitFor(
+    app,
+    `Boolean(document.querySelector('[data-subagent-activity="shimmer"] .ow-text-shimmer'))`,
+    { timeoutMs: 15_000, label: "running subagent shimmer" },
+  );
+  const rendered = await evalIn(app, `(() => {
+    const row = document.querySelector('[data-subagent-activity="shimmer"]');
+    const shimmer = row?.querySelector('.ow-text-shimmer');
+    return {
+      text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, ' ').trim() : '',
+      hasSpinner: Boolean(row?.querySelector('.animate-spin')),
+      hasShimmer: shimmer instanceof HTMLElement,
+      animationName: shimmer instanceof HTMLElement ? getComputedStyle(shimmer).animationName : '',
+    };
+  })()`);
+
+  expect(rendered).toMatchObject({
+    hasSpinner: false,
+    hasShimmer: true,
+  });
+  if (!rendered || typeof rendered !== "object" || !("text" in rendered) || typeof rendered.text !== "string") {
+    throw new Error(`Subagent activity row was not readable: ${JSON.stringify(rendered)}`);
+  }
+  expect(rendered.text).toContain("Build isolated Azure repro");
+  expect(rendered.text).toContain("Working");
+  evidence.recordAssertionEvidence(
+    "Running delegated tasks no longer show the circular spinner",
+    "The live delegated-task row contained no animate-spin indicator while it was working.",
+    true,
+  );
+
+  evidence.recordAssertionEvidence(
+    "A quiet shimmer communicates activity without obscuring the task status",
+    `The delegated-task title used the shimmer treatment while the readable row remained “${rendered.text}”.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- remove the circular loading icon from running delegated-task rows
- apply the existing quiet text shimmer to the active task title while keeping the elapsed status readable
- add a reduced-motion fallback and cover both running and completed states

## Why

The spinner adds visual weight beside every long-running delegated task. The shimmer communicates ongoing activity in the label itself and leaves the secondary status line stable.

## Verification

- `bun test --isolate tests/subagent-run-line.test.tsx` — 2 passed
- connector and session-transition overlap regression tests — 8 passed
- app TypeScript check — passed
- exact-head desktop E2E at `bb83f1956db4250cd2077a995d5c27225ecce33b` — 1 passed, 0 failed, 0 skipped; 2 assertion claims passed
