### PR TITLE
Gate Dashboard visibility with Den availability

### DIFF
--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -53,6 +53,7 @@ import {
 export type DesktopConfigStore = {
   config: DenDesktopConfig;
   loading: boolean;
+  freshConfigStatus: "pending" | "ready" | "failed";
   refresh: () => Promise<void>;
   refreshFresh: () => Promise<DenDesktopConfig>;
   /**
@@ -83,6 +84,7 @@ const DESKTOP_CONFIG_ITEMS = [
   "brandIconUrl",
   "brandAccentColor",
   "automationsEnabled",
+  "dashboardEnabled",
   "connectEnabled",
   "onboardingPrompts",
   "onboardingPromptDescriptions",
@@ -201,6 +203,7 @@ async function reconcileShellBranding(latestConfig: DenDesktopConfig): Promise<v
 type DesktopConfigState = {
   config: DenDesktopConfig;
   loading: boolean;
+  freshConfigStatus: "pending" | "ready" | "failed";
 };
 
 /**
@@ -218,8 +221,9 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   const [desktopConfigState, setDesktopConfigState] = useState<DesktopConfigState>({
     config: DEFAULT_DESKTOP_CONFIG,
     loading: true,
+    freshConfigStatus: "pending",
   });
-  const { config, loading } = desktopConfigState;
+  const { config, freshConfigStatus, loading } = desktopConfigState;
   // Bumped whenever the browser tells us the Den session or settings changed.
   const [settingsVersion, bumpSettingsVersion] = useReducer((value: number) => value + 1, 0);
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
@@ -282,6 +286,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (import.meta.env.DEV && requireFresh && devRefreshDesktopConfigRef.current) {
       const nextConfig = devRefreshDesktopConfigRef.current;
       applyDesktopConfigActions(nextConfig);
+      setDesktopConfigState((current) => ({ ...current, freshConfigStatus: "ready" }));
       void reconcileShellBranding(nextConfig).catch(() => undefined);
       return nextConfig;
     }
@@ -294,7 +299,11 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
     if (!isSignedIn || !token || !activeOrgId) {
       applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
-      setDesktopConfigState((current) => ({ ...current, loading: false }));
+      setDesktopConfigState((current) => ({
+        ...current,
+        freshConfigStatus: "failed",
+        loading: false,
+      }));
       return DEFAULT_DESKTOP_CONFIG;
     }
 
@@ -317,6 +326,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
       writeCachedDenDesktopConfig(cacheKey, nextConfig);
       applyDesktopConfigActions(nextConfig);
+      setDesktopConfigState((current) => ({ ...current, freshConfigStatus: "ready" }));
       void reconcileShellBranding(nextConfig).catch(() => undefined);
       return nextConfig;
     } catch (error) {
@@ -339,6 +349,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
       const fallbackConfig = cached ?? DEFAULT_DESKTOP_CONFIG;
       applyDesktopConfigActions(fallbackConfig);
+      setDesktopConfigState((current) => ({ ...current, freshConfigStatus: "failed" }));
       if (requireFresh) throw error;
       return fallbackConfig;
     } finally {
@@ -366,18 +377,35 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     // settingsVersion is read to tie this effect to settings-change events.
     void settingsVersion;
 
+    if (denAuth.status === "checking") {
+      setDesktopConfigState((current) => ({
+        ...current,
+        freshConfigStatus: "pending",
+        loading: true,
+      }));
+      return;
+    }
+
     if (!isSignedIn) {
       applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
-      setDesktopConfigState((current) => ({ ...current, loading: false }));
+      setDesktopConfigState((current) => ({
+        ...current,
+        freshConfigStatus: "failed",
+        loading: false,
+      }));
       return;
     }
 
     const cacheKey = getDenDesktopConfigCacheKey();
     const cached = readCachedDenDesktopConfig(cacheKey);
     applyDesktopConfigActions(cached ?? DEFAULT_DESKTOP_CONFIG);
-    setDesktopConfigState((current) => ({ ...current, loading: !cached }));
+    setDesktopConfigState((current) => ({
+      ...current,
+      freshConfigStatus: "pending",
+      loading: !cached,
+    }));
     void desktopConfigHandler();
-  }, [applyDesktopConfigActions, desktopConfigHandler, isSignedIn, settingsVersion]);
+  }, [applyDesktopConfigActions, denAuth.status, desktopConfigHandler, isSignedIn, settingsVersion]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -476,8 +504,16 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     // recent org restrictions without having to recompute every render.
     const checkRestriction: DesktopAppRestrictionChecker = ({ restriction }) =>
       checkDesktopAppRestriction({ config, restriction });
-    return { config, loading, refresh, refreshFresh, checkRestriction, connectPolicySync };
-  }, [config, loading, refresh, refreshFresh, connectPolicySync]);
+    return {
+      config,
+      freshConfigStatus,
+      loading,
+      refresh,
+      refreshFresh,
+      checkRestriction,
+      connectPolicySync,
+    };
+  }, [config, freshConfigStatus, loading, refresh, refreshFresh, connectPolicySync]);
 
   return (
     <DesktopConfigContext.Provider value={value}>

--- a/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-availability.ts
@@ -1,17 +1,22 @@
-export const MCP_APPS_DASHBOARD_FLAG_KEY = "openwork.mcpAppsDashboard";
+import { useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 
 /**
- * Local opt-in flag for the MCP Apps dashboard. The dashboard, its sidebar
- * entry, and its route stay hidden unless this flag is explicitly enabled,
- * mirroring the `openwork.developerMode` local-flag pattern.
+ * Deployment-level Dashboard availability advertised by Den.
+ *
+ * Older Den versions and stale cached configs omit the field. Treat both as
+ * disabled so hosted and self-deployed installations stay fail-closed.
  */
-export function isMcpAppsDashboardEnabled(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(MCP_APPS_DASHBOARD_FLAG_KEY) === "1";
-}
-
-export function setMcpAppsDashboardEnabled(enabled: boolean): void {
-  if (typeof window === "undefined") return;
-  if (enabled) window.localStorage.setItem(MCP_APPS_DASHBOARD_FLAG_KEY, "1");
-  else window.localStorage.removeItem(MCP_APPS_DASHBOARD_FLAG_KEY);
+export function useDashboardDeploymentAvailability(): { enabled: boolean; loading: boolean } {
+  const { config, freshConfigStatus, loading } = useDesktopConfig();
+  const denAuth = useDenAuth();
+  const decisionPending = loading
+    || denAuth.status === "checking"
+    || freshConfigStatus === "pending";
+  return {
+    enabled: !decisionPending
+      && freshConfigStatus === "ready"
+      && config.dashboardEnabled === true,
+    loading: decisionPending,
+  };
 }

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -23,10 +23,6 @@ import {
 } from "@/app/lib/den-endpoint-sources";
 import { isDesktopRuntime } from "@/app/utils";
 import { t } from "@/i18n";
-import {
-  isMcpAppsDashboardEnabled,
-  setMcpAppsDashboardEnabled,
-} from "@/react-app/domains/dashboard/dashboard-availability";
 import { ControlPlaneUrlEditor } from "../cloud/control-plane-url-editor";
 import { usePlatform } from "../../../kernel/platform";
 import {
@@ -813,7 +809,6 @@ interface AdvancedDeveloperSectionProps {
 }
 
 export function AdvancedDeveloperSection(props: AdvancedDeveloperSectionProps) {
-  const [mcpAppsDashboard, setMcpAppsDashboard] = useState(isMcpAppsDashboardEnabled);
   return (
     <LayoutSection>
       <LayoutSectionHeader>
@@ -829,26 +824,6 @@ export function AdvancedDeveloperSection(props: AdvancedDeveloperSectionProps) {
               aria-label={t("settings.developer_mode_title")}
               checked={props.developerMode}
               onCheckedChange={props.onToggleDeveloperMode}
-            />
-          </LayoutSectionItemHeaderActions>
-        </LayoutSectionItemHeader>
-      </LayoutSectionItem>
-
-      <LayoutSectionItem>
-        <LayoutSectionItemHeader>
-          <LayoutSectionItemTitle>MCP Apps dashboard</LayoutSectionItemTitle>
-          <LayoutSectionItemDescription>
-            Show the experimental MCP Apps dashboard in the sidebar. Off by
-            default; tiles and added apps are kept when you turn it back on.
-          </LayoutSectionItemDescription>
-          <LayoutSectionItemHeaderActions>
-            <Switch
-              aria-label="MCP Apps dashboard"
-              checked={mcpAppsDashboard}
-              onCheckedChange={(checked) => {
-                setMcpAppsDashboardEnabled(checked === true);
-                setMcpAppsDashboard(checked === true);
-              }}
             />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -94,7 +94,7 @@ import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
 import { DashboardPage } from "@/react-app/domains/dashboard/dashboard-page";
-import { isMcpAppsDashboardEnabled } from "@/react-app/domains/dashboard/dashboard-availability";
+import { useDashboardDeploymentAvailability } from "@/react-app/domains/dashboard/dashboard-availability";
 import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability";
 import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
 import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
@@ -497,8 +497,13 @@ export function SessionRoute() {
   const location = useLocation();
   const automationsRouteRequested = /^\/automations(?:\/|$)/.test(location.pathname);
   const dashboardRouteRequested = /^\/dashboard(?:\/|$)/.test(location.pathname);
-  const mcpAppsDashboardEnabled = isMcpAppsDashboardEnabled();
+  const {
+    enabled: mcpAppsDashboardEnabled,
+    loading: dashboardAvailabilityLoading,
+  } = useDashboardDeploymentAvailability();
   const dashboardRouteActive = mcpAppsDashboardEnabled && dashboardRouteRequested;
+  const dashboardWorkspaceRoute = dashboardRouteRequested
+    && (dashboardAvailabilityLoading || mcpAppsDashboardEnabled);
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
@@ -514,9 +519,9 @@ export function SessionRoute() {
     navigate("/", { replace: true });
   }, [automationsEnabled, automationsRouteRequested, navigate]);
   useEffect(() => {
-    if (!dashboardRouteRequested || mcpAppsDashboardEnabled) return;
+    if (!dashboardRouteRequested || dashboardAvailabilityLoading || mcpAppsDashboardEnabled) return;
     navigate("/", { replace: true });
-  }, [dashboardRouteRequested, mcpAppsDashboardEnabled, navigate]);
+  }, [dashboardAvailabilityLoading, dashboardRouteRequested, mcpAppsDashboardEnabled, navigate]);
   useEffect(() => {
     const authToken = denSettings.authToken?.trim();
     const organizationId = denSettings.activeOrgId?.trim();
@@ -616,7 +621,7 @@ export function SessionRoute() {
     runRemoteWorkspaceConnectionCheck,
   } = useWorkspaceRouteState({
     developerMode,
-    workspaceRoute: automationsRouteActive ? "automations" : dashboardRouteActive ? "dashboard" : "session",
+    workspaceRoute: automationsRouteActive ? "automations" : dashboardWorkspaceRoute ? "dashboard" : "session",
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });

--- a/apps/app/tests/dashboard-availability.test.ts
+++ b/apps/app/tests/dashboard-availability.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const read = (relative: string) =>
+  readFileSync(join(import.meta.dir, "..", relative), "utf8");
+
+describe("Dashboard availability", () => {
+  test("fails closed unless fresh desktop config explicitly enables the deployment", () => {
+    const availability = read("src/react-app/domains/dashboard/dashboard-availability.ts");
+    const provider = read("src/react-app/domains/cloud/desktop-config-provider.tsx");
+    expect(availability).toContain('freshConfigStatus === "pending"');
+    expect(availability).toContain('freshConfigStatus === "ready"');
+    expect(availability).toContain("config.dashboardEnabled === true");
+    expect(availability).not.toContain("localStorage");
+    expect(provider).toContain('if (denAuth.status === "checking")');
+    expect(provider).toContain('freshConfigStatus: "pending"');
+    expect(provider).toContain('freshConfigStatus: "ready"');
+    expect(provider).toContain('freshConfigStatus: "failed"');
+  });
+
+  test("gates the route and sidebar without a local developer override", () => {
+    const route = read("src/react-app/shell/session-route.tsx");
+    const advanced = read("src/react-app/domains/settings/pages/advanced-view-sections.tsx");
+
+    expect(route).toContain("useDashboardDeploymentAvailability()");
+    expect(route).toContain("dashboardAvailabilityLoading || mcpAppsDashboardEnabled");
+    expect(route).toContain("dashboardWorkspaceRoute ? \"dashboard\" : \"session\"");
+    expect(route).toContain("mcpAppsDashboardEnabled && dashboardRouteRequested");
+    expect(route).toContain("onOpenDashboard: mcpAppsDashboardEnabled");
+    expect(advanced).not.toContain("MCP Apps dashboard");
+    expect(advanced).not.toContain("setMcpAppsDashboardEnabled");
+  });
+});

--- a/evals/specs/dashboard-deployment-gate.e2e.test.ts
+++ b/evals/specs/dashboard-deployment-gate.e2e.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "vitest";
+import { denFetch, evalIn, go } from "@openwork/behaviors";
+import { app, needs, server, test } from "@openwork/testkit";
+
+const requirements = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test("Desktop hides Dashboard when the deployment flag is disabled", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    env: { DEN_DASHBOARDS_ENABLED: "false" },
+  });
+
+  const config = await denFetch(den.admin, "/v1/me/desktop-config", {
+    headers: { authorization: `Bearer ${den.admin.token}` },
+  });
+  expect(config.response.status, config.text).toBe(200);
+  expect(isRecord(config.body) ? config.body.dashboardEnabled : undefined).toBe(false);
+
+  await using desktop = await app({ den, as: "admin", place });
+  const sidebarHasDashboard = await evalIn(desktop, `
+    [...document.querySelectorAll("button")]
+      .some((button) => button.textContent?.trim() === "Dashboard")
+  `);
+  expect(sidebarHasDashboard).toBe(false);
+
+  await go(desktop, "/dashboard");
+  await expect.poll(
+    () => evalIn(desktop, "!/^#\\/dashboard(?:\\?|$)/.test(location.hash)"),
+    { timeout: 60_000 },
+  ).toBe(true);
+
+  evidence.recordAssertionEvidence(
+    "Disabled deployments hide Dashboard",
+    "Desktop config returned dashboardEnabled=false, the sidebar omitted Dashboard, and a direct Dashboard route request redirected away.",
+    true,
+  );
+});

--- a/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
+++ b/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
@@ -76,6 +76,7 @@ test(title, async ({ evidence, place }) => {
   needs(requirements);
   await using den = await server({
     place,
+    env: { DEN_DASHBOARDS_ENABLED: "true" },
     org: {
       name: `Managed Desktop dashboard ${Date.now()}`,
       admin: { name: "Managed Dashboard Admin" },
@@ -111,9 +112,6 @@ test(title, async ({ evidence, place }) => {
     den,
     as: "admin",
     place,
-    beforeSignIn: async (surface) => {
-      await evalIn(surface, `localStorage.setItem("openwork.mcpAppsDashboard", "1")`);
-    },
   });
   const dashboardHash = "#/dashboard";
   const dashboardOpened = await evalIn(desktop, `(() => {


### PR DESCRIPTION
## Summary

- consume the `dashboardEnabled` Den desktop-config contract landed in #4106
- remove the per-device Dashboard developer toggle and gate both the sidebar entry and direct route
- require a successful fresh desktop-config response before Dashboard can be enabled; cached policy cannot grant access and request failures fail closed
- preserve Dashboard routing while authentication and deployment policy are still resolving

## Delivery order

The Den contract landed first in #4106. This Desktop-only branch is rebased onto that merged `dev` head, so the Desktop release cannot precede the server field.

## Verification

- `bun test apps/app/tests/dashboard-availability.test.ts apps/app/tests/den-desktop-config.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `node evals/bin/evals.mjs dashboard-deployment-gate --local`
- `node evals/bin/evals.mjs org-managed-dashboard-desktop --local`

Both exact-head Desktop journeys passed with no skips after rebasing onto the merged Den contract: disabled deployments hide Dashboard and redirect direct route requests; enabled deployments preserve Dashboard through reload, cached rendering, and background refresh.