### PR TITLE
fix(server): fetch live models.dev catalog so freshly released models are usable

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -1,6 +1,10 @@
 name: Update Models
 
 on:
+  schedule:
+    # Keep the first-party catalog mirror fresh; without this the mirror only
+    # updates when someone runs the workflow by hand.
+    - cron: "17 6 * * *"
   workflow_dispatch:
     inputs:
       base_branch:
@@ -20,7 +24,7 @@ concurrency:
 env:
   MODELS_PATH: ee/apps/inference/src/models/base.json
   MODELS_URL: https://models.dev/api.json
-  BASE_BRANCH: ${{ inputs.base_branch }}
+  BASE_BRANCH: ${{ inputs.base_branch || 'dev' }}
   BRANCH_NAME: automation/update-models-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:

--- a/apps/server/src/opencode-models-url.test.ts
+++ b/apps/server/src/opencode-models-url.test.ts
@@ -39,8 +39,27 @@ describe("resolveOpencodeModelsUrl", () => {
     })).toBe("https://catalog.example.test/models");
   });
 
-  test("uses the production catalog outside development", async () => {
-    expect(await resolveOpencodeModelsUrl({ env: {} })).toBe("https://models.openworklabs.com/");
+  test("uses the live models.dev catalog outside development", async () => {
+    expect(await resolveOpencodeModelsUrl({
+      env: {},
+      fetchModels: async () => new Response(null, { status: 200 }),
+    })).toBe("https://models.dev/");
+  });
+
+  test("falls back to the mirror when models.dev is unreachable", async () => {
+    expect(await resolveOpencodeModelsUrl({
+      env: {},
+      fetchModels: async () => new Response(null, { status: 503 }),
+    })).toBe("https://models.openworklabs.com/");
+  });
+
+  test("falls back to the mirror when models.dev errors", async () => {
+    expect(await resolveOpencodeModelsUrl({
+      env: {},
+      fetchModels: async () => {
+        throw new TypeError("network down");
+      },
+    })).toBe("https://models.openworklabs.com/");
   });
 
   test("uses the local catalog when the development server is available", async () => {
@@ -50,7 +69,7 @@ describe("resolveOpencodeModelsUrl", () => {
     })).toBe("http://localhost:8791/models");
   });
 
-  test("falls back to the production catalog when the development server is unavailable", async () => {
+  test("falls back to the mirror when the development server is unavailable", async () => {
     expect(await resolveOpencodeModelsUrl({
       env: { OPENWORK_DEV_MODE: "1" },
       fetchModels: async () => new Response(null, { status: 503 }),

--- a/apps/server/src/opencode-models-url.ts
+++ b/apps/server/src/opencode-models-url.ts
@@ -1,7 +1,8 @@
 import { loopbackFetch } from "./server-fetch.js";
 
 const LOCAL_MODELS_URL = "http://localhost:8791/models";
-const PRODUCTION_MODELS_URL = "https://models.openworklabs.com/";
+const LIVE_MODELS_URL = "https://models.dev/";
+const MIRROR_MODELS_URL = "https://models.openworklabs.com/";
 
 type ResolveOpencodeModelsUrlOptions = {
   env?: NodeJS.ProcessEnv;
@@ -14,7 +15,21 @@ export async function resolveOpencodeModelsUrl(
   const env = options.env ?? process.env;
   const override = env.OPENCODE_MODELS_URL?.trim();
   if (override) return override;
-  if (env.OPENWORK_DEV_MODE !== "1") return PRODUCTION_MODELS_URL;
+  if (env.OPENWORK_DEV_MODE !== "1") {
+    // Prefer the live models.dev catalog so freshly released models are usable
+    // without waiting for the first-party mirror snapshot to be rebuilt, and
+    // fall back to the mirror when models.dev is unreachable (corporate
+    // proxies, outages).
+    try {
+      const response = await (options.fetchModels ?? fetch)(`${LIVE_MODELS_URL}api.json`, {
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (response.ok) return LIVE_MODELS_URL;
+    } catch {
+      // Unreachable catalogs fall through to the mirror below.
+    }
+    return MIRROR_MODELS_URL;
+  }
 
   try {
     const response = await (options.fetchModels ?? loopbackFetch)(`${LOCAL_MODELS_URL}/api.json`, {
@@ -25,5 +40,5 @@ export async function resolveOpencodeModelsUrl(
     // A standalone desktop dev session does not run the local inference stack.
   }
 
-  return PRODUCTION_MODELS_URL;
+  return MIRROR_MODELS_URL;
 }


### PR DESCRIPTION
## Summary

The managed engine was pinned to the first-party model catalog mirror (`https://models.openworklabs.com/`, passed as `OPENCODE_MODELS_URL`), which is a static snapshot of models.dev rebuilt only when someone runs the `update-models.yml` workflow by hand (it has no schedule). Any model released after the last manual run never reaches the engine's provider list and therefore cannot be picked or used — for example `openrouter/stealth/ox-alpha`, or `opencode/x-preview-f-free` on OpenCode Zen. This is the stale-catalog behavior reported in #4035 ("Opencode go models are outdated (do not update automatically)"): vanilla OpenCode shows those models because it reads models.dev live.

## Changes

- `apps/server/src/opencode-models-url.ts`: outside development, resolve the engine catalog from live `https://models.dev/` using a 1s reachability probe, falling back to the first-party mirror when models.dev is unreachable (corporate proxies / outages). The explicit `OPENCODE_MODELS_URL` override and the dev-mode local inference stack probe keep their current priority.
- `.github/workflows/update-models.yml`: add a daily `schedule` so the fallback mirror stays fresh instead of advancing only on manual dispatch. `BASE_BRANCH` now falls back to `dev` because `inputs.base_branch` is empty on `schedule` events.
- `apps/server/src/opencode-models-url.test.ts`: cover the new production resolution order.

Resolution order after this change:

1. explicit `OPENCODE_MODELS_URL` override (unchanged; air-gapped escape hatch)
2. dev mode: local inference stack probe at `localhost:8791` (unchanged)
3. production: live `https://models.dev/api.json` probe (1s timeout)
4. fallback: first-party mirror `https://models.openworklabs.com/`

## Test evidence

```
bun test apps/server/src/opencode-models-url.test.ts

(pass) resolveOpencodeModelsUrl > honors an explicit catalog URL
(pass) resolveOpencodeModelsUrl > uses the live models.dev catalog outside development
(pass) resolveOpencodeModelsUrl > falls back to the mirror when models.dev is unreachable
(pass) resolveOpencodeModelsUrl > falls back to the mirror when models.dev errors
(pass) resolveOpencodeModelsUrl > uses the local catalog when the development server is available
(pass) resolveOpencodeModelsUrl > falls back to the mirror when the development server is unavailable

6 pass, 1 fail, 7 tests
```

The single failure is the `startEmbeddedServer managed OpenCode models URL` case: it spawns a fake engine child process and fails on Windows with "Managed OpenCode process did not exit after SIGKILL" (`apps/server/src/managed-opencode.ts:83`). That failure is environment-specific and pre-existing: stashing this branch and re-running on pristine HEAD reproduces the same `4 pass / 1 fail` result, so it is unrelated to these changes.

Fixes #4035
