### PR TITLE
Fix Azure managed provider credential selection

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -27,6 +27,33 @@ const sameStringList = (a: string[], b: string[]) =>
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+const credentialEnvRank = (name: string) => {
+  const normalized = name.trim().toUpperCase();
+  if (/(^|_)API_KEY$/.test(normalized)) return 0;
+  if (/(^|_)ACCESS_KEY_ID$/.test(normalized)) return 1;
+  if (/(^|_)BEARER_TOKEN(_|$)/.test(normalized) || /(^|_)TOKEN$/.test(normalized)) return 2;
+  if (/(^|_)KEY$/.test(normalized)) return 3;
+  return null;
+};
+
+const selectPrimaryCredentialEnvName = (
+  envNames: string[],
+  availableNames: string[],
+) => {
+  const available = new Set(availableNames.filter((name) => name.trim().length > 0));
+  const orderedNames = [
+    ...envNames.filter((name) => available.has(name)),
+    ...[...available].filter((name) => !envNames.includes(name)),
+  ];
+  const ranked = orderedNames
+    .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
+    .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)
+    .sort((left, right) => left.rank - right.rank || left.index - right.index);
+  if (ranked[0]) return ranked[0].name;
+  if (envNames.length > 1 && envNames.some((name) => credentialEnvRank(name) !== null)) return null;
+  return orderedNames[0] ?? null;
+};
+
 const removeCloudProviderComment = (raw: string, providerId: string) =>
   raw.replace(
     new RegExp(
@@ -42,9 +69,9 @@ export const getCloudProviderEnv = (config: Record<string, unknown>) =>
 /**
  * Split a connect payload's credential into the opencode auth.json entry and
  * the env vars to upsert. Multi-env providers (`apiKeys`) set every value as
- * an env var and use the first env-ordered value as the auth entry, following
- * the models.dev convention that `env[0]` is the primary credential. Legacy
- * single-credential payloads (`apiKey`) keep today's auth-only behaviour.
+ * an env var, then choose the auth entry by credential-shaped env name rather
+ * than by position: Azure declares its resource name before its API key.
+ * Legacy single-credential payloads (`apiKey`) keep today's auth-only behaviour.
  */
 export const resolveCloudProviderCredentials = (
   provider: Pick<
@@ -62,7 +89,14 @@ export const resolveCloudProviderCredentials = (
     const value = apiKeys[name]?.trim();
     return value ? [{ key: name, value }] : [];
   });
-  const primaryApiKey = provider.apiKey?.trim() || envEntries[0]?.value || "";
+  const primaryCredentialEnvName = selectPrimaryCredentialEnvName(
+    envNames,
+    envEntries.map((entry) => entry.key),
+  );
+  const primaryApiKey =
+    provider.apiKey?.trim() ||
+    envEntries.find((entry) => entry.key === primaryCredentialEnvName)?.value ||
+    "";
   return { envEntries, primaryApiKey };
 };
 

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -41,10 +41,7 @@ const selectPrimaryCredentialEnvName = (
   availableNames: string[],
 ) => {
   const available = new Set(availableNames.filter((name) => name.trim().length > 0));
-  const orderedNames = [
-    ...envNames.filter((name) => available.has(name)),
-    ...[...available].filter((name) => !envNames.includes(name)),
-  ];
+  const orderedNames = envNames.filter((name) => available.has(name));
   const ranked = orderedNames
     .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
     .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -499,14 +499,23 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return "";
   };
 
-  const mirrorOpenWorkModelsVoiceEnv = async (provider: DenOrgLlmProviderConnection, apiKey: string) => {
+  const mirrorOpenWorkModelsVoiceEnv = async (
+    provider: DenOrgLlmProviderConnection,
+    apiKey: string,
+    resolvedEnvEntries: Array<{ key: string; value: string }>,
+  ) => {
     const trimmedKey = apiKey.trim();
     if (!trimmedKey) return;
     const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
     if (!openworkClient) return;
-    const entries = getCloudProviderEnv(provider.providerConfig)
-      .slice(0, 1)
-      .map((key) => ({ key, value: trimmedKey }));
+    const entries = [...resolvedEnvEntries];
+    if (entries.length === 0) {
+      entries.push(
+        ...getCloudProviderEnv(provider.providerConfig)
+          .slice(0, 1)
+          .map((key) => ({ key, value: trimmedKey })),
+      );
+    }
     if (provider.source === "openwork") {
       if (!entries.some((entry) => entry.key === "OPENWORK_API_KEY")) {
         entries.unshift({ key: "OPENWORK_API_KEY", value: trimmedKey });
@@ -1695,7 +1704,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           providerID: localProviderId,
           auth: { type: "api", key: primaryApiKey },
         });
-        await mirrorOpenWorkModelsVoiceEnv(provider, primaryApiKey);
+        await mirrorOpenWorkModelsVoiceEnv(provider, primaryApiKey, envEntries);
       }
       if (existingImported?.providerId && existingImported.providerId !== localProviderId) {
         try {

--- a/apps/app/tests/cloud-provider-credentials.test.ts
+++ b/apps/app/tests/cloud-provider-credentials.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveCloudProviderCredentials } from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
+import {
+  buildCloudProviderConfig,
+  resolveCloudProviderCredentials,
+} from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
 
 const AWS_ENV = [
   "AWS_ACCESS_KEY_ID",
@@ -20,7 +23,7 @@ describe("resolveCloudProviderCredentials", () => {
     ).toEqual({ envEntries: [], primaryApiKey: "sk-test" });
   });
 
-  test("multi-env payloads become env entries with env[0] as the auth key", () => {
+  test("multi-env payloads become env entries with the credential env as the auth key", () => {
     const { envEntries, primaryApiKey } = resolveCloudProviderCredentials({
       apiKey: null,
       apiKeys: {
@@ -46,6 +49,70 @@ describe("resolveCloudProviderCredentials", () => {
       providerConfig: { env: AWS_ENV },
     });
     expect(primaryApiKey).toBe("bearer-token");
+  });
+
+  test("Azure multi-env payloads use AZURE_API_KEY as auth and keep the resource env", () => {
+    const { envEntries, primaryApiKey } = resolveCloudProviderCredentials({
+      apiKey: null,
+      apiKeys: {
+        AZURE_RESOURCE_NAME: "resource-name",
+        AZURE_API_KEY: "real-api-key",
+      },
+      providerConfig: { env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] },
+    });
+
+    expect(envEntries).toEqual([
+      { key: "AZURE_RESOURCE_NAME", value: "resource-name" },
+      { key: "AZURE_API_KEY", value: "real-api-key" },
+    ]);
+    expect(primaryApiKey).toBe("real-api-key");
+  });
+
+  test("Azure resource-only payloads are not treated as authenticated", () => {
+    const { envEntries, primaryApiKey } = resolveCloudProviderCredentials({
+      apiKey: null,
+      apiKeys: { AZURE_RESOURCE_NAME: "resource-name" },
+      providerConfig: { env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] },
+    });
+
+    expect(envEntries).toEqual([{ key: "AZURE_RESOURCE_NAME", value: "resource-name" }]);
+    expect(primaryApiKey).toBe("");
+  });
+
+  test("Azure provider config names both resource and API key env vars for OpenCode", () => {
+    const config = buildCloudProviderConfig({
+      id: "lpr_azure",
+      source: "models_dev",
+      providerId: "azure",
+      name: "Azure",
+      providerConfig: {
+        id: "azure",
+        name: "Azure",
+        npm: "@ai-sdk/azure",
+        env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      },
+      hasApiKey: true,
+      models: [
+        {
+          id: "deployment",
+          name: "deployment",
+          config: {},
+          createdAt: null,
+        },
+      ],
+      createdAt: null,
+      updatedAt: null,
+      apiKey: null,
+      apiKeys: {
+        AZURE_RESOURCE_NAME: "resource-name",
+        AZURE_API_KEY: "real-api-key",
+      },
+    });
+
+    expect(config).toMatchObject({
+      id: "azure",
+      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+    });
   });
 
   test("map keys outside the config env list are still applied, after env-ordered ones", () => {

--- a/apps/app/tests/cloud-provider-credentials.test.ts
+++ b/apps/app/tests/cloud-provider-credentials.test.ts
@@ -127,6 +127,16 @@ describe("resolveCloudProviderCredentials", () => {
     ]);
   });
 
+  test("undeclared API-shaped map keys are not used as the auth credential", () => {
+    const { primaryApiKey } = resolveCloudProviderCredentials({
+      apiKey: null,
+      apiKeys: { OPENAI_API_KEY: "unrelated-secret" },
+      providerConfig: { env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] },
+    });
+
+    expect(primaryApiKey).toBe("");
+  });
+
   test("no credential at all yields empty results", () => {
     expect(
       resolveCloudProviderCredentials({

--- a/apps/app/tests/cloud-provider-reimport.test.ts
+++ b/apps/app/tests/cloud-provider-reimport.test.ts
@@ -158,6 +158,8 @@ describe("cloud provider runtime patch (re-import diff #2346)", () => {
 
     const mirrorSource = source.slice(mirrorStart, mirrorEnd);
     expect(mirrorSource).not.toContain('provider.source !== "openwork"');
+    expect(mirrorSource).toContain("resolvedEnvEntries");
+    expect(mirrorSource).toContain("const entries = [...resolvedEnvEntries]");
     expect(mirrorSource).toContain("getCloudProviderEnv(provider.providerConfig)");
     expect(mirrorSource).toContain(".slice(0, 1)");
   });

--- a/apps/server/src/managed-provider-auth.test.ts
+++ b/apps/server/src/managed-provider-auth.test.ts
@@ -83,6 +83,43 @@ describe("managed provider auth delivery", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("delivers Azure API key instead of resource name", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "azure", name: "Azure", env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] });
+    const fetchStub = stubFetch();
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: {
+        list: async () => [
+          { key: "AZURE_RESOURCE_NAME", value: "resource-name" },
+          { key: "AZURE_API_KEY", value: "real-api-key" },
+        ],
+      },
+      fetchImpl: fetchStub.impl,
+    });
+
+    expect(result.delivered).toEqual([PROVIDER]);
+    expect(fetchStub.calls[0]?.body).toEqual({ type: "api", key: "real-api-key" });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("does not treat an Azure resource name by itself as a stored credential", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "azure", name: "Azure", env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] });
+    const fetchStub = stubFetch();
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [{ key: "AZURE_RESOURCE_NAME", value: "resource-name" }] },
+      fetchImpl: fetchStub.impl,
+    });
+
+    expect(result.skipped).toEqual([{ providerId: PROVIDER, reason: "no_stored_credential" }]);
+    expect(fetchStub.calls).toHaveLength(0);
+    await rm(dir, { recursive: true, force: true });
+  });
+
   test("does not re-deliver an unchanged credential", async () => {
     const config = await makeConfig(dir);
     await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });

--- a/apps/server/src/managed-provider-auth.test.ts
+++ b/apps/server/src/managed-provider-auth.test.ts
@@ -120,6 +120,22 @@ describe("managed provider auth delivery", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("does not deliver an unrelated env-store secret to a managed provider", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "azure", name: "Azure", env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] });
+    const fetchStub = stubFetch();
+
+    const result = await syncManagedProviderAuth({
+      config,
+      env: { list: async () => [{ key: "OPENAI_API_KEY", value: "unrelated-secret" }] },
+      fetchImpl: fetchStub.impl,
+    });
+
+    expect(result.skipped).toEqual([{ providerId: PROVIDER, reason: "no_stored_credential" }]);
+    expect(fetchStub.calls).toHaveLength(0);
+    await rm(dir, { recursive: true, force: true });
+  });
+
   test("does not re-deliver an unchanged credential", async () => {
     const config = await makeConfig(dir);
     await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -70,10 +70,7 @@ function credentialEnvRank(name: string): number | null {
 
 function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iterable<string>): string | null {
   const available = new Set([...availableNames].filter((name) => name.trim().length > 0));
-  const orderedNames = [
-    ...envNames.filter((name) => available.has(name)),
-    ...[...available].filter((name) => !envNames.includes(name)),
-  ];
+  const orderedNames = envNames.filter((name) => available.has(name));
   const ranked = orderedNames
     .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
     .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -59,6 +59,30 @@ function readEnvNames(entry: Record<string, unknown>): string[] {
   return entry.env.filter((name): name is string => typeof name === "string" && name.trim().length > 0);
 }
 
+function credentialEnvRank(name: string): number | null {
+  const normalized = name.trim().toUpperCase();
+  if (/(^|_)API_KEY$/.test(normalized)) return 0;
+  if (/(^|_)ACCESS_KEY_ID$/.test(normalized)) return 1;
+  if (/(^|_)BEARER_TOKEN(_|$)/.test(normalized) || /(^|_)TOKEN$/.test(normalized)) return 2;
+  if (/(^|_)KEY$/.test(normalized)) return 3;
+  return null;
+}
+
+function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iterable<string>): string | null {
+  const available = new Set([...availableNames].filter((name) => name.trim().length > 0));
+  const orderedNames = [
+    ...envNames.filter((name) => available.has(name)),
+    ...[...available].filter((name) => !envNames.includes(name)),
+  ];
+  const ranked = orderedNames
+    .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
+    .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)
+    .sort((left, right) => left.rank - right.rank || left.index - right.index);
+  if (ranked[0]) return ranked[0].name;
+  if (envNames.length > 1 && envNames.some((name) => credentialEnvRank(name) !== null)) return null;
+  return orderedNames[0] ?? null;
+}
+
 /**
  * Forget what we believe the engine holds. Call this when the engine process is
  * replaced: opencode persists auth outside the process, but a fresh engine may
@@ -107,7 +131,7 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
       continue;
     }
 
-    const credentialName = envNames.find((name) => storedValues.has(name));
+    const credentialName = selectPrimaryCredentialEnvName(envNames, storedValues.keys());
     if (!credentialName) {
       result.skipped.push({ providerId, reason: "no_stored_credential" });
       input.logger?.warn("managed provider credential missing from env store", {

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -282,7 +282,11 @@ function providerEnvEntries(provider: CloudProviderMaterializationProvider): Env
   }
 
   if (credential.apiKey && envNames[0]) {
-    upsertEnvEntry(entries, envNames[0], credential.apiKey)
+    upsertEnvEntry(
+      entries,
+      selectPrimaryCredentialEnvName(envNames, envNames) ?? envNames[0],
+      credential.apiKey,
+    )
   }
 
   const primaryCredentialEnvName = selectPrimaryCredentialEnvName(envNames, entries.map((entry) => entry.key))

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -10,7 +10,7 @@ import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
 import { fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
-import { decodeProviderCredential, readProviderEnvNames, selectPrimaryCredentialEnvName } from "./provider-credentials.js"
+import { decodeProviderCredential, readProviderEnvNames, selectLegacyScalarCredentialEnvName, selectPrimaryCredentialEnvName } from "./provider-credentials.js"
 
 type JsonRecord = Record<string, unknown>
 type OrganizationId = typeof LlmProviderTable.$inferSelect.organizationId
@@ -284,7 +284,7 @@ function providerEnvEntries(provider: CloudProviderMaterializationProvider): Env
   if (credential.apiKey && envNames[0]) {
     upsertEnvEntry(
       entries,
-      selectPrimaryCredentialEnvName(envNames, envNames) ?? envNames[0],
+      selectLegacyScalarCredentialEnvName(envNames) ?? envNames[0],
       credential.apiKey,
     )
   }

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -10,7 +10,7 @@ import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
 import { fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
-import { decodeProviderCredential, readProviderEnvNames } from "./provider-credentials.js"
+import { decodeProviderCredential, readProviderEnvNames, selectPrimaryCredentialEnvName } from "./provider-credentials.js"
 
 type JsonRecord = Record<string, unknown>
 type OrganizationId = typeof LlmProviderTable.$inferSelect.organizationId
@@ -285,7 +285,8 @@ function providerEnvEntries(provider: CloudProviderMaterializationProvider): Env
     upsertEnvEntry(entries, envNames[0], credential.apiKey)
   }
 
-  const primaryCredential = credential.apiKey?.trim() || entries[0]?.value || ""
+  const primaryCredentialEnvName = selectPrimaryCredentialEnvName(envNames, entries.map((entry) => entry.key))
+  const primaryCredential = credential.apiKey?.trim() || entries.find((entry) => entry.key === primaryCredentialEnvName)?.value || ""
   if (provider.source === "openwork" && primaryCredential) {
     upsertEnvEntry(entries, "OPENWORK_API_KEY", primaryCredential)
     const baseUrl = readOpenWorkInferenceBaseUrl(provider.providerConfig)
@@ -364,7 +365,7 @@ function providerHasRequiredCredential(provider: CloudProviderMaterializationPro
     return true
   }
 
-  return envEntries.some((entry) => envNames.includes(entry.key))
+  return selectPrimaryCredentialEnvName(envNames, envEntries.map((entry) => entry.key)) !== null
 }
 
 function prepareMaterialization(providers: CloudProviderMaterializationProvider[]): PreparedMaterialization {

--- a/ee/apps/den-api/src/llm/provider-credentials.ts
+++ b/ee/apps/den-api/src/llm/provider-credentials.ts
@@ -32,6 +32,30 @@ export function readProviderEnvNames(providerConfig: JsonRecord): string[] {
     : []
 }
 
+function credentialEnvRank(name: string): number | null {
+  const normalized = name.trim().toUpperCase()
+  if (/(^|_)API_KEY$/.test(normalized)) return 0
+  if (/(^|_)ACCESS_KEY_ID$/.test(normalized)) return 1
+  if (/(^|_)BEARER_TOKEN(_|$)/.test(normalized) || /(^|_)TOKEN$/.test(normalized)) return 2
+  if (/(^|_)KEY$/.test(normalized)) return 3
+  return null
+}
+
+export function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iterable<string>): string | null {
+  const available = new Set([...availableNames].filter((name) => name.trim().length > 0))
+  const orderedNames = [
+    ...envNames.filter((name) => available.has(name)),
+    ...[...available].filter((name) => !envNames.includes(name)),
+  ]
+  const ranked = orderedNames
+    .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
+    .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)
+    .sort((left, right) => left.rank - right.rank || left.index - right.index)
+  if (ranked[0]) return ranked[0].name
+  if (envNames.length > 1 && envNames.some((name) => credentialEnvRank(name) !== null)) return null
+  return orderedNames[0] ?? null
+}
+
 /**
  * A stored credential is a multi-env map only when it parses to a non-empty
  * JSON object whose values are all strings. Real API keys never take that

--- a/ee/apps/den-api/src/llm/provider-credentials.ts
+++ b/ee/apps/den-api/src/llm/provider-credentials.ts
@@ -53,6 +53,10 @@ export function selectPrimaryCredentialEnvName(envNames: string[], availableName
   return orderedNames[0] ?? null
 }
 
+export function selectLegacyScalarCredentialEnvName(envNames: string[]): string | null {
+  return selectPrimaryCredentialEnvName(envNames, envNames) ?? envNames[0] ?? null
+}
+
 /**
  * A stored credential is a multi-env map only when it parses to a non-empty
  * JSON object whose values are all strings. Real API keys never take that
@@ -107,7 +111,8 @@ export function listConfiguredEnvKeys(stored: string | null, envNames: string[])
   }
 
   if (credential.apiKey) {
-    return envNames.length > 0 ? [envNames[0]] : []
+    const envName = selectLegacyScalarCredentialEnvName(envNames)
+    return envName ? [envName] : []
   }
 
   return []
@@ -143,7 +148,7 @@ export function resolveProviderCredential(input: {
     const existing = decodeProviderCredential(existingValue)
     const values: Record<string, string> = { ...(existing.apiKeys ?? {}) }
     if (!existing.apiKeys && existing.apiKey) {
-      const legacyEnvName = input.existing?.envNames[0]
+      const legacyEnvName = selectLegacyScalarCredentialEnvName(input.existing?.envNames ?? [])
       if (legacyEnvName) {
         values[legacyEnvName] = existing.apiKey
       }

--- a/ee/apps/den-api/src/llm/provider-credentials.ts
+++ b/ee/apps/den-api/src/llm/provider-credentials.ts
@@ -43,10 +43,7 @@ function credentialEnvRank(name: string): number | null {
 
 export function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iterable<string>): string | null {
   const available = new Set([...availableNames].filter((name) => name.trim().length > 0))
-  const orderedNames = [
-    ...envNames.filter((name) => available.has(name)),
-    ...[...available].filter((name) => !envNames.includes(name)),
-  ]
+  const orderedNames = envNames.filter((name) => available.has(name))
   const ranked = orderedNames
     .map((name, index) => ({ name, index, rank: credentialEnvRank(name) }))
     .filter((entry): entry is { name: string; index: number; rank: number } => entry.rank !== null)

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -480,6 +480,28 @@ describe("Cloud provider materialization", () => {
     expect(instance.runtimeProvider(provider.id)).toBeNull()
   })
 
+  test("materializes a legacy scalar Azure credential as the API key env", async () => {
+    const provider = makeAzureProvider({})
+    provider.apiKey = "legacy-api-key"
+    const instance = makeInstance()
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.providers).toBe(1)
+    expect(instance.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
+      entries: [{ key: "AZURE_API_KEY", value: "legacy-api-key" }],
+    })
+    expect(instance.runtimeProvider(provider.id)).toMatchObject({
+      id: "azure",
+      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+    })
+  })
+
   test("skips writes and reloads when observed provider and env state match", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const fingerprint = computeCloudProviderMaterializationFingerprint([provider])

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -129,6 +129,32 @@ function makeAnthropicRuntimeProvider(modelId = "claude-fable-5") {
   }
 }
 
+function makeAzureProvider(apiKeys: Record<string, string>): CloudProviderMaterializationProvider {
+  return {
+    id: createDenTypeId("llmProvider"),
+    source: "models_dev",
+    providerId: "azure",
+    name: "Azure",
+    providerConfig: {
+      id: "azure",
+      name: "Azure",
+      npm: "@ai-sdk/azure",
+      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+    },
+    apiKey: JSON.stringify(apiKeys),
+    models: [
+      {
+        modelId: "deployment",
+        name: "deployment",
+        modelConfig: {
+          id: "deployment",
+          name: "deployment",
+        },
+      },
+    ],
+  }
+}
+
 function makeStore(providers: () => CloudProviderMaterializationProvider[]): Store {
   return {
     async listProviders() {
@@ -410,6 +436,48 @@ describe("Cloud provider materialization", () => {
       },
     })
     expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
+  })
+
+  test("writes Azure resource name and API key env while preserving the provider env config", async () => {
+    const provider = makeAzureProvider({
+      AZURE_RESOURCE_NAME: "resource-name",
+      AZURE_API_KEY: "real-api-key",
+    })
+    const instance = makeInstance()
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(instance.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
+      entries: [
+        { key: "AZURE_RESOURCE_NAME", value: "resource-name" },
+        { key: "AZURE_API_KEY", value: "real-api-key" },
+      ],
+    })
+    expect(instance.runtimeProvider(provider.id)).toMatchObject({
+      id: "azure",
+      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+    })
+  })
+
+  test("does not materialize Azure from a resource name without its API key", async () => {
+    const provider = makeAzureProvider({ AZURE_RESOURCE_NAME: "resource-name" })
+    const instance = makeInstance()
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.providers).toBe(0)
+    expect(instance.envValue("AZURE_RESOURCE_NAME")).toBeNull()
+    expect(instance.runtimeProvider(provider.id)).toBeNull()
   })
 
   test("skips writes and reloads when observed provider and env state match", async () => {

--- a/ee/apps/den-api/test/provider-credentials.test.ts
+++ b/ee/apps/den-api/test/provider-credentials.test.ts
@@ -42,6 +42,15 @@ describe("selectPrimaryCredentialEnvName", () => {
     ).toBeNull()
   })
 
+  test("ignores API-shaped names that the provider did not declare", () => {
+    expect(
+      selectPrimaryCredentialEnvName(
+        ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+        ["OPENAI_API_KEY"],
+      ),
+    ).toBeNull()
+  })
+
   test("keeps AWS access key as the primary credential", () => {
     expect(selectPrimaryCredentialEnvName(AWS_ENV, ["AWS_ACCESS_KEY_ID", "AWS_REGION"])).toBe("AWS_ACCESS_KEY_ID")
   })

--- a/ee/apps/den-api/test/provider-credentials.test.ts
+++ b/ee/apps/den-api/test/provider-credentials.test.ts
@@ -6,6 +6,7 @@ import {
   listConfiguredEnvKeys,
   readProviderEnvNames,
   resolveProviderCredential,
+  selectPrimaryCredentialEnvName,
 } from "../src/llm/provider-credentials.js"
 
 const AWS_ENV = [
@@ -19,6 +20,30 @@ describe("readProviderEnvNames", () => {
   test("reads the env string list, dropping blanks and non-strings", () => {
     expect(readProviderEnvNames({ env: ["A", " ", 3, "B"] })).toEqual(["A", "B"])
     expect(readProviderEnvNames({})).toEqual([])
+  })
+})
+
+describe("selectPrimaryCredentialEnvName", () => {
+  test("prefers Azure API key over resource name", () => {
+    expect(
+      selectPrimaryCredentialEnvName(
+        ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+        ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      ),
+    ).toBe("AZURE_API_KEY")
+  })
+
+  test("does not treat Azure resource name alone as the credential", () => {
+    expect(
+      selectPrimaryCredentialEnvName(
+        ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+        ["AZURE_RESOURCE_NAME"],
+      ),
+    ).toBeNull()
+  })
+
+  test("keeps AWS access key as the primary credential", () => {
+    expect(selectPrimaryCredentialEnvName(AWS_ENV, ["AWS_ACCESS_KEY_ID", "AWS_REGION"])).toBe("AWS_ACCESS_KEY_ID")
   })
 })
 

--- a/ee/apps/den-api/test/provider-credentials.test.ts
+++ b/ee/apps/den-api/test/provider-credentials.test.ts
@@ -6,6 +6,7 @@ import {
   listConfiguredEnvKeys,
   readProviderEnvNames,
   resolveProviderCredential,
+  selectLegacyScalarCredentialEnvName,
   selectPrimaryCredentialEnvName,
 } from "../src/llm/provider-credentials.js"
 
@@ -53,6 +54,16 @@ describe("selectPrimaryCredentialEnvName", () => {
 
   test("keeps AWS access key as the primary credential", () => {
     expect(selectPrimaryCredentialEnvName(AWS_ENV, ["AWS_ACCESS_KEY_ID", "AWS_REGION"])).toBe("AWS_ACCESS_KEY_ID")
+  })
+})
+
+describe("selectLegacyScalarCredentialEnvName", () => {
+  test("maps legacy Azure scalar credentials to the declared API key env", () => {
+    expect(selectLegacyScalarCredentialEnvName(["AZURE_RESOURCE_NAME", "AZURE_API_KEY"])).toBe("AZURE_API_KEY")
+  })
+
+  test("keeps legacy AWS scalar credentials on access key id", () => {
+    expect(selectLegacyScalarCredentialEnvName(AWS_ENV)).toBe("AWS_ACCESS_KEY_ID")
   })
 })
 
@@ -169,6 +180,21 @@ describe("resolveProviderCredential", () => {
     )
   })
 
+  test("migrates a legacy Azure scalar credential into AZURE_API_KEY", () => {
+    const stored = resolveProviderCredential({
+      envNames: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      existing: {
+        value: "legacy-api-key",
+        envNames: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      },
+      apiKeys: { AZURE_RESOURCE_NAME: "resource-name" },
+    })
+
+    expect(stored).toBe(
+      JSON.stringify({ AZURE_RESOURCE_NAME: "resource-name", AZURE_API_KEY: "legacy-api-key" }),
+    )
+  })
+
   test("collapses a map back to a bare string when env shrinks to one key", () => {
     const stored = resolveProviderCredential({
       envNames: ["GATEWAY_API_KEY"],
@@ -201,8 +227,9 @@ describe("listConfiguredEnvKeys", () => {
     ])
   })
 
-  test("legacy plain credentials map to the first env key", () => {
+  test("legacy plain credentials map to the primary credential env key", () => {
     expect(listConfiguredEnvKeys("sk-test", AWS_ENV)).toEqual(["AWS_ACCESS_KEY_ID"])
+    expect(listConfiguredEnvKeys("sk-test", ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"])).toEqual(["AZURE_API_KEY"])
     expect(listConfiguredEnvKeys("sk-test", [])).toEqual([])
     expect(listConfiguredEnvKeys(null, AWS_ENV)).toEqual([])
   })


### PR DESCRIPTION
## Summary\n- choose multi-env provider auth credentials by credential-shaped env name instead of env[0]\n- keep Azure resource names in desktop/server env sync while storing AZURE_API_KEY in OpenCode auth\n- require a credential-shaped env before Den materializes multi-env providers like Azure\n\nFixes #4096.\n\n## Validation\n- pnpm --dir apps/app test tests/cloud-provider-credentials.test.ts tests/cloud-provider-reimport.test.ts\n- pnpm --dir apps/server test src/managed-provider-auth.test.ts\n- pnpm --dir ee/apps/den-api exec bun --conditions=development test test/provider-credentials.test.ts test/cloud-provider-materialization.test.ts\n- Mock local Den + desktop sync: created mock Azure provider, ran desktop cloud provider sync, verified runtime provider env is [AZURE_RESOURCE_NAME, AZURE_API_KEY], env store has both values, and OpenCode auth.json stores the mock API key rather than the mock resource name\n