### PR TITLE
Explain Azure Foundry resource names in BYOK setup

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -847,12 +847,12 @@ export function LlmProviderEditorScreen({
                                 <p className="mt-1 text-sky-800">
                                     Azure Foundry may show a project URL such as{" "}
                                     <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono text-[12px]">
-                                        https://foundry-ow-instant.services.ai.azure.com/api/projects/instant-test
+                                        https://yourFoundryResourceName.services.ai.azure.com/api/projects/your-project
                                     </code>
                                     . Paste that full URL here and we will save just the
                                     resource name, for example{" "}
                                     <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono text-[12px]">
-                                        foundry-ow-instant
+                                        yourFoundryResourceName
                                     </code>
                                     .
                                 </p>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -30,6 +30,7 @@ import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
     buildGuidedCustomProviderConfig,
     buildGuidedProviderEnvName,
+    normalizeAzureResourceNameInput,
     parseGuidedModelIds,
     readEnvNamesFromCustomProviderText,
     readGuidedCustomProviderFields,
@@ -840,10 +841,28 @@ export function LlmProviderEditorScreen({
                             Add a value for each one — values left blank keep
                             what is already saved.
                         </p>
+                        {credentialEnvNames.includes("AZURE_RESOURCE_NAME") ? (
+                            <div className="rounded-[22px] border border-sky-100 bg-sky-50 px-5 py-4 text-[13px] leading-6 text-sky-900">
+                                <p className="font-semibold">Azure resource name</p>
+                                <p className="mt-1 text-sky-800">
+                                    Azure Foundry may show a project URL such as{" "}
+                                    <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono text-[12px]">
+                                        https://foundry-ow-instant.services.ai.azure.com/api/projects/instant-test
+                                    </code>
+                                    . Paste that full URL here and we will save just the
+                                    resource name, for example{" "}
+                                    <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono text-[12px]">
+                                        foundry-ow-instant
+                                    </code>
+                                    .
+                                </p>
+                            </div>
+                        ) : null}
                         {credentialEnvNames.map((envName) => {
                             const configured =
                                 provider?.configuredEnvKeys.includes(envName) ??
                                 false;
+                            const isAzureResourceName = envName === "AZURE_RESOURCE_NAME";
                             return (
                                 <label key={envName} className="grid gap-3">
                                     <span className="flex flex-wrap items-center gap-2 text-[14px] font-medium text-gray-700">
@@ -855,20 +874,24 @@ export function LlmProviderEditorScreen({
                                                 Saved
                                             </span>
                                         ) : null}
-                                    </span>
-                                    <DenInput
-                                        type="password"
+                                     </span>
+                                     <DenInput
+                                        type={isAzureResourceName ? "text" : "password"}
                                         value={apiKeyValues[envName] ?? ""}
                                         onChange={(event) =>
                                             setApiKeyValues((current) => ({
                                                 ...current,
-                                                [envName]: event.target.value,
+                                                [envName]: isAzureResourceName
+                                                    ? normalizeAzureResourceNameInput(event.target.value)
+                                                    : event.target.value,
                                             }))
                                         }
                                         placeholder={
                                             configured
                                                 ? "Leave blank to keep current value"
-                                                : `Paste the ${envName} value`
+                                                : isAzureResourceName
+                                                  ? "Paste the resource name or Azure Foundry project URL"
+                                                  : `Paste the ${envName} value`
                                         }
                                     />
                                 </label>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-guided.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-guided.ts
@@ -65,6 +65,25 @@ export function buildGuidedProviderEnvName(providerId: string): string {
     return `${normalized || "CUSTOM_PROVIDER"}_API_KEY`;
 }
 
+export function normalizeAzureResourceNameInput(value: string): string {
+    const trimmed = value.trim();
+    if (!trimmed) return "";
+
+    try {
+        const url = new URL(trimmed);
+        const host = url.hostname.toLowerCase();
+        for (const suffix of [".services.ai.azure.com", ".openai.azure.com"]) {
+            if (host.endsWith(suffix)) {
+                return host.slice(0, -suffix.length).split(".").pop() ?? trimmed;
+            }
+        }
+    } catch {
+        // Not a URL: keep treating the value as the resource name itself.
+    }
+
+    return trimmed;
+}
+
 export function validateGuidedCustomProvider(input: {
     providerId: string;
     baseUrl: string;

--- a/ee/apps/den-web/tests/byok-page-primitives.test.ts
+++ b/ee/apps/den-web/tests/byok-page-primitives.test.ts
@@ -33,6 +33,13 @@ describe("Bring your Own Keys page", () => {
     }
   });
 
+  test("editor explains Azure Foundry project URLs for resource names", () => {
+    const editor = readComponent("dashboard", "_components", "llm-provider-editor-screen.tsx");
+    expect(editor).toContain("Azure Foundry may show a project URL");
+    expect(editor).toContain("foundry-ow-instant");
+    expect(editor).toContain("Paste the resource name or Azure Foundry project URL");
+  });
+
   test("screen is built from shared primitives instead of local markup", () => {
     for (const primitive of ["DenOptionCard", "DenSectionHeader", "DenTable", "DenBrandMark", "DenBadge", "DenNotice"]) {
       expect(screen).toContain(primitive);

--- a/ee/apps/den-web/tests/byok-page-primitives.test.ts
+++ b/ee/apps/den-web/tests/byok-page-primitives.test.ts
@@ -36,7 +36,7 @@ describe("Bring your Own Keys page", () => {
   test("editor explains Azure Foundry project URLs for resource names", () => {
     const editor = readComponent("dashboard", "_components", "llm-provider-editor-screen.tsx");
     expect(editor).toContain("Azure Foundry may show a project URL");
-    expect(editor).toContain("foundry-ow-instant");
+    expect(editor).toContain("yourFoundryResourceName");
     expect(editor).toContain("Paste the resource name or Azure Foundry project URL");
   });
 

--- a/ee/apps/den-web/tests/llm-provider-guided.test.ts
+++ b/ee/apps/den-web/tests/llm-provider-guided.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
     buildGuidedCustomProviderConfig,
     buildGuidedProviderEnvName,
+    normalizeAzureResourceNameInput,
     parseGuidedModelIds,
     readEnvNamesFromCustomProviderText,
     readGuidedCustomProviderFields,
@@ -30,6 +31,24 @@ describe("parseGuidedModelIds", () => {
 describe("buildGuidedProviderEnvName", () => {
     test("builds an uppercase env var name", () => {
         expect(buildGuidedProviderEnvName("azure-foundry")).toBe("AZURE_FOUNDRY_API_KEY");
+    });
+});
+
+describe("normalizeAzureResourceNameInput", () => {
+    test("extracts the resource name from Azure Foundry project URLs", () => {
+        expect(
+            normalizeAzureResourceNameInput(
+                "https://foundry-ow-instant.services.ai.azure.com/api/projects/instant-test",
+            ),
+        ).toBe("foundry-ow-instant");
+    });
+
+    test("extracts the resource name from Azure OpenAI endpoint URLs", () => {
+        expect(normalizeAzureResourceNameInput("https://my-resource.openai.azure.com/openai/v1/")).toBe("my-resource");
+    });
+
+    test("keeps an already-entered resource name", () => {
+        expect(normalizeAzureResourceNameInput(" foundry-ow-instant ")).toBe("foundry-ow-instant");
     });
 });
 


### PR DESCRIPTION
## Summary\n- add Azure-specific guidance for AZURE_RESOURCE_NAME in the BYOK provider editor\n- normalize pasted Azure Foundry/OpenAI endpoint URLs to only the resource name\n- use a generic placeholder example instead of a real resource name\n\n## Validation\n- pnpm --dir ee/apps/den-web exec bun test tests/byok-page-primitives.test.ts tests/llm-provider-guided.test.ts\n- pnpm --filter @openwork-ee/den-web typecheck\n