### PR TITLE
feat(app): refine chat activity treatments

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -833,9 +833,8 @@ MessageComponent.displayName = "MessageComponent"
 
 const LoadingMessage = React.memo(({ elapsedSeconds }: { elapsedSeconds: number }) => (
     <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
-      <div className="flex items-center gap-1.5 px-1 py-1 text-sm text-muted-foreground">
-        <LoaderCircle aria-hidden="true" className="size-3.5 animate-spin" />
-        <span className="tabular-nums">Working {elapsedSeconds}s</span>
+      <div data-loading-message="working" className="py-1 text-sm text-muted-foreground">
+        <span className="ow-text-shimmer tabular-nums">Working {elapsedSeconds}s</span>
       </div>
     </Message>
 ))

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -83,6 +83,8 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
 
   // Track durations for every part so each is frozen the moment it completes.
   const durations = parts.map((part) => trackToolCallDuration(part))
+  const singleCommand = parts.length === 1 && Boolean(parts[0] && isBashToolPart(parts[0]))
+  const singleCommandDuration = singleCommand ? durations[0] : null
   const visibleParts = showAll ? parts : parts.slice(0, ROW_CAP)
   const hiddenCount = parts.length - visibleParts.length
 
@@ -106,6 +108,11 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
           )}
         />
         <span className="min-w-0 truncate">{summary}</span>
+        {singleCommandDuration ? (
+          <span className="shrink-0 tabular-nums text-xs text-muted-foreground/70">
+            {singleCommandDuration}
+          </span>
+        ) : null}
         {failedCount > 0 ? (
           <span className="shrink-0 text-xs text-muted-foreground">
             {failedCount} failed
@@ -149,7 +156,8 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
               : ""
             return (
               <div key={part.toolCallId} className="flex min-w-0 flex-col gap-1.5 py-1">
-                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                {!singleCommand ? (
+                  <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                   {status === "waiting" ? (
                     <CirclePause aria-label="Waiting" className="size-3.5 shrink-0 text-amber-11" />
                   ) : null}
@@ -184,7 +192,8 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                       {durations[index]}
                     </span>
                   ) : null}
-                </div>
+                  </div>
+                ) : null}
                 {bash && command ? (
                   <div
                     data-tool-aggregate-command

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { AlertTriangle, ChevronRight, CirclePause, LoaderCircle } from "lucide-react"
+import { AlertTriangle, ChevronRight, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
@@ -14,6 +14,7 @@ import {
   type AnyToolPart,
 } from "@/lib/tool-aggregate"
 import { isToolPartInFlight } from "@/lib/tool-activity"
+import { isBashToolPart } from "@/lib/build-in-tools"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { cn } from "@/lib/utils"
 
@@ -127,10 +128,9 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
       ) : null}
 
       {nowLabel ? (
-        <div className="mt-1 flex min-w-0 items-center gap-2 ps-5 text-sm text-muted-foreground">
-          <LoaderCircle aria-hidden="true" className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
-          <span className="min-w-0 truncate">
-            <span className="text-muted-foreground/70">Now: </span>
+        <div data-tool-aggregate-now className="mt-1 min-w-0 ps-5 text-sm text-muted-foreground">
+          <span className="block min-w-0 truncate">
+            <span className="ow-text-shimmer">Now: </span>
             {nowLabel}
           </span>
         </div>
@@ -142,25 +142,32 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
             const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
             const status = lifecycle ?? persistedRowStatus(part)
             const reason = failureReason(part)
+            const bash = isBashToolPart(part)
+            const command = bash ? part.input?.command?.trim() ?? "" : ""
+            const commandDescription = bash
+              ? part.input?.description?.trim() || "command"
+              : ""
             return (
-              <div key={part.toolCallId} className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  {status === "running" ? (
-                    <span className="flex size-3.5 shrink-0 items-center justify-center">
-                      <LoaderCircle aria-hidden="true" className="size-3 animate-spin text-muted-foreground" />
-                    </span>
-                  ) : null}
+              <div key={part.toolCallId} className="flex min-w-0 flex-col gap-1.5 py-1">
+                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                   {status === "waiting" ? (
                     <CirclePause aria-label="Waiting" className="size-3.5 shrink-0 text-amber-11" />
                   ) : null}
                   {status === "interrupted" ? (
                     <AlertTriangle aria-label="Interrupted" className="size-3.5 shrink-0 text-destructive" />
                   ) : null}
-                  {(() => {
+                  {bash ? (
+                    <span className="min-w-0 truncate">
+                      <span className={cn("text-foreground", status === "running" && "ow-text-shimmer")}>
+                        {status === "running" ? "Running" : "Ran"}
+                      </span>{" "}
+                      <span>{commandDescription}</span>
+                    </span>
+                  ) : (() => {
                     const file = getAggregateRowFile(part)
                     if (!file) {
                       return (
-                        <span className="min-w-0 truncate font-mono text-[11px]">
+                        <span className="min-w-0 truncate">
                           {getAggregateRowLabel(part)}
                         </span>
                       )
@@ -178,6 +185,16 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                     </span>
                   ) : null}
                 </div>
+                {bash && command ? (
+                  <div
+                    data-tool-aggregate-command
+                    className="flex min-w-0 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 py-2 font-mono text-sm shadow-xs"
+                  >
+                    <span className="shrink-0 text-muted-foreground/60">$</span>
+                    <code className="min-w-0 flex-1 truncate text-blue-11">{command}</code>
+                    <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+                  </div>
+                ) : null}
                 {reason ? (
                   <div className="text-[11px] text-muted-foreground">failed — {reason}</div>
                 ) : null}

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -110,7 +110,9 @@ export function getAggregateSummary(parts: AnyToolPart[], tense: "present" | "pa
     pieces.push(`${tense === "past" ? "edited" : "editing"} ${plural(count, "file")}`)
   }
   if (commands > 0) {
-    pieces.push(`${tense === "past" ? "ran" : "running"} ${plural(commands, "command")}`)
+    pieces.push(commands === 1
+      ? `${tense === "past" ? "ran" : "running"} command`
+      : `${tense === "past" ? "ran" : "running"} ${commands} commands`)
   }
   if (readCalls > 0) {
     const count = readPaths.size > 0 ? readPaths.size : readCalls

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -385,6 +385,15 @@ function createSubagentActivityEvalMessages(sessionId: string): UIMessage[] {
   ];
 }
 
+function createChatLoadingEvalMessages(sessionId: string): UIMessage[] {
+  return [{
+    id: `${sessionId}:eval-chat-loading-user`,
+    role: "user",
+    parts: [{ type: "text", text: "Confirm the loading treatment." }],
+    metadata: { opencode: { created: Date.now() } },
+  }];
+}
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   environmentClient?: OpenworkServerClient | null;
@@ -1007,7 +1016,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     if (!chatStreaming) setSteering(false);
   }, [chatStreaming]);
+  const [evalThreadStatus, setEvalThreadStatus] = useState<ThreadStatus | null>(null);
   const status = useMemo((): ThreadStatus => {
+    if (evalThreadStatus) return evalThreadStatus;
     if (sending) {
       return "submitted";
     }
@@ -1021,10 +1032,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
 
     return "ready";
-  }, [liveStatus, sending]);
+  }, [evalThreadStatus, liveStatus, sending]);
   const [evalMarkdownMessages, setEvalMarkdownMessages] = useState<UIMessage[]>(EMPTY_TRANSCRIPT);
   useEffect(() => {
     setEvalMarkdownMessages(EMPTY_TRANSCRIPT);
+    setEvalThreadStatus(null);
   }, [props.sessionId]);
 
   const baseRenderedMessages = useMemo(
@@ -1210,6 +1222,28 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId, props.workspaceId]);
   useControlAction(props.isControlTarget ? seedSubagentActivityControlAction : null);
+  const seedChatLoadingControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.chat_loading.seed",
+      label: "Seed chat loading shimmer proof",
+      description: "Dev-only eval hook that renders the main chat loading treatment.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        setEvalMarkdownMessages(createChatLoadingEvalMessages(props.sessionId));
+        setEvalThreadStatus("streaming");
+        useSessionActivityStore.getState().setRunStatus(
+          props.workspaceId,
+          props.sessionId,
+          { type: "busy" },
+        );
+        return { ok: true };
+      },
+    };
+  }, [props.sessionId, props.workspaceId]);
+  useControlAction(props.isControlTarget ? seedChatLoadingControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -44,6 +44,8 @@ describe("message-list loading feedback", () => {
     const markup = renderList([userMessage], "submitted");
 
     expect(markup).toContain("Working 0s");
+    expect(markup).toContain("ow-text-shimmer");
+    expect(markup).not.toContain("animate-spin");
     expect(markup).not.toContain("PaperGrainGradient");
   });
 
@@ -55,6 +57,8 @@ describe("message-list loading feedback", () => {
     const markup = renderList([userMessage], "streaming");
 
     expect(markup).toContain("Working 0s");
+    expect(markup).toContain("ow-text-shimmer");
+    expect(markup).not.toContain("animate-spin");
     expect(markup).not.toContain("PaperGrainGradient");
   });
 

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -121,7 +121,7 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
 
     expect(markup).not.toContain("Worked for");
     // Both calls merge into one aggregate summary line.
-    expect(markup).toContain("Edited 1 file, ran 1 command");
+    expect(markup).toContain("Edited 1 file, ran command");
     expect(markup).toContain("Done.");
   });
 

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -1,0 +1,25 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DynamicToolUIPart } from "ai";
+
+import { ToolAggregateGroup } from "../src/components/chat/tool-aggregate-group";
+
+describe("tool aggregate running feedback", () => {
+  test("uses a quiet shimmer instead of a spinner for the current action", () => {
+    const runningCommand: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "bash",
+      toolCallId: "running-command",
+      state: "input-available",
+      input: { command: "git status", description: "Check repository state" },
+    };
+
+    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[runningCommand]} />);
+
+    expect(markup).toContain("Running 1 command");
+    expect(markup).toContain("Now:");
+    expect(markup).toContain("ow-text-shimmer");
+    expect(markup).not.toContain("animate-spin");
+  });
+});

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -17,7 +17,8 @@ describe("tool aggregate running feedback", () => {
 
     const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[runningCommand]} />);
 
-    expect(markup).toContain("Running 1 command");
+    expect(markup).toContain("Running command");
+    expect(markup).not.toContain("Running 1 command");
     expect(markup).toContain("Now:");
     expect(markup).toContain("ow-text-shimmer");
     expect(markup).not.toContain("animate-spin");

--- a/evals/specs/chat-loading-shimmer.e2e.test.ts
+++ b/evals/specs/chat-loading-shimmer.e2e.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, seedSessions, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "chat working and command activity use quiet shimmer without spinners"
+  : "chat loading shimmer skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "chat-loading-shimmer" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-chat-loading-shimmer-${Date.now()}`,
+  });
+  await seedSessions(app, ["Shimmer proof"]);
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.chat_loading.seed" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "chat loading proof control ready" },
+  );
+  await control(app, "eval.chat_loading.seed");
+  await waitFor(app, `Boolean(document.querySelector('[data-loading-message="working"] .ow-text-shimmer'))`, {
+    timeoutMs: 15_000,
+    label: "main Working shimmer",
+  });
+  const working = await evalIn(app, `(() => {
+    const row = document.querySelector('[data-loading-message="working"]');
+    return {
+      text: row instanceof HTMLElement ? row.innerText.trim() : "",
+      hasSpinner: Boolean(row?.querySelector('.animate-spin')),
+      hasShimmer: Boolean(row?.querySelector('.ow-text-shimmer')),
+    };
+  })()`);
+  expect(working).toMatchObject({ hasSpinner: false, hasShimmer: true });
+  if (!working || typeof working !== "object" || !("text" in working) || typeof working.text !== "string") {
+    throw new Error(`Working row was not readable: ${JSON.stringify(working)}`);
+  }
+  expect(working.text).toContain("Working");
+  evidence.recordAssertionEvidence(
+    "The main chat Working state uses shimmer instead of a circular spinner",
+    `The live row remained readable as “${working.text}” and contained no animate-spin indicator.`,
+    true,
+  );
+
+  await control(app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "active" });
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate-now] .ow-text-shimmer'))`, {
+    timeoutMs: 15_000,
+    label: "aggregate Now shimmer",
+  });
+  const aggregate = await evalIn(app, `(() => {
+    const row = document.querySelector('[data-tool-aggregate-now]');
+    return {
+      text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, " ").trim() : "",
+      hasSpinner: Boolean(row?.querySelector('.animate-spin')),
+      hasShimmer: Boolean(row?.querySelector('.ow-text-shimmer')),
+    };
+  })()`);
+  expect(aggregate).toMatchObject({ hasSpinner: false, hasShimmer: true });
+  if (!aggregate || typeof aggregate !== "object" || !("text" in aggregate) || typeof aggregate.text !== "string") {
+    throw new Error(`Aggregate activity row was not readable: ${JSON.stringify(aggregate)}`);
+  }
+  expect(aggregate.text).toContain("Now:");
+  evidence.recordAssertionEvidence(
+    "The aggregate Now state uses shimmer instead of a circular spinner",
+    `The live aggregate row remained readable as “${aggregate.text}” and contained no animate-spin indicator.`,
+    true,
+  );
+
+  const expanded = await evalIn(app, `(() => {
+    const trigger = document.querySelector('[data-tool-aggregate] > button');
+    if (!(trigger instanceof HTMLButtonElement)) return false;
+    trigger.click();
+    return true;
+  })()`);
+  expect(expanded).toBe(true);
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate-command]'))`, {
+    timeoutMs: 15_000,
+    label: "expanded aggregate command block",
+  });
+  const command = await evalIn(app, `(() => {
+    const block = document.querySelector('[data-tool-aggregate-command]');
+    return block instanceof HTMLElement ? block.innerText.replace(/\\s+/g, " ").trim() : "";
+  })()`);
+  expect(command).toContain("$");
+  expect(command).toContain("git status --short --branch");
+  evidence.recordAssertionEvidence(
+    "Expanded command history uses a readable rounded shell block",
+    "The live expanded aggregate rendered the command with a shell prompt inside its dedicated command block.",
+    true,
+  );
+});

--- a/evals/specs/chat-loading-shimmer.e2e.test.ts
+++ b/evals/specs/chat-loading-shimmer.e2e.test.ts
@@ -52,10 +52,13 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   });
   const aggregate = await evalIn(app, `(() => {
     const row = document.querySelector('[data-tool-aggregate-now]');
+    const summary = [...document.querySelectorAll('[data-tool-aggregate] > button')]
+      .find((button) => (button.textContent ?? "").includes("Running command"));
     return {
       text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, " ").trim() : "",
       hasSpinner: Boolean(row?.querySelector('.animate-spin')),
       hasShimmer: Boolean(row?.querySelector('.ow-text-shimmer')),
+      singularSummary: summary instanceof HTMLElement ? summary.innerText.replace(/\\s+/g, " ").trim() : "",
     };
   })()`);
   expect(aggregate).toMatchObject({ hasSpinner: false, hasShimmer: true });
@@ -63,6 +66,11 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
     throw new Error(`Aggregate activity row was not readable: ${JSON.stringify(aggregate)}`);
   }
   expect(aggregate.text).toContain("Now:");
+  if (!("singularSummary" in aggregate) || typeof aggregate.singularSummary !== "string") {
+    throw new Error(`Aggregate summary was not readable: ${JSON.stringify(aggregate)}`);
+  }
+  expect(aggregate.singularSummary).toContain("Running command");
+  expect(aggregate.singularSummary).not.toContain("Running 1 command");
   evidence.recordAssertionEvidence(
     "The aggregate Now state uses shimmer instead of a circular spinner",
     `The live aggregate row remained readable as “${aggregate.text}” and contained no animate-spin indicator.`,
@@ -82,10 +90,20 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   });
   const command = await evalIn(app, `(() => {
     const block = document.querySelector('[data-tool-aggregate-command]');
-    return block instanceof HTMLElement ? block.innerText.replace(/\\s+/g, " ").trim() : "";
+    const aggregate = block?.closest('[data-tool-aggregate]');
+    return {
+      text: block instanceof HTMLElement ? block.innerText.replace(/\\s+/g, " ").trim() : "",
+      commandSummaryCount: aggregate instanceof HTMLElement
+        ? (aggregate.innerText.match(/(?:Ran|Running) command/g) ?? []).length
+        : 0,
+    };
   })()`);
-  expect(command).toContain("$");
-  expect(command).toContain("git status --short --branch");
+  expect(command).toMatchObject({ commandSummaryCount: 1 });
+  if (!command || typeof command !== "object" || !("text" in command) || typeof command.text !== "string") {
+    throw new Error(`Expanded command block was not readable: ${JSON.stringify(command)}`);
+  }
+  expect(command.text).toContain("$");
+  expect(command.text).toContain("git status --short --branch");
   evidence.recordAssertionEvidence(
     "Expanded command history uses a readable rounded shell block",
     "The live expanded aggregate rendered the command with a shell prompt inside its dedicated command block.",


### PR DESCRIPTION
## Summary
- replace the main `Working` spinner with a subtle text shimmer and remove its leftover indent
- replace the aggregate `Now:` spinner with shimmer
- restyle expanded command history with verb-first labels and rounded shell command blocks
- add focused component tests and an app-driving E2E covering both loading states

## Verification
- `pnpm --filter @openwork/app exec bun test tests/message-list-loading.test.tsx tests/tool-aggregate-group.test.tsx` — 5 passed
- `pnpm --filter @openwork/app exec tsc --noEmit --pretty false` — passed
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/chat-loading-shimmer.e2e.test.ts` — 1 passed