### PR TITLE
feat(app): polish tool call rows and artifact panel

### DIFF
--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -35,7 +35,12 @@ function ConnectorMark({ connector }: { connector: ConnectorToolIdentity }) {
     <span
       data-connector-icon={connector.id}
       data-connector-name={connector.name}
-      className="flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-[10px] font-semibold text-foreground"
+      className={cn(
+        "flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-md",
+        // The muted chip only exists to make the single-letter fallback read
+        // as an avatar; real brand icons render without a background.
+        !showImage && "bg-muted text-[10px] font-semibold text-foreground",
+      )}
       title={connector.name}
       aria-hidden="true"
     >
@@ -171,10 +176,6 @@ export function CapabilityCallLine({
           className="group flex min-w-0 max-w-full cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
           aria-label={open ? `${sentence.past}. Hide failure details` : `${sentence.past} failed. Show what to do next`}
         >
-          <ChevronRight
-            aria-hidden="true"
-            className={cn("size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150", open && "rotate-90")}
-          />
           {connector ? <ConnectorMark connector={connector} /> : null}
           <span className="min-w-0 truncate">{sentence.past}</span>
           <span className="shrink-0 text-xs font-medium text-destructive">failed</span>

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1259,21 +1259,34 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
   const runActive = status === "submitted" || status === "streaming" || status === "retrying"
   const runStartedAtRef = React.useRef<number | null>(null)
   const [runElapsedSeconds, setRunElapsedSeconds] = React.useState(0)
+  // Anchor the counter to the user message that started the run (server
+  // timestamp), so switching sessions and back doesn't reset it to 0 on
+  // remount. Optimistic messages without metadata fall back to first-mount
+  // wall clock.
+  const runStartedAt = React.useMemo(() => {
+    if (!runActive) return null
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index]
+      if (message && message.role === "user") return getMessageCreated(message)
+    }
+    return null
+  }, [messages, runActive])
   React.useEffect(() => {
     if (!runActive) {
       runStartedAtRef.current = null
       setRunElapsedSeconds(0)
       return
     }
-    if (runStartedAtRef.current === null) runStartedAtRef.current = Date.now()
+    if (runStartedAt !== null) runStartedAtRef.current = runStartedAt
+    else if (runStartedAtRef.current === null) runStartedAtRef.current = Date.now()
     const updateElapsed = () => {
       const startedAt = runStartedAtRef.current
-      if (startedAt !== null) setRunElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000))
+      if (startedAt !== null) setRunElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
     }
     updateElapsed()
     const interval = window.setInterval(updateElapsed, 1000)
     return () => window.clearInterval(interval)
-  }, [runActive])
+  }, [runActive, runStartedAt])
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -11,7 +11,7 @@ import {
 import { useMessageList } from "@/components/chat/message-list-provider"
 import { taskChildSessionId, type TaskToolPart } from "@/lib/build-in-tools"
 import { isToolPartInFlight } from "@/lib/tool-activity"
-import { trackToolCallDuration } from "@/lib/tool-call-duration"
+import { getToolCallStartedAt, trackToolCallDuration } from "@/lib/tool-call-duration"
 import { cn } from "@/lib/utils"
 
 type SubagentRunLineProps = {
@@ -43,15 +43,18 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   const isFailed = part.state === "output-error"
   const duration = trackToolCallDuration(part)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  // First-seen-in-flight time lives in a module map, so remounting (like
+  // switching sessions and back) resumes the counter instead of restarting.
+  const startedAt = getToolCallStartedAt(part)
   useEffect(() => {
-    if (!inFlight) return
-    const startedAt = Date.now()
-    setElapsedSeconds(0)
-    const interval = window.setInterval(() => {
-      setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000))
-    }, 1000)
+    if (!inFlight || startedAt === null) return
+    const update = () => {
+      setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
+    }
+    update()
+    const interval = window.setInterval(update, 1000)
     return () => window.clearInterval(interval)
-  }, [inFlight, part.toolCallId])
+  }, [inFlight, startedAt, part.toolCallId])
   const title = part.input?.description?.trim() || "Sub-agent task"
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = inFlight

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { AlertTriangle, ChevronRight, CirclePause, MoreHorizontal } from "lucide-react"
+import { AlertTriangle, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
@@ -100,13 +100,6 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
         aria-expanded={expanded}
         className="group flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn(
-            "size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150",
-            expanded && "rotate-90",
-          )}
-        />
         <span className="min-w-0 truncate">{summary}</span>
         {singleCommandDuration ? (
           <span className="shrink-0 tabular-nums text-xs text-muted-foreground/70">
@@ -121,21 +114,21 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
       </button>
 
       {currentLifecycle === "waiting" ? (
-        <div className="mt-1 flex items-center gap-1.5 ps-5 text-xs text-amber-11" role="status">
+        <div className="mt-1 flex items-center gap-1.5 text-xs text-amber-11" role="status">
           <CirclePause aria-hidden="true" className="size-3.5 shrink-0" />
           <span>Choose an option or approve the request to continue.</span>
         </div>
       ) : null}
 
       {currentLifecycle === "interrupted" ? (
-        <div className="mt-1 flex items-center gap-1.5 ps-5 text-xs text-destructive" role="alert">
+        <div className="mt-1 flex items-center gap-1.5 text-xs text-destructive" role="alert">
           <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" />
           <span>This step stopped before it finished. Retry to continue.</span>
         </div>
       ) : null}
 
       {nowLabel ? (
-        <div data-tool-aggregate-now className="mt-1 min-w-0 ps-5 text-sm text-muted-foreground">
+        <div data-tool-aggregate-now className="mt-1 min-w-0 text-sm text-muted-foreground">
           <span className="block min-w-0 truncate">
             <span className="ow-text-shimmer">Now: </span>
             {nowLabel}
@@ -144,7 +137,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
       ) : null}
 
       {expanded ? (
-        <div className="mt-1.5 flex flex-col gap-1 ps-5">
+        <div className="mt-1.5 flex flex-col gap-1">
           {visibleParts.map((part, index) => {
             const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
             const status = lifecycle ?? persistedRowStatus(part)

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -20,7 +20,6 @@ import {
   Bot,
   BookOpenCheck,
   Check,
-  ChevronDown,
   CircleAlert,
   Copy,
   ExternalLink,
@@ -200,17 +199,14 @@ const Tool = ({
         <CollapsibleTrigger
           className="group text-muted-foreground hover:text-foreground flex min-w-0 flex-1 cursor-pointer items-center justify-start gap-2 overflow-hidden text-start text-sm transition-colors"
         >
-          <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
-            <span className="transition-opacity group-hover:opacity-0">
-              {inFlight ? (
-                <LoaderCircle className="size-4 animate-spin" />
-              ) : isError ? (
-                <CircleAlert className="text-destructive size-4" />
-              ) : (
-                <Icon className={cn("size-3.5", isSkill && "text-violet-11")} />
-              )}
-            </span>
-            <ChevronDown className="absolute size-4 opacity-0 transition-opacity group-hover:opacity-100 group-data-panel-open:rotate-180" />
+          <span className="inline-flex size-4 shrink-0 items-center justify-center">
+            {inFlight ? (
+              <LoaderCircle className="size-4 animate-spin" />
+            ) : isError ? (
+              <CircleAlert className="text-destructive size-4" />
+            ) : (
+              <Icon className={cn("size-3.5", isSkill && "text-violet-11")} />
+            )}
           </span>
           <span className="min-w-0 truncate">{label}</span>
           {isError && !errorAttribution ? (

--- a/apps/app/src/lib/tool-call-duration.ts
+++ b/apps/app/src/lib/tool-call-duration.ts
@@ -31,6 +31,21 @@ export function trackToolCallDuration(part: AnyToolPart): string | null {
   return formatToolCallDuration(elapsed)
 }
 
+/**
+ * Epoch ms when this call was first seen in flight, registering it if this
+ * is the first sighting. Module-scoped, so live elapsed counters survive
+ * component unmounts (e.g. switching sessions and back). Null once settled.
+ */
+export function getToolCallStartedAt(part: AnyToolPart): number | null {
+  if (!isToolPartInFlight(part)) return null
+  const callId = part.toolCallId
+  const existing = startedAtByCallId.get(callId)
+  if (existing !== undefined) return existing
+  const now = Date.now()
+  startedAtByCallId.set(callId, now)
+  return now
+}
+
 export function formatToolCallDuration(ms: number): string {
   const seconds = ms / 1000
   if (seconds < 10) return `${Math.max(0.1, Number(seconds.toFixed(1)))}s`

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-code-view.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-code-view.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource react */
-import { CodeView } from "@pierre/diffs/react";
+import { useCallback, useRef } from "react";
+import { CodeView, EditProvider, type CreateEditor } from "@pierre/diffs/react";
+import { Editor } from "@pierre/diffs/edit";
 
 const OPENWORK_CODE_CSS = `
   :host {
@@ -17,26 +19,48 @@ type ArtifactCodeViewProps = {
   name: string;
   path: string;
   content: string;
+  editable?: boolean;
+  onChange?: (content: string) => void;
 };
 
-export function ArtifactCodeView({ name, path, content }: ArtifactCodeViewProps) {
+export function ArtifactCodeView({ name, path, content, editable = false, onChange }: ArtifactCodeViewProps) {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  // Once Pierre's editor attaches it owns the document; `content` only seeds
+  // the initial doc. Re-renders must not push parent state (the autosave
+  // draft) back into the editor, or the caret would reset mid-typing.
+  // The component instance survives switching files, so reseed per path.
+  const initialContentRef = useRef(content);
+  const lastPathRef = useRef(path);
+  if (lastPathRef.current !== path) {
+    lastPathRef.current = path;
+    initialContentRef.current = content;
+  }
+  const createEditor = useCallback<CreateEditor<undefined>>((options) => new Editor(options), []);
+
   return (
     <div className="h-full overflow-hidden bg-background" data-artifact-code-view={path}>
-      <CodeView
-        className="h-full overflow-auto"
-        disableWorkerPool
-        items={[{
-          id: path,
-          type: "file",
-          file: { name, contents: content, cacheKey: path },
-        }]}
-        options={{
-          theme: { light: "github-light", dark: "github-dark" },
-          disableFileHeader: true,
-          overflow: "wrap",
-          unsafeCSS: OPENWORK_CODE_CSS,
-        }}
-      />
+      <EditProvider createEditor={createEditor}>
+        <CodeView
+          className="h-full overflow-auto"
+          disableWorkerPool
+          items={[{
+            id: path,
+            type: "file",
+            file: { name, contents: editable ? initialContentRef.current : content, cacheKey: path },
+            edit: editable,
+          }]}
+          onItemEditChange={(_item, file) => {
+            if (typeof file.contents === "string") onChangeRef.current?.(file.contents);
+          }}
+          options={{
+            theme: { light: "github-light", dark: "github-dark" },
+            disableFileHeader: true,
+            overflow: "wrap",
+            unsafeCSS: OPENWORK_CODE_CSS,
+          }}
+        />
+      </EditProvider>
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,12 +1,17 @@
 /** @jsxImportSource react */
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, ExternalLink, FolderOpen, PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
+import { Download, Ellipsis, ExternalLink, FolderOpen, PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
 
-import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
-import { isElectronRuntime } from "@/app/utils";
+import type { OpenworkServerClient, OpenworkWorkspaceCatalogEntry } from "@/app/lib/openwork-server";
+import { openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { toast } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePlatform } from "@/react-app/kernel/platform";
@@ -106,9 +111,14 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
   const [draft, setDraft] = useState("");
   const lastSyncedRef = useRef<string | null>(null);
   const failedDraftRef = useRef<string | null>(null);
-  const isDirectTextEdit = isTextContent(target) && target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target);
-  const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
-  const canUseDesktopFileActions = target.kind === "file" && !isRemoteWorkspace && platform.capabilities.revealInFileManager;
+  // Markdown and plain text open straight into the CodeMirror editor, and
+  // code opens straight into Pierre's highlighted editor. Only HTML stays
+  // behind the Edit toggle, because its default view is the rendered page.
+  const isDirectTextEdit = isTextContent(target) &&
+    (target.preview === "text" || (target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target)));
+  const isDirectCodeEdit = target.kind === "file" && target.preview === "code";
+  const canUseDesktopWorkspaceActions = !isRemoteWorkspace && platform.capabilities.revealInFileManager;
+  const canUseDesktopFileActions = target.kind === "file" && canUseDesktopWorkspaceActions;
   const workspaceName = workspaceRoot.split(/[/\\]/).filter(Boolean).pop() ?? "Workspace";
 
   const openWorkspaceFile = (entry: { path: string; size: number; mtimeMs: number }) => {
@@ -122,14 +132,6 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
       target: nextTarget,
     });
   };
-
-  const { data: fileIcon } = useQuery<string | null>({
-    queryKey: ["desktop-file-icon", externalPath] as const,
-    queryFn: async () => getDesktopFileIcon(externalPath, "small"),
-    enabled: canUseDesktopFileActions && isElectronRuntime(),
-    staleTime: Infinity,
-    gcTime: 5 * 60 * 1000,
-  });
 
   const { data, error, isError, isLoading } = useQuery<ArtifactQueryState>({
     queryKey: ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
@@ -222,20 +224,47 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
     },
   });
 
-  const download = async () => {
-    if (target.kind === "url") {
-      return;
-    }
-    
-    const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+  const downloadFile = async (path: string, name: string) => {
+    const result = await client.downloadWorkspaceFile(workspaceId, path);
     const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
     const anchor = document.createElement("a");
 
     anchor.href = url;
-    anchor.download = target.name;
+    anchor.download = name;
     anchor.click();
 
     window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const openFileExternally = async (path: string) => {
+    if (isRemoteWorkspace) {
+      await downloadFile(path, path.split(/[/\\]/).pop() ?? path);
+
+      return;
+    }
+
+    try {
+      await openDesktopPath(absoluteWorkspacePath(workspaceRoot, path));
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : "Could not open this file.");
+    }
+  };
+
+  const revealFile = async (path: string) => {
+    if (isRemoteWorkspace) return;
+    try {
+      await revealDesktopItemInDir(absoluteWorkspacePath(workspaceRoot, path));
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : "Could not show this file in your file manager.");
+    }
+  };
+
+  const download = async () => {
+    if (target.kind === "url") {
+      return;
+    }
+
+    await downloadFile(target.value, target.name);
   };
 
   const openExternal = async () => {
@@ -244,36 +273,24 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
 
       return;
     }
-    else if (!isRemoteWorkspace) {
-      try {
-        await openDesktopPath(externalPath);
-      } catch (cause) {
-        toast.error(cause instanceof Error ? cause.message : "Could not open this file.");
-      }
 
-      return;
-    }
-
-    await download();
+    await openFileExternally(target.value);
   };
 
   const revealExternal = async () => {
-    if (target.kind !== "file" || isRemoteWorkspace) return;
-    try {
-      await revealDesktopItemInDir(externalPath);
-    } catch (cause) {
-      toast.error(cause instanceof Error ? cause.message : "Could not show this file in your file manager.");
-    }
+    if (target.kind !== "file") return;
+    await revealFile(target.value);
   };
 
   const isTextEditing = data?.kind === "text" && (editing || isDirectTextEdit);
+  const isEditingSurface = data?.kind === "text" && (editing || isDirectTextEdit || isDirectCodeEdit);
   const isDirty = data?.kind === "text" && draft !== data.data;
 
   useEffect(() => {
     if (
       target.kind !== "file" ||
       data?.kind !== "text" ||
-      !(editing || isDirectTextEdit) ||
+      !(editing || isDirectTextEdit || isDirectCodeEdit) ||
       isSaving ||
       draft === data.data ||
       draft === failedDraftRef.current
@@ -286,7 +303,7 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
     }, 600);
 
     return () => window.clearTimeout(timer);
-  }, [draft, data, editing, isDirectTextEdit, isSaving, target.kind, mutate]);
+  }, [draft, data, editing, isDirectTextEdit, isDirectCodeEdit, isSaving, target.kind, mutate]);
 
   const saveSpreadsheetContent = async (payload: Data) => {
     if (target.kind !== "file") {
@@ -302,30 +319,27 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
-        <div className="flex h-10 items-center gap-2 pe-2 ps-4">
+        <div className="flex h-10 items-center gap-2 pe-2 ps-2">
+          <Tooltip>
+            <TooltipTrigger
+              render={(
+                <Button variant="ghost" size="icon-sm" onClick={() => setTreeOpen((value) => !value)} aria-label={treeOpen ? "Hide workspace files" : "Show workspace files"}>
+                  {treeOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
+                </Button>
+              )}
+            />
+            <TooltipContent>{treeOpen ? "Hide workspace files" : "Show workspace files"}</TooltipContent>
+          </Tooltip>
           <div className="min-w-0 flex-1 flex items-center gap-1.5">
-            {fileIcon ? (
-              <img src={fileIcon} alt="" className="h-4 w-4 shrink-0 object-contain" />
-            ) : null}
             <h3 className="min-w-0 truncate text-sm font-medium text-foreground">
               {target.name}
             </h3>
             <span className="shrink-0 text-xs text-muted-foreground">
-              {target.exists === false ? "missing" : isTextEditing ? (isSaving || isDirty ? "Saving\u2026" : "Saved") : ""}
+              {target.exists === false ? "missing" : isEditingSurface ? (isSaving || isDirty ? "Saving\u2026" : "Saved") : ""}
             </span>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Tooltip>
-              <TooltipTrigger
-                render={(
-                  <Button variant="ghost" size="icon-sm" onClick={() => setTreeOpen((value) => !value)} aria-label={treeOpen ? "Hide workspace files" : "Show workspace files"}>
-                    {treeOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
-                  </Button>
-                )}
-              />
-              <TooltipContent>{treeOpen ? "Hide workspace files" : "Show workspace files"}</TooltipContent>
-            </Tooltip>
-            {isTextContent(target) && data?.kind === "text" && !isDirectTextEdit ? (
+          <div className="flex shrink-0 items-center gap-1">
+            {isTextContent(target) && data?.kind === "text" && !isDirectTextEdit && !isDirectCodeEdit ? (
               <Tooltip>
                 <TooltipTrigger
                   render={(
@@ -335,52 +349,44 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
                 <TooltipContent>{editing ? "Stop editing" : "Edit artifact"}</TooltipContent>
               </Tooltip>
             ) : null}
-          {target.kind === "file" ? (
+            {target.kind === "file" || target.kind === "url" ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={(
+                    <Button variant="ghost" size="icon-sm" aria-label="Artifact actions">
+                      <Ellipsis />
+                    </Button>
+                  )}
+                />
+                <DropdownMenuContent align="end">
+                  {target.kind === "file" ? (
+                    <DropdownMenuItem onClick={() => void download()}>
+                      <Download /> Download
+                    </DropdownMenuItem>
+                  ) : null}
+                  {canUseDesktopFileActions ? (
+                    <DropdownMenuItem onClick={() => void revealExternal()}>
+                      <FolderOpen /> Show in folder
+                    </DropdownMenuItem>
+                  ) : null}
+                  {target.kind === "url" || canUseDesktopFileActions ? (
+                    <DropdownMenuItem onClick={() => void openExternal()}>
+                      <ExternalLink /> Open externally
+                    </DropdownMenuItem>
+                  ) : null}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
             <Tooltip>
               <TooltipTrigger
                 render={(
-                  <Button variant="ghost" size="icon-sm" onClick={() => void download()} aria-label="Download artifact">
-                    <Download />
+                  <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact">
+                    <X />
                   </Button>
                 )}
               />
-              <TooltipContent>Download artifact</TooltipContent>
+              <TooltipContent>Close artifact</TooltipContent>
             </Tooltip>
-          ) : null}
-          {canUseDesktopFileActions ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={(
-                  <Button variant="ghost" size="icon-sm" onClick={() => void revealExternal()} aria-label="Show in folder">
-                    <FolderOpen />
-                  </Button>
-                )}
-              />
-              <TooltipContent>Show in folder</TooltipContent>
-            </Tooltip>
-          ) : null}
-          {target.kind === "url" || isRemoteWorkspace || canUseDesktopFileActions ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={(
-                  <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
-                    <ExternalLink />
-                  </Button>
-                )}
-              />
-              <TooltipContent>{isRemoteWorkspace ? "Download artifact" : "Open externally"}</TooltipContent>
-            </Tooltip>
-          ) : null}
-          <Tooltip>
-            <TooltipTrigger
-              render={(
-                <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact">
-                  <X />
-                </Button>
-              )}
-            />
-            <TooltipContent>Close artifact</TooltipContent>
-          </Tooltip>
           </div>
         </div>
       </div>
@@ -393,6 +399,15 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
               workspaceName={workspaceName}
               selectedPath={target.value}
               onOpenFile={openWorkspaceFile}
+              fileActions={[
+                { id: "download", label: "Download", run: (entry) => void downloadFile(entry.path, entry.path.split(/[/\\]/).pop() ?? entry.path) },
+                ...(canUseDesktopWorkspaceActions
+                  ? [
+                    { id: "reveal", label: "Show in folder", run: (entry: OpenworkWorkspaceCatalogEntry) => void revealFile(entry.path) },
+                    { id: "open-external", label: "Open externally", run: (entry: OpenworkWorkspaceCatalogEntry) => void openFileExternally(entry.path) },
+                  ]
+                  : []),
+              ]}
             />
           </Suspense>
         ) : null}
@@ -407,7 +422,13 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
           <MarkdownPreview content={data.data} />
         ) : target.preview === "code" && data?.kind === "text" ? (
           <Suspense fallback={<PreviewLoading />}>
-            <ArtifactCodeView name={target.name} path={target.value} content={data.data} />
+            <ArtifactCodeView
+              name={target.name}
+              path={target.value}
+              content={data.data}
+              editable={isDirectCodeEdit}
+              onChange={setDraft}
+            />
           </Suspense>
         ) : target.preview === "sheet" ? (
           <SheetEditor

--- a/apps/app/src/react-app/domains/session/artifacts/workspace-file-tree.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/workspace-file-tree.tsx
@@ -21,19 +21,54 @@ const TREE_CSS = `
   button[data-type='item'] { border-radius: 5px; }
 `;
 
+export type WorkspaceFileAction = {
+  id: string;
+  label: string;
+  run: (entry: OpenworkWorkspaceCatalogEntry) => void;
+};
+
 type WorkspaceFileTreeProps = {
   client: OpenworkServerClient;
   workspaceId: string;
   workspaceName: string;
   selectedPath: string;
   onOpenFile: (entry: OpenworkWorkspaceCatalogEntry) => void;
+  fileActions?: readonly WorkspaceFileAction[];
 };
+
+/**
+ * Pierre slots context-menu content into the tree host's light DOM, so the
+ * document stylesheet (Tailwind) applies. Built imperatively because the
+ * composition API expects a plain HTMLElement.
+ */
+function buildFileContextMenu(
+  entry: OpenworkWorkspaceCatalogEntry,
+  actions: readonly WorkspaceFileAction[],
+  close: () => void,
+) {
+  const menu = document.createElement("div");
+  menu.setAttribute("role", "menu");
+  menu.className = "bg-popover text-popover-foreground min-w-36 rounded-lg border border-border p-1 shadow-md";
+  for (const action of actions) {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.setAttribute("role", "menuitem");
+    item.className = "hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground flex w-full items-center rounded-md px-2 py-1.5 text-start text-xs outline-none";
+    item.textContent = action.label;
+    item.addEventListener("click", () => {
+      close();
+      action.run(entry);
+    });
+    menu.appendChild(item);
+  }
+  return menu;
+}
 
 function treePath(entry: OpenworkWorkspaceCatalogEntry) {
   return entry.kind === "dir" ? `${entry.path}/` : entry.path;
 }
 
-export function WorkspaceFileTree({ client, workspaceId, workspaceName, selectedPath, onOpenFile }: WorkspaceFileTreeProps) {
+export function WorkspaceFileTree({ client, workspaceId, workspaceName, selectedPath, onOpenFile, fileActions }: WorkspaceFileTreeProps) {
   const query = useQuery({
     queryKey: ["workspace-file-tree", workspaceId] as const,
     queryFn: () => client.listWorkspaceFiles(workspaceId),
@@ -44,8 +79,24 @@ export function WorkspaceFileTree({ client, workspaceId, workspaceName, selected
   const entriesByPath = useMemo(() => new Map(entries.map((entry) => [entry.path, entry])), [entries]);
   const entriesByPathRef = useRef(entriesByPath);
   entriesByPathRef.current = entriesByPath;
+  const fileActionsRef = useRef(fileActions);
+  fileActionsRef.current = fileActions;
   const paths = useMemo(() => entries.map(treePath), [entries]);
   const { model } = useFileTree({
+    // useFileTree captures options on first render, so callbacks read refs.
+    composition: {
+      contextMenu: {
+        triggerMode: "both",
+        buttonVisibility: "when-needed",
+        render: (item, context) => {
+          if (item.kind !== "file") return null;
+          const entry = entriesByPathRef.current.get(item.path.replace(/\/$/, ""));
+          const actions = fileActionsRef.current ?? [];
+          if (!entry || entry.kind !== "file" || actions.length === 0) return null;
+          return buildFileContextMenu(entry, actions, () => context.close());
+        },
+      },
+    },
     density: "compact",
     fileTreeSearchMode: "hide-non-matches",
     flattenEmptyDirectories: true,


### PR DESCRIPTION
## What changed

Chat tool-call rows and the artifact panel get a coordinated cleanup, plus a correctness fix for the Working counter.

**Tool call rows**
- Removed the chevrons from tool rows, aggregate ("Ran N commands") rows, and failed capability lines. Full rows remain the collapsible triggers, so expand/collapse behavior and `aria-expanded` semantics are unchanged.
- `ConnectorMark` only draws its gray `bg-muted` chip for the single-letter fallback; real brand icons render bare and flex-centered.

**Artifact panel**
- Header slimmed from 5 icon buttons to: tree toggle (far left) · title + save state · Edit · one `⋯` overflow menu (Download / Show in folder / Open externally) · close.
- Removed the macOS file icon and its `getDesktopFileIcon` IPC query.
- Workspace file tree (Pierre) gains a native per-file context menu (right-click or row button) with Download / Show in folder / Open externally; desktop-only actions are gated off for remote workspaces.
- Plain text artifacts open directly editable (CodeMirror); code artifacts open directly editable in Pierre's own editor (`EditProvider` + `edit: true`) with syntax highlighting kept and the shared 600 ms debounced autosave. HTML keeps preview-first + Edit.

**Working counter fix**
- "Working Ns" was anchored to component mount, so switching sessions reset it to 0. It now anchors to the server `created` timestamp of the user message that started the run; the subagent counter resumes from the module-scoped first-seen-in-flight time (`getToolCallStartedAt`).

## Verification

Lane: **local fallback** — Daytona credentials are not configured in this environment (no Daytona API access), which is the expected OSS path.

| Check | Command | Result |
| --- | --- | --- |
| Typecheck (PR head) | `tsc -p apps/app/tsconfig.json --noEmit` | exit 0 |
| Artifact tree + Pierre code view | `OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e artifact-code-browser` | **1 passed, 0 failed, 0 skipped** (exit 0) |
| Working row shimmer | `OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e chat-loading-shimmer` | **1 passed, 0 failed, 0 skipped** (exit 0) |
| Connector branding | `OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e connector-tool-call-branding` | failed in setup (`session.create_task` returned no session ID) — **pre-existing**: identical failure on clean `origin/dev` (2e742c86a) control worktree with the same command. The spec asserts `data-connector-name` attributes, which are unchanged. |

Not covered by dedicated assertions (manually exercised only): tree context-menu actions, direct-edit autosave for text/code artifacts, and the counter surviving a session switch. Happy to follow up with specs for these if wanted before or after merge.
