### PR TITLE
fix(chat): keep interleaved thoughts chronological between tool aggregates

### DIFF
--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -1,6 +1,8 @@
 import { isReasoningUIPart, isToolUIPart, type DynamicToolUIPart, type FileUIPart, type ToolUIPart, type UIMessage } from "ai"
 import type { ThreadStatus } from "@/lib/messages"
-import { isAggregatableToolPart } from "@/lib/tool-aggregate"
+// Relative so the pure grouping contract stays importable from alias-free
+// test workspaces (evals specs import this module directly).
+import { isAggregatableToolPart } from "../../lib/tool-aggregate"
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
@@ -295,12 +297,15 @@ export function getAssistantRenderGroups(
 
     if (isToolUIPart(part)) {
       // Paper aggregation rule: consecutive command/edit/read/search calls
-      // collapse into one aggregate group. Prose, files, and other tools
-      // break the run; reasoning does not — thinking models emit a
-      // reasoning part before nearly every call, and letting it split the
-      // run degrades every aggregate to a single call.
+      // collapse into one aggregate group. Prose, files, other tools, and
+      // visible reasoning all break the run: a thought stays between the
+      // calls it separated, so the transcript reads chronologically instead
+      // of absorbing later calls into the aggregate above the thought.
+      // Hidden reasoning (showThinking off) and whitespace-only reasoning
+      // never form a group, so they keep the run — and its compact
+      // aggregate — intact.
       if (isAggregatableToolPart(part)) {
-        const previous = groups.findLast((group) => group.kind !== "reasoning")
+        const previous = groups.at(-1)
         if (previous?.kind === "tool-aggregate") {
           previous.parts.push(part)
         } else {

--- a/apps/app/src/lib/tool-activity.ts
+++ b/apps/app/src/lib/tool-activity.ts
@@ -15,8 +15,8 @@ import {
   isWebFetchToolPart,
   isWebSearchToolPart,
   isWriteToolPart,
-} from "@/lib/build-in-tools"
-import { parseFilename, truncateText } from "@/components/tools/path"
+} from "./build-in-tools"
+import { parseFilename, truncateText } from "../components/tools/path"
 
 type AnyToolPart = ToolUIPart | DynamicToolUIPart
 

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -8,8 +8,8 @@ import {
   isGrepToolPart,
   isReadToolPart,
   isWriteToolPart,
-} from "@/lib/build-in-tools"
-import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
+} from "./build-in-tools"
+import { getToolActivityLabel, isToolPartInFlight } from "./tool-activity"
 
 export type AnyToolPart = ToolUIPart | DynamicToolUIPart
 

--- a/apps/app/tests/chat-message-grouping.test.ts
+++ b/apps/app/tests/chat-message-grouping.test.ts
@@ -52,7 +52,7 @@ describe("getAssistantRenderGroups tool aggregation", () => {
     }
   });
 
-  test("reasoning between tool calls does not break the run (thinking models)", () => {
+  test("visible reasoning between tool calls breaks the run so thoughts stay chronological", () => {
     const groups = getAssistantRenderGroups(
       [
         reasoningPart("let me look"),
@@ -66,14 +66,52 @@ describe("getAssistantRenderGroups tool aggregation", () => {
       true
     );
 
+    // Thought, calls, thought, calls… in the order the model produced them —
+    // later calls are never absorbed into an aggregate above a thought.
+    expect(groups.map((group) => group.kind)).toEqual([
+      "reasoning",
+      "tool-aggregate",
+      "reasoning",
+      "tool-aggregate",
+      "reasoning",
+      "tool-aggregate",
+      "text",
+    ]);
     const aggregates = groups.filter((group) => group.kind === "tool-aggregate");
-    expect(aggregates).toHaveLength(1);
-    if (aggregates[0].kind === "tool-aggregate") {
-      expect(aggregates[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3"]);
+    expect(
+      aggregates.map((group) => (group.kind === "tool-aggregate" ? group.parts.map((part) => part.toolCallId) : []))
+    ).toEqual([["c1"], ["c2"], ["c3"]]);
+  });
+
+  test("hidden reasoning keeps the run as one compact aggregate", () => {
+    const groups = getAssistantRenderGroups(
+      [
+        reasoningPart("let me look"),
+        bashPart("c1"),
+        reasoningPart("now edit"),
+        editPart("c2", "/tmp/a.ts"),
+        bashPart("c3"),
+        textPart("Done."),
+      ],
+      false
+    );
+
+    expect(groups.map((group) => group.kind)).toEqual(["tool-aggregate", "text"]);
+    if (groups[0].kind === "tool-aggregate") {
+      expect(groups[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3"]);
     }
-    // Reasoning still renders, just without splitting the aggregate.
-    expect(groups.filter((group) => group.kind === "reasoning").length).toBeGreaterThan(0);
-    expect(groups.at(-1)?.kind).toBe("text");
+  });
+
+  test("whitespace-only reasoning does not break the run", () => {
+    const groups = getAssistantRenderGroups(
+      [bashPart("c1"), reasoningPart("  \n"), bashPart("c2")],
+      true
+    );
+
+    expect(groups.map((group) => group.kind)).toEqual(["tool-aggregate"]);
+    if (groups[0].kind === "tool-aggregate") {
+      expect(groups[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2"]);
+    }
   });
 
   test("prose between tool calls breaks the run", () => {

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -125,7 +125,7 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
     expect(markup).toContain("Done.");
   });
 
-  test("reasoning between calls does not fragment the aggregate", () => {
+  test("reasoning between calls splits the aggregate so thoughts stay in order", () => {
     const assistant: UIMessage = {
       id: "assistant-3",
       role: "assistant",
@@ -142,6 +142,17 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
 
     const markup = renderList([userMessage, assistant]);
 
-    expect(markup).toContain("Ran 2 commands");
+    // The second call is not absorbed into the aggregate above the thought.
+    expect(markup).not.toContain("Ran 2 commands");
+
+    // Thought, call, thought, call — chronological in the rendered output.
+    const firstThought = markup.indexOf("Thought");
+    const firstRun = markup.indexOf("Ran command", firstThought);
+    const secondThought = markup.indexOf("Thought", firstRun);
+    const secondRun = markup.indexOf("Ran command", secondThought);
+    expect(firstThought).toBeGreaterThan(-1);
+    expect(firstRun).toBeGreaterThan(firstThought);
+    expect(secondThought).toBeGreaterThan(firstRun);
+    expect(secondRun).toBeGreaterThan(secondThought);
   });
 });

--- a/evals/specs/chat-thought-chronology.test.ts
+++ b/evals/specs/chat-thought-chronology.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { getAssistantRenderGroups } from "../../apps/app/src/components/chat/utils";
+
+type Parts = Parameters<typeof getAssistantRenderGroups>[0];
+type Part = Parts[number];
+
+function bashPart(id: string): Part {
+  return {
+    type: "dynamic-tool",
+    toolName: "bash",
+    toolCallId: id,
+    state: "output-available",
+    input: { command: `echo ${id}`, description: "run" },
+    output: "ok",
+  };
+}
+
+function reasoningPart(text: string): Part {
+  return { type: "reasoning", text, state: "done" };
+}
+
+test("interleaved thoughts render chronologically between tool aggregates", ({ evidence }) => {
+  // The user-reported shape: R T T R T T — the model thinks, runs two
+  // commands, thinks again, runs two more.
+  const parts: Parts = [
+    reasoningPart("plan the first probe"),
+    bashPart("c1"),
+    bashPart("c2"),
+    reasoningPart("interpret and go deeper"),
+    bashPart("c3"),
+    bashPart("c4"),
+  ];
+
+  const visible = getAssistantRenderGroups(parts, true);
+
+  // Chronology: thought, aggregate, thought, aggregate — a later call is
+  // never absorbed into the aggregate above a thought, and interleaved
+  // thoughts are never merged into one block below the run.
+  expect(visible.map((group) => group.kind)).toEqual([
+    "reasoning",
+    "tool-aggregate",
+    "reasoning",
+    "tool-aggregate",
+  ]);
+  const aggregates = visible.flatMap((group) =>
+    group.kind === "tool-aggregate" ? [group.parts.map((part) => part.toolCallId)] : []
+  );
+  expect(aggregates).toEqual([["c1", "c2"], ["c3", "c4"]]);
+  const thoughts = visible.flatMap((group) => (group.kind === "reasoning" ? [group.text] : []));
+  expect(thoughts).toEqual(["plan the first probe", "interpret and go deeper"]);
+
+  // Negative half 1: with thinking hidden, the same turn still collapses to
+  // one compact aggregate — chronology never degrades hidden-thinking runs.
+  const hidden = getAssistantRenderGroups(parts, false);
+  expect(hidden.map((group) => group.kind)).toEqual(["tool-aggregate"]);
+  expect(
+    hidden[0].kind === "tool-aggregate" ? hidden[0].parts.map((part) => part.toolCallId) : []
+  ).toEqual(["c1", "c2", "c3", "c4"]);
+
+  // Negative half 2: whitespace-only reasoning forms no thought and must not
+  // fragment the aggregate even when thinking is shown.
+  const blank = getAssistantRenderGroups(
+    [bashPart("c1"), reasoningPart("  \n"), bashPart("c2")],
+    true
+  );
+  expect(blank.map((group) => group.kind)).toEqual(["tool-aggregate"]);
+
+  evidence.recordAssertionEvidence(
+    "Interleaved thoughts stay chronological between tool aggregates",
+    "An R T T R T T turn rendered as thought, two-call aggregate, thought, two-call aggregate in model order; hiding thinking kept one four-call aggregate; whitespace-only reasoning did not fragment the run.",
+    true,
+  );
+});


### PR DESCRIPTION
## What changes for users

During a long agent run, the chat used to show one "Thought" line at the top and then an ever-growing pile of "Ran N commands" — any thinking the model did *between* tool calls was shuffled below the pile and squashed into a single collapsed line. A 5-minute run looked like the agent had stopped thinking and was blindly running commands.

Now the transcript reads like a work log, in the order things actually happened:

> Thought ▸
> Ran 2 commands
> Thought ▸
> Ran 3 commands
> Thought ▸
> …

Each mid-run thought appears right where it happened, between the tool batches it separates.

- **Trust:** long runs stop feeling like a black box — you can see the agent deliberating, not looping.
- **Debuggability:** when a run goes sideways, click the exact Thought before the bad command batch to see why it did that.
- **No regression for the quiet mode:** with "Show model reasoning" off, the old compact view is unchanged — one tidy aggregate line.

Out of scope here: thoughts stay collapsed by default (auto-expand / live-thought ticker is a follow-up), and this cannot show thinking a model never emitted between calls (interleaved-thinking model config is a separate track).

## Problem

When a thinking model alternates thoughts and tool calls (R T T R T T…), `getAssistantRenderGroups` deliberately let tool calls skip past reasoning groups (`groups.findLast(kind !== "reasoning")`). Two artifacts followed:

- every later call was absorbed into the aggregate **above** the first thought, and
- all interleaved thoughts merged into **one** collapsed "Thought" line sitting **below** the growing aggregate.

A long run with plenty of thinking rendered as a couple of tool groups and nothing else — out of chronological order, with the thinking effectively invisible.

## Change

- A visible (non-empty) reasoning part now ends the current tool aggregate; the next aggregatable calls start a new aggregate after it. The transcript reads in the order the model produced it: thought, calls, thought, calls.
- Hidden reasoning (Show model reasoning off) and whitespace-only reasoning still form no group, so those runs keep one compact aggregate exactly as before.
- The grouping import chain (`chat/utils` → `lib/tool-aggregate` → `lib/tool-activity` → `components/tools/path`) switched from `@/` aliases to relative imports so the evals spec can exercise the real function from the alias-free test workspace. No behavior change.

## Proof

- `evals/specs/chat-thought-chronology.test.ts` (PR lane, app-less): asserts the R T T R T T shape renders `reasoning, tool-aggregate(c1,c2), reasoning, tool-aggregate(c3,c4)` with thoughts in model order; negative halves assert hidden thinking keeps one four-call aggregate and whitespace-only reasoning does not fragment the run.
  - `pnpm evals:pr specs/chat-thought-chronology.test.ts` → 1 passed / 0 failed / 0 skipped (local PR lane; spec is app-less, no Den or app surface required).
- Unit tests updated to the new contract: `apps/app/tests/chat-message-grouping.test.ts`, `apps/app/tests/message-list-step-fold.test.tsx`.
  - `bun test tests/chat-message-grouping.test.ts tests/message-list-step-fold.test.tsx` → 13 pass / 0 fail.
- `pnpm --dir apps/app typecheck` → clean.
- Full `bun test --isolate tests/`: 991 pass / 5 fail; the same 5 failures reproduce on pristine `origin/dev` (989 pass / 5 fail, same command) in unrelated areas (connect capability inventory, cloud workspace overlay, session provider auth sync, extensions sidebar) — pre-existing suite interference, not introduced here.
