### PR TITLE
feat(chat): fold alternating thoughts and commands into one aggregate

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -530,7 +530,7 @@ const AssistantMessage = React.memo(
             if (group.kind === "tool-aggregate") {
               return (
                 <div key={`tool-aggregate-${index}`} className="w-full">
-                  <ToolAggregateGroup parts={group.parts} />
+                  <ToolAggregateGroup parts={group.parts} thoughts={group.thoughts} />
                 </div>
               )
             }
@@ -1062,7 +1062,7 @@ function MessageGroup({
         total +
         (item.message.role === "assistant" && !isSessionErrorMessage(item.message)
           ? getAssistantRenderGroups(item.message.parts, showThinking).reduce(
-            (rows, group) => rows + (group.kind === "tool-aggregate" ? group.parts.length : 1),
+            (rows, group) => rows + (group.kind === "tool-aggregate" ? group.parts.length + group.thoughts.length : 1),
             0
           )
           : 1),

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { AlertTriangle, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
+import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
 import {
   getAggregateNowLabel,
@@ -11,6 +12,7 @@ import {
   getAggregateRowFile,
   getAggregateRowLabel,
   getAggregateSummary,
+  type AggregateThought,
   type AnyToolPart,
 } from "@/lib/tool-aggregate"
 import { isToolPartInFlight } from "@/lib/tool-activity"
@@ -26,6 +28,8 @@ const showAllByGroupKey = new Map<string, boolean>()
 
 type ToolAggregateGroupProps = {
   parts: AnyToolPart[]
+  /** Thoughts that happened inside the run, anchored by afterIndex. */
+  thoughts?: AggregateThought[]
   className?: string
 }
 
@@ -47,7 +51,7 @@ function failureReason(part: AnyToolPart): string | null {
  * summary when done. Chevron expands the chronological list — status
  * dot, monospace action, per-item duration — capped with "Show N more".
  */
-export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps) {
+export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggregateGroupProps) {
   const groupKey = parts[0]?.toolCallId ?? "aggregate"
   const latestToolCallId = parts.at(-1)?.toolCallId ?? groupKey
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
@@ -80,6 +84,10 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
       ? `Task interrupted · ${countSummary}`
       : getAggregateSummary(parts, visiblyRunning ? "present" : "past")
   const nowLabel = visiblyRunning ? getAggregateNowLabel(parts) : null
+  // The model is thinking mid-run: no tool is in flight but the run's
+  // latest thought is still streaming. Show that instead of dead air.
+  const lastThought = thoughts.at(-1)
+  const thinkingNow = !nowLabel && Boolean(lastThought?.isStreaming)
 
   // Track durations for every part so each is frozen the moment it completes.
   const durations = parts.map((part) => trackToolCallDuration(part))
@@ -87,6 +95,10 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
   const singleCommandDuration = singleCommand ? durations[0] : null
   const visibleParts = showAll ? parts : parts.slice(0, ROW_CAP)
   const hiddenCount = parts.length - visibleParts.length
+  // Expanded rows interleave the run's thoughts at their chronological
+  // slots; thoughts belonging to capped rows stay behind "Show N more".
+  const thoughtsAt = (index: number) => thoughts.filter((thought) => thought.afterIndex === index)
+  const trailingThoughts = hiddenCount > 0 ? [] : thoughts.filter((thought) => thought.afterIndex >= parts.length)
 
   return (
     <div
@@ -101,6 +113,11 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
         className="group flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <span className="min-w-0 truncate">{summary}</span>
+        {thoughts.length > 0 ? (
+          <span data-tool-aggregate-thought-count className="shrink-0 text-xs text-muted-foreground/70">
+            · {thoughts.length === 1 ? "1 thought" : `${thoughts.length} thoughts`}
+          </span>
+        ) : null}
         {singleCommandDuration ? (
           <span className="shrink-0 tabular-nums text-xs text-muted-foreground/70">
             {singleCommandDuration}
@@ -136,6 +153,12 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
         </div>
       ) : null}
 
+      {thinkingNow ? (
+        <div data-tool-aggregate-thinking className="mt-1 min-w-0 text-sm text-muted-foreground">
+          <span className="ow-text-shimmer">Thinking…</span>
+        </div>
+      ) : null}
+
       {expanded ? (
         <div className="mt-1.5 flex flex-col gap-1">
           {visibleParts.map((part, index) => {
@@ -148,7 +171,13 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
               ? part.input?.description?.trim() || "command"
               : ""
             return (
-              <div key={part.toolCallId} className="flex min-w-0 flex-col gap-1.5 py-1">
+              <Fragment key={part.toolCallId}>
+              {thoughtsAt(index).map((thought) => (
+                <div key={`thought-${index}-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
+                  <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
+                </div>
+              ))}
+              <div className="flex min-w-0 flex-col gap-1.5 py-1">
                 {!singleCommand ? (
                   <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                   {status === "waiting" ? (
@@ -201,8 +230,14 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                   <div className="text-[11px] text-muted-foreground">failed — {reason}</div>
                 ) : null}
               </div>
+              </Fragment>
             )
           })}
+          {trailingThoughts.map((thought) => (
+            <div key={`thought-trailing-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
+              <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
+            </div>
+          ))}
           {hiddenCount > 0 ? (
             <button
               type="button"

--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -2,7 +2,7 @@ import { isReasoningUIPart, isToolUIPart, type DynamicToolUIPart, type FileUIPar
 import type { ThreadStatus } from "@/lib/messages"
 // Relative so the pure grouping contract stays importable from alias-free
 // test workspaces (evals specs import this module directly).
-import { isAggregatableToolPart } from "../../lib/tool-aggregate"
+import { isAggregatableToolPart, type AggregateThought } from "../../lib/tool-aggregate"
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
@@ -172,7 +172,7 @@ type AssistantRenderGroup =
   | { kind: "reasoning"; text: string; isStreaming: boolean }
   | { kind: "file"; part: FileUIPart }
   | { kind: "tool"; part: ToolUIPart | DynamicToolUIPart }
-  | { kind: "tool-aggregate"; parts: (ToolUIPart | DynamicToolUIPart)[] }
+  | { kind: "tool-aggregate"; parts: (ToolUIPart | DynamicToolUIPart)[]; thoughts: AggregateThought[] }
 
 /**
  * Steps often arrive as one assistant message per tool call. When a
@@ -274,6 +274,25 @@ export function getAssistantRenderGroups(
       return
     }
 
+    // A thought in the middle of an aggregate run embeds into the run at
+    // its chronological slot instead of opening a new top-level group.
+    // Alternating thought/command turns then read as ONE aggregate line
+    // that advertises its thoughts, not a ladder of repeated single lines.
+    if (previous?.kind === "tool-aggregate") {
+      const lastThought = previous.thoughts.at(-1)
+      if (lastThought && lastThought.afterIndex === previous.parts.length) {
+        lastThought.text += lastThought.text ? `\n\n${part.text}` : part.text
+        lastThought.isStreaming = lastThought.isStreaming || part.state === "streaming"
+        return
+      }
+      previous.thoughts.push({
+        afterIndex: previous.parts.length,
+        text: part.text,
+        isStreaming: part.state === "streaming",
+      })
+      return
+    }
+
     groups.push({ kind: "reasoning", text: part.text, isStreaming: part.state === "streaming" })
   }
 
@@ -297,19 +316,18 @@ export function getAssistantRenderGroups(
 
     if (isToolUIPart(part)) {
       // Paper aggregation rule: consecutive command/edit/read/search calls
-      // collapse into one aggregate group. Prose, files, other tools, and
-      // visible reasoning all break the run: a thought stays between the
-      // calls it separated, so the transcript reads chronologically instead
-      // of absorbing later calls into the aggregate above the thought.
-      // Hidden reasoning (showThinking off) and whitespace-only reasoning
-      // never form a group, so they keep the run — and its compact
-      // aggregate — intact.
+      // collapse into one aggregate group. Prose, files, and other tools
+      // break the run. A thought inside the run embeds at its chronological
+      // slot (see appendReasoning), so the run stays one compact line and
+      // still reads in the order the model produced it. A thought before
+      // any call — after prose or at the turn's start — remains its own
+      // top-level group and starts a fresh run.
       if (isAggregatableToolPart(part)) {
         const previous = groups.at(-1)
         if (previous?.kind === "tool-aggregate") {
           previous.parts.push(part)
         } else {
-          groups.push({ kind: "tool-aggregate", parts: [part] })
+          groups.push({ kind: "tool-aggregate", parts: [part], thoughts: [] })
         }
         continue
       }

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -14,6 +14,17 @@ import { getToolActivityLabel, isToolPartInFlight } from "./tool-activity"
 export type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
 /**
+ * A thought that happened inside an aggregate run, anchored to its
+ * chronological slot: `afterIndex` is how many of the run's tool calls
+ * had already happened when the model produced it.
+ */
+export type AggregateThought = {
+  afterIndex: number
+  text: string
+  isStreaming: boolean
+}
+
+/**
  * Paper "Recurring actions · aggregate + latest": consecutive tool calls
  * of the same families (commands, file edits, reads, searches) collapse
  * into one aggregate line. Prose from the model always breaks a group.

--- a/apps/app/tests/chat-message-grouping.test.ts
+++ b/apps/app/tests/chat-message-grouping.test.ts
@@ -52,7 +52,7 @@ describe("getAssistantRenderGroups tool aggregation", () => {
     }
   });
 
-  test("visible reasoning between tool calls breaks the run so thoughts stay chronological", () => {
+  test("mid-run thoughts embed inside one aggregate at their chronological slots", () => {
     const groups = getAssistantRenderGroups(
       [
         reasoningPart("let me look"),
@@ -66,24 +66,35 @@ describe("getAssistantRenderGroups tool aggregation", () => {
       true
     );
 
-    // Thought, calls, thought, calls… in the order the model produced them —
-    // later calls are never absorbed into an aggregate above a thought.
-    expect(groups.map((group) => group.kind)).toEqual([
-      "reasoning",
-      "tool-aggregate",
-      "reasoning",
-      "tool-aggregate",
-      "reasoning",
-      "tool-aggregate",
-      "text",
-    ]);
-    const aggregates = groups.filter((group) => group.kind === "tool-aggregate");
-    expect(
-      aggregates.map((group) => (group.kind === "tool-aggregate" ? group.parts.map((part) => part.toolCallId) : []))
-    ).toEqual([["c1"], ["c2"], ["c3"]]);
+    // The turn-opening thought stays its own line; the run stays ONE
+    // aggregate (no thought/command ladder) that carries its mid-run
+    // thoughts in order.
+    expect(groups.map((group) => group.kind)).toEqual(["reasoning", "tool-aggregate", "text"]);
+    const aggregate = groups[1];
+    if (aggregate.kind === "tool-aggregate") {
+      expect(aggregate.parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3"]);
+      expect(aggregate.thoughts).toEqual([
+        { afterIndex: 1, text: "now edit", isStreaming: false },
+        { afterIndex: 2, text: "one more", isStreaming: false },
+      ]);
+    }
   });
 
-  test("hidden reasoning keeps the run as one compact aggregate", () => {
+  test("consecutive mid-run reasoning parts merge into one embedded thought", () => {
+    const groups = getAssistantRenderGroups(
+      [bashPart("c1"), reasoningPart("first"), reasoningPart("second"), bashPart("c2")],
+      true
+    );
+
+    expect(groups.map((group) => group.kind)).toEqual(["tool-aggregate"]);
+    if (groups[0].kind === "tool-aggregate") {
+      expect(groups[0].thoughts).toEqual([
+        { afterIndex: 1, text: "first\n\nsecond", isStreaming: false },
+      ]);
+    }
+  });
+
+  test("hidden reasoning keeps the run as one compact aggregate without thoughts", () => {
     const groups = getAssistantRenderGroups(
       [
         reasoningPart("let me look"),
@@ -99,10 +110,11 @@ describe("getAssistantRenderGroups tool aggregation", () => {
     expect(groups.map((group) => group.kind)).toEqual(["tool-aggregate", "text"]);
     if (groups[0].kind === "tool-aggregate") {
       expect(groups[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3"]);
+      expect(groups[0].thoughts).toEqual([]);
     }
   });
 
-  test("whitespace-only reasoning does not break the run", () => {
+  test("whitespace-only reasoning embeds no thought and does not break the run", () => {
     const groups = getAssistantRenderGroups(
       [bashPart("c1"), reasoningPart("  \n"), bashPart("c2")],
       true
@@ -111,6 +123,7 @@ describe("getAssistantRenderGroups tool aggregation", () => {
     expect(groups.map((group) => group.kind)).toEqual(["tool-aggregate"]);
     if (groups[0].kind === "tool-aggregate") {
       expect(groups[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2"]);
+      expect(groups[0].thoughts).toEqual([]);
     }
   });
 

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -125,7 +125,7 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
     expect(markup).toContain("Done.");
   });
 
-  test("reasoning between calls splits the aggregate so thoughts stay in order", () => {
+  test("reasoning between calls stays one aggregate line that advertises its thought", () => {
     const assistant: UIMessage = {
       id: "assistant-3",
       role: "assistant",
@@ -142,17 +142,15 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
 
     const markup = renderList([userMessage, assistant]);
 
-    // The second call is not absorbed into the aggregate above the thought.
-    expect(markup).not.toContain("Ran 2 commands");
+    // No thought/command ladder: the run is ONE aggregate line…
+    expect(markup).toContain("Ran 2 commands");
+    // …that counts the thought it carries.
+    expect(markup).toContain("1 thought");
 
-    // Thought, call, thought, call — chronological in the rendered output.
-    const firstThought = markup.indexOf("Thought");
-    const firstRun = markup.indexOf("Ran command", firstThought);
-    const secondThought = markup.indexOf("Thought", firstRun);
-    const secondRun = markup.indexOf("Ran command", secondThought);
-    expect(firstThought).toBeGreaterThan(-1);
-    expect(firstRun).toBeGreaterThan(firstThought);
-    expect(secondThought).toBeGreaterThan(firstRun);
-    expect(secondRun).toBeGreaterThan(secondThought);
+    // The turn-opening thought still renders as its own line above the run.
+    const openingThought = markup.indexOf("Thought");
+    const run = markup.indexOf("Ran 2 commands");
+    expect(openingThought).toBeGreaterThan(-1);
+    expect(run).toBeGreaterThan(openingThought);
   });
 });

--- a/evals/specs/chat-thought-chronology.test.ts
+++ b/evals/specs/chat-thought-chronology.test.ts
@@ -20,9 +20,10 @@ function reasoningPart(text: string): Part {
   return { type: "reasoning", text, state: "done" };
 }
 
-test("interleaved thoughts render chronologically between tool aggregates", ({ evidence }) => {
-  // The user-reported shape: R T T R T T — the model thinks, runs two
-  // commands, thinks again, runs two more.
+test("mid-run thoughts stay chronological inside one compact tool aggregate", ({ evidence }) => {
+  // An alternating run: the model thinks, runs two commands, thinks again,
+  // runs two more. This must NOT render as a thought/command ladder of
+  // repeated single lines, and it must NOT reorder thoughts below the run.
   const parts: Parts = [
     reasoningPart("plan the first probe"),
     bashPart("c1"),
@@ -34,41 +35,45 @@ test("interleaved thoughts render chronologically between tool aggregates", ({ e
 
   const visible = getAssistantRenderGroups(parts, true);
 
-  // Chronology: thought, aggregate, thought, aggregate — a later call is
-  // never absorbed into the aggregate above a thought, and interleaved
-  // thoughts are never merged into one block below the run.
-  expect(visible.map((group) => group.kind)).toEqual([
-    "reasoning",
-    "tool-aggregate",
-    "reasoning",
-    "tool-aggregate",
-  ]);
-  const aggregates = visible.flatMap((group) =>
-    group.kind === "tool-aggregate" ? [group.parts.map((part) => part.toolCallId)] : []
-  );
-  expect(aggregates).toEqual([["c1", "c2"], ["c3", "c4"]]);
-  const thoughts = visible.flatMap((group) => (group.kind === "reasoning" ? [group.text] : []));
-  expect(thoughts).toEqual(["plan the first probe", "interpret and go deeper"]);
+  // Compactness: the turn-opening thought is its own line, then ONE
+  // aggregate carries the whole run.
+  expect(visible.map((group) => group.kind)).toEqual(["reasoning", "tool-aggregate"]);
+  const opening = visible[0];
+  expect(opening.kind === "reasoning" ? opening.text : "").toBe("plan the first probe");
 
-  // Negative half 1: with thinking hidden, the same turn still collapses to
-  // one compact aggregate — chronology never degrades hidden-thinking runs.
+  // Chronology: the mid-run thought is anchored between c2 and c3 —
+  // after exactly two of the run's calls — not merged below the run.
+  const aggregate = visible[1];
+  if (aggregate.kind === "tool-aggregate") {
+    expect(aggregate.parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3", "c4"]);
+    expect(aggregate.thoughts).toEqual([
+      { afterIndex: 2, text: "interpret and go deeper", isStreaming: false },
+    ]);
+  }
+
+  // Negative half 1: with thinking hidden, the same turn is one aggregate
+  // with no embedded thoughts — nothing leaks and nothing fragments.
   const hidden = getAssistantRenderGroups(parts, false);
   expect(hidden.map((group) => group.kind)).toEqual(["tool-aggregate"]);
-  expect(
-    hidden[0].kind === "tool-aggregate" ? hidden[0].parts.map((part) => part.toolCallId) : []
-  ).toEqual(["c1", "c2", "c3", "c4"]);
+  if (hidden[0].kind === "tool-aggregate") {
+    expect(hidden[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3", "c4"]);
+    expect(hidden[0].thoughts).toEqual([]);
+  }
 
-  // Negative half 2: whitespace-only reasoning forms no thought and must not
-  // fragment the aggregate even when thinking is shown.
+  // Negative half 2: whitespace-only reasoning embeds no thought and does
+  // not fragment the run even when thinking is shown.
   const blank = getAssistantRenderGroups(
     [bashPart("c1"), reasoningPart("  \n"), bashPart("c2")],
     true
   );
   expect(blank.map((group) => group.kind)).toEqual(["tool-aggregate"]);
+  if (blank[0].kind === "tool-aggregate") {
+    expect(blank[0].thoughts).toEqual([]);
+  }
 
   evidence.recordAssertionEvidence(
-    "Interleaved thoughts stay chronological between tool aggregates",
-    "An R T T R T T turn rendered as thought, two-call aggregate, thought, two-call aggregate in model order; hiding thinking kept one four-call aggregate; whitespace-only reasoning did not fragment the run.",
+    "Mid-run thoughts stay chronological inside one compact aggregate",
+    "An alternating thought/command turn rendered as one opening thought plus one four-call aggregate carrying its mid-run thought anchored after the second call; hiding thinking produced the same single aggregate with no thoughts; whitespace-only reasoning embedded nothing.",
     true,
   );
 });


### PR DESCRIPTION
Follow-up to #4119.

## What changes for users

#4119 made thoughts appear in chronological order — but when a model thinks before nearly every call, the transcript became a ladder of the same lines over and over:

> Thought ▸
> Ran command
> Thought ▸
> Ran command
> Thought ▸
> Ran command

Now that whole stretch folds into **one** line that still tells you everything happened, and in what order:

> Thought ▸
> Ran 3 commands · 2 thoughts

- **Collapsed:** the aggregate header counts its thoughts (`· 2 thoughts`), so thinking is visible without the noise.
- **Expanded:** thoughts appear interleaved between the exact calls they separated — chronology from #4119 is preserved, just inside the group.
- **Live:** when the model is thinking mid-run (no tool in flight, thought still streaming), the group shows a shimmering `Thinking…` line instead of dead air.
- The turn-opening thought keeps its own line above the run, and "Show model reasoning" off still renders the identical compact aggregate with nothing embedded.

## Change

- `getAssistantRenderGroups` (`apps/app/src/components/chat/utils.ts`): a visible reasoning part arriving while a tool aggregate is open embeds into it as `{ afterIndex, text, isStreaming }` instead of opening a new top-level group; consecutive mid-run reasoning parts merge into one embedded thought. Thoughts before any call (turn start, after prose) remain top-level groups and still break runs.
- `AggregateThought` type lives in `apps/app/src/lib/tool-aggregate.ts` (alias-free, importable by the evals spec).
- `ToolAggregateGroup` gains an optional `thoughts` prop: header thought count, expanded rows interleaved via `afterIndex` (reusing `ReasoningBlock`, capped rows keep their thoughts behind "Show N more"), and the `Thinking…` live line.
- `message-list.tsx` passes `group.thoughts` and counts embedded thoughts toward the step-fold row threshold. Cross-message tool-only runs are unchanged (no thoughts by construction).

## Proof

- `evals/specs/chat-thought-chronology.test.ts` updated to the new contract: an alternating R T T R T T turn renders one opening thought + ONE four-call aggregate with its mid-run thought anchored at `afterIndex: 2`; negative halves assert hidden thinking yields the same aggregate with no thoughts, and whitespace-only reasoning embeds nothing.
  - `pnpm evals:pr specs/chat-thought-chronology.test.ts` → 1 passed / 0 failed / 0 skipped (local PR lane; app-less spec, no Den or app surface required).
- Unit tests updated/added: `chat-message-grouping.test.ts` (embedding, consecutive-thought merge, hidden, whitespace), `message-list-step-fold.test.tsx` (one aggregate line + thought count, opening thought above the run).
  - `bun test tests/chat-message-grouping.test.ts tests/message-list-step-fold.test.tsx tests/tool-aggregate-group.test.tsx` → 15 pass / 0 fail.
- `pnpm --dir apps/app typecheck` → clean.
- Full `bun test --isolate tests/` → 992 pass / 5 fail; the same 5 (connect capability inventory ×2, cloud workspace overlay, session provider auth sync, extensions sidebar) pass standalone on this head and were already demonstrated failing on pristine `origin/dev` with the same command in #4119's control run — pre-existing suite interference, untouched areas.
