### PR TITLE
Keep live run status visible across navigation

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -256,6 +256,9 @@ function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: st
   );
   const queryClient = getReactQueryClient();
   queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, sessionId), exact: true });
+  // Status entries are exempt from TanStack GC (see query-client.ts), so the
+  // tracked-session lifecycle owns their cleanup.
+  queryClient.removeQueries({ queryKey: statusKey(input.workspaceId, sessionId), exact: true });
   if (entry.refs <= 0 && entry.retainedSessionTimers.size === 0) {
     disposeWorkspaceSync(syncKey(input), entry);
   }

--- a/apps/app/src/react-app/infra/query-client.ts
+++ b/apps/app/src/react-app/infra/query-client.ts
@@ -11,7 +11,6 @@ export function getReactQueryClient(): QueryClient {
 
   for (const queryKey of [
     ["react-session-transcript"],
-    ["react-session-status"],
     ["react-session-todos"],
   ] as const) {
     queryClient.setQueryDefaults(queryKey, { gcTime: 15_000 });
@@ -24,7 +23,14 @@ export function getReactQueryClient(): QueryClient {
   // stayed "running" forever (#1916). They are cleared explicitly by
   // permission.replied / question.answered events and clearTrackedSession,
   // never by GC.
+  //
+  // Run status is in the same class: while the session route is unmounted
+  // (e.g. a Settings visit) the SSE sync keeps writing the tiny busy/idle
+  // entry with zero observers, so GC deleted the busy flag and a still-live
+  // run rendered as idle on return. Status entries are cleared by
+  // clearTrackedSession, never by GC.
   for (const queryKey of [
+    ["react-session-status"],
     ["react-session-permissions"],
     ["react-session-questions"],
   ] as const) {

--- a/apps/app/tests/query-client-gc.test.ts
+++ b/apps/app/tests/query-client-gc.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
+
+// These caches are written with setQueryData from the module-singleton SSE
+// sync while their session route can be unmounted (zero observers), so
+// TanStack GC would delete live state ~15s after the route unmounts:
+// pending permissions/questions (#1916) and the run-status busy flag, which
+// made a still-live run render as idle after a Settings visit. Their cleanup
+// is owned by permission.replied / question.answered and clearTrackedSession.
+describe("react-query gc defaults", () => {
+  test("zero-observer live session state is exempt from gc", () => {
+    const queryClient = getReactQueryClient();
+    for (const queryKey of [
+      ["react-session-status"],
+      ["react-session-permissions"],
+      ["react-session-questions"],
+    ] as const) {
+      expect(queryClient.getQueryDefaults(queryKey).gcTime).toBe(Infinity);
+    }
+  });
+
+  test("bulky transcript and todo caches stay gc-bounded", () => {
+    const queryClient = getReactQueryClient();
+    for (const queryKey of [
+      ["react-session-transcript"],
+      ["react-session-todos"],
+    ] as const) {
+      expect(queryClient.getQueryDefaults(queryKey).gcTime).toBe(15_000);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Exempt `["react-session-status"]` from the 15s TanStack GC window and tie its cleanup to `clearTrackedSession` — the same class and fix as pending permissions/questions (#1916).
- Pin the gc defaults with a regression test (`tests/query-client-gc.test.ts`).

## Why

While the session route is unmounted (opening Settings, navigating away), the module-singleton SSE sync keeps writing the tiny busy/idle status entry with zero observers, so GC deleted the busy flag ~15s after unmount. On return the UI rendered a still-live run as idle — no spinner, no Stop button — until a snapshot refetch happened to win. Status entries are small and bounded by session count; their lifecycle is owned by the tracked-session cleanup, never GC.

## Verification

- `pnpm --filter @openwork/app typecheck` — exit 0
- `bun test --isolate tests/` (apps/app) — 993 pass / 5 fail; the 5 failures are byte-for-byte the pre-existing set on `dev` (verified against a clean control worktree), no new names
- E2E tapes deliberately not run for this pass at the requester's direction.