### PR TITLE
Seed live session status on event stream connect

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -767,11 +767,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.status") {
     const props = (event.properties ?? {}) as { sessionID?: string; status?: SessionStatus };
     if (!props.sessionID || !props.status) return;
-    useSessionActivityStore.getState().setRunStatus(workspaceId, props.sessionID, props.status);
-    const tracked = isTrackedSession(entry, props.sessionID);
-    if (tracked) queryClient.setQueryData(statusKey(workspaceId, props.sessionID), props.status);
-    for (const listener of entry.sessionStatusListeners) listener({ sessionId: props.sessionID, status: props.status });
-    if (input && tracked && !isLiveStatus(props.status)) releaseRetainedSessionSoon(input, entry, props.sessionID);
+    applySessionRunStatus(entry, workspaceId, props.sessionID, props.status);
     return;
   }
 
@@ -1199,6 +1195,35 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
   };
 }
 
+/**
+ * Apply a session run status through the same path a live `session.status`
+ * event takes: the activity store, the react-query status cache for tracked
+ * sessions, and the sync listeners. Fetched (level-triggered) statuses pass
+ * `snapshotStartedAt` so they are ordered against live writes — a fetch that
+ * raced a newer SSE status is dropped instead of clobbering it.
+ */
+function applySessionRunStatus(
+  entry: SyncEntry,
+  workspaceId: string,
+  sessionId: string,
+  status: SessionStatus,
+  options: { snapshotStartedAt?: number } = {},
+) {
+  const snapshotStartedAt = options.snapshotStartedAt;
+  const store = useSessionActivityStore.getState();
+  if (typeof snapshotStartedAt === "number") {
+    const record = store.recordsByWorkspaceId[workspaceId]?.[sessionId];
+    if (snapshotStartedAt < (record?.runStatusAt ?? 0)) return;
+    store.seedSessionRun(workspaceId, sessionId, status, undefined, { snapshotStartedAt });
+  } else {
+    store.setRunStatus(workspaceId, sessionId, status);
+  }
+  const tracked = isTrackedSession(entry, sessionId);
+  if (tracked) getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), status);
+  for (const listener of entry.sessionStatusListeners) listener({ sessionId, status });
+  if (entry.input && tracked && !isLiveStatus(status)) releaseRetainedSessionSoon(entry.input, entry, sessionId);
+}
+
 async function reconcileSessionRunStatuses(entry: SyncEntry, input: SyncOptions, signal: AbortSignal) {
   const startedAt = Date.now();
   let statuses: Record<string, SessionStatus>;
@@ -1209,16 +1234,17 @@ async function reconcileSessionRunStatuses(entry: SyncEntry, input: SyncOptions,
   }
   if (signal.aborted) return;
 
-  const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId];
-  if (!records) return;
-  for (const sessionId of Object.keys(records)) {
-    useSessionActivityStore.getState().seedSessionRun(
-      input.workspaceId,
-      sessionId,
-      statuses[sessionId] ?? idleStatus,
-      undefined,
-      { snapshotStartedAt: startedAt },
-    );
+  // Level-triggered convergence on every SSE (re)connect: sessions the fetch
+  // reports live are seeded busy (heals a subscriber that missed the busy
+  // edge), and known records the fetch no longer reports are seeded idle
+  // (heals a missed idle edge). Both flow through the same path a
+  // session.status event uses so the status cache and listeners converge too.
+  const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
+  const sessionIds = new Set([...Object.keys(statuses), ...Object.keys(records)]);
+  for (const sessionId of sessionIds) {
+    applySessionRunStatus(entry, input.workspaceId, sessionId, statuses[sessionId] ?? idleStatus, {
+      snapshotStartedAt: startedAt,
+    });
   }
 }
 

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -232,6 +232,46 @@ describe("session run status ordering", () => {
 });
 
 describe("session run status reconnect reconciliation", () => {
+  test("seeds a missed busy edge into the status cache on connect", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ [sessionId]: { type: "busy" } }));
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("thinking");
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    releaseSession();
+  });
+
+  test("does not clobber a newer live status with a stale reconnect fetch", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    let resolveStatuses: (statuses: Record<string, SessionStatus>) => void = () => {};
+    __setWorkspaceSessionSyncStatusFetcherForTest(() => new Promise((resolve) => {
+      resolveStatuses = resolve;
+    }));
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    resolveStatuses({});
+    await flushMicrotasks();
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    releaseSession();
+  });
+
   test("heals an active record when a reconnect reports no active run", async () => {
     __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));


### PR DESCRIPTION
## Summary

- Extract the `session.status` event handler body into a shared `applySessionRunStatus()` and route the existing SSE (re)connect reconciliation through it, so fetched status levels take the exact same path as live edges: zustand run-status writes, the react-query `statusKey` cache the open chat reads, listener notification, and retained-session release.
- Reconcile now covers the union of fetched statuses and known records — previously sessions busy at connect time but unknown to the activity store were skipped entirely, and the `statusKey` cache was never healed at all.
- Two focused unit tests in the existing reconnect harness: a missed busy edge is seeded into the status cache on connect, and a stale reconnect fetch cannot clobber a newer live status.

## Why

`session.status` is edge-triggered: it fires once at busy/retry/idle transitions. Any subscriber that attaches after the edge — SSE reconnect, engine restart, remount — stayed wrong for the rest of the run and showed a live task as idle. Status must be level-converged on connect. Ordering is protected by the existing `runStatusAt` vs fetch-start guard, so a fetched level can never overwrite a newer edge received while the fetch was in flight.

## Verification

- `pnpm --filter @openwork/app typecheck` — exit 0
- `bun test --isolate tests/session-sync-run-status.test.ts` — 11 pass / 0 fail (+2 new)
- `bun test --isolate tests/` (apps/app) — 993 pass / 5 fail; the 5 failures are byte-for-byte the pre-existing set on `dev`, no new names
- E2E tapes deliberately not run for this pass at the requester's direction.