### PR TITLE
Resume interrupted runs from the transcript error card

### DIFF
--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -25,6 +25,8 @@ interface MessageListContextValue {
   onEditUserMessage: (messageId: string, text: string) => void
   /** Open a sub-agent (child) session in the main chat surface. */
   onOpenSubagentSession?: (sessionId: string) => void
+  /** Re-submit an interrupted run by sending its recovery prompt. */
+  onResumeInterrupted?: (recoveryPrompt: string) => void
   onMcpReconnect: (
     action: ChatToolReconnectAction,
     onProgress: (progress: ChatToolReconnectProgress) => void,
@@ -46,6 +48,7 @@ interface MessageListProviderProps {
   onForkAtMessage: (messageId: string) => void
   onEditUserMessage: (messageId: string, text: string) => void
   onOpenSubagentSession?: (sessionId: string) => void
+  onResumeInterrupted?: (recoveryPrompt: string) => void
   onMcpReconnect: (
     action: ChatToolReconnectAction,
     onProgress: (progress: ChatToolReconnectProgress) => void,
@@ -81,6 +84,7 @@ export function MessageListProvider({
   onForkAtMessage,
   onEditUserMessage,
   onOpenSubagentSession,
+  onResumeInterrupted,
   onMcpReconnect,
   onMcpReopenAuthorization,
   onMcpRetry,
@@ -92,6 +96,7 @@ export function MessageListProvider({
     onForkAtMessage,
     onEditUserMessage,
     onOpenSubagentSession,
+    onResumeInterrupted,
     onMcpReconnect,
     onMcpReopenAuthorization,
     onMcpRetry,
@@ -104,6 +109,7 @@ export function MessageListProvider({
       onForkAtMessage,
       onEditUserMessage,
       onOpenSubagentSession,
+      onResumeInterrupted,
       onMcpReconnect,
       onMcpReopenAuthorization,
       onMcpRetry,
@@ -115,6 +121,7 @@ export function MessageListProvider({
     onForkAtMessage,
     onEditUserMessage,
     onOpenSubagentSession,
+    onResumeInterrupted,
     onMcpReconnect,
     onMcpReopenAuthorization,
     onMcpRetry,
@@ -126,6 +133,7 @@ export function MessageListProvider({
     onForkAtMessage: (messageId: string) => handlersRef.current.onForkAtMessage(messageId),
     onEditUserMessage: (messageId: string, text: string) => handlersRef.current.onEditUserMessage(messageId, text),
     onOpenSubagentSession: (sessionId: string) => handlersRef.current.onOpenSubagentSession?.(sessionId),
+    onResumeInterrupted: (recoveryPrompt: string) => handlersRef.current.onResumeInterrupted?.(recoveryPrompt),
     onMcpReconnect: (
       action: ChatToolReconnectAction,
       onProgress: (progress: ChatToolReconnectProgress) => void,
@@ -136,6 +144,7 @@ export function MessageListProvider({
     onMcpRetry: (action: ChatToolReconnectAction) => handlersRef.current.onMcpRetry(action),
   }), [])
   const canOpenSubagentSession = Boolean(onOpenSubagentSession)
+  const canResumeInterrupted = Boolean(onResumeInterrupted)
   const value = React.useMemo(
     () => ({
       workspaceId,
@@ -150,6 +159,9 @@ export function MessageListProvider({
       onOpenSubagentSession: canOpenSubagentSession
         ? stableHandlers.onOpenSubagentSession
         : undefined,
+      onResumeInterrupted: canResumeInterrupted
+        ? stableHandlers.onResumeInterrupted
+        : undefined,
     }),
     [
       workspaceId,
@@ -162,6 +174,7 @@ export function MessageListProvider({
       connectorIdentities,
       stableHandlers,
       canOpenSubagentSession,
+      canResumeInterrupted,
     ],
   )
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -27,6 +27,8 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { openDesktopUrl, revealDesktopItemInDir } from "@/app/lib/desktop"
 import { isElectronRuntime } from "@/app/lib/runtime-env"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
+import { t } from "@/i18n"
+import { sessionErrorPresentationFromUIMessage } from "@/react-app/domains/session/sync/session-error"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
 import { EditTool } from "@/components/tools/edit"
@@ -801,7 +803,13 @@ type MessageComponentProps = {
 const MessageComponent = React.memo(
   ({ message, isLastMessage, isStreaming, isLastStep, hideReasoning }: MessageComponentProps) => {
     if (isSessionErrorMessage(message)) {
-      return <ErrorMessage error={getMessagesText([message]) || "Session failed"} />
+      const presentation = sessionErrorPresentationFromUIMessage(message)
+      return (
+        <ErrorMessage
+          error={getMessagesText([message]) || "Session failed"}
+          resumePrompt={presentation?.recoveryPrompt}
+        />
+      )
     }
 
     if (isEmptyMessage(message)) {
@@ -843,15 +851,33 @@ LoadingMessage.displayName = "LoadingMessage"
 
 interface ErrorMessageProps {
   error: string | null
+  /** Set only for interrupted runs (aborted / provider timeout) that can resume. */
+  resumePrompt?: string | null
 }
 
-function ErrorMessage({ error }: ErrorMessageProps) {
+function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
+  const { onResumeInterrupted } = useMessageList()
+
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
-          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
-          <p className="whitespace-pre-wrap text-destructive">{error}</p>
+        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
+          <div className="flex flex-row items-start gap-2">
+            <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
+            <p className="whitespace-pre-wrap text-destructive">{error}</p>
+          </div>
+          {resumePrompt && onResumeInterrupted ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mb-1 ml-6 h-7 w-fit border-red-400/70 bg-red-50 text-xs text-red-950 hover:bg-red-100"
+              data-testid="session-error-resume"
+              onClick={() => onResumeInterrupted(resumePrompt)}
+            >
+              {t("session.resume_interrupted")}
+            </Button>
+          ) : null}
         </div>
       </div>
     </Message>

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1199,6 +1199,7 @@ export default {
   "session.diagnostics_copied": "Diagnostics copied — paste it into your issue or support thread",
   "session.diagnostics_exported": "Diagnostics exported",
   "session.diagnostics_failed": "Could not prepare diagnostics",
+  "session.resume_interrupted": "Resume",
   "session.stop_failed": "Could not stop the run — the engine reported no active run was aborted. Try again.",
   "session.revert_failed": "Could not revert the conversation. Try again once the current run finishes.",
   "session.branch_failed": "Could not branch this conversation. Try again.",

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2031,6 +2031,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
     void typeComposerText(prompt);
   }, [typeComposerText]);
 
+  // Explicit user click on the interrupted-run error card. Re-submits the
+  // classified recovery prompt through the normal send path so the agent
+  // continues the interrupted task in this session instead of restarting it.
+  const handleResumeInterrupted = useCallback(async (recoveryPrompt: string) => {
+    try {
+      await sendDraft({
+        mode: "prompt",
+        parts: [{ type: "text", text: recoveryPrompt }],
+        attachments: [],
+        text: recoveryPrompt,
+      });
+    } catch {
+      // sendDraft already surfaced the failure on the session error state.
+    }
+  }, [sendDraft]);
+
   useEffect(() => {
     const resetReconnectState = () => {
       useChatMcpReconnectStore.getState().reset();
@@ -2368,6 +2384,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       onForkAtMessage={handleForkAtMessage}
                       onEditUserMessage={handleEditUserMessage}
                       onOpenSubagentSession={props.onOpenSubagentSession}
+                      onResumeInterrupted={handleResumeInterrupted}
                       onMcpReconnect={handleMcpReconnect}
                       onMcpReopenAuthorization={handleMcpReopenAuthorization}
                       onMcpRetry={handleMcpRetry}

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -146,4 +146,61 @@ describe("session error resilience", () => {
     expect(html).not.toContain('aria-label="Show error details"')
     expect(html).not.toContain('data-testid="session-error-details-trigger"')
   })
+
+  const renderErrorTranscriptWithResume = (error: unknown) => {
+    const message = createSessionErrorUIMessage(
+      "assistant-turn",
+      presentOpencodeSessionError(error),
+    )
+    return renderToStaticMarkup(
+      <MessageListProvider
+        workspaceId="workspace-1"
+        sessionId="session-1"
+        showThinking={false}
+        developerMode={false}
+        displaySuggestions={false}
+        providerConnectedCount={1}
+        dispatchAction={() => undefined}
+        setPrompt={() => undefined}
+        onRevertToUserMessage={() => undefined}
+        onForkAtMessage={() => undefined}
+        onEditUserMessage={() => undefined}
+        onResumeInterrupted={() => undefined}
+        onMcpReconnect={async () => "connected"}
+        onMcpReopenAuthorization={async () => undefined}
+        onMcpRetry={() => undefined}
+      >
+        <MessageList messages={[message]} status="ready" />
+      </MessageListProvider>,
+    )
+  }
+
+  test("offers Resume on the error card for an engine abort", () => {
+    const html = renderErrorTranscriptWithResume({
+      name: "MessageAbortedError",
+      data: { message: "Aborted" },
+    })
+
+    expect(html).toContain('data-testid="session-error-resume"')
+    expect(html).toContain("Resume")
+  })
+
+  test("offers Resume on the error card for a provider timeout", () => {
+    const html = renderErrorTranscriptWithResume({
+      name: "ProviderHeaderTimeoutError",
+      data: { message: "Provider response headers timed out after 10000ms" },
+    })
+
+    expect(html).toContain('data-testid="session-error-resume"')
+  })
+
+  test("hides Resume for errors that cannot be resumed", () => {
+    const html = renderErrorTranscriptWithResume({
+      name: "ProviderAuthError",
+      data: { message: "Provider authentication failed" },
+    })
+
+    expect(html).not.toContain('data-testid="session-error-resume"')
+    expect(html).not.toContain(">Resume<")
+  })
 })


### PR DESCRIPTION
## Summary

- Add an explicit Resume button to the interrupted-task error card in the transcript. Clicking it sends the session's persisted `recoveryPrompt` through the surface's real send path (`sendDraft`), which keeps composer history, activity status, and the cloud-MCP submission gate intact.
- The button only appears for error kinds that produce a recovery prompt (`aborted`, `provider-timeout`) — auth and generic errors never show it. Never auto-resumes; explicit click only.
- New string `session.resume_interrupted` in the en locale; three focused tests in the existing error-resilience harness (rendered for aborted, rendered for provider-timeout, absent for auth errors).

## Why

When an engine restart or abort interrupts a run, the transcript showed a dead-end error with no way forward: the classified `recoveryPrompt` (which instructs the agent to inspect completed work and finish only what remains) was presentation-only, and `retryLastPrompt` had no callers and loses its in-memory state across exactly the restart scenario it would be needed for. The recovery prompt is persisted in the synthetic error message metadata, so it survives reloads and restarts.

## Verification

- `pnpm --filter @openwork/app typecheck` — exit 0
- `bun test --isolate tests/` (apps/app) — 994 pass / 5 fail; the 5 failures are byte-for-byte the pre-existing set on `dev`, no new names
- E2E tapes deliberately not run for this pass at the requester's direction.

## Follow-ups

- A disabled-while-sending state to guard rapid double clicks (consistent with nearby retry buttons today).
- `actions-store.ts` / `actions-provider.tsx` remain uncalled dead code; separate cleanup decision.