### PR TITLE
feat(app): support cross-workspace split view

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/pane-runtime.ts
+++ b/apps/app/src/react-app/domains/session/chat/pane-runtime.ts
@@ -1,0 +1,65 @@
+import type { WorkspaceInfo } from "@/app/lib/desktop";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+
+type PaneWorkspace = Pick<WorkspaceInfo, "id" | "path" | "workspaceType">;
+
+export type WorkbenchPaneEndpoint<TWorkspace extends PaneWorkspace = PaneWorkspace> = {
+  status: "ready";
+  workspaceId: string;
+  workspaceTitle: string;
+  workspaceRoot: string;
+  workspaceType?: WorkspaceInfo["workspaceType"];
+  workspace: TWorkspace;
+  endpoint: ResolvedWorkspaceEndpoint;
+} | {
+  status: "unavailable";
+  workspaceId: string;
+  workspaceTitle: string;
+  message: string;
+};
+
+export function resolveWorkbenchPaneEndpoint<TWorkspace extends PaneWorkspace>(input: {
+  workspaceId: string;
+  workspaceTitle: string;
+  workspace: TWorkspace | undefined;
+  endpoint: ResolvedWorkspaceEndpoint | null;
+  connectionError?: string | null;
+}): WorkbenchPaneEndpoint<TWorkspace> {
+  if (!input.workspace) {
+    return {
+      status: "unavailable",
+      workspaceId: input.workspaceId,
+      workspaceTitle: input.workspaceTitle,
+      message: "This workspace is no longer available.",
+    };
+  }
+
+  const connectionError = input.connectionError?.trim();
+  if (connectionError) {
+    return {
+      status: "unavailable",
+      workspaceId: input.workspace.id,
+      workspaceTitle: input.workspaceTitle,
+      message: connectionError,
+    };
+  }
+
+  if (!input.endpoint?.token) {
+    return {
+      status: "unavailable",
+      workspaceId: input.workspace.id,
+      workspaceTitle: input.workspaceTitle,
+      message: "OpenWork could not connect to this workspace runtime.",
+    };
+  }
+
+  return {
+    status: "ready",
+    workspaceId: input.workspace.id,
+    workspaceTitle: input.workspaceTitle,
+    workspaceRoot: input.workspace.path?.trim() || "",
+    workspaceType: input.workspace.workspaceType,
+    workspace: input.workspace,
+    endpoint: input.endpoint,
+  };
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { ArrowLeft, Cloud, FileText, Globe, Mic2, MoreHorizontal, PanelRight, TextSearch, Zap } from "lucide-react";
+import { ArrowLeft, Cloud, FileText, Globe, Mic2, MoreHorizontal, PanelRight, TextSearch, X, Zap } from "lucide-react";
 
 import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
 import { t } from "../../../../i18n";
@@ -100,6 +100,8 @@ import {
   type ConversationHistoryDirection,
 } from "./conversation-tab-history";
 import { useWorkbenchStore, type WorkbenchSessionTab } from "./workbench-store";
+import { isSameWorkbenchSession } from "./workbench-store";
+import { ReactSessionRuntime } from "../sync/runtime-sync";
 
 const STARTUP_SKELETON_ROWS = [
   { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
@@ -176,6 +178,25 @@ export type SessionPageSurfaceProps = Omit<
   "client" | "workspaceId" | "sessionId" | "opencodeBaseUrl" | "openworkToken" | "isControlTarget"
 >;
 
+export type SessionPagePaneRuntime = {
+  status: "ready";
+  workspaceId: string;
+  workspaceTitle: string;
+  workspaceRoot: string;
+  workspaceType?: WorkspaceInfo["workspaceType"];
+  runtimeWorkspaceId: string;
+  opencodeBaseUrl: string;
+  openworkToken: string;
+  client: OpenworkServerClient;
+  environmentClient?: OpenworkServerClient | null;
+  surface: SessionPageSurfaceProps;
+} | {
+  status: "unavailable";
+  workspaceId: string;
+  workspaceTitle: string;
+  message: string;
+};
+
 export type SessionPageProps = {
   sessionNumberShortcuts: SessionNumberShortcutsState;
   selectedSessionId: string | null;
@@ -214,6 +235,7 @@ export type SessionPageProps = {
   onOpenExtensions: () => void;
   sidebar: SessionPageSidebarProps;
   surface?: SessionPageSurfaceProps | null;
+  resolvePaneRuntime?: (session: OpenSessionTab) => SessionPagePaneRuntime;
   history?: SessionPageHistoryControls | null;
   todos: TodoItem[];
   sessionLoadingById: (sessionId: string | null) => boolean;
@@ -251,11 +273,90 @@ export type SessionPageProps = {
   onSessionTabsChange?: (tabs: OpenSessionTab[]) => void;
 };
 
-function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | undefined) {
+function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | undefined, workspaceId?: string) {
   if (!id) return "";
-  const sessionsById = new Map(groups.flatMap((group) => group.sessions.map((session) => [session.id, session] as const)));
+  const matchingGroups = workspaceId ? groups.filter((group) => group.workspace.id === workspaceId) : groups;
+  const sessionsById = new Map(matchingGroups.flatMap((group) => group.sessions.map((session) => [session.id, session] as const)));
   const match = sessionsById.get(id);
   return match ? getDisplaySessionTitle(match.title) : "";
+}
+
+function workspaceTitleForId(groups: WorkspaceSessionGroup[], workspaceId: string) {
+  const workspace = groups.find((group) => group.workspace.id === workspaceId)?.workspace;
+  return workspace?.displayName?.trim()
+    || workspace?.name?.trim()
+    || workspace?.path?.trim()
+    || workspaceId;
+}
+
+function WorkbenchPaneHeader(props: {
+  pane: "primary" | "secondary";
+  session: OpenSessionTab;
+  workspaceTitle: string;
+  showWorkspace: boolean;
+  focused: boolean;
+  onFocus: () => void;
+  onClose: () => void;
+}) {
+  const title = props.session.title?.trim() || t("session.default_title");
+  return (
+    <div
+      className={cn(
+        "flex h-10 shrink-0 items-center gap-2 border-b border-border px-3",
+        props.focused && "bg-muted/40",
+      )}
+      data-workbench-pane-header={props.pane}
+      data-workbench-pane-workspace-name={props.workspaceTitle}
+    >
+      <button type="button" className="min-w-0 flex-1 text-left" onClick={props.onFocus}>
+        <span className="block truncate text-xs font-medium text-foreground">{title}</span>
+        {props.showWorkspace ? (
+          <span className="block truncate text-[10px] text-muted-foreground">{props.workspaceTitle}</span>
+        ) : null}
+      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label={`Close ${props.pane} split pane`}
+              onClick={props.onClose}
+            >
+              <X data-icon="inline-start" />
+            </Button>
+          }
+        />
+        <TooltipContent>{props.pane === "primary" ? "Keep the other session" : "Close split view"}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function UnavailableWorkbenchPane(props: {
+  workspaceTitle: string;
+  message: string;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="flex min-h-0 flex-1 items-center justify-center p-6"
+      data-workbench-pane-unavailable
+      role="status"
+    >
+      <div className="flex max-w-sm flex-col gap-3 text-center">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">{props.workspaceTitle} is unavailable</h2>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{props.message}</p>
+        </div>
+        <div className="flex justify-center gap-2">
+          <Button variant="outline" size="sm" onClick={props.onRetry}>Retry connection</Button>
+          <Button variant="ghost" size="sm" onClick={props.onClose}>Close pane</Button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function isTrackableAccessibleTarget(target: OpenTarget) {
@@ -387,17 +488,21 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
-  const workbenchWorkspaceId = useWorkbenchStore((state) => state.workspaceId);
+  const workbenchPrimary = useWorkbenchStore((state) => state.primary);
   const workbenchTabs = useWorkbenchStore((state) => state.tabs);
-  const workbenchSplitSessionId = useWorkbenchStore((state) => state.splitSessionId);
+  const workbenchSecondary = useWorkbenchStore((state) => state.secondary);
   const focusedWorkbenchPane = useWorkbenchStore((state) => state.focusedPane);
   const activeWorkbenchPane = isMobile ? "primary" : focusedWorkbenchPane;
   const syncWorkbench = useWorkbenchStore((state) => state.sync);
   const openWorkbenchTab = useWorkbenchStore((state) => state.openTab);
   const setWorkbenchSplit = useWorkbenchStore((state) => state.setSplit);
   const focusWorkbenchPane = useWorkbenchStore((state) => state.focusPane);
-  const sessionTabs = workbenchWorkspaceId === props.selectedWorkspaceId ? workbenchTabs : EMPTY_SESSION_TABS;
-  const splitSessionId = workbenchWorkspaceId === props.selectedWorkspaceId ? workbenchSplitSessionId : null;
+  const selectedSessionRef = props.selectedSessionId
+    ? { workspaceId: props.selectedWorkspaceId, sessionId: props.selectedSessionId }
+    : null;
+  const workbenchOwnsSelectedRoute = isSameWorkbenchSession(workbenchPrimary, selectedSessionRef);
+  const sessionTabs = workbenchOwnsSelectedRoute ? workbenchTabs : EMPTY_SESSION_TABS;
+  const splitSession = workbenchOwnsSelectedRoute ? workbenchSecondary : null;
   const [conversationHistory, setConversationHistory] = useState(() => (
     createConversationTabHistory(props.selectedWorkspaceId, props.selectedSessionId)
   ));
@@ -470,22 +575,12 @@ export function SessionPage(props: SessionPageProps) {
     if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
     return target.value;
   }, []);
-  const downloadOpenTarget = useCallback(async (target: OpenTarget) => {
-    if (target.kind !== "file" || !props.openworkServerClient || !props.runtimeWorkspaceId) {
-      return;
-    }
-
-    const result = await props.openworkServerClient.downloadWorkspaceFile(props.runtimeWorkspaceId, target.value);
-    const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
-    const anchor = document.createElement("a");
-
-    anchor.href = url;
-    anchor.download = target.name;
-    anchor.click();
-
-    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
-  }, [props.openworkServerClient, props.runtimeWorkspaceId]);
-  const openTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
+  const openTargetForRuntime = useCallback((runtime: {
+    client: OpenworkServerClient | null;
+    runtimeWorkspaceId: string | null;
+    workspaceRoot: string;
+    workspaceType?: WorkspaceInfo["workspaceType"];
+  }, target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
     if (target.kind === "url" || target.preview === "browser") {
       const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
@@ -498,8 +593,8 @@ export function SessionPage(props: SessionPageProps) {
     }
 
     const openFileTarget = (fileTarget: OpenTarget) => {
-      if (options?.external && props.selectedWorkspaceDisplay.workspaceType !== "remote") {
-        const path = absoluteWorkspacePath(props.selectedWorkspaceRoot, fileTarget.value);
+      if (options?.external && runtime.workspaceType !== "remote") {
+        const path = absoluteWorkspacePath(runtime.workspaceRoot, fileTarget.value);
         if (path && isElectronRuntime()) {
           void (async () => {
             try {
@@ -518,10 +613,21 @@ export function SessionPage(props: SessionPageProps) {
 
       if (!isCollectibleArtifactTarget(fileTarget)) {
         if (isOpenableFileTarget(fileTarget)) {
-          if (props.selectedWorkspaceDisplay.workspaceType === "remote") {
-            void downloadOpenTarget(fileTarget).catch(() => undefined);
+          if (runtime.workspaceType === "remote" && runtime.client && runtime.runtimeWorkspaceId) {
+            void runtime.client.downloadWorkspaceFile(runtime.runtimeWorkspaceId, fileTarget.value)
+              .then((result) => {
+                const url = URL.createObjectURL(new Blob([result.data], {
+                  type: result.contentType ?? "application/octet-stream",
+                }));
+                const anchor = document.createElement("a");
+                anchor.href = url;
+                anchor.download = fileTarget.name;
+                anchor.click();
+                window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+              })
+              .catch(() => undefined);
           } else if (isElectronRuntime()) {
-            void openDesktopPath(absoluteWorkspacePath(props.selectedWorkspaceRoot, fileTarget.value)).catch(() => undefined);
+            void openDesktopPath(absoluteWorkspacePath(runtime.workspaceRoot, fileTarget.value)).catch(() => undefined);
           }
         }
         return;
@@ -542,8 +648,8 @@ export function SessionPage(props: SessionPageProps) {
     };
 
     if (target.exists !== true) {
-      if (!props.openworkServerClient || !props.runtimeWorkspaceId) return;
-      void resolveCollectibleOpenTarget(props.openworkServerClient, props.runtimeWorkspaceId, target)
+      if (!runtime.client || !runtime.runtimeWorkspaceId) return;
+      void resolveCollectibleOpenTarget(runtime.client, runtime.runtimeWorkspaceId, target)
         .then((resolvedTarget) => {
           if (resolvedTarget) openFileTarget(resolvedTarget);
         })
@@ -552,7 +658,21 @@ export function SessionPage(props: SessionPageProps) {
     }
 
     openFileTarget(target);
-  }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.openworkServerClient, props.runtimeWorkspaceId, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
+  }, [activePanelTab?.id, browserUrlForTarget, openTab, props.selectedSessionId, setCurrentSidePanel]);
+  const openTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
+    openTargetForRuntime({
+      client: props.openworkServerClient,
+      runtimeWorkspaceId: props.runtimeWorkspaceId,
+      workspaceRoot: props.selectedWorkspaceRoot,
+      workspaceType: props.selectedWorkspaceDisplay.workspaceType,
+    }, target, options, sourceSessionId);
+  }, [
+    openTargetForRuntime,
+    props.openworkServerClient,
+    props.runtimeWorkspaceId,
+    props.selectedWorkspaceDisplay.workspaceType,
+    props.selectedWorkspaceRoot,
+  ]);
   const closeRightPane = useCallback(() => {
     setCurrentSidePanel(null);
   }, [setCurrentSidePanel]);
@@ -731,7 +851,7 @@ export function SessionPage(props: SessionPageProps) {
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
-    () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
+    () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId, props.selectedWorkspaceId),
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
   const workspaceName =
@@ -751,10 +871,11 @@ export function SessionPage(props: SessionPageProps) {
           openWorkbenchTab({
             workspaceId: props.selectedWorkspaceId,
             sessionId: targetSplit,
-            title: sessionTitleForId(props.sidebar.workspaceSessionGroups, targetSplit),
+            title: sessionTitleForId(props.sidebar.workspaceSessionGroups, targetSplit, props.selectedWorkspaceId),
+            workspaceTitle: workspaceTitleForId(props.sidebar.workspaceSessionGroups, props.selectedWorkspaceId),
           });
         }
-        setWorkbenchSplit(targetSplit);
+        setWorkbenchSplit(targetSplit ? { workspaceId: props.selectedWorkspaceId, sessionId: targetSplit } : null);
         setPendingConversationHistoryNavigation(null);
         return;
       }
@@ -771,7 +892,7 @@ export function SessionPage(props: SessionPageProps) {
       current,
       props.selectedWorkspaceId,
       props.selectedSessionId,
-      splitSessionId,
+      splitSession?.sessionId ?? null,
     ));
   }, [
     openWorkbenchTab,
@@ -780,7 +901,7 @@ export function SessionPage(props: SessionPageProps) {
     props.selectedWorkspaceId,
     props.sidebar.workspaceSessionGroups,
     setWorkbenchSplit,
-    splitSessionId,
+    splitSession,
   ]);
   useEffect(() => {
     if (!pendingConversationHistoryNavigation) return undefined;
@@ -802,6 +923,7 @@ export function SessionPage(props: SessionPageProps) {
         workspaceId: props.selectedWorkspaceId,
         sessionId: session.id,
         title: getDisplaySessionTitle(session.title),
+        workspaceTitle: workspaceName,
       })),
     });
   }, [
@@ -871,7 +993,49 @@ export function SessionPage(props: SessionPageProps) {
       reactSessionToken &&
       props.surface,
   );
-  const canRenderSplitSurface = Boolean(!isMobile && canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
+  const canRenderSplitSurface = Boolean(!isMobile && canRenderReactSurface && splitSession);
+  const splitWorkspaceTitle = splitSession
+    ? splitSession.workspaceTitle ?? workspaceTitleForId(props.sidebar.workspaceSessionGroups, splitSession.workspaceId)
+    : "";
+  const splitPaneRuntime: SessionPagePaneRuntime | null = (() => {
+    if (!splitSession) return null;
+    if (splitSession.workspaceId !== props.selectedWorkspaceId) {
+      return props.resolvePaneRuntime?.(splitSession) ?? {
+        status: "unavailable",
+        workspaceId: splitSession.workspaceId,
+        workspaceTitle: splitWorkspaceTitle,
+        message: "This workspace does not have a connected runtime.",
+      };
+    }
+    if (
+      props.runtimeWorkspaceId
+      && props.openworkServerClient
+      && reactSessionBaseUrl
+      && reactSessionToken
+      && props.surface
+    ) {
+      return {
+        status: "ready",
+        workspaceId: splitSession.workspaceId,
+        workspaceTitle: splitWorkspaceTitle,
+        workspaceRoot: props.selectedWorkspaceRoot,
+        workspaceType: props.selectedWorkspaceDisplay.workspaceType,
+        runtimeWorkspaceId: props.runtimeWorkspaceId,
+        opencodeBaseUrl: reactSessionBaseUrl,
+        openworkToken: reactSessionToken,
+        client: props.openworkServerClient,
+        environmentClient: props.environmentClient,
+        surface: props.surface,
+      };
+    }
+    return {
+      status: "unavailable",
+      workspaceId: splitSession.workspaceId,
+      workspaceTitle: splitWorkspaceTitle,
+      message: selectedWorkspaceErrorMessage || "This workspace is disconnected.",
+    };
+  })();
+  const crossWorkspaceSplit = Boolean(splitSession && splitSession.workspaceId !== props.selectedWorkspaceId);
   // Route-level refreshes must only gate the very first paint of a session.
   // Once the surface can mount it owns its own data stream, so replacing a
   // rendered chat with a loading pane (and leaving it there when a refresh
@@ -905,11 +1069,22 @@ export function SessionPage(props: SessionPageProps) {
     openWorkbenchTab({
       workspaceId,
       sessionId,
-      title: sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId),
+      title: sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId, workspaceId),
+      workspaceTitle: workspaceTitleForId(props.sidebar.workspaceSessionGroups, workspaceId),
     });
     focusWorkbenchPane("primary");
     props.sidebar.onOpenSession(workspaceId, sessionId);
   }, [focusWorkbenchPane, openWorkbenchTab, props.sidebar]);
+
+  const closeSecondaryWorkbenchPane = useCallback(() => {
+    setWorkbenchSplit(null);
+  }, [setWorkbenchSplit]);
+
+  const closePrimaryWorkbenchPane = useCallback(() => {
+    if (!splitSession) return;
+    setWorkbenchSplit(null);
+    openSessionTab(splitSession.workspaceId, splitSession.sessionId);
+  }, [openSessionTab, setWorkbenchSplit, splitSession]);
 
   // Sub-agent sessions open in the main chat surface from their task card in
   // the parent transcript (they no longer live in the sidebar).
@@ -959,11 +1134,11 @@ export function SessionPage(props: SessionPageProps) {
       }
       const sessionId = args.sessionId.trim();
       if (!sessionId) return { ok: false, error: "sessionId is required" };
-      if (sessionId === props.selectedSessionId) {
+      if (sessionId === workbenchPrimary?.sessionId) {
         focusWorkbenchPane("primary");
         return { ok: true, sessionId, reused: "primary-pane" };
       }
-      if (sessionId === splitSessionId) {
+      if (sessionId === splitSession?.sessionId) {
         focusWorkbenchPane("secondary");
         return { ok: true, sessionId, reused: "secondary-pane" };
       }
@@ -983,10 +1158,10 @@ export function SessionPage(props: SessionPageProps) {
   }), [
     focusWorkbenchPane,
     openSessionTab,
-    props.selectedSessionId,
     props.sidebar,
     sessionTabs,
-    splitSessionId,
+    splitSession,
+    workbenchPrimary,
   ]);
   useControlAction(focusWorkbenchSessionControlAction);
 
@@ -1386,61 +1561,116 @@ export function SessionPage(props: SessionPageProps) {
                       minSize={isMobile ? "0px" : "320px"}
                       className="min-h-0 min-w-0"
                       data-workbench-pane="primary"
+                      data-workbench-workspace-id={props.selectedWorkspaceId}
                       data-workbench-pane-focused={activeWorkbenchPane === "primary" ? "true" : undefined}
                       onPointerDown={() => focusWorkbenchPane("primary")}
                       onFocusCapture={() => focusWorkbenchPane("primary")}
                     >
-                      <SessionSurface
-                        // Spread `surface` first so the explicit per-workspace
-                        // routing props below CAN'T be silently overridden by
-                        // anything that leaks into `surface`. SessionSurface's
-                        // server target (client/workspaceId/sessionId/opencodeBaseUrl/openworkToken)
-                        // must come from the resolved workspace endpoint passed by
-                        // SessionRoute, not from anything in `surface`.
-                        {...props.surface!}
-                        client={props.openworkServerClient!}
-                        environmentClient={props.environmentClient}
-                        workspaceId={props.runtimeWorkspaceId!}
-                        sessionId={props.selectedSessionId!}
-                        isControlTarget={activeWorkbenchPane === "primary"}
-                        opencodeBaseUrl={reactSessionBaseUrl}
-                        openworkToken={reactSessionToken}
-                        todos={props.todos}
-                        activePermission={props.activePermission}
-                        permissionReplyBusy={props.permissionReplyBusy}
-                        respondPermission={props.respondPermission}
-                        activeQuestion={props.activeQuestion}
-                        questionReplyBusy={props.questionReplyBusy}
-                        respondQuestion={props.respondQuestion}
-                        safeStringify={props.safeStringify}
-                        onOpenTarget={openTarget}
-                        onOpenSubagentSession={openSubagentSession}
-                      />
+                      <div className="flex h-full min-h-0 flex-col">
+                        {canRenderSplitSurface && workbenchPrimary ? (
+                          <WorkbenchPaneHeader
+                            pane="primary"
+                            session={workbenchPrimary}
+                            workspaceTitle={workbenchPrimary.workspaceTitle ?? workspaceName}
+                            showWorkspace={crossWorkspaceSplit}
+                            focused={activeWorkbenchPane === "primary"}
+                            onFocus={() => focusWorkbenchPane("primary")}
+                            onClose={closePrimaryWorkbenchPane}
+                          />
+                        ) : null}
+                        <div className="min-h-0 flex-1">
+                          <SessionSurface
+                            // Spread `surface` first so the explicit per-workspace
+                            // routing props below CAN'T be silently overridden by
+                            // anything that leaks into `surface`. SessionSurface's
+                            // server target (client/workspaceId/sessionId/opencodeBaseUrl/openworkToken)
+                            // must come from the resolved workspace endpoint passed by
+                            // SessionRoute, not from anything in `surface`.
+                            {...props.surface!}
+                            client={props.openworkServerClient!}
+                            environmentClient={props.environmentClient}
+                            workspaceId={props.runtimeWorkspaceId!}
+                            sessionId={props.selectedSessionId!}
+                            isControlTarget={activeWorkbenchPane === "primary"}
+                            opencodeBaseUrl={reactSessionBaseUrl}
+                            openworkToken={reactSessionToken}
+                            todos={props.todos}
+                            activePermission={props.activePermission}
+                            permissionReplyBusy={props.permissionReplyBusy}
+                            respondPermission={props.respondPermission}
+                            activeQuestion={props.activeQuestion}
+                            questionReplyBusy={props.questionReplyBusy}
+                            respondQuestion={props.respondQuestion}
+                            safeStringify={props.safeStringify}
+                            onOpenTarget={props.surface?.onOpenTarget ?? openTarget}
+                            onOpenSubagentSession={openSubagentSession}
+                          />
+                        </div>
+                      </div>
                     </ResizablePanel>
-                    {canRenderSplitSurface ? (
+                    {canRenderSplitSurface && splitSession && splitPaneRuntime ? (
                       <>
                         <ResizableHandle />
                         <ResizablePanel
                           minSize="320px"
                           className="min-h-0 min-w-0"
                           data-workbench-pane="secondary"
+                          data-workbench-workspace-id={splitSession.workspaceId}
                           data-workbench-pane-focused={activeWorkbenchPane === "secondary" ? "true" : undefined}
                           onPointerDown={() => focusWorkbenchPane("secondary")}
                           onFocusCapture={() => focusWorkbenchPane("secondary")}
                         >
-                          <SessionSurface
-                            {...props.surface!}
-                            client={props.openworkServerClient!}
-                            environmentClient={props.environmentClient}
-                            workspaceId={props.runtimeWorkspaceId!}
-                            sessionId={splitSessionId!}
-                            isControlTarget={activeWorkbenchPane === "secondary"}
-                            opencodeBaseUrl={reactSessionBaseUrl}
-                            openworkToken={reactSessionToken}
-                            todos={[]}
-                            onOpenTarget={openTarget}
-                            onOpenSubagentSession={openSubagentSession}
-                          />
+                          <div className="flex h-full min-h-0 flex-col">
+                            <WorkbenchPaneHeader
+                              pane="secondary"
+                              session={splitSession}
+                              workspaceTitle={splitPaneRuntime.workspaceTitle}
+                              showWorkspace={crossWorkspaceSplit}
+                              focused={activeWorkbenchPane === "secondary"}
+                              onFocus={() => focusWorkbenchPane("secondary")}
+                              onClose={closeSecondaryWorkbenchPane}
+                            />
+                            {splitPaneRuntime.status === "ready" ? (
+                              <div className="min-h-0 flex-1">
+                                {crossWorkspaceSplit ? (
+                                  <ReactSessionRuntime
+                                    workspaceId={splitPaneRuntime.runtimeWorkspaceId}
+                                    sessionId={splitSession.sessionId}
+                                    opencodeBaseUrl={splitPaneRuntime.opencodeBaseUrl}
+                                    openworkToken={splitPaneRuntime.openworkToken}
+                                  />
+                                ) : null}
+                                <SessionSurface
+                                  {...splitPaneRuntime.surface}
+                                  client={splitPaneRuntime.client}
+                                  environmentClient={splitPaneRuntime.environmentClient}
+                                  workspaceId={splitPaneRuntime.runtimeWorkspaceId}
+                                  workspaceRoot={splitPaneRuntime.workspaceRoot}
+                                  sessionId={splitSession.sessionId}
+                                  isControlTarget={activeWorkbenchPane === "secondary"}
+                                  opencodeBaseUrl={splitPaneRuntime.opencodeBaseUrl}
+                                  openworkToken={splitPaneRuntime.openworkToken}
+                                  todos={[]}
+                                  onOpenTarget={(target, options, sourceSessionId) => openTargetForRuntime({
+                                    client: splitPaneRuntime.client,
+                                    runtimeWorkspaceId: splitPaneRuntime.runtimeWorkspaceId,
+                                    workspaceRoot: splitPaneRuntime.workspaceRoot,
+                                    workspaceType: splitPaneRuntime.workspaceType,
+                                  }, target, options, sourceSessionId)}
+                                  onOpenSubagentSession={(sessionId) => openSessionTab(splitSession.workspaceId, sessionId)}
+                                />
+                              </div>
+                            ) : (
+                              <UnavailableWorkbenchPane
+                                workspaceTitle={splitPaneRuntime.workspaceTitle}
+                                message={splitPaneRuntime.message}
+                                onRetry={() => void Promise.resolve(
+                                  props.sidebar.onTestWorkspaceConnection(splitPaneRuntime.workspaceId),
+                                )}
+                                onClose={closeSecondaryWorkbenchPane}
+                              />
+                            )}
+                          </div>
                         </ResizablePanel>
                       </>
                     ) : null}

--- a/apps/app/src/react-app/domains/session/chat/workbench-store.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-store.ts
@@ -2,15 +2,15 @@ import type { OpenworkSessionRef } from "@openwork/types/openwork-context";
 import { create } from "zustand";
 
 export type WorkbenchPane = "primary" | "secondary";
-export type WorkbenchSessionTab = OpenworkSessionRef;
+export type WorkbenchSessionTab = OpenworkSessionRef & {
+  workspaceTitle?: string;
+};
 
 export type WorkbenchSnapshot = {
   revision: number;
-  workspaceId: string | null;
-  workspaceTitle: string | null;
-  primarySessionId: string | null;
-  tabs: OpenworkSessionRef[];
-  splitSessionId: string | null;
+  primary: WorkbenchSessionTab | null;
+  tabs: WorkbenchSessionTab[];
+  secondary: WorkbenchSessionTab | null;
   focusedPane: WorkbenchPane;
 };
 
@@ -24,29 +24,34 @@ export type SyncWorkbenchInput = {
 
 const initialWorkbenchSnapshot: WorkbenchSnapshot = {
   revision: 0,
-  workspaceId: null,
-  workspaceTitle: null,
-  primarySessionId: null,
+  primary: null,
   tabs: [],
-  splitSessionId: null,
+  secondary: null,
   focusedPane: "primary",
 };
 
-function sameTabs(left: OpenworkSessionRef[], right: OpenworkSessionRef[]) {
-  return left.length === right.length && left.every((tab, index) => {
-    const other = right[index];
-    return other?.workspaceId === tab.workspaceId
-      && other.sessionId === tab.sessionId
-      && other.title === tab.title;
-  });
+export function isSameWorkbenchSession(
+  left: Pick<OpenworkSessionRef, "workspaceId" | "sessionId"> | null | undefined,
+  right: Pick<OpenworkSessionRef, "workspaceId" | "sessionId"> | null | undefined,
+) {
+  return Boolean(left && right && left.workspaceId === right.workspaceId && left.sessionId === right.sessionId);
+}
+
+function sameTab(left: WorkbenchSessionTab | null, right: WorkbenchSessionTab | null) {
+  if (!left || !right) return left === right;
+  return isSameWorkbenchSession(left, right)
+    && left.title === right.title
+    && left.workspaceTitle === right.workspaceTitle;
+}
+
+function sameTabs(left: WorkbenchSessionTab[], right: WorkbenchSessionTab[]) {
+  return left.length === right.length && left.every((tab, index) => sameTab(tab, right[index] ?? null));
 }
 
 function withRevision(current: WorkbenchSnapshot, next: Omit<WorkbenchSnapshot, "revision">): WorkbenchSnapshot {
   if (
-    current.workspaceId === next.workspaceId
-    && current.workspaceTitle === next.workspaceTitle
-    && current.primarySessionId === next.primarySessionId
-    && current.splitSessionId === next.splitSessionId
+    sameTab(current.primary, next.primary)
+    && sameTab(current.secondary, next.secondary)
     && current.focusedPane === next.focusedPane
     && sameTabs(current.tabs, next.tabs)
   ) {
@@ -55,92 +60,95 @@ function withRevision(current: WorkbenchSnapshot, next: Omit<WorkbenchSnapshot, 
   return { ...next, revision: current.revision + 1 };
 }
 
+function findTab(tabs: WorkbenchSessionTab[], session: Pick<OpenworkSessionRef, "workspaceId" | "sessionId">) {
+  return tabs.find((tab) => isSameWorkbenchSession(tab, session));
+}
+
+function replaceOrAppendTab(tabs: WorkbenchSessionTab[], tab: WorkbenchSessionTab) {
+  const index = tabs.findIndex((entry) => isSameWorkbenchSession(entry, tab));
+  if (index === -1) return [...tabs, tab];
+  return tabs.map((entry, entryIndex) => entryIndex === index ? { ...entry, ...tab } : entry);
+}
+
 export function syncWorkbenchSnapshot(
   current: WorkbenchSnapshot,
   input: SyncWorkbenchInput,
 ): WorkbenchSnapshot {
-  const availableById = new Map(input.sessions.map((session) => [session.sessionId, session]));
-  const currentTabs = current.workspaceId === input.workspaceId ? current.tabs : [];
-  const tabs = currentTabs
-    .filter((tab) => !input.sessionsKnown || availableById.has(tab.sessionId) || tab.sessionId === input.primarySessionId)
-    .map((tab) => availableById.get(tab.sessionId) ?? tab);
+  const workspaceTitle = input.workspaceTitle?.trim() || input.workspaceId;
+  const available = input.sessions.map((session) => ({ ...session, workspaceTitle }));
+  let tabs = current.tabs
+    .filter((tab) => (
+      tab.workspaceId !== input.workspaceId
+      || !input.sessionsKnown
+      || available.some((session) => isSameWorkbenchSession(session, tab))
+      || tab.sessionId === input.primarySessionId
+    ))
+    .map((tab) => {
+      const fresh = available.find((session) => isSameWorkbenchSession(session, tab));
+      return fresh ? { ...tab, ...fresh } : tab;
+    });
 
-  if (input.primarySessionId && !tabs.some((tab) => tab.sessionId === input.primarySessionId)) {
-    const primary = availableById.get(input.primarySessionId) ?? {
-      workspaceId: input.workspaceId,
-      sessionId: input.primarySessionId,
-    };
-    tabs.push(primary);
+  let primary: WorkbenchSessionTab | null = null;
+  if (input.primarySessionId) {
+    const ref = { workspaceId: input.workspaceId, sessionId: input.primarySessionId };
+    primary = findTab(available, ref) ?? findTab(tabs, ref) ?? { ...ref, workspaceTitle };
+    tabs = replaceOrAppendTab(tabs, primary);
   }
 
-  const splitSessionId = input.primarySessionId
-    && current.workspaceId === input.workspaceId
-    && current.splitSessionId !== input.primarySessionId
-    && current.splitSessionId
-    && tabs.some((tab) => tab.sessionId === current.splitSessionId)
-      ? current.splitSessionId
-      : null;
+  const secondary = current.secondary
+    && !isSameWorkbenchSession(current.secondary, primary)
+    ? findTab(tabs, current.secondary) ?? null
+    : null;
 
   return withRevision(current, {
-    workspaceId: input.workspaceId,
-    workspaceTitle: input.workspaceTitle?.trim() || input.workspaceId,
-    primarySessionId: input.primarySessionId,
+    primary,
     tabs,
-    splitSessionId,
-    focusedPane: splitSessionId ? current.focusedPane : "primary",
+    secondary,
+    focusedPane: secondary ? current.focusedPane : "primary",
   });
 }
 
 export function openWorkbenchTab(
   current: WorkbenchSnapshot,
-  tab: OpenworkSessionRef,
+  tab: WorkbenchSessionTab,
 ): WorkbenchSnapshot {
-  const tabs = current.workspaceId === tab.workspaceId ? [...current.tabs] : [];
-  if (!tabs.some((entry) => entry.sessionId === tab.sessionId)) {
-    tabs.push(tab);
-  }
   return withRevision(current, {
-    workspaceId: tab.workspaceId,
-    workspaceTitle: current.workspaceId === tab.workspaceId ? current.workspaceTitle : tab.workspaceId,
-    primarySessionId: current.workspaceId === tab.workspaceId ? current.primarySessionId : null,
-    tabs,
-    splitSessionId: current.workspaceId === tab.workspaceId ? current.splitSessionId : null,
-    focusedPane: current.workspaceId === tab.workspaceId ? current.focusedPane : "primary",
+    primary: current.primary,
+    tabs: replaceOrAppendTab(current.tabs, tab),
+    secondary: current.secondary,
+    focusedPane: current.focusedPane,
   });
 }
 
 export function closeWorkbenchTab(
   current: WorkbenchSnapshot,
-  sessionId: string,
+  tab: Pick<OpenworkSessionRef, "workspaceId" | "sessionId">,
 ): WorkbenchSnapshot {
-  const tabs = current.tabs.filter((tab) => tab.sessionId !== sessionId);
-  const splitSessionId = current.splitSessionId === sessionId ? null : current.splitSessionId;
+  const tabs = current.tabs.filter((entry) => !isSameWorkbenchSession(entry, tab));
+  const closesPrimary = isSameWorkbenchSession(current.primary, tab);
+  const closesSecondary = isSameWorkbenchSession(current.secondary, tab);
+  const primary = closesPrimary ? current.secondary : current.primary;
+  const secondary = closesPrimary || closesSecondary ? null : current.secondary;
   return withRevision(current, {
-    workspaceId: current.workspaceId,
-    workspaceTitle: current.workspaceTitle,
-    primarySessionId: current.primarySessionId === sessionId ? null : current.primarySessionId,
+    primary,
     tabs,
-    splitSessionId,
-    focusedPane: splitSessionId ? current.focusedPane : "primary",
+    secondary,
+    focusedPane: closesPrimary || closesSecondary ? "primary" : current.focusedPane,
   });
 }
 
 export function setWorkbenchSplit(
   current: WorkbenchSnapshot,
-  sessionId: string | null,
+  session: Pick<OpenworkSessionRef, "workspaceId" | "sessionId"> | null,
 ): WorkbenchSnapshot {
-  const splitSessionId = sessionId
-    && sessionId !== current.primarySessionId
-    && current.tabs.some((tab) => tab.sessionId === sessionId)
-      ? sessionId
-      : null;
+  const secondary = session && !isSameWorkbenchSession(session, current.primary)
+    ? findTab(current.tabs, session) ?? null
+    : null;
   return withRevision(current, {
-    workspaceId: current.workspaceId,
-    workspaceTitle: current.workspaceTitle,
-    primarySessionId: current.primarySessionId,
+    primary: current.primary,
     tabs: current.tabs,
-    splitSessionId,
-    focusedPane: splitSessionId ? "secondary" : "primary",
+    secondary,
+    focusedPane: secondary ? "secondary" : "primary",
   });
 }
 
@@ -148,22 +156,20 @@ export function focusWorkbenchPane(
   current: WorkbenchSnapshot,
   pane: WorkbenchPane,
 ): WorkbenchSnapshot {
-  const focusedPane = pane === "secondary" && !current.splitSessionId ? "primary" : pane;
+  const focusedPane = pane === "secondary" && !current.secondary ? "primary" : pane;
   return withRevision(current, {
-    workspaceId: current.workspaceId,
-    workspaceTitle: current.workspaceTitle,
-    primarySessionId: current.primarySessionId,
+    primary: current.primary,
     tabs: current.tabs,
-    splitSessionId: current.splitSessionId,
+    secondary: current.secondary,
     focusedPane,
   });
 }
 
 type WorkbenchStore = WorkbenchSnapshot & {
   sync: (input: SyncWorkbenchInput) => void;
-  openTab: (tab: OpenworkSessionRef) => void;
-  closeTab: (sessionId: string) => void;
-  setSplit: (sessionId: string | null) => void;
+  openTab: (tab: WorkbenchSessionTab) => void;
+  closeTab: (tab: Pick<OpenworkSessionRef, "workspaceId" | "sessionId">) => void;
+  setSplit: (session: Pick<OpenworkSessionRef, "workspaceId" | "sessionId"> | null) => void;
   focusPane: (pane: WorkbenchPane) => void;
 };
 
@@ -171,7 +177,7 @@ export const useWorkbenchStore = create<WorkbenchStore>((set) => ({
   ...initialWorkbenchSnapshot,
   sync: (input) => set((state) => syncWorkbenchSnapshot(state, input)),
   openTab: (tab) => set((state) => openWorkbenchTab(state, tab)),
-  closeTab: (sessionId) => set((state) => closeWorkbenchTab(state, sessionId)),
-  setSplit: (sessionId) => set((state) => setWorkbenchSplit(state, sessionId)),
+  closeTab: (tab) => set((state) => closeWorkbenchTab(state, tab)),
+  setSplit: (session) => set((state) => setWorkbenchSplit(state, session)),
   focusPane: (pane) => set((state) => focusWorkbenchPane(state, pane)),
 }));

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -7,7 +7,7 @@ import { setSessionArchived } from "../../../../app/lib/opencode-session";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useSessionManagementStore } from "../sidebar/session-management-store";
-import { useWorkbenchStore } from "../chat/workbench-store";
+import { isSameWorkbenchSession, useWorkbenchStore } from "../chat/workbench-store";
 
 type SessionLike = {
   id?: string;
@@ -135,12 +135,13 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       if (!sessionId) return { ok: false, error: "sessionId is required" };
       const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
       const workbench = useWorkbenchStore.getState();
-      if (targetWorkspace?.id === workbench.workspaceId) {
-        if (sessionId === workbench.primarySessionId) {
+      if (targetWorkspace) {
+        const target = { workspaceId: targetWorkspace.id, sessionId };
+        if (isSameWorkbenchSession(target, workbench.primary)) {
           workbench.focusPane("primary");
           return { ok: true, sessionId, reused: "primary-pane" };
         }
-        if (sessionId === workbench.splitSessionId) {
+        if (isSameWorkbenchSession(target, workbench.secondary)) {
           workbench.focusPane("secondary");
           return { ok: true, sessionId, reused: "secondary-pane" };
         }
@@ -149,7 +150,10 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       return {
         ok: true,
         sessionId,
-        reused: workbench.tabs.some((tab) => tab.sessionId === sessionId) ? "tab" : "new-tab",
+        reused: targetWorkspace && workbench.tabs.some((tab) => isSameWorkbenchSession(tab, {
+          workspaceId: targetWorkspace.id,
+          sessionId,
+        })) ? "tab" : "new-tab",
       };
     },
   }), [navigateToSession, sessionsByWorkspaceId, workspaces]);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -150,7 +150,7 @@ import {
   sidebarRowPaddingInlineStart,
 } from "./sidebar-lanes";
 import { WorkspaceAvatarPicker } from "./workspace-avatar-picker";
-import { useWorkbenchStore } from "../chat/workbench-store";
+import { isSameWorkbenchSession, useWorkbenchStore } from "../chat/workbench-store";
 import { SidebarDestination } from "./sidebar-destination";
 import { SessionTitle } from "./session-title";
 
@@ -249,6 +249,8 @@ type SessionActionsProps = {
   className: string;
   sessionId: string;
   workspaceId: string;
+  sessionTitle?: string;
+  workspaceTitle?: string;
   isPinned: boolean;
   isArchived: boolean;
 };
@@ -257,29 +259,46 @@ type SessionMenuContentProps = {
   variant: "dropdown" | "context";
   sessionId: string;
   workspaceId: string;
+  sessionTitle?: string;
+  workspaceTitle?: string;
   isPinned: boolean;
   isArchived: boolean;
 };
 
-function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchived }: SessionMenuContentProps) {
+function SessionMenuContent({
+  variant,
+  sessionId,
+  workspaceId,
+  sessionTitle,
+  workspaceTitle,
+  isPinned,
+  isArchived,
+}: SessionMenuContentProps) {
   const ctx = useSidebarContext();
   const { groups, assignments } = useWorkspaceGroups(workspaceId);
   const store = useSessionManagementStore;
   const assignedGroupId = assignments[sessionId] ?? null;
 
-  // Sidebar rows are the vertical tabs: any non-active session in the current
-  // workspace can be opened side-by-side with the active one.
-  const splitSessionId = useWorkbenchStore((state) => state.splitSessionId);
-  const isInSplit = Boolean(splitSessionId)
-    && (splitSessionId === sessionId || sessionId === ctx.selectedSessionId);
-  const canOpenInSplit = !isInSplit
-    && workspaceId === ctx.selectedWorkspaceId
-    && Boolean(ctx.selectedSessionId)
-    && sessionId !== ctx.selectedSessionId;
+  // Sidebar rows are the vertical tabs: any session can be opened beside the
+  // primary session, including one owned by another workspace.
+  const primary = useWorkbenchStore((state) => state.primary);
+  const secondary = useWorkbenchStore((state) => state.secondary);
+  const sessionRef = { workspaceId, sessionId };
+  const isInSplit = Boolean(secondary)
+    && (isSameWorkbenchSession(sessionRef, primary) || isSameWorkbenchSession(sessionRef, secondary));
+  const canOpenInSplit = Boolean(primary)
+    && !isSameWorkbenchSession(sessionRef, primary)
+    && !isSameWorkbenchSession(sessionRef, secondary);
   const openInSplitView = () => {
+    const tab = {
+      workspaceId,
+      workspaceTitle: workspaceTitle?.trim() || workspaceId,
+      sessionId,
+      title: sessionTitle,
+    };
     const workbench = useWorkbenchStore.getState();
-    workbench.openTab({ workspaceId, sessionId });
-    workbench.setSplit(sessionId);
+    workbench.openTab(tab);
+    workbench.setSplit(tab);
   };
   const closeSplitView = () => useWorkbenchStore.getState().setSplit(null);
 
@@ -454,7 +473,7 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
   );
 }
 
-function SessionActions({ className, sessionId, workspaceId, isPinned, isArchived }: SessionActionsProps) {
+function SessionActions({ className, sessionId, workspaceId, sessionTitle, workspaceTitle, isPinned, isArchived }: SessionActionsProps) {
   if (!useCanManageSession()) return null;
 
   return (
@@ -471,6 +490,8 @@ function SessionActions({ className, sessionId, workspaceId, isPinned, isArchive
           variant="dropdown"
           sessionId={sessionId}
           workspaceId={workspaceId}
+          sessionTitle={sessionTitle}
+          workspaceTitle={workspaceTitle}
           isPinned={isPinned}
           isArchived={isArchived}
         />
@@ -545,11 +566,21 @@ type SessionContextMenuProps = {
   children: React.ReactElement;
   sessionId: string;
   workspaceId: string;
+  sessionTitle?: string;
+  workspaceTitle?: string;
   isPinned: boolean;
   isArchived: boolean;
 };
 
-function SessionContextMenu({ children, sessionId, workspaceId, isPinned, isArchived }: SessionContextMenuProps) {
+function SessionContextMenu({
+  children,
+  sessionId,
+  workspaceId,
+  sessionTitle,
+  workspaceTitle,
+  isPinned,
+  isArchived,
+}: SessionContextMenuProps) {
   if (!useCanManageSession()) return children;
 
   return (
@@ -560,6 +591,8 @@ function SessionContextMenu({ children, sessionId, workspaceId, isPinned, isArch
           variant="context"
           sessionId={sessionId}
           workspaceId={workspaceId}
+          sessionTitle={sessionTitle}
+          workspaceTitle={workspaceTitle}
           isPinned={isPinned}
           isArchived={isArchived}
         />
@@ -757,32 +790,32 @@ type SidebarSplitPillProps = {
  * single unit at the top of the vertical tab list (the sidebar). Clicking a
  * segment focuses its pane; closing a segment dissolves the split.
  */
-function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selectedSessionId, onOpenSession }: SidebarSplitPillProps) {
-  const workbenchWorkspaceId = useWorkbenchStore((state) => state.workspaceId);
-  const splitSessionId = useWorkbenchStore((state) => state.splitSessionId);
+function SidebarSplitPill({ workspaceSessionGroups, onOpenSession }: SidebarSplitPillProps) {
+  const primary = useWorkbenchStore((state) => state.primary);
+  const secondary = useWorkbenchStore((state) => state.secondary);
   const focusedPane = useWorkbenchStore((state) => state.focusedPane);
 
-  if (
-    !splitSessionId
-    || !selectedSessionId
-    || workbenchWorkspaceId !== selectedWorkspaceId
-    || splitSessionId === selectedSessionId
-  ) {
+  if (!primary || !secondary) {
     return null;
   }
 
-  const titleFor = (sessionId: string) => {
-    for (const group of workspaceSessionGroups) {
-      const match = group.sessions.find((session) => session.id === sessionId);
-      if (match) return getDisplaySessionTitle(match.title);
-    }
-    return t("session.default_title");
+  const detailsFor = (workspaceId: string, sessionId: string) => {
+    const group = workspaceSessionGroups.find((candidate) => candidate.workspace.id === workspaceId);
+    const match = group?.sessions.find((session) => session.id === sessionId);
+    return {
+      title: match ? getDisplaySessionTitle(match.title) : t("session.default_title"),
+      workspaceTitle: group?.workspace.displayName?.trim()
+        || group?.workspace.name?.trim()
+        || group?.workspace.path?.trim()
+        || workspaceId,
+    };
   };
 
   const segments = [
-    { sessionId: selectedSessionId, pane: "primary" as const },
-    { sessionId: splitSessionId, pane: "secondary" as const },
+    { session: primary, pane: "primary" as const },
+    { session: secondary, pane: "secondary" as const },
   ];
+  const crossWorkspace = primary.workspaceId !== secondary.workspaceId;
 
   return (
     <div className="px-2 pb-1">
@@ -794,13 +827,14 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
         data-session-tab-split-pill
         className="flex items-stretch divide-x divide-sidebar-border overflow-hidden rounded-[11px] border border-sidebar-border"
       >
-        {segments.map(({ sessionId, pane }) => {
-          const title = titleFor(sessionId);
+        {segments.map(({ session, pane }) => {
+          const details = detailsFor(session.workspaceId, session.sessionId);
           const focused = focusedPane === pane;
           return (
             <div
               key={pane}
-              data-session-tab-id={sessionId}
+              data-session-tab-id={session.sessionId}
+              data-session-tab-workspace-id={session.workspaceId}
               className={cn(
                 "flex min-w-0 flex-1 items-center gap-1 px-2 py-1.5 text-xs transition-colors",
                 focused
@@ -811,10 +845,13 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
               <button
                 type="button"
                 className="min-w-0 flex-1 ow-fade-truncate text-left"
-                title={title}
+                title={crossWorkspace ? `${details.title} — ${details.workspaceTitle}` : details.title}
                 onClick={() => useWorkbenchStore.getState().focusPane(pane)}
               >
-                {title}
+                <span className="block truncate">{details.title}</span>
+                {crossWorkspace ? (
+                  <span className="block truncate text-[10px] text-muted-foreground">{details.workspaceTitle}</span>
+                ) : null}
               </button>
               <button
                 type="button"
@@ -825,7 +862,8 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
                   if (pane === "primary") {
                     // Closing the primary segment promotes the split session
                     // to primary, which dissolves the split.
-                    onOpenSession(selectedWorkspaceId, splitSessionId);
+                    useWorkbenchStore.getState().setSplit(null);
+                    onOpenSession(secondary.workspaceId, secondary.sessionId);
                   } else {
                     useWorkbenchStore.getState().setSplit(null);
                   }
@@ -2288,7 +2326,14 @@ function SessionMenuItem({
       data-sidebar-session-id={session.id}
       data-sidebar-session-workspace-id={workspaceId}
     >
-      <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
+      <SessionContextMenu
+        sessionId={session.id}
+        workspaceId={workspaceId}
+        sessionTitle={displayTitle}
+        workspaceTitle={workspaceName}
+        isPinned={isPinned}
+        isArchived={isArchived}
+      >
         <SidebarMenuSubButton
           isActive={isSelected}
           data-session-tab-id={session.id}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2275,6 +2275,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     <DevProfiler id="SessionSurface">
     <div
       data-session-surface-id={props.sessionId}
+      data-session-surface-workspace-id={props.workspaceId}
       onPointerDownCapture={handleFindSurfaceInteraction}
       onFocusCapture={handleFindSurfaceInteraction}
       className="flex h-full min-h-0 flex-col"

--- a/apps/app/src/react-app/shell/command-palette-models.ts
+++ b/apps/app/src/react-app/shell/command-palette-models.ts
@@ -3,6 +3,7 @@ import type { ModelBehaviorOption, ModelOption, ModelRef } from "@/app/types";
 export type CommandPaletteMode =
   | "root"
   | "sessions"
+  | "split-sessions"
   | "accessible-items"
   | "agents"
   | "groups"

--- a/apps/app/src/react-app/shell/command-palette-sessions.ts
+++ b/apps/app/src/react-app/shell/command-palette-sessions.ts
@@ -4,6 +4,21 @@ import { t } from "@/i18n";
 import type { SessionOption } from "./command-palette";
 import type { RouteSession, RouteWorkspace } from "./route-workspaces";
 
+export type CommandPaletteSessionRef = {
+  workspaceId: string;
+  sessionId: string;
+};
+
+export function buildCommandPaletteSplitSessions(
+  sessions: SessionOption[],
+  current: CommandPaletteSessionRef | null | undefined,
+) {
+  if (!current) return [];
+  return sessions.filter((session) => (
+    session.workspaceId !== current.workspaceId || session.sessionId !== current.sessionId
+  ));
+}
+
 export function buildCommandPaletteSessions(
   workspaces: RouteWorkspace[],
   sessionsByWorkspaceId: Record<string, RouteSession[]>,

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -25,7 +25,7 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { BrainCircuit, Check, ChevronLeftIcon, FileText, FolderInput, Globe, Zap } from "lucide-react";
+import { BrainCircuit, Check, ChevronLeftIcon, Columns2, FileText, FolderInput, Globe, Zap } from "lucide-react";
 import type { ModelOption, ModelRef } from "@/app/types";
 import { ProviderIcon } from "@/react-app/design-system/provider-icon";
 import { usePlatform } from "../kernel/platform";
@@ -39,6 +39,7 @@ import {
   commandPaletteBackMode,
   type CommandPaletteMode,
 } from "./command-palette-models";
+import { buildCommandPaletteSplitSessions, type CommandPaletteSessionRef } from "./command-palette-sessions";
 
 export type PaletteItem = {
   id: string;
@@ -108,6 +109,9 @@ export type CommandPaletteProps = {
   onClose: () => void;
   /** Called when a session row is chosen. */
   onOpenSession: (workspaceId: string, sessionId: string) => void;
+  /** Opens a chosen session beside the current session without navigating away. */
+  onOpenSessionInSplit?: (workspaceId: string, sessionId: string) => void;
+  currentSession?: CommandPaletteSessionRef | null;
   /** Called when "New session" is chosen. */
   onCreateNewSession: () => void;
   /** Called when "Open settings" is chosen. Accepts an optional route to jump straight to a tab. */
@@ -229,6 +233,19 @@ export function CommandPalette(props: CommandPaletteProps) {
         setMode("sessions");
       },
     },
+    ...(props.onOpenSessionInSplit && props.currentSession
+      ? [{
+          id: "open-in-split-view",
+          title: "Open in split view…",
+          detail: "Choose any session, including one from another workspace",
+          meta: "Workbench",
+          icon: <Columns2 className="text-primary" />,
+          searchText: "split view side by side session workspace",
+          action: () => {
+            setMode("split-sessions");
+          },
+        }]
+      : []),
     {
       id: "session-number-shortcuts",
       ...sessionNumberHelp,
@@ -386,6 +403,22 @@ export function CommandPalette(props: CommandPaletteProps) {
         },
       })),
     [props],
+  );
+
+  const splitSessionItems = useMemo<PaletteItem[]>(
+    () => buildCommandPaletteSplitSessions(props.sessions, props.currentSession).map((item) => ({
+      id: `split-session:${item.workspaceId}:${item.sessionId}`,
+      title: item.title,
+      detail: item.workspaceTitle,
+      meta: item.isActive ? t("session.cmd_current_workspace") : "Other workspace",
+      icon: <Columns2 className="text-muted-foreground" />,
+      searchText: `${item.searchText} split side by side`,
+      action: () => {
+        props.onOpenSessionInSplit?.(item.workspaceId, item.sessionId);
+        props.onClose();
+      },
+    })),
+    [props.currentSession, props.onClose, props.onOpenSessionInSplit, props.sessions],
   );
 
   const accessibleItems = useMemo<PaletteItem[]>(() => {
@@ -549,6 +582,8 @@ export function CommandPalette(props: CommandPaletteProps) {
 
   const items = mode === "sessions"
     ? sessionItems
+    : mode === "split-sessions"
+      ? splitSessionItems
     : mode === "accessible-items"
       ? accessibleItems
       : mode === "agents"
@@ -567,6 +602,8 @@ export function CommandPalette(props: CommandPaletteProps) {
         <CommandDialogTitle>
           {mode === "sessions"
             ? t("session.palette_title_sessions")
+            : mode === "split-sessions"
+              ? "Open in split view"
             : mode === "accessible-items"
               ? "Accessible items"
               : mode === "agents"
@@ -598,6 +635,8 @@ export function CommandPalette(props: CommandPaletteProps) {
               placeholder={
                 mode === "sessions"
                   ? t("session.palette_placeholder_sessions")
+                  : mode === "split-sessions"
+                    ? "Search sessions and workspaces..."
                   : mode === "accessible-items"
                     ? "Search servers and artifacts..."
                     : mode === "agents"
@@ -620,6 +659,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                 <CommandItem
                   key={item.id}
                   value={item}
+                  data-command-palette-item={item.id}
                   disabled={item.disabled}
                   onClick={item.action}
                 >

--- a/apps/app/src/react-app/shell/openwork-context-projector.ts
+++ b/apps/app/src/react-app/shell/openwork-context-projector.ts
@@ -98,25 +98,27 @@ function panelTab(tab: PanelTabStore["sessions"][string]["tabs"][number]): Openw
 export function buildOpenworkContext(
   input: OpenworkContextProjectorInput,
 ): OpenworkContextSnapshot {
-  const primarySessionId = input.workbench.primarySessionId;
-  const splitSessionId = input.workbench.splitSessionId;
-  const layout: OpenworkConversationLayout = primarySessionId && splitSessionId
+  const primary = input.workbench.primary;
+  const secondary = input.workbench.secondary;
+  const layout: OpenworkConversationLayout = primary && secondary
     ? {
         kind: "split",
-        primarySessionId,
-        secondarySessionId: splitSessionId,
+        primarySessionId: primary.sessionId,
+        primaryWorkspaceId: primary.workspaceId,
+        secondarySessionId: secondary.sessionId,
+        secondaryWorkspaceId: secondary.workspaceId,
         focused: input.workbench.focusedPane,
       }
-    : primarySessionId
-      ? { kind: "single", sessionId: primarySessionId }
+    : primary
+      ? { kind: "single", workspaceId: primary.workspaceId, sessionId: primary.sessionId }
       : { kind: "empty" };
 
-  const focusedSessionId = input.workbench.focusedPane === "secondary" && splitSessionId
-    ? splitSessionId
-    : primarySessionId;
+  const focusedSessionId = input.workbench.focusedPane === "secondary" && secondary
+    ? secondary.sessionId
+    : primary?.sessionId ?? null;
   const panelOwnerSessionId = focusedSessionId && input.ui.sidePanelState[focusedSessionId]
     ? focusedSessionId
-    : primarySessionId;
+    : primary?.sessionId ?? null;
   const sessionPanelKind = panelOwnerSessionId
     ? input.ui.sidePanelState[panelOwnerSessionId] ?? null
     : null;
@@ -133,31 +135,33 @@ export function buildOpenworkContext(
     provider,
     state: { kind: screen.kind, route: input.route },
   }];
-  if (input.workbench.workspaceId) {
+  const visibleWorkspaces = [primary, secondary].flatMap((session) => session ? [session] : []);
+  for (const [index, session] of visibleWorkspaces.entries()) {
+    if (visibleWorkspaces.slice(0, index).some((candidate) => candidate.workspaceId === session.workspaceId)) continue;
     resources.push({
-      ref: `workspace:${input.workbench.workspaceId}`,
+      ref: `workspace:${session.workspaceId}`,
       kind: "workspace",
-      title: input.workbench.workspaceTitle ?? input.workbench.workspaceId,
+      title: session.workspaceTitle ?? session.workspaceId,
       provider,
-      state: { active: true },
+      state: { active: primary?.workspaceId === session.workspaceId, visible: true },
     });
   }
   for (const tab of input.workbench.tabs) {
-    const primary = tab.sessionId === primarySessionId;
-    const secondary = tab.sessionId === splitSessionId;
+    const inPrimary = tab.workspaceId === primary?.workspaceId && tab.sessionId === primary.sessionId;
+    const inSecondary = tab.workspaceId === secondary?.workspaceId && tab.sessionId === secondary.sessionId;
     resources.push({
-      ref: `session:${tab.sessionId}`,
+      ref: `session:${tab.workspaceId}:${tab.sessionId}`,
       kind: "session",
       title: tab.title ?? tab.sessionId,
       provider,
       state: {
         workspaceId: tab.workspaceId,
         open: true,
-        visible: primary || secondary,
-        pane: primary ? "primary" : secondary ? "secondary" : null,
-        focused: primary
+        visible: inPrimary || inSecondary,
+        pane: inPrimary ? "primary" : inSecondary ? "secondary" : null,
+        focused: inPrimary
           ? input.workbench.focusedPane === "primary"
-          : secondary && input.workbench.focusedPane === "secondary",
+          : inSecondary && input.workbench.focusedPane === "secondary",
       },
     });
   }

--- a/apps/app/src/react-app/shell/openwork-context-publisher.tsx
+++ b/apps/app/src/react-app/shell/openwork-context-publisher.tsx
@@ -11,11 +11,9 @@ import { useUiStateStore } from "./ui-state-store";
 export function OpenworkContextPublisher() {
   const location = useLocation();
   const revision = useWorkbenchStore((state) => state.revision);
-  const workspaceId = useWorkbenchStore((state) => state.workspaceId);
-  const workspaceTitle = useWorkbenchStore((state) => state.workspaceTitle);
-  const primarySessionId = useWorkbenchStore((state) => state.primarySessionId);
+  const primary = useWorkbenchStore((state) => state.primary);
   const tabs = useWorkbenchStore((state) => state.tabs);
-  const splitSessionId = useWorkbenchStore((state) => state.splitSessionId);
+  const secondary = useWorkbenchStore((state) => state.secondary);
   const focusedPane = useWorkbenchStore((state) => state.focusedPane);
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const sidePanelState = useUiStateStore((state) => state.sidePanelState);
@@ -30,11 +28,9 @@ export function OpenworkContextPublisher() {
     capturedAt: new Date().toISOString(),
     workbench: {
       revision,
-      workspaceId,
-      workspaceTitle,
-      primarySessionId,
+      primary,
       tabs,
-      splitSessionId,
+      secondary,
       focusedPane,
     },
     ui: {
@@ -49,15 +45,13 @@ export function OpenworkContextPublisher() {
     applicationMenuVisible,
     focusedPane,
     panelSessions,
-    primarySessionId,
+    primary,
     revision,
     route,
     sidebarOpen,
     sidePanelState,
-    splitSessionId,
+    secondary,
     tabs,
-    workspaceId,
-    workspaceTitle,
     workspaceRightSidebarExpanded,
   ]);
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -91,7 +91,11 @@ import {
 } from "@/react-app/shell/route-workspaces";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
-import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
+import {
+  SessionPage,
+  type OpenSessionTab,
+  type SessionPagePaneRuntime,
+} from "@/react-app/domains/session/chat/session-page";
 import { AutomationsPage } from "@/react-app/domains/automations/automations-page";
 import { DashboardPage } from "@/react-app/domains/dashboard/dashboard-page";
 import { useDashboardDeploymentAvailability } from "@/react-app/domains/dashboard/dashboard-availability";
@@ -118,6 +122,7 @@ import { useSessionFindStore } from "@/react-app/domains/session/surface/find-st
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { getSessionModelSelection, useSessionModelStore } from "@/react-app/domains/session/surface/session-model-store";
 import { useWorkbenchStore } from "@/react-app/domains/session/chat/workbench-store";
+import { resolveWorkbenchPaneEndpoint } from "@/react-app/domains/session/chat/pane-runtime";
 import {
   nextFavoriteModel,
   useModelCollectionsStore,
@@ -151,7 +156,10 @@ import {
 import { useMcpConnectedCount } from "@/react-app/domains/connections/use-mcp-connected-count";
 import { useSessionMcpMaintenance } from "@/react-app/domains/connections/use-session-mcp-maintenance";
 import { useCloudMcpSubmitReadiness } from "@/react-app/domains/connections/use-cloud-mcp-submit-readiness";
-import type { CloudMcpSubmissionResult } from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
+import {
+  IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+  type CloudMcpSubmissionResult,
+} from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
 import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
@@ -1655,6 +1663,263 @@ export function SessionRoute() {
     submitWithCloudMcpReadiness,
     token,
   ]);
+  const resolvePaneRuntime = useCallback((session: OpenSessionTab): SessionPagePaneRuntime => {
+    const candidateWorkspace = workspaces.find((candidate) => candidate.id === session.workspaceId);
+    const workspaceTitle = session.workspaceTitle?.trim()
+      || (candidateWorkspace ? workspaceLabel(candidateWorkspace) : session.workspaceId);
+    const connection = candidateWorkspace ? workspaceConnectionStateById[candidateWorkspace.id] : undefined;
+    const workspaceError = candidateWorkspace ? errorsByWorkspaceId[candidateWorkspace.id]?.trim() : undefined;
+    const paneEndpoint = resolveWorkbenchPaneEndpoint({
+      workspaceId: session.workspaceId,
+      workspaceTitle,
+      workspace: candidateWorkspace,
+      endpoint: endpointForWorkspace(candidateWorkspace),
+      connectionError: connection?.status === "error" ? connection.message : workspaceError,
+    });
+    if (paneEndpoint.status === "unavailable") return paneEndpoint;
+    const { endpoint, workspace } = paneEndpoint;
+
+    if (paneEndpoint.workspaceId === selectedWorkspaceId && surfaceProps) {
+      return {
+        status: "ready",
+        workspaceId: paneEndpoint.workspaceId,
+        workspaceTitle: paneEndpoint.workspaceTitle,
+        workspaceRoot: selectedWorkspaceRoot,
+        workspaceType: paneEndpoint.workspaceType,
+        runtimeWorkspaceId: endpoint.workspaceId,
+        opencodeBaseUrl: endpoint.opencodeBaseUrl,
+        openworkToken: endpoint.token,
+        client: endpoint.client,
+        environmentClient: client,
+        surface: surfaceProps,
+      };
+    }
+
+    if (!surfaceProps) {
+      return {
+        status: "unavailable",
+        workspaceId: paneEndpoint.workspaceId,
+        workspaceTitle: paneEndpoint.workspaceTitle,
+        message: "The session runtime is still preparing.",
+      };
+    }
+
+    const workspaceRoot = paneEndpoint.workspaceRoot;
+    const workspaceOpencodeClient = createClient(
+      endpoint.opencodeBaseUrl,
+      workspaceRoot || undefined,
+      { token: endpoint.token, mode: "openwork" },
+    );
+    const scopedSurface = {
+      ...surfaceProps,
+      workspaceRoot,
+      modelUnavailable: false,
+      modelUnavailableMessage: null,
+      resolveModelAvailability: undefined,
+      cloudMcpSubmissionState: IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+      onOpenSettingsSection: (section: ComposerSettingsSection) => {
+        openComposerConfigure(section, {
+          openLibrary: (path) => handleOpenExtensions(path, workspace.id),
+          openSettings: (path) => handleOpenSettings(path, workspace.id),
+        });
+      },
+      onOpenConnect: () => handleOpenExtensions("", workspace.id),
+      listCommands: async (): Promise<SlashCommandOption[]> => {
+        void engineReloadVersion;
+        return listCommands(workspaceOpencodeClient, workspaceRoot || undefined);
+      },
+      listAgents: async () => {
+        void engineReloadVersion;
+        return unwrap(await workspaceOpencodeClient.app.agents()).filter(isLibraryAgent);
+      },
+      searchFiles: async (query: string) => {
+        const trimmed = query.trim();
+        if (!trimmed) return [];
+        return unwrap(await workspaceOpencodeClient.find.files({
+          query: trimmed,
+          dirs: "true",
+          limit: 50,
+          directory: workspaceRoot || undefined,
+        }));
+      },
+      isRemoteWorkspace: workspace.workspaceType === "remote",
+      isSandboxWorkspace: isSandboxWorkspace(workspace),
+      environmentRuntimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
+      onApplyEnvironmentChanges: undefined,
+      onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
+        const targetSessionId = sessionId.trim() || session.sessionId;
+        const text = (draft.resolvedText ?? draft.text).trim();
+        if (!targetSessionId || (!text && draft.attachments.length === 0)) {
+          return { outcome: "cancelled", reason: "context_changed" };
+        }
+        const sessionModelSelection = getSessionModelSelection(targetSessionId);
+        const sendModel = sessionModelSelection?.model ?? local.prefs.defaultModel;
+        const sendVariant = sessionModelSelection ? sessionModelSelection.variant : modelVariantValue;
+        return submitWithCloudMcpReadiness({
+          skipGate: true,
+          send: async () => {
+            await sendWithRevertRollback({
+              revertMessageId: draft.revertMessageId,
+              abort: () => abortSessionSafe(workspaceOpencodeClient, targetSessionId, workspaceRoot || undefined, {
+                source: "session.edit_resend.before_revert",
+                initiator: "user",
+                reason: "abort active run before replacing a reverted message",
+              }),
+              revert: async (messageId) => {
+                const reverted = await revertSession(workspaceOpencodeClient, targetSessionId, messageId);
+                applySessionRevert(endpoint.workspaceId, reverted);
+              },
+              prompt: async () => {
+                captureAnalyticsEvent("task_message_sent", {
+                  mode: draft.mode ?? "prompt",
+                  is_command: Boolean(draft.command),
+                  attachment_count: draft.attachments.length,
+                  text_length: text.length,
+                  workspace_type: workspace.workspaceType ?? "unknown",
+                  provider_id: sendModel?.providerID ?? null,
+                  model_id: sendModel?.modelID ?? null,
+                });
+                markTaskRunStart(targetSessionId);
+                const projectDimension = readWorkspaceProjectDimension(workspace.id);
+                const modelSelection = sessionModelSelection ? "manual" : "default";
+                const telemetryDimensions = [
+                  ...(projectDimension ? [{ type: "project", label: projectDimension.label }] : []),
+                  ...(sendModel ? [{
+                    type: "model",
+                    value: `${sendModel.providerID}/${sendModel.modelID}`,
+                    label: `${sendModel.providerID}/${sendModel.modelID}`,
+                  }] : []),
+                  { type: "model_selection", value: modelSelection, label: modelSelection },
+                ];
+                trackSessionActive(targetSessionId, telemetryDimensions);
+                trackTaskStarted(targetSessionId, telemetryDimensions);
+                if (draft.mode === "shell") {
+                  await shellInSession(workspaceOpencodeClient, targetSessionId, text);
+                  return;
+                }
+                if (draft.command) {
+                  const result = await workspaceOpencodeClient.session.command({
+                    sessionID: targetSessionId,
+                    command: draft.command.name,
+                    arguments: draft.command.arguments,
+                  });
+                  if (result.error) throw new Error(serializeSDKError(result.error));
+                  return;
+                }
+                const parts = await draftToParts(draft, workspaceRoot, targetSessionId, endpoint);
+                const envSystemContext = await buildOpenworkEnvSystemContext(endpoint.client, {
+                  cacheKey: targetSessionId,
+                  runtimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
+                });
+                const result = await workspaceOpencodeClient.session.promptAsync({
+                  sessionID: targetSessionId,
+                  parts,
+                  model: sendModel ?? undefined,
+                  agent: selectedAgent ?? undefined,
+                  ...(sendVariant ? { variant: sendVariant } : {}),
+                  ...(envSystemContext ? { system: envSystemContext } : {}),
+                });
+                if (result.error) throw new Error(serializeSDKError(result.error));
+                if (sendModel) {
+                  useSessionModelStore.getState().setModel(targetSessionId, sendModel, sendVariant ?? null);
+                }
+              },
+              unrevert: async () => {
+                try {
+                  await unrevertSession(workspaceOpencodeClient, targetSessionId);
+                } finally {
+                  applySessionUnrevert(endpoint.workspaceId, targetSessionId);
+                }
+              },
+              onUnrevertError: (error) => console.warn("[edit-resend] rollback failed", error),
+            });
+          },
+        });
+      },
+      onRevertToMessage: async (messageId: string, sessionId: string) => {
+        const targetSessionId = sessionId.trim() || session.sessionId;
+        try {
+          await abortSessionSafe(workspaceOpencodeClient, targetSessionId, workspaceRoot || undefined, {
+            source: "session.revert_to_message.before_revert",
+            initiator: "user",
+            reason: "abort active run before reverting transcript",
+          });
+          const reverted = await revertSession(workspaceOpencodeClient, targetSessionId, messageId);
+          applySessionRevert(endpoint.workspaceId, reverted);
+          return true;
+        } catch (error) {
+          console.warn("[revert] failed", error);
+          toast.error(t("session.revert_failed"));
+          return false;
+        }
+      },
+      onRestoreRevertedSession: async (sessionId: string) => {
+        const targetSessionId = sessionId.trim() || session.sessionId;
+        try {
+          await unrevertSession(workspaceOpencodeClient, targetSessionId);
+          applySessionUnrevert(endpoint.workspaceId, targetSessionId);
+          return true;
+        } catch (error) {
+          console.warn("[unrevert] failed", error);
+          toast.error(t("session.restore_failed"));
+          return false;
+        }
+      },
+      onForkAtMessage: (messageId: string | null, sessionId: string) => {
+        void (async () => {
+          const targetSessionId = sessionId.trim() || session.sessionId;
+          try {
+            const forked = await forkSession(workspaceOpencodeClient, targetSessionId, messageId ?? undefined);
+            writeLastSessionFor(workspace.id, forked.id);
+            rememberPendingCreatedSession(workspace.id, forked.id);
+            setSessionsByWorkspaceId((current) => ({
+              ...current,
+              [workspace.id]: [forked, ...(current[workspace.id] ?? [])],
+            }));
+            navigateToWorkspaceSession(workspace.id, forked.id);
+            void refreshRouteState();
+          } catch (error) {
+            console.warn("[fork] failed", error);
+            toast.error(t("session.branch_failed"));
+          }
+        })();
+      },
+    };
+    return {
+      status: "ready",
+      workspaceId: paneEndpoint.workspaceId,
+      workspaceTitle: paneEndpoint.workspaceTitle,
+      workspaceRoot,
+      workspaceType: paneEndpoint.workspaceType,
+      runtimeWorkspaceId: endpoint.workspaceId,
+      opencodeBaseUrl: endpoint.opencodeBaseUrl,
+      openworkToken: endpoint.token,
+      client: endpoint.client,
+      environmentClient: client,
+      surface: scopedSurface,
+    };
+  }, [
+    client,
+    endpointForWorkspace,
+    engineReloadVersion,
+    environmentRuntimeKey,
+    errorsByWorkspaceId,
+    handleOpenExtensions,
+    handleOpenSettings,
+    local.prefs.defaultModel,
+    modelVariantValue,
+    navigateToWorkspaceSession,
+    refreshRouteState,
+    rememberPendingCreatedSession,
+    selectedAgent,
+    selectedWorkspaceId,
+    selectedWorkspaceRoot,
+    setSessionsByWorkspaceId,
+    submitWithCloudMcpReadiness,
+    surfaceProps,
+    workspaceConnectionStateById,
+    workspaces,
+  ]);
   const cloudWorkspaceMainContentDecision = mapCloudWorkspaceMainContentDecision({
     status: cloudWorkspace.viewModel.variant,
     hasWorkspaces: Boolean(surfaceProps),
@@ -2015,8 +2280,8 @@ export function SessionRoute() {
 
   const cycleThinkingMode = useCallback((direction: ThinkingModeShortcutDirection = "forward") => {
     const workbench = useWorkbenchStore.getState();
-    const activeSessionId = workbench.focusedPane === "secondary" && workbench.splitSessionId
-      ? workbench.splitSessionId
+    const activeSessionId = workbench.focusedPane === "secondary" && workbench.secondary
+      ? workbench.secondary.sessionId
       : selectedSessionId;
     const selection = activeSessionId ? getSessionModelSelection(activeSessionId) : null;
     const summary = selection
@@ -2057,8 +2322,8 @@ export function SessionRoute() {
 
   const cycleFavoriteModel = useCallback(() => {
     const workbench = useWorkbenchStore.getState();
-    const activeSessionId = workbench.focusedPane === "secondary" && workbench.splitSessionId
-      ? workbench.splitSessionId
+    const activeSessionId = workbench.focusedPane === "secondary" && workbench.secondary
+      ? workbench.secondary.sessionId
       : selectedSessionId;
     const selection = activeSessionId ? getSessionModelSelection(activeSessionId) : null;
     const currentModel = selection?.model ?? local.prefs.defaultModel ?? null;
@@ -3047,6 +3312,7 @@ export function SessionRoute() {
         onReorderWorkspaces: handleReorderWorkspaces,
       }}
       surface={surfaceProps}
+      resolvePaneRuntime={resolvePaneRuntime}
       history={{
         canUndo: false,
         canRedo: false,
@@ -3194,6 +3460,21 @@ export function SessionRoute() {
         }
       }}
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
+      currentSession={selectedSessionId ? { workspaceId: selectedWorkspaceId, sessionId: selectedSessionId } : null}
+      onOpenSessionInSplit={(workspaceId, sessionId) => {
+        const option = paletteSessionOptions.find((candidate) => (
+          candidate.workspaceId === workspaceId && candidate.sessionId === sessionId
+        ));
+        const tab = {
+          workspaceId,
+          sessionId,
+          title: option?.title,
+          workspaceTitle: option?.workspaceTitle ?? workspaceId,
+        };
+        const workbench = useWorkbenchStore.getState();
+        workbench.openTab(tab);
+        workbench.setSplit(tab);
+      }}
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
       onOpenExtensions={() => handleOpenExtensions()}
       modelOptions={modelPicker.options}

--- a/apps/app/tests/command-palette-models.test.ts
+++ b/apps/app/tests/command-palette-models.test.ts
@@ -52,6 +52,7 @@ describe("command palette models", () => {
   test("navigates behavior to models to root", () => {
     expect(commandPaletteBackMode("model-behavior")).toBe("models");
     expect(commandPaletteBackMode("models")).toBe("root");
+    expect(commandPaletteBackMode("split-sessions")).toBe("root");
     expect(commandPaletteBackMode("root")).toBeNull();
   });
 });

--- a/apps/app/tests/command-palette-sessions.test.ts
+++ b/apps/app/tests/command-palette-sessions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildCommandPaletteSplitSessions } from "../src/react-app/shell/command-palette-sessions";
+import type { SessionOption } from "../src/react-app/shell/command-palette";
+
+const sessions: SessionOption[] = [
+  {
+    workspaceId: "workspace-a",
+    sessionId: "session-a",
+    title: "Current",
+    workspaceTitle: "Workspace A",
+    updatedAt: 3,
+    searchText: "current workspace a",
+    isActive: true,
+  },
+  {
+    workspaceId: "workspace-a",
+    sessionId: "session-b",
+    title: "Same workspace",
+    workspaceTitle: "Workspace A",
+    updatedAt: 2,
+    searchText: "same workspace a",
+    isActive: true,
+  },
+  {
+    workspaceId: "workspace-b",
+    sessionId: "session-a",
+    title: "Same ID, other workspace",
+    workspaceTitle: "Workspace B",
+    updatedAt: 1,
+    searchText: "same id workspace b",
+    isActive: false,
+  },
+];
+
+describe("command palette split sessions", () => {
+  test("offers same-workspace and cross-workspace sessions but not the current session", () => {
+    const options = buildCommandPaletteSplitSessions(sessions, {
+      workspaceId: "workspace-a",
+      sessionId: "session-a",
+    });
+
+    expect(options.map((option) => `${option.workspaceId}/${option.sessionId}`)).toEqual([
+      "workspace-a/session-b",
+      "workspace-b/session-a",
+    ]);
+    expect(options.some((option) => option.workspaceTitle === "Workspace B")).toBe(true);
+    expect(options.some((option) => option.workspaceId === "workspace-a" && option.sessionId === "session-a")).toBe(false);
+  });
+});

--- a/apps/app/tests/openwork-context-projector.test.ts
+++ b/apps/app/tests/openwork-context-projector.test.ts
@@ -14,14 +14,22 @@ const baseInput: ContextProjectorInput = {
   capturedAt: "2026-07-23T12:00:00.000Z",
   workbench: {
     revision: 4,
-    workspaceId: "workspace-a",
-    workspaceTitle: "Customer workspace",
-    primarySessionId: "session-a",
+    primary: {
+      workspaceId: "workspace-a",
+      workspaceTitle: "Customer workspace",
+      sessionId: "session-a",
+      title: "Primary",
+    },
     tabs: [
-      { workspaceId: "workspace-a", sessionId: "session-a", title: "Primary" },
-      { workspaceId: "workspace-a", sessionId: "session-b", title: "Secondary" },
+      { workspaceId: "workspace-a", workspaceTitle: "Customer workspace", sessionId: "session-a", title: "Primary" },
+      { workspaceId: "workspace-b", workspaceTitle: "Research workspace", sessionId: "session-b", title: "Secondary" },
     ],
-    splitSessionId: "session-b",
+    secondary: {
+      workspaceId: "workspace-b",
+      workspaceTitle: "Research workspace",
+      sessionId: "session-b",
+      title: "Secondary",
+    },
     focusedPane: "secondary",
   },
   ui: {
@@ -46,11 +54,19 @@ describe("OpenWork context projector", () => {
     expect(context.conversations.layout).toEqual({
       kind: "split",
       primarySessionId: "session-a",
+      primaryWorkspaceId: "workspace-a",
       secondarySessionId: "session-b",
+      secondaryWorkspaceId: "workspace-b",
       focused: "secondary",
     });
     expect(context.resources.find((resource) => resource.kind === "workspace")?.title)
       .toBe("Customer workspace");
+    expect(context.resources.find((resource) => resource.ref === "workspace:workspace-b")?.title)
+      .toBe("Research workspace");
+    expect(context.resources.find((resource) => resource.ref === "session:workspace-a:session-a")?.state.workspaceId)
+      .toBe("workspace-a");
+    expect(context.resources.find((resource) => resource.ref === "session:workspace-b:session-b")?.state.workspaceId)
+      .toBe("workspace-b");
     expect(context.sidePanel).toEqual({
       open: true,
       ownerSessionId: "session-b",
@@ -77,15 +93,13 @@ describe("OpenWork context projector", () => {
 
 const splitWorkbench: WorkbenchSnapshot = {
   revision: 5,
-  workspaceId: "workspace-a",
-  workspaceTitle: "Workspace A",
-  primarySessionId: "session-a",
+  primary: { workspaceId: "workspace-a", workspaceTitle: "Workspace A", sessionId: "session-a", title: "Current plan" },
   tabs: [
-    { workspaceId: "workspace-a", sessionId: "session-a", title: "Current plan" },
-    { workspaceId: "workspace-a", sessionId: "session-b", title: "Previous research" },
-    { workspaceId: "workspace-a", sessionId: "session-c", title: "Draft" },
+    { workspaceId: "workspace-a", workspaceTitle: "Workspace A", sessionId: "session-a", title: "Current plan" },
+    { workspaceId: "workspace-a", workspaceTitle: "Workspace A", sessionId: "session-b", title: "Previous research" },
+    { workspaceId: "workspace-a", workspaceTitle: "Workspace A", sessionId: "session-c", title: "Draft" },
   ],
-  splitSessionId: "session-b",
+  secondary: { workspaceId: "workspace-a", workspaceTitle: "Workspace A", sessionId: "session-b", title: "Previous research" },
   focusedPane: "secondary",
 };
 
@@ -132,10 +146,12 @@ describe("OpenWork context projector", () => {
     expect(context.conversations.layout).toEqual({
       kind: "split",
       primarySessionId: "session-a",
+      primaryWorkspaceId: "workspace-a",
       secondarySessionId: "session-b",
+      secondaryWorkspaceId: "workspace-a",
       focused: "secondary",
     });
-    expect(context.resources.find((resource) => resource.ref === "session:session-b")).toMatchObject({
+    expect(context.resources.find((resource) => resource.ref === "session:workspace-a:session-b")).toMatchObject({
       kind: "session",
       title: "Previous research",
       state: {

--- a/apps/app/tests/pane-runtime.test.ts
+++ b/apps/app/tests/pane-runtime.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkspaceInfo } from "../src/app/lib/desktop";
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+import { resolveWorkbenchPaneEndpoint } from "../src/react-app/domains/session/chat/pane-runtime";
+
+type PaneWorkspace = Pick<WorkspaceInfo, "id" | "path" | "workspaceType">;
+
+describe("split pane runtime", () => {
+  test("retains the selected pane workspace endpoint without borrowing another workspace", () => {
+    const workspaceA: PaneWorkspace = { id: "workspace-a", path: "/workspace/a", workspaceType: "local" };
+    const workspaceB: PaneWorkspace = { id: "workspace-b", path: "/workspace/b", workspaceType: "local" };
+    const localServer = { baseUrl: "http://127.0.0.1:8787", token: "pane-token" };
+    const endpointA = resolveWorkspaceEndpoint(workspaceA, localServer);
+    const endpointB = resolveWorkspaceEndpoint(workspaceB, localServer);
+
+    const pane = resolveWorkbenchPaneEndpoint({
+      workspaceId: workspaceB.id,
+      workspaceTitle: "Workspace B",
+      workspace: workspaceB,
+      endpoint: endpointB,
+    });
+
+    expect(pane.status).toBe("ready");
+    if (pane.status !== "ready") return;
+    expect(pane.workspaceId).toBe(workspaceB.id);
+    expect(pane.workspaceRoot).toBe(workspaceB.path);
+    expect(pane.endpoint.workspaceId).toBe(workspaceB.id);
+    expect(pane.endpoint.opencodeBaseUrl).toContain(`/workspace/${workspaceB.id}/opencode`);
+    expect(pane.endpoint.opencodeBaseUrl).not.toContain(`/workspace/${workspaceA.id}/opencode`);
+    expect(pane.endpoint.token).toBe(localServer.token);
+    expect(pane.endpoint).not.toBe(endpointA);
+  });
+
+  test("keeps an unavailable error local to its pane", () => {
+    const workspaceA: PaneWorkspace = { id: "workspace-a", path: "/workspace/a", workspaceType: "local" };
+    const workspaceB: PaneWorkspace = { id: "workspace-b", path: "/workspace/b", workspaceType: "local" };
+    const localServer = { baseUrl: "http://127.0.0.1:8787", token: "pane-token" };
+    const primary = resolveWorkbenchPaneEndpoint({
+      workspaceId: workspaceA.id,
+      workspaceTitle: "Workspace A",
+      workspace: workspaceA,
+      endpoint: resolveWorkspaceEndpoint(workspaceA, localServer),
+    });
+    const secondary = resolveWorkbenchPaneEndpoint({
+      workspaceId: workspaceB.id,
+      workspaceTitle: "Workspace B",
+      workspace: workspaceB,
+      endpoint: resolveWorkspaceEndpoint(workspaceB, localServer),
+      connectionError: "Workspace B is offline.",
+    });
+
+    expect(primary.status).toBe("ready");
+    expect(secondary).toEqual({
+      status: "unavailable",
+      workspaceId: workspaceB.id,
+      workspaceTitle: "Workspace B",
+      message: "Workspace B is offline.",
+    });
+  });
+});

--- a/apps/app/tests/workbench-store.test.ts
+++ b/apps/app/tests/workbench-store.test.ts
@@ -11,75 +11,109 @@ import {
 
 const emptyWorkbench: WorkbenchSnapshot = {
   revision: 0,
-  workspaceId: null,
-  workspaceTitle: null,
-  primarySessionId: null,
+  primary: null,
   tabs: [],
-  splitSessionId: null,
+  secondary: null,
   focusedPane: "primary",
 };
 
 describe("workbench store", () => {
-  test("retains open tabs and represents two visible sessions", () => {
+  test("retains workspace ownership for two visible sessions", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
-      workspaceTitle: "Customer workspace",
+      workspaceTitle: "Workspace A",
       primarySessionId: "session-a",
       sessionsKnown: true,
-      sessions: [
-        { workspaceId: "workspace-a", sessionId: "session-a", title: "Primary" },
-        { workspaceId: "workspace-a", sessionId: "session-b", title: "Secondary" },
-      ],
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a", title: "Primary" }],
     });
     state = openWorkbenchTab(state, {
-      workspaceId: "workspace-a",
+      workspaceId: "workspace-b",
+      workspaceTitle: "Workspace B",
       sessionId: "session-b",
       title: "Secondary",
     });
-    state = setWorkbenchSplit(state, "session-b");
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-b" });
 
-    expect(state.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
-    expect(state.workspaceTitle).toBe("Customer workspace");
-    expect(state.primarySessionId).toBe("session-a");
-    expect(state.splitSessionId).toBe("session-b");
+    expect(state.primary).toMatchObject({ workspaceId: "workspace-a", sessionId: "session-a" });
+    expect(state.secondary).toMatchObject({ workspaceId: "workspace-b", sessionId: "session-b" });
+    expect(state.tabs.map((tab) => `${tab.workspaceId}/${tab.sessionId}`)).toEqual([
+      "workspace-a/session-a",
+      "workspace-b/session-b",
+    ]);
     expect(state.focusedPane).toBe("secondary");
   });
 
-  test("focuses an existing split pane without duplicating its tab", () => {
+  test("preserves a cross-workspace secondary while the primary workspace synchronizes", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
       primarySessionId: "session-a",
       sessionsKnown: true,
-      sessions: [
-        { workspaceId: "workspace-a", sessionId: "session-a" },
-        { workspaceId: "workspace-a", sessionId: "session-b" },
-      ],
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a" }],
     });
-    state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
-    state = setWorkbenchSplit(state, "session-b");
-    state = focusWorkbenchPane(state, "primary");
-    state = focusWorkbenchPane(state, "secondary");
+    state = openWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+
+    const synchronized = syncWorkbenchSnapshot(state, {
+      workspaceId: "workspace-a",
+      workspaceTitle: "Workspace A renamed",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a", title: "Primary renamed" }],
+    });
+
+    expect(synchronized.primary?.title).toBe("Primary renamed");
+    expect(synchronized.secondary).toMatchObject({ workspaceId: "workspace-b", sessionId: "session-b" });
+  });
+
+  test("treats identical session IDs in different workspaces as distinct", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-shared",
+      sessionsKnown: true,
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-shared" }],
+    });
+    state = openWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-shared" });
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-shared" });
 
     expect(state.tabs).toHaveLength(2);
-    expect(state.focusedPane).toBe("secondary");
+    expect(state.secondary?.workspaceId).toBe("workspace-b");
   });
 
-  test("removes a closed split session and returns focus to primary", () => {
+  test("focuses and closes a secondary by its full workspace reference", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
       primarySessionId: "session-a",
       sessionsKnown: true,
-      sessions: [
-        { workspaceId: "workspace-a", sessionId: "session-a" },
-        { workspaceId: "workspace-a", sessionId: "session-b" },
-      ],
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a" }],
     });
-    state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
-    state = setWorkbenchSplit(state, "session-b");
-    state = closeWorkbenchTab(state, "session-b");
+    state = openWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+    state = focusWorkbenchPane(state, "primary");
+    state = focusWorkbenchPane(state, "secondary");
+    state = closeWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-b" });
 
-    expect(state.splitSessionId).toBeNull();
+    expect(state.secondary).toBeNull();
+    expect(state.primary).toMatchObject({ workspaceId: "workspace-a", sessionId: "session-a" });
     expect(state.focusedPane).toBe("primary");
+  });
+
+  test("promotes the secondary session when the primary closes", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a" }],
+    });
+    state = openWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-b" });
+    state = closeWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-a" });
+
+    expect(state.primary).toMatchObject({ workspaceId: "workspace-b", sessionId: "session-b" });
+    expect(state.secondary).toBeNull();
+    expect(state.focusedPane).toBe("primary");
+    expect(state.tabs.map((tab) => `${tab.workspaceId}/${tab.sessionId}`)).toEqual([
+      "workspace-b/session-b",
+    ]);
   });
 
   test("keeps the same revision when synchronization changes nothing", () => {
@@ -97,10 +131,9 @@ describe("workbench store", () => {
     });
 
     expect(unchanged).toBe(state);
-    expect(unchanged.revision).toBe(state.revision);
   });
 
-  test("does not prune retained tabs while the session index reloads", () => {
+  test("does not prune retained same-workspace tabs while the session index reloads", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
       primarySessionId: "session-a",
@@ -111,7 +144,7 @@ describe("workbench store", () => {
       ],
     });
     state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
-    state = setWorkbenchSplit(state, "session-b");
+    state = setWorkbenchSplit(state, { workspaceId: "workspace-a", sessionId: "session-b" });
 
     const loading = syncWorkbenchSnapshot(state, {
       workspaceId: "workspace-a",
@@ -121,6 +154,6 @@ describe("workbench store", () => {
     });
 
     expect(loading.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
-    expect(loading.splitSessionId).toBe("session-b");
+    expect(loading.secondary?.sessionId).toBe("session-b");
   });
 });

--- a/evals/specs/cross-workspace-split-view.e2e.test.ts
+++ b/evals/specs/cross-workspace-split-view.e2e.test.ts
@@ -1,0 +1,458 @@
+import { expect } from "vitest";
+import { control, evalIn, go, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { screenshot } from "@openwork/test-evidence";
+import {
+  defineWorld,
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  needs,
+  sleep,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localServicesRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const redisOpen = await localRedisIsRunning();
+const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localServicesRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : localServicesRequired && !redisOpen
+      ? " skipped — needs Redis on 127.0.0.1:6379"
+      : "";
+
+type WorkspaceListing = {
+  ids: string[];
+  activeId: string | null;
+};
+
+type SplitCandidate = {
+  workspaceId: string;
+  sessionId: string;
+  title: string;
+};
+
+type SplitFacts = {
+  layout: string;
+  primarySessionId: string;
+  secondarySessionId: string;
+  primaryLayoutWorkspaceId: string;
+  secondaryLayoutWorkspaceId: string;
+  primaryPaneWorkspaceId: string;
+  secondaryPaneWorkspaceId: string;
+  primarySurfaceWorkspaceId: string;
+  secondarySurfaceWorkspaceId: string;
+  primaryWorkspaceName: string;
+  secondaryWorkspaceName: string;
+  primaryResourceWorkspaceId: string;
+  secondaryResourceWorkspaceId: string;
+  primaryOwnsSecondarySurface: boolean;
+  secondaryOwnsPrimarySurface: boolean;
+  primaryUnavailable: boolean;
+  secondaryUnavailable: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseWorkspaceListing(value: unknown): WorkspaceListing {
+  if (!isRecord(value) || value.ok !== true || !Array.isArray(value.ids)) {
+    throw new Error(`Invalid workspace listing: ${JSON.stringify(value)}`);
+  }
+  return {
+    ids: value.ids.filter((id): id is string => typeof id === "string"),
+    activeId: typeof value.activeId === "string" ? value.activeId : null,
+  };
+}
+
+function parseSplitFacts(value: unknown): SplitFacts {
+  if (!isRecord(value)) throw new Error(`Invalid split facts: ${JSON.stringify(value)}`);
+  const text = (key: string) => typeof value[key] === "string" ? value[key] : "";
+  return {
+    layout: text("layout"),
+    primarySessionId: text("primarySessionId"),
+    secondarySessionId: text("secondarySessionId"),
+    primaryLayoutWorkspaceId: text("primaryLayoutWorkspaceId"),
+    secondaryLayoutWorkspaceId: text("secondaryLayoutWorkspaceId"),
+    primaryPaneWorkspaceId: text("primaryPaneWorkspaceId"),
+    secondaryPaneWorkspaceId: text("secondaryPaneWorkspaceId"),
+    primarySurfaceWorkspaceId: text("primarySurfaceWorkspaceId"),
+    secondarySurfaceWorkspaceId: text("secondarySurfaceWorkspaceId"),
+    primaryWorkspaceName: text("primaryWorkspaceName"),
+    secondaryWorkspaceName: text("secondaryWorkspaceName"),
+    primaryResourceWorkspaceId: text("primaryResourceWorkspaceId"),
+    secondaryResourceWorkspaceId: text("secondaryResourceWorkspaceId"),
+    primaryOwnsSecondarySurface: value.primaryOwnsSecondarySurface === true,
+    secondaryOwnsPrimarySurface: value.secondaryOwnsPrimarySurface === true,
+    primaryUnavailable: value.primaryUnavailable === true,
+    secondaryUnavailable: value.secondaryUnavailable === true,
+  };
+}
+
+async function listWorkspaces(app: Surface): Promise<WorkspaceListing> {
+  return parseWorkspaceListing(await evalIn(app, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { ok: false, ids: [], activeId: null };
+    const response = await fetch(String(info.baseUrl).replace(/\\\/+$/, "") + "/workspaces", {
+      headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+      signal: AbortSignal.timeout(15000),
+    });
+    const body = await response.json();
+    const items = Array.isArray(body?.items) ? body.items : [];
+    return {
+      ok: response.ok,
+      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+      activeId: typeof body?.activeId === "string" ? body.activeId : null,
+    };
+  })()`, { awaitPromise: true, timeoutMs: 20_000 }));
+}
+
+async function createWorkspace(app: Surface, path: string): Promise<string> {
+  const before = await listWorkspaces(app);
+  await control(app, "workspace.create", { path }, { timeoutMs: 90_000 });
+  await waitFor(app, `(() => {
+    const active = localStorage.getItem("openwork.react.activeWorkspace") ?? "";
+    return Boolean(active) && active !== ${JSON.stringify(before.activeId ?? "")};
+  })()`, { timeoutMs: 90_000, label: `workspace ${path} selected` });
+  const after = await listWorkspaces(app);
+  const created = after.ids.find((id) => !before.ids.includes(id)) ?? after.activeId;
+  if (!created) throw new Error(`workspace.create produced no workspace id for ${path}`);
+  return created;
+}
+
+async function createSessionInWorkspace(app: Surface, workspaceId: string, title: string): Promise<SplitCandidate> {
+  await go(app, `/workspace/${workspaceId}/session`, { timeoutMs: 60_000 });
+  await waitFor(app, `(localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)}`, {
+    timeoutMs: 60_000,
+    label: `workspace ${workspaceId} active before creating ${title}`,
+  });
+  const deadline = Date.now() + 90_000;
+  let created: unknown = null;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      created = await control(app, "session.create_task", undefined, { timeoutMs: 30_000 });
+      if (typeof created === "string" && created.startsWith("ses_")) break;
+      lastError = new Error(`session.create_task returned ${JSON.stringify(created)}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(500);
+  }
+  if (typeof created !== "string" || !created.startsWith("ses_")) {
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`session.create_task did not return a session id for ${title}: ${detail}`);
+  }
+  await control(app, "session.rename", { sessionId: created, title }, { timeoutMs: 30_000 });
+  const candidate = { workspaceId, sessionId: created, title };
+  await waitForSessionRow(app, candidate);
+  return candidate;
+}
+
+async function waitForSessionRow(app: Surface, candidate: SplitCandidate): Promise<void> {
+  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(
+    `[data-sidebar-session-id="${candidate.sessionId}"][data-sidebar-session-workspace-id="${candidate.workspaceId}"]`,
+  )}))`, {
+    timeoutMs: 60_000,
+    label: `sidebar row for ${candidate.title}`,
+  });
+}
+
+async function openSessionRoute(app: Surface, candidate: SplitCandidate): Promise<void> {
+  await go(app, `/workspace/${candidate.workspaceId}/session/${candidate.sessionId}`, { timeoutMs: 60_000 });
+  await waitFor(app, `(() => {
+    const surface = document.querySelector("[data-session-surface-id]");
+    return (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(candidate.workspaceId)}
+      && surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(candidate.sessionId)};
+  })()`, { timeoutMs: 60_000, label: `visible session ${candidate.title}` });
+}
+
+async function closeMenus(app: Surface): Promise<void> {
+  await evalIn(app, `(() => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }));
+    document.body.click();
+    return true;
+  })()`);
+}
+
+async function openContextMenuForSession(app: Surface, candidate: SplitCandidate): Promise<void> {
+  await closeMenus(app);
+  const opened = await evalIn(app, `(() => {
+    const row = document.querySelector(${JSON.stringify(
+      `[data-sidebar-session-id="${candidate.sessionId}"][data-sidebar-session-workspace-id="${candidate.workspaceId}"]`,
+    )});
+    if (!(row instanceof HTMLElement)) return false;
+    const target = row.querySelector(${JSON.stringify(`[data-session-tab-id="${candidate.sessionId}"]`)}) ?? row;
+    if (!(target instanceof HTMLElement)) return false;
+    row.scrollIntoView({ block: "center" });
+    const rect = target.getBoundingClientRect();
+    target.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      buttons: 2,
+      clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
+      clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
+    }));
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `Boolean(document.querySelector('[role="menu"]'))`, {
+    timeoutMs: 15_000,
+    label: `context menu rendered for ${candidate.title}`,
+  });
+}
+
+async function splitMenuVisible(app: Surface): Promise<boolean> {
+  return await evalIn(app, `Boolean(document.querySelector("[data-session-menu-open-split]"))`) === true;
+}
+
+async function clickOpenSplit(app: Surface): Promise<void> {
+  const clicked = await evalIn(app, `(() => {
+    const item = document.querySelector("[data-session-menu-open-split]");
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+async function closeSecondaryPane(app: Surface): Promise<void> {
+  const clicked = await evalIn(app, `(() => {
+    const button = document.querySelector('button[aria-label="Close secondary split pane"]');
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+  await waitFor(app, `!document.querySelector('[data-workbench-pane="secondary"]')`, {
+    timeoutMs: 15_000,
+    label: "secondary split pane closes",
+  });
+}
+
+async function openCrossWorkspaceSplitFromPalette(app: Surface, candidate: SplitCandidate): Promise<void> {
+  await closeMenus(app);
+  await evalIn(app, `(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      metaKey: true,
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    }));
+    return true;
+  })()`);
+  await waitFor(app, `Boolean(document.querySelector('[data-command-palette-item="open-in-split-view"]'))`, {
+    timeoutMs: 15_000,
+    label: "Open in split view command is visible",
+  });
+  await evalIn(app, `document.querySelector('[data-command-palette-item="open-in-split-view"]')?.click()`);
+  const candidateSelector = `[data-command-palette-item="split-session:${candidate.workspaceId}:${candidate.sessionId}"]`;
+  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(candidateSelector)}))`, {
+    timeoutMs: 15_000,
+    label: "cross-workspace session is listed in split picker",
+  });
+  await evalIn(app, `document.querySelector(${JSON.stringify(candidateSelector)})?.click()`);
+}
+
+async function readSplitFacts(app: Surface, primary: SplitCandidate, secondary: SplitCandidate): Promise<SplitFacts> {
+  return parseSplitFacts(await evalIn(app, `(() => {
+    const context = window.__openworkControl?.context?.();
+    const layout = context?.conversations?.layout;
+    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
+    const secondaryPane = document.querySelector('[data-workbench-pane="secondary"]');
+    const primarySurface = primaryPane?.querySelector('[data-session-surface-id="${primary.sessionId}"]');
+    const secondarySurface = secondaryPane?.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
+    const resources = Array.isArray(context?.resources) ? context.resources : [];
+    const primaryResource = resources.find((resource) => resource?.kind === "session"
+      && resource?.state?.pane === "primary" && resource?.state?.visible === true);
+    const secondaryResource = resources.find((resource) => resource?.kind === "session"
+      && resource?.state?.pane === "secondary" && resource?.state?.visible === true);
+    return {
+      layout: layout?.kind ?? "",
+      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
+      secondarySessionId: layout?.secondarySessionId ?? "",
+      primaryLayoutWorkspaceId: layout?.primaryWorkspaceId ?? layout?.workspaceId ?? "",
+      secondaryLayoutWorkspaceId: layout?.secondaryWorkspaceId ?? "",
+      primaryPaneWorkspaceId: primaryPane?.getAttribute("data-workbench-workspace-id") ?? "",
+      secondaryPaneWorkspaceId: secondaryPane?.getAttribute("data-workbench-workspace-id") ?? "",
+      primarySurfaceWorkspaceId: primarySurface?.getAttribute("data-session-surface-workspace-id") ?? "",
+      secondarySurfaceWorkspaceId: secondarySurface?.getAttribute("data-session-surface-workspace-id") ?? "",
+      primaryWorkspaceName: primaryPane?.querySelector('[data-workbench-pane-header="primary"]')
+        ?.getAttribute("data-workbench-pane-workspace-name") ?? "",
+      secondaryWorkspaceName: secondaryPane?.querySelector('[data-workbench-pane-header="secondary"]')
+        ?.getAttribute("data-workbench-pane-workspace-name") ?? "",
+      primaryResourceWorkspaceId: primaryResource?.state?.workspaceId ?? "",
+      secondaryResourceWorkspaceId: secondaryResource?.state?.workspaceId ?? "",
+      primaryOwnsSecondarySurface: Boolean(primaryPane?.querySelector(
+        '[data-session-surface-id="${secondary.sessionId}"]',
+      )),
+      secondaryOwnsPrimarySurface: Boolean(secondaryPane?.querySelector(
+        '[data-session-surface-id="${primary.sessionId}"]',
+      )),
+      primaryUnavailable: Boolean(primaryPane?.querySelector('[data-workbench-pane-unavailable]')),
+      secondaryUnavailable: Boolean(secondaryPane?.querySelector('[data-workbench-pane-unavailable]')),
+    };
+  })()`));
+}
+
+test.skipIf(!runnable)(
+  `same-workspace and cross-workspace split sessions retain visible ownership${skipSuffix}`,
+  { timeout: 10 * 60_000 },
+  async ({ evidence }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    const runId = `${Date.now().toString(36)}-${process.pid}`;
+    const worldDefinition = defineWorld({
+      den: {
+        orgs: {
+          "Cross Workspace Split View": {
+            admin: { name: "Split View Admin", email: `split-view-admin-${runId}@openwork.test` },
+          },
+        },
+      },
+      apps: {
+        main: {
+          signedInTo: { org: "Cross Workspace Split View", as: "admin" },
+          workspacePath: `/tmp/openwork-cross-workspace-split-${runId}-a`,
+        },
+      },
+    });
+
+    await using world = await startWorld(worldDefinition, { name: `cross-workspace-split-${runId}` });
+    const app = world.app("main");
+    const workspaceA = app.workspaceId;
+    if (!workspaceA) throw new Error("World app did not resolve a primary workspace id.");
+
+    const primary = await createSessionInWorkspace(app, workspaceA, "Primary workspace anchor");
+    const sameWorkspacePeer = await createSessionInWorkspace(app, workspaceA, "Primary workspace peer");
+    const workspaceB = await createWorkspace(app, `/tmp/openwork-cross-workspace-split-${runId}-b`);
+    const crossWorkspacePeer = await createSessionInWorkspace(app, workspaceB, "Secondary workspace peer");
+    expect(primary.workspaceId).not.toBe(crossWorkspacePeer.workspaceId);
+
+    await openSessionRoute(app, primary);
+    await waitForSessionRow(app, sameWorkspacePeer);
+    await waitForSessionRow(app, crossWorkspacePeer);
+
+    await openContextMenuForSession(app, sameWorkspacePeer);
+    expect(await splitMenuVisible(app)).toBe(true);
+    await clickOpenSplit(app);
+    await waitFor(app, `Boolean(document.querySelector('[data-workbench-pane="secondary"]'))`, {
+      timeoutMs: 30_000,
+      label: "same-workspace secondary pane opens",
+    });
+    const sameWorkspaceMountDiagnostic = await evalIn(app, `(() => {
+      const panes = [...document.querySelectorAll('[data-workbench-pane]')];
+      return panes.map((pane) => ({
+        pane: pane.getAttribute('data-workbench-pane'),
+        workspaceId: pane.getAttribute('data-workbench-workspace-id'),
+        surfaces: [...pane.querySelectorAll('[data-session-surface-id]')].map((surface) => ({
+          sessionId: surface.getAttribute('data-session-surface-id'),
+          workspaceId: surface.getAttribute('data-session-surface-workspace-id'),
+        })),
+        text: (pane.textContent ?? '').replace(/\\s+/g, ' ').trim().slice(0, 500),
+      }));
+    })()`);
+    expect(
+      await evalIn(app, `Boolean(document.querySelector(
+        '[data-workbench-pane="secondary"] [data-session-surface-id="${sameWorkspacePeer.sessionId}"]'
+      ))`),
+      `same-workspace mount diagnostic: ${JSON.stringify(sameWorkspaceMountDiagnostic)}`,
+    ).toBe(true);
+    await waitFor(app, `Boolean(document.querySelector(
+      '[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceA}"] [data-session-surface-id="${sameWorkspacePeer.sessionId}"]'
+    ))`, { timeoutMs: 60_000, label: "same-workspace split renders" });
+    const sameWorkspaceFacts = await readSplitFacts(app, primary, sameWorkspacePeer);
+    expect(sameWorkspaceFacts.primaryPaneWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.secondaryPaneWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.primarySurfaceWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.secondarySurfaceWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.primaryLayoutWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.secondaryLayoutWorkspaceId).toBe(workspaceA);
+    expect(sameWorkspaceFacts.secondaryPaneWorkspaceId).not.toBe(workspaceB);
+    expect(sameWorkspaceFacts.primaryOwnsSecondarySurface).toBe(false);
+    expect(sameWorkspaceFacts.secondaryOwnsPrimarySurface).toBe(false);
+    expect(sameWorkspaceFacts.primaryUnavailable).toBe(false);
+    expect(sameWorkspaceFacts.secondaryUnavailable).toBe(false);
+    evidence.recordAssertionEvidence(
+      "Same-workspace split remains available and renders both sessions in their owning workspace",
+      JSON.stringify(sameWorkspaceFacts),
+      sameWorkspaceFacts.layout === "split"
+        && sameWorkspaceFacts.primarySessionId === primary.sessionId
+        && sameWorkspaceFacts.secondarySessionId === sameWorkspacePeer.sessionId
+        && sameWorkspaceFacts.primaryPaneWorkspaceId === workspaceA
+        && sameWorkspaceFacts.secondaryPaneWorkspaceId === workspaceA
+        && sameWorkspaceFacts.primarySurfaceWorkspaceId === workspaceA
+        && sameWorkspaceFacts.secondarySurfaceWorkspaceId === workspaceA
+        && sameWorkspaceFacts.primaryLayoutWorkspaceId === workspaceA
+        && sameWorkspaceFacts.secondaryLayoutWorkspaceId === workspaceA
+        && sameWorkspaceFacts.secondaryPaneWorkspaceId !== workspaceB
+        && !sameWorkspaceFacts.primaryOwnsSecondarySurface
+        && !sameWorkspaceFacts.secondaryOwnsPrimarySurface
+        && !sameWorkspaceFacts.primaryUnavailable
+        && !sameWorkspaceFacts.secondaryUnavailable,
+    );
+    await closeSecondaryPane(app);
+    expect(await evalIn(app, `document.querySelector('[data-session-surface-id="${primary.sessionId}"]') !== null`)).toBe(true);
+    expect(await evalIn(app, `document.querySelector('[data-session-surface-id="${sameWorkspacePeer.sessionId}"]') === null`)).toBe(true);
+
+    await openContextMenuForSession(app, crossWorkspacePeer);
+    expect(await splitMenuVisible(app)).toBe(true);
+    await closeMenus(app);
+    await openCrossWorkspaceSplitFromPalette(app, crossWorkspacePeer);
+    await waitFor(app, `Boolean(document.querySelector(
+      '[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceB}"] [data-session-surface-id="${crossWorkspacePeer.sessionId}"]'
+    ))`, { timeoutMs: 60_000, label: "cross-workspace palette split renders" });
+
+    const crossWorkspaceFacts = await readSplitFacts(app, primary, crossWorkspacePeer);
+    expect(crossWorkspaceFacts.layout).toBe("split");
+    expect(crossWorkspaceFacts.primaryPaneWorkspaceId).toBe(workspaceA);
+    expect(crossWorkspaceFacts.primaryPaneWorkspaceId).not.toBe(workspaceB);
+    expect(crossWorkspaceFacts.secondaryPaneWorkspaceId).toBe(workspaceB);
+    expect(crossWorkspaceFacts.secondaryPaneWorkspaceId).not.toBe(workspaceA);
+    expect(crossWorkspaceFacts.primarySurfaceWorkspaceId).toBe(workspaceA);
+    expect(crossWorkspaceFacts.secondarySurfaceWorkspaceId).toBe(workspaceB);
+    expect(crossWorkspaceFacts.primaryLayoutWorkspaceId).toBe(workspaceA);
+    expect(crossWorkspaceFacts.secondaryLayoutWorkspaceId).toBe(workspaceB);
+    expect(crossWorkspaceFacts.primaryResourceWorkspaceId).toBe(workspaceA);
+    expect(crossWorkspaceFacts.secondaryResourceWorkspaceId).toBe(workspaceB);
+    expect(crossWorkspaceFacts.primaryOwnsSecondarySurface).toBe(false);
+    expect(crossWorkspaceFacts.secondaryOwnsPrimarySurface).toBe(false);
+    expect(crossWorkspaceFacts.primaryUnavailable).toBe(false);
+    expect(crossWorkspaceFacts.secondaryUnavailable).toBe(false);
+    expect(crossWorkspaceFacts.primaryWorkspaceName).not.toBe("");
+    expect(crossWorkspaceFacts.secondaryWorkspaceName).not.toBe("");
+    expect(crossWorkspaceFacts.primaryWorkspaceName).not.toBe(crossWorkspaceFacts.secondaryWorkspaceName);
+    evidence.recordAssertionEvidence(
+      "The command palette renders two sessions from different workspaces with correct visible ownership",
+      JSON.stringify(crossWorkspaceFacts),
+      crossWorkspaceFacts.layout === "split"
+        && crossWorkspaceFacts.primarySessionId === primary.sessionId
+        && crossWorkspaceFacts.secondarySessionId === crossWorkspacePeer.sessionId
+        && crossWorkspaceFacts.primaryPaneWorkspaceId === workspaceA
+        && crossWorkspaceFacts.primaryPaneWorkspaceId !== workspaceB
+        && crossWorkspaceFacts.secondaryPaneWorkspaceId === workspaceB
+        && crossWorkspaceFacts.secondaryPaneWorkspaceId !== workspaceA
+        && crossWorkspaceFacts.primarySurfaceWorkspaceId === workspaceA
+        && crossWorkspaceFacts.secondarySurfaceWorkspaceId === workspaceB
+        && crossWorkspaceFacts.primaryLayoutWorkspaceId === workspaceA
+        && crossWorkspaceFacts.secondaryLayoutWorkspaceId === workspaceB
+        && crossWorkspaceFacts.primaryResourceWorkspaceId === workspaceA
+        && crossWorkspaceFacts.secondaryResourceWorkspaceId === workspaceB
+        && crossWorkspaceFacts.primaryWorkspaceName !== crossWorkspaceFacts.secondaryWorkspaceName
+        && !crossWorkspaceFacts.primaryOwnsSecondarySurface
+        && !crossWorkspaceFacts.secondaryOwnsPrimarySurface
+        && !crossWorkspaceFacts.primaryUnavailable
+        && !crossWorkspaceFacts.secondaryUnavailable,
+    );
+    await screenshot(app);
+  },
+);

--- a/evals/specs/shared-world-engine.test.ts
+++ b/evals/specs/shared-world-engine.test.ts
@@ -12,12 +12,14 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
   const discovered = await discoverWorlds(WORLDS_DIRECTORY);
   assert.deepEqual(discovered.map((world) => world.name), [
     "azure-byok",
+    "cross-workspace-split-view",
     "desktop-prod-live",
     "dev-headless",
     "headless-prod-live",
   ]);
 
   const azureByok = await loadWorldFile(join(WORLDS_DIRECTORY, "azure-byok.ts"));
+  const crossWorkspaceSplitView = await loadWorldFile(join(WORLDS_DIRECTORY, "cross-workspace-split-view.ts"));
   const devHeadless = await loadWorldFile(join(WORLDS_DIRECTORY, "dev-headless.ts"));
   const headlessProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "headless-prod-live.ts"));
   const desktopProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "desktop-prod-live.ts"));
@@ -25,6 +27,10 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
   assert.equal(azureByok.definition.adapter, "eval");
   assert.equal(azureByok.definition.detached, true);
   assert.equal(azureByok.definition.requiresSharedState, false);
+  assert.equal(crossWorkspaceSplitView.defaultName, "cross-workspace-split-view");
+  assert.equal(crossWorkspaceSplitView.definition.adapter, "eval");
+  assert.equal(crossWorkspaceSplitView.definition.detached, true);
+  assert.equal(crossWorkspaceSplitView.definition.requiresSharedState, false);
   assert.equal(devHeadless.defaultName, "dev-headless");
   assert.equal(devHeadless.definition.detached, true);
   assert.deepEqual(devHeadless.definition.topology, {
@@ -85,7 +91,7 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
 
   evidence.recordAssertionEvidence(
     "Root world files are auto-discovered and path-loadable",
-    "Discovery returned all four approved files, and loading retained each adapter/topology contract.",
+    "Discovery returned all five approved files, and loading retained each adapter/topology contract.",
     true,
   );
   evidence.recordAssertionEvidence(

--- a/packages/types/src/openwork-context.ts
+++ b/packages/types/src/openwork-context.ts
@@ -40,11 +40,14 @@ export const openworkConversationLayoutSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("single"),
     sessionId: z.string(),
+    workspaceId: z.string().optional(),
   }),
   z.object({
     kind: z.literal("split"),
     primarySessionId: z.string(),
+    primaryWorkspaceId: z.string().optional(),
     secondarySessionId: z.string(),
+    secondaryWorkspaceId: z.string().optional(),
     focused: z.enum(["primary", "secondary"]),
   }),
 ])

--- a/worlds/cross-workspace-split-view.ts
+++ b/worlds/cross-workspace-split-view.ts
@@ -1,0 +1,30 @@
+import { createWorldDefinition } from "../packages/world/src/index.ts";
+import { parseWorldTopology } from "../evals/packages/env/src/topology.ts";
+
+/**
+ * Repro world for validating split view across two sessions that belong to
+ * different local workspaces. The world seeds the signed-in desktop and the
+ * first workspace; the scenario creates a second workspace at runtime so each
+ * run gets isolated temporary workspace paths.
+ */
+export const crossWorkspaceSplitView = createWorldDefinition({
+  den: {
+    orgs: {
+      "Cross Workspace Split View": {
+        admin: { name: "Split View Admin", email: "split-view-admin@openwork.test" },
+      },
+    },
+  },
+  apps: {
+    main: {
+      signedInTo: { org: "Cross Workspace Split View", as: "admin" },
+      workspacePath: "/tmp/openwork-cross-workspace-split-primary",
+      sessions: ["Primary split anchor", "Primary same-workspace peer"],
+    },
+  },
+}, {
+  adapter: "eval",
+  detached: true,
+}, parseWorldTopology);
+
+export default crossWorkspaceSplitView;


### PR DESCRIPTION
## Summary
- model split panes as workspace-owned session references
- add an Open in split view command-palette flow across workspaces
- resolve independent pane runtimes, clients, tokens, and pane-local errors
- clarify workspace identity in split-view UI and OpenWork context
- add a reusable repro world and deterministic E2E coverage

## Verification
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app exec bun test --isolate tests/workbench-store.test.ts tests/pane-runtime.test.ts tests/command-palette-sessions.test.ts tests/command-palette-models.test.ts tests/openwork-context-projector.test.ts` — 18 passed, 0 failed
- `env -u OPENWORK_EVAL_DAYTONA -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_ELECTRON_START_URL -u PORT OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/cross-workspace-split-view.e2e.test.ts` — 1 passed, 0 failed (local lane)

## Evidence
The E2E asserts both same-workspace and cross-workspace split affordances, renders one pane from each workspace, and verifies each pane retains its own workspace ownership without leaking the other session's identity.