### PR TITLE
Keep managed-provider runtime generation coherent

### DIFF
--- a/apps/server/src/managed-provider-auth.test.ts
+++ b/apps/server/src/managed-provider-auth.test.ts
@@ -3,6 +3,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  clearEnginePoolForConfig,
+  setEnginePoolForConfig,
+  type EnginePool,
+  type EnginePoolConnection,
+} from "./engine-pool.js";
 import { resetManagedProviderAuthCache, syncManagedProviderAuth } from "./managed-provider-auth.js";
 import { ENGINE_GLOBAL_RUNTIME_CONFIG_ID, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
@@ -23,6 +29,21 @@ function stubFetch(status = 200) {
     return new Response(status >= 400 ? "nope" : "{}", { status });
   }) as unknown as typeof globalThis.fetch;
   return { calls, impl };
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function installManagedPool(config: ServerConfig, connection: () => EnginePoolConnection): void {
+  const pool = { connections: () => [connection()] } as unknown as EnginePool;
+  setEnginePoolForConfig(config, pool);
 }
 
 async function makeConfig(dir: string): Promise<ServerConfig> {
@@ -205,6 +226,30 @@ describe("managed provider auth delivery", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("never transfers deletion ownership to a different attached engine target", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    config.opencodeBaseUrl = "http://127.0.0.1:40000";
+    await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({
+      ...current,
+      provider: {},
+    }));
+    const differentTarget = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(differentTarget.removed).toEqual([]);
+    expect(fetchStub.calls.filter((call) => call.method === "DELETE")).toHaveLength(0);
+
+    config.opencodeBaseUrl = "http://127.0.0.1:39999";
+    const originalTarget = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    expect(originalTarget.removed).toEqual([PROVIDER]);
+    expect(fetchStub.calls.filter((call) => call.method === "DELETE")).toHaveLength(1);
+    await rm(dir, { recursive: true, force: true });
+  });
+
   test("never touches providers this process did not deliver", async () => {
     const config = await makeConfig(dir);
     // No managed providers at all: a desktop user's own engine credentials must
@@ -258,6 +303,106 @@ describe("managed provider auth delivery", () => {
 
     expect(afterRestart.delivered).toEqual([PROVIDER]);
     expect(fetchStub.calls.filter((call) => call.method === "PUT")).toHaveLength(2);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("keys applied credentials to the managed engine generation even when the replacement reuses its URL", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+    let generationId = "generation-one";
+    installManagedPool(config, () => ({
+      generationId,
+      role: "primary",
+      baseUrl: "http://127.0.0.1:39999",
+      username: "engine-user",
+      password: "engine-pass",
+    }));
+
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    generationId = "generation-two";
+    const afterReplacement = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(afterReplacement.delivered).toEqual([PROVIDER]);
+    expect(fetchStub.calls.filter((call) => call.method === "PUT")).toHaveLength(2);
+    clearEnginePoolForConfig(config);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("removes owned credentials after replacement even when the new generation has no applied fingerprint", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const fetchStub = stubFetch();
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+    let generationId = "generation-one";
+    installManagedPool(config, () => ({
+      generationId,
+      role: "primary",
+      baseUrl: "http://127.0.0.1:39999",
+      username: "engine-user",
+      password: "engine-pass",
+    }));
+
+    await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+    generationId = "generation-two";
+    await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({
+      ...current,
+      provider: {},
+    }));
+    const afterReplacement = await syncManagedProviderAuth({ config, env, fetchImpl: fetchStub.impl });
+
+    expect(afterReplacement.removed).toEqual([PROVIDER]);
+    expect(fetchStub.calls.filter((call) => call.method === "DELETE")).toHaveLength(1);
+    clearEnginePoolForConfig(config);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("serializes reconciliation and ignores a completion from an obsolete managed engine generation", async () => {
+    const config = await makeConfig(dir);
+    await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+    const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+    const firstFetchStarted = deferred();
+    const releaseFirstFetch = deferred();
+    const calledGenerations: string[] = [];
+    let generationId = "generation-one";
+    installManagedPool(config, () => ({
+      generationId,
+      role: "primary",
+      baseUrl: "http://127.0.0.1:39999",
+      username: "engine-user",
+      password: "engine-pass",
+    }));
+    const fetchImpl = (async () => {
+      const calledGeneration = generationId;
+      calledGenerations.push(calledGeneration);
+      if (calledGeneration === "generation-one") {
+        firstFetchStarted.resolve();
+        await releaseFirstFetch.promise;
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const obsolete = syncManagedProviderAuth({ config, env, fetchImpl });
+    await firstFetchStarted.promise;
+    generationId = "generation-two";
+    const current = syncManagedProviderAuth({ config, env, fetchImpl });
+
+    expect(calledGenerations).toEqual(["generation-one"]);
+    releaseFirstFetch.resolve();
+    const [obsoleteResult, currentResult] = await Promise.all([obsolete, current]);
+
+    expect(obsoleteResult.delivered).toEqual([]);
+    expect(currentResult.delivered).toEqual([PROVIDER]);
+    expect(calledGenerations).toEqual(["generation-one", "generation-two"]);
+    const unchanged = await syncManagedProviderAuth({ config, env, fetchImpl });
+    expect(unchanged.unchanged).toEqual([PROVIDER]);
+    expect(calledGenerations).toHaveLength(2);
+    generationId = "generation-one";
+    const reusedGeneration = await syncManagedProviderAuth({ config, env, fetchImpl });
+    expect(reusedGeneration.delivered).toEqual([PROVIDER]);
+    expect(calledGenerations).toEqual(["generation-one", "generation-two", "generation-one"]);
+    clearEnginePoolForConfig(config);
     await rm(dir, { recursive: true, force: true });
   });
 });

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { enginePoolForConfig } from "./engine-pool.js";
 import { resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
 import { readGlobalRuntimeOpencodeConfig, runtimeProviderMap } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
@@ -42,17 +43,112 @@ export type ManagedProviderAuthResult = {
   failed: Array<{ providerId: string; status: number | null }>;
 };
 
-/**
- * Providers this process has delivered, with a fingerprint of the delivered
- * value. Redundant writes are what caused a prior production incident, so we
- * only ever write on a real change. Keyed per engine base URL so a respawned
- * engine on a different port is treated as fresh.
- */
-const deliveredFingerprints = new Map<string, string>();
+type ManagedProviderAuthState = {
+  epoch: number;
+  appliedTargetScope: string | null;
+  deliveredFingerprints: Map<string, string>;
+  ownedProviderIdsByScope: Map<string, Set<string>>;
+  tail: Promise<void>;
+};
 
-const fingerprintKey = (baseUrl: string, providerId: string) => `${baseUrl}\u0000${providerId}`;
+type ManagedProviderAuthTarget = {
+  scope: string;
+  ownershipScope: string;
+  baseUrl: string;
+  authHeader?: string;
+  isCurrent: () => boolean;
+};
+
+/**
+ * Applied state belongs to one server config and one exact engine target. A
+ * managed target includes the pool generation id, so even a replacement that
+ * reuses a port starts with no applied-state assumptions. The tail serializes
+ * competing startup, configuration, and env-store reconciliation requests.
+ * Removal ownership survives managed generations but never crosses attached
+ * workspace endpoints.
+ */
+const stateByConfig = new WeakMap<ServerConfig, ManagedProviderAuthState>();
+let cacheEpoch = 0;
 
 const fingerprint = (value: string) => createHash("sha256").update(value).digest("hex");
+
+function stateForConfig(config: ServerConfig): ManagedProviderAuthState {
+  const current = stateByConfig.get(config);
+  if (current) {
+    if (current.epoch !== cacheEpoch) {
+      current.epoch = cacheEpoch;
+      current.appliedTargetScope = null;
+      current.deliveredFingerprints.clear();
+    }
+    return current;
+  }
+  const created: ManagedProviderAuthState = {
+    epoch: cacheEpoch,
+    appliedTargetScope: null,
+    deliveredFingerprints: new Map(),
+    ownedProviderIdsByScope: new Map(),
+    tail: Promise.resolve(),
+  };
+  stateByConfig.set(config, created);
+  return created;
+}
+
+function normalizeBaseUrl(value: string | undefined): string | null {
+  const normalized = value?.trim().replace(/\/+$/, "");
+  return normalized ? normalized : null;
+}
+
+function basicAuthHeader(username: string, password: string): string | undefined {
+  const normalizedUsername = username.trim();
+  const normalizedPassword = password.trim();
+  return normalizedUsername && normalizedPassword
+    ? `Basic ${Buffer.from(`${normalizedUsername}:${normalizedPassword}`).toString("base64")}`
+    : undefined;
+}
+
+function resolveManagedProviderAuthTarget(config: ServerConfig): ManagedProviderAuthTarget | null {
+  const workspace = findManagedEngineWorkspace(config.workspaces) ?? config.workspaces[0];
+  if (!workspace) return null;
+
+  const pool = enginePoolForConfig(config);
+  if (pool) {
+    const primary = pool.connections().find((connection) => connection.role === "primary");
+    const baseUrl = normalizeBaseUrl(primary?.baseUrl);
+    if (!primary || !baseUrl) return null;
+    const authHeader = basicAuthHeader(primary.username, primary.password);
+    return {
+      scope: `workspace:${workspace.id}\u0000generation:${primary.generationId}`,
+      ownershipScope: "managed-engine",
+      baseUrl,
+      ...(authHeader ? { authHeader } : {}),
+      isCurrent: () => {
+        if (enginePoolForConfig(config) !== pool) return false;
+        const current = pool.connections().find((connection) => connection.role === "primary");
+        return current?.generationId === primary.generationId
+          && normalizeBaseUrl(current.baseUrl) === baseUrl
+          && basicAuthHeader(current.username, current.password) === authHeader;
+      },
+    };
+  }
+
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = normalizeBaseUrl(connection.baseUrl);
+  if (!baseUrl) return null;
+  const authHeader = connection.authHeader;
+  return {
+    scope: `workspace:${workspace.id}\u0000endpoint:${baseUrl}`,
+    ownershipScope: `workspace:${workspace.id}\u0000endpoint:${baseUrl}`,
+    baseUrl,
+    ...(authHeader ? { authHeader } : {}),
+    isCurrent: () => {
+      if (enginePoolForConfig(config)) return false;
+      const currentWorkspace = findManagedEngineWorkspace(config.workspaces) ?? config.workspaces[0];
+      if (currentWorkspace?.id !== workspace.id) return false;
+      const current = resolveWorkspaceOpencodeConnection(config, currentWorkspace);
+      return normalizeBaseUrl(current.baseUrl) === baseUrl && current.authHeader === authHeader;
+    },
+  };
+}
 
 function readEnvNames(entry: Record<string, unknown>): string[] {
   if (!Array.isArray(entry.env)) return [];
@@ -86,10 +182,17 @@ function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iter
  * have been started against a different store, and re-delivery is cheap.
  */
 export function resetManagedProviderAuthCache(): void {
-  deliveredFingerprints.clear();
+  cacheEpoch += 1;
 }
 
-export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): Promise<ManagedProviderAuthResult> {
+export function syncManagedProviderAuth(input: ManagedProviderAuthInput): Promise<ManagedProviderAuthResult> {
+  const state = stateForConfig(input.config);
+  const run = state.tail.then(() => reconcileManagedProviderAuth(input));
+  state.tail = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+async function reconcileManagedProviderAuth(input: ManagedProviderAuthInput): Promise<ManagedProviderAuthResult> {
   const result: ManagedProviderAuthResult = {
     delivered: [],
     unchanged: [],
@@ -97,13 +200,6 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
     skipped: [],
     failed: [],
   };
-
-  const workspace = findManagedEngineWorkspace(input.config.workspaces) ?? input.config.workspaces[0];
-  if (!workspace) return result;
-
-  const connection = resolveWorkspaceOpencodeConnection(input.config, workspace);
-  const baseUrl = connection.baseUrl?.replace(/\/+$/, "");
-  if (!baseUrl) return result;
 
   const runtimeConfig = await readGlobalRuntimeOpencodeConfig(input.config);
   const providers = runtimeProviderMap(runtimeConfig);
@@ -115,13 +211,24 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
     }
   }
 
+  const target = resolveManagedProviderAuthTarget(input.config);
+  if (!target) return result;
+  const operationEpoch = cacheEpoch;
+  const state = stateForConfig(input.config);
+  if (state.appliedTargetScope !== target.scope) {
+    state.appliedTargetScope = target.scope;
+    state.deliveredFingerprints.clear();
+  }
+  const isCurrent = () => operationEpoch === cacheEpoch && target.isCurrent();
+
   const fetchImpl = input.fetchImpl ?? globalThis.fetch;
   const headers: Record<string, string> = { "content-type": "application/json" };
-  if (connection.authHeader) headers.authorization = connection.authHeader;
+  if (target.authHeader) headers.authorization = target.authHeader;
 
   const managedIds = new Set(Object.keys(providers));
 
   for (const [providerId, entry] of Object.entries(providers)) {
+    if (!isCurrent()) return result;
     const envNames = readEnvNames(entry);
     if (envNames.length === 0) {
       result.skipped.push({ providerId, reason: "no_env_names" });
@@ -139,19 +246,19 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
     }
 
     const credential = storedValues.get(credentialName) ?? "";
-    const key = fingerprintKey(baseUrl, providerId);
     const next = fingerprint(credential);
-    if (deliveredFingerprints.get(key) === next) {
+    if (state.deliveredFingerprints.get(providerId) === next) {
       result.unchanged.push(providerId);
       continue;
     }
 
     try {
-      const response = await fetchImpl(`${baseUrl}/auth/${encodeURIComponent(providerId)}`, {
+      const response = await fetchImpl(`${target.baseUrl}/auth/${encodeURIComponent(providerId)}`, {
         method: "PUT",
         headers,
         body: JSON.stringify({ type: "api", key: credential }),
       });
+      if (!isCurrent()) return result;
       if (!response.ok) {
         result.failed.push({ providerId, status: response.status });
         input.logger?.error("managed provider auth delivery rejected by engine", {
@@ -160,9 +267,16 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
         });
         continue;
       }
-      deliveredFingerprints.set(key, next);
+      state.deliveredFingerprints.set(providerId, next);
+      let ownedProviderIds = state.ownedProviderIdsByScope.get(target.ownershipScope);
+      if (!ownedProviderIds) {
+        ownedProviderIds = new Set();
+        state.ownedProviderIdsByScope.set(target.ownershipScope, ownedProviderIds);
+      }
+      ownedProviderIds.add(providerId);
       result.delivered.push(providerId);
     } catch (error) {
+      if (!isCurrent()) return result;
       result.failed.push({ providerId, status: null });
       input.logger?.error("managed provider auth delivery failed", {
         provider_id: providerId,
@@ -173,14 +287,16 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
 
   // Only ever remove ids this process delivered. Desktop users authenticate
   // providers themselves and those must never be touched here.
-  for (const key of [...deliveredFingerprints.keys()]) {
-    const [keyBaseUrl, providerId] = key.split("\u0000");
-    if (keyBaseUrl !== baseUrl || managedIds.has(providerId ?? "")) continue;
+  const ownedProviderIds = state.ownedProviderIdsByScope.get(target.ownershipScope) ?? new Set<string>();
+  for (const providerId of [...ownedProviderIds]) {
+    if (managedIds.has(providerId)) continue;
+    if (!isCurrent()) return result;
     try {
-      const response = await fetchImpl(`${baseUrl}/auth/${encodeURIComponent(providerId ?? "")}`, {
+      const response = await fetchImpl(`${target.baseUrl}/auth/${encodeURIComponent(providerId)}`, {
         method: "DELETE",
         headers,
       });
+      if (!isCurrent()) return result;
       if (!response.ok) {
         input.logger?.error("managed provider auth removal rejected by engine", {
           provider_id: providerId,
@@ -188,15 +304,18 @@ export async function syncManagedProviderAuth(input: ManagedProviderAuthInput): 
         });
         continue;
       }
-      deliveredFingerprints.delete(key);
-      result.removed.push(providerId ?? "");
+      state.deliveredFingerprints.delete(providerId);
+      ownedProviderIds.delete(providerId);
+      result.removed.push(providerId);
     } catch (error) {
+      if (!isCurrent()) return result;
       input.logger?.error("managed provider auth removal failed", {
         provider_id: providerId,
         message: error instanceof Error ? error.message : "unknown_error",
       });
     }
   }
+  if (ownedProviderIds.size === 0) state.ownedProviderIdsByScope.delete(target.ownershipScope);
 
   return result;
 }


### PR DESCRIPTION
## Why

A slow reconciliation started against an old OpenCode engine must not overwrite or delete authentication state after the runtime has moved to a replacement generation. Workspace changes and managed-engine restarts should converge on the current engine instead of leaving stale provider state behind, and OpenWork must never delete provider credentials it did not originally deliver.

This is not a generic authentication redesign: it scopes the existing delivery/removal logic to the authoritative runtime target.

## What changed

- Managed-provider auth reconciliation is serialized per server config: competing startup, configuration, and env-store syncs run one at a time.
- Applied state is bound to one exact target scope — for managed engines, the workspace plus the engine-pool generation id (so a replacement that reuses the same port starts fresh); for attached engines, the workspace plus endpoint.
- Stale asynchronous completions are ignored: every step re-checks that the resolved target is still current before applying or recording state.
- Credentials are re-applied when the managed engine generation changes.
- Deletion ownership survives managed restarts but never crosses into a different attached workspace or endpoint, and removal still only ever touches provider entries this process delivered.
- Added focused regressions for stale-generation completion, generation replacement (including URL reuse), removal after replacement, and cross-target deletion-ownership separation.

## Verification

- `XDG_CONFIG_HOME=<temp dir> pnpm --filter openwork-server test src/managed-provider-auth.test.ts` — passed (15 tests).
- `pnpm --dir apps/server typecheck` — passed.
- `git diff --check` — passed.

Verdict: Incomplete — the focused suites above are the published evidence for this change; deterministic `@openwork/testkit` coverage at this head is tracked as follow-up and has not yet been published.

## Risk and follow-up

- Medium-touch module, but behavior for a single stable engine is unchanged: same fingerprint short-circuit, same delivery and removal endpoints.
- Deferred: full packaged Desktop proof of a live engine-generation rollover under `evals/specs`.
