### PR TITLE
Make task command admission acknowledgment-safe

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -156,11 +156,14 @@ const OPENWORK_VOICE_TRANSCRIPTION_MODEL = "gpt-4o-transcribe";
 let desktopCloudSyncQueue: Promise<void> = Promise.resolve();
 const agentDiagnosticsLastRunByServer = new WeakMap<ServerConfig, Map<string, number>>();
 const agentDiagnosticsInFlightByServer = new WeakMap<ServerConfig, Set<string>>();
+const commandAdmissionsByServer = new WeakMap<ServerConfig, Map<string, { fingerprint: string; admittedAt: number }>>();
 const AGENT_DIAGNOSTICS_RATE_LIMIT_CAPACITY = 1_000;
 const AGENT_DIAGNOSTICS_MAX_IN_FLIGHT_PER_SERVER = 16;
 const AGENT_DIAGNOSTICS_MAX_REQUEST_BYTES = 256 * 1024;
 const AGENT_DIAGNOSTICS_DEFAULT_BODY_DEADLINE_MS = 2_000;
 const AGENT_DIAGNOSTICS_ERROR_FLUSH_MS = 25;
+const COMMAND_ADMISSION_CAPACITY = 10_000;
+const COMMAND_ADMISSION_TTL_MS = 24 * 60 * 60 * 1_000;
 
 function rethrowMcpAppHostError(error: unknown): never {
   if (!(error instanceof McpAppHostError)) throw error;
@@ -956,6 +959,43 @@ function isSessionCommandProxyRequest(method: string, proxyPath: string) {
   return method === "POST" && /^\/session\/[^/]+\/command$/.test(normalizeOpencodeProxyPath(proxyPath));
 }
 
+function commandAdmissionFromBody(body: ArrayBuffer | undefined): { messageId: string; fingerprint: string } | null {
+  if (!body) return null;
+  const text = new TextDecoder().decode(body);
+  try {
+    const value: unknown = JSON.parse(text);
+    if (!isRecord(value) || typeof value.messageID !== "string" || !value.messageID.trim()) return null;
+    return { messageId: value.messageID.trim(), fingerprint: hashToken(text) };
+  } catch {
+    return null;
+  }
+}
+
+function admitSessionCommand(
+  config: ServerConfig,
+  scope: string,
+  admission: { messageId: string; fingerprint: string },
+): "accepted" | "duplicate" | "conflict" {
+  const now = Date.now();
+  const admissions = commandAdmissionsByServer.get(config) ?? new Map<string, { fingerprint: string; admittedAt: number }>();
+  commandAdmissionsByServer.set(config, admissions);
+  for (const [key, value] of admissions) {
+    if (now - value.admittedAt <= COMMAND_ADMISSION_TTL_MS) break;
+    admissions.delete(key);
+  }
+
+  const key = hashToken(`${scope}\0${admission.messageId}`);
+  const existing = admissions.get(key);
+  if (existing) return existing.fingerprint === admission.fingerprint ? "duplicate" : "conflict";
+
+  if (admissions.size >= COMMAND_ADMISSION_CAPACITY) {
+    const oldest = admissions.keys().next().value;
+    if (oldest) admissions.delete(oldest);
+  }
+  admissions.set(key, { fingerprint: admission.fingerprint, admittedAt: now });
+  return "accepted";
+}
+
 function isPromptAsyncProxyRequest(method: string, proxyPath: string) {
   return method === "POST" && /^\/session\/[^/]+\/prompt_async$/.test(normalizeOpencodeProxyPath(proxyPath));
 }
@@ -1403,6 +1443,22 @@ export async function proxyOpencodeRequest(input: {
   const targetUrl = buildOpencodeProxyUrl(baseUrl, proxyPath, input.url.search);
   // Managed OpenCode proxy traffic is loopback/engine I/O; keep streaming on Node fetch.
   if (isSessionCommandProxyRequest(method, proxyPath)) {
+    const commandAdmission = commandAdmissionFromBody(body);
+    if (commandAdmission) {
+      const admissionTarget = workspace ? `workspace\0${workspace.id}` : `engine\0${baseUrl}`;
+      const admission = admitSessionCommand(
+        input.config,
+        `${admissionTarget}\0${normalizeOpencodeProxyPath(proxyPath)}`,
+        commandAdmission,
+      );
+      if (admission === "duplicate") return jsonResponse({ ok: true, accepted: true });
+      if (admission === "conflict") {
+        return jsonResponse({
+          code: "command_admission_conflict",
+          message: "This command message ID was already admitted with different input",
+        }, 409);
+      }
+    }
     void loopbackFetch(targetUrl, {
       method,
       headers,

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { startServer } from "./server.js";
+import { proxyOpencodeRequest, startServer } from "./server.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 type Served = {
@@ -390,30 +390,103 @@ describe("workspace session read APIs", () => {
     await expect(response.json()).resolves.toMatchObject({ code: "session_not_found" });
   });
 
-  test("acknowledges proxied session commands before upstream completion", async () => {
+  test.serial("acknowledges proxied session commands before upstream completion and admits each message once", async () => {
     const workspaceRoot = await createWorkspaceRoot();
-    const command = deferred();
-    const mock = startMockOpencode({ holdCommand: command.promise });
-    const openwork = await startOpenworkServer({
-      workspaceRoot,
-      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
-    });
+    const engineUrl = "http://127.0.0.1:4111";
+    const replacementEngineUrl = "http://127.0.0.1:4222";
+    const workspace: WorkspaceInfo = {
+      id: "ws_1",
+      name: "Workspace",
+      path: workspaceRoot,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: engineUrl,
+    };
+    const config: ServerConfig = {
+      host: "127.0.0.1",
+      port: 0,
+      token: "owt_test_token",
+      hostToken: "owt_host_token",
+      approval: { mode: "auto", timeoutMs: 1_000 },
+      corsOrigins: ["*"],
+      workspaces: [workspace],
+      authorizedRoots: [workspaceRoot],
+      readOnly: false,
+      startedAt: Date.now(),
+      tokenSource: "cli",
+      hostTokenSource: "cli",
+      logFormat: "pretty",
+      logRequests: false,
+    };
+    const originalFetch = globalThis.fetch;
+    const requests: string[] = [];
+    const upstream = deferred();
+    globalThis.fetch = Object.assign(
+      (input: Parameters<typeof fetch>[0]) => {
+        requests.push(input instanceof Request ? input.url : String(input));
+        return upstream.promise.then(() => Response.json({ ok: true }));
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const sendCommand = (
+      targetWorkspace: WorkspaceInfo,
+      sessionId: string,
+      body: string,
+    ) => {
+      const proxyPath = `/session/${sessionId}/command`;
+      const url = new URL(`http://openwork.invalid/opencode${proxyPath}`);
+      return proxyOpencodeRequest({
+        config,
+        workspace: targetWorkspace,
+        proxyPath,
+        url,
+        request: new Request(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        }),
+      });
+    };
+    const commandBody = JSON.stringify({ messageID: "msg_command_once", command: "review", arguments: "" });
 
-    const response = await Promise.race([
-      fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session/ses_1/command`, {
-        method: "POST",
-        headers: { ...auth(openwork.token), "Content-Type": "application/json" },
-        body: JSON.stringify({ command: "review", arguments: "" }),
-      }),
-      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
-    ]);
+    try {
+      const response = await Promise.race([
+        sendCommand(workspace, "ses_1", commandBody),
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+      ]);
+      expect(response).not.toBe("timeout");
+      expect(response instanceof Response ? response.status : 0).toBe(200);
+      await expect(response instanceof Response ? response.json() : null).resolves.toMatchObject({ accepted: true });
 
-    expect(response).not.toBe("timeout");
-    expect(response instanceof Response ? response.status : 0).toBe(200);
-    await expect(response instanceof Response ? response.json() : null).resolves.toMatchObject({ accepted: true });
-    const sawCommand = await waitUntil(() => mock.requests.some((request) => request.pathname === "/session/ses_1/command"));
-    command.resolve();
-    expect(sawCommand).toBe(true);
+      const duplicate = await sendCommand(workspace, "ses_1", commandBody);
+      expect(duplicate.status).toBe(200);
+      await expect(duplicate.json()).resolves.toMatchObject({ accepted: true });
+
+      const conflict = await sendCommand(
+        workspace,
+        "ses_1",
+        JSON.stringify({ messageID: "msg_command_once", command: "summarize", arguments: "" }),
+      );
+      expect(conflict.status).toBe(409);
+      await expect(conflict.json()).resolves.toMatchObject({ code: "command_admission_conflict" });
+
+      const rolloverDuplicate = await sendCommand(
+        { ...workspace, baseUrl: replacementEngineUrl },
+        "ses_1",
+        commandBody,
+      );
+      const otherSession = await sendCommand(workspace, "ses_2", commandBody);
+      expect(rolloverDuplicate.status).toBe(200);
+      expect(otherSession.status).toBe(200);
+      expect(requests.map((request) => new URL(request).pathname)).toEqual([
+        "/session/ses_1/command",
+        "/session/ses_2/command",
+      ]);
+      expect(requests.every((request) => request.startsWith(engineUrl))).toBe(true);
+    } finally {
+      upstream.resolve();
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("keeps legacy /w workspace opencode proxy alias", async () => {


### PR DESCRIPTION
## Why

Retries should not duplicate a side-effecting session command or leave the user unsure whether it was admitted. The proxy acknowledges session commands before upstream completion, so a client retry after a dropped acknowledgment could dispatch the same command twice.

This gives proxied session commands a bounded, acknowledgment-safe admission boundary at the OpenWork proxy. It is not exactly-once execution across every downstream failure, and it deliberately stays out of durable distributed command-ledger territory.

## What changed

- The proxy uses the OpenCode command `messageID` plus a fingerprint of the scoped request body as the idempotency boundary, keyed per workspace (or per engine base URL when no workspace is attached) and per session path.
- Three outcomes: first admission dispatches upstream; an identical retry (same message ID, same body) is acknowledged without a second dispatch; reuse of an admitted message ID with different input returns a `409 command_admission_conflict`.
- The same message ID remains independently valid in a different session or runtime target.
- Admission storage is bounded by capacity (10k entries) and a 24h TTL, scoped to the server config lifetime.
- Extended the existing proxy acknowledgment test to cover first admission, duplicate acknowledgment, conflicting reuse, cross-session independence, and single upstream dispatch.

## Verification

- `pnpm --filter openwork-server test src/session-read-model.e2e.test.ts --test-name-pattern "admits each message once"` — passed (1 test, 10 filtered).
- `git diff --check` — passed.

Verdict: Incomplete — the focused suites above are the published evidence for this change; deterministic `@openwork/testkit` coverage at this head is tracked as follow-up and has not yet been published.

## Risk and follow-up

- Admission is recorded before the fire-and-forget upstream dispatch, matching the existing acknowledge-before-completion contract. A definite synchronous upstream dispatch failure after admission is not yet surfaced back through the duplicate path; proving and, if needed, tightening that failure path is deferred follow-up.
- In-memory admission state does not survive a server restart; a restart returns to today's behavior rather than misreporting.
