### PR TITLE
Keep streaming responsive under long active tasks

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
+++ b/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
@@ -42,6 +42,7 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
       workspaceId: props.workspaceId,
       baseUrl: props.opencodeBaseUrl,
       openworkToken: props.openworkToken,
+      visibleSessionId: props.sessionId,
       ...stableCallbacks,
     };
     const releaseWorkspace = ensureWorkspaceSessionSync(input);

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -33,23 +33,34 @@ import {
   createSessionTitleRecovery,
   type SessionTitleRecovery,
 } from "./session-title-recovery";
+import {
+  applyPendingDeltasToTranscript,
+  coalescePendingDeltas,
+  getPartMetadataId,
+  inferStubRole,
+  partitionPendingDeltasByLane,
+  partitionPendingDeltasBySession,
+  selectDeltaFlushLane,
+  type DeltaFlushLane,
+  type PendingDelta,
+} from "./session-transcript-deltas";
+
+export {
+  applyPendingDeltasToTranscript,
+  coalescePendingDeltas,
+  type DeltaFlushLane,
+  type PendingDelta,
+} from "./session-transcript-deltas";
 
 type SyncOptions = {
   workspaceId: string;
   baseUrl: string;
   openworkToken: string;
+  visibleSessionId?: string | null;
   onSessionCreated?: (session: Session) => void;
   onSessionUpdated?: (update: { sessionId: string; info: Record<string, unknown> }) => void;
   onSessionDeleted?: (sessionId: string) => void;
   onSessionStatus?: (update: { sessionId: string; status: SessionStatus }) => void;
-};
-
-type PendingDelta = {
-  sessionId: string;
-  messageId: string;
-  partId: string;
-  reasoning: boolean;
-  delta: string;
 };
 
 type ListenerRegistry<Listener> = Map<Listener, number>;
@@ -67,15 +78,19 @@ type SyncEntry = {
   sessionDeletedListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionDeleted"]>>;
   sessionStatusListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionStatus"]>>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
-  // Coalesce rapid-fire delta events from the SSE stream into one cache
-  // commit per animation frame. Without this, a long response produces a
-  // setQueryData per token; each triggers a full transcript re-render
-  // (~27ms on large sessions) which starves the main thread and looks to
-  // the user like the app "freezes after 2 words."
+  // Coalesce rapid-fire delta events from the SSE stream into one visible
+  // cache commit per animation frame. Background transcripts use a slower
+  // lane because they have no renderer waiting on token-sized updates.
   deltaFlushBuffer: PendingDelta[];
-  deltaFlushScheduled: boolean;
+  deltaFlushLane: DeltaFlushLane | null;
+  cancelDeltaFlush: (() => void) | null;
   titleRecovery: SessionTitleRecovery | null;
 };
+
+type DeltaFlushScheduler = (
+  lane: DeltaFlushLane,
+  run: () => void,
+) => () => void;
 
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
@@ -83,6 +98,7 @@ const sessionSnapshotFetchStarts = new WeakMap<OpenworkSessionSnapshot, number>(
 const workspaceSyncDisposeGraceMs = 2_000;
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
+const backgroundDeltaFlushMs = 100;
 
 function createListenerRegistry<Listener>(listener?: Listener) {
   const registry: ListenerRegistry<Listener> = new Map();
@@ -136,6 +152,31 @@ const defaultSessionStatusFetcher: SessionStatusFetcher = async (baseUrl, openwo
 
 let syncSubscriptionFactory = defaultSyncSubscriptionFactory;
 let sessionStatusFetcher = defaultSessionStatusFetcher;
+
+const defaultDeltaFlushScheduler: DeltaFlushScheduler = (lane, run) => {
+  if (
+    lane === "foreground" &&
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function" &&
+    (typeof document === "undefined" || document.visibilityState === "visible")
+  ) {
+    const frame = window.requestAnimationFrame(run);
+    return () => window.cancelAnimationFrame(frame);
+  }
+  if (typeof window !== "undefined") {
+    const timer = window.setTimeout(run, lane === "foreground" ? 50 : backgroundDeltaFlushMs);
+    return () => window.clearTimeout(timer);
+  }
+  let cancelled = false;
+  queueMicrotask(() => {
+    if (!cancelled) run();
+  });
+  return () => {
+    cancelled = true;
+  };
+};
+
+let deltaFlushScheduler = defaultDeltaFlushScheduler;
 
 export function markSessionSnapshotFetchStart(snapshot: OpenworkSessionSnapshot, startedAt: number) {
   sessionSnapshotFetchStarts.set(snapshot, startedAt);
@@ -281,6 +322,11 @@ function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: st
   entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
     (item) => item.sessionId !== sessionId,
   );
+  if (entry.deltaFlushBuffer.length === 0) {
+    entry.cancelDeltaFlush?.();
+    entry.deltaFlushLane = null;
+    entry.cancelDeltaFlush = null;
+  }
   const queryClient = getReactQueryClient();
   queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, sessionId), exact: true });
   // Status entries are exempt from TanStack GC (see query-client.ts), so the
@@ -307,6 +353,9 @@ function disposeWorkspaceSync(key: string, entry: SyncEntry) {
   }
   for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
   entry.retainedSessionTimers.clear();
+  entry.cancelDeltaFlush?.();
+  entry.deltaFlushLane = null;
+  entry.cancelDeltaFlush = null;
   entry.titleRecovery?.dispose();
   entry.dispose();
   if (syncs.get(key) === entry) syncs.delete(key);
@@ -542,18 +591,6 @@ function toUIParts(part: Part): UIMessage["parts"] {
   return [mapped];
 }
 
-function getPartMetadataId(part: UIMessage["parts"][number]) {
-  if (part.type === "dynamic-tool") {
-    const metadata = part.callProviderMetadata?.opencode;
-    if (!metadata || typeof metadata !== "object") return null;
-    return "partId" in metadata ? (metadata as { partId?: string }).partId ?? null : null;
-  }
-  if (part.type !== "text" && part.type !== "reasoning" && part.type !== "file" && part.type !== "source-url" && part.type !== "source-document") return null;
-  const metadata = part.providerMetadata?.opencode;
-  if (!metadata || typeof metadata !== "object") return null;
-  return "partId" in metadata ? (metadata as { partId?: string }).partId ?? null : null;
-}
-
 function upsertMessage(messages: UIMessage[], next: UIMessage) {
   const index = messages.findIndex((message) => message.id === next.id);
   if (index === -1) return [...messages, next];
@@ -566,28 +603,6 @@ function upsertMessage(messages: UIMessage[], next: UIMessage) {
         }
       : message,
   );
-}
-
-/**
- * When a message.part.updated or message.part.delta event arrives for a
- * messageID we haven't seen a message.updated for yet, we have to stub the
- * message so the part has somewhere to live. The stub's role used to be
- * hard-coded to "assistant", which meant that if part events beat the
- * message.updated event for a *user* turn (a common race during
- * promptAsync), that user message flashed as an assistant-styled block
- * until the real role arrived a tick later.
- *
- * Infer the stub role from the conversation instead. Chat sessions
- * alternate, so the new message is almost always the opposite role of the
- * most recent known message. If the transcript is empty the first message
- * is always the user's.
- */
-function inferStubRole(messages: UIMessage[]): UIMessage["role"] {
-  const lastMessage = messages[messages.length - 1];
-  if (!lastMessage) return "user";
-  if (lastMessage.role === "user") return "assistant";
-  if (lastMessage.role === "assistant") return "user";
-  return "assistant";
 }
 
 function upsertPart(messages: UIMessage[], messageId: string, partId: string, next: UIMessage["parts"][number]) {
@@ -603,98 +618,6 @@ function upsertPart(messages: UIMessage[], messageId: string, partId: string, ne
     parts[index] = next;
     return { ...message, parts };
   });
-}
-
-function appendDelta(messages: UIMessage[], messageId: string, partId: string, delta: string, reasoning: boolean) {
-  // Fast path: locate the target message by index, only clone that message
-  // and its parts array. The previous implementation ran messages.map AND
-  // message.parts.map on every delta event, which is O(N * P) per token.
-  // For an old session with hundreds of prior messages/parts that allocated
-  // thousands of objects per token and crushed the main thread after a
-  // handful of tokens.
-  const messageIndex = messages.findIndex((message) => message.id === messageId);
-  if (messageIndex === -1) return messages;
-
-  const target = messages[messageIndex]!;
-  const lastPart = target.parts[target.parts.length - 1];
-
-  let partIndex = -1;
-  for (let i = 0; i < target.parts.length; i++) {
-    const part = target.parts[i]!;
-    const id = getPartMetadataId(part);
-    if (reasoning && part.type === "reasoning") {
-      if (id === partId || (!id && part === lastPart)) {
-        partIndex = i;
-        break;
-      }
-    } else if (!reasoning && part.type === "text") {
-      if (id === partId || (!id && part === lastPart)) {
-        partIndex = i;
-        break;
-      }
-    }
-  }
-
-  let nextParts: UIMessage["parts"];
-  if (partIndex === -1) {
-    // No existing matching part — append a fresh one so the delta is not lost.
-    const newPart: UIMessage["parts"][number] = reasoning
-      ? {
-          type: "reasoning",
-          text: delta,
-          state: "streaming" as const,
-          providerMetadata: { opencode: { partId } },
-        }
-      : {
-          type: "text",
-          text: delta,
-          state: "streaming" as const,
-          providerMetadata: { opencode: { partId } },
-        };
-    nextParts = target.parts.slice();
-    nextParts.push(newPart);
-  } else {
-    const existing = target.parts[partIndex]!;
-    nextParts = target.parts.slice();
-    if (existing.type === "text") {
-      nextParts[partIndex] = {
-        ...existing,
-        text: `${existing.text}${delta}`,
-        state: "streaming",
-      };
-    } else if (existing.type === "reasoning") {
-      nextParts[partIndex] = {
-        ...existing,
-        text: `${existing.text}${delta}`,
-        state: "streaming",
-      };
-    }
-  }
-
-  const nextMessages = messages.slice();
-  nextMessages[messageIndex] = { ...target, parts: nextParts };
-  return nextMessages;
-}
-
-export function coalescePendingDeltas(items: PendingDelta[]) {
-  if (items.length < 2) return items;
-
-  const ordered: PendingDelta[] = [];
-  const byKey = new Map<string, PendingDelta>();
-  for (const item of items) {
-    const key = `${item.sessionId}\u0000${item.messageId}\u0000${item.partId}`;
-    const existing = byKey.get(key);
-    if (existing) {
-      existing.delta += item.delta;
-      existing.reasoning = existing.reasoning || item.reasoning;
-      continue;
-    }
-
-    const next = { ...item };
-    byKey.set(key, next);
-    ordered.push(next);
-  }
-  return ordered;
 }
 
 function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent) {
@@ -757,6 +680,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       notifyDesktopEvent({ type: "task.failed", sessionId, errorText });
       useSessionActivityStore.getState().setError(workspaceId, sessionId, errorText);
       if (isTrackedSession(entry, sessionId)) {
+        flushSessionDeltas(entry, workspaceId, sessionId);
         queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId), (current = []) => {
           // Key the error to the latest assistant turn so it lands beside the
           // turn that failed and a later turn's error becomes its own message
@@ -1048,6 +972,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     useSessionActivityStore.getState().setRunStatus(workspaceId, props.sessionID, idleStatus);
     const tracked = isTrackedSession(entry, props.sessionID);
     if (tracked) {
+      // Background deltas normally trade token-level freshness for lower
+      // notification frequency. A terminal event is the convergence point:
+      // commit its remaining text before the durable snapshot is refreshed.
+      flushSessionDeltas(entry, workspaceId, props.sessionID);
       queryClient.setQueryData(statusKey(workspaceId, props.sessionID), idleStatus);
       // A fast tool can complete and persist before its final part.updated SSE
       // reaches the renderer. Reconcile successful turns from the durable
@@ -1064,35 +992,55 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
 }
 
 function scheduleDeltaFlush(entry: SyncEntry, workspaceId: string) {
-  if (entry.deltaFlushScheduled) return;
-  entry.deltaFlushScheduled = true;
-  const run = () => {
-    entry.deltaFlushScheduled = false;
-    if (entry.deltaFlushBuffer.length === 0) return;
-    flushDeltas(entry, workspaceId);
-  };
-  if (
-    typeof window !== "undefined" &&
-    typeof window.requestAnimationFrame === "function" &&
-    (typeof document === "undefined" || document.visibilityState === "visible")
-  ) {
-    window.requestAnimationFrame(run);
-  } else if (typeof window !== "undefined") {
-    window.setTimeout(run, 50);
-  } else {
-    queueMicrotask(run);
-  }
+  if (entry.deltaFlushBuffer.length === 0) return;
+  const lane = selectDeltaFlushLane(entry.deltaFlushBuffer, entry.input.visibleSessionId);
+  if (entry.deltaFlushLane === lane || entry.deltaFlushLane === "foreground") return;
+
+  entry.cancelDeltaFlush?.();
+  entry.deltaFlushLane = lane;
+  entry.cancelDeltaFlush = deltaFlushScheduler(lane, () => {
+    if (entry.deltaFlushLane !== lane) return;
+    entry.deltaFlushLane = null;
+    entry.cancelDeltaFlush = null;
+    flushDeltas(entry, workspaceId, lane);
+    scheduleDeltaFlush(entry, workspaceId);
+  });
 }
 
-function flushDeltas(entry: SyncEntry, workspaceId: string) {
-  const queryClient = getReactQueryClient();
+function flushDeltas(entry: SyncEntry, workspaceId: string, lane: DeltaFlushLane) {
   const pending = coalescePendingDeltas(entry.deltaFlushBuffer);
-  entry.deltaFlushBuffer = [];
+  const { flushing, deferred } = partitionPendingDeltasByLane(
+    pending,
+    entry.input.visibleSessionId,
+    lane,
+  );
+  entry.deltaFlushBuffer = deferred;
+  commitDeltas(entry, workspaceId, flushing);
+}
+
+function flushSessionDeltas(entry: SyncEntry, workspaceId: string, sessionId: string) {
+  const { flushing, deferred } = partitionPendingDeltasBySession(
+    entry.deltaFlushBuffer,
+    sessionId,
+  );
+  if (flushing.length === 0) return;
+
+  entry.deltaFlushBuffer = deferred;
+  if (deferred.length === 0) {
+    entry.cancelDeltaFlush?.();
+    entry.deltaFlushLane = null;
+    entry.cancelDeltaFlush = null;
+  }
+  commitDeltas(entry, workspaceId, coalescePendingDeltas(flushing));
+}
+
+function commitDeltas(entry: SyncEntry, workspaceId: string, items: PendingDelta[]) {
+  const queryClient = getReactQueryClient();
 
   // Group by session id so each transcript cache is touched at most once
   // per flush.
   const bySession = new Map<string, PendingDelta[]>();
-  for (const item of pending) {
+  for (const item of items) {
     const bucket = bySession.get(item.sessionId);
     if (bucket) bucket.push(item);
     else bySession.set(item.sessionId, [item]);
@@ -1102,57 +1050,20 @@ function flushDeltas(entry: SyncEntry, workspaceId: string) {
     queryClient.setQueryData<UIMessage[]>(
       transcriptKey(workspaceId, sessionId),
       (current = []) => {
-        let next = current;
-        const nextById = new Map(next.map((message) => [message.id, message]));
-        // Track which message shells we've ensured exist this flush so we
-        // don't call upsertMessage for the same message on every delta.
-        const ensuredMessageIds = new Set<string>();
-        for (const item of items) {
-          if (!ensuredMessageIds.has(item.messageId)) {
-            // Preserve the existing role if the message is already in
-            // state; otherwise infer it from the alternation pattern
-            // so the brief "stub before message.updated" window doesn't
-            // mislabel the message's bubble style.
-            const existing = nextById.get(item.messageId);
-            const role = existing?.role ?? inferStubRole(next);
-            const ensuredMessage = { id: item.messageId, role, parts: existing?.parts ?? [] };
-            next = upsertMessage(next, ensuredMessage);
-            nextById.set(item.messageId, ensuredMessage);
-            ensuredMessageIds.add(item.messageId);
-          }
-          // Resolve the part kind from the transcript instead of trusting
-          // the inbound delta event (opencode emits `field: "text"` for
-          // both text and reasoning parts). If the part hasn't been
-          // declared yet via `message.part.updated`, defer the delta into
-          // `entry.pendingDeltas` so the part can be created with the
-          // correct kind later. Without this, every delta lands as a text
-          // part — and reasoning content leaks into the response markdown
-          // until the next reload reconstructs the transcript from the
-          // snapshot.
-          const ownerMessage = nextById.get(item.messageId);
-          const ownerPartsById = new Map(
-            (ownerMessage?.parts ?? []).flatMap((part) => {
-              const id = part.type === "dynamic-tool" ? part.toolCallId : getPartMetadataId(part);
-              return id ? [[id, part] as const] : [];
-            }),
-          );
-          const ownerPart = ownerPartsById.get(item.partId);
-
-          if (!ownerPart) {
-            const existing = entry.pendingDeltas.get(item.partId) ?? {
-              messageId: item.messageId,
-              reasoning: item.reasoning,
-              text: "",
-            };
-            existing.text += item.delta;
-            entry.pendingDeltas.set(item.partId, existing);
-            continue;
-          }
-
-          const reasoning = ownerPart.type === "reasoning";
-          next = appendDelta(next, item.messageId, item.partId, item.delta, reasoning);
+        const result = applyPendingDeltasToTranscript(current, items);
+        for (const item of result.unapplied) {
+          // The declaration event is the source of truth for text versus
+          // reasoning. Hold early deltas until that event arrives instead of
+          // projecting them into the wrong Markdown surface.
+          const existing = entry.pendingDeltas.get(item.partId) ?? {
+            messageId: item.messageId,
+            reasoning: item.reasoning,
+            text: "",
+          };
+          existing.text += item.delta;
+          entry.pendingDeltas.set(item.partId, existing);
         }
-        return next;
+        return result.messages;
       },
     );
   }
@@ -1282,6 +1193,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   const key = syncKey(input);
   const existing = syncs.get(key);
   if (existing) {
+    existing.input = input;
     existing.openworkToken = input.openworkToken;
     if (existing.disposeTimer) {
       clearTimeout(existing.disposeTimer);
@@ -1292,6 +1204,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     retainListener(existing.sessionDeletedListeners, input.onSessionDeleted);
     retainListener(existing.sessionStatusListeners, input.onSessionStatus);
     existing.refs += 1;
+    scheduleDeltaFlush(existing, input.workspaceId);
     return () => releaseWorkspaceSessionSync(input);
   }
 
@@ -1309,7 +1222,8 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     sessionStatusListeners: createListenerRegistry(input.onSessionStatus),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
-    deltaFlushScheduled: false,
+    deltaFlushLane: null,
+    cancelDeltaFlush: null,
     titleRecovery: null,
   };
   created.titleRecovery = createSessionTitleRecovery({
@@ -1502,7 +1416,8 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     sessionStatusListeners: createListenerRegistry(input.onSessionStatus),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
-    deltaFlushScheduled: false,
+    deltaFlushLane: null,
+    cancelDeltaFlush: null,
     titleRecovery: null,
   });
   return () => {
@@ -1530,6 +1445,17 @@ export function __applySessionSyncEventForTest(input: SyncOptions, event: Openco
   const entry = syncs.get(syncKey(input));
   if (!entry) return;
   applyEvent(entry, input.workspaceId, event);
+}
+
+export function __queueSessionSyncDeltaForTest(input: SyncOptions, delta: PendingDelta) {
+  const entry = syncs.get(syncKey(input));
+  if (!entry) return;
+  entry.deltaFlushBuffer.push(delta);
+  scheduleDeltaFlush(entry, input.workspaceId);
+}
+
+export function __setSessionSyncDeltaFlushSchedulerForTest(scheduler: DeltaFlushScheduler | null) {
+  deltaFlushScheduler = scheduler ?? defaultDeltaFlushScheduler;
 }
 
 export function __setWorkspaceSessionSyncSubscriptionFactoryForTest(factory: SyncSubscriptionFactory | null) {

--- a/apps/app/src/react-app/domains/session/sync/session-transcript-deltas.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-transcript-deltas.ts
@@ -1,0 +1,213 @@
+import type { UIMessage } from "ai";
+
+export type PendingDelta = {
+  sessionId: string;
+  messageId: string;
+  partId: string;
+  reasoning: boolean;
+  delta: string;
+};
+
+export type DeltaFlushLane = "foreground" | "background";
+
+type TranscriptMessageDraft = {
+  message: UIMessage;
+  partIndexById: Map<string, number>;
+};
+
+export function getPartMetadataId(part: UIMessage["parts"][number]) {
+  if (part.type === "dynamic-tool") {
+    const metadata = part.callProviderMetadata?.opencode;
+    if (!metadata || typeof metadata !== "object") return null;
+    const partId = Reflect.get(metadata, "partId");
+    return typeof partId === "string" ? partId : null;
+  }
+  if (part.type !== "text" && part.type !== "reasoning" && part.type !== "file" && part.type !== "source-url" && part.type !== "source-document") return null;
+  const metadata = part.providerMetadata?.opencode;
+  if (!metadata || typeof metadata !== "object") return null;
+  const partId = Reflect.get(metadata, "partId");
+  return typeof partId === "string" ? partId : null;
+}
+
+/**
+ * Infer the role of a message shell created before its message.updated event.
+ * Chat sessions alternate, so the new message normally has the opposite role
+ * from the most recent known message.
+ */
+export function inferStubRole(messages: UIMessage[]): UIMessage["role"] {
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) return "user";
+  if (lastMessage.role === "user") return "assistant";
+  if (lastMessage.role === "assistant") return "user";
+  return "assistant";
+}
+
+function indexMessageParts(parts: UIMessage["parts"]) {
+  const indexById = new Map<string, number>();
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (!part) continue;
+    const partId = part.type === "dynamic-tool" ? part.toolCallId : getPartMetadataId(part);
+    if (partId) indexById.set(partId, index);
+  }
+  return indexById;
+}
+
+/**
+ * Apply a frame's coalesced text deltas with one transcript clone and one
+ * parts clone per touched message. Message and part indexes are built once,
+ * avoiding repeated full-transcript scans in long sessions.
+ */
+export function applyPendingDeltasToTranscript(
+  messages: UIMessage[],
+  items: PendingDelta[],
+) {
+  if (items.length === 0) return { messages, unapplied: new Array<PendingDelta>() };
+
+  let nextMessages = messages;
+  const messageIndexById = new Map<string, number>();
+  const draftsByMessageId = new Map<string, TranscriptMessageDraft>();
+  const partIndexesByMessageId = new Map<string, Map<string, number>>();
+  const unapplied: PendingDelta[] = [];
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message) messageIndexById.set(message.id, index);
+  }
+
+  const ensureMessage = (item: PendingDelta) => {
+    const knownIndex = messageIndexById.get(item.messageId);
+    if (knownIndex !== undefined) return knownIndex;
+
+    if (nextMessages === messages) nextMessages = messages.slice();
+    const message: UIMessage = {
+      id: item.messageId,
+      role: inferStubRole(nextMessages),
+      parts: [],
+    };
+    const index = nextMessages.length;
+    nextMessages.push(message);
+    messageIndexById.set(item.messageId, index);
+    return index;
+  };
+
+  const draftMessage = (messageId: string, index: number) => {
+    const existingDraft = draftsByMessageId.get(messageId);
+    if (existingDraft) return existingDraft;
+
+    const current = nextMessages[index];
+    if (!current) return null;
+    const parts = current.parts.slice();
+    const message = { ...current, parts };
+    if (nextMessages === messages) nextMessages = messages.slice();
+    nextMessages[index] = message;
+    const partIndexById = partIndexesByMessageId.get(messageId) ?? indexMessageParts(parts);
+    partIndexesByMessageId.set(messageId, partIndexById);
+    const draft = { message, partIndexById };
+    draftsByMessageId.set(messageId, draft);
+    return draft;
+  };
+
+  for (const item of items) {
+    const messageIndex = ensureMessage(item);
+    const currentMessage = nextMessages[messageIndex];
+    if (!currentMessage) {
+      unapplied.push(item);
+      continue;
+    }
+
+    let partIndexById = partIndexesByMessageId.get(item.messageId);
+    if (!partIndexById) {
+      partIndexById = indexMessageParts(currentMessage.parts);
+      partIndexesByMessageId.set(item.messageId, partIndexById);
+    }
+    const ownerPartIndex = partIndexById.get(item.partId);
+    if (ownerPartIndex === undefined) {
+      unapplied.push(item);
+      continue;
+    }
+
+    const draft = draftMessage(item.messageId, messageIndex);
+    if (!draft) {
+      unapplied.push(item);
+      continue;
+    }
+    const ownerPart = draft.message.parts[ownerPartIndex];
+    if (ownerPart?.type === "text" || ownerPart?.type === "reasoning") {
+      draft.message.parts[ownerPartIndex] = {
+        ...ownerPart,
+        text: `${ownerPart.text}${item.delta}`,
+        state: "streaming",
+      };
+      continue;
+    }
+
+    const part: UIMessage["parts"][number] = {
+      type: "text",
+      text: item.delta,
+      state: "streaming",
+      providerMetadata: { opencode: { partId: item.partId } },
+    };
+    draft.partIndexById.set(item.partId, draft.message.parts.length);
+    draft.message.parts.push(part);
+  }
+
+  return { messages: nextMessages, unapplied };
+}
+
+export function coalescePendingDeltas(items: PendingDelta[]) {
+  if (items.length < 2) return items;
+
+  const ordered: PendingDelta[] = [];
+  const byKey = new Map<string, PendingDelta>();
+  for (const item of items) {
+    const key = `${item.sessionId}\u0000${item.messageId}\u0000${item.partId}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.delta += item.delta;
+      existing.reasoning = existing.reasoning || item.reasoning;
+      continue;
+    }
+
+    const next = { ...item };
+    byKey.set(key, next);
+    ordered.push(next);
+  }
+  return ordered;
+}
+
+export function selectDeltaFlushLane(
+  items: PendingDelta[],
+  visibleSessionId?: string | null,
+): DeltaFlushLane {
+  const visible = visibleSessionId?.trim();
+  return visible && items.some((item) => item.sessionId === visible)
+    ? "foreground"
+    : "background";
+}
+
+export function partitionPendingDeltasByLane(
+  items: PendingDelta[],
+  visibleSessionId: string | null | undefined,
+  lane: DeltaFlushLane,
+) {
+  const visible = visibleSessionId?.trim();
+  const flushing: PendingDelta[] = [];
+  const deferred: PendingDelta[] = [];
+  for (const item of items) {
+    const itemLane = visible === item.sessionId ? "foreground" : "background";
+    if (itemLane === lane) flushing.push(item);
+    else deferred.push(item);
+  }
+  return { flushing, deferred };
+}
+
+export function partitionPendingDeltasBySession(items: PendingDelta[], sessionId: string) {
+  const flushing: PendingDelta[] = [];
+  const deferred: PendingDelta[] = [];
+  for (const item of items) {
+    if (item.sessionId === sessionId) flushing.push(item);
+    else deferred.push(item);
+  }
+  return { flushing, deferred };
+}

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -9,6 +9,9 @@ import {
   __createWorkspaceSessionSyncForTest,
   __disposeWorkspaceSessionSyncForTest,
   __hasWorkspaceSessionSyncForTest,
+  __queueSessionSyncDeltaForTest,
+  __setSessionSyncDeltaFlushSchedulerForTest,
+  applyPendingDeltasToTranscript,
   coalescePendingDeltas,
   ensureWorkspaceSessionSync,
   permissionKey,
@@ -18,6 +21,7 @@ import {
   seedSessionState,
   trackWorkspaceSessionSync,
   transcriptKey,
+  type DeltaFlushLane,
 } from "../src/react-app/domains/session/sync/session-sync";
 
 function permission(id: string, sessionID: string): PermissionRequest {
@@ -256,6 +260,168 @@ describe("session transcript sync", () => {
       { sessionId: "session-a", messageId: "msg-a", partId: "part-b", reasoning: true, delta: "think" },
       { sessionId: "session-b", messageId: "msg-b", partId: "part-a", reasoning: false, delta: "other" },
     ]);
+  });
+
+  test("applies a frame of deltas with stable history references", () => {
+    const history = Array.from({ length: 200 }, (_, index) =>
+      uiMessage(`history-${index}`, index % 2 === 0 ? "user" : "assistant", `history ${index}`),
+    );
+    const active: UIMessage = {
+      id: "active-assistant",
+      role: "assistant",
+      parts: [
+        {
+          type: "reasoning",
+          text: "think",
+          state: "streaming",
+          providerMetadata: { opencode: { partId: "reasoning-part" } },
+        },
+        {
+          type: "text",
+          text: "answer",
+          state: "streaming",
+          providerMetadata: { opencode: { partId: "text-part" } },
+        },
+        {
+          type: "file",
+          url: "file:///tmp/result.txt",
+          mediaType: "text/plain",
+          providerMetadata: { opencode: { partId: "file-part" } },
+        },
+      ],
+    };
+    const transcript = [...history, active];
+
+    const result = applyPendingDeltasToTranscript(transcript, [
+      { sessionId: "session-a", messageId: active.id, partId: "reasoning-part", reasoning: false, delta: " more" },
+      { sessionId: "session-a", messageId: active.id, partId: "text-part", reasoning: false, delta: " one" },
+      { sessionId: "session-a", messageId: active.id, partId: "text-part", reasoning: false, delta: " two" },
+      { sessionId: "session-a", messageId: active.id, partId: "not-declared", reasoning: false, delta: "later" },
+    ]);
+
+    expect(result.unapplied.map((item) => item.delta)).toEqual(["later"]);
+    expect(result.messages).not.toBe(transcript);
+    expect(result.messages.slice(0, history.length).every((message, index) => message === history[index])).toBe(true);
+    expect(result.messages.at(-1)).not.toBe(active);
+    expect(result.messages.at(-1)?.parts[0]).toMatchObject({ type: "reasoning", text: "think more" });
+    expect(result.messages.at(-1)?.parts[1]).toMatchObject({ type: "text", text: "answer one two" });
+    expect(result.messages.at(-1)?.parts[2]).toBe(active.parts[2]);
+  });
+
+  test("commits visible deltas before background-session deltas", () => {
+    const scheduled: Array<{
+      lane: DeltaFlushLane;
+      run: () => void;
+      cancelled: boolean;
+    }> = [];
+    __setSessionSyncDeltaFlushSchedulerForTest((lane, run) => {
+      const task = { lane, run, cancelled: false };
+      scheduled.push(task);
+      return () => {
+        task.cancelled = true;
+      };
+    });
+
+    const syncInput = {
+      workspaceId: "workspace-priority",
+      baseUrl: "http://127.0.0.1:4321",
+      openworkToken: "token",
+      visibleSessionId: "session-visible",
+    };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const releaseVisible = trackWorkspaceSessionSync(syncInput, "session-visible");
+    const releaseBackground = trackWorkspaceSessionSync(syncInput, "session-background");
+    const streamMessage = (messageId: string, partId: string): UIMessage => ({
+      id: messageId,
+      role: "assistant",
+      parts: [{
+        type: "text",
+        text: "",
+        state: "streaming",
+        providerMetadata: { opencode: { partId } },
+      }],
+    });
+    const queryClient = getReactQueryClient();
+    queryClient.setQueryData(
+      transcriptKey(syncInput.workspaceId, "session-visible"),
+      [streamMessage("message-visible", "part-visible")],
+    );
+    queryClient.setQueryData(
+      transcriptKey(syncInput.workspaceId, "session-background"),
+      [streamMessage("message-background", "part-background")],
+    );
+    const commits = { visible: 0, background: 0 };
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (event.type !== "updated") return;
+      const queryKey = event.query.queryKey;
+      if (queryKey[0] !== "react-session-transcript" || queryKey[1] !== syncInput.workspaceId) return;
+      if (queryKey[2] === "session-visible") commits.visible += 1;
+      if (queryKey[2] === "session-background") commits.background += 1;
+    });
+
+    try {
+      for (let index = 0; index < 24; index += 1) {
+        __queueSessionSyncDeltaForTest(syncInput, {
+          sessionId: "session-background",
+          messageId: "message-background",
+          partId: "part-background",
+          reasoning: false,
+          delta: "b",
+        });
+      }
+      for (let index = 0; index < 24; index += 1) {
+        __queueSessionSyncDeltaForTest(syncInput, {
+          sessionId: "session-visible",
+          messageId: "message-visible",
+          partId: "part-visible",
+          reasoning: false,
+          delta: "v",
+        });
+      }
+
+      expect(scheduled.map((task) => task.lane)).toEqual(["background", "foreground"]);
+      expect(scheduled[0]?.cancelled).toBe(true);
+      scheduled[1]?.run();
+
+      expect(commits).toEqual({ visible: 1, background: 0 });
+      expect(queryClient.getQueryData<UIMessage[]>(
+        transcriptKey(syncInput.workspaceId, "session-visible"),
+      )?.[0]?.parts[0]).toMatchObject({ text: "v".repeat(24) });
+      expect(queryClient.getQueryData<UIMessage[]>(
+        transcriptKey(syncInput.workspaceId, "session-background"),
+      )?.[0]?.parts[0]).toMatchObject({ text: "" });
+
+      expect(scheduled[2]?.lane).toBe("background");
+      scheduled[2]?.run();
+      expect(commits).toEqual({ visible: 1, background: 1 });
+      expect(queryClient.getQueryData<UIMessage[]>(
+        transcriptKey(syncInput.workspaceId, "session-background"),
+      )?.[0]?.parts[0]).toMatchObject({ text: "b".repeat(24) });
+
+      __queueSessionSyncDeltaForTest(syncInput, {
+        sessionId: "session-background",
+        messageId: "message-background",
+        partId: "part-background",
+        reasoning: false,
+        delta: " complete",
+      });
+      expect(scheduled[3]?.lane).toBe("background");
+      __applySessionSyncEventForTest(syncInput, {
+        type: "session.idle",
+        properties: { sessionID: "session-background" },
+      });
+      expect(scheduled[3]?.cancelled).toBe(true);
+      expect(commits).toEqual({ visible: 1, background: 2 });
+      expect(queryClient.getQueryData<UIMessage[]>(
+        transcriptKey(syncInput.workspaceId, "session-background"),
+      )?.[0]?.parts[0]).toMatchObject({ text: `${"b".repeat(24)} complete` });
+    } finally {
+      unsubscribe();
+      releaseBackground();
+      releaseVisible();
+      cleanup();
+      __setSessionSyncDeltaFlushSchedulerForTest(null);
+    }
   });
 
   test("keeps live-only messages when an idle snapshot is stale", () => {


### PR DESCRIPTION
## Why

A long active response should keep streaming smoothly even when other sessions receive background activity. Previously every token-sized delta competed for the same transcript cache commit and render work regardless of whether its session was visible, so background streams could degrade the visible session's responsiveness.

The policy: foreground (visible-session) deltas stay on the responsive animation-frame lane; background-session deltas are coalesced on a slower bounded cadence; terminal events remain convergence points. No measured percentage improvement is claimed — no reproducible benchmark was run for this change.

## What changed

- The session runtime passes the currently visible session id into the workspace sync input.
- Delta flushing selects a lane per flush: foreground deltas flush on the animation-frame path, background deltas coalesce on a ~100ms cadence; a pending background flush is superseded when foreground work arrives.
- Pending deltas for a session are force-flushed before terminal (`session.idle`) and failure reconciliation, so lane scheduling never weakens lifecycle convergence.
- Scheduled flush work is cancelled when its owning workspace sync entry is disposed or the last tracked session is cleared.
- Transcript delta application is extracted into a focused module (`session-transcript-deltas.ts`) that applies a frame of coalesced deltas with one transcript clone and one parts clone per touched message, preserving reasoning/text part identity and delta order; undeclared parts are still held until their declaration event arrives.
- Added focused regressions for stable history references, foreground-before-background commit ordering, terminal flush, and scheduler cancellation.

## Verification

- `pnpm --dir apps/app exec bun test --isolate tests/session-sync-permissions.test.ts tests/session-sync-tool-parts.test.ts tests/session-sync-lifecycle.test.ts tests/session-sync-run-status.test.ts tests/render-cycle-state.test.tsx tests/session-render-state.test.ts` — passed (52 tests across 6 files, rerun after rebasing onto `dev` with #4127 merged; includes #4127's reattached-observer regression against the combined code).
- `pnpm --dir apps/app exec bun test tests/session-error-resilience.test.tsx` — passed (8 tests; exercises the sync test harness both this change and #4127 touch).
- `git diff --check` — passed.

Verdict: Incomplete — the focused suites above are the published evidence for this change; deterministic `@openwork/testkit` coverage at this head is tracked as follow-up and has not yet been published.

## Risk and follow-up

- Rebased onto `dev` after #4127 (listener ownership registries) merged; the one overlapping region in `session-sync.ts` was resolved to keep both behaviors, and the combined semantics are covered by the rerun suites above.
- The visible session id is owned by the latest runtime attachment per workspace sync entry. With cross-workspace split view (#4126), two sessions in the same workspace can be visible at once; the non-owning pane's deltas ride the background lane (bounded ~100ms cadence), which is a presentation-latency trade-off, not a correctness one. Making lane selection multi-pane-aware is follow-up.
- Deferred: real-app long-stream proof under `evals/specs`.
