### PR TITLE
Classify interactive command lifecycle accurately

### DIFF
--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useState } from "react"
-import { AlertTriangle, CirclePause, MoreHorizontal } from "lucide-react"
+import { CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
@@ -9,6 +9,7 @@ import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-
 import {
   getAggregateNowLabel,
   getAggregateCountSummary,
+  getToolAggregateLifecycle,
   getAggregateRowFile,
   getAggregateRowLabel,
   getAggregateSummary,
@@ -72,16 +73,14 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
     inFlightPart?.toolCallId ?? "",
     Boolean(inFlightPart),
   )
-  const anyRunning = parts.some((part) => isToolPartInFlight(part))
-  const visiblyRunning = anyRunning
-    && currentLifecycle !== "waiting"
-    && currentLifecycle !== "interrupted"
+  const aggregateLifecycle = getToolAggregateLifecycle(parts, currentLifecycle)
+  const visiblyRunning = aggregateLifecycle === "running"
   const failedCount = parts.filter((part) => part.state === "output-error").length
   const countSummary = getAggregateCountSummary(parts)
-  const summary = currentLifecycle === "waiting"
+  const summary = aggregateLifecycle === "waiting"
     ? `Waiting for your action · ${countSummary}`
-    : currentLifecycle === "interrupted"
-      ? `Task interrupted · ${countSummary}`
+    : aggregateLifecycle === "unknown"
+      ? `Status unknown · ${countSummary}`
       : getAggregateSummary(parts, visiblyRunning ? "present" : "past")
   const nowLabel = visiblyRunning ? getAggregateNowLabel(parts) : null
   // The model is thinking mid-run: no tool is in flight but the run's
@@ -104,7 +103,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
     <div
       className={className}
       data-tool-aggregate={latestToolCallId}
-      data-tool-lifecycle={currentLifecycle ?? (visiblyRunning ? "running" : "settled")}
+      data-tool-lifecycle={aggregateLifecycle}
     >
       <button
         type="button"
@@ -130,17 +129,17 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
         ) : null}
       </button>
 
-      {currentLifecycle === "waiting" ? (
+      {aggregateLifecycle === "waiting" ? (
         <div className="mt-1 flex items-center gap-1.5 text-xs text-amber-11" role="status">
           <CirclePause aria-hidden="true" className="size-3.5 shrink-0" />
           <span>Choose an option or approve the request to continue.</span>
         </div>
       ) : null}
 
-      {currentLifecycle === "interrupted" ? (
-        <div className="mt-1 flex items-center gap-1.5 text-xs text-destructive" role="alert">
-          <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" />
-          <span>This step stopped before it finished. Retry to continue.</span>
+      {aggregateLifecycle === "unknown" ? (
+        <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground" role="status">
+          <CircleHelp aria-hidden="true" className="size-3.5 shrink-0" />
+          <span>No terminal result was observed. This step may still be running; check the session before retrying.</span>
         </div>
       ) : null}
 
@@ -163,7 +162,11 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
         <div className="mt-1.5 flex flex-col gap-1">
           {visibleParts.map((part, index) => {
             const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
-            const status = lifecycle ?? persistedRowStatus(part)
+            const status = isToolPartInFlight(part)
+              ? lifecycle === "running" || lifecycle === "waiting"
+                ? lifecycle
+                : "unknown"
+              : persistedRowStatus(part)
             const reason = failureReason(part)
             const bash = isBashToolPart(part)
             const command = bash ? part.input?.command?.trim() ?? "" : ""
@@ -183,13 +186,19 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                   {status === "waiting" ? (
                     <CirclePause aria-label="Waiting" className="size-3.5 shrink-0 text-amber-11" />
                   ) : null}
-                  {status === "interrupted" ? (
-                    <AlertTriangle aria-label="Interrupted" className="size-3.5 shrink-0 text-destructive" />
+                  {status === "unknown" ? (
+                    <CircleHelp aria-label="Status unknown" className="size-3.5 shrink-0" />
                   ) : null}
                   {bash ? (
                     <span className="min-w-0 truncate">
                       <span className={cn("text-foreground", status === "running" && "ow-text-shimmer")}>
-                        {status === "running" ? "Running" : "Ran"}
+                        {status === "running"
+                          ? "Running"
+                          : status === "waiting"
+                            ? "Waiting to run"
+                            : status === "unknown"
+                              ? "Status unknown for"
+                              : "Ran"}
                       </span>{" "}
                       <span>{commandDescription}</span>
                     </span>

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -10,6 +10,7 @@ import {
   isWriteToolPart,
 } from "./build-in-tools"
 import { getToolActivityLabel, isToolPartInFlight } from "./tool-activity"
+import type { CurrentToolLifecycle } from "./current-tool-lifecycle"
 
 export type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
@@ -30,6 +31,36 @@ export type AggregateThought = {
  * into one aggregate line. Prose from the model always breaks a group.
  */
 export type ToolFamily = "command" | "edit" | "read" | "search"
+
+export type ToolAggregateLifecycle =
+  | "running"
+  | "waiting"
+  | "unknown"
+  | "completed"
+  | "failed"
+
+/**
+ * Classify only lifecycle facts available to an aggregate tool row.
+ *
+ * A terminal tool part directly proves completion or failure. An unfinished
+ * part is running/waiting only while the current-session observer says so.
+ * The observer's generic `interrupted` state merges idle/remount gaps with
+ * real session errors, so it is not proof that a process stopped. Keep that
+ * case honest until a terminal tool result arrives; directly observed aborts
+ * and infrastructure errors remain owned by the session error presentation.
+ */
+export function getToolAggregateLifecycle(
+  parts: AnyToolPart[],
+  currentLifecycle: CurrentToolLifecycle | null,
+): ToolAggregateLifecycle {
+  if (parts.some(isToolPartInFlight)) {
+    if (currentLifecycle === "running" || currentLifecycle === "waiting") {
+      return currentLifecycle
+    }
+    return "unknown"
+  }
+  return parts.some((part) => part.state === "output-error") ? "failed" : "completed"
+}
 
 export function getToolFamily(part: AnyToolPart): ToolFamily | null {
   if (isBashToolPart(part)) return "command"

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -3,19 +3,50 @@ import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DynamicToolUIPart } from "ai";
 
+import { CurrentToolLifecycleProvider } from "../src/components/chat/current-tool-lifecycle-context";
 import { ToolAggregateGroup } from "../src/components/chat/tool-aggregate-group";
+import { getToolAggregateLifecycle } from "../src/lib/tool-aggregate";
+
+const runningCommand: DynamicToolUIPart = {
+  type: "dynamic-tool",
+  toolName: "bash",
+  toolCallId: "running-command",
+  state: "input-available",
+  input: { command: "git status", description: "Check repository state" },
+};
+
+const completedCommand: DynamicToolUIPart = {
+  ...runningCommand,
+  toolCallId: "completed-command",
+  state: "output-available",
+  output: "clean",
+};
+
+const failedCommand: DynamicToolUIPart = {
+  ...runningCommand,
+  toolCallId: "failed-command",
+  state: "output-error",
+  errorText: "Process exited with code 2",
+};
 
 describe("tool aggregate running feedback", () => {
-  test("uses a quiet shimmer instead of a spinner for the current action", () => {
-    const runningCommand: DynamicToolUIPart = {
-      type: "dynamic-tool",
-      toolName: "bash",
-      toolCallId: "running-command",
-      state: "input-available",
-      input: { command: "git status", description: "Check repository state" },
-    };
+  test("classifies only lifecycle facts the aggregate can prove", () => {
+    expect(getToolAggregateLifecycle([runningCommand], "running")).toBe("running");
+    expect(getToolAggregateLifecycle([runningCommand], "waiting")).toBe("waiting");
+    expect(getToolAggregateLifecycle([runningCommand], "interrupted")).toBe("unknown");
+    expect(getToolAggregateLifecycle([completedCommand], null)).toBe("completed");
+    expect(getToolAggregateLifecycle([failedCommand], null)).toBe("failed");
+  });
 
-    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[runningCommand]} />);
+  test("uses a quiet shimmer instead of a spinner for the current action", () => {
+    const markup = renderToStaticMarkup(
+      <CurrentToolLifecycleProvider
+        activityStatus="responding"
+        currentToolCallIds={new Set([runningCommand.toolCallId])}
+      >
+        <ToolAggregateGroup parts={[runningCommand]} />
+      </CurrentToolLifecycleProvider>,
+    );
 
     expect(markup).toContain("Running command");
     expect(markup).not.toContain("Running 1 command");


### PR DESCRIPTION
## Why

OpenWork should not say "Task interrupted" and recommend retrying when it never observed a terminal process result. The current-session observer's generic `interrupted` state merges idle/remount gaps with real session errors, so presenting it as proof that a process stopped can push users toward retrying a side-effecting command that may still be running — which is unsafe.

This is a classification and safety repair for the aggregate command presentation. It does not change upstream TTY ownership or process recovery.

## What changed

- Added `getToolAggregateLifecycle`, which classifies aggregate command state from facts the aggregate can actually prove: a terminal tool part proves `completed` or `failed`; an unfinished part is `running` or `waiting` only while the current-session observer says so; otherwise the state is an honest `unknown`.
- The aggregate group renders `unknown` as "Status unknown" with guidance to check the session before retrying, replacing the previous "Task interrupted … Retry to continue" alert for that case.
- Per-row presentation follows the same rule: in-flight rows without an authoritative running/waiting observation show "Status unknown for `<command>`" instead of implying completion or interruption.
- Distinct `running`, `waiting`, `completed`, and `failed` presentations are preserved, and directly observed task failures and cancellation stay in the existing session error/resume path.
- Added focused classification regressions and updated the rendered-copy test to provide the lifecycle context a real session supplies.

## Verification

- `pnpm --dir apps/app exec bun test tests/current-tool-lifecycle.test.ts tests/current-tool-lifecycle-context.test.ts tests/tool-aggregate-group.test.tsx` — passed (7 tests across 3 files).
- `git diff --check` — passed.

Verdict: Incomplete — the focused suites above are the published evidence for this change; deterministic `@openwork/testkit` coverage at this head is tracked as follow-up and has not yet been published.

## Risk and follow-up

- Presentation-only change scoped to the aggregate tool group; no lifecycle events or process control are altered.
- The `unknown` copy is intentionally conservative; if a stronger authoritative signal becomes available (for example a definitive process-exit fact), classification can be tightened to consume it.
- Deferred: real interactive-process proof under `evals/specs`.
