### PR TITLE
fix(server): keep opencode proxy requests off the workspace bootstrap path

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1100,7 +1100,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         try {
           const actor = await requireClient(request, config, tokens);
           assertOpencodeProxyAllowed(actor, request.method, mount.restPath);
-          const workspace = await resolveWorkspace(config, mount.workspaceId);
+          const workspace = await resolveWorkspaceWithoutBootstrap(config, mount.workspaceId);
           proxyService = "opencode";
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
           const response = await proxyOpencodeRequest({ config, request, url, workspace, proxyPath: mount.restPath });

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -350,6 +350,29 @@ describe("workspace session read APIs", () => {
     expect(response.status).toBe(200);
     const proxyRequest = mock.requests.find((request) => request.pathname === "/session");
     expect(proxyRequest?.directory).toBe(encodeURIComponent(workspaceRoot));
+  });
+
+  test("keeps opencode proxy requests off the workspace bootstrap path", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+      readOnly: false,
+    });
+    const commandsDir = join(workspaceRoot, ".opencode", "commands");
+    const commandPath = join(commandsDir, "legacy.md");
+    const legacyCommand = "---\nname: legacy\ndescription: Legacy\nmodel: null\n---\nRun legacy command\n";
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(commandPath, legacyCommand, "utf8");
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session`, {
+      headers: auth(openwork.token),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mock.requests.some((request) => request.pathname === "/session")).toBe(true);
+    expect(await readFile(commandPath, "utf8")).toBe(legacyCommand);
   });
 
   test("returns 404 when the upstream session is missing", async () => {


### PR DESCRIPTION
## Why

Every request proxied to a workspace's OpenCode engine through `/workspace/:id/opencode/*` currently resolves the workspace with the bootstrapping resolver. That re-runs workspace file provisioning (`ensureWorkspaceFiles`) and command repair (`repairCommands`) on every proxied call, and when either reports a change it can trigger a baseline refresh and an engine reload from what should be read-only traffic. The proxy mount is the busiest server path while a task is running, so this is repeated filesystem work exactly where latency matters most.

Bootstrap does not need to live here. Workspace files are already provisioned at server boot (`ensureLocalWorkspaceFiles` covers every local workspace on both the embedded-server and CLI boot paths), at workspace creation, and by the control-plane routes that still use the bootstrapping `resolveWorkspace`. Session read routes already resolve without bootstrap for the same reason (#2873).

## What changed

- The OpenCode proxy mount now resolves workspaces with `resolveWorkspaceWithoutBootstrap`, which keeps the workspace-existence check (404) and the authorized-root fence (403) while skipping per-request provisioning and repair. `requireClient` auth and `assertOpencodeProxyAllowed` are unchanged.
- Workspace provisioning and command repair still run at server boot, on workspace creation, and on every bootstrapping control-plane route — first-use setup is unaffected.
- New regression: a proxied session read succeeds without rewriting a legacy command file placed in `.opencode/commands`, pinning that proxy traffic performs no bootstrap writes.

One intentional behavior note for review: proxy traffic no longer opportunistically repairs workspace files mid-session. Repair still happens on boot, workspace creation, and the control-plane routes that own it.

## Verification

All checks ran at this exact head after rebasing onto current `dev` (includes #4129, which touches the same files):

- `pnpm --filter openwork-server typecheck` — passed, exit 0.
- `pnpm --filter openwork-server exec bun --conditions=development test src/session-read-model.e2e.test.ts` — 12 pass, 0 fail, 58 assertions (includes the new bootstrap-path regression and the existing proxy/admission coverage).
- `pnpm --dir evals run test:pr` — 63 passed, 0 failed, 2 skipped, exit 0. The two skips are the standing environment-gated specs (`kube-egress-allowlist` needs a local kind substrate; `skill-grant-access` needs its declared credentials), identical to the CI lane.

Lane: local (same app-less PR lane CI runs). No app-driving E2E claim is made by this change; the mechanism is fully covered by the server test above.
