### PR TITLE
Align unfinished-tool lifecycle spec with the unknown state

### DIFF
--- a/evals/specs/unfinished-tool-lifecycle.e2e.test.ts
+++ b/evals/specs/unfinished-tool-lifecycle.e2e.test.ts
@@ -5,10 +5,10 @@ import { needs, test } from "@openwork/testkit";
 
 const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
 const title = e2eTestsEnabled
-  ? "unfinished current-turn tools expose active, waiting, and interrupted outcomes"
+  ? "unfinished current-turn tools expose active, waiting, and unknown outcomes"
   : "unfinished tool lifecycle skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
 
-function lifecycleExpression(lifecycle: "running" | "waiting" | "interrupted", text: string): string {
+function lifecycleExpression(lifecycle: "running" | "waiting" | "unknown", text: string): string {
   return `(() => {
     const rows = Array.from(document.querySelectorAll('[data-tool-lifecycle="${lifecycle}"]'));
     return rows.some((row) => (row.textContent || '').includes(${JSON.stringify(text)}));
@@ -69,19 +69,19 @@ test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
   );
 
   await control(app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "idle" });
-  await waitFor(app, lifecycleExpression("interrupted", "Task interrupted"), {
+  await waitFor(app, lifecycleExpression("unknown", "Status unknown"), {
     timeoutMs: 15_000,
-    label: "idle unfinished tools visibly interrupted",
+    label: "idle unfinished tools visibly status-unknown",
   });
   const terminalState = await evalIn(app, `(() => ({
-    interrupted: document.body.innerText.includes("This step stopped before it finished. Retry to continue."),
+    unknown: document.body.innerText.includes("No terminal result was observed. This step may still be running; check the session before retrying."),
     running: Boolean(document.querySelector('[data-tool-lifecycle="running"]')),
     waiting: Boolean(document.querySelector('[data-tool-lifecycle="waiting"]')),
   }))()`);
-  expect(terminalState).toEqual({ interrupted: true, running: false, waiting: false });
+  expect(terminalState).toEqual({ unknown: true, running: false, waiting: false });
   evidence.recordAssertionEvidence(
     "An idle task never leaves its unfinished current step silently running",
-    "The tool group converged to data-tool-lifecycle=interrupted, showed retry guidance, and exposed neither running nor waiting lifecycle rows.",
+    "The tool group converged to data-tool-lifecycle=unknown, told the user to check the session before retrying, and exposed neither running nor waiting lifecycle rows.",
     true,
   );
 });


### PR DESCRIPTION
## Why

#4131 changed the aggregate command presentation for an unfinished step with no terminal result from `interrupted` ("Task interrupted … Retry to continue.") to an honest `unknown` state ("Status unknown … check the session before retrying"). The existing e2e spec `evals/specs/unfinished-tool-lifecycle.e2e.test.ts` still asserts the old `interrupted` presentation, so the nightly/e2e lane would fail on the idle phase against current `dev`. This aligns the spec with the merged behavior before that lane runs.

## What changed

- The idle phase of the spec now waits for `data-tool-lifecycle="unknown"` with the "Status unknown" summary instead of `interrupted` / "Task interrupted".
- The terminal assertion checks the new guidance copy ("No terminal result was observed. This step may still be running; check the session before retrying.") and still requires that neither running nor waiting rows remain.
- Test title and evidence text updated to describe the unknown outcome; the active and waiting phases are unchanged.

## Verification

- `pnpm exec vitest run --config vitest.config.ts --project e2e specs/unfinished-tool-lifecycle.e2e.test.ts` — collected cleanly, 1 skipped (spec is opt-in gated behind `OPENWORK_EVAL_E2E_TESTS=1`, as designed).
- `pnpm --dir apps/app exec bun test tests/current-tool-lifecycle.test.ts tests/current-tool-lifecycle-context.test.ts tests/tool-aggregate-group.test.tsx` — passed (7 tests) on the merged behavior this spec now asserts.
- `git diff --check` — passed.

Verdict: Incomplete — the aligned spec's runtime pass rides the next opt-in e2e lane execution; collection and the merged unit coverage above are the current evidence.

## Risk and follow-up

- Spec-only change; no product code touched.
- The standalone (non-aggregate) tool row in `message-list.tsx` still renders the legacy `interrupted` presentation; extending the honest unknown state to that surface is a separate product follow-up.
