### PR TITLE
Polish chat tool-call activity presentation

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -226,6 +226,12 @@ body {
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
+/* Inline Shiki-highlighted shell commands (chat tool rows) use the same
+   dual-theme variables as the markdown code blocks above. */
+:is(.dark, [data-theme="dark"]) [data-shell-command-highlighted] span {
+  color: var(--shiki-dark) !important;
+}
+
 /* KaTeX sets its own absolute font-size; keep formulas at the surrounding text size
    so inline math does not tower over the sentence it sits in. */
 .markdown-content .katex {

--- a/apps/app/src/components/chat/file-chip.tsx
+++ b/apps/app/src/components/chat/file-chip.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowUpRight, FileText } from "lucide-react"
+import { ArrowUpRight } from "lucide-react"
 
 import { useOpenArtifactPath } from "@/lib/artifacts"
 import { cn } from "@/lib/utils"
@@ -18,9 +18,10 @@ function baseName(path: string): string {
 
 /**
  * Paper "File paths → chips": never render raw absolute paths. A file
- * reference is an inline chip — icon + basename in mono, full path in
- * the tooltip. Click opens the artifact preview; ↗ opens the file in
- * the default app. Used in aggregate rows, failure reasons, and prose.
+ * reference is a quiet inline chip — basename in mono on the same soft
+ * background as inline code in chat prose (no border, no icon), full
+ * path in the tooltip. Click opens the artifact preview; the ↗ that
+ * appears on hover opens the file in the default app.
  */
 export function FileChip({ path, className }: FileChipProps) {
   const openArtifactPath = useOpenArtifactPath()
@@ -29,7 +30,7 @@ export function FileChip({ path, className }: FileChipProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-stretch overflow-hidden rounded-md border border-border/70 bg-muted/50 align-middle",
+        "group/chip inline-flex items-center overflow-hidden rounded-md bg-gray-2/70 align-middle",
         className,
       )}
     >
@@ -37,9 +38,8 @@ export function FileChip({ path, className }: FileChipProps) {
         type="button"
         onClick={() => openArtifactPath(path)}
         title={path}
-        className="flex min-w-0 cursor-pointer items-center gap-1.5 px-1.5 py-0.5 transition-colors hover:bg-muted"
+        className="flex min-w-0 cursor-pointer items-center px-1.5 py-0.5 transition-colors hover:bg-gray-3/80"
       >
-        <FileText aria-hidden="true" className="size-3 shrink-0 text-muted-foreground" />
         <span className="min-w-0 truncate font-mono text-[11px] leading-4 text-foreground">
           {name}
         </span>
@@ -49,7 +49,7 @@ export function FileChip({ path, className }: FileChipProps) {
         onClick={() => openArtifactPath(path, { external: true })}
         title={`Open ${name} in default app`}
         aria-label={`Open ${name} in default app`}
-        className="flex cursor-pointer items-center border-l border-border/60 px-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        className="flex cursor-pointer items-center pr-1.5 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/chip:opacity-100 hover:text-foreground"
       >
         <ArrowUpRight aria-hidden="true" className="size-2.5" />
       </button>

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -861,17 +861,17 @@ function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
           <div className="flex flex-row items-start gap-2">
-            <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
+            <AlertTriangle aria-hidden="true" size={16} className="mt-0.5 shrink-0 text-destructive" />
             <p className="whitespace-pre-wrap text-destructive">{error}</p>
           </div>
           {resumePrompt && onResumeInterrupted ? (
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="sm"
-              className="mb-1 ml-6 h-7 w-fit border-red-400/70 bg-red-50 text-xs text-red-950 hover:bg-red-100"
+              className="ml-6 h-7 w-fit px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
               data-testid="session-error-resume"
               onClick={() => onResumeInterrupted(resumePrompt)}
             >

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -858,6 +858,31 @@ interface ErrorMessageProps {
 function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
   const { onResumeInterrupted } = useMessageList()
 
+  // A resumable interruption is a pause, not a failure: it renders as a
+  // quiet status line (like "Working 12s"), with Resume as the emphasis.
+  if (resumePrompt && onResumeInterrupted) {
+    return (
+      <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+        <div
+          data-testid="session-error-interrupted"
+          className="flex min-w-0 items-center gap-2 py-1 text-sm text-muted-foreground"
+        >
+          <CirclePause aria-hidden="true" className="size-4 shrink-0" />
+          <span className="min-w-0 truncate">{error}</span>
+          <span aria-hidden="true" className="text-muted-foreground/60">·</span>
+          <button
+            type="button"
+            data-testid="session-error-resume"
+            onClick={() => onResumeInterrupted(resumePrompt)}
+            className="shrink-0 cursor-pointer font-medium text-foreground underline-offset-2 transition-colors hover:underline"
+          >
+            {t("session.resume_interrupted")}
+          </button>
+        </div>
+      </Message>
+    )
+  }
+
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
@@ -866,18 +891,6 @@ function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
             <AlertTriangle aria-hidden="true" size={16} className="mt-0.5 shrink-0 text-destructive" />
             <p className="whitespace-pre-wrap text-destructive">{error}</p>
           </div>
-          {resumePrompt && onResumeInterrupted ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="ml-6 h-7 w-fit px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
-              data-testid="session-error-resume"
-              onClick={() => onResumeInterrupted(resumePrompt)}
-            >
-              {t("session.resume_interrupted")}
-            </Button>
-          ) : null}
         </div>
       </div>
     </Message>

--- a/apps/app/src/components/chat/shell-command-text.tsx
+++ b/apps/app/src/components/chat/shell-command-text.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { codeToHtml } from "shiki"
+
+/**
+ * One-line shell command with real syntax highlighting instead of
+ * monochrome blue. Highlighting is async (Shiki), so the plain command
+ * renders first and upgrades in place; results are cached so repeated
+ * commands and re-renders never flash.
+ */
+const highlightCache = new Map<string, string>()
+
+type ShellCommandTextProps = {
+  command: string
+  className?: string
+}
+
+export function ShellCommandText({ command, className }: ShellCommandTextProps) {
+  const [html, setHtml] = useState<string | null>(() => highlightCache.get(command) ?? null)
+
+  useEffect(() => {
+    const cached = highlightCache.get(command)
+    if (cached !== undefined) {
+      setHtml(cached)
+      return
+    }
+    let cancelled = false
+    codeToHtml(command, {
+      lang: "shellscript",
+      structure: "inline",
+      themes: { light: "github-light", dark: "github-dark" },
+    })
+      .then((highlighted) => {
+        highlightCache.set(command, highlighted)
+        if (!cancelled) setHtml(highlighted)
+      })
+      .catch(() => {
+        // Highlighting is progressive enhancement; the plain text stays.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [command])
+
+  if (html === null) {
+    return <code className={className}>{command}</code>
+  }
+
+  return (
+    <code
+      className={className}
+      data-shell-command-highlighted=""
+      // Shiki escapes the command text; only its own span markup is injected.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useState } from "react"
-import { CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
+import { AlertTriangle, CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { ShellCommandText } from "@/components/chat/shell-command-text"

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -4,6 +4,7 @@ import { Fragment, useState } from "react"
 import { AlertTriangle, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
+import { ShellCommandText } from "@/components/chat/shell-command-text"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
 import {
@@ -12,6 +13,7 @@ import {
   getAggregateRowFile,
   getAggregateRowLabel,
   getAggregateSummary,
+  getToolFamily,
   type AggregateThought,
   type AnyToolPart,
 } from "@/lib/tool-aggregate"
@@ -45,10 +47,55 @@ function failureReason(part: AnyToolPart): string | null {
   return firstLine ? (firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine) : null
 }
 
+type AggregateRow = {
+  /** The most recent call in the row (drives status, label, key). */
+  part: AnyToolPart
+  /** Original index of the row's first call — anchors interleaved thoughts. */
+  index: number
+  /** Original index of the row's latest call — picks its frozen duration. */
+  lastIndex: number
+  /** How many identical calls this row represents. */
+  repeat: number
+}
+
+/**
+ * The header summary counts unique files ("Read 1 file"), so repeated
+ * settled reads of the same file collapse into one row with a ×N badge
+ * instead of rendering as confusing duplicates. A thought anchored
+ * between two reads keeps them apart to preserve chronology.
+ */
+export function buildAggregateRows(parts: AnyToolPart[], thoughts: AggregateThought[]): AggregateRow[] {
+  const hasThoughtAt = (index: number) => thoughts.some((thought) => thought.afterIndex === index)
+  const rows: AggregateRow[] = []
+  parts.forEach((part, index) => {
+    const previous = rows.at(-1)
+    const file = getAggregateRowFile(part)
+    const previousFile = previous ? getAggregateRowFile(previous.part) : null
+    const mergeable =
+      previous !== undefined &&
+      file !== null &&
+      previousFile !== null &&
+      getToolFamily(part) === "read" &&
+      getToolFamily(previous.part) === "read" &&
+      file.path === previousFile.path &&
+      persistedRowStatus(part) === "done" &&
+      persistedRowStatus(previous.part) === "done" &&
+      !hasThoughtAt(index)
+    if (mergeable) {
+      previous.part = part
+      previous.lastIndex = index
+      previous.repeat += 1
+      return
+    }
+    rows.push({ part, index, lastIndex: index, repeat: 1 })
+  })
+  return rows
+}
+
 /**
  * Paper "Recurring actions · aggregate + latest": one line with live
- * totals while running plus a self-replacing "Now:" line; past-tense
- * summary when done. Chevron expands the chronological list — status
+ * totals while running plus a self-replacing shimmer line naming the
+ * current action; past-tense summary when done. Chevron expands the chronological list — status
  * dot, monospace action, per-item duration — capped with "Show N more".
  */
 export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggregateGroupProps) {
@@ -93,12 +140,62 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
   const durations = parts.map((part) => trackToolCallDuration(part))
   const singleCommand = parts.length === 1 && Boolean(parts[0] && isBashToolPart(parts[0]))
   const singleCommandDuration = singleCommand ? durations[0] : null
-  const visibleParts = showAll ? parts : parts.slice(0, ROW_CAP)
-  const hiddenCount = parts.length - visibleParts.length
+  const rows = buildAggregateRows(parts, thoughts)
+  const visibleRows = showAll ? rows : rows.slice(0, ROW_CAP)
+  const hiddenCount = rows.length - visibleRows.length
   // Expanded rows interleave the run's thoughts at their chronological
   // slots; thoughts belonging to capped rows stay behind "Show N more".
   const thoughtsAt = (index: number) => thoughts.filter((thought) => thought.afterIndex === index)
   const trailingThoughts = hiddenCount > 0 ? [] : thoughts.filter((thought) => thought.afterIndex >= parts.length)
+
+  // "Edited 1 file" above "Edited file-chip.tsx" says nothing twice.
+  // A group that is exactly one file action (and no thoughts) renders
+  // as the row itself — verb, chip, duration — with nothing to expand.
+  const soloRow = rows.length === 1 && thoughts.length === 0 ? rows[0] : undefined
+  const soloFile = soloRow ? getAggregateRowFile(soloRow.part) : null
+  if (soloRow && soloFile) {
+    const status = currentLifecycle ?? persistedRowStatus(soloRow.part)
+    const reason = failureReason(soloRow.part)
+    return (
+      <div
+        className={className}
+        data-tool-aggregate={latestToolCallId}
+        data-tool-lifecycle={currentLifecycle ?? (visiblyRunning ? "running" : "settled")}
+      >
+        <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+          <span className={cn("shrink-0", status === "running" && "text-foreground ow-text-shimmer")}>
+            {soloFile.verb}
+          </span>
+          <FileChip path={soloFile.path} className="min-w-0" />
+          {soloRow.repeat > 1 ? (
+            <span data-tool-aggregate-repeat className="shrink-0 text-xs text-muted-foreground/70">
+              ×{soloRow.repeat}
+            </span>
+          ) : null}
+          {durations[soloRow.lastIndex] ? (
+            <span className="shrink-0 tabular-nums text-xs text-muted-foreground/70">
+              {durations[soloRow.lastIndex]}
+            </span>
+          ) : null}
+        </div>
+        {status === "waiting" ? (
+          <div className="mt-1 flex items-center gap-1.5 text-xs text-amber-11" role="status">
+            <CirclePause aria-hidden="true" className="size-3.5 shrink-0" />
+            <span>Choose an option or approve the request to continue.</span>
+          </div>
+        ) : null}
+        {status === "interrupted" ? (
+          <div className="mt-1 flex items-center gap-1.5 text-xs text-destructive" role="alert">
+            <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" />
+            <span>This step stopped before it finished. Retry to continue.</span>
+          </div>
+        ) : null}
+        {reason ? (
+          <div className="mt-1 text-[11px] text-muted-foreground">failed — {reason}</div>
+        ) : null}
+      </div>
+    )
+  }
 
   return (
     <div
@@ -146,8 +243,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
 
       {nowLabel ? (
         <div data-tool-aggregate-now className="mt-1 min-w-0 text-sm text-muted-foreground">
-          <span className="block min-w-0 truncate">
-            <span className="ow-text-shimmer">Now: </span>
+          <span className="ow-text-shimmer block min-w-0 truncate">
             {nowLabel}
           </span>
         </div>
@@ -161,7 +257,8 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
 
       {expanded ? (
         <div className="mt-1.5 flex flex-col gap-1">
-          {visibleParts.map((part, index) => {
+          {visibleRows.map((row) => {
+            const part = row.part
             const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
             const status = lifecycle ?? persistedRowStatus(part)
             const reason = failureReason(part)
@@ -172,8 +269,8 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
               : ""
             return (
               <Fragment key={part.toolCallId}>
-              {thoughtsAt(index).map((thought) => (
-                <div key={`thought-${index}-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
+              {thoughtsAt(row.index).map((thought) => (
+                <div key={`thought-${row.index}-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
                   <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
                 </div>
               ))}
@@ -197,21 +294,31 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                     const file = getAggregateRowFile(part)
                     if (!file) {
                       return (
-                        <span className="min-w-0 truncate">
+                        <span className={cn("min-w-0 truncate", status === "running" && "ow-text-shimmer")}>
                           {getAggregateRowLabel(part)}
                         </span>
                       )
                     }
                     return (
                       <span className="flex min-w-0 items-center gap-1.5">
-                        <span className="shrink-0">{file.verb}</span>
+                        <span className={cn("shrink-0", status === "running" && "text-foreground ow-text-shimmer")}>
+                          {file.verb}
+                        </span>
                         <FileChip path={file.path} className="min-w-0" />
+                        {row.repeat > 1 ? (
+                          <span
+                            data-tool-aggregate-repeat
+                            className="shrink-0 text-xs text-muted-foreground/70"
+                          >
+                            ×{row.repeat}
+                          </span>
+                        ) : null}
                       </span>
                     )
                   })()}
-                  {durations[index] ? (
+                  {durations[row.lastIndex] ? (
                     <span className="shrink-0 tabular-nums text-muted-foreground/70">
-                      {durations[index]}
+                      {durations[row.lastIndex]}
                     </span>
                   ) : null}
                   </div>
@@ -219,10 +326,10 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                 {bash && command ? (
                   <div
                     data-tool-aggregate-command
-                    className="flex min-w-0 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 py-2 font-mono text-sm shadow-xs"
+                    className="flex min-w-0 items-center gap-2 rounded-xl border border-border/70 bg-gray-2/60 px-3 py-2 font-mono text-sm"
                   >
                     <span className="shrink-0 text-muted-foreground/60">$</span>
-                    <code className="min-w-0 flex-1 truncate text-blue-11">{command}</code>
+                    <ShellCommandText command={command} className="min-w-0 flex-1 truncate" />
                     <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
                   </div>
                 ) : null}

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -165,7 +165,7 @@ export function getAggregateRowLabel(part: AnyToolPart): string {
   return getToolActivityLabel(part)
 }
 
-/** Label for the single latest in-flight call — the self-replacing "Now:" line. */
+/** Label for the single latest in-flight call — the self-replacing current-action line. */
 export function getAggregateNowLabel(parts: AnyToolPart[]): string | null {
   for (let index = parts.length - 1; index >= 0; index -= 1) {
     const part = parts[index]

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -185,6 +185,27 @@ describe("session error resilience", () => {
     expect(html).toContain("Resume")
   })
 
+  test("renders a resumable interruption as a quiet status line, not an error card", () => {
+    const html = renderErrorTranscriptWithResume({
+      name: "MessageAbortedError",
+      data: { message: "Aborted" },
+    })
+
+    expect(html).toContain("Task interrupted")
+    expect(html).toContain('data-testid="session-error-interrupted"')
+    expect(html).not.toContain("border-destructive/30")
+    expect(html).not.toContain("bg-destructive/5")
+  })
+
+  test("keeps the destructive card for errors that cannot be resumed", () => {
+    const html = renderErrorTranscriptWithResume({
+      name: "ProviderAuthError",
+      data: { message: "Provider authentication failed" },
+    })
+
+    expect(html).toContain("border-destructive/30")
+  })
+
   test("offers Resume on the error card for a provider timeout", () => {
     const html = renderErrorTranscriptWithResume({
       name: "ProviderHeaderTimeoutError",

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DynamicToolUIPart } from "ai";
 
-import { ToolAggregateGroup } from "../src/components/chat/tool-aggregate-group";
+import { ToolAggregateGroup, buildAggregateRows } from "../src/components/chat/tool-aggregate-group";
 
 describe("tool aggregate running feedback", () => {
   test("uses a quiet shimmer instead of a spinner for the current action", () => {
@@ -19,8 +19,109 @@ describe("tool aggregate running feedback", () => {
 
     expect(markup).toContain("Running command");
     expect(markup).not.toContain("Running 1 command");
-    expect(markup).toContain("Now:");
+    expect(markup).not.toContain("Now:");
     expect(markup).toContain("ow-text-shimmer");
     expect(markup).not.toContain("animate-spin");
+  });
+
+  test("shimmers the whole active action without a Now prefix", () => {
+    const settledRead: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "read",
+      toolCallId: "settled-read",
+      state: "output-available",
+      input: { filePath: "/repo/other.tsx" },
+      output: "contents",
+    };
+    const runningEdit: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "edit",
+      toolCallId: "running-edit",
+      state: "input-available",
+      input: { filePath: "/repo/message-list.tsx" },
+    };
+
+    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[settledRead, runningEdit]} />);
+
+    const nowLine = markup.match(/<span class="ow-text-shimmer[^"]*"[^>]*>([^<]*)<\/span>/);
+    expect(nowLine?.[1]).not.toContain("Now:");
+    expect(nowLine?.[1]).toContain("Editing message-list.tsx");
+  });
+
+  test("a single file action renders as its row, not under a count header", () => {
+    const settledEdit: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "edit",
+      toolCallId: "settled-edit",
+      state: "output-available",
+      input: { filePath: "/repo/file-chip.tsx" },
+      output: "ok",
+    };
+
+    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[settledEdit]} />);
+
+    expect(markup).not.toContain("Edited 1 file");
+    expect(markup).not.toContain("aria-expanded");
+    expect(markup).toContain("Edited");
+    expect(markup).toContain("file-chip.tsx");
+  });
+
+  test("a single running file action shimmers its verb in the solo row", () => {
+    const runningEdit: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "edit",
+      toolCallId: "running-edit",
+      state: "input-available",
+      input: { filePath: "/repo/message-list.tsx" },
+    };
+
+    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[runningEdit]} />);
+
+    expect(markup).not.toContain("Editing 1 file");
+    expect(markup).toContain("ow-text-shimmer");
+    expect(markup).toContain("Editing");
+    expect(markup).toContain("message-list.tsx");
+  });
+});
+
+describe("tool aggregate row merging", () => {
+  const readOf = (toolCallId: string, filePath: string): DynamicToolUIPart => ({
+    type: "dynamic-tool",
+    toolName: "read",
+    toolCallId,
+    state: "output-available",
+    input: { filePath },
+    output: "contents",
+  });
+
+  test("collapses repeated settled reads of the same file into one ×N row", () => {
+    const rows = buildAggregateRows(
+      [readOf("read-1", "/repo/message-list.tsx"), readOf("read-2", "/repo/message-list.tsx")],
+      [],
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.repeat).toBe(2);
+    expect(rows[0]?.index).toBe(0);
+    expect(rows[0]?.lastIndex).toBe(1);
+  });
+
+  test("keeps reads of different files as separate rows", () => {
+    const rows = buildAggregateRows(
+      [readOf("read-1", "/repo/a.tsx"), readOf("read-2", "/repo/b.tsx")],
+      [],
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.repeat === 1)).toBe(true);
+  });
+
+  test("a thought anchored between two identical reads keeps them apart", () => {
+    const rows = buildAggregateRows(
+      [readOf("read-1", "/repo/a.tsx"), readOf("read-2", "/repo/a.tsx")],
+      [{ afterIndex: 1, text: "Checking the export shape.", isStreaming: false }],
+    );
+
+    expect(rows).toHaveLength(2);
   });
 });

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -74,9 +74,9 @@ describe("tool aggregate running feedback", () => {
 
     const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[settledRead, runningEdit]} />);
 
-    const nowLine = markup.match(/<span class="ow-text-shimmer[^"]*"[^>]*>([^<]*)<\/span>/);
-    expect(nowLine?.[1]).not.toContain("Now:");
-    expect(nowLine?.[1]).toContain("Editing message-list.tsx");
+    expect(markup).not.toContain("Now:");
+    expect(markup).toContain("ow-text-shimmer");
+    expect(markup).toContain("Editing message-list.tsx");
   });
 
   test("a single file action renders as its row, not under a count header", () => {

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -72,7 +72,14 @@ describe("tool aggregate running feedback", () => {
       input: { filePath: "/repo/message-list.tsx" },
     };
 
-    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[settledRead, runningEdit]} />);
+    const markup = renderToStaticMarkup(
+      <CurrentToolLifecycleProvider
+        activityStatus="responding"
+        currentToolCallIds={new Set([runningEdit.toolCallId])}
+      >
+        <ToolAggregateGroup parts={[settledRead, runningEdit]} />
+      </CurrentToolLifecycleProvider>,
+    );
 
     expect(markup).not.toContain("Now:");
     expect(markup).toContain("ow-text-shimmer");


### PR DESCRIPTION
## Summary
- simplify interruption and single-file tool-call presentation
- add active-action shimmer for running work
- make file chips and shell commands more discreet and readable

## Verification
- `bun test tests/tool-aggregate-group.test.tsx tests/session-error-resilience.test.tsx tests/chat-message-grouping.test.ts`
- `bunx tsc --noEmit -p tsconfig.json`

Both checks pass on commit `d55014c42508466d576cdd6e0057b393300703cd`.