### PR TITLE
fix(cloud): make worker provisioning recovery single-owner

### DIFF
--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { Daytona, DaytonaConflictError, type CreateSandboxFromImageParams, type CreateSandboxFromSnapshotParams, type Sandbox } from "@daytonaio/sdk"
+import { Daytona, DaytonaConflictError, DaytonaNotFoundError, type CreateSandboxFromImageParams, type CreateSandboxFromSnapshotParams, type Sandbox } from "@daytonaio/sdk"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { DaytonaSandboxTable, WorkerTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
@@ -92,6 +92,8 @@ const signedPreviewRefreshLeadMs = 5 * 60 * 1000
 const wakeStartMaxAttempts = 3
 const wakeStartRetryBackoffMs = 250
 const wakeStartStateChangeTimeoutMs = 60_000
+const createConflictLookupMaxAttempts = 6
+const createConflictLookupBackoffMs = 2_000
 const logger = appLogger.child({ component: "daytona_provisioner" })
 
 const slug = (value: string) =>
@@ -155,6 +157,10 @@ function assertDaytonaConfig() {
 function isDaytonaNotFoundError(error: unknown) {
   if (!(error instanceof Error)) {
     return false
+  }
+
+  if (error instanceof DaytonaNotFoundError || error.name === "DaytonaNotFoundError") {
+    return true
   }
 
   const message = error.message.toLowerCase()
@@ -1025,6 +1031,25 @@ async function getSandboxByName(runtime: DaytonaProvisioningRuntime, name: strin
   }
 }
 
+async function getSandboxAfterCreateConflict(
+  runtime: DaytonaProvisioningRuntime,
+  lookupNames: string[],
+  wait: (ms: number) => Promise<unknown>,
+) {
+  for (let attempt = 1; attempt <= createConflictLookupMaxAttempts; attempt += 1) {
+    for (const lookupName of lookupNames) {
+      const sandbox = await getSandboxByName(runtime, lookupName)
+      if (sandbox) return sandbox
+    }
+
+    if (attempt < createConflictLookupMaxAttempts) {
+      await wait(createConflictLookupBackoffMs)
+    }
+  }
+
+  return null
+}
+
 type StartedOpenWorkProcess = {
   signedPreviewUrl: string
   signedPreviewUrlExpiresAt: Date
@@ -1242,6 +1267,7 @@ async function adoptDaytonaSandbox(input: {
 export async function provisionWorkerOnDaytonaWithRuntime(
   input: ProvisionInput,
   runtime: DaytonaProvisioningRuntime,
+  options: { sleep?: (ms: number) => Promise<unknown> } = {},
 ): Promise<ProvisionedInstance> {
   const name = currentDaytonaSandboxName(input)
   const lookupNames = daytonaSandboxLookupNames(input)
@@ -1270,11 +1296,9 @@ export async function provisionWorkerOnDaytonaWithRuntime(
     }
 
     if (isDaytonaConflictError(error)) {
-      for (const lookupName of lookupNames) {
-        const conflictSandbox = await getSandboxByName(runtime, lookupName)
-        if (conflictSandbox) {
-          return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: conflictSandbox, sharedVolume })
-        }
+      const conflictSandbox = await getSandboxAfterCreateConflict(runtime, lookupNames, options.sleep ?? sleep)
+      if (conflictSandbox) {
+        return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: conflictSandbox, sharedVolume })
       }
     }
 

--- a/ee/apps/den-api/src/workers/reconciler.ts
+++ b/ee/apps/den-api/src/workers/reconciler.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, isNull, lt } from "@openwork-ee/den-db/drizzle"
 import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
+import { automationUpdateChangedRows } from "../automations/update-result.js"
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
@@ -7,10 +8,64 @@ import { captureException } from "../observability/runtime.js"
 import { continueCloudProvisioning } from "../routes/workers/shared.js"
 
 type ProvisioningWorker = typeof WorkerTable.$inferSelect
+type WorkerToken = typeof WorkerTokenTable.$inferSelect
+type ProvisioningReconcileStore = {
+  listStaleWorkers: (input: { staleBefore: Date; limit: number }) => Promise<ProvisioningWorker[]>
+  claimWorker: (input: { worker: ProvisioningWorker; staleBefore: Date; claimedAt: Date }) => Promise<boolean>
+  getActiveTokens: (workerId: ProvisioningWorker["id"]) => Promise<WorkerToken[]>
+  markFailed: (workerId: ProvisioningWorker["id"]) => Promise<void>
+}
+type ReconcileStaleProvisioningWorkersOptions = {
+  store?: ProvisioningReconcileStore
+  continueProvisioning?: typeof continueCloudProvisioning
+  now?: Date
+  staleMs?: number
+  batchSize?: number
+}
 const logger = appLogger.child({ component: "worker_reconciler" })
 
 let workerProvisioningReconcileRunning = false
 let workerProvisioningReconcilePromise: Promise<void> | null = null
+
+const databaseProvisioningReconcileStore: ProvisioningReconcileStore = {
+  async listStaleWorkers(input) {
+    return db
+      .select()
+      .from(WorkerTable)
+      .where(and(
+        eq(WorkerTable.destination, "cloud"),
+        eq(WorkerTable.status, "provisioning"),
+        lt(WorkerTable.updated_at, input.staleBefore),
+      ))
+      .orderBy(asc(WorkerTable.updated_at))
+      .limit(input.limit)
+  },
+  async claimWorker(input) {
+    const result: unknown = await db
+      .update(WorkerTable)
+      .set({ updated_at: input.claimedAt })
+      .where(and(
+        eq(WorkerTable.id, input.worker.id),
+        eq(WorkerTable.destination, "cloud"),
+        eq(WorkerTable.status, "provisioning"),
+        eq(WorkerTable.updated_at, input.worker.updated_at),
+        lt(WorkerTable.updated_at, input.staleBefore),
+      ))
+    return automationUpdateChangedRows(result)
+  },
+  async getActiveTokens(workerId) {
+    return db
+      .select()
+      .from(WorkerTokenTable)
+      .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
+  },
+  async markFailed(workerId) {
+    await db
+      .update(WorkerTable)
+      .set({ status: "failed" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "provisioning")))
+  },
+}
 
 function tokenByScope(
   tokens: Array<typeof WorkerTokenTable.$inferSelect>,
@@ -19,26 +74,24 @@ function tokenByScope(
   return tokens.find((entry) => entry.scope === scope)?.token ?? null
 }
 
-async function reconcileWorker(worker: ProvisioningWorker) {
-  const tokens = await db
-    .select()
-    .from(WorkerTokenTable)
-    .where(and(eq(WorkerTokenTable.worker_id, worker.id), isNull(WorkerTokenTable.revoked_at)))
+async function reconcileWorker(
+  worker: ProvisioningWorker,
+  store: ProvisioningReconcileStore,
+  continueProvisioning: typeof continueCloudProvisioning,
+) {
+  const tokens = await store.getActiveTokens(worker.id)
 
   const hostToken = tokenByScope(tokens, "host")
   const clientToken = tokenByScope(tokens, "client")
   const activityToken = tokenByScope(tokens, "activity")
 
   if (!hostToken || !clientToken || !activityToken) {
-    await db
-      .update(WorkerTable)
-      .set({ status: "failed" })
-      .where(and(eq(WorkerTable.id, worker.id), eq(WorkerTable.status, "provisioning")))
+    await store.markFailed(worker.id)
     logger.error("provisioning reconcile failed", { worker_id: worker.id, reason: "missing_worker_tokens" })
     return
   }
 
-  await continueCloudProvisioning({
+  await continueProvisioning({
     workerId: worker.id,
     orgId: worker.org_id,
     name: worker.name,
@@ -48,22 +101,21 @@ async function reconcileWorker(worker: ProvisioningWorker) {
   })
 }
 
-export async function reconcileStaleProvisioningWorkers() {
-  const staleBefore = new Date(Date.now() - env.workerProvisioningReconcileStaleMs)
-  const workers = await db
-    .select()
-    .from(WorkerTable)
-    .where(and(
-      eq(WorkerTable.destination, "cloud"),
-      eq(WorkerTable.status, "provisioning"),
-      lt(WorkerTable.updated_at, staleBefore),
-    ))
-    .orderBy(asc(WorkerTable.updated_at))
-    .limit(env.workerProvisioningReconcileBatchSize)
+export async function reconcileStaleProvisioningWorkers(options: ReconcileStaleProvisioningWorkersOptions = {}) {
+  const store = options.store ?? databaseProvisioningReconcileStore
+  const continueProvisioning = options.continueProvisioning ?? continueCloudProvisioning
+  const scanAt = options.now ?? new Date()
+  const staleBefore = new Date(scanAt.getTime() - (options.staleMs ?? env.workerProvisioningReconcileStaleMs))
+  const workers = await store.listStaleWorkers({
+    staleBefore,
+    limit: options.batchSize ?? env.workerProvisioningReconcileBatchSize,
+  })
 
   for (const worker of workers) {
+    if (!await store.claimWorker({ worker, staleBefore, claimedAt: options.now ?? new Date() })) continue
+
     logger.info("reconciling stale provisioning worker", { worker_id: worker.id })
-    await reconcileWorker(worker)
+    await reconcileWorker(worker, store, continueProvisioning)
   }
 
   return { checked: workers.length }

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -1,4 +1,4 @@
-import { DaytonaConflictError } from "@daytonaio/sdk"
+import { DaytonaConflictError, DaytonaNotFoundError } from "@daytonaio/sdk"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
 import type { DaytonaProvisioningRuntime, DaytonaSandboxRuntime } from "../src/workers/daytona.js"
@@ -7,6 +7,7 @@ type DaytonaModule = typeof import("../src/workers/daytona.js")
 type ProvisionInput = Parameters<DaytonaModule["provisionWorkerOnDaytonaWithRuntime"]>[0]
 type UpsertInput = Parameters<DaytonaProvisioningRuntime["upsertSandbox"]>[0]
 type CreateInput = Parameters<DaytonaProvisioningRuntime["createSandbox"]>[0]
+type SandboxLookupResult = DaytonaSandboxRuntime | Error | null
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -34,6 +35,10 @@ function provisionInput(): ProvisionInput {
     clientToken: "client-token",
     activityToken: "activity-token",
   }
+}
+
+function daytonaNotFoundError(name: string) {
+  return new DaytonaNotFoundError(`sandbox ${name} not found`)
 }
 
 function makeSandbox(input: {
@@ -106,8 +111,8 @@ function makeSandbox(input: {
 
 function makeRuntime(input: {
   sandboxName?: string
-  nameResults?: Array<DaytonaSandboxRuntime | null>
-  nameResultsByName?: Array<{ name: string; results: Array<DaytonaSandboxRuntime | null> }>
+  nameResults?: SandboxLookupResult[]
+  nameResultsByName?: Array<{ name: string; results: SandboxLookupResult[] }>
   createdSandbox?: DaytonaSandboxRuntime
   createError?: Error
   checkpointExists?: boolean
@@ -138,6 +143,9 @@ function makeRuntime(input: {
           ? entry.results[lookupCount]
           : entry.results[entry.results.length - 1]
         lookupCounts.set(sandboxIdOrName, lookupCount + 1)
+        if (result instanceof Error) {
+          throw result
+        }
         if (result) {
           return result
         }
@@ -214,6 +222,59 @@ describe("Daytona Cloud provisioning adoption", () => {
     expect(runtime.healthChecks).toBe(1)
     expect(runtime.upserts).toHaveLength(1)
     expect(runtime.upserts[0]?.sandboxId).toBe("sbx_existing")
+  })
+
+  test("rechecks a create conflict through Daytona's read-after-write window", async () => {
+    const input = provisionInput()
+    const sandboxName = daytona.currentDaytonaSandboxName(input)
+    const existing = makeSandbox({ id: "sbx_late_visible", state: "started" })
+    const notFound = daytonaNotFoundError(sandboxName)
+    const runtime = makeRuntime({
+      nameResultsByName: [{
+        name: sandboxName,
+        results: [notFound, notFound, notFound, notFound, notFound, notFound, existing.sandbox],
+      }],
+      createError: new DaytonaConflictError("Sandbox with name already exists"),
+    })
+    const sleeps: number[] = []
+
+    const result = await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime, {
+      sleep: async (ms) => {
+        sleeps.push(ms)
+      },
+    })
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.nameLookups.filter((name) => name === sandboxName)).toHaveLength(7)
+    expect(sleeps).toEqual([2_000, 2_000, 2_000, 2_000, 2_000])
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_late_visible")
+  })
+
+  test("bounds create-conflict rechecks when the sandbox stays missing", async () => {
+    const input = provisionInput()
+    const currentName = daytona.currentDaytonaSandboxName(input)
+    const legacyName = daytona.daytonaSandboxName(input)
+    const runtime = makeRuntime({
+      nameResultsByName: [
+        { name: currentName, results: [daytonaNotFoundError(currentName)] },
+        { name: legacyName, results: [daytonaNotFoundError(legacyName)] },
+      ],
+      createError: new DaytonaConflictError("Sandbox with name already exists"),
+    })
+    const sleeps: number[] = []
+
+    await expect(daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime, {
+      sleep: async (ms) => {
+        sleeps.push(ms)
+      },
+    })).rejects.toThrow("Sandbox with name already exists")
+
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.nameLookups.filter((name) => name === currentName)).toHaveLength(7)
+    expect(runtime.nameLookups.filter((name) => name === legacyName)).toHaveLength(7)
+    expect(sleeps).toEqual([2_000, 2_000, 2_000, 2_000, 2_000])
+    expect(runtime.upserts).toHaveLength(0)
   })
 
   test("creates a new sandbox when the deterministic name is unused", async () => {

--- a/ee/apps/den-api/test/worker-provisioning-reconciler.test.ts
+++ b/ee/apps/den-api/test/worker-provisioning-reconciler.test.ts
@@ -1,0 +1,168 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+type ReconcilerModule = typeof import("../src/workers/reconciler.js")
+type ReconcileOptions = NonNullable<Parameters<ReconcilerModule["reconcileStaleProvisioningWorkers"]>[0]>
+type ReconcileStore = NonNullable<ReconcileOptions["store"]>
+type ReconcileWorker = Awaited<ReturnType<ReconcileStore["listStaleWorkers"]>>[number]
+type ReconcileToken = Awaited<ReturnType<ReconcileStore["getActiveTokens"]>>[number]
+type ContinueProvisioning = NonNullable<ReconcileOptions["continueProvisioning"]>
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.PROVISIONER_MODE = "stub"
+}
+
+let reconciler: ReconcilerModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  reconciler = await import("../src/workers/reconciler.js")
+})
+
+function makeWorker(updatedAt: Date): ReconcileWorker {
+  return {
+    id: createDenTypeId("worker"),
+    org_id: createDenTypeId("org"),
+    created_by_user_id: createDenTypeId("user"),
+    name: "Cloud",
+    description: null,
+    destination: "cloud",
+    status: "provisioning",
+    image_version: null,
+    workspace_path: null,
+    sandbox_backend: "daytona",
+    last_heartbeat_at: null,
+    last_active_at: null,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  }
+}
+
+function makeTokens(workerId: ReconcileWorker["id"]): ReconcileToken[] {
+  const scopes: ReconcileToken["scope"][] = ["host", "client", "activity"]
+  return scopes.map((scope) => ({
+    id: createDenTypeId("workerToken"),
+    worker_id: workerId,
+    scope,
+    token: `${scope}-token`,
+    created_at: new Date("2026-08-26T10:00:00.000Z"),
+    revoked_at: null,
+  }))
+}
+
+function makeReconcileStore(worker: ReconcileWorker, options: { alwaysListStaleSnapshot?: boolean } = {}) {
+  let currentWorker = { ...worker }
+  let claims = 0
+  const tokens = makeTokens(worker.id)
+  const store: ReconcileStore = {
+    async listStaleWorkers(input) {
+      const candidate = options.alwaysListStaleSnapshot ? worker : currentWorker
+      return candidate.status === "provisioning" && candidate.updated_at < input.staleBefore
+        ? [{ ...candidate }].slice(0, input.limit)
+        : []
+    },
+    async claimWorker(input) {
+      if (
+        currentWorker.status !== "provisioning"
+        || currentWorker.updated_at.getTime() !== input.worker.updated_at.getTime()
+        || currentWorker.updated_at >= input.staleBefore
+      ) {
+        return false
+      }
+
+      currentWorker = { ...currentWorker, updated_at: input.claimedAt }
+      claims += 1
+      return true
+    },
+    async getActiveTokens(workerId) {
+      return tokens.filter((token) => token.worker_id === workerId)
+    },
+    async markFailed(workerId) {
+      if (currentWorker.id === workerId && currentWorker.status === "provisioning") {
+        currentWorker = { ...currentWorker, status: "failed" }
+      }
+    },
+  }
+
+  return {
+    store,
+    get worker() {
+      return currentWorker
+    },
+    get claims() {
+      return claims
+    },
+  }
+}
+
+function deferred() {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve: () => resolve?.() }
+}
+
+describe("stale cloud provisioning reconciliation", () => {
+  test("atomically claims only one of two replicas that selected the same stale worker", async () => {
+    const now = new Date("2026-08-26T10:30:00.000Z")
+    const state = makeReconcileStore(makeWorker(new Date("2026-08-26T10:00:00.000Z")), {
+      alwaysListStaleSnapshot: true,
+    })
+    let continueCalls = 0
+    const continueProvisioning: ContinueProvisioning = async () => {
+      continueCalls += 1
+    }
+
+    await Promise.all([
+      reconciler.reconcileStaleProvisioningWorkers({ store: state.store, continueProvisioning, now, staleMs: 20 * 60_000 }),
+      reconciler.reconcileStaleProvisioningWorkers({ store: state.store, continueProvisioning, now, staleMs: 20 * 60_000 }),
+    ])
+
+    expect(state.claims).toBe(1)
+    expect(continueCalls).toBe(1)
+    expect(state.worker.status).toBe("provisioning")
+    expect(state.worker.updated_at).toEqual(now)
+  })
+
+  test("keeps a second pass two seconds later from reconciling an in-flight claim", async () => {
+    const firstPassAt = new Date("2026-08-26T10:30:00.000Z")
+    const state = makeReconcileStore(makeWorker(new Date("2026-08-26T10:00:00.000Z")))
+    const started = deferred()
+    const release = deferred()
+    let continueCalls = 0
+    const continueProvisioning: ContinueProvisioning = async () => {
+      continueCalls += 1
+      started.resolve()
+      await release.promise
+    }
+
+    const firstPass = reconciler.reconcileStaleProvisioningWorkers({
+      store: state.store,
+      continueProvisioning,
+      now: firstPassAt,
+      staleMs: 20 * 60_000,
+    })
+    await started.promise
+
+    const secondPass = await reconciler.reconcileStaleProvisioningWorkers({
+      store: state.store,
+      continueProvisioning,
+      now: new Date(firstPassAt.getTime() + 2_000),
+      staleMs: 20 * 60_000,
+    })
+
+    expect(secondPass.checked).toBe(0)
+    expect(state.claims).toBe(1)
+    expect(continueCalls).toBe(1)
+    expect(state.worker.status).toBe("provisioning")
+
+    release.resolve()
+    await firstPass
+  })
+})

--- a/evals/specs/cloud-worker-provisioning-recovery.test.ts
+++ b/evals/specs/cloud-worker-provisioning-recovery.test.ts
@@ -1,0 +1,222 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { createDenTypeId } from "../../ee/packages/utils/src/typeid.js";
+import type {
+  DaytonaProvisioningRuntime,
+  DaytonaSandboxRuntime,
+} from "../../ee/apps/den-api/src/workers/daytona.js";
+
+type ReconcilerModule = typeof import("../../ee/apps/den-api/src/workers/reconciler.js");
+type DaytonaModule = typeof import("../../ee/apps/den-api/src/workers/daytona.js");
+type ReconcileOptions = NonNullable<Parameters<ReconcilerModule["reconcileStaleProvisioningWorkers"]>[0]>;
+type ReconcileStore = NonNullable<ReconcileOptions["store"]>;
+type ReconcileWorker = Awaited<ReturnType<ReconcileStore["listStaleWorkers"]>>[number];
+type ReconcileToken = Awaited<ReturnType<ReconcileStore["getActiveTokens"]>>[number];
+type ContinueProvisioning = NonNullable<ReconcileOptions["continueProvisioning"]>;
+type ProvisionInput = Parameters<DaytonaModule["provisionWorkerOnDaytonaWithRuntime"]>[0];
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test";
+  process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32);
+  process.env.BETTER_AUTH_SECRET ??= "y".repeat(32);
+  process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790";
+  process.env.CORS_ORIGINS ??= "http://127.0.0.1:8790";
+  process.env.PROVISIONER_MODE = "stub";
+  process.env.DAYTONA_API_KEY = "daytona-test-key";
+  process.env.DAYTONA_WORKER_PROXY_BASE_URL = "https://workers.example.test";
+  process.env.DAYTONA_SNAPSHOT = "openwork-test-snapshot";
+}
+
+function makeWorker(updatedAt: Date): ReconcileWorker {
+  return {
+    id: createDenTypeId("worker"),
+    org_id: createDenTypeId("org"),
+    created_by_user_id: createDenTypeId("user"),
+    name: "Cloud",
+    description: null,
+    destination: "cloud",
+    status: "provisioning",
+    image_version: null,
+    workspace_path: null,
+    sandbox_backend: "daytona",
+    last_heartbeat_at: null,
+    last_active_at: null,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  };
+}
+
+function makeTokens(workerId: ReconcileWorker["id"]): ReconcileToken[] {
+  const scopes: ReconcileToken["scope"][] = ["host", "client", "activity"];
+  return scopes.map((scope) => ({
+    id: createDenTypeId("workerToken"),
+    worker_id: workerId,
+    scope,
+    token: `${scope}-token`,
+    created_at: new Date("2026-08-26T10:00:00.000Z"),
+    revoked_at: null,
+  }));
+}
+
+function namedError(name: string, message: string) {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+function makeDaytonaRuntime(lookupName: string, visibleAtLookup: number | null) {
+  let lookupCount = 0;
+  let createCount = 0;
+  let persistedCount = 0;
+  const sandbox = {
+    id: "sbx_late_visible",
+    state: "started",
+    target: "us-test",
+    async refreshData() {},
+    async start() {},
+    async delete() {},
+    async getSignedPreviewUrl() {
+      return { url: "https://late-visible.preview.example.test" };
+    },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() {
+        return { cmdId: "cmd_1" };
+      },
+      async getSessionCommand() {
+        return { exitCode: null };
+      },
+      async getSessionCommandLogs() {
+        return { stdout: "", stderr: "" };
+      },
+    },
+  } satisfies DaytonaSandboxRuntime;
+  const runtime = {
+    async getVolume() {
+      return { id: "vol_shared", state: "ready" };
+    },
+    async getSandbox(name: string) {
+      if (name === lookupName) {
+        lookupCount += 1;
+        if (visibleAtLookup !== null && lookupCount >= visibleAtLookup) return sandbox;
+      }
+      throw namedError("DaytonaNotFoundError", `sandbox ${name} not found`);
+    },
+    async createSandbox() {
+      createCount += 1;
+      throw namedError("DaytonaConflictError", "Sandbox with name already exists");
+    },
+    async upsertSandbox() {
+      persistedCount += 1;
+    },
+    async checkpointExists() {
+      return false;
+    },
+    async verifyRestoreMarker() {
+      return false;
+    },
+    async waitForHealth() {},
+  } satisfies DaytonaProvisioningRuntime;
+
+  return {
+    runtime,
+    get lookupCount() {
+      return lookupCount;
+    },
+    get createCount() {
+      return createCount;
+    },
+    get persistedCount() {
+      return persistedCount;
+    },
+  };
+}
+
+test("cloud provisioning remains single-owner and survives Daytona read-after-write lag", async ({ evidence }) => {
+  seedRequiredEnv();
+  const [reconciler, daytona] = await Promise.all([
+    import("../../ee/apps/den-api/src/workers/reconciler.js"),
+    import("../../ee/apps/den-api/src/workers/daytona.js"),
+  ]);
+
+  const staleWorker = makeWorker(new Date("2026-08-26T10:00:00.000Z"));
+  const tokens = makeTokens(staleWorker.id);
+  const claimedAt = new Date("2026-08-26T10:30:00.000Z");
+  let durableUpdatedAt = staleWorker.updated_at;
+  let claimCount = 0;
+  let provisionAttempts = 0;
+  const store: ReconcileStore = {
+    async listStaleWorkers() {
+      return [{ ...staleWorker }];
+    },
+    async claimWorker(input) {
+      if (durableUpdatedAt.getTime() !== input.worker.updated_at.getTime()) return false;
+      durableUpdatedAt = input.claimedAt;
+      claimCount += 1;
+      return true;
+    },
+    async getActiveTokens() {
+      return tokens;
+    },
+    async markFailed() {
+      throw new Error("claimed worker unexpectedly failed");
+    },
+  };
+  const continueProvisioning: ContinueProvisioning = async () => {
+    provisionAttempts += 1;
+  };
+
+  await Promise.all([
+    reconciler.reconcileStaleProvisioningWorkers({ store, continueProvisioning, now: claimedAt }),
+    reconciler.reconcileStaleProvisioningWorkers({ store, continueProvisioning, now: claimedAt }),
+  ]);
+
+  expect(claimCount).toBe(1);
+  expect(provisionAttempts).toBe(1);
+  expect(durableUpdatedAt).toEqual(claimedAt);
+  evidence.recordAssertionEvidence(
+    "Concurrent stale-worker reconciliation has one durable owner",
+    "Both reconcilers selected the same stale worker, but the atomic claim admitted exactly one provisioning attempt.",
+    true,
+  );
+
+  const provisionInput: ProvisionInput = {
+    workerId: createDenTypeId("worker"),
+    name: "Cloud",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  };
+  const sandboxName = daytona.currentDaytonaSandboxName(provisionInput);
+  const lateVisible = makeDaytonaRuntime(sandboxName, 7);
+  let lateVisibleWaitMs = 0;
+  const provisioned = await daytona.provisionWorkerOnDaytonaWithRuntime(provisionInput, lateVisible.runtime, {
+    sleep: async (ms) => {
+      lateVisibleWaitMs += ms;
+    },
+  });
+
+  expect(provisioned.status).toBe("healthy");
+  expect(lateVisible.createCount).toBe(1);
+  expect(lateVisible.lookupCount).toBe(7);
+  expect(lateVisibleWaitMs).toBe(10_000);
+  expect(lateVisible.persistedCount).toBe(1);
+
+  const permanentlyMissing = makeDaytonaRuntime(sandboxName, null);
+  let missingWaitMs = 0;
+  await expect(daytona.provisionWorkerOnDaytonaWithRuntime(provisionInput, permanentlyMissing.runtime, {
+    sleep: async (ms) => {
+      missingWaitMs += ms;
+    },
+  })).rejects.toThrow("Sandbox with name already exists");
+
+  expect(permanentlyMissing.createCount).toBe(1);
+  expect(permanentlyMissing.lookupCount).toBe(7);
+  expect(missingWaitMs).toBe(10_000);
+  expect(permanentlyMissing.persistedCount).toBe(0);
+  evidence.recordAssertionEvidence(
+    "Daytona read-after-write lag is retried but bounded",
+    "A sandbox hidden through the observed 10-second window became healthy and persisted; a sandbox still missing after the same bounded grace rejected without persistence.",
+    true,
+  );
+});


### PR DESCRIPTION
Fixes #4136.

## Problem
Two Den replicas could select the same stale `provisioning` worker. Pass A created the Daytona sandbox; pass B hit a create-name conflict, immediately looked it up before Daytona's read-after-write visibility converged, got NotFound, and marked the worker failed even though the sandbox became healthy seconds later.

## Fix
- Atomically claim each stale worker with a status + exact `updated_at` compare-and-set before recovery; only one replica owns provisioning.
- After a Daytona create-name conflict, retry sandbox lookup six times over a bounded 10-second grace window, then preserve the original failure if the sandbox remains genuinely missing.
- Keep the in-process reconcile-loop guard, but correctness no longer depends on it.

## Verification — Passed (local lane; Daytona not required for deterministic seams)
Head `3314cba4a`:
- `bun test test/worker-provisioning-reconciler.test.ts test/daytona-provisioning.test.ts` → 17 pass, 0 fail, 100 expects
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false` → clean
- `vitest run --project pr specs/cloud-worker-provisioning-recovery.test.ts` → 1 passed, 0 failed, 0 skipped

The testkit spec proves both claims: concurrent reconcilers admit exactly one provision attempt, and Daytona read-after-write lag is retried but bounded (late-visible succeeds; permanently missing fails without persistence).