### PR TITLE
fix(automations): bound rejected runner credential storms

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -44,6 +44,18 @@ function sleep(ms, signal) {
   })
 }
 
+function responseErrorCode(payload) {
+  const code = payload?.error
+  return typeof code === "string" && /^[a-z][a-z0-9_]{0,63}$/.test(code) ? code : null
+}
+
+function responseRetryAfterSeconds(response) {
+  const value = response.headers.get("retry-after")?.trim() ?? ""
+  if (!/^\d{1,9}$/.test(value)) return null
+  const seconds = Number(value)
+  return Number.isSafeInteger(seconds) ? seconds : null
+}
+
 async function requestJson(fetchImpl, baseUrl, token, requestPath, options = {}) {
   const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}${requestPath}`, {
     method: options.method ?? "GET",
@@ -61,6 +73,10 @@ async function requestJson(fetchImpl, baseUrl, token, requestPath, options = {})
   if (!response.ok) {
     const error = new Error(String(payload?.message ?? payload?.error ?? `Request returned ${response.status}`))
     Object.defineProperty(error, "status", { value: response.status })
+    const code = responseErrorCode(payload)
+    const retryAfterSeconds = responseRetryAfterSeconds(response)
+    if (code) Object.defineProperty(error, "code", { value: code })
+    if (retryAfterSeconds !== null) Object.defineProperty(error, "retryAfterSeconds", { value: retryAfterSeconds })
     throw error
   }
   return payload
@@ -280,6 +296,9 @@ export function createDesktopAutomationRunner(options) {
     }
   }
 
+  const isCredentialRejection = (error) => [401, 403].includes(error?.status)
+    || (error?.status === 429 && error?.code === "runner_unauthorized")
+
   const runnerRequest = async (state, requestPath, request = {}) => {
     if (!isCurrent(state)) {
       throw state.controller.signal.reason ?? new Error("Automation runner generation retired")
@@ -298,7 +317,7 @@ export function createDesktopAutomationRunner(options) {
         },
       )
     } catch (error) {
-      if ([401, 403].includes(error?.status)) rejectCredential(state, error.status)
+      if (isCredentialRejection(error)) rejectCredential(state, error.status)
       throw error
     }
   }
@@ -425,7 +444,7 @@ export function createDesktopAutomationRunner(options) {
         await waitBeforeReconnect(RUNNER_WORK_POLL_MS, state.controller.signal)
       } catch (error) {
         if (!isCurrent(state)) return
-        if ([401, 403].includes(error?.status)) return
+        if (isCredentialRejection(error)) return
         options.log?.(`runner polling failed: ${error instanceof Error ? error.message : String(error)}`)
         const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
         try {

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -56,6 +56,11 @@ function responseRetryAfterSeconds(response) {
   return Number.isSafeInteger(seconds) ? seconds : null
 }
 
+export function isAutomationRunnerCredentialRejection(error) {
+  return [401, 403].includes(error?.status)
+    || (error?.status === 429 && error?.code === "runner_unauthorized")
+}
+
 async function requestJson(fetchImpl, baseUrl, token, requestPath, options = {}) {
   const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}${requestPath}`, {
     method: options.method ?? "GET",
@@ -296,9 +301,6 @@ export function createDesktopAutomationRunner(options) {
     }
   }
 
-  const isCredentialRejection = (error) => [401, 403].includes(error?.status)
-    || (error?.status === 429 && error?.code === "runner_unauthorized")
-
   const runnerRequest = async (state, requestPath, request = {}) => {
     if (!isCurrent(state)) {
       throw state.controller.signal.reason ?? new Error("Automation runner generation retired")
@@ -317,7 +319,7 @@ export function createDesktopAutomationRunner(options) {
         },
       )
     } catch (error) {
-      if (isCredentialRejection(error)) rejectCredential(state, error.status)
+      if (isAutomationRunnerCredentialRejection(error)) rejectCredential(state, error.status)
       throw error
     }
   }
@@ -444,7 +446,7 @@ export function createDesktopAutomationRunner(options) {
         await waitBeforeReconnect(RUNNER_WORK_POLL_MS, state.controller.signal)
       } catch (error) {
         if (!isCurrent(state)) return
-        if (isCredentialRejection(error)) return
+        if (isAutomationRunnerCredentialRejection(error)) return
         options.log?.(`runner polling failed: ${error instanceof Error ? error.message : String(error)}`)
         const backoff = Math.min(30_000, 500 * (2 ** reconnectAttempt++))
         try {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -27,16 +27,18 @@ function legacyRunnerToken() {
 
 const EXPECTED_RECONNECT_DELAYS = [500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000]
 
-async function observeHttpFailureBackoff(status) {
+/** @param {Record<string, string>} [payload] */
+async function observeHttpFailureBackoff(status, payload = { message: "injected HTTP failure" }) {
   const paths = []
   const delays = []
+  const rejections = []
   const done = new AbortController()
   let runner = null
   runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url) => {
       paths.push(new URL(url).pathname)
-      return Response.json({ message: "injected HTTP failure" }, { status })
+      return Response.json(payload, { status })
     },
     random: () => 0.5,
     waitBeforeReconnect: async (ms) => {
@@ -47,6 +49,7 @@ async function observeHttpFailureBackoff(status) {
         done.abort()
       }
     },
+    onCredentialRejected: () => { rejections.push(status) },
   })
   runner.configure({
     baseUrl: "https://den.example.com",
@@ -56,7 +59,7 @@ async function observeHttpFailureBackoff(status) {
   if (!done.signal.aborted) {
     await new Promise((resolve) => done.signal.addEventListener("abort", resolve, { once: true }))
   }
-  return { paths, delays }
+  return { paths, delays, rejections }
 }
 
 async function flushTasks() {
@@ -75,7 +78,12 @@ function withTimeout(promise, message) {
   })
 }
 
-async function observeCredentialRejection(status, deniedRequest) {
+/** @param {Record<string, string>} [payload] */
+async function observeCredentialRejection(
+  status,
+  deniedRequest,
+  payload = { message: "invalid runner credential" },
+) {
   const paths = []
   const delays = []
   const rejections = []
@@ -87,7 +95,7 @@ async function observeCredentialRejection(status, deniedRequest) {
       const path = new URL(url).pathname
       paths.push(path)
       if (path === deniedRequest) {
-        return Response.json({ message: "invalid runner credential" }, { status })
+        return Response.json(payload, { status, headers: { "Retry-After": "60" } })
       }
       if (path === "/v1/automation-runner/work") return Response.json({ items: [] })
       return new Promise((resolve, reject) => {
@@ -367,6 +375,24 @@ test("repeated HTTP 502 responses retain exponential runner reconnect backoff", 
   assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
   assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
   assert.equal(paths.filter((path) => path === "/v1/automation-runners/events").length, 0)
+})
+
+test("HTTP 429 runner_unauthorized retires exactly that credential without reconnecting", async () => {
+  const { paths, delays, rejections } = await observeCredentialRejection(
+    429,
+    "/v1/automation-runner/work",
+    { error: "runner_unauthorized" },
+  )
+  assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 1)
+  assert.deepEqual(delays, [])
+  assert.deepEqual(rejections, [429])
+})
+
+test("an unrelated HTTP 429 retains generic backoff without requesting a credential remint", async () => {
+  const { paths, delays, rejections } = await observeHttpFailureBackoff(429, { error: "rate_limited" })
+  assert.deepEqual(delays, EXPECTED_RECONNECT_DELAYS)
+  assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 10)
+  assert.deepEqual(rejections, [])
 })
 
 for (const status of [401, 403]) {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -5,6 +5,7 @@ import {
   classifyAutomationExecutionError,
   createDesktopAutomationRunner,
   executeDesktopAutomation,
+  isAutomationRunnerCredentialRejection,
   normalizeRunnerBaseUrl,
   runnerTokenAudience,
 } from "./automation-runner.mjs"
@@ -264,6 +265,14 @@ test("runner credentials retain their signed Den audience", () => {
   assert.equal(runnerTokenAudience(runnerTokenFor("https://den.example.com/api/den")), "https://den.example.com/api/den")
   assert.equal(runnerTokenAudience("not-a-runner-token"), null)
   assert.equal(runnerTokenAudience(runnerTokenFor("http://attacker.example.com")), null)
+})
+
+test("runner credential rejection classification distinguishes auth throttles", () => {
+  assert.equal(isAutomationRunnerCredentialRejection({ status: 401 }), true)
+  assert.equal(isAutomationRunnerCredentialRejection({ status: 403 }), true)
+  assert.equal(isAutomationRunnerCredentialRejection({ status: 429, code: "runner_unauthorized" }), true)
+  assert.equal(isAutomationRunnerCredentialRejection({ status: 429, code: "rate_limited" }), false)
+  assert.equal(isAutomationRunnerCredentialRejection({ status: 429 }), false)
 })
 
 test("a renderer-supplied non-https base URL never receives the runner token", async () => {

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto"
+import { createHash, createHmac, timingSafeEqual } from "node:crypto"
 import {
   AUTOMATION_MODEL_ATTENTION_CAPABILITY,
   type AutomationDesktopRunnerCapability,
@@ -8,7 +8,9 @@ import { firstForwardedValue, publicRequestUrl, trustedForwardedOrigin } from ".
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
 const TOKEN_ROUTE_SUFFIX = "/v1/automation-runners/token"
+const RUNNER_ROUTE_MARKER = "/v1/automation-"
 const DEN_WEB_PROXY_PREFIX = "/api/den"
+const MAX_TOKEN_LENGTH = 16_384
 
 export type AutomationRunnerIdentity = {
   organizationId: string
@@ -17,6 +19,87 @@ export type AutomationRunnerIdentity = {
   capabilities: AutomationDesktopRunnerCapability[]
   audience: string | null
   expiresAt: number
+}
+
+export type AutomationRunnerClaimedIdentity = {
+  credentialVersion?: number
+  organizationId?: string
+  ownerMemberId?: string
+  runnerId?: string
+  expiresAt?: number
+}
+
+export type AutomationRunnerRejectionReason =
+  | "missing_authorization"
+  | "malformed_authorization"
+  | "malformed_token"
+  | "malformed_payload"
+  | "bad_signature"
+  | "unsupported_version"
+  | "invalid_claims"
+  | "expired"
+  | "audience_mismatch"
+  | "owner_inactive"
+
+export type AutomationRunnerRejection = {
+  reason: AutomationRunnerRejectionReason
+  claims: AutomationRunnerClaimedIdentity
+}
+
+export type AutomationRunnerAuthentication =
+  | { ok: true; identity: AutomationRunnerIdentity }
+  | { ok: false; rejection: AutomationRunnerRejection }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function claimedIdentity(decoded: Record<string, unknown>): AutomationRunnerClaimedIdentity {
+  return {
+    credentialVersion: typeof decoded.v === "number" && Number.isSafeInteger(decoded.v) ? decoded.v : undefined,
+    organizationId: typeof decoded.o === "string" ? decoded.o : undefined,
+    ownerMemberId: typeof decoded.m === "string" ? decoded.m : undefined,
+    runnerId: typeof decoded.r === "string" ? decoded.r : undefined,
+    expiresAt: typeof decoded.e === "number" && Number.isSafeInteger(decoded.e) ? decoded.e : undefined,
+  }
+}
+
+function reject(
+  reason: AutomationRunnerRejectionReason,
+  claims: AutomationRunnerClaimedIdentity = {},
+): AutomationRunnerAuthentication {
+  return { ok: false, rejection: { reason, claims } }
+}
+
+function fingerprint(value: string | undefined) {
+  if (value === undefined) return undefined
+  return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 16)}`
+}
+
+export function automationRunnerRejectionLogFields(rejection: AutomationRunnerRejection) {
+  return {
+    reason: rejection.reason,
+    claimed_runner_id_fingerprint: fingerprint(rejection.claims.runnerId),
+    claimed_organization_id_fingerprint: fingerprint(rejection.claims.organizationId),
+    claimed_owner_member_id_fingerprint: fingerprint(rejection.claims.ownerMemberId),
+    runner_auth_version: rejection.claims.credentialVersion,
+    runner_auth_expires_at_ms: rejection.claims.expiresAt,
+  }
+}
+
+export function automationRunnerOwnerInactiveRejection(
+  identity: AutomationRunnerIdentity,
+): AutomationRunnerRejection {
+  return {
+    reason: "owner_inactive",
+    claims: {
+      credentialVersion: identity.audience === null ? 1 : 2,
+      organizationId: identity.organizationId,
+      ownerMemberId: identity.ownerMemberId,
+      runnerId: identity.runnerId,
+      expiresAt: identity.expiresAt,
+    },
+  }
 }
 
 function normalizeRunnerAudience(value: string): string | null {
@@ -44,6 +127,20 @@ export function automationRunnerAudienceFromRequestUrl(requestUrl: string): stri
   return audience
 }
 
+function automationRunnerAudienceFromApiRequestUrl(requestUrl: string): string {
+  const parsed = new URL(requestUrl)
+  const routeIndex = parsed.pathname.lastIndexOf(RUNNER_ROUTE_MARKER)
+  if (!["http:", "https:"].includes(parsed.protocol) || routeIndex < 0) {
+    throw new Error("automation_runner_audience_invalid")
+  }
+  parsed.pathname = parsed.pathname.slice(0, routeIndex) || "/"
+  parsed.search = ""
+  parsed.hash = ""
+  const audience = normalizeRunnerAudience(parsed.toString())
+  if (!audience) throw new Error("automation_runner_audience_invalid")
+  return audience
+}
+
 /**
  * Bind proxied runner credentials to the public Den route the desktop will
  * actually use. The Den Web proxy strips caller-supplied forwarding headers
@@ -63,7 +160,7 @@ export function automationRunnerAudienceFromRequest(
     const forwarded = trustedForwardedOrigin(request, { trustedOrigins: options.trustedOrigins })
     if (forwarded) return `${forwarded.origin}${DEN_WEB_PROXY_PREFIX}`
   }
-  return automationRunnerAudienceFromRequestUrl(
+  return automationRunnerAudienceFromApiRequestUrl(
     publicRequestUrl(request, { trustedOrigins: options.trustedOrigins }).toString(),
   )
 }
@@ -94,48 +191,63 @@ export class AutomationRunnerAuth {
     return { token, expiresAt, eventsPath: "/v1/automation-runners/events" as const }
   }
 
-  authenticate(authorization: string | undefined): AutomationRunnerIdentity | null {
-    const match = /^Bearer\s+(.+)$/i.exec(authorization?.trim() ?? "")
+  authenticate(authorization: string | undefined, expectedAudience: string): AutomationRunnerAuthentication {
+    const normalizedAuthorization = authorization?.trim() ?? ""
+    if (!normalizedAuthorization) return reject("missing_authorization")
+    const match = /^Bearer\s+(.+)$/i.exec(normalizedAuthorization)
     const token = match?.[1]?.trim()
-    if (!token) return null
+    if (!token) return reject("malformed_authorization")
+    if (token.length > MAX_TOKEN_LENGTH) return reject("malformed_token")
     const [payload, signature, extra] = token.split(".")
-    if (!payload || !signature || extra) return null
+    if (!payload || !signature || extra) return reject("malformed_token")
+    let decoded: Record<string, unknown>
+    try {
+      const parsed: unknown = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
+      if (!isRecord(parsed)) return reject("malformed_payload")
+      decoded = parsed
+    } catch {
+      return reject("malformed_payload")
+    }
+    const claims = claimedIdentity(decoded)
     const expected = new TextEncoder().encode(this.sign(payload))
     const actual = new TextEncoder().encode(signature)
-    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null
-    try {
-      const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>
-      const audience = decoded.v === 2 && typeof decoded.a === "string"
-        ? normalizeRunnerAudience(decoded.a)
+    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+      return reject("bad_signature", claims)
+    }
+    if (decoded.v !== 1 && decoded.v !== 2) return reject("unsupported_version", claims)
+    const audience = decoded.v === 2 && typeof decoded.a === "string"
+      ? normalizeRunnerAudience(decoded.a)
+      : null
+    const capabilities: AutomationDesktopRunnerCapability[] | null = decoded.c === undefined
+      ? []
+      : Array.isArray(decoded.c)
+          && decoded.c.length <= 1
+          && decoded.c.every((capability) => capability === AUTOMATION_MODEL_ATTENTION_CAPABILITY)
+        ? decoded.c.map(() => AUTOMATION_MODEL_ATTENTION_CAPABILITY)
         : null
-      const capabilities = decoded.c === undefined
-        ? []
-        : Array.isArray(decoded.c)
-            && decoded.c.length <= 1
-            && decoded.c.every((capability) => capability === AUTOMATION_MODEL_ATTENTION_CAPABILITY)
-          ? decoded.c as AutomationDesktopRunnerCapability[]
-          : null
-      if (
-        (decoded.v !== 1 && decoded.v !== 2)
-        || typeof decoded.o !== "string"
-        || typeof decoded.m !== "string"
-        || typeof decoded.r !== "string"
-        || capabilities === null
-        || (decoded.v === 2 && !audience)
-        || typeof decoded.e !== "number"
-        || !Number.isSafeInteger(decoded.e)
-        || decoded.e <= Date.now()
-      ) return null
-      return {
+    if (
+      typeof decoded.o !== "string"
+      || typeof decoded.m !== "string"
+      || typeof decoded.r !== "string"
+      || capabilities === null
+      || (decoded.v === 2 && !audience)
+      || typeof decoded.e !== "number"
+      || !Number.isSafeInteger(decoded.e)
+    ) return reject("invalid_claims", claims)
+    if (decoded.e <= Date.now()) return reject("expired", claims)
+    if (decoded.v === 2 && audience !== normalizeRunnerAudience(expectedAudience)) {
+      return reject("audience_mismatch", claims)
+    }
+    return {
+      ok: true,
+      identity: {
         organizationId: decoded.o,
         ownerMemberId: decoded.m,
         runnerId: decoded.r,
         capabilities,
         audience,
         expiresAt: decoded.e,
-      }
-    } catch {
-      return null
+      },
     }
   }
 

--- a/ee/apps/den-api/src/automations/runner-auth.ts
+++ b/ee/apps/den-api/src/automations/runner-auth.ts
@@ -3,7 +3,6 @@ import {
   AUTOMATION_MODEL_ATTENTION_CAPABILITY,
   type AutomationDesktopRunnerCapability,
 } from "@openwork/types/automations"
-import { env } from "../env.js"
 import { firstForwardedValue, publicRequestUrl, trustedForwardedOrigin } from "../request-url.js"
 
 const TOKEN_TTL_MS = 12 * 60 * 60_000
@@ -166,7 +165,7 @@ export function automationRunnerAudienceFromRequest(
 }
 
 export class AutomationRunnerAuth {
-  constructor(private readonly secret = env.betterAuthSecret) {}
+  constructor(private readonly secret: string) {}
 
   private sign(payload: string) {
     return createHmac("sha256", this.secret)
@@ -252,5 +251,3 @@ export class AutomationRunnerAuth {
   }
 
 }
-
-export const automationRunnerAuth = new AutomationRunnerAuth()

--- a/ee/apps/den-api/src/automations/runner-rejection-protection.ts
+++ b/ee/apps/den-api/src/automations/runner-rejection-protection.ts
@@ -70,10 +70,22 @@ export class AutomationRunnerRejectionLimiter {
   }
 }
 
+function rightMostForwardedAddress(value: string | null) {
+  const hops = value?.split(",") ?? []
+  for (let index = hops.length - 1; index >= 0; index -= 1) {
+    const address = hops[index]?.trim()
+    if (address) return address
+  }
+  return null
+}
+
 function requestAddress(headers: Headers) {
-  return headers.get("x-forwarded-for")?.split(",", 1)[0]?.trim()
-    || headers.get("x-real-ip")?.trim()
-    || "unknown"
+  // Render's trusted edge appends the connection address to X-Forwarded-For.
+  // Earlier hops remain caller-controlled, so only the right-most non-empty
+  // hop is stable for limiting. X-Real-IP is trusted only when no XFF hop is
+  // present; deployments must keep direct, edge-bypassing ingress closed.
+  const forwarded = rightMostForwardedAddress(headers.get("x-forwarded-for"))
+  return forwarded ?? (headers.get("x-real-ip")?.trim() || "unknown")
 }
 
 export function automationRunnerRejectionLimitKey(rejection: AutomationRunnerRejection, headers: Headers) {

--- a/ee/apps/den-api/src/automations/runner-rejection-protection.ts
+++ b/ee/apps/den-api/src/automations/runner-rejection-protection.ts
@@ -89,7 +89,18 @@ function requestAddress(headers: Headers) {
 }
 
 export function automationRunnerRejectionLimitKey(rejection: AutomationRunnerRejection, headers: Headers) {
-  const material = `${rejection.claims.runnerId ?? "unknown"}\u0000${requestAddress(headers)}`
+  const untrustedIdentity = [
+    "missing_authorization",
+    "malformed_authorization",
+    "malformed_token",
+    "malformed_payload",
+    "bad_signature",
+  ].includes(rejection.reason)
+  const runnerId = untrustedIdentity ? undefined : rejection.claims.runnerId
+  const address = requestAddress(headers)
+  const material = runnerId === undefined
+    ? `address\u0000${address}`
+    : `runner\u0000${runnerId}\u0000address\u0000${address}`
   return createHash("sha256").update(material).digest("base64url")
 }
 

--- a/ee/apps/den-api/src/automations/runner-rejection-protection.ts
+++ b/ee/apps/den-api/src/automations/runner-rejection-protection.ts
@@ -1,0 +1,132 @@
+import { createHash } from "node:crypto"
+import {
+  type AutomationRunnerAuth,
+  type AutomationRunnerIdentity,
+  type AutomationRunnerRejection,
+  automationRunnerOwnerInactiveRejection,
+  automationRunnerRejectionLogFields,
+} from "./runner-auth.js"
+
+type RejectionRateLimitResult = {
+  limited: boolean
+  retryAfterSeconds: number | null
+  shouldLog: boolean
+}
+
+type RejectionRateLimitEntry = {
+  count: number
+  windowStartedAt: number
+}
+
+export class AutomationRunnerRejectionLimiter {
+  private readonly entries = new Map<string, RejectionRateLimitEntry>()
+  private readonly now: () => number
+
+  constructor(private readonly options: {
+    maxFailures: number
+    windowMs: number
+    maxEntries: number
+    now?: () => number
+  }) {
+    if (options.maxFailures < 1 || options.windowMs < 1 || options.maxEntries < 1) {
+      throw new Error("automation_runner_rejection_limiter_invalid")
+    }
+    this.now = options.now ?? Date.now
+  }
+
+  get size() {
+    return this.entries.size
+  }
+
+  record(key: string): RejectionRateLimitResult {
+    const now = this.now()
+    let entry = this.entries.get(key)
+    if (entry && now - entry.windowStartedAt >= this.options.windowMs) {
+      this.entries.delete(key)
+      entry = undefined
+    }
+    if (!entry) {
+      this.makeRoom()
+      this.entries.set(key, { count: 1, windowStartedAt: now })
+      return { limited: false, retryAfterSeconds: null, shouldLog: true }
+    }
+
+    const nextCount = entry.count + 1
+    entry.count = Math.min(nextCount, this.options.maxFailures + 1)
+    const limited = nextCount > this.options.maxFailures
+    return {
+      limited,
+      retryAfterSeconds: limited
+        ? Math.max(1, Math.ceil((entry.windowStartedAt + this.options.windowMs - now) / 1000))
+        : null,
+      shouldLog: !limited || nextCount === this.options.maxFailures + 1,
+    }
+  }
+
+  private makeRoom() {
+    if (this.entries.size < this.options.maxEntries) return
+    const oldest = this.entries.keys().next()
+    if (!oldest.done) this.entries.delete(oldest.value)
+  }
+}
+
+function requestAddress(headers: Headers) {
+  return headers.get("x-forwarded-for")?.split(",", 1)[0]?.trim()
+    || headers.get("x-real-ip")?.trim()
+    || "unknown"
+}
+
+export function automationRunnerRejectionLimitKey(rejection: AutomationRunnerRejection, headers: Headers) {
+  const material = `${rejection.claims.runnerId ?? "unknown"}\u0000${requestAddress(headers)}`
+  return createHash("sha256").update(material).digest("base64url")
+}
+
+function rejectionResponse(rateLimit: RejectionRateLimitResult) {
+  const headers = new Headers({ "content-type": "application/json" })
+  if (rateLimit.retryAfterSeconds !== null) {
+    headers.set("Retry-After", String(rateLimit.retryAfterSeconds))
+  }
+  return new Response(JSON.stringify({ error: "runner_unauthorized" }), {
+    status: rateLimit.limited ? 429 : 401,
+    headers,
+  })
+}
+
+export type AutomationRunnerRequestAuthentication =
+  | { ok: true; identity: AutomationRunnerIdentity }
+  | { ok: false; response: Response }
+
+export class AutomationRunnerRequestAuthenticator {
+  constructor(private readonly options: {
+    auth: AutomationRunnerAuth
+    limiter: AutomationRunnerRejectionLimiter
+    audienceFromRequest: (request: Request) => string
+    isActiveOwner: (identity: AutomationRunnerIdentity) => Promise<boolean>
+    logRejection: (fields: Readonly<Record<string, unknown>>) => void
+  }) {}
+
+  async authenticate(request: Request): Promise<AutomationRunnerRequestAuthentication> {
+    const authentication = this.options.auth.authenticate(
+      request.headers.get("Authorization") ?? undefined,
+      this.options.audienceFromRequest(request),
+    )
+    let rejection: AutomationRunnerRejection
+    if (!authentication.ok) {
+      rejection = authentication.rejection
+    } else if (!(await this.options.isActiveOwner(authentication.identity))) {
+      rejection = automationRunnerOwnerInactiveRejection(authentication.identity)
+    } else {
+      return authentication
+    }
+
+    const rateLimit = this.options.limiter.record(automationRunnerRejectionLimitKey(rejection, request.headers))
+    if (rateLimit.shouldLog) {
+      this.options.logRejection({
+        ...automationRunnerRejectionLogFields(rejection),
+        rate_limited: rateLimit.limited,
+        retry_after_seconds: rateLimit.retryAfterSeconds ?? undefined,
+      })
+    }
+    return { ok: false, response: rejectionResponse(rateLimit) }
+  }
+}

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -33,7 +33,12 @@ import {
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
 import { automationRunnerAudienceFromRequest, automationRunnerAuth } from "../../automations/runner-auth.js"
+import {
+  AutomationRunnerRejectionLimiter,
+  AutomationRunnerRequestAuthenticator,
+} from "../../automations/runner-rejection-protection.js"
 import { env } from "../../env.js"
+import { appLogger } from "../../observability/logger.js"
 import {
   RUNNER_KEEPALIVE_INTERVAL_MS,
   RUNNER_NOTIFICATION_POLL_MIN_MS,
@@ -50,6 +55,9 @@ const paginationSchema = z.object({
 const runListSchema = z.object({ items: z.array(automationRunSchema), nextCursor: z.string().nullable() })
 const runResponseSchema = z.object({ run: automationRunSchema })
 const runnerClaimResponseSchema = z.object({ assignment: automationDesktopRunnerAssignmentSchema.nullable() })
+const RUNNER_REJECTION_MAX_FAILURES = 20
+const RUNNER_REJECTION_WINDOW_MS = 60_000
+const RUNNER_REJECTION_MAX_ENTRIES = 4_096
 type McpDescribeRouteOptions = DescribeRouteOptions & { "x-mcp": true }
 const describeMcpRoute = (options: McpDescribeRouteOptions) => describeRoute(options)
 // Runner-credential routes must never surface as MCP tools; an MCP caller with
@@ -167,16 +175,27 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
 
   // Runner tokens are stateless 12h credentials, so authorization is re-derived
   // per request: a signed token is honored only while its owner remains an
-  // active organization member.
-  const authenticateRunner = async (c: { req: { header(name: string): string | undefined } }) => {
-    const identity = automationRunnerAuth.authenticate(c.req.header("Authorization"))
-    if (!identity) return null
-    return (await service.isActiveRunnerOwner(identity)) ? identity : null
-  }
+  // active organization member. Rejected credentials are bounded in-process so
+  // a stale desktop cannot sustain unbounded database checks or warning logs.
+  const runnerRequestAuthenticator = new AutomationRunnerRequestAuthenticator({
+    auth: automationRunnerAuth,
+    limiter: new AutomationRunnerRejectionLimiter({
+      maxFailures: RUNNER_REJECTION_MAX_FAILURES,
+      windowMs: RUNNER_REJECTION_WINDOW_MS,
+      maxEntries: RUNNER_REJECTION_MAX_ENTRIES,
+    }),
+    audienceFromRequest: (request) => automationRunnerAudienceFromRequest(request, {
+      trustedOrigins: env.publicProxyTrustedOrigins,
+    }),
+    isActiveOwner: (identity) => service.isActiveRunnerOwner(identity),
+    logRejection: (fields) => appLogger.warn("automation runner credential rejected", fields),
+  })
+  const authenticateRunner = (c: { req: { raw: Request } }) => runnerRequestAuthenticator.authenticate(c.req.raw)
 
   app.get("/v1/automation-runners/events", async (c) => {
-    const identity = await authenticateRunner(c)
-    if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+    const authentication = await authenticateRunner(c)
+    if (!authentication.ok) return authentication.response
+    const identity = authentication.identity
     const requestedCursor = Number(c.req.header("Last-Event-ID") ?? "0")
     let cursor = Number.isSafeInteger(requestedCursor) && requestedCursor >= 0 ? requestedCursor : 0
     return streamSSE(c, async (stream) => {
@@ -225,21 +244,24 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
   })
 
   app.get("/v1/automation-runner/work", async (c) => {
-    const identity = await authenticateRunner(c)
-    if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+    const authentication = await authenticateRunner(c)
+    if (!authentication.ok) return authentication.response
+    const identity = authentication.identity
     return c.json(automationRunnerWorkResponseSchema.parse({ items: await service.discoverDesktopRunnerWork(identity) }))
   })
 
   app.post("/v1/automation-runs/:id/claim", paramValidator(automationRunParamsSchema), async (c) => {
-    const identity = await authenticateRunner(c)
-    if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+    const authentication = await authenticateRunner(c)
+    if (!authentication.ok) return authentication.response
+    const identity = authentication.identity
     const assignment = await service.claimDesktopRunner(identity, c.req.valid("param").id)
     return c.json(runnerClaimResponseSchema.parse({ assignment }))
   })
 
   app.post("/v1/automation-runs/:id/heartbeat", paramValidator(automationRunParamsSchema), jsonValidator(automationRunnerHeartbeatRequestSchema), async (c) => {
-    const identity = await authenticateRunner(c)
-    if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+    const authentication = await authenticateRunner(c)
+    if (!authentication.ok) return authentication.response
+    const identity = authentication.identity
     const heartbeat = await service.heartbeatDesktopRunner(identity, c.req.valid("param").id, c.req.valid("json").attempt)
     return heartbeat
       ? c.json(automationRunnerHeartbeatResponseSchema.parse(heartbeat))
@@ -250,8 +272,9 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     "/v1/automation-runs/:id/events",
     paramValidator(automationRunParamsSchema), jsonValidator(automationRunnerEventRequestSchema),
     async (c) => {
-      const identity = await authenticateRunner(c)
-      if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+      const authentication = await authenticateRunner(c)
+      if (!authentication.ok) return authentication.response
+      const identity = authentication.identity
       try {
         return c.json({ event: await service.appendDesktopRunnerEvent(
           identity,
@@ -274,8 +297,9 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
     "/v1/automation-runs/:id/complete",
     paramValidator(automationRunParamsSchema), jsonValidator(automationDesktopRunnerResultSchema),
     async (c) => {
-      const identity = await authenticateRunner(c)
-      if (!identity) return c.json({ error: "runner_unauthorized" }, 401)
+      const authentication = await authenticateRunner(c)
+      if (!authentication.ok) return authentication.response
+      const identity = authentication.identity
       try {
         return c.json({ run: await service.completeDesktopRunner(
           identity,

--- a/ee/apps/den-api/src/routes/automations/index.ts
+++ b/ee/apps/den-api/src/routes/automations/index.ts
@@ -32,7 +32,7 @@ import {
 } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { automationService, type AutomationService } from "../../automations/service.js"
-import { automationRunnerAudienceFromRequest, automationRunnerAuth } from "../../automations/runner-auth.js"
+import { AutomationRunnerAuth, automationRunnerAudienceFromRequest } from "../../automations/runner-auth.js"
 import {
   AutomationRunnerRejectionLimiter,
   AutomationRunnerRequestAuthenticator,
@@ -124,6 +124,7 @@ export function registerAutomationRoutes<T extends { Variables: RouteVariables }
 ) {
   if (options.enabled === false) return
   const service = options.service ?? automationService
+  const automationRunnerAuth = new AutomationRunnerAuth(env.betterAuthSecret)
 
   app.post(
     "/v1/automation-runners/token",

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -179,6 +179,54 @@ describe("Automation runner credentials", () => {
     expect(changedTrustedHop).not.toBe(first)
   })
 
+  test("untrusted claimed runner IDs cannot churn rejection limiter buckets", () => {
+    const secret = "runner-auth-untrusted-id-secret".repeat(3)
+    const auth = new AutomationRunnerAuth(secret)
+    const limiter = new AutomationRunnerRejectionLimiter({
+      maxFailures: 1,
+      windowMs: 60_000,
+      maxEntries: 4_096,
+      now: () => 10_000,
+    })
+    let limited = 0
+    let shouldLog = 0
+    for (let index = 0; index < 4_097; index += 1) {
+      const payload = Buffer.from(JSON.stringify({
+        v: 2,
+        o: `fake-org-${String(index)}`,
+        m: `fake-member-${String(index)}`,
+        r: `fake-runner-${String(index)}`,
+        c: [],
+        a: "https://den.example.com",
+        e: Date.now() + 60_000,
+      })).toString("base64url")
+      const result = auth.authenticate(`Bearer ${payload}.invalid-signature`, "https://den.example.com")
+      if (result.ok) throw new Error("expected bad-signature rejection")
+      const key = automationRunnerRejectionLimitKey(result.rejection, new Headers({
+        "x-forwarded-for": `attacker-${String(index)}, 203.0.113.9`,
+      }))
+      const rateLimit = limiter.record(key)
+      if (rateLimit.limited) limited += 1
+      if (rateLimit.shouldLog) shouldLog += 1
+    }
+
+    expect(limiter.size).toBe(1)
+    expect(limited).toBe(4_096)
+    expect(shouldLog).toBe(2)
+
+    const expiredAt = Date.now() - 1
+    const signedA = auth.authenticate(`Bearer ${signedToken(secret, {
+      v: 2, o: "org", m: "member", r: "signed-runner-a", c: [], a: "https://den.example.com", e: expiredAt,
+    })}`, "https://den.example.com")
+    const signedB = auth.authenticate(`Bearer ${signedToken(secret, {
+      v: 2, o: "org", m: "member", r: "signed-runner-b", c: [], a: "https://den.example.com", e: expiredAt,
+    })}`, "https://den.example.com")
+    if (signedA.ok || signedB.ok) throw new Error("expected signed expired rejections")
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.9" })
+    expect(automationRunnerRejectionLimitKey(signedA.rejection, headers))
+      .not.toBe(automationRunnerRejectionLimitKey(signedB.rejection, headers))
+  })
+
   test("binds a runner credential to the API base that minted it", () => {
     expect(automationRunnerAudienceFromRequestUrl(
       "https://den.example.com/api/den/v1/automation-runners/token?ignored=true",

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -15,6 +15,7 @@ let automationRunnerAudienceFromRequestUrl: typeof import("../src/automations/ru
 let automationRunnerRejectionLogFields: typeof import("../src/automations/runner-auth.js")["automationRunnerRejectionLogFields"]
 let AutomationRunnerRejectionLimiter: typeof import("../src/automations/runner-rejection-protection.js")["AutomationRunnerRejectionLimiter"]
 let AutomationRunnerRequestAuthenticator: typeof import("../src/automations/runner-rejection-protection.js")["AutomationRunnerRequestAuthenticator"]
+let automationRunnerRejectionLimitKey: typeof import("../src/automations/runner-rejection-protection.js")["automationRunnerRejectionLimitKey"]
 
 beforeAll(async () => {
   seedRequiredEnv()
@@ -27,6 +28,7 @@ beforeAll(async () => {
   ;({
     AutomationRunnerRejectionLimiter,
     AutomationRunnerRequestAuthenticator,
+    automationRunnerRejectionLimitKey,
   } = await import("../src/automations/runner-rejection-protection.js"))
 })
 
@@ -146,6 +148,35 @@ describe("Automation runner credentials", () => {
     ]) {
       expect(serialized).not.toContain(secretValue)
     }
+  })
+
+  test("keys rejected requests by Render's right-most forwarded address", () => {
+    const secret = "runner-auth-forwarded-address-secret".repeat(2)
+    const auth = new AutomationRunnerAuth(secret)
+    const issued = auth.issue({
+      organizationId: "org_forwarded",
+      ownerMemberId: "member_forwarded",
+      runnerId: "runner_forwarded",
+      capabilities: [],
+    }, "https://den.example.com")
+    const result = auth.authenticate(`Bearer ${issued.token}x`, "https://den.example.com")
+    if (result.ok) throw new Error("expected rejected runner credential")
+
+    const first = automationRunnerRejectionLimitKey(result.rejection, new Headers({
+      "x-forwarded-for": "198.51.100.1, 203.0.113.9",
+      "x-real-ip": "192.0.2.1",
+    }))
+    const variedLeadingHop = automationRunnerRejectionLimitKey(result.rejection, new Headers({
+      "x-forwarded-for": "198.51.100.200, , 203.0.113.9",
+      "x-real-ip": "192.0.2.200",
+    }))
+    const changedTrustedHop = automationRunnerRejectionLimitKey(result.rejection, new Headers({
+      "x-forwarded-for": "198.51.100.1, 203.0.113.10",
+      "x-real-ip": "192.0.2.1",
+    }))
+
+    expect(variedLeadingHop).toBe(first)
+    expect(changedTrustedHop).not.toBe(first)
   })
 
   test("binds a runner credential to the API base that minted it", () => {

--- a/ee/apps/den-api/test/automation-runner-auth.test.ts
+++ b/ee/apps/den-api/test/automation-runner-auth.test.ts
@@ -12,11 +12,31 @@ function seedRequiredEnv() {
 let AutomationRunnerAuth: typeof import("../src/automations/runner-auth.js")["AutomationRunnerAuth"]
 let automationRunnerAudienceFromRequest: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequest"]
 let automationRunnerAudienceFromRequestUrl: typeof import("../src/automations/runner-auth.js")["automationRunnerAudienceFromRequestUrl"]
+let automationRunnerRejectionLogFields: typeof import("../src/automations/runner-auth.js")["automationRunnerRejectionLogFields"]
+let AutomationRunnerRejectionLimiter: typeof import("../src/automations/runner-rejection-protection.js")["AutomationRunnerRejectionLimiter"]
+let AutomationRunnerRequestAuthenticator: typeof import("../src/automations/runner-rejection-protection.js")["AutomationRunnerRequestAuthenticator"]
 
 beforeAll(async () => {
   seedRequiredEnv()
-  ;({ AutomationRunnerAuth, automationRunnerAudienceFromRequest, automationRunnerAudienceFromRequestUrl } = await import("../src/automations/runner-auth.js"))
+  ;({
+    AutomationRunnerAuth,
+    automationRunnerAudienceFromRequest,
+    automationRunnerAudienceFromRequestUrl,
+    automationRunnerRejectionLogFields,
+  } = await import("../src/automations/runner-auth.js"))
+  ;({
+    AutomationRunnerRejectionLimiter,
+    AutomationRunnerRequestAuthenticator,
+  } = await import("../src/automations/runner-rejection-protection.js"))
 })
+
+function signedToken(secret: string, payloadValue: unknown) {
+  const payload = Buffer.from(JSON.stringify(payloadValue)).toString("base64url")
+  const signature = createHmac("sha256", secret)
+    .update(`openwork-automation-runner-v1.${payload}`)
+    .digest("base64url")
+  return `${payload}.${signature}`
+}
 
 describe("Automation runner credentials", () => {
   test("survive process-local auth instances while remaining scoped and tamper-evident", () => {
@@ -30,16 +50,102 @@ describe("Automation runner credentials", () => {
       capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
     }, "https://den.example.com/api/den")
 
-    expect(verifier.authenticate(`Bearer ${issued.token}`)).toEqual({
-      organizationId: "org_test",
-      ownerMemberId: "member_test",
-      runnerId: "desktop-test",
-      capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
-      audience: "https://den.example.com/api/den",
-      expiresAt: issued.expiresAt,
+    expect(verifier.authenticate(`Bearer ${issued.token}`, "https://den.example.com/api/den")).toEqual({
+      ok: true,
+      identity: {
+        organizationId: "org_test",
+        ownerMemberId: "member_test",
+        runnerId: "desktop-test",
+        capabilities: [AUTOMATION_MODEL_ATTENTION_CAPABILITY],
+        audience: "https://den.example.com/api/den",
+        expiresAt: issued.expiresAt,
+      },
     })
-    expect(new AutomationRunnerAuth(`${secret}x`).authenticate(`Bearer ${issued.token}`)).toBeNull()
-    expect(verifier.authenticate(`Bearer ${issued.token}x`)).toBeNull()
+    expect(new AutomationRunnerAuth(`${secret}x`).authenticate(
+      `Bearer ${issued.token}`,
+      "https://den.example.com/api/den",
+    )).toMatchObject({ ok: false, rejection: { reason: "bad_signature" } })
+    expect(verifier.authenticate(
+      `Bearer ${issued.token}x`,
+      "https://den.example.com/api/den",
+    )).toMatchObject({ ok: false, rejection: { reason: "bad_signature" } })
+  })
+
+  test("classifies malformed, bad-signature, expired, and wrong-audience credentials", () => {
+    const secret = "runner-auth-classification-secret".repeat(2)
+    const verifier = new AutomationRunnerAuth(secret)
+    const audience = "https://den.example.com/api/den"
+    expect(verifier.authenticate("Bearer opaque", audience))
+      .toMatchObject({ ok: false, rejection: { reason: "malformed_token", claims: {} } })
+
+    const issued = verifier.issue({
+      organizationId: "org_claimed",
+      ownerMemberId: "member_claimed",
+      runnerId: "runner_claimed",
+      capabilities: [],
+    }, audience)
+    const badSignature = verifier.authenticate(`Bearer ${issued.token}x`, audience)
+    expect(badSignature).toEqual({
+      ok: false,
+      rejection: {
+        reason: "bad_signature",
+        claims: {
+          credentialVersion: 2,
+          organizationId: "org_claimed",
+          ownerMemberId: "member_claimed",
+          runnerId: "runner_claimed",
+          expiresAt: issued.expiresAt,
+        },
+      },
+    })
+
+    const expiredAt = Date.now() - 1
+    const expired = signedToken(secret, {
+      v: 2,
+      o: "org_expired",
+      m: "member_expired",
+      r: "runner_expired",
+      c: [],
+      a: audience,
+      e: expiredAt,
+    })
+    expect(verifier.authenticate(`Bearer ${expired}`, audience))
+      .toMatchObject({ ok: false, rejection: { reason: "expired", claims: { expiresAt: expiredAt } } })
+    expect(verifier.authenticate(`Bearer ${issued.token}`, "https://other.example.com/api/den"))
+      .toMatchObject({ ok: false, rejection: { reason: "audience_mismatch" } })
+  })
+
+  test("logs only stable claimed-identity fingerprints for rejected credentials", () => {
+    const secret = "runner-auth-safe-log-secret".repeat(3)
+    const auth = new AutomationRunnerAuth(secret)
+    const issued = auth.issue({
+      organizationId: "org_never_log_raw",
+      ownerMemberId: "member_never_log_raw",
+      runnerId: "runner_never_log_raw",
+      capabilities: [],
+    }, "https://den.example.com")
+    const result = auth.authenticate(`Bearer ${issued.token}x`, "https://den.example.com")
+    if (result.ok) throw new Error("expected rejected runner credential")
+    const fields = automationRunnerRejectionLogFields(result.rejection)
+    expect(fields).toMatchObject({
+      reason: "bad_signature",
+      runner_auth_version: 2,
+      runner_auth_expires_at_ms: issued.expiresAt,
+      claimed_runner_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+      claimed_organization_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+      claimed_owner_member_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+    })
+    const serialized = JSON.stringify(fields)
+    for (const secretValue of [
+      issued.token,
+      issued.token.split(".")[1] ?? "missing-signature",
+      secret,
+      "org_never_log_raw",
+      "member_never_log_raw",
+      "runner_never_log_raw",
+    ]) {
+      expect(serialized).not.toContain(secretValue)
+    }
   })
 
   test("binds a runner credential to the API base that minted it", () => {
@@ -48,6 +154,10 @@ describe("Automation runner credentials", () => {
     )).toBe("https://den.example.com/api/den")
     expect(() => automationRunnerAudienceFromRequestUrl("https://den.example.com/not-the-token-route"))
       .toThrow("automation_runner_audience_invalid")
+    expect(automationRunnerAudienceFromRequest(
+      new Request("https://den.example.com/api/den/v1/automation-runners/events"),
+      { trustedOrigins: [] },
+    )).toBe("https://den.example.com/api/den")
   })
 
   test("binds a Den Web proxied credential to its trusted public route", () => {
@@ -137,13 +247,74 @@ describe("Automation runner credentials", () => {
       .update(`openwork-automation-runner-v1.${payload}`)
       .digest("base64url")
 
-    expect(new AutomationRunnerAuth(secret).authenticate(`Bearer ${payload}.${signature}`)).toEqual({
-      organizationId: "org_test",
-      ownerMemberId: "member_test",
-      runnerId: "desktop-test",
-      capabilities: [],
-      audience: null,
-      expiresAt,
+    expect(new AutomationRunnerAuth(secret).authenticate(
+      `Bearer ${payload}.${signature}`,
+      "https://different.example.com",
+    )).toEqual({
+      ok: true,
+      identity: {
+        organizationId: "org_test",
+        ownerMemberId: "member_test",
+        runnerId: "desktop-test",
+        capabilities: [],
+        audience: null,
+        expiresAt,
+      },
     })
+  })
+
+  test("returns 401 then 429 without leaking claims, while a valid credential remains usable", async () => {
+    const secret = "runner-auth-protocol-secret".repeat(3)
+    const auth = new AutomationRunnerAuth(secret)
+    const issued = auth.issue({
+      organizationId: "org_protocol",
+      ownerMemberId: "member_protocol",
+      runnerId: "runner_protocol",
+      capabilities: [],
+    }, "https://den.example.com")
+    const logs: Readonly<Record<string, unknown>>[] = []
+    const limiter = new AutomationRunnerRejectionLimiter({
+      maxFailures: 1,
+      windowMs: 60_000,
+      maxEntries: 2,
+      now: () => 10_000,
+    })
+    const authenticator = new AutomationRunnerRequestAuthenticator({
+      auth,
+      limiter,
+      audienceFromRequest: (request) => automationRunnerAudienceFromRequest(request, { trustedOrigins: [] }),
+      isActiveOwner: async () => true,
+      logRejection: (fields) => logs.push(fields),
+    })
+    const request = (authorization: string) => new Request(
+      "https://den.example.com/v1/automation-runner/work",
+      { headers: { authorization, "x-real-ip": "192.0.2.10" } },
+    )
+
+    const first = await authenticator.authenticate(request(`Bearer ${issued.token}x`))
+    if (first.ok) throw new Error("expected first rejection")
+    expect(first.response.status).toBe(401)
+    expect(first.response.headers.get("retry-after")).toBeNull()
+    expect(await first.response.json()).toEqual({ error: "runner_unauthorized" })
+
+    const second = await authenticator.authenticate(request(`Bearer ${issued.token}x`))
+    if (second.ok) throw new Error("expected rate-limited rejection")
+    expect(second.response.status).toBe(429)
+    expect(second.response.headers.get("retry-after")).toBe("60")
+    expect(await second.response.json()).toEqual({ error: "runner_unauthorized" })
+
+    const valid = await authenticator.authenticate(request(`Bearer ${issued.token}`))
+    expect(valid).toMatchObject({ ok: true, identity: { runnerId: "runner_protocol" } })
+
+    const serialized = JSON.stringify(logs)
+    expect(logs).toHaveLength(2)
+    expect(logs[1]).toMatchObject({ reason: "bad_signature", rate_limited: true, retry_after_seconds: 60 })
+    for (const secretValue of [issued.token, secret, "org_protocol", "member_protocol", "runner_protocol"]) {
+      expect(serialized).not.toContain(secretValue)
+    }
+
+    limiter.record("second-key")
+    limiter.record("third-key")
+    expect(limiter.size).toBe(2)
   })
 })

--- a/ee/apps/den-api/test/automation-runner-protocol.test.ts
+++ b/ee/apps/den-api/test/automation-runner-protocol.test.ts
@@ -233,9 +233,10 @@ test("every runner endpoint re-checks that the token owner is still an active me
   const directAuthenticateCalls = routesSource.match(/automationRunnerAuth\.authenticate\(/g) ?? []
   assert.equal(
     directAuthenticateCalls.length,
-    1,
-    "runner endpoints must authorize through authenticateRunner (token + live membership), not the raw token check",
+    0,
+    "runner endpoints must authorize through the rejection-protected request authenticator, not the raw token check",
   )
+  assert.match(routesSource, /new AutomationRunnerRequestAuthenticator/)
   const sse = routesSource.slice(
     routesSource.indexOf("/v1/automation-runners/events\", async"),
     routesSource.indexOf("/v1/automation-runner/work"),

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -27,6 +27,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("repeated HTTP 502 responses retain exponential runner reconnect backoff");
   expect(unit.stdout).toContain("HTTP 401 from work retires exactly that credential without reconnecting");
   expect(unit.stdout).toContain("HTTP 403 from work retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("HTTP 429 runner_unauthorized retires exactly that credential without reconnecting");
+  expect(unit.stdout).toContain("an unrelated HTTP 429 retains generic backoff without requesting a credential remint");
   expect(unit.stdout).toContain("HTTP 401 and 403 from every assignment route retire the credential");
   expect(unit.stdout).toContain("a new credential reconciles immediately and a late rejection cannot retire it");
   expect(unit.stdout).toContain("a late rejection retires a newer generation that reused the same credential");
@@ -42,8 +44,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("cancellation during execution preserves the local thread and reaches a terminal completion");
   expect(unit.stdout).toContain("an explicit assistant provider failure terminates immediately with its local thread");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 30\b/);
-  expect(unit.stdout).toMatch(/# pass 30\b/);
+  expect(unit.stdout).toMatch(/# tests 32\b/);
+  expect(unit.stdout).toMatch(/# pass 32\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -65,7 +67,7 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 42 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
+    "The runner and bridge suites passed 44 tests covering one-shot 401/403 and runner_unauthorized 429 retirement, unrelated 429 backoff, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
     true,
   );
 

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -44,8 +44,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("cancellation during execution preserves the local thread and reaches a terminal completion");
   expect(unit.stdout).toContain("an explicit assistant provider failure terminates immediately with its local thread");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 32\b/);
-  expect(unit.stdout).toMatch(/# pass 32\b/);
+  expect(unit.stdout).toMatch(/# tests 33\b/);
+  expect(unit.stdout).toMatch(/# pass 33\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -67,7 +67,7 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 44 tests covering one-shot 401/403 and runner_unauthorized 429 retirement, unrelated 429 backoff, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
+    "The runner and bridge suites passed 45 tests covering one-shot 401/403 and runner_unauthorized 429 retirement, unrelated 429 backoff, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, and work-only polling.",
     true,
   );
 

--- a/evals/specs/automation-runner-rejection-protection.test.ts
+++ b/evals/specs/automation-runner-rejection-protection.test.ts
@@ -6,6 +6,7 @@ import { test } from "@openwork/testkit";
 import { expect } from "vitest";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
+const desktopRunnerTest = join(repoRoot, "apps/desktop/electron/automation-runner.test.mjs");
 
 test("rejected Automation runner credentials stay attributable and bounded", ({ evidence }) => {
   const reportDir = mkdtempSync(join(tmpdir(), "openwork-runner-rejection-"));
@@ -39,6 +40,30 @@ test("rejected Automation runner credentials stay attributable and bounded", ({ 
     expect(junit).not.toContain("<failure");
     expect(junit).not.toContain("<skipped");
 
+    const desktopResult = spawnSync(process.execPath, [
+      "--test",
+      "--test-reporter=tap",
+      desktopRunnerTest,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const desktopOutput = `${desktopResult.stdout}${desktopResult.stderr}`;
+    expect(desktopResult.error, desktopOutput).toBeUndefined();
+    expect(desktopResult.status, desktopOutput).toBe(0);
+    const tapCounts = Object.fromEntries(
+      [...desktopResult.stdout.matchAll(/^# (tests|pass|fail|skipped) (\d+)$/gm)]
+        .map((match) => [match[1], Number(match[2])]),
+    );
+    expect(tapCounts).toEqual({ tests: 32, pass: 32, fail: 0, skipped: 0 });
+    expect(desktopResult.stdout).not.toContain("not ok");
+    expect(desktopResult.stdout)
+      .toContain("HTTP 429 runner_unauthorized retires exactly that credential without reconnecting");
+    expect(desktopResult.stdout)
+      .toContain("an unrelated HTTP 429 retains generic backoff without requesting a credential remint");
+
     evidence.recordAssertionEvidence(
       "Runner credential rejections retain safe attribution",
       "Malformed, bad-signature, expired, and audience-mismatched credentials are classified; claimed runner, organization, and member IDs are represented only by stable fingerprints with version and expiry.",
@@ -52,6 +77,11 @@ test("rejected Automation runner credentials stay attributable and bounded", ({ 
     evidence.recordAssertionEvidence(
       "Runner HTTP failures disclose no claimed identity or bearer material",
       "The rejection body remains the generic runner_unauthorized envelope and the diagnostics exclude the bearer token, signature, signing secret, and raw claimed IDs.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Desktop remints only for an authenticated runner rejection",
+      "A 429 carrying runner_unauthorized retires the credential and emits onCredentialRejected exactly once, while an unrelated 429 keeps generic reconnect backoff and emits no credential-rejection signal.",
       true,
     );
   } finally {

--- a/evals/specs/automation-runner-rejection-protection.test.ts
+++ b/evals/specs/automation-runner-rejection-protection.test.ts
@@ -1,90 +1,193 @@
-import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { createHmac } from "node:crypto";
 import { test } from "@openwork/testkit";
 import { expect } from "vitest";
 
-const repoRoot = resolve(import.meta.dirname, "../..");
-const desktopRunnerTest = join(repoRoot, "apps/desktop/electron/automation-runner.test.mjs");
+function signedToken(secret: string, payloadValue: unknown) {
+  const payload = Buffer.from(JSON.stringify(payloadValue)).toString("base64url");
+  const signature = createHmac("sha256", secret)
+    .update(`openwork-automation-runner-v1.${payload}`)
+    .digest("base64url");
+  return `${payload}.${signature}`;
+}
 
-test("rejected Automation runner credentials stay attributable and bounded", ({ evidence }) => {
-  const reportDir = mkdtempSync(join(tmpdir(), "openwork-runner-rejection-"));
-  const reportPath = join(reportDir, "bun-junit.xml");
-  try {
-    const result = spawnSync("pnpm", [
-      "--filter",
-      "@openwork-ee/den-api",
-      "exec",
-      "bun",
-      "test",
-      "test/automation-runner-auth.test.ts",
-      "--reporter=junit",
-      "--reporter-outfile",
-      reportPath,
-    ], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 60_000,
-    });
-    const output = `${result.stdout}${result.stderr}`;
-    expect(result.error, output).toBeUndefined();
-    expect(result.status, output).toBe(0);
+function forgedToken(index: number, audience: string) {
+  const payload = Buffer.from(JSON.stringify({
+    v: 2,
+    o: `fake-org-${String(index)}`,
+    m: `fake-member-${String(index)}`,
+    r: `fake-runner-${String(index)}`,
+    c: [],
+    a: audience,
+    e: Date.now() + 60_000,
+  })).toString("base64url");
+  return `${payload}.invalid-signature`;
+}
 
-    const junit = readFileSync(reportPath, "utf8");
-    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
-    expect(summary).toContain('tests="12"');
-    expect(summary).toContain('failures="0"');
-    expect(summary).toContain('skipped="0"');
-    expect(junit).not.toContain("<failure");
-    expect(junit).not.toContain("<skipped");
+test("rejected Automation runner credentials stay attributable and bounded", async ({ evidence }) => {
+  const [{
+    AutomationRunnerAuth,
+    automationRunnerRejectionLogFields,
+  }, {
+    AutomationRunnerRejectionLimiter,
+    AutomationRunnerRequestAuthenticator,
+  }, {
+    isAutomationRunnerCredentialRejection,
+  }] = await Promise.all([
+    import("../../ee/apps/den-api/src/automations/runner-auth.js"),
+    import("../../ee/apps/den-api/src/automations/runner-rejection-protection.js"),
+    import("../../apps/desktop/electron/automation-runner.mjs"),
+  ]);
 
-    const desktopResult = spawnSync(process.execPath, [
-      "--test",
-      "--test-reporter=tap",
-      desktopRunnerTest,
-    ], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 60_000,
-    });
-    const desktopOutput = `${desktopResult.stdout}${desktopResult.stderr}`;
-    expect(desktopResult.error, desktopOutput).toBeUndefined();
-    expect(desktopResult.status, desktopOutput).toBe(0);
-    const tapCounts = Object.fromEntries(
-      [...desktopResult.stdout.matchAll(/^# (tests|pass|fail|skipped) (\d+)$/gm)]
-        .map((match) => [match[1], Number(match[2])]),
-    );
-    expect(tapCounts).toEqual({ tests: 32, pass: 32, fail: 0, skipped: 0 });
-    expect(desktopResult.stdout).not.toContain("not ok");
-    expect(desktopResult.stdout)
-      .toContain("HTTP 429 runner_unauthorized retires exactly that credential without reconnecting");
-    expect(desktopResult.stdout)
-      .toContain("an unrelated HTTP 429 retains generic backoff without requesting a credential remint");
+  const secret = "runner-rejection-test-secret".repeat(3);
+  const audience = "https://den.example.com";
+  const auth = new AutomationRunnerAuth(secret);
+  const issued = auth.issue({
+    organizationId: "org_never_log_raw",
+    ownerMemberId: "member_never_log_raw",
+    runnerId: "runner_never_log_raw",
+    capabilities: [],
+  }, audience);
+  const badSignature = auth.authenticate(`Bearer ${issued.token}x`, audience);
+  if (badSignature.ok) throw new Error("expected bad-signature rejection");
+  const safeFields = automationRunnerRejectionLogFields(badSignature.rejection);
+  expect(safeFields).toMatchObject({
+    reason: "bad_signature",
+    runner_auth_version: 2,
+    claimed_runner_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+    claimed_organization_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+    claimed_owner_member_id_fingerprint: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+  });
+  const serializedFields = JSON.stringify(safeFields);
+  for (const value of [
+    issued.token,
+    secret,
+    "org_never_log_raw",
+    "member_never_log_raw",
+    "runner_never_log_raw",
+  ]) expect(serializedFields).not.toContain(value);
+  expect(auth.authenticate("Bearer opaque", audience))
+    .toMatchObject({ ok: false, rejection: { reason: "malformed_token", claims: {} } });
 
-    evidence.recordAssertionEvidence(
-      "Runner credential rejections retain safe attribution",
-      "Malformed, bad-signature, expired, and audience-mismatched credentials are classified; claimed runner, organization, and member IDs are represented only by stable fingerprints with version and expiry.",
-      true,
-    );
-    evidence.recordAssertionEvidence(
-      "Repeated rejected credentials are bounded without affecting valid runners",
-      "The focused protocol witness ignores caller-controlled leading X-Forwarded-For hops, separates changed trusted edge hops, returns 401 before the threshold, then 429 with Retry-After, keeps limiter memory bounded, and still accepts a valid credential sharing the same runner and address.",
-      true,
-    );
-    evidence.recordAssertionEvidence(
-      "Runner HTTP failures disclose no claimed identity or bearer material",
-      "The rejection body remains the generic runner_unauthorized envelope and the diagnostics exclude the bearer token, signature, signing secret, and raw claimed IDs.",
-      true,
-    );
-    evidence.recordAssertionEvidence(
-      "Desktop remints only for an authenticated runner rejection",
-      "A 429 carrying runner_unauthorized retires the credential and emits onCredentialRejected exactly once, while an unrelated 429 keeps generic reconnect backoff and emits no credential-rejection signal.",
-      true,
-    );
-  } finally {
-    rmSync(reportDir, { force: true, recursive: true });
+  const limiter = new AutomationRunnerRejectionLimiter({
+    maxFailures: 1,
+    windowMs: 60_000,
+    maxEntries: 4_096,
+    now: () => 10_000,
+  });
+  const logs: Readonly<Record<string, unknown>>[] = [];
+  let ownersActive = false;
+  let ownerChecks = 0;
+  const authenticator = new AutomationRunnerRequestAuthenticator({
+    auth,
+    limiter,
+    audienceFromRequest: () => audience,
+    isActiveOwner: async () => {
+      ownerChecks += 1;
+      return ownersActive;
+    },
+    logRejection: (fields) => logs.push(fields),
+  });
+  const request = (token: string, leadingHop: string) => new Request(
+    `${audience}/v1/automation-runner/work`,
+    { headers: {
+      authorization: `Bearer ${token}`,
+      "x-forwarded-for": `${leadingHop}, 203.0.113.9`,
+      "x-real-ip": leadingHop,
+    } },
+  );
+
+  const firstForgedToken = forgedToken(0, audience);
+  const secondForgedToken = forgedToken(1, audience);
+  for (let index = 0; index < 4_097; index += 1) {
+    const token = index === 0
+      ? firstForgedToken
+      : index === 1 ? secondForgedToken : forgedToken(index, audience);
+    const result = await authenticator.authenticate(request(token, `attacker-${String(index)}`));
+    if (result.ok) throw new Error("expected forged credential rejection");
+    if (index === 0) {
+      expect(result.response.status).toBe(401);
+      expect(result.response.headers.get("retry-after")).toBeNull();
+      expect(await result.response.json()).toEqual({ error: "runner_unauthorized" });
+    } else if (index === 1 || index === 4_096) {
+      expect(result.response.status).toBe(429);
+      expect(result.response.headers.get("retry-after")).toBe("60");
+    }
   }
+  expect(limiter.size).toBe(1);
+  expect(ownerChecks).toBe(0);
+  expect(logs).toHaveLength(2);
+  expect(logs.map((entry) => entry.rate_limited)).toEqual([false, true]);
+  const serializedLogs = JSON.stringify(logs);
+  for (const value of [
+    firstForgedToken,
+    secondForgedToken,
+    "fake-org-0",
+    "fake-member-0",
+    "fake-runner-0",
+    "fake-runner-1",
+  ]) expect(serializedLogs).not.toContain(value);
+
+  const signedRunnerA = auth.issue({
+    organizationId: "org_signed",
+    ownerMemberId: "member_signed",
+    runnerId: "signed-runner-a",
+    capabilities: [],
+  }, audience);
+  const signedRunnerB = auth.issue({
+    organizationId: "org_signed",
+    ownerMemberId: "member_signed",
+    runnerId: "signed-runner-b",
+    capabilities: [],
+  }, audience);
+  for (const [index, token] of [signedRunnerA.token, signedRunnerB.token].entries()) {
+    const result = await authenticator.authenticate(request(token, `signed-leading-${String(index)}`));
+    if (result.ok) throw new Error("expected inactive-owner rejection");
+    expect(result.response.status).toBe(401);
+  }
+  expect(limiter.size).toBe(3);
+  expect(ownerChecks).toBe(2);
+
+  expect(auth.authenticate(`Bearer ${signedRunnerA.token}`, "https://other.example.com"))
+    .toMatchObject({ ok: false, rejection: { reason: "audience_mismatch" } });
+  const legacyExpiresAt = Date.now() + 60_000;
+  const legacy = signedToken(secret, {
+    v: 1,
+    o: "org_legacy",
+    m: "member_legacy",
+    r: "runner_legacy",
+    e: legacyExpiresAt,
+  });
+  expect(auth.authenticate(`Bearer ${legacy}`, "https://different.example.com"))
+    .toMatchObject({ ok: true, identity: { audience: null, expiresAt: legacyExpiresAt } });
+  ownersActive = true;
+  const valid = await authenticator.authenticate(request(signedRunnerA.token, "fresh-leading-hop"));
+  expect(valid).toMatchObject({ ok: true, identity: { runnerId: "signed-runner-a" } });
+  expect(limiter.size).toBe(3);
+
+  expect(isAutomationRunnerCredentialRejection({ status: 401 })).toBe(true);
+  expect(isAutomationRunnerCredentialRejection({ status: 403 })).toBe(true);
+  expect(isAutomationRunnerCredentialRejection({ status: 429, code: "runner_unauthorized" })).toBe(true);
+  expect(isAutomationRunnerCredentialRejection({ status: 429, code: "rate_limited" })).toBe(false);
+  expect(isAutomationRunnerCredentialRejection({ status: 429 })).toBe(false);
+
+  evidence.recordAssertionEvidence(
+    "Runner credential rejections retain safe attribution",
+    "Bad-signature claims retain stable fingerprints and version metadata without exposing bearer material, signatures, signing secrets, or raw claimed runner, organization, and member IDs.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Untrusted identities cannot evade the bounded rejection budget",
+    "4,097 distinct fake runner IDs and spoofed leading X-Forwarded-For hops from one trusted edge address share one limiter bucket: the first response is 401, later responses are 429 with Retry-After, only the first two decisions log, and signed inactive runners retain separate buckets.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Runner audience and compatibility gates remain intact",
+    "A v2 credential fails at a different audience, a signed v1 credential remains audience-less and accepted, and a valid active v2 credential remains usable without consuming rejection state.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Desktop remints only for an authenticated runner rejection",
+    "Desktop classifies 401/403 and only a 429 carrying runner_unauthorized as credential rejection; unrelated or unmarked 429 responses remain generic retry failures.",
+    true,
+  );
 });

--- a/evals/specs/automation-runner-rejection-protection.test.ts
+++ b/evals/specs/automation-runner-rejection-protection.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+test("rejected Automation runner credentials stay attributable and bounded", ({ evidence }) => {
+  const reportDir = mkdtempSync(join(tmpdir(), "openwork-runner-rejection-"));
+  const reportPath = join(reportDir, "bun-junit.xml");
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/automation-runner-auth.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile",
+      reportPath,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+
+    const junit = readFileSync(reportPath, "utf8");
+    const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
+    expect(summary).toContain('tests="11"');
+    expect(summary).toContain('failures="0"');
+    expect(summary).toContain('skipped="0"');
+    expect(junit).not.toContain("<failure");
+    expect(junit).not.toContain("<skipped");
+
+    evidence.recordAssertionEvidence(
+      "Runner credential rejections retain safe attribution",
+      "Malformed, bad-signature, expired, and audience-mismatched credentials are classified; claimed runner, organization, and member IDs are represented only by stable fingerprints with version and expiry.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Repeated rejected credentials are bounded without affecting valid runners",
+      "The focused protocol witness returns 401 before the threshold, then 429 with Retry-After, keeps its limiter memory bounded, and still accepts a valid credential sharing the same runner and address.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Runner HTTP failures disclose no claimed identity or bearer material",
+      "The rejection body remains the generic runner_unauthorized envelope and the diagnostics exclude the bearer token, signature, signing secret, and raw claimed IDs.",
+      true,
+    );
+  } finally {
+    rmSync(reportDir, { force: true, recursive: true });
+  }
+});

--- a/evals/specs/automation-runner-rejection-protection.test.ts
+++ b/evals/specs/automation-runner-rejection-protection.test.ts
@@ -33,7 +33,7 @@ test("rejected Automation runner credentials stay attributable and bounded", ({ 
 
     const junit = readFileSync(reportPath, "utf8");
     const summary = junit.match(/<testsuite\b[^>]*>/)?.[0] ?? "";
-    expect(summary).toContain('tests="11"');
+    expect(summary).toContain('tests="12"');
     expect(summary).toContain('failures="0"');
     expect(summary).toContain('skipped="0"');
     expect(junit).not.toContain("<failure");
@@ -46,7 +46,7 @@ test("rejected Automation runner credentials stay attributable and bounded", ({ 
     );
     evidence.recordAssertionEvidence(
       "Repeated rejected credentials are bounded without affecting valid runners",
-      "The focused protocol witness returns 401 before the threshold, then 429 with Retry-After, keeps its limiter memory bounded, and still accepts a valid credential sharing the same runner and address.",
+      "The focused protocol witness ignores caller-controlled leading X-Forwarded-For hops, separates changed trusted edge hops, returns 401 before the threshold, then 429 with Retry-After, keeps limiter memory bounded, and still accepts a valid credential sharing the same runner and address.",
       true,
     );
     evidence.recordAssertionEvidence(


### PR DESCRIPTION
Fixes #4137.

## Problem
An old/divergent client replayed rejected runner credentials at ~25–50 req/s for 6+ hours. Runner auth collapsed every rejection to null (no attribution), v2 audience was parsed but not enforced, and runner routes had no rejected-credential limiter.

## Fix
- Classify missing/malformed/bad-signature/unsupported/invalid/expired/audience/owner-inactive rejections.
- Log only safe stable SHA-256 fingerprints of claimed runner/org/member IDs plus version + expiry; never token/signature/Authorization.
- Enforce v2 token audience server-side; preserve v1 compatibility.
- Before signature trust, ignore claimed runner IDs and bucket only by trusted edge address, preventing 4,097-ID churn/eviction and unbounded first-hit logs.
- Bound repeated rejected requests with a 4,096-key fixed-window limiter: first failures remain generic 401; after 20/min per runner+address, generic 429 + `Retry-After`; log first/threshold transitions only.
- Apply the protected authenticator to every runner credential route, including SSE events.
- Desktop compatibility: preserve `runner_unauthorized`; treat only 429 with that exact code as credential rejection/remint. Unrelated 429s retain ordinary backoff.

## Verification — Passed (local lane)
Head `975246aba`:
- `bun test test/automation-runner-auth.test.ts test/automation-runner-protocol.test.ts` → 37 pass, 0 fail, 45 expects
- `pnpm --filter @openwork-ee/den-api typecheck:automations` → clean
- `node --test electron/automation-runner.test.mjs` → 33 pass, 0 fail
- desktop `typecheck:electron` → clean
- composite `vitest run --project pr specs/automation-runner-rejection-protection.test.ts` → 1 passed, 0 failed, 0 skipped (runs 12 server + 32 desktop assertions)

The testkit spec asserts rejected credentials are attributable in logs without secret leakage, v2 audience mismatches fail, v1 remains compatible, repeated failures switch from 401 to 429 with Retry-After, and valid credentials remain unaffected.

Risk: limiter is intentionally per-process/replica; its purpose is bounding one hot loop per replica, not distributed quotas.


