### PR TITLE
Make the Web session shell narrow-screen safe

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/responsive-session-layout.tsx
+++ b/apps/app/src/react-app/domains/session/chat/responsive-session-layout.tsx
@@ -1,0 +1,94 @@
+/** @jsxImportSource react */
+import type { Ref } from "react";
+
+export type NarrowSessionPane = "chat" | "split" | "panel";
+
+export type NarrowPaneOption = {
+  id: NarrowSessionPane;
+  label: string;
+};
+
+export const NARROW_PANE_MIN_TARGET_PX = 44;
+
+export function shouldShowNarrowPaneSwitcher(
+  narrow: boolean,
+  hasSplit: boolean,
+  hasPanel: boolean,
+) {
+  return narrow && (hasSplit || hasPanel);
+}
+
+export function availableNarrowPane(
+  pane: NarrowSessionPane,
+  hasSplit: boolean,
+  hasPanel: boolean,
+): NarrowSessionPane {
+  if (pane === "split" && !hasSplit) return "chat";
+  if (pane === "panel" && !hasPanel) return "chat";
+  return pane;
+}
+
+export function NarrowPaneSwitcher(props: {
+  activePane: NarrowSessionPane;
+  options: NarrowPaneOption[];
+  navigationRef?: Ref<HTMLElement>;
+  onSelect: (pane: NarrowSessionPane) => void;
+}) {
+  const selectRelativePane = (currentIndex: number, key: string) => {
+    const lastIndex = props.options.length - 1;
+    const nextIndex = key === "ArrowRight"
+      ? currentIndex === lastIndex ? 0 : currentIndex + 1
+      : key === "ArrowLeft"
+        ? currentIndex === 0 ? lastIndex : currentIndex - 1
+        : key === "Home"
+          ? 0
+          : key === "End"
+            ? lastIndex
+            : null;
+    if (nextIndex === null) return false;
+    const nextPane = props.options[nextIndex];
+    if (!nextPane) return false;
+    props.onSelect(nextPane.id);
+    return true;
+  };
+
+  return (
+    <nav
+      ref={props.navigationRef}
+      className="grid shrink-0 border-b border-border bg-dls-surface px-1"
+      style={{ gridTemplateColumns: `repeat(${props.options.length}, minmax(0, 1fr))` }}
+      role="tablist"
+      aria-label="Visible session pane"
+      data-narrow-pane-switcher
+    >
+      {props.options.map((option, index) => {
+        const active = option.id === props.activePane;
+        return (
+          <button
+            key={option.id}
+            id={`narrow-session-tab-${option.id}`}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-controls={`narrow-session-pane-${option.id}`}
+            tabIndex={active ? 0 : -1}
+            data-narrow-pane={option.id}
+            className={`min-w-0 truncate border-b-2 px-2 text-xs font-medium transition-colors ${
+              active
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+            style={{ minHeight: NARROW_PANE_MIN_TARGET_PX }}
+            onClick={() => props.onSelect(option.id)}
+            onKeyDown={(event) => {
+              if (!selectRelativePane(index, event.key)) return;
+              event.preventDefault();
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -33,13 +33,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import {
   Dialog,
   DialogClose,
   DialogContent,
@@ -102,6 +95,13 @@ import {
 import { useWorkbenchStore, type WorkbenchSessionTab } from "./workbench-store";
 import { isSameWorkbenchSession } from "./workbench-store";
 import { ReactSessionRuntime } from "../sync/runtime-sync";
+import {
+  availableNarrowPane,
+  NarrowPaneSwitcher,
+  shouldShowNarrowPaneSwitcher,
+  type NarrowPaneOption,
+  type NarrowSessionPane,
+} from "./responsive-session-layout";
 
 const STARTUP_SKELETON_ROWS = [
   { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
@@ -492,7 +492,11 @@ export function SessionPage(props: SessionPageProps) {
   const workbenchTabs = useWorkbenchStore((state) => state.tabs);
   const workbenchSecondary = useWorkbenchStore((state) => state.secondary);
   const focusedWorkbenchPane = useWorkbenchStore((state) => state.focusedPane);
-  const activeWorkbenchPane = isMobile ? "primary" : focusedWorkbenchPane;
+  const [narrowPane, setNarrowPane] = useState<NarrowSessionPane>("chat");
+  const narrowPaneNavigationRef = useRef<HTMLElement>(null);
+  const activeWorkbenchPane = isMobile
+    ? narrowPane === "split" ? "secondary" : "primary"
+    : focusedWorkbenchPane;
   const syncWorkbench = useWorkbenchStore((state) => state.sync);
   const openWorkbenchTab = useWorkbenchStore((state) => state.openTab);
   const setWorkbenchSplit = useWorkbenchStore((state) => state.setSplit);
@@ -512,6 +516,53 @@ export function SessionPage(props: SessionPageProps) {
   const [createGroupWorkspaceId, setCreateGroupWorkspaceId] = useState<string | null>(null);
   const browserPanelRef = usePanelRef();
   const preserveSidePanelOnPanelOpenRef = useRef(false);
+
+  const selectNarrowPane = useCallback((pane: NarrowSessionPane) => {
+    setNarrowPane(pane);
+    if (pane === "chat") focusWorkbenchPane("primary");
+    if (pane === "split") focusWorkbenchPane("secondary");
+  }, [focusWorkbenchPane]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    const availablePane = availableNarrowPane(narrowPane, Boolean(splitSession), sidePanelOpen);
+    if (availablePane !== narrowPane) selectNarrowPane(availablePane);
+  }, [isMobile, narrowPane, selectNarrowPane, sidePanelOpen, splitSession]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    if (focusedWorkbenchPane === "secondary" && splitSession) {
+      setNarrowPane("split");
+      return;
+    }
+    setNarrowPane("chat");
+  }, [focusedWorkbenchPane, isMobile, splitSession]);
+
+  useEffect(() => {
+    if (isMobile && sidePanelOpen) setNarrowPane("panel");
+  }, [isMobile, sidePanelOpen]);
+
+  // Roving focus follows an actual pane change only; the initial mount must
+  // never steal focus from the composer or another control.
+  const lastFocusedNarrowPaneRef = useRef<NarrowSessionPane | null>(null);
+  useEffect(() => {
+    if (!isMobile) {
+      lastFocusedNarrowPaneRef.current = null;
+      return;
+    }
+    if (lastFocusedNarrowPaneRef.current === null) {
+      lastFocusedNarrowPaneRef.current = narrowPane;
+      return;
+    }
+    if (lastFocusedNarrowPaneRef.current === narrowPane) return;
+    lastFocusedNarrowPaneRef.current = narrowPane;
+    const frame = window.requestAnimationFrame(() => {
+      narrowPaneNavigationRef.current
+        ?.querySelector<HTMLElement>("[role='tab'][aria-selected='true']")
+        ?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isMobile, narrowPane]);
 
   const setCurrentSidePanel = useCallback((panel: SidePanelItem | null) => {
     setSidePanelState(GLOBAL_VOICE_SIDE_PANEL_KEY, panel === "voice" ? "voice" : null);
@@ -993,7 +1044,7 @@ export function SessionPage(props: SessionPageProps) {
       reactSessionToken &&
       props.surface,
   );
-  const canRenderSplitSurface = Boolean(!isMobile && canRenderReactSurface && splitSession);
+  const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSession);
   const splitWorkspaceTitle = splitSession
     ? splitSession.workspaceTitle ?? workspaceTitleForId(props.sidebar.workspaceSessionGroups, splitSession.workspaceId)
     : "";
@@ -1035,6 +1086,26 @@ export function SessionPage(props: SessionPageProps) {
       message: selectedWorkspaceErrorMessage || "This workspace is disconnected.",
     };
   })();
+  const narrowPaneOptions = useMemo<NarrowPaneOption[]>(() => {
+    const options: NarrowPaneOption[] = [{ id: "chat", label: "Chat" }];
+    if (splitSession) options.push({ id: "split", label: "Split chat" });
+    if (sidePanelOpen) {
+      options.push({
+        id: "panel",
+        label: activeSidePanel === "voice"
+          ? "Voice"
+          : activeSidePanel === "extensions"
+            ? "Extensions"
+            : "Tools",
+      });
+    }
+    return options;
+  }, [activeSidePanel, sidePanelOpen, splitSession]);
+  const showNarrowPaneSwitcher = shouldShowNarrowPaneSwitcher(
+    isMobile,
+    Boolean(splitSession),
+    sidePanelOpen,
+  );
   const crossWorkspaceSplit = Boolean(splitSession && splitSession.workspaceId !== props.selectedWorkspaceId);
   // Route-level refreshes must only gate the very first paint of a session.
   // Once the surface can mount it owns its own data stream, so replacing a
@@ -1234,6 +1305,30 @@ export function SessionPage(props: SessionPageProps) {
       setDeleteBusy(false);
     }
   };
+
+  const sidePanelContent = activeSidePanel === "extensions" && props.settingsSlot ? (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background">
+      {props.settingsSlot}
+    </div>
+  ) : activeSidePanel === "voice" ? (
+    <VoicePanel
+      client={props.openworkServerClient}
+      workspaceId={props.runtimeWorkspaceId}
+      sessionId={props.selectedSessionId}
+      onClose={closeRightPane}
+    />
+  ) : activeSidePanel === "panel" ? (
+    <SidePanel
+      sessionId={sidePanelSessionKey}
+      client={props.openworkServerClient}
+      workspaceId={props.runtimeWorkspaceId}
+      workspaceRoot={props.selectedWorkspaceRoot}
+      isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
+      onClose={closeRightPane}
+      onOpenExtensions={props.settingsSlot ? () => setCurrentSidePanel("extensions") : undefined}
+      onOpenVoice={voiceExtensionEnabled ? openVoiceRailPane : undefined}
+    />
+  ) : null;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text max-lg:pt-[env(safe-area-inset-top)] mac:bg-transparent">
@@ -1487,7 +1582,44 @@ export function SessionPage(props: SessionPageProps) {
             </div>
           </header>
 
-          <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 overflow-hidden">
+          {showNarrowPaneSwitcher ? (
+            <NarrowPaneSwitcher
+              activePane={narrowPane}
+              options={narrowPaneOptions}
+              navigationRef={narrowPaneNavigationRef}
+              onSelect={selectNarrowPane}
+            />
+          ) : null}
+
+          {showNarrowPaneSwitcher ? narrowPaneOptions
+            .filter((option) => option.id !== narrowPane)
+            .map((option) => (
+              <div
+                key={option.id}
+                id={`narrow-session-pane-${option.id}`}
+                role="tabpanel"
+                aria-labelledby={`narrow-session-tab-${option.id}`}
+                hidden
+              />
+            )) : null}
+
+          {isMobile && narrowPane === "panel" && sidePanelOpen ? (
+            <div
+              id="narrow-session-pane-panel"
+              role="tabpanel"
+              aria-labelledby="narrow-session-tab-panel"
+              className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-dls-surface"
+            >
+              {sidePanelContent}
+            </div>
+          ) : (
+          <ResizablePanelGroup
+            id={`narrow-session-pane-${narrowPane}`}
+            role={showNarrowPaneSwitcher ? "tabpanel" : undefined}
+            aria-labelledby={showNarrowPaneSwitcher ? `narrow-session-tab-${narrowPane}` : undefined}
+            orientation="vertical"
+            className="min-h-0 flex-1 overflow-hidden"
+          >
             <ResizablePanel minSize="180px" className="min-h-0">
             <div className="relative h-full min-w-0 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
               {props.primarySlot ? (
@@ -1557,15 +1689,16 @@ export function SessionPage(props: SessionPageProps) {
                     orientation="horizontal"
                     className="min-h-0 flex-1"
                   >
-                    <ResizablePanel
-                      minSize={isMobile ? "0px" : "320px"}
-                      className="min-h-0 min-w-0"
-                      data-workbench-pane="primary"
-                      data-workbench-workspace-id={props.selectedWorkspaceId}
-                      data-workbench-pane-focused={activeWorkbenchPane === "primary" ? "true" : undefined}
-                      onPointerDown={() => focusWorkbenchPane("primary")}
-                      onFocusCapture={() => focusWorkbenchPane("primary")}
-                    >
+                    {!isMobile || narrowPane === "chat" ? (
+                      <ResizablePanel
+                        minSize={isMobile ? "0px" : "320px"}
+                        className="min-h-0 min-w-0"
+                        data-workbench-pane="primary"
+                        data-workbench-workspace-id={props.selectedWorkspaceId}
+                        data-workbench-pane-focused={activeWorkbenchPane === "primary" ? "true" : undefined}
+                        onPointerDown={() => focusWorkbenchPane("primary")}
+                        onFocusCapture={() => focusWorkbenchPane("primary")}
+                      >
                       <div className="flex h-full min-h-0 flex-col">
                         {canRenderSplitSurface && workbenchPrimary ? (
                           <WorkbenchPaneHeader
@@ -1607,12 +1740,13 @@ export function SessionPage(props: SessionPageProps) {
                           />
                         </div>
                       </div>
-                    </ResizablePanel>
-                    {canRenderSplitSurface && splitSession && splitPaneRuntime ? (
+                      </ResizablePanel>
+                    ) : null}
+                    {canRenderSplitSurface && splitSession && splitPaneRuntime && (!isMobile || narrowPane === "split") ? (
                       <>
-                        <ResizableHandle />
+                        {!isMobile ? <ResizableHandle /> : null}
                         <ResizablePanel
-                          minSize="320px"
+                          minSize={isMobile ? "0px" : "320px"}
                           className="min-h-0 min-w-0"
                           data-workbench-pane="secondary"
                           data-workbench-workspace-id={splitSession.workspaceId}
@@ -1771,6 +1905,7 @@ export function SessionPage(props: SessionPageProps) {
               </>
             ) : null}
           </ResizablePanelGroup>
+          )}
 
               </main>
             </ResizablePanel>
@@ -1785,75 +1920,10 @@ export function SessionPage(props: SessionPageProps) {
                   className="min-h-0 overflow-hidden pl-2 lg:flex lg:flex-col"
                 >
                   <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
-                  {activeSidePanel === "extensions" && props.settingsSlot ? (
-                    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background">
-                      {props.settingsSlot}
-                    </div>
-                  ) : activeSidePanel === "voice" ? (
-                    <VoicePanel
-                      client={props.openworkServerClient}
-                      workspaceId={props.runtimeWorkspaceId}
-                      sessionId={props.selectedSessionId}
-                      onClose={closeRightPane}
-                    />
-                  ) : activeSidePanel === "panel" ? (
-                    <SidePanel
-                      sessionId={sidePanelSessionKey}
-                      client={props.openworkServerClient}
-                      workspaceId={props.runtimeWorkspaceId}
-                      workspaceRoot={props.selectedWorkspaceRoot}
-                      isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
-                      onClose={closeRightPane}
-                      onOpenExtensions={props.settingsSlot ? () => setCurrentSidePanel("extensions") : undefined}
-                      onOpenVoice={voiceExtensionEnabled ? openVoiceRailPane : undefined}
-                    />
-                  ) : null}
+                    {sidePanelContent}
                   </div>
                 </ResizablePanel>
               </>
-            ) : null}
-            {isMobile ? (
-              <Sheet
-                open={sidePanelOpen}
-                onOpenChange={(open) => {
-                  if (!open) closeRightPane();
-                }}
-              >
-                <SheetContent
-                  side="bottom"
-                  className="h-[min(88dvh,100dvh)] max-h-[88dvh] p-0 pb-[env(safe-area-inset-bottom)]"
-                >
-                  <SheetHeader className="sr-only">
-                    <SheetTitle>Session panel</SheetTitle>
-                    <SheetDescription>Artifacts, files, and session tools</SheetDescription>
-                  </SheetHeader>
-                  <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-dls-surface">
-                    {activeSidePanel === "extensions" && props.settingsSlot ? (
-                      <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background">
-                        {props.settingsSlot}
-                      </div>
-                    ) : activeSidePanel === "voice" ? (
-                      <VoicePanel
-                        client={props.openworkServerClient}
-                        workspaceId={props.runtimeWorkspaceId}
-                        sessionId={props.selectedSessionId}
-                        onClose={closeRightPane}
-                      />
-                    ) : activeSidePanel === "panel" ? (
-                      <SidePanel
-                        sessionId={sidePanelSessionKey}
-                        client={props.openworkServerClient}
-                        workspaceId={props.runtimeWorkspaceId}
-                        workspaceRoot={props.selectedWorkspaceRoot}
-                        isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
-                        onClose={closeRightPane}
-                        onOpenExtensions={props.settingsSlot ? () => setCurrentSidePanel("extensions") : undefined}
-                        onOpenVoice={voiceExtensionEnabled ? openVoiceRailPane : undefined}
-                      />
-                    ) : null}
-                  </div>
-                </SheetContent>
-              </Sheet>
             ) : null}
           </ResizablePanelGroup>
           <aside className="hidden w-9 shrink-0 flex-col items-center gap-1 px-0.5 py-2 text-muted-foreground lg:flex mac:titlebar-no-drag">

--- a/evals/specs/responsive-session-layout.e2e.test.ts
+++ b/evals/specs/responsive-session-layout.e2e.test.ts
@@ -1,0 +1,289 @@
+import { expect } from "vitest";
+import { control, evalIn, go, listSessions, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { setViewport } from "@openwork/cdp";
+import {
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  needs,
+  soloWorkspace,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localServicesRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const redisOpen = await localRedisIsRunning();
+const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localServicesRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : localServicesRequired && !redisOpen
+      ? " skipped — needs Redis on 127.0.0.1:6379"
+      : "";
+
+const sessionTitles = ["Responsive primary chat", "Responsive split chat"];
+
+async function openSessionRoute(app: Surface, workspaceId: string, sessionId: string) {
+  await go(app, `/workspace/${workspaceId}/session/${sessionId}`);
+  await waitFor(app, `Boolean(document.querySelector(
+    '[data-session-surface-id="${sessionId}"]'
+  ))`, { timeoutMs: 60_000, label: "primary session route" });
+}
+
+async function openSessionInSplit(app: Surface, workspaceId: string, sessionId: string) {
+  const opened = await evalIn(app, `(() => {
+    const row = document.querySelector(
+      '[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
+    );
+    if (!(row instanceof HTMLElement)) return false;
+    row.scrollIntoView({ block: "center" });
+    const target = row.querySelector('[data-session-tab-id="${sessionId}"]') ?? row;
+    if (!(target instanceof HTMLElement)) return false;
+    const rect = target.getBoundingClientRect();
+    target.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      buttons: 2,
+      clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
+      clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
+    }));
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `Boolean(document.querySelector('[data-session-menu-open-split]'))`, {
+    timeoutMs: 15_000,
+    label: "Open in split view menu item",
+  });
+  const clicked = await evalIn(app, `(() => {
+    const item = document.querySelector('[data-session-menu-open-split]');
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+async function pressPaneKey(app: Surface, pane: "chat" | "split" | "panel", key: string) {
+  const pressed = await evalIn(app, `(() => {
+    const tab = document.querySelector('[data-narrow-pane="${pane}"]');
+    if (!(tab instanceof HTMLElement)) return false;
+    tab.focus();
+    tab.dispatchEvent(new KeyboardEvent("keydown", { key: ${JSON.stringify(key)}, bubbles: true }));
+    return true;
+  })()`);
+  expect(pressed).toBe(true);
+}
+
+async function openToolsPanel(app: Surface) {
+  const openedMenu = await evalIn(app, `(() => {
+    const button = document.querySelector('button[aria-label="More actions"]');
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(openedMenu).toBe(true);
+  await waitFor(app, `Boolean([...document.querySelectorAll('[role="menuitem"]')]
+    .find((item) => (item.textContent ?? '').trim().startsWith('Artifacts')))`, {
+    timeoutMs: 15_000,
+    label: "Artifacts menu item",
+  });
+  const openedPanel = await evalIn(app, `(() => {
+    const item = [...document.querySelectorAll('[role="menuitem"]')]
+      .find((candidate) => (candidate.textContent ?? '').trim().startsWith('Artifacts'));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(openedPanel).toBe(true);
+}
+
+test.skipIf(!runnable)(
+  `narrow session panes stay selectable, synchronized, and inside the viewport${skipSuffix}`,
+  { timeout: 600_000 },
+  async ({ evidence }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+    const runId = Date.now();
+    await using world = await startWorld(soloWorkspace.with({
+      apps: { main: { sessions: [...sessionTitles] } },
+    }), { name: `responsive-session-layout-${runId}` });
+    const app = world.app("main");
+    const workspaceId = app.workspaceId;
+    if (!workspaceId) throw new Error("The responsive session world did not resolve a workspace.");
+
+    const sessions = await listSessions(app);
+    const primary = sessions.find((session) => session.title === sessionTitles[0]);
+    const secondary = sessions.find((session) => session.title === sessionTitles[1]);
+    if (!primary || !secondary) {
+      throw new Error(`The responsive session world did not expose both seeded sessions: ${JSON.stringify(sessions)}`);
+    }
+
+    await openSessionRoute(app, workspaceId, primary.sessionId);
+    await openSessionInSplit(app, workspaceId, secondary.sessionId);
+    await waitFor(app, `Boolean(document.querySelector(
+      '[data-workbench-pane="secondary"] [data-session-surface-id="${secondary.sessionId}"]'
+    ))`, { timeoutMs: 60_000, label: "desktop split session" });
+
+    await setViewport(app, { width: 390, height: 844, deviceScaleFactor: 1 });
+    await waitFor(app, `(() => {
+      const selected = document.querySelector('[data-narrow-pane][aria-selected="true"]');
+      const secondary = document.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
+      const primary = document.querySelector('[data-session-surface-id="${primary.sessionId}"]');
+      return selected?.getAttribute('data-narrow-pane') === 'split' && Boolean(secondary) && !primary;
+    })()`, { timeoutMs: 30_000, label: "focused split becomes the narrow visible pane" });
+
+    const initialNarrowFacts = await evalIn(app, `(() => {
+      const tabs = [...document.querySelectorAll('[data-narrow-pane]')];
+      const active = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true');
+      const activePanel = active
+        ? document.getElementById(active.getAttribute('aria-controls') ?? '')
+        : null;
+      const switcher = document.querySelector('[data-narrow-pane-switcher]');
+      const switcherRect = switcher?.getBoundingClientRect();
+      const panelRect = activePanel?.getBoundingClientRect();
+      return {
+        selected: active?.getAttribute('data-narrow-pane') ?? '',
+        tabStops: tabs.filter((tab) => tab.getAttribute('tabindex') === '0').length,
+        inactiveStops: tabs.filter((tab) => tab.getAttribute('aria-selected') === 'false'
+          && tab.getAttribute('tabindex') !== '-1').length,
+        controlsResolve: tabs.every((tab) => Boolean(document.getElementById(tab.getAttribute('aria-controls') ?? ''))),
+        labelledByActiveTab: activePanel?.getAttribute('aria-labelledby') === active?.id,
+        minimumTarget: Math.min(...tabs.map((tab) => tab.getBoundingClientRect().height)),
+        switcherInsideViewport: Boolean(switcherRect
+          && switcherRect.left >= 0
+          && switcherRect.right <= window.innerWidth
+          && switcherRect.top >= 0
+          && switcherRect.bottom <= window.innerHeight),
+        panelInsideViewport: Boolean(panelRect
+          && panelRect.left >= 0
+          && panelRect.right <= window.innerWidth
+          && panelRect.top >= 0
+          && panelRect.bottom <= window.innerHeight),
+        documentWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth,
+      };
+    })()`);
+    expect(initialNarrowFacts).toMatchObject({
+      selected: "split",
+      tabStops: 1,
+      inactiveStops: 0,
+      controlsResolve: true,
+      labelledByActiveTab: true,
+      switcherInsideViewport: true,
+      panelInsideViewport: true,
+      documentWidth: 390,
+      viewportWidth: 390,
+    });
+    expect(initialNarrowFacts).toHaveProperty("minimumTarget");
+    if (typeof initialNarrowFacts !== "object" || initialNarrowFacts === null) {
+      throw new Error(`Invalid narrow layout facts: ${JSON.stringify(initialNarrowFacts)}`);
+    }
+    const minimumTarget = Reflect.get(initialNarrowFacts, "minimumTarget");
+    expect(typeof minimumTarget === "number" && minimumTarget >= 44).toBe(true);
+    evidence.recordAssertionEvidence(
+      "Narrow split focus stays synchronized and the tab widget remains reachable",
+      JSON.stringify(initialNarrowFacts),
+      true,
+    );
+
+    await pressPaneKey(app, "split", "ArrowLeft");
+    await waitFor(app, `(() => {
+      const selected = document.querySelector('[data-narrow-pane][aria-selected="true"]');
+      return selected?.getAttribute('data-narrow-pane') === 'chat'
+        && Boolean(document.querySelector('[data-session-surface-id="${primary.sessionId}"]'))
+        && !document.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
+    })()`, { timeoutMs: 30_000, label: "ArrowLeft selects primary chat" });
+
+    const draft = "Keep this narrow-screen draft";
+    const focusedComposer = await evalIn(app, `(() => {
+      const editor = document.querySelector(
+        '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
+      );
+      if (!(editor instanceof HTMLElement)) return false;
+      editor.focus();
+      return document.activeElement === editor;
+    })()`);
+    expect(focusedComposer).toBe(true);
+    await app.client.send("Input.insertText", { text: draft });
+    await waitFor(app, `(document.querySelector(
+      '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
+    )?.textContent ?? '').includes(${JSON.stringify(draft)})`, {
+      timeoutMs: 15_000,
+      label: "narrow primary draft",
+    });
+
+    const focusSecondaryResult = await control(app, "session.open", { sessionId: secondary.sessionId });
+    expect(focusSecondaryResult).toMatchObject({ ok: true, reused: "secondary-pane" });
+    await waitFor(app, `document.querySelector('[data-narrow-pane="split"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.querySelector('[data-session-surface-id="${secondary.sessionId}"]'))`, {
+      timeoutMs: 30_000,
+      label: "session.open reveals narrow split",
+    });
+    await pressPaneKey(app, "split", "ArrowLeft");
+    await waitFor(app, `(document.querySelector(
+      '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
+    )?.textContent ?? '').includes(${JSON.stringify(draft)})`, {
+      timeoutMs: 30_000,
+      label: "draft survives narrow pane remount",
+    });
+    evidence.recordAssertionEvidence(
+      "Existing session focus actions reveal the requested narrow pane without losing the other chat draft",
+      `session.open revealed ${secondary.sessionId}; returning to ${primary.sessionId} preserved the draft.`,
+      true,
+    );
+
+    await openToolsPanel(app);
+    await waitFor(app, `document.querySelector('[data-narrow-pane="panel"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.getElementById('narrow-session-pane-panel'))`, {
+      timeoutMs: 30_000,
+      label: "tools panel becomes the narrow visible pane",
+    });
+    const panelFacts = await evalIn(app, `(() => {
+      const panel = document.getElementById('narrow-session-pane-panel');
+      const rect = panel?.getBoundingClientRect();
+      return {
+        panelInsideViewport: Boolean(rect
+          && rect.left >= 0
+          && rect.right <= window.innerWidth
+          && rect.top >= 0
+          && rect.bottom <= window.innerHeight),
+        chatHidden: document.getElementById('narrow-session-pane-chat')?.hidden === true,
+        splitHidden: document.getElementById('narrow-session-pane-split')?.hidden === true,
+        documentWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth,
+      };
+    })()`);
+    expect(panelFacts).toEqual({
+      panelInsideViewport: true,
+      chatHidden: true,
+      splitHidden: true,
+      documentWidth: 390,
+      viewportWidth: 390,
+    });
+
+    const closedPanel = await evalIn(app, `(() => {
+      const close = document.querySelector('#narrow-session-pane-panel button[aria-label="Close panel"]');
+      if (!(close instanceof HTMLButtonElement)) return false;
+      close.click();
+      return true;
+    })()`);
+    expect(closedPanel).toBe(true);
+    await waitFor(app, `!document.querySelector('[data-narrow-pane="panel"]')
+      && document.querySelector('[data-narrow-pane="chat"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.querySelector('[data-session-surface-id="${primary.sessionId}"]'))`, {
+      timeoutMs: 30_000,
+      label: "closing selected panel falls back to chat",
+    });
+    evidence.recordAssertionEvidence(
+      "The in-flow tools pane stays inside the viewport and closing it returns to chat",
+      JSON.stringify(panelFacts),
+      true,
+    );
+  },
+);


### PR DESCRIPTION
## What I noticed

On narrow viewports (below 1024px) the session shell could make core content unreachable. The split-chat pane never rendered at all on narrow screens, and the side panel (tools, extensions, voice) opened inside a bottom sheet that covered the conversation. There was no in-flow way to move between chat, a split session, and the panel.

## What I changed

I replaced the narrow-screen bottom sheet with an in-flow pane switcher. Chat, split chat, and the active side panel are exposed as an accessible tab widget with:

- one roving tab stop;
- Arrow Left, Arrow Right, Home, and End navigation with automatic pane activation;
- stable `aria-controls` and `aria-labelledby` relationships, including for inactive panes;
- 44px minimum touch targets; and
- one active `tabpanel` in normal document flow.

Narrow-pane selection now stays synchronized with the shared workbench focus. Existing commands that open or focus a split session therefore reveal that split on a narrow screen instead of updating hidden desktop-only state. When a split closes or a panel goes away, selection returns to chat without leaving shared focus stale.

The secondary resizable panel can shrink to zero on narrow screens, removing its former 320px overflow floor. Desktop behavior remains behind the existing `isMobile` boundary and keeps the same resizable layout.

## Why this matters

OpenWork Web in a small window or half-width layout keeps every session surface reachable. Keyboard and screen-reader users get coherent tab semantics, command-driven pane focus stays visible, drafts survive pane remounts through the existing session-keyed store, and tools render in flow instead of covering the conversation.

## How I validated it

- `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/web-session-narrow-screen-shell DAYTONA_SERVER_SNAPSHOT=openwork-server-clean-pr4144-e7afff pnpm evals:e2e responsive-session-layout --daytona` — 1 passed, 0 failed, 0 skipped on a clean Daytona cold boot.
  - Exercised the real session UI at 390×844.
  - Opened a real split through the UI and verified shared focus selects it.
  - Verified one tab stop, inactive tabs removed from the tab order, resolved ARIA relationships, 44px targets, and no horizontal overflow (`scrollWidth === innerWidth === 390`).
  - Switched panes by keyboard, preserved a typed composer draft, invoked the existing `session.open` action, opened and closed Tools through the UI, and verified the correct fallbacks.
- `pnpm --filter @openwork/app typecheck` — passed.
- `git diff --check` — passed.
- GitHub required tests, CodeQL, Warden, i18n audit, and Vercel previews — passed on the current head.
- Final validated commit: `e7afff4c8b56aaeec27df90b70810dc3aed71a57`, based directly on `dev` at `a3863828759594467c33e02fe491a4481a80e3b0`.

The sticky test-evidence comment contains the three recorded runtime assertions. Screenshots were not uploaded because the artifact upload token was unavailable; the DOM, interaction, focus, sizing, and overflow claims were asserted in the running app.

## Review focus

1. Shared-focus synchronization between `focusedWorkbenchPane` and the narrow selected pane, especially when an existing command focuses a split.
2. Pane unmount semantics: only the selected narrow surface is mounted; the runtime proof verifies that the session-keyed composer draft survives returning to chat.
3. Tab-widget semantics and keyboard behavior, including hidden placeholder tabpanels used to keep `aria-controls` stable.

## Risk and rollback

The change is bounded to the session page, its responsive layout component, and one app-driving E2E spec. New behavior is behind the narrow-screen branch. Reverting the single commit restores the previous Sheet-based layout; there are no data or migration changes.
