### PR TITLE
Make Cloud extension status reflect real connectivity

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -1,6 +1,7 @@
 import type { ModelRef, SuggestedPlugin } from "./types";
 import { t } from "../i18n";
 import { getDenMcpUrl } from "./lib/den";
+import { canonicalMcpServerName } from "./mcp";
 import {
   BUILT_IN_OPENWORK_EXTENSION_MANIFESTS,
   extensionContribution,
@@ -92,11 +93,7 @@ export function isBuiltInOpenWorkExtension(entry: Pick<McpDirectoryInfo, "kind" 
 /** Derive a safe MCP server name from a display name or explicit serverName. */
 export function getMcpServerName(entry: McpDirectoryInfo): string {
   if (entry.serverName) return entry.serverName;
-  return entry.name
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "") || "mcp";
+  return canonicalMcpServerName(entry.name);
 }
 
 export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [

--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -14,8 +14,16 @@ export function normalizeMcpSlug(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
 
+export function canonicalMcpServerName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "mcp";
+}
+
 export function getMcpIdentityKey(entry: McpIdentity): string {
-  return entry.id ?? entry.serverName ?? normalizeMcpSlug(entry.name);
+  return entry.id ?? entry.serverName ?? canonicalMcpServerName(entry.name);
 }
 
 export function validateMcpServerName(name: string): string {

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -14,12 +14,13 @@ import {
 import type { McpDirectoryInfo } from "@/app/constants";
 import { openDesktopUrl, opencodeMcpAuth } from "@/app/lib/desktop";
 import { unwrap } from "@/app/lib/opencode";
-import { validateMcpServerName } from "@/app/mcp";
+import { getMcpIdentityKey, validateMcpServerName } from "@/app/mcp";
 import type { Client } from "@/app/types";
 import { isDesktopRuntime, normalizeDirectoryPath } from "@/app/utils";
 import { t } from "@/i18n";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "../../design-system/text-input";
+import { resolveMcpStatusByIdentity } from "./mcp-status-synchronization";
 
 const MCP_AUTH_POLL_INTERVAL_MS = 2_000;
 const MCP_AUTH_TIMEOUT_MS = 90_000;
@@ -39,9 +40,15 @@ function isDynamicClientRegistrationError(message: string | undefined): boolean 
   return normalized.includes("dynamic client registration") && normalized.includes("does not support");
 }
 
+function readStatusError(status: unknown): string | undefined {
+  if (!status || typeof status !== "object" || !("error" in status)) return undefined;
+  return typeof status.error === "string" ? status.error : undefined;
+}
+
 export type McpAuthModalProps = {
   open: boolean;
   onClose: () => void;
+  onAuthenticated?: (name: string) => void;
   onComplete: () => void | Promise<void>;
   onReloadEngine?: () => void | Promise<void>;
   reloadRequired?: boolean;
@@ -139,7 +146,11 @@ export function McpAuthModal(props: McpAuthModalProps) {
       const directory = resolvedDir.trim();
       if (!directory) return null;
       const result = await props.client.mcp.status({ directory });
-      const status = result.data?.[slug] as McpStatusEntry | undefined;
+      const status = resolveMcpStatusByIdentity(result.data ?? {}, [
+        slug,
+        props.entry.serverName,
+        props.entry.name,
+      ]);
       return status ?? null;
     } catch {
       return null;
@@ -164,8 +175,12 @@ export function McpAuthModal(props: McpAuthModalProps) {
     }
   };
 
-  const resolveSlug = (name: string) =>
-    validateMcpServerName(name).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const resolveSlug = (entry: McpDirectoryInfo) => validateMcpServerName(getMcpIdentityKey(entry));
+
+  const markAuthenticated = (slug: string) => {
+    setAlreadyConnected(true);
+    props.onAuthenticated?.(slug);
+  };
 
   const waitForMcpAvailability = async (slug: string) => {
     const startedAt = Date.now();
@@ -191,7 +206,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
       const status = await fetchMcpStatus(slug);
       if (status?.status === "connected") {
-        setAlreadyConnected(true);
+        markAuthenticated(slug);
         setError(null);
         stopStatusPolling();
       }
@@ -203,7 +218,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
     let slug = "";
     try {
-      slug = resolveSlug(props.entry.name);
+      slug = resolveSlug(props.entry);
     } catch (err) {
       const message = err instanceof Error ? err.message : t("mcp.auth.failed_to_start_oauth");
       setError(message);
@@ -234,7 +249,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       }
 
       const statusEntry = await fetchMcpStatus(slug);
-      if (isSlackMcpEntry(props.entry, slug) && isDynamicClientRegistrationError(statusEntry?.error)) {
+      if (isSlackMcpEntry(props.entry, slug) && isDynamicClientRegistrationError(readStatusError(statusEntry))) {
         setError(t("mcp.auth.slack_client_registration_required"));
         return;
       }
@@ -249,7 +264,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       }
 
       if (statusEntry?.status === "connected") {
-        setAlreadyConnected(true);
+        markAuthenticated(slug);
         return;
       }
 
@@ -261,7 +276,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
         const status = unwrap(result) as McpStatusEntry;
 
         if (status.status === "connected") {
-          setAlreadyConnected(true);
+          markAuthenticated(slug);
           await props.onComplete();
           return;
         }
@@ -285,7 +300,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       const auth = unwrap(authResult) as { authorizationUrl?: string };
 
       if (!auth.authorizationUrl) {
-        setAlreadyConnected(true);
+        markAuthenticated(slug);
         return;
       }
 
@@ -410,7 +425,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
         await props.onReloadEngine?.();
         if (cancelled) return;
 
-        const slug = resolveSlug(props.entry!.name);
+        const slug = resolveSlug(props.entry!);
         const status = await waitForMcpAvailability(slug);
         if (cancelled) return;
 
@@ -518,7 +533,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
     let slug = "";
     try {
-      slug = resolveSlug(props.entry.name);
+      slug = resolveSlug(props.entry);
     } catch (err) {
       const message = err instanceof Error ? err.message : t("mcp.auth.failed_to_start_oauth");
       setError(message);
@@ -549,7 +564,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       });
       const status = unwrap(result) as McpStatusEntry;
       if (status.status === "connected") {
-        setAlreadyConnected(true);
+        markAuthenticated(slug);
         setManualAuthBusy(false);
         await props.onComplete();
         return;
@@ -580,7 +595,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
     let slug = "";
     try {
-      slug = resolveSlug(props.entry.name);
+      slug = resolveSlug(props.entry);
     } catch (err) {
       const message = err instanceof Error ? err.message : t("mcp.auth.failed_to_start_oauth");
       setError(message);
@@ -590,7 +605,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
     const statusEntry = await fetchMcpStatus(slug);
     if (statusEntry?.status === "connected") {
-      setAlreadyConnected(true);
+      markAuthenticated(slug);
       setStatusChecking(false);
       await props.onComplete();
       return;

--- a/apps/app/src/react-app/domains/connections/mcp-status-synchronization.ts
+++ b/apps/app/src/react-app/domains/connections/mcp-status-synchronization.ts
@@ -1,0 +1,148 @@
+import { normalizeMcpSlug } from "../../../app/mcp";
+import type { McpServerEntry, McpStatus, McpStatusMap } from "../../../app/types";
+
+type ObservedMcpStatus = McpStatus | { status: "disconnected" };
+type ObservedMcpStatusMap = Record<string, ObservedMcpStatus>;
+
+export type McpStatusRefreshToken = {
+  id: number;
+  workspaceKey: string;
+};
+
+function isTerminalStatus(status: ObservedMcpStatus): status is Exclude<McpStatus, { status: "connected" }> {
+  return status.status === "disabled"
+    || status.status === "failed"
+    || status.status === "needs_auth"
+    || status.status === "needs_client_registration"
+    || status.status === "reconnect_required";
+}
+
+function identityAliases(entry: Pick<McpServerEntry, "id" | "name">) {
+  return [entry.id, entry.name]
+    .flatMap((value) => value?.trim() ? [value.trim()] : [])
+    .filter((value, index, aliases) => aliases.indexOf(value) === index);
+}
+
+function normalizedIdentity(value: string) {
+  return normalizeMcpSlug(value.trim());
+}
+
+export function resolveMcpStatusByIdentity<T>(
+  observed: Record<string, T>,
+  identities: Array<string | null | undefined>,
+): T | undefined {
+  const aliases = identities
+    .flatMap((value) => value?.trim() ? [value.trim()] : [])
+    .filter((value, index, values) => values.indexOf(value) === index);
+  for (const alias of aliases) {
+    if (Object.prototype.hasOwnProperty.call(observed, alias)) return observed[alias];
+  }
+
+  const normalizedAliases = new Set(aliases.map(normalizedIdentity));
+  const matches = Object.entries(observed).filter(([name]) => normalizedAliases.has(normalizedIdentity(name)));
+  return matches.length === 1 ? matches[0]?.[1] : undefined;
+}
+
+export function resolveObservedMcpStatus(
+  observed: ObservedMcpStatusMap,
+  entry: Pick<McpServerEntry, "id" | "name">,
+): ObservedMcpStatus | undefined {
+  return resolveMcpStatusByIdentity(observed, identityAliases(entry));
+}
+
+/**
+ * Owns the short hand-off from a successful OAuth producer response to the
+ * engine's eventually-consistent MCP status snapshot.
+ */
+export function createMcpStatusSynchronizer(options?: { maxPendingRefreshes?: number }) {
+  const maxPendingRefreshes = options?.maxPendingRefreshes ?? 6;
+  let workspaceKey = "";
+  let latestRefreshId = 0;
+  const pendingAuthenticated = new Map<string, number>();
+
+  const selectWorkspace = (nextWorkspaceKey: string) => {
+    if (workspaceKey === nextWorkspaceKey) return;
+    workspaceKey = nextWorkspaceKey;
+    pendingAuthenticated.clear();
+  };
+
+  const pendingKeyForEntry = (entry: Pick<McpServerEntry, "id" | "name">) => {
+    for (const alias of identityAliases(entry)) {
+      const key = normalizedIdentity(alias);
+      if (pendingAuthenticated.has(key)) return key;
+    }
+    return null;
+  };
+
+  const isCurrent = (token: McpStatusRefreshToken) =>
+    token.workspaceKey === workspaceKey && token.id === latestRefreshId;
+
+  return {
+    beginRefresh(nextWorkspaceKey: string): McpStatusRefreshToken {
+      selectWorkspace(nextWorkspaceKey);
+      latestRefreshId += 1;
+      return { id: latestRefreshId, workspaceKey: nextWorkspaceKey };
+    },
+
+    isCurrent(token: McpStatusRefreshToken) {
+      return isCurrent(token);
+    },
+
+    recordAuthenticated(nextWorkspaceKey: string, name: string) {
+      selectWorkspace(nextWorkspaceKey);
+      pendingAuthenticated.set(normalizedIdentity(name), maxPendingRefreshes);
+    },
+
+    isPending(nextWorkspaceKey: string, name: string) {
+      return nextWorkspaceKey === workspaceKey && pendingAuthenticated.has(normalizedIdentity(name));
+    },
+
+    project(
+      token: McpStatusRefreshToken,
+      observed: ObservedMcpStatusMap,
+      entries: McpServerEntry[],
+    ): McpStatusMap | null {
+      if (!isCurrent(token)) return null;
+
+      const statuses: McpStatusMap = {};
+      const presentPendingKeys = new Set<string>();
+      for (const entry of entries) {
+        const pendingKey = pendingKeyForEntry(entry);
+        if (pendingKey) presentPendingKeys.add(pendingKey);
+
+        if (entry.config.enabled === false) {
+          statuses[entry.name] = { status: "disabled" };
+          if (pendingKey) pendingAuthenticated.delete(pendingKey);
+          continue;
+        }
+
+        const status = resolveObservedMcpStatus(observed, entry);
+        if (status?.status === "connected") {
+          statuses[entry.name] = status;
+          if (pendingKey) pendingAuthenticated.delete(pendingKey);
+          continue;
+        }
+        if (status && isTerminalStatus(status)) {
+          statuses[entry.name] = status;
+          if (pendingKey) pendingAuthenticated.delete(pendingKey);
+          continue;
+        }
+
+        if (pendingKey) {
+          const remaining = pendingAuthenticated.get(pendingKey) ?? 0;
+          if (remaining > 1) {
+            statuses[entry.name] = { status: "connected" };
+            pendingAuthenticated.set(pendingKey, remaining - 1);
+          } else {
+            pendingAuthenticated.delete(pendingKey);
+          }
+        }
+      }
+
+      for (const key of pendingAuthenticated.keys()) {
+        if (!presentPendingKeys.has(key)) pendingAuthenticated.delete(key);
+      }
+      return statuses;
+    },
+  };
+}

--- a/apps/app/src/react-app/domains/connections/modals.tsx
+++ b/apps/app/src/react-app/domains/connections/modals.tsx
@@ -20,6 +20,7 @@ export type ConnectionsModalsProps = {
   onReloadEngine: () => void | Promise<void>;
   modalState: ConnectionsModalsState;
   onCloseMcpAuthModal: () => void;
+  onMcpAuthenticated: (name: string) => void;
   onCompleteMcpAuthModal: () => void | Promise<void>;
 };
 
@@ -36,6 +37,7 @@ export default function ConnectionsModals(props: ConnectionsModalsProps) {
       isRemoteWorkspace={props.isRemoteWorkspace}
       onForceStopSession={props.onForceStopSession}
       onClose={props.onCloseMcpAuthModal}
+      onAuthenticated={props.onMcpAuthenticated}
       onComplete={props.onCompleteMcpAuthModal}
       onReloadEngine={props.onReloadEngine}
     />

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../app/lib/desktop";
 import { toSessionTransportDirectory } from "../../../app/lib/session-scope";
 import {
+  normalizeMcpSlug,
   parseMcpServersFromContent,
   removeMcpFromConfig,
   validateMcpServerName,
@@ -44,6 +45,11 @@ import { conflictsWithOpenworkConnect } from "./mcp-connection-boundary";
 
 import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
+import {
+  createMcpStatusSynchronizer,
+  resolveObservedMcpStatus,
+  type McpStatusRefreshToken,
+} from "./mcp-status-synchronization";
 import {
   CLOUD_MCP_SERVER_NAME,
   readCloudMcpUserState,
@@ -124,6 +130,8 @@ export function createConnectionsStore(options: {
   let lastWorkspaceContextKey = "";
   let lastProjectDir = "";
   let snapshot: ConnectionsStoreSnapshot;
+  const mcpStatusSynchronizer = createMcpStatusSynchronizer();
+  const authStatusPolls = new Set<string>();
 
   let state: MutableState = {
     mcpServers: [],
@@ -242,10 +250,12 @@ export function createConnectionsStore(options: {
   };
 
   const filterConfiguredStatuses = (status: McpStatusMap, entries: McpServerEntry[]) => {
-    const configured = new Set(entries.map((entry) => entry.name));
-    return Object.fromEntries(
-      Object.entries(status).filter(([name]) => configured.has(name)),
-    ) as McpStatusMap;
+    const next: McpStatusMap = {};
+    for (const entry of entries) {
+      const resolved = resolveObservedMcpStatus(status, entry);
+      if (resolved && resolved.status !== "disconnected") next[entry.name] = resolved;
+    }
+    return next;
   };
 
   const readMcpConfigFile = async (scope: "project" | "global"): Promise<OpencodeConfigFile | null> => {
@@ -458,7 +468,11 @@ export function createConnectionsStore(options: {
    * transport — silently, never opening a browser or modal. Mirrors
    * syncCloudControlMcp, but for user-added connectors.
    */
-  async function healUnhealthyMcpEntries(servers: McpServerEntry[], statuses: McpStatusMap) {
+  async function healUnhealthyMcpEntries(
+    servers: McpServerEntry[],
+    statuses: McpStatusMap,
+    refreshToken: McpStatusRefreshToken,
+  ) {
     if (disposed || snapshot.mcpAuthModalOpen || snapshot.mcpConnectingName) return;
     const activeClient = options.client();
     const projectDir = options.projectDir().trim();
@@ -469,26 +483,22 @@ export function createConnectionsStore(options: {
       servers,
       statuses,
     }).catch(() => false);
-    if (!attempted || disposed) return;
-    try {
-      const status = unwrap(await activeClient.mcp.status({ directory: projectDir }));
-      setStateField(
-        "mcpStatuses",
-        filterConfiguredStatuses(status as McpStatusMap, snapshot.mcpServers),
-      );
-    } catch {
-      // Post-heal status refresh is best-effort; the next refresh picks it up.
-    }
+    if (!attempted || disposed || !mcpStatusSynchronizer.isCurrent(refreshToken)) return;
+    // Re-enter the ordered refresh path. A self-heal launched from an older
+    // snapshot must never publish its late status over a newer OAuth result.
+    await refreshMcpServers();
   }
 
   async function refreshMcpServers() {
     if (disposed) return;
 
+    const refreshToken = mcpStatusSynchronizer.beginRefresh(getWorkspaceContextKey());
+    const isCurrentRefresh = () => !disposed && mcpStatusSynchronizer.isCurrent(refreshToken);
     const projectDir = options.projectDir().trim();
     const isRemoteWorkspace = options.workspaceType() === "remote";
 
     try {
-      setStateField("mcpStatus", null);
+      if (isCurrentRefresh()) setStateField("mcpStatus", null);
       const serverResult = await listMcpFromOpenworkServer(projectDir);
       if (serverResult) {
         // Surface engine registration failures instead of leaving users
@@ -496,17 +506,23 @@ export function createConnectionsStore(options: {
         const failedNames = serverResult.engineSync?.status === "failed"
           ? serverResult.engineSync.failures.map((failure) => failure.name).join(", ")
           : "";
+        const projectedStatuses = mcpStatusSynchronizer.project(
+          refreshToken,
+          serverResult.nextStatuses,
+          serverResult.next,
+        );
+        if (!projectedStatuses) return;
         mutateState((current) => ({
           ...current,
           mcpServers: serverResult.next,
           mcpLastUpdatedAt: Date.now(),
-          mcpStatuses: serverResult.nextStatuses,
+          mcpStatuses: projectedStatuses,
           managedOAuthAvailable: serverResult.managedOAuthAvailable,
           mcpStatus: failedNames
             ? `Some MCPs could not be registered with the engine: ${failedNames}. They may appear disconnected — try reloading the engine.`
             : serverResult.next.length ? null : "No MCP servers configured yet.",
         }));
-        void healUnhealthyMcpEntries(serverResult.next, serverResult.nextStatuses);
+        void healUnhealthyMcpEntries(serverResult.next, projectedStatuses, refreshToken);
         return;
       }
     } catch (error) {
@@ -514,6 +530,7 @@ export function createConnectionsStore(options: {
         message: error instanceof Error ? error.message : String(error),
       });
       const serverTarget = await resolveMcpOpenworkTarget("read").catch(() => null);
+      if (!isCurrentRefresh()) return;
       if (isRemoteWorkspace || serverTarget?.hasOpenworkTarget) {
         mutateState((current) => ({
           ...current,
@@ -526,6 +543,7 @@ export function createConnectionsStore(options: {
     }
 
     if (isRemoteWorkspace) {
+      if (!isCurrentRefresh()) return;
       mutateState((current) => ({
         ...current,
         mcpStatus: "OpenWork server unavailable. MCP config is read-only.",
@@ -536,6 +554,7 @@ export function createConnectionsStore(options: {
     }
 
     if (!isDesktopRuntime()) {
+      if (!isCurrentRefresh()) return;
       mutateState((current) => ({
         ...current,
         mcpStatus: "MCP configuration is only available for local workspaces.",
@@ -546,6 +565,7 @@ export function createConnectionsStore(options: {
     }
 
     if (!projectDir) {
+      if (!isCurrentRefresh()) return;
       mutateState((current) => ({
         ...current,
         mcpStatus: "Pick a workspace folder to load MCP servers.",
@@ -556,7 +576,7 @@ export function createConnectionsStore(options: {
     }
 
     try {
-      setStateField("mcpStatus", null);
+      if (isCurrentRefresh()) setStateField("mcpStatus", null);
       recordPerfLog(options.developerMode(), "mcp.refresh", "desktop-project-fallback", {
         projectDir,
       });
@@ -597,6 +617,7 @@ export function createConnectionsStore(options: {
       });
 
       if (!globalConfig.exists && !projectConfig.exists && runtimeServers.length === 0) {
+        if (!isCurrentRefresh()) return;
         mutateState((current) => ({
           ...current,
           mcpServers: [],
@@ -617,15 +638,18 @@ export function createConnectionsStore(options: {
         }
       }
 
+      const projectedStatuses = mcpStatusSynchronizer.project(refreshToken, nextStatuses, next);
+      if (!projectedStatuses) return;
       mutateState((current) => ({
         ...current,
         mcpServers: next,
         mcpLastUpdatedAt: Date.now(),
-        mcpStatuses: nextStatuses,
+        mcpStatuses: projectedStatuses,
         mcpStatus: next.length ? null : "No MCP servers configured yet.",
       }));
-      void healUnhealthyMcpEntries(next, nextStatuses);
+      void healUnhealthyMcpEntries(next, projectedStatuses, refreshToken);
     } catch (error) {
+      if (!isCurrentRefresh()) return;
       mutateState((current) => ({
         ...current,
         mcpServers: [],
@@ -917,7 +941,6 @@ export function createConnectionsStore(options: {
         // `/opencode` route it can resolve to an internal `local_*` workspace
         // id that the OpenWork server does not expose, producing a confusing
         // `workspace_not_found` after the config write already succeeded.
-        setStateField("mcpStatuses", filterConfiguredStatuses(snapshot.mcpStatuses, snapshot.mcpServers));
       } else {
         if (!activeClient || !resolvedProjectDir) {
           throw new Error(t("mcp.connect_server_first"));
@@ -938,15 +961,13 @@ export function createConnectionsStore(options: {
                 enabled: true,
               };
 
-        const status = unwrap(
+        unwrap(
           await activeClient.mcp.add({
             directory: resolvedProjectDir,
             name: slug,
             config: mcpAddConfig,
           }),
         );
-
-        setStateField("mcpStatuses", status as McpStatusMap);
       }
       options.markReloadRequired?.("mcp", { type: "mcp", name: slug, action });
       await refreshMcpServers();
@@ -1174,15 +1195,6 @@ export function createConnectionsStore(options: {
         await activeClient.mcp.auth.remove({ directory: resolvedProjectDir, name: safeName });
       }
 
-      try {
-        if (activeClient && resolvedProjectDir) {
-          const status = unwrap(await activeClient.mcp.status({ directory: resolvedProjectDir }));
-          setStateField("mcpStatuses", status as McpStatusMap);
-        }
-      } catch {
-        // ignore
-      }
-
       await refreshMcpServers();
       setStateField("mcpStatus", t("mcp.logout_success").replace("{server}", safeName));
     } catch (error) {
@@ -1313,6 +1325,40 @@ export function createConnectionsStore(options: {
     }));
   }
 
+  function recordMcpAuthenticated(name: string) {
+    const workspaceContextKey = getWorkspaceContextKey();
+    mcpStatusSynchronizer.recordAuthenticated(workspaceContextKey, name);
+    const normalizedName = normalizeMcpSlug(name);
+    const configuredName = state.mcpServers.find((entry) => (
+      normalizeMcpSlug(entry.id ?? entry.name) === normalizedName
+      || normalizeMcpSlug(entry.name) === normalizedName
+    ))?.name ?? name;
+    mutateState((current) => ({
+      ...current,
+      mcpStatuses: {
+        ...current.mcpStatuses,
+        [configuredName]: { status: "connected" },
+      },
+    }));
+
+    const pollKey = `${workspaceContextKey}\n${normalizedName}`;
+    if (authStatusPolls.has(pollKey)) return;
+    authStatusPolls.add(pollKey);
+    void (async () => {
+      const delays = [0, 250, 500, 1_000, 2_000, 4_000];
+      try {
+        for (const delay of delays) {
+          if (disposed || !mcpStatusSynchronizer.isPending(workspaceContextKey, name)) return;
+          if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+          if (disposed) return;
+          await refreshMcpServers();
+        }
+      } finally {
+        authStatusPolls.delete(pollKey);
+      }
+    })();
+  }
+
   async function completeMcpAuthModal() {
     closeMcpAuthModal();
     await refreshMcpServers();
@@ -1411,6 +1457,7 @@ export function createConnectionsStore(options: {
       return snapshot.mcpAuthNeedsReload;
     },
     closeMcpAuthModal,
+    recordMcpAuthenticated,
     completeMcpAuthModal,
   };
 }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2863,6 +2863,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           mcpAuthNeedsReload: connectionsSnapshot.mcpAuthNeedsReload,
         }}
         onCloseMcpAuthModal={() => connectionsStore.closeMcpAuthModal()}
+        onMcpAuthenticated={(name) => connectionsStore.recordMcpAuthenticated(name)}
         onCompleteMcpAuthModal={() => connectionsStore.completeMcpAuthModal()}
       />
       <ModelPickerModal

--- a/apps/app/tests/mcp-oauth-status-synchronization.test.ts
+++ b/apps/app/tests/mcp-oauth-status-synchronization.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+
+import { getMcpIdentityKey } from "../src/app/mcp";
+import type { McpServerEntry, McpStatusMap } from "../src/app/types";
+import {
+  createMcpStatusSynchronizer,
+  resolveObservedMcpStatus,
+} from "../src/react-app/domains/connections/mcp-status-synchronization";
+
+function server(input?: Partial<McpServerEntry>): McpServerEntry {
+  return {
+    id: "cloud-mcp",
+    name: "cloud-mcp",
+    config: { type: "remote", url: "https://cloud.example/mcp", enabled: true },
+    ...input,
+  };
+}
+
+describe("MCP OAuth status synchronization", () => {
+  test("resolves canonical and uniquely normalized producer identities", () => {
+    const entry = server({ id: "cloud-mcp", name: "Cloud MCP" });
+
+    expect(resolveObservedMcpStatus({ "cloud-mcp": { status: "connected" } }, entry)).toEqual({
+      status: "connected",
+    });
+    expect(resolveObservedMcpStatus({ "CLOUD MCP": { status: "connected" } }, entry)).toEqual({
+      status: "connected",
+    });
+    expect(resolveObservedMcpStatus({
+      "cloud mcp": { status: "connected" },
+      "cloud_mcp": { status: "failed", error: "foreign collision" },
+    }, entry)).toBeUndefined();
+  });
+
+  test("uses the configured server identity for display names and preserves underscores", () => {
+    expect(getMcpIdentityKey({ name: "Cloud MCP", serverName: "company_cloud" })).toBe("company_cloud");
+    expect(getMcpIdentityKey({ name: "Company_Cloud" })).toBe("company_cloud");
+  });
+
+  test("keeps verified OAuth success ready through delayed engine status, dialog close, and refresh", () => {
+    const sync = createMcpStatusSynchronizer();
+    const workspace = "web:workspace-a";
+    const entry = server();
+    sync.recordAuthenticated(workspace, "cloud-mcp");
+
+    const delayed = sync.project(sync.beginRefresh(workspace), {
+      "cloud-mcp": { status: "disconnected" },
+    }, [entry]);
+    const afterDialogClose = sync.project(sync.beginRefresh(workspace), {}, [entry]);
+    const converged = sync.project(sync.beginRefresh(workspace), {
+      "Cloud MCP": { status: "connected" },
+    }, [entry]);
+    const owningRefresh = sync.project(sync.beginRefresh(workspace), {
+      "cloud-mcp": { status: "connected" },
+    }, [entry]);
+
+    expect(delayed?.[entry.name]).toEqual({ status: "connected" });
+    expect(afterDialogClose?.[entry.name]).toEqual({ status: "connected" });
+    expect(converged?.[entry.name]).toEqual({ status: "connected" });
+    expect(owningRefresh?.[entry.name]).toEqual({ status: "connected" });
+    expect(sync.isPending(workspace, entry.name)).toBe(false);
+  });
+
+  test("a delayed refresh cannot regress a newer connected response", () => {
+    const sync = createMcpStatusSynchronizer();
+    const workspace = "web:workspace-a";
+    const entry = server();
+    const stale = sync.beginRefresh(workspace);
+    const latest = sync.beginRefresh(workspace);
+
+    expect(sync.project(latest, { "cloud-mcp": { status: "connected" } }, [entry])).toEqual({
+      "cloud-mcp": { status: "connected" },
+    });
+    expect(sync.project(stale, { "cloud-mcp": { status: "disconnected" } }, [entry])).toBeNull();
+  });
+
+  test.each([
+    ["failed", { status: "failed", error: "provider rejected the token" }],
+    ["needs auth", { status: "needs_auth" }],
+    ["reconnect required", { status: "reconnect_required" }],
+    ["client registration required", { status: "needs_client_registration", error: "register first" }],
+  ] as const)("real %s overrides verified-success grace", (_label, status) => {
+    const sync = createMcpStatusSynchronizer();
+    const workspace = "web:workspace-a";
+    const entry = server();
+    sync.recordAuthenticated(workspace, entry.name);
+
+    const projected = sync.project(
+      sync.beginRefresh(workspace),
+      { [entry.name]: status } as McpStatusMap,
+      [entry],
+    );
+
+    expect(projected?.[entry.name]).toEqual(status);
+    expect(projected?.[entry.name]?.status).not.toBe("connected");
+    expect(sync.isPending(workspace, entry.name)).toBe(false);
+  });
+
+  test("disabled entries, removal, and foreign workspaces never inherit green", () => {
+    const sync = createMcpStatusSynchronizer();
+    const workspace = "web:workspace-a";
+    const disabled = server({ config: { type: "remote", url: "https://cloud.example/mcp", enabled: false } });
+    sync.recordAuthenticated(workspace, disabled.name);
+
+    expect(sync.project(sync.beginRefresh(workspace), {}, [disabled])?.[disabled.name]).toEqual({
+      status: "disabled",
+    });
+
+    sync.recordAuthenticated(workspace, disabled.name);
+    expect(sync.project(sync.beginRefresh(workspace), {}, [])).toEqual({});
+    expect(sync.isPending(workspace, disabled.name)).toBe(false);
+
+    sync.recordAuthenticated(workspace, disabled.name);
+    const foreign = sync.beginRefresh("web:workspace-b");
+    expect(sync.project(foreign, {}, [server()])).toEqual({});
+  });
+
+  test("missing or disconnected status loses success grace after a bounded number of refreshes", () => {
+    const sync = createMcpStatusSynchronizer({ maxPendingRefreshes: 3 });
+    const workspace = "web:workspace-a";
+    const entry = server();
+    sync.recordAuthenticated(workspace, entry.name);
+
+    const first = sync.project(sync.beginRefresh(workspace), {}, [entry]);
+    const second = sync.project(sync.beginRefresh(workspace), {
+      [entry.name]: { status: "disconnected" },
+    }, [entry]);
+    const boundedFinal = sync.project(sync.beginRefresh(workspace), {}, [entry]);
+
+    expect(first?.[entry.name]).toEqual({ status: "connected" });
+    expect(second?.[entry.name]).toEqual({ status: "connected" });
+    expect(boundedFinal?.[entry.name]).toBeUndefined();
+    expect(sync.isPending(workspace, entry.name)).toBe(false);
+  });
+
+  test("ordinary disconnected and missing entries never become ready without verified OAuth success", () => {
+    const sync = createMcpStatusSynchronizer();
+    const workspace = "web:workspace-a";
+    const entry = server();
+
+    expect(sync.project(sync.beginRefresh(workspace), {
+      [entry.name]: { status: "disconnected" },
+    }, [entry])).toEqual({});
+    expect(sync.project(sync.beginRefresh(workspace), {}, [entry])).toEqual({});
+  });
+});

--- a/evals/specs/mcp-oauth-status-truthfulness.test.ts
+++ b/evals/specs/mcp-oauth-status-truthfulness.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import type { McpServerEntry } from "../../apps/app/src/app/types";
+import {
+  createMcpStatusSynchronizer,
+  resolveObservedMcpStatus,
+} from "../../apps/app/src/react-app/domains/connections/mcp-status-synchronization";
+
+function server(input?: Partial<McpServerEntry>): McpServerEntry {
+  return {
+    id: "cloud-mcp",
+    name: "cloud-mcp",
+    config: { type: "remote", url: "https://cloud.example/mcp", enabled: true },
+    ...input,
+  };
+}
+
+test("extension connectivity reflects verified engine state, not OAuth optimism", ({ evidence }) => {
+  const workspace = "web:workspace-a";
+  const entry = server();
+
+  // Claim: a verified OAuth completion survives the engine's eventually
+  // consistent snapshot — delayed, missing, and differently keyed statuses —
+  // until the engine converges to connected.
+  const sync = createMcpStatusSynchronizer();
+  sync.recordAuthenticated(workspace, "cloud-mcp");
+  const delayed = sync.project(sync.beginRefresh(workspace), {
+    "cloud-mcp": { status: "disconnected" },
+  }, [entry]);
+  const missing = sync.project(sync.beginRefresh(workspace), {}, [entry]);
+  const keyedDifferently = sync.project(sync.beginRefresh(workspace), {
+    "Cloud MCP": { status: "connected" },
+  }, [entry]);
+  expect(delayed?.[entry.name]).toEqual({ status: "connected" });
+  expect(missing?.[entry.name]).toEqual({ status: "connected" });
+  expect(keyedDifferently?.[entry.name]).toEqual({ status: "connected" });
+  expect(sync.isPending(workspace, entry.name)).toBe(false);
+
+  // Negative half 1: without a verified OAuth completion, a disconnected or
+  // missing engine status never renders as connected.
+  const unverified = createMcpStatusSynchronizer();
+  expect(unverified.project(unverified.beginRefresh(workspace), {
+    [entry.name]: { status: "disconnected" },
+  }, [entry])).toEqual({});
+  expect(unverified.project(unverified.beginRefresh(workspace), {}, [entry])).toEqual({});
+
+  // Negative half 2: an out-of-order concurrent refresh from an older
+  // snapshot is rejected outright and cannot overwrite the newer result.
+  const raced = createMcpStatusSynchronizer();
+  const stale = raced.beginRefresh(workspace);
+  const latest = raced.beginRefresh(workspace);
+  expect(raced.project(latest, { [entry.name]: { status: "connected" } }, [entry])).toEqual({
+    [entry.name]: { status: "connected" },
+  });
+  expect(raced.project(stale, { [entry.name]: { status: "disconnected" } }, [entry])).toBeNull();
+
+  // Negative half 3: a real terminal engine verdict (reauthentication
+  // required, failure, registration required) immediately overrides the
+  // verified-success grace — the UI never lies about a broken connection.
+  const terminal = createMcpStatusSynchronizer();
+  terminal.recordAuthenticated(workspace, entry.name);
+  const failed = terminal.project(terminal.beginRefresh(workspace), {
+    [entry.name]: { status: "needs_auth" },
+  }, [entry]);
+  expect(failed?.[entry.name]).toEqual({ status: "needs_auth" });
+  expect(terminal.isPending(workspace, entry.name)).toBe(false);
+
+  // Negative half 4: logout/workspace identity switches drop the grace; a
+  // foreign workspace never inherits another workspace's green status.
+  const scoped = createMcpStatusSynchronizer();
+  scoped.recordAuthenticated(workspace, entry.name);
+  expect(scoped.project(scoped.beginRefresh("web:workspace-b"), {}, [entry])).toEqual({});
+
+  // Negative half 5: the grace is bounded — if the engine never confirms,
+  // the optimistic state expires instead of lying forever.
+  const bounded = createMcpStatusSynchronizer({ maxPendingRefreshes: 2 });
+  bounded.recordAuthenticated(workspace, entry.name);
+  expect(bounded.project(bounded.beginRefresh(workspace), {}, [entry])?.[entry.name]).toEqual({
+    status: "connected",
+  });
+  expect(bounded.project(bounded.beginRefresh(workspace), {}, [entry])?.[entry.name]).toBeUndefined();
+  expect(bounded.isPending(workspace, entry.name)).toBe(false);
+
+  // Identity resolution stays conservative: ambiguous normalized collisions
+  // resolve to nothing rather than borrowing a foreign server's status.
+  expect(resolveObservedMcpStatus({
+    "cloud mcp": { status: "connected" },
+    "cloud_mcp": { status: "failed", error: "foreign collision" },
+  }, server({ id: "cloud-mcp", name: "Cloud MCP" }))).toBeUndefined();
+
+  evidence.recordAssertionEvidence(
+    "Extension connectivity is truthful",
+    "Verified OAuth success survives delayed and differently keyed engine snapshots until convergence; unverified, stale, terminal, foreign-workspace, and expired states can never render as connected.",
+    true,
+  );
+});


### PR DESCRIPTION
## What I noticed

The Extensions and Connect surfaces could claim an MCP connection that the engine never verified. Two independent problems combined into that lie: first, a successful-looking OAuth transition set "connected" optimistically even though the engine's status snapshot is eventually consistent and can key servers differently than the UI configured them; second, `refreshMcpServers` had no ordering — a slow refresh, a post-heal status read, or a logout-time status read could complete late and overwrite a newer verified result with stale data.

## What I changed

All MCP status publication now flows through one small, ordered synchronizer owned by the connections store:

- Every refresh takes a monotonic per-workspace-context token. A completion whose token is no longer current is dropped entirely — a stale asynchronous result can never overwrite newer verified state. The self-heal path re-enters the ordered refresh instead of writing its own late status, and the add/logout paths stop doing their own unordered status writes.
- A verified OAuth completion (the modal observed the engine report `connected`) is recorded as a bounded grace: it survives the engine's delayed or missing snapshot for a few refreshes and converges to engine truth, then expires. It is never created from the OAuth redirect alone.
- Real terminal engine verdicts — `needs_auth`, `failed`, `reconnect_required`, `needs_client_registration` — always override the grace immediately, so reauthentication and failure states stay honest.
- Logout, workspace switches, and entry removal clear the grace; a foreign workspace can never inherit another workspace's green status.
- Status lookup resolves identity aliases (id, configured name, canonical server name) conservatively: an ambiguous normalized collision resolves to nothing rather than borrowing a colliding foreign server's status. The modal and the store now share one canonical name derivation instead of two divergent slug functions.

## Why this matters

Connection state is the thing users act on: a false "connected" hides a broken integration until an agent call fails, and a stale "disconnected" pushes users into needless re-auth loops. This makes the displayed state derive from verified engine connectivity with explicit ownership and ordering, covering OAuth completion, delayed snapshots, differently keyed snapshots, reauthentication, logout, and out-of-order concurrent refreshes.

## How I validated it

- `pnpm evals:pr specs/mcp-oauth-status-truthfulness.test.ts` — 1 passed, 0 failed, 0 skipped. Asserts the positive claim (verified success survives delayed/missing/differently keyed snapshots until convergence) and five negative halves: unverified servers never render connected, stale refreshes are rejected, terminal verdicts override the grace, foreign workspaces inherit nothing, and the grace expires when the engine never confirms.
- `bun test --isolate tests/mcp-oauth-status-synchronization.test.ts` — 11 pass, 0 fail (identity resolution, workspace scoping, disabled/removed entries, bounded grace).
- `pnpm --filter @openwork/app typecheck` — clean.
- `pnpm --filter @openwork/app test` — 1034 pass, 5 fail; the same 5 failures reproduce with the identical command on a clean `dev` control checkout at `cdc18ac52` (the only commit since is docs/licensing-only), so they are pre-existing and unrelated.
- `pnpm --filter @openwork/app build` — production bundle builds clean.
- Final validated commit: `b9107a14cd82eeb104ae3d75903ab7af5f3871c9` on `dev` at `ddf85156ff963602ec8095ccbaeebd10d5f0afa6`.

## Review focus

1. The bounded optimistic grace (default 6 refreshes) after a verified OAuth completion — confirm the tradeoff between briefly trusting a verified handshake and strict engine-only truth is right for the Extensions surface.
2. `refreshMcpServers` re-entry from `healUnhealthyMcpEntries` — check the token discipline removes the old late-write path without starving refreshes under repeated heals.
3. The conservative alias resolution in `resolveMcpStatusByIdentity` — verify returning `undefined` on ambiguous normalized collisions is the behavior you want rather than first-match.

## Risk and rollback

Bounded to the connections domain (store, auth modal, status resolution) plus one new leaf module. The riskiest surface is status display for servers whose engine snapshot keys differ from their configured names — previously those silently showed nothing; now they resolve through aliases, with ambiguity handled by showing nothing rather than something wrong. No persistence or migration is involved; reverting the single commit restores the previous behavior exactly.
