### PR TITLE
Keep Web composer drafts private and conflict-safe

### DIFF
--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -117,6 +117,7 @@ export function shouldRetryDenAuthOnSignal(input: {
 export type DenAuthStore = {
   status: DenAuthStatus;
   user: DenUser | null;
+  verifiedIdentity: { principalId: string; organizationId: string } | null;
   error: string | null;
   isSignedIn: boolean;
   refresh: () => Promise<void>;
@@ -187,6 +188,11 @@ function pendingServerSwitchForDeepLink(input: {
 export function DenAuthProvider({ children }: DenAuthProviderProps) {
   const [status, setStatus] = useState<DenAuthStatus>("checking");
   const [user, setUser] = useState<DenUser | null>(null);
+  const [verifiedIdentity, setVerifiedIdentity] = useState<{
+    principalId: string;
+    organizationId: string;
+  } | null>(null);
+  const verifiedCredentialRef = useRef<{ token: string; organizationId: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Monotonic token so stale async refreshes can't clobber a newer result.
   const refreshTokenRef = useRef(0);
@@ -219,9 +225,21 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     const currentRun = ++refreshTokenRef.current;
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
+    const organizationId = settings.activeOrgId?.trim() ?? "";
+    const verifiedCredential = verifiedCredentialRef.current;
+
+    if (
+      !verifiedCredential
+      || verifiedCredential.token !== token
+      || verifiedCredential.organizationId !== organizationId
+    ) {
+      verifiedCredentialRef.current = null;
+      setVerifiedIdentity(null);
+    }
 
     if (!token) {
       setUser(null);
+      setVerifiedIdentity(null);
       setError(null);
       lastSignalRetryAtRef.current = null;
       updateStatus("signed_out");
@@ -258,6 +276,17 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
 
       if (currentRun !== refreshTokenRef.current) return;
 
+      const confirmedSettings = readDenSettings();
+      const confirmedToken = confirmedSettings.authToken?.trim() ?? "";
+      const confirmedOrganizationId = confirmedSettings.activeOrgId?.trim() ?? "";
+      const principalId = nextUser.id.trim();
+      if (confirmedToken === token && principalId && confirmedOrganizationId) {
+        verifiedCredentialRef.current = { token, organizationId: confirmedOrganizationId };
+        setVerifiedIdentity({ principalId, organizationId: confirmedOrganizationId });
+      } else {
+        verifiedCredentialRef.current = null;
+        setVerifiedIdentity(null);
+      }
       setUser(nextUser);
       setError(null);
       lastSignalRetryAtRef.current = null;
@@ -270,6 +299,8 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
       if (failureStatus === "signed_out") {
         clearDenSession();
         setUser(null);
+        verifiedCredentialRef.current = null;
+        setVerifiedIdentity(null);
         lastSignalRetryAtRef.current = null;
         clearDesktopSentrySession();
       }
@@ -293,8 +324,10 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     };
 
     window.addEventListener(denSessionUpdatedEvent, handleSessionUpdated);
+    window.addEventListener(denSettingsChangedEvent, handleSessionUpdated);
     return () => {
       window.removeEventListener(denSessionUpdatedEvent, handleSessionUpdated);
+      window.removeEventListener(denSettingsChangedEvent, handleSessionUpdated);
     };
   }, [refresh]);
 
@@ -507,11 +540,12 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     () => ({
       status,
       user,
+      verifiedIdentity,
       error,
       isSignedIn: hasRetainedDenSession(status),
       refresh,
     }),
-    [error, refresh, status, user],
+    [error, refresh, status, user, verifiedIdentity],
   );
 
   return (

--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -54,6 +54,31 @@ const EMPTY_PASTE_PARTS: ComposerPastePart[] = [];
 const EMPTY_HISTORY: string[] = [];
 const EMPTY_QUEUED_DRAFTS: QueuedComposerItem[] = [];
 const HISTORY_LIMIT = 50;
+const composerSessionDraftScopes = new Map<string, string>();
+
+export function claimComposerSessionDraftScope(sessionId: string, scopeKey: string) {
+  const session = sessionId.trim();
+  if (!session) return;
+  composerSessionDraftScopes.set(session, scopeKey);
+}
+
+export function getComposerSessionDraftScope(sessionId: string) {
+  return composerSessionDraftScopes.get(sessionId.trim()) ?? null;
+}
+
+export function persistableComposerDraftText(text: string) {
+  return text.replace(/\[attachment [^\]]+\]/g, "");
+}
+
+export function composerDraftNeedsHydration(input: {
+  claimedScopeKey: string | null;
+  nextScopeKey: string;
+  currentText: string;
+  storedText: string;
+}) {
+  return input.claimedScopeKey !== input.nextScopeKey
+    || persistableComposerDraftText(input.currentText) !== input.storedText;
+}
 
 function createEmptyComposerSession(): ComposerSessionState {
   return {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
@@ -14,6 +14,7 @@ import type { ComposerSettingsSection } from "@/react-app/domains/settings/libra
 import { type CloudImportedPlugin } from "@/app/cloud/import-state";
 import { createDenClient, readDenSettings } from "@/app/lib/den";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { useSessionDraftState } from "@/react-app/domains/session/sync/draft-store";
 import type {
   OpenworkServerClient,
   OpenworkSessionSnapshot,
@@ -77,6 +78,8 @@ import {
 } from "@/react-app/domains/session/sync/session-sync";
 import { resolveForkBoundaryId } from "@/react-app/domains/session/sync/transcript-reconcile";
 import {
+  claimComposerSessionDraftScope,
+  composerDraftNeedsHydration,
   getComposerAttachments,
   getComposerDraft,
   getComposerHistory,
@@ -84,6 +87,8 @@ import {
   getComposerPasteParts,
   getComposerQueuedDrafts,
   getComposerRevertMessageId,
+  getComposerSessionDraftScope,
+  persistableComposerDraftText,
   useComposerStateStore,
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
@@ -400,6 +405,7 @@ export type SessionSurfaceProps = {
   workspaceId: string;
   workspaceRoot: string;
   sessionId: string;
+  draftScope: string | null;
   isControlTarget: boolean;
   opencodeBaseUrl: string;
   openworkToken: string;
@@ -798,6 +804,45 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const setComposerMentions = useComposerStateStore((state) => state.setMentions);
   const setComposerPasteParts = useComposerStateStore((state) => state.setPasteParts);
   const clearComposerSession = useComposerStateStore((state) => state.clearSession);
+  const {
+    scopeKey: persistedDraftKey,
+    snapshot: persistedDraftSnapshot,
+    save: persistDraft,
+  } = useSessionDraftState(props.draftScope, props.workspaceId, props.sessionId);
+  const appliedPersistedDraftRef = useRef<{
+    scopeKey: string;
+    snapshot: typeof persistedDraftSnapshot;
+  } | null>(null);
+
+  // Layout timing is intentional: an account/org boundary must replace the
+  // previous scope's in-memory Zustand draft before the browser can paint it.
+  useLayoutEffect(() => {
+    const applied = appliedPersistedDraftRef.current;
+    if (applied?.scopeKey === persistedDraftKey && applied.snapshot === persistedDraftSnapshot) return;
+
+    const claimedScopeKey = getComposerSessionDraftScope(props.sessionId);
+    claimComposerSessionDraftScope(props.sessionId, persistedDraftKey);
+    appliedPersistedDraftRef.current = {
+      scopeKey: persistedDraftKey,
+      snapshot: persistedDraftSnapshot,
+    };
+
+    const currentState = useComposerStateStore.getState();
+    const currentDraft = getComposerDraft(currentState, props.sessionId);
+    const nextDraft = persistedDraftSnapshot?.text ?? "";
+    if (!composerDraftNeedsHydration({
+      claimedScopeKey,
+      nextScopeKey: persistedDraftKey,
+      currentText: currentDraft,
+      storedText: nextDraft,
+    })) return;
+
+    for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
+      revokeAttachmentPreview(attachment);
+    }
+    clearComposerSession(props.sessionId);
+    if (nextDraft) replaceComposerDraft(props.sessionId, nextDraft);
+  }, [clearComposerSession, persistedDraftKey, persistedDraftSnapshot, props.sessionId, replaceComposerDraft]);
   const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
   const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
   // Queued follow-up drafts live in the shared composer store keyed by session
@@ -1669,8 +1714,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.cloudMcpSubmissionState.status]);
 
   useEffect(() => {
-    props.onDraftChange(buildDraft(draft, attachments));
-  }, [attachments, buildDraft, draft, props.onDraftChange]);
+    const nextDraft = buildDraft(draft, attachments);
+    persistDraft({ text: persistableComposerDraftText(nextDraft.text), mode: nextDraft.mode });
+    props.onDraftChange(nextDraft);
+  }, [attachments, buildDraft, draft, persistDraft, props.onDraftChange]);
 
   const handleAttachFiles = useCallback((files: File[]) => {
     if (!props.attachmentsEnabled) {

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -30,7 +30,7 @@ import type {
   ModelRef,
 } from "../../../../app/types";
 import { addOpencodeCacheHint, safeStringify } from "../../../../app/utils";
-import { clearSessionDraft, saveSessionDraft } from "./draft-store";
+import { clearSessionDraft, LOCAL_SESSION_DRAFT_SCOPE, saveSessionDraft } from "./draft-store";
 import { firstLineLocalFileParts } from "./prompt-file-parts";
 import { composerAttachmentToFilePart } from "./attachment-file-part";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
@@ -396,12 +396,12 @@ export function createSessionActionsStore(options: {
 
       const session = unwrap(rawResult);
       if (initialPrompt) {
-        saveSessionDraft(id, session.id, {
+        saveSessionDraft(LOCAL_SESSION_DRAFT_SCOPE, id, session.id, {
           text: initialPrompt,
           mode: "prompt",
         });
       } else {
-        clearSessionDraft(id, session.id);
+        clearSessionDraft(LOCAL_SESSION_DRAFT_SCOPE, id, session.id);
       }
 
       options.setBusyLabel("status.loading_session");
@@ -527,7 +527,7 @@ export function createSessionActionsStore(options: {
       if (!compactCommand) {
         setLastPromptSent(content);
       }
-      clearSessionDraft(options.selectedWorkspaceId().trim(), sessionID);
+      clearSessionDraft(LOCAL_SESSION_DRAFT_SCOPE, options.selectedWorkspaceId().trim(), sessionID);
       if (!hasExplicitDraft) {
         options.setPrompt("");
       }
@@ -791,7 +791,7 @@ export function createSessionActionsStore(options: {
     const directory = toSessionTransportDirectory(root);
     const params = directory ? { sessionID: trimmed, directory } : { sessionID: trimmed };
     unwrap(await c.session.delete(params));
-    clearSessionDraft(options.selectedWorkspaceId().trim(), trimmed);
+    clearSessionDraft(LOCAL_SESSION_DRAFT_SCOPE, options.selectedWorkspaceId().trim(), trimmed);
 
     options.setSessions(options.sessions().filter((s) => s.id !== trimmed));
     const activeWsId = options.selectedWorkspaceId();

--- a/apps/app/src/react-app/domains/session/sync/draft-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-store.ts
@@ -8,161 +8,387 @@ export type SessionDraftSnapshot = {
   mode: PromptMode;
 };
 
-const STORAGE_KEY = "openwork.session-drafts.v1";
-const MAX_DRAFT_COUNT = 100;
+export type SessionDraftIdentity = {
+  principalId: string;
+  organizationId: string;
+};
 
-let draftCache: Map<string, SessionDraftSnapshot> | null = null;
+export type SessionDraftWriteResult =
+  | { status: "saved"; snapshot: SessionDraftSnapshot | null }
+  | { status: "conflict"; snapshot: SessionDraftSnapshot | null }
+  | { status: "unavailable"; snapshot: SessionDraftSnapshot | null };
 
-const listeners = new Set<() => void>();
+type StoredDraft = SessionDraftSnapshot & {
+  revision: number;
+};
 
-export const sessionDraftScopeKey = (
-  workspaceId: string,
-  sessionId: string | null | undefined,
-) => {
-  const workspace = workspaceId.trim();
-  const session = (sessionId ?? "").trim();
-  if (!workspace || !session) return "";
-  return `${workspace}:${session}`;
+type DraftDocument = {
+  version: 2;
+  nextRevision: number;
+  drafts: Record<string, StoredDraft>;
+};
+
+type DraftStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+type DraftStorageMutation = {
+  key: string | null;
+  newValue: string | null;
+};
+
+type DraftStoreOptions = {
+  storage: DraftStorage;
+  subscribeToStorage?: (listener: (mutation: DraftStorageMutation) => void) => () => void;
+};
+
+export const SESSION_DRAFT_STORAGE_KEY = "openwork.session-drafts.v2";
+export const LEGACY_SESSION_DRAFT_STORAGE_KEY = "openwork.session-drafts.v1";
+export const LOCAL_SESSION_DRAFT_SCOPE = "local";
+export const MAX_SESSION_DRAFT_COUNT = 100;
+
+const EMPTY_DOCUMENT: DraftDocument = {
+  version: 2,
+  nextRevision: 1,
+  drafts: {},
 };
 
 const isPromptMode = (value: unknown): value is PromptMode =>
   value === "prompt" || value === "shell";
 
-const emitDraftStoreChange = () => {
-  for (const listener of listeners) {
-    listener();
-  }
-};
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
-const subscribeDraftStore = (callback: () => void) => {
-  listeners.add(callback);
-  return () => {
-    listeners.delete(callback);
-  };
-};
+const normalizedOpaqueId = (value: string) => encodeURIComponent(value.trim());
 
-const loadDraftCache = () => {
-  if (draftCache) return draftCache;
-  draftCache = new Map<string, SessionDraftSnapshot>();
-  if (typeof window === "undefined") return draftCache;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return draftCache;
-    const parsed = JSON.parse(raw) as Record<string, { text?: unknown; mode?: unknown }>;
-    if (!parsed || typeof parsed !== "object") return draftCache;
-    for (const [key, value] of Object.entries(parsed)) {
-      if (!key || !value || typeof value !== "object") continue;
-      const text = typeof value.text === "string" ? value.text : "";
-      const mode = isPromptMode(value.mode) ? value.mode : "prompt";
-      if (!text && mode === "prompt") continue;
-      draftCache.set(key, { text, mode });
-    }
-  } catch {
-    return draftCache;
-  }
-  return draftCache;
-};
+export function cloudSessionDraftScope(identity: SessionDraftIdentity | null | undefined): string | null {
+  const principalId = identity?.principalId.trim() ?? "";
+  const organizationId = identity?.organizationId.trim() ?? "";
+  if (!principalId || !organizationId) return null;
+  return `cloud:${normalizedOpaqueId(principalId)}:${normalizedOpaqueId(organizationId)}`;
+}
 
-const persistDraftCache = () => {
-  if (typeof window === "undefined") return;
-  const cache = loadDraftCache();
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(cache)));
-  } catch {
-    // ignore storage write failures
-  }
-};
+export function resolveSessionDraftScope(input: {
+  hasCloudCredential: boolean;
+  verifiedIdentity: SessionDraftIdentity | null | undefined;
+}) {
+  return input.hasCloudCredential
+    ? cloudSessionDraftScope(input.verifiedIdentity)
+    : LOCAL_SESSION_DRAFT_SCOPE;
+}
 
-export const getSessionDraft = (
+export function sessionDraftScopeKey(
+  scopeId: string | null | undefined,
   workspaceId: string,
   sessionId: string | null | undefined,
-) => {
-  const key = sessionDraftScopeKey(workspaceId, sessionId);
-  if (!key) return null;
-  return loadDraftCache().get(key) ?? null;
-};
+) {
+  const scope = scopeId?.trim() ?? "";
+  const workspace = workspaceId.trim();
+  const session = sessionId?.trim() ?? "";
+  if (!scope || !workspace || !session) return "";
+  return [scope, workspace, session].map(normalizedOpaqueId).join("|");
+}
+
+function parseDocument(raw: string | null): DraftDocument {
+  if (!raw) return EMPTY_DOCUMENT;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== 2 || !isRecord(parsed.drafts)) {
+      return EMPTY_DOCUMENT;
+    }
+
+    const drafts: Record<string, StoredDraft> = {};
+    let highestRevision = 0;
+    for (const [key, value] of Object.entries(parsed.drafts)) {
+      if (!key || !isRecord(value) || typeof value.text !== "string" || !isPromptMode(value.mode)) continue;
+      if (typeof value.revision !== "number" || !Number.isSafeInteger(value.revision) || value.revision < 1) continue;
+      if (!value.text && value.mode === "prompt") continue;
+      drafts[key] = { text: value.text, mode: value.mode, revision: value.revision };
+      highestRevision = Math.max(highestRevision, value.revision);
+    }
+
+    const declaredNextRevision = typeof parsed.nextRevision === "number"
+      && Number.isSafeInteger(parsed.nextRevision)
+      && parsed.nextRevision > 0
+      ? parsed.nextRevision
+      : 1;
+
+    return {
+      version: 2,
+      nextRevision: Math.max(declaredNextRevision, highestRevision + 1),
+      drafts,
+    };
+  } catch {
+    return EMPTY_DOCUMENT;
+  }
+}
+
+function sameStoredDraft(left: StoredDraft | undefined, right: StoredDraft | undefined) {
+  if (!left || !right) return left === right;
+  return left.revision === right.revision
+    && left.text === right.text
+    && left.mode === right.mode;
+}
+
+function documentFingerprint(document: DraftDocument) {
+  return JSON.stringify(document);
+}
+
+/**
+ * A context-local draft store. Each browser window owns one instance while
+ * sharing localStorage with its peers. Mutations always merge against a fresh
+ * read and use the last observed per-draft revision as a compare-and-swap
+ * guard, so an old tab cannot replace a newer draft or resurrect a clear.
+ */
+export function createSessionDraftStore(options: DraftStoreOptions) {
+  let cache: DraftDocument | null = null;
+  let cacheFingerprint = "";
+  let legacyHandled = false;
+  const listeners = new Set<() => void>();
+  const visibleSnapshots = new WeakMap<StoredDraft, SessionDraftSnapshot>();
+
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const readRaw = () => {
+    try {
+      return options.storage.getItem(SESSION_DRAFT_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  };
+
+  const removeAmbiguousLegacyDrafts = () => {
+    if (legacyHandled) return;
+    legacyHandled = true;
+    try {
+      if (options.storage.getItem(LEGACY_SESSION_DRAFT_STORAGE_KEY) !== null) {
+        // v1 has no identity or organization boundary. It cannot be safely
+        // attributed even to the unsigned local scope, so migration is
+        // deliberately fail-closed rather than exposing ambiguous text.
+        options.storage.removeItem(LEGACY_SESSION_DRAFT_STORAGE_KEY);
+      }
+    } catch {
+      // Storage may be unavailable in privacy modes; drafts remain in-memory.
+    }
+  };
+
+  const replaceCache = (document: DraftDocument) => {
+    const nextFingerprint = documentFingerprint(document);
+    const changed = cache !== null && cacheFingerprint !== nextFingerprint;
+    cache = document;
+    cacheFingerprint = nextFingerprint;
+    if (changed) emit();
+  };
+
+  const loadCache = () => {
+    removeAmbiguousLegacyDrafts();
+    if (!cache) replaceCache(parseDocument(readRaw()));
+    return cache ?? EMPTY_DOCUMENT;
+  };
+
+  const reconcile = (raw = readRaw()) => {
+    removeAmbiguousLegacyDrafts();
+    replaceCache(parseDocument(raw));
+  };
+
+  const storageCleanup = options.subscribeToStorage?.((mutation) => {
+    if (mutation.key !== null && mutation.key !== SESSION_DRAFT_STORAGE_KEY) return;
+    reconcile(mutation.key === SESSION_DRAFT_STORAGE_KEY ? mutation.newValue : readRaw());
+  });
+
+  const write = (document: DraftDocument) => {
+    const serialized = JSON.stringify(document);
+    try {
+      options.storage.setItem(SESSION_DRAFT_STORAGE_KEY, serialized);
+      replaceCache(document);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const currentSnapshot = (key: string) => {
+    const stored = loadCache().drafts[key];
+    if (!stored) return null;
+    const existing = visibleSnapshots.get(stored);
+    if (existing) return existing;
+    const snapshot = { text: stored.text, mode: stored.mode };
+    visibleSnapshots.set(stored, snapshot);
+    return snapshot;
+  };
+
+  const get = (
+    scopeId: string | null | undefined,
+    workspaceId: string,
+    sessionId: string | null | undefined,
+  ) => {
+    const key = sessionDraftScopeKey(scopeId, workspaceId, sessionId);
+    return key ? currentSnapshot(key) : null;
+  };
+
+  const clear = (
+    scopeId: string | null | undefined,
+    workspaceId: string,
+    sessionId: string | null | undefined,
+  ): SessionDraftWriteResult => {
+    const key = sessionDraftScopeKey(scopeId, workspaceId, sessionId);
+    if (!key) return { status: "unavailable", snapshot: null };
+
+    const expected = loadCache().drafts[key];
+    const latestDocument = parseDocument(readRaw());
+    const latest = latestDocument.drafts[key];
+    if (!sameStoredDraft(expected, latest)) {
+      replaceCache(latestDocument);
+      return { status: "conflict", snapshot: currentSnapshot(key) };
+    }
+    if (!latest) return { status: "saved", snapshot: null };
+
+    const drafts = { ...latestDocument.drafts };
+    delete drafts[key];
+    const nextDocument: DraftDocument = { ...latestDocument, drafts };
+    if (!write(nextDocument)) return { status: "unavailable", snapshot: currentSnapshot(key) };
+    return { status: "saved", snapshot: null };
+  };
+
+  const save = (
+    scopeId: string | null | undefined,
+    workspaceId: string,
+    sessionId: string | null | undefined,
+    snapshot: SessionDraftSnapshot,
+  ): SessionDraftWriteResult => {
+    const key = sessionDraftScopeKey(scopeId, workspaceId, sessionId);
+    if (!key) return { status: "unavailable", snapshot: null };
+    if (!snapshot.text && snapshot.mode === "prompt") {
+      return clear(scopeId, workspaceId, sessionId);
+    }
+
+    const expected = loadCache().drafts[key];
+    const latestDocument = parseDocument(readRaw());
+    const latest = latestDocument.drafts[key];
+    if (!sameStoredDraft(expected, latest)) {
+      replaceCache(latestDocument);
+      return { status: "conflict", snapshot: currentSnapshot(key) };
+    }
+
+    const revision = latestDocument.nextRevision;
+    const drafts = {
+      ...latestDocument.drafts,
+      [key]: { text: snapshot.text, mode: snapshot.mode, revision },
+    };
+    const oldest = Object.entries(drafts)
+      .sort((left, right) => left[1].revision - right[1].revision)
+      .slice(0, Math.max(0, Object.keys(drafts).length - MAX_SESSION_DRAFT_COUNT));
+    for (const [oldestKey] of oldest) delete drafts[oldestKey];
+
+    const nextDocument: DraftDocument = {
+      version: 2,
+      nextRevision: revision + 1,
+      drafts,
+    };
+    const normalized = { text: snapshot.text, mode: snapshot.mode };
+    if (!write(nextDocument)) return { status: "unavailable", snapshot: currentSnapshot(key) };
+    return { status: "saved", snapshot: normalized };
+  };
+
+  return {
+    get,
+    save,
+    clear,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      storageCleanup?.();
+      listeners.clear();
+    },
+  };
+}
+
+type SessionDraftStore = ReturnType<typeof createSessionDraftStore>;
+
+let browserStore: SessionDraftStore | null = null;
+let browserStorage: Storage | null = null;
+
+function getBrowserStore(): SessionDraftStore | null {
+  if (typeof window === "undefined") return null;
+  let storage: Storage;
+  try {
+    storage = window.localStorage;
+  } catch {
+    return null;
+  }
+  if (browserStore && browserStorage === storage) return browserStore;
+  browserStore?.dispose();
+  browserStorage = storage;
+  browserStore = createSessionDraftStore({
+    storage,
+    subscribeToStorage: (listener) => {
+      const handleStorage = (event: StorageEvent) => listener({ key: event.key, newValue: event.newValue });
+      window.addEventListener("storage", handleStorage);
+      return () => window.removeEventListener("storage", handleStorage);
+    },
+  });
+  return browserStore;
+}
+
+const subscribeBrowserDraftStore = (listener: () => void) =>
+  getBrowserStore()?.subscribe(listener) ?? (() => undefined);
+
+export const getSessionDraft = (
+  scopeId: string | null | undefined,
+  workspaceId: string,
+  sessionId: string | null | undefined,
+) => getBrowserStore()?.get(scopeId, workspaceId, sessionId) ?? null;
 
 export const saveSessionDraft = (
+  scopeId: string | null | undefined,
   workspaceId: string,
   sessionId: string | null | undefined,
   snapshot: SessionDraftSnapshot,
-) => {
-  const key = sessionDraftScopeKey(workspaceId, sessionId);
-  if (!key) return;
-
-  const normalized: SessionDraftSnapshot = {
-    text: snapshot.text,
-    mode: snapshot.mode,
-  };
-
-  if (!normalized.text && normalized.mode === "prompt") {
-    clearSessionDraft(workspaceId, sessionId);
-    return;
-  }
-
-  const cache = loadDraftCache();
-  cache.delete(key);
-  cache.set(key, normalized);
-  while (cache.size > MAX_DRAFT_COUNT) {
-    const oldest = cache.keys().next();
-    if (oldest.done) break;
-    cache.delete(oldest.value);
-  }
-  persistDraftCache();
-  emitDraftStoreChange();
-};
+) => getBrowserStore()?.save(scopeId, workspaceId, sessionId, snapshot)
+  ?? { status: "unavailable", snapshot: null };
 
 export const clearSessionDraft = (
+  scopeId: string | null | undefined,
   workspaceId: string,
   sessionId: string | null | undefined,
-) => {
-  const key = sessionDraftScopeKey(workspaceId, sessionId);
-  if (!key) return;
-  const cache = loadDraftCache();
-  if (!cache.delete(key)) return;
-  persistDraftCache();
-  emitDraftStoreChange();
-};
-
-export function useSessionDraftSnapshot(
-  workspaceId: string,
-  sessionId: string | null | undefined,
-) {
-  const scopeKey = useMemo(
-    () => sessionDraftScopeKey(workspaceId, sessionId),
-    [workspaceId, sessionId],
-  );
-
-  return useSyncExternalStore(
-    subscribeDraftStore,
-    () => (scopeKey ? loadDraftCache().get(scopeKey) ?? null : null),
-    () => null,
-  );
-}
+) => getBrowserStore()?.clear(scopeId, workspaceId, sessionId)
+  ?? { status: "unavailable", snapshot: null };
 
 export function useSessionDraftState(
+  scopeId: string | null | undefined,
   workspaceId: string,
   sessionId: string | null | undefined,
 ) {
-  const snapshot = useSessionDraftSnapshot(workspaceId, sessionId);
-  const scopeKey = useMemo(
-    () => sessionDraftScopeKey(workspaceId, sessionId),
-    [workspaceId, sessionId],
+  const key = useMemo(
+    () => sessionDraftScopeKey(scopeId, workspaceId, sessionId),
+    [scopeId, workspaceId, sessionId],
+  );
+  const snapshot = useSyncExternalStore(
+    subscribeBrowserDraftStore,
+    () => key ? getSessionDraft(scopeId, workspaceId, sessionId) : null,
+    () => null,
   );
 
   const save = useCallback(
-    (nextSnapshot: SessionDraftSnapshot) => {
-      saveSessionDraft(workspaceId, sessionId, nextSnapshot);
-    },
-    [workspaceId, sessionId],
+    (nextSnapshot: SessionDraftSnapshot) => saveSessionDraft(scopeId, workspaceId, sessionId, nextSnapshot),
+    [scopeId, workspaceId, sessionId],
+  );
+  const clear = useCallback(
+    () => clearSessionDraft(scopeId, workspaceId, sessionId),
+    [scopeId, workspaceId, sessionId],
   );
 
-  const clear = useCallback(() => {
-    clearSessionDraft(workspaceId, sessionId);
-  }, [workspaceId, sessionId]);
-
   return useMemo(
-    () => ({ scopeKey, snapshot, save, clear }),
-    [clear, save, scopeKey, snapshot],
+    () => ({ scopeKey: key, snapshot, save, clear }),
+    [clear, key, save, snapshot],
   );
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -195,8 +195,15 @@ import {
   publishInspectorSlice,
   recordInspectorEvent,
 } from "../../app/lib/app-inspector";
-import { saveSessionDraft } from "@/react-app/domains/session/sync/draft-store";
-import { useComposerStateStore } from "@/react-app/domains/session/surface/composer-state-store";
+import {
+  resolveSessionDraftScope,
+  saveSessionDraft,
+  sessionDraftScopeKey,
+} from "@/react-app/domains/session/sync/draft-store";
+import {
+  claimComposerSessionDraftScope,
+  useComposerStateStore,
+} from "@/react-app/domains/session/surface/composer-state-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
 import { useBootOverlayVisible } from "./boot-state";
@@ -520,6 +527,10 @@ export function SessionRoute() {
   const automationsEnabled = isDesktopRuntime() && automationDeploymentEnabled;
   const automationsRouteActive = automationsEnabled && automationsRouteRequested;
   const denSettings = readDenSettings();
+  const sessionDraftScope = resolveSessionDraftScope({
+    hasCloudCredential: Boolean(denSettings.authToken?.trim()),
+    verifiedIdentity: denAuth.verifiedIdentity,
+  });
   const [automationsSupported, setAutomationsSupported] = useState(false);
   const [automationsNeedAttention, setAutomationsNeedAttention] = useState(false);
   useEffect(() => {
@@ -1359,6 +1370,7 @@ export function SessionRoute() {
     // local server with the local `rem_*` id.
     return {
       workspaceRoot: selectedWorkspaceRoot,
+      draftScope: sessionDraftScope,
       developerMode: false,
       modelLabel,
       onModelClick: (sessionId?: string) => {
@@ -1655,6 +1667,7 @@ export function SessionRoute() {
     providerConnectedIds,
     selectedAgent,
     selectedSessionId,
+    sessionDraftScope,
     selectedModelUnavailable,
     selectedWorkspace,
     selectedWorkspaceId,
@@ -2934,7 +2947,11 @@ export function SessionRoute() {
           if (firstTaskPrompt) {
             // Attachment chips only survive in-memory (File objects), so the
             // persisted fallback draft drops their tokens.
-            saveSessionDraft(targetWorkspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+            saveSessionDraft(sessionDraftScope, targetWorkspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+            claimComposerSessionDraftScope(
+              session.id,
+              sessionDraftScopeKey(sessionDraftScope, targetWorkspaceId, session.id),
+            );
             // The composer reads its draft from the composer state store, not
             // the persisted draft store — seed both so the prompt shows up.
             useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
@@ -3274,7 +3291,11 @@ export function SessionRoute() {
                 const firstTaskAttachments = attachments ?? [];
                 // Attachment chips only survive in-memory (File objects), so the
                 // persisted fallback draft drops their tokens.
-                saveSessionDraft(workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+                saveSessionDraft(sessionDraftScope, workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+                claimComposerSessionDraftScope(
+                  session.id,
+                  sessionDraftScopeKey(sessionDraftScope, workspaceId, session.id),
+                );
                 // The composer reads its draft from the composer state store,
                 // not the persisted draft store — seed both.
                 useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);

--- a/apps/app/tests/composer-state-store.test.ts
+++ b/apps/app/tests/composer-state-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { ComposerDraft } from "../src/app/types";
 import {
+  composerDraftNeedsHydration,
   getComposerQueuedDrafts,
   getComposerRevertMessageId,
   useComposerStateStore,
@@ -101,5 +102,29 @@ describe("composer state store", () => {
     clearRevertTarget("session-a");
     expect(getComposerRevertMessageId(useComposerStateStore.getState(), "session-a")).toBeNull();
     expect(useComposerStateStore.getState().sessions["session-a"]?.draft).toBe("original prompt");
+  });
+
+  test("retains live attachment state only inside the same claimed draft scope", () => {
+    const currentText = "Review this[attachment att-private]";
+    const storedText = "Review this";
+
+    expect(composerDraftNeedsHydration({
+      claimedScopeKey: "alice-org-a|workspace|session",
+      nextScopeKey: "alice-org-a|workspace|session",
+      currentText,
+      storedText,
+    })).toBe(false);
+    expect(composerDraftNeedsHydration({
+      claimedScopeKey: "alice-org-a|workspace|session",
+      nextScopeKey: "bob-org-a|workspace|session",
+      currentText,
+      storedText,
+    })).toBe(true);
+    expect(composerDraftNeedsHydration({
+      claimedScopeKey: "alice-org-a|workspace|session",
+      nextScopeKey: "alice-org-b|workspace|session",
+      currentText: storedText,
+      storedText,
+    })).toBe(true);
   });
 });

--- a/apps/app/tests/draft-store.test.ts
+++ b/apps/app/tests/draft-store.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  cloudSessionDraftScope,
+  createSessionDraftStore,
+  LEGACY_SESSION_DRAFT_STORAGE_KEY,
+  LOCAL_SESSION_DRAFT_SCOPE,
+  MAX_SESSION_DRAFT_COUNT,
+  resolveSessionDraftScope,
+  SESSION_DRAFT_STORAGE_KEY,
+} from "../src/react-app/domains/session/sync/draft-store";
+
+type StorageMutation = { key: string | null; newValue: string | null };
+
+function sharedStorageContexts() {
+  const values = new Map<string, string>();
+  const listeners = new Map<string, Set<(mutation: StorageMutation) => void>>();
+
+  const context = (id: string) => ({
+    storage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+        for (const [listenerId, contextListeners] of listeners) {
+          if (listenerId === id) continue;
+          for (const listener of contextListeners) listener({ key, newValue: value });
+        }
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+        for (const [listenerId, contextListeners] of listeners) {
+          if (listenerId === id) continue;
+          for (const listener of contextListeners) listener({ key, newValue: null });
+        }
+      },
+    },
+    subscribeToStorage: (listener: (mutation: StorageMutation) => void) => {
+      const contextListeners = listeners.get(id) ?? new Set<(mutation: StorageMutation) => void>();
+      contextListeners.add(listener);
+      listeners.set(id, contextListeners);
+      return () => {
+        contextListeners.delete(listener);
+      };
+    },
+  });
+
+  return { context, values };
+}
+
+const aliceOps = cloudSessionDraftScope({ principalId: "usr_alice", organizationId: "org_ops" });
+const aliceFinance = cloudSessionDraftScope({ principalId: "usr_alice", organizationId: "org_finance" });
+const bobOps = cloudSessionDraftScope({ principalId: "usr_bob", organizationId: "org_ops" });
+
+describe("session draft storage v2", () => {
+  test("makes credential changes unreadable until the new account and organization are verified", () => {
+    expect(resolveSessionDraftScope({
+      hasCloudCredential: true,
+      verifiedIdentity: null,
+    })).toBeNull();
+    expect(resolveSessionDraftScope({
+      hasCloudCredential: true,
+      verifiedIdentity: { principalId: "usr_alice", organizationId: "org_ops" },
+    })).toBe(aliceOps);
+    expect(resolveSessionDraftScope({
+      hasCloudCredential: true,
+      verifiedIdentity: { principalId: "usr_alice", organizationId: "org_finance" },
+    })).toBe(aliceFinance);
+    expect(resolveSessionDraftScope({
+      hasCloudCredential: true,
+      verifiedIdentity: { principalId: "usr_bob", organizationId: "org_ops" },
+    })).toBe(bobOps);
+    expect(resolveSessionDraftScope({
+      hasCloudCredential: false,
+      verifiedIdentity: { principalId: "usr_alice", organizationId: "org_ops" },
+    })).toBe(LOCAL_SESSION_DRAFT_SCOPE);
+  });
+
+  test("refreshes the same authorized scope without exposing it across account, organization, or local scopes", () => {
+    const shared = sharedStorageContexts();
+    const firstWindow = createSessionDraftStore(shared.context("first"));
+
+    expect(aliceOps).toBeTruthy();
+    expect(firstWindow.save(aliceOps, "workspace-a", "session-a", {
+      text: "Alice operations draft",
+      mode: "prompt",
+    }).status).toBe("saved");
+
+    firstWindow.dispose();
+    const refreshedWindow = createSessionDraftStore(shared.context("refresh"));
+    expect(refreshedWindow.get(aliceOps, "workspace-a", "session-a")).toEqual({
+      text: "Alice operations draft",
+      mode: "prompt",
+    });
+    expect(refreshedWindow.get(aliceFinance, "workspace-a", "session-a")).toBeNull();
+    expect(refreshedWindow.get(bobOps, "workspace-a", "session-a")).toBeNull();
+    expect(refreshedWindow.get(LOCAL_SESSION_DRAFT_SCOPE, "workspace-a", "session-a")).toBeNull();
+    expect(refreshedWindow.get(null, "workspace-a", "session-a")).toBeNull();
+  });
+
+  test("reconciles same-scope storage events between independent windows", () => {
+    const shared = sharedStorageContexts();
+    const firstWindow = createSessionDraftStore(shared.context("first"));
+    const secondWindow = createSessionDraftStore(shared.context("second"));
+    let firstChanges = 0;
+    let secondChanges = 0;
+    firstWindow.subscribe(() => firstChanges += 1);
+    secondWindow.subscribe(() => secondChanges += 1);
+
+    // Load both context-local caches before either tab writes.
+    expect(firstWindow.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(secondWindow.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+
+    firstWindow.save(aliceOps, "workspace-a", "session-a", { text: "from first", mode: "prompt" });
+    expect(secondWindow.get(aliceOps, "workspace-a", "session-a")?.text).toBe("from first");
+    expect(secondChanges).toBe(1);
+
+    secondWindow.save(aliceOps, "workspace-a", "session-a", { text: "from second", mode: "prompt" });
+    expect(firstWindow.get(aliceOps, "workspace-a", "session-a")?.text).toBe("from second");
+    expect(firstChanges).toBe(2);
+  });
+
+  test("rejects a stale writer instead of silently overwriting a newer stored draft", () => {
+    const shared = sharedStorageContexts();
+    const firstContext = shared.context("first");
+    const staleContext = shared.context("stale");
+    const firstWindow = createSessionDraftStore({ storage: firstContext.storage });
+    const staleWindow = createSessionDraftStore({ storage: staleContext.storage });
+
+    expect(firstWindow.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(staleWindow.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    firstWindow.save(aliceOps, "workspace-a", "session-a", { text: "newer", mode: "prompt" });
+
+    const conflict = staleWindow.save(aliceOps, "workspace-a", "session-a", {
+      text: "stale overwrite",
+      mode: "prompt",
+    });
+    expect(conflict).toEqual({
+      status: "conflict",
+      snapshot: { text: "newer", mode: "prompt" },
+    });
+    expect(firstWindow.get(aliceOps, "workspace-a", "session-a")?.text).toBe("newer");
+  });
+
+  test("clear removes only the exact draft and a stale clear preserves a newer revision", () => {
+    const shared = sharedStorageContexts();
+    const writer = createSessionDraftStore(shared.context("writer"));
+    writer.save(aliceOps, "workspace-a", "session-a", { text: "target", mode: "prompt" });
+    writer.save(aliceOps, "workspace-a", "session-b", { text: "other session", mode: "prompt" });
+    writer.save(aliceOps, "workspace-b", "session-a", { text: "other workspace", mode: "prompt" });
+    writer.save(bobOps, "workspace-a", "session-a", { text: "other account", mode: "prompt" });
+
+    expect(writer.clear(aliceOps, "workspace-a", "session-a").status).toBe("saved");
+    expect(writer.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(writer.get(aliceOps, "workspace-a", "session-b")?.text).toBe("other session");
+    expect(writer.get(aliceOps, "workspace-b", "session-a")?.text).toBe("other workspace");
+    expect(writer.get(bobOps, "workspace-a", "session-a")?.text).toBe("other account");
+
+    writer.save(aliceOps, "workspace-a", "session-a", { text: "before send", mode: "prompt" });
+    const staleContext = shared.context("stale");
+    const staleWindow = createSessionDraftStore({ storage: staleContext.storage });
+    expect(staleWindow.get(aliceOps, "workspace-a", "session-a")?.text).toBe("before send");
+    writer.save(aliceOps, "workspace-a", "session-a", { text: "newer tab edit", mode: "prompt" });
+
+    expect(staleWindow.clear(aliceOps, "workspace-a", "session-a")).toEqual({
+      status: "conflict",
+      snapshot: { text: "newer tab edit", mode: "prompt" },
+    });
+    expect(writer.get(aliceOps, "workspace-a", "session-a")?.text).toBe("newer tab edit");
+  });
+
+  test("keeps unsigned local drafts usable and separate", () => {
+    const shared = sharedStorageContexts();
+    const store = createSessionDraftStore(shared.context("local"));
+    store.save(LOCAL_SESSION_DRAFT_SCOPE, "workspace-local", "session-local", {
+      text: "local draft",
+      mode: "prompt",
+    });
+
+    expect(store.get(LOCAL_SESSION_DRAFT_SCOPE, "workspace-local", "session-local")?.text).toBe("local draft");
+    expect(store.get(aliceOps, "workspace-local", "session-local")).toBeNull();
+  });
+
+  test("drops ambiguous legacy v1 data without broadening who may read it", () => {
+    const shared = sharedStorageContexts();
+    shared.values.set(LEGACY_SESSION_DRAFT_STORAGE_KEY, JSON.stringify({
+      "workspace-a:session-a": { text: "unknown former owner", mode: "prompt" },
+    }));
+    const store = createSessionDraftStore(shared.context("migration"));
+
+    expect(store.get(LOCAL_SESSION_DRAFT_SCOPE, "workspace-a", "session-a")).toBeNull();
+    expect(store.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(shared.values.has(LEGACY_SESSION_DRAFT_STORAGE_KEY)).toBe(false);
+  });
+
+  test("evicts only the least-recently-written drafts over the bounded limit", () => {
+    const shared = sharedStorageContexts();
+    const store = createSessionDraftStore(shared.context("eviction"));
+    for (let index = 0; index <= MAX_SESSION_DRAFT_COUNT; index += 1) {
+      expect(store.save(aliceOps, "workspace-a", `session-${index}`, {
+        text: `draft-${index}`,
+        mode: "prompt",
+      }).status).toBe("saved");
+    }
+
+    expect(store.get(aliceOps, "workspace-a", "session-0")).toBeNull();
+    expect(store.get(aliceOps, "workspace-a", "session-1")?.text).toBe("draft-1");
+    expect(store.get(aliceOps, "workspace-a", `session-${MAX_SESSION_DRAFT_COUNT}`)?.text)
+      .toBe(`draft-${MAX_SESSION_DRAFT_COUNT}`);
+  });
+
+  test("treats malformed data as empty and repairs it on the next valid save", () => {
+    const shared = sharedStorageContexts();
+    shared.values.set(SESSION_DRAFT_STORAGE_KEY, "{not-json");
+    const store = createSessionDraftStore(shared.context("malformed"));
+
+    expect(store.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(store.save(aliceOps, "workspace-a", "session-a", {
+      text: "recovered",
+      mode: "prompt",
+    }).status).toBe("saved");
+    expect(() => JSON.parse(shared.values.get(SESSION_DRAFT_STORAGE_KEY) ?? "")).not.toThrow();
+    expect(store.get(aliceOps, "workspace-a", "session-a")?.text).toBe("recovered");
+  });
+
+  test("never crashes when reads, migration, or quota-limited writes fail", () => {
+    const unavailableStorage = {
+      getItem: () => {
+        throw new Error("storage denied");
+      },
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+      removeItem: () => {
+        throw new Error("storage denied");
+      },
+    };
+    const store = createSessionDraftStore({ storage: unavailableStorage });
+
+    expect(() => store.get(aliceOps, "workspace-a", "session-a")).not.toThrow();
+    expect(store.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(store.save(aliceOps, "workspace-a", "session-a", {
+      text: "cannot persist",
+      mode: "prompt",
+    }).status).toBe("unavailable");
+    expect(store.clear(aliceOps, "workspace-a", "session-a").status).toBe("saved");
+  });
+});

--- a/evals/specs/session-draft-scope-integrity.test.ts
+++ b/evals/specs/session-draft-scope-integrity.test.ts
@@ -1,0 +1,174 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  cloudSessionDraftScope,
+  createSessionDraftStore,
+  LEGACY_SESSION_DRAFT_STORAGE_KEY,
+  LOCAL_SESSION_DRAFT_SCOPE,
+  resolveSessionDraftScope,
+  SESSION_DRAFT_STORAGE_KEY,
+} from "../../apps/app/src/react-app/domains/session/sync/draft-store";
+
+type StorageMutation = { key: string | null; newValue: string | null };
+
+function sharedStorageContexts() {
+  const values = new Map<string, string>();
+  const listeners = new Map<string, Set<(mutation: StorageMutation) => void>>();
+
+  const context = (id: string) => ({
+    storage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+        for (const [listenerId, contextListeners] of listeners) {
+          if (listenerId === id) continue;
+          for (const listener of contextListeners) listener({ key, newValue: value });
+        }
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+        for (const [listenerId, contextListeners] of listeners) {
+          if (listenerId === id) continue;
+          for (const listener of contextListeners) listener({ key, newValue: null });
+        }
+      },
+    },
+    subscribeToStorage: (listener: (mutation: StorageMutation) => void) => {
+      const contextListeners = listeners.get(id) ?? new Set<(mutation: StorageMutation) => void>();
+      contextListeners.add(listener);
+      listeners.set(id, contextListeners);
+      return () => {
+        contextListeners.delete(listener);
+      };
+    },
+  });
+
+  return { context, values };
+}
+
+const aliceOps = cloudSessionDraftScope({ principalId: "usr_alice", organizationId: "org_ops" });
+const aliceFinance = cloudSessionDraftScope({ principalId: "usr_alice", organizationId: "org_finance" });
+const bobOps = cloudSessionDraftScope({ principalId: "usr_bob", organizationId: "org_ops" });
+
+test("composer drafts stay private per identity and safe under concurrent tabs", ({ evidence }) => {
+  const shared = sharedStorageContexts();
+
+  // Claim: a draft written under one verified identity survives a reload and
+  // is readable again by exactly that identity.
+  const firstWindow = createSessionDraftStore(shared.context("first"));
+  expect(aliceOps).toBeTruthy();
+  expect(firstWindow.save(aliceOps, "workspace-a", "session-a", {
+    text: "Alice operations draft",
+    mode: "prompt",
+  }).status).toBe("saved");
+  firstWindow.dispose();
+  const reloaded = createSessionDraftStore(shared.context("reload"));
+  expect(reloaded.get(aliceOps, "workspace-a", "session-a")).toEqual({
+    text: "Alice operations draft",
+    mode: "prompt",
+  });
+
+  // Negative half 1 (identity and organization transitions): a different
+  // account, a different organization of the same account, the unsigned
+  // local scope, and an unverified credential (null scope) each read nothing.
+  expect(reloaded.get(bobOps, "workspace-a", "session-a")).toBeNull();
+  expect(reloaded.get(aliceFinance, "workspace-a", "session-a")).toBeNull();
+  expect(reloaded.get(LOCAL_SESSION_DRAFT_SCOPE, "workspace-a", "session-a")).toBeNull();
+  expect(reloaded.get(null, "workspace-a", "session-a")).toBeNull();
+
+  // Scope resolution: a cloud credential without a verified identity resolves
+  // to no scope at all — drafts become inaccessible the moment the verified
+  // identity or organization changes, not after the next round trip.
+  expect(resolveSessionDraftScope({ hasCloudCredential: true, verifiedIdentity: null })).toBeNull();
+  expect(resolveSessionDraftScope({
+    hasCloudCredential: true,
+    verifiedIdentity: { principalId: "usr_alice", organizationId: "org_ops" },
+  })).toBe(aliceOps);
+  expect(resolveSessionDraftScope({
+    hasCloudCredential: false,
+    verifiedIdentity: { principalId: "usr_alice", organizationId: "org_ops" },
+  })).toBe(LOCAL_SESSION_DRAFT_SCOPE);
+
+  // Claim: two live tabs reconcile through storage events — the second tab
+  // observes the first tab's write without a reload.
+  const tabA = createSessionDraftStore(shared.context("tab-a"));
+  const tabB = createSessionDraftStore(shared.context("tab-b"));
+  let tabBChanges = 0;
+  tabB.subscribe(() => {
+    tabBChanges += 1;
+  });
+  expect(tabB.get(aliceOps, "workspace-a", "session-b")).toBeNull();
+  tabA.save(aliceOps, "workspace-a", "session-b", { text: "from tab A", mode: "prompt" });
+  expect(tabB.get(aliceOps, "workspace-a", "session-b")?.text).toBe("from tab A");
+  expect(tabBChanges).toBe(1);
+
+  // Negative half 2 (stale writes): a tab holding an old revision can neither
+  // overwrite a newer draft nor clear it; both operations surface the newer
+  // snapshot as a conflict instead of silently losing it. After observing a
+  // conflict the tab is resynchronized, so its next operation acts on the
+  // newer revision intentionally rather than accidentally.
+  const staleSaveTab = createSessionDraftStore({ storage: shared.context("stale-save").storage });
+  const staleClearTab = createSessionDraftStore({ storage: shared.context("stale-clear").storage });
+  expect(staleSaveTab.get(aliceOps, "workspace-a", "session-b")?.text).toBe("from tab A");
+  expect(staleClearTab.get(aliceOps, "workspace-a", "session-b")?.text).toBe("from tab A");
+  tabA.save(aliceOps, "workspace-a", "session-b", { text: "newer edit", mode: "prompt" });
+  expect(staleSaveTab.save(aliceOps, "workspace-a", "session-b", {
+    text: "stale overwrite",
+    mode: "prompt",
+  })).toEqual({ status: "conflict", snapshot: { text: "newer edit", mode: "prompt" } });
+  expect(staleClearTab.clear(aliceOps, "workspace-a", "session-b")).toEqual({
+    status: "conflict",
+    snapshot: { text: "newer edit", mode: "prompt" },
+  });
+  expect(tabA.get(aliceOps, "workspace-a", "session-b")?.text).toBe("newer edit");
+  // Post-conflict recovery: the resynchronized tab may now clear on purpose.
+  expect(staleClearTab.clear(aliceOps, "workspace-a", "session-b").status).toBe("saved");
+  expect(tabA.get(aliceOps, "workspace-a", "session-b")).toBeNull();
+
+  // Negative half 3 (legacy storage): v1 drafts carry no identity boundary,
+  // so they are dropped fail-closed instead of being exposed to any scope.
+  const legacy = sharedStorageContexts();
+  legacy.values.set(LEGACY_SESSION_DRAFT_STORAGE_KEY, JSON.stringify({
+    "workspace-a:session-a": { text: "unknown former owner", mode: "prompt" },
+  }));
+  const migrated = createSessionDraftStore(legacy.context("migration"));
+  expect(migrated.get(LOCAL_SESSION_DRAFT_SCOPE, "workspace-a", "session-a")).toBeNull();
+  expect(migrated.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+  expect(legacy.values.has(LEGACY_SESSION_DRAFT_STORAGE_KEY)).toBe(false);
+
+  // Negative half 4 (untrusted storage): malformed documents read as empty
+  // and repair on the next valid save; a storage that throws never crashes
+  // the composer and reports the write as unavailable rather than saved.
+  const corrupt = sharedStorageContexts();
+  corrupt.values.set(SESSION_DRAFT_STORAGE_KEY, "{not-json");
+  const repaired = createSessionDraftStore(corrupt.context("repair"));
+  expect(repaired.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+  expect(repaired.save(aliceOps, "workspace-a", "session-a", {
+    text: "recovered",
+    mode: "prompt",
+  }).status).toBe("saved");
+  const denied = createSessionDraftStore({
+    storage: {
+      getItem: () => {
+        throw new Error("storage denied");
+      },
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+      removeItem: () => {
+        throw new Error("storage denied");
+      },
+    },
+  });
+  expect(denied.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+  expect(denied.save(aliceOps, "workspace-a", "session-a", {
+    text: "cannot persist",
+    mode: "prompt",
+  }).status).toBe("unavailable");
+
+  evidence.recordAssertionEvidence(
+    "Composer drafts are private and conflict-safe",
+    "Drafts survive reloads within one verified identity scope; other accounts, organizations, the local scope, and unverified credentials read nothing; concurrent tabs reconcile via storage events; stale writers and clears conflict instead of overwriting; legacy v1 data is dropped fail-closed; corrupt or denied storage degrades safely.",
+    true,
+  );
+});


### PR DESCRIPTION
## What I noticed

Composer drafts persisted into one shared localStorage document with no identity boundary and no write discipline. On a shared browser that has real consequences: sign out, and the next signed-in account could hydrate the previous person's unfinished message; switch organizations, and drafts written in one org context stayed readable in the other. Separately, two tabs editing the same session could silently overwrite each other — the tab with the older snapshot won whenever it wrote last — and a corrupted or quota-limited storage could throw inside the composer path.

## What I changed

The persisted draft store is now a versioned (v2) document keyed by an explicit scope plus workspace and session:

- **Scope ownership is explicit.** The unsigned local scope is `local`; a cloud scope exists only for a *verified* principal and organization reported by the Den session provider (a new `verifiedIdentity` value that is set strictly when the fetched user matches the exact credential and org that initiated the refresh, and cleared on logout, token change, or org change). A credential that has not been re-verified resolves to no scope at all, so drafts become inaccessible the instant identity verification lapses — not after the next round trip.
- **Stale writes conflict instead of winning.** Every save/clear merges against a fresh storage read and uses the per-draft revision as a compare-and-swap guard. A tab holding an old revision gets `conflict` plus the newer snapshot back; a stale clear cannot delete or resurrect a newer draft. After a conflict the tab is resynchronized, so its next operation is intentional.
- **Storage events reconcile live tabs**, scoped to the draft document key.
- **Legacy storage fails closed.** v1 drafts carry no identity attribution, so they are removed rather than migrated into any scope — no guessing about who wrote them.
- **Untrusted storage degrades safely.** Malformed documents parse as empty and repair on the next valid save; storage that throws (privacy modes, quota) reports `unavailable` and keeps drafts in memory instead of crashing.
- **The in-memory composer store participates.** Each session claims a draft scope; when the scope key changes at an account/org boundary, a layout effect replaces the previous scope's text and revokes its attachment previews before the browser can paint them.

## Why this matters

Drafts are unsent, often sensitive text. This makes their ownership match the verified cloud identity and organization, keeps concurrent tabs from destroying newer work, and removes a whole class of cross-identity leakage on shared machines — while unsigned local use keeps working exactly as before.

## How I validated it

- `pnpm evals:pr specs/session-draft-scope-integrity.test.ts` — 1 passed, 0 failed, 0 skipped. Covers reload continuity within one identity; unreadability across account, organization, local, and unverified scopes; two-tab reconciliation via storage events; stale save and stale clear conflicts plus post-conflict recovery; fail-closed legacy v1 removal; malformed-storage repair and denied-storage degradation.
- `bun test --isolate tests/draft-store.test.ts tests/composer-state-store.test.ts` — 16 pass, 0 fail (scope resolution, cross-scope isolation, eviction order, hydration-scope claims for attachment state).
- `pnpm --filter @openwork/app typecheck` — clean.
- `pnpm --filter @openwork/app test` — 1034 pass, 5 fail; the identical 5 failures reproduce with the same command on a clean `dev` control checkout at `cdc18ac52` (only a docs/licensing commit separates it from this base), so they are pre-existing and unrelated.
- `pnpm --filter @openwork/app build` — production bundle builds clean.
- Final validated commit: `9c6113016dbdb20c0ddeb07a0495770530232acd` on `dev` at `ddf85156ff963602ec8095ccbaeebd10d5f0afa6`.

## Review focus

1. The `verifiedIdentity` contract in `den-auth-provider.tsx` — it must only be set when the fetched user corresponds to the exact token and organization that initiated the refresh, and must clear on logout, credential change, org change, and stale-refresh rejection. This is the single source the draft scope trusts.
2. The fail-closed v1 removal — existing users lose currently persisted drafts once (in-memory drafts in open tabs are unaffected). I chose deletion over migration because v1 data cannot be attributed to an identity; confirm you agree.
3. The `useLayoutEffect` hydration boundary in `session-surface.tsx` — verify the scope-claim logic cannot fight the queued-draft or revert flows in the composer store.

## Risk and rollback

The blast radius is draft persistence and hydration; message sending, transcripts, and attachments-in-flight are untouched. The riskiest change is scope resolution: if identity verification misbehaved, drafts would err on the side of being invisible (no scope) rather than leaking — the failure mode is losing a persisted draft, never exposing one. Reverting the single commit restores v1 behavior; the v2 storage key is separate, so a revert cannot mis-read v2 documents.
