### PR TITLE
Make per-turn instruction assembly latency-safe

### DIFF
--- a/apps/server/src/opencode-plugins/agent-instruction-compose.test.ts
+++ b/apps/server/src/opencode-plugins/agent-instruction-compose.test.ts
@@ -31,10 +31,25 @@ describe("agent instruction compose primitives", () => {
     ]);
   });
 
-  test("composeAgentInstructions returns ordered bodies only", () => {
-    expect(composeAgentInstructions([
+  test("composeAgentInstructions combines section groups once and returns ordered bodies", () => {
+    let observedBodyReads = 0;
+    const observedSection = {
+      id: "observed",
+      get body() {
+        observedBodyReads += 1;
+        return "three";
+      },
+    };
+
+    expect(composeAgentInstructions(
       createInstructionSection("a", "one"),
-      createInstructionSection("b", "two"),
-    ])).toEqual(["one", "two"]);
+      [
+        createInstructionSection("a", "ignored duplicate"),
+        createInstructionSection("empty", "  "),
+        createInstructionSection("b", "two"),
+      ],
+      observedSection,
+    )).toEqual(["one", "two", "three"]);
+    expect(observedBodyReads).toBe(1);
   });
 });

--- a/apps/server/src/opencode-plugins/agent-instruction-compose.ts
+++ b/apps/server/src/opencode-plugins/agent-instruction-compose.ts
@@ -5,6 +5,7 @@
  * combine — merge sections in order, one id wins (first non-empty)
  * delete  — drop a section by id
  * expand  — replace a section body with derived text when present
+ * compose — combine sections and return their prompt bodies
  *
  * Sections are the unit of overlap control: routing/tools/skills/session each
  * own one id so transforms stop stacking contradictory brochure text.
@@ -15,12 +16,14 @@ export type AgentInstructionSection = {
   body: string;
 };
 
+type AgentInstructionSectionGroup = AgentInstructionSection | AgentInstructionSection[] | null | undefined;
+
 export function createInstructionSection(id: string, body: string): AgentInstructionSection {
   return { id, body: body.trim() };
 }
 
 export function combineInstructionSections(
-  ...groups: Array<AgentInstructionSection | AgentInstructionSection[] | null | undefined>
+  ...groups: AgentInstructionSectionGroup[]
 ): AgentInstructionSection[] {
   const seen = new Set<string>();
   const combined: AgentInstructionSection[] = [];
@@ -55,6 +58,19 @@ export function expandInstructionSection(
   )).filter((section) => section.body.length > 0);
 }
 
-export function composeAgentInstructions(sections: AgentInstructionSection[]): string[] {
-  return combineInstructionSections(sections).map((section) => section.body);
+export function composeAgentInstructions(...groups: AgentInstructionSectionGroup[]): string[] {
+  const seen = new Set<string>();
+  const instructions: string[] = [];
+  for (const group of groups) {
+    if (!group) continue;
+    const sections = Array.isArray(group) ? group : [group];
+    for (const section of sections) {
+      if (seen.has(section.id)) continue;
+      const body = section.body;
+      if (!body) continue;
+      seen.add(section.id);
+      instructions.push(body);
+    }
+  }
+  return instructions;
 }

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
 import {
-  combineInstructionSections,
   composeAgentInstructions,
   createInstructionSection,
 } from "./agent-instruction-compose.js";
@@ -945,17 +944,16 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
         directory: normalizeOpenCodeContext(mergedInput).directory ?? factoryContext.directory ?? null,
       });
     }
-    // One section id per concern — combine drops empties/duplicates so routing,
+    // One section id per concern — composition drops empties/duplicates so routing,
     // remote skills, session, and browser guidance never overlap by accident.
-    const sections = combineInstructionSections(
+    output.system.push(...composeAgentInstructions(
       createInstructionSection("routing", extensionInstruction),
       createInstructionSection("agent-surface", OPENWORK_AGENT_SURFACE_INSTRUCTION),
       createInstructionSection("skill-authoring", skillAuthoring.prompt),
       createInstructionSection("connect-skills", skillInstruction),
       createInstructionSection("automations", automationInstruction),
       createInstructionSection("browser", OPENWORK_BROWSER_INSTRUCTION),
-    );
-    output.system.push(...composeAgentInstructions(sections));
+    ));
   },
   tool: {
     openwork_context: {

--- a/evals/specs/instruction-assembly-equivalence.test.ts
+++ b/evals/specs/instruction-assembly-equivalence.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  combineInstructionSections,
+  composeAgentInstructions,
+  createInstructionSection,
+} from "../../apps/server/src/opencode-plugins/agent-instruction-compose";
+
+test("per-turn instruction assembly dedupes once and stays behaviorally equivalent", ({ evidence }) => {
+  // Claim: the single-pass composer produces exactly the output of the
+  // previous combine-then-compose pipeline for every caller shape — ordering
+  // preserved, one id wins with first-non-empty semantics, empties dropped.
+  const groups = [
+    createInstructionSection("routing", "route the turn"),
+    [
+      createInstructionSection("routing", "ignored duplicate"),
+      createInstructionSection("skills", "   "),
+      createInstructionSection("skills", "use the skill index"),
+      createInstructionSection("browser", "browser guidance"),
+    ],
+    null,
+    undefined,
+    createInstructionSection("session", "session guidance"),
+  ];
+  const legacy = combineInstructionSections(...groups).map((section) => section.body);
+  const composed = composeAgentInstructions(...groups);
+  expect(composed).toEqual(legacy);
+  expect(composed).toEqual([
+    "route the turn",
+    "use the skill index",
+    "browser guidance",
+    "session guidance",
+  ]);
+
+  // The previous call shape — one already-combined array — composes
+  // identically, so existing callers cannot observe a behavior change.
+  expect(composeAgentInstructions(combineInstructionSections(...groups))).toEqual(legacy);
+
+  // Negative half 1: an empty body never claims its id, so a later
+  // non-empty section with the same id still wins (first-non-empty).
+  expect(composeAgentInstructions(
+    createInstructionSection("only", ""),
+    createInstructionSection("only", "real body"),
+  )).toEqual(["real body"]);
+
+  // Negative half 2: per-turn assembly reads each retained section body
+  // exactly once — the redundant second combination pass is gone.
+  let bodyReads = 0;
+  const observedSection = {
+    id: "observed",
+    get body() {
+      bodyReads += 1;
+      return "observed body";
+    },
+  };
+  expect(composeAgentInstructions(
+    createInstructionSection("routing", "route the turn"),
+    observedSection,
+  )).toEqual(["route the turn", "observed body"]);
+  expect(bodyReads).toBe(1);
+
+  // Negative half 3: a duplicate id never reaches its body at all.
+  let duplicateReads = 0;
+  const duplicateSection = {
+    id: "routing",
+    get body() {
+      duplicateReads += 1;
+      return "should not be read";
+    },
+  };
+  composeAgentInstructions(
+    createInstructionSection("routing", "route the turn"),
+    duplicateSection,
+  );
+  expect(duplicateReads).toBe(0);
+
+  evidence.recordAssertionEvidence(
+    "Instruction assembly is single-pass and equivalent",
+    "The composed system prompt matches the legacy combine-then-compose output for grouped, flat, sparse, duplicate, and empty inputs; each retained body is read once and duplicate ids are never read.",
+    true,
+  );
+});


### PR DESCRIPTION
## What I noticed

Instruction assembly runs on every single agent turn, and it was doing its deduplication work twice. The extensions plugin first combined all system-prompt sections into a deduplicated, ordered list, and then `composeAgentInstructions` ran the exact same combination pass again over the already-combined output before extracting the bodies. That is redundant per-turn work on the hot path that shapes every prompt.

## What I changed

`composeAgentInstructions` now accepts section groups directly (single sections, arrays, or sparse `null`/`undefined` entries — the same shape `combineInstructionSections` takes) and composes in one pass. Duplicate ids are skipped **before** their bodies are read, empty bodies never claim an id so first-non-empty semantics are preserved, and ordering is exactly what the two-pass pipeline produced. The extensions plugin drops its redundant pre-combination and feeds sections straight into the composer. Callers that still pass an already-combined array get identical output, and `combineInstructionSections` remains available as a primitive for section-list manipulation.

I kept this deliberately small and localized — the current architecture's section primitives (`create`/`combine`/`delete`/`expand`) are unchanged; only composition gained a direct group-accepting form.

## Why this matters

Per-turn latency budget is spent before the model sees a token. Removing a full redundant iteration, set construction, and body materialization from every turn is a small but strictly free win, and skipping body reads for duplicate ids means future sections with computed bodies can never pay for text that will be discarded.

## How I validated it

- `pnpm evals:pr specs/instruction-assembly-equivalence.test.ts` — 1 passed, 0 failed, 0 skipped. Asserts byte-equivalence between the legacy combine-then-compose pipeline and the single-pass composer for grouped, flat, sparse, duplicate, and empty inputs, plus the negative halves: each retained body is read exactly once, and a duplicate id's body is never read at all.
- `bun --conditions=development test src/opencode-plugins/agent-instruction-compose.test.ts` — 3 pass, 0 fail.
- `bun --conditions=development test src/opencode-plugins/` (owning module) — 80 pass, 0 fail across 8 files.
- `pnpm --filter openwork-server typecheck` — clean.
- `pnpm --filter openwork-server build` — the production plugin bundle (which ships `openwork-extensions-preview`) builds clean.
- Final validated commit: `d8710a9dc8e64db2e8a6fae8915375f9e9ea7cb1` on `dev` at `ddf85156ff963602ec8095ccbaeebd10d5f0afa6`.

## Review focus

1. The first-non-empty semantics: in both old and new code an empty body does not claim its id. The equivalence spec pins this; please confirm it matches your intent for section overlap control.
2. Whether you want `combineInstructionSections` kept exported as a primitive (I kept it — `delete`/`expand` operate on combined lists) or folded away in a follow-up.

## Risk and rollback

The change is confined to one pure module and its single caller; there is no state, I/O, or ordering dependency beyond the function itself, and the equivalence spec locks the observable output. Reverting the single commit restores the two-pass pipeline with no data implications.
