### PR TITLE
Bound Den proxy request bodies and return structured size errors

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -11,17 +11,20 @@ const previousDenWebPublicOrigin = process.env.DEN_WEB_PUBLIC_ORIGIN;
 describe("Den upstream proxy", () => {
   let server;
   let observed = null;
+  let upstreamRequestCount = 0;
   let logs = [];
 
   beforeAll(() => {
     server = Bun.serve({
       port: 0,
       async fetch(request) {
+        upstreamRequestCount += 1;
         const url = new URL(request.url);
         observed = {
           method: request.method,
           path: `${url.pathname}${url.search}`,
           body: await request.text(),
+          contentType: request.headers.get("content-type"),
           cookie: request.headers.get("cookie"),
           authorization: request.headers.get("authorization"),
           custom: request.headers.get("x-custom-proxy-test"),
@@ -97,6 +100,8 @@ describe("Den upstream proxy", () => {
   beforeEach(() => {
     delete process.env.DEN_BASE_URL;
     delete process.env.DEN_WEB_PUBLIC_ORIGIN;
+    observed = null;
+    upstreamRequestCount = 0;
     logs = [];
     setStructuredLogSink({
       log(level, message, fields) {
@@ -126,6 +131,141 @@ describe("Den upstream proxy", () => {
   });
 
   const INSTANCE_ORIGIN = "https://8787-2bnptanfwxs5j8vu.daytonaproxy01.net";
+  const TEST_BODY_LIMIT = 12;
+  const limitedProxyOptions = { routePrefix: "/api/den", maxRequestBodyBytes: TEST_BODY_LIMIT };
+
+  test("rejects an oversized declared body before contacting Den", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      method: "POST",
+      headers: {
+        "content-length": String(TEST_BODY_LIMIT + 1),
+        "content-type": "application/json",
+        "x-request-id": "declared-limit-request",
+        authorization: "Bearer must-not-log",
+        origin: INSTANCE_ORIGIN,
+      },
+      body: "{}",
+    });
+
+    const response = await proxyUpstream(request, [], limitedProxyOptions);
+
+    expect(response.status).toBe(413);
+    expect(response.headers.get("x-request-id")).toBe("declared-limit-request");
+    expect(response.headers.get("access-control-allow-origin")).toBe(INSTANCE_ORIGIN);
+    expect(await response.json()).toEqual({
+      error: "request_too_large",
+      requestId: "declared-limit-request",
+      maxBytes: TEST_BODY_LIMIT,
+      declaredBytes: TEST_BODY_LIMIT + 1,
+    });
+    expect(upstreamRequestCount).toBe(0);
+    expect(observed).toBeNull();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      level: "warn",
+      message: "den-web upstream proxy rejected request body",
+      fields: {
+        route_prefix: "/api/den",
+        method: "POST",
+        status: 413,
+        max_bytes: TEST_BODY_LIMIT,
+        declared_bytes: TEST_BODY_LIMIT + 1,
+      },
+    });
+    expect(JSON.stringify(logs[0])).not.toContain("must-not-log");
+  });
+
+  test("stops an oversized chunked body and does not contact Den", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("12345678"));
+        controller.enqueue(encoder.encode("90123"));
+        controller.enqueue(encoder.encode("secret multipart filename.png"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      method: "POST",
+      headers: { "x-request-id": "chunked-limit-request" },
+      body,
+      duplex: "half",
+    });
+    expect(request.headers.get("content-length")).toBeNull();
+
+    const response = await proxyUpstream(request, [], limitedProxyOptions);
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error: "request_too_large",
+      requestId: "chunked-limit-request",
+      maxBytes: TEST_BODY_LIMIT,
+      observedBytes: TEST_BODY_LIMIT + 1,
+    });
+    expect(cancelled).toBe(true);
+    expect(upstreamRequestCount).toBe(0);
+    expect(observed).toBeNull();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      level: "warn",
+      message: "den-web upstream proxy rejected request body",
+      fields: {
+        route_prefix: "/api/den",
+        method: "POST",
+        status: 413,
+        max_bytes: TEST_BODY_LIMIT,
+        observed_bytes: TEST_BODY_LIMIT + 1,
+      },
+    });
+    const serializedLog = JSON.stringify(logs[0]);
+    expect(serializedLog).not.toContain("secret");
+    expect(serializedLog).not.toContain("filename.png");
+  });
+
+  test("accepts request bodies exactly at and immediately below the limit", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+
+    for (const size of [TEST_BODY_LIMIT - 1, TEST_BODY_LIMIT]) {
+      const body = "x".repeat(size);
+      const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+        method: "POST",
+        headers: { "content-length": String(size) },
+        body,
+      });
+
+      const response = await proxyUpstream(request, [], limitedProxyOptions);
+
+      expect(response.status).toBe(207);
+      expect(observed.body).toBe(body);
+    }
+    expect(upstreamRequestCount).toBe(2);
+  });
+
+  test("continues to proxy ordinary multipart requests without logging their contents", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const body = new FormData();
+    body.set("logo", new File(["multipart-private-content"], "private-brand-name.png", { type: "image/png" }));
+    const request = new NextRequest("https://app.example.com/api/den/v1/org/brand-assets", {
+      method: "POST",
+      body,
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(response.status).toBe(207);
+    expect(observed.contentType).toStartWith("multipart/form-data; boundary=");
+    expect(observed.body).toContain("private-brand-name.png");
+    expect(observed.body).toContain("multipart-private-content");
+    expect(upstreamRequestCount).toBe(1);
+    const serializedLog = JSON.stringify(logs[0]);
+    expect(serializedLog).not.toContain("private-brand-name.png");
+    expect(serializedLog).not.toContain("multipart-private-content");
+  });
 
   test("answers the preflight for a rotating Cloud instance origin", async () => {
     const { proxyUpstream } = await import("./upstream-proxy.ts");
@@ -335,6 +475,7 @@ describe("Den upstream proxy", () => {
       method: "POST",
       path: "/v1/me?include=org",
       body: JSON.stringify({ ok: true }),
+      contentType: "application/json",
       cookie: "ow_session=sess_test",
       authorization: "Bearer tok_test",
       custom: "kept",

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -188,6 +188,8 @@ describe("Den upstream proxy", () => {
       },
       cancel() {
         cancelled = true;
+        // A producer can acknowledge cancellation without ever settling it.
+        return new Promise(() => {});
       },
     });
     const request = new NextRequest("https://app.example.com/api/den/v1/me", {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -46,6 +46,9 @@ const AUTH_COOKIE_PREFIXES = [
   "__Secure-better-auth.",
   "better-auth-",
 ];
+// Covers the existing 20 MiB Gmail attachment flow after base64/JSON overhead;
+// individual upload endpoints keep enforcing their narrower limits downstream.
+const DEFAULT_REQUEST_BODY_MAX_BYTES = 32 * 1024 * 1024;
 
 /**
  * OpenWork Cloud instances are served from Daytona preview origins that are
@@ -110,6 +113,7 @@ type ProxyOptions = {
   upstreamPathPrefix?: string;
   rewriteAuthLocationsToRequestOrigin?: boolean;
   upstreamDeadlineMs?: number;
+  maxRequestBodyBytes?: number;
 };
 
 type UpstreamAbortCause = "client" | "deadline" | "downstream";
@@ -536,14 +540,91 @@ function errorName(error: unknown): string {
   return error instanceof Error ? error.name : typeof error;
 }
 
-async function readRequestBody(request: NextRequest): Promise<Blob | null> {
-  if (request.method === "GET" || request.method === "HEAD") return null;
+type DeclaredBodySize = {
+  bytes?: number;
+  exceedsLimit: boolean;
+};
+
+type RequestBodyReadResult =
+  | { ok: true; body: Blob | null; observedBytes?: number }
+  | { ok: false; observedBytes: number };
+
+function requestBodyMaxBytes(options: ProxyOptions): number {
+  const maxBytes = options.maxRequestBodyBytes ?? DEFAULT_REQUEST_BODY_MAX_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError("maxRequestBodyBytes must be a non-negative safe integer.");
+  }
+  return maxBytes;
+}
+
+function declaredRequestBodySize(request: NextRequest, maxBytes: number): DeclaredBodySize {
+  if (request.method === "GET" || request.method === "HEAD") return { exceedsLimit: false };
+  const header = request.headers.get("content-length")?.trim();
+  if (!header || !/^\d+$/.test(header)) return { exceedsLimit: false };
+
+  const normalized = header.replace(/^0+/, "") || "0";
+  const limit = String(maxBytes);
+  const exceedsLimit = normalized.length > limit.length
+    || (normalized.length === limit.length && normalized > limit);
+  const bytes = Number(normalized);
+  return Number.isSafeInteger(bytes) ? { bytes, exceedsLimit } : { exceedsLimit };
+}
+
+async function readRequestBody(request: NextRequest, maxBytes: number): Promise<RequestBodyReadResult> {
+  if (request.method === "GET" || request.method === "HEAD") return { ok: true, body: null };
+  if (!request.body) return { ok: true, body: null, observedBytes: 0 };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let observedBytes = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      observedBytes += chunk.value.byteLength;
+      if (observedBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The 413 response does not depend on the request producer accepting cancellation.
+        }
+        return { ok: false, observedBytes };
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
   // Forward a Blob, never an ArrayBuffer or a view: Next 16's patched fetch
   // hands buffer-backed bodies to undici with their backing ArrayBuffer
   // detached — even a fresh copy — so every proxied write threw "Cannot
   // perform ArrayBuffer.prototype.slice on a detached ArrayBuffer" while
   // GETs (null body) kept working. A Blob owns its bytes and survives the hop.
-  return request.blob();
+  return { ok: true, body: new Blob(chunks as BlobPart[]), observedBytes };
+}
+
+function requestTooLargeResponse(input: {
+  referenceId: string;
+  maxBytes: number;
+  instanceOrigin: string | null;
+  declaredBytes?: number;
+  observedBytes?: number;
+}): Response {
+  const id = input.referenceId;
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-request-id": id,
+  });
+  if (input.instanceOrigin) applyCloudInstanceCorsHeaders(headers, input.instanceOrigin);
+
+  return new Response(JSON.stringify({
+    error: "request_too_large",
+    requestId: id,
+    maxBytes: input.maxBytes,
+    ...(input.declaredBytes === undefined ? {} : { declaredBytes: input.declaredBytes }),
+    ...(input.observedBytes === undefined ? {} : { observedBytes: input.observedBytes }),
+  }), { status: 413, headers });
 }
 
 export async function proxyUpstream(
@@ -586,6 +667,45 @@ export async function proxyUpstream(
     return new Response(null, { status: 204, headers: preflight });
   }
 
+  const maxBytes = requestBodyMaxBytes(options);
+  const declaredSize = declaredRequestBodySize(request, maxBytes);
+  if (declaredSize.exceedsLimit) {
+    denWebLogger.warn("den-web upstream proxy rejected request body", {
+      route_prefix: options.routePrefix,
+      method: request.method,
+      status: 413,
+      max_bytes: maxBytes,
+      ...(declaredSize.bytes === undefined ? {} : { declared_bytes: declaredSize.bytes }),
+      duration_ms: elapsedMs(startedAtMs),
+      request_id: referenceId,
+    });
+    return requestTooLargeResponse({
+      referenceId,
+      maxBytes,
+      instanceOrigin,
+      declaredBytes: declaredSize.bytes,
+    });
+  }
+
+  const bodyRead = await readRequestBody(request, maxBytes);
+  if (!bodyRead.ok) {
+    denWebLogger.warn("den-web upstream proxy rejected request body", {
+      route_prefix: options.routePrefix,
+      method: request.method,
+      status: 413,
+      max_bytes: maxBytes,
+      observed_bytes: bodyRead.observedBytes,
+      duration_ms: elapsedMs(startedAtMs),
+      request_id: referenceId,
+    });
+    return requestTooLargeResponse({
+      referenceId,
+      maxBytes,
+      instanceOrigin,
+      observedBytes: bodyRead.observedBytes,
+    });
+  }
+
   const targetPath = getTargetPath(request, segments, options.routePrefix);
   const targetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
   const requestHeaders = await cloneRequestHeaders(
@@ -594,7 +714,6 @@ export async function proxyUpstream(
     referenceId,
     instanceOrigin !== null,
   );
-  const requestBody = await readRequestBody(request);
   const upstreamAbort = createUpstreamAbort(
     request.signal,
     options.upstreamDeadlineMs ?? UPSTREAM_DEADLINE_MS,
@@ -606,7 +725,7 @@ export async function proxyUpstream(
       upstream = await fetch(targetUrl, {
         method: request.method,
         headers: requestHeaders,
-        body: requestBody,
+        body: bodyRead.body,
         redirect: "manual",
         signal: upstreamAbort.signal,
       });
@@ -642,6 +761,8 @@ export async function proxyUpstream(
       upstream_origin: upstreamOrigin(apiBase),
       upstream_path: `/${[normalizePathPrefix(options.upstreamPathPrefix ?? ""), targetPath].filter(Boolean).join("/")}`,
       status: upstream.status,
+      ...(declaredSize.bytes === undefined ? {} : { declared_bytes: declaredSize.bytes }),
+      ...(bodyRead.observedBytes === undefined ? {} : { observed_bytes: bodyRead.observedBytes }),
       duration_ms: elapsedMs(startedAtMs),
       request_id: referenceId,
     });

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -583,11 +583,8 @@ async function readRequestBody(request: NextRequest, maxBytes: number): Promise<
       if (chunk.done) break;
       observedBytes += chunk.value.byteLength;
       if (observedBytes > maxBytes) {
-        try {
-          await reader.cancel();
-        } catch {
-          // The 413 response does not depend on the request producer accepting cancellation.
-        }
+        // Refusal must not wait for an uncooperative producer to finish cancelling.
+        void reader.cancel().catch(() => {});
         return { ok: false, observedBytes };
       }
       chunks.push(chunk.value);

--- a/evals/specs/den-proxy-request-body-limit.test.ts
+++ b/evals/specs/den-proxy-request-body-limit.test.ts
@@ -1,29 +1,89 @@
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { expect } from "vitest";
-import { test } from "@openwork/testkit";
+import { eventually, localMysqlIsRunning, localRedisIsRunning, needs, server, SkipError, test } from "@openwork/testkit";
 
-const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const maxBytes = 32 * 1024 * 1024;
 
-test("the Den Web proxy bounds request bodies and rejects oversized ones before contacting Den", async ({ evidence }) => {
-  const unit = spawnSync("pnpm", [
-    "--dir",
-    "ee/apps/den-web",
-    "exec",
-    "bun",
-    "--conditions=development",
-    "test",
-    "app/api/_lib/upstream-proxy.test.mjs",
-  ], { cwd: repoRoot, encoding: "utf8" });
-  const output = `${unit.stdout}${unit.stderr}`;
-  expect(unit.error, output).toBeUndefined();
-  expect(unit.status, output).toBe(0);
-  expect(output).toContain(" 23 pass");
-  expect(output).toContain(" 0 fail");
+function postBody(url: URL, requestId: string, declared: boolean): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": requestId,
+        ...(declared ? { "content-length": String(maxBytes + 1) } : { "transfer-encoding": "chunked" }),
+      },
+      signal: AbortSignal.timeout(60_000),
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("error", reject);
+      response.on("end", () => {
+        resolve(new Response(Buffer.concat(chunks), { status: response.statusCode }));
+        request.destroy();
+      });
+    });
+    request.on("error", reject);
+    if (declared) {
+      // Reject the declaration without waiting for its advertised payload.
+      request.flushHeaders();
+    } else {
+      request.end(Buffer.alloc(maxBytes + 1, "x"));
+    }
+  });
+}
 
+test("the auth proxy rejects oversized bodies before Den while ordinary sign-in still works", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs({ commands: ["bun"] });
+  if (place.kind === "local" && !await localMysqlIsRunning()) {
+    throw new SkipError("local MySQL on 127.0.0.1:3306");
+  }
+  if (place.kind === "local" && !await localRedisIsRunning()) {
+    throw new SkipError("local Redis on 127.0.0.1:6379");
+  }
+  await using den = await server({ place, web: true, org: { name: "Proxy body limit" } });
+  const nonce = `${Date.now().toString(36)}-${process.pid}`;
+  const declaredId = `proxy-declared-${nonce}`;
+  const chunkedId = `proxy-chunked-${nonce}`;
+  const acceptedId = `proxy-accepted-${nonce}`;
+  const url = new URL("/api/auth/sign-in/email", den.ref.webUrl);
+
+  const declared = await postBody(url, declaredId, true);
+  expect(declared.status).toBe(413);
+  expect(await declared.json()).toMatchObject({
+    error: "request_too_large", requestId: declaredId, maxBytes, declaredBytes: maxBytes + 1,
+  });
+
+  const chunked = await postBody(url, chunkedId, false);
+  expect(chunked.status).toBe(413);
+  expect(await chunked.json()).toMatchObject({
+    error: "request_too_large", requestId: chunkedId, maxBytes, observedBytes: maxBytes + 1,
+  });
+
+  const accepted = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-request-id": acceptedId, origin: den.ref.webUrl },
+    body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  expect(accepted.status).toBe(200);
+  expect(accepted.headers.get("set-cookie")).toContain("session_token");
+
+  // Observe the accepted control before using absence to prove non-delivery.
+  await eventually(async () => (await den.apiLog()).includes(acceptedId), { within: 10_000 });
+  const log = await den.apiLog();
+  expect(log).toContain(acceptedId);
+  expect(log).not.toContain(declaredId);
+  expect(log).not.toContain(chunkedId);
   evidence.recordAssertionEvidence(
-    "Oversized request bodies are rejected with structured 413 responses and Den is never contacted",
-    "The proxy suite passed: declared and chunked oversized bodies returned request_too_large with request ids and CORS headers while the upstream server observed zero requests, bodies at and immediately below the limit proxied byte-for-byte, ordinary multipart uploads continued, and rejection logs carried sizes without credentials or file contents.",
-    true,
+    "Declared and chunked oversized bodies stop at the web boundary without contacting Den",
+    "Both real auth-proxy requests returned structured 413 responses; the API log contained the accepted control request and neither rejection id.",
+    !log.includes(declaredId) && !log.includes(chunkedId) && log.includes(acceptedId),
+  );
+  evidence.recordAssertionEvidence(
+    "An ordinary sign-in still reaches Den and returns its session cookie",
+    `HTTP ${accepted.status}; session cookie present: ${Boolean(accepted.headers.get("set-cookie")?.includes("session_token"))}`,
+    accepted.status === 200 && Boolean(accepted.headers.get("set-cookie")?.includes("session_token")),
   );
 });

--- a/evals/specs/den-proxy-request-body-limit.test.ts
+++ b/evals/specs/den-proxy-request-body-limit.test.ts
@@ -5,7 +5,7 @@ import { eventually, localMysqlIsRunning, localRedisIsRunning, needs, server, Sk
 
 const maxBytes = 32 * 1024 * 1024;
 
-function postBody(url: URL, requestId: string, declared: boolean): Promise<Response> {
+function postBody(url: URL, requestId: string, declared: boolean): Promise<{ response: Response; senderEnded: boolean }> {
   return new Promise((resolve, reject) => {
     const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(url, {
       method: "POST",
@@ -16,11 +16,12 @@ function postBody(url: URL, requestId: string, declared: boolean): Promise<Respo
       },
       signal: AbortSignal.timeout(60_000),
     }, (response) => {
+      const senderEnded = request.writableEnded;
       const chunks: Buffer[] = [];
       response.on("data", (chunk: Buffer) => chunks.push(chunk));
       response.on("error", reject);
       response.on("end", () => {
-        resolve(new Response(Buffer.concat(chunks), { status: response.statusCode }));
+        resolve({ response: new Response(Buffer.concat(chunks), { status: response.statusCode }), senderEnded });
         request.destroy();
       });
     });
@@ -29,7 +30,18 @@ function postBody(url: URL, requestId: string, declared: boolean): Promise<Respo
       // Reject the declaration without waiting for its advertised payload.
       request.flushHeaders();
     } else {
-      request.end(Buffer.alloc(maxBytes + 1, "x"));
+      const chunk = Buffer.alloc(64 * 1024, "x");
+      let written = 0;
+      const writeNext = () => {
+        if (request.destroyed || written > maxBytes) return;
+        const size = Math.min(chunk.length, maxBytes + 1 - written);
+        written += size;
+        if (request.write(chunk.subarray(0, size))) setImmediate(writeNext);
+        else request.once("drain", writeNext);
+      };
+      writeNext();
+      // Deliberately never end the sender: buffering until EOF must time out,
+      // while a streaming limit returns 413 as soon as the limit is crossed.
     }
   });
 }
@@ -49,13 +61,15 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
   const acceptedId = `proxy-accepted-${nonce}`;
   const url = new URL("/api/auth/sign-in/email", den.ref.webUrl);
 
-  const declared = await postBody(url, declaredId, true);
+  const { response: declared, senderEnded: declaredEnded } = await postBody(url, declaredId, true);
+  expect(declaredEnded).toBe(false);
   expect(declared.status).toBe(413);
   expect(await declared.json()).toMatchObject({
     error: "request_too_large", requestId: declaredId, maxBytes, declaredBytes: maxBytes + 1,
   });
 
-  const chunked = await postBody(url, chunkedId, false);
+  const { response: chunked, senderEnded: chunkedEnded } = await postBody(url, chunkedId, false);
+  expect(chunkedEnded).toBe(false);
   expect(chunked.status).toBe(413);
   expect(await chunked.json()).toMatchObject({
     error: "request_too_large", requestId: chunkedId, maxBytes, observedBytes: maxBytes + 1,

--- a/evals/specs/den-proxy-request-body-limit.test.ts
+++ b/evals/specs/den-proxy-request-body-limit.test.ts
@@ -1,0 +1,29 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+test("the Den Web proxy bounds request bodies and rejects oversized ones before contacting Den", async ({ evidence }) => {
+  const unit = spawnSync("pnpm", [
+    "--dir",
+    "ee/apps/den-web",
+    "exec",
+    "bun",
+    "--conditions=development",
+    "test",
+    "app/api/_lib/upstream-proxy.test.mjs",
+  ], { cwd: repoRoot, encoding: "utf8" });
+  const output = `${unit.stdout}${unit.stderr}`;
+  expect(unit.error, output).toBeUndefined();
+  expect(unit.status, output).toBe(0);
+  expect(output).toContain(" 23 pass");
+  expect(output).toContain(" 0 fail");
+
+  evidence.recordAssertionEvidence(
+    "Oversized request bodies are rejected with structured 413 responses and Den is never contacted",
+    "The proxy suite passed: declared and chunked oversized bodies returned request_too_large with request ids and CORS headers while the upstream server observed zero requests, bodies at and immediately below the limit proxied byte-for-byte, ordinary multipart uploads continued, and rejection logs carried sizes without credentials or file contents.",
+    true,
+  );
+});

--- a/evals/specs/den-proxy-request-body-limit.test.ts
+++ b/evals/specs/den-proxy-request-body-limit.test.ts
@@ -46,7 +46,7 @@ function postBody(url: URL, requestId: string, declared: boolean): Promise<{ res
   });
 }
 
-test("the auth proxy rejects oversized bodies before Den while ordinary sign-in still works", { timeout: 300_000 }, async ({ evidence, place }) => {
+test("the auth proxy rejects oversized bodies before sender EOF and preserves ordinary sign-in", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs({ commands: ["bun"] });
   if (place.kind === "local" && !await localMysqlIsRunning()) {
     throw new SkipError("local MySQL on 127.0.0.1:3306");
@@ -113,8 +113,8 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
   expect(accepted.status).toBe(200);
   expect(accepted.headers.get("set-cookie")).toContain("session_token");
 
-  // Observe the accepted control before using the exact request delta to prove
-  // non-delivery; any completed rejected request must be an additional record.
+  // Observe the accepted control and compare completed requests only. This
+  // completion-log witness cannot exclude upstream contact still in flight.
   const requests = await eventually(readNewRequests, {
     within: 10_000,
     label: "successful auth control in Den's access log",
@@ -125,8 +125,8 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
     method: "POST", route: "/api/auth/*", status: 200,
   }]);
   evidence.recordAssertionEvidence(
-    "Declared and chunked oversized bodies stop at the web boundary without contacting Den",
-    `Neither rejection added a Den HTTP completion. After the successful control, the isolated server recorded exactly ${requests.length} new request: POST /api/auth/* with HTTP 200 and a server-generated ID.`,
+    "Den records only the successful sign-in completion during the request sequence",
+    `No new HTTP completions were observed after either rejection. Through the successful control, the isolated server recorded exactly ${requests.length} new completion: POST /api/auth/* with HTTP 200 and a server-generated ID. This observation does not exclude upstream contact still in flight.`,
     requests.length === 1 && requests.every(({ method, route, status }) => method === "POST" && route === "/api/auth/*" && status === 200),
   );
   evidence.recordAssertionEvidence(

--- a/evals/specs/den-proxy-request-body-limit.test.ts
+++ b/evals/specs/den-proxy-request-body-limit.test.ts
@@ -55,10 +55,32 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
     throw new SkipError("local Redis on 127.0.0.1:6379");
   }
   await using den = await server({ place, web: true, org: { name: "Proxy body limit" } });
+  const readCompletedRequests = async () => (await den.apiLog()).split(/\r?\n/).flatMap((line) => {
+    if (!line.startsWith("{")) return [];
+    const entry: unknown = JSON.parse(line);
+    if (typeof entry !== "object" || entry === null
+      || Reflect.get(entry, "component") !== "http" || Reflect.get(entry, "message") !== "request completed") return [];
+    const requestId = Reflect.get(entry, "request_id");
+    const method = Reflect.get(entry, "http_method");
+    const route = Reflect.get(entry, "http_route");
+    const status = Reflect.get(entry, "http_status_code");
+    if (typeof requestId !== "string" || typeof method !== "string" || typeof route !== "string" || typeof status !== "number") {
+      throw new Error("Malformed Den HTTP completion record.");
+    }
+    return [{ requestId, method, route, status }];
+  });
+  // Den generates its own IDs and normalizes auth paths. Use the exclusively
+  // owned server's completed requests, after its setup response is recorded.
+  const setupRequests = await eventually(readCompletedRequests, {
+    within: 10_000,
+    label: "isolated organization setup in Den's access log",
+    until: (requests) => requests.some(({ method, route, status }) => method === "POST" && route === "/v1/org" && status === 201),
+  });
+  const setupIds = new Set(setupRequests.map(({ requestId }) => requestId));
+  const readNewRequests = async () => (await readCompletedRequests()).filter(({ requestId }) => !setupIds.has(requestId));
   const nonce = `${Date.now().toString(36)}-${process.pid}`;
   const declaredId = `proxy-declared-${nonce}`;
   const chunkedId = `proxy-chunked-${nonce}`;
-  const acceptedId = `proxy-accepted-${nonce}`;
   const url = new URL("/api/auth/sign-in/email", den.ref.webUrl);
 
   const { response: declared, senderEnded: declaredEnded } = await postBody(url, declaredId, true);
@@ -67,6 +89,7 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
   expect(await declared.json()).toMatchObject({
     error: "request_too_large", requestId: declaredId, maxBytes, declaredBytes: maxBytes + 1,
   });
+  expect(await readNewRequests()).toHaveLength(0);
 
   const { response: chunked, senderEnded: chunkedEnded } = await postBody(url, chunkedId, false);
   expect(chunkedEnded).toBe(false);
@@ -74,26 +97,37 @@ test("the auth proxy rejects oversized bodies before Den while ordinary sign-in 
   expect(await chunked.json()).toMatchObject({
     error: "request_too_large", requestId: chunkedId, maxBytes, observedBytes: maxBytes + 1,
   });
+  expect(await readNewRequests()).toHaveLength(0);
+  evidence.recordAssertionEvidence(
+    "Declared and chunked oversized bodies receive structured 413 responses before sender EOF",
+    `Declared: HTTP ${declared.status}, sender ended: ${declaredEnded}; chunked: HTTP ${chunked.status}, sender ended: ${chunkedEnded}; limit: ${maxBytes} bytes.`,
+    declared.status === 413 && chunked.status === 413 && !declaredEnded && !chunkedEnded,
+  );
 
   const accepted = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json", "x-request-id": acceptedId, origin: den.ref.webUrl },
+    headers: { "content-type": "application/json", origin: den.ref.webUrl },
     body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
     signal: AbortSignal.timeout(30_000),
   });
   expect(accepted.status).toBe(200);
   expect(accepted.headers.get("set-cookie")).toContain("session_token");
 
-  // Observe the accepted control before using absence to prove non-delivery.
-  await eventually(async () => (await den.apiLog()).includes(acceptedId), { within: 10_000 });
-  const log = await den.apiLog();
-  expect(log).toContain(acceptedId);
-  expect(log).not.toContain(declaredId);
-  expect(log).not.toContain(chunkedId);
+  // Observe the accepted control before using the exact request delta to prove
+  // non-delivery; any completed rejected request must be an additional record.
+  const requests = await eventually(readNewRequests, {
+    within: 10_000,
+    label: "successful auth control in Den's access log",
+    until: (entries) => entries.some(({ method, route, status }) => method === "POST" && route === "/api/auth/*" && status === 200),
+  });
+  expect(requests).toEqual([{
+    requestId: expect.stringMatching(/^req_[a-z0-9]+$/),
+    method: "POST", route: "/api/auth/*", status: 200,
+  }]);
   evidence.recordAssertionEvidence(
     "Declared and chunked oversized bodies stop at the web boundary without contacting Den",
-    "Both real auth-proxy requests returned structured 413 responses; the API log contained the accepted control request and neither rejection id.",
-    !log.includes(declaredId) && !log.includes(chunkedId) && log.includes(acceptedId),
+    `Neither rejection added a Den HTTP completion. After the successful control, the isolated server recorded exactly ${requests.length} new request: POST /api/auth/* with HTTP 200 and a server-generated ID.`,
+    requests.length === 1 && requests.every(({ method, route, status }) => method === "POST" && route === "/api/auth/*" && status === 200),
   );
   evidence.recordAssertionEvidence(
     "An ordinary sign-in still reaches Den and returns its session cookie",


### PR DESCRIPTION
## Summary

Bound request buffering in the active Den Web auth proxy to 32 MiB and return structured `413 request_too_large` errors.

- Reject an oversized Content-Length declaration before waiting for its payload.
- Enforce the same limit while reading chunked bodies; reject as soon as it is crossed without waiting for sender EOF or stream-cancellation completion.
- Preserve ordinary request forwarding and sign-in behavior.
- Exercise the real auth-proxy route rather than the retired `/api/den/*` wrapper.

Current signed head: `d548c79bab359b148c39a7f210897652856b1060`.
Rebased onto `dev@d37c72280b0bf4547e6ec6b41b2e5bcfc437c293`.

## Integration repair

Den now generates request IDs internally instead of trusting incoming `x-request-id`. The existing HTTP test's accepted-control lookup was therefore stale. It now reads generated IDs and normalized access-completion records from its isolated Den, observes zero new completions after each rejection, then exactly one successful auth completion. The incremental sender-open assertions remain unchanged. Product request-ID policy and logging are unchanged.

## Verification — Incomplete overall; selected HTTP claims passed

Passed on the exact published head:

```sh
corepack pnpm --filter @openwork-ee/den-web exec bun test --conditions development app/api/_lib/upstream-proxy.test.mjs app/api/_lib/upstream-proxy-lifecycle.test.mjs
# exit 0; 28 passed, 0 failed, 0 skipped; 122 assertions
corepack pnpm evals:pr specs/den-proxy-request-body-limit.test.ts
# exit 0; 1 passed, 0 failed, 0 skipped; 3 passed evidence claims; 0 pending judgments
git diff --check d37c72280b0bf4547e6ec6b41b2e5bcfc437c293...HEAD
# exit 0
```

The app-less HTTP journey used freshly launched isolated local Den and Den Web resources. It verifies structured 413 responses for declared and chunked oversized input before sender EOF, ordinary sign-in returning 200 with a session cookie, and exactly one new completed Den request for the successful control. Owned processes and fixture data were cleaned up.

Exact-head run: `2026-09-10T19-27-27-208Z-the-auth-proxy-rejects-oversized-bodies-before-sender-eof-and-preserves-ordinary`.

**Proof limitation:** completion-log observations cannot exclude upstream contact still in flight. Strict non-forwarding therefore remains Incomplete; the passing evidence records this limitation instead of claiming packet-level ingress proof. Deployed-edge and desktop behavior were not tested. Final local review is deferred.

Earlier setup failures and the stale request-ID timeout were resolved before the successful exact-head run. Previous-head runs and approvals are historical, not current candidate clearance.
