### PR TITLE
Add word-wrap control to rendered code blocks

### DIFF
--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -43,6 +43,7 @@ const MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT = 160;
 const MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH = 280;
 const CODE_COPY_ICON = `<svg data-openwork-code-copy-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 const CODE_COPIED_ICON = `<svg data-openwork-code-copy-check-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true" hidden><path d="M20 6 9 17l-5-5"/></svg>`;
+const CODE_WRAP_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true"><path d="M3 6h18M3 12h15a3 3 0 1 1 0 6h-3"/><path d="m12 18-3 3 3 3"/></svg>`;
 const INLINE_CODE_FILE_EXTENSIONS = new Set([
   "astro", "bash", "c", "cc", "cpp", "cs", "css", "dart", "docx", "ex", "exs", "gif", "go", "graphql",
   "h", "hpp", "htm", "html", "java", "jpeg", "jpg", "js", "json", "jsonc", "jsx", "key", "kt", "kts",
@@ -145,15 +146,19 @@ function codeCopyButton() {
   return `<button type="button" data-openwork-code-copy="" class="absolute right-2 top-2 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 bg-background/95 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label="Copy code block" title="Copy code block">${CODE_COPY_ICON}${CODE_COPIED_ICON}<span data-openwork-code-copy-label="" class="sr-only" aria-live="polite">Copy code block</span></button>`;
 }
 
+function codeWrapButton() {
+  return `<button type="button" data-openwork-code-wrap="" class="absolute right-11 top-2 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 bg-background/95 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label="Enable word wrap" aria-pressed="false" title="Enable word wrap">${CODE_WRAP_ICON}</button>`;
+}
+
 function chatCodeBlockContainer(html: string, shiki: boolean) {
   const shikiAttribute = shiki ? ` data-openwork-shiki="true"` : "";
 
-  return `<div data-openwork-code-block=""${shikiAttribute} class="relative my-4 overflow-hidden rounded-[18px] border border-border/70 bg-gray-2/60 font-mono text-xs leading-6 text-foreground">${codeCopyButton()}${html}</div>`;
+  return `<div data-openwork-code-block=""${shikiAttribute} class="relative my-4 overflow-hidden rounded-[18px] border border-border/70 bg-gray-2/60 font-mono text-xs leading-6 text-foreground">${codeWrapButton()}${codeCopyButton()}${html}</div>`;
 }
 
 function chatCodeBlockHtml(text: string, lang: string | undefined) {
   return chatCodeBlockContainer(
-    `<pre class="overflow-x-auto px-4 pb-3 pt-11"><code${codeLanguageClass(lang)}>${escapeHtml(text)}</code></pre>`,
+    `<pre data-openwork-code-scroll="" class="overflow-x-auto px-4 pb-3 pt-11"><code${codeLanguageClass(lang)}>${escapeHtml(text)}</code></pre>`,
     false,
   );
 }
@@ -196,6 +201,31 @@ export function setCodeCopyButtonState(button: HTMLButtonElement, copied: boolea
   button.setAttribute("aria-label", copied ? "Code block copied" : "Copy code block");
 }
 
+export function codeWrapClassStates(wrapped: boolean) {
+  return {
+    "overflow-x-auto": !wrapped,
+    "overflow-x-hidden": wrapped,
+    "whitespace-pre-wrap": wrapped,
+    "break-words": wrapped,
+  };
+}
+
+export function setCodeWrapButtonState(button: HTMLButtonElement, wrapped: boolean) {
+  const codeBlock = button.closest("[data-openwork-code-block]");
+  const pre = codeBlock?.querySelector("pre");
+
+  for (const [className, enabled] of Object.entries(codeWrapClassStates(wrapped))) {
+    for (const container of codeBlock?.querySelectorAll("[data-openwork-code-scroll]") ?? []) {
+      container.classList.toggle(className, enabled);
+    }
+  }
+  pre?.classList.toggle("whitespace-pre-wrap", wrapped);
+  pre?.classList.toggle("break-words", wrapped);
+  button.setAttribute("aria-pressed", String(wrapped));
+  button.setAttribute("aria-label", wrapped ? "Disable word wrap" : "Enable word wrap");
+  button.title = wrapped ? "Disable word wrap" : "Enable word wrap";
+}
+
 function sanitizeMarkdownHtml(value: string) {
   if (typeof DOMPurify.sanitize !== "function") {
     return value;
@@ -215,10 +245,13 @@ function sanitizeMarkdownHtml(value: string) {
       "data-openwork-code-copy-check-icon",
       "data-openwork-code-copy-icon",
       "data-openwork-code-copy-label",
+      "data-openwork-code-scroll",
+      "data-openwork-code-wrap",
       "aria-label",
-       "data-openwork-image-preview",
-       "data-openwork-inline-code-path",
-       "data-openwork-link-href",
+      "aria-pressed",
+      "data-openwork-image-preview",
+      "data-openwork-inline-code-path",
+      "data-openwork-link-href",
       "data-openwork-link-chevron",
       "data-openwork-shiki",
       "decoding",
@@ -272,7 +305,7 @@ function markdownProfileForPresentation(presentation: MarkdownPresentation): Mar
     imagePresentation: "chat",
     tableHeaderClassName: "border border-border p-2 bg-muted text-left",
     tableCellClassName: "border border-border p-2 align-top",
-    shikiContainer: chatCodeBlockContainer(`<div class="overflow-x-auto px-4 pb-3 pt-11">%s</div>`, true),
+    shikiContainer: chatCodeBlockContainer(`<div data-openwork-code-scroll="" class="overflow-x-auto px-4 pb-3 pt-11">%s</div>`, true),
     shikiTheme: { kind: "dual", light: "github-light", dark: "github-dark" },
   };
 }

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -17,6 +17,7 @@ import {
   renderHighlightedMarkdownHtml,
   renderMarkdownHtml,
   setCodeCopyButtonState,
+  setCodeWrapButtonState,
   syncMarkdownImagePreviews,
 } from "./markdown-primitive";
 import { LinkActionMenu } from "./link-action-menu";
@@ -102,6 +103,7 @@ function MarkdownBlockInner({
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const codeCopyResetTimers = useRef(new Map<HTMLButtonElement, number>());
+  const codeWrapStates = useRef(new Map<number, boolean>());
   const { openTargets, onOpenTarget } = useOpenTargets();
   const openArtifactPath = useOpenArtifactPath();
   const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
@@ -131,6 +133,22 @@ function MarkdownBlockInner({
     }, CODE_COPY_RESET_DELAY_MS);
     codeCopyResetTimers.current.set(button, resetTimer);
   }, []);
+
+  const syncCodeWrapStates = useCallback(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    for (const [index, codeBlock] of root.querySelectorAll("[data-openwork-code-block]").entries()) {
+      const button = codeBlock.querySelector("[data-openwork-code-wrap]");
+      if (button instanceof HTMLButtonElement) {
+        setCodeWrapButtonState(button, codeWrapStates.current.get(index) ?? false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    codeWrapStates.current.clear();
+  }, [text]);
 
   useEffect(() => {
     const timers = codeCopyResetTimers.current;
@@ -184,6 +202,7 @@ function MarkdownBlockInner({
       }
 
       applyTextHighlights(root, highlightQuery ?? "");
+      syncCodeWrapStates();
     });
   }, [highlightQuery, html]);
 
@@ -218,6 +237,22 @@ function MarkdownBlockInner({
         event.preventDefault();
         event.stopPropagation();
         openArtifactPath(inlineCodePath.dataset.openworkInlineCodePath ?? "");
+        return;
+      }
+
+      const wrapButton = event.target.closest("[data-openwork-code-wrap]");
+      if (wrapButton instanceof HTMLButtonElement) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const codeBlock = wrapButton.closest("[data-openwork-code-block]");
+        const codeBlocks = Array.from(root.querySelectorAll("[data-openwork-code-block]"));
+        const index = codeBlock ? codeBlocks.indexOf(codeBlock) : -1;
+        if (index >= 0) {
+          const wrapped = !(codeWrapStates.current.get(index) ?? false);
+          codeWrapStates.current.set(index, wrapped);
+          setCodeWrapButtonState(wrapButton, wrapped);
+        }
         return;
       }
 

--- a/apps/app/tests/markdown-code-block.test.ts
+++ b/apps/app/tests/markdown-code-block.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
 import { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "../src/components/markdown/markdown";
-import { renderHighlightedMarkdownHtml as renderPrimitiveHighlightedMarkdownHtml, renderMarkdownHtml as renderPrimitiveMarkdownHtml } from "../src/components/markdown/markdown-primitive";
+import {
+  codeWrapClassStates,
+  renderHighlightedMarkdownHtml as renderPrimitiveHighlightedMarkdownHtml,
+  renderMarkdownHtml as renderPrimitiveMarkdownHtml,
+} from "../src/components/markdown/markdown-primitive";
 import { textHighlightParts } from "../src/components/markdown/text-highlights";
 
 const CODE = "const value = 1;\nconsole.log(value);";
 const MARKDOWN = `\`\`\`ts\n${CODE}\n\`\`\``;
 
 describe("markdown code blocks", () => {
-  test("renders fallback code blocks with subtle theme-aware styling and copy affordance", () => {
+  test("renders fallback code blocks with subtle theme-aware styling, copy, and word-wrap affordances", () => {
     const html = renderMarkdownHtml(MARKDOWN);
 
     expect(html).toContain("data-openwork-code-block");
@@ -16,15 +20,37 @@ describe("markdown code blocks", () => {
     expect(html).toContain("data-openwork-code-copy");
     expect(html).toContain("data-openwork-code-copy-icon");
     expect(html).toContain("data-openwork-code-copy-check-icon");
+    expect(html).toContain("data-openwork-code-wrap");
+    expect(html).toContain("data-openwork-code-scroll");
     expect(html).toContain("h-7 w-7");
     expect(html).toContain('aria-label="Copy code block"');
     expect(html).toContain('aria-live="polite"');
     expect(html).toContain('class="sr-only"');
     expect(html).toContain('title="Copy code block"');
+    expect(html).toContain('aria-label="Enable word wrap"');
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('title="Enable word wrap"');
     expect(html).not.toContain(">Copy</span>");
     expect(html).toContain("pt-11");
+    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain(CODE);
     expect(html).toContain(CODE.split("\n")[0]);
     expect(html).toContain(CODE.split("\n")[1]);
+  });
+
+  test("maps word-wrap state to visual styles without changing the rendered code", () => {
+    expect(codeWrapClassStates(false)).toEqual({
+      "overflow-x-auto": true,
+      "overflow-x-hidden": false,
+      "whitespace-pre-wrap": false,
+      "break-words": false,
+    });
+    expect(codeWrapClassStates(true)).toEqual({
+      "overflow-x-auto": false,
+      "overflow-x-hidden": true,
+      "whitespace-pre-wrap": true,
+      "break-words": true,
+    });
   });
 
   test("renders highlighted code blocks with the same copy affordance and dual Shiki themes", async () => {
@@ -35,6 +61,8 @@ describe("markdown code blocks", () => {
     expect(html).toContain("data-openwork-code-copy");
     expect(html).toContain("data-openwork-code-copy-icon");
     expect(html).toContain("data-openwork-code-copy-check-icon");
+    expect(html).toContain("data-openwork-code-wrap");
+    expect(html).toContain("data-openwork-code-scroll");
     expect(html).toContain("--shiki-dark");
     expect(html).toContain("github-light");
     expect(html).toContain("github-dark");

--- a/evals/specs/markdown-code-wrap-control.test.ts
+++ b/evals/specs/markdown-code-wrap-control.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const markdownPrimitiveSource = readFileSync(
+  fileURLToPath(new URL("../../apps/app/src/components/markdown/markdown-primitive.ts", import.meta.url)),
+  "utf8",
+);
+
+test("rendered code blocks expose an accessible word-wrap control that defaults to unwrapped", async ({ evidence }) => {
+  expect(markdownPrimitiveSource).toContain('data-openwork-code-wrap=""');
+  expect(markdownPrimitiveSource).toContain('aria-pressed="false"');
+  expect(markdownPrimitiveSource).toContain('aria-label="Enable word wrap"');
+  expect(markdownPrimitiveSource).toContain('data-openwork-code-scroll=""');
+  expect(markdownPrimitiveSource).toContain("export function codeWrapClassStates");
+  expect(markdownPrimitiveSource).toContain("export function setCodeWrapButtonState");
+  // The sanitizer must keep the wrap control interactive after re-rendering.
+  expect(markdownPrimitiveSource).toContain('"data-openwork-code-wrap",');
+  expect(markdownPrimitiveSource).toContain('"aria-pressed",');
+  // The unwrapped default keeps horizontal scrolling; wrapping is opt-in.
+  expect(markdownPrimitiveSource).toMatch(/"overflow-x-auto": !wrapped/);
+  expect(markdownPrimitiveSource).toMatch(/"whitespace-pre-wrap": wrapped/);
+
+  evidence.recordAssertionEvidence(
+    "Code blocks render an explicit wrap toggle without changing the default presentation",
+    "The chat code block container renders an aria-pressed word-wrap button beside the copy control, the sanitizer allowlists its attributes, and the wrap state maps to pure class toggles that keep overflow scrolling as the default.",
+    true,
+  );
+
+  const unit = spawnSync("pnpm", [
+    "--dir",
+    "apps/app",
+    "exec",
+    "bun",
+    "test",
+    "tests/markdown-code-block.test.ts",
+  ], { cwd: repoRoot, encoding: "utf8" });
+  const output = `${unit.stdout}${unit.stderr}`;
+  expect(unit.error, output).toBeUndefined();
+  expect(unit.status, output).toBe(0);
+  expect(output).toContain(" 10 pass");
+  expect(output).toContain(" 0 fail");
+
+  evidence.recordAssertionEvidence(
+    "The markdown code block unit suite passes with the wrap affordance",
+    "All 10 unit tests passed, covering the fallback and Shiki containers, the wrap class-state mapping, unchanged copy behavior, and unchanged rendered code text.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

Long lines in rendered chat code blocks force horizontal scrolling, which makes shell one-liners, logs, and generated commands hard to read. This adds an explicit word-wrap toggle to every rendered code block while keeping the current unwrapped presentation as the default.

- `markdown-primitive.ts` renders a wrap button beside the existing copy button in both the fallback and Shiki containers, with `aria-pressed`, `aria-label`, and `title` state. The scrollable region is tagged `data-openwork-code-scroll`, and `codeWrapClassStates` maps the wrap state to pure class toggles (`overflow-x-auto` ↔ `overflow-x-hidden` / `whitespace-pre-wrap` / `break-words`) without touching the rendered code text. The sanitizer allowlists the new attributes so the control survives re-renders.
- `markdown.tsx` tracks per-block wrap state by block index, restores it after markdown re-renders (streaming updates), and resets it when the message text changes.
- The toggle is per code block, so a wrapped log can sit next to an unwrapped table in the same message.

## Verification

Local lane, all at this head:

- `pnpm evals:pr specs/markdown-code-wrap-control.test.ts` — 1 passed / 0 failed / 0 skipped
- `pnpm --dir apps/app exec bun test tests/markdown-code-block.test.ts` — 10 pass / 0 fail (fallback and Shiki containers render the wrap affordance, class-state mapping is pure, copy behavior and rendered code text unchanged)
- `pnpm --filter @openwork/app typecheck` — clean

Not run here: repository-wide suites and app-driving E2E (left to CI).
