### PR TITLE
Keep the artifact rail count visible

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1856,7 +1856,7 @@ export function SessionPage(props: SessionPageProps) {
               </Sheet>
             ) : null}
           </ResizablePanelGroup>
-          <aside className="hidden w-9 shrink-0 flex-col items-center gap-1 px-0.5 py-2 text-muted-foreground lg:flex mac:titlebar-no-drag">
+          <aside className="hidden w-10 shrink-0 flex-col items-center gap-1 px-1 py-2 text-muted-foreground lg:flex mac:titlebar-no-drag">
             {isElectronRuntime() ? (
               <Button
                 variant="ghost"

--- a/evals/specs/artifact-rail-layout.test.ts
+++ b/evals/specs/artifact-rail-layout.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const sessionPageSource = readFileSync(
+  fileURLToPath(new URL("../../apps/app/src/react-app/domains/session/chat/session-page.tsx", import.meta.url)),
+  "utf8",
+);
+const buttonSource = readFileSync(
+  fileURLToPath(new URL("../../apps/app/src/components/ui/button.tsx", import.meta.url)),
+  "utf8",
+);
+
+function spacingValue(source: string, pattern: RegExp) {
+  const value = source.match(pattern)?.[1];
+  if (value === undefined) {
+    throw new Error(`Missing geometry class matching ${pattern}`);
+  }
+  return Number(value) * 4;
+}
+
+test("the artifact count badge stays inside the desktop rail", async ({ evidence }) => {
+  const rail = sessionPageSource.match(/<aside className="([^"]+)">/)?.[1] ?? "";
+  const badge = sessionPageSource.match(/<span className="([^"]*translate-x-1[^"]*)">/)?.[1] ?? "";
+  const buttonSize = spacingValue(buttonSource, /"icon-sm": "size-([\d.]+)"/);
+  const railWidth = spacingValue(rail, /(?:^|\s)w-([\d.]+)(?:\s|$)/);
+  const railPadding = spacingValue(rail, /(?:^|\s)px-([\d.]+)(?:\s|$)/);
+  const railTopPadding = spacingValue(rail, /(?:^|\s)py-([\d.]+)(?:\s|$)/);
+  const badgeOffset = spacingValue(badge, /(?:^|\s)translate-x-([\d.]+)(?:\s|$)/);
+  const badgeTopOffset = spacingValue(badge, /(?:^|\s)-translate-y-([\d.]+)(?:\s|$)/);
+  const badgeHeight = spacingValue(badge, /(?:^|\s)leading-([\d.]+)(?:\s|$)/);
+
+  for (const { chatWidth, badgeWidth } of [
+    { chatWidth: 720, badgeWidth: 14 },
+    { chatWidth: 720, badgeWidth: 22 },
+    { chatWidth: 360, badgeWidth: 14 },
+    { chatWidth: 360, badgeWidth: 22 },
+  ]) {
+    const railLeft = chatWidth;
+    const railRight = railLeft + railWidth;
+    const badgeRight = railLeft + railPadding + buttonSize + badgeOffset;
+    const badgeLeft = badgeRight - badgeWidth;
+    const badgeTop = railTopPadding - badgeTopOffset;
+    const badgeBottom = badgeTop + badgeHeight;
+
+    expect(badgeRight).toBeGreaterThan(badgeLeft);
+    expect(badgeBottom).toBeGreaterThan(badgeTop);
+    expect(badgeLeft).toBeGreaterThanOrEqual(railLeft);
+    expect(badgeRight).toBeLessThanOrEqual(railRight);
+    expect(badgeTop).toBeGreaterThanOrEqual(0);
+  }
+
+  expect(sessionPageSource).toContain('artifactTargetCount > 9 ? "9+" : artifactTargetCount');
+
+  evidence.recordAssertionEvidence(
+    "Artifact counts remain fully visible in the desktop rail",
+    "The one-digit and compact 9+ badges fit inside the rail at narrow and wide chat widths without changing the 9+ presentation.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

The artifact count badge in the desktop right rail renders at `translate-x-1` off an `icon-sm` button inside a `w-9` / `px-0.5` rail, which pushes its right edge past the rail boundary; the ancestor clips it, so counts show up cut off.

This widens the rail by one spacing step (`w-9 px-0.5` → `w-10 px-1`) so the offset badge fits entirely inside the rail at both narrow and wide chat widths. The badge itself, its `9+` compaction, and every other rail affordance are unchanged.

## Verification

Local lane, at this head:

- `pnpm evals:pr specs/artifact-rail-layout.test.ts` — 1 passed / 0 failed / 0 skipped. The spec derives the button, rail, and badge geometry from the source classes and asserts the one-digit and compact `9+` badges stay inside the rail bounds at 360px and 720px chat widths, and that the `9+` presentation is retained.

Not run here: repository-wide suites and app-driving E2E (left to CI).
