### PR TITLE
feat(packaging): add pull-only Docker evaluation stack

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -73,7 +73,8 @@
           {
             "group": "Overview",
             "pages": [
-              "start-here/self-host"
+              "start-here/self-host",
+              "self-host/evaluate-with-docker-compose"
             ]
           },
           {

--- a/packages/docs/self-host/evaluate-with-docker-compose.mdx
+++ b/packages/docs/self-host/evaluate-with-docker-compose.mdx
@@ -6,7 +6,7 @@ description: "Run the OpenWork control plane from published images without cloni
 Use the pull-only Docker Compose stack to evaluate Den web, Den API, and organization management on one machine. The stack downloads published OpenWork images and MySQL, runs database migrations, and starts the browser experience at `http://localhost:3005`.
 
 <Warning>
-  This stack is for evaluation only. It enables public signup by default, uses development credentials and plain HTTP, keeps MySQL on one local Docker volume, and uses a stub worker provisioner. Do not expose it to the public internet or use it for production data.
+  This stack is for evaluation only. Its HTTP ports bind to loopback, but it enables public signup by default, uses development credentials, keeps MySQL on one local Docker volume, and uses a stub worker provisioner. Do not change the port bindings to expose it on a network or use it for production data.
 </Warning>
 
 ## Before you start
@@ -33,7 +33,7 @@ Install Docker Engine or Docker Desktop with Docker Compose v2. The machine must
 
 3. Open [http://localhost:3005](http://localhost:3005) and create an account.
 
-The stack exposes Den web on port `3005` and Den API on port `8788`. MySQL is reachable only inside the Compose network.
+The stack exposes Den web on `127.0.0.1:3005` and Den API on `127.0.0.1:8788`. MySQL is reachable only inside the Compose network.
 
 ## Configure the evaluation
 
@@ -41,7 +41,6 @@ Set variables in your shell before running `docker compose`, or save them in a `
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `OPENWORK_HOST` | `localhost` | Host name or IP that browsers use to reach this machine. Do not include a scheme or port. |
 | `OPENWORK_WEB_PORT` | `3005` | Host port for Den web. |
 | `OPENWORK_API_PORT` | `8788` | Host port for Den API. |
 | `OPENWORK_AUTH_SECRET` | Required | Better Auth signing secret of at least 32 random characters. |
@@ -61,14 +60,18 @@ printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
   "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
 ```
 
-To open the evaluation from another device on your local network, set `OPENWORK_HOST` to the Docker host's reachable name or IP before starting the stack. For example:
+## Connect from another machine
+
+Keep the Compose ports bound to loopback. To evaluate a stack running on a remote host, create an encrypted SSH tunnel from your local machine:
 
 ```bash
-OPENWORK_HOST=192.168.1.20 \
-  docker compose -f docker-compose.eval.yml up -d --wait
+ssh -N \
+  -L 3005:127.0.0.1:3005 \
+  -L 8788:127.0.0.1:8788 \
+  user@docker-host
 ```
 
-Then open `http://192.168.1.20:3005`. Allow inbound TCP ports `3005` and `8788` only from the network you trust.
+Then open [http://localhost:3005](http://localhost:3005). Authentication and API traffic travel through the SSH tunnel rather than across the network as plaintext HTTP.
 
 ## Inspect or stop the stack
 

--- a/packages/docs/self-host/evaluate-with-docker-compose.mdx
+++ b/packages/docs/self-host/evaluate-with-docker-compose.mdx
@@ -19,8 +19,13 @@ Install Docker Engine or Docker Desktop with Docker Compose v2. The machine must
 
    ```bash
    curl -fsSLo docker-compose.eval.yml \
-     https://raw.githubusercontent.com/different-ai/openwork/dev/packaging/docker/docker-compose.eval.yml
+     https://raw.githubusercontent.com/different-ai/openwork/9f8645ebc482c15ab99c0cf155aabaa411e1ca6a/packaging/docker/docker-compose.eval.yml
+   printf '%s  %s\n' \
+     '69cc7f2666157b7697ebf69b31b0c83887dd99e796c7d956f9ccaab8fa8bf2fc' \
+     'docker-compose.eval.yml' | shasum -a 256 --check
    ```
+
+   Continue only when the checksum command prints `docker-compose.eval.yml: OK`. The commit-specific URL and checksum ensure you run the reviewed Compose definition rather than the latest content of a mutable branch.
 
 2. Start the services and wait for their health checks:
 

--- a/packages/docs/self-host/evaluate-with-docker-compose.mdx
+++ b/packages/docs/self-host/evaluate-with-docker-compose.mdx
@@ -1,0 +1,104 @@
+---
+title: "Evaluate with Docker Compose"
+description: "Run the OpenWork control plane from published images without cloning or building the repository."
+---
+
+Use the pull-only Docker Compose stack to evaluate Den web, Den API, and organization management on one machine. The stack downloads published OpenWork images and MySQL, runs database migrations, and starts the browser experience at `http://localhost:3005`.
+
+<Warning>
+  This stack is for evaluation only. It enables public signup by default, uses development credentials and plain HTTP, keeps MySQL on one local Docker volume, and uses a stub worker provisioner. Do not expose it to the public internet or use it for production data.
+</Warning>
+
+## Before you start
+
+Install Docker Engine or Docker Desktop with Docker Compose v2. The machine must be able to pull images from GitHub Container Registry and Docker Hub.
+
+## Start the stack
+
+1. Download the Compose file into an empty directory:
+
+   ```bash
+   curl -fsSLo docker-compose.eval.yml \
+     https://raw.githubusercontent.com/different-ai/openwork/dev/packaging/docker/docker-compose.eval.yml
+   ```
+
+2. Start the services and wait for their health checks:
+
+   ```bash
+   umask 077
+   printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
+     "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
+   docker compose -f docker-compose.eval.yml up -d --wait
+   ```
+
+3. Open [http://localhost:3005](http://localhost:3005) and create an account.
+
+The stack exposes Den web on port `3005` and Den API on port `8788`. MySQL is reachable only inside the Compose network.
+
+## Configure the evaluation
+
+Set variables in your shell before running `docker compose`, or save them in a `.env` file beside `docker-compose.eval.yml`.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OPENWORK_HOST` | `localhost` | Host name or IP that browsers use to reach this machine. Do not include a scheme or port. |
+| `OPENWORK_WEB_PORT` | `3005` | Host port for Den web. |
+| `OPENWORK_API_PORT` | `8788` | Host port for Den API. |
+| `OPENWORK_AUTH_SECRET` | Required | Better Auth signing secret of at least 32 random characters. |
+| `OPENWORK_DB_ENCRYPTION_KEY` | Required | Key of at least 32 random characters used to encrypt selected database values. |
+| `OPENWORK_ORG_NAME` | `OpenWork Evaluation` | Name of the single organization. |
+| `OPENWORK_ALLOW_SIGNUP` | `true` | Whether anyone who can reach the site can create an account. |
+
+The setup command writes unique secrets to `.env` so subsequent Compose commands reuse them. Keep this file private and do not commit it. To rotate the secrets, replace their values before recreating the services.
+
+The Compose file pins the MySQL, Den API, and Den web images to immutable digests. Download a newer Compose file to evaluate a newer release rather than changing only an image tag.
+
+If you create `.env` separately, generate unique secrets with:
+
+```bash
+umask 077
+printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
+  "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
+```
+
+To open the evaluation from another device on your local network, set `OPENWORK_HOST` to the Docker host's reachable name or IP before starting the stack. For example:
+
+```bash
+OPENWORK_HOST=192.168.1.20 \
+  docker compose -f docker-compose.eval.yml up -d --wait
+```
+
+Then open `http://192.168.1.20:3005`. Allow inbound TCP ports `3005` and `8788` only from the network you trust.
+
+## Inspect or stop the stack
+
+View service state and logs:
+
+```bash
+docker compose -f docker-compose.eval.yml ps
+docker compose -f docker-compose.eval.yml logs -f
+```
+
+Stop the services while retaining the evaluation database:
+
+```bash
+docker compose -f docker-compose.eval.yml down
+```
+
+Stop the services and permanently delete the evaluation database:
+
+```bash
+docker compose -f docker-compose.eval.yml down -v
+```
+
+## Evaluation limitations
+
+The stack does not provide:
+
+- production worker provisioning or cloud sandboxes;
+- transactional email or email verification;
+- TLS termination, private ingress, or secret management;
+- database high availability, backups, or a restore plan; or
+- production-safe authentication and database defaults.
+
+For production, use the [supported private-cloud architecture](/self-host/deploy-to-your-cloud/overview) with Kubernetes, Helm, managed MySQL, HTTPS, private networking, managed secrets, and the secure [first-administrator flow](/self-host/deploy-to-your-cloud/first-administrator).

--- a/packages/docs/start-here/pricing-and-licensing.mdx
+++ b/packages/docs/start-here/pricing-and-licensing.mdx
@@ -70,9 +70,10 @@ can and cannot move between tiers, and how the MIT conversion works — see
 
 ## Evaluating and pilots
 
-You can evaluate self-serve for free for 30 days — clone the repo, deploy in
-your own environment, and test at any scale. Need longer? Evaluation
-extensions are granted in writing —
+You can evaluate self-serve for free for 30 days. The [pull-only Docker Compose
+stack](/self-host/evaluate-with-docker-compose) is the quickest way to deploy
+the control plane in your own environment without cloning or building the
+repository. Need longer? Evaluation extensions are granted in writing —
 [ask us](mailto:sales@openworklabs.com). If you want a supported pilot
 instead (a dedicated engineering contact, deployment guidance, and response
 targets), [talk to sales](mailto:sales@openworklabs.com).

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -7,6 +7,10 @@ Most users just use the [desktop app](https://openworklabs.com/download). Self-h
 
 Want hosted workspaces, team Collections, or shared providers without running infra? Use [OpenWork Cloud](/cloud/get-started) instead. Rolling this out across a company? [Book a call](https://calendar.app.google/86QpCENvhfEzDFLu5) about [Enterprise](/cloud/enterprise).
 
+<Note>
+  Want to try the self-hosted control plane before planning production infrastructure? Start the [pull-only Docker Compose evaluation stack](/self-host/evaluate-with-docker-compose). It uses published images and does not require cloning or building the repository.
+</Note>
+
 ## What you deploy
 
 OpenWork is split into normal services:

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -1,5 +1,22 @@
 # OpenWork Host (Docker)
 
+## Pull-only evaluation stack
+
+Run Den API, Den web, and MySQL from published images without cloning or building the repository:
+
+```bash
+curl -fsSLo docker-compose.eval.yml \
+  https://raw.githubusercontent.com/different-ai/openwork/dev/packaging/docker/docker-compose.eval.yml
+umask 077
+printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
+  "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
+docker compose -f docker-compose.eval.yml up -d --wait
+```
+
+Open `http://localhost:3005` and create an account. See the [evaluation guide](../../packages/docs/self-host/evaluate-with-docker-compose.mdx) for configuration, LAN access, limitations, and cleanup.
+
+This stack is for evaluation only. It enables public signup, uses development credentials and HTTP, and does not provide production workers, sandboxes, or email delivery.
+
 ## Den local stack (Docker)
 
 One command for the Den control plane, local MySQL, and the cloud web app.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -6,7 +6,10 @@ Run Den API, Den web, and MySQL from published images without cloning or buildin
 
 ```bash
 curl -fsSLo docker-compose.eval.yml \
-  https://raw.githubusercontent.com/different-ai/openwork/dev/packaging/docker/docker-compose.eval.yml
+  https://raw.githubusercontent.com/different-ai/openwork/9f8645ebc482c15ab99c0cf155aabaa411e1ca6a/packaging/docker/docker-compose.eval.yml
+printf '%s  %s\n' \
+  '69cc7f2666157b7697ebf69b31b0c83887dd99e796c7d956f9ccaab8fa8bf2fc' \
+  'docker-compose.eval.yml' | shasum -a 256 --check
 umask 077
 printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
   "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -13,9 +13,9 @@ printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
 docker compose -f docker-compose.eval.yml up -d --wait
 ```
 
-Open `http://localhost:3005` and create an account. See the [evaluation guide](../../packages/docs/self-host/evaluate-with-docker-compose.mdx) for configuration, LAN access, limitations, and cleanup.
+Open `http://localhost:3005` and create an account. See the [evaluation guide](../../packages/docs/self-host/evaluate-with-docker-compose.mdx) for configuration, secure remote access, limitations, and cleanup.
 
-This stack is for evaluation only. It enables public signup, uses development credentials and HTTP, and does not provide production workers, sandboxes, or email delivery.
+This stack is for evaluation only. Its HTTP ports bind to loopback, but it still enables public signup, uses development credentials, and does not provide production workers, sandboxes, or email delivery.
 
 ## Den local stack (Docker)
 

--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -1,0 +1,114 @@
+# OpenWork evaluation stack — pull-only, one command:
+#
+#   docker compose -f docker-compose.eval.yml up -d --wait
+#
+# Then open http://localhost:3005 and sign up.
+#
+# No repo clone, no build, no launcher script. Uses the published GHCR images.
+# NOT a production posture: dev-grade MySQL credentials, stub worker provisioner,
+# no cloud sandboxes, no email delivery, public signup enabled by default.
+#
+# Knobs (all optional):
+#   OPENWORK_HOST          host/IP people will use in the browser   (default: localhost)
+#   OPENWORK_WEB_PORT      host port for the web app                (default: 3005)
+#   OPENWORK_API_PORT      host port for the Den API                (default: 8788)
+#   OPENWORK_AUTH_SECRET   Better Auth secret                       (default: eval-only value — change it)
+#   OPENWORK_ALLOW_SIGNUP  allow public signup for evaluation       (default: true)
+#   OPENWORK_VERSION       image tag                                (default: 0.18.37)
+
+name: openwork-eval
+
+services:
+  mysql:
+    image: mysql:8.4
+    command:
+      - --performance_schema=OFF
+      - --innodb-buffer-pool-size=128M
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: openwork_den
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -ppassword --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    volumes:
+      - openwork-eval-mysql:/var/lib/mysql
+    # intentionally no host port: MySQL stays internal to the compose network
+
+  den-migrate:
+    image: ghcr.io/different-ai/openwork-den-api:${OPENWORK_VERSION:-0.18.37}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: ["sh", "-lc"]
+    command: ["cd /app/ee/packages/den-db && (node ./dist/scripts/bootstrap.js || node --import tsx ./dist/scripts/bootstrap.js)"]
+    environment:
+      DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
+      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:-eval-only-den-db-encryption-key-0123456789}
+
+  den:
+    image: ghcr.io/different-ai/openwork-den-api:${OPENWORK_VERSION:-0.18.37}
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      den-migrate:
+        condition: service_completed_successfully
+    ports:
+      - "${OPENWORK_API_PORT:-8788}:8788"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8788/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    environment:
+      PORT: "8788"
+      DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
+      BETTER_AUTH_SECRET: ${OPENWORK_AUTH_SECRET:-eval-only-auth-secret-0123456789abcdef}
+      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:-eval-only-den-db-encryption-key-0123456789}
+      BETTER_AUTH_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      DEN_ORG_MODE: single_org
+      DEN_SINGLE_ORG_NAME: ${OPENWORK_ORG_NAME:-OpenWork Evaluation}
+      DEN_SINGLE_ORG_SLUG: default
+      DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: ${OPENWORK_ALLOW_SIGNUP:-true}
+      DEN_REQUIRE_EMAIL_VERIFICATION: "false"
+      DEN_API_PUBLIC_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}
+      DEN_MCP_RESOURCE_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}/mcp
+      CORS_ORIGINS: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
+      DEN_BETTER_AUTH_TRUSTED_ORIGINS: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
+      PROVISIONER_MODE: stub
+      WORKER_URL_TEMPLATE: https://workers.local/{workerId}
+
+  web:
+    image: ghcr.io/different-ai/openwork-den-web:${OPENWORK_VERSION:-0.18.37}
+    restart: unless-stopped
+    depends_on:
+      den:
+        condition: service_healthy
+    ports:
+      - "${OPENWORK_WEB_PORT:-3005}:3005"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3005/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 60s
+    environment:
+      # Browser-reachable API origin (what runtime-config hands to clients).
+      DEN_API_BASE: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}
+      # Container-internal fallback for server-side calls.
+      DEN_AUTH_FALLBACK_BASE: http://den:8788
+      DEN_AUTH_ORIGIN: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      DEN_WEB_PUBLIC_ORIGIN: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      DEN_WEB_OPENWORK_AUTH_CALLBACK_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      DEN_ORG_MODE: single_org
+      DEN_SINGLE_ORG_NAME: ${OPENWORK_ORG_NAME:-OpenWork Evaluation}
+      DEN_SINGLE_ORG_SLUG: default
+      DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: ${OPENWORK_ALLOW_SIGNUP:-true}
+
+volumes:
+  openwork-eval-mysql:

--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -1,5 +1,8 @@
-# OpenWork evaluation stack — pull-only, one command:
+# OpenWork evaluation stack — pull-only, no repository clone or build:
 #
+#   umask 077
+#   printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \
+#     "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
 #   docker compose -f docker-compose.eval.yml up -d --wait
 #
 # Then open http://localhost:3005 and sign up.
@@ -8,19 +11,22 @@
 # NOT a production posture: dev-grade MySQL credentials, stub worker provisioner,
 # no cloud sandboxes, no email delivery, public signup enabled by default.
 #
-# Knobs (all optional):
+# Required secrets:
+#   OPENWORK_AUTH_SECRET       Better Auth secret (at least 32 random characters)
+#   OPENWORK_DB_ENCRYPTION_KEY Den DB encryption key (at least 32 random characters)
+#
+# Optional knobs:
 #   OPENWORK_HOST          host/IP people will use in the browser   (default: localhost)
 #   OPENWORK_WEB_PORT      host port for the web app                (default: 3005)
 #   OPENWORK_API_PORT      host port for the Den API                (default: 8788)
-#   OPENWORK_AUTH_SECRET   Better Auth secret                       (default: eval-only value — change it)
 #   OPENWORK_ALLOW_SIGNUP  allow public signup for evaluation       (default: true)
-#   OPENWORK_VERSION       image tag                                (default: 0.18.37)
+#   OPENWORK_ORG_NAME      single organization name                 (default: OpenWork Evaluation)
 
 name: openwork-eval
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
     command:
       - --performance_schema=OFF
       - --innodb-buffer-pool-size=128M
@@ -38,7 +44,7 @@ services:
     # intentionally no host port: MySQL stays internal to the compose network
 
   den-migrate:
-    image: ghcr.io/different-ai/openwork-den-api:${OPENWORK_VERSION:-0.18.37}
+    image: ghcr.io/different-ai/openwork-den-api:0.18.37@sha256:5ae1fab94ae2badd49ae74649cfb38ca679a7afc7e9ae8926c927553a34caabd
     depends_on:
       mysql:
         condition: service_healthy
@@ -47,10 +53,10 @@ services:
     command: ["cd /app/ee/packages/den-db && (node ./dist/scripts/bootstrap.js || node --import tsx ./dist/scripts/bootstrap.js)"]
     environment:
       DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
-      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:-eval-only-den-db-encryption-key-0123456789}
+      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
 
   den:
-    image: ghcr.io/different-ai/openwork-den-api:${OPENWORK_VERSION:-0.18.37}
+    image: ghcr.io/different-ai/openwork-den-api:0.18.37@sha256:5ae1fab94ae2badd49ae74649cfb38ca679a7afc7e9ae8926c927553a34caabd
     restart: unless-stopped
     depends_on:
       mysql:
@@ -68,8 +74,8 @@ services:
     environment:
       PORT: "8788"
       DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
-      BETTER_AUTH_SECRET: ${OPENWORK_AUTH_SECRET:-eval-only-auth-secret-0123456789abcdef}
-      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:-eval-only-den-db-encryption-key-0123456789}
+      BETTER_AUTH_SECRET: ${OPENWORK_AUTH_SECRET:?Set OPENWORK_AUTH_SECRET to at least 32 random characters}
+      DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
       BETTER_AUTH_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
       DEN_ORG_MODE: single_org
       DEN_SINGLE_ORG_NAME: ${OPENWORK_ORG_NAME:-OpenWork Evaluation}
@@ -84,7 +90,7 @@ services:
       WORKER_URL_TEMPLATE: https://workers.local/{workerId}
 
   web:
-    image: ghcr.io/different-ai/openwork-den-web:${OPENWORK_VERSION:-0.18.37}
+    image: ghcr.io/different-ai/openwork-den-web:0.18.37@sha256:9ca96fb73bc3512852409f1508876e418cd56f6d5187ff4e0c683f5b69a2dda3
     restart: unless-stopped
     depends_on:
       den:

--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -16,7 +16,6 @@
 #   OPENWORK_DB_ENCRYPTION_KEY Den DB encryption key (at least 32 random characters)
 #
 # Optional knobs:
-#   OPENWORK_HOST          host/IP people will use in the browser   (default: localhost)
 #   OPENWORK_WEB_PORT      host port for the web app                (default: 3005)
 #   OPENWORK_API_PORT      host port for the Den API                (default: 8788)
 #   OPENWORK_ALLOW_SIGNUP  allow public signup for evaluation       (default: true)
@@ -64,7 +63,7 @@ services:
       den-migrate:
         condition: service_completed_successfully
     ports:
-      - "${OPENWORK_API_PORT:-8788}:8788"
+      - "127.0.0.1:${OPENWORK_API_PORT:-8788}:8788"
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8788/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 5s
@@ -76,16 +75,16 @@ services:
       DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
       BETTER_AUTH_SECRET: ${OPENWORK_AUTH_SECRET:?Set OPENWORK_AUTH_SECRET to at least 32 random characters}
       DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
-      BETTER_AUTH_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      BETTER_AUTH_URL: http://localhost:${OPENWORK_WEB_PORT:-3005}
       DEN_ORG_MODE: single_org
       DEN_SINGLE_ORG_NAME: ${OPENWORK_ORG_NAME:-OpenWork Evaluation}
       DEN_SINGLE_ORG_SLUG: default
       DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: ${OPENWORK_ALLOW_SIGNUP:-true}
       DEN_REQUIRE_EMAIL_VERIFICATION: "false"
-      DEN_API_PUBLIC_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}
-      DEN_MCP_RESOURCE_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}/mcp
-      CORS_ORIGINS: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
-      DEN_BETTER_AUTH_TRUSTED_ORIGINS: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
+      DEN_API_PUBLIC_URL: http://localhost:${OPENWORK_API_PORT:-8788}
+      DEN_MCP_RESOURCE_URL: http://localhost:${OPENWORK_API_PORT:-8788}/mcp
+      CORS_ORIGINS: http://localhost:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://localhost:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
+      DEN_BETTER_AUTH_TRUSTED_ORIGINS: http://localhost:${OPENWORK_WEB_PORT:-3005},http://127.0.0.1:${OPENWORK_WEB_PORT:-3005},http://localhost:${OPENWORK_API_PORT:-8788},http://127.0.0.1:${OPENWORK_API_PORT:-8788}
       PROVISIONER_MODE: stub
       WORKER_URL_TEMPLATE: https://workers.local/{workerId}
 
@@ -96,7 +95,7 @@ services:
       den:
         condition: service_healthy
     ports:
-      - "${OPENWORK_WEB_PORT:-3005}:3005"
+      - "127.0.0.1:${OPENWORK_WEB_PORT:-3005}:3005"
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3005/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 5s
@@ -105,12 +104,12 @@ services:
       start_period: 60s
     environment:
       # Browser-reachable API origin (what runtime-config hands to clients).
-      DEN_API_BASE: http://${OPENWORK_HOST:-localhost}:${OPENWORK_API_PORT:-8788}
+      DEN_API_BASE: http://localhost:${OPENWORK_API_PORT:-8788}
       # Container-internal fallback for server-side calls.
       DEN_AUTH_FALLBACK_BASE: http://den:8788
-      DEN_AUTH_ORIGIN: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
-      DEN_WEB_PUBLIC_ORIGIN: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
-      DEN_WEB_OPENWORK_AUTH_CALLBACK_URL: http://${OPENWORK_HOST:-localhost}:${OPENWORK_WEB_PORT:-3005}
+      DEN_AUTH_ORIGIN: http://localhost:${OPENWORK_WEB_PORT:-3005}
+      DEN_WEB_PUBLIC_ORIGIN: http://localhost:${OPENWORK_WEB_PORT:-3005}
+      DEN_WEB_OPENWORK_AUTH_CALLBACK_URL: http://localhost:${OPENWORK_WEB_PORT:-3005}
       DEN_ORG_MODE: single_org
       DEN_SINGLE_ORG_NAME: ${OPENWORK_ORG_NAME:-OpenWork Evaluation}
       DEN_SINGLE_ORG_SLUG: default


### PR DESCRIPTION
## Summary
- add a pull-only Docker Compose evaluation stack using published GHCR Den images
- pin MySQL, Den API, and Den web to immutable multi-architecture image digests
- require unique Better Auth and database encryption secrets instead of committed defaults
- run committed database migrations before starting Den API
- derive browser-reachable API and CORS origins from configurable host and ports
- keep MySQL internal to the Compose network and document evaluation-only limitations
- add a self-host evaluation guide, docs navigation, and links from the self-host, licensing, and Docker packaging docs

## Validation
- `OPENWORK_AUTH_SECRET=<32-char-value> OPENWORK_DB_ENCRYPTION_KEY=<32-char-value> docker compose -f packaging/docker/docker-compose.eval.yml config`
- confirmed Compose rejects configuration when required secrets are absent
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8'))"`
- `git diff --check`
- published image version `0.18.37` was previously exercised with clean migrations, health checks, and browser signup

## Notes
This is an evaluation stack, not a production deployment topology. It uses a stub worker provisioner, public signup by default, and does not provide cloud sandboxes or email delivery. No customer or personal information is included.