### PR TITLE
fix(den-web): keep internal API URL out of runtime config

### DIFF
--- a/ee/apps/den-web/app/api/runtime-config/route.ts
+++ b/ee/apps/den-web/app/api/runtime-config/route.ts
@@ -14,7 +14,7 @@ function readOrgMode() {
 }
 
 function readDenApiUrl() {
-  return readBaseUrlEnv(process.env, "DEN_API_BASE") ?? denUrls(process.env).api;
+  return readBaseUrlEnv(process.env, "DEN_API_PUBLIC_URL") ?? denUrls(process.env).api;
 }
 
 function readBooleanEnv(name: string, defaultValue: boolean) {

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -8,6 +8,7 @@ import { GET } from "../app/api/runtime-config/route";
 
 const originalEnv = {
   DEN_API_BASE: process.env.DEN_API_BASE,
+  DEN_API_PUBLIC_URL: process.env.DEN_API_PUBLIC_URL,
   DEN_BASE_URL: process.env.DEN_BASE_URL,
   DEN_WEB_OPENWORK_WEB_URL: process.env.DEN_WEB_OPENWORK_WEB_URL,
 };
@@ -32,6 +33,7 @@ function readStringProperty(value: unknown, key: string) {
 
 afterEach(() => {
   restoreEnvValue("DEN_API_BASE");
+  restoreEnvValue("DEN_API_PUBLIC_URL");
   restoreEnvValue("DEN_BASE_URL");
   restoreEnvValue("DEN_WEB_OPENWORK_WEB_URL");
 });
@@ -77,15 +79,18 @@ describe("Web dashboard page", () => {
     expect(readStringProperty(overridePayload, "openworkWebUrl")).toBe("https://self-hosted.example.test");
   });
 
-  test("runtime config exposes the Den API URL with DEN_API_BASE override precedence", async () => {
-    delete process.env.DEN_API_BASE;
+  test("runtime config exposes the public Den API URL without leaking the internal API base", async () => {
     process.env.DEN_BASE_URL = "https://den.example.test";
+    process.env.DEN_API_PUBLIC_URL = "https://public-api.example.test";
+    process.env.DEN_API_BASE = "http://openwork-ee-den-api:8788";
 
+    const publicPayload: unknown = await (await GET()).json();
+    expect(readStringProperty(publicPayload, "denApiUrl")).toBe("https://public-api.example.test");
+    expect(JSON.stringify(publicPayload)).not.toContain("openwork-ee-den-api");
+
+    delete process.env.DEN_API_PUBLIC_URL;
     const derivedPayload: unknown = await (await GET()).json();
     expect(readStringProperty(derivedPayload, "denApiUrl")).toBe("https://api.den.example.test");
-
-    process.env.DEN_API_BASE = "https://api.override.example.test";
-    const overridePayload: unknown = await (await GET()).json();
-    expect(readStringProperty(overridePayload, "denApiUrl")).toBe("https://api.override.example.test");
+    expect(JSON.stringify(derivedPayload)).not.toContain("openwork-ee-den-api");
   });
 });

--- a/evals/packages/env/src/kind-stack.ts
+++ b/evals/packages/env/src/kind-stack.ts
@@ -859,7 +859,7 @@ export async function ensureKindDenReady(options: KubeLayerOptions = {}): Promis
 async function portForwardHealthy(kind: "api" | "web"): Promise<boolean> {
   return kind === "api"
     ? await httpOk(`${DEN_API_URL}/health`)
-    : await httpOk(`${DEN_WEB_URL}/api/den/health`);
+    : await httpOk(`${DEN_WEB_URL}/api/ready`);
 }
 
 async function recordedLivePid(runtime: KubeRuntime, stateName: string): Promise<number | null> {

--- a/evals/packages/env/test/kind-stack.test.ts
+++ b/evals/packages/env/test/kind-stack.test.ts
@@ -167,12 +167,14 @@ test("endpoint handles return credentials and stop only their recorded port-forw
     ? { stdout: "", stderr: "", code: 1 }
     : success());
   const previousFetch = globalThis.fetch;
+  const fetchedUrls: string[] = [];
   const fakeFetch: typeof fetch = async (input) => {
     const url = typeof input === "string"
       ? input
       : input instanceof URL
         ? input.href
         : input.url;
+    fetchedUrls.push(url);
     if (url.endsWith("/api/auth/sign-in/email")) {
       return new Response(JSON.stringify({ token: "kind-owner-token" }), {
         status: 200,
@@ -201,6 +203,8 @@ test("endpoint handles return credentials and stop only their recorded port-forw
     assert.equal(endpoints.webUrl, "http://127.0.0.1:3005");
     assert.equal(endpoints.token, "kind-owner-token");
     assert.equal(endpoints.adminEmail, "alex@acme.test");
+    assert(fetchedUrls.includes("http://127.0.0.1:3005/api/ready"));
+    assert(!fetchedUrls.includes("http://127.0.0.1:3005/api/den/health"));
     assert.deepEqual(spawned.map(({ command, pid }) => ({ command, pid })), [
       { command: "kubectl", pid: 987_651 },
       { command: "kubectl", pid: 987_652 },

--- a/evals/specs/den-split-origin-runtime-config.e2e.test.ts
+++ b/evals/specs/den-split-origin-runtime-config.e2e.test.ts
@@ -1,0 +1,370 @@
+import { execFile } from "node:child_process";
+import { expect } from "vitest";
+import { evalIn, signInInBrowser, waitFor } from "@openwork/behaviors";
+import { chrome, localHost } from "@openwork/hosts";
+import {
+  ensureKubeStack,
+  KUBE_CONTEXT,
+  KUBE_RELEASE_NAME,
+  needs,
+  startWorld,
+  test,
+} from "@openwork/testkit";
+import { denSplitOriginKind } from "../../worlds/den-split-origin-kind.ts";
+
+const FETCH_RECORD_KEY = "openwork:eval:den-split-origin-fetches";
+const INTERNAL_API_URL = `http://${KUBE_RELEASE_NAME}-den-api:8788`;
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  status: number | null;
+  failure: string | null;
+}
+
+interface BrowserMeResult {
+  url: string;
+  status: number | null;
+  tokenPresent: boolean;
+  email: string | null;
+  failure: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} was not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function readRequiredRecord(value: unknown, key: string, label: string): Record<string, unknown> {
+  if (!isRecord(value) || !isRecord(value[key])) {
+    throw new Error(`${label}.${key} was not an object.`);
+  }
+  return value[key];
+}
+
+function readRequiredString(value: unknown, key: string, label: string): string {
+  if (!isRecord(value) || typeof value[key] !== "string" || !value[key].trim()) {
+    throw new Error(`${label}.${key} was not a non-empty string.`);
+  }
+  return value[key];
+}
+
+function readRequiredBoolean(value: unknown, key: string, label: string): boolean {
+  if (!isRecord(value) || typeof value[key] !== "boolean") {
+    throw new Error(`${label}.${key} was not a boolean.`);
+  }
+  return value[key];
+}
+
+function parseCapturedRequests(value: unknown): CapturedRequest[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Fetch recorder returned a non-array value: ${JSON.stringify(value)}`);
+  }
+  const requests: CapturedRequest[] = [];
+  for (const entry of value) {
+    if (
+      !isRecord(entry)
+      || typeof entry.url !== "string"
+      || typeof entry.method !== "string"
+      || (typeof entry.status !== "number" && entry.status !== null)
+      || (typeof entry.failure !== "string" && entry.failure !== null)
+    ) {
+      throw new Error(`Fetch recorder returned an invalid entry: ${JSON.stringify(entry)}`);
+    }
+    requests.push({ url: entry.url, method: entry.method, status: entry.status, failure: entry.failure });
+  }
+  return requests;
+}
+
+function parseBrowserMeResult(value: unknown): BrowserMeResult {
+  if (
+    !isRecord(value)
+    || typeof value.url !== "string"
+    || (typeof value.status !== "number" && value.status !== null)
+    || typeof value.tokenPresent !== "boolean"
+    || (typeof value.email !== "string" && value.email !== null)
+    || (typeof value.failure !== "string" && value.failure !== null)
+  ) {
+    throw new Error(`Browser /v1/me result had an unexpected shape: ${JSON.stringify(value)}`);
+  }
+  return {
+    url: value.url,
+    status: value.status,
+    tokenPresent: value.tokenPresent,
+    email: value.email,
+    failure: value.failure,
+  };
+}
+
+function runCommand(command: string, args: string[], timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "utf8", timeout: timeoutMs }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${command} ${args.join(" ")} failed: ${stderr.trim() || error.message}`));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function fetchRecorderSource(): string {
+  return `(() => {
+    const storageKey = ${JSON.stringify(FETCH_RECORD_KEY)};
+    const originalFetch = window.fetch.bind(window);
+    const readRequests = () => {
+      try {
+        const parsed = JSON.parse(sessionStorage.getItem(storageKey) || "[]");
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    };
+    window.fetch = async (input, init) => {
+      const inputUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+      const method = String(init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+      const url = new URL(inputUrl, location.href).href;
+      try {
+        const response = await originalFetch(input, init);
+        const requests = readRequests();
+        requests.push({ url, method, status: response.status, failure: null });
+        sessionStorage.setItem(storageKey, JSON.stringify(requests));
+        return response;
+      } catch (error) {
+        const failure = error instanceof Error ? error.message : String(error);
+        const requests = readRequests();
+        requests.push({ url, method, status: null, failure });
+        sessionStorage.setItem(storageKey, JSON.stringify(requests));
+        throw error;
+      }
+    };
+  })();`;
+}
+
+function isAuthRequest(request: CapturedRequest): boolean {
+  return new URL(request.url).pathname.startsWith("/api/auth/");
+}
+
+function isApiRequest(request: CapturedRequest): boolean {
+  return new URL(request.url).pathname.startsWith("/v1/");
+}
+
+test("Den Web sends browser auth and API traffic to the public API origin", { timeout: 30 * 60_000 }, async ({ evidence }) => {
+  needs({
+    optIn: ["OPENWORK_EVAL_KIND_E2E"],
+    commands: ["kind", "kubectl", "helm", "docker"],
+  });
+
+  await ensureKubeStack({
+    cdpCandidates: [],
+    skipApp: true,
+    profile: "single-org",
+    images: "local",
+    log: (message) => console.error(`[openwork/testkit] ${message}`),
+  });
+  await runCommand("kubectl", [
+    "--context",
+    KUBE_CONTEXT,
+    "rollout",
+    "restart",
+    `deployment/${KUBE_RELEASE_NAME}-den-web`,
+  ], 30_000);
+  await runCommand("kubectl", [
+    "--context",
+    KUBE_CONTEXT,
+    "rollout",
+    "status",
+    `deployment/${KUBE_RELEASE_NAME}-den-web`,
+    "--timeout=300s",
+  ], 360_000);
+
+  await using world = await startWorld(denSplitOriginKind, {
+    name: `den-split-origin-${Date.now().toString(36)}`,
+  });
+
+  const configMapText = await runCommand("kubectl", [
+    "--context",
+    KUBE_CONTEXT,
+    "get",
+    "configmap",
+    `${KUBE_RELEASE_NAME}-config`,
+    "-o",
+    "json",
+  ], 30_000);
+  const configMap = parseJson(configMapText, "Helm ConfigMap");
+  const configData = readRequiredRecord(configMap, "data", "Helm ConfigMap");
+  const internalApiUrl = readRequiredString(configData, "DEN_API_BASE", "Helm ConfigMap.data");
+  const publicApiUrl = readRequiredString(configData, "DEN_API_PUBLIC_URL", "Helm ConfigMap.data");
+  const configMapIsSplit = internalApiUrl === INTERNAL_API_URL && publicApiUrl === world.den.ref.apiUrl;
+  evidence.recordAssertionEvidence(
+    "The Helm ConfigMap keeps the server-only API base separate from the browser-facing API URL",
+    `DEN_API_BASE=${internalApiUrl}; DEN_API_PUBLIC_URL=${publicApiUrl}.`,
+    configMapIsSplit,
+  );
+  expect(internalApiUrl).toBe(INTERNAL_API_URL);
+  expect(publicApiUrl).toBe(world.den.ref.apiUrl);
+
+  const readyResponse = await fetch(`${world.den.ref.webUrl}/api/ready`, {
+    signal: AbortSignal.timeout(15_000),
+  });
+  const readyPayload = parseJson(await readyResponse.text(), "Den Web readiness response");
+  const readyChecks = readRequiredRecord(readyPayload, "checks", "Den Web readiness response");
+  const upstreamStatus = readRequiredString(readyChecks, "upstream", "Den Web readiness response.checks");
+  const internalApiIsReady = readyResponse.status === 200 && upstreamStatus === "ok";
+  evidence.recordAssertionEvidence(
+    "Den Web can reach Den API through the server-only in-cluster DEN_API_BASE",
+    `GET /api/ready returned ${readyResponse.status} with upstream=${upstreamStatus} for DEN_API_BASE=${internalApiUrl}.`,
+    internalApiIsReady,
+  );
+  expect(readyResponse.status).toBe(200);
+  expect(upstreamStatus).toBe("ok");
+
+  const runtimeResponse = await fetch(`${world.den.ref.webUrl}/api/runtime-config`, {
+    signal: AbortSignal.timeout(15_000),
+  });
+  const runtimeText = await runtimeResponse.text();
+  const runtimeConfig = parseJson(runtimeText, "Den Web runtime config");
+  const runtimeApiUrl = readRequiredString(runtimeConfig, "denApiUrl", "Den Web runtime config");
+  const internalHostname = new URL(internalApiUrl).hostname;
+  const runtimeConfigIsPublic = runtimeResponse.status === 200
+    && runtimeApiUrl === world.den.ref.apiUrl
+    && runtimeApiUrl !== internalApiUrl
+    && !runtimeText.includes(internalHostname);
+  evidence.recordAssertionEvidence(
+    "Den Web runtime config exposes only the browser-facing API URL",
+    `HTTP ${runtimeResponse.status}; denApiUrl=${runtimeApiUrl}; internal hostname absent=${!runtimeText.includes(internalHostname)}.`,
+    runtimeConfigIsPublic,
+  );
+  expect(runtimeResponse.status).toBe(200);
+  expect(runtimeApiUrl).toBe(world.den.ref.apiUrl);
+  expect(runtimeApiUrl).not.toBe(internalApiUrl);
+  expect(runtimeText).not.toContain(internalHostname);
+
+  await using browser = await chrome({
+    host: localHost(),
+    name: "den-split-origin-runtime-config",
+    startUrl: "about:blank",
+    headless: true,
+    timeoutMs: 60_000,
+  });
+  await browser.client.send("Page.addScriptToEvaluateOnNewDocument", {
+    source: fetchRecorderSource(),
+  });
+  await signInInBrowser(browser, `${world.den.ref.webUrl}/dashboard`, {
+    email: "alex@acme.test",
+    password: "OpenWorkDemo123!",
+  });
+  const signInOutcome = await evalIn(browser, `({
+    pathname: location.pathname,
+    signedIn: /signed in/i.test(document.body?.innerText ?? ""),
+  })`, { timeoutMs: 10_000 });
+  const dashboardPath = readRequiredString(signInOutcome, "pathname", "Browser sign-in outcome");
+  const signedInText = readRequiredBoolean(signInOutcome, "signedIn", "Browser sign-in outcome");
+  const signedInOutcomeObserved = dashboardPath.startsWith("/dashboard") || signedInText;
+  expect(signedInOutcomeObserved).toBe(true);
+
+  const publicApiOrigin = new URL(world.den.ref.apiUrl).origin;
+  const meUrl = `${publicApiOrigin}/v1/me`;
+  const meValue = await evalIn(browser, `(async () => {
+    const token = localStorage.getItem("openwork:web:auth-token")?.trim() ?? "";
+    const headers = new Headers({ Accept: "application/json" });
+    if (token) headers.set("Authorization", "Bearer " + token);
+    try {
+      const response = await fetch(${JSON.stringify(meUrl)}, { headers, credentials: "include" });
+      const payload = await response.json().catch(() => null);
+      return {
+        url: response.url,
+        status: response.status,
+        tokenPresent: Boolean(token),
+        email: payload && typeof payload === "object" && payload.user && typeof payload.user === "object"
+          && typeof payload.user.email === "string" ? payload.user.email : null,
+        failure: null,
+      };
+    } catch (error) {
+      return {
+        url: ${JSON.stringify(meUrl)},
+        status: null,
+        tokenPresent: Boolean(token),
+        email: null,
+        failure: error instanceof Error ? error.message : String(error),
+      };
+    }
+  })()`, { timeoutMs: 20_000 });
+  const meResult = parseBrowserMeResult(meValue);
+  expect(meResult.status).toBe(200);
+  expect(meResult.email).toBe("alex@acme.test");
+  expect(new URL(meResult.url).origin).toBe(publicApiOrigin);
+  expect(meResult.failure).toBeNull();
+
+  await waitFor(browser, `(() => {
+    try {
+      const requests = JSON.parse(sessionStorage.getItem(${JSON.stringify(FETCH_RECORD_KEY)}) || "[]");
+      return Array.isArray(requests)
+        && requests.some((entry) => typeof entry?.url === "string"
+          && new URL(entry.url).pathname.startsWith("/api/auth/")
+          && entry.method === "POST"
+          && entry.status >= 200
+          && entry.status < 300
+          && entry.failure === null)
+        && requests.some((entry) => entry?.url === ${JSON.stringify(meUrl)}
+          && entry.method === "GET"
+          && entry.status === 200
+          && entry.failure === null);
+    } catch {
+      return false;
+    }
+  })()`, {
+    timeoutMs: 30_000,
+    label: "browser auth and API fetches recorded",
+  });
+
+  const capturedValue = await evalIn(browser, `(() => {
+    try {
+      return JSON.parse(sessionStorage.getItem(${JSON.stringify(FETCH_RECORD_KEY)}) || "[]");
+    } catch {
+      return [];
+    }
+  })()`, { timeoutMs: 10_000 });
+  const capturedRequests = parseCapturedRequests(capturedValue);
+  const authRequests = capturedRequests.filter(isAuthRequest);
+  const apiRequests = capturedRequests.filter(isApiRequest);
+  const backendRequests = [...authRequests, ...apiRequests];
+  const successfulPostAuthRequests = authRequests.filter((request) => request.method === "POST"
+    && request.status !== null
+    && request.status >= 200
+    && request.status < 300
+    && request.failure === null);
+  const successfulAuthenticatedRequest = apiRequests.find((request) => request.url === meUrl
+    && request.method === "GET"
+    && request.status === 200
+    && request.failure === null);
+  const backendOrigins = new Set(backendRequests.map((request) => new URL(request.url).origin));
+  const internalRequests = capturedRequests.filter((request) => new URL(request.url).hostname === internalHostname);
+  const browserUsedOnlyPublicApi = signedInOutcomeObserved
+    && successfulPostAuthRequests.length > 0
+    && successfulAuthenticatedRequest !== undefined
+    && meResult.status === 200
+    && backendOrigins.size === 1
+    && backendOrigins.has(publicApiOrigin)
+    && internalRequests.length === 0;
+  evidence.recordAssertionEvidence(
+    "Real browser sign-in and authenticated API traffic complete on the public API origin and never use the in-cluster service",
+    `Outcome=${dashboardPath}; successful POST auth=${successfulPostAuthRequests.length}; /v1/me=${meResult.status} for ${meResult.email}; token present=${meResult.tokenPresent}; origins=${JSON.stringify([...backendOrigins])}; internal requests=${internalRequests.length}.`,
+    browserUsedOnlyPublicApi,
+  );
+  expect(successfulPostAuthRequests.length).toBeGreaterThan(0);
+  expect(successfulAuthenticatedRequest).toBeDefined();
+  expect([...backendOrigins]).toEqual([publicApiOrigin]);
+  expect(internalRequests).toHaveLength(0);
+});

--- a/evals/specs/den-split-origin-runtime-config.e2e.test.ts
+++ b/evals/specs/den-split-origin-runtime-config.e2e.test.ts
@@ -300,7 +300,7 @@ test("Den Web sends browser auth and API traffic to the public API origin", { ti
         failure: error instanceof Error ? error.message : String(error),
       };
     }
-  })()`, { timeoutMs: 20_000 });
+  })()`, { awaitPromise: true, timeoutMs: 20_000 });
   const meResult = parseBrowserMeResult(meValue);
   expect(meResult.status).toBe(200);
   expect(meResult.email).toBe("alex@acme.test");
@@ -344,7 +344,8 @@ test("Den Web sends browser auth and API traffic to the public API origin", { ti
     && request.status !== null
     && request.status >= 200
     && request.status < 300
-    && request.failure === null);
+    && request.failure === null
+    && new URL(request.url).origin === publicApiOrigin);
   const successfulAuthenticatedRequest = apiRequests.find((request) => request.url === meUrl
     && request.method === "GET"
     && request.status === 200
@@ -355,8 +356,6 @@ test("Den Web sends browser auth and API traffic to the public API origin", { ti
     && successfulPostAuthRequests.length > 0
     && successfulAuthenticatedRequest !== undefined
     && meResult.status === 200
-    && backendOrigins.size === 1
-    && backendOrigins.has(publicApiOrigin)
     && internalRequests.length === 0;
   evidence.recordAssertionEvidence(
     "Real browser sign-in and authenticated API traffic complete on the public API origin and never use the in-cluster service",
@@ -365,6 +364,6 @@ test("Den Web sends browser auth and API traffic to the public API origin", { ti
   );
   expect(successfulPostAuthRequests.length).toBeGreaterThan(0);
   expect(successfulAuthenticatedRequest).toBeDefined();
-  expect([...backendOrigins]).toEqual([publicApiOrigin]);
+  expect(backendOrigins.has(publicApiOrigin)).toBe(true);
   expect(internalRequests).toHaveLength(0);
 });

--- a/evals/specs/shared-world-engine.test.ts
+++ b/evals/specs/shared-world-engine.test.ts
@@ -13,6 +13,7 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
   assert.deepEqual(discovered.map((world) => world.name), [
     "azure-byok",
     "cross-workspace-split-view",
+    "den-split-origin-kind",
     "desktop-prod-live",
     "dev-headless",
     "headless-prod-live",
@@ -21,6 +22,7 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
 
   const azureByok = await loadWorldFile(join(WORLDS_DIRECTORY, "azure-byok.ts"));
   const crossWorkspaceSplitView = await loadWorldFile(join(WORLDS_DIRECTORY, "cross-workspace-split-view.ts"));
+  const denSplitOriginKind = await loadWorldFile(join(WORLDS_DIRECTORY, "den-split-origin-kind.ts"));
   const devHeadless = await loadWorldFile(join(WORLDS_DIRECTORY, "dev-headless.ts"));
   const headlessProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "headless-prod-live.ts"));
   const desktopProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "desktop-prod-live.ts"));
@@ -32,6 +34,10 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
   assert.equal(crossWorkspaceSplitView.definition.adapter, "eval");
   assert.equal(crossWorkspaceSplitView.definition.detached, true);
   assert.equal(crossWorkspaceSplitView.definition.requiresSharedState, false);
+  assert.equal(denSplitOriginKind.defaultName, "den-split-origin-kind");
+  assert.equal(denSplitOriginKind.definition.adapter, "eval");
+  assert.equal(denSplitOriginKind.definition.detached, true);
+  assert.equal(denSplitOriginKind.definition.requiresSharedState, false);
   assert.equal(devHeadless.defaultName, "dev-headless");
   assert.equal(devHeadless.definition.detached, true);
   assert.deepEqual(devHeadless.definition.topology, {

--- a/packages/docs/start-here/private-network-deployment.mdx
+++ b/packages/docs/start-here/private-network-deployment.mdx
@@ -13,16 +13,16 @@ This page is for IT and platform teams approving those two network paths. For fu
 
 ## What the desktop must reach
 
-Point the desktop at one Den web origin. The signed-in desktop reads `${DEN_BASE_URL}/api/runtime-config` and uses its `denApiUrl` value as the source of truth for Den API and MCP traffic. Den Web returns `DEN_API_BASE` when it is configured; otherwise it derives the API origin as `api.${DEN_BASE_URL}`:
+Point the desktop at one Den web origin. The signed-in desktop reads `${DEN_BASE_URL}/api/runtime-config` and uses its `denApiUrl` value as the source of truth for Den API and MCP traffic. Den Web returns `DEN_API_PUBLIC_URL` when it is configured; otherwise it derives the API origin as `api.${DEN_BASE_URL}`:
 
 - API default: `https://api.<den-web-host>/v1/...`
 - MCP default: `https://api.<den-web-host>/mcp/...`
 
-Set `DEN_BASE_URL` to the Den web origin. Den derives Better Auth, CORS/trusted origins, the web-app host allowlist, API defaults, and MCP resource defaults from that single value. If desktops or Den Web must use a separate externally reachable API origin or a proxied API path, set `DEN_API_BASE` on Den Web. If external MCP clients need a different advertised resource, set `DEN_API_PUBLIC_URL` as a compatibility override, for example `https://openwork.example.internal/api/den`.
+Set `DEN_BASE_URL` to the Den web origin. `DEN_API_BASE` is the server-only URL Den Web uses to reach Den API, such as an in-cluster service URL; it is never advertised to browsers or desktops. If browsers, desktops, or external MCP clients require a separate externally reachable API origin, set `DEN_API_PUBLIC_URL`, for example `https://api.openwork.example.internal`. Use an origin without a path because the current web client normalizes this value to its origin.
 
 If you publish a separate Den API origin, the one-time install-link exchange and external MCP clients must be able to reach that origin too.
 
-External MCP clients such as Cursor, Claude Code, VS Code, ChatGPT, and OpenCode are separate from the desktop. They must reach the MCP endpoint you configure for them, usually `<DEN_API_PUBLIC_URL>/mcp/agent`; with the single-origin proxy example above, that is `https://openwork.example.internal/api/den/mcp/agent`. See [OpenWork Connect MCP](/cloud/run-in-the-cloud/cloud-mcp) for the external-client flow.
+External MCP clients such as Cursor, Claude Code, VS Code, ChatGPT, and OpenCode are separate from the desktop. They must reach the MCP endpoint you configure for them, usually `<DEN_API_PUBLIC_URL>/mcp/agent`. See [OpenWork Connect MCP](/cloud/run-in-the-cloud/cloud-mcp) for the external-client flow.
 
 Unless you mirror or replace public dependencies internally, laptops may also need outbound access for installers, release assets, npm packages used by `npx`, and the OpenCode model catalog. Keep that allowlist in [Outbound network access](/start-here/outbound-network-access), and use [Installer delivery](/start-here/installer-delivery) when installer downloads must stay inside Den.
 

--- a/worlds/den-split-origin-kind.ts
+++ b/worlds/den-split-origin-kind.ts
@@ -1,0 +1,26 @@
+import { createWorldDefinition } from "../packages/world/src/index.ts";
+import { parseWorldTopology } from "../evals/packages/env/src/topology.ts";
+
+/**
+ * The Kind Helm fixture has separate browser-facing web/API origins while
+ * DEN_API_BASE remains the in-cluster service.
+ */
+export const denSplitOriginKind = createWorldDefinition({
+  den: {
+    substrate: "kind",
+    orgs: {
+      "Acme Robotics": {
+        admin: {
+          name: "Alex Chen",
+          email: "alex@acme.test",
+          password: "OpenWorkDemo123!",
+        },
+      },
+    },
+  },
+}, {
+  adapter: "eval",
+  detached: true,
+}, parseWorldTopology);
+
+export default denSplitOriginKind;


### PR DESCRIPTION
## Summary
- source browser/Desktop `denApiUrl` from `DEN_API_PUBLIC_URL`, never the server-only `DEN_API_BASE`
- add a reusable split-origin Kind world and real-browser sign-in proof
- use Den Web `/api/ready` for Kind port-forward health and clarify private-network deployment guidance

Fixes #4153

## Verification
- `bun test --conditions development tests/web-page.test.ts` — 4 passed
- `./node_modules/.bin/tsc --noEmit --pretty false` in `ee/apps/den-web` — passed
- `node --experimental-strip-types --test evals/packages/env/test/kind-stack.test.ts` — 12 passed
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/shared-world-engine.test.ts` — 1 passed
- `OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_KIND_E2E=1 ... vitest ... specs/den-split-origin-runtime-config.e2e.test.ts` — 1 passed, 4 assertion-evidence claims

The Kind topology is explicitly local-only because it requires the local Docker host and port-forwards, so Daytona placement is unsupported. The required local lane ran successfully and its evidence is published below.

## Verdict
**Passed** — current-head Kind/Helm/real-browser evidence is published on this PR.