### PR TITLE
fix(evals): reset dirty Daytona snapshots before checkout

### DIFF
--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -135,7 +135,7 @@ if [ -n "${OPENWORK_DEN_URLS_FILE:-}" ]; then
 fi
 
 echo "==> Checking out $REF..."
-daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$REF\"; FORCE_INSTALL=\"$FORCE_INSTALL\"; if git fetch origin \"\$REF\"; then git checkout --detach FETCH_HEAD; else git fetch origin dev --depth 50 || true; git checkout \"\$REF\"; fi; git rev-parse --short HEAD; if [ \"\$FORCE_INSTALL\" = 1 ]; then rm -f .openwork-daytona/pnpm-lock.sha256 .openwork-daytona/den-web-build.tree .openwork-daytona/den-api-assets.tree; fi'"
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$REF\"; FORCE_INSTALL=\"$FORCE_INSTALL\"; git reset --hard HEAD; if git fetch origin \"\$REF\"; then git checkout --detach FETCH_HEAD; else git fetch origin dev --depth 50 || true; git checkout \"\$REF\"; fi; git rev-parse --short HEAD; if [ \"\$FORCE_INSTALL\" = 1 ]; then rm -f .openwork-daytona/pnpm-lock.sha256 .openwork-daytona/den-web-build.tree .openwork-daytona/den-api-assets.tree; fi'"
 
 echo "==> Uploading server start script..."
 START_SCRIPT_B64="$(base64 < "$ROOT_DIR/.devcontainer/start-daytona-server.sh" | tr -d '\n')"

--- a/evals/specs/daytona-snapshot-checkout.test.ts
+++ b/evals/specs/daytona-snapshot-checkout.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join, resolve } from "node:path"
+import { tmpdir } from "node:os"
+import { expect } from "vitest"
+import { test } from "@openwork/testkit"
+
+const repoRoot = resolve(import.meta.dirname, "../..")
+
+test("Daytona snapshot checkout discards tracked changes but preserves untracked caches", ({ evidence }) => {
+  const script = readFileSync(resolve(repoRoot, ".devcontainer/test-server-on-daytona.sh"), "utf8")
+  const reset = "git reset --hard HEAD"
+  const checkout = "git checkout --detach FETCH_HEAD"
+
+  expect(script).toContain(reset)
+  expect(script.indexOf(reset)).toBeLessThan(script.indexOf(checkout))
+
+  const workspace = mkdtempSync(join(tmpdir(), "openwork-daytona-snapshot-"))
+  const generatedFile = join(workspace, "next-env.d.ts")
+  const cacheFile = join(workspace, "node_modules", ".cache", "marker")
+
+  try {
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: workspace, encoding: "utf8" }).trim()
+    git("init", "--quiet")
+    git("config", "user.name", "OpenWork Test")
+    git("config", "user.email", "test@openwork.local")
+    writeFileSync(generatedFile, "snapshot\n")
+    git("add", "next-env.d.ts")
+    git("commit", "--quiet", "-m", "snapshot")
+    writeFileSync(generatedFile, "requested ref\n")
+    git("commit", "--quiet", "-am", "requested ref")
+    const requestedRef = git("rev-parse", "HEAD")
+    git("checkout", "--quiet", "--detach", "HEAD~1")
+
+    writeFileSync(generatedFile, "generated dirty change\n")
+    mkdirSync(resolve(cacheFile, ".."), { recursive: true })
+    writeFileSync(cacheFile, "keep\n")
+
+    git("reset", "--hard", "HEAD")
+    git("checkout", "--quiet", "--detach", requestedRef)
+
+    expect(readFileSync(generatedFile, "utf8")).toBe("requested ref\n")
+    expect(readFileSync(cacheFile, "utf8")).toBe("keep\n")
+    expect(git("status", "--short")).toBe("?? node_modules/")
+    evidence.recordAssertionEvidence(
+      "Dirty Daytona snapshots can check out the requested ref without deleting dependency caches",
+      "The checkout resets tracked generated changes first, reaches the requested commit, and leaves an untracked node_modules cache intact.",
+      true,
+    )
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- reset tracked snapshot changes before checking out the requested Daytona server ref
- preserve untracked dependency and build caches
- add deterministic testkit coverage for the dirty-snapshot checkout contract

## Root cause
Nightly run https://github.com/different-ai/openwork/actions/runs/33043484788/job/98422094508 failed because the `openwork-server` snapshot contained a generated tracked change to `ee/apps/den-web/next-env.d.ts`, so `git checkout --detach FETCH_HEAD` aborted.

## Verification
- `PATH="/Users/benjaminshafii/.nvm/versions/node/v24.15.0/bin:$PATH" pnpm evals:pr specs/daytona-snapshot-checkout.test.ts` — Passed: 1 file, 1 test, 0 skipped
- local deterministic lane; the spec reproduces the tracked-dirty checkout and verifies the untracked cache remains intact