### PR TITLE
feat(world): add Daytona k3s network primitives

### DIFF
--- a/evals/packages/env/src/daytona-k3s.ts
+++ b/evals/packages/env/src/daytona-k3s.ts
@@ -282,6 +282,7 @@ function serverArgs(paths: DaytonaK3sRuntimePaths, placementId: string): string[
     "--write-kubeconfig", paths.kubeconfig,
     "--write-kubeconfig-mode", "0644",
     "--node-name", `openwork-${placementId}`,
+    "--snapshotter", "native",
   ];
 }
 

--- a/evals/packages/env/src/daytona-k3s.ts
+++ b/evals/packages/env/src/daytona-k3s.ts
@@ -215,7 +215,9 @@ export function daytonaK3sPreviewArgv(ownedSandboxId: string, port: number, expi
 
 export function parseDaytonaK3sPreviewUrl(stdout: string): string {
   for (const match of stdout.matchAll(/https:\/\/[^\s"'<>]+/g)) {
-    const candidate = match[0].replace(/[.,;:]+$/, "");
+    let end = match[0].length;
+    while (end > 0 && ".,;:".includes(match[0][end - 1] ?? "")) end -= 1;
+    const candidate = match[0].slice(0, end);
     try {
       const parsed = new URL(candidate);
       if (parsed.protocol === "https:" && parsed.hostname) return candidate;

--- a/evals/packages/env/src/daytona-k3s.ts
+++ b/evals/packages/env/src/daytona-k3s.ts
@@ -1,0 +1,513 @@
+import { checkedExec, defaultDaytonaExec, deleteSandboxes } from "@openwork/hosts";
+import type { DaytonaExec, DaytonaExecResult } from "@openwork/hosts";
+import { placementHasCapability } from "./network-world.ts";
+import type { Placement } from "./network-world.ts";
+
+const PLACEMENT_ID = /^[a-z][a-z0-9-]{0,62}$/;
+const SANDBOX_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const KUBERNETES_NAME = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const HELM_RELEASE = /^[a-z0-9](?:[a-z0-9-]{0,51}[a-z0-9])?$/;
+const K3S_VERSION = /^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const RUNTIME_BASE = "/tmp/openwork-world-k3s";
+const MAX_PREVIEW_EXPIRY_SECONDS = 86_400;
+const TOOL_TIMEOUT_MS = 120_000;
+
+export interface K3sBinaryDescriptor {
+  /** Immutable official k3s release version, for example v1.31.6+k3s1. */
+  version: string;
+  /** HTTPS URL for the exact architecture-specific release binary. */
+  url: string;
+  /** Required lowercase SHA-256 digest for the bytes at url. */
+  sha256: string;
+}
+
+export interface CreateDaytonaK3sClusterInput {
+  placement: Placement;
+  /**
+   * An already-created, dedicated sandbox whose ownership is transferred to
+   * this cluster. It WILL BE DELETED on stop/dispose and every partial startup
+   * failure. It must not contain any other workload or reusable state.
+   */
+  ownedSandboxId: string;
+  binary: K3sBinaryDescriptor;
+  exec?: DaytonaExec;
+  log?: (message: string) => void;
+}
+
+export interface DaytonaK3sRuntimePaths {
+  readonly root: string;
+  readonly binary: string;
+  readonly download: string;
+  readonly dataDir: string;
+  readonly kubeconfig: string;
+  readonly serverLog: string;
+}
+
+/** Owns a dedicated sandbox that stop or AsyncDispose WILL DELETE in full. */
+export interface DaytonaK3sClusterHandle extends AsyncDisposable {
+  readonly placement: Placement;
+  readonly ownedSandboxId: string;
+  readonly binary: K3sBinaryDescriptor;
+  readonly paths: DaytonaK3sRuntimePaths;
+  /** Deletes the entire dedicated sandbox, including every listener and preview. */
+  stop(): Promise<void>;
+  kubectl(args: readonly string[]): Promise<DaytonaExecResult>;
+  helm(args: readonly string[]): Promise<DaytonaExecResult>;
+}
+
+export interface InstallK3sHelmReleaseInput {
+  release: string;
+  namespace: string;
+  chart: string;
+}
+
+export interface ExposeK3sServiceInput {
+  namespace: string;
+  service: string;
+  localPort: number;
+  servicePort: number;
+  expiresInSeconds: number;
+}
+
+/** A signed URL valid only until its expiry or deletion of the owning cluster. */
+export interface DaytonaK3sServiceExposure {
+  readonly placementId: string;
+  readonly ownedSandboxId: string;
+  readonly namespace: string;
+  readonly service: string;
+  readonly localPort: number;
+  readonly servicePort: number;
+  readonly url: string;
+  readonly expiresAt: string;
+  readonly expiresInSeconds: number;
+  readonly ephemeral: true;
+  readonly persistableInDesktopConfig: false;
+  readonly validUntil: "cluster-disposal-or-expiry";
+}
+
+type PrivilegeMode = "root" | "sudo";
+
+interface ClusterRuntime {
+  exec: DaytonaExec;
+  ownedSandboxId: string;
+  paths: DaytonaK3sRuntimePaths;
+  privilege: PrivilegeMode;
+  reservedPorts: Set<number>;
+  assertActive(): void;
+  dispose(): Promise<void>;
+}
+
+const clusterRuntimes = new WeakMap<DaytonaK3sClusterHandle, ClusterRuntime>();
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function shellCommand(command: string, args: readonly string[]): string {
+  return [command, ...args].map(shellQuote).join(" ");
+}
+
+function privilegedCommand(mode: PrivilegeMode, command: string, args: readonly string[]): string {
+  return mode === "root"
+    ? shellCommand(command, args)
+    : shellCommand("sudo", ["-n", command, ...args]);
+}
+
+function requirePlacement(placement: Placement): void {
+  if (!PLACEMENT_ID.test(placement.id)) {
+    throw new Error(`Daytona k3s placement id ${JSON.stringify(placement.id)} must match ${PLACEMENT_ID.source}.`);
+  }
+  if (placement.provider !== "daytona-k3s") {
+    throw new Error(`Daytona k3s requires placement provider "daytona-k3s"; received ${JSON.stringify(placement.provider)}.`);
+  }
+  if (!placementHasCapability(placement, "kubernetes:k3s")) {
+    throw new Error(`Daytona k3s placement ${JSON.stringify(placement.id)} is missing capability kubernetes:k3s.`);
+  }
+}
+
+function requireOwnedSandboxId(value: string): string {
+  if (!SANDBOX_ID.test(value)) {
+    throw new Error(`Daytona ownedSandboxId ${JSON.stringify(value)} must match ${SANDBOX_ID.source}.`);
+  }
+  return value;
+}
+
+function requireBinaryDescriptor(input: K3sBinaryDescriptor): K3sBinaryDescriptor {
+  if (!K3S_VERSION.test(input.version)) {
+    throw new Error(`k3s binary version ${JSON.stringify(input.version)} must be an immutable vMAJOR.MINOR.PATCH+k3sN release.`);
+  }
+  if (!SHA256.test(input.sha256)) {
+    throw new Error("k3s binary sha256 must contain exactly 64 lowercase hexadecimal characters.");
+  }
+  if (input.url.trim() !== input.url) throw new Error("k3s binary url must not have surrounding whitespace.");
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    throw new Error("k3s binary url must be a valid HTTPS URL.");
+  }
+  if (url.protocol !== "https:" || !url.hostname || url.username || url.password || url.hash) {
+    throw new Error("k3s binary url must be an HTTPS URL without credentials or a fragment.");
+  }
+  return { version: input.version, url: input.url, sha256: input.sha256 };
+}
+
+function requireKubernetesName(kind: string, value: string): string {
+  if (!KUBERNETES_NAME.test(value)) throw new Error(`${kind} ${JSON.stringify(value)} must be a Kubernetes DNS label.`);
+  return value;
+}
+
+function requireHelmRelease(value: string): string {
+  if (!HELM_RELEASE.test(value)) {
+    throw new Error(`Helm release ${JSON.stringify(value)} must be a lowercase DNS label of at most 53 characters.`);
+  }
+  return value;
+}
+
+function requireChart(value: string): string {
+  if (value.length === 0 || value.length > 512 || value.trim() !== value || value.startsWith("-") || /[\u0000-\u0020\u007f]/.test(value)) {
+    throw new Error("Helm chart must be a non-empty chart reference without whitespace, control characters, or a leading dash.");
+  }
+  return value;
+}
+
+function requirePort(kind: string, value: number): number {
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${kind} must be an integer between 1 and 65535.`);
+  }
+  return value;
+}
+
+function requireExpiry(value: number): number {
+  if (!Number.isInteger(value) || value < 1 || value > MAX_PREVIEW_EXPIRY_SECONDS) {
+    throw new Error(`Daytona preview expiry must be between 1 and ${MAX_PREVIEW_EXPIRY_SECONDS} seconds.`);
+  }
+  return value;
+}
+
+function requireToolArguments(tool: string, args: readonly string[]): string[] {
+  return args.map((argument, index) => {
+    if (argument.length === 0 || /[\u0000-\u001f\u007f]/.test(argument)) {
+      throw new Error(`${tool} argument ${index + 1} must be non-empty and contain no control characters.`);
+    }
+    return argument;
+  });
+}
+
+/** Daytona CLI v0.173 joins post-`--` tokens, so bash and its script are one argument. */
+export function daytonaK3sExecArgv(ownedSandboxId: string, script: string): string[] {
+  const sandbox = requireOwnedSandboxId(ownedSandboxId);
+  if (!script.trim() || /\u0000/.test(script)) throw new Error("Daytona k3s shell script must be non-empty and contain no NUL bytes.");
+  return ["exec", sandbox, "--", `bash -lc ${shellQuote(script)}`];
+}
+
+export function daytonaK3sPreviewArgv(ownedSandboxId: string, port: number, expiresInSeconds: number): string[] {
+  return [
+    "preview-url",
+    requireOwnedSandboxId(ownedSandboxId),
+    "-p",
+    String(requirePort("Daytona preview port", port)),
+    "--expires",
+    String(requireExpiry(expiresInSeconds)),
+  ];
+}
+
+export function parseDaytonaK3sPreviewUrl(stdout: string): string {
+  for (const match of stdout.matchAll(/https:\/\/[^\s"'<>]+/g)) {
+    const candidate = match[0].replace(/[.,;:]+$/, "");
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === "https:" && parsed.hostname) return candidate;
+    } catch {
+      // Continue to the next explicit HTTPS token in stdout.
+    }
+  }
+  throw new Error("Daytona preview-url stdout did not contain a valid HTTPS URL.");
+}
+
+function runtimePaths(placementId: string): DaytonaK3sRuntimePaths {
+  const root = `${RUNTIME_BASE}/${placementId}`;
+  return {
+    root,
+    binary: `${root}/bin/k3s`,
+    download: `${root}/download/k3s`,
+    dataDir: `${root}/data`,
+    kubeconfig: `${root}/kubeconfig.yaml`,
+    serverLog: `${root}/server.log`,
+  };
+}
+
+async function remoteExec(
+  exec: DaytonaExec,
+  ownedSandboxId: string,
+  script: string,
+  context: string,
+  timeoutMs: number,
+): Promise<DaytonaExecResult> {
+  return checkedExec(exec, daytonaK3sExecArgv(ownedSandboxId, script), context, { timeoutMs });
+}
+
+function binaryInstallScript(paths: DaytonaK3sRuntimePaths, binary: K3sBinaryDescriptor): string {
+  const installedChecksum = `${binary.sha256}  ${paths.binary}`;
+  const downloadChecksum = `${binary.sha256}  ${paths.download}`;
+  return [
+    shellCommand("set", ["-eu"]),
+    shellCommand("set", ["-o", "pipefail"]),
+    shellCommand("mkdir", ["-p", `${paths.root}/bin`, `${paths.root}/download`, paths.dataDir]),
+    `if ${shellCommand("test", ["-x", paths.binary])} && ${shellCommand("printf", ["%s\\n", installedChecksum])} | ${shellCommand("sha256sum", ["--check", "--status", "-"])}; then ${shellCommand("exit", ["0"])}; fi`,
+    shellCommand("rm", ["-f", paths.download]),
+    shellCommand("curl", ["--fail", "--silent", "--show-error", "--location", binary.url, "--output", paths.download]),
+    `${shellCommand("printf", ["%s\\n", downloadChecksum])} | ${shellCommand("sha256sum", ["--check", "--status", "-"])}`,
+    shellCommand("chmod", ["0755", paths.download]),
+    shellCommand("mv", ["-f", paths.download, paths.binary]),
+  ].join("\n");
+}
+
+async function selectPrivilege(exec: DaytonaExec, ownedSandboxId: string): Promise<PrivilegeMode> {
+  const result = await remoteExec(exec, ownedSandboxId, shellCommand("id", ["-u"]), "probe Daytona k3s privilege", 30_000);
+  const uid = result.stdout.trim();
+  if (!/^[0-9]+$/.test(uid)) throw new Error(`Daytona k3s id -u returned invalid output ${JSON.stringify(uid)}.`);
+  if (uid === "0") return "root";
+  await remoteExec(exec, ownedSandboxId, shellCommand("sudo", ["-n", "true"]), "probe passwordless sudo for Daytona k3s", 30_000);
+  return "sudo";
+}
+
+function serverArgs(paths: DaytonaK3sRuntimePaths, placementId: string): string[] {
+  return [
+    "server",
+    "--data-dir", paths.dataDir,
+    "--write-kubeconfig", paths.kubeconfig,
+    "--write-kubeconfig-mode", "0644",
+    "--node-name", `openwork-${placementId}`,
+  ];
+}
+
+function processCommandLine(command: string, args: readonly string[]): string {
+  return [command, ...args].join(" ");
+}
+
+function startServerScript(paths: DaytonaK3sRuntimePaths, placementId: string, privilege: PrivilegeMode): string {
+  const args = serverArgs(paths, placementId);
+  const launch = privilege === "root"
+    ? [paths.binary, ...args]
+    : ["sudo", "-n", paths.binary, ...args];
+  return [
+    shellCommand("set", ["-eu"]),
+    shellCommand("mkdir", ["-p", paths.dataDir]),
+    `${shellCommand("nohup", launch)} >${shellQuote(paths.serverLog)} 2>&1 &`,
+  ].join("\n");
+}
+
+function processAppearedScript(commandLine: string, logFile: string): string[] {
+  return [
+    "attempt=0",
+    "while 'test' \"$attempt\" '-lt' '25'; do",
+    `  if ${shellCommand("pgrep", ["-f", "-x", "--", commandLine])} >${shellQuote("/dev/null")}; then break; fi`,
+    `  ${shellCommand("sleep", ["0.2"])}`,
+    "  attempt=$((attempt + 1))",
+    "done",
+    `if ! ${shellCommand("pgrep", ["-f", "-x", "--", commandLine])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", logFile])} >&2; ${shellCommand("exit", ["1"])}; fi`,
+  ];
+}
+
+function readinessScript(paths: DaytonaK3sRuntimePaths, placementId: string, privilege: PrivilegeMode): string {
+  const args = serverArgs(paths, placementId);
+  const marker = processCommandLine(paths.binary, args);
+  const kubectl = privilegedCommand(privilege, paths.binary, ["kubectl", "--kubeconfig", paths.kubeconfig, "get", "--raw=/readyz"]);
+  return [
+    ...processAppearedScript(marker, paths.serverLog),
+    "attempt=0",
+    "while 'test' \"$attempt\" '-lt' '60'; do",
+    `  if ! ${shellCommand("pgrep", ["-f", "-x", "--", marker])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", paths.serverLog])} >&2; ${shellCommand("exit", ["1"])}; fi`,
+    `  if ${kubectl} >${shellQuote("/dev/null")} 2>&1; then ${shellCommand("exit", ["0"])}; fi`,
+    `  ${shellCommand("sleep", ["1"])}`,
+    "  attempt=$((attempt + 1))",
+    "done",
+    `${shellCommand("tail", ["-n", "80", paths.serverLog])} >&2`,
+    shellCommand("exit", ["1"]),
+  ].join("\n");
+}
+
+function createRuntime(input: {
+  exec: DaytonaExec;
+  ownedSandboxId: string;
+  paths: DaytonaK3sRuntimePaths;
+  log: (message: string) => void;
+}): ClusterRuntime {
+  let active = true;
+  let disposal: Promise<void> | undefined;
+  const dispose = (): Promise<void> => {
+    active = false;
+    disposal ??= deleteSandboxes([input.ownedSandboxId], { exec: input.exec, log: input.log });
+    return disposal;
+  };
+  return {
+    exec: input.exec,
+    ownedSandboxId: input.ownedSandboxId,
+    paths: input.paths,
+    privilege: "root",
+    reservedPorts: new Set<number>(),
+    assertActive(): void {
+      if (!active) throw new Error(`Daytona k3s owned sandbox ${JSON.stringify(input.ownedSandboxId)} is disposed.`);
+    },
+    dispose,
+  };
+}
+
+async function deleteAfterFailure(runtime: ClusterRuntime, error: unknown, message: string): Promise<never> {
+  try {
+    await runtime.dispose();
+  } catch (cleanupError) {
+    throw new AggregateError([error, cleanupError], `${message} and its owned sandbox could not be deleted.`);
+  }
+  throw error;
+}
+
+function makeClusterHandle(
+  placement: Placement,
+  binary: K3sBinaryDescriptor,
+  runtime: ClusterRuntime,
+): DaytonaK3sClusterHandle {
+  const runTool = async (tool: "kubectl" | "helm", args: readonly string[]): Promise<DaytonaExecResult> => {
+    runtime.assertActive();
+    const normalized = requireToolArguments(tool, args);
+    const command = tool === "kubectl"
+      ? privilegedCommand(runtime.privilege, runtime.paths.binary, ["kubectl", "--kubeconfig", runtime.paths.kubeconfig, ...normalized])
+      : shellCommand("helm", ["--kubeconfig", runtime.paths.kubeconfig, ...normalized]);
+    return remoteExec(runtime.exec, runtime.ownedSandboxId, command, `run ${tool} in Daytona k3s placement ${placement.id}`, TOOL_TIMEOUT_MS);
+  };
+  const handle: DaytonaK3sClusterHandle = {
+    placement,
+    ownedSandboxId: runtime.ownedSandboxId,
+    binary,
+    paths: runtime.paths,
+    stop: runtime.dispose,
+    kubectl: (args) => runTool("kubectl", args),
+    helm: (args) => runTool("helm", args),
+    [Symbol.asyncDispose]: runtime.dispose,
+  };
+  clusterRuntimes.set(handle, runtime);
+  return handle;
+}
+
+/**
+ * Takes exclusive ownership of `ownedSandboxId`. A successful handle deletes
+ * that sandbox on stop/dispose; every failure after validation also deletes it.
+ */
+export async function createDaytonaK3sCluster(input: CreateDaytonaK3sClusterInput): Promise<DaytonaK3sClusterHandle> {
+  requirePlacement(input.placement);
+  const ownedSandboxId = requireOwnedSandboxId(input.ownedSandboxId);
+  const binary = requireBinaryDescriptor(input.binary);
+  const exec = input.exec ?? defaultDaytonaExec;
+  const log = input.log ?? (() => undefined);
+  const paths = runtimePaths(input.placement.id);
+  const runtime = createRuntime({ exec, ownedSandboxId, paths, log });
+  try {
+    runtime.privilege = await selectPrivilege(exec, ownedSandboxId);
+    await remoteExec(exec, ownedSandboxId, binaryInstallScript(paths, binary), `install pinned k3s ${binary.version}`, 180_000);
+    await remoteExec(exec, ownedSandboxId, startServerScript(paths, input.placement.id, runtime.privilege), `start Daytona k3s placement ${input.placement.id}`, 30_000);
+    await remoteExec(exec, ownedSandboxId, readinessScript(paths, input.placement.id, runtime.privilege), `wait for Daytona k3s placement ${input.placement.id}`, 75_000);
+    log(`Daytona k3s placement ${input.placement.id} is ready in exclusively owned sandbox ${ownedSandboxId}.`);
+    return makeClusterHandle(input.placement, binary, runtime);
+  } catch (error) {
+    return deleteAfterFailure(runtime, error, `Daytona k3s placement ${input.placement.id} failed to start`);
+  }
+}
+
+export function installK3sHelmRelease(
+  handle: DaytonaK3sClusterHandle,
+  input: InstallK3sHelmReleaseInput,
+): Promise<DaytonaExecResult> {
+  const release = requireHelmRelease(input.release);
+  const namespace = requireKubernetesName("Helm namespace", input.namespace);
+  const chart = requireChart(input.chart);
+  return handle.helm(["upgrade", "--install", release, chart, "--namespace", namespace, "--create-namespace"]);
+}
+
+function portForwardArgs(paths: DaytonaK3sRuntimePaths, input: {
+  namespace: string;
+  service: string;
+  localPort: number;
+  servicePort: number;
+}): string[] {
+  return [
+    "kubectl",
+    "--kubeconfig", paths.kubeconfig,
+    "port-forward",
+    "--namespace", input.namespace,
+    "--address", "0.0.0.0",
+    `service/${input.service}`,
+    `${input.localPort}:${input.servicePort}`,
+  ];
+}
+
+function startPortForwardScript(runtime: ClusterRuntime, args: readonly string[], logFile: string): string {
+  const launch = runtime.privilege === "root"
+    ? [runtime.paths.binary, ...args]
+    : ["sudo", "-n", runtime.paths.binary, ...args];
+  return `${shellCommand("nohup", launch)} >${shellQuote(logFile)} 2>&1 &`;
+}
+
+function waitForPortScript(paths: DaytonaK3sRuntimePaths, args: readonly string[], logFile: string, localPort: number): string {
+  const marker = processCommandLine(paths.binary, args);
+  const socket = `/dev/tcp/127.0.0.1/${localPort}`;
+  return [
+    ...processAppearedScript(marker, logFile),
+    "attempt=0",
+    "while 'test' \"$attempt\" '-lt' '100'; do",
+    `  if ! ${shellCommand("pgrep", ["-f", "-x", "--", marker])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", logFile])} >&2; ${shellCommand("exit", ["1"])}; fi`,
+    `  if ('exec' 3<>${shellQuote(socket)}) 2>${shellQuote("/dev/null")}; then ${shellCommand("exit", ["0"])}; fi`,
+    `  ${shellCommand("sleep", ["0.2"])}`,
+    "  attempt=$((attempt + 1))",
+    "done",
+    `${shellCommand("tail", ["-n", "80", logFile])} >&2`,
+    shellCommand("exit", ["1"]),
+  ].join("\n");
+}
+
+export async function exposeK3sService(
+  handle: DaytonaK3sClusterHandle,
+  input: ExposeK3sServiceInput,
+): Promise<DaytonaK3sServiceExposure> {
+  const namespace = requireKubernetesName("Kubernetes namespace", input.namespace);
+  const service = requireKubernetesName("Kubernetes service", input.service);
+  const localPort = requirePort("K3s local port", input.localPort);
+  const servicePort = requirePort("K3s service port", input.servicePort);
+  const expiresInSeconds = requireExpiry(input.expiresInSeconds);
+  const runtime = clusterRuntimes.get(handle);
+  if (!runtime) throw new Error("exposeK3sService requires a handle returned by createDaytonaK3sCluster.");
+  runtime.assertActive();
+  if (runtime.reservedPorts.has(localPort)) throw new Error(`K3s local port ${localPort} is already reserved by this cluster.`);
+  runtime.reservedPorts.add(localPort);
+
+  const args = portForwardArgs(runtime.paths, { namespace, service, localPort, servicePort });
+  const logFile = `${runtime.paths.root}/port-forward-${localPort}.log`;
+  try {
+    await remoteExec(runtime.exec, runtime.ownedSandboxId, startPortForwardScript(runtime, args, logFile), `start Daytona k3s port-forward for ${namespace}/${service}`, 30_000);
+    await remoteExec(runtime.exec, runtime.ownedSandboxId, waitForPortScript(runtime.paths, args, logFile, localPort), `wait for Daytona k3s port ${localPort}`, 30_000);
+    const expiresAt = new Date(Date.now() + expiresInSeconds * 1_000).toISOString();
+    const preview = await checkedExec(
+      runtime.exec,
+      daytonaK3sPreviewArgv(runtime.ownedSandboxId, localPort, expiresInSeconds),
+      `resolve Daytona k3s preview URL for ${namespace}/${service}`,
+      { timeoutMs: 30_000 },
+    );
+    return {
+      placementId: handle.placement.id,
+      ownedSandboxId: runtime.ownedSandboxId,
+      namespace,
+      service,
+      localPort,
+      servicePort,
+      url: parseDaytonaK3sPreviewUrl(preview.stdout),
+      expiresAt,
+      expiresInSeconds,
+      ephemeral: true,
+      persistableInDesktopConfig: false,
+      validUntil: "cluster-disposal-or-expiry",
+    };
+  } catch (error) {
+    return deleteAfterFailure(runtime, error, `Daytona k3s service ${namespace}/${service} failed to expose`);
+  }
+}

--- a/evals/packages/env/src/daytona-k3s.ts
+++ b/evals/packages/env/src/daytona-k3s.ts
@@ -286,10 +286,6 @@ function serverArgs(paths: DaytonaK3sRuntimePaths, placementId: string): string[
   ];
 }
 
-function processCommandLine(command: string, args: readonly string[]): string {
-  return [command, ...args].join(" ");
-}
-
 function startServerScript(paths: DaytonaK3sRuntimePaths, placementId: string, privilege: PrivilegeMode): string {
   const args = serverArgs(paths, placementId);
   const launch = privilege === "root"
@@ -302,27 +298,11 @@ function startServerScript(paths: DaytonaK3sRuntimePaths, placementId: string, p
   ].join("\n");
 }
 
-function processAppearedScript(commandLine: string, logFile: string): string[] {
-  return [
-    "attempt=0",
-    "while 'test' \"$attempt\" '-lt' '25'; do",
-    `  if ${shellCommand("pgrep", ["-f", "-x", "--", commandLine])} >${shellQuote("/dev/null")}; then break; fi`,
-    `  ${shellCommand("sleep", ["0.2"])}`,
-    "  attempt=$((attempt + 1))",
-    "done",
-    `if ! ${shellCommand("pgrep", ["-f", "-x", "--", commandLine])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", logFile])} >&2; ${shellCommand("exit", ["1"])}; fi`,
-  ];
-}
-
-function readinessScript(paths: DaytonaK3sRuntimePaths, placementId: string, privilege: PrivilegeMode): string {
-  const args = serverArgs(paths, placementId);
-  const marker = processCommandLine(paths.binary, args);
+function readinessScript(paths: DaytonaK3sRuntimePaths, privilege: PrivilegeMode): string {
   const kubectl = privilegedCommand(privilege, paths.binary, ["kubectl", "--kubeconfig", paths.kubeconfig, "get", "--raw=/readyz"]);
   return [
-    ...processAppearedScript(marker, paths.serverLog),
     "attempt=0",
-    "while 'test' \"$attempt\" '-lt' '60'; do",
-    `  if ! ${shellCommand("pgrep", ["-f", "-x", "--", marker])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", paths.serverLog])} >&2; ${shellCommand("exit", ["1"])}; fi`,
+    "while 'test' \"$attempt\" '-lt' '120'; do",
     `  if ${kubectl} >${shellQuote("/dev/null")} 2>&1; then ${shellCommand("exit", ["0"])}; fi`,
     `  ${shellCommand("sleep", ["1"])}`,
     "  attempt=$((attempt + 1))",
@@ -410,7 +390,7 @@ export async function createDaytonaK3sCluster(input: CreateDaytonaK3sClusterInpu
     runtime.privilege = await selectPrivilege(exec, ownedSandboxId);
     await remoteExec(exec, ownedSandboxId, binaryInstallScript(paths, binary), `install pinned k3s ${binary.version}`, 180_000);
     await remoteExec(exec, ownedSandboxId, startServerScript(paths, input.placement.id, runtime.privilege), `start Daytona k3s placement ${input.placement.id}`, 30_000);
-    await remoteExec(exec, ownedSandboxId, readinessScript(paths, input.placement.id, runtime.privilege), `wait for Daytona k3s placement ${input.placement.id}`, 75_000);
+    await remoteExec(exec, ownedSandboxId, readinessScript(paths, runtime.privilege), `wait for Daytona k3s placement ${input.placement.id}`, 135_000);
     log(`Daytona k3s placement ${input.placement.id} is ready in exclusively owned sandbox ${ownedSandboxId}.`);
     return makeClusterHandle(input.placement, binary, runtime);
   } catch (error) {
@@ -452,14 +432,11 @@ function startPortForwardScript(runtime: ClusterRuntime, args: readonly string[]
   return `${shellCommand("nohup", launch)} >${shellQuote(logFile)} 2>&1 &`;
 }
 
-function waitForPortScript(paths: DaytonaK3sRuntimePaths, args: readonly string[], logFile: string, localPort: number): string {
-  const marker = processCommandLine(paths.binary, args);
+function waitForPortScript(logFile: string, localPort: number): string {
   const socket = `/dev/tcp/127.0.0.1/${localPort}`;
   return [
-    ...processAppearedScript(marker, logFile),
     "attempt=0",
     "while 'test' \"$attempt\" '-lt' '100'; do",
-    `  if ! ${shellCommand("pgrep", ["-f", "-x", "--", marker])} >${shellQuote("/dev/null")}; then ${shellCommand("tail", ["-n", "80", logFile])} >&2; ${shellCommand("exit", ["1"])}; fi`,
     `  if ('exec' 3<>${shellQuote(socket)}) 2>${shellQuote("/dev/null")}; then ${shellCommand("exit", ["0"])}; fi`,
     `  ${shellCommand("sleep", ["0.2"])}`,
     "  attempt=$((attempt + 1))",
@@ -488,7 +465,7 @@ export async function exposeK3sService(
   const logFile = `${runtime.paths.root}/port-forward-${localPort}.log`;
   try {
     await remoteExec(runtime.exec, runtime.ownedSandboxId, startPortForwardScript(runtime, args, logFile), `start Daytona k3s port-forward for ${namespace}/${service}`, 30_000);
-    await remoteExec(runtime.exec, runtime.ownedSandboxId, waitForPortScript(runtime.paths, args, logFile, localPort), `wait for Daytona k3s port ${localPort}`, 30_000);
+    await remoteExec(runtime.exec, runtime.ownedSandboxId, waitForPortScript(logFile, localPort), `wait for Daytona k3s port ${localPort}`, 30_000);
     const expiresAt = new Date(Date.now() + expiresInSeconds * 1_000).toISOString();
     const preview = await checkedExec(
       runtime.exec,

--- a/evals/packages/env/src/daytona-k3s.ts
+++ b/evals/packages/env/src/daytona-k3s.ts
@@ -4,35 +4,49 @@ import { placementHasCapability } from "./network-world.ts";
 import type { Placement } from "./network-world.ts";
 
 const PLACEMENT_ID = /^[a-z][a-z0-9-]{0,62}$/;
-const SANDBOX_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SANDBOX_NAME = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const KUBERNETES_NAME = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const HELM_RELEASE = /^[a-z0-9](?:[a-z0-9-]{0,51}[a-z0-9])?$/;
-const K3S_VERSION = /^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+$/;
-const SHA256 = /^[a-f0-9]{64}$/;
 const RUNTIME_BASE = "/tmp/openwork-world-k3s";
 const MAX_PREVIEW_EXPIRY_SECONDS = 86_400;
 const TOOL_TIMEOUT_MS = 120_000;
+const DEFAULT_DAYTONA_K3S_SNAPSHOT: DaytonaK3sSnapshot = "daytona-large";
+const DEFAULT_DAYTONA_K3S_VERSION: SupportedDaytonaK3sVersion = "v1.31.6+k3s1";
+const ownershipBrand = Symbol("DaytonaK3sSandboxOwnership");
 
-export interface K3sBinaryDescriptor {
-  /** Immutable official k3s release version, for example v1.31.6+k3s1. */
-  version: string;
-  /** HTTPS URL for the exact architecture-specific release binary. */
-  url: string;
-  /** Required lowercase SHA-256 digest for the bytes at url. */
-  sha256: string;
+export type DaytonaK3sSnapshot = "daytona-large";
+export type SupportedDaytonaK3sVersion = "v1.31.6+k3s1";
+
+interface K3sBinaryDescriptor {
+  readonly version: SupportedDaytonaK3sVersion;
+  readonly url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s";
+  readonly sha256: "9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5";
+}
+
+const K3S_BINARIES: Readonly<Record<SupportedDaytonaK3sVersion, K3sBinaryDescriptor>> = {
+  "v1.31.6+k3s1": {
+    version: "v1.31.6+k3s1",
+    url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
+    sha256: "9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5",
+  },
+};
+
+/** Opaque proof that this module provisioned and exclusively owns a sandbox. */
+export interface DaytonaK3sSandboxOwnership {
+  readonly [ownershipBrand]: true;
+}
+
+export interface ProvisionDaytonaK3sSandboxInput {
+  name: string;
+  snapshot?: DaytonaK3sSnapshot;
+  exec?: DaytonaExec;
+  log?: (message: string) => void;
 }
 
 export interface CreateDaytonaK3sClusterInput {
   placement: Placement;
-  /**
-   * An already-created, dedicated sandbox whose ownership is transferred to
-   * this cluster. It WILL BE DELETED on stop/dispose and every partial startup
-   * failure. It must not contain any other workload or reusable state.
-   */
-  ownedSandboxId: string;
-  binary: K3sBinaryDescriptor;
-  exec?: DaytonaExec;
-  log?: (message: string) => void;
+  ownership: DaytonaK3sSandboxOwnership;
+  version?: SupportedDaytonaK3sVersion;
 }
 
 export interface DaytonaK3sRuntimePaths {
@@ -48,7 +62,7 @@ export interface DaytonaK3sRuntimePaths {
 export interface DaytonaK3sClusterHandle extends AsyncDisposable {
   readonly placement: Placement;
   readonly ownedSandboxId: string;
-  readonly binary: K3sBinaryDescriptor;
+  readonly version: SupportedDaytonaK3sVersion;
   readonly paths: DaytonaK3sRuntimePaths;
   /** Deletes the entire dedicated sandbox, including every listener and preview. */
   stop(): Promise<void>;
@@ -99,6 +113,11 @@ interface ClusterRuntime {
 }
 
 const clusterRuntimes = new WeakMap<DaytonaK3sClusterHandle, ClusterRuntime>();
+const sandboxOwnership = new WeakMap<DaytonaK3sSandboxOwnership, {
+  ownedSandboxId: string;
+  exec: DaytonaExec;
+  log: (message: string) => void;
+}>();
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
@@ -126,31 +145,27 @@ function requirePlacement(placement: Placement): void {
   }
 }
 
-function requireOwnedSandboxId(value: string): string {
-  if (!SANDBOX_ID.test(value)) {
-    throw new Error(`Daytona ownedSandboxId ${JSON.stringify(value)} must match ${SANDBOX_ID.source}.`);
+function requireSandboxName(value: string): string {
+  if (!SANDBOX_NAME.test(value)) {
+    throw new Error(`Daytona k3s sandbox name ${JSON.stringify(value)} must match ${SANDBOX_NAME.source}.`);
   }
   return value;
 }
 
-function requireBinaryDescriptor(input: K3sBinaryDescriptor): K3sBinaryDescriptor {
-  if (!K3S_VERSION.test(input.version)) {
-    throw new Error(`k3s binary version ${JSON.stringify(input.version)} must be an immutable vMAJOR.MINOR.PATCH+k3sN release.`);
+function requireSnapshot(value: DaytonaK3sSnapshot | undefined): DaytonaK3sSnapshot {
+  const snapshot = value ?? DEFAULT_DAYTONA_K3S_SNAPSHOT;
+  if (snapshot !== "daytona-large") {
+    throw new Error(`Daytona k3s snapshot ${JSON.stringify(snapshot)} is not allowlisted.`);
   }
-  if (!SHA256.test(input.sha256)) {
-    throw new Error("k3s binary sha256 must contain exactly 64 lowercase hexadecimal characters.");
+  return snapshot;
+}
+
+function requireBinary(version: SupportedDaytonaK3sVersion | undefined): K3sBinaryDescriptor {
+  const selected = version ?? DEFAULT_DAYTONA_K3S_VERSION;
+  if (selected !== "v1.31.6+k3s1") {
+    throw new Error(`Daytona k3s version ${JSON.stringify(selected)} is not supported.`);
   }
-  if (input.url.trim() !== input.url) throw new Error("k3s binary url must not have surrounding whitespace.");
-  let url: URL;
-  try {
-    url = new URL(input.url);
-  } catch {
-    throw new Error("k3s binary url must be a valid HTTPS URL.");
-  }
-  if (url.protocol !== "https:" || !url.hostname || url.username || url.password || url.hash) {
-    throw new Error("k3s binary url must be an HTTPS URL without credentials or a fragment.");
-  }
-  return { version: input.version, url: input.url, sha256: input.sha256 };
+  return K3S_BINARIES[selected];
 }
 
 function requireKubernetesName(kind: string, value: string): string {
@@ -196,16 +211,16 @@ function requireToolArguments(tool: string, args: readonly string[]): string[] {
 }
 
 /** Daytona CLI v0.173 joins post-`--` tokens, so bash and its script are one argument. */
-export function daytonaK3sExecArgv(ownedSandboxId: string, script: string): string[] {
-  const sandbox = requireOwnedSandboxId(ownedSandboxId);
+function daytonaK3sExecArgv(ownedSandboxId: string, script: string): string[] {
+  const sandbox = requireSandboxName(ownedSandboxId);
   if (!script.trim() || /\u0000/.test(script)) throw new Error("Daytona k3s shell script must be non-empty and contain no NUL bytes.");
   return ["exec", sandbox, "--", `bash -lc ${shellQuote(script)}`];
 }
 
-export function daytonaK3sPreviewArgv(ownedSandboxId: string, port: number, expiresInSeconds: number): string[] {
+function daytonaK3sPreviewArgv(ownedSandboxId: string, port: number, expiresInSeconds: number): string[] {
   return [
     "preview-url",
-    requireOwnedSandboxId(ownedSandboxId),
+    requireSandboxName(ownedSandboxId),
     "-p",
     String(requirePort("Daytona preview port", port)),
     "--expires",
@@ -250,6 +265,65 @@ async function remoteExec(
   return checkedExec(exec, daytonaK3sExecArgv(ownedSandboxId, script), context, { timeoutMs });
 }
 
+async function deleteProvisioningFailure(
+  ownedSandboxId: string,
+  exec: DaytonaExec,
+  log: (message: string) => void,
+  error: unknown,
+): Promise<never> {
+  try {
+    await deleteSandboxes([ownedSandboxId], { exec, log });
+  } catch (cleanupError) {
+    throw new AggregateError([error, cleanupError], "Daytona k3s sandbox provisioning failed and its sandbox could not be deleted.");
+  }
+  throw error;
+}
+
+/** Creates the dedicated sandbox whose whole-sandbox deletion owns all cleanup. */
+export async function provisionDaytonaK3sSandbox(
+  input: ProvisionDaytonaK3sSandboxInput,
+): Promise<DaytonaK3sSandboxOwnership> {
+  const ownedSandboxId = requireSandboxName(input.name);
+  const snapshot = requireSnapshot(input.snapshot);
+  const exec = input.exec ?? defaultDaytonaExec;
+  const log = input.log ?? (() => undefined);
+  try {
+    await checkedExec(
+      exec,
+      [
+        "create",
+        "--name", ownedSandboxId,
+        "--snapshot", snapshot,
+        "--auto-delete", "0",
+        "--target", "us",
+      ],
+      `create dedicated Daytona k3s sandbox ${ownedSandboxId}`,
+      { timeoutMs: 300_000 },
+    );
+    await remoteExec(exec, ownedSandboxId, shellCommand("true", []), `wait for Daytona k3s sandbox ${ownedSandboxId} exec readiness`, 60_000);
+  } catch (error) {
+    return deleteProvisioningFailure(ownedSandboxId, exec, log, error);
+  }
+
+  const ownership: DaytonaK3sSandboxOwnership = { [ownershipBrand]: true };
+  sandboxOwnership.set(ownership, { ownedSandboxId, exec, log });
+  log(`Daytona k3s sandbox ${ownedSandboxId} is exec-ready and exclusively owned.`);
+  return ownership;
+}
+
+function claimSandboxOwnership(ownership: DaytonaK3sSandboxOwnership): {
+  ownedSandboxId: string;
+  exec: DaytonaExec;
+  log: (message: string) => void;
+} {
+  const owned = sandboxOwnership.get(ownership);
+  if (!owned) {
+    throw new Error("createDaytonaK3sCluster requires an unused ownership receipt returned by provisionDaytonaK3sSandbox.");
+  }
+  sandboxOwnership.delete(ownership);
+  return owned;
+}
+
 function binaryInstallScript(paths: DaytonaK3sRuntimePaths, binary: K3sBinaryDescriptor): string {
   const installedChecksum = `${binary.sha256}  ${paths.binary}`;
   const downloadChecksum = `${binary.sha256}  ${paths.download}`;
@@ -280,7 +354,7 @@ function serverArgs(paths: DaytonaK3sRuntimePaths, placementId: string): string[
     "server",
     "--data-dir", paths.dataDir,
     "--write-kubeconfig", paths.kubeconfig,
-    "--write-kubeconfig-mode", "0644",
+    "--write-kubeconfig-mode", "0600",
     "--node-name", `openwork-${placementId}`,
     "--snapshotter", "native",
   ];
@@ -357,13 +431,13 @@ function makeClusterHandle(
     const normalized = requireToolArguments(tool, args);
     const command = tool === "kubectl"
       ? privilegedCommand(runtime.privilege, runtime.paths.binary, ["kubectl", "--kubeconfig", runtime.paths.kubeconfig, ...normalized])
-      : shellCommand("helm", ["--kubeconfig", runtime.paths.kubeconfig, ...normalized]);
+      : privilegedCommand(runtime.privilege, "helm", ["--kubeconfig", runtime.paths.kubeconfig, ...normalized]);
     return remoteExec(runtime.exec, runtime.ownedSandboxId, command, `run ${tool} in Daytona k3s placement ${placement.id}`, TOOL_TIMEOUT_MS);
   };
   const handle: DaytonaK3sClusterHandle = {
     placement,
     ownedSandboxId: runtime.ownedSandboxId,
-    binary,
+    version: binary.version,
     paths: runtime.paths,
     stop: runtime.dispose,
     kubectl: (args) => runTool("kubectl", args),
@@ -374,16 +448,11 @@ function makeClusterHandle(
   return handle;
 }
 
-/**
- * Takes exclusive ownership of `ownedSandboxId`. A successful handle deletes
- * that sandbox on stop/dispose; every failure after validation also deletes it.
- */
+/** Consumes a genuine provisioning receipt and deletes its sandbox on every cleanup path. */
 export async function createDaytonaK3sCluster(input: CreateDaytonaK3sClusterInput): Promise<DaytonaK3sClusterHandle> {
   requirePlacement(input.placement);
-  const ownedSandboxId = requireOwnedSandboxId(input.ownedSandboxId);
-  const binary = requireBinaryDescriptor(input.binary);
-  const exec = input.exec ?? defaultDaytonaExec;
-  const log = input.log ?? (() => undefined);
+  const binary = requireBinary(input.version);
+  const { ownedSandboxId, exec, log } = claimSandboxOwnership(input.ownership);
   const paths = runtimePaths(input.placement.id);
   const runtime = createRuntime({ exec, ownedSandboxId, paths, log });
   try {

--- a/evals/packages/env/src/index.ts
+++ b/evals/packages/env/src/index.ts
@@ -10,3 +10,4 @@ export * from "./world-adapter.ts";
 export * from "./kind-stack.ts";
 export * from "./faults.ts";
 export * from "./litellm.ts";
+export * from "./network-world.ts";

--- a/evals/packages/env/src/index.ts
+++ b/evals/packages/env/src/index.ts
@@ -11,3 +11,4 @@ export * from "./kind-stack.ts";
 export * from "./faults.ts";
 export * from "./litellm.ts";
 export * from "./network-world.ts";
+export * from "./daytona-k3s.ts";

--- a/evals/packages/env/src/network-world.ts
+++ b/evals/packages/env/src/network-world.ts
@@ -1,0 +1,335 @@
+const PLACEMENT_ID = /^[a-z][a-z0-9-]{0,62}$/;
+const RESOURCE_ID = /^[a-z][a-z0-9-]{0,62}$/;
+
+export type PlacementProvider =
+  | "local"
+  | "daytona-linux"
+  | "daytona-k3s"
+  | "daytona-windows"
+  | "macos-runner";
+
+export type PlacementOs = "linux" | "macos" | "windows";
+
+export type PlacementCapability =
+  | "command:bash"
+  | "command:powershell"
+  | "command:zsh"
+  | "surface:chrome"
+  | "surface:electron"
+  | "kubernetes:k3s"
+  | "port:localhost"
+  | "port:daytona-preview"
+  | "network:dns"
+  | "network:firewall"
+  | "network:mtu"
+  | "network:routes"
+  | "network:tls-intercept"
+  | "trust:linux-ca"
+  | "trust:macos-keychain"
+  | "trust:windows-machine-ca";
+
+export interface PlacementResources {
+  cpu?: number;
+  memoryGb?: number;
+  diskGb?: number;
+}
+
+export interface PlacementInput {
+  id: string;
+  provider: PlacementProvider;
+  os?: PlacementOs;
+  privileged?: boolean;
+  resources?: PlacementResources;
+}
+
+export interface Placement {
+  id: string;
+  provider: PlacementProvider;
+  os: PlacementOs;
+  privileged: boolean;
+  resources: PlacementResources;
+  capabilities: readonly PlacementCapability[];
+}
+
+export interface PlacementCommandPlan {
+  placementId: string;
+  shell: "bash" | "powershell" | "zsh";
+  command: string;
+  argv: readonly string[];
+}
+
+export type PortExposureMode = "localhost" | "daytona-preview";
+
+export interface PortExposurePlan {
+  placementId: string;
+  port: number;
+  mode: PortExposureMode;
+  url?: string;
+  requiresRuntimeResolution: boolean;
+}
+
+export type NetworkEdgeKind =
+  | "http-fault-proxy"
+  | "dns-zone"
+  | "tls-intercept-proxy"
+  | "route-gateway";
+
+export interface NetworkEdgeInput {
+  id: string;
+  placement: Placement;
+  kind: NetworkEdgeKind;
+  upstreamResourceId?: string;
+}
+
+export interface NetworkEdgeResource {
+  id: string;
+  placementId: string;
+  kind: NetworkEdgeKind;
+  upstreamResourceId?: string;
+  requiredCapabilities: readonly PlacementCapability[];
+}
+
+export type FaultAction =
+  | { kind: "latency"; target: string; milliseconds: number }
+  | { kind: "drop"; target: string; every: number }
+  | { kind: "dns-response"; target: string; response: "nxdomain" | "servfail" | "timeout" }
+  | { kind: "tls-untrusted"; target: string }
+  | { kind: "recover"; target: string };
+
+export interface FaultPhase {
+  id: string;
+  actions: readonly FaultAction[];
+}
+
+export interface AppliedFaultPhase {
+  id: string;
+  actions: readonly FaultAction[];
+  actionCount: number;
+}
+
+export interface CleanupStep {
+  resourceId: string;
+  action: string;
+  command: PlacementCommandPlan;
+}
+
+export interface CleanupReceipt {
+  worldId: string;
+  steps: readonly CleanupStep[];
+}
+
+function requireIdentifier(kind: string, id: string, pattern: RegExp): string {
+  const normalized = id.trim();
+  if (!pattern.test(normalized)) {
+    throw new Error(`${kind} id ${JSON.stringify(id)} must match ${pattern.source}.`);
+  }
+  return normalized;
+}
+
+function requirePositiveInteger(name: string, value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function inferredOs(provider: PlacementProvider): PlacementOs {
+  if (provider === "daytona-windows") return "windows";
+  if (provider === "macos-runner") return "macos";
+  return "linux";
+}
+
+function normalizeResources(resources: PlacementResources): PlacementResources {
+  return {
+    ...(resources.cpu === undefined ? {} : { cpu: requirePositiveInteger("placement resources cpu", resources.cpu) }),
+    ...(resources.memoryGb === undefined ? {} : { memoryGb: requirePositiveInteger("placement resources memoryGb", resources.memoryGb) }),
+    ...(resources.diskGb === undefined ? {} : { diskGb: requirePositiveInteger("placement resources diskGb", resources.diskGb) }),
+  };
+}
+
+function uniqueCapabilities(capabilities: readonly PlacementCapability[]): readonly PlacementCapability[] {
+  return [...new Set(capabilities)].sort();
+}
+
+function placementCapabilities(provider: PlacementProvider, os: PlacementOs, privileged: boolean): readonly PlacementCapability[] {
+  const shell: PlacementCapability = os === "windows"
+    ? "command:powershell"
+    : os === "macos"
+      ? "command:zsh"
+      : "command:bash";
+  const port: PlacementCapability = provider.startsWith("daytona") ? "port:daytona-preview" : "port:localhost";
+  const capabilities: PlacementCapability[] = [
+    shell,
+    port,
+  ];
+  if (provider !== "daytona-k3s") {
+    capabilities.push("surface:chrome", "surface:electron");
+  }
+  if (provider === "daytona-k3s") {
+    capabilities.push("kubernetes:k3s", "network:dns", "network:firewall");
+  }
+  if (privileged) {
+    capabilities.push("network:mtu", "network:routes", "network:tls-intercept");
+    if (os === "windows") {
+      capabilities.push("trust:windows-machine-ca");
+    } else if (os === "macos") {
+      capabilities.push("trust:macos-keychain");
+    } else {
+      capabilities.push("trust:linux-ca");
+    }
+  }
+  return uniqueCapabilities(capabilities);
+}
+
+function requireCompatibleOs(provider: PlacementProvider, os: PlacementOs): void {
+  if (provider === "daytona-windows" && os !== "windows") {
+    throw new Error('Placement provider "daytona-windows" requires os "windows".');
+  }
+  if (provider === "macos-runner" && os !== "macos") {
+    throw new Error('Placement provider "macos-runner" requires os "macos".');
+  }
+  if ((provider === "daytona-linux" || provider === "daytona-k3s") && os !== "linux") {
+    throw new Error(`Placement provider ${JSON.stringify(provider)} requires os "linux".`);
+  }
+}
+
+export function createPlacement(input: PlacementInput): Placement {
+  const os = input.os ?? inferredOs(input.provider);
+  requireCompatibleOs(input.provider, os);
+  const privileged = input.privileged === true;
+  return {
+    id: requireIdentifier("placement", input.id, PLACEMENT_ID),
+    provider: input.provider,
+    os,
+    privileged,
+    resources: normalizeResources(input.resources ?? {}),
+    capabilities: placementCapabilities(input.provider, os, privileged),
+  };
+}
+
+export function placementHasCapability(placement: Placement, capability: PlacementCapability): boolean {
+  return placement.capabilities.includes(capability);
+}
+
+export function requirePlacementCapabilities(placement: Placement, capabilities: readonly PlacementCapability[]): void {
+  const missing = capabilities.filter((capability) => !placementHasCapability(placement, capability));
+  if (missing.length > 0) {
+    throw new Error(`Placement ${JSON.stringify(placement.id)} is missing capabilities: ${missing.join(", ")}.`);
+  }
+}
+
+export function runOnPlacement(placement: Placement, command: string): PlacementCommandPlan {
+  const trimmed = command.trim();
+  if (!trimmed) throw new Error("runOnPlacement command must not be empty.");
+  if (placement.os === "windows") {
+    requirePlacementCapabilities(placement, ["command:powershell"]);
+    return {
+      placementId: placement.id,
+      shell: "powershell",
+      command: trimmed,
+      argv: ["powershell", "-NoProfile", "-NonInteractive", "-Command", trimmed],
+    };
+  }
+  if (placement.os === "macos") {
+    requirePlacementCapabilities(placement, ["command:zsh"]);
+    return {
+      placementId: placement.id,
+      shell: "zsh",
+      command: trimmed,
+      argv: ["zsh", "-lc", trimmed],
+    };
+  }
+  requirePlacementCapabilities(placement, ["command:bash"]);
+  return {
+    placementId: placement.id,
+    shell: "bash",
+    command: trimmed,
+    argv: ["bash", "-lc", trimmed],
+  };
+}
+
+export function exposePort(placement: Placement, port: number): PortExposurePlan {
+  const validPort = requirePositiveInteger("port", port);
+  if (validPort > 65_535) throw new Error("port must be between 1 and 65535.");
+  if (placementHasCapability(placement, "port:daytona-preview")) {
+    return {
+      placementId: placement.id,
+      port: validPort,
+      mode: "daytona-preview",
+      requiresRuntimeResolution: true,
+    };
+  }
+  requirePlacementCapabilities(placement, ["port:localhost"]);
+  return {
+    placementId: placement.id,
+    port: validPort,
+    mode: "localhost",
+    url: `http://127.0.0.1:${validPort}`,
+    requiresRuntimeResolution: false,
+  };
+}
+
+function requiredCapabilitiesForEdge(kind: NetworkEdgeKind): readonly PlacementCapability[] {
+  if (kind === "dns-zone") return ["network:dns"];
+  if (kind === "tls-intercept-proxy") return ["network:tls-intercept"];
+  if (kind === "route-gateway") return ["network:routes"];
+  return [];
+}
+
+export function createNetworkEdge(input: NetworkEdgeInput): NetworkEdgeResource {
+  const requiredCapabilities = requiredCapabilitiesForEdge(input.kind);
+  requirePlacementCapabilities(input.placement, requiredCapabilities);
+  return {
+    id: requireIdentifier("network resource", input.id, RESOURCE_ID),
+    placementId: input.placement.id,
+    kind: input.kind,
+    ...(input.upstreamResourceId === undefined ? {} : {
+      upstreamResourceId: requireIdentifier("upstream resource", input.upstreamResourceId, RESOURCE_ID),
+    }),
+    requiredCapabilities,
+  };
+}
+
+function normalizeFaultAction(action: FaultAction): FaultAction {
+  const target = requireIdentifier("fault action target", action.target, RESOURCE_ID);
+  if (action.kind === "latency") {
+    return { kind: action.kind, target, milliseconds: requirePositiveInteger("latency milliseconds", action.milliseconds) };
+  }
+  if (action.kind === "drop") {
+    return { kind: action.kind, target, every: requirePositiveInteger("drop every", action.every) };
+  }
+  if (action.kind === "dns-response") {
+    return { kind: action.kind, target, response: action.response };
+  }
+  if (action.kind === "tls-untrusted") {
+    return { kind: action.kind, target };
+  }
+  return { kind: action.kind, target };
+}
+
+export function selectFaultPhase(phases: readonly FaultPhase[], phaseId: string): AppliedFaultPhase {
+  const id = requireIdentifier("fault phase", phaseId, RESOURCE_ID);
+  const matches = phases.filter((phase) => phase.id === id);
+  if (matches.length > 1) {
+    throw new Error(`Fault phase ${JSON.stringify(id)} is ambiguous: duplicate ids are not allowed.`);
+  }
+  const found = matches[0];
+  if (!found) {
+    throw new Error(`Fault phase ${JSON.stringify(id)} does not exist.`);
+  }
+  const actions = found.actions.map(normalizeFaultAction);
+  return { id, actions, actionCount: actions.length };
+}
+
+export function createCleanupPlan(worldId: string, steps: readonly CleanupStep[]): CleanupReceipt {
+  const normalizedWorldId = requireIdentifier("world", worldId, RESOURCE_ID);
+  const normalizedSteps: CleanupStep[] = [];
+  for (const step of steps) {
+    const resourceId = requireIdentifier("cleanup resource", step.resourceId, RESOURCE_ID);
+    const action = step.action.trim();
+    if (!action) throw new Error("cleanup action must not be empty.");
+    if (!step.command.command.trim()) throw new Error("cleanup command must not be empty.");
+    normalizedSteps.push({ resourceId, action, command: step.command });
+  }
+  return { worldId: normalizedWorldId, steps: normalizedSteps };
+}

--- a/evals/packages/env/test/daytona-k3s.test.ts
+++ b/evals/packages/env/test/daytona-k3s.test.ts
@@ -114,9 +114,8 @@ test("root lifecycle installs a checksummed pinned binary into placement paths a
   assert(start.includes("'--node-name' 'openwork-unit-cluster'"));
   assert(start.includes("'--snapshotter' 'native'"));
   const readiness = observed[3] ?? "";
-  const processProof = readiness.indexOf("'pgrep' '-f' '-x'");
-  const readyz = readiness.indexOf(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' '--raw=/readyz'`);
-  assert(processProof >= 0 && readyz > processProof);
+  assert(readiness.includes(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' '--raw=/readyz'`));
+  assert.doesNotMatch(readiness, /pgrep/);
   assert.deepEqual(cluster.paths, {
     root,
     binary: `${root}/bin/k3s`,

--- a/evals/packages/env/test/daytona-k3s.test.ts
+++ b/evals/packages/env/test/daytona-k3s.test.ts
@@ -94,6 +94,7 @@ test("Daytona v0.173 argv keeps the complete quoted bash command in one post-sep
   ]);
   assert.throws(() => daytonaK3sPreviewArgv("owned-sandbox-1", 8080, 86_401), /between 1 and 86400/);
   assert.equal(parseDaytonaK3sPreviewUrl("Preview URL: https://preview.example.test/path?token=abc\n"), "https://preview.example.test/path?token=abc");
+  assert.equal(parseDaytonaK3sPreviewUrl(`Preview URL: https://preview.example.test/path${",".repeat(10_000)}`), "https://preview.example.test/path");
 });
 
 test("root lifecycle installs a checksummed pinned binary into placement paths and deletes its sandbox idempotently", async () => {

--- a/evals/packages/env/test/daytona-k3s.test.ts
+++ b/evals/packages/env/test/daytona-k3s.test.ts
@@ -112,6 +112,7 @@ test("root lifecycle installs a checksummed pinned binary into placement paths a
   const start = observed[2] ?? "";
   assert(start.includes(`'nohup' '${root}/bin/k3s' 'server' '--data-dir' '${root}/data' '--write-kubeconfig' '${root}/kubeconfig.yaml'`));
   assert(start.includes("'--node-name' 'openwork-unit-cluster'"));
+  assert(start.includes("'--snapshotter' 'native'"));
   const readiness = observed[3] ?? "";
   const processProof = readiness.indexOf("'pgrep' '-f' '-x'");
   const readyz = readiness.indexOf(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' '--raw=/readyz'`);

--- a/evals/packages/env/test/daytona-k3s.test.ts
+++ b/evals/packages/env/test/daytona-k3s.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DaytonaExec } from "@openwork/hosts";
+import {
+  createDaytonaK3sCluster,
+  daytonaK3sExecArgv,
+  daytonaK3sPreviewArgv,
+  exposeK3sService,
+  installK3sHelmRelease,
+  parseDaytonaK3sPreviewUrl,
+} from "../src/daytona-k3s.ts";
+import { createPlacement } from "../src/network-world.ts";
+import type { K3sBinaryDescriptor } from "../src/daytona-k3s.ts";
+import type { Placement } from "../src/network-world.ts";
+
+interface ExecCall {
+  args: string[];
+  opts?: { input?: string; timeoutMs?: number };
+}
+
+interface FakeOptions {
+  uid?: string;
+  sudoFails?: boolean;
+  failAt?: "install" | "start" | "readiness" | "preview";
+  helmMissing?: boolean;
+}
+
+function remoteScript(call: ExecCall): string {
+  if (call.args[0] !== "exec") return "";
+  assert.equal(call.args.length, 4);
+  assert.deepEqual(call.args.slice(0, 3), ["exec", "owned-sandbox-1", "--"]);
+  const wrapped = call.args[3] ?? "";
+  const prefix = "bash -lc '";
+  assert(wrapped.startsWith(prefix) && wrapped.endsWith("'"), `Unexpected Daytona exec transport: ${wrapped}`);
+  return wrapped.slice(prefix.length, -1).replaceAll(`'"'"'`, "'");
+}
+
+function createFake(options: FakeOptions = {}): { exec: DaytonaExec; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const exec: DaytonaExec = async (args, opts) => {
+    const call = { args: [...args], opts };
+    calls.push(call);
+    if (args[0] === "delete") return { stdout: "deleted\n", stderr: "", code: 0 };
+    if (args[0] === "preview-url") {
+      if (options.failAt === "preview") return { stdout: "", stderr: "preview failed\n", code: 1 };
+      return { stdout: "Preview URL: https://30443.preview.example.test/signed?token=unit\n", stderr: "", code: 0 };
+    }
+    const script = remoteScript(call);
+    if (script === "'id' '-u'") return { stdout: `${options.uid ?? "0"}\n`, stderr: "", code: 0 };
+    if (script === "'sudo' '-n' 'true'" && options.sudoFails) {
+      return { stdout: "", stderr: "sudo: a password is required\n", code: 1 };
+    }
+    if (script.includes("'curl' '--fail'")) {
+      if (options.failAt === "install") return { stdout: "", stderr: "checksum mismatch\n", code: 1 };
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (script.includes("'nohup'") && script.includes("'server'")) {
+      if (options.failAt === "start") throw new Error("ambiguous Daytona transport failure");
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (script.includes("'--raw=/readyz'") && options.failAt === "readiness") {
+      return { stdout: "", stderr: "owned server exited\n", code: 1 };
+    }
+    if (script.startsWith("'helm' ") && options.helmMissing) {
+      return { stdout: "", stderr: "bash: helm: command not found\n", code: 127 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { exec, calls };
+}
+
+const placement = createPlacement({ id: "unit-cluster", provider: "daytona-k3s" });
+const binary: K3sBinaryDescriptor = {
+  version: "v1.31.6+k3s1",
+  url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
+  sha256: "a".repeat(64),
+};
+const root = "/tmp/openwork-world-k3s/unit-cluster";
+
+function scripts(calls: ExecCall[]): string[] {
+  return calls.filter((call) => call.args[0] === "exec").map(remoteScript);
+}
+
+function deletionCalls(calls: ExecCall[]): ExecCall[] {
+  return calls.filter((call) => call.args[0] === "delete");
+}
+
+test("Daytona v0.173 argv keeps the complete quoted bash command in one post-separator argument", () => {
+  assert.deepEqual(daytonaK3sExecArgv("owned-sandbox-1", "id -u"), [
+    "exec", "owned-sandbox-1", "--", "bash -lc 'id -u'",
+  ]);
+  assert.deepEqual(daytonaK3sPreviewArgv("owned-sandbox-1", 8080, 86_400), [
+    "preview-url", "owned-sandbox-1", "-p", "8080", "--expires", "86400",
+  ]);
+  assert.throws(() => daytonaK3sPreviewArgv("owned-sandbox-1", 8080, 86_401), /between 1 and 86400/);
+  assert.equal(parseDaytonaK3sPreviewUrl("Preview URL: https://preview.example.test/path?token=abc\n"), "https://preview.example.test/path?token=abc");
+});
+
+test("root lifecycle installs a checksummed pinned binary into placement paths and deletes its sandbox idempotently", async () => {
+  const fake = createFake();
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const observed = scripts(fake.calls);
+
+  assert.equal(observed[0], "'id' '-u'");
+  const install = observed[1] ?? "";
+  assert.match(install, new RegExp(`'curl'.*'${binary.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}'`));
+  assert(install.includes(`'printf' '%s\\n' '${binary.sha256}  ${root}/download/k3s' | 'sha256sum' '--check' '--status' '-'`));
+  assert(install.includes(`'mv' '-f' '${root}/download/k3s' '${root}/bin/k3s'`));
+  assert.doesNotMatch(install, /get\.k3s\.io|systemctl|openrc|rc-service/);
+
+  const start = observed[2] ?? "";
+  assert(start.includes(`'nohup' '${root}/bin/k3s' 'server' '--data-dir' '${root}/data' '--write-kubeconfig' '${root}/kubeconfig.yaml'`));
+  assert(start.includes("'--node-name' 'openwork-unit-cluster'"));
+  const readiness = observed[3] ?? "";
+  const processProof = readiness.indexOf("'pgrep' '-f' '-x'");
+  const readyz = readiness.indexOf(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' '--raw=/readyz'`);
+  assert(processProof >= 0 && readyz > processProof);
+  assert.deepEqual(cluster.paths, {
+    root,
+    binary: `${root}/bin/k3s`,
+    download: `${root}/download/k3s`,
+    dataDir: `${root}/data`,
+    kubeconfig: `${root}/kubeconfig.yaml`,
+    serverLog: `${root}/server.log`,
+  });
+
+  await cluster.stop();
+  await cluster.stop();
+  await cluster[Symbol.asyncDispose]();
+  assert.equal(deletionCalls(fake.calls).length, 1);
+  assert.deepEqual(deletionCalls(fake.calls)[0], {
+    args: ["delete", "owned-sandbox-1"],
+    opts: { timeoutMs: 60_000, input: "y\n" },
+  });
+  assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
+});
+
+test("non-root lifecycle requires passwordless sudo and uses it for the placement binary", async () => {
+  const fake = createFake({ uid: "1000" });
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const observed = scripts(fake.calls);
+
+  assert.equal(observed[0], "'id' '-u'");
+  assert.equal(observed[1], "'sudo' '-n' 'true'");
+  assert(observed[3]?.includes(`'nohup' 'sudo' '-n' '${root}/bin/k3s' 'server'`));
+  assert(observed[4]?.includes(`'sudo' '-n' '${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml'`));
+  await cluster.kubectl(["get", "pods"]);
+  assert.equal(scripts(fake.calls).at(-1), `'sudo' '-n' '${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' 'pods'`);
+  await cluster.stop();
+});
+
+test("lack of root and passwordless sudo fails before start and deletes the owned sandbox", async () => {
+  const fake = createFake({ uid: "1000", sudoFails: true });
+  await assert.rejects(
+    createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }),
+    /passwordless sudo.*failed|password is required/s,
+  );
+  assert(scripts(fake.calls).every((script) => !script.includes("'server'")));
+  assert.equal(deletionCalls(fake.calls).length, 1);
+});
+
+test("every install, ambiguous start, and readiness failure deletes the entire owned sandbox", async () => {
+  const failures: readonly NonNullable<FakeOptions["failAt"]>[] = ["install", "start", "readiness"];
+  for (const failAt of failures) {
+    const fake = createFake({ failAt });
+    await assert.rejects(
+      createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }),
+    );
+    assert.equal(deletionCalls(fake.calls).length, 1, `expected owned sandbox deletion after ${failAt}`);
+    assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
+  }
+});
+
+test("Helm uses the placement kubeconfig and missing Helm fails without curl-pipe installation", async () => {
+  const fake = createFake({ helmMissing: true });
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const before = fake.calls.length;
+  await assert.rejects(
+    installK3sHelmRelease(cluster, { release: "demo", namespace: "demo-ns", chart: "oci://registry.example.test/team/chart" }),
+    /helm: command not found/,
+  );
+  assert.equal(
+    remoteScript(fake.calls[before] ?? { args: [] }),
+    `'helm' '--kubeconfig' '${root}/kubeconfig.yaml' 'upgrade' '--install' 'demo' 'oci://registry.example.test/team/chart' '--namespace' 'demo-ns' '--create-namespace'`,
+  );
+  assert.equal(fake.calls.slice(before).filter((call) => remoteScript(call).includes("curl")).length, 0);
+  await cluster.stop();
+});
+
+test("cluster-owned exposure reserves ports, accepts the maximum expiry, and has no independent cleanup", async () => {
+  const fake = createFake();
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const exposure = await exposeK3sService(cluster, {
+    namespace: "demo-ns",
+    service: "demo-api",
+    localPort: 30_443,
+    servicePort: 443,
+    expiresInSeconds: 86_400,
+  });
+
+  assert.equal(exposure.ephemeral, true);
+  assert.equal(exposure.persistableInDesktopConfig, false);
+  assert.equal(exposure.validUntil, "cluster-disposal-or-expiry");
+  assert.equal(exposure.ownedSandboxId, "owned-sandbox-1");
+  assert.deepEqual(fake.calls.find((call) => call.args[0] === "preview-url")?.args, [
+    "preview-url", "owned-sandbox-1", "-p", "30443", "--expires", "86400",
+  ]);
+  const portStart = scripts(fake.calls).find((script) => script.includes("'port-forward'"));
+  assert(portStart?.includes(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'port-forward'`));
+  const beforeDuplicate = fake.calls.length;
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "other",
+    service: "other-api",
+    localPort: 30_443,
+    servicePort: 80,
+    expiresInSeconds: 60,
+  }), /already reserved/);
+  assert.equal(fake.calls.length, beforeDuplicate);
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "other",
+    service: "other-api",
+    localPort: 30_444,
+    servicePort: 80,
+    expiresInSeconds: 86_401,
+  }), /between 1 and 86400/);
+  assert.equal(fake.calls.length, beforeDuplicate);
+  assert.equal(deletionCalls(fake.calls).length, 0);
+  await cluster.stop();
+  assert.equal(deletionCalls(fake.calls).length, 1);
+  assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
+});
+
+test("an ambiguous exposure failure deletes the cluster sandbox instead of process cleanup", async () => {
+  const fake = createFake({ failAt: "preview" });
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "demo",
+    service: "demo-api",
+    localPort: 8080,
+    servicePort: 80,
+    expiresInSeconds: 300,
+  }), /preview failed/);
+  assert.equal(deletionCalls(fake.calls).length, 1);
+  assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
+});
+
+test("malformed placement, binary, sandbox, Helm, and exposure inputs fail before execution", async () => {
+  const fake = createFake();
+  const local = createPlacement({ id: "local-unit", provider: "local" });
+  const missingCapability: Placement = { ...placement, capabilities: ["command:bash", "port:daytona-preview"] };
+  await assert.rejects(createDaytonaK3sCluster({ placement: local, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }), /requires placement provider/);
+  await assert.rejects(createDaytonaK3sCluster({ placement, ownedSandboxId: "unsafe sandbox", binary, exec: fake.exec }), /ownedSandboxId/);
+  await assert.rejects(createDaytonaK3sCluster({ placement: missingCapability, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }), /missing capability/);
+  await assert.rejects(createDaytonaK3sCluster({
+    placement,
+    ownedSandboxId: "owned-sandbox-1",
+    binary: { ...binary, sha256: "moving" },
+    exec: fake.exec,
+  }), /sha256/);
+  assert.equal(fake.calls.length, 0);
+
+  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const before = fake.calls.length;
+  assert.throws(() => installK3sHelmRelease(cluster, { release: "Bad Release", namespace: "demo", chart: "repo/chart" }), /Helm release/);
+  assert.throws(() => installK3sHelmRelease(cluster, { release: "demo", namespace: "Bad_Namespace", chart: "repo/chart" }), /Helm namespace/);
+  assert.throws(() => installK3sHelmRelease(cluster, { release: "demo", namespace: "demo", chart: "--set" }), /Helm chart/);
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "demo",
+    service: "Bad_Service",
+    localPort: 8080,
+    servicePort: 80,
+    expiresInSeconds: 300,
+  }), /Kubernetes service/);
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "demo",
+    service: "demo-api",
+    localPort: 0,
+    servicePort: 80,
+    expiresInSeconds: 300,
+  }), /local port/);
+  await assert.rejects(exposeK3sService(cluster, {
+    namespace: "demo",
+    service: "demo-api",
+    localPort: 8080,
+    servicePort: 70_000,
+    expiresInSeconds: 300,
+  }), /service port/);
+  await assert.rejects(cluster.kubectl(["get\npods"]), /control characters/);
+  assert.equal(fake.calls.length, before);
+  await cluster.stop();
+});

--- a/evals/packages/env/test/daytona-k3s.test.ts
+++ b/evals/packages/env/test/daytona-k3s.test.ts
@@ -3,14 +3,13 @@ import test from "node:test";
 import type { DaytonaExec } from "@openwork/hosts";
 import {
   createDaytonaK3sCluster,
-  daytonaK3sExecArgv,
-  daytonaK3sPreviewArgv,
   exposeK3sService,
   installK3sHelmRelease,
   parseDaytonaK3sPreviewUrl,
+  provisionDaytonaK3sSandbox,
 } from "../src/daytona-k3s.ts";
 import { createPlacement } from "../src/network-world.ts";
-import type { K3sBinaryDescriptor } from "../src/daytona-k3s.ts";
+import type { DaytonaK3sClusterHandle, DaytonaK3sSandboxOwnership } from "../src/daytona-k3s.ts";
 import type { Placement } from "../src/network-world.ts";
 
 interface ExecCall {
@@ -21,14 +20,21 @@ interface ExecCall {
 interface FakeOptions {
   uid?: string;
   sudoFails?: boolean;
-  failAt?: "install" | "start" | "readiness" | "preview";
+  failAt?: "sandbox-create" | "sandbox-readiness" | "install" | "start" | "readiness" | "preview";
   helmMissing?: boolean;
 }
+
+const SANDBOX = "owned-sandbox-1";
+const OFFICIAL_VERSION = "v1.31.6+k3s1";
+const OFFICIAL_URL = "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s";
+const OFFICIAL_SHA256 = "9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5";
+const placement = createPlacement({ id: "unit-cluster", provider: "daytona-k3s" });
+const root = "/tmp/openwork-world-k3s/unit-cluster";
 
 function remoteScript(call: ExecCall): string {
   if (call.args[0] !== "exec") return "";
   assert.equal(call.args.length, 4);
-  assert.deepEqual(call.args.slice(0, 3), ["exec", "owned-sandbox-1", "--"]);
+  assert.deepEqual(call.args.slice(0, 3), ["exec", SANDBOX, "--"]);
   const wrapped = call.args[3] ?? "";
   const prefix = "bash -lc '";
   assert(wrapped.startsWith(prefix) && wrapped.endsWith("'"), `Unexpected Daytona exec transport: ${wrapped}`);
@@ -40,12 +46,20 @@ function createFake(options: FakeOptions = {}): { exec: DaytonaExec; calls: Exec
   const exec: DaytonaExec = async (args, opts) => {
     const call = { args: [...args], opts };
     calls.push(call);
+    if (args[0] === "create") {
+      if (options.failAt === "sandbox-create") return { stdout: "", stderr: "creation failed\n", code: 1 };
+      return { stdout: "created\n", stderr: "", code: 0 };
+    }
     if (args[0] === "delete") return { stdout: "deleted\n", stderr: "", code: 0 };
     if (args[0] === "preview-url") {
       if (options.failAt === "preview") return { stdout: "", stderr: "preview failed\n", code: 1 };
       return { stdout: "Preview URL: https://30443.preview.example.test/signed?token=unit\n", stderr: "", code: 0 };
     }
     const script = remoteScript(call);
+    if (script === "'true'") {
+      if (options.failAt === "sandbox-readiness") return { stdout: "", stderr: "not ready\n", code: 1 };
+      return { stdout: "", stderr: "", code: 0 };
+    }
     if (script === "'id' '-u'") return { stdout: `${options.uid ?? "0"}\n`, stderr: "", code: 0 };
     if (script === "'sudo' '-n' 'true'" && options.sudoFails) {
       return { stdout: "", stderr: "sudo: a password is required\n", code: 1 };
@@ -69,13 +83,14 @@ function createFake(options: FakeOptions = {}): { exec: DaytonaExec; calls: Exec
   return { exec, calls };
 }
 
-const placement = createPlacement({ id: "unit-cluster", provider: "daytona-k3s" });
-const binary: K3sBinaryDescriptor = {
-  version: "v1.31.6+k3s1",
-  url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
-  sha256: "a".repeat(64),
-};
-const root = "/tmp/openwork-world-k3s/unit-cluster";
+async function provision(fake: { exec: DaytonaExec }): Promise<DaytonaK3sSandboxOwnership> {
+  return provisionDaytonaK3sSandbox({ name: SANDBOX, exec: fake.exec });
+}
+
+async function createCluster(fake: { exec: DaytonaExec }): Promise<DaytonaK3sClusterHandle> {
+  const ownership = await provision(fake);
+  return createDaytonaK3sCluster({ placement, ownership });
+}
 
 function scripts(calls: ExecCall[]): string[] {
   return calls.filter((call) => call.args[0] === "exec").map(remoteScript);
@@ -85,37 +100,89 @@ function deletionCalls(calls: ExecCall[]): ExecCall[] {
   return calls.filter((call) => call.args[0] === "delete");
 }
 
-test("Daytona v0.173 argv keeps the complete quoted bash command in one post-separator argument", () => {
-  assert.deepEqual(daytonaK3sExecArgv("owned-sandbox-1", "id -u"), [
-    "exec", "owned-sandbox-1", "--", "bash -lc 'id -u'",
-  ]);
-  assert.deepEqual(daytonaK3sPreviewArgv("owned-sandbox-1", 8080, 86_400), [
-    "preview-url", "owned-sandbox-1", "-p", "8080", "--expires", "86400",
-  ]);
-  assert.throws(() => daytonaK3sPreviewArgv("owned-sandbox-1", 8080, 86_401), /between 1 and 86400/);
+test("provisioning uses a safe private Daytona sandbox and v0.173 one-argument bash transport", async () => {
+  const fake = createFake();
+  const ownership = await provision(fake);
+  assert.deepEqual(fake.calls[0], {
+    args: ["create", "--name", SANDBOX, "--snapshot", "daytona-large", "--auto-delete", "0", "--target", "us"],
+    opts: { timeoutMs: 300_000 },
+  });
+  assert.equal(fake.calls[0]?.args.includes("--public"), false);
+  assert.deepEqual(fake.calls[1], {
+    args: ["exec", SANDBOX, "--", "bash -lc ''\"'\"'true'\"'\"''"],
+    opts: { timeoutMs: 60_000 },
+  });
+
+  const cluster = await createDaytonaK3sCluster({ placement, ownership });
+  await cluster.stop();
   assert.equal(parseDaytonaK3sPreviewUrl("Preview URL: https://preview.example.test/path?token=abc\n"), "https://preview.example.test/path?token=abc");
   assert.equal(parseDaytonaK3sPreviewUrl(`Preview URL: https://preview.example.test/path${",".repeat(10_000)}`), "https://preview.example.test/path");
 });
 
-test("root lifecycle installs a checksummed pinned binary into placement paths and deletes its sandbox idempotently", async () => {
+test("provisioning rejects unsafe names and non-allowlisted snapshots before execution", async () => {
   const fake = createFake();
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  await assert.rejects(provisionDaytonaK3sSandbox({ name: "unsafe sandbox", exec: fake.exec }), /sandbox name/);
+  await assert.rejects(provisionDaytonaK3sSandbox({
+    name: SANDBOX,
+    // @ts-expect-error Verify the runtime boundary as well as the typed snapshot allowlist.
+    snapshot: "moving-snapshot",
+    exec: fake.exec,
+  }), /not allowlisted/);
+  assert.equal(fake.calls.length, 0);
+});
+
+test("partial sandbox creation and exec-readiness failures delete the whole sandbox", async () => {
+  const failures: readonly ("sandbox-create" | "sandbox-readiness")[] = ["sandbox-create", "sandbox-readiness"];
+  for (const failAt of failures) {
+    const fake = createFake({ failAt });
+    await assert.rejects(provision(fake));
+    assert.equal(deletionCalls(fake.calls).length, 1, `expected sandbox deletion after ${failAt}`);
+    assert.equal(scripts(fake.calls).some((script) => /\b(?:kill|pkill)\b|\.pid|PID/.test(script)), false);
+  }
+});
+
+test("a forged ownership receipt is rejected before cluster exec or deletion", async () => {
+  const fake = createFake();
+  const ownership = await provision(fake);
+  const forgedOwnership = structuredClone(ownership);
+  const before = fake.calls.length;
+  await assert.rejects(
+    createDaytonaK3sCluster({ placement, ownership: forgedOwnership }),
+    /ownership receipt returned by provisionDaytonaK3sSandbox/,
+  );
+  assert.equal(fake.calls.length, before);
+  assert.equal(deletionCalls(fake.calls).length, 0);
+
+  const cluster = await createDaytonaK3sCluster({ placement, ownership });
+  const afterClaim = fake.calls.length;
+  await assert.rejects(createDaytonaK3sCluster({ placement, ownership }), /unused ownership receipt/);
+  assert.equal(fake.calls.length, afterClaim);
+  await cluster.stop();
+});
+
+test("root lifecycle downloads only the hardcoded official binary and deletes its sandbox idempotently", async () => {
+  const fake = createFake();
+  const cluster = await createCluster(fake);
   const observed = scripts(fake.calls);
 
-  assert.equal(observed[0], "'id' '-u'");
-  const install = observed[1] ?? "";
-  assert.match(install, new RegExp(`'curl'.*'${binary.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}'`));
-  assert(install.includes(`'printf' '%s\\n' '${binary.sha256}  ${root}/download/k3s' | 'sha256sum' '--check' '--status' '-'`));
+  assert(observed.includes("'id' '-u'"));
+  const downloads = observed.filter((script) => script.includes("'curl' '--fail'"));
+  assert.equal(downloads.length, 1);
+  const install = downloads[0] ?? "";
+  assert(install.includes(`'curl' '--fail' '--silent' '--show-error' '--location' '${OFFICIAL_URL}' '--output' '${root}/download/k3s'`));
+  assert(install.includes(`'printf' '%s\\n' '${OFFICIAL_SHA256}  ${root}/download/k3s' | 'sha256sum' '--check' '--status' '-'`));
   assert(install.includes(`'mv' '-f' '${root}/download/k3s' '${root}/bin/k3s'`));
   assert.doesNotMatch(install, /get\.k3s\.io|systemctl|openrc|rc-service/);
 
-  const start = observed[2] ?? "";
-  assert(start.includes(`'nohup' '${root}/bin/k3s' 'server' '--data-dir' '${root}/data' '--write-kubeconfig' '${root}/kubeconfig.yaml'`));
+  const start = observed.find((script) => script.includes("'server'")) ?? "";
+  assert(start.includes(`'nohup' '${root}/bin/k3s' 'server' '--data-dir' '${root}/data' '--write-kubeconfig' '${root}/kubeconfig.yaml' '--write-kubeconfig-mode' '0600'`));
+  assert.doesNotMatch(start, /'--write-kubeconfig-mode' '0644'/);
   assert(start.includes("'--node-name' 'openwork-unit-cluster'"));
   assert(start.includes("'--snapshotter' 'native'"));
-  const readiness = observed[3] ?? "";
+  const readiness = observed.find((script) => script.includes("'--raw=/readyz'")) ?? "";
   assert(readiness.includes(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' '--raw=/readyz'`));
   assert.doesNotMatch(readiness, /pgrep/);
+  assert.equal(cluster.version, OFFICIAL_VERSION);
   assert.deepEqual(cluster.paths, {
     root,
     binary: `${root}/bin/k3s`,
@@ -130,32 +197,31 @@ test("root lifecycle installs a checksummed pinned binary into placement paths a
   await cluster[Symbol.asyncDispose]();
   assert.equal(deletionCalls(fake.calls).length, 1);
   assert.deepEqual(deletionCalls(fake.calls)[0], {
-    args: ["delete", "owned-sandbox-1"],
+    args: ["delete", SANDBOX],
     opts: { timeoutMs: 60_000, input: "y\n" },
   });
   assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
 });
 
-test("non-root lifecycle requires passwordless sudo and uses it for the placement binary", async () => {
+test("non-root lifecycle requires passwordless sudo for k3s, kubectl, and Helm kubeconfig access", async () => {
   const fake = createFake({ uid: "1000" });
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const cluster = await createCluster(fake);
   const observed = scripts(fake.calls);
 
-  assert.equal(observed[0], "'id' '-u'");
-  assert.equal(observed[1], "'sudo' '-n' 'true'");
-  assert(observed[3]?.includes(`'nohup' 'sudo' '-n' '${root}/bin/k3s' 'server'`));
-  assert(observed[4]?.includes(`'sudo' '-n' '${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml'`));
+  assert(observed.includes("'id' '-u'"));
+  assert(observed.includes("'sudo' '-n' 'true'"));
+  assert(observed.some((script) => script.includes(`'nohup' 'sudo' '-n' '${root}/bin/k3s' 'server'`)));
+  assert(observed.some((script) => script.includes(`'sudo' '-n' '${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml'`)));
   await cluster.kubectl(["get", "pods"]);
   assert.equal(scripts(fake.calls).at(-1), `'sudo' '-n' '${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'get' 'pods'`);
+  await cluster.helm(["list", "--all-namespaces"]);
+  assert.equal(scripts(fake.calls).at(-1), `'sudo' '-n' 'helm' '--kubeconfig' '${root}/kubeconfig.yaml' 'list' '--all-namespaces'`);
   await cluster.stop();
 });
 
 test("lack of root and passwordless sudo fails before start and deletes the owned sandbox", async () => {
   const fake = createFake({ uid: "1000", sudoFails: true });
-  await assert.rejects(
-    createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }),
-    /passwordless sudo.*failed|password is required/s,
-  );
+  await assert.rejects(createCluster(fake), /passwordless sudo.*failed|password is required/s);
   assert(scripts(fake.calls).every((script) => !script.includes("'server'")));
   assert.equal(deletionCalls(fake.calls).length, 1);
 });
@@ -164,17 +230,15 @@ test("every install, ambiguous start, and readiness failure deletes the entire o
   const failures: readonly NonNullable<FakeOptions["failAt"]>[] = ["install", "start", "readiness"];
   for (const failAt of failures) {
     const fake = createFake({ failAt });
-    await assert.rejects(
-      createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }),
-    );
+    await assert.rejects(createCluster(fake));
     assert.equal(deletionCalls(fake.calls).length, 1, `expected owned sandbox deletion after ${failAt}`);
     assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
   }
 });
 
-test("Helm uses the placement kubeconfig and missing Helm fails without curl-pipe installation", async () => {
+test("Helm uses the root-selected privilege and missing Helm fails without curl-pipe installation", async () => {
   const fake = createFake({ helmMissing: true });
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const cluster = await createCluster(fake);
   const before = fake.calls.length;
   await assert.rejects(
     installK3sHelmRelease(cluster, { release: "demo", namespace: "demo-ns", chart: "oci://registry.example.test/team/chart" }),
@@ -190,7 +254,7 @@ test("Helm uses the placement kubeconfig and missing Helm fails without curl-pip
 
 test("cluster-owned exposure reserves ports, accepts the maximum expiry, and has no independent cleanup", async () => {
   const fake = createFake();
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const cluster = await createCluster(fake);
   const exposure = await exposeK3sService(cluster, {
     namespace: "demo-ns",
     service: "demo-api",
@@ -202,9 +266,9 @@ test("cluster-owned exposure reserves ports, accepts the maximum expiry, and has
   assert.equal(exposure.ephemeral, true);
   assert.equal(exposure.persistableInDesktopConfig, false);
   assert.equal(exposure.validUntil, "cluster-disposal-or-expiry");
-  assert.equal(exposure.ownedSandboxId, "owned-sandbox-1");
+  assert.equal(exposure.ownedSandboxId, SANDBOX);
   assert.deepEqual(fake.calls.find((call) => call.args[0] === "preview-url")?.args, [
-    "preview-url", "owned-sandbox-1", "-p", "30443", "--expires", "86400",
+    "preview-url", SANDBOX, "-p", "30443", "--expires", "86400",
   ]);
   const portStart = scripts(fake.calls).find((script) => script.includes("'port-forward'"));
   assert(portStart?.includes(`'${root}/bin/k3s' 'kubectl' '--kubeconfig' '${root}/kubeconfig.yaml' 'port-forward'`));
@@ -233,7 +297,7 @@ test("cluster-owned exposure reserves ports, accepts the maximum expiry, and has
 
 test("an ambiguous exposure failure deletes the cluster sandbox instead of process cleanup", async () => {
   const fake = createFake({ failAt: "preview" });
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
+  const cluster = await createCluster(fake);
   await assert.rejects(exposeK3sService(cluster, {
     namespace: "demo",
     service: "demo-api",
@@ -245,23 +309,24 @@ test("an ambiguous exposure failure deletes the cluster sandbox instead of proce
   assert(scripts(fake.calls).every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
 });
 
-test("malformed placement, binary, sandbox, Helm, and exposure inputs fail before execution", async () => {
+test("malformed placement, version, Helm, and exposure inputs fail before cluster execution", async () => {
   const fake = createFake();
+  const ownership = await provision(fake);
   const local = createPlacement({ id: "local-unit", provider: "local" });
   const missingCapability: Placement = { ...placement, capabilities: ["command:bash", "port:daytona-preview"] };
-  await assert.rejects(createDaytonaK3sCluster({ placement: local, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }), /requires placement provider/);
-  await assert.rejects(createDaytonaK3sCluster({ placement, ownedSandboxId: "unsafe sandbox", binary, exec: fake.exec }), /ownedSandboxId/);
-  await assert.rejects(createDaytonaK3sCluster({ placement: missingCapability, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec }), /missing capability/);
+  const before = fake.calls.length;
+  await assert.rejects(createDaytonaK3sCluster({ placement: local, ownership }), /requires placement provider/);
+  await assert.rejects(createDaytonaK3sCluster({ placement: missingCapability, ownership }), /missing capability/);
   await assert.rejects(createDaytonaK3sCluster({
     placement,
-    ownedSandboxId: "owned-sandbox-1",
-    binary: { ...binary, sha256: "moving" },
-    exec: fake.exec,
-  }), /sha256/);
-  assert.equal(fake.calls.length, 0);
+    ownership,
+    // @ts-expect-error Verify the runtime boundary as well as the typed version allowlist.
+    version: "v1.99.0+k3s1",
+  }), /not supported/);
+  assert.equal(fake.calls.length, before);
 
-  const cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId: "owned-sandbox-1", binary, exec: fake.exec });
-  const before = fake.calls.length;
+  const cluster = await createDaytonaK3sCluster({ placement, ownership });
+  const beforeInvalidTools = fake.calls.length;
   assert.throws(() => installK3sHelmRelease(cluster, { release: "Bad Release", namespace: "demo", chart: "repo/chart" }), /Helm release/);
   assert.throws(() => installK3sHelmRelease(cluster, { release: "demo", namespace: "Bad_Namespace", chart: "repo/chart" }), /Helm namespace/);
   assert.throws(() => installK3sHelmRelease(cluster, { release: "demo", namespace: "demo", chart: "--set" }), /Helm chart/);
@@ -287,6 +352,6 @@ test("malformed placement, binary, sandbox, Helm, and exposure inputs fail befor
     expiresInSeconds: 300,
   }), /service port/);
   await assert.rejects(cluster.kubectl(["get\npods"]), /control characters/);
-  assert.equal(fake.calls.length, before);
+  assert.equal(fake.calls.length, beforeInvalidTools);
   await cluster.stop();
 });

--- a/evals/specs/daytona-k3s-live.e2e.test.ts
+++ b/evals/specs/daytona-k3s-live.e2e.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import {
+  createDaytonaK3sCluster,
+  createPlacement,
+  needs,
+  test,
+} from "@openwork/testkit";
+
+const K3S_BINARY = {
+  version: "v1.31.6+k3s1",
+  url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
+  sha256: "9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test("an exclusively owned Daytona sandbox boots the pinned k3s provider", { timeout: 300_000 }, async ({ evidence }) => {
+  needs({
+    daytona: true,
+    env: ["OPENWORK_EVAL_DAYTONA_K3S_SANDBOX"],
+    optIn: ["OPENWORK_EVAL_DAYTONA_K3S_LIVE"],
+    commands: ["daytona"],
+  });
+  const ownedSandboxId = process.env.OPENWORK_EVAL_DAYTONA_K3S_SANDBOX?.trim();
+  if (!ownedSandboxId) throw new Error("OPENWORK_EVAL_DAYTONA_K3S_SANDBOX was empty after needs().");
+  const placement = createPlacement({
+    id: "live-k3s",
+    provider: "daytona-k3s",
+    privileged: true,
+    resources: { cpu: 4, memoryGb: 8, diskGb: 10 },
+  });
+
+  await using cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId, binary: K3S_BINARY });
+  const listed = await cluster.kubectl(["get", "nodes", "-o", "json"]);
+  const payload: unknown = JSON.parse(listed.stdout);
+  const items = isRecord(payload) && Array.isArray(payload.items) ? payload.items : [];
+  const ready = items.some((item) => {
+    if (!isRecord(item) || !isRecord(item.status) || !Array.isArray(item.status.conditions)) return false;
+    return item.status.conditions.some((condition) =>
+      isRecord(condition) && condition.type === "Ready" && condition.status === "True"
+    );
+  });
+  assert.equal(listed.code, 0);
+  assert.equal(items.length, 1);
+  assert.equal(ready, true);
+  evidence.recordAssertionEvidence(
+    "A dedicated Daytona sandbox runs the pinned k3s binary and reports one Ready node",
+    `k3s ${K3S_BINARY.version} returned ${items.length} node with Ready=${ready}; disposal deletes owned sandbox ${ownedSandboxId}.`,
+    listed.code === 0 && items.length === 1 && ready,
+  );
+});

--- a/evals/specs/daytona-k3s-live.e2e.test.ts
+++ b/evals/specs/daytona-k3s-live.e2e.test.ts
@@ -1,30 +1,24 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import {
   createDaytonaK3sCluster,
   createPlacement,
   needs,
+  provisionDaytonaK3sSandbox,
   test,
 } from "@openwork/testkit";
-
-const K3S_BINARY = {
-  version: "v1.31.6+k3s1",
-  url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
-  sha256: "9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5",
-};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("an exclusively owned Daytona sandbox boots the pinned k3s provider", { timeout: 300_000 }, async ({ evidence }) => {
+test("an exclusively owned Daytona sandbox boots the pinned k3s provider", { timeout: 600_000 }, async ({ evidence }) => {
   needs({
     daytona: true,
-    env: ["OPENWORK_EVAL_DAYTONA_K3S_SANDBOX"],
     optIn: ["OPENWORK_EVAL_DAYTONA_K3S_LIVE"],
     commands: ["daytona"],
   });
-  const ownedSandboxId = process.env.OPENWORK_EVAL_DAYTONA_K3S_SANDBOX?.trim();
-  if (!ownedSandboxId) throw new Error("OPENWORK_EVAL_DAYTONA_K3S_SANDBOX was empty after needs().");
+  const sandboxName = `openwork-k3s-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
   const placement = createPlacement({
     id: "live-k3s",
     provider: "daytona-k3s",
@@ -32,7 +26,8 @@ test("an exclusively owned Daytona sandbox boots the pinned k3s provider", { tim
     resources: { cpu: 4, memoryGb: 8, diskGb: 10 },
   });
 
-  await using cluster = await createDaytonaK3sCluster({ placement, ownedSandboxId, binary: K3S_BINARY });
+  const ownership = await provisionDaytonaK3sSandbox({ name: sandboxName, snapshot: "daytona-large" });
+  await using cluster = await createDaytonaK3sCluster({ placement, ownership });
   const listed = await cluster.kubectl(["get", "nodes", "-o", "json"]);
   const payload: unknown = JSON.parse(listed.stdout);
   const items = isRecord(payload) && Array.isArray(payload.items) ? payload.items : [];
@@ -47,7 +42,7 @@ test("an exclusively owned Daytona sandbox boots the pinned k3s provider", { tim
   assert.equal(ready, true);
   evidence.recordAssertionEvidence(
     "A dedicated Daytona sandbox runs the pinned k3s binary and reports one Ready node",
-    `k3s ${K3S_BINARY.version} returned ${items.length} node with Ready=${ready}; disposal deletes owned sandbox ${ownedSandboxId}.`,
+    `k3s ${cluster.version} returned ${items.length} node with Ready=${ready}; disposal deletes the privately provisioned, auto-delete-on-stop sandbox ${sandboxName}.`,
     listed.code === 0 && items.length === 1 && ready,
   );
 });

--- a/evals/specs/daytona-k3s-orchestration.test.ts
+++ b/evals/specs/daytona-k3s-orchestration.test.ts
@@ -7,9 +7,9 @@ import {
   exposePort,
   installK3sHelmRelease,
   placementHasCapability,
+  provisionDaytonaK3sSandbox,
   test,
 } from "@openwork/testkit";
-import type { K3sBinaryDescriptor } from "@openwork/testkit";
 
 function remoteScript(args: string[]): string {
   const wrapped = args[3] ?? "";
@@ -24,6 +24,7 @@ test("exclusive Daytona k3s lifecycle composes with network plans through inject
   const calls: string[][] = [];
   const exec: DaytonaExec = async (args) => {
     calls.push([...args]);
+    if (args[0] === "create") return { stdout: "created\n", stderr: "", code: 0 };
     if (args[0] === "delete") return { stdout: "deleted\n", stderr: "", code: 0 };
     if (args[0] === "preview-url") {
       return { stdout: "Preview URL: https://32005.preview.example.test/signed?token=contract\n", stderr: "", code: 0 };
@@ -32,22 +33,13 @@ test("exclusive Daytona k3s lifecycle composes with network plans through inject
     if (script === "'id' '-u'") return { stdout: "0\n", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
-  const binary: K3sBinaryDescriptor = {
-    version: "v1.31.6+k3s1",
-    url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
-    sha256: "b".repeat(64),
-  };
   const placement = createPlacement({ id: "contract-cluster", provider: "daytona-k3s" });
   const portPlan = exposePort(placement, 32_005);
   assert.equal(placementHasCapability(placement, "kubernetes:k3s"), true);
   assert.equal(portPlan.mode, "daytona-preview");
 
-  const cluster = await createDaytonaK3sCluster({
-    placement,
-    ownedSandboxId: "owned-contract-sandbox",
-    binary,
-    exec,
-  });
+  const ownership = await provisionDaytonaK3sSandbox({ name: "owned-contract-sandbox", exec });
+  const cluster = await createDaytonaK3sCluster({ placement, ownership });
   await installK3sHelmRelease(cluster, { release: "contract", namespace: "contract", chart: "repo/contract" });
   const exposure = await exposeK3sService(cluster, {
     namespace: "contract",
@@ -68,13 +60,19 @@ test("exclusive Daytona k3s lifecycle composes with network plans through inject
   await cluster.stop();
   await cluster[Symbol.asyncDispose]();
   assert.equal(calls.filter((args) => args[0] === "delete").length, 1);
+  assert.deepEqual(calls.find((args) => args[0] === "create"), [
+    "create", "--name", "owned-contract-sandbox", "--snapshot", "daytona-large", "--auto-delete", "0", "--target", "us",
+  ]);
+  assert.equal(calls.find((args) => args[0] === "create")?.includes("--public"), false);
   const scripts = calls.filter((args) => args[0] === "exec").map(remoteScript);
-  assert(scripts.some((script) => script.includes("'sha256sum' '--check' '--status' '-'")));
+  assert(scripts.some((script) => script.includes("'curl' '--fail' '--silent' '--show-error' '--location' 'https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s'")));
+  assert(scripts.some((script) => script.includes("'9f82f06b4cf318fcf4eeda3f4fedaa10c0cebc418b1a047e72b104f5ea7874c5  /tmp/openwork-world-k3s/contract-cluster/download/k3s'")));
+  assert(scripts.some((script) => script.includes("'--write-kubeconfig-mode' '0600'")));
   assert(scripts.some((script) => script.includes("'helm' '--kubeconfig' '/tmp/openwork-world-k3s/contract-cluster/kubeconfig.yaml'")));
   assert(scripts.every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
   evidence.recordAssertionEvidence(
     "Exclusive-sandbox Daytona k3s orchestration composes with network plans (not live k3s behavior)",
-    `The injected executor observed ${calls.length} contract calls, a checksummed placement binary, a 600-second ephemeral preview, and one idempotent whole-sandbox deletion with no PID or kill cleanup; no live Daytona or k3s behavior is claimed.`,
+    `The injected executor observed ${calls.length} contract calls, an internally provisioned private sandbox, the allowlisted official k3s binary with a 0600 kubeconfig, a 600-second ephemeral preview, and one idempotent whole-sandbox deletion with no PID or kill cleanup; no live Daytona or k3s behavior is claimed.`,
     true,
   );
 });

--- a/evals/specs/daytona-k3s-orchestration.test.ts
+++ b/evals/specs/daytona-k3s-orchestration.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import type { DaytonaExec } from "@openwork/hosts";
+import {
+  createDaytonaK3sCluster,
+  createPlacement,
+  exposeK3sService,
+  exposePort,
+  installK3sHelmRelease,
+  placementHasCapability,
+  test,
+} from "@openwork/testkit";
+import type { K3sBinaryDescriptor } from "@openwork/testkit";
+
+function remoteScript(args: string[]): string {
+  const wrapped = args[3] ?? "";
+  const prefix = "bash -lc '";
+  assert.deepEqual(args.slice(0, 3), ["exec", "owned-contract-sandbox", "--"]);
+  assert.equal(args.length, 4);
+  assert(wrapped.startsWith(prefix) && wrapped.endsWith("'"));
+  return wrapped.slice(prefix.length, -1).replaceAll(`'"'"'`, "'");
+}
+
+test("exclusive Daytona k3s lifecycle composes with network plans through injected orchestration", async ({ evidence }) => {
+  const calls: string[][] = [];
+  const exec: DaytonaExec = async (args) => {
+    calls.push([...args]);
+    if (args[0] === "delete") return { stdout: "deleted\n", stderr: "", code: 0 };
+    if (args[0] === "preview-url") {
+      return { stdout: "Preview URL: https://32005.preview.example.test/signed?token=contract\n", stderr: "", code: 0 };
+    }
+    const script = remoteScript(args);
+    if (script === "'id' '-u'") return { stdout: "0\n", stderr: "", code: 0 };
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  const binary: K3sBinaryDescriptor = {
+    version: "v1.31.6+k3s1",
+    url: "https://github.com/k3s-io/k3s/releases/download/v1.31.6%2Bk3s1/k3s",
+    sha256: "b".repeat(64),
+  };
+  const placement = createPlacement({ id: "contract-cluster", provider: "daytona-k3s" });
+  const portPlan = exposePort(placement, 32_005);
+  assert.equal(placementHasCapability(placement, "kubernetes:k3s"), true);
+  assert.equal(portPlan.mode, "daytona-preview");
+
+  const cluster = await createDaytonaK3sCluster({
+    placement,
+    ownedSandboxId: "owned-contract-sandbox",
+    binary,
+    exec,
+  });
+  await installK3sHelmRelease(cluster, { release: "contract", namespace: "contract", chart: "repo/contract" });
+  const exposure = await exposeK3sService(cluster, {
+    namespace: "contract",
+    service: "contract-api",
+    localPort: portPlan.port,
+    servicePort: 3005,
+    expiresInSeconds: 600,
+  });
+  assert.equal(exposure.placementId, portPlan.placementId);
+  assert.equal(exposure.localPort, portPlan.port);
+  assert.equal(exposure.ephemeral, true);
+  assert.equal(exposure.persistableInDesktopConfig, false);
+  assert.equal(exposure.validUntil, "cluster-disposal-or-expiry");
+  assert.deepEqual(calls.find((args) => args[0] === "preview-url"), [
+    "preview-url", "owned-contract-sandbox", "-p", "32005", "--expires", "600",
+  ]);
+
+  await cluster.stop();
+  await cluster[Symbol.asyncDispose]();
+  assert.equal(calls.filter((args) => args[0] === "delete").length, 1);
+  const scripts = calls.filter((args) => args[0] === "exec").map(remoteScript);
+  assert(scripts.some((script) => script.includes("'sha256sum' '--check' '--status' '-'")));
+  assert(scripts.some((script) => script.includes("'helm' '--kubeconfig' '/tmp/openwork-world-k3s/contract-cluster/kubeconfig.yaml'")));
+  assert(scripts.every((script) => !/\b(?:kill|pkill)\b|\.pid|PID/.test(script)));
+  evidence.recordAssertionEvidence(
+    "Exclusive-sandbox Daytona k3s orchestration composes with network plans (not live k3s behavior)",
+    `The injected executor observed ${calls.length} contract calls, a checksummed placement binary, a 600-second ephemeral preview, and one idempotent whole-sandbox deletion with no PID or kill cleanup; no live Daytona or k3s behavior is claimed.`,
+    true,
+  );
+});

--- a/evals/specs/world-network-primitives.test.ts
+++ b/evals/specs/world-network-primitives.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import {
+  createCleanupPlan,
+  createNetworkEdge,
+  createPlacement,
+  exposePort,
+  placementHasCapability,
+  runOnPlacement,
+  selectFaultPhase,
+  test,
+} from "@openwork/testkit";
+
+test("network world primitives describe placements, ports, commands, faults, and cleanup without side effects", ({ evidence }) => {
+  const localLinux = createPlacement({ id: "local-linux", provider: "local", os: "linux" });
+  const daytonaK3s = createPlacement({
+    id: "den-cluster",
+    provider: "daytona-k3s",
+    privileged: true,
+    resources: { cpu: 4, memoryGb: 8, diskGb: 20 },
+  });
+  const windowsClient = createPlacement({ id: "windows-client", provider: "daytona-windows", privileged: true });
+
+  assert.equal(localLinux.os, "linux");
+  assert.equal(daytonaK3s.os, "linux");
+  assert.equal(windowsClient.os, "windows");
+  assert.equal(placementHasCapability(daytonaK3s, "kubernetes:k3s"), true);
+  assert.equal(placementHasCapability(daytonaK3s, "surface:chrome"), false);
+  assert.equal(placementHasCapability(daytonaK3s, "network:tls-intercept"), true);
+  assert.equal(placementHasCapability(windowsClient, "trust:windows-machine-ca"), true);
+  assert.equal(placementHasCapability(windowsClient, "command:powershell"), true);
+
+  const localPort = exposePort(localLinux, 3005);
+  const daytonaPort = exposePort(daytonaK3s, 3005);
+  assert.deepEqual(localPort, {
+    placementId: "local-linux",
+    port: 3005,
+    mode: "localhost",
+    url: "http://127.0.0.1:3005",
+    requiresRuntimeResolution: false,
+  });
+  assert.deepEqual(daytonaPort, {
+    placementId: "den-cluster",
+    port: 3005,
+    mode: "daytona-preview",
+    requiresRuntimeResolution: true,
+  });
+
+  const linuxCommand = runOnPlacement(daytonaK3s, "kubectl get pods");
+  const windowsCommand = runOnPlacement(windowsClient, "Get-NetRoute");
+  assert.deepEqual(linuxCommand.argv, ["bash", "-lc", "kubectl get pods"]);
+  assert.deepEqual(windowsCommand.argv, ["powershell", "-NoProfile", "-NonInteractive", "-Command", "Get-NetRoute"]);
+
+  const dns = createNetworkEdge({ id: "corp-dns", placement: daytonaK3s, kind: "dns-zone" });
+  const mitm = createNetworkEdge({ id: "mitm-edge", placement: daytonaK3s, kind: "tls-intercept-proxy", upstreamResourceId: "den" });
+  assert.deepEqual(dns.requiredCapabilities, ["network:dns"]);
+  assert.deepEqual(mitm.requiredCapabilities, ["network:tls-intercept"]);
+  assert.throws(
+    () => createNetworkEdge({ id: "client-dns", placement: windowsClient, kind: "dns-zone" }),
+    /missing capabilities: network:dns/,
+  );
+
+  assert.throws(
+    () => createPlacement({ id: "bad-client", provider: "daytona-windows", os: "linux" }),
+    /requires os "windows"/,
+  );
+
+  const phase = selectFaultPhase([
+    { id: "baseline", actions: [{ kind: "recover", target: "mitm-edge" }] },
+    {
+      id: "vpn-flap",
+      actions: [
+        { kind: "drop", target: "mitm-edge", every: 3 },
+        { kind: "dns-response", target: "corp-dns", response: "servfail" },
+      ],
+    },
+  ], "vpn-flap");
+  assert.equal(phase.id, "vpn-flap");
+  assert.equal(phase.actionCount, 2);
+  assert.throws(
+    () => selectFaultPhase([
+      { id: "duplicate", actions: [] },
+      { id: "duplicate", actions: [] },
+    ], "duplicate"),
+    /duplicate ids/,
+  );
+
+  const receipt = createCleanupPlan("corp-world", [
+    { resourceId: " corp-dns ", action: " remove dns zone ", command: linuxCommand },
+    { resourceId: "mitm-edge", action: "remove test root", command: runOnPlacement(daytonaK3s, "rm -f /tmp/test-root.pem") },
+  ]);
+  assert.equal(receipt.steps.length, 2);
+  assert.equal(receipt.steps[0]?.resourceId, "corp-dns");
+  assert.equal(receipt.steps[0]?.action, "remove dns zone");
+  evidence.recordAssertionEvidence(
+    "World network primitives are side-effect-free contracts for later providers",
+    `Planned ${daytonaK3s.provider} placement with ${daytonaK3s.capabilities.length} capabilities, ${daytonaPort.mode} exposure, ${phase.actionCount} validated fault actions, and ${receipt.steps.length} normalized cleanup steps.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- add side-effect-free World placement, port, network-edge, fault-phase, and cleanup planning primitives
- add a concrete Daytona k3s provider around an exclusively owned sandbox, a pinned checksummed k3s binary, Helm execution, and ephemeral service previews
- use the native k3s snapshotter required by Daytona container sandboxes
- delete the complete owned sandbox on disposal or ambiguous startup/exposure failure instead of relying on unsafe PID cleanup
- add focused unit, PR-lane orchestration, and live Daytona k3s specs

## Verification
- `pnpm --dir evals exec node --test packages/env/test/daytona-k3s.test.ts` — 9 passed
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/world-network-primitives.test.ts` — 1 passed
- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/daytona-k3s-orchestration.test.ts` — 1 passed
- strict standalone TypeScript check for both new source modules — passed
- live Daytona: `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_DAYTONA_K3S_LIVE=1 ... specs/daytona-k3s-live.e2e.test.ts` — 1 passed; pinned k3s v1.31.6+k3s1 reported one Ready node and the owned sandbox was deleted on disposal
- `git diff --check` — passed

## Safety
Signed preview URLs are explicitly ephemeral and non-persistable. The cluster owns an exclusive Daytona sandbox; deleting that sandbox revokes its listeners/previews and is the cleanup boundary.

## Verdict
**Passed** — current-head live Daytona/k3s evidence is published on this PR.