### PR TITLE
fix(app): bound workspace session hydration

### DIFF
--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -138,6 +138,18 @@ export async function commitRouteWorkspaceSelection(input: {
   await input.activateWorkspace(workspaceId);
 }
 
+export async function mapRouteWorkspaceLoads<T, R>(
+  workspaces: readonly T[],
+  load: (workspace: T) => Promise<R>,
+): Promise<R[]> {
+  const batchSize = 4;
+  const results: R[] = [];
+  for (let offset = 0; offset < workspaces.length; offset += batchSize) {
+    results.push(...await Promise.all(workspaces.slice(offset, offset + batchSize).map(load)));
+  }
+  return results;
+}
+
 /**
  * Every workspace with an unloaded session index gets a background load, with
  * the routed workspace first so the visible pane fills fastest. Loading only

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -60,6 +60,7 @@ import {
 import {
   commitRouteWorkspaceSelection,
   createRouteRefreshLifecycle,
+  mapRouteWorkspaceLoads,
   routeWorkspaceSelectionCommitter,
 } from "@/react-app/shell/route-refresh-control";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
@@ -1490,8 +1491,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         await routeWorkspaceSelectionCommitter.settled();
         if (!attempt.isCurrent()) return;
       }
-      const sessionEntries = await Promise.all(
-        nextWorkspaces.map(async (workspace) => {
+      const sessionEntries = await mapRouteWorkspaceLoads(
+        nextWorkspaces,
+        async (workspace) => {
           const endpoint = routeWorkspaceServerClientResolver(workspace);
           if (!endpoint) {
             return { workspaceId: workspace.id, sessions: [], error: null as string | null };
@@ -1534,7 +1536,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               connectionState: null,
             };
           }
-        }),
+        },
       );
       if (!attempt.isCurrent()) return;
 

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -50,6 +50,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import {
   commitRouteWorkspaceSelection,
   createRouteRefreshLifecycle,
+  mapRouteWorkspaceLoads,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
   routeWorkspaceSelectionCommitter,
@@ -57,7 +58,6 @@ import {
 import {
   classifyRouteSessionReadError,
   describeRouteError,
-  isTransientStartupError,
   mapDesktopWorkspace,
   refreshRouteWorkspaceListState,
   stabilizeRouteWorkspaceOrder,
@@ -398,7 +398,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           // or run out of attempts — the sidebar keeps its "loading" state
           // in the meantime instead of flashing "error" next to the
           // workspace name.
-          if (attempt + 1 < MAX_ATTEMPTS && isTransientStartupError(message)) {
+          if (attempt + 1 < MAX_ATTEMPTS && classifyRouteSessionReadError(error) === "retryable") {
             if (backgroundSessionLoadInFlight.current.get(workspace.id) === requestStartedAt) {
               backgroundSessionLoadInFlight.current.delete(workspace.id);
             }
@@ -431,7 +431,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         }
       };
 
-      await Promise.all(workspaces.map((workspace) => fetchOnce(workspace, 0)));
+      await mapRouteWorkspaceLoads(workspaces, (workspace) => fetchOnce(workspace, 0));
     },
     [endpointForWorkspace, mergeFetchedSessionsWithPending],
   );

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -7,6 +7,7 @@ import {
   refreshRouteWorkspaceListState,
   stabilizeRouteWorkspaceOrder,
 } from "../src/react-app/shell/route-workspaces";
+import { mapRouteWorkspaceLoads } from "../src/react-app/shell/route-refresh-control";
 import {
   mergeWorkspaceRouteSession,
   preserveWorkspaceRouteSession,
@@ -126,6 +127,36 @@ describe("workspace route session read errors", () => {
       wait: async () => undefined,
     })).rejects.toMatchObject({ status: 403 });
     expect(attempts).toBe(1);
+  });
+});
+
+describe("workspace route session load budget", () => {
+  test("loads workspaces in bounded batches while preserving order", async () => {
+    let active = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+    const workspaces = Array.from({ length: 10 }, (_, index) => index);
+
+    const resultPromise = mapRouteWorkspaceLoads(workspaces, async (workspace) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve) => release.push(resolve));
+      active -= 1;
+      return `workspace-${workspace}`;
+    });
+
+    await Bun.sleep(0);
+    expect(active).toBe(4);
+    release.splice(0).forEach((resolve) => resolve());
+    await Bun.sleep(0);
+    expect(active).toBe(4);
+    release.splice(0).forEach((resolve) => resolve());
+    await Bun.sleep(0);
+    expect(active).toBe(2);
+    release.splice(0).forEach((resolve) => resolve());
+
+    expect(await resultPromise).toEqual(workspaces.map((workspace) => `workspace-${workspace}`));
+    expect(peak).toBe(4);
   });
 });
 

--- a/evals/specs/workspace-session-load-budget.test.ts
+++ b/evals/specs/workspace-session-load-budget.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { mapRouteWorkspaceLoads } from "../../apps/app/src/react-app/shell/route-refresh-control";
+
+test("workspace session hydration stays within its request budget", async ({ evidence }) => {
+  let active = 0;
+  let peak = 0;
+  const release: Array<() => void> = [];
+  const workspaces = Array.from({ length: 20 }, (_, index) => index);
+
+  const resultPromise = mapRouteWorkspaceLoads(workspaces, async (workspace) => {
+    active += 1;
+    peak = Math.max(peak, active);
+    await new Promise<void>((resolve) => release.push(resolve));
+    active -= 1;
+    return workspace;
+  });
+
+  for (let offset = 0; offset < workspaces.length; offset += 4) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(active).toBe(Math.min(4, workspaces.length - offset));
+    release.splice(0).forEach((resolve) => resolve());
+  }
+
+  expect(await resultPromise).toEqual(workspaces);
+  expect(peak).toBe(4);
+  evidence.recordAssertionEvidence(
+    "Session hydration cannot fan out across every workspace at once",
+    `Twenty workspace reads completed in order with peak concurrency ${peak}.`,
+    peak === 4,
+  );
+});


### PR DESCRIPTION
## Summary
- cap workspace session-list hydration at four concurrent reads in both session and Settings routes
- recognize structured `opencode_unconfigured` errors as bounded startup retries
- add unit and agent-first coverage for ordering and peak concurrency

## User impact
Normal behavior and session ordering are unchanged. Users with more than four workspaces may see later sidebar sections populate slightly later, while engine restarts no longer trigger an all-workspace request burst.

## Verification
- `bun test --isolate tests/workspace-routes.test.ts` — 18 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm evals:pr specs/workspace-session-load-budget.test.ts` — 1 passed, 0 failed, 0 skipped (local lane)

An exploratory invocation of the package-wide app test script also ran all 1,051 app tests because that script does not accept a file filter; 1,046 passed and 5 unrelated suites failed. It is not used as proof for this scoped change.