### PR TITLE
fix(sso): allow super-admin provider setup

### DIFF
--- a/evals/specs/sso-super-admin-registration.test.ts
+++ b/evals/specs/sso-super-admin-registration.test.ts
@@ -1,0 +1,125 @@
+import { expect } from "vitest";
+import { denFetch, freshSession } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { inviteMember, localMysqlIsRunning, server, test } from "@openwork/testkit";
+
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !localPlacement
+  ? "super-admin SSO registration skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+  : !mysqlOpen
+    ? "super-admin SSO registration skipped — needs MySQL on 127.0.0.1:3306"
+    : "a workspace super-admin can register SAML SSO without an internal authorization error";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(admin: DenSession, organizationName: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: auth(admin) });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === organizationName);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function memberIdByEmail(admin: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/org", {
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const id = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the super-admin membership failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+test.skipIf(!localPlacement || !mysqlOpen)(title, { timeout: 300_000 }, async ({ evidence, place }) => {
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const organizationName = `Super-admin SSO ${runId}`;
+  const password = "OpenWorkEval123!";
+
+  await using den = await server({ place, org: { name: organizationName, members: {} } });
+  const superAdmin = await inviteMember(den, "superAdmin", {
+    email: `sso-super-admin.${runId}@openwork.test`,
+    name: "SSO Super Admin",
+    password,
+  });
+  const orgId = await organizationId(den.admin, organizationName);
+  const memberId = await memberIdByEmail(den.admin, orgId, superAdmin.email);
+  const memberSignIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: superAdmin.email, password }),
+  });
+  const memberCookie = memberSignIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  expect(memberCookie).toBeTruthy();
+
+  const samlBody = JSON.stringify({
+    issuer: "http://127.0.0.1/google-saml",
+    domain: `super-admin-${runId}.test`,
+    entryPoint: "https://accounts.google.com/o/saml2/idp?idpid=test",
+    cert: "test-google-signing-certificate",
+    audience: den.ref.apiUrl,
+  });
+  const memberRegistration = await denFetch(den.ref, "/v1/sso/saml", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${superAdmin.token}`,
+      cookie: memberCookie,
+      "x-openwork-org-id": orgId,
+    },
+    body: samlBody,
+  });
+  expect(memberRegistration.response.status, memberRegistration.text).toBe(403);
+
+  const owner = await freshSession(den.admin);
+  const promoted = await denFetch(owner, `/v1/members/${encodeURIComponent(memberId)}/role`, {
+    method: "POST",
+    headers: { ...auth(owner), "x-openwork-org-id": orgId },
+    body: JSON.stringify({ role: "super-admin" }),
+  });
+  expect(promoted.response.status, promoted.text).toBe(200);
+
+  const signedIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: superAdmin.email, password }),
+  });
+  const sessionCookie = signedIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  expect(sessionCookie).toBeTruthy();
+
+  const registration = await denFetch(den.ref, "/v1/sso/saml", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${superAdmin.token}`,
+      cookie: sessionCookie,
+      "x-openwork-org-id": orgId,
+    },
+    body: samlBody,
+  });
+
+  expect(registration.response.status, registration.text).toBe(201);
+  expect(isRecord(registration.body) && isRecord(registration.body.connection)).toBe(true);
+  expect(registration.text).not.toMatch(/organization owner or admin/i);
+  expect(registration.text).not.toMatch(/internal server error/i);
+  evidence.recordAssertionEvidence(
+    "A super-admin can save SAML settings through the real SSO registration route",
+    `A member received HTTP ${memberRegistration.response.status}; after promotion to super-admin the same route returned HTTP ${registration.response.status} without either authorization mismatch error.`,
+    registration.response.status === 201
+      && memberRegistration.response.status === 403
+      && !/organization owner or admin/i.test(registration.text)
+      && !/internal server error/i.test(registration.text),
+  );
+});

--- a/patches/@better-auth__sso@1.7.0-beta.10.patch
+++ b/patches/@better-auth__sso@1.7.0-beta.10.patch
@@ -1,0 +1,6 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1436 +1436 @@
+-const ADMIN_ROLES = ["owner", "admin"];
++const ADMIN_ROLES = ["owner", "super-admin", "admin"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ patchedDependencies:
   '@better-auth/drizzle-adapter@1.7.0-beta.10':
     hash: cd64da0c48130585986f4c25fac25093e761675db1885d837df7dc31c358f7f8
     path: patches/@better-auth__drizzle-adapter@1.7.0-beta.10.patch
+  '@better-auth/sso@1.7.0-beta.10':
+    hash: eb4378a8959f462bbf23acb54e46dd781d29b1ef295f507e6d23a8a42ad7e56b
+    path: patches/@better-auth__sso@1.7.0-beta.10.patch
   '@modelcontextprotocol/client@2.0.0':
     hash: 702e2000a3f78e99cfa6971ac4c90466d482174e49340634c0f5b1f346285c12
     path: patches/@modelcontextprotocol__client@2.0.0.patch
@@ -489,7 +492,7 @@ importers:
         version: 1.7.0-beta.10(@better-auth/core@1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(better-auth@1.7.0-beta.10(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.2)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.3.7(zod@4.3.6))
       '@better-auth/sso':
         specifier: 1.7.0-beta.10
-        version: 1.7.0-beta.10(@better-auth/core@1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-beta.10(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.2)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.3.7(zod@4.3.6))
+        version: 1.7.0-beta.10(patch_hash=eb4378a8959f462bbf23acb54e46dd781d29b1ef295f507e6d23a8a42ad7e56b)(@better-auth/core@1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-beta.10(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.2)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.3.7(zod@4.3.6))
       '@daytonaio/sdk':
         specifier: ^0.201.0
         version: 0.201.0
@@ -9841,7 +9844,7 @@ snapshots:
       better-call: 1.3.7(zod@4.3.6)
       zod: 4.3.6
 
-  '@better-auth/sso@1.7.0-beta.10(@better-auth/core@1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-beta.10(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.2)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.3.7(zod@4.3.6))':
+  '@better-auth/sso@1.7.0-beta.10(patch_hash=eb4378a8959f462bbf23acb54e46dd781d29b1ef295f507e6d23a8a42ad7e56b)(@better-auth/core@1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-beta.10(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.2)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.11(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.3.7(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.7.0-beta.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,5 +118,6 @@ allowBuilds:
   sharp: true
 patchedDependencies:
   '@better-auth/drizzle-adapter@1.7.0-beta.10': patches/@better-auth__drizzle-adapter@1.7.0-beta.10.patch
+  '@better-auth/sso@1.7.0-beta.10': patches/@better-auth__sso@1.7.0-beta.10.patch
   '@modelcontextprotocol/client@2.0.0': patches/@modelcontextprotocol__client@2.0.0.patch
   '@modelcontextprotocol/sdk': patches/@modelcontextprotocol__sdk.patch


### PR DESCRIPTION
## Summary
- patch Better Auth SSO authorization to recognize OpenWork's `super-admin` role
- keep plain members forbidden from SAML provider registration
- add a real Den regression spec covering member denial and super-admin success

## Verification
- Local fallback (Daytona credentials unavailable): `pnpm evals:pr specs/sso-super-admin-registration.test.ts`
- Passed: 1 test file, 1 test; 0 failed, 0 skipped
- Final verified commit: `8e58b7ee19ee175ff71b3a5b5170b715de85b7a9`