### PR TITLE
fix(app): humanize provider connectivity errors in session banner

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -804,10 +804,14 @@ const MessageComponent = React.memo(
   ({ message, isLastMessage, isStreaming, isLastStep, hideReasoning }: MessageComponentProps) => {
     if (isSessionErrorMessage(message)) {
       const presentation = sessionErrorPresentationFromUIMessage(message)
+      const technicalDetails = presentation?.kind === "provider-connectivity" || presentation?.kind === "provider-timeout"
+        ? presentation.technicalDetails
+        : null
       return (
         <ErrorMessage
           error={getMessagesText([message]) || "Session failed"}
           resumePrompt={presentation?.recoveryPrompt}
+          technicalDetails={technicalDetails}
         />
       )
     }
@@ -853,9 +857,10 @@ interface ErrorMessageProps {
   error: string | null
   /** Set only for interrupted runs (aborted / provider timeout) that can resume. */
   resumePrompt?: string | null
+  technicalDetails?: string | null
 }
 
-function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
+function ErrorMessage({ error, resumePrompt, technicalDetails }: ErrorMessageProps) {
   const { onResumeInterrupted } = useMessageList()
 
   // A resumable interruption is a pause, not a failure: it renders as a
@@ -866,6 +871,7 @@ function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
         <div
           data-testid="session-error-interrupted"
           className="flex min-w-0 items-center gap-2 py-1 text-sm text-muted-foreground"
+          title={technicalDetails ?? undefined}
         >
           <CirclePause aria-hidden="true" className="size-4 shrink-0" />
           <span className="min-w-0 truncate">{error}</span>
@@ -886,7 +892,10 @@ function ErrorMessage({ error, resumePrompt }: ErrorMessageProps) {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="flex min-w-0 flex-1 flex-col gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+        <div
+          className="flex min-w-0 flex-1 flex-col gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm"
+          title={technicalDetails ?? undefined}
+        >
           <div className="flex flex-row items-start gap-2">
             <AlertTriangle aria-hidden="true" size={16} className="mt-0.5 shrink-0 text-destructive" />
             <p className="whitespace-pre-wrap text-destructive">{error}</p>

--- a/apps/app/src/react-app/domains/session/sync/session-error.test.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.test.ts
@@ -1,0 +1,38 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toContain: (expected: string) => void;
+};
+
+import {
+  describeProviderTransportError,
+  presentOpencodeSessionError,
+} from "./session-error";
+
+const reportedError = "Cannot connect to API: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+const friendlyError = "Couldn't reach the AI provider. Check your internet connection and try again.";
+
+describe("provider transport error presentation", () => {
+  test("maps the reported transport error and retains its diagnostic text", () => {
+    const presentation = presentOpencodeSessionError(reportedError);
+
+    expect(presentation.title).toBe(friendlyError);
+    expect(presentation.technicalDetails).toContain(reportedError);
+  });
+
+  test("does not map rate-limit or authentication errors", () => {
+    const rateLimitError = "429 Too Many Requests: rate limit exceeded";
+    const authError = "401 Unauthorized: invalid API key";
+
+    expect(describeProviderTransportError(rateLimitError)).toBe(rateLimitError);
+    expect(describeProviderTransportError(authError)).toBe(authError);
+  });
+
+  test("passes empty and unknown errors through unchanged", () => {
+    const unknownError = "The model returned malformed JSON";
+
+    expect(describeProviderTransportError("")).toBe("");
+    expect(describeProviderTransportError(unknownError)).toBe(unknownError);
+  });
+});

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -3,7 +3,7 @@ import type { UIMessage } from "ai";
 import { safeStringify } from "../../../../app/utils";
 import { normalizeErrorText } from "../../../../lib/error-text";
 
-export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "generic";
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "provider-connectivity" | "generic";
 
 export type OpencodeSessionErrorPresentation = {
   kind: OpencodeSessionErrorKind;
@@ -18,6 +18,29 @@ const interruptedTaskRecoveryPrompt = [
   "First inspect the conversation and workspace to verify which actions already completed.",
   "Preserve completed work, do not repeat side effects, and finish only what remains.",
 ].join(" ");
+
+const providerTransportErrorMessage = "Couldn't reach the AI provider. Check your internet connection and try again.";
+const providerTransportErrorSignatures = [
+  "cannot connect to api",
+  "socket connection was closed",
+  "fetch failed",
+  "econnreset",
+  "etimedout",
+  "enotfound",
+  "eai_again",
+  "socket hang up",
+  "other side closed",
+  "headers timeout",
+];
+
+function isProviderTransportError(message: string) {
+  const lower = message.toLowerCase();
+  return providerTransportErrorSignatures.some((signature) => lower.includes(signature));
+}
+
+export function describeProviderTransportError(message: string) {
+  return isProviderTransportError(message) ? providerTransportErrorMessage : message;
+}
 
 function recordValue(value: unknown, key: string) {
   if (!value || typeof value !== "object") return undefined;
@@ -69,6 +92,7 @@ function sessionErrorKind(name: string | null, message: string | null, code: str
   ) {
     return "provider-timeout";
   }
+  if (isProviderTransportError(searchable)) return "provider-connectivity";
   return "generic";
 }
 
@@ -180,7 +204,9 @@ function technicalErrorDetails(error: unknown, fallback: string, fields: ReturnT
 export function presentOpencodeSessionError(error: unknown, fallback = "Session failed"): OpencodeSessionErrorPresentation {
   const fields = sessionErrorFields(error, fallback);
   const kind = sessionErrorKind(fields.name, fields.message, fields.code);
-  const fallbackTitle = normalizeSessionError(fields.message ?? defaultErrorMessage(fields.name, fallback));
+  const fallbackTitle = normalizeSessionError(
+    describeProviderTransportError(fields.message ?? defaultErrorMessage(fields.name, fallback)),
+  );
   return {
     kind,
     title: errorTitle(kind, fallbackTitle),


### PR DESCRIPTION
## Problem

On flaky networks (reported on a personal 5G hotspot, v0.18.35), the session banner shows the raw engine transport error verbatim:

> Cannot connect to API: The socket connection was closed unexpectedly. For more information, pass \`verbose: true\` in the second argument to fetch()

Root cause of the wording: the bundled OpenCode engine (Bun) loses its outbound HTTPS connection to the LLM provider; the Vercel AI SDK wraps it as \`Cannot connect to API: …\` (\`@ai-sdk/provider-utils\` \`handle-fetch-error.ts\`) and OpenWork rendered that string unmodified. Upstream context: anomalyco/opencode#1692 (5G-hotspot PMTU failures produce exactly this Bun error).

## Change (UI presentation only)

- \`session-error.ts\`: classify provider transport signatures (\`Cannot connect to API\`, \`socket connection was closed\`, \`ECONNRESET\`, \`ETIMEDOUT\`, \`fetch failed\`, …) as a new \`provider-connectivity\` kind and present: **"Couldn't reach the AI provider. Check your internet connection and try again."**
- \`message-list.tsx\`: the banner keeps the raw engine text available as \`title\` hover details for diagnostics.
- No engine, retry, or server behavior changes.

## Verification

- \`pnpm --filter @openwork/app exec bun test src/react-app/domains/session/sync/session-error.test.ts\` — 3 pass / 0 fail (exact reported banner string maps; auth/rate-limit strings pass through unchanged).
- \`pnpm --filter @openwork/app exec bun test tests/session-error-resilience.test.tsx\` — 10 pass / 0 fail.
- \`pnpm --filter @openwork/app typecheck\` — exit 0.

Reproduction research: a Daytona E2E at v0.18.35 (\`local-openwork-api-tcp-reset\`) proved a forced TCP reset surfaces a raw error and only user-driven retry recovers; this PR fixes the user-facing wording seam identified from that investigation.