### PR TITLE
fix(cloud): harden stable worker compatibility routing

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -42,6 +42,7 @@ import { registerTelemetryRoutes } from "./routes/telemetry/index.js"
 import { registerVersionRoutes } from "./routes/version/index.js"
 import { registerWebhookRoutes } from "./routes/webhooks/index.js"
 import { registerWorkerRoutes } from "./routes/workers/index.js"
+import { registerCloudWorkerCompatibilityPreflightRoute } from "./routes/workers/compatibility.js"
 import type { AuthContextVariables } from "./session.js"
 import { sessionMiddleware } from "./session.js"
 import { isOperationalErrorPath, normalizeOperationalErrorResponse, operationalErrorResponse } from "./operational-errors.js"
@@ -121,6 +122,10 @@ app.use(
     maxAge: 600,
   }),
 )
+
+// This bearer-token-only compatibility surface must accept native/file-origin
+// preflights before the credentialed browser allowlist can intercept OPTIONS.
+registerCloudWorkerCompatibilityPreflightRoute(app)
 
 if (env.corsOrigins.length > 0) {
   app.use(

--- a/ee/apps/den-api/src/automations/cloud-agent-executor.ts
+++ b/ee/apps/den-api/src/automations/cloud-agent-executor.ts
@@ -10,6 +10,7 @@ import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/wo
 import { organizationCloudEnabled } from "../capability-sources/cloud-rollout.js"
 import { CLOUD_INSTANCE_BACKEND } from "../workers/cloud-constants.js"
 import { wakeCloudWorker } from "../workers/cloud-lifecycle.js"
+import { fetchPreviewNoRedirect, previewFetch } from "../workers/preview-fetch.js"
 import { resolveAutomationModelAccess } from "./authority.js"
 
 const WORKER_READY_TIMEOUT_MS = 120_000
@@ -174,7 +175,7 @@ export async function resolveCloudAgentWorkspace(
   fetchImpl: typeof fetch = fetch,
 ) {
   try {
-    const response = await fetchImpl(`${access.url}/workspaces`, {
+    const response = await fetchPreviewNoRedirect(fetchImpl, `${access.url}/workspaces`, {
       headers: workerHeaders(access),
       signal: AbortSignal.any([signal, AbortSignal.timeout(WORKER_REQUEST_TIMEOUT_MS)]),
     })
@@ -301,7 +302,7 @@ async function connectHealth(input: {
     probe: "true",
   })
   const request = async (method: "GET" | "POST", path: string, body?: unknown) => {
-    const response = await fetch(`${input.baseUrl}${path}`, {
+    const response = await fetchPreviewNoRedirect(previewFetch(), `${input.baseUrl}${path}`, {
       method,
       headers: {
         ...workerHeaders(input.access),
@@ -466,6 +467,7 @@ export async function executeCloudAgent(input: CloudAgentExecutorInput): Promise
       token: runtime.access.clientToken,
       hostToken: runtime.access.hostToken,
       requestTimeoutMs: WORKER_REQUEST_TIMEOUT_MS,
+      fetch: (url, init = {}) => fetchPreviewNoRedirect(previewFetch(), url, init),
       defaultModel: {
         providerId: input.action.model.providerId,
         modelId: input.action.model.modelId,

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -9,7 +9,7 @@ import {
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
-import { fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
+import { fetchPreviewNoRedirect, fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
 import { decodeProviderCredential, readProviderEnvNames, selectLegacyScalarCredentialEnvName, selectPrimaryCredentialEnvName } from "./provider-credentials.js"
 
 type JsonRecord = Record<string, unknown>
@@ -423,7 +423,7 @@ async function fetchWithTimeout(fetchImpl: FetchImpl, url: string, init: Request
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), requestTimeoutMs)
   try {
-    return await fetchImpl(url, { ...init, signal: controller.signal })
+    return await fetchPreviewNoRedirect(fetchImpl, url, { ...init, signal: controller.signal })
   } finally {
     clearTimeout(timeout)
   }

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -7,6 +7,7 @@ import { db } from "../db.js"
 import { env } from "../env.js"
 import { organizationCloudEnabled } from "../capability-sources/cloud-rollout.js"
 import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/worker-access.js"
+import { fetchPreviewNoRedirect, previewFetch } from "../workers/preview-fetch.js"
 import { scoreText, tokenize, type CapabilityMatch } from "./search.js"
 
 /**
@@ -244,7 +245,7 @@ export async function resolveRemoteSessionWorkspace(
   fetchImpl: typeof fetch = fetch,
 ) {
   try {
-    const response = await fetchImpl(`${access.url}/workspaces`, {
+    const response = await fetchPreviewNoRedirect(fetchImpl, `${access.url}/workspaces`, {
       headers: workerHeaders(access),
       signal: AbortSignal.timeout(WORKER_REQUEST_TIMEOUT_MS),
     })
@@ -339,6 +340,7 @@ function defaultCreateClient(runtime: RemoteSessionRuntime): RemoteSessionThread
     token: runtime.clientToken,
     hostToken: runtime.hostToken,
     requestTimeoutMs: WORKER_REQUEST_TIMEOUT_MS,
+    fetch: (url, init = {}) => fetchPreviewNoRedirect(previewFetch(), url, init),
   })
 }
 

--- a/ee/apps/den-api/src/routes/workers/compatibility.ts
+++ b/ee/apps/den-api/src/routes/workers/compatibility.ts
@@ -20,14 +20,8 @@ function unauthorizedResponse() {
   })
 }
 
-export function registerCloudWorkerCompatibilityRoutes<T extends { Variables: WorkerRouteVariables }>(
-  app: Hono<T>,
-  options: CloudWorkerCompatibilityOptions = {},
-) {
-  // Worker credentials are explicit bearer values rather than ambient browser
-  // credentials, so reflecting the caller lets published desktop WebViews keep
-  // streaming after the Daytona preview origin rotates.
-  app.use("/v1/cloud/workers/*", cors({
+function cloudWorkerCompatibilityCors() {
+  return cors({
     origin: (origin) => origin,
     allowHeaders: [
       "Accept",
@@ -41,7 +35,23 @@ export function registerCloudWorkerCompatibilityRoutes<T extends { Variables: Wo
     ],
     allowMethods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     maxAge: 600,
-  }))
+  })
+}
+
+export function registerCloudWorkerCompatibilityPreflightRoute<T extends { Variables: WorkerRouteVariables }>(
+  app: Hono<T>,
+) {
+  app.options("/v1/cloud/workers/*", cloudWorkerCompatibilityCors())
+}
+
+export function registerCloudWorkerCompatibilityRoutes<T extends { Variables: WorkerRouteVariables }>(
+  app: Hono<T>,
+  options: CloudWorkerCompatibilityOptions = {},
+) {
+  // Worker credentials are explicit bearer values rather than ambient browser
+  // credentials, so reflecting the caller lets published desktop WebViews keep
+  // streaming after the Daytona preview origin rotates.
+  app.use("/v1/cloud/workers/*", cloudWorkerCompatibilityCors())
 
   app.all("/v1/cloud/workers/:workerId/*", tokenRoute, async (c) => {
     let workerId: WorkerId

--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -90,6 +90,12 @@ const workerTokensResponseSchema = z.object({
     openworkUrl: z.string().nullable(),
     workspaceId: z.string().nullable(),
   }).nullable(),
+  directPreview: z.object({
+    version: z.literal(1),
+    openworkUrl: z.string(),
+    workspaceId: z.string().nullable(),
+    expiresAt: z.string().datetime(),
+  }).nullable().optional(),
 }).meta({ ref: "WorkerTokensResponse" })
 
 const workerTokensRequestSchema = z.object({

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -25,6 +25,7 @@ import { withProvisionDeadline } from "../../workers/provision-deadline.js"
 import { customDomainForWorker } from "../../workers/vanity-domain.js"
 import { resolveCloudRuntimeAccess } from "../../workers/worker-access.js"
 import { CLOUD_INSTANCE_BACKEND } from "../../workers/cloud-constants.js"
+import { fetchPreviewNoRedirect } from "../../workers/preview-fetch.js"
 
 const logger = appLogger.child({ component: "worker_routes" })
 
@@ -67,6 +68,10 @@ type UserId = typeof AuthUserTable.$inferSelect.id
 type ProvisionWorker = typeof provisionWorker
 type ProvisionedWorker = Awaited<ReturnType<ProvisionWorker>>
 type ResolveCloudRuntimeAccess = typeof resolveCloudRuntimeAccess
+type LoadActiveWorkerTokens = (workerId: WorkerId) => Promise<Array<{
+  scope: typeof WorkerTokenTable.$inferSelect.scope
+  token: string
+}>>
 type CloudProvisioningStore = {
   updateWorkerStatus: (input: {
     workerId: WorkerId
@@ -182,7 +187,7 @@ async function resolveConnectUrlFromWorker(instanceUrl: string, clientToken: str
   }
 
   try {
-    const response = await fetchImpl(`${baseUrl}/workspaces`, {
+    const response = await fetchPreviewNoRedirect(fetchImpl, `${baseUrl}/workspaces`, {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -323,7 +328,7 @@ export async function fetchWorkerRuntimeJson(input: {
 
   for (const candidate of access.candidates) {
     try {
-      const response = await (options.fetchImpl ?? fetch)(`${normalizeUrl(candidate)}${input.path}`, {
+      const response = await fetchPreviewNoRedirect(options.fetchImpl ?? fetch, `${normalizeUrl(candidate)}${input.path}`, {
         method: input.method ?? "GET",
         headers: {
           Accept: "application/json",
@@ -371,6 +376,14 @@ export async function getLatestWorkerInstance(workerId: WorkerId) {
     .limit(1)
 
   return rows[0] ?? null
+}
+
+async function loadActiveWorkerTokens(workerId: WorkerId) {
+  return db
+    .select({ scope: WorkerTokenTable.scope, token: WorkerTokenTable.token })
+    .from(WorkerTokenTable)
+    .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
+    .orderBy(asc(WorkerTokenTable.created_at))
 }
 
 export function toInstanceResponse(instance: WorkerInstanceRow | null) {
@@ -503,37 +516,58 @@ export async function requireCloudAccessOrPayment(input: {
 
 export async function getWorkerTokensAndConnect(worker: WorkerRow, options: {
   resolveCloudAccess?: ResolveCloudRuntimeAccess
+  loadActiveTokens?: LoadActiveWorkerTokens
   fetchImpl?: typeof fetch
   includeExpiringOpenworkUrl?: boolean
   apiPublicUrl?: string
 } = {}) {
   if (worker.destination === "cloud" && worker.sandbox_backend === CLOUD_INSTANCE_BACKEND) {
-    const resolved = await (options.resolveCloudAccess ?? resolveCloudRuntimeAccess)({ organizationId: worker.org_id, workerId: worker.id })
-    if (resolved.status !== "ready") {
+    const tokenRows = await (options.loadActiveTokens ?? loadActiveWorkerTokens)(worker.id)
+    const hostToken = tokenRows.find((entry) => entry.scope === "host")?.token ?? null
+    const clientToken = tokenRows.find((entry) => entry.scope === "client")?.token ?? null
+    if (!hostToken || !clientToken) {
       return {
         error: {
           status: 409,
           body: {
-            error: "worker_runtime_unavailable",
-            message: "Worker runtime access is not ready yet. Wait for provisioning to finish and try again.",
+            error: "worker_tokens_unavailable",
+            message: "Worker tokens are missing for this worker. Launch a new worker and try again.",
           },
         },
       }
     }
-    const previewConnect = await resolveConnectUrlFromWorker(resolved.url, resolved.clientToken, options.fetchImpl)
+
+    const stableRootUrl = cloudWorkerCompatibilityUrl(worker.id, options.apiPublicUrl ?? env.apiPublicUrl)
+    if (!options.includeExpiringOpenworkUrl) {
+      return {
+        tokens: { owner: hostToken, host: hostToken, client: clientToken },
+        connect: stableRootUrl ? { openworkUrl: stableRootUrl, workspaceId: null } : null,
+      }
+    }
+
+    const resolved = await (options.resolveCloudAccess ?? resolveCloudRuntimeAccess)({ organizationId: worker.org_id, workerId: worker.id })
+      .catch(() => null)
+    const previewConnect = resolved?.status === "ready"
+      ? await resolveConnectUrlFromWorker(resolved.url, clientToken, options.fetchImpl)
+      : null
     const stableOpenworkUrl = cloudWorkerCompatibilityUrl(
       worker.id,
       options.apiPublicUrl ?? env.apiPublicUrl,
       previewConnect?.workspaceId,
     )
-    const connect = options.includeExpiringOpenworkUrl
-      ? previewConnect
-      : stableOpenworkUrl
-        ? { openworkUrl: stableOpenworkUrl, workspaceId: previewConnect?.workspaceId ?? null }
-        : null
     return {
-      tokens: { owner: resolved.hostToken, host: resolved.hostToken, client: resolved.clientToken },
-      connect,
+      tokens: { owner: hostToken, host: hostToken, client: clientToken },
+      connect: stableOpenworkUrl
+        ? { openworkUrl: stableOpenworkUrl, workspaceId: previewConnect?.workspaceId ?? null }
+        : null,
+      directPreview: resolved?.status === "ready" && previewConnect
+        ? {
+            version: 1 as const,
+            openworkUrl: previewConnect.openworkUrl,
+            workspaceId: previewConnect.workspaceId,
+            expiresAt: resolved.expiresAt.toISOString(),
+          }
+        : null,
     }
   }
 

--- a/ee/apps/den-api/src/workers/preview-fetch.ts
+++ b/ee/apps/den-api/src/workers/preview-fetch.ts
@@ -50,6 +50,14 @@ export async function fetchWithConnectRetry(input: {
   }
 }
 
+export function fetchPreviewNoRedirect(
+  fetchImpl: FetchLike,
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return fetchImpl(url, { ...init, redirect: "error" })
+}
+
 export function createPreviewFetch(options: { connectTimeoutMs: number }): FetchLike {
   const agent = new Agent({
     connect: {
@@ -73,7 +81,7 @@ export function createPreviewFetch(options: { connectTimeoutMs: number }): Fetch
       method: request.method,
       headers,
       body: request.body ? await request.arrayBuffer() : undefined,
-      redirect: request.redirect,
+      redirect: "error",
       signal: request.signal,
       dispatcher: agent,
     })

--- a/ee/apps/den-api/src/workers/worker-compatibility-proxy.ts
+++ b/ee/apps/den-api/src/workers/worker-compatibility-proxy.ts
@@ -22,7 +22,11 @@ export type CloudWorkerCompatibilityOptions = {
   authenticate?: AuthenticateWorkerRequest
   resolveCloudAccess?: ResolveCloudAccess
   fetchImpl?: typeof fetch
+  maxActiveRequestsPerWorker?: number
 }
+
+const DEFAULT_MAX_ACTIVE_REQUESTS_PER_WORKER = 16
+const activeRequestsByWorker = new Map<WorkerId, number>()
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -144,12 +148,58 @@ function downstreamResponseHeaders(upstream: Response) {
   return headers
 }
 
-function jsonError(status: 401 | 502 | 503, error: "unauthorized" | "worker_runtime_proxy_failed" | "worker_runtime_unavailable") {
+function jsonError(
+  status: 401 | 429 | 502 | 503,
+  error: "too_many_requests" | "unauthorized" | "worker_runtime_proxy_failed" | "worker_runtime_unavailable",
+  headers: HeadersInit = {},
+) {
   return Response.json({ error }, {
     status,
     headers: {
       "Cache-Control": "no-store",
       Pragma: "no-cache",
+      ...headers,
+    },
+  })
+}
+
+function acquireWorkerRequest(workerId: WorkerId, maximum: number) {
+  const active = activeRequestsByWorker.get(workerId) ?? 0
+  if (active >= maximum) return null
+  activeRequestsByWorker.set(workerId, active + 1)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const remaining = (activeRequestsByWorker.get(workerId) ?? 1) - 1
+    if (remaining > 0) activeRequestsByWorker.set(workerId, remaining)
+    else activeRequestsByWorker.delete(workerId)
+  }
+}
+
+function releaseOnStreamCompletion(body: ReadableStream<Uint8Array>, release: () => void) {
+  const reader = body.getReader()
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read()
+        if (chunk.done) {
+          release()
+          controller.close()
+          return
+        }
+        controller.enqueue(chunk.value)
+      } catch (error) {
+        release()
+        controller.error(error)
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason)
+      } finally {
+        release()
+      }
     },
   })
 }
@@ -196,47 +246,60 @@ export async function proxyCloudWorkerCompatibilityRequest(input: {
     return jsonError(401, "unauthorized")
   }
 
-  let access: Awaited<ReturnType<ResolveCloudAccess>>
+  const maximum = Math.max(1, options.maxActiveRequestsPerWorker ?? DEFAULT_MAX_ACTIVE_REQUESTS_PER_WORKER)
+  const release = acquireWorkerRequest(input.workerId, maximum)
+  if (!release) return jsonError(429, "too_many_requests", { "Retry-After": "1" })
+
+  let releaseWithResponseBody = false
   try {
-    access = await (options.resolveCloudAccess ?? resolveCloudRuntimeAccess)({
-      organizationId: authorization.organizationId,
-      workerId: input.workerId,
+    const method = input.request.method.toUpperCase()
+
+    let access: Awaited<ReturnType<ResolveCloudAccess>>
+    try {
+      access = await (options.resolveCloudAccess ?? resolveCloudRuntimeAccess)({
+        organizationId: authorization.organizationId,
+        workerId: input.workerId,
+      })
+    } catch {
+      return jsonError(503, "worker_runtime_unavailable")
+    }
+    if (access.status !== "ready") return jsonError(503, "worker_runtime_unavailable")
+
+    const target = upstreamUrl(access.url, input.request, input.workerId)
+    if (!target) return jsonError(502, "worker_runtime_proxy_failed")
+
+    let upstream: Response
+    try {
+      const requestBody = isReadMethod(method) ? null : input.request.body
+      const baseInit: RequestInit = {
+        method,
+        headers: upstreamRequestHeaders(input.request, authorization, access),
+        cache: "no-store",
+        redirect: "error",
+        signal: input.request.signal,
+      }
+      const requestInit: RequestInit | (RequestInit & { duplex: "half" }) = requestBody
+        ? { ...baseInit, body: requestBody, duplex: "half" }
+        : baseInit
+      upstream = await (options.fetchImpl ?? fetch)(target, requestInit)
+    } catch {
+      return jsonError(502, "worker_runtime_proxy_failed")
+    }
+    if (upstream.status >= 300 && upstream.status < 400) {
+      await upstream.body?.cancel().catch(() => undefined)
+      return jsonError(502, "worker_runtime_proxy_failed")
+    }
+
+    const responseBody = method === "HEAD" || NO_BODY_STATUSES.has(upstream.status) ? null : upstream.body
+    if (!responseBody) await upstream.body?.cancel().catch(() => undefined)
+    const downstreamBody = responseBody ? releaseOnStreamCompletion(responseBody, release) : null
+    releaseWithResponseBody = downstreamBody !== null
+    return new Response(downstreamBody, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: downstreamResponseHeaders(upstream),
     })
-  } catch {
-    return jsonError(503, "worker_runtime_unavailable")
+  } finally {
+    if (!releaseWithResponseBody) release()
   }
-  if (access.status !== "ready") return jsonError(503, "worker_runtime_unavailable")
-
-  const target = upstreamUrl(access.url, input.request, input.workerId)
-  if (!target) return jsonError(502, "worker_runtime_proxy_failed")
-
-  const method = input.request.method.toUpperCase()
-  const requestBody = isReadMethod(method)
-    ? undefined
-    : await input.request.arrayBuffer().then((body) => body.byteLength > 0 ? body : undefined)
-
-  let upstream: Response
-  try {
-    upstream = await (options.fetchImpl ?? fetch)(target, {
-      method,
-      headers: upstreamRequestHeaders(input.request, authorization, access),
-      body: requestBody,
-      cache: "no-store",
-      redirect: "error",
-      signal: input.request.signal,
-    })
-  } catch {
-    return jsonError(502, "worker_runtime_proxy_failed")
-  }
-  if (upstream.status >= 300 && upstream.status < 400) {
-    await upstream.body?.cancel().catch(() => undefined)
-    return jsonError(502, "worker_runtime_proxy_failed")
-  }
-
-  const responseBody = method === "HEAD" || NO_BODY_STATUSES.has(upstream.status) ? null : upstream.body
-  return new Response(responseBody, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers: downstreamResponseHeaders(upstream),
-  })
 }

--- a/ee/apps/den-api/test/cloud-agent-signed-preview-routing.test.ts
+++ b/ee/apps/den-api/test/cloud-agent-signed-preview-routing.test.ts
@@ -106,6 +106,7 @@ test("Cloud Automations discover their workspace through the signed preview", as
   const requested: string[] = []
   const fetchImpl: typeof fetch = async (input, init) => {
     requested.push(String(input))
+    expect(init?.redirect).toBe("error")
     expect(new Headers(init?.headers).get("authorization")).toBe("Bearer client-token")
     expect(new Headers(init?.headers).get("x-openwork-host-token")).toBe("host-token")
     return Response.json({ activeId: "workspace-automation" })

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -12,6 +12,7 @@ type FetchCall = {
   path: string
   headers: Record<string, string>
   body: unknown
+  redirect: RequestRedirect | null
 }
 
 const organizationId = createDenTypeId("organization")
@@ -197,6 +198,7 @@ function makeInstance(input: {
       path: parsed.pathname,
       headers: headersRecord(init?.headers),
       body,
+      redirect: init?.redirect ?? null,
     })
 
     if (method === "GET" && parsed.pathname.startsWith("/env/")) {
@@ -417,6 +419,7 @@ describe("Cloud provider materialization", () => {
     })
     expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
     expect(instance.calls[3]?.headers.authorization).toBeUndefined()
+    expect(instance.calls.every((call) => call.redirect === "error")).toBe(true)
     expect(instance.calls[3]?.body).toEqual({
       provider: {
         [provider.id]: {

--- a/ee/apps/den-api/test/preview-fetch.test.ts
+++ b/ee/apps/den-api/test/preview-fetch.test.ts
@@ -1,5 +1,26 @@
+import { createServer, type Server } from "node:http"
 import { describe, expect, test } from "bun:test"
-import { createPreviewFetch, fetchWithConnectRetry, type FetchLike } from "../src/workers/preview-fetch.js"
+import { createPreviewFetch, fetchPreviewNoRedirect, fetchWithConnectRetry, type FetchLike } from "../src/workers/preview-fetch.js"
+
+function listen(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject)
+      resolve()
+    })
+  })
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}
+
+function serverUrl(server: Server) {
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("test server did not bind")
+  return `http://127.0.0.1:${address.port}`
+}
 
 function connectError() {
   return Object.assign(new Error("connect failed"), { code: "ECONNRESET" })
@@ -64,5 +85,47 @@ describe("preview fetch", () => {
     await expect(createPreviewFetch({ connectTimeoutMs: 100 })("https://preview.test", {
       signal: controller.signal,
     })).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  test("307 and 308 redirects never receive preview bodies or tokens", async () => {
+    const targetRequests: Array<{ authorization: string | null; hostToken: string | null; body: string }> = []
+    const target = createServer((request, response) => {
+      const chunks: Buffer[] = []
+      request.on("data", (chunk: Buffer) => chunks.push(chunk))
+      request.on("end", () => {
+        targetRequests.push({
+          authorization: request.headers.authorization ?? null,
+          hostToken: typeof request.headers["x-openwork-host-token"] === "string" ? request.headers["x-openwork-host-token"] : null,
+          body: Buffer.concat(chunks).toString("utf8"),
+        })
+        response.end("unexpected")
+      })
+    })
+    let redirectStatus = 307
+    const preview = createServer((_request, response) => {
+      response.writeHead(redirectStatus, { Location: `${serverUrl(target)}/redirect-target` })
+      response.end()
+    })
+    await Promise.all([listen(target), listen(preview)])
+    try {
+      for (const status of [307, 308]) {
+        redirectStatus = status
+        await expect(fetchPreviewNoRedirect(
+          (url, init) => fetch(url, init),
+          `${serverUrl(preview)}/env`,
+          {
+            method: "PUT",
+            headers: {
+              Authorization: "Bearer client-secret",
+              "X-OpenWork-Host-Token": "host-secret",
+            },
+            body: JSON.stringify({ secret: "body-secret" }),
+          },
+        )).rejects.toBeDefined()
+      }
+      expect(targetRequests).toEqual([])
+    } finally {
+      await Promise.all([close(preview), close(target)])
+    }
   })
 })

--- a/ee/apps/den-api/test/remote-session-capabilities.test.ts
+++ b/ee/apps/den-api/test/remote-session-capabilities.test.ts
@@ -273,6 +273,7 @@ test("remote sessions route workspace discovery only to the signed preview", asy
   const requested: string[] = []
   const fetchImpl: typeof fetch = async (input, init) => {
     requested.push(String(input))
+    expect(init?.redirect).toBe("error")
     expect(new Headers(init?.headers).get("authorization")).toBe("Bearer client-token")
     expect(new Headers(init?.headers).get("x-openwork-host-token")).toBe("host-token")
     return Response.json({ activeId: "workspace-signed-preview" })

--- a/ee/apps/den-api/test/worker-runtime-signed-preview.test.ts
+++ b/ee/apps/den-api/test/worker-runtime-signed-preview.test.ts
@@ -1,6 +1,7 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, expect, test } from "bun:test"
 import { Hono } from "hono"
+import { cors } from "hono/cors"
 import type { WorkerRouteVariables } from "../src/routes/workers/shared.js"
 import type { CloudRuntimeStore } from "../src/workers/worker-access.js"
 
@@ -92,8 +93,9 @@ test("generic Daytona runtime routes refresh expiry and request only the fresh p
       startRecovery: () => {},
       now: () => new Date("2026-08-27T10:00:00.000Z").getTime(),
     }),
-    fetchImpl: async (input) => {
+    fetchImpl: async (input, init) => {
       requested.push(String(input))
+      expect(init?.redirect).toBe("error")
       return Response.json({ version: "fresh" })
     },
   })
@@ -136,16 +138,24 @@ test("cloud worker tokens expose expiring URLs only by explicit opt-in", async (
     clientToken: "client-token",
     hostToken: "host-token",
   })
+  const loadActiveTokens = async () => [
+    { scope: "host" as const, token: "host-token" },
+    { scope: "client" as const, token: "client-token" },
+  ]
   const legacy = await shared.getWorkerTokensAndConnect(runtimeWorker, {
     apiPublicUrl: "https://den.example.test/api/den",
     resolveCloudAccess,
-    fetchImpl: async (input) => {
+    loadActiveTokens,
+    fetchImpl: async (input, init) => {
       requested.push(String(input))
+      expect(init?.redirect).toBe("error")
       return Response.json({ activeId: "created-workspace", items: [] })
     },
   })
   const resolved = await shared.getWorkerTokensAndConnect(runtimeWorker, {
     includeExpiringOpenworkUrl: true,
+    apiPublicUrl: "https://den.example.test/api/den",
+    loadActiveTokens,
     resolveCloudAccess: async () => ({
       status: "ready",
       workerId: runtimeWorker.id,
@@ -154,8 +164,9 @@ test("cloud worker tokens expose expiring URLs only by explicit opt-in", async (
       clientToken: "client-token",
       hostToken: "host-token",
     }),
-    fetchImpl: async (input) => {
+    fetchImpl: async (input, init) => {
       requested.push(String(input))
+      expect(init?.redirect).toBe("error")
       return Response.json({ activeId: "created-workspace", items: [] })
     },
   })
@@ -163,30 +174,59 @@ test("cloud worker tokens expose expiring URLs only by explicit opt-in", async (
   expect(legacy).toEqual({
     tokens: { owner: "host-token", host: "host-token", client: "client-token" },
     connect: {
-      openworkUrl: `https://den.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}/w/created-workspace`,
-      workspaceId: "created-workspace",
+      openworkUrl: `https://den.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}`,
+      workspaceId: null,
     },
   })
   expect(resolved).toEqual({
     tokens: { owner: "host-token", host: "host-token", client: "client-token" },
     connect: {
+      openworkUrl: `https://den.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}/w/created-workspace`,
+      workspaceId: "created-workspace",
+    },
+    directPreview: {
+      version: 1,
       openworkUrl: "https://create-token.preview.example.test/w/created-workspace",
       workspaceId: "created-workspace",
+      expiresAt: "2026-08-27T12:00:00.000Z",
     },
   })
   expect(requested).toEqual([
     "https://create-token.preview.example.test/workspaces",
-    "https://create-token.preview.example.test/workspaces",
   ])
   expect("connect" in legacy ? legacy.connect?.openworkUrl : null).not.toContain("preview.example.test")
+  expect("directPreview" in legacy).toBe(false)
   expect(requested.join(" ")).not.toContain("workers.example.test")
+})
+
+test("cloud worker tokens retain the stable route while provisioning", async () => {
+  const runtimeWorker = { ...worker(), status: "provisioning" as const }
+  const resolved = await shared.getWorkerTokensAndConnect(runtimeWorker, {
+    apiPublicUrl: "https://den.example.test/api/den",
+    includeExpiringOpenworkUrl: true,
+    loadActiveTokens: async () => [
+      { scope: "host", token: "host-token" },
+      { scope: "client", token: "client-token" },
+    ],
+    resolveCloudAccess: async () => ({ status: "waking", workerId: runtimeWorker.id, reason: "reprovisioning" }),
+  })
+
+  expect(resolved).toEqual({
+    tokens: { owner: "host-token", host: "host-token", client: "client-token" },
+    connect: {
+      openworkUrl: `https://den.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}`,
+      workspaceId: null,
+    },
+    directPreview: null,
+  })
 })
 
 function registerCompatibilityTestApp(input: {
   workerId: ReturnType<typeof createDenTypeId<"worker">>
   runtimeUrls?: string[]
   requests: Array<{ url: string; init: RequestInit }>
-  response?: (url: string, init: RequestInit) => Response
+  response?: (url: string, init: RequestInit) => Response | Promise<Response>
+  maxActiveRequestsPerWorker?: number
 }) {
   const app = new Hono<{ Variables: WorkerRouteVariables }>()
   const organizationId = createDenTypeId("organization")
@@ -216,11 +256,50 @@ function registerCompatibilityTestApp(input: {
     fetchImpl: async (url, init = {}) => {
       const normalized = { url: String(url), init }
       input.requests.push(normalized)
-      return input.response?.(normalized.url, init) ?? Response.json({ ok: true })
+      return await input.response?.(normalized.url, init) ?? Response.json({ ok: true })
     },
+    maxActiveRequestsPerWorker: input.maxActiveRequestsPerWorker,
   })
   return app
 }
+
+test("cloud worker OPTIONS bypasses global credentialed CORS for native origins", async () => {
+  const app = new Hono<{ Variables: WorkerRouteVariables }>()
+  compatibility.registerCloudWorkerCompatibilityPreflightRoute(app)
+  app.use("*", cors({
+    origin: ["https://browser.example.test"],
+    credentials: true,
+    allowHeaders: ["Content-Type", "Authorization"],
+    allowMethods: ["GET", "POST", "OPTIONS"],
+  }))
+  compatibility.registerCloudWorkerCompatibilityRoutes(app, {
+    authenticate: async () => {
+      throw new Error("preflight must not authenticate")
+    },
+  })
+
+  for (const origin of ["null", "openwork://desktop"]) {
+    const response = await app.request("https://den.example.test/v1/cloud/workers/worker_native/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "PATCH",
+        "Access-Control-Request-Headers": "content-type,x-openwork-host-token,x-opencode-directory",
+      },
+    })
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin)
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull()
+    expect(response.headers.get("access-control-allow-headers")?.toLowerCase()).toContain("x-openwork-host-token")
+    expect(response.headers.get("access-control-allow-methods")).toContain("PATCH")
+  }
+
+  const unrelated = await app.request("https://den.example.test/v1/other", {
+    method: "OPTIONS",
+    headers: { Origin: "openwork://desktop", "Access-Control-Request-Method": "POST" },
+  })
+  expect(unrelated.headers.get("access-control-allow-origin")).toBeNull()
+})
 
 test("stable cloud worker route refreshes the preview on every request", async () => {
   const workerId = createDenTypeId("worker")
@@ -262,6 +341,11 @@ test("stable cloud worker route enforces worker token and method scope", async (
     headers: { "X-OpenWork-Host-Token": "host-token", "Content-Type": "application/json" },
     body: "{}",
   })
+  const desktopHandoffWrite = await app.request(route, {
+    method: "POST",
+    headers: { Authorization: "Bearer host-token", "Content-Type": "application/json" },
+    body: JSON.stringify({ from: "desktop-handoff" }),
+  })
 
   expect(clientRead.status).toBe(200)
   expect(clientWrite.status).toBe(401)
@@ -270,7 +354,11 @@ test("stable cloud worker route enforces worker token and method scope", async (
   expect(wrongWorker.status).toBe(401)
   expect(await wrongWorker.json()).toEqual({ error: "unauthorized" })
   expect(hostWrite.status).toBe(200)
-  expect(requests).toHaveLength(2)
+  expect(desktopHandoffWrite.status).toBe(200)
+  expect(requests).toHaveLength(3)
+  const handoffHeaders = new Headers(requests[2]?.init.headers)
+  expect(handoffHeaders.get("authorization")).toBe("Bearer fresh-client-token")
+  expect(handoffHeaders.get("x-openwork-host-token")).toBe("fresh-host-token")
 })
 
 test("stable cloud worker route safely proxies bodies, headers, and streaming responses", async () => {
@@ -362,4 +450,106 @@ test("stable cloud worker route never relays a runtime redirect", async () => {
   expect(response.headers.get("location")).toBeNull()
   expect(await response.json()).toEqual({ error: "worker_runtime_proxy_failed" })
   expect(requests[0]?.init.redirect).toBe("error")
+})
+
+test("stable cloud worker route streams a multi-chunk large request without buffering", async () => {
+  const workerId = createDenTypeId("worker")
+  const requests: Array<{ url: string; init: RequestInit }> = []
+  const observedChunks: Array<{ length: number; firstByte: number }> = []
+  const app = registerCompatibilityTestApp({
+    workerId,
+    requests,
+    response: async (_url, init) => {
+      expect("duplex" in init && init.duplex).toBe("half")
+      const body = new Response(init.body).body
+      if (!body) throw new Error("upstream request body was not streamed")
+      const reader = body.getReader()
+      for (;;) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        observedChunks.push({ length: chunk.value.byteLength, firstByte: chunk.value[0] ?? -1 })
+      }
+      return Response.json({ streamed: true })
+    },
+  })
+  const route = `https://den.example.test/v1/cloud/workers/${workerId}/workspace/demo/files/raw`
+  const chunkSize = 3 * 1024 * 1024
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const value of [1, 2, 3]) controller.enqueue(new Uint8Array(chunkSize).fill(value))
+      controller.close()
+    },
+  })
+  const requestInit: RequestInit & { duplex: "half" } = {
+    method: "POST",
+    headers: { "X-OpenWork-Host-Token": "host-token" },
+    body,
+    duplex: "half",
+  }
+  const response = await app.request(new Request(route, requestInit))
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ streamed: true })
+  expect(observedChunks).toEqual([
+    { length: chunkSize, firstByte: 1 },
+    { length: chunkSize, firstByte: 2 },
+    { length: chunkSize, firstByte: 3 },
+  ])
+  expect(requests).toHaveLength(1)
+})
+
+test("stable cloud worker route releases its slot after an upstream request error", async () => {
+  const workerId = createDenTypeId("worker")
+  const requests: Array<{ url: string; init: RequestInit }> = []
+  let calls = 0
+  const app = registerCompatibilityTestApp({
+    workerId,
+    requests,
+    maxActiveRequestsPerWorker: 1,
+    response: () => {
+      calls += 1
+      if (calls === 1) throw new Error("upstream failed")
+      return Response.json({ recovered: true })
+    },
+  })
+  const route = `https://den.example.test/v1/cloud/workers/${workerId}/health`
+  const failed = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+  const recovered = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+
+  expect(failed.status).toBe(502)
+  expect(recovered.status).toBe(200)
+  expect(await recovered.json()).toEqual({ recovered: true })
+})
+
+test("stable cloud worker route limits active streams and releases on cancel", async () => {
+  const workerId = createDenTypeId("worker")
+  const requests: Array<{ url: string; init: RequestInit }> = []
+  let upstreamCalls = 0
+  const app = registerCompatibilityTestApp({
+    workerId,
+    requests,
+    maxActiveRequestsPerWorker: 1,
+    response: () => {
+      upstreamCalls += 1
+      if (upstreamCalls > 1) return Response.json({ ok: true })
+      return new Response(new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode("data: held\n\n")) } }), {
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    },
+  })
+  const route = `https://den.example.test/v1/cloud/workers/${workerId}/event-stream`
+  const first = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+  const limited = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+
+  expect(first.status).toBe(200)
+  expect(limited.status).toBe(429)
+  expect(limited.headers.get("retry-after")).toBe("1")
+  await first.body?.cancel()
+
+  const afterCancel = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+  expect(afterCancel.status).toBe(200)
+  expect(await afterCancel.json()).toEqual({ ok: true })
+  const afterClose = await app.request(route, { headers: { Authorization: "Bearer client-token" } })
+  expect(afterClose.status).toBe(200)
+  await afterClose.body?.cancel()
 })

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -126,6 +126,8 @@ export type WorkerLaunch = {
   provider: string | null;
   instanceUrl: string | null;
   openworkUrl: string | null;
+  previewOpenworkUrl?: string | null;
+  previewExpiresAt?: string | null;
   workspaceId: string | null;
   clientToken: string | null;
   ownerToken: string | null;
@@ -146,6 +148,8 @@ export type WorkerTokens = {
   ownerToken: string | null;
   hostToken: string | null;
   openworkUrl: string | null;
+  previewOpenworkUrl: string | null;
+  previewExpiresAt: string | null;
   workspaceId: string | null;
 };
 
@@ -580,6 +584,8 @@ export function getWorker(payload: unknown): WorkerLaunch | null {
     provider: instance && typeof instance.provider === "string" ? instance.provider : null,
     instanceUrl: getDurableWorkerInstanceUrl(instance),
     openworkUrl: getDurableWorkerInstanceUrl(instance),
+    previewOpenworkUrl: null,
+    previewExpiresAt: null,
     workspaceId: null,
     clientToken: tokens && typeof tokens.client === "string" ? tokens.client : null,
     ownerToken: tokens && typeof tokens.owner === "string"
@@ -620,6 +626,9 @@ export function getWorkerTokens(payload: unknown): WorkerTokens | null {
 
   const tokens = payload.tokens;
   const connect = isRecord(payload.connect) ? payload.connect : null;
+  const directPreview = isRecord(payload.directPreview) && payload.directPreview.version === 1
+    ? payload.directPreview
+    : null;
   const clientToken = typeof tokens.client === "string" ? tokens.client : null;
   const ownerToken = typeof tokens.owner === "string"
     ? tokens.owner
@@ -628,19 +637,23 @@ export function getWorkerTokens(payload: unknown): WorkerTokens | null {
       : null;
   const hostToken = typeof tokens.host === "string" ? tokens.host : null;
   const openworkUrl = connect && typeof connect.openworkUrl === "string" ? connect.openworkUrl : null;
+  const previewOpenworkUrl = directPreview && typeof directPreview.openworkUrl === "string" ? directPreview.openworkUrl : null;
+  const previewExpiresAt = directPreview && typeof directPreview.expiresAt === "string" ? directPreview.expiresAt : null;
   const workspaceId = connect && typeof connect.workspaceId === "string" ? connect.workspaceId : null;
 
   if (!clientToken && !ownerToken && !hostToken) {
     return null;
   }
 
-  return { clientToken, ownerToken, hostToken, openworkUrl, workspaceId };
+  return { clientToken, ownerToken, hostToken, openworkUrl, previewOpenworkUrl, previewExpiresAt, workspaceId };
 }
 
 export function withWorkerConnection(worker: WorkerLaunch, tokens: WorkerTokens): WorkerLaunch {
   return {
     ...worker,
     openworkUrl: tokens.openworkUrl,
+    previewOpenworkUrl: tokens.previewOpenworkUrl,
+    previewExpiresAt: tokens.previewExpiresAt,
     workspaceId: tokens.workspaceId,
     clientToken: tokens.clientToken,
     ownerToken: tokens.ownerToken,
@@ -648,10 +661,50 @@ export function withWorkerConnection(worker: WorkerLaunch, tokens: WorkerTokens)
   };
 }
 
-export function workerNeedsConnectionResolution(worker: WorkerLaunch): boolean {
+export function getWorkerConnectionTargets(worker: WorkerLaunch | null) {
+  const desktopUrl = worker?.openworkUrl ?? worker?.instanceUrl ?? null;
+  const webUrl = worker?.previewOpenworkUrl
+    ?? (worker?.provider === "daytona" || worker?.instanceUrl === null ? null : desktopUrl);
+  return { desktopUrl, webUrl };
+}
+
+export function getWorkerConnectionTokens(worker: WorkerLaunch | null) {
+  return {
+    desktopToken: worker?.hostToken ?? worker?.ownerToken ?? null,
+    webToken: worker?.clientToken ?? null,
+  };
+}
+
+export function workerConnectionEquals(current: WorkerLaunch, next: WorkerLaunch) {
+  return current.openworkUrl === next.openworkUrl
+    && current.previewOpenworkUrl === next.previewOpenworkUrl
+    && current.previewExpiresAt === next.previewExpiresAt
+    && current.workspaceId === next.workspaceId
+    && current.clientToken === next.clientToken
+    && current.ownerToken === next.ownerToken
+    && current.hostToken === next.hostToken;
+}
+
+const WORKER_PREVIEW_REFRESH_LEAD_MS = 30_000;
+
+export function workerNeedsConnectionResolution(worker: WorkerLaunch, now = Date.now()): boolean {
   if (worker.status.trim().toLowerCase() === "failed") return false;
   const hasRequiredTokens = Boolean(worker.clientToken?.trim() && (worker.hostToken?.trim() || worker.ownerToken?.trim()));
-  return !hasRequiredTokens || !worker.openworkUrl?.trim();
+  if (!hasRequiredTokens || !worker.openworkUrl?.trim()) return true;
+
+  const usesExpiringPreview = worker.provider === "daytona" || worker.instanceUrl === null || Boolean(worker.previewOpenworkUrl);
+  if (!usesExpiringPreview) return false;
+  if (!worker.workspaceId?.trim() || !worker.previewOpenworkUrl?.trim() || !worker.previewExpiresAt) return true;
+
+  const expiresAt = Date.parse(worker.previewExpiresAt);
+  return !Number.isFinite(expiresAt) || expiresAt <= now + WORKER_PREVIEW_REFRESH_LEAD_MS;
+}
+
+export function getWorkerConnectionRefreshDelay(worker: WorkerLaunch, now = Date.now()): number | null {
+  if (worker.status.trim().toLowerCase() === "failed") return null;
+  if (workerNeedsConnectionResolution(worker, now)) return 0;
+  if (!worker.previewExpiresAt) return null;
+  return Math.max(0, Date.parse(worker.previewExpiresAt) - now - WORKER_PREVIEW_REFRESH_LEAD_MS);
 }
 
 export function getWorkerRuntimeSnapshot(payload: unknown): WorkerRuntimeSnapshot | null {
@@ -938,6 +991,8 @@ export function isWorkerLaunch(value: unknown): value is WorkerLaunch {
     (typeof value.provider === "string" || value.provider === null) &&
     (typeof value.instanceUrl === "string" || value.instanceUrl === null) &&
     (typeof value.openworkUrl === "string" || value.openworkUrl === null || typeof value.openworkUrl === "undefined") &&
+    (typeof value.previewOpenworkUrl === "string" || value.previewOpenworkUrl === null || typeof value.previewOpenworkUrl === "undefined") &&
+    (typeof value.previewExpiresAt === "string" || value.previewExpiresAt === null || typeof value.previewExpiresAt === "undefined") &&
     (typeof value.workspaceId === "string" || value.workspaceId === null || typeof value.workspaceId === "undefined") &&
     (typeof value.clientToken === "string" || value.clientToken === null) &&
     (typeof value.ownerToken === "string" || value.ownerToken === null || typeof value.ownerToken === "undefined") &&
@@ -953,6 +1008,8 @@ export function listItemToWorker(item: WorkerListItem, current: WorkerLaunch | n
     provider: item.provider,
     instanceUrl: item.instanceUrl,
     openworkUrl: current?.workerId === item.workerId ? current.openworkUrl ?? item.instanceUrl : item.instanceUrl,
+    previewOpenworkUrl: current?.workerId === item.workerId ? current.previewOpenworkUrl ?? null : null,
+    previewExpiresAt: current?.workerId === item.workerId ? current.previewExpiresAt ?? null : null,
     workspaceId: current?.workerId === item.workerId ? current.workspaceId : null,
     clientToken: current?.workerId === item.workerId ? current.clientToken : null,
     ownerToken: current?.workerId === item.workerId ? current.ownerToken : null,

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -37,6 +37,9 @@ import {
   getToken,
   getUser,
   getWorker,
+  getWorkerConnectionTargets,
+  getWorkerConnectionTokens,
+  getWorkerConnectionRefreshDelay,
   getWorkerConnectionPollDelay,
   getWorkerRuntimeSnapshot,
   getWorkerStatusCopy,
@@ -55,6 +58,7 @@ import {
   resetPosthogUser,
   resolveOpenworkWorkspaceUrl,
   withWorkerConnection,
+  workerConnectionEquals,
   workerNeedsConnectionResolution,
   trackPosthogEvent
 } from "../_lib/den-flow";
@@ -308,19 +312,19 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       : selectedWorker
         ? listItemToWorker(selectedWorker, worker)
         : worker;
-  const openworkConnectUrl = activeWorker?.openworkUrl ?? activeWorker?.instanceUrl ?? null;
-  const preferredOpenworkToken = activeWorker?.clientToken ?? activeWorker?.ownerToken ?? null;
+  const { desktopUrl: openworkConnectUrl, webUrl: previewConnectUrl } = getWorkerConnectionTargets(activeWorker);
+  const { desktopToken: desktopOpenworkToken, webToken: webOpenworkToken } = getWorkerConnectionTokens(activeWorker);
   const hasWorkspaceScopedUrl = Boolean(openworkConnectUrl && /\/w\/[^/?#]+/.test(openworkConnectUrl));
   const openworkDeepLink = buildOpenworkDeepLink(
     openworkConnectUrl,
-    preferredOpenworkToken,
+    desktopOpenworkToken,
     activeWorker?.workerId ?? null,
     activeWorker?.workerName ?? null
   );
   const openworkAppConnectUrl = buildOpenworkAppConnectUrl(
     runtimeConfig.openworkAppConnectUrl,
-    openworkConnectUrl,
-    preferredOpenworkToken,
+    previewConnectUrl,
+    webOpenworkToken,
     activeWorker?.workerId ?? null,
     activeWorker?.workerName ?? null,
     { autoConnect: true }
@@ -646,7 +650,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   async function withResolvedOpenworkCredentials(candidate: WorkerLaunch, options: { quiet?: boolean } = {}) {
     const existingConnectUrl = candidate.openworkUrl?.trim() ?? "";
     const existingWorkspaceId = candidate.workspaceId?.trim() ?? "";
-    if (existingConnectUrl && existingWorkspaceId) {
+    if (existingConnectUrl && (existingWorkspaceId || existingConnectUrl.includes("/v1/cloud/workers/"))) {
       return {
         ...candidate,
         openworkUrl: existingConnectUrl,
@@ -1605,6 +1609,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
               provider: summary.provider,
               instanceUrl: summary.instanceUrl,
               openworkUrl: summary.instanceUrl,
+              previewOpenworkUrl: null,
+              previewExpiresAt: null,
               workspaceId: null,
               clientToken: null,
               ownerToken: null,
@@ -1702,6 +1708,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
               provider: null,
               instanceUrl: null,
               openworkUrl: tokens.openworkUrl,
+              previewOpenworkUrl: tokens.previewOpenworkUrl,
+              previewExpiresAt: tokens.previewExpiresAt,
               workspaceId: tokens.workspaceId,
               clientToken: tokens.clientToken,
               ownerToken: tokens.ownerToken,
@@ -1711,13 +1719,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       const resolvedWorker = await withResolvedOpenworkCredentials(nextWorker, { quiet: true });
       setWorker((current) => {
         if (!current || current.workerId !== resolvedWorker.workerId) return resolvedWorker;
-        if (
-          current.openworkUrl === resolvedWorker.openworkUrl &&
-          current.workspaceId === resolvedWorker.workspaceId &&
-          current.clientToken === resolvedWorker.clientToken &&
-          current.ownerToken === resolvedWorker.ownerToken &&
-          current.hostToken === resolvedWorker.hostToken
-        ) return current;
+        if (workerConnectionEquals(current, resolvedWorker)) return current;
         return resolvedWorker;
       });
       setPendingRestoredWorkerId(null);
@@ -2042,7 +2044,11 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
       const restored: WorkerLaunch = {
         ...parsed,
-        openworkUrl: parsed.openworkUrl ?? parsed.instanceUrl,
+        openworkUrl: parsed.provider === "daytona" && parsed.openworkUrl && !parsed.openworkUrl.includes("/v1/cloud/workers/")
+          ? null
+          : parsed.openworkUrl ?? parsed.instanceUrl,
+        previewOpenworkUrl: null,
+        previewExpiresAt: null,
         workspaceId: parsed.workspaceId ?? parseWorkspaceIdFromUrl(parsed.instanceUrl ?? ""),
         clientToken: null,
         ownerToken: null,
@@ -2066,6 +2072,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     const serializable: WorkerLaunch = {
       ...worker,
+      previewOpenworkUrl: null,
+      previewExpiresAt: null,
       clientToken: null,
       ownerToken: null,
       hostToken: null
@@ -2075,7 +2083,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   }, [worker]);
 
   useEffect(() => {
-    if (!user || !worker || actionBusy !== null || launchBusy || pendingRestoredWorkerId === worker.workerId || !workerNeedsConnectionResolution(worker)) {
+    if (!user || !worker || actionBusy !== null || launchBusy || pendingRestoredWorkerId === worker.workerId) {
       return;
     }
 
@@ -2091,12 +2099,14 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       timer = window.setTimeout(() => void poll(), delay);
     };
 
-    void poll();
+    const refreshDelay = getWorkerConnectionRefreshDelay(worker);
+    if (refreshDelay === null) return;
+    timer = window.setTimeout(() => void poll(), refreshDelay);
     return () => {
       cancelled = true;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [actionBusy, launchBusy, pendingRestoredWorkerId, user?.id, worker?.workerId, worker?.status, worker?.clientToken, worker?.hostToken, worker?.openworkUrl]);
+  }, [actionBusy, launchBusy, pendingRestoredWorkerId, user?.id, worker?.workerId, worker?.status, worker?.clientToken, worker?.hostToken, worker?.openworkUrl, worker?.previewOpenworkUrl, worker?.previewExpiresAt]);
 
   const provisioningWorkerIds = workers
     .filter((item) => item.status === "provisioning")

--- a/ee/apps/den-web/app/(den)/dashboard/_components/background-agents-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/background-agents-screen.tsx
@@ -312,7 +312,7 @@ export function BackgroundAgentsScreen() {
         `/v1/workers/${encodeURIComponent(workerId)}/tokens`,
         {
           method: "POST",
-          body: JSON.stringify({}),
+          body: JSON.stringify({ includeExpiringOpenworkUrl: true }),
         },
         12000,
       );
@@ -334,7 +334,7 @@ export function BackgroundAgentsScreen() {
         clientToken: tokens.clientToken,
         openworkAppConnectUrl: buildOpenworkAppConnectUrl(
           runtimeConfig.openworkAppConnectUrl,
-          tokens.openworkUrl,
+          tokens.previewOpenworkUrl,
           tokens.clientToken,
           workerId,
           workerName,
@@ -342,7 +342,7 @@ export function BackgroundAgentsScreen() {
         ),
         openworkDeepLink: buildOpenworkDeepLink(
           tokens.openworkUrl,
-          tokens.clientToken,
+          tokens.hostToken ?? tokens.ownerToken,
           workerId,
           workerName,
         ),

--- a/ee/apps/den-web/tests/daytona-worker-url.test.ts
+++ b/ee/apps/den-web/tests/daytona-worker-url.test.ts
@@ -1,12 +1,18 @@
 import { expect, test } from "bun:test";
 import {
+  buildOpenworkAppConnectUrl,
+  buildOpenworkDeepLink,
   getWorker,
+  getWorkerConnectionTargets,
+  getWorkerConnectionTokens,
+  getWorkerConnectionRefreshDelay,
   getWorkerConnectionPollDelay,
   getWorkerSummary,
   getWorkerTokens,
   getWorkersList,
   withWorkerConnection,
   workerNeedsConnectionResolution,
+  workerConnectionEquals,
 } from "../app/(den)/_lib/den-flow";
 
 const daytonaInstance = {
@@ -24,15 +30,52 @@ test("Den Web never treats Daytona list or detail URLs as durable connections", 
   expect(getWorkersList({ workers: [{ ...worker, instance: daytonaInstance }] })[0]?.instanceUrl).toBeNull();
 })
 
-test("Den Web keeps durable non-Daytona URLs and resolver-backed token URLs", () => {
+test("Den Web keeps durable URLs and separates stable connections from direct previews", () => {
   const worker = { id: "worker-1", name: "Remote", status: "healthy" };
   const renderInstance = { provider: "render", status: "healthy", url: "https://durable.render.example.test" };
 
   expect(getWorkerSummary({ worker, instance: renderInstance })?.instanceUrl).toBe("https://durable.render.example.test");
-  expect(getWorkerTokens({
+  const tokens = getWorkerTokens({
     tokens: { client: "client-token", host: "host-token" },
-    connect: { openworkUrl: "https://fresh.preview.example.test/w/workspace", workspaceId: "workspace" },
-  })?.openworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
+    connect: { openworkUrl: "https://den.example.test/v1/cloud/workers/worker-1/w/workspace", workspaceId: "workspace" },
+    directPreview: {
+      version: 1,
+      openworkUrl: "https://fresh.preview.example.test/w/workspace",
+      workspaceId: "workspace",
+      expiresAt: "2026-08-27T12:00:00.000Z",
+    },
+  });
+  expect(tokens?.openworkUrl).toBe("https://den.example.test/v1/cloud/workers/worker-1/w/workspace");
+  expect(tokens?.previewOpenworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
+  expect(tokens?.previewExpiresAt).toBe("2026-08-27T12:00:00.000Z");
+  const daytonaWorker = getWorker({ worker, instance: daytonaInstance, tokens: {} });
+  if (!daytonaWorker || !tokens) throw new Error("worker connection payload did not parse");
+  expect(getWorkerConnectionTargets({
+    ...daytonaWorker,
+    openworkUrl: tokens.openworkUrl,
+    previewOpenworkUrl: tokens.previewOpenworkUrl,
+  })).toEqual({
+    desktopUrl: "https://den.example.test/v1/cloud/workers/worker-1/w/workspace",
+    webUrl: "https://fresh.preview.example.test/w/workspace",
+  });
+  const connectedWorker = withWorkerConnection(daytonaWorker, tokens);
+  const connectionTokens = getWorkerConnectionTokens(connectedWorker);
+  expect(connectionTokens).toEqual({ desktopToken: "host-token", webToken: "client-token" });
+  const desktopLink = buildOpenworkDeepLink(
+    connectedWorker.openworkUrl,
+    connectionTokens.desktopToken,
+    connectedWorker.workerId,
+    connectedWorker.workerName,
+  );
+  const webLink = buildOpenworkAppConnectUrl(
+    "https://app.example.test/connect-remote",
+    connectedWorker.previewOpenworkUrl ?? null,
+    connectionTokens.webToken,
+    connectedWorker.workerId,
+    connectedWorker.workerName,
+  );
+  expect(new URL(desktopLink ?? "").searchParams.get("openworkToken")).toBe("host-token");
+  expect(new URL(webLink ?? "").searchParams.get("openworkToken")).toBe("client-token");
 })
 
 test("create tokens without a URL keep polling until the late resolver URL is adopted", () => {
@@ -57,17 +100,31 @@ test("create tokens without a URL keep polling until the late resolver URL is ad
   const late = getWorkerTokens({
     tokens: { client: "client-token", owner: "host-token", host: "host-token" },
     connect: {
+      openworkUrl: "https://den.example.test/v1/cloud/workers/worker-late-url/w/workspace",
+      workspaceId: "workspace",
+    },
+    directPreview: {
+      version: 1,
       openworkUrl: "https://late.preview.example.test/w/workspace",
       workspaceId: "workspace",
+      expiresAt: "2026-08-27T12:00:00.000Z",
     },
   });
   if (!late) throw new Error("late token payload did not parse");
   const ready = withWorkerConnection(waiting, late);
 
-  expect(ready.openworkUrl).toBe("https://late.preview.example.test/w/workspace");
+  expect(ready.openworkUrl).toBe("https://den.example.test/v1/cloud/workers/worker-late-url/w/workspace");
+  expect(ready.previewOpenworkUrl).toBe("https://late.preview.example.test/w/workspace");
   expect(ready.clientToken).toBe("client-token");
   expect(ready.hostToken).toBe("host-token");
-  expect(workerNeedsConnectionResolution(ready)).toBe(false);
+  const now = new Date("2026-08-27T10:00:00.000Z").getTime();
+  expect(workerNeedsConnectionResolution(ready, now)).toBe(false);
+  expect(getWorkerConnectionRefreshDelay(ready, now)).toBe(119 * 60 * 1000 + 30 * 1000);
+  expect(workerNeedsConnectionResolution(ready, new Date("2026-08-27T11:59:45.000Z").getTime())).toBe(true);
+  const expiryOnlyRefresh = { ...ready, previewExpiresAt: "2026-08-27T14:00:00.000Z" };
+  expect(workerConnectionEquals(ready, expiryOnlyRefresh)).toBe(false);
+  const adopted = workerConnectionEquals(ready, expiryOnlyRefresh) ? ready : expiryOnlyRefresh;
+  expect(adopted.previewExpiresAt).toBe("2026-08-27T14:00:00.000Z");
   expect(workerNeedsConnectionResolution({ ...waiting, status: "failed" })).toBe(false);
   expect([1, 2, 3, 30].map(getWorkerConnectionPollDelay)).toEqual([1_000, 2_000, 4_000, 4_000]);
 })

--- a/evals/specs/cloud-runtime-signed-preview.test.ts
+++ b/evals/specs/cloud-runtime-signed-preview.test.ts
@@ -37,7 +37,7 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
     { probeCloudRuntimeSignedPreview, resolveCloudRuntimeAccess },
     { getWorkerTokensAndConnect, persistedWorkerInstanceUrl },
     { proxyCloudWorkerCompatibilityRequest },
-    { getWorker, getWorkerTokens, withWorkerConnection, workerNeedsConnectionResolution },
+    { getWorker, getWorkerConnectionTokens, getWorkerTokens, withWorkerConnection, workerConnectionEquals, workerNeedsConnectionResolution },
   ] = await Promise.all([
     import("../../ee/apps/den-api/src/workers/worker-access.js"),
     import("../../ee/apps/den-api/src/routes/workers/shared.js"),
@@ -118,33 +118,45 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
     updated_at: new Date("2026-08-27T09:00:00.000Z"),
   } satisfies Parameters<typeof getWorkerTokensAndConnect>[0];
   const resolveTokenAccess = async () => result;
+  const loadActiveTokens = async () => [
+    { scope: "host" as const, token: "host-token" },
+    { scope: "client" as const, token: "client-token" },
+  ];
   const legacyTokens = await getWorkerTokensAndConnect(legacyWorker, {
     apiPublicUrl: "https://api.example.test/api/den",
     resolveCloudAccess: resolveTokenAccess,
+    loadActiveTokens,
     fetchImpl: async () => Response.json({ activeId: "workspace", items: [] }),
   });
   const webTokens = await getWorkerTokensAndConnect(legacyWorker, {
     apiPublicUrl: "https://api.example.test/api/den",
     includeExpiringOpenworkUrl: true,
     resolveCloudAccess: resolveTokenAccess,
+    loadActiveTokens,
     fetchImpl: async () => Response.json({ activeId: "workspace", items: [] }),
   });
   if (!("connect" in legacyTokens) || !legacyTokens.connect) throw new Error("legacy worker tokens did not include a stable route");
-  if (!("connect" in webTokens) || !webTokens.connect) throw new Error("Web worker tokens did not include a preview route");
-  expect(legacyTokens.connect.openworkUrl).toBe(`https://api.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}/w/workspace`);
+  if (!("connect" in webTokens) || !webTokens.connect || !("directPreview" in webTokens) || !webTokens.directPreview) throw new Error("Web worker tokens did not separate stable and preview routes");
+  expect(legacyTokens.connect.openworkUrl).toBe(`https://api.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}`);
   expect(legacyTokens.connect.openworkUrl).not.toContain("preview.example.test");
-  expect(webTokens.connect.openworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
-  const legacyStableRoot = legacyTokens.connect.openworkUrl.replace(/\/w\/[^/]+$/, "");
+  expect(webTokens.connect.openworkUrl).toBe(`https://api.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}/w/workspace`);
+  expect(webTokens.directPreview.openworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
+  expect(webTokens.directPreview.expiresAt).toBe("2026-08-27T12:00:00.000Z");
+  const legacyStableRoot = legacyTokens.connect.openworkUrl;
   const legacyProxyTargets: string[] = [];
+  const authenticateStableRequest = async ({ request, workerId }: { request: Request; workerId: typeof runtimeWorker.id }) => {
+    if (workerId !== runtimeWorker.id) return null;
+    if (request.headers.get("authorization") === "Bearer host-token") return { organizationId: legacyWorker.org_id, scope: "host" as const };
+    if (request.headers.get("authorization") === "Bearer client-token") return { organizationId: legacyWorker.org_id, scope: "client" as const };
+    return null;
+  };
   const legacyProxyResponse = await proxyCloudWorkerCompatibilityRequest({
     request: new Request(`${legacyStableRoot}/workspaces?published=1`, {
       headers: { Authorization: "Bearer client-token" },
     }),
     workerId: runtimeWorker.id,
   }, {
-    authenticate: async ({ request, workerId }) => request.headers.get("authorization") === "Bearer client-token" && workerId === runtimeWorker.id
-      ? { organizationId: legacyWorker.org_id, scope: "client" }
-      : null,
+    authenticate: authenticateStableRequest,
     resolveCloudAccess: async () => ({
       ...result,
       status: "ready",
@@ -157,6 +169,41 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
   });
   expect(legacyProxyResponse.status).toBe(200);
   expect(legacyProxyTargets).toEqual(["https://refreshed-after-token.preview.example.test/workspaces?published=1"]);
+  await legacyProxyResponse.body?.cancel();
+  const clientWrite = await proxyCloudWorkerCompatibilityRequest({
+    request: new Request(`${legacyStableRoot}/workspace/workspace/files/raw`, {
+      method: "POST",
+      headers: { Authorization: "Bearer client-token", "Content-Type": "application/json" },
+      body: "{}",
+    }),
+    workerId: runtimeWorker.id,
+  }, { authenticate: authenticateStableRequest, resolveCloudAccess: resolveTokenAccess });
+  expect(clientWrite.status).toBe(401);
+  const handoffWriteRequests: RequestInit[] = [];
+  const handoffWriteBodies: string[] = [];
+  const desktopWrite = await proxyCloudWorkerCompatibilityRequest({
+    request: new Request(`${legacyStableRoot}/workspace/workspace/files/raw`, {
+      method: "POST",
+      headers: { Authorization: "Bearer host-token", "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "handoff.txt", dataBase64: "aGk=" }),
+    }),
+    workerId: runtimeWorker.id,
+  }, {
+    authenticate: authenticateStableRequest,
+    resolveCloudAccess: resolveTokenAccess,
+    fetchImpl: async (_url, init = {}) => {
+      handoffWriteRequests.push(init);
+      expect("duplex" in init && init.duplex).toBe("half");
+      handoffWriteBodies.push(await new Response(init.body).text());
+      return Response.json({ ok: true });
+    },
+  });
+  expect(desktopWrite.status).toBe(200);
+  const desktopWriteHeaders = new Headers(handoffWriteRequests[0]?.headers);
+  expect(desktopWriteHeaders.get("authorization")).toBe("Bearer client-token");
+  expect(desktopWriteHeaders.get("x-openwork-host-token")).toBe("host-token");
+  expect(handoffWriteBodies).toEqual([JSON.stringify({ path: "handoff.txt", dataBase64: "aGk=" })]);
+  await desktopWrite.body?.cancel();
   const created = getWorker({
     worker: { id: runtimeWorker.id, name: runtimeWorker.name, status: "provisioning" },
     instance: null,
@@ -167,8 +214,11 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
   const lateTokens = getWorkerTokens(webTokens);
   if (!lateTokens) throw new Error("late worker token payload did not parse");
   const webWorker = withWorkerConnection(created, lateTokens);
-  expect(webWorker.openworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
-  expect(workerNeedsConnectionResolution(webWorker)).toBe(false);
+  expect(webWorker.openworkUrl).toBe(`https://api.example.test/api/den/v1/cloud/workers/${runtimeWorker.id}/w/workspace`);
+  expect(webWorker.previewOpenworkUrl).toBe("https://fresh.preview.example.test/w/workspace");
+  expect(workerNeedsConnectionResolution(webWorker, new Date("2026-08-27T10:00:00.000Z").getTime())).toBe(false);
+  expect(getWorkerConnectionTokens(webWorker)).toEqual({ desktopToken: "host-token", webToken: "client-token" });
+  expect(workerConnectionEquals(webWorker, { ...webWorker, previewExpiresAt: "2026-08-27T14:00:00.000Z" })).toBe(false);
 
   let redirectedTargetHit = false;
   const target = createServer((_request, response) => {
@@ -193,7 +243,7 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
   }
   evidence.recordAssertionEvidence(
     "Published desktops keep a stable worker URL while Daytona previews refresh",
-    "A legacy empty token request received a non-null configured Den API worker route with its workspace mount and no preview hostname; the existing client token reached a separately refreshed preview through that stable route. Web opt-in still received the direct fresh preview, the removed standalone worker host was never used, persistence kept only a lifecycle URL, and a sandbox-controlled redirect was rejected.",
+    "The legacy token response returned tokens and the configured Den API worker root without consulting a preview; Web retained a workspace-scoped stable route and received the expiring preview separately with its expiry. Desktop selected the host token and successfully streamed a write while client-only compatibility writes were denied; Web selected the client token and expiry-only preview refreshes were observable. The removed standalone worker host was never used, persistence kept only a lifecycle URL, and a sandbox-controlled redirect was rejected.",
     true,
   );
 });

--- a/packages/headless-threads/src/client.test.ts
+++ b/packages/headless-threads/src/client.test.ts
@@ -1,3 +1,4 @@
+import { createServer, type Server } from "node:http";
 import { describe, expect, test } from "bun:test";
 
 import { createHeadlessThreadClient } from "./client.js";
@@ -11,6 +12,26 @@ type Beat = { status: HeadlessThreadStatus; messages: MessageWire[] };
 
 const SESSION_ID = "ses_1";
 const BASE_URL = "http://openwork.test";
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}
+
+function serverUrl(server: Server): string {
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return `http://127.0.0.1:${address.port}`;
+}
 
 function reply(id: string, role: string, text?: string, parentID?: string): MessageWire {
   return {
@@ -387,6 +408,36 @@ describe("failures", () => {
     });
 
     await expect(client.getThreadSnapshot(SESSION_ID)).rejects.toBeDefined();
+  });
+
+  test("a custom Cloud fetch cannot follow a 307 with the thread body or tokens", async () => {
+    const targetRequests: Array<{ authorization: string | undefined; hostToken: string | undefined }> = [];
+    const target = createServer((request, response) => {
+      targetRequests.push({
+        authorization: request.headers.authorization,
+        hostToken: typeof request.headers["x-openwork-host-token"] === "string" ? request.headers["x-openwork-host-token"] : undefined,
+      });
+      response.end("unexpected");
+    });
+    const preview = createServer((_request, response) => {
+      response.writeHead(307, { Location: `${serverUrl(target)}/captured` });
+      response.end();
+    });
+    await Promise.all([listen(target), listen(preview)]);
+    try {
+      const client = createHeadlessThreadClient({
+        baseUrl: serverUrl(preview),
+        workspaceId: "ws_1",
+        token: "client-secret",
+        hostToken: "host-secret",
+        fetch: (url, init) => fetch(url, init),
+      });
+
+      await expect(client.createThread({ title: "Secret thread" })).rejects.toBeDefined();
+      expect(targetRequests).toEqual([]);
+    } finally {
+      await Promise.all([close(preview), close(target)]);
+    }
   });
 });
 

--- a/packages/headless-threads/src/client.ts
+++ b/packages/headless-threads/src/client.ts
@@ -92,6 +92,7 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
         ...(body === undefined ? {} : { "Content-Type": "application/json" }),
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      redirect: "error",
       signal: requestSignal(signal),
     });
     const text = await response.text().catch(() => "");

--- a/packages/headless-threads/src/types.ts
+++ b/packages/headless-threads/src/types.ts
@@ -190,7 +190,7 @@ export interface HeadlessThreadClient {
  */
 export type HeadlessFetch = (
   input: string,
-  init?: { method?: string; headers?: Record<string, string>; body?: string; signal?: AbortSignal },
+  init?: { method?: string; headers?: Record<string, string>; body?: string; redirect?: RequestRedirect; signal?: AbortSignal },
 ) => Promise<Response>;
 
 export interface HeadlessThreadClientOptions {


### PR DESCRIPTION
Follow-up to #4157. The original PR auto-merged while its final reviewed hardening commit was propagating; this PR contains only that missing commit rebased onto current dev.

## Fixes included

- Native/file CORS preflights are handled before global CORS for stable Cloud worker routes.
- Stable compatibility URL uses host/owner credentials for Desktop writes; direct Web preview uses client credentials.
- Web preview URL + expiry refresh even when stable tokens are unchanged.
- Every direct signed-preview fetch rejects redirects, including materialization, remote sessions, Cloud Automations, and headless clients; prevents 307/308 body/token forwarding SSRF.
- Stable compatibility proxy validates worker token + method scope, strips unsafe/hop headers, rejects redirects, streams request and response bodies without buffering, and bounds per-worker concurrent streams.
- Published `/tokens {}` clients keep a stable den-api worker URL while fresh previews rotate behind it.

## Verification — Passed (local lane)

Head `66fa45a51`:
- 63 den-api focused tests passed.
- 21 headless-thread client tests passed.
- 3 Den Web tests passed.
- den-api, headless-threads, and Den Web typechecks clean.
- Testkit signed-preview spec: 2 passed.
- Independent blocker review: no blockers.