### PR TITLE
fix(den-api): heartbeat provisioning claims so orphaned cloud workers are rescued in minutes

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -768,7 +768,10 @@ export const env = {
   initialAdminBootstrapCode,
   provisionerMode: parsed.PROVISIONER_MODE ?? "stub",
   workerProvisioningReconcileIntervalMs: Number(parsed.WORKER_PROVISIONING_RECONCILE_INTERVAL_MS ?? "60000"),
-  workerProvisioningReconcileStaleMs: Number(parsed.WORKER_PROVISIONING_RECONCILE_STALE_MS ?? "1200000"),
+  // Live provisioning owners heartbeat `updated_at` every 30 seconds, so this
+  // staleness only fires after several missed beats. Keep it several multiples
+  // of `provisioningHeartbeatIntervalMs`.
+  workerProvisioningReconcileStaleMs: Number(parsed.WORKER_PROVISIONING_RECONCILE_STALE_MS ?? "180000"),
   workerProvisioningReconcileBatchSize: Number(parsed.WORKER_PROVISIONING_RECONCILE_BATCH_SIZE ?? "10"),
   cloudProvisionDeadlineMs: Number(parsed.CLOUD_PROVISION_DEADLINE_MS ?? "900000"),
   cloudMaterializationFailureCooldownMs: Number(parsed.CLOUD_MATERIALIZATION_FAILURE_COOLDOWN_MS ?? "120000"),

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -22,6 +22,7 @@ import type { AuthContextVariables } from "../../session.js"
 import { materializeCloudWorkerProviders } from "../../llm/cloud-provider-materialization.js"
 import { deprovisionWorker, provisionWorker } from "../../workers/provisioner.js"
 import { withProvisionDeadline } from "../../workers/provision-deadline.js"
+import { touchProvisioningWorker, withProvisioningHeartbeat } from "../../workers/provisioning-heartbeat.js"
 import { customDomainForWorker } from "../../workers/vanity-domain.js"
 import { resolveCloudRuntimeAccess } from "../../workers/worker-access.js"
 import { CLOUD_INSTANCE_BACKEND } from "../../workers/cloud-constants.js"
@@ -81,12 +82,14 @@ type CloudProvisioningStore = {
     onlyWhenStatusIn?: WorkerStatus[]
   }) => Promise<void>
   insertWorkerInstance: (input: { workerId: WorkerId; provisioned: ProvisionedWorker }) => Promise<void>
+  touchProvisioningWorker: (workerId: WorkerId) => Promise<void>
 }
 type ContinueCloudProvisioningOptions = {
   provisionWorker?: ProvisionWorker
   store?: CloudProvisioningStore
   materializeProviders?: typeof materializeCloudWorkerProviders
   deadlineMs?: number
+  heartbeatIntervalMs?: number
 }
 
 export const token = () => randomBytes(32).toString("hex")
@@ -122,6 +125,7 @@ const databaseCloudProvisioningStore: CloudProvisioningStore = {
       status: input.provisioned.status,
     })
   },
+  touchProvisioningWorker,
 }
 
 export function persistedWorkerInstanceUrl(provisioned: Pick<ProvisionedWorker, "provider" | "url">) {
@@ -435,44 +439,51 @@ async function runCloudProvisioning(input: {
   const deadlineMs = options.deadlineMs ?? env.cloudProvisionDeadlineMs
 
   try {
-    const provisioned = await withProvisionDeadline({
-      promise: provision({
-        workerId: input.workerId,
-        name: input.name,
-        hostToken: input.hostToken,
-        clientToken: input.clientToken,
-        activityToken: input.activityToken,
-      }),
-      deadlineMs,
-      label: `cloud provisioning for ${input.workerId}`,
-    })
-
-    if (provisioned.status === "healthy" && input.orgId) {
-      try {
-        await materializeProviders({
-          organizationId: input.orgId,
-          workerId: input.workerId,
-          instanceUrl: provisioned.url,
-          hostToken: input.hostToken,
-          clientToken: input.clientToken,
-          force: true,
-        })
-      } catch (error) {
-        logger.warn("worker provisioning provider materialization warning", {
-          worker_id: input.workerId,
-          message: error instanceof Error ? error.message : "provider_materialization_failed",
-        })
-      }
-    }
-
-    await store.updateWorkerStatus({
+    await withProvisioningHeartbeat({
       workerId: input.workerId,
-      status: provisioned.status,
-      imageVersion: provisioned.imageVersion,
-      onlyWhenStatusIn: provisioningSuccessWritableStatuses,
-    })
+      touch: store.touchProvisioningWorker,
+      intervalMs: options.heartbeatIntervalMs,
+      run: async () => {
+        const provisioned = await withProvisionDeadline({
+          promise: provision({
+            workerId: input.workerId,
+            name: input.name,
+            hostToken: input.hostToken,
+            clientToken: input.clientToken,
+            activityToken: input.activityToken,
+          }),
+          deadlineMs,
+          label: `cloud provisioning for ${input.workerId}`,
+        })
 
-    await store.insertWorkerInstance({ workerId: input.workerId, provisioned })
+        if (provisioned.status === "healthy" && input.orgId) {
+          try {
+            await materializeProviders({
+              organizationId: input.orgId,
+              workerId: input.workerId,
+              instanceUrl: provisioned.url,
+              hostToken: input.hostToken,
+              clientToken: input.clientToken,
+              force: true,
+            })
+          } catch (error) {
+            logger.warn("worker provisioning provider materialization warning", {
+              worker_id: input.workerId,
+              message: error instanceof Error ? error.message : "provider_materialization_failed",
+            })
+          }
+        }
+
+        await store.updateWorkerStatus({
+          workerId: input.workerId,
+          status: provisioned.status,
+          imageVersion: provisioned.imageVersion,
+          onlyWhenStatusIn: provisioningSuccessWritableStatuses,
+        })
+
+        await store.insertWorkerInstance({ workerId: input.workerId, provisioned })
+      },
+    })
   } catch (error) {
     await store.updateWorkerStatus({ workerId: input.workerId, status: "failed", onlyWhenStatus: "provisioning" })
 

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -15,6 +15,7 @@ import {
   type StopWorkerOnDaytonaResult,
 } from "./daytona.js"
 import { withProvisionDeadline } from "./provision-deadline.js"
+import { touchProvisioningWorker, withProvisioningHeartbeat } from "./provisioning-heartbeat.js"
 
 type WorkerId = typeof WorkerTable.$inferSelect.id
 type WorkerStatus = typeof WorkerTable.$inferSelect.status
@@ -31,6 +32,7 @@ type CloudLifecycleStore = {
   reserveWake: (workerId: WorkerId) => Promise<boolean>
   reserveIdleStop: (input: { workerId: WorkerId; idleBefore: Date }) => Promise<boolean>
   updateWorkerStatus: (input: { workerId: WorkerId; status: WorkerStatus; imageVersion?: string | null; onlyWhenStatus?: WorkerStatus }) => Promise<void>
+  touchProvisioningWorker: (workerId: WorkerId) => Promise<void>
 }
 
 type WakeCloudWorkerOptions = {
@@ -39,6 +41,7 @@ type WakeCloudWorkerOptions = {
   provisionWorker?: ProvisionWorkerOnDaytona
   materializeProviders?: typeof materializeCloudWorkerProviders
   deadlineMs?: number
+  heartbeatIntervalMs?: number
 }
 
 type StopIdleCloudWorkersOptions = {
@@ -154,6 +157,7 @@ const databaseCloudLifecycleStore: CloudLifecycleStore = {
         ? and(eq(WorkerTable.id, input.workerId), eq(WorkerTable.status, input.onlyWhenStatus))
         : eq(WorkerTable.id, input.workerId))
   },
+  touchProvisioningWorker,
 }
 
 export function cloudWorkerIdleReferenceTime(worker: Pick<CloudWorker, "last_active_at" | "updated_at">) {
@@ -214,42 +218,49 @@ async function runClaimedCloudWorkerRecovery(workerId: WorkerId, options: WakeCl
       clientToken,
       activityToken,
     }
-    const woken = await withProvisionDeadline({
-      promise: (async () => {
-        try {
-          return await wakeWorker(wakeInput)
-        } catch (error) {
-          if (!isDaytonaSandboxMissingError(error)) {
-            throw error
+    await withProvisioningHeartbeat({
+      workerId,
+      touch: store.touchProvisioningWorker,
+      intervalMs: options.heartbeatIntervalMs,
+      run: async () => {
+        const woken = await withProvisionDeadline({
+          promise: (async () => {
+            try {
+              return await wakeWorker(wakeInput)
+            } catch (error) {
+              if (!isDaytonaSandboxMissingError(error)) {
+                throw error
+              }
+
+              logger.warn("worker wake sandbox missing; reprovisioning", { worker_id: workerId, error })
+              return provisionWorker(wakeInput)
+            }
+          })(),
+          deadlineMs,
+          label: `cloud wake for ${workerId}`,
+        })
+
+        if (woken.status === "healthy" && worker.org_id) {
+          try {
+            await materializeProviders({
+              organizationId: worker.org_id,
+              workerId,
+              instanceUrl: woken.url,
+              hostToken,
+              clientToken,
+              force: true,
+            })
+          } catch (error) {
+            logger.warn("worker wake provider materialization warning", {
+              worker_id: workerId,
+              message: error instanceof Error ? error.message : "provider_materialization_failed",
+            })
           }
-
-          logger.warn("worker wake sandbox missing; reprovisioning", { worker_id: workerId, error })
-          return provisionWorker(wakeInput)
         }
-      })(),
-      deadlineMs,
-      label: `cloud wake for ${workerId}`,
+
+        await store.updateWorkerStatus({ workerId, status: woken.status, imageVersion: woken.imageVersion, onlyWhenStatus: "provisioning" })
+      },
     })
-
-    if (woken.status === "healthy" && worker.org_id) {
-      try {
-        await materializeProviders({
-          organizationId: worker.org_id,
-          workerId,
-          instanceUrl: woken.url,
-          hostToken,
-          clientToken,
-          force: true,
-        })
-      } catch (error) {
-        logger.warn("worker wake provider materialization warning", {
-          worker_id: workerId,
-          message: error instanceof Error ? error.message : "provider_materialization_failed",
-        })
-      }
-    }
-
-    await store.updateWorkerStatus({ workerId, status: woken.status, imageVersion: woken.imageVersion, onlyWhenStatus: "provisioning" })
   } catch (error) {
     await safelyMarkWorkerFailed(store, workerId)
     logger.error("worker wake failed", { worker_id: workerId, error })

--- a/ee/apps/den-api/src/workers/provisioning-heartbeat.ts
+++ b/ee/apps/den-api/src/workers/provisioning-heartbeat.ts
@@ -1,0 +1,60 @@
+import { and, eq } from "@openwork-ee/den-db/drizzle"
+import { WorkerTable } from "@openwork-ee/den-db/schema"
+import { db } from "../db.js"
+import { appLogger } from "../observability/logger.js"
+
+type WorkerId = typeof WorkerTable.$inferSelect.id
+
+const logger = appLogger.child({ component: "provisioning_heartbeat" })
+
+/**
+ * The stale-provisioning reconciler reads a quiet `updated_at` as an orphaned
+ * claim, so every live provisioning owner must keep touching its row until it
+ * writes a terminal status. Keep this interval well below
+ * `WORKER_PROVISIONING_RECONCILE_STALE_MS` so several missed beats are needed
+ * before another owner may reclaim the worker.
+ */
+export const provisioningHeartbeatIntervalMs = 30_000
+
+/**
+ * Bump the claim fence for a worker that is still provisioning. The status
+ * predicate keeps the touch inert after any owner writes a terminal status,
+ * and the explicit timestamp write keeps MySQL from skipping `ON UPDATE`
+ * when no column value changes.
+ */
+export async function touchProvisioningWorker(workerId: WorkerId) {
+  await db
+    .update(WorkerTable)
+    .set({ updated_at: new Date() })
+    .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "provisioning")))
+}
+
+/**
+ * Run one claimed provisioning action while keeping its worker row visibly
+ * alive. Touch failures are logged and dropped: a missed beat only risks an
+ * earlier reconcile of a live claim, never a wrong worker status, so the
+ * provider action must not fail because of one.
+ */
+export async function withProvisioningHeartbeat<T>(input: {
+  workerId: WorkerId
+  run: () => Promise<T>
+  touch?: (workerId: WorkerId) => Promise<void>
+  intervalMs?: number
+}): Promise<T> {
+  const touch = input.touch ?? touchProvisioningWorker
+  const intervalMs = input.intervalMs ?? provisioningHeartbeatIntervalMs
+  let beat: Promise<void> = Promise.resolve()
+  const timer = setInterval(() => {
+    beat = beat.then(() => touch(input.workerId)).catch((error) => {
+      logger.warn("provisioning heartbeat touch failed", { worker_id: input.workerId, error })
+    })
+  }, intervalMs)
+  timer.unref()
+
+  try {
+    return await input.run()
+  } finally {
+    clearInterval(timer)
+    await beat.catch(() => undefined)
+  }
+}

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -59,7 +59,14 @@ function makeToken(workerId: TestWorker["id"], scope: TestWorkerToken["scope"]):
 function makeStore(input: { workers: TestWorker[]; tokens?: TestWorkerToken[] }) {
   const updates: StatusUpdate[] = []
   const tokens = input.tokens ?? []
+  let touches = 0
   const store: Store = {
+    async touchProvisioningWorker(workerId) {
+      const worker = input.workers.find((entry) => entry.id === workerId)
+      if (!worker || worker.status !== "provisioning") return
+      worker.updated_at = new Date()
+      touches += 1
+    },
     async getWorker(workerId) {
       return input.workers.find((worker) => worker.id === workerId) ?? null
     },
@@ -99,7 +106,13 @@ function makeStore(input: { workers: TestWorker[]; tokens?: TestWorkerToken[] })
     },
   }
 
-  return { store, updates }
+  return {
+    store,
+    updates,
+    get touches() {
+      return touches
+    },
+  }
 }
 
 function makeDaytonaWakeRuntime(input: {

--- a/ee/apps/den-api/test/cloud-provisioning-image-version.test.ts
+++ b/ee/apps/den-api/test/cloud-provisioning-image-version.test.ts
@@ -33,6 +33,7 @@ describe("cloud provisioning image version", () => {
       async insertWorkerInstance(input) {
         inserts.push(input)
       },
+      async touchProvisioningWorker() {},
     }
     const workerId = createDenTypeId("worker")
     const materializedUrls: string[] = []

--- a/ee/apps/den-api/test/cloud-provisioning-state-machine.test.ts
+++ b/ee/apps/den-api/test/cloud-provisioning-state-machine.test.ts
@@ -75,6 +75,7 @@ function makeProvisioningStore(initialStatus: WorkerStatus) {
     async insertWorkerInstance(input) {
       instances.push(input.provisioned)
     },
+    async touchProvisioningWorker() {},
   }
 
   return {

--- a/ee/apps/den-api/test/cloud-runtime-access.test.ts
+++ b/ee/apps/den-api/test/cloud-runtime-access.test.ts
@@ -269,6 +269,7 @@ describe("Cloud runtime access resolver", () => {
         if (input.onlyWhenStatus && runtimeWorker.status !== input.onlyWhenStatus) return
         runtimeWorker.status = input.status
       },
+      async touchProvisioningWorker() {},
     }
     const runtimeStore: CloudRuntimeStore = {
       async claimFailedWorker() {

--- a/evals/specs/cloud-worker-provisioning-recovery.test.ts
+++ b/evals/specs/cloud-worker-provisioning-recovery.test.ts
@@ -8,6 +8,12 @@ import type {
 
 type ReconcilerModule = typeof import("../../ee/apps/den-api/src/workers/reconciler.js");
 type DaytonaModule = typeof import("../../ee/apps/den-api/src/workers/daytona.js");
+type LifecycleModule = typeof import("../../ee/apps/den-api/src/workers/cloud-lifecycle.js");
+type SharedWorkersModule = typeof import("../../ee/apps/den-api/src/routes/workers/shared.js");
+type LifecycleOptions = NonNullable<Parameters<LifecycleModule["recoverClaimedCloudWorker"]>[1]>;
+type LifecycleStore = NonNullable<LifecycleOptions["store"]>;
+type ContinueOptions = NonNullable<Parameters<SharedWorkersModule["continueCloudProvisioning"]>[1]>;
+type ProvisioningStore = NonNullable<ContinueOptions["store"]>;
 type ReconcileOptions = NonNullable<Parameters<ReconcilerModule["reconcileStaleProvisioningWorkers"]>[0]>;
 type ReconcileStore = NonNullable<ReconcileOptions["store"]>;
 type ReconcileWorker = Awaited<ReturnType<ReconcileStore["listStaleWorkers"]>>[number];
@@ -61,6 +67,18 @@ function namedError(name: string, message: string) {
   const error = new Error(message);
   error.name = name;
   return error;
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number, label: string) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+    await sleep(2);
+  }
 }
 
 function makeDaytonaRuntime(lookupName: string, visibleAtLookup: number | null) {
@@ -220,4 +238,188 @@ test("cloud provisioning remains single-owner and survives Daytona read-after-wr
     "A sandbox hidden through the observed 10-second window became healthy and persisted; a sandbox still missing after the same bounded grace rejected without persistence.",
     true,
   );
+});
+
+test("a live provisioning claim heartbeats its fence while an orphaned claim is rescued after the shorter staleness", async ({ evidence }) => {
+  seedRequiredEnv();
+  const [lifecycle, shared, reconciler, heartbeat, envModule] = await Promise.all([
+    import("../../ee/apps/den-api/src/workers/cloud-lifecycle.js"),
+    import("../../ee/apps/den-api/src/routes/workers/shared.js"),
+    import("../../ee/apps/den-api/src/workers/reconciler.js"),
+    import("../../ee/apps/den-api/src/workers/provisioning-heartbeat.js"),
+    import("../../ee/apps/den-api/src/env.js"),
+  ]);
+
+  // The rescue window only shrinks safely because live owners beat well below it.
+  expect(heartbeat.provisioningHeartbeatIntervalMs).toBe(30_000);
+  expect(envModule.env.workerProvisioningReconcileStaleMs).toBe(180_000);
+  expect(envModule.env.workerProvisioningReconcileStaleMs)
+    .toBeGreaterThanOrEqual(4 * heartbeat.provisioningHeartbeatIntervalMs);
+
+  const claimedAt = new Date("2026-08-27T10:00:00.000Z");
+  const worker = makeWorker(claimedAt);
+  const tokens = makeTokens(worker.id);
+  let durableUpdatedAt = claimedAt;
+  let touches = 0;
+  const statusWrites: Array<{ status: string; onlyWhenStatus?: string }> = [];
+  const lifecycleStore: LifecycleStore = {
+    async getWorker() {
+      return worker;
+    },
+    async getActiveTokens() {
+      return tokens;
+    },
+    async listIdleWorkers() {
+      return [];
+    },
+    async reserveWake() {
+      return false;
+    },
+    async reserveIdleStop() {
+      return false;
+    },
+    async updateWorkerStatus(input) {
+      statusWrites.push({ status: input.status, onlyWhenStatus: input.onlyWhenStatus });
+      if (input.onlyWhenStatus && worker.status !== input.onlyWhenStatus) return;
+      worker.status = input.status;
+    },
+    async touchProvisioningWorker() {
+      if (worker.status !== "provisioning") return;
+      durableUpdatedAt = new Date();
+      touches += 1;
+    },
+  };
+
+  const recovery = lifecycle.recoverClaimedCloudWorker(worker.id, {
+    store: lifecycleStore,
+    heartbeatIntervalMs: 5,
+    wakeWorker: async () => {
+      await waitUntil(() => touches >= 3, 2_000, "three provisioning heartbeats");
+      return { provider: "daytona", url: "https://waking.preview.example.test", status: "healthy" };
+    },
+    materializeProviders: async () => ({ ok: true, status: "noop", fingerprint: "owp:v1:test", providers: 0 }),
+  });
+
+  // Negative half: a reconciler holding the pre-claim snapshot must lose the
+  // updated_at fence against the live heartbeat and start nothing.
+  let rescueAttempts = 0;
+  const fencedStore: ReconcileStore = {
+    async listStaleWorkers() {
+      return [{ ...worker, status: "provisioning", updated_at: claimedAt }];
+    },
+    async claimWorker(input) {
+      if (durableUpdatedAt.getTime() !== input.worker.updated_at.getTime()) return false;
+      durableUpdatedAt = input.claimedAt;
+      return true;
+    },
+    async getActiveTokens() {
+      return tokens;
+    },
+    async markFailed() {
+      throw new Error("live worker unexpectedly failed");
+    },
+  };
+  await waitUntil(() => touches >= 1, 2_000, "the first provisioning heartbeat");
+  await reconciler.reconcileStaleProvisioningWorkers({
+    store: fencedStore,
+    continueProvisioning: async () => {
+      rescueAttempts += 1;
+    },
+    now: new Date("2026-08-27T10:10:00.000Z"),
+  });
+  expect(rescueAttempts).toBe(0);
+
+  await recovery;
+  expect(worker.status).toBe("healthy");
+  expect(statusWrites.at(-1)).toEqual({ status: "healthy", onlyWhenStatus: "provisioning" });
+  expect(touches).toBeGreaterThanOrEqual(3);
+  const touchesAfterRecovery = touches;
+  await sleep(30);
+  expect(touches).toBe(touchesAfterRecovery);
+  evidence.recordAssertionEvidence(
+    "A live provisioning claim is fenced, not reclaimed",
+    "The claim owner's heartbeat moved updated_at while its provider action ran, a reconciler holding the stale snapshot lost the claim and started nothing, and the heartbeat stopped once the owner wrote healthy.",
+    true,
+  );
+
+  // With the owner dead, no heartbeat moves the fence: the same snapshot now
+  // wins the claim and concurrent reconcilers admit exactly one rescue.
+  const orphan = makeWorker(new Date("2026-08-27T11:00:00.000Z"));
+  const orphanTokens = makeTokens(orphan.id);
+  let orphanUpdatedAt = orphan.updated_at;
+  let orphanRescues = 0;
+  const orphanStore: ReconcileStore = {
+    async listStaleWorkers() {
+      return [{ ...orphan }];
+    },
+    async claimWorker(input) {
+      if (orphanUpdatedAt.getTime() !== input.worker.updated_at.getTime()) return false;
+      orphanUpdatedAt = input.claimedAt;
+      return true;
+    },
+    async getActiveTokens() {
+      return orphanTokens;
+    },
+    async markFailed() {
+      throw new Error("orphaned worker unexpectedly failed");
+    },
+  };
+  const orphanRescueAt = new Date("2026-08-27T11:03:30.000Z");
+  await Promise.all([
+    reconciler.reconcileStaleProvisioningWorkers({
+      store: orphanStore,
+      continueProvisioning: async () => {
+        orphanRescues += 1;
+      },
+      now: orphanRescueAt,
+    }),
+    reconciler.reconcileStaleProvisioningWorkers({
+      store: orphanStore,
+      continueProvisioning: async () => {
+        orphanRescues += 1;
+      },
+      now: orphanRescueAt,
+    }),
+  ]);
+  expect(orphanRescues).toBe(1);
+  evidence.recordAssertionEvidence(
+    "An orphaned provisioning claim is rescued once within the shorter staleness",
+    "Three and a half minutes after its last touch, concurrent reconcilers admitted exactly one recovery attempt for the worker whose owner stopped heartbeating.",
+    true,
+  );
+
+  // Initial provisioning heartbeats through the same primitive as wake recovery.
+  let provisioningTouches = 0;
+  const provisioningWrites: string[] = [];
+  const provisioningStore: ProvisioningStore = {
+    async updateWorkerStatus(input) {
+      provisioningWrites.push(input.status);
+    },
+    async insertWorkerInstance() {},
+    async touchProvisioningWorker() {
+      provisioningTouches += 1;
+    },
+  };
+  await shared.continueCloudProvisioning({
+    workerId: createDenTypeId("worker"),
+    name: "Cloud",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }, {
+    store: provisioningStore,
+    heartbeatIntervalMs: 5,
+    provisionWorker: async () => {
+      await waitUntil(() => provisioningTouches >= 2, 2_000, "two provisioning heartbeats");
+      return {
+        provider: "daytona",
+        url: "https://fresh.preview.example.test",
+        status: "healthy",
+        imageVersion: "openwork-test-snapshot",
+      };
+    },
+    materializeProviders: async () => ({ ok: true, status: "noop", fingerprint: "owp:v1:test", providers: 0 }),
+  });
+  expect(provisioningTouches).toBeGreaterThanOrEqual(2);
+  expect(provisioningWrites).toEqual(["healthy"]);
 });


### PR DESCRIPTION
## Problem

A Cloud worker whose provisioning owner died — a den-api replica crash or restart mid wake/provision — sat in `provisioning` for up to ~21 minutes. `resolveCloudRuntimeState` returns `waking`/`provisioning` for that state without starting anything (correct: another owner may hold the claim), so every member poll rendered the boot ladder while nothing drove recovery. Only `reconcileStaleProvisioningWorkers` could rescue it, and its 20-minute staleness default had to sit above the 15-minute provision deadline because a live claim was indistinguishable from a dead one.

## What changes

- New `withProvisioningHeartbeat` (`ee/apps/den-api/src/workers/provisioning-heartbeat.ts`): a live provisioning owner touches its worker row every 30 seconds while the provider action runs. The touch is fenced on `status = provisioning`, so it goes inert the moment any owner writes a terminal status. Touch failures are logged and dropped — a missed beat only risks an earlier reconcile of a live claim, never a wrong status.
- Both provisioning owners heartbeat: the claimed wake/recovery primitive (`runClaimedCloudWorkerRecovery`) and initial cloud provisioning (`runCloudProvisioning`).
- `WORKER_PROVISIONING_RECONCILE_STALE_MS` default drops from 20 minutes to 3. A dead owner's worker is now rescued in roughly four minutes (staleness + the 60-second loop) instead of ~21.
- A live claim cannot be reclaimed: the reconciler's exact `updated_at` compare-and-swap loses against any heartbeat that landed after its stale snapshot was read. This is asserted, not assumed.

## What does not change

- The resolver's read path, route surfaces, client polling, and the wake/recovery claim semantics are untouched.
- Terminal status writes keep their existing `onlyWhenStatus`/`onlyWhenStatusIn` guards.
- Operators can still override the staleness and reconcile interval via env.

## Verification — Passed (local lane; Daytona credentials unavailable in this environment)

- `corepack pnpm evals:pr specs/cloud-worker-provisioning-recovery.test.ts` — 1 file, 2 tests passed, 0 failed, 0 skipped. The new spec asserts: a live claim heartbeats its fence and a reconciler holding the pre-claim snapshot starts nothing; the heartbeat stops once the owner writes `healthy`; with the owner dead, concurrent reconcilers admit exactly one rescue; initial provisioning heartbeats through the same primitive; staleness stays ≥ 4× the heartbeat interval.
- `corepack pnpm --filter @openwork-ee/den-api exec bun test test/cloud-lifecycle.test.ts test/cloud-provisioning-state-machine.test.ts test/cloud-provisioning-image-version.test.ts test/cloud-runtime-access.test.ts test/cloud-instance-route.test.ts` — 62 passed, 0 failed, 195 assertions.
- `corepack pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — passed.
- `git diff --check` — passed.

The full `bun test` den-api suite needs MySQL at 127.0.0.1:3306 and was not run in this environment; the focused owning suites above cover every changed path.