### PR TITLE
fix(app): stop Settings visits from restarting a healthy local server mid-run

### DIFF
--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -753,25 +753,58 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   };
 
   async function ensureLocalOpenworkServerClient(): Promise<OpenworkServerClient | null> {
-    let hostInfo = state.openworkServerHostInfo;
-    if (hostInfo?.baseUrl?.trim() && hostInfo.clientToken?.trim()) {
-      const existing = createOpenworkServerClient({
-        baseUrl: hostInfo.baseUrl.trim(),
-        token: hostInfo.clientToken.trim(),
-        hostToken: hostInfo.hostToken?.trim() || undefined,
+    const healthyClientFromInfo = async (
+      info: OpenworkServerInfo | null,
+    ): Promise<OpenworkServerClient | null> => {
+      const baseUrl = info?.baseUrl?.trim() ?? "";
+      const token = info?.clientToken?.trim() ?? "";
+      if (!baseUrl || !token) return null;
+      const candidate = createOpenworkServerClient({
+        baseUrl,
+        token,
+        hostToken: info?.hostToken?.trim() || undefined,
       });
       try {
-        await existing.health();
-        if (options.startupPreference() !== "server") {
-          await reconnectOpenworkServer();
-        }
-        return existing;
+        await candidate.health();
       } catch {
-        // Fall through to a local restart.
+        return null;
       }
+      return candidate;
+    };
+
+    const cached = await healthyClientFromInfo(state.openworkServerHostInfo);
+    if (cached) {
+      if (options.startupPreference() !== "server") {
+        await reconnectOpenworkServer();
+      }
+      return cached;
     }
 
     if (!isDesktopRuntime()) return null;
+
+    // A store that has not observed the server yet (a fresh route mount)
+    // must not treat it as dead: the restart below tears down the embedded
+    // server AND its managed engine, killing every live run. Ask the desktop
+    // bridge for the live server first and restart only when that running
+    // server is genuinely unreachable.
+    let hostInfo: OpenworkServerInfo | null = null;
+    try {
+      hostInfo = await openworkServerInfo() as OpenworkServerInfo;
+      mutateState((current) => ({
+        ...current,
+        openworkServerHostInfo: hostInfo,
+        openworkServerHostInfoReady: true,
+      }));
+    } catch {
+      hostInfo = null;
+    }
+    const live = await healthyClientFromInfo(hostInfo);
+    if (live) {
+      if (options.startupPreference() !== "server") {
+        await reconnectOpenworkServer();
+      }
+      return live;
+    }
 
     try {
       hostInfo = await openworkServerRestart({

--- a/apps/app/src/react-app/domains/session/surface/model-availability.ts
+++ b/apps/app/src/react-app/domains/session/surface/model-availability.ts
@@ -105,3 +105,73 @@ export function computeModelAvailability(
 
   return { status: "available" };
 }
+
+/**
+ * How long a catalog-derived "unavailable" verdict must persist before it is
+ * shown. Settings visits and engine reload/restart churn can settle a
+ * momentarily incomplete catalog (e.g. `connected` not yet populated), which
+ * used to flash "Model no longer available" for a beat before the next
+ * refresh restored the model.
+ */
+export const MODEL_UNAVAILABLE_CONFIRMATION_MS = 1_200;
+
+export type UnavailableConfirmationGate = {
+  /**
+   * Confirm one verdict for one model identity. Catalog denials
+   * (`model_missing`, `provider_not_connected`) surface only after they have
+   * persisted for the confirmation window; younger denials render as pending
+   * so a transition blip never flashes the warning or blocks a send. Policy
+   * blocks (`provider_blocked`) are deliberate local state and pass through
+   * immediately, as do `available` and `pending`.
+   */
+  confirm: (
+    model: ModelRef | null | undefined,
+    verdict: ModelAvailability,
+  ) => ModelAvailability;
+  /**
+   * Milliseconds until the youngest tracked denial matures (0 when one is
+   * already mature but not yet re-rendered), or null when nothing is tracked.
+   * Callers use this to schedule a re-evaluation so a genuine denial still
+   * surfaces without further catalog changes.
+   */
+  nextRecheckDelay: (nowMs?: number) => number | null;
+};
+
+export function createUnavailableConfirmationGate(options?: {
+  confirmMs?: number;
+  now?: () => number;
+}): UnavailableConfirmationGate {
+  const confirmMs = options?.confirmMs ?? MODEL_UNAVAILABLE_CONFIRMATION_MS;
+  const now = options?.now ?? Date.now;
+  const firstDeniedAtByModel = new Map<string, number>();
+  const keyOf = (model: ModelRef | null | undefined) =>
+    `${model?.providerID?.trim() ?? ""}:${model?.modelID?.trim() ?? ""}`;
+
+  return {
+    confirm(model, verdict) {
+      const key = keyOf(model);
+      if (verdict.status !== "unavailable" || verdict.reason === "provider_blocked") {
+        firstDeniedAtByModel.delete(key);
+        return verdict;
+      }
+      const current = now();
+      const deniedAt = firstDeniedAtByModel.get(key);
+      if (deniedAt === undefined) {
+        firstDeniedAtByModel.set(key, current);
+        return { status: "pending" };
+      }
+      if (current - deniedAt < confirmMs) return { status: "pending" };
+      return verdict;
+    },
+    nextRecheckDelay(nowMs) {
+      const current = nowMs ?? now();
+      let next: number | null = null;
+      for (const deniedAt of firstDeniedAtByModel.values()) {
+        const remaining = confirmMs - (current - deniedAt);
+        if (remaining <= 0) return 0;
+        next = next === null ? remaining : Math.min(next, remaining);
+      }
+      return next;
+    },
+  };
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -117,7 +118,7 @@ import { composerAttachmentsToWorkspaceFileParts } from "@/react-app/domains/ses
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { getModelBehaviorSummary, nextModelBehaviorValue, previousModelBehaviorValue } from "@/app/lib/model-behavior";
-import { computeModelAvailability, type ModelAvailability } from "@/react-app/domains/session/surface/model-availability";
+import { computeModelAvailability, createUnavailableConfirmationGate, type ModelAvailability } from "@/react-app/domains/session/surface/model-availability";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { getSessionModelSelection, useSessionModelStore } from "@/react-app/domains/session/surface/session-model-store";
@@ -1109,8 +1110,20 @@ export function SessionRoute() {
   // directory, so a workspace switch supersedes the old catalog (the new key
   // reads as unsettled → pending) instead of judging the new workspace with
   // stale data.
+  //
+  // Catalog denials are additionally confirmation-gated: Settings visits and
+  // engine reload churn can settle a momentarily incomplete catalog, and a
+  // denial younger than the confirmation window renders as pending instead of
+  // flashing "Model no longer available" during the transition. The recheck
+  // tick re-evaluates tracked denials so a genuine one still surfaces once it
+  // matures, even without further catalog changes.
+  const modelAvailabilityGate = useMemo(() => createUnavailableConfirmationGate(), []);
+  const [availabilityRecheckTick, bumpAvailabilityRecheck] = useReducer(
+    (value: number) => value + 1,
+    0,
+  );
   const resolveModelAvailability = useCallback((model: ModelRef | null): ModelAvailability =>
-    computeModelAvailability(model, {
+    modelAvailabilityGate.confirm(model, computeModelAvailability(model, {
       workspaceReady: Boolean(selectedWorkspaceId && opencodeClient),
       loading,
       signedIn: denAuth.isSignedIn,
@@ -1120,18 +1133,27 @@ export function SessionRoute() {
       checkRestriction: checkDesktopRestriction,
       cloudProviderList,
       providerList: providerListQuery.data,
-    }), [
+    })), [
+    // The tick only forces re-evaluation of denials tracked by the gate.
+    availabilityRecheckTick,
     checkDesktopRestriction,
     cloudProviderList,
     cloudProviderSyncReady,
     denAuth.isSignedIn,
     loading,
+    modelAvailabilityGate,
     opencodeClient,
     openWorkModelsSyncing,
     providerListQuery.data,
     restrictToCloudProviders,
     selectedWorkspaceId,
   ]);
+  useEffect(() => {
+    const delay = modelAvailabilityGate.nextRecheckDelay();
+    if (delay === null) return;
+    const timer = window.setTimeout(() => bumpAvailabilityRecheck(), delay + 16);
+    return () => window.clearTimeout(timer);
+  }, [modelAvailabilityGate, resolveModelAvailability]);
   const selectedModelUnavailable =
     resolveModelAvailability(local.prefs.defaultModel ?? null).status === "unavailable";
   // The composer the user is looking at: the selected conversation's

--- a/apps/app/tests/model-availability.test.ts
+++ b/apps/app/tests/model-availability.test.ts
@@ -4,6 +4,8 @@ import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 import type { ProviderListItem } from "../src/app/types";
 import {
   computeModelAvailability,
+  createUnavailableConfirmationGate,
+  type ModelAvailability,
   type ModelAvailabilityContext,
 } from "../src/react-app/domains/session/surface/model-availability";
 
@@ -168,5 +170,72 @@ describe("computeModelAvailability", () => {
       status: "unavailable",
       reason: "model_missing",
     });
+  });
+});
+
+describe("createUnavailableConfirmationGate", () => {
+  const missing: ModelAvailability = { status: "unavailable", reason: "model_missing" };
+  const available: ModelAvailability = { status: "available" };
+  const pending: ModelAvailability = { status: "pending" };
+
+  function gateAt(startMs: number, confirmMs = 1_000) {
+    let nowMs = startMs;
+    const gate = createUnavailableConfirmationGate({ confirmMs, now: () => nowMs });
+    return { gate, advance: (ms: number) => { nowMs += ms; }, nowMs: () => nowMs };
+  }
+
+  test("a transient catalog denial renders as pending, never unavailable", () => {
+    const { gate, advance } = gateAt(10_000);
+    // Settings→thread transition: the catalog settles briefly without the model.
+    expect(gate.confirm(sessionModel, missing)).toEqual(pending);
+    advance(300);
+    expect(gate.confirm(sessionModel, missing)).toEqual(pending);
+    // The next refresh restores the model before the window matures.
+    advance(300);
+    expect(gate.confirm(sessionModel, available)).toEqual(available);
+    // The denial history is cleared: a later blip starts a fresh window.
+    advance(5_000);
+    expect(gate.confirm(sessionModel, missing)).toEqual(pending);
+  });
+
+  test("a genuine denial surfaces once it survives the confirmation window", () => {
+    const { gate, advance } = gateAt(10_000);
+    expect(gate.confirm(sessionModel, missing)).toEqual(pending);
+    advance(1_000);
+    expect(gate.confirm(sessionModel, missing)).toEqual(missing);
+    // Steady state stays denied without flicker.
+    advance(50);
+    expect(gate.confirm(sessionModel, missing)).toEqual(missing);
+  });
+
+  test("nextRecheckDelay schedules exactly the remaining confirmation time", () => {
+    const { gate, advance, nowMs } = gateAt(10_000);
+    expect(gate.nextRecheckDelay(nowMs())).toBeNull();
+    gate.confirm(sessionModel, missing);
+    expect(gate.nextRecheckDelay(nowMs())).toBe(1_000);
+    advance(400);
+    expect(gate.nextRecheckDelay(nowMs())).toBe(600);
+    advance(700);
+    expect(gate.nextRecheckDelay(nowMs())).toBe(0);
+    // A recovered model clears the tracked denial.
+    gate.confirm(sessionModel, available);
+    expect(gate.nextRecheckDelay(nowMs())).toBeNull();
+  });
+
+  test("denials are tracked per model identity", () => {
+    const { gate, advance } = gateAt(10_000);
+    expect(gate.confirm(sessionModel, missing)).toEqual(pending);
+    advance(1_000);
+    // The session model's denial matured; the default's is brand new.
+    expect(gate.confirm(sessionModel, missing)).toEqual(missing);
+    expect(gate.confirm(defaultModel, missing)).toEqual(pending);
+  });
+
+  test("policy blocks, available, and pending pass through immediately", () => {
+    const { gate } = gateAt(10_000);
+    const blocked: ModelAvailability = { status: "unavailable", reason: "provider_blocked" };
+    expect(gate.confirm(sessionModel, blocked)).toEqual(blocked);
+    expect(gate.confirm(sessionModel, available)).toEqual(available);
+    expect(gate.confirm(sessionModel, pending)).toEqual(pending);
   });
 });

--- a/apps/app/tests/openwork-server-local-recovery-restart-guard.test.ts
+++ b/apps/app/tests/openwork-server-local-recovery-restart-guard.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createOpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
+
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+
+type BridgeCalls = { info: number; restart: number };
+
+function installDesktopWindow(input: {
+  serverInfo: (() => unknown) | null;
+  restartInfo?: () => unknown;
+  calls: BridgeCalls;
+}) {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => void storage.set(key, value),
+        removeItem: (key: string) => void storage.delete(key),
+      },
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      __OPENWORK_ELECTRON__: {
+        invokeDesktop: async (command: string) => {
+          if (command === "openworkServerInfo") {
+            input.calls.info += 1;
+            if (!input.serverInfo) throw new Error("server info unavailable");
+            return input.serverInfo();
+          }
+          if (command === "openworkServerRestart") {
+            input.calls.restart += 1;
+            if (!input.restartInfo) throw new Error("restart unavailable");
+            return input.restartInfo();
+          }
+          throw new Error(`Unexpected desktop command: ${command}`);
+        },
+      },
+    },
+  });
+}
+
+function createStore() {
+  return createOpenworkServerStore({
+    startupPreference: () => "server",
+    documentVisible: () => true,
+    developerMode: () => false,
+    runtimeWorkspaceId: () => "workspace_local",
+    activeClient: () => null,
+    selectedWorkspaceDisplay: () => ({
+      id: "workspace_local",
+      name: "Local",
+      path: "/tmp/openwork-restart-guard",
+      preset: "starter",
+      workspaceType: "local",
+    }),
+    restartLocalServer: async () => true,
+    createRemoteWorkspaceFlow: async () => false,
+  });
+}
+
+const HEALTHY_INFO = {
+  running: true,
+  baseUrl: "http://127.0.0.1:61234",
+  port: 61234,
+  clientToken: "client-token",
+  hostToken: "host-token",
+  ownerToken: "owner-token",
+  remoteAccessEnabled: false,
+};
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  globalThis.fetch = originalFetch;
+});
+
+describe("local openwork server recovery restart guard", () => {
+  test("a fresh store with a healthy live server never restarts it", async () => {
+    const calls: BridgeCalls = { info: 0, restart: 0 };
+    installDesktopWindow({ serverInfo: () => HEALTHY_INFO, calls });
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true, version: "test", uptimeMs: 1 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const store = createStore();
+    // Fresh store: no start(), no observed host info — the exact state a
+    // just-mounted Settings route races its cloud reconcile against.
+    const client = await store.ensureLocalOpenworkServerClient();
+
+    expect(client).not.toBeNull();
+    expect(client?.baseUrl).toBe("http://127.0.0.1:61234");
+    expect(calls.restart).toBe(0);
+  });
+
+  test("a genuinely dead local server still restarts", async () => {
+    const calls: BridgeCalls = { info: 0, restart: 0 };
+    installDesktopWindow({
+      // The bridge answers, but the recorded server is gone.
+      serverInfo: () => ({ running: false, baseUrl: "", clientToken: "" }),
+      restartInfo: () => HEALTHY_INFO,
+      calls,
+    });
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true, version: "test", uptimeMs: 1 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const store = createStore();
+    const client = await store.ensureLocalOpenworkServerClient();
+
+    expect(calls.restart).toBe(1);
+    expect(client).not.toBeNull();
+    expect(client?.baseUrl).toBe("http://127.0.0.1:61234");
+  });
+});

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type Ref } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { AlertTriangle, Check, Loader2, Plug, Wrench } from "lucide-react";
@@ -166,7 +166,7 @@ function YourConnectionRow({
   presets: ReturnType<typeof useMcpConnectionPresets>["data"];
   onSetup: (target: PluginMcpSetupTarget) => void;
   highlighted: boolean;
-  rowRef?: React.Ref<HTMLDivElement>;
+  rowRef?: Ref<HTMLDivElement>;
   polling: boolean;
   connecting: boolean;
   disconnecting: boolean;

--- a/evals/specs/settings-visit-live-run-continuity.e2e.test.ts
+++ b/evals/specs/settings-visit-live-run-continuity.e2e.test.ts
@@ -1,0 +1,243 @@
+import { expect } from "vitest";
+import {
+  control,
+  evalIn,
+  readAvailableModels,
+  selectModel,
+  sendComposerMessage,
+  go,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot } from "@openwork/test-evidence";
+import { app, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+/**
+ * ACCEPTANCE TAPE — opening Settings while a run is streaming must not stop,
+ * detach, or stall the conversation.
+ *
+ * This is the exact user gesture behind the "Settings stops my conversation"
+ * report: a long task is live in the active workspace, the user opens
+ * Settings on that same workspace, stays there past the sync grace windows,
+ * and returns to the conversation. The run must still be live server-side
+ * AND the UI must still present it as live on return, the transcript must
+ * include output that streamed while Settings was open, and the task must
+ * complete without an interruption card.
+ *
+ * The workspace-switch tape (workspace-switch-task-survival) proves the
+ * runtime/engine survive retargeting; this tape proves the renderer-side
+ * conversation continuity for a same-workspace Settings round trip.
+ */
+
+const requirements: TestNeeds = {
+  env: ["ANTHROPIC_API_KEY"],
+  optIn: ["OPENWORK_EVAL_E2E_TESTS", "OPENWORK_EVAL_SETTINGS_LIVE_RUN_E2E_TEST"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `settings visit live-run continuity skipped — needs: ${missingRequirements.join(", ")}`
+  : "a streaming conversation survives a Settings visit on the same workspace";
+
+const COMPLETE_MARKER = "SETTINGS-VISIT-RUN-COMPLETE";
+const stopEnabledExpression = `(() => {
+  const stop = window.__openworkControl?.listActions().find((action) => action.id === "composer.stop");
+  return Boolean(stop && !stop.disabled);
+})()`;
+
+function serverStatusExpression(workspaceId: string) {
+  return `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const response = await fetch(
+      "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/opencode/session/status",
+      { headers: { Authorization: "Bearer " + token } },
+    );
+    return response.status + ":" + (await response.text()).slice(0, 500);
+  })()`;
+}
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 900_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({ place });
+  await using desktopApp = await app({ den, as: "admin", place });
+  const workspaceId = desktopApp.workspaceId;
+  const anthropicKey = process.env.ANTHROPIC_API_KEY?.trim() ?? "";
+
+  const configured = await evalIn(desktopApp, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      return response.status + ":" + (await response.text()).slice(0, 300);
+    };
+    const workspaceId = ${JSON.stringify(workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({ opencode: { provider: { anthropic: { options: { apiKey: ${JSON.stringify(anthropicKey)} } } } } }),
+    });
+    if (!patched.startsWith("200:")) return patched;
+    return request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+  })()`, { awaitPromise: true, timeoutMs: 90_000 });
+  expect(String(configured)).toMatch(/^20[04]:/);
+
+  const models = await readAvailableModels(desktopApp);
+  const chosen = models.find((model) => model.selectable && /sonnet/i.test(model.id))
+    ?? models.find((model) => model.selectable && /anthropic/i.test(model.providerName))
+    ?? models.find((model) => model.selectable);
+  if (!chosen) throw new Error("No selectable model was available for the settings continuity tape.");
+  await selectModel(desktopApp, chosen.id);
+
+  const createdSessionId = await control(desktopApp, "session.create_task");
+  const sessionId = typeof createdSessionId === "string" ? createdSessionId : "";
+  expect(sessionId).not.toBe("");
+
+  await sendComposerMessage(desktopApp, [
+    "Run the bash command `sleep 40 && echo settings-visit-task-done`.",
+    "Wait for it to finish, then reply with exactly:",
+    COMPLETE_MARKER,
+  ].join(" "));
+  await waitFor(desktopApp, stopEnabledExpression, { timeoutMs: 60_000, label: "long task became active" });
+
+  const statusWhileRunning = String(await evalIn(desktopApp, serverStatusExpression(workspaceId), {
+    awaitPromise: true,
+    timeoutMs: 30_000,
+  }));
+  evidence.recordAssertionEvidence(
+    "The engine reports a busy session before the Settings visit",
+    `GET /opencode/session/status → ${statusWhileRunning} (created session: ${sessionId})`,
+    statusWhileRunning.startsWith("200:") && statusWhileRunning.includes("busy"),
+  );
+  const busySessionId = /"(ses_[a-zA-Z0-9]+)"\s*:\s*\{"type":"busy"/.exec(statusWhileRunning)?.[1] ?? sessionId;
+
+  // Diagnostic taps: record every renderer fetch and the engine identity so a
+  // red run shows exactly which call killed the run (explicit abort/reload vs
+  // an engine restart losing the run silently).
+  await evalIn(desktopApp, `(() => {
+    window.__settingsVisitFetches = [];
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const rawUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = String(init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+      if (method !== "GET") window.__settingsVisitFetches.push(method + " " + rawUrl);
+      return originalFetch(input, init);
+    };
+    return true;
+  })()`);
+  const engineBefore = await evalIn(
+    desktopApp,
+    `window.__OPENWORK_ELECTRON__.invokeDesktop("engineInfo")`,
+    { awaitPromise: true },
+  );
+  const serverBefore = await evalIn(
+    desktopApp,
+    `window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo")`,
+    { awaitPromise: true },
+  );
+
+  // The user gesture: open Settings on the SAME workspace while the run streams.
+  await go(desktopApp, `/workspace/${encodeURIComponent(workspaceId)}/settings/general`);
+  await waitFor(desktopApp, `window.location.hash.includes("/settings/general")`, {
+    timeoutMs: 30_000,
+    label: "Settings route mounted",
+  });
+
+  // Linger past the workspace-sync dispose grace (2s) and the SSE stale
+  // watchdog window so any wrongly-dropped stream would be observable.
+  await new Promise((resolve) => setTimeout(resolve, 15_000));
+
+  // Server-side truth after the linger, before returning: the run must
+  // still exist. If this is already idle/aborted, Settings killed the run
+  // itself; if busy here but dead in the UI, the renderer lost the run.
+  const statusAfterLinger = String(await evalIn(desktopApp, serverStatusExpression(workspaceId), {
+    awaitPromise: true,
+    timeoutMs: 30_000,
+  }));
+
+  // Probe the pre-Settings engine generation DIRECTLY: if it is gone, the
+  // pool retired a draining engine early (or reloaded in place); if it is
+  // alive and busy, the drain works and the loss is in routing/UI.
+  const engineBeforeRecord = engineBefore as Record<string, unknown>;
+  const oldEngineProbe = String(await evalIn(desktopApp, `(async () => {
+    try {
+      const response = await fetch(
+        ${JSON.stringify(String(engineBeforeRecord.baseUrl ?? ""))} + "/session/status?directory=" + encodeURIComponent(${JSON.stringify(String(engineBeforeRecord.projectDir ?? ""))}),
+        { headers: { Authorization: "Basic " + btoa(${JSON.stringify(String(engineBeforeRecord.opencodeUsername ?? ""))} + ":" + ${JSON.stringify(String(engineBeforeRecord.opencodePassword ?? ""))}) } },
+      );
+      return response.status + ":" + (await response.text()).slice(0, 500);
+    } catch (error) {
+      return "unreachable:" + String(error);
+    }
+  })()`, { awaitPromise: true, timeoutMs: 30_000 }));
+  const serverBusyAfterLinger = statusAfterLinger.startsWith("200:") && statusAfterLinger.includes("busy");
+  const mutatingFetches = await evalIn(desktopApp, `JSON.stringify(window.__settingsVisitFetches ?? [])`);
+  const engineAfter = await evalIn(
+    desktopApp,
+    `window.__OPENWORK_ELECTRON__.invokeDesktop("engineInfo")`,
+    { awaitPromise: true },
+  );
+  const serverAfter = await evalIn(
+    desktopApp,
+    `window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo")`,
+    { awaitPromise: true },
+  );
+  evidence.recordAssertionEvidence(
+    "The engine still reports the run after 15s in Settings",
+    [
+      `GET /opencode/session/status → ${statusAfterLinger}`,
+      `old engine direct probe → ${oldEngineProbe}`,
+      `engine before: ${JSON.stringify(engineBefore)}`,
+      `engine after: ${JSON.stringify(engineAfter)}`,
+      `server before: ${JSON.stringify(serverBefore)}`,
+      `server after: ${JSON.stringify(serverAfter)}`,
+      `mutating fetches during Settings: ${String(mutatingFetches)}`,
+    ].join("\n"),
+    serverBusyAfterLinger,
+  );
+
+  // Return to the exact conversation, as the Settings close button does.
+  await go(desktopApp, `/workspace/${encodeURIComponent(workspaceId)}/session/${encodeURIComponent(busySessionId)}`);
+  await waitFor(desktopApp, `!window.location.hash.includes("/settings")`, {
+    timeoutMs: 30_000,
+    label: "session route restored",
+  });
+
+  // The prompt bubble itself contains the marker text once; an assistant
+  // reply adds a second occurrence, so completion means count >= 2.
+  const completeMarkerCountExpression = `document.body.innerText.split(${JSON.stringify(COMPLETE_MARKER)}).length - 1 >= 2`;
+  // The returning session view must present the run as live within a moment
+  // (or already show the completed reply if the task finished meanwhile).
+  await waitFor(desktopApp, `(${stopEnabledExpression}) || (${completeMarkerCountExpression})`, {
+    timeoutMs: 15_000,
+    label: "run presented as live (or completed) after returning from Settings",
+  });
+  const liveOnReturn = await evalIn(desktopApp, stopEnabledExpression);
+  const completedAlready = await evalIn(desktopApp, completeMarkerCountExpression);
+  evidence.recordAssertionEvidence(
+    "The conversation is still live (or already completed) in the UI after returning from Settings",
+    `composer.stop enabled: ${String(liveOnReturn)}; completion marker rendered: ${String(completedAlready)}; server status after linger: ${statusAfterLinger}.`,
+    liveOnReturn === true || completedAlready === true,
+  );
+
+  await waitFor(desktopApp, completeMarkerCountExpression, {
+    timeoutMs: 300_000,
+    label: "live task completed after the Settings round trip",
+  });
+  const interrupted = await evalIn(
+    desktopApp,
+    `document.body.innerText.includes("The message was interrupted")`,
+  );
+
+  await screenshot(desktopApp);
+
+  expect(serverBusyAfterLinger).toBe(true);
+  expect(liveOnReturn === true || completedAlready === true).toBe(true);
+  expect(interrupted).toBe(false);
+  evidence.recordAssertionEvidence(
+    "A same-workspace Settings visit does not stop or stall the streaming conversation",
+    `${COMPLETE_MARKER} rendered after a 15s Settings visit with the engine pid and server generation unchanged and no interruption card.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Problem

Opening Settings while a task is running can interrupt the engine or force a generation transition. A freshly mounted Settings-side server store starts without cached host info, and its connection reconciliation proceeds straight to `openworkServerRestart` even when the existing local server is healthy — tearing down the embedded server and its managed engine, killing every live run. The same transition churn also briefly settles an incomplete model catalog, flashing a false "Model no longer available" block.

## Fix

- `openwork-server-store.ts`: before restarting, a store with no observed host info now asks the desktop bridge for the live server (`openworkServerInfo`) and health-checks it. A healthy live server is adopted as-is; restart happens only when the running server is genuinely unreachable.
- `model-availability.ts` + `session-route.tsx`: catalog-derived denials (`model_missing`, `provider_not_connected`) are confirmation-gated for 1.2s and render as pending until they persist; a recheck tick re-evaluates tracked denials so a genuine denial still surfaces without further catalog changes.
- `your-connections-screen.tsx` (den-web): the row ref prop was typed through the ambient React UMD namespace. The workspace legitimately carries two `@types/react` majors (landing pins 18), so which copy backs that ambient namespace depends on install hoisting order; when 18 wins, `next build` fails against the React 19 div ref prop. Importing `Ref` from `react` resolves it through this package's own pinned types regardless of hoisting. This also unblocks Den sandbox provisioning, which rebuilds den-web from source.

## Negative halves preserved

- A genuinely dead local server still restarts (unit-covered in `openwork-server-local-recovery-restart-guard.test.ts`).
- An authoritative policy denial (`provider_blocked`) bypasses the gate and blocks immediately; a matured catalog denial still surfaces via the scheduled recheck (unit-covered in `model-availability.test.ts`).

## Proof

All runs at head `622cc4161`.

- `pnpm evals:e2e settings-visit-live-run-continuity --daytona` — exit 0, 1 passed / 0 failed / 0 skipped (Daytona lane, fresh Den + desktop sandboxes). A streaming run survives a 15s same-workspace Settings visit with the engine and server generation unchanged, stays live on return, and completes without an interruption card.
- `pnpm evals:e2e session-model-availability --daytona` — exit 0, 1 passed / 0 failed / 0 skipped. A conversation keeps its remembered model when the global default breaks across a workspace switch; the genuine unavailable state still surfaces for the broken default and recovery clears it, proving the confirmation gate does not suppress matured denials.
- `bun test --isolate tests/model-availability.test.ts tests/openwork-server-local-recovery-restart-guard.test.ts` — 18 pass / 0 fail (42 assertions).
- `pnpm --filter @openwork/app typecheck` — clean; `pnpm --filter @openwork-ee/den-web build` — compiles with the type fix.

Full `apps/app` suite: 1054 pass / 5 fail — the identical 5 failures reproduce on a clean `origin/dev` control worktree with the same command (pre-existing, unrelated: connect capability inventory ×2, cloud workspace boot takeover, session-route logout wiring, extensions sidebar).

Note: the shared `openwork-eval-vnc` Daytona snapshot was found deleted-and-errored (`no matching manifest for linux/amd64` — the GHCR eval image is arm64-only while Daytona runners are amd64). It was recreated from `.devcontainer/Dockerfile.daytona-vnc` on Daytona's own builders to restore the desktop E2E lane; `.github/workflows/daytona-eval-image.yml` still publishes arm64-only and needs a follow-up.
